### PR TITLE
Handle error for failing to create TUN device

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4272,6 +4272,7 @@ dependencies = [
  "talpid-tunnel",
  "talpid-types",
  "talpid-wireguard",
+ "tap",
  "thiserror",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ log = "0.4.20"
 serde = "1.0.192"
 serde_json = "1.0.91"
 signature = "1"
+tap = "1.0.1"
 thiserror = "1.0.38"
 tokio = { version = "1.8", features = ["process", "rt-multi-thread", "fs"] }
 tracing = "0.1"

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -3,6 +3,7 @@ use std::{collections::HashSet, net::IpAddr};
 use default_net::interface::get_default_interface;
 use ipnetwork::IpNetwork;
 use talpid_routing::{Node, RequiredRoute, RouteManager};
+use tap::TapFallible;
 use tracing::{debug, error, info, trace};
 use tun::Device;
 
@@ -152,7 +153,9 @@ pub async fn setup_routing(
     enable_wireguard: bool,
     disable_routing: bool,
 ) -> Result<tun::AsyncDevice> {
-    let dev = tun::create_as_async(&config.mixnet_tun_config)?;
+    info!("Creating tun device");
+    let dev = tun::create_as_async(&config.mixnet_tun_config)
+        .tap_err(|err| error!("Failed to create tun device: {}", err))?;
     let device_name = dev.get_ref().name().to_string();
     info!("Created tun device {device_name}: ip={device_ip}, broadcast={device_broadcast}, netmask={device_netmask}, destination={device_destination}, mtu={device_mtu}",
         device_name = device_name,


### PR DESCRIPTION
Failing to setup TUN device due to missing permissions is a very common error, so explicitly handle that until we have a better more general flow where all errors are caught in this way.
