### PR TITLE
Fix makefile to work on macOS with arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ ifeq ($(OS),Darwin)
   ifeq ($(ARCH),x86_64)
     ARCH := x86_64-apple-darwin
   else ifeq ($(ARCH),arm64)
-    ARCH := arm64-apple-darwin
+    ARCH := aarch64-apple-darwin
   # Add more architectures as needed
   endif
 endif


### PR DESCRIPTION
<img width="611" alt="Screenshot 2024-01-09 at 14 06 14" src="https://github.com/nymtech/nym-vpn-client/assets/2559446/9da0850c-142c-4135-9729-eeb7bd32fa64">

It seems that on macOS, the `aarch64-apple-darwin` folder is created instead of `arm64-apple-darwin`

Seems to make the `make` the command work 🚀
![Screenshot 2024-01-09 at 14 09 14](https://github.com/nymtech/nym-vpn-client/assets/2559446/a8463d5d-3a94-4cd9-be86-ad2f60c581f6)
