### PR TITLE
ci: tar artifact to avoid losing file permissions

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -133,6 +133,7 @@ jobs:
         run: |
           npm run tauri build
           ls -la target/release/bundle
+          tar -cvf bundle.tar target/release/bundle
         # TODO ignore `Error invalid utf-8 sequence of 1 bytes from index X` error
         continue-on-error: true
 
@@ -140,4 +141,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: nym-vpn-desktop_${{ env.APP_VERSION }}_${{ env.PLATFORM_ARCH }}
-          path: nym-vpn-desktop/src-tauri/target/release/bundle
+          path: nym-vpn-desktop/src-tauri/bundle.tar


### PR DESCRIPTION
See https://github.com/actions/upload-artifact?tab=readme-ov-file#permission-loss

Fixes the MacOS artifacts getting broken by the `x` permissions being stripped by zip.

https://nymtech.atlassian.net/browse/NC-481