### PR TITLE
Universal macOS build support

### DIFF
--- a/.github/workflows/build-wireguard-go.yml
+++ b/.github/workflows/build-wireguard-go.yml
@@ -12,6 +12,8 @@ on:
         - ubuntu-20.04
         - ubuntu-22.04
         - custom-runner-mac-m1
+    concurrency:
+      group: "build-wireguard"
 
   # reusable workflow
   workflow_call:
@@ -56,12 +58,7 @@ jobs:
           go-version: 'stable'
 
       - name: Build wireguard
-        if: contains(inputs.os, 'ubuntu')
         run: ./wireguard/build-wireguard-go.sh
-
-      - name: Build wireguard macOS universal
-        if: contains(inputs.os, 'mac-m1')
-        run: ./wireguard/build-wireguard-go.sh --universal
 
       - name: Upload artifacts (ubuntu-22.04 x86_64)
         uses: actions/upload-artifact@v4
@@ -83,11 +80,12 @@ jobs:
 
       - name: Upload artifacts (macOS x86_64)
         uses: actions/upload-artifact@v4
-        if: contains(inputs.os, 'mac-m1')
+#        if: contains(inputs.os, 'mac-m1')
+        if: contains(inputs.os, 'macos-latest')
         with:
           name: wireguard-go_macos_x86_64
           path: |
-            build/lib/amd64-apple-darwin
+            build/lib/x86_64-apple-darwin
           retention-days: 1
 
 

--- a/.github/workflows/build-wireguard-go.yml
+++ b/.github/workflows/build-wireguard-go.yml
@@ -11,7 +11,6 @@ on:
         options:
         - ubuntu-20.04
         - ubuntu-22.04
-        - macos-latest
         - custom-runner-mac-m1
 
   # reusable workflow
@@ -47,7 +46,7 @@ jobs:
       # TODO: check that this is actually used
       - name: Install Protoc
         uses: arduino/setup-protoc@v2
-        if: contains(inputs.os, 'macos') || contains(inputs.os, 'mac-m1') || contains(inputs.os, 'windows')
+        if: contains(inputs.os, 'mac-m1') || contains(inputs.os, 'windows')
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -57,7 +56,12 @@ jobs:
           go-version: 'stable'
 
       - name: Build wireguard
+        if: contains(inputs.os, 'ubuntu')
         run: ./wireguard/build-wireguard-go.sh
+
+      - name: Build wireguard macOS universal
+        if: contains(inputs.os, 'mac-m1')
+        run: ./wireguard/build-wireguard-go.sh --universal
 
       - name: Upload artifacts (ubuntu-22.04 x86_64)
         uses: actions/upload-artifact@v4
@@ -77,20 +81,31 @@ jobs:
             build/lib/x86_64-unknown-linux-gnu
           retention-days: 1
 
-      - name: Upload artifacts (macos x86_64)
+      - name: Upload artifacts (macOS x86_64)
         uses: actions/upload-artifact@v4
-        if: contains(inputs.os, 'macos')
+        if: contains(inputs.os, 'mac-m1')
         with:
           name: wireguard-go_macos_x86_64
           path: |
-            build/lib/x86_64-apple-darwin
+            build/lib/amd64-apple-darwin
           retention-days: 1
 
-      - name: Upload artifacts (macos aarch64)
+
+      - name: Upload artifacts (macOS aarch64)
         uses: actions/upload-artifact@v4
         if: contains(inputs.os, 'mac-m1')
         with:
           name: wireguard-go_macos_aarch64
           path: |
             build/lib/aarch64-apple-darwin
+          retention-days: 1
+
+
+      - name: Upload artifacts (macOS universal)
+        uses: actions/upload-artifact@v4
+        if: contains(inputs.os, 'mac-m1')
+        with:
+          name: wireguard-go_macos_universal
+          path: |
+            build/lib/universal-apple-darwin
           retention-days: 1

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -14,8 +14,7 @@ jobs:
           [
             ubuntu-22.04-16-core,
             ubuntu-20.04-16-core,
-            macos-latest,
-            custom-runner-mac-m1,
+            custom-runner-mac-m1
           ]
     uses: ./.github/workflows/build-wireguard-go.yml
     with:
@@ -30,8 +29,7 @@ jobs:
           [
             ubuntu-22.04-16-core,
             ubuntu-20.04-16-core,
-            macos-latest,
-            custom-runner-mac-m1,
+            custom-runner-mac-m1
           ]
     runs-on: ${{ matrix.os }}
     env:
@@ -71,8 +69,15 @@ jobs:
             platform_arch=ubuntu-20.04_x86_64
           elif ${{ contains(matrix.os, 'mac-m1') }}; then
             platform_arch=macos_aarch64
-          elif ${{ contains(matrix.os, 'macos') }}; then
-            platform_arch=macos_x86_64
+            platform_arch_amd64=macos_x86_64
+            platform_arch_universal=macos_universal
+            wg_go_lib_name_amd64="wireguard-go_$platform_arch_amd64"
+            wg_go_lib_name_universal="wireguard-go_$platform_arch_universal"
+            
+            echo "platform_arch_amd64=$platform_arch_amd64" >> $GITHUB_ENV
+            echo "platform_arch_universal=platform_arch_universal" >> $GITHUB_ENV
+            echo "wg_go_lib_name_amd64=$wg_go_lib_name_amd64" >> $GITHUB_ENV
+            echo "wg_go_lib_name_universal=wg_go_lib_name_universal" >> $GITHUB_ENV
           else
             echo " ✗ unknown platform/arch [${{ matrix.os }}]"
             exit 1
@@ -90,6 +95,20 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ env.WG_GO_LIB_NAME }}
+          path: ${{ env.WG_GO_LIB_PATH }}
+
+      - name: Download wireguard-go artifacts for macOS x86
+        uses: actions/download-artifact@v4
+        if: contains(matrix.os, 'mac-m1')
+        with:
+          name: ${{ env.wg_go_lib_name_amd64 }}
+          path: ${{ env.WG_GO_LIB_PATH }}
+
+      - name: Download wireguard-go artifacts for macOS unviersal
+        uses: actions/download-artifact@v4
+        if: contains(matrix.os, 'mac-m1')
+        with:
+          name: ${{ env.wg_go_lib_name_universal }}
           path: ${{ env.WG_GO_LIB_PATH }}
 
       - name: Get version
@@ -112,7 +131,7 @@ jobs:
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v2
-        if: contains(matrix.os, 'macos') || contains(matrix.os, 'mac-m1')
+        if: contains(matrix.os, 'mac-m1')
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -141,5 +160,49 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: nym-vpn-desktop_${{ env.APP_VERSION }}_${{ env.PLATFORM_ARCH }}
+          path: nym-vpn-desktop/src-tauri/bundle.tar
+          retention-days: 10
+
+      - name: Build desktop client macOS x64_86
+        if: contains(matrix.os, 'mac-m1')
+        working-directory: nym-vpn-desktop/src-tauri
+        env:
+          RUSTFLAGS: "-L ${{ env.WG_GO_LIB_PATH }}"
+          TAURI_PRIVATE_KEY: ${{ env.TAURI_PRIVATE_KEY }}
+          TAURI_KEY_PASSWORD: ${{ env.TAURI_PRIVATE_PASSWORD }}
+        shell: bash
+        run: |
+          npm run tauri build -- --target x86_64-apple-darwin  
+          ls -la target/release/bundle
+          tar -cvf bundle.tar target/release/bundle
+        # TODO ignore `Error invalid utf-8 sequence of 1 bytes from index X` error
+        continue-on-error: true
+
+      - name: Upload artifacts (${{ env.platform_arch_amd64 }})
+        uses: actions/upload-artifact@v4
+        with:
+          name: nym-vpn-desktop_${{ env.APP_VERSION }}_${{ env.platform_arch_amd64 }}
+          path: nym-vpn-desktop/src-tauri/bundle.tar
+          retention-days: 10
+
+      - name: Build desktop client macOS universal
+        if: contains(matrix.os, 'mac-m1')
+        working-directory: nym-vpn-desktop/src-tauri
+        env:
+          RUSTFLAGS: "-L ${{ env.WG_GO_LIB_PATH }}"
+          TAURI_PRIVATE_KEY: ${{ env.TAURI_PRIVATE_KEY }}
+          TAURI_KEY_PASSWORD: ${{ env.TAURI_PRIVATE_PASSWORD }}
+        shell: bash
+        run: |
+          npm run tauri build -- --target universal-apple-darwin 
+          ls -la target/release/bundle
+          tar -cvf bundle.tar target/release/bundle
+        # TODO ignore `Error invalid utf-8 sequence of 1 bytes from index X` error
+        continue-on-error: true
+
+      - name: Upload artifacts (${{ env.platform_arch_universal }})
+        uses: actions/upload-artifact@v4
+        with:
+          name: nym-vpn-desktop_${{ env.APP_VERSION }}_${{ env.platform_arch_universal }}
           path: nym-vpn-desktop/src-tauri/bundle.tar
           retention-days: 10

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -2,7 +2,8 @@ name: release-desktop
 
 on:
   workflow_dispatch:
-
+concurrency:
+  group: "release-desktop"
 env:
   CARGO_TERM_COLOR: always
 
@@ -12,9 +13,10 @@ jobs:
       matrix:
         os:
           [
-            ubuntu-22.04-16-core,
-            ubuntu-20.04-16-core,
-            custom-runner-mac-m1
+#            ubuntu-22.04-16-core,
+#            ubuntu-20.04-16-core,
+#            custom-runner-mac-m1
+            macos-latest
           ]
     uses: ./.github/workflows/build-wireguard-go.yml
     with:
@@ -27,9 +29,10 @@ jobs:
       matrix:
         os:
           [
-            ubuntu-22.04-16-core,
-            ubuntu-20.04-16-core,
-            custom-runner-mac-m1
+#            ubuntu-22.04-16-core,
+#            ubuntu-20.04-16-core,
+#            custom-runner-mac-m1
+            macos-latest
           ]
     runs-on: ${{ matrix.os }}
     env:
@@ -69,15 +72,17 @@ jobs:
             platform_arch=ubuntu-20.04_x86_64
           elif ${{ contains(matrix.os, 'mac-m1') }}; then
             platform_arch=macos_aarch64
-            platform_arch_amd64=macos_x86_64
+            platform_arch_x86=macos_x86_64
             platform_arch_universal=macos_universal
-            wg_go_lib_name_amd64="wireguard-go_$platform_arch_amd64"
+            wg_go_lib_name_x86="wireguard-go_$platform_arch_x86"
             wg_go_lib_name_universal="wireguard-go_$platform_arch_universal"
             
-            echo "platform_arch_amd64=$platform_arch_amd64" >> $GITHUB_ENV
-            echo "platform_arch_universal=platform_arch_universal" >> $GITHUB_ENV
-            echo "wg_go_lib_name_amd64=$wg_go_lib_name_amd64" >> $GITHUB_ENV
-            echo "wg_go_lib_name_universal=wg_go_lib_name_universal" >> $GITHUB_ENV
+            echo "platform_arch_x86=$platform_arch_x86" >> $GITHUB_ENV
+            echo "platform_arch_universal=$platform_arch_universal" >> $GITHUB_ENV
+            echo "wg_go_lib_name_x86=$wg_go_lib_name_x86" >> $GITHUB_ENV
+            echo "wg_go_lib_name_universal=$wg_go_lib_name_universal" >> $GITHUB_ENV
+           elif ${{ contains(matrix.os, 'macos') }}; then
+            platform_arch=macos_x86_64
           else
             echo " ✗ unknown platform/arch [${{ matrix.os }}]"
             exit 1
@@ -101,10 +106,10 @@ jobs:
         uses: actions/download-artifact@v4
         if: contains(matrix.os, 'mac-m1')
         with:
-          name: ${{ env.wg_go_lib_name_amd64 }}
+          name: ${{ env.wg_go_lib_name_x86 }}
           path: ${{ env.WG_GO_LIB_PATH }}
 
-      - name: Download wireguard-go artifacts for macOS unviersal
+      - name: Download wireguard-go artifacts for macOS universal
         uses: actions/download-artifact@v4
         if: contains(matrix.os, 'mac-m1')
         with:
@@ -124,6 +129,11 @@ jobs:
         with:
           components: rustfmt, clippy
 
+      - name: Install extra architectures macOS
+        if: contains(matrix.os, 'mac-m1')
+        run: |
+          rustup target add x86_64-apple-darwin
+
       - name: Install Node
         uses: actions/setup-node@v3
         with:
@@ -131,7 +141,8 @@ jobs:
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v2
-        if: contains(matrix.os, 'mac-m1')
+#        if: contains(matrix.os, 'mac-m1')
+        if: contains(matrix.os, 'macos-latest')
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -142,67 +153,124 @@ jobs:
         working-directory: nym-vpn-desktop
         run: npm i
 
+#      - name: Install the Apple developer certificate for code signing
+#        if: contains(matrix.os, 'mac-m1')
+#        env:
+#          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+#          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+#          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+#          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+#        run: |
+#          # create variables
+#          CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
+#          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+#
+#          # import certificate and provisioning profile from secrets
+#          echo $APPLE_CERTIFICATE | base64 --decode > $CERTIFICATE_PATH
+#
+#          # create temporary keychain
+#          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+#          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+#          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+#
+#          # import certificate to keychain
+#          security import $CERTIFICATE_PATH -P "$APPLE_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+#          security list-keychain -d user -s $KEYCHAIN_PATH
+
       - name: Build desktop client
         working-directory: nym-vpn-desktop/src-tauri
         env:
           RUSTFLAGS: "-L ${{ env.WG_GO_LIB_PATH }}"
           TAURI_PRIVATE_KEY: ${{ env.TAURI_PRIVATE_KEY }}
           TAURI_KEY_PASSWORD: ${{ env.TAURI_PRIVATE_PASSWORD }}
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#          ENABLE_CODE_SIGNING: ${{ secrets.APPLE_CERTIFICATE }}
+#          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+#          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+#          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+#          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_IDENTITY_ID }}
+#          APPLE_ID: ${{ secrets.APPLE_ID }}
+#          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
         shell: bash
         run: |
           npm run tauri build
-          ls -la target/release/bundle
-          tar -cvf bundle.tar target/release/bundle
         # TODO ignore `Error invalid utf-8 sequence of 1 bytes from index X` error
         continue-on-error: true
+
+#      - name: tar artifacts (${{ env.PLATFORM_ARCH }})
+#        working-directory: nym-vpn-desktop/src-tauri
+#        shell: bash
+#        run: |
+#          ls -la target/release/bundle
+#          tar -cvf bundle.tar target/release/bundle
 
       - name: Upload artifacts (${{ env.PLATFORM_ARCH }})
         uses: actions/upload-artifact@v4
         with:
           name: nym-vpn-desktop_${{ env.APP_VERSION }}_${{ env.PLATFORM_ARCH }}
-          path: nym-vpn-desktop/src-tauri/bundle.tar
+#          path: nym-vpn-desktop/src-tauri/target/release/bundle/dmg/nym-vpn_${{ env.APP_VERSION }}_aarch64.dmg
+          path: nym-vpn-desktop/src-tauri/target/release/bundle/dmg/nym-vpn_${{ env.APP_VERSION }}_x64.dmg
           retention-days: 10
 
-      - name: Build desktop client macOS x64_86
-        if: contains(matrix.os, 'mac-m1')
-        working-directory: nym-vpn-desktop/src-tauri
-        env:
-          RUSTFLAGS: "-L ${{ env.WG_GO_LIB_PATH }}"
-          TAURI_PRIVATE_KEY: ${{ env.TAURI_PRIVATE_KEY }}
-          TAURI_KEY_PASSWORD: ${{ env.TAURI_PRIVATE_PASSWORD }}
-        shell: bash
-        run: |
-          npm run tauri build -- --target x86_64-apple-darwin  
-          ls -la target/release/bundle
-          tar -cvf bundle.tar target/release/bundle
-        # TODO ignore `Error invalid utf-8 sequence of 1 bytes from index X` error
-        continue-on-error: true
+#      - name: Clean up keychain
+#        if: contains(matrix.os, 'mac-m1')
+#        run: |
+#          security delete-keychain $RUNNER_TEMP/app-signing.keychain-db
 
-      - name: Upload artifacts (${{ env.platform_arch_amd64 }})
-        uses: actions/upload-artifact@v4
-        with:
-          name: nym-vpn-desktop_${{ env.APP_VERSION }}_${{ env.platform_arch_amd64 }}
-          path: nym-vpn-desktop/src-tauri/bundle.tar
-          retention-days: 10
+#      - name: Build desktop client macOS x64_86
+#        if: contains(matrix.os, 'mac-m1')
+#        working-directory: nym-vpn-desktop/src-tauri
+#        env:
+#          RUSTFLAGS: "-L ${{ env.WG_GO_LIB_PATH }}"
+#          TAURI_PRIVATE_KEY: ${{ env.TAURI_PRIVATE_KEY }}
+#          TAURI_KEY_PASSWORD: ${{ env.TAURI_PRIVATE_PASSWORD }}
+#        shell: bash
+#        run: |
+#          npm run tauri build -- --target x86_64-apple-darwin
+#        # TODO ignore `Error invalid utf-8 sequence of 1 bytes from index X` error
+#        continue-on-error: true
 
-      - name: Build desktop client macOS universal
-        if: contains(matrix.os, 'mac-m1')
-        working-directory: nym-vpn-desktop/src-tauri
-        env:
-          RUSTFLAGS: "-L ${{ env.WG_GO_LIB_PATH }}"
-          TAURI_PRIVATE_KEY: ${{ env.TAURI_PRIVATE_KEY }}
-          TAURI_KEY_PASSWORD: ${{ env.TAURI_PRIVATE_PASSWORD }}
-        shell: bash
-        run: |
-          npm run tauri build -- --target universal-apple-darwin 
-          ls -la target/release/bundle
-          tar -cvf bundle.tar target/release/bundle
-        # TODO ignore `Error invalid utf-8 sequence of 1 bytes from index X` error
-        continue-on-error: true
-
-      - name: Upload artifacts (${{ env.platform_arch_universal }})
-        uses: actions/upload-artifact@v4
-        with:
-          name: nym-vpn-desktop_${{ env.APP_VERSION }}_${{ env.platform_arch_universal }}
-          path: nym-vpn-desktop/src-tauri/bundle.tar
-          retention-days: 10
+#      - name: tar artifacts macOS x64_86
+#        if: contains(matrix.os, 'mac-m1')
+#        working-directory: nym-vpn-desktop/src-tauri
+#        shell: bash
+#        run: |
+#          ls -la target/release/bundle
+#          tar -cvf bundle.tar target/release/bundle
+#
+#      - name: Upload artifacts (${{ env.platform_arch_x86 }})
+#        if: contains(matrix.os, 'mac-m1')
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: nym-vpn-desktop_${{ env.APP_VERSION }}_${{ env.platform_arch_x86 }}
+#          path: nym-vpn-desktop/src-tauri/bundle.tar
+#          retention-days: 10
+#
+#      - name: Build desktop client macOS universal
+#        if: contains(matrix.os, 'mac-m1')
+#        working-directory: nym-vpn-desktop/src-tauri
+#        env:
+#          RUSTFLAGS: "-L ${{ env.WG_GO_LIB_PATH }}"
+#          TAURI_PRIVATE_KEY: ${{ env.TAURI_PRIVATE_KEY }}
+#          TAURI_KEY_PASSWORD: ${{ env.TAURI_PRIVATE_PASSWORD }}
+#        shell: bash
+#        run: |
+#          npm run tauri build -- --target universal-apple-darwin
+#        # TODO ignore `Error invalid utf-8 sequence of 1 bytes from index X` error
+#        continue-on-error: true
+#
+#      - name: tar artifacts macOS universal
+#        if: contains(matrix.os, 'mac-m1')
+#        working-directory: nym-vpn-desktop/src-tauri
+#        shell: bash
+#        run: |
+#          ls -la target/release/bundle
+#          tar -cvf bundle.tar target/release/bundle
+#
+#      - name: Upload artifacts (${{ env.platform_arch_universal }})
+#        uses: actions/upload-artifact@v4
+#        if: contains(matrix.os, 'mac-m1')
+#        with:
+#          name: nym-vpn-desktop_${{ env.APP_VERSION }}_${{ env.platform_arch_universal }}
+#          path: nym-vpn-desktop/src-tauri/bundle.tar
+#          retention-days: 10


### PR DESCRIPTION
https://github.com/nymtech/nym-vpn-client/actions/runs/7652611640

This adds the ability to create universal builds for macOS.

On Apple silicon machines WG builds: aarch64, amd64 and universal build.

Desktop client:
Removed the `macos-latest` machine.
Added extra architectures and steps to produce 3 macOS builds: aarch64, amd64 and universal build.

Moved the `.tar` command out of `npm run tauri build` step, due to known failure. `Error invalid utf-8 sequence of 1 bytes from index 0`. 
It seems like after failure, the `.tar` command is not executed.
