### PR TITLE
Remove duplicate version

### DIFF
--- a/nym-vpn-desktop/src-tauri/tauri.conf.json
+++ b/nym-vpn-desktop/src-tauri/tauri.conf.json
@@ -7,8 +7,7 @@
     "withGlobalTauri": false
   },
   "package": {
-    "productName": "nym-vpn",
-    "version": "0.0.4-dev"
+    "productName": "nym-vpn"
   },
   "tauri": {
     "updater": {


### PR DESCRIPTION
Remove the duplicate version entry in the tauri config file. It should now automatically pick up the one in the Cargo.toml file instead
