### PR TITLE
Update tauri.conf.json with signing attributes

### DIFF
--- a/nym-vpn-desktop/src-tauri/tauri.conf.json
+++ b/nym-vpn-desktop/src-tauri/tauri.conf.json
@@ -35,7 +35,14 @@
         "icons/128x128@2x.png",
         "icons/icon.icns",
         "icons/icon.ico"
-      ]
+      ],
+      "macOS": {
+        "frameworks": [],
+        "minimumSystemVersion": "",
+        "exceptionDomain": "",
+        "signingIdentity": "Developer ID Application: Nym Technologies SA (VW5DZLFHM5)",
+        "entitlements": null
+      }
     },
     "security": {
       "csp": null


### PR DESCRIPTION
Add signing identity to `tauri.conf.json`. 

This is required so we could sign and notarize the app.