### PR TITLE
feat(desktop): add cli feature

### DIFF
--- a/nym-vpn-desktop/README.md
+++ b/nym-vpn-desktop/README.md
@@ -136,6 +136,17 @@ cd src-tauri
 RUST_LOG=trace cargo tauri dev
 ```
 
+#### Disabling the splash-screen
+
+While developing, you might want to disable the splash-screen
+to speedup app loading time.
+Either set the `APP_NOSPLASH` env variable to `true` or pass the
+`--nosplash` flag to the app
+
+```shell
+npm run dev:app -- -- -- --nosplash
+```
+
 ## Dev in the browser
 
 For convenience and better development experience, we can run the
@@ -153,6 +164,18 @@ Browser mode requires all tauri [commands](https://tauri.app/v1/guides/features/
 When creating new tauri command, be sure to add the corresponding
 mock definition into `src/dev/tauri-cmd-mocks/` and update
 `src/dev/setup.ts` accordingly.
+
+## CLI
+
+We are using [clap](https://docs.rs/clap/latest/clap/) to handle CLI for the app.
+
+In dev mode, you can pass CLI arguments and flags with the `--` separator
+
+```shell
+npm run dev:app -- -- -- --help
+# or
+cargo tauri dev -- -- --help
+```
 
 ## Type bindings
 

--- a/nym-vpn-desktop/src-tauri/Cargo.lock
+++ b/nym-vpn-desktop/src-tauri/Cargo.lock
@@ -7041,6 +7041,7 @@ version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
 dependencies = [
+ "indexmap 2.1.0",
  "itoa 1.0.10",
  "ryu",
  "serde",
@@ -8110,13 +8111,14 @@ checksum = "69758bda2e78f098e4ccb393021a0963bb3442eac05f135c30f61b7370bbafae"
 
 [[package]]
 name = "tauri"
-version = "1.5.4"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd27c04b9543776a972c86ccf70660b517ecabbeced9fb58d8b961a13ad129af"
+checksum = "0da520ff07c0745199204f7a7a62a8c6ee1666313b792b051ca170eca04649aa"
 dependencies = [
  "anyhow",
  "cocoa",
  "dirs-next",
+ "dunce",
  "embed_plist",
  "encoding_rs",
  "flate2",
@@ -8237,9 +8239,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cae61fbc731f690a4899681c9052dde6d05b159b44563ace8186fc1bfb7d158"
+checksum = "a561ae38c6b27510c77a3ab4cf65bebe18fba51ca4569e023fb9e194ff4995fb"
 dependencies = [
  "cocoa",
  "gtk",

--- a/nym-vpn-desktop/src-tauri/Cargo.lock
+++ b/nym-vpn-desktop/src-tauri/Cargo.lock
@@ -649,6 +649,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "build-info"
+version = "0.0.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "155eb070980e96aeb4ef3b8620b0febb2ae5e17451dc1b329681bdd4eb0a94e1"
+dependencies = [
+ "build-info-common",
+ "build-info-proc",
+]
+
+[[package]]
+name = "build-info-build"
+version = "0.0.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b69d6331ec579144d39e1c128f343d23e9b837617df1bed4ed032e141f83f06a"
+dependencies = [
+ "anyhow",
+ "base64 0.21.6",
+ "bincode",
+ "build-info-common",
+ "cargo_metadata 0.18.1",
+ "chrono",
+ "git2",
+ "glob",
+ "pretty_assertions",
+ "rustc_version",
+ "serde_json",
+ "zstd",
+]
+
+[[package]]
+name = "build-info-common"
+version = "0.0.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8209c0c2b13da7e5f7202e591b6d41b46c8f0e78d031dedf5cff71cc8c6ec773"
+dependencies = [
+ "chrono",
+ "derive_more",
+ "semver 1.0.21",
+ "serde",
+]
+
+[[package]]
+name = "build-info-proc"
+version = "0.0.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc1874cb1995691fb01f9bb56e75f9660d2614e74607fa71c08a8b3bd7e30e4"
+dependencies = [
+ "anyhow",
+ "base64 0.21.6",
+ "bincode",
+ "build-info-common",
+ "chrono",
+ "num-bigint",
+ "num-traits",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.48",
+ "zstd",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -774,6 +837,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver 1.0.21",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "cargo_toml"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -789,6 +866,7 @@ version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
+ "jobserver",
  "libc",
 ]
 
@@ -1759,6 +1837,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2689,6 +2773,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "git2"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b3ba52851e73b46a4c3df1d89343741112003f0f6f13beb0dfac9e457c3fdcd"
+dependencies = [
+ "bitflags 2.4.1",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "glib"
 version = "0.15.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3569,6 +3666,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3684,6 +3790,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libgit2-sys"
+version = "0.16.2+1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3717,6 +3835,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "898745e570c7d0453cc1fbc4a701eb6c662ed54e8fec8b7d14be137ebeeb9d14"
 dependencies = [
  "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037731f5d3aaa87a5675e895b63ddff1a87624bc29f77004ea829809654e48f6"
+dependencies = [
+ "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -4218,6 +4348,17 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -5229,6 +5370,8 @@ name = "nym-vpn-desktop"
 version = "0.0.5-dev"
 dependencies = [
  "anyhow",
+ "build-info",
+ "build-info-build",
  "clap",
  "dotenvy",
  "futures",
@@ -6010,6 +6153,16 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
+dependencies = [
+ "diff",
+ "yansi",
+]
 
 [[package]]
 name = "pretty_env_logger"
@@ -9042,7 +9195,7 @@ dependencies = [
  "anyhow",
  "askama",
  "camino",
- "cargo_metadata",
+ "cargo_metadata 0.15.4",
  "clap",
  "fs-err",
  "glob",
@@ -9128,7 +9281,7 @@ source = "git+https://github.com/mozilla/uniffi-rs?rev=f5fc9d7e9aa08889aedc45dd8
 dependencies = [
  "anyhow",
  "camino",
- "cargo_metadata",
+ "cargo_metadata 0.15.4",
  "fs-err",
  "once_cell",
 ]
@@ -10115,6 +10268,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
 name = "zerocopy"
 version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10152,4 +10311,33 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
+]
+
+[[package]]
+name = "zstd"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a27595e173641171fc74a1232b7b1c7a7cb6e18222c11e9dfb9888fa424c53c"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "6.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee98ffd0b48ee95e6c5168188e44a54550b1564d9d530ee21d5f0eaed1069581"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.9+zstd.1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/nym-vpn-desktop/src-tauri/Cargo.lock
+++ b/nym-vpn-desktop/src-tauri/Cargo.lock
@@ -168,9 +168,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.5"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d664a92ecae85fd0a7392615844904654d1d5f5514837f471ddef4a057aba1b6"
+checksum = "96b09b5178381e0874812a9b157f7fe84982617e48f71f4e3235482775e5b540"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -930,9 +930,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.14"
+version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e92c5c1a78c62968ec57dbc2440366a2d6e5a23faf829970ff1585dc6b18e2"
+checksum = "c918d541ef2913577a0f9566e9ce27cb35b6df072075769e0b26cb5a554520da"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -940,14 +940,14 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.14"
+version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4323769dc8a61e2c39ad7dc26f6f2800524691a44d74fe3d1071a5c24db6370"
+checksum = "9f3e7391dad68afb0c2ede1bf619f579a3dc9c2ec67f089baa397123a2f3d1eb"
 dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.10.0",
+ "strsim 0.11.0",
 ]
 
 [[package]]
@@ -971,9 +971,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.4.7"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
@@ -983,9 +983,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "classic-mceliece-rust"
@@ -5229,6 +5229,7 @@ name = "nym-vpn-desktop"
 version = "0.0.5-dev"
 dependencies = [
  "anyhow",
+ "clap",
  "dotenvy",
  "futures",
  "itertools 0.12.0",
@@ -7479,6 +7480,12 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "subslice"

--- a/nym-vpn-desktop/src-tauri/Cargo.toml
+++ b/nym-vpn-desktop/src-tauri/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 
 [build-dependencies]
 tauri-build = { version = "1.5", features = [] }
+build-info-build = "0.0.34"
 
 [dependencies]
 tauri = { version = "1.5.2", features = ["process-all", "shell-open"] }
@@ -30,6 +31,7 @@ futures = "0.3.15"
 reqwest = { version = "0.11", features = ["json"] }
 itertools = "0.12"
 clap = { version = "4.5", features = ["derive"] }
+build-info = "0.0.34"
 
 # TODO Ugly workaround to force a working setup for nym-vpn-lib
 # We should get rid of this ASAP

--- a/nym-vpn-desktop/src-tauri/Cargo.toml
+++ b/nym-vpn-desktop/src-tauri/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 tauri-build = { version = "1.5", features = [] }
 
 [dependencies]
-tauri = { version = "1.5.2", features = [ "process-all", "shell-open"] }
+tauri = { version = "1.5.2", features = ["process-all", "shell-open"] }
 tokio = { version = "1.33", features = ["rt", "sync", "time", "fs"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -29,6 +29,7 @@ nym-vpn-lib = { path = "../../nym-vpn-lib" }
 futures = "0.3.15"
 reqwest = { version = "0.11", features = ["json"] }
 itertools = "0.12"
+clap = { version = "4.5", features = ["derive"] }
 
 # TODO Ugly workaround to force a working setup for nym-vpn-lib
 # We should get rid of this ASAP

--- a/nym-vpn-desktop/src-tauri/Cargo.toml
+++ b/nym-vpn-desktop/src-tauri/Cargo.toml
@@ -12,7 +12,7 @@ tauri-build = { version = "1.5", features = [] }
 build-info-build = "0.0.34"
 
 [dependencies]
-tauri = { version = "1.5.2", features = ["process-all", "shell-open"] }
+tauri = { version = "1.6.0", features = ["process-all", "shell-open"] }
 tokio = { version = "1.33", features = ["rt", "sync", "time", "fs"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/nym-vpn-desktop/src-tauri/build.rs
+++ b/nym-vpn-desktop/src-tauri/build.rs
@@ -1,3 +1,4 @@
 fn main() {
+    build_info_build::build_script();
     tauri_build::build()
 }

--- a/nym-vpn-desktop/src-tauri/src/cli.rs
+++ b/nym-vpn-desktop/src-tauri/src/cli.rs
@@ -1,0 +1,14 @@
+use std::sync::Arc;
+
+use clap::Parser;
+use serde::{Deserialize, Serialize};
+
+pub type ManagedCli = Arc<Cli>;
+
+#[derive(Parser, Serialize, Deserialize, Debug, Clone, Copy)]
+#[command(version, about, long_about = None)]
+pub struct Cli {
+    /// Disable the splash-screen
+    #[arg(short, long)]
+    pub nosplash: bool,
+}

--- a/nym-vpn-desktop/src-tauri/src/cli.rs
+++ b/nym-vpn-desktop/src-tauri/src/cli.rs
@@ -31,6 +31,7 @@ version:       {}
 target:        {}
 profile:       {}
 build date:    {}
+tauri version: {}
 rustc version: {}
 rustc channel: {}
 ",
@@ -39,6 +40,7 @@ rustc channel: {}
         info.target.triple,
         info.profile,
         info.timestamp,
+        tauri::VERSION,
         info.compiler.version,
         info.compiler.channel,
     );

--- a/nym-vpn-desktop/src-tauri/src/cli.rs
+++ b/nym-vpn-desktop/src-tauri/src/cli.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use clap::Parser;
 use serde::{Deserialize, Serialize};
+use tauri::PackageInfo;
 
 pub type ManagedCli = Arc<Cli>;
 
@@ -22,33 +23,37 @@ pub struct Cli {
     pub build_info: bool,
 }
 
-pub fn print_build_info() {
+pub fn print_build_info(package_info: &PackageInfo) {
     let info = build_info();
 
     print!(
-        r"binary:        {}
-version:       {}
-target:        {}
-profile:       {}
-build date:    {}
-tauri version: {}
-rustc version: {}
-rustc channel: {}
+        r"crate name:      {}
+version:         {}
+tauri version:   {}
+package name:    {}
+package version: {}
+target:          {}
+profile:         {}
+build date:      {}
+rustc version:   {}
+rustc channel:   {}
 ",
         info.crate_info.name,
         info.crate_info.version,
+        tauri::VERSION,
+        package_info.name,
+        package_info.version,
         info.target.triple,
         info.profile,
         info.timestamp,
-        tauri::VERSION,
         info.compiler.version,
         info.compiler.channel,
     );
     if let Some(git) = info.version_control.as_ref().unwrap().git() {
         println!(
-            r"commit sha:    {}
-commit date:   {}
-git branch:    {}
+            r"commit sha:      {}
+commit date:     {}
+git branch:      {}
 ",
             git.commit_id,
             git.commit_timestamp,

--- a/nym-vpn-desktop/src-tauri/src/cli.rs
+++ b/nym-vpn-desktop/src-tauri/src/cli.rs
@@ -5,10 +5,54 @@ use serde::{Deserialize, Serialize};
 
 pub type ManagedCli = Arc<Cli>;
 
+// generate `crate::build_info` function that returns the data
+// collected during build time
+// see https://github.com/danielschemmel/build-info
+build_info::build_info!(fn build_info);
+
 #[derive(Parser, Serialize, Deserialize, Debug, Clone, Copy)]
-#[command(version, about, long_about = None)]
+#[command(author, version, about, long_about = None)]
 pub struct Cli {
     /// Disable the splash-screen
     #[arg(short, long)]
     pub nosplash: bool,
+
+    /// Print build information
+    #[arg(short, long)]
+    pub build_info: bool,
+}
+
+pub fn print_build_info() {
+    let info = build_info();
+
+    print!(
+        r"binary:        {}
+version:       {}
+target:        {}
+profile:       {}
+build date:    {}
+rustc version: {}
+rustc channel: {}
+",
+        info.crate_info.name,
+        info.crate_info.version,
+        info.target.triple,
+        info.profile,
+        info.timestamp,
+        info.compiler.version,
+        info.compiler.channel,
+    );
+    if let Some(git) = info.version_control.as_ref().unwrap().git() {
+        println!(
+            r"commit sha:    {}
+commit date:   {}
+git branch:    {}
+",
+            git.commit_id,
+            git.commit_timestamp,
+            git.branch.as_ref().unwrap_or(&"".to_string())
+        );
+    } else {
+        println!("git:           not available");
+    }
 }

--- a/nym-vpn-desktop/src-tauri/src/commands/cli.rs
+++ b/nym-vpn-desktop/src-tauri/src/commands/cli.rs
@@ -1,0 +1,14 @@
+use tauri::State;
+use tracing::{debug, instrument};
+
+use crate::{
+    cli::{Cli, ManagedCli},
+    error::CmdError,
+};
+
+#[instrument(skip_all)]
+#[tauri::command]
+pub fn cli_args(cli: State<'_, ManagedCli>) -> Result<Cli, CmdError> {
+    debug!("cli_args");
+    Ok(*cli.inner().clone())
+}

--- a/nym-vpn-desktop/src-tauri/src/commands/mod.rs
+++ b/nym-vpn-desktop/src-tauri/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod app_data;
+pub mod cli;
 pub mod connection;
 pub mod node_location;
 pub mod window;

--- a/nym-vpn-desktop/src-tauri/src/main.rs
+++ b/nym-vpn-desktop/src-tauri/src/main.rs
@@ -18,7 +18,7 @@ use states::app::AppState;
 use nym_vpn_lib::nym_config;
 
 use crate::{
-    cli::Cli,
+    cli::{print_build_info, Cli},
     fs::{config::AppConfig, data::AppData, storage::AppStorage},
 };
 
@@ -61,6 +61,11 @@ async fn main() -> Result<()> {
     // parse the command line arguments
     let cli = Cli::parse();
     trace!("cli args: {:#?}", cli);
+
+    if cli.build_info {
+        print_build_info();
+        return Ok(());
+    }
 
     let app_data_store = {
         let mut app_data_path =

--- a/nym-vpn-desktop/src-tauri/src/main.rs
+++ b/nym-vpn-desktop/src-tauri/src/main.rs
@@ -62,8 +62,10 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
     trace!("cli args: {:#?}", cli);
 
+    let context = tauri::generate_context!();
+
     if cli.build_info {
-        print_build_info();
+        print_build_info(context.package_info());
         return Ok(());
     }
 
@@ -164,7 +166,7 @@ async fn main() -> Result<()> {
             window::show_main_window,
             commands::cli::cli_args,
         ])
-        .run(tauri::generate_context!())
+        .run(context)
         .expect("error while running tauri application");
 
     Ok(())

--- a/nym-vpn-desktop/src/App.tsx
+++ b/nym-vpn-desktop/src/App.tsx
@@ -7,6 +7,7 @@ import router from './router';
 import { sleep } from './helpers';
 import { MainStateProvider } from './state';
 import './i18n/config';
+import { Cli } from './types';
 import { ThemeSetter } from './ui';
 
 function App() {
@@ -14,7 +15,17 @@ function App() {
   dayjs.locale(i18n.language);
 
   useEffect(() => {
-    const showAppWindow = async () => {
+    const showSplashAnimation = async () => {
+      const args = await invoke<Cli>(`cli_args`);
+      // if NOSPLASH is set, skip the splash-screen animation
+      if (import.meta.env.APP_NOSPLASH || args?.nosplash) {
+        console.log('splash-screen disabled');
+        const splash = document.getElementById('splash');
+        if (splash) {
+          splash.remove();
+        }
+        return;
+      }
       // allow more time to the app window to be fully ready
       // avoiding the initial "white flash"
       await sleep(100);
@@ -29,7 +40,7 @@ function App() {
         })
         .catch((e) => console.error(e));
     };
-    showAppWindow();
+    showSplashAnimation();
   }, []);
 
   return (

--- a/nym-vpn-desktop/src/state/provider.tsx
+++ b/nym-vpn-desktop/src/state/provider.tsx
@@ -1,6 +1,8 @@
+import { invoke } from '@tauri-apps/api';
 import React, { useEffect, useReducer } from 'react';
 import { MainDispatchContext, MainStateContext } from '../contexts';
 import { sleep } from '../helpers';
+import { Cli } from '../types';
 import init from './init';
 import { initialState, reducer } from './main';
 import { useTauriEvents } from './useTauriEvents';
@@ -18,6 +20,11 @@ export function MainStateProvider({ children }: Props) {
   useEffect(() => {
     init(dispatch).then(async () => {
       dispatch({ type: 'init-done' });
+      const args = await invoke<Cli>(`cli_args`);
+      // skip the animation if NOSPLASH is set
+      if (import.meta.env.APP_NOSPLASH || args?.nosplash) {
+        return;
+      }
       // wait for the splash screen to be visible for a short time as
       // init phase is very fast, avoiding flashing the splash screen
       // note: the real duration of splashscreen is this value minus the one

--- a/nym-vpn-desktop/src/types/tauri-ipc.ts
+++ b/nym-vpn-desktop/src/types/tauri-ipc.ts
@@ -4,3 +4,7 @@ export interface CmdError {
   source: CmdErrorSource;
   message: string;
 }
+
+export interface Cli {
+  nosplash: boolean;
+}

--- a/nym-vpn-desktop/src/vite-env.d.ts
+++ b/nym-vpn-desktop/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly APP_NOSPLASH: string | undefined;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/nym-vpn-desktop/vite.config.ts
+++ b/nym-vpn-desktop/vite.config.ts
@@ -16,5 +16,5 @@ export default defineConfig(async () => ({
   },
   // 3. to make use of `TAURI_DEBUG` and other env variables
   // https://tauri.app/v1/api/config#buildconfig.beforedevcommand
-  envPrefix: ['VITE_', 'TAURI_'],
+  envPrefix: ['VITE_', 'TAURI_', 'APP_'],
 }));


### PR DESCRIPTION
Add CLI feature to the app using clap.

Add a flag (`nosplash`) to disable the "splash-screen" experience, on demand. Also any `APP_NOSPLASH` env variable set will disable it.

So while developing one can disable the splash by setting in the `.env`

```
APP_NOSPLASH=true
```
or passing `--nosplash` as cli arg.

add `--build-info` flag to print detailed build info

```
crate name:      nym-vpn-desktop
version:         0.0.5-dev
tauri version:   1.6.0
package name:    nym-vpn
package version: 0.0.5-dev
target:          x86_64-unknown-linux-gnu
profile:         debug
build date:      2024-02-20 16:33:11.456542043 UTC
rustc version:   1.75.0
rustc channel:   Stable
commit sha:      9516e2b0023788f41dc9aebaea135e3e68102f1b
commit date:     2024-02-20 16:04:58 UTC
git branch:      feat/desktop/nosplash
```
