### PR TITLE
refactor(desktop): use 2 separate country lists for entry exit gateways

### DIFF
--- a/nym-vpn-desktop/src-tauri/Cargo.lock
+++ b/nym-vpn-desktop/src-tauri/Cargo.lock
@@ -5580,6 +5580,7 @@ dependencies = [
  "dotenvy",
  "futures",
  "itertools 0.12.0",
+ "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=cec05a99f4e71d6c719b2dd16f61a9d6085d658f)",
  "nym-explorer-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=cec05a99f4e71d6c719b2dd16f61a9d6085d658f)",
  "nym-vpn-lib",
  "once_cell",

--- a/nym-vpn-desktop/src-tauri/Cargo.toml
+++ b/nym-vpn-desktop/src-tauri/Cargo.toml
@@ -40,6 +40,7 @@ shadowsocks-service = { version = "~1.14.3" }
 
 # TODO keep the rev in sync with the one used in nym-vpn-lib
 nym-explorer-api-requests = { git = "https://github.com/nymtech/nym", rev = "cec05a99f4e71d6c719b2dd16f61a9d6085d658f" }
+nym-api-requests = { git = "https://github.com/nymtech/nym", rev = "cec05a99f4e71d6c719b2dd16f61a9d6085d658f" }
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem

--- a/nym-vpn-desktop/src-tauri/src/commands/node_location.rs
+++ b/nym-vpn-desktop/src-tauri/src/commands/node_location.rs
@@ -97,6 +97,7 @@ pub async fn get_entry_countries() -> Result<Vec<Country>, CmdError> {
         .filter_map(|gateway| gateway.location)
         // remove any duplicate two letter country code
         .unique_by(|location| location.two_letter_iso_country_code.clone())
+        // mapping to a list of Country
         .map(|location| {
             let mut name = location.country_name;
             // TODO yes this is what we get from the API for UK
@@ -166,6 +167,7 @@ pub async fn get_exit_countries() -> Result<Vec<Country>, CmdError> {
         })
         // remove any duplicate two letter country code
         .unique_by(|location| location.two_letter_iso_country_code.clone())
+        // mapping to a list of Country
         .map(|location| {
             let mut name = location.country_name;
             // TODO yes this is what we get from the API for UK

--- a/nym-vpn-desktop/src-tauri/src/commands/node_location.rs
+++ b/nym-vpn-desktop/src-tauri/src/commands/node_location.rs
@@ -11,7 +11,7 @@ use crate::{
     states::{app::NodeLocation, SharedAppData, SharedAppState},
 };
 
-#[derive(Debug, Serialize, Deserialize, TS, Clone)]
+#[derive(Debug, Serialize, Deserialize, TS, Clone, Eq, PartialEq)]
 pub enum NodeType {
     Entry,
     Exit,
@@ -80,8 +80,18 @@ pub async fn get_node_location(
     })
 }
 
-#[instrument(skip_all)]
+#[instrument]
 #[tauri::command]
+pub async fn get_countries(node_type: NodeType) -> Result<Vec<Country>, CmdError> {
+    debug!("get_countries");
+    if node_type == NodeType::Entry {
+        get_entry_countries().await
+    } else {
+        get_exit_countries().await
+    }
+}
+
+#[instrument(skip_all)]
 pub async fn get_entry_countries() -> Result<Vec<Country>, CmdError> {
     debug!("get_entry_countries");
     let json = explorer_api::get_gateways().await.map_err(|_| {
@@ -122,7 +132,6 @@ pub async fn get_entry_countries() -> Result<Vec<Country>, CmdError> {
 }
 
 #[instrument(skip_all)]
-#[tauri::command]
 pub async fn get_exit_countries() -> Result<Vec<Country>, CmdError> {
     debug!("get_exit_countries");
     let explorer_response = explorer_api::get_gateways().await.map_err(|_| {

--- a/nym-vpn-desktop/src-tauri/src/http/client.rs
+++ b/nym-vpn-desktop/src-tauri/src/http/client.rs
@@ -1,7 +1,8 @@
 use std::time::Duration;
 
 use once_cell::sync::Lazy;
-use reqwest::{Client as HttpClient, ClientBuilder};
+use reqwest::{Client as HttpClient, ClientBuilder, StatusCode};
+use thiserror::Error;
 use tracing::debug;
 
 pub static HTTP_CLIENT: Lazy<HttpClient> = Lazy::new(|| {
@@ -10,3 +11,11 @@ pub static HTTP_CLIENT: Lazy<HttpClient> = Lazy::new(|| {
     debug!("Creating HTTP client with default timeout: {:?}", timeout);
     ClientBuilder::new().timeout(timeout).build().unwrap()
 });
+
+#[derive(Error, Debug)]
+pub enum HttpError {
+    #[error("request failed [{0:?}]")]
+    RequestError(Option<StatusCode>),
+    #[error("failed to deserialize json response: {0}")]
+    ResponseError(String),
+}

--- a/nym-vpn-desktop/src-tauri/src/http/explorer_api.rs
+++ b/nym-vpn-desktop/src-tauri/src/http/explorer_api.rs
@@ -1,4 +1,28 @@
-pub const EXPLORER_API_URL: &str = "https://sandbox-explorer.nymtech.net/api/v1";
-pub const GATEWAYS_ENDPOINT: &str = "/gateways/";
+use crate::http::client::{HttpError, HTTP_CLIENT};
+use std::env;
+use tracing::{debug, error, info};
 
-pub type JsonGateway = nym_explorer_api_requests::PrettyDetailedGatewayBond;
+pub const EXPLORER_API_URL: &str = "https://sandbox-explorer.nymtech.net/api/v1";
+pub const GATEWAYS_ENDPOINT: &str = "/gateways";
+
+pub type ExplorerJsonGateway = nym_explorer_api_requests::PrettyDetailedGatewayBond;
+
+pub async fn get_gateways() -> Result<Vec<ExplorerJsonGateway>, HttpError> {
+    let explorer_api_url = env::var("EXPLORER_API")
+        .map(|url| format!("{}/v1", url))
+        .unwrap_or_else(|_| EXPLORER_API_URL.to_string());
+    let url = format!("{}{}", explorer_api_url, GATEWAYS_ENDPOINT);
+
+    info!("fetching countries from explorer API [{url}]");
+    let res = HTTP_CLIENT.get(url).send().await.map_err(|e| {
+        error!("HTTP request GET {GATEWAYS_ENDPOINT} failed: {e}");
+        HttpError::RequestError(e.status())
+    })?;
+
+    debug!("deserializing json response");
+    let json: Vec<ExplorerJsonGateway> = res.json().await.map_err(|e| {
+        error!("HTTP request GET {GATEWAYS_ENDPOINT} failed to deserialize json response: {e}");
+        HttpError::ResponseError(e.to_string())
+    })?;
+    Ok(json)
+}

--- a/nym-vpn-desktop/src-tauri/src/http/explorer_api.rs
+++ b/nym-vpn-desktop/src-tauri/src/http/explorer_api.rs
@@ -1,24 +1,35 @@
 use crate::http::client::{HttpError, HTTP_CLIENT};
+use reqwest::Response;
 use std::env;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, instrument};
 
 pub const EXPLORER_API_URL: &str = "https://sandbox-explorer.nymtech.net/api/v1";
 pub const GATEWAYS_ENDPOINT: &str = "/gateways";
 
 pub type ExplorerJsonGateway = nym_explorer_api_requests::PrettyDetailedGatewayBond;
 
-pub async fn get_gateways() -> Result<Vec<ExplorerJsonGateway>, HttpError> {
+#[instrument]
+pub fn get_url() -> String {
     let explorer_api_url = env::var("EXPLORER_API")
         .map(|url| format!("{}/v1", url))
         .unwrap_or_else(|_| EXPLORER_API_URL.to_string());
-    let url = format!("{}{}", explorer_api_url, GATEWAYS_ENDPOINT);
+    format!("{}{}", explorer_api_url, GATEWAYS_ENDPOINT)
+}
+
+#[instrument]
+pub async fn get_gateways() -> Result<Response, HttpError> {
+    let url = get_url();
 
     info!("fetching countries from explorer API [{url}]");
     let res = HTTP_CLIENT.get(url).send().await.map_err(|e| {
         error!("HTTP request GET {GATEWAYS_ENDPOINT} failed: {e}");
         HttpError::RequestError(e.status())
     })?;
+    Ok(res)
+}
 
+#[instrument]
+pub async fn deserialize_json(res: Response) -> Result<Vec<ExplorerJsonGateway>, HttpError> {
     debug!("deserializing json response");
     let json: Vec<ExplorerJsonGateway> = res.json().await.map_err(|e| {
         error!("HTTP request GET {GATEWAYS_ENDPOINT} failed to deserialize json response: {e}");

--- a/nym-vpn-desktop/src-tauri/src/http/mod.rs
+++ b/nym-vpn-desktop/src-tauri/src/http/mod.rs
@@ -1,2 +1,3 @@
 pub mod client;
 pub mod explorer_api;
+pub mod nym_api;

--- a/nym-vpn-desktop/src-tauri/src/http/nym_api.rs
+++ b/nym-vpn-desktop/src-tauri/src/http/nym_api.rs
@@ -11,10 +11,10 @@ pub const GATEWAYS_ENDPOINT: &str = "/gateways/described";
 pub type NymApiJsonGateway = nym_api_requests::models::DescribedGateway;
 
 pub async fn get_gateways() -> Result<Vec<NymApiJsonGateway>, HttpError> {
-    let explorer_api_url = env::var("EXPLORER_API")
+    let nym_api_url = env::var("NYM_API")
         .map(|url| format!("{}/v1", url))
         .unwrap_or_else(|_| NYM_API_URL.to_string());
-    let url = format!("{}{}", explorer_api_url, GATEWAYS_ENDPOINT);
+    let url = format!("{}{}", nym_api_url, GATEWAYS_ENDPOINT);
 
     info!("fetching countries from Nym API [{url}]");
     let res = HTTP_CLIENT.get(url).send().await.map_err(|e| {

--- a/nym-vpn-desktop/src-tauri/src/http/nym_api.rs
+++ b/nym-vpn-desktop/src-tauri/src/http/nym_api.rs
@@ -1,0 +1,31 @@
+use std::env;
+use tracing::{debug, error, info};
+
+use crate::http::client::HTTP_CLIENT;
+
+use super::client::HttpError;
+
+pub const NYM_API_URL: &str = "https://sandbox-nym-api1.nymtech.net/api/v1";
+pub const GATEWAYS_ENDPOINT: &str = "/gateways/described";
+
+pub type NymApiJsonGateway = nym_api_requests::models::DescribedGateway;
+
+pub async fn get_gateways() -> Result<Vec<NymApiJsonGateway>, HttpError> {
+    let explorer_api_url = env::var("EXPLORER_API")
+        .map(|url| format!("{}/v1", url))
+        .unwrap_or_else(|_| NYM_API_URL.to_string());
+    let url = format!("{}{}", explorer_api_url, GATEWAYS_ENDPOINT);
+
+    info!("fetching countries from Nym API [{url}]");
+    let res = HTTP_CLIENT.get(url).send().await.map_err(|e| {
+        error!("HTTP request GET {GATEWAYS_ENDPOINT} failed: {e}");
+        HttpError::RequestError(e.status())
+    })?;
+
+    debug!("deserializing json response");
+    let json: Vec<NymApiJsonGateway> = res.json().await.map_err(|e| {
+        error!("HTTP request GET {GATEWAYS_ENDPOINT} failed to deserialize json response: {e}");
+        HttpError::ResponseError(e.to_string())
+    })?;
+    Ok(json)
+}

--- a/nym-vpn-desktop/src-tauri/src/http/nym_api.rs
+++ b/nym-vpn-desktop/src-tauri/src/http/nym_api.rs
@@ -1,7 +1,6 @@
+use reqwest::Response;
 use std::env;
-use tracing::{debug, error, info};
-
-use crate::http::client::HTTP_CLIENT;
+use tracing::{debug, error, instrument};
 
 use super::client::HttpError;
 
@@ -10,18 +9,16 @@ pub const GATEWAYS_ENDPOINT: &str = "/gateways/described";
 
 pub type NymApiJsonGateway = nym_api_requests::models::DescribedGateway;
 
-pub async fn get_gateways() -> Result<Vec<NymApiJsonGateway>, HttpError> {
+#[instrument]
+pub fn get_url() -> String {
     let nym_api_url = env::var("NYM_API")
         .map(|url| format!("{}/v1", url))
         .unwrap_or_else(|_| NYM_API_URL.to_string());
-    let url = format!("{}{}", nym_api_url, GATEWAYS_ENDPOINT);
+    format!("{}{}", nym_api_url, GATEWAYS_ENDPOINT)
+}
 
-    info!("fetching countries from Nym API [{url}]");
-    let res = HTTP_CLIENT.get(url).send().await.map_err(|e| {
-        error!("HTTP request GET {GATEWAYS_ENDPOINT} failed: {e}");
-        HttpError::RequestError(e.status())
-    })?;
-
+#[instrument]
+pub async fn deserialize_json(res: Response) -> Result<Vec<NymApiJsonGateway>, HttpError> {
     debug!("deserializing json response");
     let json: Vec<NymApiJsonGateway> = res.json().await.map_err(|e| {
         error!("HTTP request GET {GATEWAYS_ENDPOINT} failed to deserialize json response: {e}");

--- a/nym-vpn-desktop/src-tauri/src/main.rs
+++ b/nym-vpn-desktop/src-tauri/src/main.rs
@@ -162,8 +162,7 @@ async fn main() -> Result<()> {
             node_location::get_node_location,
             node_location::set_node_location,
             node_location::get_fastest_node_location,
-            node_location::get_entry_countries,
-            node_location::get_exit_countries,
+            node_location::get_countries,
             window::show_main_window,
             commands::cli::cli_args,
         ])

--- a/nym-vpn-desktop/src-tauri/src/main.rs
+++ b/nym-vpn-desktop/src-tauri/src/main.rs
@@ -162,7 +162,8 @@ async fn main() -> Result<()> {
             node_location::get_node_location,
             node_location::set_node_location,
             node_location::get_fastest_node_location,
-            node_location::get_node_countries,
+            node_location::get_entry_countries,
+            node_location::get_exit_countries,
             window::show_main_window,
             commands::cli::cli_args,
         ])

--- a/nym-vpn-desktop/src/dev/setup.ts
+++ b/nym-vpn-desktop/src/dev/setup.ts
@@ -36,7 +36,7 @@ export function mockTauriIPC() {
       return 'Disconnected';
     }
 
-    if (cmd === 'get_node_countries') {
+    if (cmd === 'get_countries') {
       return new Promise<Country[]>((resolve) =>
         resolve([
           {

--- a/nym-vpn-desktop/src/pages/location/NodeLocation.tsx
+++ b/nym-vpn-desktop/src/pages/location/NodeLocation.tsx
@@ -26,7 +26,8 @@ function NodeLocation({ node }: { node: NodeHop }) {
   const {
     entryNodeLocation,
     exitNodeLocation,
-    countryList,
+    entryCountryList,
+    exitCountryList,
     fastestNodeLocation,
   } = useMainState();
 
@@ -47,11 +48,14 @@ function NodeLocation({ node }: { node: NodeHop }) {
 
   // request backend to refresh cache
   useEffect(() => {
-    invoke<Country[]>('get_node_countries')
+    invoke<Country[]>('get_countries')
       .then((countries) => {
         dispatch({
           type: 'set-country-list',
-          countries,
+          payload: {
+            hop: node,
+            countries,
+          },
         });
       })
       .catch((e: CmdError) =>
@@ -64,11 +68,12 @@ function NodeLocation({ node }: { node: NodeHop }) {
         })
         .catch((e: CmdError) => console.error(e));
     }
-  }, [dispatch]);
+  }, [node, dispatch]);
 
   // update the UI country list whenever the country list or
   // fastest country change (likely from the backend)
   useEffect(() => {
+    const countryList = node === 'entry' ? entryCountryList : exitCountryList;
     const list = [
       ...countryList.map((country) => ({ country, isFastest: false })),
     ];
@@ -79,7 +84,7 @@ function NodeLocation({ node }: { node: NodeHop }) {
     setUiCountryList(list);
     setFilteredCountries(list);
     setSearch('');
-  }, [countryList, fastestNodeLocation]);
+  }, [node, entryCountryList, exitCountryList, fastestNodeLocation]);
 
   const filter = (value: string) => {
     if (value !== '') {

--- a/nym-vpn-desktop/src/pages/location/NodeLocation.tsx
+++ b/nym-vpn-desktop/src/pages/location/NodeLocation.tsx
@@ -48,7 +48,9 @@ function NodeLocation({ node }: { node: NodeHop }) {
 
   // request backend to refresh cache
   useEffect(() => {
-    invoke<Country[]>('get_countries')
+    invoke<Country[]>('get_countries', {
+      nodeType: node === 'entry' ? 'Entry' : 'Exit',
+    })
       .then((countries) => {
         dispatch({
           type: 'set-country-list',

--- a/nym-vpn-desktop/src/state/init.ts
+++ b/nym-vpn-desktop/src/state/init.ts
@@ -24,8 +24,15 @@ const getSessionStartTime = async () => {
 };
 
 // init country list
-const getCountries = async () => {
-  return await invoke<Country[]>('get_node_countries');
+const getEntryCountries = async () => {
+  return await invoke<Country[]>('get_countries', {
+    nodeType: 'Entry',
+  });
+};
+const getExitCountries = async () => {
+  return await invoke<Country[]>('get_countries', {
+    nodeType: 'Exit',
+  });
 };
 
 // init node locations
@@ -70,11 +77,31 @@ async function init(dispatch: StateDispatch) {
     },
   };
 
-  const getCountriesRq: TauriReq<typeof getCountries> = {
-    name: 'get_node_countries',
-    request: () => getCountries(),
+  const getEntryCountriesRq: TauriReq<typeof getEntryCountries> = {
+    name: 'get_countries',
+    request: () => getEntryCountries(),
     onFulfilled: (countries) => {
-      dispatch({ type: 'set-country-list', countries });
+      dispatch({
+        type: 'set-country-list',
+        payload: {
+          hop: 'entry',
+          countries,
+        },
+      });
+    },
+  };
+
+  const getExitCountriesRq: TauriReq<typeof getExitCountries> = {
+    name: 'get_countries',
+    request: () => getExitCountries(),
+    onFulfilled: (countries) => {
+      dispatch({
+        type: 'set-country-list',
+        payload: {
+          hop: 'exit',
+          countries,
+        },
+      });
     },
   };
 
@@ -107,7 +134,7 @@ async function init(dispatch: StateDispatch) {
   };
 
   const getFastestLocationRq: TauriReq<typeof getFastestNodeLocation> = {
-    name: 'get_node_countries',
+    name: 'get_fastest_node_location',
     request: () => getFastestNodeLocation(),
     onFulfilled: (country) => {
       dispatch({ type: 'set-fastest-node-location', country });
@@ -161,7 +188,8 @@ async function init(dispatch: StateDispatch) {
   await fireRequests([
     initStateRq,
     syncConTimeRq,
-    getCountriesRq,
+    getEntryCountriesRq,
+    getExitCountriesRq,
     getEntryLocationRq,
     getExitLocationRq,
     getFastestLocationRq,

--- a/nym-vpn-desktop/src/state/main.ts
+++ b/nym-vpn-desktop/src/state/main.ts
@@ -37,7 +37,10 @@ export type StateAction =
   | { type: 'set-ui-theme'; theme: UiTheme }
   | { type: 'set-theme-mode'; mode: ThemeMode }
   | { type: 'system-theme-changed'; theme: UiTheme }
-  | { type: 'set-country-list'; countries: Country[] }
+  | {
+      type: 'set-country-list';
+      payload: { hop: NodeHop; countries: Country[] };
+    }
   | {
       type: 'set-node-location';
       payload: { hop: NodeHop; location: NodeLocation };
@@ -63,7 +66,8 @@ export const initialState: AppState = {
   // TODO ⚠ these should be set to 'Fastest' when the backend is ready
   exitNodeLocation: DefaultNodeCountry,
   fastestNodeLocation: DefaultNodeCountry,
-  countryList: [],
+  entryCountryList: [],
+  exitCountryList: [],
   rootFontSize: DefaultRootFontSize,
 };
 
@@ -106,9 +110,15 @@ export function reducer(state: AppState, action: StateAction): AppState {
         monitoring: action.monitoring,
       };
     case 'set-country-list':
+      if (action.payload.hop === 'entry') {
+        return {
+          ...state,
+          entryCountryList: action.payload.countries,
+        };
+      }
       return {
         ...state,
-        countryList: action.countries,
+        exitCountryList: action.payload.countries,
       };
     case 'set-partial-state': {
       return { ...state, ...action.partialState };

--- a/nym-vpn-desktop/src/types/app-state.ts
+++ b/nym-vpn-desktop/src/types/app-state.ts
@@ -39,7 +39,8 @@ export type AppState = {
   entryNodeLocation: NodeLocation;
   exitNodeLocation: NodeLocation;
   fastestNodeLocation: Country;
-  countryList: Country[];
+  entryCountryList: Country[];
+  exitCountryList: Country[];
   rootFontSize: number;
 };
 


### PR DESCRIPTION
- use 2 different country lists for entry and exit gateways
- exit gateways filtered out gateway with **no** IPR