### PR TITLE
Use geoip location for country selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2380,7 +2380,7 @@ dependencies = [
 [[package]]
 name = "http-api-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -3299,7 +3299,7 @@ dependencies = [
 [[package]]
 name = "nym-api-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "bs58 0.5.0",
  "cosmrs",
@@ -3318,7 +3318,7 @@ dependencies = [
 [[package]]
 name = "nym-bandwidth-controller"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "bip39",
  "log",
@@ -3338,7 +3338,7 @@ dependencies = [
 [[package]]
 name = "nym-bin-common"
 version = "0.6.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "atty",
  "clap",
@@ -3356,7 +3356,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core"
 version = "1.1.15"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -3406,7 +3406,7 @@ dependencies = [
 [[package]]
 name = "nym-coconut"
 version = "0.5.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "bls12_381",
  "bs58 0.5.0",
@@ -3427,7 +3427,7 @@ dependencies = [
 [[package]]
 name = "nym-coconut-bandwidth-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -3437,7 +3437,7 @@ dependencies = [
 [[package]]
 name = "nym-coconut-dkg-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -3451,7 +3451,7 @@ dependencies = [
 [[package]]
 name = "nym-config"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "dirs 5.0.1",
  "handlebars",
@@ -3465,7 +3465,7 @@ dependencies = [
 [[package]]
 name = "nym-contracts-common"
 version = "0.5.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "bs58 0.5.0",
  "cosmwasm-schema",
@@ -3478,7 +3478,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-storage"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "async-trait",
  "log",
@@ -3491,7 +3491,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-utils"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "log",
  "nym-bandwidth-controller",
@@ -3508,7 +3508,7 @@ dependencies = [
 [[package]]
 name = "nym-credentials"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "bincode",
  "bls12_381",
@@ -3527,7 +3527,7 @@ dependencies = [
 [[package]]
 name = "nym-credentials-interface"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "bls12_381",
  "nym-coconut",
@@ -3538,7 +3538,7 @@ dependencies = [
 [[package]]
 name = "nym-crypto"
 version = "0.4.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "aes 0.8.3",
  "blake3",
@@ -3564,7 +3564,7 @@ dependencies = [
 [[package]]
 name = "nym-dkg"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "bitvec",
  "bls12_381",
@@ -3586,7 +3586,7 @@ dependencies = [
 [[package]]
 name = "nym-ephemera-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -3597,7 +3597,7 @@ dependencies = [
 [[package]]
 name = "nym-exit-policy"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "serde",
  "thiserror",
@@ -3607,7 +3607,7 @@ dependencies = [
 [[package]]
 name = "nym-explorer-api-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "nym-api-requests",
  "nym-contracts-common",
@@ -3619,7 +3619,7 @@ dependencies = [
 [[package]]
 name = "nym-explorer-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "log",
  "nym-explorer-api-requests",
@@ -3632,7 +3632,7 @@ dependencies = [
 [[package]]
 name = "nym-gateway-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "futures",
  "getrandom 0.2.12",
@@ -3665,7 +3665,7 @@ dependencies = [
 [[package]]
 name = "nym-gateway-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "bs58 0.5.0",
  "futures",
@@ -3687,7 +3687,7 @@ dependencies = [
 [[package]]
 name = "nym-group-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "cosmwasm-schema",
  "cw-controllers",
@@ -3699,7 +3699,7 @@ dependencies = [
 [[package]]
 name = "nym-ip-packet-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "bincode",
  "bytes",
@@ -3715,7 +3715,7 @@ dependencies = [
 [[package]]
 name = "nym-mixnet-contract-common"
 version = "0.6.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "bs58 0.4.0",
  "cosmwasm-schema",
@@ -3734,7 +3734,7 @@ dependencies = [
 [[package]]
 name = "nym-multisig-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -3750,7 +3750,7 @@ dependencies = [
 [[package]]
 name = "nym-name-service-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -3764,7 +3764,7 @@ dependencies = [
 [[package]]
 name = "nym-network-defaults"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "cfg-if",
  "dotenvy",
@@ -3780,7 +3780,7 @@ dependencies = [
 [[package]]
 name = "nym-node-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -3798,7 +3798,7 @@ dependencies = [
 [[package]]
 name = "nym-nonexhaustive-delayqueue"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -3809,7 +3809,7 @@ dependencies = [
 [[package]]
 name = "nym-ordered-buffer"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "log",
  "thiserror",
@@ -3818,7 +3818,7 @@ dependencies = [
 [[package]]
 name = "nym-outfox"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "blake3",
  "chacha20 0.9.1",
@@ -3836,7 +3836,7 @@ dependencies = [
 [[package]]
 name = "nym-pemstore"
 version = "0.3.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "pem",
 ]
@@ -3844,7 +3844,7 @@ dependencies = [
 [[package]]
 name = "nym-sdk"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "async-trait",
  "bip39",
@@ -3880,7 +3880,7 @@ dependencies = [
 [[package]]
 name = "nym-service-provider-directory-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -3893,7 +3893,7 @@ dependencies = [
 [[package]]
 name = "nym-service-providers-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "async-trait",
  "log",
@@ -3907,7 +3907,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-client-core"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "anyhow",
  "dirs 4.0.0",
@@ -3940,7 +3940,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-proxy-helpers"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "bytes",
  "futures",
@@ -3955,7 +3955,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "bincode",
  "log",
@@ -3971,7 +3971,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "log",
  "nym-crypto",
@@ -3995,7 +3995,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-acknowledgements"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "nym-crypto",
  "nym-pemstore",
@@ -4012,7 +4012,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-addressing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-types",
@@ -4023,7 +4023,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-anonymous-replies"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "bs58 0.5.0",
  "nym-crypto",
@@ -4041,7 +4041,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-chunking"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "log",
  "nym-sphinx-addressing",
@@ -4054,7 +4054,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-cover"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-acknowledgements",
@@ -4072,7 +4072,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-forwarding"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "nym-outfox",
  "nym-sphinx-addressing",
@@ -4084,7 +4084,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-framing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "bytes",
  "nym-sphinx-params",
@@ -4096,7 +4096,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-params"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-types",
@@ -4107,7 +4107,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-routing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "nym-sphinx-addressing",
  "nym-sphinx-types",
@@ -4117,7 +4117,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-types"
 version = "0.2.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "nym-outfox",
  "sphinx-packet",
@@ -4127,7 +4127,7 @@ dependencies = [
 [[package]]
 name = "nym-task"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "futures",
  "log",
@@ -4141,7 +4141,7 @@ dependencies = [
 [[package]]
 name = "nym-topology"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "async-trait",
  "bs58 0.5.0",
@@ -4164,7 +4164,7 @@ dependencies = [
 [[package]]
 name = "nym-validator-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -4214,7 +4214,7 @@ dependencies = [
 [[package]]
 name = "nym-vesting-contract-common"
 version = "0.7.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -4310,7 +4310,7 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-types"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "base64 0.21.7",
  "dashmap",
@@ -7483,7 +7483,7 @@ checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
 [[package]]
 name = "wasm-utils"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "futures",
  "getrandom 0.2.12",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4260,6 +4260,7 @@ dependencies = [
  "nym-client-core",
  "nym-config",
  "nym-crypto",
+ "nym-explorer-client",
  "nym-ip-packet-requests",
  "nym-node-requests",
  "nym-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ exclude = ["nym-vpn-desktop/src-tauri"]
 # nym-task = { path = "../nym/common/task" }
 # nym-validator-client = { path = "../nym/common/client-libs/validator-client" }
 # nym-wireguard-types = { path = "../nym/common/wireguard-types" }
+# nym-explorer-client = { path = "../nym/explorer-api/explorer-client" }
 
 [workspace.dependencies]
 tokio = { version = "1.8" }

--- a/nym-vpn-cli/src/commands.rs
+++ b/nym-vpn-cli/src/commands.rs
@@ -155,6 +155,9 @@ fn validate_ipv6(ip: &str) -> Result<Ipv6Addr, String> {
 pub fn override_from_env(args: &CliArgs, config: Config) -> Config {
     let mut config = config
         .with_optional_env(Config::with_custom_api_url, None, NYM_API)
+        // TODO: there is a landmine here, if the user sets non-mainnet nym-api, but doesn't
+        // specify explorer-api, it will default to mainnet explorer-api and location lookup will
+        // implicitly fail instead of explicitly fail.
         .with_optional_env(Config::with_custom_explorer_url, None, EXPLORER_API);
     if let Some(ref private_key) = args.private_key {
         config = config.with_local_private_key(private_key.clone());

--- a/nym-vpn-cli/src/commands.rs
+++ b/nym-vpn-cli/src/commands.rs
@@ -1,7 +1,7 @@
 // Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use clap::Parser;
+use clap::{Args, Parser};
 use ipnetwork::{Ipv4Network, Ipv6Network};
 use nym_vpn_lib::nym_config::defaults::var_names::NYM_API;
 use nym_vpn_lib::nym_config::OptionalSet;
@@ -34,39 +34,11 @@ pub(crate) struct CliArgs {
     #[arg(long)]
     pub(crate) mixnet_client_path: Option<PathBuf>,
 
-    /// Mixnet public ID of the entry gateway.
-    #[clap(long, conflicts_with = "entry_gateway_country", alias = "entry-id")]
-    pub(crate) entry_gateway_id: Option<String>,
+    #[command(flatten)]
+    pub(crate) entry: CliEntry,
 
-    /// Auto-select entry gateway by country ISO.
-    #[clap(long, conflicts_with = "entry_gateway_id", alias = "entry-country")]
-    pub(crate) entry_gateway_country: Option<String>,
-
-    /// Mixnet recipient address.
-    #[arg(
-        long,
-        conflicts_with = "exit_router_country",
-        conflicts_with = "exit_gateway_id",
-        alias = "exit-address"
-    )]
-    pub(crate) exit_router_address: Option<String>,
-
-    #[clap(
-        long,
-        conflicts_with = "exit_router_country",
-        conflicts_with = "exit_router_address",
-        alias = "exit-id"
-    )]
-    pub(crate) exit_gateway_id: Option<String>,
-
-    /// Mixnet recipient address.
-    #[arg(
-        long,
-        alias = "exit-country",
-        conflicts_with = "exit_router_address",
-        conflicts_with = "exit_gateway_id"
-    )]
-    pub(crate) exit_router_country: Option<String>,
+    #[command(flatten)]
+    pub(crate) exit: CliExit,
 
     /// Enable the wireguard traffic between the client and the entry gateway.
     #[arg(
@@ -115,6 +87,33 @@ pub(crate) struct CliArgs {
     /// Disable constant rate background loop cover traffic
     #[arg(long)]
     pub(crate) disable_background_cover_traffic: bool,
+}
+
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+pub(crate) struct CliEntry {
+    /// Mixnet public ID of the entry gateway.
+    #[clap(long, alias = "entry-id")]
+    pub(crate) entry_gateway_id: Option<String>,
+
+    /// Auto-select entry gateway by country ISO.
+    #[clap(long, alias = "entry-country")]
+    pub(crate) entry_gateway_country: Option<String>,
+}
+
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+pub(crate) struct CliExit {
+    /// Mixnet recipient address.
+    #[clap(long, alias = "exit-address")]
+    pub(crate) exit_router_address: Option<String>,
+
+    #[clap(long, alias = "exit-id")]
+    pub(crate) exit_gateway_id: Option<String>,
+
+    /// Mixnet recipient address.
+    #[clap(long, alias = "exit-country")]
+    pub(crate) exit_gateway_country: Option<String>,
 }
 
 fn validate_wg_ip(ip: &str) -> Result<Ipv4Addr, String> {

--- a/nym-vpn-cli/src/commands.rs
+++ b/nym-vpn-cli/src/commands.rs
@@ -3,7 +3,7 @@
 
 use clap::{Args, Parser};
 use ipnetwork::{Ipv4Network, Ipv6Network};
-use nym_vpn_lib::nym_config::defaults::var_names::NYM_API;
+use nym_vpn_lib::nym_config::defaults::var_names::{EXPLORER_API, NYM_API};
 use nym_vpn_lib::nym_config::OptionalSet;
 use nym_vpn_lib::{gateway_client::Config, nym_bin_common::bin_info_local_vergen};
 use std::{
@@ -153,7 +153,9 @@ fn validate_ipv6(ip: &str) -> Result<Ipv6Addr, String> {
 }
 
 pub fn override_from_env(args: &CliArgs, config: Config) -> Config {
-    let mut config = config.with_optional_env(Config::with_custom_api_url, None, NYM_API);
+    let mut config = config
+        .with_optional_env(Config::with_custom_api_url, None, NYM_API)
+        .with_optional_env(Config::with_custom_explorer_url, None, EXPLORER_API);
     if let Some(ref private_key) = args.private_key {
         config = config.with_local_private_key(private_key.clone());
     }

--- a/nym-vpn-cli/src/main.rs
+++ b/nym-vpn-cli/src/main.rs
@@ -27,12 +27,12 @@ pub fn setup_logging() {
 }
 
 fn parse_entry_point(args: &commands::CliArgs) -> Result<EntryPoint> {
-    if let Some(ref entry_gateway_id) = args.entry_gateway_id {
+    if let Some(ref entry_gateway_id) = args.entry.entry_gateway_id {
         Ok(EntryPoint::Gateway {
             identity: NodeIdentity::from_base58_string(entry_gateway_id.clone())
                 .map_err(|_| Error::NodeIdentityFormattingError)?,
         })
-    } else if let Some(ref entry_gateway_country) = args.entry_gateway_country {
+    } else if let Some(ref entry_gateway_country) = args.entry.entry_gateway_country {
         Ok(EntryPoint::Location {
             location: entry_gateway_country.clone(),
         })
@@ -42,19 +42,19 @@ fn parse_entry_point(args: &commands::CliArgs) -> Result<EntryPoint> {
 }
 
 fn parse_exit_point(args: &commands::CliArgs) -> Result<ExitPoint> {
-    if let Some(ref exit_router_address) = args.exit_router_address {
+    if let Some(ref exit_router_address) = args.exit.exit_router_address {
         Ok(ExitPoint::Address {
             address: Recipient::try_from_base58_string(exit_router_address.clone())
                 .map_err(|_| Error::RecipientFormattingError)?,
         })
-    } else if let Some(ref exit_router_id) = args.exit_gateway_id {
+    } else if let Some(ref exit_router_id) = args.exit.exit_gateway_id {
         Ok(ExitPoint::Gateway {
             identity: NodeIdentity::from_base58_string(exit_router_id.clone())
                 .map_err(|_| Error::NodeIdentityFormattingError)?,
         })
-    } else if let Some(ref exit_router_country) = args.exit_router_country {
+    } else if let Some(ref exit_gateway_country) = args.exit.exit_gateway_country {
         Ok(ExitPoint::Location {
-            location: exit_router_country.clone(),
+            location: exit_gateway_country.clone(),
         })
     } else {
         Err(Error::MissingExitPointInformation)
@@ -72,7 +72,9 @@ async fn run() -> Result<()> {
     info!("nym-api: {}", gateway_config.api_url());
 
     let entry_point = parse_entry_point(&args)?;
+    dbg!(&entry_point);
     let exit_point = parse_exit_point(&args)?;
+    dbg!(&exit_point);
     let nym_ips = if let (Some(ipv4), Some(ipv6)) = (args.nym_ipv4, args.nym_ipv6) {
         Some(IpPair::new(ipv4, ipv6))
     } else {

--- a/nym-vpn-cli/src/main.rs
+++ b/nym-vpn-cli/src/main.rs
@@ -70,6 +70,13 @@ async fn run() -> Result<()> {
     // Setup gateway configuration
     let gateway_config = override_from_env(&args, GatewayConfig::default());
     info!("nym-api: {}", gateway_config.api_url());
+    info!(
+        "explorer-api: {}",
+        gateway_config
+            .explorer_url()
+            .map(|url| url.to_string())
+            .unwrap_or("unavailable".to_string())
+    );
 
     let entry_point = parse_entry_point(&args)?;
     let exit_point = parse_exit_point(&args)?;

--- a/nym-vpn-cli/src/main.rs
+++ b/nym-vpn-cli/src/main.rs
@@ -72,9 +72,7 @@ async fn run() -> Result<()> {
     info!("nym-api: {}", gateway_config.api_url());
 
     let entry_point = parse_entry_point(&args)?;
-    dbg!(&entry_point);
     let exit_point = parse_exit_point(&args)?;
-    dbg!(&exit_point);
     let nym_ips = if let (Some(ipv4), Some(ipv6)) = (args.nym_ipv4, args.nym_ipv6) {
         Some(IpPair::new(ipv4, ipv6))
     } else {

--- a/nym-vpn-lib/Cargo.toml
+++ b/nym-vpn-lib/Cargo.toml
@@ -46,17 +46,17 @@ talpid-tunnel = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev =
 talpid-types = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "fde37701018191d16bc66c37616588aa120b9549" }
 talpid-wireguard = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "fde37701018191d16bc66c37616588aa120b9549" }
 
-nym-bin-common = { git = "https://github.com/nymtech/nym", rev = "bd0cbbc18a305624a684473385f466cc086cdd5d" }
-nym-client-core = { git = "https://github.com/nymtech/nym", rev = "bd0cbbc18a305624a684473385f466cc086cdd5d" }
-nym-config = { git = "https://github.com/nymtech/nym", rev = "bd0cbbc18a305624a684473385f466cc086cdd5d" }
-nym-crypto = { git = "https://github.com/nymtech/nym", rev = "bd0cbbc18a305624a684473385f466cc086cdd5d" }
-nym-ip-packet-requests = { git = "https://github.com/nymtech/nym", rev = "bd0cbbc18a305624a684473385f466cc086cdd5d" }
-nym-node-requests = { git = "https://github.com/nymtech/nym", rev = "bd0cbbc18a305624a684473385f466cc086cdd5d" }
-nym-sdk = { git = "https://github.com/nymtech/nym", rev = "bd0cbbc18a305624a684473385f466cc086cdd5d" }
-nym-task = { git = "https://github.com/nymtech/nym", rev = "bd0cbbc18a305624a684473385f466cc086cdd5d" }
-nym-validator-client = { git = "https://github.com/nymtech/nym", rev = "bd0cbbc18a305624a684473385f466cc086cdd5d" }
-nym-wireguard-types = { git = "https://github.com/nymtech/nym", rev = "bd0cbbc18a305624a684473385f466cc086cdd5d" }
-nym-explorer-client = { git = "https://github.com/nymtech/nym", rev = "bd0cbbc18a305624a684473385f466cc086cdd5d" }
+nym-bin-common = { git = "https://github.com/nymtech/nym", rev = "fa8e81d9dd1e93e133c666ef777757edd7fdce25" }
+nym-client-core = { git = "https://github.com/nymtech/nym", rev = "fa8e81d9dd1e93e133c666ef777757edd7fdce25" }
+nym-config = { git = "https://github.com/nymtech/nym", rev = "fa8e81d9dd1e93e133c666ef777757edd7fdce25" }
+nym-crypto = { git = "https://github.com/nymtech/nym", rev = "fa8e81d9dd1e93e133c666ef777757edd7fdce25" }
+nym-ip-packet-requests = { git = "https://github.com/nymtech/nym", rev = "fa8e81d9dd1e93e133c666ef777757edd7fdce25" }
+nym-node-requests = { git = "https://github.com/nymtech/nym", rev = "fa8e81d9dd1e93e133c666ef777757edd7fdce25" }
+nym-sdk = { git = "https://github.com/nymtech/nym", rev = "fa8e81d9dd1e93e133c666ef777757edd7fdce25" }
+nym-task = { git = "https://github.com/nymtech/nym", rev = "fa8e81d9dd1e93e133c666ef777757edd7fdce25" }
+nym-validator-client = { git = "https://github.com/nymtech/nym", rev = "fa8e81d9dd1e93e133c666ef777757edd7fdce25" }
+nym-wireguard-types = { git = "https://github.com/nymtech/nym", rev = "fa8e81d9dd1e93e133c666ef777757edd7fdce25" }
+nym-explorer-client = { git = "https://github.com/nymtech/nym", rev = "fa8e81d9dd1e93e133c666ef777757edd7fdce25" }
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_logger = "0.13.1"

--- a/nym-vpn-lib/Cargo.toml
+++ b/nym-vpn-lib/Cargo.toml
@@ -56,6 +56,7 @@ nym-sdk = { git = "https://github.com/nymtech/nym", rev = "bd0cbbc18a305624a6844
 nym-task = { git = "https://github.com/nymtech/nym", rev = "bd0cbbc18a305624a684473385f466cc086cdd5d" }
 nym-validator-client = { git = "https://github.com/nymtech/nym", rev = "bd0cbbc18a305624a684473385f466cc086cdd5d" }
 nym-wireguard-types = { git = "https://github.com/nymtech/nym", rev = "bd0cbbc18a305624a684473385f466cc086cdd5d" }
+nym-explorer-client = { git = "https://github.com/nymtech/nym", rev = "bd0cbbc18a305624a684473385f466cc086cdd5d" }
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_logger = "0.13.1"

--- a/nym-vpn-lib/src/error.rs
+++ b/nym-vpn-lib/src/error.rs
@@ -58,6 +58,9 @@ pub enum Error {
     #[error("{0}")]
     ValidatorClientError(#[from] nym_validator_client::ValidatorClientError),
 
+    #[error(transparent)]
+    ExplorerApiError(#[from] nym_explorer_client::ExplorerApiError),
+
     #[error("missing Gateway exit information")]
     MissingExitPointInformation,
 

--- a/nym-vpn-lib/src/error.rs
+++ b/nym-vpn-lib/src/error.rs
@@ -61,6 +61,11 @@ pub enum Error {
     #[error(transparent)]
     ExplorerApiError(#[from] nym_explorer_client::ExplorerApiError),
 
+    #[error("failed to fetch location data from explorer-api: {error}")]
+    FailedFetchLocationData {
+        error: nym_explorer_client::ExplorerApiError,
+    },
+
     #[error("missing Gateway exit information")]
     MissingExitPointInformation,
 

--- a/nym-vpn-lib/src/error.rs
+++ b/nym-vpn-lib/src/error.rs
@@ -87,6 +87,9 @@ pub enum Error {
         source: nym_validator_client::ValidatorClientError,
     },
 
+    #[error("gateway was requested by location, but we don't have any location data - is the explorer-api set correctly?")]
+    RequestedGatewayByLocationWithoutLocationDataAvailable,
+
     #[error("requested gateway not found in the remote list: {0}")]
     RequestedGatewayIdNotFound(String),
 
@@ -131,6 +134,9 @@ pub enum Error {
 
     #[error("no matching gateway found")]
     NoMatchingGateway,
+
+    #[error("no gateway available for location {0}")]
+    NoMatchingGatewayForLocation(String),
 
     #[error("deadlock when trying to aquire mixnet client mutes")]
     MixnetClientDeadlock,

--- a/nym-vpn-lib/src/gateway_client.rs
+++ b/nym-vpn-lib/src/gateway_client.rs
@@ -7,6 +7,7 @@ use crate::mixnet_processor::IpPacketRouterAddress;
 use crate::UniffiCustomTypeConverter;
 use nym_config::defaults::DEFAULT_NYM_NODE_HTTP_PORT;
 use nym_crypto::asymmetric::encryption;
+use nym_explorer_client::{ExplorerClient, Location, PrettyDetailedGatewayBond};
 use nym_node_requests::api::client::NymNodeApiClientExt;
 use nym_node_requests::api::v1::gateway::client_interfaces::wireguard::models::{
     ClientMessage, ClientRegistrationResponse, InitMessage, PeerPublicKey,
@@ -25,6 +26,7 @@ use url::Url;
 #[derive(Clone, Debug)]
 pub struct Config {
     pub(crate) api_url: Url,
+    pub(crate) explorer_url: Option<Url>,
     pub(crate) local_private_key: Option<String>,
 }
 
@@ -40,9 +42,14 @@ impl Default for Config {
             .expect("rust sdk mainnet default missing api_url")
             .parse()
             .expect("rust sdk mainnet default api_url not parseable");
+        let default_explorer_url = network_defaults.explorer_api.clone().map(|url| {
+            url.parse()
+                .expect("rust sdk mainnet default explorer url not parseable")
+        });
 
         Config {
             api_url: default_api_url,
+            explorer_url: default_explorer_url,
             local_private_key: Default::default(),
         }
     }
@@ -52,10 +59,17 @@ impl Config {
     pub fn api_url(&self) -> &Url {
         &self.api_url
     }
+
     pub fn with_custom_api_url(mut self, api_url: Url) -> Self {
         self.api_url = api_url;
         self
     }
+
+    pub fn with_custom_explorer_url(mut self, explorer_url: Url) -> Self {
+        self.explorer_url = Some(explorer_url);
+        self
+    }
+
     pub fn with_local_private_key(mut self, local_private_key: String) -> Self {
         self.local_private_key = Some(local_private_key);
         self
@@ -113,17 +127,24 @@ impl UniffiCustomTypeConverter for NodeIdentity {
 }
 
 impl EntryPoint {
-    pub fn lookup_gateway_identity(&self, gateways: &[DescribedGateway]) -> Result<NodeIdentity> {
+    pub fn lookup_gateway_identity(
+        &self,
+        gateways: &[DescribedGatewayWithLocation],
+    ) -> Result<NodeIdentity> {
         match &self {
             EntryPoint::Gateway { identity } => Ok(*identity),
             EntryPoint::Location { location } => {
-                let described_gateways: Vec<&DescribedGateway> = gateways
+                let gateways_with_specified_location: Vec<&DescribedGateway> = gateways
                     .iter()
-                    .filter(|described_gateway| {
-                        described_gateway.bond.gateway.location == *location
+                    .filter(|gateway| {
+                        gateway
+                            .location
+                            .as_ref()
+                            .map_or(false, |l| &l.two_letter_iso_country_code == location)
                     })
+                    .map(|described_gateway| &described_gateway.gateway)
                     .collect();
-                let random_gateway: &DescribedGateway = described_gateways
+                let random_gateway: &DescribedGateway = gateways_with_specified_location
                     .iter()
                     .choose(&mut rand::thread_rng())
                     .ok_or(Error::NoMatchingGateway)?;
@@ -139,27 +160,32 @@ impl EntryPoint {
 impl ExitPoint {
     pub fn lookup_router_address(
         &self,
-        gateways: &[DescribedGateway],
+        gateways: &[DescribedGatewayWithLocation],
     ) -> Result<IpPacketRouterAddress> {
         match &self {
             ExitPoint::Address { address } => Ok(IpPacketRouterAddress(*address)),
             ExitPoint::Gateway { identity } => {
-                let described_gateway = gateways
+                let gateway = gateways
                     .iter()
-                    .find(|described_gateway| {
-                        described_gateway.bond.gateway.identity_key == *identity.to_string()
+                    .find(|gateway| {
+                        // sing with me: gateway gateway gateway mushroom mushroom
+                        gateway.gateway.bond.gateway.identity_key == *identity.to_string()
                     })
                     .ok_or(Error::NoMatchingGateway)?;
-                IpPacketRouterAddress::try_from_described_gateway(described_gateway)
+                IpPacketRouterAddress::try_from_described_gateway(&gateway.gateway)
             }
             ExitPoint::Location { location } => {
-                let described_gateways: Vec<&DescribedGateway> = gateways
+                let gateways_with_specified_location: Vec<&DescribedGateway> = gateways
                     .iter()
-                    .filter(|described_gateway| {
-                        described_gateway.bond.gateway.location == *location
+                    .filter(|gateway| {
+                        gateway
+                            .location
+                            .as_ref()
+                            .map_or(false, |l| &l.two_letter_iso_country_code == location)
                     })
+                    .map(|described_gateway| &described_gateway.gateway)
                     .collect();
-                let random_gateway: &DescribedGateway = described_gateways
+                let random_gateway = gateways_with_specified_location
                     .iter()
                     .choose(&mut rand::thread_rng())
                     .ok_or(Error::NoMatchingGateway)?;
@@ -169,8 +195,14 @@ impl ExitPoint {
     }
 }
 
+pub struct DescribedGatewayWithLocation {
+    pub gateway: DescribedGateway,
+    pub location: Option<Location>,
+}
+
 pub struct GatewayClient {
     api_client: NymApiClient,
+    explorer_client: Option<ExplorerClient>,
     keypair: Option<encryption::KeyPair>,
 }
 #[derive(Clone, Debug)]
@@ -183,6 +215,11 @@ pub struct GatewayData {
 impl GatewayClient {
     pub fn new(config: Config) -> Result<Self> {
         let api_client = NymApiClient::new(config.api_url);
+        let explorer_client = if let Some(url) = config.explorer_url {
+            Some(ExplorerClient::new(url)?)
+        } else {
+            None
+        };
 
         let keypair = if let Some(local_private_key) = config.local_private_key {
             let private_key_intermediate = PublicKey::from_base64(&local_private_key)
@@ -200,6 +237,7 @@ impl GatewayClient {
 
         Ok(GatewayClient {
             api_client,
+            explorer_client,
             keypair,
         })
     }
@@ -210,6 +248,33 @@ impl GatewayClient {
             .get_cached_described_gateways()
             .await
             .map_err(|source| Error::FailedToLookupDescribedGateways { source })
+    }
+
+    pub async fn lookup_gateways_in_explorer(&self) -> Result<Vec<PrettyDetailedGatewayBond>> {
+        if let Some(explorer_client) = &self.explorer_client {
+            explorer_client.get_gateways().await.map_err(Into::into)
+        } else {
+            todo!("Explorer client not found");
+        }
+    }
+
+    pub async fn lookup_described_gateways_with_location(
+        &self,
+    ) -> Result<Vec<DescribedGatewayWithLocation>> {
+        let described_gateways = self.lookup_described_gateways().await?;
+        let gateway_locations = self.lookup_gateways_in_explorer().await?;
+        described_gateways
+            .into_iter()
+            .map(|gateway| {
+                let location = gateway_locations
+                    .iter()
+                    .find(|gateway_location| {
+                        gateway_location.gateway.identity_key == gateway.bond.gateway.identity_key
+                    })
+                    .and_then(|gateway_location| gateway_location.location.clone());
+                Ok(DescribedGatewayWithLocation { gateway, location })
+            })
+            .collect()
     }
 
     pub async fn lookup_gateway_ip(&self, gateway_identity: &str) -> Result<IpAddr> {

--- a/nym-vpn-lib/src/gateway_client.rs
+++ b/nym-vpn-lib/src/gateway_client.rs
@@ -193,10 +193,7 @@ impl ExitPoint {
                 IpPacketRouterAddress::try_from_described_gateway(&gateway.gateway)
             }
             ExitPoint::Location { location } => {
-                // let exit_gateways = filter_on_ipr_available(gateways);
                 let exit_gateways = gateways.iter().filter(|g| g.has_ip_packet_router());
-                // let gateways_with_specified_location =
-                //     filter_on_country_code(exit_gateways, location);
                 let gateways_with_specified_location = exit_gateways
                     .filter(|gateway| gateway.is_two_letter_iso_country_code(location));
                 let random_gateway = gateways_with_specified_location

--- a/nym-vpn-lib/src/lib.rs
+++ b/nym-vpn-lib/src/lib.rs
@@ -288,7 +288,9 @@ impl NymVpn {
         // let gateways = &gateway_client.lookup_described_gateways().await?;
         // let gateways_from_explorer = gateway_client.lookup_gateways_in_explorer().await?;
         // dbg!(&gateways_from_explorer);
-        let gateways = gateway_client.lookup_described_gateways_with_location().await?;
+        let gateways = gateway_client
+            .lookup_described_gateways_with_location()
+            .await?;
         let entry_gateway_id = self.entry_point.lookup_gateway_identity(&gateways)?;
         let exit_router_address = self.exit_point.lookup_router_address(&gateways)?;
 

--- a/nym-vpn-lib/src/lib.rs
+++ b/nym-vpn-lib/src/lib.rs
@@ -285,9 +285,6 @@ impl NymVpn {
         // Create a gateway client that we use to interact with the entry gateway, in particular to
         // handle wireguard registration
         let gateway_client = GatewayClient::new(self.gateway_config.clone())?;
-        // let gateways = &gateway_client.lookup_described_gateways().await?;
-        // let gateways_from_explorer = gateway_client.lookup_gateways_in_explorer().await?;
-        // dbg!(&gateways_from_explorer);
         let gateways = gateway_client
             .lookup_described_gateways_with_location()
             .await?;

--- a/nym-vpn-lib/src/lib.rs
+++ b/nym-vpn-lib/src/lib.rs
@@ -128,8 +128,8 @@ pub struct NymVpn {
 
 impl NymVpn {
     pub fn new(
-        entry_gateway: EntryPoint,
-        exit_router: ExitPoint,
+        entry_point: EntryPoint,
+        exit_point: ExitPoint,
         #[cfg(target_os = "android")] android_context: talpid_types::android::AndroidContext,
     ) -> Self {
         let tun_provider = Arc::new(Mutex::new(TunProvider::new(
@@ -145,8 +145,8 @@ impl NymVpn {
         Self {
             gateway_config: gateway_client::Config::default(),
             mixnet_client_path: None,
-            entry_point: entry_gateway,
-            exit_point: exit_router,
+            entry_point,
+            exit_point,
             enable_wireguard: false,
             private_key: None,
             wg_ip: None,
@@ -285,9 +285,12 @@ impl NymVpn {
         // Create a gateway client that we use to interact with the entry gateway, in particular to
         // handle wireguard registration
         let gateway_client = GatewayClient::new(self.gateway_config.clone())?;
-        let gateways = &gateway_client.lookup_described_gateways().await?;
-        let entry_gateway_id = self.entry_point.lookup_gateway_identity(gateways)?;
-        let exit_router_address = self.exit_point.lookup_router_address(gateways)?;
+        // let gateways = &gateway_client.lookup_described_gateways().await?;
+        // let gateways_from_explorer = gateway_client.lookup_gateways_in_explorer().await?;
+        // dbg!(&gateways_from_explorer);
+        let gateways = gateway_client.lookup_described_gateways_with_location().await?;
+        let entry_gateway_id = self.entry_point.lookup_gateway_identity(&gateways)?;
+        let exit_router_address = self.exit_point.lookup_router_address(&gateways)?;
 
         info!("Determined criteria for location {entry_gateway_id}");
         info!("Exit router address {exit_router_address}");


### PR DESCRIPTION
Implement geoip lookup support for location based gateway selection in nym-vpn-lib by querying the explorer-api. This fixes country lookup in the desktop client. Care has been made to make the availability of the explorer-api optional. Without it you can still specify entry/exit by identity or address.
