### PR TITLE
ci(desktop-release): add tauri update bunlde

### DIFF
--- a/.github/workflows/build-wireguard-go.yml
+++ b/.github/workflows/build-wireguard-go.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Upload artifacts (macos universal)
         uses: actions/upload-artifact@v4
-        if: inputs.os == 'custom-runner-mac-m1'
+        if: contains(inputs.os, 'mac')
         with:
           name: wireguard-go_macos_universal
           path: |

--- a/.github/workflows/release-nym-vpn-desktop.yml
+++ b/.github/workflows/release-nym-vpn-desktop.yml
@@ -38,6 +38,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       WG_GO_LIB_PATH: ${{ github.workspace }}/lib
+      UPDATE_BUNDLE_DIR: update_bundle
     outputs:
       update_bundle_name: ${{ steps.set_env.outputs.update_bundle_name }}
 
@@ -94,11 +95,12 @@ jobs:
             echo " ✗ unknown platform/arch [${{ matrix.os }}]"
             exit 1
           fi
+          version=${{ steps.package-version.outputs.metadata }}
           wg_go_lib_name="wireguard-go_$platform_arch"
-          artifact_dir="nym-vpn-desktop_${{ steps.package-version.outputs.metadata }}_$platform_arch"
+          artifact_dir="nym-vpn-desktop_${version}_$platform_arch"
           artifact_archive="$artifact_dir.tar.gz"
           artifact_checksum="$artifact_archive.sha256sum"
-          update_bundle_name="$artifact_dir"_bundle
+          update_bundle_name="update-bundle_${version}_$platform_arch"
           # debug
           echo " ✓ PLATFORM_ARCH: $platform_arch"
           echo " ✓ WG_GO_LIB_NAME: $wg_go_lib_name"
@@ -106,6 +108,7 @@ jobs:
           echo " ✓ ARTIFACT_DIR: $artifact_dir"
           echo " ✓ ARTIFACT_ARCHIVE: $artifact_archive"
           echo " ✓ UPDATE_BUNDLE_NAME: $update_bundle_name"
+          echo " ✓ UPDATE_BUNDLE_DIR: ${{ env.UPDATE_BUNDLE_DIR }}"
           # set github env
           echo "PLATFORM_ARCH=$platform_arch" >> $GITHUB_ENV
           echo "WG_GO_LIB_NAME=$wg_go_lib_name" >> $GITHUB_ENV
@@ -182,6 +185,15 @@ jobs:
           ls -la target/${{ env.ARCH_TARGET }}/release/bundle || true
           ls -la target/${{ env.ARCH_TARGET }}/release/bundle/* || true
 
+      - name: Move update bundle artifacts
+        shell: bash
+        run: |
+          echo "moving update bundle's archive and signature into ${{ env.UPDATE_BUNDLE_DIR }}"
+          mkdir ${{ env.UPDATE_BUNDLE_DIR }}
+          mv nym-vpn-desktop/src-tauri/target/**/release/bundle/appimage/nym-vpn*.AppImage.tar.gz* ${{ env.UPDATE_BUNDLE_DIR }} || true
+          mv nym-vpn-desktop/src-tauri/target/**/release/bundle/macos/nym-vpn*.app.tar.gz* ${{ env.UPDATE_BUNDLE_DIR }} || true
+          ls -la ${{ env.UPDATE_BUNDLE_DIR }}
+
       - name: Create archive
         shell: bash
         run: |
@@ -203,11 +215,9 @@ jobs:
         with:
           name: ${{ env.UPDATE_BUNDLE_NAME }}
           # upload both the update bundle and its signature
-          # - nymvpn.*.tar.gz
-          # - nymvpn.*.tar.gz.sig
-          path: |
-            nym-vpn-desktop/src-tauri/target/**/release/bundle/appimage/nym-vpn*.AppImage.tar.gz*
-            nym-vpn-desktop/src-tauri/target/**/release/bundle/macos/nym-vpn*.app.tar.gz*
+          # - nym-vpn.*.tar.gz
+          # - nym-vpn.*.tar.gz.sig
+          path: ${{ env.UPDATE_BUNDLE_DIR }}
           retention-days: 2
 
       # Build info, but for now it's just the version
@@ -236,6 +246,7 @@ jobs:
     env:
       GH_REPO: ${{ github.repository }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      UPDATE_BUNDLE_DIR: update_bundle
     permissions:
       contents: write
     steps:
@@ -250,7 +261,7 @@ jobs:
           UPDATE_BUNDLE_NAME: ${{ needs.build.outputs.update_bundle_name }}
         with:
           name: ${{ env.UPDATE_BUNDLE_NAME }}
-          path: update_bundle
+          path: ${{ env.UPDATE_BUNDLE_DIR }}
 
       # Setup TAG_NAME, which is used as a general "name"
       - if: github.event_name == 'workflow_dispatch'
@@ -308,5 +319,5 @@ jobs:
           echo "Creating release nodes: output"
           cat $RUNNER_TEMP/release-notes.md
           echo "Creating release"
-          echo gh release create $TAG_NAME $PRERELEASE --notes-file "$RUNNER_TEMP/release-notes.md" --title "$SUBJECT" --target $GITHUB_SHA nym-vpn-desktop_*.tar.gz/* update_bundle/*
-          gh release create $TAG_NAME $PRERELEASE --notes-file "$RUNNER_TEMP/release-notes.md" --title "$SUBJECT" --target $GITHUB_SHA nym-vpn-desktop_*.tar.gz/* update_bundle/*
+          echo gh release create $TAG_NAME $PRERELEASE --notes-file "$RUNNER_TEMP/release-notes.md" --title "$SUBJECT" --target $GITHUB_SHA nym-vpn-desktop_*.tar.gz/* "${{ env.UPDATE_BUNDLE_DIR }}/*"
+          gh release create $TAG_NAME $PRERELEASE --notes-file "$RUNNER_TEMP/release-notes.md" --title "$SUBJECT" --target $GITHUB_SHA nym-vpn-desktop_*.tar.gz/* "${{ env.UPDATE_BUNDLE_DIR }}/*"

--- a/.github/workflows/release-nym-vpn-desktop.yml
+++ b/.github/workflows/release-nym-vpn-desktop.yml
@@ -39,8 +39,6 @@ jobs:
     env:
       WG_GO_LIB_PATH: ${{ github.workspace }}/lib
       UPDATE_BUNDLE_DIR: update_bundle
-    outputs:
-      update_bundle_name: ${{ steps.set_env.outputs.update_bundle_name }}
 
     steps:
       - name: "Cleanup working directory"
@@ -116,8 +114,6 @@ jobs:
           echo "ARTIFACT_ARCHIVE=$artifact_archive" >> $GITHUB_ENV
           echo "ARTIFACT_CHECKSUM=$artifact_checksum" >> $GITHUB_ENV
           echo "UPDATE_BUNDLE_NAME=$update_bundle_name" >> $GITHUB_ENV
-          # set job outputs
-          echo "update_bundle_name=$update_bundle_name" >> "$GITHUB_OUTPUT"
 
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -322,8 +318,6 @@ jobs:
           echo 'EOF' >> $GITHUB_ENV
 
       - name: Publish release
-        env:
-          UPDATE_BUNDLE_DIR: ${{ needs.build.outputs.update_bundle_name }}
         run: |
           echo "build info"
           echo "$BUILD_INFO"
@@ -331,10 +325,9 @@ jobs:
           echo "$SHA256_CHECKSUMS"
           echo "Creating release notes"
           echo "Update bundle dir"
-          echo $UPDATE_BUNDLE_DIR
           envsubst < "$GITHUB_WORKSPACE/.github/workflows/$NOTES_FILE" > "$RUNNER_TEMP/release-notes.md"
           echo "Creating release nodes: output"
           cat $RUNNER_TEMP/release-notes.md
           echo "Creating release"
-          echo gh release create $TAG_NAME $PRERELEASE --notes-file "$RUNNER_TEMP/release-notes.md" --title "$SUBJECT" --target $GITHUB_SHA nym-vpn-desktop_*.tar.gz/* $UPDATE_BUNDLE_DIR/*
-          gh release create $TAG_NAME $PRERELEASE --notes-file "$RUNNER_TEMP/release-notes.md" --title "$SUBJECT" --target $GITHUB_SHA nym-vpn-desktop_*.tar.gz/* $UPDATE_BUNDLE_DIR/*
+          echo gh release create $TAG_NAME $PRERELEASE --notes-file "$RUNNER_TEMP/release-notes.md" --title "$SUBJECT" --target $GITHUB_SHA nym-vpn-desktop_*.tar.gz/* update-bundle_*/*
+          gh release create $TAG_NAME $PRERELEASE --notes-file "$RUNNER_TEMP/release-notes.md" --title "$SUBJECT" --target $GITHUB_SHA nym-vpn-desktop_*.tar.gz/* update-bundle_*/*

--- a/.github/workflows/release-nym-vpn-desktop.yml
+++ b/.github/workflows/release-nym-vpn-desktop.yml
@@ -183,30 +183,32 @@ jobs:
           ls -la target/${{ env.ARCH_TARGET }}/release/bundle || true
           ls -la target/${{ env.ARCH_TARGET }}/release/bundle/* || true
 
-      - name: Move updater bundle artifacts
+      - name: Move updater bundle artifacts (Linux)
+        if: contains(matrix.os, 'ubuntu')
         shell: bash
         env:
-          # this should translate to
-          # - nym-vpn-desktop/src-tauri/target/release/bundle/appimage/ - Linux
-          # - nym-vpn-desktop/src-tauri/target/universal-apple-darwin/release/bundle/macos/ - Mac
-          BUNDLE_PATH: nym-vpn-desktop/src-tauri/target/${{ env.ARCH_TARGET }}/release/bundle/${{ contains(matrix.os, 'mac') && 'macos' || 'appimage' }}
-          # source bundle name
-          # - nym-vpn*.AppImage.tar.gz(.sig) - Linux
-          # - nym-vpn.app.tar.gz(.sig) - Mac
-          SOURCE_BUNDLE_NAME: ${{ contains(matrix.os, 'mac') && 'nym-vpn.app.tar.gz' || 'nym-vpn*.AppImage.tar.gz' }}
-          # target bundle name
-          # - updater_amd64.AppImage.tar.gz(.sig) - Linux
-          # - updater_universal.app.tar.gz(.sig) - Mac
-          TARGET_BUNDLE_NAME: ${{ contains(matrix.os, 'mac') && 'updater_universal.app.tar.gz' || 'updater_amd64.AppImage.tar.gz' }}
+          SRC_BUNDLE: nym-vpn-desktop/src-tauri/target/release/bundle/appimage/nym-vpn*.AppImage.tar.gz
+          TARGET_BUNDLE: updater_amd64.AppImage.tar.gz
         run: |
           echo "moving updater bundle and signature into ${{ env.UPDATER_BUNDLE_DIR }}"
-          echo " ✓ BUNDLE_PATH: ${{ env.BUNDLE_PATH }}"
-          echo " ✓ SOURCE_BUNDLE_NAME: ${{ env.SOURCE_BUNDLE_NAME }}"
-          echo " ✓ TARGET_BUNDLE_NAME: ${{ env.TARGET_BUNDLE_NAME }}"
           rm -rf $UPDATER_BUNDLE_DIR || true
           mkdir $UPDATER_BUNDLE_DIR
-          mv ${{ env.BUNDLE_PATH }}/${{ env.SOURCE_BUNDLE_NAME }}     ${{ env.UPDATER_BUNDLE_DIR }}/${{ env.TARGET_BUNDLE_NAME }}
-          mv ${{ env.BUNDLE_PATH }}/${{ env.SOURCE_BUNDLE_NAME }}.sig ${{ env.UPDATER_BUNDLE_DIR }}/${{ env.TARGET_BUNDLE_NAME }}.sig
+          mv ${{ env.SRC_BUNDLE }}     $UPDATER_BUNDLE_DIR/${TARGET_BUNDLE}
+          mv ${{ env.SRC_BUNDLE }}.sig $UPDATER_BUNDLE_DIR/${TARGET_BUNDLE}.sig
+          ls -la $UPDATER_BUNDLE_DIR
+
+      - name: Move updater bundle artifacts (Macos)
+        if: contains(matrix.os, 'mac')
+        shell: bash
+        env:
+          SRC_BUNDLE: nym-vpn-desktop/src-tauri/target/universal-apple-darwin/release/bundle/macos/nym-vpn.app.tar.gz
+          TARGET_BUNDLE: updater_universal.app.tar.gz
+        run: |
+          echo "moving updater bundle and signature into ${{ env.UPDATER_BUNDLE_DIR }}"
+          rm -rf $UPDATER_BUNDLE_DIR || true
+          mkdir $UPDATER_BUNDLE_DIR
+          mv ${{ env.SRC_BUNDLE }}     $UPDATER_BUNDLE_DIR/${TARGET_BUNDLE}
+          mv ${{ env.SRC_BUNDLE }}.sig $UPDATER_BUNDLE_DIR/${TARGET_BUNDLE}.sig
           ls -la $UPDATER_BUNDLE_DIR
 
       - name: Upload updater bundle (${{ env.PLATFORM_ARCH }})

--- a/.github/workflows/release-nym-vpn-desktop.yml
+++ b/.github/workflows/release-nym-vpn-desktop.yml
@@ -63,12 +63,7 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y libdbus-1-dev libmnl-dev libnftnl-dev \
             protobuf-compiler libwebkit2gtk-4.0-dev build-essential curl wget libssl-dev \
-            libgtk-3-dev squashfs-tools libayatana-appindicator3-dev make fd-find
-
-      - name: Install system dependencies (Mac)
-        if: contains(matrix.os, 'macos')
-        run: |
-          brew install fd
+            libgtk-3-dev squashfs-tools libayatana-appindicator3-dev make
 
       - name: Get package version
         id: package-version
@@ -192,28 +187,31 @@ jobs:
           ls -la target/${{ env.ARCH_TARGET }}/release/bundle || true
           ls -la target/${{ env.ARCH_TARGET }}/release/bundle/* || true
 
-      - name: Move update bundle artifacts (Linux)
-        if: contains(matrix.os, 'ubuntu')
+      - name: Move update bundle artifacts
         shell: bash
-        # ja on ubuntu `fd` is specifically named `fdfind` …
+        env:
+          # this should translate to
+          # - nym-vpn-desktop/src-tauri/target/release/bundle/appimage/ - Linux
+          # - nym-vpn-desktop/src-tauri/target/universal-apple-darwin/release/bundle/macos/ - Mac
+          BUNDLE_PATH: nym-vpn-desktop/src-tauri/target/${{ env.ARCH_TARGET }}/release/bundle/${{ contains(matrix.os, 'mac') && 'macos' || 'appimage' }}
+          # source bundle name
+          # - nym-vpn*.AppImage.tar.gz(.sig) - Linux
+          # - nym-vpn.app.tar.gz(.sig) - Mac
+          SOURCE_BUNDLE_NAME: ${{ contains(matrix.os, 'mac') && 'nym-vpn.app.tar.gz' || 'nym-vpn*.AppImage.tar.gz' }}
+          # target bundle name
+          # - update_amd64.AppImage.tar.gz(.sig) - Linux
+          # - update_universal.app.tar.gz(.sig) - Mac
+          TARGET_BUNDLE_NAME: ${{ contains(matrix.os, 'mac') && 'update_universal.app.tar.gz' || 'update_amd64.AppImage.tar.gz' }}
         run: |
           echo "moving update bundle and signature into ${{ env.UPDATE_BUNDLE_DIR }}"
-          rm -rf ${{ env.UPDATE_BUNDLE_DIR }} || true
-          mkdir ${{ env.UPDATE_BUNDLE_DIR }}
-          fdfind -I 'nym-vpn.*.AppImage.tar.gz$' -x mv '{}' '${{ env.UPDATE_BUNDLE_DIR }}/update_x86_64.AppImage.tar.gz'
-          fdfind -I 'nym-vpn.*.AppImage.tar.gz.sig$' -x mv '{}' '${{ env.UPDATE_BUNDLE_DIR }}/update_x86_64.AppImage.tar.gz.sig'
-          ls -la ${{ env.UPDATE_BUNDLE_DIR }}
-
-      - name: Move update bundle artifacts (Mac)
-        if: contains(matrix.os, 'mac')
-        shell: bash
-        run: |
-          echo "moving update bundle and signature into ${{ env.UPDATE_BUNDLE_DIR }}"
-          rm -rf ${{ env.UPDATE_BUNDLE_DIR }} || true
-          mkdir ${{ env.UPDATE_BUNDLE_DIR }}
-          fd -I 'nym-vpn.*.app.tar.gz$' -x mv '{}' '${{ env.UPDATE_BUNDLE_DIR }}/update_universal.app.tar.gz'
-          fd -I 'nym-vpn.*.app.tar.gz.sig$' -x mv '{}' '${{ env.UPDATE_BUNDLE_DIR }}/update_universal.app.tar.gz.sig'
-          ls -la ${{ env.UPDATE_BUNDLE_DIR }}
+          echo " ✓ BUNDLE_PATH: ${{ env.BUNDLE_PATH }}"
+          echo " ✓ SOURCE_BUNDLE_NAME: ${{ env.SOURCE_BUNDLE_NAME }}"
+          echo " ✓ TARGET_BUNDLE_NAME: ${{ env.TARGET_BUNDLE_NAME }}"
+          rm -rf $UPDATE_BUNDLE_DIR || true
+          mkdir $UPDATE_BUNDLE_DIR
+          mv ${{ env.BUNDLE_PATH }}/${{ env.SOURCE_BUNDLE_NAME }}     ${{ env.UPDATE_BUNDLE_DIR }}/${{ env.TARGET_BUNDLE_NAME }}
+          mv ${{ env.BUNDLE_PATH }}/${{ env.SOURCE_BUNDLE_NAME }}.sig ${{ env.UPDATE_BUNDLE_DIR }}/${{ env.TARGET_BUNDLE_NAME }}.sig
+          ls -la $UPDATE_BUNDLE_DIR
 
       - name: Upload update bundle (${{ env.PLATFORM_ARCH }})
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release-nym-vpn-desktop.yml
+++ b/.github/workflows/release-nym-vpn-desktop.yml
@@ -175,6 +175,8 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          # TODO try fixing `error running bundle_dmg.sh` (macos build)
+          NO_STRIP: true
         shell: bash
         run: |
           npm run tauri build -- ${{ env.CARGO_TARGET }}

--- a/.github/workflows/release-nym-vpn-desktop.yml
+++ b/.github/workflows/release-nym-vpn-desktop.yml
@@ -197,21 +197,33 @@ jobs:
         shell: bash
         # ja on ubuntu `fd` is specifically named `fdfind` …
         run: |
-          echo "moving update bundle's archive and signature into ${{ env.UPDATE_BUNDLE_DIR }}"
+          echo "moving update bundle and signature into ${{ env.UPDATE_BUNDLE_DIR }}"
           rm -rf ${{ env.UPDATE_BUNDLE_DIR }} || true
           mkdir ${{ env.UPDATE_BUNDLE_DIR }}
-          fdfind -I 'nym-vpn.*.AppImage.tar.gz(.sig)?' -x mv '{}' '${{ env.UPDATE_BUNDLE_DIR }}/{/}'
+          fdfind -I 'nym-vpn.*.AppImage.tar.gz$' -x mv '{}' '${{ env.UPDATE_BUNDLE_DIR }}/update_x86_64.AppImage.tar.gz'
+          fdfind -I 'nym-vpn.*.AppImage.tar.gz.sig$' -x mv '{}' '${{ env.UPDATE_BUNDLE_DIR }}/update_x86_64.AppImage.tar.gz.sig'
           ls -la ${{ env.UPDATE_BUNDLE_DIR }}
 
       - name: Move update bundle artifacts (Mac)
         if: contains(matrix.os, 'mac')
         shell: bash
         run: |
-          echo "moving update bundle's archive and signature into ${{ env.UPDATE_BUNDLE_DIR }}"
+          echo "moving update bundle and signature into ${{ env.UPDATE_BUNDLE_DIR }}"
           rm -rf ${{ env.UPDATE_BUNDLE_DIR }} || true
           mkdir ${{ env.UPDATE_BUNDLE_DIR }}
-          fd -I 'nym-vpn.*.app.tar.gz(.sig)?' -x mv '{}' '${{ env.UPDATE_BUNDLE_DIR }}/{/}'
+          fd -I 'nym-vpn.*.app.tar.gz$' -x mv '{}' '${{ env.UPDATE_BUNDLE_DIR }}/update_universal.app.tar.gz'
+          fd -I 'nym-vpn.*.app.tar.gz.sig$' -x mv '{}' '${{ env.UPDATE_BUNDLE_DIR }}/update_universal.app.tar.gz.sig'
           ls -la ${{ env.UPDATE_BUNDLE_DIR }}
+
+      - name: Upload update bundle (${{ env.PLATFORM_ARCH }})
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.UPDATE_BUNDLE_NAME }}
+          # upload both the update bundle and its signature
+          # - nym-vpn.*.tar.gz
+          # - nym-vpn.*.tar.gz.sig
+          path: ${{ env.UPDATE_BUNDLE_DIR }}
+          retention-days: 2
 
       - name: Create archive
         shell: bash
@@ -227,16 +239,6 @@ jobs:
         with:
           name: ${{ env.ARTIFACT_ARCHIVE }}
           path: ${{ env.ARTIFACT_ARCHIVE }}
-          retention-days: 2
-
-      - name: Upload tauri update bundle (${{ env.PLATFORM_ARCH }})
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.UPDATE_BUNDLE_NAME }}
-          # upload both the update bundle and its signature
-          # - nym-vpn.*.tar.gz
-          # - nym-vpn.*.tar.gz.sig
-          path: ${{ env.UPDATE_BUNDLE_DIR }}
           retention-days: 2
 
       # Build info, but for now it's just the version

--- a/.github/workflows/release-nym-vpn-desktop.yml
+++ b/.github/workflows/release-nym-vpn-desktop.yml
@@ -58,12 +58,17 @@ jobs:
             nym-vpn-desktop
             nym-vpn-lib
 
-      - name: Install system dependencies
+      - name: Install system dependencies (Linux)
         if: contains(matrix.os, 'ubuntu')
         run: |
           sudo apt-get update && sudo apt-get install -y libdbus-1-dev libmnl-dev libnftnl-dev \
             protobuf-compiler libwebkit2gtk-4.0-dev build-essential curl wget libssl-dev \
-            libgtk-3-dev squashfs-tools libayatana-appindicator3-dev make
+            libgtk-3-dev squashfs-tools libayatana-appindicator3-dev make fd-find
+
+      - name: Install system dependencies (Mac)
+        if: contains(matrix.os, 'macos')
+        run: |
+          brew install fd
 
       - name: Get package version
         id: package-version

--- a/.github/workflows/release-nym-vpn-desktop.yml
+++ b/.github/workflows/release-nym-vpn-desktop.yml
@@ -276,7 +276,7 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
 
-      - name: Download tauri update bundle
+      - name: Download update bundle
         uses: actions/download-artifact@v4
         env:
           UPDATE_BUNDLE_NAME: ${{ needs.build.outputs.update_bundle_name }}
@@ -341,4 +341,4 @@ jobs:
           cat $RUNNER_TEMP/release-notes.md
           echo "Creating release"
           echo gh release create $TAG_NAME $PRERELEASE --notes-file "$RUNNER_TEMP/release-notes.md" --title "$SUBJECT" --target $GITHUB_SHA nym-vpn-desktop_*.tar.gz/* "${{ env.UPDATE_BUNDLE_DIR }}/*"
-          gh release create $TAG_NAME $PRERELEASE --notes-file "$RUNNER_TEMP/release-notes.md" --title "$SUBJECT" --target $GITHUB_SHA nym-vpn-desktop_*.tar.gz/* "${{ env.UPDATE_BUNDLE_DIR }}/*"
+          gh release create $TAG_NAME $PRERELEASE --notes-file "$RUNNER_TEMP/release-notes.md" --title "$SUBJECT" --target $GITHUB_SHA nym-vpn-desktop_*.tar.gz/* ${{ env.UPDATE_BUNDLE_DIR }}/*

--- a/.github/workflows/release-nym-vpn-desktop.yml
+++ b/.github/workflows/release-nym-vpn-desktop.yml
@@ -198,6 +198,7 @@ jobs:
         # ja on ubuntu `fd` is specifically named `fdfind` …
         run: |
           echo "moving update bundle's archive and signature into ${{ env.UPDATE_BUNDLE_DIR }}"
+          rm -rf ${{ env.UPDATE_BUNDLE_DIR }} || true
           mkdir ${{ env.UPDATE_BUNDLE_DIR }}
           fdfind -I 'nym-vpn.*.AppImage.tar.gz(.sig)?' -x mv '{}' '${{ env.UPDATE_BUNDLE_DIR }}/{/}'
           ls -la ${{ env.UPDATE_BUNDLE_DIR }}
@@ -207,6 +208,7 @@ jobs:
         shell: bash
         run: |
           echo "moving update bundle's archive and signature into ${{ env.UPDATE_BUNDLE_DIR }}"
+          rm -rf ${{ env.UPDATE_BUNDLE_DIR }} || true
           mkdir ${{ env.UPDATE_BUNDLE_DIR }}
           fd -I 'nym-vpn.*.app.tar.gz(.sig)?' -x mv '{}' '${{ env.UPDATE_BUNDLE_DIR }}/{/}'
           ls -la ${{ env.UPDATE_BUNDLE_DIR }}

--- a/.github/workflows/release-nym-vpn-desktop.yml
+++ b/.github/workflows/release-nym-vpn-desktop.yml
@@ -336,9 +336,11 @@ jobs:
           echo "checksums"
           echo "$SHA256_CHECKSUMS"
           echo "Creating release notes"
+          echo "Update bundle dir"
+          echo $UPDATE_BUNDLE_DIR
           envsubst < "$GITHUB_WORKSPACE/.github/workflows/$NOTES_FILE" > "$RUNNER_TEMP/release-notes.md"
           echo "Creating release nodes: output"
           cat $RUNNER_TEMP/release-notes.md
           echo "Creating release"
-          echo gh release create $TAG_NAME $PRERELEASE --notes-file "$RUNNER_TEMP/release-notes.md" --title "$SUBJECT" --target $GITHUB_SHA nym-vpn-desktop_*.tar.gz/* "${{ env.UPDATE_BUNDLE_DIR }}/*"
+          echo gh release create $TAG_NAME $PRERELEASE --notes-file "$RUNNER_TEMP/release-notes.md" --title "$SUBJECT" --target $GITHUB_SHA nym-vpn-desktop_*.tar.gz/* ${{ env.UPDATE_BUNDLE_DIR }}/*
           gh release create $TAG_NAME $PRERELEASE --notes-file "$RUNNER_TEMP/release-notes.md" --title "$SUBJECT" --target $GITHUB_SHA nym-vpn-desktop_*.tar.gz/* ${{ env.UPDATE_BUNDLE_DIR }}/*

--- a/.github/workflows/release-nym-vpn-desktop.yml
+++ b/.github/workflows/release-nym-vpn-desktop.yml
@@ -239,9 +239,6 @@ jobs:
     permissions:
       contents: write
     steps:
-      - env:
-          UPDATE_BUNDLE_NAME: ${{ needs.build.outputs.update_bundle_name }}
-
       - uses: actions/checkout@v4
 
       - name: Download artifacts
@@ -249,6 +246,8 @@ jobs:
 
       - name: Download tauri update bundle
         uses: actions/download-artifact@v4
+        env:
+          UPDATE_BUNDLE_NAME: ${{ needs.build.outputs.update_bundle_name }}
         with:
           name: ${{ env.UPDATE_BUNDLE_NAME }}
           path: update_bundle

--- a/.github/workflows/release-nym-vpn-desktop.yml
+++ b/.github/workflows/release-nym-vpn-desktop.yml
@@ -192,8 +192,8 @@ jobs:
         run: |
           echo "moving update bundle's archive and signature into ${{ env.UPDATE_BUNDLE_DIR }}"
           mkdir ${{ env.UPDATE_BUNDLE_DIR }}
-          mv nym-vpn-desktop/src-tauri/target/**/release/bundle/appimage/nym-vpn*.AppImage.tar.gz* ${{ env.UPDATE_BUNDLE_DIR }} || true
-          mv nym-vpn-desktop/src-tauri/target/**/release/bundle/macos/nym-vpn*.app.tar.gz* ${{ env.UPDATE_BUNDLE_DIR }} || true
+          fd -I 'nym-vpn.*.AppImage.tar.gz(.sig)?' -x mv '{}' '${{ env.UPDATE_BUNDLE_DIR }}/{/}'
+          fd -I 'nym-vpn.*.app.tar.gz(.sig)?' -x mv '{}' '${{ env.UPDATE_BUNDLE_DIR }}/{/}'
           ls -la ${{ env.UPDATE_BUNDLE_DIR }}
 
       - name: Create archive

--- a/.github/workflows/release-nym-vpn-desktop.yml
+++ b/.github/workflows/release-nym-vpn-desktop.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       WG_GO_LIB_PATH: ${{ github.workspace }}/lib
-      UPDATE_BUNDLE_DIR: update_bundle
+      UPDATER_BUNDLE_DIR: updater_bundle
 
     steps:
       - name: "Cleanup working directory"
@@ -98,22 +98,22 @@ jobs:
           artifact_dir="nym-vpn-desktop_${version}_$platform_arch"
           artifact_archive="$artifact_dir.tar.gz"
           artifact_checksum="$artifact_archive.sha256sum"
-          update_bundle_name="update-bundle_${version}_$platform_arch"
+          updater_bundle_name="updater-bundle_${version}_$platform_arch"
           # debug
           echo " ✓ PLATFORM_ARCH: $platform_arch"
           echo " ✓ WG_GO_LIB_NAME: $wg_go_lib_name"
           echo " ✓ WG_GO_LIB_PATH: ${{ env.WG_GO_LIB_PATH }}"
           echo " ✓ ARTIFACT_DIR: $artifact_dir"
           echo " ✓ ARTIFACT_ARCHIVE: $artifact_archive"
-          echo " ✓ UPDATE_BUNDLE_NAME: $update_bundle_name"
-          echo " ✓ UPDATE_BUNDLE_DIR: ${{ env.UPDATE_BUNDLE_DIR }}"
+          echo " ✓ UPDATER_BUNDLE_NAME: $updater_bundle_name"
+          echo " ✓ UPDATER_BUNDLE_DIR: ${{ env.UPDATER_BUNDLE_DIR }}"
           # set github env
           echo "PLATFORM_ARCH=$platform_arch" >> $GITHUB_ENV
           echo "WG_GO_LIB_NAME=$wg_go_lib_name" >> $GITHUB_ENV
           echo "ARTIFACT_DIR=$artifact_dir" >> $GITHUB_ENV
           echo "ARTIFACT_ARCHIVE=$artifact_archive" >> $GITHUB_ENV
           echo "ARTIFACT_CHECKSUM=$artifact_checksum" >> $GITHUB_ENV
-          echo "UPDATE_BUNDLE_NAME=$update_bundle_name" >> $GITHUB_ENV
+          echo "UPDATER_BUNDLE_NAME=$updater_bundle_name" >> $GITHUB_ENV
 
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -183,7 +183,7 @@ jobs:
           ls -la target/${{ env.ARCH_TARGET }}/release/bundle || true
           ls -la target/${{ env.ARCH_TARGET }}/release/bundle/* || true
 
-      - name: Move update bundle artifacts
+      - name: Move updater bundle artifacts
         shell: bash
         env:
           # this should translate to
@@ -195,28 +195,28 @@ jobs:
           # - nym-vpn.app.tar.gz(.sig) - Mac
           SOURCE_BUNDLE_NAME: ${{ contains(matrix.os, 'mac') && 'nym-vpn.app.tar.gz' || 'nym-vpn*.AppImage.tar.gz' }}
           # target bundle name
-          # - update_amd64.AppImage.tar.gz(.sig) - Linux
-          # - update_universal.app.tar.gz(.sig) - Mac
-          TARGET_BUNDLE_NAME: ${{ contains(matrix.os, 'mac') && 'update_universal.app.tar.gz' || 'update_amd64.AppImage.tar.gz' }}
+          # - updater_amd64.AppImage.tar.gz(.sig) - Linux
+          # - updater_universal.app.tar.gz(.sig) - Mac
+          TARGET_BUNDLE_NAME: ${{ contains(matrix.os, 'mac') && 'updater_universal.app.tar.gz' || 'updater_amd64.AppImage.tar.gz' }}
         run: |
-          echo "moving update bundle and signature into ${{ env.UPDATE_BUNDLE_DIR }}"
+          echo "moving updater bundle and signature into ${{ env.UPDATER_BUNDLE_DIR }}"
           echo " ✓ BUNDLE_PATH: ${{ env.BUNDLE_PATH }}"
           echo " ✓ SOURCE_BUNDLE_NAME: ${{ env.SOURCE_BUNDLE_NAME }}"
           echo " ✓ TARGET_BUNDLE_NAME: ${{ env.TARGET_BUNDLE_NAME }}"
-          rm -rf $UPDATE_BUNDLE_DIR || true
-          mkdir $UPDATE_BUNDLE_DIR
-          mv ${{ env.BUNDLE_PATH }}/${{ env.SOURCE_BUNDLE_NAME }}     ${{ env.UPDATE_BUNDLE_DIR }}/${{ env.TARGET_BUNDLE_NAME }}
-          mv ${{ env.BUNDLE_PATH }}/${{ env.SOURCE_BUNDLE_NAME }}.sig ${{ env.UPDATE_BUNDLE_DIR }}/${{ env.TARGET_BUNDLE_NAME }}.sig
-          ls -la $UPDATE_BUNDLE_DIR
+          rm -rf $UPDATER_BUNDLE_DIR || true
+          mkdir $UPDATER_BUNDLE_DIR
+          mv ${{ env.BUNDLE_PATH }}/${{ env.SOURCE_BUNDLE_NAME }}     ${{ env.UPDATER_BUNDLE_DIR }}/${{ env.TARGET_BUNDLE_NAME }}
+          mv ${{ env.BUNDLE_PATH }}/${{ env.SOURCE_BUNDLE_NAME }}.sig ${{ env.UPDATER_BUNDLE_DIR }}/${{ env.TARGET_BUNDLE_NAME }}.sig
+          ls -la $UPDATER_BUNDLE_DIR
 
-      - name: Upload update bundle (${{ env.PLATFORM_ARCH }})
+      - name: Upload updater bundle (${{ env.PLATFORM_ARCH }})
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.UPDATE_BUNDLE_NAME }}
-          # upload both the update bundle and its signature
-          # - nym-vpn.*.tar.gz
-          # - nym-vpn.*.tar.gz.sig
-          path: ${{ env.UPDATE_BUNDLE_DIR }}
+          name: ${{ env.UPDATER_BUNDLE_NAME }}
+          # upload both the updater bundle and its signature
+          # - updater_*.tar.gz
+          # - updater_*.tar.gz.sig
+          path: ${{ env.UPDATER_BUNDLE_DIR }}
           retention-days: 2
 
       - name: Create archive
@@ -324,10 +324,9 @@ jobs:
           echo "checksums"
           echo "$SHA256_CHECKSUMS"
           echo "Creating release notes"
-          echo "Update bundle dir"
           envsubst < "$GITHUB_WORKSPACE/.github/workflows/$NOTES_FILE" > "$RUNNER_TEMP/release-notes.md"
           echo "Creating release nodes: output"
           cat $RUNNER_TEMP/release-notes.md
           echo "Creating release"
-          echo gh release create $TAG_NAME $PRERELEASE --notes-file "$RUNNER_TEMP/release-notes.md" --title "$SUBJECT" --target $GITHUB_SHA nym-vpn-desktop_*.tar.gz/* update-bundle_*/*
-          gh release create $TAG_NAME $PRERELEASE --notes-file "$RUNNER_TEMP/release-notes.md" --title "$SUBJECT" --target $GITHUB_SHA nym-vpn-desktop_*.tar.gz/* update-bundle_*/*
+          echo gh release create $TAG_NAME $PRERELEASE --notes-file "$RUNNER_TEMP/release-notes.md" --title "$SUBJECT" --target $GITHUB_SHA nym-vpn-desktop_*.tar.gz/* updater-bundle_*/*
+          gh release create $TAG_NAME $PRERELEASE --notes-file "$RUNNER_TEMP/release-notes.md" --title "$SUBJECT" --target $GITHUB_SHA nym-vpn-desktop_*.tar.gz/* updater-bundle_*/*

--- a/.github/workflows/release-nym-vpn-desktop.yml
+++ b/.github/workflows/release-nym-vpn-desktop.yml
@@ -24,7 +24,9 @@ jobs:
   build-wireguard-go:
     strategy:
       matrix:
-        os: [ubuntu-22.04-16-core, custom-runner-mac-m1]
+        # os: [ubuntu-22.04-16-core, custom-runner-mac-m1]
+        # TODO temp disable mac build, runner is down
+        os: [ubuntu-22.04-16-core]
     uses: ./.github/workflows/build-wireguard-go.yml
     with:
       os: ${{ matrix.os }}
@@ -34,7 +36,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04-16-core, macos-14]
+        # os: [ubuntu-22.04-16-core, macos-14]
+        # TODO temp disable mac build, runner is down
+        os: [ubuntu-22.04-16-core]
     runs-on: ${{ matrix.os }}
     env:
       WG_GO_LIB_PATH: ${{ github.workspace }}/lib

--- a/.github/workflows/release-nym-vpn-desktop.yml
+++ b/.github/workflows/release-nym-vpn-desktop.yml
@@ -181,7 +181,7 @@ jobs:
           APPLE_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           # TODO try fixing `error running bundle_dmg.sh` (macos build)
-          NO_STRIP: true
+          NO_STRIP: ${{ contains(matrix.os, 'mac') && 'true' }}
         shell: bash
         run: |
           npm run tauri build -- ${{ env.CARGO_TARGET }}

--- a/.github/workflows/release-nym-vpn-desktop.yml
+++ b/.github/workflows/release-nym-vpn-desktop.yml
@@ -267,22 +267,16 @@ jobs:
     env:
       GH_REPO: ${{ github.repository }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      UPDATE_BUNDLE_DIR: update_bundle
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v4
 
+      # Downloads *all* artifacts produced by the `build` job
+      # Each individual artifact will be located in a directory
+      # named with the same name of the artifact (upload)
       - name: Download artifacts
         uses: actions/download-artifact@v4
-
-      - name: Download update bundle
-        uses: actions/download-artifact@v4
-        env:
-          UPDATE_BUNDLE_NAME: ${{ needs.build.outputs.update_bundle_name }}
-        with:
-          name: ${{ env.UPDATE_BUNDLE_NAME }}
-          path: ${{ env.UPDATE_BUNDLE_DIR }}
 
       # Setup TAG_NAME, which is used as a general "name"
       - if: github.event_name == 'workflow_dispatch'
@@ -330,6 +324,8 @@ jobs:
           echo 'EOF' >> $GITHUB_ENV
 
       - name: Publish release
+        env:
+          UPDATE_BUNDLE_DIR: ${{ needs.build.outputs.update_bundle_name }}
         run: |
           echo "build info"
           echo "$BUILD_INFO"
@@ -342,5 +338,5 @@ jobs:
           echo "Creating release nodes: output"
           cat $RUNNER_TEMP/release-notes.md
           echo "Creating release"
-          echo gh release create $TAG_NAME $PRERELEASE --notes-file "$RUNNER_TEMP/release-notes.md" --title "$SUBJECT" --target $GITHUB_SHA nym-vpn-desktop_*.tar.gz/* ${{ env.UPDATE_BUNDLE_DIR }}/*
-          gh release create $TAG_NAME $PRERELEASE --notes-file "$RUNNER_TEMP/release-notes.md" --title "$SUBJECT" --target $GITHUB_SHA nym-vpn-desktop_*.tar.gz/* ${{ env.UPDATE_BUNDLE_DIR }}/*
+          echo gh release create $TAG_NAME $PRERELEASE --notes-file "$RUNNER_TEMP/release-notes.md" --title "$SUBJECT" --target $GITHUB_SHA nym-vpn-desktop_*.tar.gz/* $UPDATE_BUNDLE_DIR/*
+          gh release create $TAG_NAME $PRERELEASE --notes-file "$RUNNER_TEMP/release-notes.md" --title "$SUBJECT" --target $GITHUB_SHA nym-vpn-desktop_*.tar.gz/* $UPDATE_BUNDLE_DIR/*

--- a/.github/workflows/release-nym-vpn-desktop.yml
+++ b/.github/workflows/release-nym-vpn-desktop.yml
@@ -38,6 +38,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       WG_GO_LIB_PATH: ${{ github.workspace }}/lib
+    outputs:
+      update_bundle_name: ${{ steps.set_env.outputs.update_bundle_name }}
 
     steps:
       - name: "Cleanup working directory"
@@ -80,6 +82,7 @@ jobs:
         run: exit 1
 
       - name: Set env
+        id: set_env
         run: |
           if ${{ contains(matrix.os, 'ubuntu-22.04') }}; then
             platform_arch=ubuntu-22.04_x86_64
@@ -95,18 +98,23 @@ jobs:
           artifact_dir="nym-vpn-desktop_${{ steps.package-version.outputs.metadata }}_$platform_arch"
           artifact_archive="$artifact_dir.tar.gz"
           artifact_checksum="$artifact_archive.sha256sum"
+          update_bundle_name="$artifact_dir"_bundle
           # debug
           echo " ✓ PLATFORM_ARCH: $platform_arch"
           echo " ✓ WG_GO_LIB_NAME: $wg_go_lib_name"
           echo " ✓ WG_GO_LIB_PATH: ${{ env.WG_GO_LIB_PATH }}"
           echo " ✓ ARTIFACT_DIR: $artifact_dir"
           echo " ✓ ARTIFACT_ARCHIVE: $artifact_archive"
+          echo " ✓ UPDATE_BUNDLE_NAME: $update_bundle_name"
           # set github env
           echo "PLATFORM_ARCH=$platform_arch" >> $GITHUB_ENV
           echo "WG_GO_LIB_NAME=$wg_go_lib_name" >> $GITHUB_ENV
           echo "ARTIFACT_DIR=$artifact_dir" >> $GITHUB_ENV
           echo "ARTIFACT_ARCHIVE=$artifact_archive" >> $GITHUB_ENV
           echo "ARTIFACT_CHECKSUM=$artifact_checksum" >> $GITHUB_ENV
+          echo "UPDATE_BUNDLE_NAME=$update_bundle_name" >> $GITHUB_ENV
+          # set job outputs
+          echo "update_bundle_name=$update_bundle_name" >> "$GITHUB_OUTPUT"
 
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -190,6 +198,18 @@ jobs:
           path: ${{ env.ARTIFACT_ARCHIVE }}
           retention-days: 2
 
+      - name: Upload tauri update bundle (${{ env.PLATFORM_ARCH }})
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.UPDATE_BUNDLE_NAME }}
+          # upload both the update bundle and its signature
+          # - nymvpn.*.tar.gz
+          # - nymvpn.*.tar.gz.sig
+          path: |
+            nym-vpn-desktop/src-tauri/target/**/release/bundle/appimage/nym-vpn*.AppImage.tar.gz*
+            nym-vpn-desktop/src-tauri/target/**/release/bundle/macos/nym-vpn*.app.tar.gz*
+          retention-days: 2
+
       # Build info, but for now it's just the version
       - name: Generate build info (${{ env.PLATFORM_ARCH }})
         if: contains(matrix.os, 'ubuntu-22.04')
@@ -219,9 +239,19 @@ jobs:
     permissions:
       contents: write
     steps:
+      - env:
+          UPDATE_BUNDLE_NAME: ${{ needs.build.outputs.update_bundle_name }}
+
       - uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v4
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+
+      - name: Download tauri update bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.UPDATE_BUNDLE_NAME }}
+          path: update_bundle
 
       # Setup TAG_NAME, which is used as a general "name"
       - if: github.event_name == 'workflow_dispatch'
@@ -279,5 +309,5 @@ jobs:
           echo "Creating release nodes: output"
           cat $RUNNER_TEMP/release-notes.md
           echo "Creating release"
-          echo gh release create $TAG_NAME $PRERELEASE --notes-file "$RUNNER_TEMP/release-notes.md" --title "$SUBJECT" --target $GITHUB_SHA nym-vpn-desktop_*.tar.gz/*
-          gh release create $TAG_NAME $PRERELEASE --notes-file "$RUNNER_TEMP/release-notes.md" --title "$SUBJECT" --target $GITHUB_SHA nym-vpn-desktop_*.tar.gz/*
+          echo gh release create $TAG_NAME $PRERELEASE --notes-file "$RUNNER_TEMP/release-notes.md" --title "$SUBJECT" --target $GITHUB_SHA nym-vpn-desktop_*.tar.gz/* update_bundle/*
+          gh release create $TAG_NAME $PRERELEASE --notes-file "$RUNNER_TEMP/release-notes.md" --title "$SUBJECT" --target $GITHUB_SHA nym-vpn-desktop_*.tar.gz/* update_bundle/*

--- a/.github/workflows/release-nym-vpn-desktop.yml
+++ b/.github/workflows/release-nym-vpn-desktop.yml
@@ -24,9 +24,7 @@ jobs:
   build-wireguard-go:
     strategy:
       matrix:
-        # os: [ubuntu-22.04-16-core, custom-runner-mac-m1]
-        # TODO temp disable mac build, runner is down
-        os: [ubuntu-22.04-16-core]
+        os: [ubuntu-22.04-16-core, macos-14]
     uses: ./.github/workflows/build-wireguard-go.yml
     with:
       os: ${{ matrix.os }}
@@ -36,9 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # os: [ubuntu-22.04-16-core, macos-14]
-        # TODO temp disable mac build, runner is down
-        os: [ubuntu-22.04-16-core]
+        os: [ubuntu-22.04-16-core, macos-14]
     runs-on: ${{ matrix.os }}
     env:
       WG_GO_LIB_PATH: ${{ github.workspace }}/lib

--- a/.github/workflows/release-nym-vpn-desktop.yml
+++ b/.github/workflows/release-nym-vpn-desktop.yml
@@ -192,12 +192,22 @@ jobs:
           ls -la target/${{ env.ARCH_TARGET }}/release/bundle || true
           ls -la target/${{ env.ARCH_TARGET }}/release/bundle/* || true
 
-      - name: Move update bundle artifacts
+      - name: Move update bundle artifacts (Linux)
+        if: contains(matrix.os, 'ubuntu')
+        shell: bash
+        # ja on ubuntu `fd` is specifically named `fdfind` …
+        run: |
+          echo "moving update bundle's archive and signature into ${{ env.UPDATE_BUNDLE_DIR }}"
+          mkdir ${{ env.UPDATE_BUNDLE_DIR }}
+          fdfind -I 'nym-vpn.*.AppImage.tar.gz(.sig)?' -x mv '{}' '${{ env.UPDATE_BUNDLE_DIR }}/{/}'
+          ls -la ${{ env.UPDATE_BUNDLE_DIR }}
+
+      - name: Move update bundle artifacts (Mac)
+        if: contains(matrix.os, 'mac')
         shell: bash
         run: |
           echo "moving update bundle's archive and signature into ${{ env.UPDATE_BUNDLE_DIR }}"
           mkdir ${{ env.UPDATE_BUNDLE_DIR }}
-          fd -I 'nym-vpn.*.AppImage.tar.gz(.sig)?' -x mv '{}' '${{ env.UPDATE_BUNDLE_DIR }}/{/}'
           fd -I 'nym-vpn.*.app.tar.gz(.sig)?' -x mv '{}' '${{ env.UPDATE_BUNDLE_DIR }}/{/}'
           ls -la ${{ env.UPDATE_BUNDLE_DIR }}
 

--- a/nym-vpn-desktop/src-tauri/Cargo.lock
+++ b/nym-vpn-desktop/src-tauri/Cargo.lock
@@ -4072,6 +4072,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "minisign-verify"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "933dca44d65cdd53b355d0b73d380a2ff5da71f87f036053188bf1eab6a19881"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5706,6 +5712,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc-foundation"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
+dependencies = [
+ "block",
+ "objc",
+ "objc_id",
+]
+
+[[package]]
 name = "objc_exception"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6815,10 +6832,12 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.24.1",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 0.25.4",
  "winreg 0.50.0",
@@ -6842,6 +6861,30 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac 0.12.1",
  "subtle 2.4.1",
+]
+
+[[package]]
+name = "rfd"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0149778bd99b6959285b0933288206090c50e2327f47a9c463bfdbf45c8823ea"
+dependencies = [
+ "block",
+ "dispatch",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "objc",
+ "objc-foundation",
+ "objc_id",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows 0.37.0",
 ]
 
 [[package]]
@@ -8391,6 +8434,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0da520ff07c0745199204f7a7a62a8c6ee1666313b792b051ca170eca04649aa"
 dependencies = [
  "anyhow",
+ "base64 0.21.6",
+ "bytes",
  "cocoa",
  "dirs-next",
  "dunce",
@@ -8404,6 +8449,8 @@ dependencies = [
  "heck 0.4.1",
  "http",
  "ignore",
+ "indexmap 1.9.3",
+ "minisign-verify",
  "objc",
  "once_cell",
  "open",
@@ -8411,6 +8458,8 @@ dependencies = [
  "rand 0.8.5",
  "raw-window-handle",
  "regex",
+ "reqwest",
+ "rfd",
  "semver 1.0.21",
  "serde",
  "serde_json",
@@ -8424,12 +8473,14 @@ dependencies = [
  "tauri-utils",
  "tempfile",
  "thiserror",
+ "time",
  "tokio",
  "url",
  "uuid 1.6.1",
  "webkit2gtk",
  "webview2-com",
  "windows 0.39.0",
+ "zip",
 ]
 
 [[package]]
@@ -9808,6 +9859,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
 
 [[package]]
+name = "wasm-streams"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4609d447824375f43e1ffbc051b50ad8f4b3ae8219680c94452ea05eb240ac7"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-utils"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
@@ -10013,6 +10077,19 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57b543186b344cc61c85b5aab0d2e3adf4e0f99bc076eff9aa5927bcc0b8a647"
+dependencies = [
+ "windows_aarch64_msvc 0.37.0",
+ "windows_i686_gnu 0.37.0",
+ "windows_i686_msvc 0.37.0",
+ "windows_x86_64_gnu 0.37.0",
+ "windows_x86_64_msvc 0.37.0",
+]
 
 [[package]]
 name = "windows"
@@ -10235,6 +10312,12 @@ checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2623277cb2d1c216ba3b578c0f3cf9cdebeddb6e66b1b218bb33596ea7769c3a"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7711666096bd4096ffa835238905bb33fb87267910e154b18b44eaabb340f2"
@@ -10262,6 +10345,12 @@ name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3925fd0b0b804730d44d4b6278c50f9699703ec49bcd628020f46f4ba07d9e1"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -10295,6 +10384,12 @@ checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce907ac74fe331b524c1298683efbf598bb031bc84d5e274db2083696d07c57c"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bc7cbfe58828921e10a9f446fcaaf649204dcfe6c1ddd712c5eebae6bda1106"
@@ -10322,6 +10417,12 @@ name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2babfba0828f2e6b32457d5341427dcbb577ceef556273229959ac23a10af33d"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -10370,6 +10471,12 @@ name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4dd6dc7df2d84cf7b33822ed5b86318fb1781948e9663bacd047fc9dd52259d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -10593,6 +10700,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/nym-vpn-desktop/src-tauri/Cargo.lock
+++ b/nym-vpn-desktop/src-tauri/Cargo.lock
@@ -4072,12 +4072,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
-name = "minisign-verify"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "933dca44d65cdd53b355d0b73d380a2ff5da71f87f036053188bf1eab6a19881"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5712,17 +5706,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc-foundation"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
-dependencies = [
- "block",
- "objc",
- "objc_id",
-]
-
-[[package]]
 name = "objc_exception"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6832,12 +6815,10 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.24.1",
- "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
  "web-sys",
  "webpki-roots 0.25.4",
  "winreg 0.50.0",
@@ -6861,30 +6842,6 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac 0.12.1",
  "subtle 2.4.1",
-]
-
-[[package]]
-name = "rfd"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0149778bd99b6959285b0933288206090c50e2327f47a9c463bfdbf45c8823ea"
-dependencies = [
- "block",
- "dispatch",
- "glib-sys",
- "gobject-sys",
- "gtk-sys",
- "js-sys",
- "lazy_static",
- "log",
- "objc",
- "objc-foundation",
- "objc_id",
- "raw-window-handle",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "windows 0.37.0",
 ]
 
 [[package]]
@@ -8434,8 +8391,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0da520ff07c0745199204f7a7a62a8c6ee1666313b792b051ca170eca04649aa"
 dependencies = [
  "anyhow",
- "base64 0.21.6",
- "bytes",
  "cocoa",
  "dirs-next",
  "dunce",
@@ -8449,8 +8404,6 @@ dependencies = [
  "heck 0.4.1",
  "http",
  "ignore",
- "indexmap 1.9.3",
- "minisign-verify",
  "objc",
  "once_cell",
  "open",
@@ -8458,8 +8411,6 @@ dependencies = [
  "rand 0.8.5",
  "raw-window-handle",
  "regex",
- "reqwest",
- "rfd",
  "semver 1.0.21",
  "serde",
  "serde_json",
@@ -8473,14 +8424,12 @@ dependencies = [
  "tauri-utils",
  "tempfile",
  "thiserror",
- "time",
  "tokio",
  "url",
  "uuid 1.6.1",
  "webkit2gtk",
  "webview2-com",
  "windows 0.39.0",
- "zip",
 ]
 
 [[package]]
@@ -9859,19 +9808,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
 
 [[package]]
-name = "wasm-streams"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4609d447824375f43e1ffbc051b50ad8f4b3ae8219680c94452ea05eb240ac7"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "wasm-utils"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
@@ -10077,19 +10013,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57b543186b344cc61c85b5aab0d2e3adf4e0f99bc076eff9aa5927bcc0b8a647"
-dependencies = [
- "windows_aarch64_msvc 0.37.0",
- "windows_i686_gnu 0.37.0",
- "windows_i686_msvc 0.37.0",
- "windows_x86_64_gnu 0.37.0",
- "windows_x86_64_msvc 0.37.0",
-]
 
 [[package]]
 name = "windows"
@@ -10312,12 +10235,6 @@ checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2623277cb2d1c216ba3b578c0f3cf9cdebeddb6e66b1b218bb33596ea7769c3a"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7711666096bd4096ffa835238905bb33fb87267910e154b18b44eaabb340f2"
@@ -10345,12 +10262,6 @@ name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3925fd0b0b804730d44d4b6278c50f9699703ec49bcd628020f46f4ba07d9e1"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -10384,12 +10295,6 @@ checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce907ac74fe331b524c1298683efbf598bb031bc84d5e274db2083696d07c57c"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bc7cbfe58828921e10a9f446fcaaf649204dcfe6c1ddd712c5eebae6bda1106"
@@ -10417,12 +10322,6 @@ name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2babfba0828f2e6b32457d5341427dcbb577ceef556273229959ac23a10af33d"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -10471,12 +10370,6 @@ name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4dd6dc7df2d84cf7b33822ed5b86318fb1781948e9663bacd047fc9dd52259d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -10700,17 +10593,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
-]
-
-[[package]]
-name = "zip"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
-dependencies = [
- "byteorder",
- "crc32fast",
- "crossbeam-utils",
 ]
 
 [[package]]

--- a/nym-vpn-desktop/src-tauri/Cargo.lock
+++ b/nym-vpn-desktop/src-tauri/Cargo.lock
@@ -3188,7 +3188,7 @@ dependencies = [
 [[package]]
 name = "http-api-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -4484,17 +4484,17 @@ dependencies = [
 [[package]]
 name = "nym-api-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "bs58 0.5.0",
  "cosmrs",
  "cosmwasm-std",
  "ecdsa 0.16.9",
  "getset",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
- "nym-node-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-node-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "schemars",
  "serde",
  "tendermint",
@@ -4503,15 +4503,15 @@ dependencies = [
 [[package]]
 name = "nym-bandwidth-controller"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "bip39",
  "log",
- "nym-coconut 0.5.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-coconut 0.5.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "nym-credential-storage",
  "nym-credentials",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "nym-network-defaults",
  "nym-validator-client",
  "rand 0.7.3",
@@ -4541,7 +4541,7 @@ dependencies = [
 [[package]]
 name = "nym-bin-common"
 version = "0.6.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "atty",
  "clap",
@@ -4559,7 +4559,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core"
 version = "1.1.15"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "async-trait",
  "base64 0.21.6",
@@ -4573,13 +4573,13 @@ dependencies = [
  "nym-bandwidth-controller",
  "nym-config",
  "nym-credential-storage",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "nym-explorer-client",
  "nym-gateway-client",
  "nym-gateway-requests",
  "nym-network-defaults",
  "nym-nonexhaustive-delayqueue",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "nym-sphinx",
  "nym-task",
  "nym-topology",
@@ -4630,7 +4630,7 @@ dependencies = [
 [[package]]
 name = "nym-coconut"
 version = "0.5.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "bls12_381",
  "bs58 0.5.0",
@@ -4639,8 +4639,8 @@ dependencies = [
  "getrandom 0.2.12",
  "group",
  "itertools 0.10.5",
- "nym-dkg 0.1.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-dkg 0.1.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "rand 0.8.5",
  "serde",
  "serde_derive",
@@ -4651,7 +4651,7 @@ dependencies = [
 [[package]]
 name = "nym-coconut-bandwidth-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -4661,21 +4661,21 @@ dependencies = [
 [[package]]
 name = "nym-coconut-dkg-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-utils",
  "cw2",
  "cw4",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "nym-multisig-contract-common",
 ]
 
 [[package]]
 name = "nym-config"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "dirs 5.0.1",
  "handlebars",
@@ -4702,7 +4702,7 @@ dependencies = [
 [[package]]
 name = "nym-contracts-common"
 version = "0.5.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "bs58 0.5.0",
  "cosmwasm-schema",
@@ -4715,7 +4715,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-storage"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "async-trait",
  "log",
@@ -4728,12 +4728,12 @@ dependencies = [
 [[package]]
 name = "nym-credential-utils"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "log",
  "nym-bandwidth-controller",
  "nym-client-core",
- "nym-coconut 0.5.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-coconut 0.5.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "nym-config",
  "nym-credential-storage",
  "nym-credentials",
@@ -4745,15 +4745,15 @@ dependencies = [
 [[package]]
 name = "nym-credentials"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "bincode",
  "bls12_381",
  "cosmrs",
  "log",
- "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "nym-validator-client",
  "serde",
  "thiserror",
@@ -4775,10 +4775,10 @@ dependencies = [
 [[package]]
 name = "nym-credentials-interface"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "bls12_381",
- "nym-coconut 0.5.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-coconut 0.5.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "serde",
  "thiserror",
 ]
@@ -4803,7 +4803,7 @@ dependencies = [
 [[package]]
 name = "nym-crypto"
 version = "0.4.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "aes 0.8.3",
  "blake3",
@@ -4815,8 +4815,8 @@ dependencies = [
  "generic-array 0.14.7",
  "hkdf 0.12.4",
  "hmac 0.12.1",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "rand 0.7.3",
  "serde",
  "serde_bytes",
@@ -4851,7 +4851,7 @@ dependencies = [
 [[package]]
 name = "nym-dkg"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "bitvec",
  "bls12_381",
@@ -4859,7 +4859,7 @@ dependencies = [
  "ff",
  "group",
  "lazy_static",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
@@ -4873,12 +4873,12 @@ dependencies = [
 [[package]]
 name = "nym-ephemera-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-utils",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
 ]
 
 [[package]]
@@ -4894,7 +4894,7 @@ dependencies = [
 [[package]]
 name = "nym-exit-policy"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "serde",
  "thiserror",
@@ -4916,11 +4916,11 @@ dependencies = [
 [[package]]
 name = "nym-explorer-api-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
- "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "schemars",
  "serde",
 ]
@@ -4928,10 +4928,10 @@ dependencies = [
 [[package]]
 name = "nym-explorer-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "log",
- "nym-explorer-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-explorer-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "reqwest",
  "serde",
  "thiserror",
@@ -4941,7 +4941,7 @@ dependencies = [
 [[package]]
 name = "nym-gateway-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "futures",
  "getrandom 0.2.12",
@@ -4950,10 +4950,10 @@ dependencies = [
  "nym-bandwidth-controller",
  "nym-credential-storage",
  "nym-credentials",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "nym-gateway-requests",
  "nym-network-defaults",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "nym-sphinx",
  "nym-task",
  "nym-validator-client",
@@ -4974,16 +4974,16 @@ dependencies = [
 [[package]]
 name = "nym-gateway-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "bs58 0.5.0",
  "futures",
  "generic-array 0.14.7",
  "log",
  "nym-credentials",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "nym-sphinx",
  "rand 0.7.3",
  "serde",
@@ -4996,7 +4996,7 @@ dependencies = [
 [[package]]
 name = "nym-group-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "cosmwasm-schema",
  "cw-controllers",
@@ -5008,11 +5008,11 @@ dependencies = [
 [[package]]
 name = "nym-ip-packet-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "bincode",
  "bytes",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "nym-sphinx",
  "rand 0.8.5",
  "serde",
@@ -5043,14 +5043,14 @@ dependencies = [
 [[package]]
 name = "nym-mixnet-contract-common"
 version = "0.6.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "bs58 0.4.0",
  "cosmwasm-schema",
  "cosmwasm-std",
  "humantime-serde",
  "log",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "schemars",
  "serde",
  "serde-json-wasm",
@@ -5062,7 +5062,7 @@ dependencies = [
 [[package]]
 name = "nym-multisig-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -5078,13 +5078,13 @@ dependencies = [
 [[package]]
 name = "nym-name-service-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-controllers",
  "cw-utils",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "serde",
  "thiserror",
 ]
@@ -5092,7 +5092,7 @@ dependencies = [
 [[package]]
 name = "nym-network-defaults"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "cfg-if",
  "dotenvy",
@@ -5124,15 +5124,15 @@ dependencies = [
 [[package]]
 name = "nym-node-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "async-trait",
  "base64 0.21.6",
  "http-api-client",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
- "nym-exit-policy 0.1.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
- "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-exit-policy 0.1.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "schemars",
  "serde",
  "serde_json",
@@ -5142,7 +5142,7 @@ dependencies = [
 [[package]]
 name = "nym-nonexhaustive-delayqueue"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -5153,7 +5153,7 @@ dependencies = [
 [[package]]
 name = "nym-ordered-buffer"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "log",
  "thiserror",
@@ -5162,7 +5162,7 @@ dependencies = [
 [[package]]
 name = "nym-outfox"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "blake3",
  "chacha20 0.9.1",
@@ -5188,7 +5188,7 @@ dependencies = [
 [[package]]
 name = "nym-pemstore"
 version = "0.3.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "pem",
 ]
@@ -5196,7 +5196,7 @@ dependencies = [
 [[package]]
 name = "nym-sdk"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "async-trait",
  "bip39",
@@ -5211,7 +5211,7 @@ dependencies = [
  "nym-credential-storage",
  "nym-credential-utils",
  "nym-credentials",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "nym-gateway-requests",
  "nym-network-defaults",
  "nym-ordered-buffer",
@@ -5232,24 +5232,24 @@ dependencies = [
 [[package]]
 name = "nym-service-provider-directory-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-controllers",
  "cw-utils",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "thiserror",
 ]
 
 [[package]]
 name = "nym-service-providers-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "async-trait",
  "log",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "nym-sphinx-anonymous-replies",
  "serde",
  "serde_json",
@@ -5259,7 +5259,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-client-core"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "anyhow",
  "dirs 4.0.0",
@@ -5268,9 +5268,9 @@ dependencies = [
  "nym-bandwidth-controller",
  "nym-client-core",
  "nym-config",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "nym-credential-storage",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "nym-network-defaults",
  "nym-service-providers-common",
  "nym-socks5-proxy-helpers",
@@ -5292,7 +5292,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-proxy-helpers"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "bytes",
  "futures",
@@ -5307,11 +5307,11 @@ dependencies = [
 [[package]]
 name = "nym-socks5-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "bincode",
  "log",
- "nym-exit-policy 0.1.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-exit-policy 0.1.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "nym-service-providers-common",
  "nym-sphinx-addressing",
  "serde",
@@ -5323,10 +5323,10 @@ dependencies = [
 [[package]]
 name = "nym-sphinx"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "log",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "nym-sphinx-acknowledgements",
  "nym-sphinx-addressing",
  "nym-sphinx-anonymous-replies",
@@ -5336,7 +5336,7 @@ dependencies = [
  "nym-sphinx-framing",
  "nym-sphinx-params",
  "nym-sphinx-routing",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "nym-topology",
  "rand 0.7.3",
  "rand_distr",
@@ -5347,14 +5347,14 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-acknowledgements"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "nym-sphinx-addressing",
  "nym-sphinx-params",
  "nym-sphinx-routing",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "nym-topology",
  "rand 0.7.3",
  "thiserror",
@@ -5364,10 +5364,10 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-addressing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "serde",
  "thiserror",
 ]
@@ -5375,14 +5375,14 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-anonymous-replies"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "bs58 0.5.0",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "nym-sphinx-addressing",
  "nym-sphinx-params",
  "nym-sphinx-routing",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "nym-topology",
  "rand 0.7.3",
  "serde",
@@ -5393,12 +5393,12 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-chunking"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "log",
  "nym-sphinx-addressing",
  "nym-sphinx-params",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "rand 0.7.3",
  "thiserror",
 ]
@@ -5406,16 +5406,16 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-cover"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "nym-sphinx-acknowledgements",
  "nym-sphinx-addressing",
  "nym-sphinx-chunking",
  "nym-sphinx-forwarding",
  "nym-sphinx-params",
  "nym-sphinx-routing",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "nym-topology",
  "rand 0.7.3",
  "thiserror",
@@ -5424,23 +5424,23 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-forwarding"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "nym-outfox",
  "nym-sphinx-addressing",
  "nym-sphinx-params",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "thiserror",
 ]
 
 [[package]]
 name = "nym-sphinx-framing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "bytes",
  "nym-sphinx-params",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "thiserror",
  "tokio-util",
 ]
@@ -5448,10 +5448,10 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-params"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "serde",
  "thiserror",
 ]
@@ -5459,10 +5459,10 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-routing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "nym-sphinx-addressing",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "thiserror",
 ]
 
@@ -5478,7 +5478,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-types"
 version = "0.2.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "nym-outfox",
  "sphinx-packet",
@@ -5488,7 +5488,7 @@ dependencies = [
 [[package]]
 name = "nym-task"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "futures",
  "log",
@@ -5502,19 +5502,19 @@ dependencies = [
 [[package]]
 name = "nym-topology"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "async-trait",
  "bs58 0.5.0",
  "log",
- "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "nym-config",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "nym-sphinx-addressing",
  "nym-sphinx-routing",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "rand 0.7.3",
  "semver 0.11.0",
  "serde",
@@ -5525,7 +5525,7 @@ dependencies = [
 [[package]]
 name = "nym-validator-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -5545,15 +5545,15 @@ dependencies = [
  "http-api-client",
  "itertools 0.10.5",
  "log",
- "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
- "nym-coconut 0.5.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-coconut 0.5.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "nym-coconut-bandwidth-contract-common",
  "nym-coconut-dkg-common",
  "nym-config",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "nym-ephemera-common",
  "nym-group-contract-common",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "nym-multisig-contract-common",
  "nym-name-service-common",
  "nym-network-defaults",
@@ -5575,12 +5575,12 @@ dependencies = [
 [[package]]
 name = "nym-vesting-contract-common"
 version = "0.7.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "serde",
  "thiserror",
 ]
@@ -5634,19 +5634,21 @@ dependencies = [
  "lazy_static",
  "log",
  "nix 0.23.2",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "nym-client-core",
  "nym-config",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-explorer-client",
  "nym-ip-packet-requests",
- "nym-node-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-node-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "nym-sdk",
  "nym-task",
  "nym-validator-client",
- "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "oslog",
  "rand 0.7.3",
  "rand 0.8.5",
+ "reqwest",
  "serde",
  "serde_json",
  "signature 1.4.0",
@@ -5659,10 +5661,12 @@ dependencies = [
  "tap",
  "thiserror",
  "tokio",
+ "tokio-tungstenite",
  "tokio-util",
  "tracing",
  "tracing-subscriber",
  "tun2",
+ "tungstenite",
  "uniffi",
  "url",
 ]
@@ -5684,13 +5688,13 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-types"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "base64 0.21.6",
  "dashmap",
  "hmac 0.12.1",
  "log",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
  "serde",
  "sha2 0.10.8",
  "thiserror",
@@ -6835,6 +6839,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots 0.25.4",
  "winreg 0.50.0",
 ]
 
@@ -7823,7 +7828,7 @@ dependencies = [
  "thiserror",
  "tokio-stream",
  "url",
- "webpki-roots",
+ "webpki-roots 0.22.6",
 ]
 
 [[package]]
@@ -8948,6 +8953,7 @@ checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
 dependencies = [
  "futures-util",
  "log",
+ "rustls 0.21.10",
  "tokio",
  "tungstenite",
 ]
@@ -9390,6 +9396,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
+ "rustls 0.21.10",
  "sha1",
  "thiserror",
  "url",
@@ -9867,7 +9874,7 @@ dependencies = [
 [[package]]
 name = "wasm-utils"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
+source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
 dependencies = [
  "futures",
  "getrandom 0.2.12",
@@ -9969,6 +9976,12 @@ checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webview2-com"

--- a/nym-vpn-desktop/src-tauri/Cargo.lock
+++ b/nym-vpn-desktop/src-tauri/Cargo.lock
@@ -3188,7 +3188,7 @@ dependencies = [
 [[package]]
 name = "http-api-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -4072,6 +4072,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "minisign-verify"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "933dca44d65cdd53b355d0b73d380a2ff5da71f87f036053188bf1eab6a19881"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4478,17 +4484,17 @@ dependencies = [
 [[package]]
 name = "nym-api-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "bs58 0.5.0",
  "cosmrs",
  "cosmwasm-std",
  "ecdsa 0.16.9",
  "getset",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
- "nym-node-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-node-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "schemars",
  "serde",
  "tendermint",
@@ -4497,15 +4503,15 @@ dependencies = [
 [[package]]
 name = "nym-bandwidth-controller"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "bip39",
  "log",
- "nym-coconut 0.5.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-coconut 0.5.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "nym-credential-storage",
  "nym-credentials",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "nym-network-defaults",
  "nym-validator-client",
  "rand 0.7.3",
@@ -4535,7 +4541,7 @@ dependencies = [
 [[package]]
 name = "nym-bin-common"
 version = "0.6.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "atty",
  "clap",
@@ -4553,7 +4559,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core"
 version = "1.1.15"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "async-trait",
  "base64 0.21.6",
@@ -4567,13 +4573,13 @@ dependencies = [
  "nym-bandwidth-controller",
  "nym-config",
  "nym-credential-storage",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "nym-explorer-client",
  "nym-gateway-client",
  "nym-gateway-requests",
  "nym-network-defaults",
  "nym-nonexhaustive-delayqueue",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "nym-sphinx",
  "nym-task",
  "nym-topology",
@@ -4624,7 +4630,7 @@ dependencies = [
 [[package]]
 name = "nym-coconut"
 version = "0.5.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "bls12_381",
  "bs58 0.5.0",
@@ -4633,8 +4639,8 @@ dependencies = [
  "getrandom 0.2.12",
  "group",
  "itertools 0.10.5",
- "nym-dkg 0.1.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-dkg 0.1.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "rand 0.8.5",
  "serde",
  "serde_derive",
@@ -4645,7 +4651,7 @@ dependencies = [
 [[package]]
 name = "nym-coconut-bandwidth-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -4655,21 +4661,21 @@ dependencies = [
 [[package]]
 name = "nym-coconut-dkg-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-utils",
  "cw2",
  "cw4",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "nym-multisig-contract-common",
 ]
 
 [[package]]
 name = "nym-config"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "dirs 5.0.1",
  "handlebars",
@@ -4696,7 +4702,7 @@ dependencies = [
 [[package]]
 name = "nym-contracts-common"
 version = "0.5.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "bs58 0.5.0",
  "cosmwasm-schema",
@@ -4709,7 +4715,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-storage"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "async-trait",
  "log",
@@ -4722,12 +4728,12 @@ dependencies = [
 [[package]]
 name = "nym-credential-utils"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "log",
  "nym-bandwidth-controller",
  "nym-client-core",
- "nym-coconut 0.5.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-coconut 0.5.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "nym-config",
  "nym-credential-storage",
  "nym-credentials",
@@ -4739,15 +4745,15 @@ dependencies = [
 [[package]]
 name = "nym-credentials"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "bincode",
  "bls12_381",
  "cosmrs",
  "log",
- "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "nym-validator-client",
  "serde",
  "thiserror",
@@ -4769,10 +4775,10 @@ dependencies = [
 [[package]]
 name = "nym-credentials-interface"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "bls12_381",
- "nym-coconut 0.5.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-coconut 0.5.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "serde",
  "thiserror",
 ]
@@ -4797,7 +4803,7 @@ dependencies = [
 [[package]]
 name = "nym-crypto"
 version = "0.4.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "aes 0.8.3",
  "blake3",
@@ -4809,8 +4815,8 @@ dependencies = [
  "generic-array 0.14.7",
  "hkdf 0.12.4",
  "hmac 0.12.1",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "rand 0.7.3",
  "serde",
  "serde_bytes",
@@ -4845,7 +4851,7 @@ dependencies = [
 [[package]]
 name = "nym-dkg"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "bitvec",
  "bls12_381",
@@ -4853,7 +4859,7 @@ dependencies = [
  "ff",
  "group",
  "lazy_static",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
@@ -4867,12 +4873,12 @@ dependencies = [
 [[package]]
 name = "nym-ephemera-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-utils",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
 ]
 
 [[package]]
@@ -4888,7 +4894,7 @@ dependencies = [
 [[package]]
 name = "nym-exit-policy"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "serde",
  "thiserror",
@@ -4910,11 +4916,11 @@ dependencies = [
 [[package]]
 name = "nym-explorer-api-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
- "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "schemars",
  "serde",
 ]
@@ -4922,10 +4928,10 @@ dependencies = [
 [[package]]
 name = "nym-explorer-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "log",
- "nym-explorer-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-explorer-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "reqwest",
  "serde",
  "thiserror",
@@ -4935,7 +4941,7 @@ dependencies = [
 [[package]]
 name = "nym-gateway-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "futures",
  "getrandom 0.2.12",
@@ -4944,10 +4950,10 @@ dependencies = [
  "nym-bandwidth-controller",
  "nym-credential-storage",
  "nym-credentials",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "nym-gateway-requests",
  "nym-network-defaults",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "nym-sphinx",
  "nym-task",
  "nym-validator-client",
@@ -4968,16 +4974,16 @@ dependencies = [
 [[package]]
 name = "nym-gateway-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "bs58 0.5.0",
  "futures",
  "generic-array 0.14.7",
  "log",
  "nym-credentials",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "nym-sphinx",
  "rand 0.7.3",
  "serde",
@@ -4990,7 +4996,7 @@ dependencies = [
 [[package]]
 name = "nym-group-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "cosmwasm-schema",
  "cw-controllers",
@@ -5002,11 +5008,11 @@ dependencies = [
 [[package]]
 name = "nym-ip-packet-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "bincode",
  "bytes",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "nym-sphinx",
  "rand 0.8.5",
  "serde",
@@ -5037,14 +5043,14 @@ dependencies = [
 [[package]]
 name = "nym-mixnet-contract-common"
 version = "0.6.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "bs58 0.4.0",
  "cosmwasm-schema",
  "cosmwasm-std",
  "humantime-serde",
  "log",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "schemars",
  "serde",
  "serde-json-wasm",
@@ -5056,7 +5062,7 @@ dependencies = [
 [[package]]
 name = "nym-multisig-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -5072,13 +5078,13 @@ dependencies = [
 [[package]]
 name = "nym-name-service-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-controllers",
  "cw-utils",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "serde",
  "thiserror",
 ]
@@ -5086,7 +5092,7 @@ dependencies = [
 [[package]]
 name = "nym-network-defaults"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "cfg-if",
  "dotenvy",
@@ -5118,15 +5124,15 @@ dependencies = [
 [[package]]
 name = "nym-node-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "async-trait",
  "base64 0.21.6",
  "http-api-client",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
- "nym-exit-policy 0.1.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
- "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-exit-policy 0.1.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "schemars",
  "serde",
  "serde_json",
@@ -5136,7 +5142,7 @@ dependencies = [
 [[package]]
 name = "nym-nonexhaustive-delayqueue"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -5147,7 +5153,7 @@ dependencies = [
 [[package]]
 name = "nym-ordered-buffer"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "log",
  "thiserror",
@@ -5156,7 +5162,7 @@ dependencies = [
 [[package]]
 name = "nym-outfox"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "blake3",
  "chacha20 0.9.1",
@@ -5182,7 +5188,7 @@ dependencies = [
 [[package]]
 name = "nym-pemstore"
 version = "0.3.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "pem",
 ]
@@ -5190,7 +5196,7 @@ dependencies = [
 [[package]]
 name = "nym-sdk"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "async-trait",
  "bip39",
@@ -5205,7 +5211,7 @@ dependencies = [
  "nym-credential-storage",
  "nym-credential-utils",
  "nym-credentials",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "nym-gateway-requests",
  "nym-network-defaults",
  "nym-ordered-buffer",
@@ -5226,24 +5232,24 @@ dependencies = [
 [[package]]
 name = "nym-service-provider-directory-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-controllers",
  "cw-utils",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "thiserror",
 ]
 
 [[package]]
 name = "nym-service-providers-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "async-trait",
  "log",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "nym-sphinx-anonymous-replies",
  "serde",
  "serde_json",
@@ -5253,7 +5259,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-client-core"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "anyhow",
  "dirs 4.0.0",
@@ -5262,9 +5268,9 @@ dependencies = [
  "nym-bandwidth-controller",
  "nym-client-core",
  "nym-config",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "nym-credential-storage",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "nym-network-defaults",
  "nym-service-providers-common",
  "nym-socks5-proxy-helpers",
@@ -5286,7 +5292,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-proxy-helpers"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "bytes",
  "futures",
@@ -5301,11 +5307,11 @@ dependencies = [
 [[package]]
 name = "nym-socks5-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "bincode",
  "log",
- "nym-exit-policy 0.1.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-exit-policy 0.1.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "nym-service-providers-common",
  "nym-sphinx-addressing",
  "serde",
@@ -5317,10 +5323,10 @@ dependencies = [
 [[package]]
 name = "nym-sphinx"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "log",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "nym-sphinx-acknowledgements",
  "nym-sphinx-addressing",
  "nym-sphinx-anonymous-replies",
@@ -5330,7 +5336,7 @@ dependencies = [
  "nym-sphinx-framing",
  "nym-sphinx-params",
  "nym-sphinx-routing",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "nym-topology",
  "rand 0.7.3",
  "rand_distr",
@@ -5341,14 +5347,14 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-acknowledgements"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "nym-sphinx-addressing",
  "nym-sphinx-params",
  "nym-sphinx-routing",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "nym-topology",
  "rand 0.7.3",
  "thiserror",
@@ -5358,10 +5364,10 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-addressing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "serde",
  "thiserror",
 ]
@@ -5369,14 +5375,14 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-anonymous-replies"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "bs58 0.5.0",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "nym-sphinx-addressing",
  "nym-sphinx-params",
  "nym-sphinx-routing",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "nym-topology",
  "rand 0.7.3",
  "serde",
@@ -5387,12 +5393,12 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-chunking"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "log",
  "nym-sphinx-addressing",
  "nym-sphinx-params",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "rand 0.7.3",
  "thiserror",
 ]
@@ -5400,16 +5406,16 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-cover"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "nym-sphinx-acknowledgements",
  "nym-sphinx-addressing",
  "nym-sphinx-chunking",
  "nym-sphinx-forwarding",
  "nym-sphinx-params",
  "nym-sphinx-routing",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "nym-topology",
  "rand 0.7.3",
  "thiserror",
@@ -5418,23 +5424,23 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-forwarding"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "nym-outfox",
  "nym-sphinx-addressing",
  "nym-sphinx-params",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "thiserror",
 ]
 
 [[package]]
 name = "nym-sphinx-framing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "bytes",
  "nym-sphinx-params",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "thiserror",
  "tokio-util",
 ]
@@ -5442,10 +5448,10 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-params"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "serde",
  "thiserror",
 ]
@@ -5453,10 +5459,10 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-routing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "nym-sphinx-addressing",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "thiserror",
 ]
 
@@ -5472,7 +5478,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-types"
 version = "0.2.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "nym-outfox",
  "sphinx-packet",
@@ -5482,7 +5488,7 @@ dependencies = [
 [[package]]
 name = "nym-task"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "futures",
  "log",
@@ -5496,19 +5502,19 @@ dependencies = [
 [[package]]
 name = "nym-topology"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "async-trait",
  "bs58 0.5.0",
  "log",
- "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "nym-config",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "nym-sphinx-addressing",
  "nym-sphinx-routing",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "rand 0.7.3",
  "semver 0.11.0",
  "serde",
@@ -5519,7 +5525,7 @@ dependencies = [
 [[package]]
 name = "nym-validator-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -5539,15 +5545,15 @@ dependencies = [
  "http-api-client",
  "itertools 0.10.5",
  "log",
- "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
- "nym-coconut 0.5.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-coconut 0.5.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "nym-coconut-bandwidth-contract-common",
  "nym-coconut-dkg-common",
  "nym-config",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "nym-ephemera-common",
  "nym-group-contract-common",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "nym-multisig-contract-common",
  "nym-name-service-common",
  "nym-network-defaults",
@@ -5569,12 +5575,12 @@ dependencies = [
 [[package]]
 name = "nym-vesting-contract-common"
 version = "0.7.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "serde",
  "thiserror",
 ]
@@ -5628,21 +5634,19 @@ dependencies = [
  "lazy_static",
  "log",
  "nix 0.23.2",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "nym-client-core",
  "nym-config",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
- "nym-explorer-client",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "nym-ip-packet-requests",
- "nym-node-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-node-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "nym-sdk",
  "nym-task",
  "nym-validator-client",
- "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "oslog",
  "rand 0.7.3",
  "rand 0.8.5",
- "reqwest",
  "serde",
  "serde_json",
  "signature 1.4.0",
@@ -5655,12 +5659,10 @@ dependencies = [
  "tap",
  "thiserror",
  "tokio",
- "tokio-tungstenite",
  "tokio-util",
  "tracing",
  "tracing-subscriber",
  "tun2",
- "tungstenite",
  "uniffi",
  "url",
 ]
@@ -5682,13 +5684,13 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-types"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "base64 0.21.6",
  "dashmap",
  "hmac 0.12.1",
  "log",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d)",
  "serde",
  "sha2 0.10.8",
  "thiserror",
@@ -5703,6 +5705,17 @@ checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
 dependencies = [
  "malloc_buf",
  "objc_exception",
+]
+
+[[package]]
+name = "objc-foundation"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
+dependencies = [
+ "block",
+ "objc",
+ "objc_id",
 ]
 
 [[package]]
@@ -6815,12 +6828,13 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.24.1",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
- "webpki-roots 0.25.4",
  "winreg 0.50.0",
 ]
 
@@ -6842,6 +6856,30 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac 0.12.1",
  "subtle 2.4.1",
+]
+
+[[package]]
+name = "rfd"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0149778bd99b6959285b0933288206090c50e2327f47a9c463bfdbf45c8823ea"
+dependencies = [
+ "block",
+ "dispatch",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "objc",
+ "objc-foundation",
+ "objc_id",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows 0.37.0",
 ]
 
 [[package]]
@@ -7785,7 +7823,7 @@ dependencies = [
  "thiserror",
  "tokio-stream",
  "url",
- "webpki-roots 0.22.6",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -8391,6 +8429,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0da520ff07c0745199204f7a7a62a8c6ee1666313b792b051ca170eca04649aa"
 dependencies = [
  "anyhow",
+ "base64 0.21.6",
+ "bytes",
  "cocoa",
  "dirs-next",
  "dunce",
@@ -8404,6 +8444,8 @@ dependencies = [
  "heck 0.4.1",
  "http",
  "ignore",
+ "indexmap 1.9.3",
+ "minisign-verify",
  "objc",
  "once_cell",
  "open",
@@ -8411,6 +8453,8 @@ dependencies = [
  "rand 0.8.5",
  "raw-window-handle",
  "regex",
+ "reqwest",
+ "rfd",
  "semver 1.0.21",
  "serde",
  "serde_json",
@@ -8424,12 +8468,14 @@ dependencies = [
  "tauri-utils",
  "tempfile",
  "thiserror",
+ "time",
  "tokio",
  "url",
  "uuid 1.6.1",
  "webkit2gtk",
  "webview2-com",
  "windows 0.39.0",
+ "zip",
 ]
 
 [[package]]
@@ -8902,7 +8948,6 @@ checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.21.10",
  "tokio",
  "tungstenite",
 ]
@@ -9345,7 +9390,6 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
- "rustls 0.21.10",
  "sha1",
  "thiserror",
  "url",
@@ -9808,9 +9852,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
 
 [[package]]
+name = "wasm-streams"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4609d447824375f43e1ffbc051b50ad8f4b3ae8219680c94452ea05eb240ac7"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-utils"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=fa8e81d9dd1e93e133c666ef777757edd7fdce25#fa8e81d9dd1e93e133c666ef777757edd7fdce25"
+source = "git+https://github.com/nymtech/nym?rev=bd0cbbc18a305624a684473385f466cc086cdd5d#bd0cbbc18a305624a684473385f466cc086cdd5d"
 dependencies = [
  "futures",
  "getrandom 0.2.12",
@@ -9914,12 +9971,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
-
-[[package]]
 name = "webview2-com"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10013,6 +10064,19 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57b543186b344cc61c85b5aab0d2e3adf4e0f99bc076eff9aa5927bcc0b8a647"
+dependencies = [
+ "windows_aarch64_msvc 0.37.0",
+ "windows_i686_gnu 0.37.0",
+ "windows_i686_msvc 0.37.0",
+ "windows_x86_64_gnu 0.37.0",
+ "windows_x86_64_msvc 0.37.0",
+]
 
 [[package]]
 name = "windows"
@@ -10235,6 +10299,12 @@ checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2623277cb2d1c216ba3b578c0f3cf9cdebeddb6e66b1b218bb33596ea7769c3a"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7711666096bd4096ffa835238905bb33fb87267910e154b18b44eaabb340f2"
@@ -10262,6 +10332,12 @@ name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3925fd0b0b804730d44d4b6278c50f9699703ec49bcd628020f46f4ba07d9e1"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -10295,6 +10371,12 @@ checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce907ac74fe331b524c1298683efbf598bb031bc84d5e274db2083696d07c57c"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bc7cbfe58828921e10a9f446fcaaf649204dcfe6c1ddd712c5eebae6bda1106"
@@ -10322,6 +10404,12 @@ name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2babfba0828f2e6b32457d5341427dcbb577ceef556273229959ac23a10af33d"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -10370,6 +10458,12 @@ name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4dd6dc7df2d84cf7b33822ed5b86318fb1781948e9663bacd047fc9dd52259d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -10593,6 +10687,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/nym-vpn-desktop/src-tauri/Cargo.toml
+++ b/nym-vpn-desktop/src-tauri/Cargo.toml
@@ -12,7 +12,7 @@ tauri-build = { version = "1.5", features = [] }
 build-info-build = "0.0.34"
 
 [dependencies]
-tauri = { version = "1.6.0", features = [ "updater", "process-all", "shell-open"] }
+tauri = { version = "1.6.0", features = [ "process-all", "shell-open"] }
 tokio = { version = "1.33", features = ["rt", "sync", "time", "fs"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/nym-vpn-desktop/src-tauri/Cargo.toml
+++ b/nym-vpn-desktop/src-tauri/Cargo.toml
@@ -12,7 +12,7 @@ tauri-build = { version = "1.5", features = [] }
 build-info-build = "0.0.34"
 
 [dependencies]
-tauri = { version = "1.6.0", features = ["process-all", "shell-open"] }
+tauri = { version = "1.6.0", features = [ "updater", "process-all", "shell-open"] }
 tokio = { version = "1.33", features = ["rt", "sync", "time", "fs"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/nym-vpn-desktop/src-tauri/Cargo.toml
+++ b/nym-vpn-desktop/src-tauri/Cargo.toml
@@ -12,7 +12,7 @@ tauri-build = { version = "1.5", features = [] }
 build-info-build = "0.0.34"
 
 [dependencies]
-tauri = { version = "1.6.0", features = [ "process-all", "shell-open"] }
+tauri = { version = "1.6.0", features = [ "updater", "process-all", "shell-open"] }
 tokio = { version = "1.33", features = ["rt", "sync", "time", "fs"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/nym-vpn-desktop/src-tauri/tauri.conf.json
+++ b/nym-vpn-desktop/src-tauri/tauri.conf.json
@@ -11,7 +11,7 @@
   },
   "tauri": {
     "updater": {
-      "active": false,
+      "active": true,
       "dialog": false,
       "endpoints": [
         "https://releases.myapp.com/{{target}}/{{arch}}/{{current_version}}"

--- a/nym-vpn-desktop/src-tauri/tauri.conf.json
+++ b/nym-vpn-desktop/src-tauri/tauri.conf.json
@@ -11,12 +11,12 @@
   },
   "tauri": {
     "updater": {
-      "active": false,
+      "active": true,
+      "dialog": false,
       "endpoints": [
         "https://releases.myapp.com/{{target}}/{{arch}}/{{current_version}}"
       ],
-      "dialog": true,
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDUxMjFCMDhFOTczQzE5MjUKUldRbEdUeVhqckFoVVljRDZNZkRQZzIyYTBSZUVmSk1SVUlaTC9OeTk0NDFYUVl1blhWV2VTQi8K"
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDU3RjI2N0FFRUEyRERGOEQKUldTTjN5M3FybWZ5VjhxOFRsLzQ2c1N0NW1PVVNxVEVVQkszYjZHc3RtcEFDOW1ZN2lIN1NGdk0K"
     },
     "allowlist": {
       "all": false,

--- a/nym-vpn-desktop/src-tauri/tauri.conf.json
+++ b/nym-vpn-desktop/src-tauri/tauri.conf.json
@@ -11,7 +11,7 @@
   },
   "tauri": {
     "updater": {
-      "active": true,
+      "active": false,
       "dialog": false,
       "endpoints": [
         "https://releases.myapp.com/{{target}}/{{arch}}/{{current_version}}"


### PR DESCRIPTION
- update tauri config to activate updater
- update desktop release workflow to include generated tauri update bundles in the release uploaded files

####  tl;dr

When tauri updater feature is enabled, and signing keys properly provided, `tauri build` will generate update bundle artifacts

**linux**
- `nym-vpn.AppImage.tar.gz` - bundle
- `nym-vpn.AppImage.tar.gz.sig` - the signature

**mac**
- `nym-vpn.app.tar.gz`
- `nym-vpn.app.tar.gz.sig`

This PR enable tauri updater and upload bundle/sig along other release artifacts