### PR TITLE
refactor(desktop): drop get_db_batch switch to db direct access

### DIFF
--- a/nym-vpn-desktop/src-tauri/src/commands/db.rs
+++ b/nym-vpn-desktop/src-tauri/src/commands/db.rs
@@ -1,12 +1,11 @@
 use serde::{Deserialize, Serialize};
 use tauri::State;
-use tracing::{debug, instrument, trace};
+use tracing::{debug, instrument};
 use ts_rs::TS;
 
 use crate::{
     db::{Db, DbError, JsonValue, Key},
     error::{CmdError, CmdErrorSource},
-    states::app::{NodeLocation, VpnMode},
 };
 
 #[derive(Default, Serialize, Deserialize, Debug, Clone, TS)]
@@ -16,81 +15,6 @@ pub enum UiTheme {
     #[default]
     Light,
     System,
-}
-
-#[derive(Default, Serialize, Deserialize, Debug, Clone, TS)]
-#[ts(export)]
-pub struct AppData {
-    pub monitoring: Option<bool>,
-    pub autoconnect: Option<bool>,
-    pub entry_location_enabled: Option<bool>,
-    pub ui_theme: Option<UiTheme>,
-    pub ui_root_font_size: Option<u32>,
-    pub vpn_mode: Option<VpnMode>,
-    pub entry_node_location: Option<NodeLocation>,
-    pub exit_node_location: Option<NodeLocation>,
-}
-
-#[instrument(skip_all)]
-#[tauri::command]
-pub async fn db_get_batch(db: State<'_, Db>) -> Result<AppData, CmdError> {
-    debug!("db_get_batch");
-    let err_msg = "Failed to retrieve db data".to_string();
-    let entry_node_location = db
-        .get_typed::<NodeLocation>(Key::EntryNodeLocation)
-        .map_err(|_| CmdError::new(CmdErrorSource::InternalError, err_msg.clone()))?;
-    let exit_node_location = db
-        .get_typed::<NodeLocation>(Key::ExitNodeLocation)
-        .map_err(|_| CmdError::new(CmdErrorSource::InternalError, err_msg.clone()))?;
-    let vpn_mode = db
-        .get_typed::<VpnMode>(Key::VpnMode)
-        .map_err(|_| CmdError::new(CmdErrorSource::InternalError, err_msg.clone()))?;
-    let ui_theme = db
-        .get_typed::<UiTheme>(Key::UiTheme)
-        .map_err(|_| CmdError::new(CmdErrorSource::InternalError, err_msg.clone()))?;
-    let entry_location_enabled = db
-        .get_typed::<bool>(Key::EntryLocationEnabled)
-        .map_err(|_| CmdError::new(CmdErrorSource::InternalError, err_msg.clone()))?;
-    let ui_root_font_size = db
-        .get_typed::<u32>(Key::UiRootFontSize)
-        .map_err(|_| CmdError::new(CmdErrorSource::InternalError, err_msg.clone()))?;
-    let monitoring = db
-        .get_typed::<bool>(Key::Monitoring)
-        .map_err(|_| CmdError::new(CmdErrorSource::InternalError, err_msg.clone()))?;
-    let autoconnect = db
-        .get_typed::<bool>(Key::Autoconnect)
-        .map_err(|_| CmdError::new(CmdErrorSource::InternalError, err_msg.clone()))?;
-
-    trace!(
-        r"
-entry_node_location: {:?}
-exit_node_location: {:?}
-vpn_mode: {:?}
-ui_theme: {:?}
-entry_location_enabled: {:?}
-ui_root_font_size: {:?}
-monitoring: {:?}
-autoconnect: {:?}",
-        entry_node_location,
-        exit_node_location,
-        vpn_mode,
-        ui_theme,
-        entry_location_enabled,
-        ui_root_font_size,
-        monitoring,
-        autoconnect
-    );
-
-    Ok(AppData {
-        entry_node_location,
-        exit_node_location,
-        vpn_mode,
-        ui_theme,
-        entry_location_enabled,
-        ui_root_font_size,
-        monitoring,
-        autoconnect,
-    })
 }
 
 #[instrument(skip(db))]

--- a/nym-vpn-desktop/src-tauri/src/db.rs
+++ b/nym-vpn-desktop/src-tauri/src/db.rs
@@ -135,6 +135,7 @@ impl Db {
                 DbError::Deserialize(e)
             });
 
+        info!("get key [{key}] with value {res:?}");
         self.discard_deserialize(key, res)
     }
 
@@ -150,6 +151,7 @@ impl Db {
                 DbError::Deserialize(e)
             });
 
+        info!("get key [{key}] with value {res:?}");
         self.discard_deserialize(key, res)
     }
 

--- a/nym-vpn-desktop/src-tauri/src/main.rs
+++ b/nym-vpn-desktop/src-tauri/src/main.rs
@@ -147,7 +147,6 @@ async fn main() -> Result<()> {
             cmd_db::db_set,
             cmd_db::db_get,
             cmd_db::db_flush,
-            cmd_db::db_get_batch,
             node_location::get_node_location,
             node_location::set_node_location,
             node_location::get_fastest_node_location,

--- a/nym-vpn-desktop/src/dev/setup.ts
+++ b/nym-vpn-desktop/src/dev/setup.ts
@@ -1,11 +1,7 @@
 import { mockIPC, mockWindows } from '@tauri-apps/api/mocks';
 import { emit } from '@tauri-apps/api/event';
-import {
-  AppDataFromBackend,
-  ConnectionState,
-  NodeLocationBackend,
-} from '../types';
-import { ConnectionEvent, DefaultNodeCountry } from '../constants';
+import { ConnectionState, NodeLocationBackend } from '../types';
+import { ConnectionEvent } from '../constants';
 import { Country } from '../types';
 
 export function mockTauriIPC() {
@@ -76,27 +72,6 @@ export function mockTauriIPC() {
         resolve({
           name: 'France',
           code: 'FR',
-        }),
-      );
-    }
-
-    if (cmd === 'set_root_font_size') {
-      return new Promise<void>((resolve) => resolve());
-    }
-
-    if (cmd === 'db_get_batch') {
-      return new Promise<AppDataFromBackend>((resolve) =>
-        resolve({
-          monitoring: false,
-          autoconnect: false,
-          entry_location_enabled: false,
-          ui_theme: 'Dark',
-          ui_root_font_size: 12,
-          vpn_mode: 'TwoHop',
-          // entry_node_location: 'Fastest',
-          // exit_node_location: 'Fastest',
-          entry_node_location: { Country: DefaultNodeCountry },
-          exit_node_location: { Country: DefaultNodeCountry },
         }),
       );
     }

--- a/nym-vpn-desktop/src/state/init.ts
+++ b/nym-vpn-desktop/src/state/init.ts
@@ -2,16 +2,17 @@ import { invoke } from '@tauri-apps/api';
 import { getVersion } from '@tauri-apps/api/app';
 import { appWindow } from '@tauri-apps/api/window';
 import { DefaultRootFontSize, DefaultThemeMode } from '../constants';
+import { kvGet } from '../kvStore';
 import {
-  AppDataFromBackend,
   ConnectionState,
   Country,
   NodeLocationBackend,
   StateDispatch,
+  ThemeMode,
   UiTheme,
+  VpnMode,
 } from '../types';
 import fireRequests, { TauriReq } from './helper';
-import { initialState } from './main';
 
 // initialize connection state
 const getInitialConnectionState = async () => {
@@ -52,12 +53,11 @@ const getFastestNodeLocation = async () => {
   return await invoke<Country>('get_fastest_node_location');
 };
 
-// get saved on disk app data and restore state from it
-const getAppData = async () => {
-  const theme = await appWindow.theme();
-  const winTheme: UiTheme = theme === 'dark' ? 'Dark' : 'Light';
-  const appData = await invoke<AppDataFromBackend>('db_get_batch');
-  return { winTheme, data: appData };
+const getTheme = async () => {
+  const winTheme: UiTheme =
+    (await appWindow.theme()) === 'dark' ? 'Dark' : 'Light';
+  const themeMode = await kvGet<ThemeMode>('UiTheme');
+  return { winTheme, themeMode };
 };
 
 async function init(dispatch: StateDispatch) {
@@ -149,44 +149,65 @@ async function init(dispatch: StateDispatch) {
     },
   };
 
-  const getSavedAppDataRq: TauriReq<typeof getAppData> = {
-    name: 'get_app_data',
-    request: () => getAppData(),
-    onFulfilled: ({ winTheme, data }) => {
-      console.log('app data read from disk:');
-      console.log(data);
-
-      if (data.ui_root_font_size) {
-        document.documentElement.style.fontSize = `${data.ui_root_font_size}px`;
-      }
-
+  const getThemeRq: TauriReq<typeof getTheme> = {
+    name: 'getTheme',
+    request: () => getTheme(),
+    onFulfilled: ({ winTheme, themeMode }) => {
       let uiTheme: UiTheme = 'Light';
-      if (data.ui_theme === 'System') {
+      if (themeMode === 'System') {
         uiTheme = winTheme;
       } else {
         // if no theme has been saved, fallback to system theme
-        uiTheme = data.ui_theme || winTheme;
+        uiTheme = themeMode || winTheme;
       }
+      dispatch({ type: 'set-ui-theme', theme: uiTheme });
+      dispatch({ type: 'set-theme-mode', mode: themeMode || DefaultThemeMode });
+    },
+  };
 
-      const partialState: Partial<typeof initialState> = {
-        entrySelector: data.entry_location_enabled || false,
-        uiTheme,
-        themeMode: data.ui_theme || DefaultThemeMode,
-        vpnMode: data.vpn_mode || 'TwoHop',
-        autoConnect: data.autoconnect || false,
-        monitoring: data.monitoring || false,
-        rootFontSize: data.ui_root_font_size || DefaultRootFontSize,
-      };
+  const getVpnModeRq: TauriReq<() => Promise<VpnMode | undefined>> = {
+    name: 'getVpnMode',
+    request: () => kvGet<VpnMode>('VpnMode'),
+    onFulfilled: (vpnMode) => {
+      dispatch({ type: 'set-vpn-mode', mode: vpnMode || 'TwoHop' });
+    },
+  };
+
+  const getRootFontSizeRq: TauriReq<() => Promise<number | undefined>> = {
+    name: 'getRootFontSize',
+    request: () => kvGet<number>('UiRootFontSize'),
+    onFulfilled: (size) => {
+      // if a font size was saved, set the UI font size accordingly
+      if (size) {
+        document.documentElement.style.fontSize = `${size}px`;
+      }
       dispatch({
-        type: 'set-partial-state',
-        partialState,
+        type: 'set-root-font-size',
+        size: size || DefaultRootFontSize,
       });
+    },
+  };
+
+  const getEntrySelectorRq: TauriReq<() => Promise<boolean | undefined>> = {
+    name: 'getEntrySelector',
+    request: () => kvGet<boolean>('EntryLocationEnabled'),
+    onFulfilled: (enabled) => {
+      dispatch({ type: 'set-entry-selector', entrySelector: enabled || false });
+    },
+  };
+
+  const getMonitoringRq: TauriReq<() => Promise<boolean | undefined>> = {
+    name: 'getMonitoring',
+    request: () => kvGet<boolean>('Monitoring'),
+    onFulfilled: (monitoring) => {
+      dispatch({ type: 'set-monitoring', monitoring: monitoring || false });
     },
   };
 
   // fire all requests concurrently
   await fireRequests([
     initStateRq,
+    getVpnModeRq,
     syncConTimeRq,
     getEntryCountriesRq,
     getExitCountriesRq,
@@ -194,7 +215,10 @@ async function init(dispatch: StateDispatch) {
     getExitLocationRq,
     getFastestLocationRq,
     getVersionRq,
-    getSavedAppDataRq,
+    getThemeRq,
+    getRootFontSizeRq,
+    getEntrySelectorRq,
+    getMonitoringRq,
   ]);
 }
 

--- a/nym-vpn-desktop/src/state/main.ts
+++ b/nym-vpn-desktop/src/state/main.ts
@@ -18,7 +18,6 @@ import {
 
 export type StateAction =
   | { type: 'init-done' }
-  | { type: 'set-partial-state'; partialState: Partial<AppState> }
   | { type: 'change-connection-state'; state: ConnectionState }
   | { type: 'set-vpn-mode'; mode: VpnMode }
   | { type: 'set-entry-selector'; entrySelector: boolean }
@@ -120,9 +119,6 @@ export function reducer(state: AppState, action: StateAction): AppState {
         ...state,
         exitCountryList: action.payload.countries,
       };
-    case 'set-partial-state': {
-      return { ...state, ...action.partialState };
-    }
     case 'change-connection-state': {
       console.log(
         `__REDUCER [change-connection-state] changing connection state to ${action.state}`,

--- a/nym-vpn-desktop/src/types/app-data.ts
+++ b/nym-vpn-desktop/src/types/app-data.ts
@@ -1,17 +1,3 @@
-import { VpnMode } from './app-state';
 import { Country } from './common';
 
 export type NodeLocationBackend = 'Fastest' | { Country: Country };
-export type UiThemeBackend = 'System' | 'Dark' | 'Light';
-
-// tauri type, hence the use of snake_case
-export interface AppDataFromBackend {
-  monitoring: boolean | null;
-  autoconnect: boolean | null;
-  entry_location_enabled: boolean | null;
-  ui_theme: UiThemeBackend | null;
-  ui_root_font_size: number | null;
-  vpn_mode: VpnMode | null;
-  entry_node_location: NodeLocationBackend | null;
-  exit_node_location: NodeLocationBackend | null;
-}


### PR DESCRIPTION
followup PR to continue the refactoring/cleanup job switch to k/v store

- drop `AppData` structure since we dont need it anymore, JS side is embracing the power of direct live access to k/v db 😈 