### PR TITLE
Add build-info output to desktop releases

### DIFF
--- a/.github/workflows/release-nym-vpn-cli.yml
+++ b/.github/workflows/release-nym-vpn-cli.yml
@@ -246,7 +246,7 @@ jobs:
       - if: env.TAG_NAME != 'nightly'
         run: |
           (echo "SUBJECT=$TAG_NAME"
-           echo 'PRERELEASE=--prerelease'
+           echo 'PRERELEASE='
            echo 'NOTES_FILE=release-notes.md') >> $GITHUB_ENV
 
       # Recall that download-artifact will extract into a directory that

--- a/.github/workflows/release-nym-vpn-desktop.yml
+++ b/.github/workflows/release-nym-vpn-desktop.yml
@@ -247,7 +247,7 @@ jobs:
       - name: Generate build info (${{ env.PLATFORM_ARCH }})
         if: contains(matrix.os, 'ubuntu-22.04')
         run: |
-          ./src-tauri/target/release/bundle/appimage/nym-vpn_*-dev_amd64.AppImage --build-info > build-info.txt
+          ./nym-vpn-desktop/src-tauri/target/release/bundle/appimage/nym-vpn_*-dev_amd64.AppImage --build-info > build-info.txt
           cat build-info.txt
 
       - name: Upload build-info (${{ env.PLATFORM_ARCH }})

--- a/.github/workflows/release-nym-vpn-desktop.yml
+++ b/.github/workflows/release-nym-vpn-desktop.yml
@@ -247,7 +247,7 @@ jobs:
       - name: Generate build info (${{ env.PLATFORM_ARCH }})
         if: contains(matrix.os, 'ubuntu-22.04')
         run: |
-          ./src-tauri/target/release/bundle/appimage/nym-vpn_0.0.7-dev_amd64.AppImage --build-info > build-info.txt
+          ./src-tauri/target/release/bundle/appimage/nym-vpn_*-dev_amd64.AppImage --build-info > build-info.txt
           cat build-info.txt
 
       - name: Upload build-info (${{ env.PLATFORM_ARCH }})

--- a/.github/workflows/release-nym-vpn-desktop.yml
+++ b/.github/workflows/release-nym-vpn-desktop.yml
@@ -61,7 +61,7 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y libdbus-1-dev libmnl-dev libnftnl-dev \
             protobuf-compiler libwebkit2gtk-4.0-dev build-essential curl wget libssl-dev \
-            libgtk-3-dev squashfs-tools libayatana-appindicator3-dev make
+            libgtk-3-dev squashfs-tools libayatana-appindicator3-dev make libfuse2
 
       - name: Get package version
         id: package-version

--- a/.github/workflows/release-nym-vpn-desktop.yml
+++ b/.github/workflows/release-nym-vpn-desktop.yml
@@ -309,7 +309,7 @@ jobs:
       - if: env.TAG_NAME != 'nightly-desktop'
         run: |
           (echo "SUBJECT=$TAG_NAME"
-           echo 'PRERELEASE=--prerelease'
+           echo 'PRERELEASE='
            echo 'NOTES_FILE=release-notes-desktop.md') >> $GITHUB_ENV
 
       # Recall that download-artifact will extract into a directory that

--- a/.github/workflows/release-nym-vpn-desktop.yml
+++ b/.github/workflows/release-nym-vpn-desktop.yml
@@ -247,7 +247,7 @@ jobs:
       - name: Generate build info (${{ env.PLATFORM_ARCH }})
         if: contains(matrix.os, 'ubuntu-22.04')
         run: |
-          ./nym-vpn-desktop/src-tauri/target/release/bundle/appimage/nym-vpn_*-dev_amd64.AppImage --build-info > build-info.txt
+          ./nym-vpn-desktop/src-tauri/target/release/bundle/appimage/nym-vpn_*_amd64.AppImage --build-info > build-info.txt
           cat build-info.txt
 
       - name: Upload build-info (${{ env.PLATFORM_ARCH }})

--- a/.github/workflows/release-nym-vpn-desktop.yml
+++ b/.github/workflows/release-nym-vpn-desktop.yml
@@ -247,7 +247,7 @@ jobs:
       - name: Generate build info (${{ env.PLATFORM_ARCH }})
         if: contains(matrix.os, 'ubuntu-22.04')
         run: |
-          echo ${{ steps.package-version.outputs.metadata }} > build-info.txt
+          ./src-tauri/target/release/bundle/appimage/nym-vpn_0.0.7-dev_amd64.AppImage --build-info > build-info.txt
           cat build-info.txt
 
       - name: Upload build-info (${{ env.PLATFORM_ARCH }})

--- a/nym-vpn-desktop/src-tauri/src/cli.rs
+++ b/nym-vpn-desktop/src-tauri/src/cli.rs
@@ -49,7 +49,7 @@ rustc channel:   {}
         info.compiler.version,
         info.compiler.channel,
     );
-    if let Some(git) = info.version_control.as_ref().unwrap().git() {
+    if let Some(git) = info.version_control.as_ref().and_then(|vc| vc.git()) {
         println!(
             r"commit sha:      {}
 commit date:     {}


### PR DESCRIPTION
- **Manual releases should not be prerelease anymore**
- **Proper build info for desktop client in release notes**
