### PR TITLE
Return strongly typed errors from nym-vpn-lib

### DIFF
--- a/nym-vpn-desktop/src-tauri/Cargo.lock
+++ b/nym-vpn-desktop/src-tauri/Cargo.lock
@@ -914,6 +914,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
 name = "chacha"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3517,12 +3523,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c429fffa658f288669529fc26565f728489a2e39bc7b24a428aaaf51355182e"
 
 [[package]]
-name = "ioctl-sys"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bd11f3a29434026f5ff98c730b668ba74b1033637b8817940b54d040696133c"
-
-[[package]]
 name = "ipconfig"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3789,9 +3789,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.152"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libdbus-sys"
@@ -4316,6 +4316,18 @@ checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.4.1",
+ "cfg-if",
+ "cfg_aliases",
  "libc",
 ]
 
@@ -6101,7 +6113,7 @@ dependencies = [
  "derive_builder",
  "errno 0.2.8",
  "error-chain",
- "ioctl-sys 0.6.0",
+ "ioctl-sys",
  "ipnetwork",
  "libc",
 ]
@@ -9310,22 +9322,24 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbc25e23adc6cac7dd895ce2780f255902290fc39b00e1ae3c33e89f3d20fa66"
 dependencies = [
- "ioctl-sys 0.6.0",
+ "ioctl-sys",
  "libc",
  "thiserror",
 ]
 
 [[package]]
 name = "tun2"
-version = "1.0.1"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0bc4dcfe2bca93d2acc036d09242ece6a778f807428980586677a8c6c556171"
+checksum = "a0fdabd4855ef6e8a27bce19f1c424493ec742a331db7ccc82bec7ed877ba383"
 dependencies = [
  "bytes",
+ "cfg-if",
  "futures-core",
- "ioctl-sys 0.8.0",
+ "ipnet",
  "libc",
  "log",
+ "nix 0.28.0",
  "thiserror",
  "tokio",
  "tokio-util",

--- a/nym-vpn-desktop/src-tauri/src/vpn_client.rs
+++ b/nym-vpn-desktop/src-tauri/src/vpn_client.rs
@@ -5,7 +5,7 @@ use futures::StreamExt;
 use nym_vpn_lib::gateway_client::{Config as GatewayClientConfig, EntryPoint, ExitPoint};
 use nym_vpn_lib::nym_config::defaults::var_names::{EXPLORER_API, NYM_API};
 use nym_vpn_lib::nym_config::OptionalSet;
-use nym_vpn_lib::{NymVpn, NymVpnExitError, NymVpnExitStatusMessage, StatusReceiver};
+use nym_vpn_lib::{NymVpn, NymVpnExitStatusMessage, StatusReceiver};
 use tauri::Manager;
 use time::OffsetDateTime;
 use tracing::{debug, error, info, instrument, trace};

--- a/nym-vpn-lib/src/error.rs
+++ b/nym-vpn-lib/src/error.rs
@@ -49,7 +49,7 @@ pub enum Error {
     #[error("recipient is not formatted correctly")]
     RecipientFormattingError,
 
-    #[error("{0}")]
+    #[error("failed setting up local TUN network device: {0}")]
     TunError(#[from] tun2::Error),
 
     #[error("{0}")]

--- a/nym-vpn-lib/src/error.rs
+++ b/nym-vpn-lib/src/error.rs
@@ -22,8 +22,10 @@ pub enum Error {
     #[error("{0}")]
     DNSError(#[from] talpid_core::dns::Error),
 
+    // We are not returning the underlying talpid_core::firewall:Error error as I ran into issues
+    // with the Send marker trait not being implemented when building on Mac. Possibly we can fix
+    // this in the future.
     #[error("{0}")]
-    // FirewallError(#[from] talpid_core::firewall::Error),
     FirewallError(String),
 
     #[error("{0}")]

--- a/nym-vpn-lib/src/error.rs
+++ b/nym-vpn-lib/src/error.rs
@@ -23,7 +23,8 @@ pub enum Error {
     DNSError(#[from] talpid_core::dns::Error),
 
     #[error("{0}")]
-    FirewallError(#[from] talpid_core::firewall::Error),
+    // FirewallError(#[from] talpid_core::firewall::Error),
+    FirewallError(String),
 
     #[error("{0}")]
     WireguardError(#[from] talpid_wireguard::Error),

--- a/nym-vpn-lib/src/lib.rs
+++ b/nym-vpn-lib/src/lib.rs
@@ -186,8 +186,8 @@ impl NymVpn {
             self.enable_two_hop,
         )
         .await?;
-        info!("Successfully connected to IP packet router on the exit gateway!");
-        info!("Using IP addresses: {ips}");
+        info!("Successfully connected to IP packet router!");
+        info!("Using mixnet VPN IP addresses: {ips}");
 
         // We need the IP of the gateway to correctly configure the routing table
         let mixnet_client_address = mixnet_client.nym_address().await;
@@ -327,11 +327,13 @@ impl NymVpn {
         // The IP address of the gateway inside the tunnel. This will depend on if wireguard is
         // enabled
         let tunnel_gateway_ip = routing::TunnelGatewayIp::new(wireguard_config.clone());
-        info!("tunnel_gateway_ip: {tunnel_gateway_ip}");
+        if self.enable_wireguard {
+            info!("Wireguard tunnel gateway ip: {tunnel_gateway_ip}");
+        }
 
         // Get the IP address of the local LAN gateway
         let default_lan_gateway_ip = routing::LanGatewayIp::get_default_interface()?;
-        info!("default_lan_gateway_ip: {default_lan_gateway_ip}");
+        debug!("default_lan_gateway_ip: {default_lan_gateway_ip}");
 
         let task_manager = TaskManager::new(10);
 

--- a/nym-vpn-lib/src/lib.rs
+++ b/nym-vpn-lib/src/lib.rs
@@ -507,7 +507,6 @@ pub enum NymVpnCtrlMessage {
 // not all error cases satisfied the Sync marker trait.
 #[derive(thiserror::Error, Debug)]
 pub enum NymVpnExitError {
-    // Generic { reason: String },
     #[error("{reason}")]
     Generic { reason: Error },
 
@@ -518,14 +517,6 @@ pub enum NymVpnExitError {
     #[error("failed to reset dns monitor: {reason}")]
     FailedToResetDnsMonitor { reason: String },
 }
-
-// impl NymVpnExitError {
-//     fn generic(err: &dyn std::error::Error) -> Self {
-//         NymVpnExitError::Generic {
-//             reason: err.to_string(),
-//         }
-//     }
-// }
 
 #[derive(Debug)]
 pub enum NymVpnExitStatusMessage {

--- a/nym-vpn-lib/src/lib.rs
+++ b/nym-vpn-lib/src/lib.rs
@@ -473,7 +473,7 @@ impl NymVpn {
             .await
             .map_err(|err| {
                 error!("Failed to handle interrupt: {err}");
-                Box::new(NymVpnExitError::generic(&err))
+                Box::new(NymVpnExitError::Generic { reason: err })
             })?;
         tunnel.dns_monitor.reset().map_err(|err| {
             error!("Failed to reset dns monitor: {err}");
@@ -507,8 +507,9 @@ pub enum NymVpnCtrlMessage {
 // not all error cases satisfied the Sync marker trait.
 #[derive(thiserror::Error, Debug)]
 pub enum NymVpnExitError {
+    // Generic { reason: String },
     #[error("{reason}")]
-    Generic { reason: String },
+    Generic { reason: Error },
 
     // TODO: capture the concrete error type once we have time to investigate on Mac
     #[error("failed to reset firewall policy: {reason}")]
@@ -518,13 +519,13 @@ pub enum NymVpnExitError {
     FailedToResetDnsMonitor { reason: String },
 }
 
-impl NymVpnExitError {
-    fn generic(err: &dyn std::error::Error) -> Self {
-        NymVpnExitError::Generic {
-            reason: err.to_string(),
-        }
-    }
-}
+// impl NymVpnExitError {
+//     fn generic(err: &dyn std::error::Error) -> Self {
+//         NymVpnExitError::Generic {
+//             reason: err.to_string(),
+//         }
+//     }
+// }
 
 #[derive(Debug)]
 pub enum NymVpnExitStatusMessage {

--- a/nym-vpn-lib/src/lib.rs
+++ b/nym-vpn-lib/src/lib.rs
@@ -460,10 +460,7 @@ impl NymVpn {
         vpn_ctrl_rx: mpsc::UnboundedReceiver<NymVpnCtrlMessage>,
     ) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
         let (mut tunnel, mut task_manager, route_manager, wireguard_waiting, tunnel_close_tx) =
-            self.setup_tunnel()
-                .await?;
-                // .map_err(|err| Box::new(NymVpnExitError::generic(&err)))?;
-                // .map_err(|err| Box::new(NymVpnExitError::generic(&err)))?;
+            self.setup_tunnel().await?;
 
         // Signal back that we are ready and up with all cylinders firing
         task_manager.start_status_listener(vpn_status_tx).await;

--- a/nym-vpn-lib/src/lib.rs
+++ b/nym-vpn-lib/src/lib.rs
@@ -461,8 +461,9 @@ impl NymVpn {
     ) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
         let (mut tunnel, mut task_manager, route_manager, wireguard_waiting, tunnel_close_tx) =
             self.setup_tunnel()
-                .await
-                .map_err(|err| Box::new(NymVpnExitError::generic(&err)))?;
+                .await?;
+                // .map_err(|err| Box::new(NymVpnExitError::generic(&err)))?;
+                // .map_err(|err| Box::new(NymVpnExitError::generic(&err)))?;
 
         // Signal back that we are ready and up with all cylinders firing
         task_manager.start_status_listener(vpn_status_tx).await;

--- a/nym-vpn-lib/src/lib.rs
+++ b/nym-vpn-lib/src/lib.rs
@@ -192,7 +192,7 @@ impl NymVpn {
         // We need the IP of the gateway to correctly configure the routing table
         let mixnet_client_address = mixnet_client.nym_address().await;
         let gateway_used = mixnet_client_address.gateway().to_base58_string();
-        info!("Using gateway: {gateway_used}");
+        debug!("Entry gateway used for setting up routing table: {gateway_used}");
         let entry_mixnet_gateway_ip: IpAddr =
             gateway_client.lookup_gateway_ip(&gateway_used).await?;
         debug!("Gateway ip resolves to: {entry_mixnet_gateway_ip}");

--- a/nym-vpn-lib/src/lib.rs
+++ b/nym-vpn-lib/src/lib.rs
@@ -477,15 +477,15 @@ impl NymVpn {
             })?;
         tunnel.dns_monitor.reset().map_err(|err| {
             error!("Failed to reset dns monitor: {err}");
-            Box::new(NymVpnExitError::FailedToResetDnsMonitor {
+            NymVpnExitError::FailedToResetDnsMonitor {
                 reason: err.to_string(),
-            })
+            }
         })?;
         tunnel.firewall.reset_policy().map_err(|err| {
             error!("Failed to reset firewall policy: {err}");
-            Box::new(NymVpnExitError::FailedToResetFirewallPolicy {
+            NymVpnExitError::FailedToResetFirewallPolicy {
                 reason: err.to_string(),
-            })
+            }
         })?;
 
         result

--- a/nym-vpn-lib/src/lib.rs
+++ b/nym-vpn-lib/src/lib.rs
@@ -443,8 +443,9 @@ impl NymVpn {
         tunnel.dns_monitor.reset().tap_err(|err| {
             error!("Failed to reset dns monitor: {err}");
         })?;
-        tunnel.firewall.reset_policy().tap_err(|err| {
+        tunnel.firewall.reset_policy().map_err(|err| {
             error!("Failed to reset firewall policy: {err}");
+            Error::FirewallError(err.to_string())
         })?;
 
         Ok(())

--- a/nym-vpn-lib/src/mixnet_connect.rs
+++ b/nym-vpn-lib/src/mixnet_connect.rs
@@ -146,7 +146,7 @@ async fn wait_for_connect_response(
                             continue;
                         };
                         if response.id() == Some(request_id) {
-                            info!("Got response with matching id");
+                            debug!("Got response with matching id");
                             return Ok(response);
                         }
                     }
@@ -198,7 +198,7 @@ pub async fn connect_to_ip_packet_router(
     ips: Option<IpPair>,
     enable_two_hop: bool,
 ) -> Result<IpPair> {
-    info!("Sending connect request");
+    debug!("Sending connect request");
     let request_id = send_connect_to_ip_packet_router(
         &mixnet_client,
         ip_packet_router_address,
@@ -207,7 +207,7 @@ pub async fn connect_to_ip_packet_router(
     )
     .await?;
 
-    info!("Waiting for reply...");
+    debug!("Waiting for reply...");
     let response = wait_for_connect_response(&mixnet_client, request_id).await?;
 
     let mixnet_client_address = mixnet_client.nym_address().await;

--- a/nym-vpn-lib/src/routing.rs
+++ b/nym-vpn-lib/src/routing.rs
@@ -133,8 +133,8 @@ impl LanGatewayIp {
             error!("Failed to get default interface: {}", err);
             crate::error::Error::DefaultInterfaceError
         })?;
-        info!("Default interface: {}", default_interface.name);
-        debug!("Default interface: {:?}", default_interface);
+        info!("Default network interface: {}", default_interface.name);
+        debug!("Default network interface: {:?}", default_interface);
         Ok(LanGatewayIp(default_interface))
     }
 }

--- a/nym-vpn-lib/src/routing.rs
+++ b/nym-vpn-lib/src/routing.rs
@@ -190,7 +190,7 @@ pub async fn setup_routing(
     route_manager: &mut RouteManager,
     config: RoutingConfig,
 ) -> Result<tun2::AsyncDevice> {
-    info!("Creating tun device");
+    debug!("Creating tun device");
     let mixnet_tun_config = config.mixnet_tun_config.clone();
     #[cfg(target_os = "android")]
     let mixnet_tun_config = {
@@ -257,8 +257,8 @@ pub async fn setup_routing(
         config.tunnel_gateway_ip.ipv4,
         config.tunnel_gateway_ip.ipv6,
     );
-    info!("Using node_v4: {:?}", node_v4);
-    info!("Using node_v6: {:?}", node_v6);
+    debug!("Using node_v4: {:?}", node_v4);
+    debug!("Using node_v6: {:?}", node_v6);
 
     let mut routes = [
         ("0.0.0.0/0".to_string(), node_v4),

--- a/nym-vpn-lib/src/tunnel.rs
+++ b/nym-vpn-lib/src/tunnel.rs
@@ -36,7 +36,9 @@ impl Tunnel {
             let command_tx = Arc::new(command_tx);
             let weak_command_tx = Arc::downgrade(&command_tx);
             debug!("Starting firewall");
-            let firewall = Firewall::new()?;
+            // let firewall = Firewall::new()?;
+            let firewall = Firewall::new()
+                .map_err(|err| crate::error::Error::FirewallError(err.to_string()))?;
             debug!("Starting dns monitor");
             let dns_monitor = DnsMonitor::new(weak_command_tx)?;
             (firewall, dns_monitor)
@@ -59,7 +61,9 @@ impl Tunnel {
         #[cfg(all(not(target_os = "macos"), not(target_os = "linux")))]
         let (firewall, dns_monitor) = {
             debug!("Starting firewall");
-            let firewall = Firewall::new()?;
+            // let firewall = Firewall::new()?;
+            let firewall = Firewall::new()
+                .map_err(|err| crate::error::Error::FirewallError(err.to_string()))?;
             debug!("Starting dns monitor");
             let dns_monitor = DnsMonitor::new()?;
             (firewall, dns_monitor)

--- a/nym-vpn-lib/src/tunnel.rs
+++ b/nym-vpn-lib/src/tunnel.rs
@@ -36,7 +36,6 @@ impl Tunnel {
             let command_tx = Arc::new(command_tx);
             let weak_command_tx = Arc::downgrade(&command_tx);
             debug!("Starting firewall");
-            // let firewall = Firewall::new()?;
             let firewall = Firewall::new()
                 .map_err(|err| crate::error::Error::FirewallError(err.to_string()))?;
             debug!("Starting dns monitor");
@@ -61,7 +60,6 @@ impl Tunnel {
         #[cfg(all(not(target_os = "macos"), not(target_os = "linux")))]
         let (firewall, dns_monitor) = {
             debug!("Starting firewall");
-            // let firewall = Firewall::new()?;
             let firewall = Firewall::new()
                 .map_err(|err| crate::error::Error::FirewallError(err.to_string()))?;
             debug!("Starting dns monitor");

--- a/nym-vpn-lib/src/tunnel.rs
+++ b/nym-vpn-lib/src/tunnel.rs
@@ -46,7 +46,8 @@ impl Tunnel {
         let (firewall, dns_monitor) = {
             let fwmark = 0; // ?
             debug!("Starting firewall");
-            let firewall = Firewall::new(fwmark).map_err(|err| crate::error::Error::FirewallError(err.to_string()))?;
+            let firewall = Firewall::new(fwmark)
+                .map_err(|err| crate::error::Error::FirewallError(err.to_string()))?;
             debug!("Starting dns monitor");
             let dns_monitor = DnsMonitor::new(
                 tokio::runtime::Handle::current(),

--- a/nym-vpn-lib/src/tunnel.rs
+++ b/nym-vpn-lib/src/tunnel.rs
@@ -46,7 +46,7 @@ impl Tunnel {
         let (firewall, dns_monitor) = {
             let fwmark = 0; // ?
             debug!("Starting firewall");
-            let firewall = Firewall::new(fwmark)?;
+            let firewall = Firewall::new(fwmark).map_err(|err| crate::error::Error::FirewallError(err.to_string()))?;
             debug!("Starting dns monitor");
             let dns_monitor = DnsMonitor::new(
                 tokio::runtime::Handle::current(),


### PR DESCRIPTION
To better propagate errors from nym vpn lib to the client, return strongly typed errors instead of mapping to String
