### PR TITLE
Extend GatewayClient for use downstream in clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4264,6 +4264,7 @@ dependencies = [
  "err-derive",
  "futures",
  "ipnetwork",
+ "itertools 0.12.1",
  "jnix",
  "lazy_static",
  "log",

--- a/nym-vpn-desktop/src-tauri/Cargo.lock
+++ b/nym-vpn-desktop/src-tauri/Cargo.lock
@@ -3578,9 +3578,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -5601,7 +5601,7 @@ dependencies = [
  "clap",
  "dotenvy",
  "futures",
- "itertools 0.12.0",
+ "itertools 0.12.1",
  "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=9ff37d2f9f27762d8900e353306029ed13abfb6c)",
  "nym-explorer-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=9ff37d2f9f27762d8900e353306029ed13abfb6c)",
  "nym-vpn-lib",
@@ -5636,6 +5636,7 @@ dependencies = [
  "err-derive",
  "futures",
  "ipnetwork",
+ "itertools 0.12.1",
  "jnix",
  "lazy_static",
  "log",
@@ -7740,7 +7741,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce81b7bd7c4493975347ef60d8c7e8b742d4694f4c49f93e0a12ea263938176c"
 dependencies = [
- "itertools 0.12.0",
+ "itertools 0.12.1",
  "nom",
  "unicode_categories",
 ]

--- a/nym-vpn-desktop/src-tauri/Cargo.lock
+++ b/nym-vpn-desktop/src-tauri/Cargo.lock
@@ -2927,9 +2927,9 @@ dependencies = [
 
 [[package]]
 name = "goblin"
-version = "0.6.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6b4de4a8eb6c46a8c77e1d3be942cb9a8bf073c22374578e5ba4b08ed0ff68"
+checksum = "bb07a4ffed2093b118a525b1d8f5204ae274faed5604537caf7135d0f18d9887"
 dependencies = [
  "log",
  "plain",
@@ -7091,18 +7091,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scroll"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
+checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
 dependencies = [
  "scroll_derive",
 ]
 
 [[package]]
 name = "scroll_derive"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
+checksum = "7f81c2fde025af7e69b1d1420531c8a8811ca898919db177141a85313b1cb932"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9466,8 +9466,9 @@ checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "uniffi"
-version = "0.25.3"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=f5fc9d7e9aa08889aedc45dd81ae9b4d3ec4cbe8#f5fc9d7e9aa08889aedc45dd81ae9b4d3ec4cbe8"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ad0be8bba6c242d2d16922de4a9c8f167b9491729fda552e70f8626bf7302cb"
 dependencies = [
  "anyhow",
  "camino",
@@ -9480,8 +9481,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.25.3"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=f5fc9d7e9aa08889aedc45dd81ae9b4d3ec4cbe8#f5fc9d7e9aa08889aedc45dd81ae9b4d3ec4cbe8"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab31006ab9c9c6870739f0e74235729d1478d82e73571b8f53c25aa176d67535"
 dependencies = [
  "anyhow",
  "askama",
@@ -9504,8 +9506,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_build"
-version = "0.25.3"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=f5fc9d7e9aa08889aedc45dd81ae9b4d3ec4cbe8#f5fc9d7e9aa08889aedc45dd81ae9b4d3ec4cbe8"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aa3a7608c6872dc1ce53199d816a24d2e19af952d82ce557ecc8692a4ae9cba"
 dependencies = [
  "anyhow",
  "camino",
@@ -9514,8 +9517,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_checksum_derive"
-version = "0.25.3"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=f5fc9d7e9aa08889aedc45dd81ae9b4d3ec4cbe8#f5fc9d7e9aa08889aedc45dd81ae9b4d3ec4cbe8"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72775b3afa6adb30e0c92b3107858d2fcb0ff1a417ac242db1f648b0e2dd0ef2"
 dependencies = [
  "quote",
  "syn 2.0.48",
@@ -9523,8 +9527,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_core"
-version = "0.25.3"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=f5fc9d7e9aa08889aedc45dd81ae9b4d3ec4cbe8#f5fc9d7e9aa08889aedc45dd81ae9b4d3ec4cbe8"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d6e8db3f4e558faf0e25ac4b5bd775567973a4e18809f1123e74de52a853692"
 dependencies = [
  "anyhow",
  "bytes",
@@ -9538,8 +9543,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.25.3"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=f5fc9d7e9aa08889aedc45dd81ae9b4d3ec4cbe8#f5fc9d7e9aa08889aedc45dd81ae9b4d3ec4cbe8"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a126650799f97d97d8e38e3f10f15c65f5bc5a76b021bec21823efe9dd831a02"
 dependencies = [
  "bincode",
  "camino",
@@ -9556,8 +9562,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_meta"
-version = "0.25.3"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=f5fc9d7e9aa08889aedc45dd81ae9b4d3ec4cbe8#f5fc9d7e9aa08889aedc45dd81ae9b4d3ec4cbe8"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f64a99e905671738d9d293f9cce58708ce1af8e13ea29f9d6b6925114fc2e85"
 dependencies = [
  "anyhow",
  "bytes",
@@ -9567,8 +9574,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_testing"
-version = "0.25.3"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=f5fc9d7e9aa08889aedc45dd81ae9b4d3ec4cbe8#f5fc9d7e9aa08889aedc45dd81ae9b4d3ec4cbe8"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdca5719a22edf34c8239cc6ac9e3906d7ebc2a3e8a5e6ece4c3dffc312a4251"
 dependencies = [
  "anyhow",
  "camino",
@@ -9579,8 +9587,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_udl"
-version = "0.25.3"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=f5fc9d7e9aa08889aedc45dd81ae9b4d3ec4cbe8#f5fc9d7e9aa08889aedc45dd81ae9b4d3ec4cbe8"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6817c15714acccd0d0459f99b524cabebfdd622376464a2c6466a6485bdb4b"
 dependencies = [
  "anyhow",
  "textwrap",
@@ -9974,8 +9983,9 @@ dependencies = [
 
 [[package]]
 name = "weedle2"
-version = "4.0.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=f5fc9d7e9aa08889aedc45dd81ae9b4d3ec4cbe8#f5fc9d7e9aa08889aedc45dd81ae9b4d3ec4cbe8"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
 dependencies = [
  "nom",
 ]

--- a/nym-vpn-lib/Cargo.toml
+++ b/nym-vpn-lib/Cargo.toml
@@ -18,6 +18,7 @@ bytes = "1.0"
 default-net = "0.21.0"
 futures = "0.3.15"
 ipnetwork = "0.16"
+itertools = "0.12.1"
 lazy_static = "1.4.0"
 log = "0.4.20"
 rand = "0.7.3"
@@ -30,8 +31,8 @@ tokio = { workspace = true, features = ["process", "rt-multi-thread", "fs", "syn
 tokio-util = { version = "0.7.10", features = ["codec"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-uniffi = { version = "0.26.1", features = ["cli"] }
 tun2 = { version = "1.2.3", features = ["async"] }
+uniffi = { version = "0.26.1", features = ["cli"] }
 url = "2.4"
 
 # Used in order to correctly import rustls for sub-dependencies

--- a/nym-vpn-lib/src/error.rs
+++ b/nym-vpn-lib/src/error.rs
@@ -150,8 +150,8 @@ pub enum Error {
     #[error("failed to select gateway based on low latency: {source}")]
     FailedToSelectGatewayBasedOnLowLatency { source: ClientCoreError },
 
-    #[error("failed to select entry gateway randomly")]
-    FailedToSelectEntryGatewayRandomly,
+    #[error("failed to select gateway randomly")]
+    FailedToSelectGatewayRandomly,
 
     #[error("deadlock when trying to aquire mixnet client mutes")]
     MixnetClientDeadlock,

--- a/nym-vpn-lib/src/gateway_client.rs
+++ b/nym-vpn-lib/src/gateway_client.rs
@@ -148,6 +148,50 @@ impl UniffiCustomTypeConverter for NodeIdentity {
     }
 }
 
+fn select_random_described_gateway<'a, I>(gateways: I) -> Result<&'a DescribedGatewayWithLocation>
+where
+    I: IntoIterator<Item = &'a DescribedGatewayWithLocation>,
+{
+    gateways
+        .into_iter()
+        .choose(&mut rand::thread_rng())
+        .ok_or(Error::FailedToSelectGatewayRandomly)
+}
+
+fn select_random_gateway_node<'a, I>(gateways: I) -> Result<NodeIdentity>
+where
+    I: IntoIterator<Item = &'a DescribedGatewayWithLocation>,
+{
+    let random_gateway = select_random_described_gateway(gateways)?;
+    NodeIdentity::from_base58_string(random_gateway.identity_key())
+        .map_err(|_| Error::NodeIdentityFormattingError)
+}
+
+async fn select_random_low_latency_gateway_node(
+    gateways: &[DescribedGatewayWithLocation],
+) -> Result<NodeIdentity> {
+    let mut rng = rand::rngs::OsRng;
+    let must_use_tls = FORCE_TLS_FOR_GATEWAY_SELECTION;
+    let gateway_nodes: Vec<nym_topology::gateway::Node> = gateways
+        .iter()
+        .filter_map(|gateway| nym_topology::gateway::Node::try_from(&gateway.gateway).ok())
+        .collect();
+    choose_gateway_by_latency(&mut rng, &gateway_nodes, must_use_tls)
+        .await
+        .map(|gateway| *gateway.identity())
+        .map_err(|err| Error::FailedToSelectGatewayBasedOnLowLatency { source: err })
+}
+
+async fn select_random_low_latency_described_gateway(
+    gateways: &[DescribedGatewayWithLocation],
+) -> Result<&DescribedGatewayWithLocation> {
+    let low_latency_gateway = select_random_low_latency_gateway_node(gateways).await?;
+    gateways
+        .iter()
+        .find(|gateway| gateway.identity_key() == &low_latency_gateway.to_string())
+        .ok_or(Error::NoMatchingGateway)
+}
+
 impl EntryPoint {
     pub async fn lookup_gateway_identity(
         &self,
@@ -169,41 +213,15 @@ impl EntryPoint {
                 let gateways_with_specified_location = gateways
                     .iter()
                     .filter(|g| g.is_two_letter_iso_country_code(location));
-                let random_gateway = gateways_with_specified_location
-                    .choose(&mut rand::thread_rng())
-                    .ok_or(Error::NoMatchingGatewayForLocation(location.to_string()))?;
-                NodeIdentity::from_base58_string(random_gateway.identity_key())
-                    .map_err(|_| Error::NodeIdentityFormattingError)
+                select_random_gateway_node(gateways_with_specified_location)
             }
             EntryPoint::RandomLowLatency => {
-                // Recall, even though the mixnet client is able to randomly select a gateway, we
-                // have to do it up front since it affects how we setup the routing table when
-                // wireguard is enabled for the first hop
                 log::info!("Selecting a random low latency entry gateway");
-                let mut rng = rand::rngs::OsRng;
-                let must_use_tls = FORCE_TLS_FOR_GATEWAY_SELECTION;
-                let gateway_nodes: Vec<nym_topology::gateway::Node> = gateways
-                    .iter()
-                    .filter_map(|gateway| {
-                        nym_topology::gateway::Node::try_from(&gateway.gateway).ok()
-                    })
-                    .collect();
-                choose_gateway_by_latency(&mut rng, &gateway_nodes, must_use_tls)
-                    .await
-                    .map(|gateway| *gateway.identity())
-                    .map_err(|err| Error::FailedToSelectGatewayBasedOnLowLatency { source: err })
+                select_random_low_latency_gateway_node(gateways).await
             }
             EntryPoint::Random => {
-                // Recall, even though the mixnet client is able to randomly select a gateway, we
-                // have to do it up front since it affects how we setup the routing table when
-                // wireguard is enabled for the first hop
                 log::info!("Selecting a random entry gateway");
-                let random_gateway = gateways
-                    .iter()
-                    .choose(&mut rand::thread_rng())
-                    .ok_or(Error::FailedToSelectEntryGatewayRandomly)?;
-                NodeIdentity::from_base58_string(random_gateway.identity_key())
-                    .map_err(|_| Error::NodeIdentityFormattingError)
+                select_random_gateway_node(gateways)
             }
         }
     }
@@ -326,7 +344,7 @@ impl GatewayClient {
         })
     }
 
-    pub async fn lookup_described_gateways(&self) -> Result<Vec<DescribedGateway>> {
+    async fn lookup_described_gateways(&self) -> Result<Vec<DescribedGateway>> {
         log::info!("Fetching gateways from nym-api...");
         self.api_client
             .get_cached_described_gateways()
@@ -334,9 +352,7 @@ impl GatewayClient {
             .map_err(|source| Error::FailedToLookupDescribedGateways { source })
     }
 
-    pub async fn lookup_gateways_in_explorer(
-        &self,
-    ) -> Option<Result<Vec<PrettyDetailedGatewayBond>>> {
+    async fn lookup_gateways_in_explorer(&self) -> Option<Result<Vec<PrettyDetailedGatewayBond>>> {
         log::info!("Fetching gateway geo-locations from nym-explorer...");
         if let Some(explorer_client) = &self.explorer_client {
             Some(
@@ -383,6 +399,23 @@ impl GatewayClient {
                 .map(DescribedGatewayWithLocation::from)
                 .collect()),
         }
+    }
+
+    pub async fn lookup_described_exit_gateways_with_location(
+        &self,
+    ) -> Result<Vec<DescribedGatewayWithLocation>> {
+        let described_gateways = self.lookup_described_gateways_with_location().await?;
+        Ok(described_gateways
+            .into_iter()
+            .filter(|gateway| gateway.has_ip_packet_router())
+            .collect())
+    }
+
+    pub async fn lookup_low_latency_entry_gateway(&self) -> Result<DescribedGatewayWithLocation> {
+        let described_gateways = self.lookup_described_gateways_with_location().await?;
+        select_random_low_latency_described_gateway(&described_gateways)
+            .await
+            .cloned()
     }
 
     pub async fn lookup_gateway_ip(&self, gateway_identity: &str) -> Result<IpAddr> {


### PR DESCRIPTION
Expand the API for GatewayClient to provide
- Fetch a low latency gateway
- List of all countres
- List of all exit countries
- List of all described exit gateways (in addition to the already existing list of all described gateways)