### PR TITLE
Use mainnet by default in desktop client

### DIFF
--- a/nym-vpn-desktop/src-tauri/src/cli.rs
+++ b/nym-vpn-desktop/src-tauri/src/cli.rs
@@ -21,6 +21,10 @@ pub struct Cli {
     /// Print build information
     #[arg(short, long)]
     pub build_info: bool,
+
+    /// Sandbox network
+    #[arg(short, long)]
+    pub sandbox: bool,
 }
 
 pub fn print_build_info(package_info: &PackageInfo) {

--- a/nym-vpn-desktop/src-tauri/src/main.rs
+++ b/nym-vpn-desktop/src-tauri/src/main.rs
@@ -83,8 +83,13 @@ async fn main() -> Result<()> {
     let app_config = app_config_store.read().await?;
     debug!("app_config: {app_config:?}");
 
-    // check for the existence of the env_config_file if provided
-    if let Some(env_config_file) = &app_config.env_config_file {
+    // By default, mainnet is used. The network can be overridden by either setting the `--sandbox`
+    // flag or providing a custom env file.
+    if cli.sandbox {
+        // TODO: instead bundle a sandbox env file we can use
+        network::setup_sandbox_environment();
+    } else if let Some(env_config_file) = &app_config.env_config_file {
+        // check for the existence of the env_config_file if provided
         debug!("provided env_config_file: {}", env_config_file.display());
         if !(try_exists(env_config_file)
             .await
@@ -97,10 +102,6 @@ async fn main() -> Result<()> {
             error!(err_message);
             return Err(anyhow!(err_message));
         }
-    } else if cli.sandbox {
-        // If no env_config_file is provided, setup the sandbox environment
-        // This is tempory until we switch to mainnet
-        network::setup_sandbox_environment();
     }
 
     // Read the env variables in the provided file and export them all to the local environment.

--- a/nym-vpn-desktop/src-tauri/src/main.rs
+++ b/nym-vpn-desktop/src-tauri/src/main.rs
@@ -88,19 +88,21 @@ async fn main() -> Result<()> {
     if cli.sandbox {
         // TODO: instead bundle a sandbox env file we can use
         network::setup_sandbox_environment();
-    } else if let Some(env_config_file) = &app_config.env_config_file {
-        // check for the existence of the env_config_file if provided
-        debug!("provided env_config_file: {}", env_config_file.display());
-        if !(try_exists(env_config_file)
-            .await
-            .context("an error happened while reading env_config_file `{}`")?)
-        {
-            let err_message = format!(
-                "app config, env_config_file `{}`: file not found",
-                env_config_file.display()
-            );
-            error!(err_message);
-            return Err(anyhow!(err_message));
+    } else {
+        if let Some(env_config_file) = &app_config.env_config_file {
+            // check for the existence of the env_config_file if provided
+            debug!("provided env_config_file: {}", env_config_file.display());
+            if !(try_exists(env_config_file)
+                .await
+                .context("an error happened while reading env_config_file `{}`")?)
+            {
+                let err_message = format!(
+                    "app config, env_config_file `{}`: file not found",
+                    env_config_file.display()
+                );
+                error!(err_message);
+                return Err(anyhow!(err_message));
+            }
         }
 
         // Read the env variables in the provided file and export them all to the local environment.

--- a/nym-vpn-desktop/src-tauri/src/main.rs
+++ b/nym-vpn-desktop/src-tauri/src/main.rs
@@ -102,10 +102,10 @@ async fn main() -> Result<()> {
             error!(err_message);
             return Err(anyhow!(err_message));
         }
-    }
 
-    // Read the env variables in the provided file and export them all to the local environment.
-    nym_config::defaults::setup_env(app_config.env_config_file.clone());
+        // Read the env variables in the provided file and export them all to the local environment.
+        nym_config::defaults::setup_env(app_config.env_config_file.clone());
+    }
 
     info!("Creating k/v embedded db");
     let db = Db::new()?;

--- a/nym-vpn-desktop/src-tauri/src/main.rs
+++ b/nym-vpn-desktop/src-tauri/src/main.rs
@@ -97,7 +97,7 @@ async fn main() -> Result<()> {
             error!(err_message);
             return Err(anyhow!(err_message));
         }
-    } else {
+    } else if cli.sandbox {
         // If no env_config_file is provided, setup the sandbox environment
         // This is tempory until we switch to mainnet
         network::setup_sandbox_environment();


### PR DESCRIPTION
By default connect to mainnet in the desktop client. Add `--sandbox` cli flag for convenience.