### PR TITLE
feat: vpn proto service definition

### DIFF
--- a/proto/nymvpn.proto
+++ b/proto/nymvpn.proto
@@ -1,0 +1,98 @@
+syntax = "proto3";
+
+package nym.vpn;
+
+message Gateway {
+  string id = 1;
+  Location location = 2;
+}
+
+message Location {
+  string two_letter_country_code = 1;
+}
+
+message Node {
+  oneof node {
+    Location location = 1;
+    Gateway gateway = 2;
+    bool fastest = 3;
+  }
+}
+
+message ConnectRequest {
+  Node entry = 1;
+  Node exit = 2;
+}
+
+message ConnectResponse {
+  string message = 1;
+}
+
+enum VpnMode {
+  MODE_UNSPECIFIED = 0;
+  MIXNET_FIVE_HOP = 1;
+  MIXNET_TWO_HOP = 2;
+  WIREGUARD_TWO_HOP = 3;
+}
+
+enum ConnectionStatus {
+  STATUS_UNSPECIFIED = 0;
+  CONNECTED = 1;
+  DISCONNECTED = 2;
+  CONNECTING = 3;
+  DISCONNECTING = 4;
+  UNKNOWN = 5; // errored pending state etc
+}
+
+message LocationListResponse {
+  repeated Location location = 1;
+}
+
+message SetVpnModeRequest {
+  VpnMode mode = 1;
+}
+
+message GetVpnModeResponse {
+  VpnMode mode = 1;
+}
+
+message GatewayResponse {
+  Gateway gateways = 1;
+}
+
+message ConnectionStatusUpdate {
+  ConnectionStatus status = 1;
+  repeated ConnectionProgress connection_progress = 2;
+  optional Error error = 3;
+}
+
+message ConnectionProgress {
+  string message = 1;
+}
+
+message Error {
+  string message = 1;
+  // ErrorType type = 2; // TOBE implemented
+  optional string source = 3;
+}
+
+message SetUserCredentialsRequest {
+  string key = 1;
+}
+
+service NymVpnService {
+  rpc SetUserCredentials (SetUserCredentialsRequest) returns () {}
+  rpc Connect (ConnectRequest) returns () {}
+  rpc Disconnect () returns () {}
+  rpc ListenToConnectionStatus () returns (stream ConnectionStatusUpdate) {}
+  // Cancel any connection pending state (connecting, disconnecting etc)
+  // and return to disconnected state
+  rpc Cancel () returns () {}
+  rpc GetEntryNodeLocations () returns (LocationListResponse) {}
+  rpc GetExitNodeLocations () returns (LocationListResponse) {}
+  rpc GetFastestEntryGateway () returns (GatewayResponse) {}
+  rpc GetFastestExitGateway () returns (GatewayResponse) {}
+  rpc SetVpnMode (SetVpnModeRequest) returns () {}
+  rpc GetVpnMode () returns (GetVpnModeResponse) {}
+}
+


### PR DESCRIPTION
Initial proposition for protobuf service definition of the future IPC layer (between daemon and client apps)

based on the following resources:
- https://grpc.io/docs/what-is-grpc/core-concepts/
- https://protobuf.dev/programming-guides/proto3/
- https://protobuf.dev/programming-guides/style/
- https://protobuf.dev/programming-guides/dos-donts/
- https://protobuf.dev/programming-guides/api/