### PR TITLE
Don't install clang to avoid getting rate limited

### DIFF
--- a/.github/workflows/ci-nym-vpn-cli.yml
+++ b/.github/workflows/ci-nym-vpn-cli.yml
@@ -36,7 +36,7 @@ jobs:
           ls -la ./
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev libmnl-dev libnftnl-dev protobuf-compiler git curl gcc g++ make unzip clang
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev libmnl-dev libnftnl-dev protobuf-compiler git curl gcc g++ make unzip
         if: contains(matrix.os, 'ubuntu')
 
       - name: Support longpaths on windows


### PR DESCRIPTION
Since I suspect we don't need clang after all in the cli CI workflow, let's not install since it we'll get rate limited for excessive downloads. This saves >100 MB per ci run per ubuntu platform