### PR TITLE
Fix/uniffi android

### DIFF
--- a/nym-vpn-lib/src/gateway_client.rs
+++ b/nym-vpn-lib/src/gateway_client.rs
@@ -442,7 +442,7 @@ impl GatewayClient {
             .filter_map(|gateway| {
                 gateway
                     .two_letter_iso_country_code()
-                    .map(|value| Country::Name { value })
+                    .map(|value| Country::Code { value })
             })
             .unique()
             .collect())
@@ -455,7 +455,7 @@ impl GatewayClient {
             .filter_map(|gateway| {
                 gateway
                     .two_letter_iso_country_code()
-                    .map(|value| Country::Name { value })
+                    .map(|value| Country::Code { value })
             })
             .unique()
             .collect())

--- a/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-lib/src/platform/mod.rs
@@ -197,14 +197,6 @@ async fn get_gateway_countries(
     explorer_url: String,
     exit_only: bool,
 ) -> Result<Vec<Country>, FFIError> {
-    let current = get_vpn_state().await;
-    if current != ClientState::Connected {
-        warn!("vpn not started");
-        return Err(FFIError::IncorrectState {
-            current,
-            expected: ClientState::Connected,
-        });
-    }
 
     let api_url = Url::from_str(&api_url).map_err(|e| FFIError::UrlParse {
         inner: e.to_string(),
@@ -239,14 +231,6 @@ async fn get_low_latency_entry_country(
     api_url: String,
     explorer_url: String,
 ) -> Result<Country, FFIError> {
-    let current = get_vpn_state().await;
-    if current != ClientState::Connected {
-        warn!("vpn not started");
-        return Err(FFIError::IncorrectState {
-            current,
-            expected: ClientState::Connected,
-        });
-    }
 
     let api_url = Url::from_str(&api_url).map_err(|e| FFIError::UrlParse {
         inner: e.to_string(),

--- a/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-lib/src/platform/mod.rs
@@ -197,7 +197,6 @@ async fn get_gateway_countries(
     explorer_url: String,
     exit_only: bool,
 ) -> Result<Vec<Country>, FFIError> {
-
     let api_url = Url::from_str(&api_url).map_err(|e| FFIError::UrlParse {
         inner: e.to_string(),
     })?;
@@ -231,7 +230,6 @@ async fn get_low_latency_entry_country(
     api_url: String,
     explorer_url: String,
 ) -> Result<Country, FFIError> {
-
     let api_url = Url::from_str(&api_url).map_err(|e| FFIError::UrlParse {
         inner: e.to_string(),
     })?;


### PR DESCRIPTION
Remove vpn status check from gateway calls because we need to call this API before we use the vpn

Fix gateways call bug where lib was returning country name enum instead of country code