### PR TITLE
Prepare for extracting out GatewayClient

### DIFF
--- a/nym-vpn-cli/src/commands.rs
+++ b/nym-vpn-cli/src/commands.rs
@@ -6,8 +6,7 @@ use ipnetwork::{Ipv4Network, Ipv6Network};
 use nym_vpn_lib::nym_config::defaults::var_names::{EXPLORER_API, NYM_API};
 use nym_vpn_lib::nym_config::OptionalSet;
 use nym_vpn_lib::{
-    gateway_client::{Config, WgConfig},
-    nym_bin_common::bin_info_local_vergen,
+    gateway_client::Config, nym_bin_common::bin_info_local_vergen, wg_gateway_client::WgConfig,
 };
 use std::{
     net::{Ipv4Addr, Ipv6Addr},

--- a/nym-vpn-cli/src/commands.rs
+++ b/nym-vpn-cli/src/commands.rs
@@ -5,7 +5,10 @@ use clap::{Args, Parser};
 use ipnetwork::{Ipv4Network, Ipv6Network};
 use nym_vpn_lib::nym_config::defaults::var_names::{EXPLORER_API, NYM_API};
 use nym_vpn_lib::nym_config::OptionalSet;
-use nym_vpn_lib::{gateway_client::Config, nym_bin_common::bin_info_local_vergen};
+use nym_vpn_lib::{
+    gateway_client::{Config, WgConfig},
+    nym_bin_common::bin_info_local_vergen,
+};
 use std::{
     net::{Ipv4Addr, Ipv6Addr},
     path::PathBuf,
@@ -156,13 +159,16 @@ fn validate_ipv6(ip: &str) -> Result<Ipv6Addr, String> {
     Ok(ip)
 }
 
-pub fn override_from_env(args: &CliArgs, config: Config) -> Config {
-    let mut config = config
+pub fn override_from_env(_args: &CliArgs, config: Config) -> Config {
+    config
         .with_optional_env(Config::with_custom_api_url, None, NYM_API)
         // TODO: there is a landmine here, if the user sets non-mainnet nym-api, but doesn't
         // specify explorer-api, it will default to mainnet explorer-api and location lookup will
         // implicitly fail instead of explicitly fail.
-        .with_optional_env(Config::with_custom_explorer_url, None, EXPLORER_API);
+        .with_optional_env(Config::with_custom_explorer_url, None, EXPLORER_API)
+}
+
+pub fn wg_override_from_env(args: &CliArgs, mut config: WgConfig) -> WgConfig {
     if let Some(ref private_key) = args.private_key {
         config = config.with_local_private_key(private_key.clone());
     }

--- a/nym-vpn-cli/src/main.rs
+++ b/nym-vpn-cli/src/main.rs
@@ -3,9 +3,8 @@
 
 mod commands;
 
-use nym_vpn_lib::gateway_client::{
-    Config as GatewayConfig, EntryPoint, ExitPoint, WgConfig as WgGatewayConfig,
-};
+use nym_vpn_lib::gateway_client::{Config as GatewayConfig, EntryPoint, ExitPoint};
+use nym_vpn_lib::wg_gateway_client::WgConfig as WgGatewayConfig;
 use nym_vpn_lib::{error::*, IpPair, NodeIdentity};
 use nym_vpn_lib::{NymVpn, Recipient};
 

--- a/nym-vpn-cli/src/main.rs
+++ b/nym-vpn-cli/src/main.rs
@@ -3,11 +3,13 @@
 
 mod commands;
 
-use nym_vpn_lib::gateway_client::{Config as GatewayConfig, EntryPoint, ExitPoint};
+use nym_vpn_lib::gateway_client::{
+    Config as GatewayConfig, EntryPoint, ExitPoint, WgConfig as WgGatewayConfig,
+};
 use nym_vpn_lib::{error::*, IpPair, NodeIdentity};
 use nym_vpn_lib::{NymVpn, Recipient};
 
-use crate::commands::override_from_env;
+use crate::commands::{override_from_env, wg_override_from_env};
 use clap::Parser;
 use log::*;
 use nym_vpn_lib::nym_config::defaults::setup_env;
@@ -80,6 +82,9 @@ async fn run() -> Result<()> {
             .unwrap_or("unavailable".to_string())
     );
 
+    // Setup wireguard gateway configuration
+    let wg_gateway_config = wg_override_from_env(&args, WgGatewayConfig::default());
+
     let entry_point = parse_entry_point(&args)?;
     let exit_point = parse_exit_point(&args)?;
     let nym_ips = if let (Some(ipv4), Some(ipv6)) = (args.nym_ipv4, args.nym_ipv6) {
@@ -90,6 +95,7 @@ async fn run() -> Result<()> {
 
     let mut nym_vpn = NymVpn::new(entry_point, exit_point);
     nym_vpn.gateway_config = gateway_config;
+    nym_vpn.wg_gateway_config = wg_gateway_config;
     nym_vpn.mixnet_client_path = args.mixnet_client_path;
     nym_vpn.enable_wireguard = args.enable_wireguard;
     nym_vpn.private_key = args.private_key;

--- a/nym-vpn-desktop/src-tauri/Cargo.lock
+++ b/nym-vpn-desktop/src-tauri/Cargo.lock
@@ -3668,15 +3668,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipnetwork"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "iprange"
 version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5613,7 +5604,7 @@ dependencies = [
  "err-derive",
  "futures",
  "hickory-resolver",
- "ipnetwork 0.16.0",
+ "ipnetwork",
  "itertools 0.12.1",
  "jnix",
  "lazy_static",
@@ -5633,7 +5624,7 @@ dependencies = [
  "nym-validator-client",
  "nym-wireguard-types",
  "oslog",
- "pnet",
+ "pnet_packet",
  "rand 0.7.3",
  "reqwest",
  "serde",
@@ -6092,7 +6083,7 @@ dependencies = [
  "errno 0.2.8",
  "error-chain",
  "ioctl-sys",
- "ipnetwork 0.16.0",
+ "ipnetwork",
  "libc",
 ]
 
@@ -6305,39 +6296,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "pnet"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "130c5b738eeda2dc5796fe2671e49027e6935e817ab51b930a36ec9e6a206a64"
-dependencies = [
- "ipnetwork 0.20.0",
- "pnet_base",
- "pnet_datalink",
- "pnet_packet",
- "pnet_sys",
- "pnet_transport",
-]
-
-[[package]]
 name = "pnet_base"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe4cf6fb3ab38b68d01ab2aea03ed3d1132b4868fa4e06285f29f16da01c5f4c"
 dependencies = [
  "no-std-net",
-]
-
-[[package]]
-name = "pnet_datalink"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad5854abf0067ebbd3967f7d45ebc8976ff577ff0c7bd101c4973ae3c70f98fe"
-dependencies = [
- "ipnetwork 0.20.0",
- "libc",
- "pnet_base",
- "pnet_sys",
- "winapi",
 ]
 
 [[package]]
@@ -6371,28 +6335,6 @@ dependencies = [
  "pnet_base",
  "pnet_macros",
  "pnet_macros_support",
-]
-
-[[package]]
-name = "pnet_sys"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "417c0becd1b573f6d544f73671070b039051e5ad819cc64aa96377b536128d00"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "pnet_transport"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2637e14d7de974ee2f74393afccbc8704f3e54e6eb31488715e72481d1662cc3"
-dependencies = [
- "libc",
- "pnet_base",
- "pnet_packet",
- "pnet_sys",
 ]
 
 [[package]]
@@ -8205,7 +8147,7 @@ dependencies = [
  "hex",
  "inotify 0.10.2",
  "internet-checksum",
- "ipnetwork 0.16.0",
+ "ipnetwork",
  "jnix",
  "lazy_static",
  "libc",
@@ -8322,7 +8264,7 @@ source = "git+https://github.com/nymtech/nym-vpn-mullvad-libs?rev=2a5b83ed9f8cf6
 dependencies = [
  "err-derive",
  "futures",
- "ipnetwork 0.16.0",
+ "ipnetwork",
  "lazy_static",
  "libc",
  "log",
@@ -8356,7 +8298,7 @@ dependencies = [
  "duct",
  "err-derive",
  "futures",
- "ipnetwork 0.16.0",
+ "ipnetwork",
  "jnix",
  "log",
  "nix 0.23.2",
@@ -8391,7 +8333,7 @@ source = "git+https://github.com/nymtech/nym-vpn-mullvad-libs?rev=2a5b83ed9f8cf6
 dependencies = [
  "base64 0.13.1",
  "err-derive",
- "ipnetwork 0.16.0",
+ "ipnetwork",
  "jnix",
  "rand 0.8.5",
  "serde",
@@ -8425,7 +8367,7 @@ dependencies = [
  "futures",
  "hex",
  "internet-checksum",
- "ipnetwork 0.16.0",
+ "ipnetwork",
  "lazy_static",
  "libc",
  "log",

--- a/nym-vpn-lib/src/config.rs
+++ b/nym-vpn-lib/src/config.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::error::*;
-use crate::gateway_client::GatewayData;
+use crate::wg_gateway_client::GatewayData;
 use std::net::Ipv4Addr;
 use std::str::FromStr;
 use talpid_types::net::wireguard::{

--- a/nym-vpn-lib/src/gateway_client.rs
+++ b/nym-vpn-lib/src/gateway_client.rs
@@ -7,22 +7,14 @@ use hickory_resolver::config::{ResolverConfig, ResolverOpts};
 use hickory_resolver::TokioAsyncResolver;
 use itertools::Itertools;
 use nym_client_core::init::helpers::choose_gateway_by_latency;
-use nym_config::defaults::DEFAULT_NYM_NODE_HTTP_PORT;
-use nym_crypto::asymmetric::encryption;
 use nym_explorer_client::{ExplorerClient, Location, PrettyDetailedGatewayBond};
-use nym_node_requests::api::client::NymNodeApiClientExt;
-use nym_node_requests::api::v1::gateway::client_interfaces::wireguard::models::{
-    ClientMessage, ClientRegistrationResponse, InitMessage, PeerPublicKey,
-};
 use nym_sdk::mixnet::{NodeIdentity, Recipient};
 use nym_validator_client::client::IdentityKey;
 use nym_validator_client::models::DescribedGateway;
 use nym_validator_client::NymApiClient;
 use rand::seq::IteratorRandom;
 use serde::{Deserialize, Serialize};
-use std::net::{IpAddr, SocketAddr};
-use std::str::FromStr;
-use talpid_types::net::wireguard::PublicKey;
+use std::net::IpAddr;
 use tracing::{debug, info};
 use url::Url;
 
@@ -74,24 +66,6 @@ impl Config {
 
     pub fn with_custom_explorer_url(mut self, explorer_url: Url) -> Self {
         self.explorer_url = Some(explorer_url);
-        self
-    }
-}
-
-#[derive(Clone, Debug, Default)]
-pub struct WgConfig {
-    pub(crate) local_private_key: Option<String>,
-}
-
-impl WgConfig {
-    pub fn new() -> Self {
-        WgConfig {
-            local_private_key: None,
-        }
-    }
-
-    pub fn with_local_private_key(mut self, local_private_key: String) -> Self {
-        self.local_private_key = Some(local_private_key);
         self
     }
 }
@@ -326,96 +300,6 @@ impl From<DescribedGateway> for DescribedGatewayWithLocation {
 pub struct GatewayClient {
     api_client: NymApiClient,
     explorer_client: Option<ExplorerClient>,
-}
-
-pub struct WgGatewayClient {
-    keypair: Option<encryption::KeyPair>,
-}
-
-#[derive(Clone, Debug)]
-pub struct GatewayData {
-    pub(crate) public_key: PublicKey,
-    pub(crate) endpoint: SocketAddr,
-    pub(crate) private_ip: IpAddr,
-}
-
-impl WgGatewayClient {
-    pub fn new(config: WgConfig) -> Result<Self> {
-        let keypair = if let Some(local_private_key) = config.local_private_key {
-            let private_key_intermediate = PublicKey::from_base64(&local_private_key)
-                .map_err(|_| crate::error::Error::InvalidWireGuardKey)?;
-            let private_key =
-                encryption::PrivateKey::from_bytes(private_key_intermediate.as_bytes())?;
-            let public_key = encryption::PublicKey::from(&private_key);
-            let keypair =
-                encryption::KeyPair::from_bytes(&private_key.to_bytes(), &public_key.to_bytes())
-                    .expect("The keys should be valid from the previous decoding");
-            Some(keypair)
-        } else {
-            None
-        };
-
-        Ok(WgGatewayClient { keypair })
-    }
-
-    pub async fn register_wireguard(
-        &self,
-        // gateway_identity: &str,
-        gateway_host: IpAddr,
-        wg_ip: IpAddr,
-    ) -> Result<GatewayData> {
-        // info!("Lookup ip for {}", gateway_identity);
-        // let gateway_host = self.lookup_gateway_ip(gateway_identity).await?;
-        // info!("Received wg gateway ip: {}", gateway_host);
-
-        let gateway_api_client = nym_node_requests::api::Client::new_url(
-            format!("{}:{}", gateway_host, DEFAULT_NYM_NODE_HTTP_PORT),
-            None,
-        )?;
-
-        // In the CLI it's ensured that the keypair is always present when wireguard is enabled.
-        let keypair = self.keypair.as_ref().unwrap();
-
-        debug!("Registering with the wg gateway...");
-        let init_message = ClientMessage::Initial(InitMessage {
-            pub_key: PeerPublicKey::new(keypair.public_key().to_bytes().into()),
-        });
-        let ClientRegistrationResponse::PendingRegistration {
-            nonce,
-            gateway_data,
-            wg_port,
-        } = gateway_api_client
-            .post_gateway_register_client(&init_message)
-            .await?
-        else {
-            return Err(crate::error::Error::InvalidGatewayAPIResponse);
-        };
-        debug!("Received nonce: {}", nonce);
-        debug!("Received wg_port: {}", wg_port);
-        debug!("Received gateway data: {:?}", gateway_data);
-
-        // Unwrap since we have already checked that we have the keypair.
-        debug!("Verifying data");
-        gateway_data.verify(keypair.private_key(), nonce)?;
-
-        // let mut mac = HmacSha256::new_from_slice(client_dh.as_bytes()).unwrap();
-        // mac.update(client_static_public.as_bytes());
-        // mac.update(&nonce.to_le_bytes());
-        // let mac = mac.finalize().into_bytes();
-        //
-        // let finalized_message = ClientMessage::Final(GatewayClient {
-        //     pub_key: PeerPublicKey::new(client_static_public),
-        //     mac: ClientMac::new(mac.as_slice().to_vec()),
-        // });
-        let gateway_data = GatewayData {
-            public_key: PublicKey::from(gateway_data.pub_key().to_bytes()),
-            endpoint: SocketAddr::from_str(&format!("{}:{}", gateway_host, wg_port))?,
-            private_ip: wg_ip,
-            // private_ip: "10.1.0.2".parse().unwrap(), // placeholder value for now
-        };
-
-        Ok(gateway_data)
-    }
 }
 
 impl GatewayClient {

--- a/nym-vpn-lib/src/gateway_client.rs
+++ b/nym-vpn-lib/src/gateway_client.rs
@@ -32,7 +32,6 @@ const FORCE_TLS_FOR_GATEWAY_SELECTION: bool = false;
 pub struct Config {
     pub(crate) api_url: Url,
     pub(crate) explorer_url: Option<Url>,
-    pub(crate) local_private_key: Option<String>,
 }
 
 impl Default for Config {
@@ -55,7 +54,6 @@ impl Default for Config {
         Config {
             api_url: default_api_url,
             explorer_url: default_explorer_url,
-            local_private_key: Default::default(),
         }
     }
 }
@@ -77,6 +75,19 @@ impl Config {
     pub fn with_custom_explorer_url(mut self, explorer_url: Url) -> Self {
         self.explorer_url = Some(explorer_url);
         self
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct WgConfig {
+    pub(crate) local_private_key: Option<String>,
+}
+
+impl WgConfig {
+    pub fn new() -> Self {
+        WgConfig {
+            local_private_key: None,
+        }
     }
 
     pub fn with_local_private_key(mut self, local_private_key: String) -> Self {
@@ -329,7 +340,7 @@ pub struct GatewayData {
 }
 
 impl WgGatewayClient {
-    pub fn new(config: Config) -> Result<Self> {
+    pub fn new(config: WgConfig) -> Result<Self> {
         let keypair = if let Some(local_private_key) = config.local_private_key {
             let private_key_intermediate = PublicKey::from_base64(&local_private_key)
                 .map_err(|_| crate::error::Error::InvalidWireGuardKey)?;
@@ -559,7 +570,6 @@ impl GatewayClient {
         info!("Resolved {ip_or_hostname} to {ip}");
         Ok(ip)
     }
-
 }
 
 async fn try_resolve_hostname(hostname: &str) -> Result<IpAddr> {

--- a/nym-vpn-lib/src/lib.rs
+++ b/nym-vpn-lib/src/lib.rs
@@ -5,7 +5,7 @@ uniffi::setup_scaffolding!();
 
 use crate::config::WireguardConfig;
 use crate::error::{Error, Result};
-use crate::gateway_client::{Config, GatewayClient};
+use crate::gateway_client::{Config, WgConfig, GatewayClient};
 use crate::mixnet_connect::setup_mixnet_client;
 use crate::mixnet_processor::IpPacketRouterAddress;
 use crate::tunnel::{setup_route_manager, start_tunnel, Tunnel};
@@ -84,6 +84,9 @@ pub struct NymVpn {
     /// Gateway configuration
     pub gateway_config: Config,
 
+    /// Wireguard Gateway configuration
+    pub wg_gateway_config: WgConfig,
+
     /// Path to the data directory of a previously initialised mixnet client, where the keys reside.
     pub mixnet_client_path: Option<PathBuf>,
 
@@ -155,6 +158,7 @@ impl NymVpn {
 
         Self {
             gateway_config: gateway_client::Config::default(),
+            wg_gateway_config: gateway_client::WgConfig::default(),
             mixnet_client_path: None,
             entry_point,
             exit_point,
@@ -355,7 +359,7 @@ impl NymVpn {
             .lookup_described_gateways_with_location()
             .await?;
 
-        let wg_gateway_client = WgGatewayClient::new(self.gateway_config.clone())?;
+        let wg_gateway_client = WgGatewayClient::new(self.wg_gateway_config.clone())?;
 
         // If the entry or exit point relies on location, do a basic defensive consistency check on
         // the fetched location data. If none of the gateways have location data, we can't proceed

--- a/nym-vpn-lib/src/lib.rs
+++ b/nym-vpn-lib/src/lib.rs
@@ -5,13 +5,14 @@ uniffi::setup_scaffolding!();
 
 use crate::config::WireguardConfig;
 use crate::error::{Error, Result};
-use crate::gateway_client::{Config, WgConfig, GatewayClient};
+use crate::gateway_client::{Config, GatewayClient};
 use crate::mixnet_connect::setup_mixnet_client;
 use crate::mixnet_processor::IpPacketRouterAddress;
 use crate::tunnel::{setup_route_manager, start_tunnel, Tunnel};
 use crate::util::{handle_interrupt, wait_for_interrupt};
+use crate::wg_gateway_client::{WgConfig, WgGatewayClient};
 use futures::channel::{mpsc, oneshot};
-use gateway_client::{EntryPoint, ExitPoint, WgGatewayClient};
+use gateway_client::{EntryPoint, ExitPoint};
 use log::{debug, error, info};
 use mixnet_connect::SharedMixnetClient;
 use nym_task::TaskManager;
@@ -53,6 +54,7 @@ pub mod routing;
 pub mod tunnel;
 mod uniffi_custom_impls;
 mod util;
+pub mod wg_gateway_client;
 
 async fn init_wireguard_config(
     gateway_client: &GatewayClient,
@@ -158,7 +160,7 @@ impl NymVpn {
 
         Self {
             gateway_config: gateway_client::Config::default(),
-            wg_gateway_config: gateway_client::WgConfig::default(),
+            wg_gateway_config: wg_gateway_client::WgConfig::default(),
             mixnet_client_path: None,
             entry_point,
             exit_point,

--- a/nym-vpn-lib/src/lib.rs
+++ b/nym-vpn-lib/src/lib.rs
@@ -5,9 +5,8 @@ uniffi::setup_scaffolding!();
 
 use crate::config::WireguardConfig;
 use crate::error::{Error, Result};
-use crate::gateway_client::{Config, GatewayClient};
+use crate::gateway_client::{Config, GatewayClient, IpPacketRouterAddress};
 use crate::mixnet_connect::setup_mixnet_client;
-use crate::mixnet_processor::IpPacketRouterAddress;
 use crate::tunnel::{setup_route_manager, start_tunnel, Tunnel};
 use crate::util::{handle_interrupt, wait_for_interrupt};
 use crate::wg_gateway_client::{WgConfig, WgGatewayClient};

--- a/nym-vpn-lib/src/mixnet_connect.rs
+++ b/nym-vpn-lib/src/mixnet_connect.rs
@@ -26,7 +26,7 @@ use tracing::{debug, error, info};
 
 use crate::{
     error::{Error, Result},
-    mixnet_processor::IpPacketRouterAddress,
+    gateway_client::IpPacketRouterAddress,
 };
 
 #[derive(Clone)]

--- a/nym-vpn-lib/src/mixnet_processor.rs
+++ b/nym-vpn-lib/src/mixnet_processor.rs
@@ -14,7 +14,6 @@ use nym_ip_packet_requests::{
 };
 use nym_sdk::mixnet::{InputMessage, MixnetMessageSender, Recipient};
 use nym_task::{connections::TransmissionLane, TaskClient, TaskManager};
-use nym_validator_client::models::DescribedGateway;
 use tokio::task::JoinHandle;
 use tokio::time::timeout;
 use tokio_util::codec::Decoder;
@@ -24,6 +23,7 @@ use tun2::{AbstractDevice, AsyncDevice};
 use crate::{
     connection_monitor::{self, ConnectionStatusEvent},
     error::{Error, Result},
+    gateway_client::IpPacketRouterAddress,
     icmp_connection_beacon,
     mixnet_connect::SharedMixnetClient,
 };
@@ -38,37 +38,6 @@ impl Config {
         Config {
             ip_packet_router_address,
         }
-    }
-}
-
-#[derive(Debug, Copy, Clone)]
-pub struct IpPacketRouterAddress(pub Recipient);
-
-impl IpPacketRouterAddress {
-    pub fn try_from_base58_string(ip_packet_router_nym_address: &str) -> Result<Self> {
-        Ok(Self(
-            Recipient::try_from_base58_string(ip_packet_router_nym_address)
-                .map_err(|_| Error::RecipientFormattingError)?,
-        ))
-    }
-
-    pub fn try_from_described_gateway(gateway: &DescribedGateway) -> Result<Self> {
-        let address = gateway
-            .self_described
-            .clone()
-            .and_then(|described_gateway| described_gateway.ip_packet_router)
-            .map(|ipr| ipr.address)
-            .ok_or(Error::MissingIpPacketRouterAddress)?;
-        Ok(Self(
-            Recipient::try_from_base58_string(address)
-                .map_err(|_| Error::RecipientFormattingError)?,
-        ))
-    }
-}
-
-impl std::fmt::Display for IpPacketRouterAddress {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
     }
 }
 

--- a/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-lib/src/platform/mod.rs
@@ -194,7 +194,6 @@ async fn get_gateway_countries(
     let config = gateway_client::Config {
         api_url,
         explorer_url: Some(explorer_url),
-        ..Default::default()
     };
     let gateway_client = GatewayClient::new(config)?;
 
@@ -218,7 +217,6 @@ async fn get_low_latency_entry_country(
     let config = gateway_client::Config {
         api_url,
         explorer_url: Some(explorer_url),
-        ..Default::default()
     };
     let gateway_client = GatewayClient::new(config)?;
     let described = gateway_client.lookup_low_latency_entry_gateway().await?;

--- a/nym-vpn-lib/src/wg_gateway_client.rs
+++ b/nym-vpn-lib/src/wg_gateway_client.rs
@@ -1,0 +1,122 @@
+// Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use crate::error::Result;
+use nym_config::defaults::DEFAULT_NYM_NODE_HTTP_PORT;
+use nym_crypto::asymmetric::encryption;
+use nym_node_requests::api::client::NymNodeApiClientExt;
+use nym_node_requests::api::v1::gateway::client_interfaces::wireguard::models::{
+    ClientMessage, ClientRegistrationResponse, InitMessage, PeerPublicKey,
+};
+use std::net::{IpAddr, SocketAddr};
+use std::str::FromStr;
+use talpid_types::net::wireguard::PublicKey;
+use tracing::debug;
+
+#[derive(Clone, Debug, Default)]
+pub struct WgConfig {
+    pub(crate) local_private_key: Option<String>,
+}
+
+impl WgConfig {
+    pub fn new() -> Self {
+        WgConfig {
+            local_private_key: None,
+        }
+    }
+
+    pub fn with_local_private_key(mut self, local_private_key: String) -> Self {
+        self.local_private_key = Some(local_private_key);
+        self
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct GatewayData {
+    pub(crate) public_key: PublicKey,
+    pub(crate) endpoint: SocketAddr,
+    pub(crate) private_ip: IpAddr,
+}
+
+pub struct WgGatewayClient {
+    keypair: Option<encryption::KeyPair>,
+}
+
+impl WgGatewayClient {
+    pub fn new(config: WgConfig) -> Result<Self> {
+        let keypair = if let Some(local_private_key) = config.local_private_key {
+            let private_key_intermediate = PublicKey::from_base64(&local_private_key)
+                .map_err(|_| crate::error::Error::InvalidWireGuardKey)?;
+            let private_key =
+                encryption::PrivateKey::from_bytes(private_key_intermediate.as_bytes())?;
+            let public_key = encryption::PublicKey::from(&private_key);
+            let keypair =
+                encryption::KeyPair::from_bytes(&private_key.to_bytes(), &public_key.to_bytes())
+                    .expect("The keys should be valid from the previous decoding");
+            Some(keypair)
+        } else {
+            None
+        };
+
+        Ok(WgGatewayClient { keypair })
+    }
+
+    pub async fn register_wireguard(
+        &self,
+        // gateway_identity: &str,
+        gateway_host: IpAddr,
+        wg_ip: IpAddr,
+    ) -> Result<GatewayData> {
+        // info!("Lookup ip for {}", gateway_identity);
+        // let gateway_host = self.lookup_gateway_ip(gateway_identity).await?;
+        // info!("Received wg gateway ip: {}", gateway_host);
+
+        let gateway_api_client = nym_node_requests::api::Client::new_url(
+            format!("{}:{}", gateway_host, DEFAULT_NYM_NODE_HTTP_PORT),
+            None,
+        )?;
+
+        // In the CLI it's ensured that the keypair is always present when wireguard is enabled.
+        let keypair = self.keypair.as_ref().unwrap();
+
+        debug!("Registering with the wg gateway...");
+        let init_message = ClientMessage::Initial(InitMessage {
+            pub_key: PeerPublicKey::new(keypair.public_key().to_bytes().into()),
+        });
+        let ClientRegistrationResponse::PendingRegistration {
+            nonce,
+            gateway_data,
+            wg_port,
+        } = gateway_api_client
+            .post_gateway_register_client(&init_message)
+            .await?
+        else {
+            return Err(crate::error::Error::InvalidGatewayAPIResponse);
+        };
+        debug!("Received nonce: {}", nonce);
+        debug!("Received wg_port: {}", wg_port);
+        debug!("Received gateway data: {:?}", gateway_data);
+
+        // Unwrap since we have already checked that we have the keypair.
+        debug!("Verifying data");
+        gateway_data.verify(keypair.private_key(), nonce)?;
+
+        // let mut mac = HmacSha256::new_from_slice(client_dh.as_bytes()).unwrap();
+        // mac.update(client_static_public.as_bytes());
+        // mac.update(&nonce.to_le_bytes());
+        // let mac = mac.finalize().into_bytes();
+        //
+        // let finalized_message = ClientMessage::Final(GatewayClient {
+        //     pub_key: PeerPublicKey::new(client_static_public),
+        //     mac: ClientMac::new(mac.as_slice().to_vec()),
+        // });
+        let gateway_data = GatewayData {
+            public_key: PublicKey::from(gateway_data.pub_key().to_bytes()),
+            endpoint: SocketAddr::from_str(&format!("{}:{}", gateway_host, wg_port))?,
+            private_ip: wg_ip,
+            // private_ip: "10.1.0.2".parse().unwrap(), // placeholder value for now
+        };
+
+        Ok(gateway_data)
+    }
+}


### PR DESCRIPTION
The idea is to extract GatewayClient to its own crate, since it's something that is useful to be able to use independently from the vpn lib, especially once we move to a daemon/service architecture

- **Extract out WgGatewayClient**
- **Extract out WgConfig**
- **Split into two files**
