### PR TITLE
Store keys in data dir instead of config dir

### DIFF
--- a/nym-vpn-cli/src/commands.rs
+++ b/nym-vpn-cli/src/commands.rs
@@ -33,7 +33,7 @@ pub(crate) struct CliArgs {
 
     /// Path to the data directory of the mixnet client.
     #[arg(long)]
-    pub(crate) config_path: Option<PathBuf>,
+    pub(crate) data_path: Option<PathBuf>,
 
     #[command(subcommand)]
     pub(crate) command: Commands,

--- a/nym-vpn-cli/src/main.rs
+++ b/nym-vpn-cli/src/main.rs
@@ -146,7 +146,7 @@ async fn import_credential(
 fn mixnet_config_path() -> Option<PathBuf> {
     let network_name =
         std::env::var(var_names::NETWORK_NAME).expect("NETWORK_NAME env var not set");
-    dirs::config_dir().map(|dir| dir.join(CONFIG_DIRECTORY_NAME).join(network_name))
+    dirs::data_dir().map(|dir| dir.join(CONFIG_DIRECTORY_NAME).join(network_name))
 }
 
 #[tokio::main]

--- a/nym-vpn-cli/src/main.rs
+++ b/nym-vpn-cli/src/main.rs
@@ -142,7 +142,6 @@ async fn import_credential(
     nym_vpn_lib::credentials::import_credential(raw_credential, config_path).await
 }
 
-#[allow(unused)]
 fn mixnet_config_path() -> Option<PathBuf> {
     let network_name =
         std::env::var(var_names::NETWORK_NAME).expect("NETWORK_NAME env var not set");

--- a/nym-vpn-cli/src/main.rs
+++ b/nym-vpn-cli/src/main.rs
@@ -76,18 +76,18 @@ async fn run() -> Result<()> {
     debug!("{:?}", nym_vpn_lib::nym_bin_common::bin_info!());
     setup_env(args.config_env_file.as_ref());
 
-    let config_path = args.config_path.or(mixnet_config_path());
+    let data_path = args.data_path.or(mixnet_data_path());
 
     match args.command {
-        Commands::Run(args) => run_vpn(args, config_path).await,
+        Commands::Run(args) => run_vpn(args, data_path).await,
         Commands::ImportCredential(args) => {
-            let config_path = config_path.ok_or(Error::ConfigPathNotSet)?;
-            import_credential(args, config_path).await
+            let data_path = data_path.ok_or(Error::ConfigPathNotSet)?;
+            import_credential(args, data_path).await
         }
     }
 }
 
-async fn run_vpn(args: commands::RunArgs, config_path: Option<PathBuf>) -> Result<()> {
+async fn run_vpn(args: commands::RunArgs, data_path: Option<PathBuf>) -> Result<()> {
     // Setup gateway configuration
     let gateway_config = override_from_env(&args, GatewayConfig::default());
     info!("nym-api: {}", gateway_config.api_url());
@@ -113,7 +113,7 @@ async fn run_vpn(args: commands::RunArgs, config_path: Option<PathBuf>) -> Resul
     let mut nym_vpn = NymVpn::new(entry_point, exit_point);
     nym_vpn.gateway_config = gateway_config;
     nym_vpn.wg_gateway_config = wg_gateway_config;
-    nym_vpn.mixnet_config_path = config_path;
+    nym_vpn.mixnet_data_path = data_path;
     nym_vpn.enable_wireguard = args.enable_wireguard;
     nym_vpn.private_key = args.private_key;
     nym_vpn.wg_ip = args.wg_ip;
@@ -130,19 +130,16 @@ async fn run_vpn(args: commands::RunArgs, config_path: Option<PathBuf>) -> Resul
     Ok(())
 }
 
-async fn import_credential(
-    args: commands::ImportCredentialArgs,
-    config_path: PathBuf,
-) -> Result<()> {
+async fn import_credential(args: commands::ImportCredentialArgs, data_path: PathBuf) -> Result<()> {
     let data: ImportCredentialTypeEnum = args.credential_type.into();
     let raw_credential = match data {
         ImportCredentialTypeEnum::Path(path) => fs::read(path)?,
         ImportCredentialTypeEnum::Data(data) => data,
     };
-    nym_vpn_lib::credentials::import_credential(raw_credential, config_path).await
+    nym_vpn_lib::credentials::import_credential(raw_credential, data_path).await
 }
 
-fn mixnet_config_path() -> Option<PathBuf> {
+fn mixnet_data_path() -> Option<PathBuf> {
     let network_name =
         std::env::var(var_names::NETWORK_NAME).expect("NETWORK_NAME env var not set");
     dirs::data_dir().map(|dir| dir.join(CONFIG_DIRECTORY_NAME).join(network_name))

--- a/nym-vpn-lib/src/credentials.rs
+++ b/nym-vpn-lib/src/credentials.rs
@@ -5,8 +5,8 @@ use nym_sdk::mixnet::StoragePaths;
 use crate::error::{Error, Result};
 
 // Import binary credential data
-pub async fn import_credential(credential: Vec<u8>, config_path: PathBuf) -> Result<()> {
-    let storage_path = StoragePaths::new_from_dir(config_path)?;
+pub async fn import_credential(credential: Vec<u8>, data_path: PathBuf) -> Result<()> {
+    let storage_path = StoragePaths::new_from_dir(data_path)?;
     let credential_path = storage_path.credential_database_path;
     let credentials_store =
         nym_credential_storage::initialise_persistent_storage(credential_path).await;
@@ -19,15 +19,15 @@ pub async fn import_credential(credential: Vec<u8>, config_path: PathBuf) -> Res
 }
 
 // Import credential data from a base58 string
-pub async fn import_credential_base58(credential: &str, config_path: PathBuf) -> Result<()> {
+pub async fn import_credential_base58(credential: &str, data_path: PathBuf) -> Result<()> {
     let raw_credential = bs58::decode(credential)
         .into_vec()
         .map_err(|err| Error::FailedToDecodeBase58Credential { source: err })?;
-    import_credential(raw_credential, config_path).await
+    import_credential(raw_credential, data_path).await
 }
 
 // Import credential data from a binary file
-pub async fn import_credential_file(credential_file: PathBuf, config_path: PathBuf) -> Result<()> {
+pub async fn import_credential_file(credential_file: PathBuf, data_path: PathBuf) -> Result<()> {
     let raw_credential = fs::read(credential_file)?;
-    import_credential(raw_credential, config_path).await
+    import_credential(raw_credential, data_path).await
 }

--- a/nym-vpn-lib/src/lib.rs
+++ b/nym-vpn-lib/src/lib.rs
@@ -92,7 +92,7 @@ pub struct NymVpn {
     pub wg_gateway_config: WgConfig,
 
     /// Path to the data directory of a previously initialised mixnet client, where the keys reside.
-    pub mixnet_config_path: Option<PathBuf>,
+    pub mixnet_data_path: Option<PathBuf>,
 
     /// Mixnet public ID of the entry gateway.
     pub entry_point: EntryPoint,
@@ -165,7 +165,7 @@ impl NymVpn {
         Self {
             gateway_config: nym_gateway_directory::Config::default(),
             wg_gateway_config: wg_gateway_client::WgConfig::default(),
-            mixnet_config_path: None,
+            mixnet_data_path: None,
             entry_point,
             exit_point,
             enable_wireguard: false,
@@ -292,7 +292,7 @@ impl NymVpn {
             Duration::from_secs(10),
             setup_mixnet_client(
                 entry_gateway,
-                &self.mixnet_config_path,
+                &self.mixnet_data_path,
                 task_manager.subscribe_named("mixnet_client_main"),
                 self.enable_wireguard,
                 self.enable_two_hop,


### PR DESCRIPTION
- Switch mixnet default config path to data dir
- Rename mixnet_config_path to mixnet_data_path to better reflect reality
