### PR TITLE
Send structured android messages in log

### DIFF
--- a/nym-vpn-lib/src/platform/android.rs
+++ b/nym-vpn-lib/src/platform/android.rs
@@ -335,7 +335,7 @@ impl From<&crate::Error> for AndroidControlMessage {
     }
 }
 
-fn send_android_control_message(exit_status_msg: &NymVpnExitStatusMessage) {
+fn print_android_control_message(exit_status_msg: &NymVpnExitStatusMessage) {
     let android_control_message: AndroidControlMessage = exit_status_msg.into();
     let android_control_message_str = match serde_json::to_string(&android_control_message) {
         Ok(json) => json,

--- a/nym-vpn-lib/src/platform/android.rs
+++ b/nym-vpn-lib/src/platform/android.rs
@@ -335,7 +335,7 @@ impl From<&crate::Error> for AndroidControlMessage {
     }
 }
 
-fn print_android_control_message(exit_status_msg: &NymVpnExitStatusMessage) {
+pub(super) fn print_android_control_message(exit_status_msg: &NymVpnExitStatusMessage) {
     let android_control_message: AndroidControlMessage = exit_status_msg.into();
     let android_control_message_str = match serde_json::to_string(&android_control_message) {
         Ok(json) => json,

--- a/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-lib/src/platform/mod.rs
@@ -81,7 +81,10 @@ async fn wait_for_shutdown(
     // wait for notify to be set...
     stop_handle.notified().await;
     handle.vpn_ctrl_tx.send(NymVpnCtrlMessage::Stop)?;
-    match handle.vpn_exit_rx.await? {
+    let exit_status_msg = handle.vpn_exit_rx.await?;
+    #[cfg(target_os = "android")]
+    send_android_control_message(&exit_status_msg);
+    match exit_status_msg {
         NymVpnExitStatusMessage::Failed(error) => {
             error!(
                 "{:?}",

--- a/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-lib/src/platform/mod.rs
@@ -83,7 +83,7 @@ async fn wait_for_shutdown(
     handle.vpn_ctrl_tx.send(NymVpnCtrlMessage::Stop)?;
     let exit_status_msg = handle.vpn_exit_rx.await?;
     #[cfg(target_os = "android")]
-    send_android_control_message(&exit_status_msg);
+    print_android_control_message(&exit_status_msg);
     match exit_status_msg {
         NymVpnExitStatusMessage::Failed(error) => {
             error!(

--- a/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-lib/src/platform/mod.rs
@@ -83,7 +83,7 @@ async fn wait_for_shutdown(
     handle.vpn_ctrl_tx.send(NymVpnCtrlMessage::Stop)?;
     let exit_status_msg = handle.vpn_exit_rx.await?;
     #[cfg(target_os = "android")]
-    print_android_control_message(&exit_status_msg);
+    android::print_android_control_message(&exit_status_msg);
     match exit_status_msg {
         NymVpnExitStatusMessage::Failed(error) => {
             error!(


### PR DESCRIPTION
Send structured (JSON) messages in log for the Android frontend to consume. In particular, send a message if the VPN stops
