### PR TITLE
Extend error log message on vpn exit fail

### DIFF
--- a/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-lib/src/platform/mod.rs
@@ -84,7 +84,7 @@ async fn wait_for_shutdown(
     match handle.vpn_exit_rx.await? {
         NymVpnExitStatusMessage::Failed(error) => {
             error!(
-                "{:?}",
+                "Stopped Nym VPN with error: {:?}",
                 error
                     .downcast_ref::<NymVpnExitError>()
                     .ok_or(crate::Error::StopError)?


### PR DESCRIPTION
Alternative to https://github.com/nymtech/nym-vpn-client/pull/257

Simpler solution to signal exit to Android frontend