### PR TITLE
Lawrence/remove msi build

### DIFF
--- a/.github/workflows/release-nym-vpn-cli.yml
+++ b/.github/workflows/release-nym-vpn-cli.yml
@@ -124,7 +124,6 @@ jobs:
             wg_go_lib_name="wireguard-go_apple_universal"
           elif ${{ contains(matrix.os, 'windows') }}; then
             platform_arch=x86_64-pc-windows-msvc
-            rustflags="-L ${{ env.WG_GO_LIB_PATH }}/x86_64-pc-windows-msvc -L ${{ env.WG_GO_LIB_PATH }}/ -Clink-args=/LIBPATH:${{ env.WG_GO_LIB_PATH }}/x64-Debug"
             wg_go_lib_name="wireguard-go_$platform_arch"
           else
             echo " ✗ unknown platform/arch [${{ matrix.os }}]"
@@ -239,8 +238,8 @@ jobs:
         shell: bash
         run: |
           cd ${GITHUB_WORKSPACE}/nym-vpn-mullvad-libs
-          ./build-windows-modules.sh
-          mv ${GITHUB_WORKSPACE}/nym-vpn-mullvad-libs/windows/winfw/bin/x64-Debug ${GITHUB_WORKSPACE}/lib/
+          CPP_BUILD_MODES=Release ./build-windows-modules.sh
+          mv ${GITHUB_WORKSPACE}/nym-vpn-mullvad-libs/windows/winfw/bin/x64-Release ${GITHUB_WORKSPACE}/lib/
 
       - name: Build native
         if: contains(matrix.target, 'native') && !contains(matrix.os, 'windows')
@@ -251,7 +250,7 @@ jobs:
       - name: Build Windows
         if: contains(matrix.os, 'windows')
         env:
-          RUSTFLAGS: "-L ${{ env.WG_GO_LIB_PATH }}/x86_64-pc-windows-msvc -L ${{ env.WG_GO_LIB_PATH }}/ -Clink-args=/LIBPATH:${{ env.WG_GO_LIB_PATH }}/x64-Debug"
+          RUSTFLAGS: "-L ${{ env.WG_GO_LIB_PATH }}/x86_64-pc-windows-msvc -L ${{ env.WG_GO_LIB_PATH }}/ -Clink-args=/LIBPATH:${{ env.WG_GO_LIB_PATH }}/x64-Release"
         run: cargo build --release --verbose
 
       - name: Build universal (macos)

--- a/.github/workflows/release-nym-vpn-desktop.yml
+++ b/.github/workflows/release-nym-vpn-desktop.yml
@@ -124,9 +124,7 @@ jobs:
             platform_arch=x86_64-pc-windows-msvc
             wg_go_lib_name="wireguard-go_$platform_arch"
             rustflags="-L ${GITHUB_WORKSPACE}/nym-vpn-desktop/src-tauri/x86_64-pc-windows-msvc -L ${GITHUB_WORKSPACE}/nym-vpn-desktop/src-tauri/ -Clink-args=/LIBPATH:${GITHUB_WORKSPACE}/nym-vpn-desktop/src-tauri/x64-Debug"
-            sed -i 's/-dev/-1/g' nym-vpn-desktop/src-tauri/Cargo.toml
             sed -i 's/"bundle": {/"bundle": {"resources": ["wintun.dll", "vcruntime140.dll", "libwg.dll", "winfw.dll"],/g' nym-vpn-desktop/src-tauri/tauri.conf.json
-            version=$(sed 's/-dev/-1/g' <<< $version)
           else
             echo " ✗ unknown platform/arch [${{ matrix.os }}]"
             exit 1

--- a/.github/workflows/release-nym-vpn-desktop.yml
+++ b/.github/workflows/release-nym-vpn-desktop.yml
@@ -123,7 +123,7 @@ jobs:
           elif ${{ contains(matrix.os, 'windows') }}; then
             platform_arch=x86_64-pc-windows-msvc
             wg_go_lib_name="wireguard-go_$platform_arch"
-            rustflags="-L ${GITHUB_WORKSPACE}/nym-vpn-desktop/src-tauri/x86_64-pc-windows-msvc -L ${GITHUB_WORKSPACE}/nym-vpn-desktop/src-tauri/ -Clink-args=/LIBPATH:${GITHUB_WORKSPACE}/nym-vpn-desktop/src-tauri/x64-Debug"
+            rustflags="-L ${GITHUB_WORKSPACE}/nym-vpn-desktop/src-tauri/x86_64-pc-windows-msvc -L ${GITHUB_WORKSPACE}/nym-vpn-desktop/src-tauri/ -Clink-args=/LIBPATH:${GITHUB_WORKSPACE}/nym-vpn-desktop/src-tauri/x64-Release"
             sed -i 's/"bundle": {/"bundle": {"resources": ["wintun.dll", "vcruntime140.dll", "libwg.dll", "winfw.dll"],/g' nym-vpn-desktop/src-tauri/tauri.conf.json
           else
             echo " ✗ unknown platform/arch [${{ matrix.os }}]"
@@ -196,9 +196,9 @@ jobs:
         shell: bash
         run: |
           cd ${GITHUB_WORKSPACE}/nym-vpn-mullvad-libs
-          ./build-windows-modules.sh
-          mv ${GITHUB_WORKSPACE}/nym-vpn-mullvad-libs/windows/winfw/bin/x64-Debug ${GITHUB_WORKSPACE}/nym-vpn-desktop/src-tauri/
-          cp ${GITHUB_WORKSPACE}/nym-vpn-desktop/src-tauri/x64-Debug/winfw.dll ${GITHUB_WORKSPACE}/nym-vpn-desktop/src-tauri/
+          CPP_BUILD_MODES=Release ./build-windows-modules.sh
+          mv ${GITHUB_WORKSPACE}/nym-vpn-mullvad-libs/windows/winfw/bin/x64-Release ${GITHUB_WORKSPACE}/nym-vpn-desktop/src-tauri/
+          cp ${GITHUB_WORKSPACE}/nym-vpn-desktop/src-tauri/x64-Release/winfw.dll ${GITHUB_WORKSPACE}/nym-vpn-desktop/src-tauri/
 
       - name: Download/Unzip/Move wintun.zip and winpcap.zip, also move wireguard lib for windows
         if: contains(matrix.os, 'windows')

--- a/nym-vpn-desktop/src-tauri/tauri.conf.json
+++ b/nym-vpn-desktop/src-tauri/tauri.conf.json
@@ -22,7 +22,7 @@
     },
     "bundle": {
       "active": true,
-      "targets": "all",
+      "targets": ["deb", "appimage", "nsis", "app", "dmg", "updater"],
       "identifier": "net.nymtech.vpn",
       "icon": [
         "icons/32x32.png"     , "icons/128x128.png"   , "icons/128x128@2x.png",


### PR DESCRIPTION
- removes `msi` build and its `sed` shenanigans
- changes to use mullvad windows libs in release mode instead of debug