### PR TITLE
feat(grpc): add health client gen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4723,6 +4723,7 @@ dependencies = [
  "clap",
  "dirs 5.0.1",
  "futures",
+ "http 0.2.12",
  "nym-task",
  "nym-vpn-lib",
  "nym-vpn-proto",

--- a/crates/nym-vpn-proto/build.rs
+++ b/crates/nym-vpn-proto/build.rs
@@ -5,10 +5,14 @@ use std::{env, path::PathBuf};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // needed for reflection
-    let descriptor_path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("vpn_descriptor.bin");
+    let vpn_fd = PathBuf::from(env::var("OUT_DIR").unwrap()).join("vpn_descriptor.bin");
+    tonic_build::configure()
+        .file_descriptor_set_path(vpn_fd)
+        .compile(&["../../proto/nym/vpn.proto"], &["../../proto/nym/"])?;
 
     tonic_build::configure()
-        .file_descriptor_set_path(descriptor_path)
-        .compile(&["../../proto/nym/vpn.proto"], &["../../proto/nym/"])?;
+        // server implementation is handled by tonic-health crate
+        .build_server(false)
+        .compile(&["../../proto/grpc/health.proto"], &["../../proto/grpc/"])?;
     Ok(())
 }

--- a/crates/nym-vpn-proto/src/lib.rs
+++ b/crates/nym-vpn-proto/src/lib.rs
@@ -1,3 +1,7 @@
 tonic::include_proto!("nym.vpn");
 
-pub const FILE_DESCRIPTOR_SET: &[u8] = tonic::include_file_descriptor_set!("vpn_descriptor");
+// client implementation only
+tonic::include_proto!("grpc.health.v1");
+
+// needed for reflection
+pub const VPN_FD_SET: &[u8] = tonic::include_file_descriptor_set!("vpn_descriptor");

--- a/nym-vpnd/Cargo.toml
+++ b/nym-vpnd/Cargo.toml
@@ -28,6 +28,9 @@ tracing.workspace = true
 tonic-health.workspace = true
 tonic-reflection.workspace = true
 
+# match the version required by tonic
+http = "0.2.12"
+
 nym-vpn-lib = { path = "../nym-vpn-lib" }
 nym-vpn-proto = { path = "../crates/nym-vpn-proto" }
 nym-task.workspace = true

--- a/nym-vpnd/src/command_interface/start.rs
+++ b/nym-vpnd/src/command_interface/start.rs
@@ -4,10 +4,10 @@
 use std::{net::SocketAddr, path::PathBuf};
 
 use nym_task::TaskManager;
-use nym_vpn_proto::{nym_vpnd_server::NymVpndServer, FILE_DESCRIPTOR_SET};
+use nym_vpn_proto::{nym_vpnd_server::NymVpndServer, VPN_FD_SET};
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tonic::transport::Server;
-use tracing::info;
+use tracing::{debug, debug_span, info, info_span, trace, trace_span, Span};
 
 use super::{
     config::{default_socket_path, default_uri_addr},
@@ -15,6 +15,24 @@ use super::{
     socket_stream::setup_socket_stream,
 };
 use crate::{cli::CliArgs, service::VpnServiceCommand};
+
+fn grpc_span(req: &http::Request<()>) -> Span {
+    let service = req.uri().path().trim_start_matches('/');
+    let method = service.split('/').last().unwrap_or(service);
+    if service.contains("grpc.reflection.v1") {
+        let span = trace_span!("grpc_reflection");
+        trace!(target: "grpc_reflection", "← {} {:?}", method, req.body());
+        return span;
+    }
+    if service.contains("grpc.health.v1") {
+        let span = debug_span!("grpc_health");
+        debug!(target: "grpc_health", "← {} {:?}", method, req.body());
+        return span;
+    }
+    let span = info_span!("grpc_vpnd");
+    info!(target: "grpc_vpnd", "← {} {:?}", method, req.body());
+    span
+}
 
 fn spawn_uri_listener(vpn_command_tx: UnboundedSender<VpnServiceCommand>, addr: SocketAddr) {
     info!("Starting HTTP listener on: {addr}");
@@ -24,12 +42,13 @@ fn spawn_uri_listener(vpn_command_tx: UnboundedSender<VpnServiceCommand>, addr: 
             .set_serving::<NymVpndServer<CommandInterface>>()
             .await;
         let reflection_service = tonic_reflection::server::Builder::configure()
-            .register_encoded_file_descriptor_set(FILE_DESCRIPTOR_SET)
+            .register_encoded_file_descriptor_set(VPN_FD_SET)
             .build()
             .unwrap();
         let command_interface = CommandInterface::new_with_uri(vpn_command_tx, addr);
 
         Server::builder()
+            .trace_fn(grpc_span)
             .add_service(health_service)
             .add_service(reflection_service)
             .add_service(NymVpndServer::new(command_interface))
@@ -47,7 +66,7 @@ fn spawn_socket_listener(vpn_command_tx: UnboundedSender<VpnServiceCommand>, soc
             .set_serving::<NymVpndServer<CommandInterface>>()
             .await;
         let reflection_service = tonic_reflection::server::Builder::configure()
-            .register_encoded_file_descriptor_set(FILE_DESCRIPTOR_SET)
+            .register_encoded_file_descriptor_set(VPN_FD_SET)
             .build()
             .unwrap();
         let command_interface = CommandInterface::new_with_path(vpn_command_tx, &socket_path);
@@ -55,6 +74,7 @@ fn spawn_socket_listener(vpn_command_tx: UnboundedSender<VpnServiceCommand>, soc
         let incoming = setup_socket_stream(&socket_path);
 
         Server::builder()
+            .trace_fn(grpc_span)
             .add_service(health_service)
             .add_service(reflection_service)
             .add_service(NymVpndServer::new(command_interface))


### PR DESCRIPTION
- add generation of service health client
- add nice tracing of grpc requests

minimum grpc tracing level can be set using `grpc` key in `RUST_LOG` env var

```
RUST_LOG=nym_vpnd=debug,grpc=trace
```