### PR TITLE
Set DNS to something we can resolve through the tunnel

### DIFF
--- a/nym-vpn-cli/src/commands.rs
+++ b/nym-vpn-cli/src/commands.rs
@@ -5,7 +5,7 @@ use clap::{Args, Parser, Subcommand};
 use ipnetwork::{Ipv4Network, Ipv6Network};
 use nym_vpn_lib::{nym_bin_common::bin_info_local_vergen, wg_gateway_client::WgConfig};
 use std::{
-    net::{Ipv4Addr, Ipv6Addr},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr},
     path::PathBuf,
     str::FromStr,
     sync::OnceLock,
@@ -91,6 +91,10 @@ pub(crate) struct RunArgs {
     /// The MTU of the nym TUN device that wraps IP packets in sphinx packets.
     #[arg(long, alias = "mtu")]
     pub(crate) nym_mtu: Option<u16>,
+
+    /// The DNS server to use
+    #[arg(long)]
+    pub(crate) dns: Option<IpAddr>,
 
     /// Disable routing all traffic through the nym TUN device. When the flag is set, the nym TUN
     /// device will be created, but to route traffic through it you will need to do it manually,

--- a/nym-vpn-cli/src/main.rs
+++ b/nym-vpn-cli/src/main.rs
@@ -147,6 +147,7 @@ async fn run_vpn(args: commands::RunArgs, data_path: Option<PathBuf>) -> Result<
         nym_vpn.gateway_config = gateway_config;
         nym_vpn.nym_ips = nym_ips;
         nym_vpn.nym_mtu = args.nym_mtu;
+        nym_vpn.dns = args.dns;
         nym_vpn.disable_routing = args.disable_routing;
         nym_vpn.enable_two_hop = args.enable_two_hop;
         nym_vpn.vpn_config.wg_gateway_config = wg_gateway_config;
@@ -160,6 +161,7 @@ async fn run_vpn(args: commands::RunArgs, data_path: Option<PathBuf>) -> Result<
         nym_vpn.gateway_config = gateway_config;
         nym_vpn.nym_ips = nym_ips;
         nym_vpn.nym_mtu = args.nym_mtu;
+        nym_vpn.dns = args.dns;
         nym_vpn.disable_routing = args.disable_routing;
         nym_vpn.enable_two_hop = args.enable_two_hop;
         nym_vpn.vpn_config.mixnet_data_path = data_path;

--- a/nym-vpn-lib/src/lib.rs
+++ b/nym-vpn-lib/src/lib.rs
@@ -165,6 +165,9 @@ pub struct NymVpn<T: Vpn> {
     /// The MTU of the TUN device.
     pub nym_mtu: Option<u16>,
 
+    /// The DNS server to use
+    pub dns: Option<IpAddr>,
+
     /// Disable routing all traffic through the VPN TUN device.
     pub disable_routing: bool,
 
@@ -206,6 +209,7 @@ impl NymVpn<WireguardVpn> {
             exit_point,
             nym_ips: None,
             nym_mtu: None,
+            dns: None,
             disable_routing: false,
             enable_two_hop: false,
             vpn_config: WireguardVpn {
@@ -247,6 +251,7 @@ impl NymVpn<MixnetVpn> {
             exit_point,
             nym_ips: None,
             nym_mtu: None,
+            dns: None,
             disable_routing: false,
             enable_two_hop: false,
             vpn_config: MixnetVpn {
@@ -310,6 +315,7 @@ impl NymVpn<MixnetVpn> {
             #[cfg(target_os = "ios")]
             self.ios_tun_provider.clone(),
             dns_monitor,
+            self.dns,
         )
         .await?;
 

--- a/nym-vpn-lib/src/lib.rs
+++ b/nym-vpn-lib/src/lib.rs
@@ -443,13 +443,16 @@ impl SpecificVpn {
 
         // Finished starting everything, now wait for mixnet client shutdown
         match tunnels {
-            AllTunnelsSetup::Mix(TunnelSetup { specific_setup, .. }) => {
+            AllTunnelsSetup::Mix(TunnelSetup { mut specific_setup, .. }) => {
                 wait_for_interrupt(specific_setup.task_manager).await;
                 handle_interrupt(Arc::new(RwLock::new(specific_setup.route_manager)), None)
                     .await
                     .tap_err(|err| {
                         error!("Failed to handle interrupt: {err}");
                     })?;
+                specific_setup.dns_monitor.reset().tap_err(|err| {
+                    error!("Failed to reset dns monitor: {err}");
+                })?;
             }
             AllTunnelsSetup::Wg {
                 route_manager,

--- a/nym-vpn-lib/src/routing.rs
+++ b/nym-vpn-lib/src/routing.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use netdev::Interface;
-use talpid_core::dns::DnsMonitor;
 use std::fmt::{Display, Formatter};
 use std::net::{Ipv4Addr, Ipv6Addr};
 #[cfg(target_os = "android")]
@@ -10,6 +9,7 @@ use std::os::fd::{AsRawFd, RawFd};
 #[cfg(target_os = "android")]
 use std::sync::{Arc, Mutex};
 use std::{collections::HashSet, net::IpAddr};
+use talpid_core::dns::DnsMonitor;
 
 use ipnetwork::IpNetwork;
 use netdev::interface::get_default_interface;

--- a/nym-vpn-lib/src/routing.rs
+++ b/nym-vpn-lib/src/routing.rs
@@ -26,6 +26,7 @@ use crate::error::Result;
 use crate::{MixnetVpn, NymVpn};
 
 const DEFAULT_TUN_MTU: u16 = 1500;
+const DEFAULT_DNS_SERVER: IpAddr = IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1));
 
 #[derive(Clone)]
 pub struct RoutingConfig {
@@ -201,6 +202,7 @@ pub async fn setup_mixnet_routing(
         dyn crate::platform::swift::OSTunProvider,
     >,
     dns_monitor: &mut DnsMonitor,
+    dns: Option<IpAddr>,
 ) -> Result<tun2::AsyncDevice> {
     debug!("Creating tun device");
     let mixnet_tun_config = config.mixnet_tun_config.clone();
@@ -319,7 +321,9 @@ pub async fn setup_mixnet_routing(
     debug!("Routes: {:#?}", routes.clone().collect::<HashSet<_>>());
     route_manager.add_routes(routes.collect()).await?;
 
-    dns_monitor.set(&device_name, &[IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1))])?;
+    // Set the DNS server
+    let dns_server = dns.unwrap_or(DEFAULT_DNS_SERVER);
+    dns_monitor.set(&device_name, &[dns_server])?;
 
     Ok(dev)
 }

--- a/nym-vpn-lib/src/routing.rs
+++ b/nym-vpn-lib/src/routing.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use netdev::Interface;
+use talpid_core::dns::DnsMonitor;
 use std::fmt::{Display, Formatter};
 use std::net::{Ipv4Addr, Ipv6Addr};
 #[cfg(target_os = "android")]
@@ -199,6 +200,7 @@ pub async fn setup_mixnet_routing(
     #[cfg(target_os = "ios")] ios_tun_provider: std::sync::Arc<
         dyn crate::platform::swift::OSTunProvider,
     >,
+    dns_monitor: &mut DnsMonitor,
 ) -> Result<tun2::AsyncDevice> {
     debug!("Creating tun device");
     let mixnet_tun_config = config.mixnet_tun_config.clone();
@@ -316,6 +318,8 @@ pub async fn setup_mixnet_routing(
     info!("Adding routes to route manager");
     debug!("Routes: {:#?}", routes.clone().collect::<HashSet<_>>());
     route_manager.add_routes(routes.collect()).await?;
+
+    dns_monitor.set(&device_name, &[IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1))])?;
 
     Ok(dev)
 }

--- a/nym-vpn-lib/src/tunnel_setup.rs
+++ b/nym-vpn-lib/src/tunnel_setup.rs
@@ -1,7 +1,6 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::net::{IpAddr, Ipv4Addr};
 use std::sync::{Arc, RwLock};
 
 use crate::error::Result;
@@ -205,10 +204,6 @@ async fn setup_mix_tunnel(
         route_manager.handle()?,
     )?;
 
-    let interface = "tun0";
-    let dns_entres = vec![IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1))];
-    dns_monitor.set(interface, &dns_entres)?;
-
     // Now it's time start all the stuff that needs running inside the tunnel, and that we need
     // correctly unwind if it fails
     // - Sets up mixnet client, and connects
@@ -222,6 +217,7 @@ async fn setup_mix_tunnel(
             &task_manager,
             &gateway_directory_client,
             default_lan_gateway_ip,
+            &mut dns_monitor,
         )
         .await;
     let mixnet_connection_info = match ret {

--- a/nym-vpn-lib/src/tunnel_setup.rs
+++ b/nym-vpn-lib/src/tunnel_setup.rs
@@ -1,6 +1,7 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use std::net::{IpAddr, Ipv4Addr};
 use std::sync::{Arc, RwLock};
 
 use crate::error::Result;
@@ -33,6 +34,7 @@ pub struct MixTunnelSetup {
     pub route_manager: RouteManager,
     pub mixnet_connection_info: MixnetConnectionInfo,
     pub task_manager: TaskManager,
+    pub dns_monitor: DnsMonitor,
 }
 
 impl TunnelSpecifcSetup for MixTunnelSetup {}
@@ -203,6 +205,10 @@ async fn setup_mix_tunnel(
         route_manager.handle()?,
     )?;
 
+    let interface = "tun0";
+    let dns_entres = vec![IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1))];
+    dns_monitor.set(interface, &dns_entres)?;
+
     // Now it's time start all the stuff that needs running inside the tunnel, and that we need
     // correctly unwind if it fails
     // - Sets up mixnet client, and connects
@@ -254,6 +260,7 @@ async fn setup_mix_tunnel(
             route_manager,
             mixnet_connection_info,
             task_manager,
+            dns_monitor,
         },
     }))
 }

--- a/nym-vpnc/src/cli.rs
+++ b/nym-vpnc/src/cli.rs
@@ -4,7 +4,7 @@
 use anyhow::{anyhow, Result};
 use clap::{Args, Parser, Subcommand};
 use nym_gateway_directory::{EntryPoint, ExitPoint, NodeIdentity, Recipient};
-use std::path::PathBuf;
+use std::{net::IpAddr, path::PathBuf};
 
 #[derive(Parser)]
 #[clap(author = "Nymtech", version, about)]
@@ -32,6 +32,10 @@ pub(crate) struct ConnectArgs {
 
     #[command(flatten)]
     pub(crate) exit: CliExit,
+
+    /// Set the IP address of the DNS server to use.
+    #[arg(long)]
+    pub(crate) dns: Option<IpAddr>,
 
     /// Disable routing all traffic through the nym TUN device. When the flag is set, the nym TUN
     /// device will be created, but to route traffic through it you will need to do it manually,

--- a/nym-vpnc/src/main.rs
+++ b/nym-vpnc/src/main.rs
@@ -10,7 +10,7 @@ use vpnd_client::ClientType;
 
 use crate::{
     cli::{Command, ImportCredentialTypeEnum},
-    protobuf_conversion::{into_entry_point, into_exit_point},
+    protobuf_conversion::{into_entry_point, into_exit_point, ipaddr_into_string},
 };
 
 mod cli;
@@ -44,6 +44,7 @@ async fn connect(client_type: ClientType, connect_args: &cli::ConnectArgs) -> Re
     let request = tonic::Request::new(ConnectRequest {
         entry: entry.map(into_entry_point),
         exit: exit.map(into_exit_point),
+        dns: connect_args.dns.map(ipaddr_into_string),
         disable_routing: connect_args.disable_routing,
         enable_two_hop: connect_args.enable_two_hop,
         enable_poisson_rate: connect_args.enable_poisson_rate,

--- a/nym-vpnc/src/protobuf_conversion.rs
+++ b/nym-vpnc/src/protobuf_conversion.rs
@@ -94,3 +94,7 @@ pub(crate) fn into_exit_point(exit: ExitPoint) -> nym_vpn_proto::ExitNode {
         ExitPoint::Random => new_exit_node_random(),
     }
 }
+
+pub(crate) fn ipaddr_into_string(ip: std::net::IpAddr) -> nym_vpn_proto::Dns {
+    nym_vpn_proto::Dns { ip: ip.to_string() }
+}

--- a/nym-vpnd/src/command_interface/error.rs
+++ b/nym-vpnd/src/command_interface/error.rs
@@ -1,0 +1,8 @@
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum CommandInterfaceError {
+    #[error("failed to parse DNS IP address: {ip}")]
+    FailedToParseDnsIp {
+        ip: String,
+        source: std::net::AddrParseError,
+    },
+}

--- a/nym-vpnd/src/command_interface/listener.rs
+++ b/nym-vpnd/src/command_interface/listener.rs
@@ -88,87 +88,74 @@ impl NymVpnd for CommandInterface {
 
         let connect_request = request.into_inner();
 
-        let entry = if let Some(ref entry) = connect_request.entry {
-            if let Some(ref entry_node_enum) = entry.entry_node_enum {
-                match entry_node_enum {
-                    nym_vpn_proto::entry_node::EntryNodeEnum::Location(location) => {
-                        info!(
-                            "Connecting to entry node in country: {:?}",
-                            location.two_letter_iso_country_code
-                        );
-                        Some(EntryPoint::Location {
-                            location: location.two_letter_iso_country_code.to_string(),
-                        })
-                    }
-                    nym_vpn_proto::entry_node::EntryNodeEnum::Gateway(gateway) => {
-                        info!("Connecting to entry node with gateway id: {:?}", gateway.id);
-                        let identity =
-                            NodeIdentity::from_base58_string(&gateway.id).map_err(|err| {
-                                error!("Failed to parse gateway id: {:?}", err);
-                                tonic::Status::invalid_argument("Invalid gateway id")
-                            })?;
-                        Some(EntryPoint::Gateway { identity })
-                    }
-                    nym_vpn_proto::entry_node::EntryNodeEnum::RandomLowLatency(_) => {
-                        info!("Connecting to low latency entry node");
-                        Some(EntryPoint::RandomLowLatency)
-                    }
-                    nym_vpn_proto::entry_node::EntryNodeEnum::Random(_) => {
-                        info!("Connecting to random entry node");
-                        Some(EntryPoint::Random)
-                    }
-                }
-            } else {
-                None
+        let entry = match connect_request
+            .entry
+            .clone()
+            .and_then(|e| e.entry_node_enum)
+        {
+            Some(nym_vpn_proto::entry_node::EntryNodeEnum::Location(location)) => {
+                info!(
+                    "Connecting to entry node in country: {:?}",
+                    location.two_letter_iso_country_code
+                );
+                Some(EntryPoint::Location {
+                    location: location.two_letter_iso_country_code.to_string(),
+                })
             }
-        } else {
-            None
+            Some(nym_vpn_proto::entry_node::EntryNodeEnum::Gateway(gateway)) => {
+                info!("Connecting to entry node with gateway id: {:?}", gateway.id);
+                let identity = NodeIdentity::from_base58_string(&gateway.id).map_err(|err| {
+                    error!("Failed to parse gateway id: {:?}", err);
+                    tonic::Status::invalid_argument("Invalid gateway id")
+                })?;
+                Some(EntryPoint::Gateway { identity })
+            }
+            Some(nym_vpn_proto::entry_node::EntryNodeEnum::RandomLowLatency(_)) => {
+                info!("Connecting to low latency entry node");
+                Some(EntryPoint::RandomLowLatency)
+            }
+            Some(nym_vpn_proto::entry_node::EntryNodeEnum::Random(_)) => {
+                info!("Connecting to random entry node");
+                Some(EntryPoint::Random)
+            }
+            None => None,
         };
 
-        let exit = if let Some(ref exit) = connect_request.exit {
-            if let Some(ref exit_node_enum) = exit.exit_node_enum {
-                match exit_node_enum {
-                    nym_vpn_proto::exit_node::ExitNodeEnum::Address(address) => {
-                        info!(
-                            "Connecting to exit node at address: {:?}",
-                            address.nym_address
-                        );
-                        let address =
-                            Recipient::try_from_base58_string(address.nym_address.clone())
-                                .map_err(|err| {
-                                    error!("Failed to parse exit node address: {:?}", err);
-                                    tonic::Status::invalid_argument("Invalid exit node address")
-                                })?;
-                        Some(ExitPoint::Address { address })
-                    }
-                    nym_vpn_proto::exit_node::ExitNodeEnum::Gateway(gateway) => {
-                        info!("Connecting to exit node with gateway id: {:?}", gateway.id);
-                        let identity =
-                            NodeIdentity::from_base58_string(&gateway.id).map_err(|err| {
-                                error!("Failed to parse gateway id: {:?}", err);
-                                tonic::Status::invalid_argument("Invalid gateway id")
-                            })?;
-                        Some(ExitPoint::Gateway { identity })
-                    }
-                    nym_vpn_proto::exit_node::ExitNodeEnum::Location(location) => {
-                        info!(
-                            "Connecting to exit node in country: {:?}",
-                            location.two_letter_iso_country_code
-                        );
-                        Some(ExitPoint::Location {
-                            location: location.two_letter_iso_country_code.to_string(),
-                        })
-                    }
-                    nym_vpn_proto::exit_node::ExitNodeEnum::Random(_) => {
-                        info!("Connecting to low latency exit node");
-                        Some(ExitPoint::Random)
-                    }
-                }
-            } else {
-                None
+        let exit = match connect_request.exit.clone().and_then(|e| e.exit_node_enum) {
+            Some(nym_vpn_proto::exit_node::ExitNodeEnum::Address(address)) => {
+                info!(
+                    "Connecting to exit node at address: {:?}",
+                    address.nym_address
+                );
+                let address = Recipient::try_from_base58_string(address.nym_address.clone())
+                    .map_err(|err| {
+                        error!("Failed to parse exit node address: {:?}", err);
+                        tonic::Status::invalid_argument("Invalid exit node address")
+                    })?;
+                Some(ExitPoint::Address { address })
             }
-        } else {
-            None
+            Some(nym_vpn_proto::exit_node::ExitNodeEnum::Gateway(gateway)) => {
+                info!("Connecting to exit node with gateway id: {:?}", gateway.id);
+                let identity = NodeIdentity::from_base58_string(&gateway.id).map_err(|err| {
+                    error!("Failed to parse gateway id: {:?}", err);
+                    tonic::Status::invalid_argument("Invalid gateway id")
+                })?;
+                Some(ExitPoint::Gateway { identity })
+            }
+            Some(nym_vpn_proto::exit_node::ExitNodeEnum::Location(location)) => {
+                info!(
+                    "Connecting to exit node in country: {:?}",
+                    location.two_letter_iso_country_code
+                );
+                Some(ExitPoint::Location {
+                    location: location.two_letter_iso_country_code.to_string(),
+                })
+            }
+            Some(nym_vpn_proto::exit_node::ExitNodeEnum::Random(_)) => {
+                info!("Connecting to low latency exit node");
+                Some(ExitPoint::Random)
+            }
+            None => None,
         };
 
         let options = ConnectOptions::try_from(connect_request).map_err(|err| {

--- a/nym-vpnd/src/command_interface/mod.rs
+++ b/nym-vpnd/src/command_interface/mod.rs
@@ -3,6 +3,7 @@
 
 mod config;
 mod connection_handler;
+mod error;
 mod listener;
 mod socket_stream;
 mod start;

--- a/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpnd/src/service/vpn_service.rs
@@ -1,6 +1,7 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use std::net::IpAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -51,6 +52,7 @@ pub struct ConnectArgs {
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct ConnectOptions {
+    pub(crate) dns: Option<IpAddr>,
     pub(crate) disable_routing: bool,
     pub(crate) enable_two_hop: bool,
     pub(crate) enable_poisson_rate: bool,
@@ -198,6 +200,7 @@ impl NymVpnService {
             nym_vpn_lib::NymVpn::new_mixnet_vpn(config.entry_point, config.exit_point);
         nym_vpn.gateway_config = gateway_directory::Config::new_from_env();
         nym_vpn.vpn_config.mixnet_data_path = Some(self.data_dir.clone());
+        nym_vpn.dns = options.dns;
         nym_vpn.disable_routing = options.disable_routing;
         nym_vpn.enable_two_hop = options.enable_two_hop;
         nym_vpn.vpn_config.enable_poisson_rate = options.enable_poisson_rate;

--- a/proto/nym/vpn.proto
+++ b/proto/nym/vpn.proto
@@ -36,14 +36,19 @@ message ExitNode {
   }
 }
 
+message Dns {
+  string ip = 1;
+}
+
 message ConnectRequest {
   EntryNode entry = 1;
   ExitNode exit = 2;
-  bool disable_routing = 3;
-  bool enable_two_hop = 4;
-  bool enable_poisson_rate = 5;
-  bool disable_background_cover_traffic = 6;
-  bool enable_credentials_mode = 7;
+  Dns dns = 3;
+  bool disable_routing = 4;
+  bool enable_two_hop = 5;
+  bool enable_poisson_rate = 6;
+  bool disable_background_cover_traffic = 7;
+  bool enable_credentials_mode = 8;
 }
 
 message ConnectResponse {


### PR DESCRIPTION
Try setting DNS to something that we can resolve on the exit gateway through the tunnel. I just picked 1.1.1.1 as the first thing the came to my mind, the important part is that it goes through the tunnel.

Add `--dns` flag to `nym-vpn-cli` and `nym-vpnc` for the user to set their favourite DNS