### PR TITLE
Fix importing base58 encoded credential string in nym-vpn-cli

### DIFF
--- a/nym-vpn-cli/src/commands.rs
+++ b/nym-vpn-cli/src/commands.rs
@@ -166,8 +166,8 @@ pub(crate) struct ImportCredentialArgs {
 #[group(required = true, multiple = false)]
 pub(crate) struct ImportCredentialType {
     /// Credential encoded using base58.
-    #[arg(long, value_parser = parse_encoded_credential_data)]
-    pub(crate) credential_data: Option<Vec<u8>>,
+    #[arg(long)]
+    pub(crate) credential_data: Option<String>,
 
     /// Path to the credential file.
     #[arg(long, value_parser = check_path)]
@@ -231,14 +231,10 @@ fn check_path(path: &str) -> Result<PathBuf, String> {
     Ok(path)
 }
 
-fn parse_encoded_credential_data(raw: &str) -> bs58::decode::Result<Vec<u8>> {
-    bs58::decode(raw).into_vec()
-}
-
 // Workaround until clap supports enums for ArgGroups
 pub enum ImportCredentialTypeEnum {
     Path(PathBuf),
-    Data(Vec<u8>),
+    Data(String),
 }
 
 impl From<ImportCredentialType> for ImportCredentialTypeEnum {

--- a/nym-vpn-cli/src/main.rs
+++ b/nym-vpn-cli/src/main.rs
@@ -181,10 +181,14 @@ async fn import_credential(args: commands::ImportCredentialArgs, data_path: Path
     let data: ImportCredentialTypeEnum = args.credential_type.into();
     let raw_credential = match data {
         ImportCredentialTypeEnum::Path(path) => fs::read(path)?,
-        ImportCredentialTypeEnum::Data(data) => data,
+        ImportCredentialTypeEnum::Data(data) => parse_encoded_credential_data(&data)?,
     };
     fs::create_dir_all(&data_path)?;
     Ok(nym_vpn_lib::credentials::import_credential(raw_credential, data_path).await?)
+}
+
+fn parse_encoded_credential_data(raw: &str) -> bs58::decode::Result<Vec<u8>> {
+    bs58::decode(raw).into_vec()
 }
 
 fn mixnet_data_path() -> Option<PathBuf> {

--- a/nym-vpn-lib/src/error.rs
+++ b/nym-vpn-lib/src/error.rs
@@ -168,7 +168,10 @@ pub enum Error {
     },
 
     #[error("failed decode base58 credential: {source}")]
-    FailedToDecodeBase58Credential { source: bs58::decode::Error },
+    FailedToDecodeBase58Credential {
+        #[from]
+        source: bs58::decode::Error,
+    },
 
     #[error("config path not set")]
     ConfigPathNotSet,


### PR DESCRIPTION
Bugfix for importing a base58 string credential in `nym-vpn-cli`

```sh
$ sudo -E ./nym-vpn-cli import-credential --credential-data 2eS7WLv6A....
```