### PR TITLE
Use clone_from to fix clippy warning

### DIFF
--- a/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-lib/src/platform/mod.rs
@@ -133,7 +133,9 @@ fn sync_run_vpn(config: VPNConfig) -> Result<NymVpn<MixnetVpn>, FFIError> {
     vpn.gateway_config.explorer_url = Some(config.explorer_url);
     vpn.gateway_config.harbour_master_url = None;
     vpn.enable_two_hop = config.enable_two_hop;
-    vpn.vpn_config.mixnet_data_path = config.credential_data_path.clone();
+    vpn.vpn_config
+        .mixnet_data_path
+        .clone_from(&config.credential_data_path);
     Ok(vpn)
 }
 


### PR DESCRIPTION
Fix

```
error: assigning the result of `Clone::clone()` may be inefficient
   --> nym-vpn-lib/src/platform/mod.rs:136:5
    |
136 |     vpn.vpn_config.mixnet_data_path = config.credential_data_path.clone();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `clone_from()`: `vpn.vpn_config.mixnet_data_path.clone_from(&config.credential_data_path)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assigning_clones
    = note: `-D clippy::assigning-clones` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::assigning_clones)]`
```