### PR TITLE
Fix panic on initialize persistent storage

### DIFF
--- a/nym-vpn-lib/src/credentials/error.rs
+++ b/nym-vpn-lib/src/credentials/error.rs
@@ -10,6 +10,9 @@ pub enum CredentialError {
     NymCredentialsError(#[from] nym_credentials::Error),
 
     #[error(transparent)]
+    NymCredentialStorageError(#[from] nym_credential_storage::error::StorageError),
+
+    #[error(transparent)]
     IoError(#[from] std::io::Error),
 
     #[error("the free pass has already expired! The expiration was set to {expiry_date}")]

--- a/nym-vpn-lib/src/credentials/helpers.rs
+++ b/nym-vpn-lib/src/credentials/helpers.rs
@@ -21,8 +21,10 @@ pub(super) async fn get_credentials_store(
     let storage_path = StoragePaths::new_from_dir(data_path)?;
     let credential_db_path = storage_path.credential_database_path;
     debug!("Credential store: {}", credential_db_path.display());
-    let storage =
-        nym_credential_storage::initialise_persistent_storage(credential_db_path.clone()).await;
+    let storage = nym_credential_storage::persistent_storage::PersistentStorage::init(
+        credential_db_path.clone(),
+    )
+    .await?;
 
     #[cfg(target_family = "unix")]
     {


### PR DESCRIPTION
Fix panic if credential storage is unable to initialise by handling the error and reporting back
