### PR TITLE
Add extra macOS linker flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ build-wireguard:
 build-vpn-cli:
 	RUSTFLAGS="-L $(CURDIR)/build/lib/$(ARCH)" cargo build --release
 
+build-vpn-cli:
+	RUSTFLAGS="-L $(CURDIR)/build/lib/$(ARCH) -C link-arg=-all_load -C link-arg=-ObjC -C link-arg=-sectcreate -C link-arg=__TEXT -C link-arg=__info_plist -C link-arg=$(CURDIR)/nym-vpnd/mac/Info.plist -C link-arg=-sectcreate -C link-arg=__TEXT -C link-arg=__launchd_plist -C link-arg=$(CURDIR)/nym-vpnd/mac/Launchd.plist" cargo build --release
+
 # Desktop application build
 build-vpn-desktop:
 	npm install --prefix nym-vpn-desktop

--- a/nym-vpnd/mac/Info.plist
+++ b/nym-vpnd/mac/Info.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleIdentifier</key>
+	<string>net.nymtech.vpn.helper</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>NymVPNHelper</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.1</string>
+	<key>CFBundleVersion</key>
+	<string>0.1</string>
+	<key>SMAuthorizedClients</key>
+	<array>
+		<string>identifier &quot;net.nymtech.vpn&quot; and anchor apple generic and certificate leaf[subject.CN] = 0x4170706c6520446576656c6f706d656e743a20526f6b617320416d6272617a657669c48d697573202847364853574e4d38423729 and certificate 1[field.1.2.840.113635.100.6.2.1] /* exists */</string>
+	</array>
+</dict>
+</plist>

--- a/nym-vpnd/mac/Launchd.plist
+++ b/nym-vpnd/mac/Launchd.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>net.nymtech.vpn.helper</string>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<true/>
+	<key>Program</key>
+	<string>/Library/PrivilegedHelperTools/net.nymtech.vpn.helper</string>
+	<key>SMAuthorizedClients</key>
+	<array>
+		<string>identifier &quot;net.nymtech.vpn&quot;</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
Add support to load daemon via native macOS API, through native macOS app.

Versioning is done:
```
	<key>CFBundleShortVersionString</key>
	<string>0.1</string>
	<key>CFBundleVersion</key>
	<string>1</string>
```
https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleversion
https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring


