### PR TITLE
Strongly typed connection failure in nym-vpnd

### DIFF
--- a/crates/nym-gateway-directory/src/gateway_client.rs
+++ b/crates/nym-gateway-directory/src/gateway_client.rs
@@ -14,7 +14,7 @@ use itertools::Itertools;
 use nym_explorer_client::{ExplorerClient, Location, PrettyDetailedGatewayBond};
 use nym_harbour_master_client::{Gateway as HmGateway, HarbourMasterApiClientExt};
 use nym_validator_client::{models::DescribedGateway, NymApiClient};
-use std::{net::IpAddr, time::Duration};
+use std::{fmt, net::IpAddr, time::Duration};
 use tracing::{debug, info, warn};
 use url::Url;
 
@@ -37,6 +37,25 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self::new_mainnet()
+    }
+}
+
+fn to_string<T: fmt::Display>(value: &Option<T>) -> String {
+    match value {
+        Some(value) => value.to_string(),
+        None => "unset".to_string(),
+    }
+}
+
+impl fmt::Display for Config {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "api_url: {}, explorer_url: {}, harbour_master_url: {}",
+            self.api_url,
+            to_string(&self.explorer_url),
+            to_string(&self.harbour_master_url)
+        )
     }
 }
 

--- a/nym-vpn-lib/src/error.rs
+++ b/nym-vpn-lib/src/error.rs
@@ -193,6 +193,8 @@ pub enum Error {
     #[error("invalid credential: {reason}")]
     InvalidCredential {
         reason: crate::credentials::CheckImportedCredentialError,
+        path: PathBuf,
+        gateway_id: String,
     },
 
     #[error(transparent)]

--- a/nym-vpn-lib/src/error.rs
+++ b/nym-vpn-lib/src/error.rs
@@ -202,6 +202,27 @@ pub enum Error {
 
     #[error(transparent)]
     IpPacketRouterClientError(#[from] nym_ip_packet_client::Error),
+
+    #[error("failed to setup gateway directory client: {source}")]
+    FailedtoSetupGatewayDirectoryClient {
+        config: Box<nym_gateway_directory::Config>,
+        source: nym_gateway_directory::Error,
+    },
+
+    #[error("failed to lookup gateways: {source}")]
+    FailedToLookupGateways {
+        source: nym_gateway_directory::Error,
+    },
+
+    #[error("failed to lookup gateway identity: {source}")]
+    FailedToLookupGatewayIdentity {
+        source: nym_gateway_directory::Error,
+    },
+
+    #[error("failed to lookup router address: {source}")]
+    FailedToLookupRouterAddress {
+        source: nym_gateway_directory::Error,
+    },
 }
 
 // Result type based on our error type

--- a/nym-vpn-lib/src/lib.rs
+++ b/nym-vpn-lib/src/lib.rs
@@ -12,7 +12,9 @@ use futures::channel::{mpsc, oneshot};
 use log::{debug, error, info};
 use mixnet_connect::SharedMixnetClient;
 use nym_connection_monitor::ConnectionMonitorTask;
-use nym_gateway_directory::{Config, EntryPoint, ExitPoint, GatewayClient, IpPacketRouterAddress};
+use nym_gateway_directory::{
+    Config as GatewayDirectoryConfig, EntryPoint, ExitPoint, GatewayClient, IpPacketRouterAddress,
+};
 use nym_ip_packet_client::IprClient;
 use nym_task::TaskManager;
 use std::net::{IpAddr, Ipv4Addr};
@@ -144,7 +146,7 @@ impl From<NymVpn<MixnetVpn>> for SpecificVpn {
 
 pub struct NymVpn<T: Vpn> {
     /// Gateway configuration
-    pub gateway_config: Config,
+    pub gateway_config: GatewayDirectoryConfig,
 
     /// Mixnet public ID of the entry gateway.
     pub entry_point: EntryPoint,
@@ -424,7 +426,7 @@ impl<T: Vpn> NymVpn<T> {
     }
 }
 impl SpecificVpn {
-    pub fn gateway_config(&self) -> Config {
+    pub fn gateway_config(&self) -> GatewayDirectoryConfig {
         match self {
             SpecificVpn::Wg(vpn) => vpn.gateway_config.clone(),
             SpecificVpn::Mix(vpn) => vpn.gateway_config.clone(),

--- a/nym-vpn-lib/src/mixnet_connect.rs
+++ b/nym-vpn-lib/src/mixnet_connect.rs
@@ -296,7 +296,11 @@ pub(crate) async fn setup_mixnet_client(
             // UGLY: flow needs to restructured to sort this out, but I don't want to refactor all
             // that just before release.
             task_client.disarm();
-            return Err(Error::InvalidCredential { reason: err });
+            return Err(Error::InvalidCredential {
+                reason: err,
+                path: path.to_path_buf(),
+                gateway_id,
+            });
         };
 
         let key_storage_path = StoragePaths::new_from_dir(path)?;

--- a/nym-vpn-lib/src/tunnel_setup.rs
+++ b/nym-vpn-lib/src/tunnel_setup.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::routing::{catch_all_ipv4, catch_all_ipv6, replace_default_prefixes};
 use crate::tunnel::setup_route_manager;
 use crate::util::handle_interrupt;
@@ -283,13 +283,19 @@ async fn setup_mix_tunnel(
 pub async fn setup_tunnel(nym_vpn: &mut SpecificVpn) -> Result<AllTunnelsSetup> {
     // Create a gateway client that we use to interact with the entry gateway, in particular to
     // handle wireguard registration
-    let gateway_directory_client = GatewayClient::new(nym_vpn.gateway_config())?;
+    let gateway_directory_client = GatewayClient::new(nym_vpn.gateway_config()).map_err(|err| {
+        Error::FailedtoSetupGatewayDirectoryClient {
+            config: Box::new(nym_vpn.gateway_config()),
+            source: err,
+        }
+    })?;
     let GatewayQueryResult {
         entry_gateways,
         exit_gateways,
     } = gateway_directory_client
         .lookup_described_entry_and_exit_gateways_with_location()
-        .await?;
+        .await
+        .map_err(|err| Error::FailedToLookupGateways { source: err })?;
 
     // This info would be useful at at least debug level, but it's just so much data that it
     // would be overwhelming
@@ -299,11 +305,14 @@ pub async fn setup_tunnel(nym_vpn: &mut SpecificVpn) -> Result<AllTunnelsSetup> 
     let (entry_gateway_id, entry_location) = nym_vpn
         .entry_point()
         .lookup_gateway_identity(&entry_gateways)
-        .await?;
+        .await
+        .map_err(|err| Error::FailedToLookupGatewayIdentity { source: err })?;
     let entry_location_str = entry_location.as_deref().unwrap_or("unknown");
 
-    let (exit_router_address, exit_location) =
-        nym_vpn.exit_point().lookup_router_address(&exit_gateways)?;
+    let (exit_router_address, exit_location) = nym_vpn
+        .exit_point()
+        .lookup_router_address(&exit_gateways)
+        .map_err(|err| Error::FailedToLookupRouterAddress { source: err })?;
     let exit_location_str = exit_location.as_deref().unwrap_or("unknown");
     let exit_gateway_id = exit_router_address.gateway();
 

--- a/nym-vpnd/src/command_interface/mod.rs
+++ b/nym-vpnd/src/command_interface/mod.rs
@@ -3,10 +3,11 @@
 
 mod config;
 mod connection_handler;
-mod credential_import;
 mod error;
 mod helpers;
 mod listener;
+mod proto_error;
+mod proto_response;
 mod socket_stream;
 mod start;
 mod status_broadcaster;

--- a/nym-vpnd/src/command_interface/proto_error.rs
+++ b/nym-vpnd/src/command_interface/proto_error.rs
@@ -76,6 +76,11 @@ impl From<ConnectionFailedError> for ProtoError {
                 .into_iter()
                 .collect(),
             },
+            ConnectionFailedError::StartMixnetTimeout(timeout) => ProtoError {
+                kind: ErrorType::Timeout as i32,
+                message: timeout.to_string(),
+                details: Default::default(),
+            },
             ConnectionFailedError::Generic(reason) => ProtoError {
                 kind: ErrorType::Generic as i32,
                 message: reason,

--- a/nym-vpnd/src/command_interface/proto_error.rs
+++ b/nym-vpnd/src/command_interface/proto_error.rs
@@ -62,6 +62,13 @@ impl From<ImportCredentialError> for ProtoImportError {
 impl From<ConnectionFailedError> for ProtoError {
     fn from(err: ConnectionFailedError) -> Self {
         match err {
+            ConnectionFailedError::Unhandled(ref reason) => ProtoError {
+                kind: ErrorType::Unhandled as i32,
+                message: err.to_string(),
+                details: hashmap! {
+                    "reason".to_string() => reason.clone(),
+                },
+            },
             ConnectionFailedError::InvalidCredential {
                 reason,
                 location,
@@ -81,10 +88,37 @@ impl From<ConnectionFailedError> for ProtoError {
                 message: timeout.to_string(),
                 details: Default::default(),
             },
-            ConnectionFailedError::Generic(reason) => ProtoError {
-                kind: ErrorType::Generic as i32,
-                message: reason,
-                details: Default::default(),
+            ConnectionFailedError::FailedToSetupGatewayDirectoryClient {
+                ref config,
+                ref reason,
+            } => ProtoError {
+                kind: ErrorType::GatewayDirectory as i32,
+                message: err.to_string(),
+                details: hashmap! {
+                    "config".to_string() => config.to_string(),
+                    "reason".to_string() => reason.clone(),
+                },
+            },
+            ConnectionFailedError::FailedToLookupGateways { ref reason } => ProtoError {
+                kind: ErrorType::GatewayDirectory as i32,
+                message: err.to_string(),
+                details: hashmap! {
+                    "reason".to_string() => reason.clone(),
+                },
+            },
+            ConnectionFailedError::FailedToLookupGatewayIdentity { ref reason } => ProtoError {
+                kind: ErrorType::GatewayDirectory as i32,
+                message: err.to_string(),
+                details: hashmap! {
+                    "reason".to_string() => reason.clone(),
+                },
+            },
+            ConnectionFailedError::FailedToLookupRouterAddress { ref reason } => ProtoError {
+                kind: ErrorType::GatewayDirectory as i32,
+                message: err.to_string(),
+                details: hashmap! {
+                    "reason".to_string() => reason.clone(),
+                },
             },
         }
     }

--- a/nym-vpnd/src/command_interface/proto_response.rs
+++ b/nym-vpnd/src/command_interface/proto_response.rs
@@ -1,0 +1,41 @@
+// Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use crate::service::{VpnServiceStateChange, VpnServiceStatusResult};
+use nym_vpn_proto::{ConnectionStateChange, ConnectionStatus, Error as ProtoError, StatusResponse};
+
+impl From<VpnServiceStatusResult> for StatusResponse {
+    fn from(status: VpnServiceStatusResult) -> Self {
+        let mut error = None;
+        let status = match status {
+            VpnServiceStatusResult::NotConnected => ConnectionStatus::NotConnected,
+            VpnServiceStatusResult::Connecting => ConnectionStatus::Connecting,
+            VpnServiceStatusResult::Connected => ConnectionStatus::Connected,
+            VpnServiceStatusResult::Disconnecting => ConnectionStatus::Disconnecting,
+            VpnServiceStatusResult::ConnectionFailed(reason) => {
+                error = Some(ProtoError::from(reason));
+                ConnectionStatus::ConnectionFailed
+            }
+        } as i32;
+
+        StatusResponse { status, error }
+    }
+}
+
+impl From<VpnServiceStateChange> for ConnectionStateChange {
+    fn from(status: VpnServiceStateChange) -> Self {
+        let mut error = None;
+        let status = match status {
+            VpnServiceStateChange::NotConnected => ConnectionStatus::NotConnected,
+            VpnServiceStateChange::Connecting => ConnectionStatus::Connecting,
+            VpnServiceStateChange::Connected => ConnectionStatus::Connected,
+            VpnServiceStateChange::Disconnecting => ConnectionStatus::Disconnecting,
+            VpnServiceStateChange::ConnectionFailed(reason) => {
+                error = Some(ProtoError::from(reason));
+                ConnectionStatus::ConnectionFailed
+            }
+        } as i32;
+
+        ConnectionStateChange { status, error }
+    }
+}

--- a/nym-vpnd/src/service/error.rs
+++ b/nym-vpnd/src/service/error.rs
@@ -73,3 +73,89 @@ impl From<VpnLibImportCredentialError> for ImportCredentialError {
         }
     }
 }
+
+#[derive(Clone, Debug, thiserror::Error)]
+pub enum ConnectionFailedError {
+    #[error("failed to get next usable credential: {reason}")]
+    InvalidCredential {
+        reason: String,
+        location: String,
+        gateway_id: String,
+    },
+
+    #[error("failed to connect: {0}")]
+    Generic(String),
+}
+
+impl From<&nym_vpn_lib::error::Error> for ConnectionFailedError {
+    fn from(err: &nym_vpn_lib::error::Error) -> Self {
+        match err {
+            nym_vpn_lib::error::Error::InvalidCredential {
+                reason,
+                path,
+                gateway_id,
+            } => ConnectionFailedError::InvalidCredential {
+                reason: reason.to_string(),
+                location: path.to_string_lossy().to_string(),
+                gateway_id: gateway_id.clone(),
+            },
+            nym_vpn_lib::error::Error::IO(_)
+            | nym_vpn_lib::error::Error::InvalidWireGuardKey
+            | nym_vpn_lib::error::Error::AddrParseError(_)
+            | nym_vpn_lib::error::Error::RoutingError(_)
+            | nym_vpn_lib::error::Error::DNSError(_)
+            | nym_vpn_lib::error::Error::FirewallError(_)
+            | nym_vpn_lib::error::Error::WireguardError(_)
+            | nym_vpn_lib::error::Error::JoinError(_)
+            | nym_vpn_lib::error::Error::CanceledError(_)
+            | nym_vpn_lib::error::Error::FailedToSendWireguardTunnelClose
+            | nym_vpn_lib::error::Error::FailedToSendWireguardShutdown
+            | nym_vpn_lib::error::Error::SDKError(_)
+            | nym_vpn_lib::error::Error::NodeIdentityFormattingError
+            | nym_vpn_lib::error::Error::TunError(_)
+            | nym_vpn_lib::error::Error::WireguardConfigError(_)
+            | nym_vpn_lib::error::Error::RecipientFormattingError
+            | nym_vpn_lib::error::Error::ValidatorClientError(_)
+            | nym_vpn_lib::error::Error::ExplorerApiError(_)
+            | nym_vpn_lib::error::Error::MissingExitPointInformation
+            | nym_vpn_lib::error::Error::MissingEntryPointInformation
+            | nym_vpn_lib::error::Error::KeyRecoveryError(_)
+            | nym_vpn_lib::error::Error::NymNodeApiClientError(_)
+            | nym_vpn_lib::error::Error::RequestedGatewayByLocationWithoutLocationDataAvailable
+            | nym_vpn_lib::error::Error::InvalidGatewayAPIResponse
+            | nym_vpn_lib::error::Error::WireguardTypesError(_)
+            | nym_vpn_lib::error::Error::DefaultInterfaceError
+            | nym_vpn_lib::error::Error::ReceivedResponseWithOldVersion { .. }
+            | nym_vpn_lib::error::Error::ReceivedResponseWithNewVersion { .. }
+            | nym_vpn_lib::error::Error::GotReplyIntendedForWrongAddress
+            | nym_vpn_lib::error::Error::UnexpectedConnectResponse
+            | nym_vpn_lib::error::Error::NoMixnetMessagesReceived
+            | nym_vpn_lib::error::Error::TimeoutWaitingForConnectResponse
+            | nym_vpn_lib::error::Error::StaticConnectRequestDenied { .. }
+            | nym_vpn_lib::error::Error::DynamicConnectRequestDenied { .. }
+            | nym_vpn_lib::error::Error::MixnetClientDeadlock
+            | nym_vpn_lib::error::Error::StartMixnetTimeout(_)
+            | nym_vpn_lib::error::Error::NotStarted
+            | nym_vpn_lib::error::Error::StopError
+            | nym_vpn_lib::error::Error::TunProvider(_)
+            | nym_vpn_lib::error::Error::TalpidCoreMpsc(_)
+            | nym_vpn_lib::error::Error::FailedToSerializeMessage { .. }
+            | nym_vpn_lib::error::Error::IcmpEchoRequestPacketCreationFailure
+            | nym_vpn_lib::error::Error::IcmpPacketCreationFailure
+            | nym_vpn_lib::error::Error::Ipv4PacketCreationFailure
+            | nym_vpn_lib::error::Error::CountryCodeNotFound
+            | nym_vpn_lib::error::Error::CountryExitGatewaysOutdated
+            | nym_vpn_lib::error::Error::GatewayDirectoryError(_)
+            | nym_vpn_lib::error::Error::FailedToImportCredential { .. }
+            | nym_vpn_lib::error::Error::FailedToDecodeBase58Credential { .. }
+            | nym_vpn_lib::error::Error::ConfigPathNotSet
+            | nym_vpn_lib::error::Error::ConnectionMonitorError(_)
+            | nym_vpn_lib::error::Error::RootPrivilegesRequired { .. }
+            | nym_vpn_lib::error::Error::RouteManagerPoisonedLock
+            | nym_vpn_lib::error::Error::ImportCredentialError(_)
+            | nym_vpn_lib::error::Error::IpPacketRouterClientError(_) => {
+                ConnectionFailedError::Generic(format!("unhandled error: {:#?}", err))
+            }
+        }
+    }
+}

--- a/nym-vpnd/src/service/error.rs
+++ b/nym-vpnd/src/service/error.rs
@@ -83,6 +83,9 @@ pub enum ConnectionFailedError {
         gateway_id: String,
     },
 
+    #[error("timeout starting mixnet client after {0} seconds")]
+    StartMixnetTimeout(u64),
+
     #[error("failed to connect: {0}")]
     Generic(String),
 }
@@ -99,6 +102,9 @@ impl From<&nym_vpn_lib::error::Error> for ConnectionFailedError {
                 location: path.to_string_lossy().to_string(),
                 gateway_id: gateway_id.clone(),
             },
+            nym_vpn_lib::error::Error::StartMixnetTimeout(timeout_sec) => {
+                ConnectionFailedError::StartMixnetTimeout(*timeout_sec)
+            }
             nym_vpn_lib::error::Error::IO(_)
             | nym_vpn_lib::error::Error::InvalidWireGuardKey
             | nym_vpn_lib::error::Error::AddrParseError(_)
@@ -134,7 +140,6 @@ impl From<&nym_vpn_lib::error::Error> for ConnectionFailedError {
             | nym_vpn_lib::error::Error::StaticConnectRequestDenied { .. }
             | nym_vpn_lib::error::Error::DynamicConnectRequestDenied { .. }
             | nym_vpn_lib::error::Error::MixnetClientDeadlock
-            | nym_vpn_lib::error::Error::StartMixnetTimeout(_)
             | nym_vpn_lib::error::Error::NotStarted
             | nym_vpn_lib::error::Error::StopError
             | nym_vpn_lib::error::Error::TunProvider(_)

--- a/nym-vpnd/src/service/exit_listener.rs
+++ b/nym-vpnd/src/service/exit_listener.rs
@@ -42,7 +42,7 @@ impl VpnServiceExitListener {
 
                         let connection_failed_err = match vpn_lib_err {
                             Some(vpn_lib_err) => vpn_lib_err,
-                            None => ConnectionFailedError::Generic(err.to_string()),
+                            None => ConnectionFailedError::Unhandled(err.to_string()),
                         };
 
                         self.shared_vpn_state

--- a/nym-vpnd/src/service/mod.rs
+++ b/nym-vpnd/src/service/mod.rs
@@ -8,7 +8,7 @@ mod start;
 mod status_listener;
 mod vpn_service;
 
-pub(crate) use error::ImportCredentialError;
+pub(crate) use error::{ConnectionFailedError, ImportCredentialError};
 pub(crate) use start::start_vpn_service;
 pub(crate) use vpn_service::{
     ConnectArgs, ConnectOptions, VpnServiceCommand, VpnServiceConnectResult,

--- a/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpnd/src/service/vpn_service.rs
@@ -19,7 +19,7 @@ use super::config::{
     create_config_file, create_data_dir, read_config_file, write_config_file, ConfigSetupError,
     NymVpnServiceConfig, DEFAULT_CONFIG_DIR, DEFAULT_CONFIG_FILE, DEFAULT_DATA_DIR,
 };
-use super::error::ImportCredentialError;
+use super::error::{ConnectionFailedError, ImportCredentialError};
 use super::exit_listener::VpnServiceExitListener;
 use super::status_listener::VpnServiceStatusListener;
 
@@ -30,7 +30,7 @@ pub enum VpnState {
     Connecting,
     Connected,
     Disconnecting,
-    ConnectionFailed(String),
+    ConnectionFailed(ConnectionFailedError),
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -109,11 +109,11 @@ pub enum VpnServiceStatusResult {
     Connecting,
     Connected,
     Disconnecting,
-    ConnectionFailed(String),
+    ConnectionFailed(ConnectionFailedError),
 }
 
 impl VpnServiceStatusResult {
-    pub fn error(&self) -> Option<String> {
+    pub fn error(&self) -> Option<ConnectionFailedError> {
         match self {
             VpnServiceStatusResult::ConnectionFailed(reason) => Some(reason.clone()),
             _ => None,
@@ -139,11 +139,11 @@ pub enum VpnServiceStateChange {
     Connecting,
     Connected,
     Disconnecting,
-    ConnectionFailed(String),
+    ConnectionFailed(ConnectionFailedError),
 }
 
 impl VpnServiceStateChange {
-    pub fn error(&self) -> Option<String> {
+    pub fn error(&self) -> Option<ConnectionFailedError> {
         match self {
             VpnServiceStateChange::ConnectionFailed(reason) => Some(reason.clone()),
             _ => None,

--- a/proto/nym/vpn.proto
+++ b/proto/nym/vpn.proto
@@ -86,7 +86,24 @@ message ConnectionStatusUpdate {
 }
 
 message Error {
-  string message = 1;
+  enum ErrorType {
+    ERROR_TYPE_UNSPECIFIED = 0;
+    NO_VALID_CREDENTIALS = 1;
+    AUTHENTICATION_FAILED = 2;
+    NETWORK_ISSUE = 3;
+    INVALID_CONFIGURATION = 4;
+    TIMEOUT = 5;
+    PERMISSION_DENIED = 6;
+    GENERIC = 7;
+  }
+
+  ErrorType kind = 1;
+
+  // Detailed error message for logging and debuggning
+  string message = 2;
+
+  // Optional additional details
+  map<string, string> details = 3;
 }
 
 message ImportUserCredentialRequest {

--- a/proto/nym/vpn.proto
+++ b/proto/nym/vpn.proto
@@ -88,13 +88,28 @@ message ConnectionStatusUpdate {
 message Error {
   enum ErrorType {
     ERROR_TYPE_UNSPECIFIED = 0;
-    NO_VALID_CREDENTIALS = 1;
-    AUTHENTICATION_FAILED = 2;
-    NETWORK_ISSUE = 3;
-    INVALID_CONFIGURATION = 4;
-    TIMEOUT = 5;
-    PERMISSION_DENIED = 6;
-    GENERIC = 7;
+
+    // An error that was not explicitly handled by the vpn service. This should
+    // not happend but it will while we interate on mapping out all possible
+    // error that can happen
+    UNHANDLED = 1;
+
+    // If the credential storage does not contain any valid credentials when connecting
+
+    NO_VALID_CREDENTIALS = 2;
+
+    // AUTHENTICATION_FAILED = 3;
+    // NETWORK_ISSUE = 4;
+    // INVALID_CONFIGURATION = 5;
+
+    // Connection timeout. This could happen  in a number of contexts, and the
+    // provided details needs to be investigated to determine what went wrong
+    TIMEOUT = 6;
+
+    // PERMISSION_DENIED = 7;
+
+    // Looking up gateways can fail in a number of ways.
+    GATEWAY_DIRECTORY = 8;
   }
 
   ErrorType kind = 1;
@@ -118,10 +133,22 @@ message ImportUserCredentialResponse {
 message ImportError {
   enum ImportErrorType {
     IMPORT_ERROR_TYPE_UNSPECIFIED = 0;
+
+    // Credential import is not supported while the vpn is already connected
     VPN_RUNNING = 1;
+
+    // Importing the same credential twice will return an error
     CREDENTIAL_ALREADY_IMPORTED = 2;
+
+    // If the credential storage fails in some way. It's very likely due to a
+    // permission error.
     STORAGE_ERROR = 3;
+
+    // If the provided credential fails to deserialize. This is probably due to
+    // incorrect credential, but it could also be due to other internal reasons
     DESERIALIZATION_FAILURE = 4;
+
+    // Credentials have a date when they expire
     CREDENTIAL_EXPIRED = 5;
   }
 


### PR DESCRIPTION
Send strongly typed connection fail errors from nym-vpnd. There are so many possible error cases so currently most of them are mapped to Unhandled. This is something we'll have to gradually iterate on, to at least map the common ones to specific enum cases