### PR TITLE
Feat/unexpected halt error state

### DIFF
--- a/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-lib/src/platform/mod.rs
@@ -100,9 +100,7 @@ async fn wait_for_shutdown(
     Ok(())
 }
 
-async fn wait_for_error(
-    handle: NymVpnHandle,
-) -> crate::error::Result<()> {
+async fn wait_for_error(handle: NymVpnHandle) -> crate::error::Result<()> {
     match handle.vpn_exit_rx.await? {
         NymVpnExitStatusMessage::Failed(error) => {
             debug!("received exit status message for vpn");

--- a/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-lib/src/platform/mod.rs
@@ -52,6 +52,9 @@ async fn stop_and_reset_shutdown_handle() -> Result<(), FFIError> {
     if let Some(sh) = &*guard {
         debug!("notifying waiters");
         sh.notify_waiters();
+        debug!("waiting for waiters to be notified");
+        sh.notified().await;
+        debug!("waiters notified");
     } else {
         return Err(FFIError::VpnNotStarted);
     }

--- a/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-lib/src/platform/mod.rs
@@ -95,6 +95,8 @@ async fn wait_for_shutdown(
     stop_handle: Arc<Notify>,
     handle: NymVpnHandle,
 ) -> crate::error::Result<()> {
+    stop_handle.notified().await;
+    handle.vpn_ctrl_tx.send(NymVpnCtrlMessage::Stop)?;
     match handle.vpn_exit_rx.await? {
         NymVpnExitStatusMessage::Failed(error) => {
             debug!("received exit status message for vpn");
@@ -109,9 +111,6 @@ async fn wait_for_shutdown(
         }
         NymVpnExitStatusMessage::Stopped => debug!("Stopped Nym VPN"),
     }
-
-    stop_handle.notified().await;
-    handle.vpn_ctrl_tx.send(NymVpnCtrlMessage::Stop)?;
 
     Ok(())
 }

--- a/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-lib/src/platform/mod.rs
@@ -110,6 +110,9 @@ async fn wait_for_shutdown(
         NymVpnExitStatusMessage::Stopped => debug!("Stopped Nym VPN"),
     }
 
+    stop_handle.notified().await;
+    handle.vpn_ctrl_tx.send(NymVpnCtrlMessage::Stop)?;
+
     Ok(())
 }
 

--- a/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-lib/src/platform/mod.rs
@@ -65,10 +65,6 @@ async fn stop_and_reset_shutdown_handle() -> Result<(), FFIError> {
 
 async fn reset_shutdown_handle() -> Result<(), FFIError> {
     let mut guard = VPN_SHUTDOWN_HANDLE.lock().await;
-    if let Some(sh) = &*guard {
-        debug!("notifying waiters");
-        sh.notify_one();
-    }
     *guard = None;
     debug!("VPN shutdown handle reset");
     Ok(())
@@ -103,10 +99,10 @@ async fn wait_for_shutdown(
     handle: NymVpnHandle,
 ) -> crate::error::Result<()> {
     // wait for notify to be set...
-    debug!("wait for notify to be set");
-    stop_handle.notified().await;
-    debug!("notify for shutdown set");
-    handle.vpn_ctrl_tx.send(NymVpnCtrlMessage::Stop)?;
+    //debug!("wait for notify to be set");
+    //stop_handle.notified().await;
+    //debug!("notify for shutdown set");
+    //handle.vpn_ctrl_tx.send(NymVpnCtrlMessage::Stop)?;
     debug!("sent stop control message");
     match handle.vpn_exit_rx.await? {
         NymVpnExitStatusMessage::Failed(error) => {

--- a/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-lib/src/platform/mod.rs
@@ -111,7 +111,7 @@ async fn wait_for_shutdown(
                     .ok_or(crate::Error::StopError)?
             );
         }
-        NymVpnExitStatusMessage::Stopped => debug!("Stopped Nym VPN")
+        NymVpnExitStatusMessage::Stopped => debug!("Stopped Nym VPN"),
     }
     Ok(())
 }

--- a/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-lib/src/platform/mod.rs
@@ -89,6 +89,7 @@ async fn _async_run_vpn(vpn: SpecificVpn) -> Result<(Arc<Notify>, NymVpnHandle),
         TaskStatus::Ready => debug!("Started Nym VPN"),
         TaskStatus::ReadyWithGateway(gateway) => debug!("Started Nym VPN: connected to {gateway}"),
     }
+
     debug!("result with handles");
     Ok((stop_handle, handle))
 }
@@ -98,11 +99,16 @@ async fn wait_for_shutdown(
     handle: NymVpnHandle,
 ) -> crate::error::Result<()> {
     // wait for notify to be set...
+    debug!("wait for notify to be set");
     stop_handle.notified().await;
+    debug!("notify for shutdown set");
     handle.vpn_ctrl_tx.send(NymVpnCtrlMessage::Stop)?;
+    debug!("sent stop control message");
     match handle.vpn_exit_rx.await? {
         NymVpnExitStatusMessage::Failed(error) => {
+            debug!("received exit status message for vpn");
             RUNNING.store(false, Ordering::Relaxed);
+            debug!("running set to false");
             error!(
                 "Stopped Nym VPN with error: {:?}",
                 error

--- a/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-lib/src/platform/mod.rs
@@ -100,7 +100,7 @@ async fn wait_for_shutdown(
     Ok(())
 }
 
-async fn wait_for_error(handle: NymVpnHandle) -> crate::error::Result<()> {
+async fn wait_for_exit(handle: &NymVpnHandle) -> crate::error::Result<()> {
     match handle.vpn_exit_rx.await? {
         NymVpnExitStatusMessage::Failed(error) => {
             debug!("received exit status message for vpn");
@@ -233,7 +233,7 @@ async fn run_vpn(vpn: SpecificVpn) -> Result<(), FFIError> {
                 stop_handle.notify_one();
             });
             RUNTIME.spawn(async move {
-                wait_for_error(handle)
+                wait_for_exit(handle.borrow())
                     .await
                     .map_err(|err| {
                         warn!("error during vpn run: {}", err);

--- a/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-lib/src/platform/mod.rs
@@ -65,6 +65,10 @@ async fn stop_and_reset_shutdown_handle() -> Result<(), FFIError> {
 
 async fn reset_shutdown_handle() -> Result<(), FFIError> {
     let mut guard = VPN_SHUTDOWN_HANDLE.lock().await;
+    if let Some(sh) = &*guard {
+        debug!("notifying waiters");
+        sh.notify_one();
+    }
     *guard = None;
     debug!("VPN shutdown handle reset");
     Ok(())

--- a/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-lib/src/platform/mod.rs
@@ -52,9 +52,6 @@ async fn stop_and_reset_shutdown_handle() -> Result<(), FFIError> {
     if let Some(sh) = &*guard {
         debug!("notifying waiters");
         sh.notify_waiters();
-        debug!("waiting for waiters to be notified");
-        sh.notified().await;
-        debug!("waiters notified");
     } else {
         return Err(FFIError::VpnNotStarted);
     }
@@ -98,12 +95,6 @@ async fn wait_for_shutdown(
     stop_handle: Arc<Notify>,
     handle: NymVpnHandle,
 ) -> crate::error::Result<()> {
-    // wait for notify to be set...
-    //debug!("wait for notify to be set");
-    //stop_handle.notified().await;
-    //debug!("notify for shutdown set");
-    //handle.vpn_ctrl_tx.send(NymVpnCtrlMessage::Stop)?;
-    debug!("sent stop control message");
     match handle.vpn_exit_rx.await? {
         NymVpnExitStatusMessage::Failed(error) => {
             debug!("received exit status message for vpn");


### PR DESCRIPTION
Fixes bug where UnexpectedHalt scenarios resulting in a NymVpnExitStatusMessage were not collected from receiver due to the stop handle notifier and caused the running state not to be reset to false. 