### PR TITLE
Fix incorrect versions for vpn-lib vpnd vpnc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4659,7 +4659,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-lib"
-version = "0.1.3-dev"
+version = "0.1.4-dev"
 dependencies = [
  "android_logger",
  "anyhow",
@@ -4737,7 +4737,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpnc"
-version = "0.1.3-dev"
+version = "0.1.4-dev"
 dependencies = [
  "anyhow",
  "bs58 0.5.1",
@@ -4755,7 +4755,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpnd"
-version = "0.1.3-dev"
+version = "0.1.4-dev"
 dependencies = [
  "anyhow",
  "clap",

--- a/nym-vpn-lib/Cargo.toml
+++ b/nym-vpn-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nym-vpn-lib"
-version = "0.1.3-dev"
+version = "0.1.4-dev"
 edition = "2021"
 license = "GPL-3.0-only"
 

--- a/nym-vpnc/Cargo.toml
+++ b/nym-vpnc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nym-vpnc"
-version = "0.1.3-dev"
+version = "0.1.4-dev"
 description = "Nym VPN console client"
 authors.workspace = true
 repository.workspace = true

--- a/nym-vpnd/Cargo.toml
+++ b/nym-vpnd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nym-vpnd"
-version = "0.1.3-dev"
+version = "0.1.4-dev"
 description = "Nym VPN daemon"
 authors.workspace = true
 repository.workspace = true

--- a/scripts/bump-nym-vpn-cli-to-next-dev-version.sh
+++ b/scripts/bump-nym-vpn-cli-to-next-dev-version.sh
@@ -7,15 +7,22 @@ set -euo pipefail
 
 source "$(dirname "$0")/common.sh"
 
-NAME="nym-vpn-cli"
+TAG_BASE_NAME="nym-vpn-cli"
+PACKAGES=(nym-vpn-lib nym-vpn-cli nym-vpnd nym-vpnc)
 
 get_current_version() {
-    echo "$(cargo get package.version --entry="nym-vpn-cli")"
+    echo "$(cargo get package.version --entry="${PACKAGES[0]}")"
 }
 
 run_cargo_set_version() {
     local next_version=$1
-    local command="cargo set-version -p nym-vpn-cli $next_version"
+
+    local package_flags=""
+    for PACKAGE in "${PACKAGES[@]}"; do
+        package_flags+=" -p $PACKAGE"
+    done
+
+    local command="cargo set-version $package_flags $next_version"
 
     # Run the command with --dry-run option first
     echo "Running in dry-run mode: $command --dry-run"
@@ -36,7 +43,7 @@ main() {
     fi
 
     run_cargo_set_version "$next_version"
-    git_commit_new_dev_version "$next_version" "$NAME"
+    git_commit_new_dev_version "$next_version" "$TAG_BASE_NAME"
 }
 
 main

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -51,8 +51,8 @@ ask_and_tag_release() {
 
 git_commit_new_dev_version () {
     local version=$1
-    local name=$2
-    git commit -a -m "Bump $name to next dev version $version"
+    local tag_base_name=$2
+    git commit -a -m "Bump $tag_base_name to next dev version $version"
 }
 
 increment_version() {

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -36,11 +36,11 @@ ask_for_confirmation() {
 ask_and_tag_release() {
     local tag_name=$1
     local version=$2
-    local name=$3
+    local tag_base_name=$3
     read -p "Do you want to tag this commit with: $tag_name ? (Y/N): " confirm_tag
     if [[ $confirm_tag =~ ^[Yy]$ ]]; then
         echo "Tagging the commit with tag: $tag_name"
-        git commit -a -m "Bump $name to $version"
+        git commit -a -m "Bump $tag_base_name to $version"
         git tag $tag_name
         # Optionally, push the tag to remote repository
         # git push origin $tag

--- a/scripts/create-nym-vpn-cli-release.sh
+++ b/scripts/create-nym-vpn-cli-release.sh
@@ -12,21 +12,25 @@ set -euo pipefail
 
 source "$(dirname "$0")/common.sh"
 
-NAME=nym-vpn-cli
-PACKAGE=nym-vpn-cli
+TAG_BASE_NAME=nym-vpn-cli
+PACKAGES=(nym-vpn-lib nym-vpn-cli nym-vpnd nym-vpnc)
 
 cargo_version_bump() {
-    local command="cargo set-version -p $PACKAGE --bump patch"
+    local package_flags=""
+    for PACKAGE in "${PACKAGES[@]}"; do
+        package_flags+=" -p $PACKAGE"
+    done
+    local command="cargo set-version $package_flags --bump patch"
     echo "Running in dry-run mode: $command --dry-run"
     $command --dry-run
     ask_for_confirmation "$command"
 }
 
 tag_release() {
-    local version=$(cargo get package.version --entry="$PACKAGE")
-    local tag_name="$NAME-v$version"
+    local version=$(cargo get package.version --entry="${PACKAGES[0]}")
+    local tag_name="$TAG_BASE_NAME-v$version"
     echo "New version: $version, prepared tag: $tag_name"
-    ask_and_tag_release "$tag_name" "$version" "$NAME"
+    ask_and_tag_release "$tag_name" "$version" "$TAG_BASE_NAME"
 }
 
 main() {

--- a/scripts/create-nym-vpn-cli-release.sh
+++ b/scripts/create-nym-vpn-cli-release.sh
@@ -26,6 +26,18 @@ cargo_version_bump() {
     ask_for_confirmation "$command"
 }
 
+assert_same_versions() {
+    local first_version=$(cargo get package.version --entry="${PACKAGES[0]}")
+    for PACKAGE in "${PACKAGES[@]}"; do
+        local version=$(cargo get package.version --entry="$PACKAGE")
+        if [[ "$version" != "$first_version" ]]; then
+            echo "Error: Version mismatch detected. $PACKAGE has version $version, but expected $first_version."
+            exit 1
+        fi
+    done
+    echo "All packages have the same version: $first_version"
+}
+
 tag_release() {
     local version=$(cargo get package.version --entry="${PACKAGES[0]}")
     local tag_name="$TAG_BASE_NAME-v$version"
@@ -37,6 +49,7 @@ main() {
     check_unstaged_changes
     confirm_root_directory
     cargo_version_bump
+    assert_same_versions
     tag_release
 }
 


### PR DESCRIPTION
- Fix that we missed to bump the versions of vpnd, vpnc, vpn-lib last time we bumped the nym-vpn-cli version. These are supposed to stay in sync
- Fix script for creating nym-vpn-cli release
- Fix script for bumping nym-vpn-cli to next dev version

NOTE: in the near future we'll rename this tag to `nym-vpn-core`, and also move the root workspace to a dedicated subdirectory