### PR TITLE
refactor(vpnx): backend specialized error handling

### DIFF
--- a/nym-vpn-x/src-tauri/src/commands/cli.rs
+++ b/nym-vpn-x/src-tauri/src/commands/cli.rs
@@ -3,12 +3,12 @@ use tracing::{debug, instrument};
 
 use crate::{
     cli::{Cli, ManagedCli},
-    error::BkdError,
+    error::BackendError,
 };
 
 #[instrument(skip_all)]
 #[tauri::command]
-pub fn cli_args(cli: State<'_, ManagedCli>) -> Result<&Cli, BkdError> {
+pub fn cli_args(cli: State<'_, ManagedCli>) -> Result<&Cli, BackendError> {
     debug!("cli_args");
     Ok(cli.inner())
 }

--- a/nym-vpn-x/src-tauri/src/commands/cli.rs
+++ b/nym-vpn-x/src-tauri/src/commands/cli.rs
@@ -3,12 +3,12 @@ use tracing::{debug, instrument};
 
 use crate::{
     cli::{Cli, ManagedCli},
-    error::CmdError,
+    error::BkdError,
 };
 
 #[instrument(skip_all)]
 #[tauri::command]
-pub fn cli_args(cli: State<'_, ManagedCli>) -> Result<&Cli, CmdError> {
+pub fn cli_args(cli: State<'_, ManagedCli>) -> Result<&Cli, BkdError> {
     debug!("cli_args");
     Ok(cli.inner())
 }

--- a/nym-vpn-x/src-tauri/src/commands/credential.rs
+++ b/nym-vpn-x/src-tauri/src/commands/credential.rs
@@ -4,7 +4,7 @@ use tauri::State;
 use tracing::{debug, info, instrument, warn};
 
 use crate::{
-    error::{BkdError, ErrorKey},
+    error::{BackendError, ErrorKey},
     grpc::client::GrpcClient,
 };
 
@@ -13,12 +13,12 @@ use crate::{
 pub async fn add_credential(
     credential: String,
     grpc: State<'_, Arc<GrpcClient>>,
-) -> Result<(), BkdError> {
+) -> Result<(), BackendError> {
     debug!("add_credential");
 
     let bytes = bs58::decode(credential).into_vec().map_err(|e| {
         info!("failed to decode base58 credential: {:?}", e);
-        BkdError::new("bad credential format", ErrorKey::CredentialInvalid)
+        BackendError::new("bad credential format", ErrorKey::CredentialInvalid)
     })?;
 
     let res = grpc.import_credential(bytes).await?;
@@ -28,7 +28,7 @@ pub async fn add_credential(
     } else {
         warn!("failed to import credential");
         let error = res.error.map(|e| e.into()).unwrap_or_else(|| {
-            BkdError::new("failed to import credential", ErrorKey::UnknownError)
+            BackendError::new("failed to import credential", ErrorKey::UnknownError)
         });
         Err(error)
     }

--- a/nym-vpn-x/src-tauri/src/commands/daemon.rs
+++ b/nym-vpn-x/src-tauri/src/commands/daemon.rs
@@ -1,4 +1,4 @@
-use crate::error::BkdError;
+use crate::error::BackendError;
 use crate::grpc::client::{GrpcClient, VpndStatus};
 use crate::states::SharedAppState;
 use std::sync::Arc;
@@ -10,7 +10,7 @@ use tracing::{debug, instrument, warn};
 pub async fn daemon_status(
     app_state: State<'_, SharedAppState>,
     grpc_client: State<'_, Arc<GrpcClient>>,
-) -> Result<VpndStatus, BkdError> {
+) -> Result<VpndStatus, BackendError> {
     debug!("daemon_status");
     let status = grpc_client
         .check(app_state.inner())

--- a/nym-vpn-x/src-tauri/src/commands/daemon.rs
+++ b/nym-vpn-x/src-tauri/src/commands/daemon.rs
@@ -1,4 +1,4 @@
-use crate::error::CmdError;
+use crate::error::BkdError;
 use crate::grpc::client::{GrpcClient, VpndStatus};
 use crate::states::SharedAppState;
 use std::sync::Arc;
@@ -10,7 +10,7 @@ use tracing::{debug, instrument, warn};
 pub async fn daemon_status(
     app_state: State<'_, SharedAppState>,
     grpc_client: State<'_, Arc<GrpcClient>>,
-) -> Result<VpndStatus, CmdError> {
+) -> Result<VpndStatus, BkdError> {
     debug!("daemon_status");
     let status = grpc_client
         .check(app_state.inner())

--- a/nym-vpn-x/src-tauri/src/commands/db.rs
+++ b/nym-vpn-x/src-tauri/src/commands/db.rs
@@ -3,15 +3,15 @@ use tracing::{debug, instrument};
 
 use crate::{
     db::{Db, DbError, JsonValue, Key},
-    error::BkdError,
+    error::BackendError,
 };
 
 #[instrument(skip(db))]
 #[tauri::command]
-pub async fn db_get(db: State<'_, Db>, key: Key) -> Result<Option<JsonValue>, BkdError> {
+pub async fn db_get(db: State<'_, Db>, key: Key) -> Result<Option<JsonValue>, BackendError> {
     debug!("db_get");
     db.get(key)
-        .map_err(|_| BkdError::new_internal(&format!("Failed to get key [{key}]"), None))
+        .map_err(|_| BackendError::new_internal(&format!("Failed to get key [{key}]"), None))
 }
 
 #[instrument(skip(db))]
@@ -20,21 +20,21 @@ pub async fn db_set(
     db: State<'_, Db>,
     key: Key,
     value: JsonValue,
-) -> Result<Option<JsonValue>, BkdError> {
+) -> Result<Option<JsonValue>, BackendError> {
     debug!("db_set");
     db.insert(key, &value).map_err(|e| match e {
         DbError::Serialize(e) => {
-            BkdError::new_internal(&format!("Failed to insert key, bad JSON input: {e}"), None)
+            BackendError::new_internal(&format!("Failed to insert key, bad JSON input: {e}"), None)
         }
-        _ => BkdError::new_internal(&format!("Failed to insert key: {e}"), None),
+        _ => BackendError::new_internal(&format!("Failed to insert key: {e}"), None),
     })
 }
 
 #[instrument(skip(db))]
 #[tauri::command]
-pub async fn db_flush(db: State<'_, Db>) -> Result<usize, BkdError> {
+pub async fn db_flush(db: State<'_, Db>) -> Result<usize, BackendError> {
     debug!("db_flush");
     db.flush()
         .await
-        .map_err(|_| BkdError::new_internal("Failed to flush db", None))
+        .map_err(|_| BackendError::new_internal("Failed to flush db", None))
 }

--- a/nym-vpn-x/src-tauri/src/commands/db.rs
+++ b/nym-vpn-x/src-tauri/src/commands/db.rs
@@ -3,19 +3,15 @@ use tracing::{debug, instrument};
 
 use crate::{
     db::{Db, DbError, JsonValue, Key},
-    error::{CmdError, CmdErrorSource},
+    error::BkdError,
 };
 
 #[instrument(skip(db))]
 #[tauri::command]
-pub async fn db_get(db: State<'_, Db>, key: Key) -> Result<Option<JsonValue>, CmdError> {
+pub async fn db_get(db: State<'_, Db>, key: Key) -> Result<Option<JsonValue>, BkdError> {
     debug!("db_get");
-    db.get(key).map_err(|_| {
-        CmdError::new(
-            CmdErrorSource::InternalError,
-            &format!("Failed to get key [{key}]"),
-        )
-    })
+    db.get(key)
+        .map_err(|_| BkdError::new_internal(&format!("Failed to get key [{key}]"), None))
 }
 
 #[instrument(skip(db))]
@@ -24,25 +20,21 @@ pub async fn db_set(
     db: State<'_, Db>,
     key: Key,
     value: JsonValue,
-) -> Result<Option<JsonValue>, CmdError> {
+) -> Result<Option<JsonValue>, BkdError> {
     debug!("db_set");
     db.insert(key, &value).map_err(|e| match e {
-        DbError::Serialize(e) => CmdError::new(
-            CmdErrorSource::CallerError,
-            &format!("Failed to insert key, bad JSON input: {e}"),
-        ),
-        _ => CmdError::new(
-            CmdErrorSource::InternalError,
-            &format!("Failed to insert key: {e}"),
-        ),
+        DbError::Serialize(e) => {
+            BkdError::new_internal(&format!("Failed to insert key, bad JSON input: {e}"), None)
+        }
+        _ => BkdError::new_internal(&format!("Failed to insert key: {e}"), None),
     })
 }
 
 #[instrument(skip(db))]
 #[tauri::command]
-pub async fn db_flush(db: State<'_, Db>) -> Result<usize, CmdError> {
+pub async fn db_flush(db: State<'_, Db>) -> Result<usize, BkdError> {
     debug!("db_flush");
     db.flush()
         .await
-        .map_err(|_| CmdError::new(CmdErrorSource::InternalError, "Failed to flush db"))
+        .map_err(|_| BkdError::new_internal("Failed to flush db", None))
 }

--- a/nym-vpn-x/src-tauri/src/commands/log.rs
+++ b/nym-vpn-x/src-tauri/src/commands/log.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use tracing::{debug, error, info, instrument, trace, warn};
 use ts_rs::TS;
 
-use crate::error::BkdError;
+use crate::error::BackendError;
 
 #[derive(Debug, Serialize, Deserialize, TS, Clone)]
 pub enum Level {
@@ -15,7 +15,7 @@ pub enum Level {
 
 #[instrument(skip_all)]
 #[tauri::command]
-pub fn log_js(message: String, level: Option<Level>) -> Result<(), BkdError> {
+pub fn log_js(message: String, level: Option<Level>) -> Result<(), BackendError> {
     match level {
         Some(Level::Trace) => trace!(message),
         Some(Level::Debug) => debug!(message),

--- a/nym-vpn-x/src-tauri/src/commands/log.rs
+++ b/nym-vpn-x/src-tauri/src/commands/log.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use tracing::{debug, error, info, instrument, trace, warn};
 use ts_rs::TS;
 
-use crate::error::CmdError;
+use crate::error::BkdError;
 
 #[derive(Debug, Serialize, Deserialize, TS, Clone)]
 pub enum Level {
@@ -15,7 +15,7 @@ pub enum Level {
 
 #[instrument(skip_all)]
 #[tauri::command]
-pub fn log_js(message: String, level: Option<Level>) -> Result<(), CmdError> {
+pub fn log_js(message: String, level: Option<Level>) -> Result<(), BkdError> {
     match level {
         Some(Level::Trace) => trace!(message),
         Some(Level::Debug) => debug!(message),

--- a/nym-vpn-x/src-tauri/src/commands/node_location.rs
+++ b/nym-vpn-x/src-tauri/src/commands/node_location.rs
@@ -6,7 +6,7 @@ use ts_rs::TS;
 use crate::{
     country::Country,
     db::{Db, Key},
-    error::BkdError,
+    error::BackendError,
     gateway::{get_gateway_countries, get_low_latency_entry_country},
     states::{app::NodeLocation, SharedAppState},
 };
@@ -24,7 +24,7 @@ pub async fn set_node_location(
     db: State<'_, Db>,
     node_type: NodeType,
     location: NodeLocation,
-) -> Result<(), BkdError> {
+) -> Result<(), BackendError> {
     debug!("set_node_location");
     let mut state = app_state.lock().await;
     match node_type {
@@ -41,11 +41,11 @@ pub async fn set_node_location(
     match node_type {
         NodeType::Entry => {
             db.insert(Key::EntryNodeLocation, &location)
-                .map_err(|_| BkdError::new_internal("Failed to save location in db", None))?;
+                .map_err(|_| BackendError::new_internal("Failed to save location in db", None))?;
         }
         NodeType::Exit => {
             db.insert(Key::ExitNodeLocation, &location)
-                .map_err(|_| BkdError::new_internal("Failed to save location in db", None))?;
+                .map_err(|_| BackendError::new_internal("Failed to save location in db", None))?;
         }
     }
 
@@ -54,11 +54,11 @@ pub async fn set_node_location(
 
 #[instrument]
 #[tauri::command]
-pub async fn get_fastest_node_location() -> Result<Country, BkdError> {
+pub async fn get_fastest_node_location() -> Result<Country, BackendError> {
     debug!("get_fastest_node_location");
     get_low_latency_entry_country().await.map_err(|e| {
         error!("failed to get fastest node location: {}", e);
-        BkdError::new_internal("failed to get fastest node location", None)
+        BackendError::new_internal("failed to get fastest node location", None)
     })
 }
 
@@ -67,7 +67,7 @@ pub async fn get_fastest_node_location() -> Result<Country, BkdError> {
 pub async fn get_node_location(
     app_state: State<'_, SharedAppState>,
     node_type: NodeType,
-) -> Result<NodeLocation, BkdError> {
+) -> Result<NodeLocation, BackendError> {
     debug!("get_node_location");
     Ok(match node_type {
         NodeType::Entry => app_state.lock().await.entry_node_location.clone(),
@@ -77,16 +77,16 @@ pub async fn get_node_location(
 
 #[instrument]
 #[tauri::command]
-pub async fn get_countries(node_type: NodeType) -> Result<Vec<Country>, BkdError> {
+pub async fn get_countries(node_type: NodeType) -> Result<Vec<Country>, BackendError> {
     debug!("get_countries");
     match node_type {
         NodeType::Entry => get_gateway_countries(false).await.map_err(|e| {
             error!("failed to get node locations: {}", e);
-            BkdError::new_internal("failed to get node locations", None)
+            BackendError::new_internal("failed to get node locations", None)
         }),
         NodeType::Exit => get_gateway_countries(true).await.map_err(|e| {
             error!("failed to get node locations: {}", e);
-            BkdError::new_internal("failed to get node locations", None)
+            BackendError::new_internal("failed to get node locations", None)
         }),
     }
 }

--- a/nym-vpn-x/src-tauri/src/commands/node_location.rs
+++ b/nym-vpn-x/src-tauri/src/commands/node_location.rs
@@ -6,7 +6,7 @@ use ts_rs::TS;
 use crate::{
     country::Country,
     db::{Db, Key},
-    error::{CmdError, CmdErrorSource},
+    error::BkdError,
     gateway::{get_gateway_countries, get_low_latency_entry_country},
     states::{app::NodeLocation, SharedAppState},
 };
@@ -24,7 +24,7 @@ pub async fn set_node_location(
     db: State<'_, Db>,
     node_type: NodeType,
     location: NodeLocation,
-) -> Result<(), CmdError> {
+) -> Result<(), BkdError> {
     debug!("set_node_location");
     let mut state = app_state.lock().await;
     match node_type {
@@ -40,20 +40,12 @@ pub async fn set_node_location(
     debug!("saving new location in db");
     match node_type {
         NodeType::Entry => {
-            db.insert(Key::EntryNodeLocation, &location).map_err(|_| {
-                CmdError::new(
-                    CmdErrorSource::InternalError,
-                    "Failed to save location in db",
-                )
-            })?;
+            db.insert(Key::EntryNodeLocation, &location)
+                .map_err(|_| BkdError::new_internal("Failed to save location in db", None))?;
         }
         NodeType::Exit => {
-            db.insert(Key::ExitNodeLocation, &location).map_err(|_| {
-                CmdError::new(
-                    CmdErrorSource::InternalError,
-                    "Failed to save location in db",
-                )
-            })?;
+            db.insert(Key::ExitNodeLocation, &location)
+                .map_err(|_| BkdError::new_internal("Failed to save location in db", None))?;
         }
     }
 
@@ -62,14 +54,11 @@ pub async fn set_node_location(
 
 #[instrument]
 #[tauri::command]
-pub async fn get_fastest_node_location() -> Result<Country, CmdError> {
+pub async fn get_fastest_node_location() -> Result<Country, BkdError> {
     debug!("get_fastest_node_location");
     get_low_latency_entry_country().await.map_err(|e| {
         error!("failed to get fastest node location: {}", e);
-        CmdError::new(
-            CmdErrorSource::InternalError,
-            "failed to get fastest node location",
-        )
+        BkdError::new_internal("failed to get fastest node location", None)
     })
 }
 
@@ -78,7 +67,7 @@ pub async fn get_fastest_node_location() -> Result<Country, CmdError> {
 pub async fn get_node_location(
     app_state: State<'_, SharedAppState>,
     node_type: NodeType,
-) -> Result<NodeLocation, CmdError> {
+) -> Result<NodeLocation, BkdError> {
     debug!("get_node_location");
     Ok(match node_type {
         NodeType::Entry => app_state.lock().await.entry_node_location.clone(),
@@ -88,22 +77,16 @@ pub async fn get_node_location(
 
 #[instrument]
 #[tauri::command]
-pub async fn get_countries(node_type: NodeType) -> Result<Vec<Country>, CmdError> {
+pub async fn get_countries(node_type: NodeType) -> Result<Vec<Country>, BkdError> {
     debug!("get_countries");
     match node_type {
         NodeType::Entry => get_gateway_countries(false).await.map_err(|e| {
             error!("failed to get node locations: {}", e);
-            CmdError::new(
-                CmdErrorSource::InternalError,
-                "failed to get node locations",
-            )
+            BkdError::new_internal("failed to get node locations", None)
         }),
         NodeType::Exit => get_gateway_countries(true).await.map_err(|e| {
             error!("failed to get node locations: {}", e);
-            CmdError::new(
-                CmdErrorSource::InternalError,
-                "failed to get node locations",
-            )
+            BkdError::new_internal("failed to get node locations", None)
         }),
     }
 }

--- a/nym-vpn-x/src-tauri/src/commands/window.rs
+++ b/nym-vpn-x/src-tauri/src/commands/window.rs
@@ -1,19 +1,18 @@
 use tauri::Manager;
 use tracing::{debug, error, info, instrument};
 
-use crate::error::{CmdError, CmdErrorSource};
+use crate::error::BkdError;
 
 #[instrument(skip_all)]
 #[tauri::command]
-pub fn show_main_window(window: tauri::Window) -> Result<(), CmdError> {
+pub fn show_main_window(window: tauri::Window) -> Result<(), BkdError> {
     debug!("show_window");
-    let main_window = window.get_window("main").ok_or(CmdError::new(
-        CmdErrorSource::InternalError,
-        "Failed to get the app window",
-    ))?;
+    let main_window = window
+        .get_window("main")
+        .ok_or(BkdError::new_internal("Failed to get the app window", None))?;
     let is_visible = main_window.is_visible().map_err(|e| {
         error!("Failed to get `main` window visibility: {}", e);
-        CmdError::new(CmdErrorSource::InternalError, "Failed to show app window")
+        BkdError::new_internal("Failed to show app window", None)
     })?;
 
     if is_visible {
@@ -24,7 +23,7 @@ pub fn show_main_window(window: tauri::Window) -> Result<(), CmdError> {
     info!("showing `main` window");
     main_window.show().map_err(|e| {
         error!("Failed to show `main` window: {}", e);
-        CmdError::new(CmdErrorSource::InternalError, "Failed to show app window")
+        BkdError::new_internal("Failed to show app window", None)
     })?;
     Ok(())
 }

--- a/nym-vpn-x/src-tauri/src/commands/window.rs
+++ b/nym-vpn-x/src-tauri/src/commands/window.rs
@@ -1,18 +1,19 @@
 use tauri::Manager;
 use tracing::{debug, error, info, instrument};
 
-use crate::error::BkdError;
+use crate::error::BackendError;
 
 #[instrument(skip_all)]
 #[tauri::command]
-pub fn show_main_window(window: tauri::Window) -> Result<(), BkdError> {
+pub fn show_main_window(window: tauri::Window) -> Result<(), BackendError> {
     debug!("show_window");
-    let main_window = window
-        .get_window("main")
-        .ok_or(BkdError::new_internal("Failed to get the app window", None))?;
+    let main_window = window.get_window("main").ok_or(BackendError::new_internal(
+        "Failed to get the app window",
+        None,
+    ))?;
     let is_visible = main_window.is_visible().map_err(|e| {
         error!("Failed to get `main` window visibility: {}", e);
-        BkdError::new_internal("Failed to show app window", None)
+        BackendError::new_internal("Failed to show app window", None)
     })?;
 
     if is_visible {
@@ -23,7 +24,7 @@ pub fn show_main_window(window: tauri::Window) -> Result<(), BkdError> {
     info!("showing `main` window");
     main_window.show().map_err(|e| {
         error!("Failed to show `main` window: {}", e);
-        BkdError::new_internal("Failed to show app window", None)
+        BackendError::new_internal("Failed to show app window", None)
     })?;
     Ok(())
 }

--- a/nym-vpn-x/src-tauri/src/error.rs
+++ b/nym-vpn-x/src-tauri/src/error.rs
@@ -104,8 +104,8 @@ impl From<nym_vpn_proto::Error> for BkdError {
     }
 }
 
-/// Enum of the possible typed errors emitted by the daemon and
-/// passed to the UI layer
+/// Enum of the possible specialized errors emitted by the daemon
+/// or the app backend side, to be passed to the UI layer
 #[derive(Debug, Serialize, Deserialize, TS, Clone)]
 #[ts(export)]
 pub enum ErrorKey {

--- a/nym-vpn-x/src-tauri/src/error.rs
+++ b/nym-vpn-x/src-tauri/src/error.rs
@@ -109,9 +109,10 @@ impl From<nym_vpn_proto::Error> for BkdError {
 #[derive(Debug, Serialize, Deserialize, TS, Clone)]
 #[ts(export)]
 pub enum ErrorKey {
-    /// Any unhandled error
+    /// Generic unhandled error
     UnknownError,
-    /// Any error that is not explicitly handled
+    /// Any error that is not explicitly handled, and not related
+    /// to the application layer
     /// Extra data should be passed along to help specialize the problem
     InternalError,
     /// gRPC bare layer error, when a RPC call fails (aka `Tonic::Status`)

--- a/nym-vpn-x/src-tauri/src/events.rs
+++ b/nym-vpn-x/src-tauri/src/events.rs
@@ -1,7 +1,8 @@
 use tauri::Manager;
 use tracing::{debug, trace};
+use ts_rs::TS;
 
-use crate::{grpc::client::VpndStatus, states::app::ConnectionState};
+use crate::{error::BkdError, grpc::client::VpndStatus, states::app::ConnectionState};
 
 pub const EVENT_VPND_STATUS: &str = "vpnd-status";
 pub const EVENT_CONNECTION_STATE: &str = "connection-state";
@@ -18,15 +19,16 @@ pub struct ProgressEventPayload {
     pub key: ConnectProgressMsg,
 }
 
-#[derive(Clone, serde::Serialize)]
+#[derive(Clone, serde::Serialize, TS)]
+#[ts(export)]
 pub struct ConnectionEventPayload {
     state: ConnectionState,
-    error: Option<String>,
+    error: Option<BkdError>,
     start_time: Option<i64>, // unix timestamp in seconds
 }
 
 impl ConnectionEventPayload {
-    pub fn new(state: ConnectionState, error: Option<String>, start_time: Option<i64>) -> Self {
+    pub fn new(state: ConnectionState, error: Option<BkdError>, start_time: Option<i64>) -> Self {
         Self {
             state,
             error,
@@ -39,7 +41,7 @@ pub trait AppHandleEventEmitter {
     fn emit_vpnd_status(&self, status: VpndStatus);
     fn emit_connecting(&self);
     fn emit_disconnecting(&self);
-    fn emit_disconnected(&self, error: Option<String>);
+    fn emit_disconnected(&self, error: Option<BkdError>);
     fn emit_connection_progress(&self, key: ConnectProgressMsg);
 }
 
@@ -66,7 +68,7 @@ impl AppHandleEventEmitter for tauri::AppHandle {
         .ok();
     }
 
-    fn emit_disconnected(&self, error: Option<String>) {
+    fn emit_disconnected(&self, error: Option<BkdError>) {
         debug!("sending event [{}]: Disconnected", EVENT_CONNECTION_STATE);
         self.emit_all(
             EVENT_CONNECTION_STATE,

--- a/nym-vpn-x/src-tauri/src/events.rs
+++ b/nym-vpn-x/src-tauri/src/events.rs
@@ -2,7 +2,7 @@ use tauri::Manager;
 use tracing::{debug, trace};
 use ts_rs::TS;
 
-use crate::{error::BkdError, grpc::client::VpndStatus, states::app::ConnectionState};
+use crate::{error::BackendError, grpc::client::VpndStatus, states::app::ConnectionState};
 
 pub const EVENT_VPND_STATUS: &str = "vpnd-status";
 pub const EVENT_CONNECTION_STATE: &str = "connection-state";
@@ -23,12 +23,16 @@ pub struct ProgressEventPayload {
 #[ts(export)]
 pub struct ConnectionEventPayload {
     state: ConnectionState,
-    error: Option<BkdError>,
+    error: Option<BackendError>,
     start_time: Option<i64>, // unix timestamp in seconds
 }
 
 impl ConnectionEventPayload {
-    pub fn new(state: ConnectionState, error: Option<BkdError>, start_time: Option<i64>) -> Self {
+    pub fn new(
+        state: ConnectionState,
+        error: Option<BackendError>,
+        start_time: Option<i64>,
+    ) -> Self {
         Self {
             state,
             error,
@@ -41,7 +45,7 @@ pub trait AppHandleEventEmitter {
     fn emit_vpnd_status(&self, status: VpndStatus);
     fn emit_connecting(&self);
     fn emit_disconnecting(&self);
-    fn emit_disconnected(&self, error: Option<BkdError>);
+    fn emit_disconnected(&self, error: Option<BackendError>);
     fn emit_connection_progress(&self, key: ConnectProgressMsg);
 }
 
@@ -68,7 +72,7 @@ impl AppHandleEventEmitter for tauri::AppHandle {
         .ok();
     }
 
-    fn emit_disconnected(&self, error: Option<BkdError>) {
+    fn emit_disconnected(&self, error: Option<BackendError>) {
         debug!("sending event [{}]: Disconnected", EVENT_CONNECTION_STATE);
         self.emit_all(
             EVENT_CONNECTION_STATE,

--- a/nym-vpn-x/src-tauri/src/grpc/client.rs
+++ b/nym-vpn-x/src-tauri/src/grpc/client.rs
@@ -20,7 +20,7 @@ use tracing::{debug, error, info, instrument, warn};
 use ts_rs::TS;
 
 use crate::cli::Cli;
-use crate::error::BkdError;
+use crate::error::BackendError;
 use crate::fs::config::AppConfig;
 use crate::states::app::ConnectionState;
 use crate::vpn_status;
@@ -159,7 +159,7 @@ impl GrpcClient {
         vpn_status::update(
             app,
             ConnectionState::from(res.status()),
-            res.error.map(BkdError::from),
+            res.error.map(BackendError::from),
         )
         .await?;
         Ok(())
@@ -205,7 +205,7 @@ impl GrpcClient {
             vpn_status::update(
                 app,
                 ConnectionState::from(status.status()),
-                status.error.map(BkdError::from),
+                status.error.map(BackendError::from),
             )
             .await?;
         }

--- a/nym-vpn-x/src-tauri/src/grpc/client.rs
+++ b/nym-vpn-x/src-tauri/src/grpc/client.rs
@@ -20,6 +20,7 @@ use tracing::{debug, error, info, instrument, warn};
 use ts_rs::TS;
 
 use crate::cli::Cli;
+use crate::error::BkdError;
 use crate::fs::config::AppConfig;
 use crate::states::app::ConnectionState;
 use crate::vpn_status;
@@ -44,8 +45,8 @@ pub enum VpndStatus {
 
 #[derive(Error, Debug)]
 pub enum VpndError {
-    #[error("rpc error")]
-    RpcError(#[from] tonic::Status),
+    #[error("gRPC call error")]
+    GrpcError(#[from] tonic::Status),
     #[error("failed to connect to daemon using HTTP transport")]
     FailedToConnectHttp(#[from] tonic::transport::Error),
     #[error("failed to connect to daemon using IPC transport")]
@@ -140,7 +141,7 @@ impl GrpcClient {
         let request = Request::new(StatusRequest {});
         let response = vpnd.vpn_status(request).await.map_err(|e| {
             error!("grpc vpn_status: {}", e);
-            VpndError::RpcError(e)
+            VpndError::GrpcError(e)
         })?;
         debug!("grpc response: {:?}", response);
 
@@ -158,7 +159,7 @@ impl GrpcClient {
         vpn_status::update(
             app,
             ConnectionState::from(res.status()),
-            res.error.as_ref().map(|e| e.message.clone()),
+            res.error.map(BkdError::from),
         )
         .await?;
         Ok(())
@@ -204,7 +205,7 @@ impl GrpcClient {
             vpn_status::update(
                 app,
                 ConnectionState::from(status.status()),
-                status.error.as_ref().map(|e| e.message.clone()),
+                status.error.map(BkdError::from),
             )
             .await?;
         }
@@ -236,7 +237,7 @@ impl GrpcClient {
         });
         let response = vpnd.vpn_connect(request).await.map_err(|e| {
             error!("grpc vpn_connect: {}", e);
-            VpndError::RpcError(e)
+            VpndError::GrpcError(e)
         })?;
         debug!("grpc response: {:?}", response);
 
@@ -252,7 +253,7 @@ impl GrpcClient {
         let request = Request::new(DisconnectRequest {});
         let response = vpnd.vpn_disconnect(request).await.map_err(|e| {
             error!("grpc vpn_disconnect: {}", e);
-            VpndError::RpcError(e)
+            VpndError::GrpcError(e)
         })?;
         debug!("grpc response: {:?}", response);
 
@@ -271,7 +272,7 @@ impl GrpcClient {
         let request = Request::new(ImportUserCredentialRequest { credential });
         let response = vpnd.import_user_credential(request).await.map_err(|e| {
             error!("grpc import_user_credential: {}", e);
-            VpndError::RpcError(e)
+            VpndError::GrpcError(e)
         })?;
         debug!("grpc response: {:?}", response);
 

--- a/nym-vpn-x/src-tauri/src/vpn_status.rs
+++ b/nym-vpn-x/src-tauri/src/vpn_status.rs
@@ -1,3 +1,4 @@
+use crate::error::BkdError;
 use crate::events::{ConnectionEventPayload, EVENT_CONNECTION_STATE};
 use crate::states::{app::ConnectionState, SharedAppState};
 use anyhow::Result;
@@ -9,7 +10,7 @@ use tracing::{info, instrument, trace, warn};
 pub async fn update(
     app: &tauri::AppHandle,
     status: ConnectionState,
-    error: Option<String>,
+    error: Option<BkdError>,
 ) -> Result<()> {
     let state = app.state::<SharedAppState>();
     trace!("vpn status: {:?}", status);

--- a/nym-vpn-x/src-tauri/src/vpn_status.rs
+++ b/nym-vpn-x/src-tauri/src/vpn_status.rs
@@ -1,4 +1,4 @@
-use crate::error::BkdError;
+use crate::error::BackendError;
 use crate::events::{ConnectionEventPayload, EVENT_CONNECTION_STATE};
 use crate::states::{app::ConnectionState, SharedAppState};
 use anyhow::Result;
@@ -10,7 +10,7 @@ use tracing::{info, instrument, trace, warn};
 pub async fn update(
     app: &tauri::AppHandle,
     status: ConnectionState,
-    error: Option<BkdError>,
+    error: Option<BackendError>,
 ) -> Result<()> {
     let state = app.state::<SharedAppState>();
     trace!("vpn status: {:?}", status);

--- a/nym-vpn-x/src/App.tsx
+++ b/nym-vpn-x/src/App.tsx
@@ -2,6 +2,7 @@ import { invoke } from '@tauri-apps/api';
 import { Suspense, useEffect } from 'react';
 import { RouterProvider } from 'react-router-dom';
 import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
 import { useTranslation } from 'react-i18next';
 import { NotificationProvider } from './contexts';
 import router from './router';
@@ -14,6 +15,7 @@ import { RouteLoading, ThemeSetter } from './ui';
 function App() {
   const { i18n } = useTranslation();
   dayjs.locale(i18n.language);
+  dayjs.extend(customParseFormat);
 
   useEffect(() => {
     const showSplashAnimation = async () => {

--- a/nym-vpn-x/src/hooks/index.ts
+++ b/nym-vpn-x/src/hooks/index.ts
@@ -1,2 +1,2 @@
 export { default as useThrottle } from './useThrottle';
-export { default as useCmdErrorI18n } from './useCmdErrorI18n';
+export { default as useI18nError } from './useI18nError';

--- a/nym-vpn-x/src/hooks/useI18nError.ts
+++ b/nym-vpn-x/src/hooks/useI18nError.ts
@@ -10,7 +10,7 @@ import { BkdErrorKey } from '../types';
 function useI18nError() {
   const { t } = useTranslation('errors');
 
-  const getErrorTranslation = useCallback(
+  const translateError = useCallback(
     (key: BkdErrorKey) => {
       switch (key) {
         case 'InternalError':
@@ -48,7 +48,7 @@ function useI18nError() {
     [t],
   );
 
-  return { eT: getErrorTranslation };
+  return { tE: translateError };
 }
 
 export default useI18nError;

--- a/nym-vpn-x/src/hooks/useI18nError.ts
+++ b/nym-vpn-x/src/hooks/useI18nError.ts
@@ -1,20 +1,30 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { CmdErrorI18nKey } from '../types';
+import { BkdErrorKey } from '../types';
 
 /**
- * Hook to get the translation function for command errors
+ * Hook to get the translation function for backend errors
  *
  * @returns The translation function
  */
-function useCmdErrorI18n() {
+function useI18nError() {
   const { t } = useTranslation('errors');
 
   const getErrorTranslation = useCallback(
-    (key: CmdErrorI18nKey) => {
+    (key: BkdErrorKey) => {
       switch (key) {
-        case 'UnknownError':
-          return t('unknown');
+        case 'InternalError':
+          return t('internal');
+        case 'NotConnectedToDaemon':
+          return t('daemon.not-connected');
+        case 'GrpcError':
+          return t('grpc');
+        case 'ConnectionTimeout':
+          return t('connection.timeout');
+        case 'ConnectionGatewayLookup':
+          return t('connection.gateway-lookup');
+        case 'ConnectionNoValidCredential':
+          return t('connection.no-valid-credential');
         case 'CredentialInvalid':
           return t('credential.invalid');
         case 'CredentialVpnRunning':
@@ -27,6 +37,12 @@ function useCmdErrorI18n() {
           return t('credential.deserialize');
         case 'CredentialExpired':
           return t('credential.expired');
+        case 'UnknownError':
+          return t('unknown');
+
+        default:
+          console.warn(`Unknown error key: ${key}`);
+          return t('unknown');
       }
     },
     [t],
@@ -35,4 +51,4 @@ function useCmdErrorI18n() {
   return { eT: getErrorTranslation };
 }
 
-export default useCmdErrorI18n;
+export default useI18nError;

--- a/nym-vpn-x/src/i18n/en/errors.json
+++ b/nym-vpn-x/src/i18n/en/errors.json
@@ -1,11 +1,21 @@
 {
   "unknown": "Unknown error",
+  "internal": "Internal error",
+  "daemon": {
+    "not-connected": "Not connected to the daemon"
+  },
+  "grpc": "Internal gRPC error",
+  "connection": {
+    "timeout": "Connection timeout",
+    "gateway-lookup": "Failed to lookup gateway",
+    "no-valid-credential": "No valid credential, please add a credential first"
+  },
   "credential": {
     "invalid": "Invalid credential",
     "expired": "Credential expired",
     "no-duplicate": "This credential has already been imported",
     "storage": "Failed to import credential because of an internal error",
-    "deserialize": "Failed to import credential because of an internal error",
+    "deserialize": "Failed to deserialize the credential",
     "vpn-running": "You cannot import a credential while connected to the VPN"
   }
 }

--- a/nym-vpn-x/src/pages/credential/AddCredential.tsx
+++ b/nym-vpn-x/src/pages/credential/AddCredential.tsx
@@ -20,7 +20,7 @@ function AddCredential() {
   const { push } = useNotifications();
   const navigate = useNavigate();
   const { t } = useTranslation('addCredential');
-  const { eT } = useI18nError();
+  const { tE } = useI18nError();
 
   const onChange = (credential: string) => {
     setCredential(credential);
@@ -45,10 +45,10 @@ function AddCredential() {
           // TODO the expiration date format passed from the backend is not ISO_8601
           // So we have to parse it manually
           setError(
-            `${eT(e.key)}: ${dayjs(e.data.expiration, 'YYYY-MM-DD').format('YYYY-MM-DD')}`,
+            `${tE(e.key)}: ${dayjs(e.data.expiration, 'YYYY-MM-DD').format('YYYY-MM-DD')}`,
           );
         } else {
-          setError(eT(e.key));
+          setError(tE(e.key));
         }
       });
   };

--- a/nym-vpn-x/src/pages/credential/AddCredential.tsx
+++ b/nym-vpn-x/src/pages/credential/AddCredential.tsx
@@ -9,7 +9,7 @@ import { NymDarkOutlineIcon, NymIcon } from '../../assets';
 import { useMainState, useNotifications } from '../../contexts';
 import { useI18nError } from '../../hooks';
 import { routes } from '../../router';
-import { BkdError } from '../../types';
+import { BackendError } from '../../types';
 import { Button, PageAnim, TextArea } from '../../ui';
 
 function AddCredential() {
@@ -39,7 +39,7 @@ function AddCredential() {
           closeIcon: true,
         });
       })
-      .catch((e: BkdError) => {
+      .catch((e: BackendError) => {
         console.log('backend error:', e);
         if (e.key === 'CredentialExpired' && e.data?.expiration) {
           // TODO the expiration date format passed from the backend is not ISO_8601

--- a/nym-vpn-x/src/pages/credential/AddCredential.tsx
+++ b/nym-vpn-x/src/pages/credential/AddCredential.tsx
@@ -4,11 +4,12 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { motion } from 'framer-motion';
 import { useNavigate } from 'react-router-dom';
+import dayjs from 'dayjs';
 import { NymDarkOutlineIcon, NymIcon } from '../../assets';
 import { useMainState, useNotifications } from '../../contexts';
-import { useCmdErrorI18n } from '../../hooks';
+import { useI18nError } from '../../hooks';
 import { routes } from '../../router';
-import { CmdError } from '../../types';
+import { BkdError } from '../../types';
 import { Button, PageAnim, TextArea } from '../../ui';
 
 function AddCredential() {
@@ -19,7 +20,7 @@ function AddCredential() {
   const { push } = useNotifications();
   const navigate = useNavigate();
   const { t } = useTranslation('addCredential');
-  const { eT } = useCmdErrorI18n();
+  const { eT } = useI18nError();
 
   const onChange = (credential: string) => {
     setCredential(credential);
@@ -38,12 +39,16 @@ function AddCredential() {
           closeIcon: true,
         });
       })
-      .catch((e: CmdError) => {
+      .catch((e: BkdError) => {
         console.log('backend error:', e);
-        if (e.i18n_key) {
-          setError(eT(e.i18n_key));
+        if (e.key === 'CredentialExpired' && e.data?.expiration) {
+          // TODO the expiration date format passed from the backend is not ISO_8601
+          // So we have to parse it manually
+          setError(
+            `${eT(e.key)}: ${dayjs(e.data.expiration, 'YYYY-MM-DD').format('YYYY-MM-DD')}`,
+          );
         } else {
-          setError(eT('UnknownError'));
+          setError(eT(e.key));
         }
       });
   };

--- a/nym-vpn-x/src/pages/home/ConnectionStatus.tsx
+++ b/nym-vpn-x/src/pages/home/ConnectionStatus.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useMainState } from '../../contexts';
 import { AnimateIn } from '../../ui';
+import { useI18nError } from '../../hooks';
 import ConnectionBadge from './ConnectionBadge';
 import ConnectionTimer from './ConnectionTimer';
 
@@ -10,6 +11,7 @@ function ConnectionStatus() {
   const [showBadge, setShowBadge] = useState(true);
 
   const { t } = useTranslation('home');
+  const { eT } = useI18nError();
 
   useEffect(() => {
     // Quickly hide and show badge when state changes to trigger
@@ -55,7 +57,9 @@ function ConnectionStatus() {
             duration={200}
             className="w-4/5 h-2/3 overflow-auto break-words text-center"
           >
-            <p className="text-sm text-teaberry font-bold">{state.error}</p>
+            <p className="text-sm text-teaberry font-bold">
+              {state.error.key ? eT(state.error.key) : state.error.message}
+            </p>
           </AnimateIn>
         )}
       </div>

--- a/nym-vpn-x/src/pages/home/ConnectionStatus.tsx
+++ b/nym-vpn-x/src/pages/home/ConnectionStatus.tsx
@@ -11,7 +11,7 @@ function ConnectionStatus() {
   const [showBadge, setShowBadge] = useState(true);
 
   const { t } = useTranslation('home');
-  const { eT } = useI18nError();
+  const { tE } = useI18nError();
 
   useEffect(() => {
     // Quickly hide and show badge when state changes to trigger
@@ -58,7 +58,7 @@ function ConnectionStatus() {
             className="w-4/5 h-2/3 overflow-auto break-words text-center"
           >
             <p className="text-sm text-teaberry font-bold">
-              {state.error.key ? eT(state.error.key) : state.error.message}
+              {state.error.key ? tE(state.error.key) : state.error.message}
             </p>
           </AnimateIn>
         )}

--- a/nym-vpn-x/src/pages/home/Home.tsx
+++ b/nym-vpn-x/src/pages/home/Home.tsx
@@ -5,7 +5,7 @@ import { invoke } from '@tauri-apps/api';
 import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { useMainDispatch, useMainState } from '../../contexts';
-import { CmdError, StateDispatch } from '../../types';
+import { BkdError, StateDispatch } from '../../types';
 import { routes } from '../../router';
 import { kvGet } from '../../kvStore';
 import { Button } from '../../ui';
@@ -35,9 +35,9 @@ function Home() {
           console.log('disconnect result');
           console.log(result);
         })
-        .catch((e: CmdError) => {
+        .catch((e: BkdError) => {
           console.warn('backend error:', e);
-          dispatch({ type: 'set-error', error: e.message });
+          dispatch({ type: 'set-error', error: e });
         });
     } else if (state === 'Disconnected') {
       dispatch({ type: 'connect' });
@@ -46,15 +46,15 @@ function Home() {
           console.log('connect result');
           console.log(result);
         })
-        .catch((e: CmdError) => {
+        .catch((e: BkdError) => {
           console.warn('backend error:', e);
-          dispatch({ type: 'set-error', error: e.message });
+          dispatch({ type: 'set-error', error: e });
         });
     }
   };
 
   useEffect(() => {
-    if (error?.includes('invalid credential')) {
+    if (error?.key === 'ConnectionNoValidCredential') {
       navigate(routes.credential);
       dispatch({ type: 'reset-error' });
     }

--- a/nym-vpn-x/src/pages/home/Home.tsx
+++ b/nym-vpn-x/src/pages/home/Home.tsx
@@ -5,7 +5,7 @@ import { invoke } from '@tauri-apps/api';
 import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { useMainDispatch, useMainState } from '../../contexts';
-import { BkdError, StateDispatch } from '../../types';
+import { BackendError, StateDispatch } from '../../types';
 import { routes } from '../../router';
 import { kvGet } from '../../kvStore';
 import { Button } from '../../ui';
@@ -35,7 +35,7 @@ function Home() {
           console.log('disconnect result');
           console.log(result);
         })
-        .catch((e: BkdError) => {
+        .catch((e: BackendError) => {
           console.warn('backend error:', e);
           dispatch({ type: 'set-error', error: e });
         });
@@ -46,7 +46,7 @@ function Home() {
           console.log('connect result');
           console.log(result);
         })
-        .catch((e: BkdError) => {
+        .catch((e: BackendError) => {
           console.warn('backend error:', e);
           dispatch({ type: 'set-error', error: e });
         });

--- a/nym-vpn-x/src/pages/location/NodeLocation.tsx
+++ b/nym-vpn-x/src/pages/location/NodeLocation.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { invoke } from '@tauri-apps/api';
 import { useMainDispatch, useMainState } from '../../contexts';
 import {
-  BkdError,
+  BackendError,
   Country,
   NodeHop,
   StateDispatch,
@@ -62,7 +62,7 @@ function NodeLocation({ node }: { node: NodeHop }) {
         .then((country) => {
           dispatch({ type: 'set-fastest-node-location', country });
         })
-        .catch((e: BkdError) => console.error(e));
+        .catch((e: BackendError) => console.error(e));
     }
   }, [node, dispatch, fetchEntryCountries, fetchExitCountries]);
 

--- a/nym-vpn-x/src/pages/location/NodeLocation.tsx
+++ b/nym-vpn-x/src/pages/location/NodeLocation.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { invoke } from '@tauri-apps/api';
 import { useMainDispatch, useMainState } from '../../contexts';
 import {
-  CmdError,
+  BkdError,
   Country,
   NodeHop,
   StateDispatch,
@@ -62,7 +62,7 @@ function NodeLocation({ node }: { node: NodeHop }) {
         .then((country) => {
           dispatch({ type: 'set-fastest-node-location', country });
         })
-        .catch((e: CmdError) => console.error(e));
+        .catch((e: BkdError) => console.error(e));
     }
   }, [node, dispatch, fetchEntryCountries, fetchExitCountries]);
 

--- a/nym-vpn-x/src/state/main.ts
+++ b/nym-vpn-x/src/state/main.ts
@@ -5,6 +5,7 @@ import {
   DefaultThemeMode,
 } from '../constants';
 import {
+  AppError,
   AppState,
   CodeDependency,
   ConnectProgressMsg,
@@ -25,7 +26,7 @@ export type StateAction =
   | { type: 'set-daemon-status'; status: DaemonStatus }
   | { type: 'set-vpn-mode'; mode: VpnMode }
   | { type: 'set-entry-selector'; entrySelector: boolean }
-  | { type: 'set-error'; error: string }
+  | { type: 'set-error'; error: AppError }
   | { type: 'reset-error' }
   | { type: 'new-progress-message'; message: ConnectProgressMsg }
   | { type: 'connect' }

--- a/nym-vpn-x/src/state/useExit.ts
+++ b/nym-vpn-x/src/state/useExit.ts
@@ -2,7 +2,7 @@ import { invoke } from '@tauri-apps/api';
 import { exit as processExit } from '@tauri-apps/api/process';
 import { useMainDispatch, useMainState } from '../contexts';
 import { kvFlush } from '../kvStore';
-import { CmdError, StateDispatch } from '../types';
+import { BkdError, StateDispatch } from '../types';
 
 // Hook to exit the app
 export function useExit() {
@@ -23,7 +23,7 @@ export function useExit() {
           console.log(result);
           await processExit(0);
         })
-        .catch(async (e: CmdError) => {
+        .catch(async (e: BkdError) => {
           console.warn('backend error:', e);
           await processExit(1);
         });

--- a/nym-vpn-x/src/state/useExit.ts
+++ b/nym-vpn-x/src/state/useExit.ts
@@ -2,7 +2,7 @@ import { invoke } from '@tauri-apps/api';
 import { exit as processExit } from '@tauri-apps/api/process';
 import { useMainDispatch, useMainState } from '../contexts';
 import { kvFlush } from '../kvStore';
-import { BkdError, StateDispatch } from '../types';
+import { BackendError, StateDispatch } from '../types';
 
 // Hook to exit the app
 export function useExit() {
@@ -23,7 +23,7 @@ export function useExit() {
           console.log(result);
           await processExit(0);
         })
-        .catch(async (e: BkdError) => {
+        .catch(async (e: BackendError) => {
           console.warn('backend error:', e);
           await processExit(1);
         });

--- a/nym-vpn-x/src/state/useTauriEvents.ts
+++ b/nym-vpn-x/src/state/useTauriEvents.ts
@@ -6,6 +6,7 @@ import dayjs from 'dayjs';
 import { kvSet } from '../kvStore';
 import {
   AppState,
+  BkdError,
   ConnectionEventPayload,
   DaemonStatus,
   ProgressEventPayload,
@@ -14,12 +15,12 @@ import {
 } from '../types';
 import { ConnectionEvent, DaemonEvent, ProgressEvent } from '../constants';
 
-function handleError(dispatch: StateDispatch, error?: string | null) {
+function handleError(dispatch: StateDispatch, error?: BkdError | null) {
   if (!error) {
     dispatch({ type: 'reset-error' });
     return;
   }
-  console.warn('received backend error:', error);
+  console.log('received backend error:', error);
   dispatch({ type: 'set-error', error });
 }
 
@@ -43,7 +44,8 @@ export function useTauriEvents(dispatch: StateDispatch, state: AppState) {
         case 'Connected':
           dispatch({
             type: 'set-connected',
-            startTime: event.payload.start_time || dayjs().unix(),
+            startTime:
+              (event.payload.start_time as unknown as number) || dayjs().unix(),
           });
           handleError(dispatch, event.payload.error);
           break;

--- a/nym-vpn-x/src/state/useTauriEvents.ts
+++ b/nym-vpn-x/src/state/useTauriEvents.ts
@@ -6,7 +6,7 @@ import dayjs from 'dayjs';
 import { kvSet } from '../kvStore';
 import {
   AppState,
-  BkdError,
+  BackendError,
   ConnectionEventPayload,
   DaemonStatus,
   ProgressEventPayload,
@@ -15,7 +15,7 @@ import {
 } from '../types';
 import { ConnectionEvent, DaemonEvent, ProgressEvent } from '../constants';
 
-function handleError(dispatch: StateDispatch, error?: BkdError | null) {
+function handleError(dispatch: StateDispatch, error?: BackendError | null) {
   if (!error) {
     dispatch({ type: 'reset-error' });
     return;

--- a/nym-vpn-x/src/types/app-state.ts
+++ b/nym-vpn-x/src/types/app-state.ts
@@ -2,7 +2,7 @@ import { Dispatch } from 'react';
 import { Dayjs } from 'dayjs';
 import { StateAction } from '../state';
 import { Country, NodeLocation, ThemeMode, UiTheme } from './common';
-import { BkdError, BkdErrorKey } from './tauri-ipc';
+import { BackendError, BkdErrorKey } from './tauri-ipc';
 
 export type ConnectionState =
   | 'Connected'
@@ -73,7 +73,7 @@ export type AppState = {
 
 export type ConnectionEventPayload = {
   state: ConnectionState;
-  error?: BkdError | null;
+  error?: BackendError | null;
   start_time?: bigint | null; // unix timestamp in seconds
 };
 

--- a/nym-vpn-x/src/types/app-state.ts
+++ b/nym-vpn-x/src/types/app-state.ts
@@ -2,6 +2,7 @@ import { Dispatch } from 'react';
 import { Dayjs } from 'dayjs';
 import { StateAction } from '../state';
 import { Country, NodeLocation, ThemeMode, UiTheme } from './common';
+import { BkdError, BkdErrorKey } from './tauri-ipc';
 
 export type ConnectionState =
   | 'Connected'
@@ -42,7 +43,7 @@ export type AppState = {
   daemonStatus: DaemonStatus;
   version: string | null;
   loading: boolean;
-  error?: string | null;
+  error?: AppError | null;
   progressMessages: ConnectProgressMsg[];
   sessionStartDate?: Dayjs | null;
   vpnMode: VpnMode;
@@ -72,8 +73,8 @@ export type AppState = {
 
 export type ConnectionEventPayload = {
   state: ConnectionState;
-  error?: string | null;
-  start_time?: number | null; // unix timestamp in seconds
+  error?: BkdError | null;
+  start_time?: bigint | null; // unix timestamp in seconds
 };
 
 export type ConnectProgressMsg = 'Initializing' | 'InitDone';
@@ -85,3 +86,9 @@ export type ProgressEventPayload = {
 export type StateDispatch = Dispatch<StateAction>;
 
 export type FetchCountriesFn = () => Promise<void> | undefined;
+
+export type AppError = {
+  message: string;
+  key?: BkdErrorKey | null;
+  data?: Record<string, string> | null;
+};

--- a/nym-vpn-x/src/types/tauri-ipc.ts
+++ b/nym-vpn-x/src/types/tauri-ipc.ts
@@ -1,9 +1,7 @@
-export type CmdErrorSource = 'InternalError' | 'CallerError' | 'Unknown';
-
-export interface CmdError {
-  source: CmdErrorSource;
+export interface BkdError {
   message: string;
-  i18n_key?: CmdErrorI18nKey | null;
+  key: BkdErrorKey;
+  data: Record<string, string> | null;
 }
 
 export interface Cli {
@@ -22,8 +20,14 @@ export type DbKey =
   | 'WindowSize'
   | 'WelcomeScreenSeen';
 
-export type CmdErrorI18nKey =
+export type BkdErrorKey =
   | 'UnknownError'
+  | 'InternalError'
+  | 'GrpcError'
+  | 'NotConnectedToDaemon'
+  | 'ConnectionTimeout'
+  | 'ConnectionGatewayLookup'
+  | 'ConnectionNoValidCredential'
   | 'CredentialInvalid'
   | 'CredentialVpnRunning'
   | 'CredentialAlreadyImported'

--- a/nym-vpn-x/src/types/tauri-ipc.ts
+++ b/nym-vpn-x/src/types/tauri-ipc.ts
@@ -1,4 +1,4 @@
-export interface BkdError {
+export interface BackendError {
   message: string;
   key: BkdErrorKey;
   data: Record<string, string> | null;


### PR DESCRIPTION
Refactors the overall backend to frontend error handling. The purpose is adding localization and specialization to error messages in the UI.
Any call to the App backend will potentially return the following error type including an error `key` that the frontend can safely use to map to localized error messages:

```rust
/// Generic error type made to be passed to the frontend and
/// displayed in the UI as localized error message
/// `Bkd` stands for 'Backend', source side from where the error is emitted
pub struct BkdError {
    /// Human readable error message for debugging/logs purposes
    pub message: String,
    /// Error key to be used in the UI to display localized error message
    pub key: ErrorKey,
    /// Extra data to be passed along to help specialize the problem
    pub data: Option<HashMap<String, String>>,
}
```

**NOTE** `key` is a required field, that is any backend error is now "specialized"

For now, this is the keys supported and exposed by the app backend
```rust
pub enum ErrorKey {
    /// Generic unhandled error
    UnknownError,
    /// Any error that is not explicitly handled, and not related
    /// to the application layer
    /// Extra data should be passed along to help specialize the problem
    InternalError,
    /// gRPC bare layer error, when a RPC call fails (aka `Tonic::Status`)
    /// That is, the error does not come from the application layer
    GrpcError,
    /// Happens when the app is not connected to a running daemon
    /// and attempts to make a gRPC call
    NotConnectedToDaemon,
    /// Forwarded from proto
    ConnectionTimeout,
    /// Forwarded from proto
    ConnectionGatewayLookup,
    /// Forwarded from proto
    ConnectionNoValidCredential,
    /// Forwarded from proto
    CredentialInvalid,
    /// Forwarded from proto
    CredentialVpnRunning,
    /// Forwarded from proto
    CredentialAlreadyImported,
    /// Forwarded from proto
    CredentialStorageError,
    /// Forwarded from proto
    CredentialDeserializationFailure,
    /// Forwarded from proto
    CredentialExpired,
}
```

This new error system allows the frontend to improve its error reporting in the UI, eg.

```typescript
    await invoke('add_credential', { credential: credential.trim() })
      .then(() => {
        navigate(routes.root);
      })
      .catch((e: BkdError) => {
        console.log('backend error:', e);
        if (e.key === 'CredentialExpired' && e.data?.expiration) {
          // TODO the expiration date format passed from the backend is not ISO_8601
          // So we have to parse it manually
          setError(
            `${eT(e.key)}: ${dayjs(e.data.expiration, 'YYYY-MM-DD').format('YYYY-MM-DD')}`,
          );
        } else {
          setError(eT(e.key));
        }
      });
```

```typescript
  useEffect(() => {
    if (error?.key === 'ConnectionNoValidCredential') {
      navigate(routes.credential);
      dispatch({ type: 'reset-error' });
    }
  }, [error, dispatch, navigate]);
```