### PR TITLE
feat(legacy, vpnx): reset config file on read or parse failure

### DIFF
--- a/nym-vpn-desktop/src-tauri/src/main.rs
+++ b/nym-vpn-desktop/src-tauri/src/main.rs
@@ -7,7 +7,7 @@ use anyhow::{anyhow, Result};
 use clap::Parser;
 use tauri::{api::path::config_dir, Manager};
 use tokio::sync::Mutex;
-use tracing::{debug, error, info, trace};
+use tracing::{debug, error, info, trace, warn};
 
 use commands::db as cmd_db;
 use commands::window as cmd_window;
@@ -93,7 +93,19 @@ async fn main() -> Result<()> {
         &app_config_store.full_path.display()
     );
 
-    let app_config = app_config_store.read().await?;
+    let app_config = match app_config_store.read().await {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            warn!("failed to read app config: {e}, falling back to default (empty) config");
+            debug!("clearing the config file");
+            app_config_store
+                .clear()
+                .await
+                .inspect_err(|e| error!("failed to clear the config file: {e}"))
+                .ok();
+            AppConfig::default()
+        }
+    };
     debug!("app_config: {app_config:?}");
 
     // use the provided network configuration file or sandbox if cli flag is set

--- a/nym-vpn-desktop/src-tauri/src/states/app.rs
+++ b/nym-vpn-desktop/src-tauri/src/states/app.rs
@@ -37,8 +37,8 @@ pub struct ConnectionInfo {
 #[derive(Default, Debug, Serialize, Deserialize, TS, Clone, PartialEq, Eq)]
 #[ts(export)]
 pub enum VpnMode {
-    Mixnet,
     #[default]
+    Mixnet,
     TwoHop,
 }
 

--- a/nym-vpn-x/src-tauri/src/states/app.rs
+++ b/nym-vpn-x/src-tauri/src/states/app.rs
@@ -36,8 +36,8 @@ pub struct ConnectionInfo {
 #[derive(Default, Debug, Serialize, Deserialize, TS, Clone, PartialEq, Eq)]
 #[ts(export)]
 pub enum VpnMode {
-    Mixnet,
     #[default]
+    Mixnet,
     TwoHop,
 }
 


### PR DESCRIPTION
- at app startup ignore any read or parsing failures of the config file
- on error, try to clear config content and fallback to default config
- do not exit the app on config read failure
- swap default vpn mode to 5hop