### PR TITLE
Remove unused binary submodules

### DIFF
--- a/nym-vpn-core/nym-vpn-lib/Cargo.toml
+++ b/nym-vpn-core/nym-vpn-lib/Cargo.toml
@@ -44,12 +44,12 @@ reqwest = { workspace = true, default_features = false, features = ["rustls-tls"
 tokio-tungstenite = { version = "0.20.1", features = ["rustls"] }
 tungstenite = { version = "0.20.1", default-features = false, features = ["rustls"] }
 
-talpid-core = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "c248ea193" }
-talpid-platform-metadata = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "c248ea193" }
-talpid-routing = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "c248ea193" }
-talpid-tunnel = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "c248ea193" }
-talpid-types = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "c248ea193" }
-talpid-wireguard = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "c248ea193" }
+talpid-core = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "2b0cea7fe7" }
+talpid-platform-metadata = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "2b0cea7fe7" }
+talpid-routing = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "2b0cea7fe7" }
+talpid-tunnel = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "2b0cea7fe7" }
+talpid-types = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "2b0cea7fe7" }
+talpid-wireguard = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "2b0cea7fe7" }
 
 nym-bandwidth-controller.workspace = true
 nym-bin-common.workspace = true

--- a/nym-vpn-core/nym-vpn-lib/Cargo.toml
+++ b/nym-vpn-core/nym-vpn-lib/Cargo.toml
@@ -44,12 +44,12 @@ reqwest = { workspace = true, default_features = false, features = ["rustls-tls"
 tokio-tungstenite = { version = "0.20.1", features = ["rustls"] }
 tungstenite = { version = "0.20.1", default-features = false, features = ["rustls"] }
 
-talpid-core = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "f84c584b" }
-talpid-platform-metadata = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "f84c584b" }
-talpid-routing = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "f84c584b" }
-talpid-tunnel = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "f84c584b" }
-talpid-types = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "f84c584b" }
-talpid-wireguard = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "f84c584b" }
+talpid-core = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "164e254aa" }
+talpid-platform-metadata = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "164e254aa" }
+talpid-routing = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "164e254aa" }
+talpid-tunnel = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "164e254aa" }
+talpid-types = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "164e254aa" }
+talpid-wireguard = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "164e254aa" }
 
 nym-bandwidth-controller.workspace = true
 nym-bin-common.workspace = true

--- a/nym-vpn-core/nym-vpn-lib/Cargo.toml
+++ b/nym-vpn-core/nym-vpn-lib/Cargo.toml
@@ -44,12 +44,12 @@ reqwest = { workspace = true, default_features = false, features = ["rustls-tls"
 tokio-tungstenite = { version = "0.20.1", features = ["rustls"] }
 tungstenite = { version = "0.20.1", default-features = false, features = ["rustls"] }
 
-talpid-core = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "8eddbbc8" }
-talpid-platform-metadata = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "8eddbbc8" }
-talpid-routing = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "8eddbbc8" }
-talpid-tunnel = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "8eddbbc8" }
-talpid-types = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "8eddbbc8" }
-talpid-wireguard = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "8eddbbc8" }
+talpid-core = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "f84c584b" }
+talpid-platform-metadata = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "f84c584b" }
+talpid-routing = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "f84c584b" }
+talpid-tunnel = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "f84c584b" }
+talpid-types = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "f84c584b" }
+talpid-wireguard = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "f84c584b" }
 
 nym-bandwidth-controller.workspace = true
 nym-bin-common.workspace = true

--- a/nym-vpn-core/nym-vpn-lib/Cargo.toml
+++ b/nym-vpn-core/nym-vpn-lib/Cargo.toml
@@ -44,12 +44,12 @@ reqwest = { workspace = true, default_features = false, features = ["rustls-tls"
 tokio-tungstenite = { version = "0.20.1", features = ["rustls"] }
 tungstenite = { version = "0.20.1", default-features = false, features = ["rustls"] }
 
-talpid-core = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "c43a60bbb7bb8defa99889de4c45a3cce258620a" }
-talpid-platform-metadata = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "c43a60bbb7bb8defa99889de4c45a3cce258620a" }
-talpid-routing = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "c43a60bbb7bb8defa99889de4c45a3cce258620a" }
-talpid-tunnel = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "c43a60bbb7bb8defa99889de4c45a3cce258620a" }
-talpid-types = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "c43a60bbb7bb8defa99889de4c45a3cce258620a" }
-talpid-wireguard = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "c43a60bbb7bb8defa99889de4c45a3cce258620a" }
+talpid-core = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "c248ea193" }
+talpid-platform-metadata = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "c248ea193" }
+talpid-routing = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "c248ea193" }
+talpid-tunnel = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "c248ea193" }
+talpid-types = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "c248ea193" }
+talpid-wireguard = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "c248ea193" }
 
 nym-bandwidth-controller.workspace = true
 nym-bin-common.workspace = true

--- a/nym-vpn-core/nym-vpn-lib/Cargo.toml
+++ b/nym-vpn-core/nym-vpn-lib/Cargo.toml
@@ -44,12 +44,12 @@ reqwest = { workspace = true, default_features = false, features = ["rustls-tls"
 tokio-tungstenite = { version = "0.20.1", features = ["rustls"] }
 tungstenite = { version = "0.20.1", default-features = false, features = ["rustls"] }
 
-talpid-core = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "2b0cea7fe7" }
-talpid-platform-metadata = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "2b0cea7fe7" }
-talpid-routing = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "2b0cea7fe7" }
-talpid-tunnel = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "2b0cea7fe7" }
-talpid-types = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "2b0cea7fe7" }
-talpid-wireguard = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "2b0cea7fe7" }
+talpid-core = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "8eddbbc8" }
+talpid-platform-metadata = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "8eddbbc8" }
+talpid-routing = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "8eddbbc8" }
+talpid-tunnel = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "8eddbbc8" }
+talpid-types = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "8eddbbc8" }
+talpid-wireguard = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "8eddbbc8" }
 
 nym-bandwidth-controller.workspace = true
 nym-bin-common.workspace = true


### PR DESCRIPTION
Update to latest commit in the mullvad libs repo, which skips a few submodules that we don't need for now