### PR TITLE
fix(vpnx): use connection time provided by daemon

### DIFF
--- a/nym-vpn-x/src-tauri/src/vpn_status.rs
+++ b/nym-vpn-x/src-tauri/src/vpn_status.rs
@@ -11,6 +11,7 @@ pub async fn update(
     app: &tauri::AppHandle,
     status: ConnectionState,
     error: Option<BackendError>,
+    connection_time: Option<OffsetDateTime>,
 ) -> Result<()> {
     let state = app.state::<SharedAppState>();
     trace!("vpn status: {:?}", status);
@@ -27,17 +28,20 @@ pub async fn update(
     match status {
         ConnectionState::Connected => {
             info!("vpn status → [Connected]");
-            let now = OffsetDateTime::now_utc();
+            let t = connection_time.unwrap_or_else(|| {
+                info!("established connection time was not given, using current utc time");
+                OffsetDateTime::now_utc()
+            });
             let mut app_state = state.lock().await;
             app_state.state = status.clone();
-            app_state.connection_start_time = Some(now);
+            app_state.connection_start_time = Some(t);
             drop(app_state);
             app.emit_all(
                 EVENT_CONNECTION_STATE,
                 ConnectionEventPayload::new(
                     ConnectionState::Connected,
                     error,
-                    Some(now.unix_timestamp()),
+                    Some(t.unix_timestamp()),
                 ),
             )
             .ok();


### PR DESCRIPTION
- use the reported "established connection time" as reported by daemon
- when it's not reported as on `Connected` event, fallback to utc current time
- for any reason if the app lost the vpn connection state, on next state refresh, if vpn still connected, the connection timer will be set as expected