### PR TITLE
Run nym-vpnd in background service on windows

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -1852,6 +1852,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
+name = "eventlog"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d403b58223ab151849e734d79809b1b208555dd0c00a26d103c5736db921a3f7"
+dependencies = [
+ "log",
+ "regex",
+ "registry",
+ "sha2 0.10.8",
+ "thiserror",
+ "winapi",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4771,8 +4785,10 @@ dependencies = [
  "anyhow",
  "clap",
  "dirs 5.0.1",
+ "eventlog",
  "futures",
  "http 0.2.12",
+ "log",
  "maplit",
  "nym-task",
  "nym-vpn-lib",
@@ -4793,6 +4809,9 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vergen",
+ "winapi",
+ "windows-service 0.6.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -5667,6 +5686,19 @@ name = "regex-syntax"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+
+[[package]]
+name = "registry"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf3b6d580d46b9d6d6c291f90c5d762e8b93a268a96e429556419fcd7e349f94"
+dependencies = [
+ "bitflags 1.3.2",
+ "log",
+ "thiserror",
+ "utfx",
+ "winapi",
+]
 
 [[package]]
 name = "reqwest"
@@ -6853,7 +6885,7 @@ dependencies = [
  "uuid 0.8.2",
  "which",
  "widestring",
- "windows-service",
+ "windows-service 0.5.0",
  "windows-sys 0.42.0",
  "winreg 0.7.0",
  "zeroize",
@@ -8153,6 +8185,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
+name = "utfx"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "133bf74f01486773317ddfcde8e2e20d2933cc3b68ab797e5d718bef996a81de"
+
+[[package]]
 name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8464,6 +8502,17 @@ dependencies = [
  "err-derive",
  "widestring",
  "windows-sys 0.36.1",
+]
+
+[[package]]
+name = "windows-service"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd9db37ecb5b13762d95468a2fc6009d4b2c62801243223aabd44fca13ad13c8"
+dependencies = [
+ "bitflags 1.3.2",
+ "widestring",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -301,6 +301,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,7 +330,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.3.4",
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
@@ -339,10 +345,44 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "tower",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.3",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.1",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -359,6 +399,50 @@ dependencies = [
  "mime",
  "rustversion",
  "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 0.1.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-server"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ad46c3ec4e12f4a4b6835e173ba21c25e484c9d02b49770bf006ce5367c036"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls 0.21.10",
+ "rustls-pemfile 2.1.2",
+ "tokio",
+ "tokio-rustls 0.24.1",
+ "tower",
  "tower-service",
 ]
 
@@ -2266,6 +2350,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
+ "indexmap 2.2.6",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "handlebars"
 version = "3.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2545,7 +2648,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -2568,6 +2671,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
+ "h2 0.4.5",
  "http 1.1.0",
  "http-body 1.0.0",
  "httparse",
@@ -4783,6 +4887,8 @@ name = "nym-vpnd"
 version = "0.1.7-dev"
 dependencies = [
  "anyhow",
+ "axum 0.7.5",
+ "axum-server",
  "clap",
  "dirs 5.0.1",
  "eventlog",
@@ -4806,6 +4912,7 @@ dependencies = [
  "tonic 0.11.0",
  "tonic-health",
  "tonic-reflection",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "vergen",
@@ -5711,7 +5818,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
@@ -5729,7 +5836,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "system-configuration 0.5.1",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -5771,7 +5878,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "tokio",
  "tokio-rustls 0.25.0",
  "tower-service",
@@ -6239,6 +6346,16 @@ checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+dependencies = [
+ "itoa",
  "serde",
 ]
 
@@ -6769,6 +6886,12 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "synstructure"
@@ -7508,12 +7631,12 @@ checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.6.20",
  "base64 0.13.1",
  "bytes",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
@@ -7540,10 +7663,10 @@ checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.6.20",
  "base64 0.21.7",
  "bytes",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
@@ -7629,6 +7752,22 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "bitflags 2.5.0",
+ "bytes",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]

--- a/nym-vpn-core/nym-vpnd/Cargo.toml
+++ b/nym-vpn-core/nym-vpnd/Cargo.toml
@@ -31,6 +31,7 @@ tonic-reflection.workspace = true
 tonic.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 tracing.workspace = true
+log.workspace = true
 
 # match the version required by tonic
 http = "0.2.12"
@@ -38,6 +39,24 @@ http = "0.2.12"
 nym-vpn-lib = { path = "../nym-vpn-lib" }
 nym-vpn-proto = { path = "../crates/nym-vpn-proto" }
 nym-task.workspace = true
+
+[target.'cfg(windows)'.dependencies]
+windows-service = "0.6.0"
+eventlog = "0.2.2"
+winapi = { version = "0.3", features = ["winnt", "excpt"] }
+
+[target.'cfg(windows)'.dependencies.windows-sys]
+version = "0.45.0"
+features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Security_Authorization",
+    "Win32_Security_Authentication_Identity",
+    "Win32_System_Diagnostics_Debug",
+    "Win32_System_Kernel",
+    "Win32_System_Memory",
+    "Win32_System_Threading",
+]
 
 [build-dependencies]
 vergen = { workspace = true, default-features = false, features = [

--- a/nym-vpn-core/nym-vpnd/Cargo.toml
+++ b/nym-vpn-core/nym-vpnd/Cargo.toml
@@ -9,7 +9,6 @@ documentation.workspace = true
 edition.workspace = true
 license.workspace = true
 
-
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
@@ -32,6 +31,10 @@ tonic.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 tracing.workspace = true
 log.workspace = true
+
+tower-http = { version = "0.5.2", features = ["cors"] }
+axum = { version = "0.7.4" }
+axum-server = { version = "0.6.0", features = ["tls-rustls"] }
 
 # match the version required by tonic
 http = "0.2.12"

--- a/nym-vpn-core/nym-vpnd/src/cli.rs
+++ b/nym-vpn-core/nym-vpnd/src/cli.rs
@@ -45,6 +45,9 @@ pub(crate) struct Command {
 
     #[arg(long)]
     pub(crate) start: bool,
+
+    #[arg(long)]
+    pub(crate) run_as_service: bool,
 }
 
 fn check_path(path: &str) -> Result<PathBuf, String> {

--- a/nym-vpn-core/nym-vpnd/src/cli.rs
+++ b/nym-vpn-core/nym-vpnd/src/cli.rs
@@ -52,6 +52,12 @@ pub(crate) struct Command {
     pub(crate) run_as_service: bool,
 }
 
+impl Command {
+    pub(crate) fn is_any(&self) -> bool {
+        self.install || self.uninstall || self.start || self.run_as_service
+    }
+}
+
 fn check_path(path: &str) -> Result<PathBuf, String> {
     let path = PathBuf::from(path);
     if !path.exists() {

--- a/nym-vpn-core/nym-vpnd/src/cli.rs
+++ b/nym-vpn-core/nym-vpnd/src/cli.rs
@@ -52,6 +52,7 @@ pub(crate) struct Command {
     pub(crate) run_as_service: bool,
 }
 
+#[cfg(windows)]
 impl Command {
     pub(crate) fn is_any(&self) -> bool {
         self.install || self.uninstall || self.start || self.run_as_service

--- a/nym-vpn-core/nym-vpnd/src/cli.rs
+++ b/nym-vpn-core/nym-vpnd/src/cli.rs
@@ -1,7 +1,9 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use clap::{Args, Parser};
+#[cfg(windows)]
+use clap::Args;
+use clap::Parser;
 use nym_vpn_lib::nym_bin_common::bin_info_local_vergen;
 use std::{path::PathBuf, sync::OnceLock};
 

--- a/nym-vpn-core/nym-vpnd/src/cli.rs
+++ b/nym-vpn-core/nym-vpnd/src/cli.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use clap::Parser;
+use clap::{Args, Parser};
 use nym_vpn_lib::nym_bin_common::bin_info_local_vergen;
 use std::{path::PathBuf, sync::OnceLock};
 
@@ -23,6 +23,28 @@ pub(crate) struct CliArgs {
 
     #[arg(long)]
     pub(crate) disable_socket_listener: bool,
+
+    #[cfg(windows)]
+    #[arg(long)]
+    pub(crate) disable_service: bool,
+
+    #[cfg(windows)]
+    #[command(flatten)]
+    pub(crate) command: Command,
+}
+
+#[cfg(windows)]
+#[derive(Args, Debug, Clone)]
+#[group(multiple = false)]
+pub(crate) struct Command {
+    #[arg(long)]
+    pub(crate) install: bool,
+
+    #[arg(long)]
+    pub(crate) uninstall: bool,
+
+    #[arg(long)]
+    pub(crate) start: bool,
 }
 
 fn check_path(path: &str) -> Result<PathBuf, String> {

--- a/nym-vpn-core/nym-vpnd/src/command_interface/listener.rs
+++ b/nym-vpn-core/nym-vpnd/src/command_interface/listener.rs
@@ -31,12 +31,6 @@ enum ListenerType {
     Uri(#[allow(unused)] SocketAddr),
 }
 
-#[derive(Default)]
-pub(crate) struct CommandInterfaceOptions {
-    pub(crate) disable_socket_listener: bool,
-    pub(crate) enable_http_listener: bool,
-}
-
 pub(super) struct CommandInterface {
     // Listen to state changes from the VPN service
     vpn_state_changes_rx: broadcast::Receiver<VpnServiceStateChange>,

--- a/nym-vpn-core/nym-vpnd/src/command_interface/listener.rs
+++ b/nym-vpn-core/nym-vpnd/src/command_interface/listener.rs
@@ -31,6 +31,12 @@ enum ListenerType {
     Uri(#[allow(unused)] SocketAddr),
 }
 
+#[derive(Default)]
+pub(crate) struct CommandInterfaceOptions {
+    pub(crate) disable_socket_listener: bool,
+    pub(crate) enable_http_listener: bool,
+}
+
 pub(super) struct CommandInterface {
     // Listen to state changes from the VPN service
     vpn_state_changes_rx: broadcast::Receiver<VpnServiceStateChange>,

--- a/nym-vpn-core/nym-vpnd/src/command_interface/mod.rs
+++ b/nym-vpn-core/nym-vpnd/src/command_interface/mod.rs
@@ -13,5 +13,4 @@ mod socket_stream;
 mod start;
 mod status_broadcaster;
 
-pub(crate) use listener::CommandInterfaceOptions;
-pub(crate) use start::start_command_interface;
+pub(crate) use start::{start_command_interface, CommandInterfaceOptions};

--- a/nym-vpn-core/nym-vpnd/src/command_interface/mod.rs
+++ b/nym-vpn-core/nym-vpnd/src/command_interface/mod.rs
@@ -13,4 +13,5 @@ mod socket_stream;
 mod start;
 mod status_broadcaster;
 
+pub(crate) use listener::CommandInterfaceOptions;
 pub(crate) use start::start_command_interface;

--- a/nym-vpn-core/nym-vpnd/src/command_interface/start.rs
+++ b/nym-vpn-core/nym-vpnd/src/command_interface/start.rs
@@ -118,7 +118,6 @@ pub(crate) fn start_command_interface(
     // Channel to send commands to the vpn service
     let (vpn_command_tx, vpn_command_rx) = tokio::sync::mpsc::unbounded_channel();
 
-    // let args = args.clone();
     let command_interface_options = command_interface_options.unwrap_or_default();
     let socket_path = default_socket_path();
     let uri_addr = default_uri_addr();
@@ -133,7 +132,6 @@ pub(crate) fn start_command_interface(
             .unwrap();
 
         command_rt.block_on(async move {
-            // if !args.disable_socket_listener {
             if !command_interface_options.disable_socket_listener {
                 spawn_socket_listener(
                     vpn_state_changes_rx.resubscribe(),
@@ -142,7 +140,6 @@ pub(crate) fn start_command_interface(
                 );
             }
 
-            // if args.enable_http_listener {
             if command_interface_options.enable_http_listener {
                 spawn_uri_listener(vpn_state_changes_rx, vpn_command_tx.clone(), uri_addr);
             }

--- a/nym-vpn-core/nym-vpnd/src/command_interface/start.rs
+++ b/nym-vpn-core/nym-vpnd/src/command_interface/start.rs
@@ -10,17 +10,14 @@ use tokio::sync::{
     mpsc::{UnboundedReceiver, UnboundedSender},
 };
 use tonic::transport::Server;
-use tracing::{debug, debug_span, info, info_span, trace, trace_span, Span};
+use tracing::{debug, debug_span, error, info, info_span, trace, trace_span, Span};
 
 use super::{
     config::{default_socket_path, default_uri_addr},
-    listener::CommandInterface,
+    listener::{CommandInterface, CommandInterfaceOptions},
     socket_stream::setup_socket_stream,
 };
-use crate::{
-    cli::CliArgs,
-    service::{VpnServiceCommand, VpnServiceStateChange},
-};
+use crate::service::{VpnServiceCommand, VpnServiceStateChange};
 
 fn grpc_span(req: &http::Request<()>) -> Span {
     let service = req.uri().path().trim_start_matches('/');
@@ -105,7 +102,9 @@ fn spawn_socket_listener(
 pub(crate) fn start_command_interface(
     vpn_state_changes_rx: broadcast::Receiver<VpnServiceStateChange>,
     mut task_manager: TaskManager,
-    args: &CliArgs,
+    // args: &CliArgs,
+    command_interface_options: Option<CommandInterfaceOptions>,
+    mut event_rx: tokio::sync::mpsc::UnboundedReceiver<()>,
 ) -> (
     std::thread::JoinHandle<()>,
     UnboundedReceiver<VpnServiceCommand>,
@@ -114,7 +113,8 @@ pub(crate) fn start_command_interface(
     // Channel to send commands to the vpn service
     let (vpn_command_tx, vpn_command_rx) = tokio::sync::mpsc::unbounded_channel();
 
-    let args = args.clone();
+    // let args = args.clone();
+    let command_interface_options = command_interface_options.unwrap_or_default();
     let socket_path = default_socket_path();
     let uri_addr = default_uri_addr();
 
@@ -128,7 +128,8 @@ pub(crate) fn start_command_interface(
             .unwrap();
 
         command_rt.block_on(async move {
-            if !args.disable_socket_listener {
+            // if !args.disable_socket_listener {
+            if !command_interface_options.disable_socket_listener {
                 spawn_socket_listener(
                     vpn_state_changes_rx.resubscribe(),
                     vpn_command_tx.clone(),
@@ -136,7 +137,8 @@ pub(crate) fn start_command_interface(
                 );
             }
 
-            if args.enable_http_listener {
+            // if args.enable_http_listener {
+            if command_interface_options.enable_http_listener {
                 spawn_uri_listener(vpn_state_changes_rx, vpn_command_tx.clone(), uri_addr);
             }
 
@@ -163,7 +165,16 @@ pub(crate) fn start_command_interface(
             // Wait for interrupt
             // Send shutdown signal to all tasks
             // Wait for all tasks to finish
-            let _ = task_manager.catch_interrupt().await;
+            tokio::select! {
+                _ = task_manager.catch_interrupt() => {
+                    info!("caught interrupt");
+                },
+                _ = event_rx.recv() => {
+                    error!("caught event stop");
+                    task_manager.signal_shutdown().ok();
+                    task_manager.wait_for_shutdown().await;
+                }
+            }
 
             info!("Command interface exiting");
         });

--- a/nym-vpn-core/nym-vpnd/src/command_interface/start.rs
+++ b/nym-vpn-core/nym-vpnd/src/command_interface/start.rs
@@ -14,7 +14,7 @@ use tracing::{debug, debug_span, error, info, info_span, trace, trace_span, Span
 
 use super::{
     config::{default_socket_path, default_uri_addr},
-    listener::{CommandInterface, CommandInterfaceOptions},
+    listener::CommandInterface,
     socket_stream::setup_socket_stream,
 };
 use crate::service::{VpnServiceCommand, VpnServiceStateChange};
@@ -99,10 +99,15 @@ fn spawn_socket_listener(
     });
 }
 
+#[derive(Default)]
+pub(crate) struct CommandInterfaceOptions {
+    pub(crate) disable_socket_listener: bool,
+    pub(crate) enable_http_listener: bool,
+}
+
 pub(crate) fn start_command_interface(
     vpn_state_changes_rx: broadcast::Receiver<VpnServiceStateChange>,
     mut task_manager: TaskManager,
-    // args: &CliArgs,
     command_interface_options: Option<CommandInterfaceOptions>,
     mut event_rx: tokio::sync::mpsc::UnboundedReceiver<()>,
 ) -> (

--- a/nym-vpn-core/nym-vpnd/src/main.rs
+++ b/nym-vpn-core/nym-vpnd/src/main.rs
@@ -5,6 +5,7 @@ mod cli;
 mod command_interface;
 mod logging;
 mod service;
+#[cfg(windows)]
 mod win_service;
 
 fn run_inner() -> Result<(), Box<dyn std::error::Error>> {

--- a/nym-vpn-core/nym-vpnd/src/win_service/install.rs
+++ b/nym-vpn-core/nym-vpnd/src/win_service/install.rs
@@ -1,0 +1,87 @@
+use super::{service::get_service_info, SERVICE_DESCRIPTION, SERVICE_DISPLAY_NAME, SERVICE_NAME};
+use std::{
+    thread::sleep,
+    time::{Duration, Instant},
+};
+use windows_service::{
+    service::{ServiceAccess, ServiceState},
+    service_manager::{ServiceManager, ServiceManagerAccess},
+};
+use windows_sys::Win32::Foundation::ERROR_SERVICE_DOES_NOT_EXIST;
+
+// see https://github.com/mullvad/windows-service-rs/blob/main/examples/install_service.rs
+pub(super) fn install_service() -> windows_service::Result<()> {
+    let manager_access = ServiceManagerAccess::CONNECT | ServiceManagerAccess::CREATE_SERVICE;
+    let service_manager = ServiceManager::local_computer(None::<&str>, manager_access)?;
+
+    println!("Registering event logger {}...", SERVICE_DISPLAY_NAME);
+    eventlog::register(SERVICE_DISPLAY_NAME).unwrap();
+
+    println!("Registering {} service...", SERVICE_NAME);
+    if service_manager
+        .open_service(SERVICE_NAME, ServiceAccess::QUERY_STATUS)
+        .is_err()
+    {
+        let service_info = get_service_info();
+        let service =
+            service_manager.create_service(&service_info, ServiceAccess::CHANGE_CONFIG)?;
+        service.set_description(SERVICE_DESCRIPTION)?;
+    }
+
+    println!("{} service has been registered.", SERVICE_NAME);
+
+    Ok(())
+}
+
+// see https://github.com/mullvad/windows-service-rs/blob/main/examples/uninstall_service.rs
+pub(super) fn uninstall_service() -> windows_service::Result<()> {
+    let manager_access = ServiceManagerAccess::CONNECT;
+    let service_manager = ServiceManager::local_computer(None::<&str>, manager_access)?;
+
+    let service_access = ServiceAccess::QUERY_STATUS | ServiceAccess::STOP | ServiceAccess::DELETE;
+    let service = service_manager.open_service(SERVICE_NAME, service_access)?;
+
+    // The service will be marked for deletion as long as this function call succeeds.
+    // However, it will not be deleted from the database until it is stopped and all open handles to it are closed.
+    service.delete()?;
+    // Our handle to it is not closed yet. So we can still query it.
+    if service.query_status()?.current_state != ServiceState::Stopped {
+        // If the service cannot be stopped, it will be deleted when the system restarts.
+        service.stop()?;
+    }
+    // Explicitly close our open handle to the service. This is automatically called when `service` goes out of scope.
+    drop(service);
+
+    // Win32 API does not give us a way to wait for service deletion.
+    // To check if the service is deleted from the database, we have to poll it ourselves.
+    let start = Instant::now();
+    let timeout = Duration::from_secs(5);
+    while start.elapsed() < timeout {
+        if let Err(windows_service::Error::Winapi(e)) =
+            service_manager.open_service(SERVICE_NAME, ServiceAccess::QUERY_STATUS)
+        {
+            if e.raw_os_error() == Some(ERROR_SERVICE_DOES_NOT_EXIST as i32) {
+                println!("{} is deleted.", SERVICE_NAME);
+                return Ok(());
+            }
+        }
+        sleep(Duration::from_secs(1));
+    }
+    println!("{} is marked for deletion.", SERVICE_NAME);
+
+    Ok(())
+}
+
+pub(super) fn start_service() -> windows_service::Result<()> {
+    let manager_access = ServiceManagerAccess::CONNECT;
+    let service_manager = ServiceManager::local_computer(None::<&str>, manager_access)?;
+
+    let service_access = ServiceAccess::QUERY_STATUS | ServiceAccess::START;
+    let service = service_manager.open_service(SERVICE_NAME, service_access)?;
+
+    if service.query_status()?.current_state != ServiceState::Running {
+        // TODO: figure out how to pass an empty array or null
+        service.start(&[std::ffi::OsStr::new("")])?;
+    }
+    Ok(())
+}

--- a/nym-vpn-core/nym-vpnd/src/win_service/mod.rs
+++ b/nym-vpn-core/nym-vpnd/src/win_service/mod.rs
@@ -1,0 +1,5 @@
+mod install;
+mod service;
+
+pub(crate) use service::start;
+pub(crate) use service::{SERVICE_DESCRIPTION, SERVICE_DISPLAY_NAME, SERVICE_NAME};

--- a/nym-vpn-core/nym-vpnd/src/win_service/service.rs
+++ b/nym-vpn-core/nym-vpnd/src/win_service/service.rs
@@ -1,0 +1,187 @@
+use std::env;
+use std::ffi::OsString;
+// use std::sync::{Arc, mpsc};
+// use std::sync::mpsc::{Receiver, Sender};
+use std::time::Duration;
+
+// use log::info;
+// use tokio::runtime::Runtime;
+// use tokio::sync::Mutex;
+use tracing::info;
+use windows_service::service::{
+    ServiceControl, ServiceControlAccept, ServiceDependency, ServiceErrorControl, ServiceExitCode,
+    ServiceInfo, ServiceStartType, ServiceState, ServiceStatus, ServiceType,
+};
+use windows_service::service_control_handler::{self, ServiceControlHandlerResult};
+use windows_service::service_dispatcher;
+
+use crate::cli::CliArgs;
+
+use super::install;
+
+// use crate::daemon::DaemonState;
+
+// mod daemon;
+// mod install;
+
+windows_service::define_windows_service!(ffi_service_main, my_service_main);
+
+pub(crate) static SERVICE_NAME: &str = "nym-vpnd";
+pub(crate) static SERVICE_DISPLAY_NAME: &str = "NymVPN Service";
+
+pub(crate) static SERVICE_DESCRIPTION: &str =
+    "A service that creates and runs tunnels to the Nym network";
+static SERVICE_TYPE: ServiceType = ServiceType::OWN_PROCESS;
+
+fn my_service_main(arguments: Vec<OsString>) {
+    if let Err(_e) = run_service(arguments) {
+        // Handle error in some way.
+    }
+}
+
+fn run_service(_arguments: Vec<OsString>) -> windows_service::Result<()> {
+    info!("Creating tokio runtime...");
+
+    // let rt = Arc::new(Runtime::new().unwrap());
+    // let (tx, rx): (
+    //     Sender<crate::daemon::DaemonState>,
+    //     Receiver<crate::daemon::DaemonState>,
+    // ) = mpsc::channel();
+    // let daemon = Arc::new(Mutex::new(daemon::Daemon::new(tx.clone())));
+
+    // let rt_handler = rt.clone();
+    // let daemon_handler = daemon.clone();
+    let event_handler = move |control_event| -> ServiceControlHandlerResult {
+        match control_event {
+            ServiceControl::Stop => {
+                // rt_handler.block_on(async {
+                //     let mut guard = daemon_handler.lock().await;
+                //     guard.stop().await;
+                // });
+                ServiceControlHandlerResult::NoError
+            }
+            ServiceControl::Interrogate => {
+                // rt_handler.block_on(async {
+                //     let guard = daemon_handler.lock().await;
+                //     let status = guard.get_status().await;
+                //     info!("Status is {:#?}", status)
+                // });
+                ServiceControlHandlerResult::NoError
+            }
+            _ => ServiceControlHandlerResult::NotImplemented,
+        }
+    };
+
+    // Register system service event handler
+    let status_handle = service_control_handler::register(SERVICE_NAME, event_handler)?;
+
+    let next_status = ServiceStatus {
+        service_type: SERVICE_TYPE,
+        current_state: ServiceState::Running,
+        controls_accepted: ServiceControlAccept::STOP,
+        exit_code: ServiceExitCode::Win32(0),
+        checkpoint: 0,
+        wait_hint: Duration::default(),
+        process_id: None,
+    };
+
+    info!("Service is starting...");
+    // rt.block_on(async {
+    //     let mut guard = daemon.lock().await;
+    //     guard.start().await;
+    // });
+
+    // Tell the system that the service is running now
+    status_handle.set_service_status(next_status)?;
+
+    info!("Service has started");
+
+    // let mut state = DaemonState::Running;
+    // while state != DaemonState::Stopped {
+    //     rt.block_on(async {
+    //         state = rx.recv().unwrap();
+    //     });
+    // }
+
+    info!("Service is stopping!");
+
+    // Tell the system that service has stopped.
+    status_handle.set_service_status(ServiceStatus {
+        service_type: SERVICE_TYPE,
+        current_state: ServiceState::Stopped,
+        controls_accepted: ServiceControlAccept::empty(),
+        exit_code: ServiceExitCode::Win32(0),
+        checkpoint: 0,
+        wait_hint: Duration::default(),
+        process_id: None,
+    })?;
+
+    info!("Service has stopped!");
+
+    Ok(())
+}
+
+// #[derive(thiserror::Error, Debug)]
+// pub enum InstallError {
+//     #[error("Unable to connect to service manager")]
+//     ConnectServiceManager(#[source] windows_service::Error),
+
+//     #[error("Unable to create a service")]
+//     CreateService(#[source] windows_service::Error),
+// }
+
+pub(super) fn get_service_info() -> ServiceInfo {
+    ServiceInfo {
+        name: OsString::from(SERVICE_NAME),
+        display_name: OsString::from(SERVICE_DISPLAY_NAME),
+        service_type: SERVICE_TYPE,
+        start_type: ServiceStartType::AutoStart,
+        error_control: ServiceErrorControl::Normal,
+        executable_path: env::current_exe().unwrap(),
+        launch_arguments: vec![OsString::from("--run-as-service"), OsString::from("-v")],
+        dependencies: vec![
+            // Base Filter Engine
+            ServiceDependency::Service(OsString::from("BFE")),
+            // Network Store Interface Service
+            // This service delivers network notifications (e.g. interface addition/deleting etc).
+            ServiceDependency::Service(OsString::from("NSI")),
+        ],
+        account_name: None, // run as System
+        account_password: None,
+    }
+}
+
+// fn main() -> Result<(), windows_service::Error> {
+pub(crate) fn start(args: CliArgs) -> Result<(), windows_service::Error> {
+    if args.command.install {
+        println!(
+            "Processing request to install {} as a service...",
+            SERVICE_NAME
+        );
+        install::install_service()?;
+        return Ok(());
+    }
+
+    if args.command.install {
+        println!(
+            "Processing request to uninstall {} as a service...",
+            SERVICE_NAME
+        );
+        install::uninstall_service()?;
+        return Ok(());
+    }
+
+    if args.command.start {
+        println!("Processing request to start service {}...", SERVICE_NAME);
+        install::start_service()?;
+        return Ok(());
+    }
+
+    println!("Configuring logging source...");
+    eventlog::init(SERVICE_DISPLAY_NAME, log::Level::Info).unwrap();
+
+    // Register generated `ffi_service_main` with the system and start the service, blocking
+    // this thread until the service is stopped.
+    service_dispatcher::start(SERVICE_NAME, ffi_service_main)?;
+    Ok(())
+}


### PR DESCRIPTION
# Overview

Add support for running nym-vpnd as a windows service. The service is registered with the windows event log and log messages are sent there.

# How to use

1. First register the service
```
./nym-vpnd --install
```
2. Then start the service in the Windows Service control app

# Future

This is the first PR towards fully supporting running as a background service. 
Known issues:
- Stop is reported as failed in the UI, but will succeed after awhile if you refresh the service status
- The handler controlling the vpn lib is not yet started as it fails the service to start
- The gPRC listener is functional, but cannot interact with the vpn lib yet, and as such all grpc messages will timeout