### PR TITLE
chore(vpnx): watch vpn status

### DIFF
--- a/nym-vpn-x/src-tauri/src/main.rs
+++ b/nym-vpn-x/src-tauri/src/main.rs
@@ -190,7 +190,8 @@ async fn main() -> Result<()> {
                 info!("starting vpn status watch");
                 loop {
                     if c_grpc.refresh_vpn_status(&handle).await.is_ok() {
-                        c_grpc.watch_vpn_status(&handle).await.ok();
+                        c_grpc.watch_vpn_state(&handle).await.ok();
+                        c_grpc.watch_vpn_status().await.ok();
                     }
                     sleep(VPND_RETRY_INTERVAL).await;
                     debug!("vpn status watch retry");


### PR DESCRIPTION
Add rpc call to `ListenToConnectionStatus`. 
In the future, the data received could be passed to the UI layer to display addtional details on current connection states.
(For now it's logged only)