### PR TITLE
upgrade to latest stable protoc

### DIFF
--- a/.github/workflows/build-nym-vpn-android.yml
+++ b/.github/workflows/build-nym-vpn-android.yml
@@ -105,7 +105,12 @@ jobs:
 
       - name: Install deps
         run: |
-          sudo apt-get update && sudo apt-get install -y libdbus-1-dev libmnl-dev libnftnl-dev protobuf-compiler git curl gcc g++ make unzip
+          sudo apt-get update && sudo apt-get install -y libdbus-1-dev libmnl-dev libnftnl-dev git curl gcc g++ make unzip
+
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Nightly versioning
         if: ${{ inputs.nightly }}

--- a/.github/workflows/build-nym-vpn-core-android.yml
+++ b/.github/workflows/build-nym-vpn-core-android.yml
@@ -29,7 +29,12 @@ jobs:
 
       - name: Install system dependencies
         run: |
-          sudo apt-get update && sudo apt-get install -y libdbus-1-dev libmnl-dev libnftnl-dev protobuf-compiler
+          sudo apt-get update && sudo apt-get install -y libdbus-1-dev libmnl-dev libnftnl-dev
+
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install rust toolchain
         uses: brndnmtthws/rust-action-rustup@v1

--- a/.github/workflows/build-nym-vpn-core-deb.yml
+++ b/.github/workflows/build-nym-vpn-core-deb.yml
@@ -23,7 +23,12 @@ jobs:
 
       - name: Install system dependencies
         run: |
-          sudo apt-get update && sudo apt-get install -y libdbus-1-dev libmnl-dev libnftnl-dev protobuf-compiler
+          sudo apt-get update && sudo apt-get install -y libdbus-1-dev libmnl-dev libnftnl-dev
+
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install rust toolchain
         uses: brndnmtthws/rust-action-rustup@v1

--- a/.github/workflows/build-nym-vpn-core-ios.yml
+++ b/.github/workflows/build-nym-vpn-core-ios.yml
@@ -45,7 +45,7 @@ jobs:
           cargo install --git https://github.com/neacsu/cargo-swift.git
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@v2
+        uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build-nym-vpn-core-linux.yml
+++ b/.github/workflows/build-nym-vpn-core-linux.yml
@@ -29,7 +29,12 @@ jobs:
 
       - name: Install system dependencies
         run: |
-          sudo apt-get update && sudo apt-get install -y libdbus-1-dev libmnl-dev libnftnl-dev protobuf-compiler
+          sudo apt-get update && sudo apt-get install -y libdbus-1-dev libmnl-dev libnftnl-dev
+
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install rust toolchain
         uses: brndnmtthws/rust-action-rustup@v1

--- a/.github/workflows/build-nym-vpn-desktop-linux.yml
+++ b/.github/workflows/build-nym-vpn-desktop-linux.yml
@@ -42,7 +42,12 @@ jobs:
 
       - name: Install system dependencies
         run: |
-          sudo apt-get update && sudo apt-get install -y libdbus-1-dev libmnl-dev libnftnl-dev protobuf-compiler libwebkit2gtk-4.0-dev build-essential curl wget libssl-dev libgtk-3-dev squashfs-tools libayatana-appindicator3-dev make libfuse2 librsvg2-dev file
+          sudo apt-get update && sudo apt-get install -y libdbus-1-dev libmnl-dev libnftnl-dev libwebkit2gtk-4.0-dev build-essential curl wget libssl-dev libgtk-3-dev squashfs-tools libayatana-appindicator3-dev make libfuse2 librsvg2-dev file
+
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install rust toolchain
         uses: brndnmtthws/rust-action-rustup@v1

--- a/.github/workflows/ci-nym-vpn-core.yml
+++ b/.github/workflows/ci-nym-vpn-core.yml
@@ -35,7 +35,7 @@ jobs:
           ls -la ./
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev libmnl-dev libnftnl-dev protobuf-compiler git curl gcc g++ make unzip
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev libmnl-dev libnftnl-dev git curl gcc g++ make unzip
         if: contains(matrix.os, 'ubuntu')
 
       - name: Support longpaths on windows
@@ -106,8 +106,7 @@ jobs:
           go-version: "stable"
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@v2
-        if: contains(matrix.os, 'macos') || contains(matrix.os, 'windows')
+        uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci-nym-vpn-desktop-rust.yml
+++ b/.github/workflows/ci-nym-vpn-desktop-rust.yml
@@ -33,7 +33,7 @@ jobs:
         if: contains(matrix.os, 'ubuntu')
         run: |
           sudo apt-get update && sudo apt-get install -y libdbus-1-dev libmnl-dev libnftnl-dev \
-            protobuf-compiler libwebkit2gtk-4.0-dev build-essential curl wget libssl-dev \
+            libwebkit2gtk-4.0-dev build-essential curl wget libssl-dev \
             libgtk-3-dev squashfs-tools libayatana-appindicator3-dev git curl gcc g++ make
 
       - name: Support longpaths on windows
@@ -91,8 +91,7 @@ jobs:
           go-version: "stable"
 
       - name: Install protoc
-        uses: arduino/setup-protoc@v2
-        if: contains(matrix.os, 'macos') || contains(matrix.os, 'mac-m1') || contains(matrix.os, 'windows')
+        uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci-nymvpn-x-rust.yml
+++ b/.github/workflows/ci-nymvpn-x-rust.yml
@@ -36,7 +36,7 @@ jobs:
         if: contains(matrix.os, 'ubuntu')
         run: |
           sudo apt-get update && sudo apt-get install -y libdbus-1-dev libmnl-dev libnftnl-dev \
-            protobuf-compiler libwebkit2gtk-4.0-dev build-essential curl wget libssl-dev \
+            libwebkit2gtk-4.0-dev build-essential curl wget libssl-dev \
             libgtk-3-dev squashfs-tools libayatana-appindicator3-dev git curl gcc g++ make unzip
 
       - name: Support longpaths on windows

--- a/.github/workflows/publish-nym-vpn-android.yml
+++ b/.github/workflows/publish-nym-vpn-android.yml
@@ -189,7 +189,12 @@ jobs:
 
       - name: Install deps
         run: |
-          sudo apt-get update && sudo apt-get install -y libdbus-1-dev libmnl-dev libnftnl-dev protobuf-compiler git curl gcc g++ make unzip
+          sudo apt-get update && sudo apt-get install -y libdbus-1-dev libmnl-dev libnftnl-dev git curl gcc g++ make unzip
+
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3

--- a/nym-vpn-x/src-tauri/Cargo.lock
+++ b/nym-vpn-x/src-tauri/Cargo.lock
@@ -2697,9 +2697,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35b8f021164e6a984c9030023544c57789c51760065cd510572fedcfb04164e8"
+checksum = "28757f23aa75c98f254cf0405e6d8c25b831b32921b050a66692427679b1f243"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -6328,9 +6328,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
@@ -6355,9 +6355,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
Bump for arduino/setup-protoc to v3

Remove deb package install of protoc as it is outdated and does not support our grpc optional for expiry/credential import API.

Also, it is best for us to use the same protoc install for all workflows and platforms. 