### PR TITLE
chore: change android nightly version name to include timestamp

### DIFF
--- a/.github/workflows/build-nym-vpn-android.yml
+++ b/.github/workflows/build-nym-vpn-android.yml
@@ -113,8 +113,7 @@ jobs:
           versionCode=$(date '+%s')
           sed -i -e 's/\(VERSION_CODE = \).\(.*\)/\VERSION_CODE = '"$versionCode"'/' buildSrc/src/main/kotlin/Constants.kt
           versionName=$(grep "VERSION_NAME" buildSrc/src/main/kotlin/Constants.kt | awk '{print $5}' | tr -d '"')
-          headCount=$(git rev-list --first-parent --count HEAD)
-          sed -i -e 's/\(VERSION_NAME = \).\(.*\)/\VERSION_NAME = "'"$versionName"'-'"$headCount"'"/' buildSrc/src/main/kotlin/Constants.kt
+          sed -i -e 's/\(VERSION_NAME = \).\(.*\)/\VERSION_NAME = "'"$versionName"'-'"$versionCode"'"/' buildSrc/src/main/kotlin/Constants.kt
 
       # Here we need to decode keystore.jks from base64 string and place it
       # in the folder specified in the release signing configuration

--- a/.github/workflows/publish-nym-vpn-android.yml
+++ b/.github/workflows/publish-nym-vpn-android.yml
@@ -148,8 +148,13 @@ jobs:
           append_body: true
 
 
+  publish-nym-fdroid:
+    runs-on: ubuntu-22.04-arc
+    needs:
+      - publish-github
+    if: inputs.release_type == 'release'
+    steps:
       - name: Dispatch update for fdroid repo
-        if: inputs.release_type == 'release'
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.ANDROID_PAT }}


### PR DESCRIPTION
Moves fdroid publish to a separate job.