### PR TITLE
fix: separate fastlane metadata deployment

### DIFF
--- a/.github/workflows/publish-nym-vpn-android.yml
+++ b/.github/workflows/publish-nym-vpn-android.yml
@@ -171,9 +171,7 @@ jobs:
 
   publish-play:
     if: ${{ inputs.track != 'none' && inputs.track != '' }}
-    # issue here: https://github.com/ruby/setup-ruby?tab=readme-ov-file#using-self-hosted-runners
-    #runs-on: ubuntu-22.04-arc
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04-arc
     defaults:
       run:
         working-directory: nym-vpn-android
@@ -185,13 +183,11 @@ jobs:
       KEY_STORE_FILE: 'android_keystore.jks'
       KEY_STORE_LOCATION: ${{ github.workspace }}/nym-vpn-android/app/keystore/
     steps:
-      - name: Setup ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.2' # Not needed with a .ruby-version file
-          bundler-cache: true
-
       - uses: actions/checkout@v4
+
+      - name: Setup ruby
+        run: |
+          sudo apt install ruby-full
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4

--- a/.github/workflows/publish-nym-vpn-android.yml
+++ b/.github/workflows/publish-nym-vpn-android.yml
@@ -255,31 +255,6 @@ jobs:
         working-directory: ${{ github.workspace }}/nym-vpn-android
         run: |
           bundle install
-          bundle exec fastlane ${{ inputs.track }}
-
-  publish-play-metadata:
-    if: github.event.inputs.publish-metadata == 'true'
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: nym-vpn-android
-    steps:
-      - name: Setup ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.2' # Not needed with a .ruby-version file
-          bundler-cache: true
-
-      - uses: actions/checkout@v4
-
-      - name: Create service_account.json
-        id: createServiceAccount
-        run: echo '${{ secrets.ANDROID_SERVICE_ACCOUNT_JSON }}' > service_account.json
-
-      - name: Distribute app to fastlane track 🚀
-        working-directory: ${{ github.workspace }}/nym-vpn-android
-        run: |
-          bundle install
-          bundle exec fastlane metadata
+          bundle exec fastlane ${{ inputs.track }} metadata:${{github.event.inputs.publish-metadata == 'true'}}
       
 

--- a/.github/workflows/publish-nym-vpn-android.yml
+++ b/.github/workflows/publish-nym-vpn-android.yml
@@ -7,7 +7,7 @@ on:
     inputs:
       track:
         type: choice
-        description: "Fastlane release track"
+        description: "Google play release track"
         options:
           - none
           - internal
@@ -16,10 +16,14 @@ on:
           - production
         default: alpha
         required: true
+      publish-bundle:
+        type: boolean
+        default: true
+        description: With app
       publish-metadata:
         type: boolean
         default: false
-        description: With fastlane metadata
+        description: With metadata
       tag_name:
         description: "Tag name for release"
         required: false
@@ -255,6 +259,6 @@ jobs:
         working-directory: ${{ github.workspace }}/nym-vpn-android
         run: |
           bundle install
-          bundle exec fastlane ${{ inputs.track }} metadata:${{github.event.inputs.publish-metadata == 'true'}}
-      
-
+          bundle exec fastlane ${{ inputs.track }} bundle:${{github.event.inputs.publish-bundle == 'true'}} metadata:${{github.event.inputs.publish-metadata == 'true'}}
+          
+          

--- a/.github/workflows/publish-nym-vpn-android.yml
+++ b/.github/workflows/publish-nym-vpn-android.yml
@@ -255,10 +255,15 @@ jobs:
         id: createServiceAccount
         run: echo '${{ secrets.ANDROID_SERVICE_ACCOUNT_JSON }}' > service_account.json
 
+      - name: Get version code
+        run: |
+          version_code=$(grep "VERSION_CODE" ${{ github.workspace }}/nym-vpn-android/buildSrc/src/main/kotlin/Constants.kt | awk '{print $5}' | tr -d '\n')
+          echo "VERSION_CODE=$version_code" >> $GITHUB_ENV
+
       - name: Distribute app to fastlane track 🚀
         working-directory: ${{ github.workspace }}/nym-vpn-android
         run: |
           bundle install
-          bundle exec fastlane ${{ inputs.track }} bundle:${{github.event.inputs.publish-bundle == 'true'}} metadata:${{github.event.inputs.publish-metadata == 'true'}}
+          bundle exec fastlane ${{ inputs.track }} bundle:${{github.event.inputs.publish-bundle == 'true'}} metadata:${{github.event.inputs.publish-metadata == 'true'}} version:${{ env.VERSION_CODE }}
           
           

--- a/.github/workflows/publish-nym-vpn-android.yml
+++ b/.github/workflows/publish-nym-vpn-android.yml
@@ -249,6 +249,9 @@ jobs:
         id: createServiceAccount
         run: echo '${{ secrets.ANDROID_SERVICE_ACCOUNT_JSON }}' > service_account.json
 
+      - name: Install bundler
+        run: gem install bundler
+
       - name: Distribute app to fastlane track 🚀
         working-directory: ${{ github.workspace }}/nym-vpn-android
         run: |

--- a/.github/workflows/publish-nym-vpn-android.yml
+++ b/.github/workflows/publish-nym-vpn-android.yml
@@ -173,7 +173,7 @@ jobs:
     if: ${{ inputs.track != 'none' && inputs.track != '' }}
     # issue here: https://github.com/ruby/setup-ruby?tab=readme-ov-file#using-self-hosted-runners
     #runs-on: ubuntu-22.04-arc
-    runs-on: ubuntu-22.04-arc
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: nym-vpn-android
@@ -185,6 +185,12 @@ jobs:
       KEY_STORE_FILE: 'android_keystore.jks'
       KEY_STORE_LOCATION: ${{ github.workspace }}/nym-vpn-android/app/keystore/
     steps:
+      - name: Setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2' # Not needed with a .ruby-version file
+          bundler-cache: true
+
       - uses: actions/checkout@v4
 
       - name: Set up JDK 17
@@ -249,13 +255,10 @@ jobs:
         id: createServiceAccount
         run: echo '${{ secrets.ANDROID_SERVICE_ACCOUNT_JSON }}' > service_account.json
 
-      - name: Install bundler
-        run: sudo gem install bundler
-
       - name: Distribute app to fastlane track 🚀
         working-directory: ${{ github.workspace }}/nym-vpn-android
         run: |
-          sudo bundle install
-          sudo bundle exec fastlane ${{ inputs.track }} bundle:${{github.event.inputs.publish-bundle == 'true'}} metadata:${{github.event.inputs.publish-metadata == 'true'}}
+          bundle install
+          bundle exec fastlane ${{ inputs.track }} bundle:${{github.event.inputs.publish-bundle == 'true'}} metadata:${{github.event.inputs.publish-metadata == 'true'}}
           
           

--- a/.github/workflows/publish-nym-vpn-android.yml
+++ b/.github/workflows/publish-nym-vpn-android.yml
@@ -16,6 +16,10 @@ on:
           - production
         default: alpha
         required: true
+      publish-metadata:
+        type: boolean
+        default: false
+        description: With fastlane metadata
       tag_name:
         description: "Tag name for release"
         required: false
@@ -29,10 +33,6 @@ on:
           - release
         default: release
         required: true
-      publish-metadata:
-        type: boolean
-        default: false
-        description: Publish Google Play metadata
 
   push:
     tags:

--- a/.github/workflows/publish-nym-vpn-android.yml
+++ b/.github/workflows/publish-nym-vpn-android.yml
@@ -250,7 +250,7 @@ jobs:
         run: echo '${{ secrets.ANDROID_SERVICE_ACCOUNT_JSON }}' > service_account.json
 
       - name: Install bundler
-        run: gem install bundler
+        run: sudo gem install bundler
 
       - name: Distribute app to fastlane track 🚀
         working-directory: ${{ github.workspace }}/nym-vpn-android

--- a/.github/workflows/publish-nym-vpn-android.yml
+++ b/.github/workflows/publish-nym-vpn-android.yml
@@ -18,12 +18,12 @@ on:
         required: true
       publish-bundle:
         type: boolean
-        default: true
-        description: With app
+        default: false
+        description: Skip app bundle
       publish-metadata:
         type: boolean
-        default: false
-        description: With metadata
+        default: true
+        description: Skip app metadata
       tag_name:
         description: "Tag name for release"
         required: false
@@ -264,6 +264,6 @@ jobs:
         working-directory: ${{ github.workspace }}/nym-vpn-android
         run: |
           bundle install
-          bundle exec fastlane ${{ inputs.track }} bundle:${{github.event.inputs.publish-bundle == 'true'}} metadata:${{github.event.inputs.publish-metadata == 'true'}} version:${{ env.VERSION_CODE }}
+          bundle exec fastlane ${{ inputs.track }} skip_bundle:${{github.event.inputs.publish-bundle == 'true'}} skip_metadata:${{github.event.inputs.publish-metadata == 'true'}}
           
           

--- a/.github/workflows/publish-nym-vpn-android.yml
+++ b/.github/workflows/publish-nym-vpn-android.yml
@@ -186,8 +186,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup ruby
-        run: |
-          sudo apt install ruby-full
+        run: sudo apt-get install ruby-full
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4

--- a/.github/workflows/publish-nym-vpn-android.yml
+++ b/.github/workflows/publish-nym-vpn-android.yml
@@ -255,7 +255,7 @@ jobs:
       - name: Distribute app to fastlane track 🚀
         working-directory: ${{ github.workspace }}/nym-vpn-android
         run: |
-          bundle install
-          bundle exec fastlane ${{ inputs.track }} bundle:${{github.event.inputs.publish-bundle == 'true'}} metadata:${{github.event.inputs.publish-metadata == 'true'}}
+          sudo bundle install
+          sudo bundle exec fastlane ${{ inputs.track }} bundle:${{github.event.inputs.publish-bundle == 'true'}} metadata:${{github.event.inputs.publish-metadata == 'true'}}
           
           

--- a/.github/workflows/publish-nym-vpn-android.yml
+++ b/.github/workflows/publish-nym-vpn-android.yml
@@ -185,7 +185,6 @@ jobs:
       KEY_STORE_FILE: 'android_keystore.jks'
       KEY_STORE_LOCATION: ${{ github.workspace }}/nym-vpn-android/app/keystore/
     steps:
-      -
       - uses: actions/checkout@v4
 
       - name: Set up JDK 17

--- a/.github/workflows/publish-nym-vpn-android.yml
+++ b/.github/workflows/publish-nym-vpn-android.yml
@@ -186,9 +186,9 @@ jobs:
         with:
           ruby-version: '3.2' # Not needed with a .ruby-version file
           bundler-cache: true
+
       - uses: actions/checkout@v4
-        with:
-          submodules: true
+
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -269,6 +269,9 @@ jobs:
         with:
           ruby-version: '3.2' # Not needed with a .ruby-version file
           bundler-cache: true
+
+      - uses: actions/checkout@v4
+
       - name: Create service_account.json
         id: createServiceAccount
         run: echo '${{ secrets.ANDROID_SERVICE_ACCOUNT_JSON }}' > service_account.json

--- a/.github/workflows/publish-nym-vpn-android.yml
+++ b/.github/workflows/publish-nym-vpn-android.yml
@@ -29,6 +29,10 @@ on:
           - release
         default: release
         required: true
+      publish-metadata:
+        type: boolean
+        default: false
+        description: Publish Google Play metadata
 
   push:
     tags:
@@ -252,3 +256,27 @@ jobs:
         run: |
           bundle install
           bundle exec fastlane ${{ inputs.track }}
+
+  publish-play-metadata:
+    if: github.event.inputs.use-emoji == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: nym-vpn-android
+    steps:
+      - name: Setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2' # Not needed with a .ruby-version file
+          bundler-cache: true
+      - name: Create service_account.json
+        id: createServiceAccount
+        run: echo '${{ secrets.ANDROID_SERVICE_ACCOUNT_JSON }}' > service_account.json
+
+      - name: Distribute app to fastlane track 🚀
+        working-directory: ${{ github.workspace }}/nym-vpn-android
+        run: |
+          bundle install
+          bundle exec fastlane metadata
+      
+

--- a/.github/workflows/publish-nym-vpn-android.yml
+++ b/.github/workflows/publish-nym-vpn-android.yml
@@ -258,7 +258,7 @@ jobs:
           bundle exec fastlane ${{ inputs.track }}
 
   publish-play-metadata:
-    if: github.event.inputs.use-emoji == 'true'
+    if: github.event.inputs.publish-metadata == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/publish-nym-vpn-android.yml
+++ b/.github/workflows/publish-nym-vpn-android.yml
@@ -171,7 +171,9 @@ jobs:
 
   publish-play:
     if: ${{ inputs.track != 'none' && inputs.track != '' }}
-    runs-on: ubuntu-22.04-arc
+    # issue here: https://github.com/ruby/setup-ruby?tab=readme-ov-file#using-self-hosted-runners
+    #runs-on: ubuntu-22.04-arc
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: nym-vpn-android
@@ -183,10 +185,13 @@ jobs:
       KEY_STORE_FILE: 'android_keystore.jks'
       KEY_STORE_LOCATION: ${{ github.workspace }}/nym-vpn-android/app/keystore/
     steps:
-      - uses: actions/checkout@v4
-
       - name: Setup ruby
-        run: sudo apt-get install ruby-full
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2' # Not needed with a .ruby-version file
+          bundler-cache: true
+
+      - uses: actions/checkout@v4
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4

--- a/.github/workflows/publish-nym-vpn-android.yml
+++ b/.github/workflows/publish-nym-vpn-android.yml
@@ -173,7 +173,7 @@ jobs:
     if: ${{ inputs.track != 'none' && inputs.track != '' }}
     # issue here: https://github.com/ruby/setup-ruby?tab=readme-ov-file#using-self-hosted-runners
     #runs-on: ubuntu-22.04-arc
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04-arc
     defaults:
       run:
         working-directory: nym-vpn-android
@@ -185,12 +185,7 @@ jobs:
       KEY_STORE_FILE: 'android_keystore.jks'
       KEY_STORE_LOCATION: ${{ github.workspace }}/nym-vpn-android/app/keystore/
     steps:
-      - name: Setup ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.2' # Not needed with a .ruby-version file
-          bundler-cache: true
-
+      -
       - uses: actions/checkout@v4
 
       - name: Set up JDK 17

--- a/nym-vpn-android/fastlane/Fastfile
+++ b/nym-vpn-android/fastlane/Fastfile
@@ -2,28 +2,33 @@ default_platform(:android)
 
 platform :android do
 
-  desc 'Deploy a new internal version to the Google Play Store'
+  desc 'Deploy an internal version to the Google Play Store'
   lane :internal do
     gradle(task: "clean bundleGeneralRelease")
-    upload_to_play_store(track: 'internal', skip_upload_apk: true)
+    upload_to_play_store(track: 'internal', skip_upload_apk: true, skip_upload_metadata: true)
   end
 
   desc "Deploy an alpha version to the Google Play"
     lane :alpha do
       gradle(task: "clean bundleGeneralRelease")
-      upload_to_play_store(track: 'alpha', skip_upload_apk: true)
+      upload_to_play_store(track: 'alpha', skip_upload_apk: true, skip_upload_metadata: true)
   end
 
   desc "Deploy a beta version to the Google Play"
   lane :beta do
     gradle(task: "clean bundleGeneralRelease")
-    upload_to_play_store(track: 'beta', skip_upload_apk: true)
+    upload_to_play_store(track: 'beta', skip_upload_apk: true, skip_upload_metadata: true)
   end
 
-  desc "Deploy a new version to the Google Play"
+  desc "Deploy a production version to the Google Play"
     lane :production do
       gradle(task: "clean bundleGeneralRelease")
-      upload_to_play_store(skip_upload_apk: true)
+      upload_to_play_store(track: 'production', skip_upload_apk: true, skip_upload_metadata: true)
+  end
+
+  desc "Deploy a metadata to the Google Play"
+      lane :metadata do
+        upload_to_play_store(skip_upload_apk: true, skip_upload_aab: true)
   end
 
 end

--- a/nym-vpn-android/fastlane/Fastfile
+++ b/nym-vpn-android/fastlane/Fastfile
@@ -3,32 +3,39 @@ default_platform(:android)
 platform :android do
 
   desc 'Deploy an internal version to Google Play'
-  lane :internal do
+  lane :internal do |options|
     gradle(task: "clean bundleGeneralRelease")
     upload_to_play_store(track: 'internal', skip_upload_apk: true, skip_upload_metadata: true)
+    if options[:metadata]
+      upload_to_play_store(skip_upload_apk: true, skip_upload_aab: true)
+    end
   end
 
   desc "Deploy an alpha version to Google Play"
-    lane :alpha do
-      gradle(task: "clean bundleGeneralRelease")
-      upload_to_play_store(track: 'alpha', skip_upload_apk: true, skip_upload_metadata: true)
+  lane :alpha do |options|
+    gradle(task: "clean bundleGeneralRelease")
+    upload_to_play_store(track: 'alpha', skip_upload_apk: true, skip_upload_metadata: true)
+    if options[:metadata]
+	  upload_to_play_store(skip_upload_apk: true, skip_upload_aab: true)
+    end
   end
 
   desc "Deploy a beta version to Google Play"
-  lane :beta do
+  lane :beta do |options|
     gradle(task: "clean bundleGeneralRelease")
     upload_to_play_store(track: 'beta', skip_upload_apk: true, skip_upload_metadata: true)
+    if options[:metadata]
+	  upload_to_play_store(skip_upload_apk: true, skip_upload_aab: true)
+	end
   end
 
   desc "Deploy a production version to Google Play"
-    lane :production do
-      gradle(task: "clean bundleGeneralRelease")
-      upload_to_play_store(track: 'production', skip_upload_apk: true, skip_upload_metadata: true)
-  end
-
-  desc "Deploy metadata to Google Play"
-    lane :metadata do
-      upload_to_play_store(skip_upload_apk: true, skip_upload_aab: true)
+  lane :production do |options|
+    gradle(task: "clean bundleGeneralRelease")
+    upload_to_play_store(track: 'production', skip_upload_apk: true, skip_upload_metadata: true)
+    if options[:metadata]
+	  upload_to_play_store(skip_upload_apk: true, skip_upload_aab: true)
+    end
   end
 
 end

--- a/nym-vpn-android/fastlane/Fastfile
+++ b/nym-vpn-android/fastlane/Fastfile
@@ -3,25 +3,25 @@ default_platform(:android)
 platform :android do |options|
 
   desc 'Deploy an internal version to Google Play'
-  lane :internal do
+  lane :internal do |options|
     gradle(task: "clean bundleGeneralRelease")
     upload_to_play_store(track: 'internal', skip_upload_apk: true, skip_upload_metadata: options[:metadata])
   end
 
   desc "Deploy an alpha version to Google Play"
-  lane :alpha do
+  lane :alpha do |options|
     gradle(task: "clean bundleGeneralRelease")
     upload_to_play_store(track: 'alpha', skip_upload_apk: true, skip_upload_metadata: options[:metadata])
   end
 
   desc "Deploy a beta version to Google Play"
-  lane :beta do
+  lane :beta do |options|
     gradle(task: "clean bundleGeneralRelease")
     upload_to_play_store(track: 'beta', skip_upload_apk: true, skip_upload_metadata: options[:metadata])
   end
 
   desc "Deploy a production version to Google Play"
-  lane :production do
+  lane :production do |options|
     gradle(task: "clean bundleGeneralRelease")
     upload_to_play_store(track: 'production', skip_upload_apk: true, skip_upload_metadata: options[:metadata])
   end

--- a/nym-vpn-android/fastlane/Fastfile
+++ b/nym-vpn-android/fastlane/Fastfile
@@ -7,7 +7,7 @@ platform :android do
 		gradle(task: "clean bundleGeneralRelease")
 		skip_bundle = options[:skip_bundle]
 		skip_metadata = options[:skip_metadata]
-		upload_to_play_store(track: 'internal', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata, skip_upload_changelogs: skip_metadata)
+		upload_to_play_store(track: 'internal', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata)
 	end
 
 	desc "Deploy an alpha version to Google Play"
@@ -15,7 +15,7 @@ platform :android do
 		gradle(task: "clean bundleGeneralRelease")
 		skip_bundle = options[:skip_bundle]
 		skip_metadata = options[:skip_metadata]
-		upload_to_play_store(track: 'alpha', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata, skip_upload_changelogs: skip_metadata)
+		upload_to_play_store(track: 'alpha', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata)
 	end
 
 	desc "Deploy a beta version to Google Play"
@@ -23,7 +23,7 @@ platform :android do
 		gradle(task: "clean bundleGeneralRelease")
 		skip_bundle = options[:skip_bundle]
 		skip_metadata = options[:skip_metadata]
-		upload_to_play_store(track: 'beta', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata, skip_upload_changelogs: skip_metadata)
+		upload_to_play_store(track: 'beta', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata)
 	end
 
 	desc "Deploy a production version to Google Play"
@@ -31,7 +31,7 @@ platform :android do
 		gradle(task: "clean bundleGeneralRelease")
 		skip_bundle = options[:skip_bundle]
 		skip_metadata = options[:skip_metadata]
-		upload_to_play_store(track: 'production', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata, skip_upload_changelogs: skip_metadata)
+		upload_to_play_store(track: 'production', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata)
 	end
 end
 

--- a/nym-vpn-android/fastlane/Fastfile
+++ b/nym-vpn-android/fastlane/Fastfile
@@ -1,27 +1,27 @@
 default_platform(:android)
 
-platform :android do
+platform :android do |options|
 
   desc 'Deploy an internal version to Google Play'
-  lane :internal do |options|
+  lane :internal do
     gradle(task: "clean bundleGeneralRelease")
     upload_to_play_store(track: 'internal', skip_upload_apk: true, skip_upload_metadata: options[:metadata])
   end
 
   desc "Deploy an alpha version to Google Play"
-  lane :alpha do |options|
+  lane :alpha do
     gradle(task: "clean bundleGeneralRelease")
     upload_to_play_store(track: 'alpha', skip_upload_apk: true, skip_upload_metadata: options[:metadata])
   end
 
   desc "Deploy a beta version to Google Play"
-  lane :beta do |options|
+  lane :beta do
     gradle(task: "clean bundleGeneralRelease")
     upload_to_play_store(track: 'beta', skip_upload_apk: true, skip_upload_metadata: options[:metadata])
   end
 
   desc "Deploy a production version to Google Play"
-  lane :production do |options|
+  lane :production do
     gradle(task: "clean bundleGeneralRelease")
     upload_to_play_store(track: 'production', skip_upload_apk: true, skip_upload_metadata: options[:metadata])
   end

--- a/nym-vpn-android/fastlane/Fastfile
+++ b/nym-vpn-android/fastlane/Fastfile
@@ -7,8 +7,7 @@ platform :android do
 		gradle(task: "clean bundleGeneralRelease")
 		skip_bundle = options[:bundle]
 		skip_metadata = options[:metadata]
-		version_code = options[:version]
-		upload_to_play_store(track: 'internal', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata, version_code: version_code, aab: lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH])
+		upload_to_play_store(track: 'internal', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata, skip_upload_changelogs: skip_metadata)
 	end
 
 	desc "Deploy an alpha version to Google Play"
@@ -16,8 +15,7 @@ platform :android do
 		gradle(task: "clean bundleGeneralRelease")
 		skip_bundle = options[:bundle]
 		skip_metadata = options[:metadata]
-		version_code = options[:version]
-		upload_to_play_store(track: 'alpha', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata, version_code: version_code, aab: lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH])
+		upload_to_play_store(track: 'alpha', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata, skip_upload_changelogs: skip_metadata)
 	end
 
 	desc "Deploy a beta version to Google Play"
@@ -25,8 +23,7 @@ platform :android do
 		gradle(task: "clean bundleGeneralRelease")
 		skip_bundle = options[:bundle]
 		skip_metadata = options[:metadata]
-		version_code = options[:version]
-		upload_to_play_store(track: 'beta', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata, version_code: version_code, aab: lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH])
+		upload_to_play_store(track: 'beta', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata, skip_upload_changelogs: skip_metadata)
 	end
 
 	desc "Deploy a production version to Google Play"
@@ -34,8 +31,7 @@ platform :android do
 		gradle(task: "clean bundleGeneralRelease")
 		skip_bundle = options[:bundle]
 		skip_metadata = options[:metadata]
-		version_code = options[:version]
-		upload_to_play_store(track: 'production', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata, version_code: version_code, aab: lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH])
+		upload_to_play_store(track: 'production', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata, skip_upload_changelogs: skip_metadata)
 	end
 end
 

--- a/nym-vpn-android/fastlane/Fastfile
+++ b/nym-vpn-android/fastlane/Fastfile
@@ -1,29 +1,27 @@
 default_platform(:android)
 
-platform :android do |options|
 
-  desc 'Deploy an internal version to Google Play'
-  lane :internal do |options|
-    gradle(task: "clean bundleGeneralRelease")
-    upload_to_play_store(track: 'internal', skip_upload_apk: true, skip_upload_metadata: options[:metadata])
-  end
-
-  desc "Deploy an alpha version to Google Play"
-  lane :alpha do |options|
-    gradle(task: "clean bundleGeneralRelease")
-    upload_to_play_store(track: 'alpha', skip_upload_apk: true, skip_upload_metadata: options[:metadata])
-  end
-
-  desc "Deploy a beta version to Google Play"
-  lane :beta do |options|
-    gradle(task: "clean bundleGeneralRelease")
-    upload_to_play_store(track: 'beta', skip_upload_apk: true, skip_upload_metadata: options[:metadata])
-  end
-
-  desc "Deploy a production version to Google Play"
-  lane :production do |options|
-    gradle(task: "clean bundleGeneralRelease")
-    upload_to_play_store(track: 'production', skip_upload_apk: true, skip_upload_metadata: options[:metadata])
-  end
-
+desc 'Deploy an internal version to Google Play'
+lane :internal do |options|
+gradle(task: "clean bundleGeneralRelease")
+upload_to_play_store(track: 'internal', skip_upload_apk: true, skip_upload_metadata: options[:metadata])
 end
+
+desc "Deploy an alpha version to Google Play"
+lane :alpha do |options|
+gradle(task: "clean bundleGeneralRelease")
+upload_to_play_store(track: 'alpha', skip_upload_apk: true, skip_upload_metadata: options[:metadata])
+end
+
+desc "Deploy a beta version to Google Play"
+lane :beta do |options|
+gradle(task: "clean bundleGeneralRelease")
+upload_to_play_store(track: 'beta', skip_upload_apk: true, skip_upload_metadata: options[:metadata])
+end
+
+desc "Deploy a production version to Google Play"
+lane :production do |options|
+gradle(task: "clean bundleGeneralRelease")
+upload_to_play_store(track: 'production', skip_upload_apk: true, skip_upload_metadata: options[:metadata])
+end
+

--- a/nym-vpn-android/fastlane/Fastfile
+++ b/nym-vpn-android/fastlane/Fastfile
@@ -2,31 +2,31 @@ default_platform(:android)
 
 platform :android do
 
-  desc 'Deploy an internal version to the Google Play Store'
+  desc 'Deploy an internal version to Google Play'
   lane :internal do
     gradle(task: "clean bundleGeneralRelease")
     upload_to_play_store(track: 'internal', skip_upload_apk: true, skip_upload_metadata: true)
   end
 
-  desc "Deploy an alpha version to the Google Play"
+  desc "Deploy an alpha version to Google Play"
     lane :alpha do
       gradle(task: "clean bundleGeneralRelease")
       upload_to_play_store(track: 'alpha', skip_upload_apk: true, skip_upload_metadata: true)
   end
 
-  desc "Deploy a beta version to the Google Play"
+  desc "Deploy a beta version to Google Play"
   lane :beta do
     gradle(task: "clean bundleGeneralRelease")
     upload_to_play_store(track: 'beta', skip_upload_apk: true, skip_upload_metadata: true)
   end
 
-  desc "Deploy a production version to the Google Play"
+  desc "Deploy a production version to Google Play"
     lane :production do
       gradle(task: "clean bundleGeneralRelease")
       upload_to_play_store(track: 'production', skip_upload_apk: true, skip_upload_metadata: true)
   end
 
-  desc "Deploy a metadata to the Google Play"
+  desc "Deploy metadata to Google Play"
       lane :metadata do
         upload_to_play_store(skip_upload_apk: true, skip_upload_aab: true)
   end

--- a/nym-vpn-android/fastlane/Fastfile
+++ b/nym-vpn-android/fastlane/Fastfile
@@ -27,8 +27,8 @@ platform :android do
   end
 
   desc "Deploy metadata to Google Play"
-      lane :metadata do
-        upload_to_play_store(skip_upload_apk: true, skip_upload_aab: true)
+    lane :metadata do
+      upload_to_play_store(skip_upload_apk: true, skip_upload_aab: true)
   end
 
 end

--- a/nym-vpn-android/fastlane/Fastfile
+++ b/nym-vpn-android/fastlane/Fastfile
@@ -7,7 +7,7 @@ platform :android do
 		gradle(task: "clean bundleGeneralRelease")
 		skip_bundle = options[:skip_bundle]
 		skip_metadata = options[:skip_metadata]
-		upload_to_play_store(track: 'internal', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata)
+		upload_to_play_store(track: 'internal', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata, skip_upload_changelogs: skip_metadata)
 	end
 
 	desc "Deploy an alpha version to Google Play"
@@ -15,7 +15,7 @@ platform :android do
 		gradle(task: "clean bundleGeneralRelease")
 		skip_bundle = options[:skip_bundle]
 		skip_metadata = options[:skip_metadata]
-		upload_to_play_store(track: 'alpha', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata)
+		upload_to_play_store(track: 'alpha', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata, skip_upload_changelogs: skip_metadata)
 	end
 
 	desc "Deploy a beta version to Google Play"
@@ -23,7 +23,7 @@ platform :android do
 		gradle(task: "clean bundleGeneralRelease")
 		skip_bundle = options[:skip_bundle]
 		skip_metadata = options[:skip_metadata]
-		upload_to_play_store(track: 'beta', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata)
+		upload_to_play_store(track: 'beta', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata, skip_upload_changelogs: skip_metadata)
 	end
 
 	desc "Deploy a production version to Google Play"
@@ -31,7 +31,7 @@ platform :android do
 		gradle(task: "clean bundleGeneralRelease")
 		skip_bundle = options[:skip_bundle]
 		skip_metadata = options[:skip_metadata]
-		upload_to_play_store(track: 'production', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata)
+		upload_to_play_store(track: 'production', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata, skip_upload_changelogs: skip_metadata)
 	end
 end
 

--- a/nym-vpn-android/fastlane/Fastfile
+++ b/nym-vpn-android/fastlane/Fastfile
@@ -1,27 +1,29 @@
 default_platform(:android)
 
+platform :android do
 
-desc 'Deploy an internal version to Google Play'
-lane :internal do |options|
-gradle(task: "clean bundleGeneralRelease")
-upload_to_play_store(track: 'internal', skip_upload_apk: true, skip_upload_metadata: options[:metadata])
-end
+	desc 'Deploy an internal version to Google Play'
+	lane :internal do |options|
+		gradle(task: "clean bundleGeneralRelease")
+		upload_to_play_store(track: 'internal', skip_upload_apk: true, skip_upload_aab: options[:bundle], skip_upload_metadata: options[:metadata])
+	end
 
-desc "Deploy an alpha version to Google Play"
-lane :alpha do |options|
-gradle(task: "clean bundleGeneralRelease")
-upload_to_play_store(track: 'alpha', skip_upload_apk: true, skip_upload_metadata: options[:metadata])
-end
+	desc "Deploy an alpha version to Google Play"
+	lane :alpha do |options|
+		gradle(task: "clean bundleGeneralRelease")
+		upload_to_play_store(track: 'alpha', skip_upload_apk: true, skip_upload_aab: options[:bundle], skip_upload_metadata: options[:metadata])
+	end
 
-desc "Deploy a beta version to Google Play"
-lane :beta do |options|
-gradle(task: "clean bundleGeneralRelease")
-upload_to_play_store(track: 'beta', skip_upload_apk: true, skip_upload_metadata: options[:metadata])
-end
+	desc "Deploy a beta version to Google Play"
+	lane :beta do |options|
+		gradle(task: "clean bundleGeneralRelease")
+		upload_to_play_store(track: 'beta', skip_upload_apk: true, skip_upload_aab: options[:bundle], skip_upload_metadata: options[:metadata])
+	end
 
-desc "Deploy a production version to Google Play"
-lane :production do |options|
-gradle(task: "clean bundleGeneralRelease")
-upload_to_play_store(track: 'production', skip_upload_apk: true, skip_upload_metadata: options[:metadata])
+	desc "Deploy a production version to Google Play"
+	lane :production do |options|
+		gradle(task: "clean bundleGeneralRelease")
+		upload_to_play_store(track: 'production', skip_upload_apk: true, skip_upload_aab: options[:bundle], skip_upload_metadata: options[:metadata])
+	end
 end
 

--- a/nym-vpn-android/fastlane/Fastfile
+++ b/nym-vpn-android/fastlane/Fastfile
@@ -7,7 +7,8 @@ platform :android do
 		gradle(task: "clean bundleGeneralRelease")
 		skip_bundle = options[:bundle]
 		skip_metadata = options[:metadata]
-		upload_to_play_store(track: 'internal', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata)
+		version_code = options[:version]
+		upload_to_play_store(track: 'internal', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata, version_code: version_code)
 	end
 
 	desc "Deploy an alpha version to Google Play"
@@ -15,7 +16,8 @@ platform :android do
 		gradle(task: "clean bundleGeneralRelease")
 		skip_bundle = options[:bundle]
 		skip_metadata = options[:metadata]
-		upload_to_play_store(track: 'alpha', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata)
+		version_code = options[:version]
+		upload_to_play_store(track: 'alpha', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata, version_code: version_code)
 	end
 
 	desc "Deploy a beta version to Google Play"
@@ -23,7 +25,8 @@ platform :android do
 		gradle(task: "clean bundleGeneralRelease")
 		skip_bundle = options[:bundle]
 		skip_metadata = options[:metadata]
-		upload_to_play_store(track: 'beta', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata)
+		version_code = options[:version]
+		upload_to_play_store(track: 'beta', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata, version_code: version_code)
 	end
 
 	desc "Deploy a production version to Google Play"
@@ -31,7 +34,8 @@ platform :android do
 		gradle(task: "clean bundleGeneralRelease")
 		skip_bundle = options[:bundle]
 		skip_metadata = options[:metadata]
-		upload_to_play_store(track: 'production', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata)
+		version_code = options[:version]
+		upload_to_play_store(track: 'production', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata, version_code: version_code)
 	end
 end
 

--- a/nym-vpn-android/fastlane/Fastfile
+++ b/nym-vpn-android/fastlane/Fastfile
@@ -5,32 +5,32 @@ platform :android do
 	desc 'Deploy an internal version to Google Play'
 	lane :internal do |options|
 		gradle(task: "clean bundleGeneralRelease")
-		skip_bundle = options[:bundle]
-		skip_metadata = options[:metadata]
+		skip_bundle = options[:skip_bundle]
+		skip_metadata = options[:skip_metadata]
 		upload_to_play_store(track: 'internal', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata, skip_upload_changelogs: skip_metadata)
 	end
 
 	desc "Deploy an alpha version to Google Play"
 	lane :alpha do |options|
 		gradle(task: "clean bundleGeneralRelease")
-		skip_bundle = options[:bundle]
-		skip_metadata = options[:metadata]
+		skip_bundle = options[:skip_bundle]
+		skip_metadata = options[:skip_metadata]
 		upload_to_play_store(track: 'alpha', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata, skip_upload_changelogs: skip_metadata)
 	end
 
 	desc "Deploy a beta version to Google Play"
 	lane :beta do |options|
 		gradle(task: "clean bundleGeneralRelease")
-		skip_bundle = options[:bundle]
-		skip_metadata = options[:metadata]
+		skip_bundle = options[:skip_bundle]
+		skip_metadata = options[:skip_metadata]
 		upload_to_play_store(track: 'beta', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata, skip_upload_changelogs: skip_metadata)
 	end
 
 	desc "Deploy a production version to Google Play"
 	lane :production do |options|
 		gradle(task: "clean bundleGeneralRelease")
-		skip_bundle = options[:bundle]
-		skip_metadata = options[:metadata]
+		skip_bundle = options[:skip_bundle]
+		skip_metadata = options[:skip_metadata]
 		upload_to_play_store(track: 'production', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata, skip_upload_changelogs: skip_metadata)
 	end
 end

--- a/nym-vpn-android/fastlane/Fastfile
+++ b/nym-vpn-android/fastlane/Fastfile
@@ -5,25 +5,33 @@ platform :android do
 	desc 'Deploy an internal version to Google Play'
 	lane :internal do |options|
 		gradle(task: "clean bundleGeneralRelease")
-		upload_to_play_store(track: 'internal', skip_upload_apk: true, skip_upload_aab: options[:bundle], skip_upload_metadata: options[:metadata])
+		skip_bundle = options[:bundle]
+		skip_metadata = options[:metadata]
+		upload_to_play_store(track: 'internal', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata)
 	end
 
 	desc "Deploy an alpha version to Google Play"
 	lane :alpha do |options|
 		gradle(task: "clean bundleGeneralRelease")
-		upload_to_play_store(track: 'alpha', skip_upload_apk: true, skip_upload_aab: options[:bundle], skip_upload_metadata: options[:metadata])
+		skip_bundle = options[:bundle]
+		skip_metadata = options[:metadata]
+		upload_to_play_store(track: 'alpha', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata)
 	end
 
 	desc "Deploy a beta version to Google Play"
 	lane :beta do |options|
 		gradle(task: "clean bundleGeneralRelease")
-		upload_to_play_store(track: 'beta', skip_upload_apk: true, skip_upload_aab: options[:bundle], skip_upload_metadata: options[:metadata])
+		skip_bundle = options[:bundle]
+		skip_metadata = options[:metadata]
+		upload_to_play_store(track: 'beta', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata)
 	end
 
 	desc "Deploy a production version to Google Play"
 	lane :production do |options|
 		gradle(task: "clean bundleGeneralRelease")
-		upload_to_play_store(track: 'production', skip_upload_apk: true, skip_upload_aab: options[:bundle], skip_upload_metadata: options[:metadata])
+		skip_bundle = options[:bundle]
+		skip_metadata = options[:metadata]
+		upload_to_play_store(track: 'production', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata)
 	end
 end
 

--- a/nym-vpn-android/fastlane/Fastfile
+++ b/nym-vpn-android/fastlane/Fastfile
@@ -8,7 +8,7 @@ platform :android do
 		skip_bundle = options[:bundle]
 		skip_metadata = options[:metadata]
 		version_code = options[:version]
-		upload_to_play_store(track: 'internal', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata, version_code: version_code)
+		upload_to_play_store(track: 'internal', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata, version_code: version_code, aab: lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH])
 	end
 
 	desc "Deploy an alpha version to Google Play"
@@ -17,7 +17,7 @@ platform :android do
 		skip_bundle = options[:bundle]
 		skip_metadata = options[:metadata]
 		version_code = options[:version]
-		upload_to_play_store(track: 'alpha', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata, version_code: version_code)
+		upload_to_play_store(track: 'alpha', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata, version_code: version_code, aab: lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH])
 	end
 
 	desc "Deploy a beta version to Google Play"
@@ -26,7 +26,7 @@ platform :android do
 		skip_bundle = options[:bundle]
 		skip_metadata = options[:metadata]
 		version_code = options[:version]
-		upload_to_play_store(track: 'beta', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata, version_code: version_code)
+		upload_to_play_store(track: 'beta', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata, version_code: version_code, aab: lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH])
 	end
 
 	desc "Deploy a production version to Google Play"
@@ -35,7 +35,7 @@ platform :android do
 		skip_bundle = options[:bundle]
 		skip_metadata = options[:metadata]
 		version_code = options[:version]
-		upload_to_play_store(track: 'production', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata, version_code: version_code)
+		upload_to_play_store(track: 'production', skip_upload_apk: true, skip_upload_aab: skip_bundle, skip_upload_metadata: skip_metadata, version_code: version_code, aab: lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH])
 	end
 end
 

--- a/nym-vpn-android/fastlane/Fastfile
+++ b/nym-vpn-android/fastlane/Fastfile
@@ -5,37 +5,25 @@ platform :android do
   desc 'Deploy an internal version to Google Play'
   lane :internal do |options|
     gradle(task: "clean bundleGeneralRelease")
-    upload_to_play_store(track: 'internal', skip_upload_apk: true, skip_upload_metadata: true)
-    if options[:metadata]
-      upload_to_play_store(skip_upload_apk: true, skip_upload_aab: true)
-    end
+    upload_to_play_store(track: 'internal', skip_upload_apk: true, skip_upload_metadata: options[:metadata])
   end
 
   desc "Deploy an alpha version to Google Play"
   lane :alpha do |options|
     gradle(task: "clean bundleGeneralRelease")
-    upload_to_play_store(track: 'alpha', skip_upload_apk: true, skip_upload_metadata: true)
-    if options[:metadata]
-	  upload_to_play_store(skip_upload_apk: true, skip_upload_aab: true)
-    end
+    upload_to_play_store(track: 'alpha', skip_upload_apk: true, skip_upload_metadata: options[:metadata])
   end
 
   desc "Deploy a beta version to Google Play"
   lane :beta do |options|
     gradle(task: "clean bundleGeneralRelease")
-    upload_to_play_store(track: 'beta', skip_upload_apk: true, skip_upload_metadata: true)
-    if options[:metadata]
-	  upload_to_play_store(skip_upload_apk: true, skip_upload_aab: true)
-	end
+    upload_to_play_store(track: 'beta', skip_upload_apk: true, skip_upload_metadata: options[:metadata])
   end
 
   desc "Deploy a production version to Google Play"
   lane :production do |options|
     gradle(task: "clean bundleGeneralRelease")
-    upload_to_play_store(track: 'production', skip_upload_apk: true, skip_upload_metadata: true)
-    if options[:metadata]
-	  upload_to_play_store(skip_upload_apk: true, skip_upload_aab: true)
-    end
+    upload_to_play_store(track: 'production', skip_upload_apk: true, skip_upload_metadata: options[:metadata])
   end
 
 end


### PR DESCRIPTION
Fixes issue where sometimes metadata deployment fails. In these cases, we still want to publish the new version while we resolve the metadata issue separately. 