### PR TITLE
chore: weblate fmt

### DIFF
--- a/.github/workflows/ci-nymvpn-x-js.yml
+++ b/.github/workflows/ci-nymvpn-x-js.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Check formatting
         working-directory: nym-vpn-x
-        run: npm run fmt:ci
+        run: npm run fmt:check
 
       #      - name: Run tests
       #        working-directory: nym-vpn-x

--- a/nym-vpn-x/.prettierignore-ci
+++ b/nym-vpn-x/.prettierignore-ci
@@ -1,7 +1,0 @@
-src-tauri/target
-src-tauri/src
-src-tauri/about.hbs
-public
-
-# weblate generated json files do not respect prettier code format
-src/i18n/*/**

--- a/nym-vpn-x/package.json
+++ b/nym-vpn-x/package.json
@@ -22,7 +22,6 @@
     "lint:fix": "eslint --fix src/",
     "fmt": "prettier --write --ignore-unknown \"**/*\"",
     "fmt:check": "prettier --check --ignore-unknown \"**/*\"",
-    "fmt:ci": "prettier --check --ignore-unknown --ignore-path .gitignore --ignore-path .prettierignore-ci \"**/*\"",
     "tscheck": "tsc --noEmit",
     "tauri": "tauri",
     "gen:licenses": "run-p --aggregate-output gen:licenses:rust gen:licenses:js",


### PR DESCRIPTION
Configured Weblate to generate JSON translation files using 2 spaces for indent, so custom fmt ignore logic is useless