### PR TITLE
feat(vpnx): add cli commands for embedded db ops

### DIFF
--- a/nym-vpn-x/src-tauri/src/cli.rs
+++ b/nym-vpn-x/src-tauri/src/cli.rs
@@ -1,8 +1,12 @@
-use std::{path::PathBuf, sync::Arc};
-
-use clap::Parser;
+use crate::db::{Db, Key};
+use anyhow::{anyhow, Result};
+use clap::{Parser, Subcommand};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::str::FromStr;
+use std::{path::PathBuf, sync::Arc};
 use tauri::PackageInfo;
+use tracing::{error, info};
 
 pub type ManagedCli = Arc<Cli>;
 
@@ -41,6 +45,73 @@ pub struct Cli {
     /// Open a console to see the log stream (Windows only)
     #[arg(short, long)]
     pub console: bool,
+
+    #[command(subcommand)]
+    pub command: Option<Commands>,
+}
+
+#[derive(Subcommand, Serialize, Deserialize, Debug, Clone)]
+pub enum Commands {
+    /// Embedded database operations
+    Db {
+        #[command(subcommand)]
+        command: Option<DbCommands>,
+    },
+}
+
+#[derive(Subcommand, Serialize, Deserialize, Debug, Clone)]
+pub enum DbCommands {
+    /// Get a key
+    Get {
+        #[arg()]
+        key: String,
+    },
+    /// Set a key
+    Set {
+        #[arg()]
+        key: String,
+        /// as JSON string
+        #[arg()]
+        value: String,
+    },
+    /// Delete a key
+    Del {
+        #[arg()]
+        key: String,
+    },
+}
+
+pub fn db_command(db: &Db, command: &DbCommands) -> Result<()> {
+    match command {
+        DbCommands::Get { key: k } => {
+            info!("cli db get {k}");
+            let key = Key::from_str(k).map_err(|_| anyhow!("invalid key"))?;
+            if let Some(value) = db.get(key)? {
+                println!("{value}");
+            } else {
+                println!("key is not set");
+            }
+            Ok(())
+        }
+        DbCommands::Set { key: k, value: v } => {
+            info!("cli db set {k} {v}");
+            let key = Key::from_str(k).map_err(|_| anyhow!("invalid key"))?;
+            let value: Value = serde_json::from_str(v).map_err(|e| {
+                error!("failed to deserialize json value: {e}");
+                anyhow!("invalid value")
+            })?;
+            db.insert(key, value)?;
+            println!("key set to {v}");
+            Ok(())
+        }
+        DbCommands::Del { key: k } => {
+            info!("cli db del {k}");
+            let key = Key::from_str(k).map_err(|_| anyhow!("invalid key"))?;
+            db.remove(key)?;
+            println!("key removed");
+            Ok(())
+        }
+    }
 }
 
 pub fn print_build_info(package_info: &PackageInfo) {

--- a/nym-vpn-x/src-tauri/src/db.rs
+++ b/nym-vpn-x/src-tauri/src/db.rs
@@ -8,7 +8,7 @@ use std::{
     io,
     path::PathBuf,
 };
-use strum::AsRefStr;
+use strum::{AsRefStr, EnumString};
 use tauri::api::path::data_dir;
 use thiserror::Error;
 use tracing::{error, info, instrument, warn};
@@ -21,7 +21,7 @@ const DB_DIR: &str = "db";
 pub type JsonValue = Value;
 
 #[allow(dead_code)]
-#[derive(Deserialize, Serialize, AsRefStr, Debug, Clone, Copy, TS)]
+#[derive(Deserialize, Serialize, AsRefStr, EnumString, Debug, Clone, Copy, TS)]
 #[ts(export)]
 pub enum Key {
     #[strum(serialize = "monitoring")]


### PR DESCRIPTION
Add sub-commands to CLI to performs get/set operations on the embedded database (useful for debug&dev purpose)

```
nymvpn-x db get window_size
nymvpn-x db set welcome_screen_seen false
```