### PR TITLE
feat(vpnx): add optional log file support for debugging

### DIFF
--- a/.pkg/linux/install
+++ b/.pkg/linux/install
@@ -153,7 +153,7 @@ wrapper="#! /bin/bash
 # https://github.com/nymtech/nym-vpn-client/issues/305
 export WEBKIT_DISABLE_DMABUF_RENDERER=1
 
-RUST_LOG=info,nym_vpn_x=debug INSTALL_DIR/$target_appimage"
+LOG_FILE=1 RUST_LOG=info,nym_vpn_x=trace INSTALL_DIR/$target_appimage"
 ###
 
 ### desktop entry ###

--- a/nym-vpn-x/.pkg/aur/nymvpn-x-wrapper.sh
+++ b/nym-vpn-x/.pkg/aur/nymvpn-x-wrapper.sh
@@ -4,4 +4,4 @@
 # https://github.com/nymtech/nym-vpn-client/issues/305
 export WEBKIT_DISABLE_DMABUF_RENDERER=1
 
-RUST_LOG=info,nym_vpn_x=debug /usr/bin/nymvpn-x
+LOG_FILE=1 RUST_LOG=info,nym_vpn_x=trace /usr/bin/nymvpn-x

--- a/nym-vpn-x/src-tauri/Cargo.lock
+++ b/nym-vpn-x/src-tauri/Cargo.lock
@@ -5136,6 +5136,7 @@ dependencies = [
  "tonic",
  "tower",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "ts-rs",
  "windows 0.57.0",
@@ -8172,6 +8173,18 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/nym-vpn-x/src-tauri/Cargo.lock
+++ b/nym-vpn-x/src-tauri/Cargo.lock
@@ -161,6 +161,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
+name = "arboard"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb4009533e8ff8f1450a5bcbc30f4242a1d34442221f72314bea1f5dc9c7f89"
+dependencies = [
+ "clipboard-win",
+ "core-graphics 0.23.2",
+ "image 0.25.2",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "parking_lot 0.12.1",
+ "windows-sys 0.48.0",
+ "wl-clipboard-rs",
+ "x11rb",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -640,6 +659,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "blocking"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -821,6 +849,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -957,6 +991,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
 name = "chacha"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1057,6 +1097,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15efe7a882b08f34e38556b14f2fb3daa98769d06c7f0c1b076dfd0d983bc892"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "cocoa"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1066,8 +1115,8 @@ dependencies = [
  "block",
  "cocoa-foundation",
  "core-foundation",
- "core-graphics",
- "foreign-types",
+ "core-graphics 0.22.3",
+ "foreign-types 0.3.2",
  "libc",
  "objc",
 ]
@@ -1176,7 +1225,20 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.3.2",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-graphics-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -1702,6 +1764,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-new"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d150dea618e920167e5973d70ae6ece4385b7164e0d799fe7c122dd0a5d912ad"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1819,10 +1892,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
+name = "dlib"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dtoa"
@@ -2044,6 +2132,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0474425d51df81997e2f90a21591180b38eccf27292d755f3e30750225c175b"
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2230,7 +2324,28 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 dependencies = [
- "foreign-types-shared",
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared 0.3.1",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2238,6 +2353,12 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -2535,6 +2656,16 @@ dependencies = [
  "typenum",
  "version_check",
  "zeroize",
+]
+
+[[package]]
+name = "gethostname"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818"
+dependencies = [
+ "libc",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -3004,6 +3135,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "hostname"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3349,6 +3489,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99314c8a2152b8ddb211f924cdae532d8c5e4c8bb54728e12fff1b0cd5963a10"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "num-traits",
+ "png",
+ "tiff",
+]
+
+[[package]]
 name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3525,6 +3678,12 @@ checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "jpeg-decoder"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
 
 [[package]]
 name = "js-sys"
@@ -3946,6 +4105,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "memoffset 0.7.1",
+]
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.5.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -5180,6 +5351,105 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+
+[[package]]
+name = "objc2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+dependencies = [
+ "objc-sys",
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
+dependencies = [
+ "bitflags 2.5.0",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-data",
+ "objc2-core-image",
+ "objc2-foundation",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
+dependencies = [
+ "bitflags 2.5.0",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-foundation",
+ "objc2-metal",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7891e71393cd1f227313c9379a26a584ff3d7e6e7159e988851f0934c993f0f8"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+dependencies = [
+ "bitflags 2.5.0",
+ "block2",
+ "libc",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
+dependencies = [
+ "bitflags 2.5.0",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
+dependencies = [
+ "bitflags 2.5.0",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+ "objc2-metal",
+]
+
+[[package]]
 name = "objc_exception"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5242,7 +5512,7 @@ checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
 dependencies = [
  "bitflags 2.5.0",
  "cfg-if",
- "foreign-types",
+ "foreign-types 0.3.2",
  "libc",
  "once_cell",
  "openssl-macros",
@@ -5302,6 +5572,16 @@ checksum = "ae99c7fa6dd38c7cafe1ec085e804f8f555a2f8659b0dbe03f1f9963a9b51092"
 dependencies = [
  "log",
  "serde",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "os_pipe"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29d73ba8daf8fac13b0501d1abeddcfe21ba7401ada61a819144b6c2a4f32209"
+dependencies = [
+ "libc",
  "windows-sys 0.52.0",
 ]
 
@@ -6003,6 +6283,15 @@ name = "quick-xml"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f24d770aeca0eacb81ac29dfbc55ebcc09312fdd1f8bbecdc7e4a84e000e3b4"
 dependencies = [
  "memchr",
 ]
@@ -7387,7 +7676,7 @@ dependencies = [
  "cc",
  "cocoa",
  "core-foundation",
- "core-graphics",
+ "core-graphics 0.22.3",
  "crossbeam-channel",
  "dirs-next",
  "dispatch",
@@ -7400,7 +7689,7 @@ dependencies = [
  "glib",
  "glib-sys",
  "gtk",
- "image",
+ "image 0.24.9",
  "instant",
  "jni",
  "lazy_static",
@@ -7480,7 +7769,7 @@ dependencies = [
  "heck 0.5.0",
  "http 0.2.12",
  "ignore",
- "nix",
+ "nix 0.26.4",
  "notify-rust",
  "objc",
  "once_cell",
@@ -7599,6 +7888,7 @@ version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4c3db170233096aa30330feadcd895bf9317be97e624458560a20e814db7955"
 dependencies = [
+ "arboard",
  "cocoa",
  "gtk",
  "percent-encoding",
@@ -7836,6 +8126,17 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "tiff"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1310fcea54c6a9a4fd1aad794ecc02c31682f6bfbecdf460bf19533eed1e3e"
+dependencies = [
+ "flate2",
+ "jpeg-decoder",
+ "weezl",
 ]
 
 [[package]]
@@ -8267,6 +8568,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree_magic_mini"
+version = "3.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469a727cac55b41448315cc10427c069c618ac59bb6a4480283fcd811749bdc2"
+dependencies = [
+ "fnv",
+ "home",
+ "memchr",
+ "nom",
+ "once_cell",
+ "petgraph",
+]
+
+[[package]]
 name = "treediff"
 version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8641,6 +8956,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90e11ce2ca99c97b940ee83edbae9da2d56a08f9ea8158550fd77fa31722993"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix 0.38.32",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e321577a0a165911bdcfb39cf029302479d7527b517ee58ab0f6ad09edf0943"
+dependencies = [
+ "bitflags 2.5.0",
+ "rustix 0.38.32",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f81f365b8b4a97f422ac0e8737c438024b5951734506b0e1d775c73030561f4"
+dependencies = [
+ "bitflags 2.5.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad1f61b76b6c2d8742e10f9ba5c3737f6530b4c243132c2a2ccc8aa96fe25cd6"
+dependencies = [
+ "bitflags 2.5.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7b56f89937f1cf2ee1f1259cf2936a17a1f45d8f0aa1019fae6d470d304cfa6"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.34.0",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43676fe2daf68754ecf1d72026e4e6c15483198b5d24e888b74d3f22f887a148"
+dependencies = [
+ "dlib",
+ "log",
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8777,6 +9165,12 @@ dependencies = [
  "windows-bindgen",
  "windows-metadata",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 
 [[package]]
 name = "widestring"
@@ -9292,6 +9686,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "wl-clipboard-rs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12b41773911497b18ca8553c3daaf8ec9fe9819caf93d451d3055f69de028adb"
+dependencies = [
+ "derive-new",
+ "libc",
+ "log",
+ "nix 0.28.0",
+ "os_pipe",
+ "tempfile",
+ "thiserror",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
+
+[[package]]
 name = "wry"
 version = "0.24.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9300,7 +9714,7 @@ dependencies = [
  "base64 0.13.1",
  "block",
  "cocoa",
- "core-graphics",
+ "core-graphics 0.22.3",
  "crossbeam-channel",
  "dunce",
  "gdk",
@@ -9358,6 +9772,23 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d91ffca73ee7f68ce055750bf9f6eca0780b8c85eff9bc046a3b0da41755e12"
+dependencies = [
+ "gethostname",
+ "rustix 0.38.32",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec107c4503ea0b4a98ef47356329af139c0a4f7750e621cf2973cd3385ebcb3d"
 
 [[package]]
 name = "x25519-dalek"
@@ -9422,7 +9853,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "hex",
- "nix",
+ "nix 0.26.4",
  "once_cell",
  "ordered-stream",
  "rand 0.8.5",

--- a/nym-vpn-x/src-tauri/Cargo.toml
+++ b/nym-vpn-x/src-tauri/Cargo.toml
@@ -17,7 +17,9 @@ tauri-build = { version = "1.5", features = [] }
 build-info-build = "0.0.37"
 
 [dependencies]
-tauri = { version = "1.7.1", features = [ "notification-all",
+tauri = { version = "1.7.1", features = [
+    "dialog-open",
+    "notification-all",
     "system-tray",
     "window-set-size",
     "os-all",

--- a/nym-vpn-x/src-tauri/Cargo.toml
+++ b/nym-vpn-x/src-tauri/Cargo.toml
@@ -17,7 +17,7 @@ tauri-build = { version = "1.5", features = [] }
 build-info-build = "0.0.37"
 
 [dependencies]
-tauri = { version = "1.7.1", features = [
+tauri = { version = "1.7.1", features = [ "clipboard-write-text",
     "dialog-open",
     "notification-all",
     "system-tray",

--- a/nym-vpn-x/src-tauri/Cargo.toml
+++ b/nym-vpn-x/src-tauri/Cargo.toml
@@ -32,6 +32,7 @@ tracing-subscriber = { version = "0.3.1", features = [
     "tracing-log",
     "env-filter",
 ] }
+tracing-appender = "0.2"
 anyhow = "1.0"
 dotenvy = "0.15.7"
 thiserror = "1.0"
@@ -52,7 +53,6 @@ reqwest = { version = "0.12", features = ["json"] }
 rust_iso3166 = "0.1"
 
 # nym deps
-
 nym-config = { git = "https://github.com/nymtech/nym", rev = "fd1d437" }
 nym-vpn-proto = { path = "../../nym-vpn-core/crates/nym-vpn-proto" }
 nym-gateway-directory = { path = "../../nym-vpn-core/crates/nym-gateway-directory/" }

--- a/nym-vpn-x/src-tauri/src/commands/fs.rs
+++ b/nym-vpn-x/src-tauri/src/commands/fs.rs
@@ -1,23 +1,23 @@
-use tauri::api::path::cache_dir;
 use tracing::{debug, error, instrument};
 
-use crate::{error::BackendError, log::LOG_DIR, APP_DIR};
+use crate::error::BackendError;
+use crate::fs::path::LOG_DIR_PATH;
 
 #[instrument]
 #[tauri::command]
 pub async fn log_dir() -> Result<String, BackendError> {
     debug!("log_dir");
-    let cache_dir = cache_dir().ok_or_else(|| {
-        let err = "Failed to get cache directory path";
+    let log_path = LOG_DIR_PATH.clone().ok_or_else(|| {
+        let err = "Failed to get log directory path";
         error!(err);
         BackendError::new_internal(err, None)
     })?;
-    let log_path = cache_dir.join(format!("{}/{}", APP_DIR, LOG_DIR));
     let log_dir = log_path.to_str().ok_or_else(|| {
         let err = "Failed to get log directory path";
         error!(err);
         BackendError::new_internal(err, None)
     })?;
+
     debug!("log directory: {}", log_dir);
     Ok(log_dir.into())
 }

--- a/nym-vpn-x/src-tauri/src/commands/fs.rs
+++ b/nym-vpn-x/src-tauri/src/commands/fs.rs
@@ -1,0 +1,23 @@
+use tauri::api::path::cache_dir;
+use tracing::{debug, error, instrument};
+
+use crate::{error::BackendError, log::LOG_DIR, APP_DIR};
+
+#[instrument]
+#[tauri::command]
+pub async fn log_dir() -> Result<String, BackendError> {
+    debug!("log_dir");
+    let cache_dir = cache_dir().ok_or_else(|| {
+        let err = "Failed to get cache directory path";
+        error!(err);
+        BackendError::new_internal(err, None)
+    })?;
+    let log_path = cache_dir.join(format!("{}/{}", APP_DIR, LOG_DIR));
+    let log_dir = log_path.to_str().ok_or_else(|| {
+        let err = "Failed to get log directory path";
+        error!(err);
+        BackendError::new_internal(err, None)
+    })?;
+    debug!("log directory: {}", log_dir);
+    Ok(log_dir.into())
+}

--- a/nym-vpn-x/src-tauri/src/commands/mod.rs
+++ b/nym-vpn-x/src-tauri/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod connection;
 pub mod credential;
 pub mod daemon;
 pub mod db;
+pub mod fs;
 pub mod log;
 pub mod node_location;
 pub mod window;

--- a/nym-vpn-x/src-tauri/src/envi.rs
+++ b/nym-vpn-x/src-tauri/src/envi.rs
@@ -1,0 +1,9 @@
+use std::env;
+
+/// Check if an environment variable is truthy, i.e. set to "1" or "true"
+pub fn is_truthy(var: &str) -> bool {
+    match env::var(var) {
+        Ok(val) => val == "1" || val == "true",
+        Err(_) => false,
+    }
+}

--- a/nym-vpn-x/src-tauri/src/fs/mod.rs
+++ b/nym-vpn-x/src-tauri/src/fs/mod.rs
@@ -1,4 +1,5 @@
 pub mod config;
 pub mod log;
+pub mod path;
 pub mod storage;
 pub mod util;

--- a/nym-vpn-x/src-tauri/src/fs/path.rs
+++ b/nym-vpn-x/src-tauri/src/fs/path.rs
@@ -1,0 +1,24 @@
+use once_cell::sync::Lazy;
+use std::path::PathBuf;
+use tauri::api::path::cache_dir;
+use tracing::error;
+
+use crate::fs::util::check_dir;
+use crate::APP_DIR;
+
+pub const LOG_DIR: &str = "log";
+
+pub static LOG_DIR_PATH: Lazy<Option<PathBuf>> = Lazy::new(|| {
+    let log_dir = cache_dir()
+        .map(|mut p| {
+            p.push(APP_DIR);
+            p.push(LOG_DIR);
+            p
+        })
+        .and_then(|p| check_dir(&p).map(|_| p).ok());
+
+    if log_dir.is_none() {
+        error!("Failed to get the log directory");
+    }
+    log_dir
+});

--- a/nym-vpn-x/src-tauri/src/fs/storage.rs
+++ b/nym-vpn-x/src-tauri/src/fs/storage.rs
@@ -27,7 +27,7 @@ where
         full_path.push(filename);
 
         // check if the directory exists, if not create it
-        check_dir(&dir_path).await?;
+        check_dir(&dir_path)?;
         // check if the file exists, if not create it
         check_file(&full_path).await?;
 

--- a/nym-vpn-x/src-tauri/src/fs/util.rs
+++ b/nym-vpn-x/src-tauri/src/fs/util.rs
@@ -5,18 +5,10 @@ use tracing::{debug, error};
 
 /// Check if a directory exists, if not create it including all
 /// parent components
-pub async fn check_dir(path: &PathBuf) -> Result<()> {
-    if !fs::try_exists(&path)
-        .await
-        .inspect_err(|e| error!("Failed to check if path exists `{}`: {e}", path.display()))
-        .context(format!(
-            "Failed to check if path exists `{}`",
-            path.display()
-        ))?
-    {
+pub fn check_dir(path: &PathBuf) -> Result<()> {
+    if !path.is_dir() {
         debug!("directory `{}` does not exist, creating it", path.display());
-        return fs::create_dir_all(&path)
-            .await
+        return std::fs::create_dir_all(path)
             .inspect_err(|e| error!("Failed to create directory `{}`: {e}", path.display()))
             .context(format!("Failed to create directory `{}`", path.display()));
     }

--- a/nym-vpn-x/src-tauri/src/log.rs
+++ b/nym-vpn-x/src-tauri/src/log.rs
@@ -7,7 +7,7 @@ use tracing_appender::{non_blocking::WorkerGuard, rolling};
 use crate::{envi, fs::util::check_dir, APP_DIR};
 
 const ENV_LOG_FILE: &str = "LOG_FILE";
-const LOG_DIR: &str = "log";
+pub const LOG_DIR: &str = "log";
 const LOG_FILE: &str = "app.log";
 
 fn rotate_log_file(log_dir: PathBuf) -> Result<()> {

--- a/nym-vpn-x/src-tauri/src/log.rs
+++ b/nym-vpn-x/src-tauri/src/log.rs
@@ -1,0 +1,63 @@
+use std::{fs, path::PathBuf};
+
+use anyhow::{anyhow, Result};
+use tauri::api::path::cache_dir;
+use tracing_appender::{non_blocking::WorkerGuard, rolling};
+
+use crate::{envi, fs::util::check_dir, APP_DIR};
+
+const ENV_LOG_FILE: &str = "LOG_FILE";
+const LOG_DIR: &str = "log";
+const LOG_FILE: &str = "app.log";
+
+fn rotate_log_file(cache_dir: PathBuf) -> Result<()> {
+    let log_file = cache_dir.join(LOG_FILE);
+    if log_file.is_file() {
+        let old_file = cache_dir.join(format!("{}.old", LOG_FILE));
+        let data = fs::read(&log_file).inspect_err(|e| {
+            eprintln!(
+                "failed to read log file during log rotation {}: {e}",
+                log_file.display()
+            )
+        })?;
+        fs::write(&old_file, data).inspect_err(|e| {
+            eprintln!(
+                "failed to write log file during log rotation {}: {e}",
+                old_file.display()
+            )
+        })?;
+    }
+    Ok(())
+}
+
+pub async fn setup_tracing() -> Result<Option<WorkerGuard>> {
+    let filter = tracing_subscriber::EnvFilter::builder()
+        .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
+        .from_env()
+        .unwrap()
+        .add_directive("hyper::proto=info".parse().unwrap())
+        .add_directive("netlink_proto=info".parse().unwrap());
+
+    if envi::is_truthy(ENV_LOG_FILE) {
+        let cache_dir = cache_dir().ok_or(anyhow!("Failed to retrieve cache directory path"))?;
+        let cache_dir = cache_dir.join(format!("{}/{}", APP_DIR, LOG_DIR));
+        check_dir(&cache_dir).await?;
+        rotate_log_file(cache_dir.clone()).ok();
+
+        let appender = rolling::never(cache_dir, LOG_FILE);
+        let (writer, _guard) = tracing_appender::non_blocking(appender);
+
+        tracing_subscriber::fmt()
+            .with_env_filter(filter)
+            .compact()
+            .with_writer(writer)
+            .init();
+        Ok(Some(_guard))
+    } else {
+        tracing_subscriber::fmt()
+            .with_env_filter(filter)
+            .compact()
+            .init();
+        Ok(None)
+    }
+}

--- a/nym-vpn-x/src-tauri/src/main.rs
+++ b/nym-vpn-x/src-tauri/src/main.rs
@@ -18,6 +18,7 @@ use anyhow::{anyhow, Result};
 use clap::Parser;
 use commands::daemon as cmd_daemon;
 use commands::db as cmd_db;
+use commands::fs as cmd_fs;
 use commands::log as cmd_log;
 use commands::window as cmd_window;
 use commands::*;
@@ -211,7 +212,8 @@ async fn main() -> Result<()> {
             commands::cli::cli_args,
             cmd_log::log_js,
             credential::add_credential,
-            cmd_daemon::daemon_status
+            cmd_daemon::daemon_status,
+            cmd_fs::log_dir,
         ])
         // keep the app running in the background on window close request
         .on_window_event(|event| {

--- a/nym-vpn-x/src-tauri/src/main.rs
+++ b/nym-vpn-x/src-tauri/src/main.rs
@@ -2,8 +2,8 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Duration;
-use std::{env, sync::Arc};
 
 use crate::cli::{db_command, Commands};
 use crate::window::AppWindow;
@@ -18,6 +18,7 @@ use anyhow::{anyhow, Result};
 use clap::Parser;
 use commands::daemon as cmd_daemon;
 use commands::db as cmd_db;
+use commands::log as cmd_log;
 use commands::window as cmd_window;
 use commands::*;
 use nym_config::defaults;
@@ -31,12 +32,14 @@ mod cli;
 mod commands;
 mod country;
 mod db;
+mod envi;
 mod error;
 mod events;
 mod fs;
 mod gateway;
 mod grpc;
 mod http;
+mod log;
 mod states;
 mod system_tray;
 mod vpn_status;
@@ -49,26 +52,12 @@ const ENV_APP_NOSPLASH: &str = "APP_NOSPLASH";
 const VPND_RETRY_INTERVAL: Duration = Duration::from_secs(2);
 const SYSTRAY_ID: &str = "main";
 
-pub fn setup_logging() {
-    let filter = tracing_subscriber::EnvFilter::builder()
-        .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
-        .from_env()
-        .unwrap()
-        .add_directive("hyper::proto=info".parse().unwrap())
-        .add_directive("netlink_proto=info".parse().unwrap());
-
-    tracing_subscriber::fmt()
-        .with_env_filter(filter)
-        .compact()
-        .init();
-}
-
 #[tokio::main]
 async fn main() -> Result<()> {
     tauri::async_runtime::set(tokio::runtime::Handle::current());
 
     dotenvy::dotenv().ok();
-    setup_logging();
+    let _guard = log::setup_tracing().await?;
 
     // parse the command line arguments
     let cli = Cli::parse();
@@ -146,7 +135,7 @@ async fn main() -> Result<()> {
             app_win.restore_size(&db)?;
             app_win.restore_position(&db)?;
 
-            let env_nosplash = env::var(ENV_APP_NOSPLASH).map(|_| true).unwrap_or(false);
+            let env_nosplash = envi::is_truthy(ENV_APP_NOSPLASH);
             trace!("env APP_NOSPLASH: {}", env_nosplash);
 
             // if splash-screen is disabled, remove it and show
@@ -220,7 +209,7 @@ async fn main() -> Result<()> {
             node_location::get_countries,
             cmd_window::show_main_window,
             commands::cli::cli_args,
-            log::log_js,
+            cmd_log::log_js,
             credential::add_credential,
             cmd_daemon::daemon_status
         ])

--- a/nym-vpn-x/src-tauri/tauri.conf.json
+++ b/nym-vpn-x/src-tauri/tauri.conf.json
@@ -21,9 +21,8 @@
       "shell": { "all": false, "open": true },
       "os": { "all": true },
       "window": { "setSize": true },
-      "notification": {
-        "all": true
-      }
+      "notification": { "all": true },
+      "dialog": { "open": true }
     },
     "bundle": {
       "active": true,

--- a/nym-vpn-x/src-tauri/tauri.conf.json
+++ b/nym-vpn-x/src-tauri/tauri.conf.json
@@ -6,23 +6,43 @@
     "distDir": "../dist",
     "withGlobalTauri": false
   },
-  "package": { "productName": "nymvpn-x" },
+  "package": {
+    "productName": "nymvpn-x"
+  },
   "tauri": {
     "updater": {
       "active": false,
       "dialog": true,
       "endpoints": ["https://nymvpn.net/api/updater/vpn"],
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDU3RjI2N0FFRUEyRERGOEQKUldTTjN5M3FybWZ5VjhxOFRsLzQ2c1N0NW1PVVNxVEVVQkszYjZHc3RtcEFDOW1ZN2lIN1NGdk0K",
-      "windows": { "installMode": "passive" }
+      "windows": {
+        "installMode": "passive"
+      }
     },
     "allowlist": {
       "all": false,
-      "process": { "all": true },
-      "shell": { "all": false, "open": true },
-      "os": { "all": true },
-      "window": { "setSize": true },
-      "notification": { "all": true },
-      "dialog": { "open": true }
+      "process": {
+        "all": true
+      },
+      "shell": {
+        "all": false,
+        "open": true
+      },
+      "os": {
+        "all": true
+      },
+      "window": {
+        "setSize": true
+      },
+      "notification": {
+        "all": true
+      },
+      "dialog": {
+        "open": true
+      },
+      "clipboard": {
+        "writeText": true
+      }
     },
     "bundle": {
       "active": true,
@@ -55,7 +75,9 @@
         }
       }
     },
-    "security": { "csp": null },
+    "security": {
+      "csp": null
+    },
     "windows": [
       {
         "fullscreen": false,

--- a/nym-vpn-x/src/i18n/en/settings.json
+++ b/nym-vpn-x/src/i18n/en/settings.json
@@ -44,5 +44,6 @@
   "logs": "Logs",
   "quit": "Quit NymVPN",
   "add-credential-button": "Add credential to connect",
-  "log-dialog-title": "App logs"
+  "log-dialog-title": "App logs",
+  "log-path-copied": "Log path copied to clipboard"
 }

--- a/nym-vpn-x/src/i18n/en/settings.json
+++ b/nym-vpn-x/src/i18n/en/settings.json
@@ -43,5 +43,6 @@
   "display-theme": "Display theme",
   "logs": "Logs",
   "quit": "Quit NymVPN",
-  "add-credential-button": "Add credential to connect"
+  "add-credential-button": "Add credential to connect",
+  "log-dialog-title": "App logs"
 }

--- a/nym-vpn-x/src/pages/settings/Settings.tsx
+++ b/nym-vpn-x/src/pages/settings/Settings.tsx
@@ -1,6 +1,8 @@
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import dayjs from 'dayjs';
+import { invoke } from '@tauri-apps/api';
+import { open } from '@tauri-apps/api/dialog';
 import { useThrottle } from '../../hooks';
 import { kvSet } from '../../kvStore';
 import { routes } from '../../router';
@@ -70,6 +72,28 @@ function Settings() {
     showMonitoringAlert();
     dispatch({ type: 'set-monitoring', monitoring: isChecked });
     kvSet('Monitoring', isChecked);
+  };
+
+  const handleLogs = async () => {
+    let selected;
+    try {
+      const log_dir = await invoke<string>('log_dir');
+      selected = await open({
+        title: t('log-dialog-title'),
+        defaultPath: log_dir,
+        directory: false,
+        multiple: false,
+        filters: [
+          {
+            name: 'app',
+            extensions: ['log', 'log.old'],
+          },
+        ],
+      });
+    } catch (e) {
+      console.error(e);
+    }
+    console.log(selected);
   };
 
   return (
@@ -149,10 +173,9 @@ function Settings() {
       />
       <SettingsMenuCard
         title={t('logs')}
-        onClick={() => navigate(routes.logs)}
+        onClick={handleLogs}
         leadingIcon="sort"
         trailingIcon="arrow_right"
-        disabled
       />
       <SettingsGroup
         settings={[

--- a/nym-vpn-x/src/pages/settings/Settings.tsx
+++ b/nym-vpn-x/src/pages/settings/Settings.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import dayjs from 'dayjs';
 import { invoke } from '@tauri-apps/api';
 import { open } from '@tauri-apps/api/dialog';
+import { writeText } from '@tauri-apps/api/clipboard';
 import { useThrottle } from '../../hooks';
 import { kvSet } from '../../kvStore';
 import { routes } from '../../router';
@@ -93,7 +94,17 @@ function Settings() {
     } catch (e) {
       console.error(e);
     }
-    console.log(selected);
+    if (selected) {
+      if (Array.isArray(selected) && selected[0]) {
+        await writeText(selected[0]);
+      } else if (typeof selected === 'string') {
+        await writeText(selected);
+      }
+      push({
+        text: t('log-path-copied'),
+        autoHideDuration: 4000,
+      });
+    }
   };
 
   return (

--- a/nym-vpn-x/src/pages/settings/Settings.tsx
+++ b/nym-vpn-x/src/pages/settings/Settings.tsx
@@ -77,16 +77,16 @@ function Settings() {
   const handleLogs = async () => {
     let selected;
     try {
-      const log_dir = await invoke<string>('log_dir');
+      const logDir = await invoke<string>('log_dir');
       selected = await open({
         title: t('log-dialog-title'),
-        defaultPath: log_dir,
+        defaultPath: logDir,
         directory: false,
         multiple: false,
         filters: [
           {
             name: 'app',
-            extensions: ['log', 'log.old'],
+            extensions: ['log', 'old.log'],
           },
         ],
       });


### PR DESCRIPTION
Feature to be integrated in the UI and to allow the user manually sharing his logs for debugging purpose (bug report and so on)

- allow writing client app logs into a local file by setting the env var `LOG_FILE=1`
- logs are written in `/home/_user_/.cache/nymvpn-x/log/app.log` (Linux) `C:\Users\_username_\AppData\Local\nymvpn-x\log\app.log` (Windows)
- basic logs rotation (at app launch, the previous logs session are saved as `app.old.log`) so that the latest (or current) session and the previous session is always saved
- packages use `LOG_FILE=1` (_TODO_ deb), so when the app is launched via either desktop entry (Linux) or any desktop shortcut (via Windows) /desktop menus app logs are saved
- In app settings the "Logs" menu item opens a file dialog that lets the user access the log files (copy them and so on), when user selects one file its path is copied to clipboard + an in-app notification is sent
- the log directory is automatically created at runtime if it does not exist yet

![image](https://github.com/user-attachments/assets/a5632eb6-df28-49a9-a1bd-58e9a1851d02)
<img src="https://github.com/user-attachments/assets/37bb9660-8d07-4f87-94df-e3d60eaa4cbd" width="260px" />
