### PR TITLE
Lookup gateways using new nymvpn.com api in nym-vpn-lib

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -4038,6 +4038,7 @@ dependencies = [
  "nym-sdk",
  "nym-topology",
  "nym-validator-client",
+ "nym-vpn-api-client",
  "rand 0.8.5",
  "serde",
  "thiserror",

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -4033,6 +4033,7 @@ dependencies = [
  "itertools 0.13.0",
  "log",
  "nym-client-core",
+ "nym-config",
  "nym-explorer-client",
  "nym-harbour-master-client",
  "nym-sdk",

--- a/nym-vpn-core/crates/nym-gateway-directory/Cargo.toml
+++ b/nym-vpn-core/crates/nym-gateway-directory/Cargo.toml
@@ -16,6 +16,7 @@ nym-harbour-master-client = { path = "../nym-harbour-master-client" }
 nym-sdk.workspace = true
 nym-topology.workspace = true
 nym-validator-client.workspace = true
+nym-vpn-api-client = { path = "../nym-vpn-api-client" }
 rand.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/nym-vpn-core/crates/nym-gateway-directory/Cargo.toml
+++ b/nym-vpn-core/crates/nym-gateway-directory/Cargo.toml
@@ -11,6 +11,7 @@ hickory-resolver.workspace = true
 itertools.workspace = true
 log.workspace = true
 nym-client-core.workspace = true
+nym-config.workspace = true
 nym-explorer-client.workspace = true
 nym-harbour-master-client = { path = "../nym-harbour-master-client" }
 nym-sdk.workspace = true

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/auth_addresses.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/auth_addresses.rs
@@ -10,6 +10,13 @@ use nym_sdk::mixnet::Recipient;
 #[derive(Debug, Copy, Clone)]
 pub struct AuthAddress(pub Option<Recipient>);
 
+impl AuthAddress {
+    pub(crate) fn try_from_base58_string(address: &str) -> Result<Self> {
+        let recipient = Recipient::try_from_base58_string(address).unwrap();
+        Ok(AuthAddress(Some(recipient)))
+    }
+}
+
 #[derive(Debug, Copy, Clone)]
 pub struct AuthAddresses {
     entry_addr: AuthAddress,

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/auth_addresses.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/auth_addresses.rs
@@ -12,7 +12,8 @@ pub struct AuthAddress(pub Option<Recipient>);
 
 impl AuthAddress {
     pub(crate) fn try_from_base58_string(address: &str) -> Result<Self> {
-        let recipient = Recipient::try_from_base58_string(address).unwrap();
+        let recipient = Recipient::try_from_base58_string(address)
+            .map_err(|_| Error::RecipientFormattingError)?;
         Ok(AuthAddress(Some(recipient)))
     }
 }

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/described_gateway.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/described_gateway.rs
@@ -1,13 +1,16 @@
 // Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use std::str::FromStr;
+
 use crate::{
     error::{Error, Result},
     helpers::*,
+    IpPacketRouterAddress,
 };
 use chrono::{DateTime, Utc};
 use nym_explorer_client::Location;
-use nym_sdk::mixnet::NodeIdentity;
+use nym_sdk::mixnet::{NodeIdentity, Recipient};
 use nym_validator_client::{client::IdentityKey, models::DescribedGateway};
 
 use super::gateway::{Gateway, GatewayList};
@@ -87,6 +90,16 @@ impl DescribedGatewayWithLocation {
 
     pub fn country_name(&self) -> Option<String> {
         self.location.as_ref().map(|l| l.country_name.clone())
+    }
+
+    pub fn ip_packet_router_address(&self) -> Option<IpPacketRouterAddress> {
+        self.gateway
+            .self_described
+            .as_ref()
+            .and_then(|d| d.ip_packet_router.as_ref())
+            .map(|ipr| ipr.address.clone())
+            .and_then(|address| Recipient::from_str(&address).ok())
+            .map(|address| IpPacketRouterAddress(address.clone()))
     }
 }
 

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/described_gateway.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/described_gateway.rs
@@ -1,8 +1,6 @@
 // Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::str::FromStr;
-
 use crate::{
     error::{Error, Result},
     helpers::*,
@@ -10,7 +8,7 @@ use crate::{
 };
 use chrono::{DateTime, Utc};
 use nym_explorer_client::Location;
-use nym_sdk::mixnet::{NodeIdentity, Recipient};
+use nym_sdk::mixnet::NodeIdentity;
 use nym_validator_client::{client::IdentityKey, models::DescribedGateway};
 
 const BUILD_VERSION: &str = "1.1.34";
@@ -97,8 +95,7 @@ impl DescribedGatewayWithLocation {
             .as_ref()
             .and_then(|d| d.ip_packet_router.as_ref())
             .map(|ipr| ipr.address.clone())
-            .and_then(|address| Recipient::from_str(&address).ok())
-            .map(|address| IpPacketRouterAddress(address.clone()))
+            .and_then(|address| IpPacketRouterAddress::try_from_base58_string(&address).ok())
     }
 }
 

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/described_gateway.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/described_gateway.rs
@@ -13,8 +13,6 @@ use nym_explorer_client::Location;
 use nym_sdk::mixnet::{NodeIdentity, Recipient};
 use nym_validator_client::{client::IdentityKey, models::DescribedGateway};
 
-use super::gateway::{Gateway, GatewayList};
-
 const BUILD_VERSION: &str = "1.1.34";
 const BUILD_TIME: &str = "2024-03-25T10:47:53.981548588Z";
 
@@ -118,8 +116,6 @@ pub trait LookupGateway {
         &self,
         gateways: &[DescribedGatewayWithLocation],
     ) -> Result<(NodeIdentity, Option<String>)>;
-
-    async fn lookup_gateway_identity2(&self, gateways: &GatewayList) -> Result<Gateway>;
 }
 
 pub fn verify_identity(

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/described_gateway.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/described_gateway.rs
@@ -10,6 +10,8 @@ use nym_explorer_client::Location;
 use nym_sdk::mixnet::NodeIdentity;
 use nym_validator_client::{client::IdentityKey, models::DescribedGateway};
 
+use super::gateway::{Gateway, GatewayList};
+
 const BUILD_VERSION: &str = "1.1.34";
 const BUILD_TIME: &str = "2024-03-25T10:47:53.981548588Z";
 
@@ -103,6 +105,8 @@ pub trait LookupGateway {
         &self,
         gateways: &[DescribedGatewayWithLocation],
     ) -> Result<(NodeIdentity, Option<String>)>;
+
+    async fn lookup_gateway_identity2(&self, gateways: &GatewayList) -> Result<Gateway>;
 }
 
 pub fn verify_identity(

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/described_gateway.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/described_gateway.rs
@@ -16,6 +16,7 @@ use nym_validator_client::{client::IdentityKey, models::DescribedGateway};
 const BUILD_VERSION: &str = "1.1.34";
 const BUILD_TIME: &str = "2024-03-25T10:47:53.981548588Z";
 
+// DEPRECATED: will be deleted once we port nym-gateway-probe over
 #[derive(Clone, Debug)]
 pub struct DescribedGatewayWithLocation {
     pub gateway: DescribedGateway,
@@ -110,6 +111,8 @@ impl From<DescribedGateway> for DescribedGatewayWithLocation {
     }
 }
 
+// DEPRECATED: This is the old way of selecting a random gateway. It is now done in the
+// GatewayList. This will be deleted after we port nym-gateway-probe over
 #[async_trait::async_trait]
 pub trait LookupGateway {
     async fn lookup_gateway_identity(

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/entry_point.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/entry_point.rs
@@ -6,9 +6,13 @@ use std::fmt::{Display, Formatter};
 use crate::{error::Result, DescribedGatewayWithLocation, Error};
 use nym_sdk::mixnet::NodeIdentity;
 use serde::{Deserialize, Serialize};
+use tracing::debug;
 
-use super::described_gateway::{
-    by_location, by_random, by_random_low_latency, verify_identity, LookupGateway,
+use super::{
+    described_gateway::{
+        by_location, by_random, by_random_low_latency, verify_identity, LookupGateway,
+    },
+    gateway::{Gateway, GatewayList},
 };
 
 // The entry point is always a gateway identity, or some other entry that can be resolved to a
@@ -74,6 +78,37 @@ impl LookupGateway for EntryPoint {
             EntryPoint::Random => {
                 log::info!("Selecting a random entry gateway");
                 by_random(gateways)
+            }
+        }
+    }
+
+    async fn lookup_gateway_identity2(&self, gateways: &GatewayList) -> Result<Gateway> {
+        match &self {
+            EntryPoint::Gateway { identity } => {
+                debug!("Selecting gateway by identity: {}", identity);
+                gateways
+                    .gateway_with_identity(identity)
+                    .ok_or_else(|| Error::NoMatchingGateway)
+                    .cloned()
+            }
+            EntryPoint::Location { location } => {
+                debug!("Selecting gateway by location: {}", location);
+                gateways
+                    .random_gateway_located_at(location.to_string())
+                    .ok_or_else(|| Error::NoMatchingGatewayForLocation {
+                        requested_location: location.clone(),
+                        available_countries: gateways.all_iso_codes(),
+                    })
+            }
+            EntryPoint::RandomLowLatency => {
+                debug!("Selecting a random low latency gateway");
+                todo!("Need to add client address to Gateway type");
+            }
+            EntryPoint::Random => {
+                debug!("Selecting a random gateway");
+                gateways
+                    .random_gateway()
+                    .ok_or_else(|| Error::FailedToSelectGatewayRandomly)
             }
         }
     }

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/entry_point.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/entry_point.rs
@@ -53,7 +53,7 @@ impl EntryPoint {
         matches!(self, EntryPoint::Location { .. })
     }
 
-    pub fn lookup_gateway_identity2(&self, gateways: &GatewayList) -> Result<Gateway> {
+    pub fn lookup_gateway(&self, gateways: &GatewayList) -> Result<Gateway> {
         match &self {
             EntryPoint::Gateway { identity } => {
                 debug!("Selecting gateway by identity: {}", identity);
@@ -85,6 +85,8 @@ impl EntryPoint {
     }
 }
 
+// DEPRECATED: This is the old way of selecting a random gateway. It is now done in the
+// GatewayList. This will be deleted after we port nym-gateway-probe over
 #[async_trait::async_trait]
 impl LookupGateway for EntryPoint {
     async fn lookup_gateway_identity(

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/exit_point.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/exit_point.rs
@@ -54,127 +54,127 @@ impl ExitPoint {
         matches!(self, ExitPoint::Location { .. })
     }
 
-    pub fn lookup_router_address(
-        &self,
-        gateways: &[DescribedGatewayWithLocation],
-        entry_gateway: Option<&NodeIdentity>,
-    ) -> Result<(IpPacketRouterAddress, Option<String>)> {
-        match &self {
-            ExitPoint::Address { address } => {
-                // There is no validation done when a ip packet router is specified by address
-                // since it might be private and not available in any directory.
-                Ok((IpPacketRouterAddress(*address), None))
-            }
-            ExitPoint::Gateway { identity } => {
-                let gateway = by_identity(gateways, identity)?;
-                Ok((
-                    IpPacketRouterAddress::try_from_described_gateway(&gateway.gateway)?,
-                    gateway.two_letter_iso_country_code(),
-                ))
-            }
-            ExitPoint::Location { location } => {
-                log::info!("Selecting a random exit gateway in location: {}", location);
-                let exit_gateways = gateways
-                    .iter()
-                    .filter(|g| g.has_ip_packet_router())
-                    .filter(|g| g.is_current_build())
-                    .cloned()
-                    .collect::<Vec<_>>();
+    // pub fn lookup_router_address(
+    //     &self,
+    //     gateways: &[DescribedGatewayWithLocation],
+    //     entry_gateway: Option<&NodeIdentity>,
+    // ) -> Result<(IpPacketRouterAddress, Option<String>)> {
+    //     match &self {
+    //         ExitPoint::Address { address } => {
+    //             // There is no validation done when a ip packet router is specified by address
+    //             // since it might be private and not available in any directory.
+    //             Ok((IpPacketRouterAddress(*address), None))
+    //         }
+    //         ExitPoint::Gateway { identity } => {
+    //             let gateway = by_identity(gateways, identity)?;
+    //             Ok((
+    //                 IpPacketRouterAddress::try_from_described_gateway(&gateway.gateway)?,
+    //                 gateway.two_letter_iso_country_code(),
+    //             ))
+    //         }
+    //         ExitPoint::Location { location } => {
+    //             log::info!("Selecting a random exit gateway in location: {}", location);
+    //             let exit_gateways = gateways
+    //                 .iter()
+    //                 .filter(|g| g.has_ip_packet_router())
+    //                 .filter(|g| g.is_current_build())
+    //                 .cloned()
+    //                 .collect::<Vec<_>>();
+    //
+    //             // If there is only one exit gateway available and it is the entry gateway, we
+    //             // should not use it as the exit gateway.
+    //             if exit_gateways.len() == 1
+    //                 && exit_gateways[0].node_identity().as_ref() == entry_gateway
+    //             {
+    //                 return Err(Error::OnlyAvailableExitGatewayIsTheEntryGateway {
+    //                     requested_location: location.clone(),
+    //                     gateway: Box::new(exit_gateways[0].clone()),
+    //                 });
+    //             }
+    //
+    //             let exit_gateways = exit_gateways
+    //                 .into_iter()
+    //                 .filter(|g| g.node_identity().as_ref() != entry_gateway)
+    //                 .collect::<Vec<_>>();
+    //
+    //             let gateway = by_location_described(&exit_gateways, location)?;
+    //             Ok((
+    //                 IpPacketRouterAddress::try_from_described_gateway(&gateway.gateway)?,
+    //                 gateway.two_letter_iso_country_code(),
+    //             ))
+    //         }
+    //         ExitPoint::Random => {
+    //             log::info!("Selecting a random exit gateway");
+    //             let exit_gateways = gateways
+    //                 .iter()
+    //                 .filter(|g| g.has_ip_packet_router())
+    //                 .filter(|g| g.is_current_build())
+    //                 .filter(|g| g.node_identity().as_ref() != entry_gateway)
+    //                 .cloned()
+    //                 .collect::<Vec<_>>();
+    //             let gateway = by_random_described(&exit_gateways)?;
+    //             Ok((
+    //                 IpPacketRouterAddress::try_from_described_gateway(&gateway.gateway)?,
+    //                 gateway.two_letter_iso_country_code(),
+    //             ))
+    //         }
+    //     }
+    // }
 
-                // If there is only one exit gateway available and it is the entry gateway, we
-                // should not use it as the exit gateway.
-                if exit_gateways.len() == 1
-                    && exit_gateways[0].node_identity().as_ref() == entry_gateway
-                {
-                    return Err(Error::OnlyAvailableExitGatewayIsTheEntryGateway {
-                        requested_location: location.clone(),
-                        gateway: Box::new(exit_gateways[0].clone()),
-                    });
-                }
-
-                let exit_gateways = exit_gateways
-                    .into_iter()
-                    .filter(|g| g.node_identity().as_ref() != entry_gateway)
-                    .collect::<Vec<_>>();
-
-                let gateway = by_location_described(&exit_gateways, location)?;
-                Ok((
-                    IpPacketRouterAddress::try_from_described_gateway(&gateway.gateway)?,
-                    gateway.two_letter_iso_country_code(),
-                ))
-            }
-            ExitPoint::Random => {
-                log::info!("Selecting a random exit gateway");
-                let exit_gateways = gateways
-                    .iter()
-                    .filter(|g| g.has_ip_packet_router())
-                    .filter(|g| g.is_current_build())
-                    .filter(|g| g.node_identity().as_ref() != entry_gateway)
-                    .cloned()
-                    .collect::<Vec<_>>();
-                let gateway = by_random_described(&exit_gateways)?;
-                Ok((
-                    IpPacketRouterAddress::try_from_described_gateway(&gateway.gateway)?,
-                    gateway.two_letter_iso_country_code(),
-                ))
-            }
-        }
-    }
-
-    pub fn lookup_router_address2(
-        &self,
-        gateways: &GatewayList,
-        entry_gateway: Option<&NodeIdentity>,
-    ) -> Result<IpPacketRouterAddress> {
-        match &self {
-            ExitPoint::Address { address } => {
-                // There is no validation done when a ip packet router is specified by address
-                // since it might be private and not available in any directory.
-                Ok(IpPacketRouterAddress(*address))
-            }
-            ExitPoint::Gateway { identity } => {
-                debug!("Selecting gateway by identity: {}", identity);
-                gateways
-                    .gateway_with_identity(identity)
-                    .ok_or(Error::NoMatchingGateway)?
-                    .ipr_address
-                    .ok_or(Error::MissingIpPacketRouterAddress)
-            }
-            ExitPoint::Location { location } => {
-                log::info!("Selecting a random exit gateway in location: {}", location);
-                let exit_gateways = gateways
-                    .gateways_located_at(location.to_string())
-                    .cloned()
-                    .collect::<Vec<_>>();
-
-                // If there is only one exit gateway available and it is the entry gateway, we
-                // should not use it as the exit gateway.
-                if exit_gateways.len() == 1 && Some(&exit_gateways[0].identity) == entry_gateway {
-                    return Err(Error::OnlyAvailableExitGatewayIsTheEntryGateway2 {
-                        requested_location: location.clone(),
-                        gateway: exit_gateways[0].identity,
-                    });
-                }
-
-                GatewayList::new(exit_gateways)
-                    .random_gateway_located_at(location.to_string())
-                    .ok_or_else(|| Error::NoMatchingExitGatewayForLocation {
-                        requested_location: location.clone(),
-                        available_countries: gateways.all_iso_codes(),
-                    })?
-                    .ipr_address
-                    .ok_or(Error::MissingIpPacketRouterAddress)
-            }
-            ExitPoint::Random => {
-                log::info!("Selecting a random exit gateway");
-                gateways
-                    .random_gateway()
-                    .ok_or(Error::FailedToSelectGatewayRandomly)?
-                    .ipr_address
-                    .ok_or(Error::MissingIpPacketRouterAddress)
-            }
-        }
-    }
+    // pub fn lookup_router_address2(
+    //     &self,
+    //     gateways: &GatewayList,
+    //     entry_gateway: Option<&NodeIdentity>,
+    // ) -> Result<IpPacketRouterAddress> {
+    //     match &self {
+    //         ExitPoint::Address { address } => {
+    //             // There is no validation done when a ip packet router is specified by address
+    //             // since it might be private and not available in any directory.
+    //             Ok(IpPacketRouterAddress(*address))
+    //         }
+    //         ExitPoint::Gateway { identity } => {
+    //             debug!("Selecting gateway by identity: {}", identity);
+    //             gateways
+    //                 .gateway_with_identity(identity)
+    //                 .ok_or(Error::NoMatchingGateway)?
+    //                 .ipr_address
+    //                 .ok_or(Error::MissingIpPacketRouterAddress)
+    //         }
+    //         ExitPoint::Location { location } => {
+    //             log::info!("Selecting a random exit gateway in location: {}", location);
+    //             let exit_gateways = gateways
+    //                 .gateways_located_at(location.to_string())
+    //                 .cloned()
+    //                 .collect::<Vec<_>>();
+    //
+    //             // If there is only one exit gateway available and it is the entry gateway, we
+    //             // should not use it as the exit gateway.
+    //             if exit_gateways.len() == 1 && Some(&exit_gateways[0].identity) == entry_gateway {
+    //                 return Err(Error::OnlyAvailableExitGatewayIsTheEntryGateway2 {
+    //                     requested_location: location.clone(),
+    //                     gateway: exit_gateways[0].identity,
+    //                 });
+    //             }
+    //
+    //             GatewayList::new(exit_gateways)
+    //                 .random_gateway_located_at(location.to_string())
+    //                 .ok_or_else(|| Error::NoMatchingExitGatewayForLocation {
+    //                     requested_location: location.clone(),
+    //                     available_countries: gateways.all_iso_codes(),
+    //                 })?
+    //                 .ipr_address
+    //                 .ok_or(Error::MissingIpPacketRouterAddress)
+    //         }
+    //         ExitPoint::Random => {
+    //             log::info!("Selecting a random exit gateway");
+    //             gateways
+    //                 .random_gateway()
+    //                 .ok_or(Error::FailedToSelectGatewayRandomly)?
+    //                 .ipr_address
+    //                 .ok_or(Error::MissingIpPacketRouterAddress)
+    //         }
+    //     }
+    // }
 
     pub fn lookup_gateway_identity2(&self, gateways: &GatewayList) -> Result<Gateway> {
         match &self {

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/exit_point.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/exit_point.rs
@@ -12,7 +12,6 @@ use crate::{
     DescribedGatewayWithLocation, Error, IpPacketRouterAddress,
 };
 use nym_sdk::mixnet::{NodeIdentity, Recipient};
-use nym_topology::IntoGatewayNode;
 use serde::{Deserialize, Serialize};
 use tracing::debug;
 

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/exit_point.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/exit_point.rs
@@ -131,10 +131,13 @@ impl ExitPoint {
                 let ipr_address = IpPacketRouterAddress(*address);
                 let gateway_address = ipr_address.gateway();
 
-                gateways
+                // Now fetch the gateway that the IPR is connected to, and override it's IPR address
+                let mut gateway = gateways
                     .gateway_with_identity(gateway_address)
                     .ok_or(Error::NoMatchingGateway)
-                    .cloned()
+                    .cloned()?;
+                gateway.ipr_address = Some(ipr_address);
+                Ok(gateway)
             }
             ExitPoint::Gateway { identity } => {
                 debug!("Selecting gateway by identity: {}", identity);

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/exit_point.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/exit_point.rs
@@ -13,9 +13,11 @@ use crate::{
 };
 use nym_sdk::mixnet::{NodeIdentity, Recipient};
 use serde::{Deserialize, Serialize};
+use tracing::debug;
 
-use super::described_gateway::{
-    by_identity, by_location, by_random, verify_identity, LookupGateway,
+use super::{
+    described_gateway::{by_identity, by_location, by_random, verify_identity, LookupGateway},
+    gateway::{Gateway, GatewayList},
 };
 
 // The exit point is a nym-address, but if the exit ip-packet-router is running embedded on a
@@ -157,6 +159,42 @@ impl LookupGateway for ExitPoint {
             ExitPoint::Random => {
                 log::info!("Selecting a random exit gateway");
                 by_random(gateways)
+            }
+        }
+    }
+
+    async fn lookup_gateway_identity2(&self, gateways: &GatewayList) -> Result<Gateway> {
+        match &self {
+            ExitPoint::Address { address } => {
+                debug!("Selecting gateway by address: {}", address);
+                todo!();
+                gateways
+                    .gateway_with_identity(address.identity())
+                    .ok_or_else(|| Error::NoMatchingGateway)
+                    .cloned()
+            }
+            ExitPoint::Gateway { identity } => {
+                debug!("Selecting gateway by identity: {}", identity);
+                todo!();
+                gateways
+                    .gateway_with_identity(identity)
+                    .ok_or_else(|| Error::NoMatchingGateway)
+                    .cloned()
+            }
+            ExitPoint::Location { location } => {
+                debug!("Selecting gateway by location: {}", location);
+                todo!();
+                gateways
+                    .random_gateway_located_at(location.to_string())
+                    .ok_or_else(|| Error::NoMatchingGatewayForLocation {
+                        requested_location: location.clone(),
+                        available_countries: gateways.all_iso_codes(),
+                    })
+            }
+            ExitPoint::Random => {
+                todo!();
+                log::info!("Selecting a random exit gateway");
+                // gateways.random_gateway()
             }
         }
     }

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/exit_point.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/exit_point.rs
@@ -13,13 +13,12 @@ use crate::{
 };
 use nym_sdk::mixnet::{NodeIdentity, Recipient};
 use nym_topology::IntoGatewayNode;
-use nym_validator_client::models::DescribedGateway;
 use serde::{Deserialize, Serialize};
 use tracing::debug;
 
 use super::{
     described_gateway::{by_identity, by_location, by_random, verify_identity, LookupGateway},
-    gateway::{Gateway, GatewayList},
+    gateway::GatewayList,
 };
 
 // The exit point is a nym-address, but if the exit ip-packet-router is running embedded on a
@@ -242,40 +241,40 @@ impl LookupGateway for ExitPoint {
         }
     }
 
-    async fn lookup_gateway_identity2(&self, gateways: &GatewayList) -> Result<Gateway> {
-        match &self {
-            ExitPoint::Address { address } => {
-                debug!("Selecting gateway by address: {}", address);
-                todo!();
-                // gateways
-                //     .gateway_with_identity(address.identity())
-                //     .ok_or_else(|| Error::NoMatchingGateway)
-                //     .cloned()
-            }
-            ExitPoint::Gateway { identity } => {
-                debug!("Selecting gateway by identity: {}", identity);
-                gateways
-                    .gateway_with_identity(identity)
-                    .ok_or_else(|| Error::NoMatchingGateway)
-                    .cloned()
-            }
-            ExitPoint::Location { location } => {
-                debug!("Selecting gateway by location: {}", location);
-                gateways
-                    .random_gateway_located_at(location.to_string())
-                    .ok_or_else(|| Error::NoMatchingGatewayForLocation {
-                        requested_location: location.clone(),
-                        available_countries: gateways.all_iso_codes(),
-                    })
-            }
-            ExitPoint::Random => {
-                log::info!("Selecting a random exit gateway");
-                gateways
-                    .random_gateway()
-                    .ok_or_else(|| Error::FailedToSelectGatewayRandomly)
-            }
-        }
-    }
+    // async fn lookup_gateway_identity2(&self, gateways: &GatewayList) -> Result<Gateway> {
+    //     match &self {
+    //         ExitPoint::Address { address } => {
+    //             debug!("Selecting gateway by address: {}", address);
+    //             todo!();
+    //             // gateways
+    //             //     .gateway_with_identity(address.identity())
+    //             //     .ok_or_else(|| Error::NoMatchingGateway)
+    //             //     .cloned()
+    //         }
+    //         ExitPoint::Gateway { identity } => {
+    //             debug!("Selecting gateway by identity: {}", identity);
+    //             gateways
+    //                 .gateway_with_identity(identity)
+    //                 .ok_or_else(|| Error::NoMatchingGateway)
+    //                 .cloned()
+    //         }
+    //         ExitPoint::Location { location } => {
+    //             debug!("Selecting gateway by location: {}", location);
+    //             gateways
+    //                 .random_gateway_located_at(location.to_string())
+    //                 .ok_or_else(|| Error::NoMatchingGatewayForLocation {
+    //                     requested_location: location.clone(),
+    //                     available_countries: gateways.all_iso_codes(),
+    //                 })
+    //         }
+    //         ExitPoint::Random => {
+    //             log::info!("Selecting a random exit gateway");
+    //             gateways
+    //                 .random_gateway()
+    //                 .ok_or_else(|| Error::FailedToSelectGatewayRandomly)
+    //         }
+    //     }
+    // }
 }
 
 pub fn extract_router_address(

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
@@ -2,17 +2,17 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use itertools::Itertools;
-use nym_sdk::mixnet::{NodeIdentity, Recipient};
+use nym_sdk::mixnet::NodeIdentity;
 use rand::seq::IteratorRandom;
 
-use crate::IpPacketRouterAddress;
+use crate::{AuthAddress, IpPacketRouterAddress};
 
 #[derive(Clone, Debug)]
 pub struct Gateway {
     pub identity: NodeIdentity,
     pub location: Option<Location>,
     pub ipr_address: Option<IpPacketRouterAddress>,
-    pub authenticator_address: Option<Recipient>,
+    pub authenticator_address: Option<AuthAddress>,
 }
 
 impl Gateway {
@@ -111,6 +111,7 @@ impl GatewayList {
     }
 
     pub fn remove_gateway(&mut self, entry_gateway: &Gateway) {
-        self.gateways.retain(|gateway| gateway.identity() != entry_gateway.identity());
+        self.gateways
+            .retain(|gateway| gateway.identity() != entry_gateway.identity());
     }
 }

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
@@ -2,13 +2,15 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use itertools::Itertools;
-use nym_sdk::mixnet::NodeIdentity;
+use nym_sdk::mixnet::{NodeIdentity, Recipient};
 use rand::seq::IteratorRandom;
 
 #[derive(Clone, Debug)]
 pub struct Gateway {
     pub identity: NodeIdentity,
     pub location: Option<Location>,
+    pub ipr_address: Option<Recipient>,
+    pub authenticator_address: Option<Recipient>,
 }
 
 impl Gateway {
@@ -50,6 +52,8 @@ impl From<nym_vpn_api_client::Gateway> for Gateway {
         Gateway {
             identity: NodeIdentity::from_base58_string(&gateway.identity_key).unwrap(),
             location: Some(gateway.location.into()),
+            ipr_address: None,
+            authenticator_address: None,
         }
     }
 }

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
@@ -140,4 +140,12 @@ impl GatewayList {
         self.gateways
             .retain(|gateway| gateway.identity() != entry_gateway.identity());
     }
+
+    pub fn len(&self) -> usize {
+        self.gateways.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.gateways.is_empty()
+    }
 }

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
@@ -6,7 +6,7 @@ use nym_sdk::mixnet::NodeIdentity;
 use nym_topology::IntoGatewayNode;
 use rand::seq::IteratorRandom;
 
-use crate::{AuthAddress, IpPacketRouterAddress};
+use crate::{error::Result, AuthAddress, Error, IpPacketRouterAddress};
 
 #[derive(Clone, Debug)]
 pub struct Gateway {
@@ -54,14 +54,17 @@ impl From<nym_vpn_api_client::Location> for Location {
     }
 }
 
-impl From<nym_vpn_api_client::Gateway> for Gateway {
-    fn from(gateway: nym_vpn_api_client::Gateway) -> Self {
-        Gateway {
-            identity: NodeIdentity::from_base58_string(&gateway.identity_key).unwrap(),
+impl TryFrom<nym_vpn_api_client::Gateway> for Gateway {
+    type Error = Error;
+    fn try_from(gateway: nym_vpn_api_client::Gateway) -> Result<Self> {
+        let identity = NodeIdentity::from_base58_string(&gateway.identity_key)
+            .map_err(|_| Error::RecipientFormattingError)?;
+        Ok(Gateway {
+            identity,
             location: Some(gateway.location.into()),
             ipr_address: None,
             authenticator_address: None,
-        }
+        })
     }
 }
 

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
@@ -73,7 +73,7 @@ impl TryFrom<nym_validator_client::models::DescribedGateway> for Gateway {
     type Error = Error;
 
     fn try_from(gateway: nym_validator_client::models::DescribedGateway) -> Result<Self> {
-        let identity = NodeIdentity::from_base58_string(&gateway.identity())
+        let identity = NodeIdentity::from_base58_string(gateway.identity())
             .map_err(|_| Error::RecipientFormattingError)?;
         let ipr_address = gateway
             .self_described

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
@@ -1,0 +1,106 @@
+// Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use itertools::Itertools;
+use nym_sdk::mixnet::NodeIdentity;
+use rand::seq::IteratorRandom;
+
+#[derive(Clone, Debug)]
+pub struct Gateway {
+    pub identity: NodeIdentity,
+    pub location: Option<Location>,
+}
+
+impl Gateway {
+    pub fn identity(&self) -> &NodeIdentity {
+        &self.identity
+    }
+
+    pub fn two_letter_iso_country_code(&self) -> Option<&str> {
+        self.location
+            .as_ref()
+            .map(|l| l.two_letter_iso_country_code.as_str())
+    }
+
+    pub fn is_two_letter_iso_country_code(&self, code: &str) -> bool {
+        self.two_letter_iso_country_code()
+            .map_or(false, |gw_code| gw_code == code)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Location {
+    pub two_letter_iso_country_code: String,
+    pub latitude: f64,
+    pub longitude: f64,
+}
+
+impl From<nym_vpn_api_client::Location> for Location {
+    fn from(location: nym_vpn_api_client::Location) -> Self {
+        Location {
+            two_letter_iso_country_code: location.two_letter_iso_country_code,
+            latitude: location.latitude,
+            longitude: location.longitude,
+        }
+    }
+}
+
+impl From<nym_vpn_api_client::Gateway> for Gateway {
+    fn from(gateway: nym_vpn_api_client::Gateway) -> Self {
+        Gateway {
+            identity: NodeIdentity::from_base58_string(&gateway.identity_key).unwrap(),
+            location: Some(gateway.location.into()),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GatewayList {
+    gateways: Vec<Gateway>,
+}
+
+impl GatewayList {
+    pub fn new(gateways: Vec<Gateway>) -> Self {
+        GatewayList { gateways }
+    }
+
+    pub fn all_locations(&self) -> impl Iterator<Item = &Location> {
+        self.gateways
+            .iter()
+            .filter_map(|gateway| gateway.location.as_ref())
+    }
+
+    pub fn all_iso_codes(&self) -> Vec<String> {
+        self.all_locations()
+            .map(|code| code.two_letter_iso_country_code.clone())
+            .unique()
+            .collect()
+    }
+
+    pub fn gateway_with_identity(&self, identity: &NodeIdentity) -> Option<&Gateway> {
+        self.gateways
+            .iter()
+            .find(|gateway| gateway.identity() == identity)
+    }
+
+    pub fn gateways_located_at(&self, code: String) -> impl Iterator<Item = &Gateway> {
+        self.gateways.iter().filter(move |gateway| {
+            gateway
+                .two_letter_iso_country_code()
+                .map_or(false, |gw_code| gw_code == code)
+        })
+    }
+
+    pub fn random_gateway(&self) -> Option<Gateway> {
+        self.gateways
+            .iter()
+            .choose(&mut rand::thread_rng())
+            .cloned()
+    }
+
+    pub fn random_gateway_located_at(&self, code: String) -> Option<Gateway> {
+        self.gateways_located_at(code)
+            .choose(&mut rand::thread_rng())
+            .cloned()
+    }
+}

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
@@ -5,11 +5,13 @@ use itertools::Itertools;
 use nym_sdk::mixnet::{NodeIdentity, Recipient};
 use rand::seq::IteratorRandom;
 
+use crate::IpPacketRouterAddress;
+
 #[derive(Clone, Debug)]
 pub struct Gateway {
     pub identity: NodeIdentity,
     pub location: Option<Location>,
-    pub ipr_address: Option<Recipient>,
+    pub ipr_address: Option<IpPacketRouterAddress>,
     pub authenticator_address: Option<Recipient>,
 }
 
@@ -106,5 +108,9 @@ impl GatewayList {
         self.gateways_located_at(code)
             .choose(&mut rand::thread_rng())
             .cloned()
+    }
+
+    pub fn remove_gateway(&mut self, entry_gateway: &Gateway) {
+        self.gateways.retain(|gateway| gateway.identity() != entry_gateway.identity());
     }
 }

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/mod.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/mod.rs
@@ -2,5 +2,5 @@ pub(crate) mod auth_addresses;
 pub(crate) mod described_gateway;
 pub(crate) mod entry_point;
 pub(crate) mod exit_point;
-pub(crate) mod ipr_addresses;
 pub(crate) mod gateway;
+pub(crate) mod ipr_addresses;

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/mod.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/mod.rs
@@ -3,3 +3,4 @@ pub(crate) mod described_gateway;
 pub(crate) mod entry_point;
 pub(crate) mod exit_point;
 pub(crate) mod ipr_addresses;
+pub(crate) mod gateway;

--- a/nym-vpn-core/crates/nym-gateway-directory/src/error.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/error.rs
@@ -25,6 +25,9 @@ pub enum Error {
     #[error(transparent)]
     HarbourMasterApiError(#[from] nym_harbour_master_client::HarbourMasterApiError),
 
+    #[error(transparent)]
+    NymVpnApiClientError(#[from] nym_vpn_api_client::VpnApiClientError),
+
     #[error("failed to fetch location data from explorer-api: {error}")]
     FailedFetchLocationData {
         error: nym_explorer_client::ExplorerApiError,

--- a/nym-vpn-core/crates/nym-gateway-directory/src/error.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/error.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use nym_client_core::error::ClientCoreError;
-use nym_sdk::mixnet::NodeIdentity;
 
 use crate::DescribedGatewayWithLocation;
 
@@ -85,12 +84,6 @@ pub enum Error {
     OnlyAvailableExitGatewayIsTheEntryGateway {
         requested_location: String,
         gateway: Box<DescribedGatewayWithLocation>,
-    },
-
-    #[error("the only available exit gateway is the entry gateway")]
-    OnlyAvailableExitGatewayIsTheEntryGateway2 {
-        requested_location: String,
-        gateway: NodeIdentity,
     },
 }
 

--- a/nym-vpn-core/crates/nym-gateway-directory/src/error.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/error.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use nym_client_core::error::ClientCoreError;
+use nym_sdk::mixnet::NodeIdentity;
 
 use crate::DescribedGatewayWithLocation;
 
@@ -84,6 +85,12 @@ pub enum Error {
     OnlyAvailableExitGatewayIsTheEntryGateway {
         requested_location: String,
         gateway: Box<DescribedGatewayWithLocation>,
+    },
+
+    #[error("the only available exit gateway is the entry gateway")]
+    OnlyAvailableExitGatewayIsTheEntryGateway2 {
+        requested_location: String,
+        gateway: NodeIdentity,
     },
 }
 

--- a/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
@@ -497,6 +497,7 @@ impl GatewayClient {
 
     pub async fn lookup_entry_gateways(&self) -> Result<GatewayList> {
         let entry_gateways = if let Some(nym_vpn_api_client) = &self.nym_vpn_api_client {
+            info!("Fetching entry gateways from nym-vpn-api...");
             let entry_gateways = nym_vpn_api_client.get_entry_gateways().await.unwrap();
             let mut entry_gateways: Vec<_> =
                 entry_gateways.into_iter().map(Gateway::from).collect();
@@ -519,6 +520,7 @@ impl GatewayClient {
 
     pub async fn lookup_exit_gateways(&self) -> Result<GatewayList> {
         let exit_gateways = if let Some(nym_vpn_api_client) = &self.nym_vpn_api_client {
+            info!("Fetching exit gateways from nym-vpn-api...");
             let exit_gateways = nym_vpn_api_client.get_exit_gateways().await.unwrap();
             let mut exit_gateways: Vec<_> = exit_gateways.into_iter().map(Gateway::from).collect();
 

--- a/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
@@ -517,7 +517,11 @@ impl GatewayClient {
             self.lookup_described_gateways()
                 .await?
                 .into_iter()
-                .map(Gateway::from)
+                .filter_map(|gw| {
+                    Gateway::try_from(gw)
+                        .inspect_err(|err| warn!("Failed to parse gateway: {err}"))
+                        .ok()
+                })
                 .collect()
         };
 
@@ -546,8 +550,11 @@ impl GatewayClient {
             self.lookup_described_gateways()
                 .await?
                 .into_iter()
-                .map(Gateway::from)
-                .filter(Gateway::has_ipr_address)
+                .filter_map(|gw| {
+                    Gateway::try_from(gw)
+                        .inspect_err(|err| warn!("Failed to parse gateway: {err}"))
+                        .ok()
+                })
                 .collect()
         };
 

--- a/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
@@ -499,8 +499,14 @@ impl GatewayClient {
         let entry_gateways = if let Some(nym_vpn_api_client) = &self.nym_vpn_api_client {
             info!("Fetching entry gateways from nym-vpn-api...");
             let entry_gateways = nym_vpn_api_client.get_entry_gateways().await.unwrap();
-            let mut entry_gateways: Vec<_> =
-                entry_gateways.into_iter().map(Gateway::from).collect();
+            let mut entry_gateways: Vec<_> = entry_gateways
+                .into_iter()
+                .filter_map(|gw| {
+                    Gateway::try_from(gw)
+                        .inspect_err(|err| warn!("Failed to parse gateway: {err}"))
+                        .ok()
+                })
+                .collect();
 
             // Lookup the IPR and authenticator addresses from the nym-api as a temporary hack until
             // the nymvpn.com endpoints are updated to also include these fields.
@@ -522,7 +528,14 @@ impl GatewayClient {
         let exit_gateways = if let Some(nym_vpn_api_client) = &self.nym_vpn_api_client {
             info!("Fetching exit gateways from nym-vpn-api...");
             let exit_gateways = nym_vpn_api_client.get_exit_gateways().await.unwrap();
-            let mut exit_gateways: Vec<_> = exit_gateways.into_iter().map(Gateway::from).collect();
+            let mut exit_gateways: Vec<_> = exit_gateways
+                .into_iter()
+                .filter_map(|gw| {
+                    Gateway::try_from(gw)
+                        .inspect_err(|err| warn!("Failed to parse gateway: {err}"))
+                        .ok()
+                })
+                .collect();
 
             // Lookup the IPR and authenticator addresses from the nym-api as a temporary hack until
             // the nymvpn.com endpoints are updated to also include these fields.

--- a/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
@@ -227,16 +227,14 @@ impl GatewayClient {
             None
         };
 
-        // TODO: this only works with mainnet currently!
-        // We need to add a nym_vpn_api url to the config that is setup with the network
-        // environment.
         let nym_vpn_api_client = if let Some(url) = config.nym_vpn_api_url {
-            nym_vpn_api_client::ClientBuilder::new::<_, crate::error::Error>(url)
-                .unwrap()
-                .with_user_agent(user_agent)
-                .with_timeout(Duration::from_secs(10))
-                .build::<crate::error::Error>()
-                .ok()
+            Some(
+                nym_vpn_api_client::ClientBuilder::new(url)
+                    .map_err(nym_vpn_api_client::VpnApiClientError::from)?
+                    .with_user_agent(user_agent)
+                    .with_timeout(Duration::from_secs(10))
+                    .build()?,
+            )
         } else {
             None
         };
@@ -498,7 +496,7 @@ impl GatewayClient {
     pub async fn lookup_entry_gateways(&self) -> Result<GatewayList> {
         let entry_gateways = if let Some(nym_vpn_api_client) = &self.nym_vpn_api_client {
             info!("Fetching entry gateways from nym-vpn-api...");
-            let entry_gateways = nym_vpn_api_client.get_entry_gateways().await.unwrap();
+            let entry_gateways = nym_vpn_api_client.get_entry_gateways().await?;
             let mut entry_gateways: Vec<_> = entry_gateways
                 .into_iter()
                 .filter_map(|gw| {
@@ -531,7 +529,7 @@ impl GatewayClient {
     pub async fn lookup_exit_gateways(&self) -> Result<GatewayList> {
         let exit_gateways = if let Some(nym_vpn_api_client) = &self.nym_vpn_api_client {
             info!("Fetching exit gateways from nym-vpn-api...");
-            let exit_gateways = nym_vpn_api_client.get_exit_gateways().await.unwrap();
+            let exit_gateways = nym_vpn_api_client.get_exit_gateways().await?;
             let mut exit_gateways: Vec<_> = exit_gateways
                 .into_iter()
                 .filter_map(|gw| {

--- a/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
@@ -553,6 +553,7 @@ impl GatewayClient {
                         .inspect_err(|err| warn!("Failed to parse gateway: {err}"))
                         .ok()
                 })
+                .filter(Gateway::has_ipr_address)
                 .collect()
         };
 

--- a/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
@@ -9,7 +9,7 @@ use crate::{
         filter_on_harbour_master_exit_data, select_random_low_latency_described_gateway,
         try_resolve_hostname,
     },
-    DescribedGatewayWithLocation, Error, IpPacketRouterAddress,
+    AuthAddress, DescribedGatewayWithLocation, Error, IpPacketRouterAddress,
 };
 use itertools::Itertools;
 use nym_explorer_client::{ExplorerClient, Location, PrettyDetailedGatewayBond};
@@ -499,7 +499,8 @@ fn append_ipr_and_authenticator_addresses(
                 .clone()
                 .and_then(|d| d.authenticator)
                 .map(|auth| auth.address)
-                .and_then(|address| Recipient::try_from_base58_string(address).ok());
+                .and_then(|address| Recipient::try_from_base58_string(address).ok())
+                .map(|r| AuthAddress(Some(r)))
         }
     }
 }

--- a/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
@@ -479,7 +479,10 @@ impl GatewayClient {
 
 // Append the IPR and authenticator addresses to the gateways. This is a temporary hack until the
 // nymvpn.com endpoints are updated to also include these fields.
-fn append_ipr_and_authenticator_addresses(gateways: &mut [Gateway], described_gateways: Vec<DescribedGateway>) {
+fn append_ipr_and_authenticator_addresses(
+    gateways: &mut [Gateway],
+    described_gateways: Vec<DescribedGateway>,
+) {
     for gateway in gateways.iter_mut() {
         if let Some(described_gateway) = described_gateways
             .iter()

--- a/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
@@ -9,7 +9,7 @@ use crate::{
         filter_on_harbour_master_exit_data, select_random_low_latency_described_gateway,
         try_resolve_hostname,
     },
-    DescribedGatewayWithLocation, Error,
+    DescribedGatewayWithLocation, Error, IpPacketRouterAddress,
 };
 use itertools::Itertools;
 use nym_explorer_client::{ExplorerClient, Location, PrettyDetailedGatewayBond};
@@ -493,7 +493,7 @@ fn append_ipr_and_authenticator_addresses(
                 .clone()
                 .and_then(|d| d.ip_packet_router)
                 .map(|ipr| ipr.address)
-                .and_then(|address| Recipient::try_from_base58_string(address).ok());
+                .and_then(|address| IpPacketRouterAddress::try_from_base58_string(&address).ok());
             gateway.authenticator_address = described_gateway
                 .self_described
                 .clone()

--- a/nym-vpn-core/crates/nym-gateway-directory/src/helpers.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/helpers.rs
@@ -1,10 +1,7 @@
 // Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use crate::{
-    entries::gateway::Gateway, error::Result, DescribedGatewayWithLocation, Error,
-    FORCE_TLS_FOR_GATEWAY_SELECTION,
-};
+use crate::{error::Result, DescribedGatewayWithLocation, Error, FORCE_TLS_FOR_GATEWAY_SELECTION};
 use hickory_resolver::{
     config::{ResolverConfig, ResolverOpts},
     TokioAsyncResolver,
@@ -87,18 +84,6 @@ where
         .into_iter()
         .filter_map(|gateway| gateway.two_letter_iso_country_code())
         .unique()
-        .collect()
-}
-
-pub(crate) fn list_all_country_iso_codes2<'a, I>(gateways: I) -> Vec<String>
-where
-    I: IntoIterator<Item = &'a Gateway>,
-{
-    gateways
-        .into_iter()
-        .filter_map(|gateway| gateway.two_letter_iso_country_code())
-        .unique()
-        .map(|code| code.to_string())
         .collect()
 }
 

--- a/nym-vpn-core/crates/nym-gateway-directory/src/lib.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/lib.rs
@@ -19,5 +19,6 @@ pub use crate::{
 };
 
 pub use nym_sdk::mixnet::{NodeIdentity, Recipient};
+pub use nym_validator_client::models::DescribedGateway;
 
 const FORCE_TLS_FOR_GATEWAY_SELECTION: bool = false;

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/helpers.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/helpers.rs
@@ -9,7 +9,7 @@ use crate::{
     Client, ClientBuilder, VpnApiClientExt,
 };
 
-const NYM_VPN_API: &str = "https://nymvpn.com/api";
+pub const NYM_VPN_API: &str = "https://nymvpn.com/api";
 
 pub fn client_with_user_agent(user_agent: UserAgent) -> Result<Client> {
     ClientBuilder::new(NYM_VPN_API)?

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/helpers.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/helpers.rs
@@ -11,7 +11,7 @@ use crate::{
 
 const NYM_VPN_API: &str = "https://nymvpn.com/api";
 
-fn client_with_user_agent(user_agent: UserAgent) -> Result<Client> {
+pub fn client_with_user_agent(user_agent: UserAgent) -> Result<Client> {
     ClientBuilder::new(NYM_VPN_API)?
         .with_timeout(Duration::from_secs(10))
         .with_user_agent(user_agent)

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/lib.rs
@@ -7,7 +7,7 @@ mod routes;
 pub use client::{Client, ClientBuilder, VpnApiClientExt, VpnApiError};
 pub use error::VpnApiClientError;
 pub use helpers::{
-    get_countries, get_entry_countries, get_entry_gateways, get_exit_countries, get_exit_gateways,
-    get_gateways,
+    client_with_user_agent, get_countries, get_entry_countries, get_entry_gateways,
+    get_exit_countries, get_exit_gateways, get_gateways,
 };
 pub use responses::{Country, Gateway, Location};

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/lib.rs
@@ -11,3 +11,7 @@ pub use helpers::{
     get_exit_countries, get_exit_gateways, get_gateways,
 };
 pub use responses::{Country, Gateway, Location};
+
+// TODO: We need to generalise this into a nymvpn network config struct similar to the mixnet
+// one, that wraps and appends NymNetworkDetails
+pub use helpers::NYM_VPN_API as MAINNET_NYM_VPN_API_URL;

--- a/nym-vpn-core/nym-vpn-cli/src/main.rs
+++ b/nym-vpn-core/nym-vpn-cli/src/main.rs
@@ -142,6 +142,13 @@ async fn run_vpn(args: commands::RunArgs, data_path: Option<PathBuf>) -> Result<
             .map(|url| url.to_string())
             .unwrap_or("unavailable".to_string())
     );
+    info!(
+        "nym-vpn-api: {}",
+        gateway_config
+            .nym_vpn_api_url()
+            .map(|url| url.to_string())
+            .unwrap_or("unavailable".to_string())
+    );
 
     let entry_point = parse_entry_point(&args)?;
     let exit_point = parse_exit_point(&args)?;

--- a/nym-vpn-core/nym-vpn-lib/src/error.rs
+++ b/nym-vpn-core/nym-vpn-lib/src/error.rs
@@ -232,6 +232,9 @@ pub enum Error {
 
     #[error("wiregurad authentication is not possible due to one of the gateways not running the authenticator process: {0}")]
     AuthenticationNotPossible(String),
+
+    #[error("failed to find authenticator address")]
+    AuthenticatorAddressNotFound,
 }
 
 // Result type based on our error type

--- a/nym-vpn-core/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-core/nym-vpn-lib/src/platform/mod.rs
@@ -330,6 +330,7 @@ async fn get_gateway_countries(
         api_url,
         explorer_url: Some(explorer_url),
         harbour_master_url,
+        nym_vpn_api_url: None,
     };
     let user_agent = user_agent
         .map(nym_sdk::UserAgent::from)
@@ -384,6 +385,7 @@ async fn get_low_latency_entry_country(
         api_url,
         explorer_url: Some(explorer_url),
         harbour_master_url,
+        nym_vpn_api_url: None,
     };
     let user_agent = user_agent
         .map(nym_sdk::UserAgent::from)

--- a/nym-vpn-core/nym-vpn-lib/src/tunnel_setup.rs
+++ b/nym-vpn-core/nym-vpn-lib/src/tunnel_setup.rs
@@ -330,33 +330,23 @@ pub async fn setup_tunnel(
         .unwrap();
     let entry_gateway2 = nym_vpn
         .entry_point()
-        .lookup_gateway_identity2(&entry_gateways2)
-        .await?;
+        .lookup_gateway_identity2(&entry_gateways2)?;
 
     let exit_gateways2 = gateway_directory_client
         .lookup_exit_gateways()
         .await
         .unwrap();
-    let exit_gateway2 = nym_vpn
-        .exit_point()
-        .lookup_gateway_identity2(&exit_gateways2)
-        .await?;
+    let exit_router_address2 = nym_vpn.exit_point().lookup_router_address2(
+        &exit_gateways2,
+        &exit_gateways,
+        Some(&entry_gateway_id),
+    )?;
 
     // JON ---
 
     info!("Using entry gateway: {entry_gateway_id}, location: {entry_location_str}");
     info!("Using exit gateway: {exit_gateway_id}, location: {exit_location:?}");
     info!("Using exit router address {exit_router_address}");
-
-    // Lookup gateways using nym-vpn-api-client
-    // let entry_gw = nym_vpn_api_client::get_entry_gateways(user_agent.clone())
-    //     .await
-    //     .unwrap();
-    // let exit_gw = nym_vpn_api_client::get_entry_gateways(user_agent)
-    //     .await
-    //     .unwrap();
-
-    // Select gateway based on location
 
     // Get the IP address of the local LAN gateway
     let default_lan_gateway_ip = routing::LanGatewayIp::get_default_interface()?;

--- a/nym-vpn-core/nym-vpn-lib/src/tunnel_setup.rs
+++ b/nym-vpn-core/nym-vpn-lib/src/tunnel_setup.rs
@@ -316,13 +316,26 @@ pub async fn setup_tunnel(
         .map_err(|err| Error::FailedToLookupGatewayIdentity { source: err })?;
     let entry_location_str = entry_location.as_deref().unwrap_or("unknown");
 
-    let entry_gateways2 = nym_vpn_api_client::get_entry_gateways(user_agent.clone())
+    // JON ---
+    let entry_gateways2 = gateway_directory_client
+        .lookup_entry_gateways()
         .await
         .unwrap();
-    let (entry_gateway_id2, entry_location) = nym_vpn
+    let entry_gateway2 = nym_vpn
         .entry_point()
         .lookup_gateway_identity2(&entry_gateways2)
         .await?;
+
+    let exit_gateways2 = gateway_directory_client
+        .lookup_exit_gateways()
+        .await
+        .unwrap();
+    let exit_gateway2 = nym_vpn
+        .exit_point()
+        .lookup_gateway_identity2(&exit_gateways2)
+        .await?;
+
+    // JON ---
 
     let (exit_router_address, exit_location) = nym_vpn
         .exit_point()

--- a/nym-vpn-core/nym-vpn-lib/src/tunnel_setup.rs
+++ b/nym-vpn-core/nym-vpn-lib/src/tunnel_setup.rs
@@ -310,6 +310,8 @@ pub async fn setup_tunnel(
     let exit_gateway = nym_vpn.exit_point().lookup_gateway(&exit_gateways)?;
 
     {
+        info!("Found {} entry gateways", entry_gateways.len());
+        info!("Found {} exit gateways", exit_gateways.len());
         info!(
             "Using entry gateway: {}, location: {}",
             *entry_gateway.identity(),

--- a/nym-vpn-core/nym-vpn-lib/src/tunnel_setup.rs
+++ b/nym-vpn-core/nym-vpn-lib/src/tunnel_setup.rs
@@ -298,9 +298,7 @@ pub async fn setup_tunnel(
         .lookup_entry_gateways()
         .await
         .unwrap();
-    let entry_gateway = nym_vpn
-        .entry_point()
-        .lookup_gateway_identity2(&entry_gateways)?;
+    let entry_gateway = nym_vpn.entry_point().lookup_gateway(&entry_gateways)?;
 
     // Setup the gateway that we will use as the exit point
     let mut exit_gateways = gateway_directory_client
@@ -309,9 +307,7 @@ pub async fn setup_tunnel(
         .unwrap();
     // Exclude the entry gateway from the list of exit gateways for privacy reasons
     exit_gateways.remove_gateway(&entry_gateway);
-    let exit_gateway = nym_vpn
-        .exit_point()
-        .lookup_gateway_identity2(&exit_gateways)?;
+    let exit_gateway = nym_vpn.exit_point().lookup_gateway(&exit_gateways)?;
 
     {
         info!(

--- a/nym-vpn-core/nym-vpn-lib/src/tunnel_setup.rs
+++ b/nym-vpn-core/nym-vpn-lib/src/tunnel_setup.rs
@@ -293,6 +293,7 @@ pub async fn setup_tunnel(
             source: err,
         })?;
 
+    // Setup the gateway that we will use as the entry point
     let entry_gateways = gateway_directory_client
         .lookup_entry_gateways()
         .await
@@ -301,10 +302,12 @@ pub async fn setup_tunnel(
         .entry_point()
         .lookup_gateway_identity2(&entry_gateways)?;
 
+    // Setup the gateway that we will use as the exit point
     let mut exit_gateways = gateway_directory_client
         .lookup_exit_gateways()
         .await
         .unwrap();
+    // Exclude the entry gateway from the list of exit gateways for privacy reasons
     exit_gateways.remove_gateway(&entry_gateway);
     let exit_gateway = nym_vpn
         .exit_point()

--- a/nym-vpn-core/nym-vpn-lib/src/tunnel_setup.rs
+++ b/nym-vpn-core/nym-vpn-lib/src/tunnel_setup.rs
@@ -294,17 +294,11 @@ pub async fn setup_tunnel(
         })?;
 
     // Setup the gateway that we will use as the entry point
-    let entry_gateways = gateway_directory_client
-        .lookup_entry_gateways()
-        .await
-        .unwrap();
+    let entry_gateways = gateway_directory_client.lookup_entry_gateways().await?;
     let entry_gateway = nym_vpn.entry_point().lookup_gateway(&entry_gateways)?;
 
     // Setup the gateway that we will use as the exit point
-    let mut exit_gateways = gateway_directory_client
-        .lookup_exit_gateways()
-        .await
-        .unwrap();
+    let mut exit_gateways = gateway_directory_client.lookup_exit_gateways().await?;
     // Exclude the entry gateway from the list of exit gateways for privacy reasons
     exit_gateways.remove_gateway(&entry_gateway);
     let exit_gateway = nym_vpn.exit_point().lookup_gateway(&exit_gateways)?;

--- a/nym-vpn-core/nym-vpn-lib/src/tunnel_setup.rs
+++ b/nym-vpn-core/nym-vpn-lib/src/tunnel_setup.rs
@@ -316,6 +316,13 @@ pub async fn setup_tunnel(
         .map_err(|err| Error::FailedToLookupGatewayIdentity { source: err })?;
     let entry_location_str = entry_location.as_deref().unwrap_or("unknown");
 
+    let (exit_router_address, exit_location) = nym_vpn
+        .exit_point()
+        .lookup_router_address(&exit_gateways, Some(&entry_gateway_id))
+        .map_err(|err| Error::FailedToLookupRouterAddress { source: err })?;
+
+    let exit_gateway_id = exit_router_address.gateway();
+
     // JON ---
     let entry_gateways2 = gateway_directory_client
         .lookup_entry_gateways()
@@ -336,13 +343,6 @@ pub async fn setup_tunnel(
         .await?;
 
     // JON ---
-
-    let (exit_router_address, exit_location) = nym_vpn
-        .exit_point()
-        .lookup_router_address(&exit_gateways, Some(&entry_gateway_id))
-        .map_err(|err| Error::FailedToLookupRouterAddress { source: err })?;
-
-    let exit_gateway_id = exit_router_address.gateway();
 
     info!("Using entry gateway: {entry_gateway_id}, location: {entry_location_str}");
     info!("Using exit gateway: {exit_gateway_id}, location: {exit_location:?}");

--- a/nym-vpn-core/nym-vpnd/src/service/error.rs
+++ b/nym-vpn-core/nym-vpnd/src/service/error.rs
@@ -192,6 +192,7 @@ impl From<&nym_vpn_lib::error::Error> for ConnectionFailedError {
             | nym_vpn_lib::error::Error::InvalidGatewayAuthResponse
             | nym_vpn_lib::error::Error::AuthenticatorClientError(_)
             | nym_vpn_lib::error::Error::AuthenticationNotPossible(_)
+            | nym_vpn_lib::error::Error::AuthenticatorAddressNotFound
             | nym_vpn_lib::error::Error::BadWireguardEvent => {
                 ConnectionFailedError::Unhandled(format!("unhandled error: {err:#?}"))
             }


### PR DESCRIPTION
This PR primary purpose is to replace calls to nym-api + explorer-api + harbourmaster with calls to nymvpn.com, which should greatly simplify things. This initial step makes calls to nymvpn.com and then annotates them with data from the nym-api, until the IPR and authenticator addresses are added to the nymvpn.com endpoint responses. Nonetheless, this allows us to drop the explicit dependency on explore-api and harbourmaster.

After this there are now a lot of code that is only used in nym-gateway-probe, which after we also port over to the new types introduced in this PR we can remove.

- Use nymvpn.com API for fetching entry and exit gateways
- Remove requests to harbourmaster
- Remove requests to explorer-api