### PR TITLE
Add min mixnode performance to daemon connect options

### DIFF
--- a/nym-vpn-core/nym-vpnc/src/cli.rs
+++ b/nym-vpn-core/nym-vpnc/src/cli.rs
@@ -64,6 +64,11 @@ pub(crate) struct ConnectArgs {
     /// Enable credentials mode.
     #[arg(long)]
     pub(crate) enable_credentials_mode: bool,
+
+    /// An integer between 0 and 100 representing the minimum mixnode performance required to
+    /// consider a mixnode for routing traffic.
+    #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]
+    pub(crate) min_mixnode_performance: Option<u8>,
 }
 
 #[derive(Args)]

--- a/nym-vpn-core/nym-vpnc/src/main.rs
+++ b/nym-vpn-core/nym-vpnc/src/main.rs
@@ -7,6 +7,7 @@ use nym_vpn_proto::{
     ConnectRequest, DisconnectRequest, Empty, ImportUserCredentialRequest, InfoRequest,
     ListEntryGatewaysRequest, ListExitGatewaysRequest, StatusRequest,
 };
+use protobuf_conversion::into_threshold;
 use vpnd_client::ClientType;
 
 use crate::{
@@ -58,6 +59,7 @@ async fn connect(client_type: ClientType, connect_args: &cli::ConnectArgs) -> Re
         enable_poisson_rate: connect_args.enable_poisson_rate,
         disable_background_cover_traffic: connect_args.disable_background_cover_traffic,
         enable_credentials_mode: connect_args.enable_credentials_mode,
+        min_mixnode_performance: connect_args.min_mixnode_performance.map(into_threshold),
     });
 
     let mut client = vpnd_client::get_client(client_type).await?;

--- a/nym-vpn-core/nym-vpnc/src/protobuf_conversion.rs
+++ b/nym-vpn-core/nym-vpnc/src/protobuf_conversion.rs
@@ -100,7 +100,9 @@ pub(crate) fn ipaddr_into_string(ip: std::net::IpAddr) -> nym_vpn_proto::Dns {
 }
 
 pub(crate) fn into_threshold(performance: u8) -> nym_vpn_proto::Threshold {
-    nym_vpn_proto::Threshold { min_performance: performance.into() }
+    nym_vpn_proto::Threshold {
+        min_performance: performance.into(),
+    }
 }
 
 pub(crate) fn parse_offset_datetime(

--- a/nym-vpn-core/nym-vpnc/src/protobuf_conversion.rs
+++ b/nym-vpn-core/nym-vpnc/src/protobuf_conversion.rs
@@ -99,6 +99,10 @@ pub(crate) fn ipaddr_into_string(ip: std::net::IpAddr) -> nym_vpn_proto::Dns {
     nym_vpn_proto::Dns { ip: ip.to_string() }
 }
 
+pub(crate) fn into_threshold(performance: u8) -> nym_vpn_proto::Threshold {
+    nym_vpn_proto::Threshold { min_performance: performance.into() }
+}
+
 pub(crate) fn parse_offset_datetime(
     timestamp: prost_types::Timestamp,
 ) -> Result<time::OffsetDateTime, time::Error> {

--- a/nym-vpn-core/nym-vpnd/src/command_interface/listener.rs
+++ b/nym-vpn-core/nym-vpnd/src/command_interface/listener.rs
@@ -351,6 +351,9 @@ impl TryFrom<ConnectRequest> for ConnectOptions {
             enable_poisson_rate: request.enable_poisson_rate,
             disable_background_cover_traffic: request.disable_background_cover_traffic,
             enable_credentials_mode: request.enable_credentials_mode,
+            min_mixnode_performance: request
+                .min_mixnode_performance
+                .map(|t| t.min_performance.min(100) as u8),
         })
     }
 }

--- a/nym-vpn-core/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/nym-vpnd/src/service/vpn_service.rs
@@ -115,6 +115,7 @@ pub(crate) struct ConnectOptions {
     pub(crate) enable_poisson_rate: bool,
     pub(crate) disable_background_cover_traffic: bool,
     pub(crate) enable_credentials_mode: bool,
+    pub(crate) min_mixnode_performance: Option<u8>,
 }
 
 #[derive(Debug)]

--- a/nym-vpn-core/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/nym-vpnd/src/service/vpn_service.rs
@@ -433,6 +433,7 @@ impl NymVpnService {
             .mixnet_client_config
             .disable_background_cover_traffic = options.disable_background_cover_traffic;
         nym_vpn.mixnet_client_config.enable_credentials_mode = options.enable_credentials_mode;
+        nym_vpn.mixnet_client_config.min_mixnode_performance = options.min_mixnode_performance;
 
         let handle = nym_vpn_lib::spawn_nym_vpn_with_new_runtime(nym_vpn.into()).unwrap();
 

--- a/nym-vpn-x/src-tauri/src/grpc/client.rs
+++ b/nym-vpn-x/src-tauri/src/grpc/client.rs
@@ -292,6 +292,7 @@ impl GrpcClient {
             disable_background_cover_traffic: false,
             enable_credentials_mode: false,
             dns,
+            min_mixnode_performance: None,
         });
         let response = vpnd.vpn_connect(request).await.map_err(|e| {
             error!("grpc vpn_connect: {}", e);

--- a/proto/nym/vpn.proto
+++ b/proto/nym/vpn.proto
@@ -49,6 +49,10 @@ message InfoResponse {
   string git_commit = 4;
 }
 
+message Threshold {
+  uint32 min_performance = 1;
+}
+
 message ConnectRequest {
   EntryNode entry = 1;
   ExitNode exit = 2;
@@ -58,6 +62,7 @@ message ConnectRequest {
   bool enable_poisson_rate = 6;
   bool disable_background_cover_traffic = 7;
   bool enable_credentials_mode = 8;
+  Threshold min_mixnode_performance = 9;
 }
 
 message ConnectResponse {


### PR DESCRIPTION
Pass the new min_mixnode_performance flag to the vpnd connect RPC