### PR TITLE
Use nym repo fork before ecash

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -3562,7 +3562,7 @@ dependencies = [
 [[package]]
 name = "nym-api-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "bs58 0.5.1",
  "cosmrs",
@@ -3596,7 +3596,7 @@ dependencies = [
 [[package]]
 name = "nym-authenticator-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "bincode",
  "nym-sphinx",
@@ -3608,7 +3608,7 @@ dependencies = [
 [[package]]
 name = "nym-bandwidth-controller"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "bip39",
  "log",
@@ -3628,7 +3628,7 @@ dependencies = [
 [[package]]
 name = "nym-bin-common"
 version = "0.6.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "const-str",
  "log",
@@ -3642,7 +3642,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core"
 version = "1.1.15"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -3698,7 +3698,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-config-types"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "humantime-serde",
  "nym-config",
@@ -3714,7 +3714,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-gateways-storage"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "async-trait",
  "cosmrs",
@@ -3733,7 +3733,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-surb-storage"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -3750,7 +3750,7 @@ dependencies = [
 [[package]]
 name = "nym-coconut"
 version = "0.5.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "bls12_381",
  "bs58 0.5.1",
@@ -3771,7 +3771,7 @@ dependencies = [
 [[package]]
 name = "nym-coconut-bandwidth-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -3781,7 +3781,7 @@ dependencies = [
 [[package]]
 name = "nym-coconut-dkg-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -3795,7 +3795,7 @@ dependencies = [
 [[package]]
 name = "nym-config"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "dirs 5.0.1",
  "handlebars",
@@ -3825,7 +3825,7 @@ dependencies = [
 [[package]]
 name = "nym-contracts-common"
 version = "0.5.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "bs58 0.5.1",
  "cosmwasm-schema",
@@ -3840,7 +3840,7 @@ dependencies = [
 [[package]]
 name = "nym-country-group"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "serde",
  "tracing",
@@ -3849,7 +3849,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-storage"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "async-trait",
  "log",
@@ -3862,7 +3862,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-utils"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "log",
  "nym-bandwidth-controller",
@@ -3879,7 +3879,7 @@ dependencies = [
 [[package]]
 name = "nym-credentials"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "bincode",
  "bls12_381",
@@ -3898,7 +3898,7 @@ dependencies = [
 [[package]]
 name = "nym-credentials-interface"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "bls12_381",
  "nym-coconut",
@@ -3909,7 +3909,7 @@ dependencies = [
 [[package]]
 name = "nym-crypto"
 version = "0.4.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "aes 0.8.4",
  "blake3",
@@ -3935,7 +3935,7 @@ dependencies = [
 [[package]]
 name = "nym-dkg"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "bitvec",
  "bls12_381",
@@ -3957,7 +3957,7 @@ dependencies = [
 [[package]]
 name = "nym-exit-policy"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "serde",
  "thiserror",
@@ -3967,7 +3967,7 @@ dependencies = [
 [[package]]
 name = "nym-explorer-api-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "nym-api-requests",
  "nym-contracts-common",
@@ -3979,7 +3979,7 @@ dependencies = [
 [[package]]
 name = "nym-explorer-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "log",
  "nym-explorer-api-requests",
@@ -3992,7 +3992,7 @@ dependencies = [
 [[package]]
 name = "nym-gateway-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "futures",
  "getrandom 0.2.12",
@@ -4084,7 +4084,7 @@ dependencies = [
 [[package]]
 name = "nym-gateway-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "bs58 0.5.1",
  "futures",
@@ -4108,7 +4108,7 @@ dependencies = [
 [[package]]
 name = "nym-group-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "cosmwasm-schema",
  "cw-controllers",
@@ -4133,7 +4133,7 @@ dependencies = [
 [[package]]
 name = "nym-http-api-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "async-trait",
  "http 1.1.0",
@@ -4150,7 +4150,7 @@ dependencies = [
 [[package]]
 name = "nym-id"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "nym-credential-storage",
  "nym-credentials",
@@ -4177,7 +4177,7 @@ dependencies = [
 [[package]]
 name = "nym-ip-packet-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "bincode",
  "bytes",
@@ -4195,7 +4195,7 @@ dependencies = [
 [[package]]
 name = "nym-metrics"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "dashmap",
  "lazy_static",
@@ -4206,7 +4206,7 @@ dependencies = [
 [[package]]
 name = "nym-mixnet-contract-common"
 version = "0.6.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "bs58 0.4.0",
  "cosmwasm-schema",
@@ -4225,7 +4225,7 @@ dependencies = [
 [[package]]
 name = "nym-multisig-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -4241,7 +4241,7 @@ dependencies = [
 [[package]]
 name = "nym-network-defaults"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "cfg-if",
  "dotenvy",
@@ -4257,7 +4257,7 @@ dependencies = [
 [[package]]
 name = "nym-node-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -4279,7 +4279,7 @@ dependencies = [
 [[package]]
 name = "nym-nonexhaustive-delayqueue"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -4290,7 +4290,7 @@ dependencies = [
 [[package]]
 name = "nym-ordered-buffer"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "log",
  "thiserror",
@@ -4299,7 +4299,7 @@ dependencies = [
 [[package]]
 name = "nym-outfox"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "blake3",
  "chacha20 0.9.1",
@@ -4317,7 +4317,7 @@ dependencies = [
 [[package]]
 name = "nym-pemstore"
 version = "0.3.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "pem",
 ]
@@ -4325,7 +4325,7 @@ dependencies = [
 [[package]]
 name = "nym-sdk"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "async-trait",
  "bip39",
@@ -4361,7 +4361,7 @@ dependencies = [
 [[package]]
 name = "nym-service-providers-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "async-trait",
  "log",
@@ -4375,7 +4375,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-client-core"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "anyhow",
  "dirs 4.0.0",
@@ -4408,7 +4408,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-proxy-helpers"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "bytes",
  "futures",
@@ -4423,7 +4423,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "bincode",
  "log",
@@ -4439,7 +4439,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "log",
  "nym-crypto",
@@ -4463,7 +4463,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-acknowledgements"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "nym-crypto",
  "nym-pemstore",
@@ -4480,7 +4480,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-addressing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-types",
@@ -4491,7 +4491,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-anonymous-replies"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "bs58 0.5.1",
  "nym-crypto",
@@ -4509,7 +4509,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-chunking"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "log",
  "nym-sphinx-addressing",
@@ -4522,7 +4522,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-cover"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-acknowledgements",
@@ -4540,7 +4540,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-forwarding"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "nym-outfox",
  "nym-sphinx-addressing",
@@ -4552,7 +4552,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-framing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "bytes",
  "nym-sphinx-params",
@@ -4564,7 +4564,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-params"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-types",
@@ -4575,7 +4575,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-routing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "nym-sphinx-addressing",
  "nym-sphinx-types",
@@ -4585,7 +4585,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-types"
 version = "0.2.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "nym-outfox",
  "sphinx-packet",
@@ -4595,7 +4595,7 @@ dependencies = [
 [[package]]
 name = "nym-task"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "futures",
  "log",
@@ -4609,7 +4609,7 @@ dependencies = [
 [[package]]
 name = "nym-topology"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "async-trait",
  "bs58 0.5.1",
@@ -4632,7 +4632,7 @@ dependencies = [
 [[package]]
 name = "nym-validator-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -4679,7 +4679,7 @@ dependencies = [
 [[package]]
 name = "nym-vesting-contract-common"
 version = "0.7.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -4881,7 +4881,7 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-types"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "base64 0.21.7",
  "dashmap",
@@ -8413,7 +8413,7 @@ checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 [[package]]
 name = "wasm-utils"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "console_error_panic_hook",
  "futures",

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -99,22 +99,24 @@ url = "2.5"
 vergen = { version = "8.3.1", default-features = false }
 zeroize = "1.6.0"
 
-nym-authenticator-requests = { git = "https://github.com/nymtech/nym", rev = "6f66986" }
-nym-bandwidth-controller = { git = "https://github.com/nymtech/nym", rev = "6f66986" }
-nym-bin-common = { git = "https://github.com/nymtech/nym", rev = "6f66986" }
-nym-client-core = { git = "https://github.com/nymtech/nym", rev = "6f66986" }
-nym-config = { git = "https://github.com/nymtech/nym", rev = "6f66986" }
-nym-credential-storage = { git = "https://github.com/nymtech/nym", rev = "6f66986" }
-nym-credentials = { git = "https://github.com/nymtech/nym", rev = "6f66986" }
-nym-crypto = { git = "https://github.com/nymtech/nym", rev = "6f66986" }
-nym-explorer-client = { git = "https://github.com/nymtech/nym", rev = "6f66986" }
-nym-http-api-client = { git = "https://github.com/nymtech/nym", rev = "6f66986" }
-nym-id = { git = "https://github.com/nymtech/nym", rev = "6f66986" }
-nym-ip-packet-requests = { git = "https://github.com/nymtech/nym", rev = "6f66986" }
-nym-node-requests = { git = "https://github.com/nymtech/nym", rev = "6f66986" }
-nym-pemstore = { git = "https://github.com/nymtech/nym", rev = "6f66986" }
-nym-sdk = { git = "https://github.com/nymtech/nym", rev = "6f66986" }
-nym-task = { git = "https://github.com/nymtech/nym", rev = "6f66986" }
-nym-topology = { git = "https://github.com/nymtech/nym", rev = "6f66986" }
-nym-validator-client = { git = "https://github.com/nymtech/nym", rev = "6f66986" }
-nym-wireguard-types = { git = "https://github.com/nymtech/nym", rev = "6f66986" }
+# Use the develop-pre-ecash-for-vpn branch until we have ported the vpn client to use ecash
+
+nym-authenticator-requests = { git = "https://github.com/nymtech/nym", rev = "e5d68a5e" }
+nym-bandwidth-controller = { git = "https://github.com/nymtech/nym", rev = "e5d68a5e" }
+nym-bin-common = { git = "https://github.com/nymtech/nym", rev = "e5d68a5e" }
+nym-client-core = { git = "https://github.com/nymtech/nym", rev = "e5d68a5e" }
+nym-config = { git = "https://github.com/nymtech/nym", rev = "e5d68a5e" }
+nym-credential-storage = { git = "https://github.com/nymtech/nym", rev = "e5d68a5e" }
+nym-credentials = { git = "https://github.com/nymtech/nym", rev = "e5d68a5e" }
+nym-crypto = { git = "https://github.com/nymtech/nym", rev = "e5d68a5e" }
+nym-explorer-client = { git = "https://github.com/nymtech/nym", rev = "e5d68a5e" }
+nym-http-api-client = { git = "https://github.com/nymtech/nym", rev = "e5d68a5e" }
+nym-id = { git = "https://github.com/nymtech/nym", rev = "e5d68a5e" }
+nym-ip-packet-requests = { git = "https://github.com/nymtech/nym", rev = "e5d68a5e" }
+nym-node-requests = { git = "https://github.com/nymtech/nym", rev = "e5d68a5e" }
+nym-pemstore = { git = "https://github.com/nymtech/nym", rev = "e5d68a5e" }
+nym-sdk = { git = "https://github.com/nymtech/nym", rev = "e5d68a5e" }
+nym-task = { git = "https://github.com/nymtech/nym", rev = "e5d68a5e" }
+nym-topology = { git = "https://github.com/nymtech/nym", rev = "e5d68a5e" }
+nym-validator-client = { git = "https://github.com/nymtech/nym", rev = "e5d68a5e" }
+nym-wireguard-types = { git = "https://github.com/nymtech/nym", rev = "e5d68a5e" }

--- a/nym-vpn-x/src-tauri/Cargo.lock
+++ b/nym-vpn-x/src-tauri/Cargo.lock
@@ -4249,7 +4249,7 @@ dependencies = [
 [[package]]
 name = "nym-api-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "bs58 0.5.1",
  "cosmrs",
@@ -4269,7 +4269,7 @@ dependencies = [
 [[package]]
 name = "nym-bandwidth-controller"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "bip39",
  "log",
@@ -4289,7 +4289,7 @@ dependencies = [
 [[package]]
 name = "nym-bin-common"
 version = "0.6.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "const-str",
  "log",
@@ -4303,7 +4303,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core"
 version = "1.1.15"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -4359,7 +4359,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-config-types"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "humantime-serde",
  "nym-config",
@@ -4375,7 +4375,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-gateways-storage"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "async-trait",
  "cosmrs",
@@ -4394,7 +4394,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-surb-storage"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -4411,7 +4411,7 @@ dependencies = [
 [[package]]
 name = "nym-coconut"
 version = "0.5.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "bls12_381",
  "bs58 0.5.1",
@@ -4432,7 +4432,7 @@ dependencies = [
 [[package]]
 name = "nym-coconut-bandwidth-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -4442,7 +4442,7 @@ dependencies = [
 [[package]]
 name = "nym-coconut-dkg-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -4456,7 +4456,7 @@ dependencies = [
 [[package]]
 name = "nym-config"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "dirs 5.0.1",
  "handlebars",
@@ -4470,7 +4470,7 @@ dependencies = [
 [[package]]
 name = "nym-contracts-common"
 version = "0.5.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "bs58 0.5.1",
  "cosmwasm-schema",
@@ -4485,7 +4485,7 @@ dependencies = [
 [[package]]
 name = "nym-country-group"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "serde",
  "tracing",
@@ -4494,7 +4494,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-storage"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "async-trait",
  "log",
@@ -4507,7 +4507,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-utils"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "log",
  "nym-bandwidth-controller",
@@ -4524,7 +4524,7 @@ dependencies = [
 [[package]]
 name = "nym-credentials"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "bincode",
  "bls12_381",
@@ -4543,7 +4543,7 @@ dependencies = [
 [[package]]
 name = "nym-credentials-interface"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "bls12_381",
  "nym-coconut",
@@ -4554,7 +4554,7 @@ dependencies = [
 [[package]]
 name = "nym-crypto"
 version = "0.4.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "aes",
  "blake3",
@@ -4580,7 +4580,7 @@ dependencies = [
 [[package]]
 name = "nym-dkg"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "bitvec",
  "bls12_381",
@@ -4602,7 +4602,7 @@ dependencies = [
 [[package]]
 name = "nym-exit-policy"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "serde",
  "thiserror",
@@ -4612,7 +4612,7 @@ dependencies = [
 [[package]]
 name = "nym-explorer-api-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "nym-api-requests",
  "nym-contracts-common",
@@ -4624,7 +4624,7 @@ dependencies = [
 [[package]]
 name = "nym-explorer-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "log",
  "nym-explorer-api-requests",
@@ -4637,7 +4637,7 @@ dependencies = [
 [[package]]
 name = "nym-gateway-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "futures",
  "getrandom 0.2.12",
@@ -4696,7 +4696,7 @@ dependencies = [
 [[package]]
 name = "nym-gateway-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "bs58 0.5.1",
  "futures",
@@ -4720,7 +4720,7 @@ dependencies = [
 [[package]]
 name = "nym-group-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "cosmwasm-schema",
  "cw-controllers",
@@ -4745,7 +4745,7 @@ dependencies = [
 [[package]]
 name = "nym-http-api-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "async-trait",
  "http 1.1.0",
@@ -4762,7 +4762,7 @@ dependencies = [
 [[package]]
 name = "nym-id"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "nym-credential-storage",
  "nym-credentials",
@@ -4775,7 +4775,7 @@ dependencies = [
 [[package]]
 name = "nym-metrics"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "dashmap",
  "lazy_static",
@@ -4786,7 +4786,7 @@ dependencies = [
 [[package]]
 name = "nym-mixnet-contract-common"
 version = "0.6.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "bs58 0.4.0",
  "cosmwasm-schema",
@@ -4805,7 +4805,7 @@ dependencies = [
 [[package]]
 name = "nym-multisig-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -4821,7 +4821,7 @@ dependencies = [
 [[package]]
 name = "nym-network-defaults"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "cfg-if",
  "dotenvy",
@@ -4837,7 +4837,7 @@ dependencies = [
 [[package]]
 name = "nym-node-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "base64 0.21.7",
  "celes",
@@ -4857,7 +4857,7 @@ dependencies = [
 [[package]]
 name = "nym-nonexhaustive-delayqueue"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -4868,7 +4868,7 @@ dependencies = [
 [[package]]
 name = "nym-ordered-buffer"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "log",
  "thiserror",
@@ -4877,7 +4877,7 @@ dependencies = [
 [[package]]
 name = "nym-outfox"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "blake3",
  "chacha20",
@@ -4895,7 +4895,7 @@ dependencies = [
 [[package]]
 name = "nym-pemstore"
 version = "0.3.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "pem",
 ]
@@ -4903,7 +4903,7 @@ dependencies = [
 [[package]]
 name = "nym-sdk"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "async-trait",
  "bip39",
@@ -4939,7 +4939,7 @@ dependencies = [
 [[package]]
 name = "nym-service-providers-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "async-trait",
  "log",
@@ -4953,7 +4953,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-client-core"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "anyhow",
  "dirs 4.0.0",
@@ -4986,7 +4986,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-proxy-helpers"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "bytes",
  "futures",
@@ -5001,7 +5001,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "bincode",
  "log",
@@ -5017,7 +5017,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "log",
  "nym-crypto",
@@ -5041,7 +5041,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-acknowledgements"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "nym-crypto",
  "nym-pemstore",
@@ -5058,7 +5058,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-addressing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-types",
@@ -5069,7 +5069,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-anonymous-replies"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "bs58 0.5.1",
  "nym-crypto",
@@ -5087,7 +5087,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-chunking"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "log",
  "nym-sphinx-addressing",
@@ -5100,7 +5100,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-cover"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-acknowledgements",
@@ -5118,7 +5118,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-forwarding"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "nym-outfox",
  "nym-sphinx-addressing",
@@ -5130,7 +5130,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-framing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "bytes",
  "nym-sphinx-params",
@@ -5142,7 +5142,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-params"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-types",
@@ -5153,7 +5153,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-routing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "nym-sphinx-addressing",
  "nym-sphinx-types",
@@ -5163,7 +5163,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-types"
 version = "0.2.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "nym-outfox",
  "sphinx-packet",
@@ -5173,7 +5173,7 @@ dependencies = [
 [[package]]
 name = "nym-task"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "futures",
  "log",
@@ -5187,7 +5187,7 @@ dependencies = [
 [[package]]
 name = "nym-topology"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "async-trait",
  "bs58 0.5.1",
@@ -5210,7 +5210,7 @@ dependencies = [
 [[package]]
 name = "nym-validator-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -5257,7 +5257,7 @@ dependencies = [
 [[package]]
 name = "nym-vesting-contract-common"
 version = "0.7.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -5332,7 +5332,7 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-types"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "base64 0.21.7",
  "dashmap",
@@ -8942,7 +8942,7 @@ checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 [[package]]
 name = "wasm-utils"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=6f66986#6f669866e92e637772726ad05caa5c5501a830f3"
+source = "git+https://github.com/nymtech/nym?rev=e5d68a5e#e5d68a5e7fba071e46bc8c2eb068f15c08fbb15f"
 dependencies = [
  "console_error_panic_hook",
  "futures",

--- a/nym-vpn-x/src-tauri/Cargo.toml
+++ b/nym-vpn-x/src-tauri/Cargo.toml
@@ -55,10 +55,10 @@ reqwest = { version = "0.12", features = ["json"] }
 rust_iso3166 = "0.1"
 
 # nym deps
-nym-config = { git = "https://github.com/nymtech/nym", rev = "6f66986" }
+nym-config = { git = "https://github.com/nymtech/nym", rev = "e5d68a5e" }
 nym-vpn-proto = { path = "../../nym-vpn-core/crates/nym-vpn-proto" }
 nym-gateway-directory = { path = "../../nym-vpn-core/crates/nym-gateway-directory/" }
-nym-bin-common = { git = "https://github.com/nymtech/nym", rev = "6f66986" }
+nym-bin-common = { git = "https://github.com/nymtech/nym", rev = "e5d68a5e" }
 [target."cfg(windows)".dependencies]
 windows = { version = "0.57.0", features = [
     "Win32_System_Console",


### PR DESCRIPTION
To fix the handling of NYM_VPN_API env variable that affects non-mainnets, use a fork of develop from before ecash but with the fix applied.