### PR TITLE
Joint core workspace version to simplify releases

### DIFF
--- a/.github/workflows/publish-nym-vpn-core.yml
+++ b/.github/workflows/publish-nym-vpn-core.yml
@@ -73,40 +73,11 @@ jobs:
           toolchain: stable
           components: rustfmt, clippy
 
-      - name: Get package version cli
-        id: package-version-cli
+      - name: Get nym-vpn-core workspace version
+        id: workspace-version
         uses: nicolaiunrein/cargo-get@master
         with:
-          subcommand: package.version --entry nym-vpn-core/nym-vpn-cli
-
-      - name: Get package version vpnc
-        id: package-version-vpnc
-        uses: nicolaiunrein/cargo-get@master
-        with:
-          subcommand: package.version --entry nym-vpn-core/crates/nym-vpnc
-
-      - name: Get package version vpnd
-        id: package-version-vpnd
-        uses: nicolaiunrein/cargo-get@master
-        with:
-          subcommand: package.version --entry nym-vpn-core/crates/nym-vpnd
-
-      - name: Get package version lib
-        id: package-version-lib
-        uses: nicolaiunrein/cargo-get@master
-        with:
-          subcommand: package.version --entry nym-vpn-core/nym-vpn-lib
-
-      - name: Check tag name consistency
-        if: github.event_name == 'push'
-        shell: bash
-        run: |
-          if [[ "${{ steps.package-version-cli.outputs.metadata }}" == "${{ steps.package-version-vpnc.outputs.metadata }}" && "${{ steps.package-version-cli.outputs.metadata }}" == "${{ steps.package-version-vpnd.outputs.metadata }}" && "${{ steps.package-version-cli.outputs.metadata }}" == "${{ steps.package-version-lib.outputs.metadata }}" ]]; then
-            if [[ nym-vpn-core-v${{ steps.package-version-cli.outputs.metadata }}  != ${{ github.ref_name }} ]]; then
-            exit 1
-            fi
-            else exit 1
-          fi
+          subcommand: workspace.package.version --entry nym-vpn-core
 
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -121,11 +92,11 @@ jobs:
 
       - name: Generate checksums and create tar.gz archive per platform
         run: |
-          ARCHIVE_LINUX=nym-vpn-core-v${{ steps.package-version-lib.outputs.metadata }}_linux_x86_64
-          ARCHIVE_MAC=nym-vpn-core-v${{ steps.package-version-lib.outputs.metadata }}_macos_universal
-          ARCHIVE_ANDROID=nym-vpn-core-v${{ steps.package-version-lib.outputs.metadata }}_android_aarch64
-          ARCHIVE_IOS=nym-vpn-core-v${{ steps.package-version-lib.outputs.metadata }}_ios_universal
-          ARCHIVE_WINDOWS=nym-vpn-core-v${{ steps.package-version-lib.outputs.metadata }}_windows_x86_64
+          ARCHIVE_LINUX=nym-vpn-core-v${{ steps.workspace-version.outputs.metadata }}_linux_x86_64
+          ARCHIVE_MAC=nym-vpn-core-v${{ steps.workspace-version.outputs.metadata }}_macos_universal
+          ARCHIVE_ANDROID=nym-vpn-core-v${{ steps.workspace-version.outputs.metadata }}_android_aarch64
+          ARCHIVE_IOS=nym-vpn-core-v${{ steps.workspace-version.outputs.metadata }}_ios_universal
+          ARCHIVE_WINDOWS=nym-vpn-core-v${{ steps.workspace-version.outputs.metadata }}_windows_x86_64
           echo "ARCHIVE_LINUX=${ARCHIVE_LINUX}" >> $GITHUB_ENV
           echo "ARCHIVE_MAC=${ARCHIVE_MAC}" >> $GITHUB_ENV
           echo "ARCHIVE_ANDROID=${ARCHIVE_ANDROID}" >> $GITHUB_ENV
@@ -171,7 +142,7 @@ jobs:
       - name: Setting subject, prerelease and notes files
         if: ${{ contains(env.TAG_NAME, 'nightly') }}
         run: |
-          (echo "SUBJECT=nym-vpn-core-v${{ steps.package-version-lib.outputs.metadata }} nightly prerelease build";
+          (echo "SUBJECT=nym-vpn-core-v${{ steps.workspace-version.outputs.metadata }} nightly prerelease build";
            echo 'PRERELEASE=--prerelease';
            echo 'NOTES_FILE=release-notes/release-notes-core-nightly.md') >> $GITHUB_ENV
           gh release delete nightly --yes || true

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -4051,7 +4051,7 @@ dependencies = [
 
 [[package]]
 name = "nym-gateway-probe"
-version = "0.1.0"
+version = "0.1.12-dev"
 dependencies = [
  "anyhow",
  "bincode",

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -39,6 +39,7 @@ members = [
 # nym-wireguard-types = { path = "../../nym/common/wireguard-types" }
 
 [workspace.package]
+version = "0.1.12-dev"
 authors = ["Nym Technologies SA"]
 repository = "https://github.com/nymtech/nym-vpn-client"
 homepage = "https://nymtech.net"

--- a/nym-vpn-core/crates/nym-gateway-probe/Cargo.toml
+++ b/nym-vpn-core/crates/nym-gateway-probe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nym-gateway-probe"
-version = "0.1.0"
+version.workspace = true
 authors.workspace = true
 repository.workspace = true
 homepage.workspace = true

--- a/nym-vpn-core/crates/nym-vpnc/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpnc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nym-vpnc"
-version = "0.1.12-dev"
 description = "NymVPN commandline client"
+version.workspace = true
 authors.workspace = true
 repository.workspace = true
 homepage.workspace = true

--- a/nym-vpn-core/crates/nym-vpnd/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpnd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nym-vpnd"
-version = "0.1.12-dev"
 description = "NymVPN daemon"
+version.workspace = true
 authors.workspace = true
 repository.workspace = true
 homepage.workspace = true

--- a/nym-vpn-core/nym-vpn-cli/Cargo.toml
+++ b/nym-vpn-core/nym-vpn-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nym-vpn-cli"
-version = "0.1.12-dev"
 description = "Standalone NymVPN commandline client"
+version.workspace = true
 authors.workspace = true
 repository.workspace = true
 homepage.workspace = true

--- a/nym-vpn-core/nym-vpn-lib/Cargo.toml
+++ b/nym-vpn-core/nym-vpn-lib/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
 name = "nym-vpn-lib"
-version = "0.1.12-dev"
-edition = "2021"
-license = "GPL-3.0-only"
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lib]
 crate-type = ["cdylib", "lib", "staticlib"]

--- a/scripts/bump-nym-vpn-core-to-next-dev-version.sh
+++ b/scripts/bump-nym-vpn-core-to-next-dev-version.sh
@@ -8,21 +8,17 @@ set -euo pipefail
 source "$(dirname "$0")/common.sh"
 
 TAG_BASE_NAME="nym-vpn-core"
-PACKAGES=(nym-vpn-lib nym-vpn-cli nym-vpnd nym-vpnc)
 DIRNAME="nym-vpn-core"
+PACKAGE=nym-vpn-lib
 
 get_current_version() {
-    echo "$(cargo get package.version --entry="${PACKAGES[0]}")"
+    echo "$(cargo get workspace.package.version)"
 }
 
 run_cargo_set_version() {
     local next_version=$1
 
-    local package_flags=""
-    for PACKAGE in "${PACKAGES[@]}"; do
-        package_flags+=" -p $PACKAGE"
-    done
-
+    local package_flags="-p $PACKAGE"
     local command="cargo set-version $package_flags $next_version"
 
     # Run the command with --dry-run option first

--- a/scripts/create-nym-vpn-core-release.sh
+++ b/scripts/create-nym-vpn-core-release.sh
@@ -15,8 +15,8 @@ source "$(dirname "$0")/common.sh"
 TAG_BASE_NAME=nym-vpn-core
 DIRNAME=nym-vpn-core
 
-# We want to set the workspace version, but I didn't manage cargo set-version
-# to do this explicitly, but instead do it implicitly by specifying the lib
+# We want to set the workspace version, but I didn't manage to get cargo
+# set-version to do this explicitly, only implicitly by specifying the lib
 # crate. This seems to trigger a version bump at the workspace level, affecting
 # all relevant crates.
 PACKAGE=nym-vpn-lib

--- a/scripts/create-nym-vpn-core-release.sh
+++ b/scripts/create-nym-vpn-core-release.sh
@@ -13,15 +13,17 @@ set -euo pipefail
 source "$(dirname "$0")/common.sh"
 
 TAG_BASE_NAME=nym-vpn-core
-PACKAGES=(nym-vpn-lib nym-vpn-cli nym-vpnd nym-vpnc)
 DIRNAME=nym-vpn-core
+
+# We want to set the workspace version, but I didn't manage cargo set-version
+# to do this explicitly, but instead do it implicitly by specifying the lib
+# crate. This seems to trigger a version bump at the workspace level, affecting
+# all relevant crates.
+PACKAGE=nym-vpn-lib
 
 cargo_version_bump() {
     cd $DIRNAME
-    local package_flags=""
-    for PACKAGE in "${PACKAGES[@]}"; do
-        package_flags+=" -p $PACKAGE"
-    done
+    local package_flags="-p $PACKAGE"
     local command="cargo set-version $package_flags --bump patch"
     echo "Running in dry-run mode: $command --dry-run"
     $command --dry-run
@@ -29,23 +31,9 @@ cargo_version_bump() {
     cd ..
 }
 
-assert_same_versions() {
-    cd $DIRNAME
-    local first_version=$(cargo get package.version --entry="${PACKAGES[0]}")
-    for PACKAGE in "${PACKAGES[@]}"; do
-        local version=$(cargo get package.version --entry="$PACKAGE")
-        if [[ "$version" != "$first_version" ]]; then
-            echo "Error: Version mismatch detected. $PACKAGE has version $version, but expected $first_version."
-            exit 1
-        fi
-    done
-    echo "All packages have the same version: $first_version"
-    cd ..
-}
-
 tag_release() {
     cd $DIRNAME
-    local version=$(cargo get package.version --entry="${PACKAGES[0]}")
+    local version=$(cargo get workspace.package.version)
     local tag_name="$TAG_BASE_NAME-v$version"
     echo "New version: $version, prepared tag: $tag_name"
     ask_and_tag_release "$tag_name" "$version" "$TAG_BASE_NAME"
@@ -55,7 +43,6 @@ main() {
     check_unstaged_changes
     confirm_root_directory
     cargo_version_bump
-    assert_same_versions
     tag_release
 }
 


### PR DESCRIPTION
Set the version for the nym-vpn-core workspace that we can inherit for all the crates where we care about versions. Makes our life easier since we anyway sync these versions manually.