### PR TITLE
Add min gateway performance flag

### DIFF
--- a/nym-vpn-core/nym-vpn-cli/src/commands.rs
+++ b/nym-vpn-core/nym-vpn-cli/src/commands.rs
@@ -95,8 +95,15 @@ pub(crate) struct RunArgs {
     #[arg(long)]
     pub(crate) enable_credentials_mode: bool,
 
+    /// Set the minimum performance level for mixnodes.
     #[arg(long)]
     pub(crate) min_mixnode_performance: Option<u8>,
+
+    // Set the minimum performance level for gateways.
+    // NOTE: hidden since it's not respected yet by the gateway directory client, and is only
+    // useful to testnet development.
+    #[arg(long, hide = true)]
+    pub(crate) min_gateway_performance: Option<u8>,
 }
 
 #[derive(Args)]

--- a/nym-vpn-core/nym-vpn-lib/src/lib.rs
+++ b/nym-vpn-core/nym-vpn-lib/src/lib.rs
@@ -141,6 +141,9 @@ pub struct MixnetClientConfig {
 
     /// The minimum performance of mixnodes to use.
     pub min_mixnode_performance: Option<u8>,
+
+    /// The minimum performance of gateways to use.
+    pub min_gateway_performance: Option<u8>,
 }
 
 pub struct NymVpn<T: Vpn> {
@@ -227,6 +230,7 @@ impl NymVpn<WireguardVpn> {
                 disable_background_cover_traffic: false,
                 enable_credentials_mode: false,
                 min_mixnode_performance: None,
+                min_gateway_performance: None,
             },
             data_path: None,
             gateway_config: nym_gateway_directory::Config::default(),
@@ -274,6 +278,7 @@ impl NymVpn<MixnetVpn> {
                 disable_background_cover_traffic: false,
                 enable_credentials_mode: false,
                 min_mixnode_performance: None,
+                min_gateway_performance: None,
             },
             data_path: None,
             gateway_config: nym_gateway_directory::Config::default(),

--- a/nym-vpn-core/nym-vpn-lib/src/mixnet_connect.rs
+++ b/nym-vpn-core/nym-vpn-lib/src/mixnet_connect.rs
@@ -89,6 +89,7 @@ pub(crate) async fn setup_mixnet_client(
     disable_background_cover_traffic: bool,
     enable_credentials_mode: bool,
     min_mixnode_performance: Option<u8>,
+    min_gateway_performance: Option<u8>,
 ) -> Result<SharedMixnetClient> {
     // Disable Poisson rate limiter by default
     let mut debug_config = nym_client_core::config::DebugConfig::default();
@@ -118,6 +119,13 @@ pub(crate) async fn setup_mixnet_client(
     info!(
         "mixnet client minimum mixnode performance: {}",
         debug_config.topology.minimum_mixnode_performance,
+    );
+    if let Some(min_gateway_performance) = min_gateway_performance {
+        debug_config.topology.minimum_gateway_performance = min_gateway_performance;
+    }
+    info!(
+        "mixnet client minimum gateway performance: {}",
+        debug_config.topology.minimum_gateway_performance,
     );
 
     // TODO: add support for two-hop mixnet traffic as a setting on the mixnet_client.

--- a/nym-vpn-core/nym-vpn-lib/src/tunnel_setup.rs
+++ b/nym-vpn-core/nym-vpn-lib/src/tunnel_setup.rs
@@ -353,6 +353,7 @@ pub async fn setup_tunnel(
                 .disable_background_cover_traffic,
             nym_vpn.mixnet_client_config().enable_credentials_mode,
             nym_vpn.mixnet_client_config().min_mixnode_performance,
+            nym_vpn.mixnet_client_config().min_gateway_performance,
         ),
     )
     .await

--- a/nym-vpn-core/nym-vpn-lib/src/tunnel_setup.rs
+++ b/nym-vpn-core/nym-vpn-lib/src/tunnel_setup.rs
@@ -347,13 +347,7 @@ pub async fn setup_tunnel(
             task_manager.subscribe_named("mixnet_client_main"),
             false,
             nym_vpn.enable_two_hop(),
-            nym_vpn.mixnet_client_config().enable_poisson_rate,
-            nym_vpn
-                .mixnet_client_config()
-                .disable_background_cover_traffic,
-            nym_vpn.mixnet_client_config().enable_credentials_mode,
-            nym_vpn.mixnet_client_config().min_mixnode_performance,
-            nym_vpn.mixnet_client_config().min_gateway_performance,
+            nym_vpn.mixnet_client_config(),
         ),
     )
     .await


### PR DESCRIPTION
Add `--min-gateway-performance` flag to the CLI.
It's marked as hidden as it's not useful to end-users until we integrate it with the gateway directory client.
Nonetheless it's still very useful during development on testnets where you often want to set it to zero.
