### PR TITLE
Handle same entry and exit gw in vpnd

### DIFF
--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/error.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/error.rs
@@ -167,6 +167,15 @@ impl From<ConnectionFailedError> for ProtoError {
                     "available_countries".to_string() => available_countries.join(", "),
                 },
             },
+            ConnectionFailedError::SameEntryAndExitGatewayFromCountry {
+                ref requested_location,
+            } => ProtoError {
+                kind: ErrorType::GatewayDirectorySameEntryAndExitGw as i32,
+                message: err.to_string(),
+                details: hashmap! {
+                    "requested_location".to_string() => requested_location.clone(),
+                },
+            },
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/service/error.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/error.rs
@@ -122,6 +122,9 @@ pub enum ConnectionFailedError {
 
     #[error("failed to lookup gateway ip: {gateway_id}")]
     FailedToLookupGatewayIp { gateway_id: String, reason: String },
+
+    #[error("unable to use same entry and exit gateway for location: {requested_location}")]
+    SameEntryAndExitGatewayFromCountry { requested_location: String },
 }
 
 use nym_vpn_lib::gateway_directory::Error as DirError;
@@ -199,6 +202,11 @@ impl From<&nym_vpn_lib::error::Error> for ConnectionFailedError {
                         reason: source.to_string(),
                     }
                 }
+                GatewayDirectoryError::SameEntryAndExitGatewayFromCountry {
+                    requested_location,
+                } => ConnectionFailedError::SameEntryAndExitGatewayFromCountry {
+                    requested_location: requested_location.clone(),
+                },
             },
             nym_vpn_lib::error::Error::IO(_)
             | nym_vpn_lib::error::Error::InvalidWireGuardKey

--- a/nym-vpn-core/nym-vpn-lib/src/error.rs
+++ b/nym-vpn-core/nym-vpn-lib/src/error.rs
@@ -251,6 +251,9 @@ pub enum GatewayDirectoryError {
         gateway_id: String,
         source: nym_gateway_directory::Error,
     },
+
+    #[error("unable to use same entry and exit gateway for location: {requested_location}")]
+    SameEntryAndExitGatewayFromCountry { requested_location: String },
 }
 
 // Result type based on our error type

--- a/nym-vpn-core/nym-vpn-lib/src/tunnel_setup.rs
+++ b/nym-vpn-core/nym-vpn-lib/src/tunnel_setup.rs
@@ -406,40 +406,44 @@ async fn select_gateways(
     gateway_directory_client: &GatewayClient,
     nym_vpn: &SpecificVpn,
 ) -> std::result::Result<SelectedGateways, GatewayDirectoryError> {
-    // Setup the gateway that we will use as the entry point
-    let entry_gateways = gateway_directory_client
-        .lookup_entry_gateways()
-        .await
-        .map_err(|source| GatewayDirectoryError::FailedToLookupGateways { source })?;
-
-    let entry_gateway = nym_vpn
-        .entry_point()
-        .lookup_gateway(&entry_gateways)
-        .map_err(|source| GatewayDirectoryError::FailedToSelectEntryGateway { source })?;
+    // The set of exit gateways is smaller than the set of entry gateways, so we start by selecting
+    // the exit gateway and then filter out the exit gateway from the set of entry gateways.
 
     // Setup the gateway that we will use as the exit point
-    let mut exit_gateways = gateway_directory_client
+    let exit_gateways = gateway_directory_client
         .lookup_exit_gateways()
         .await
         .map_err(|source| GatewayDirectoryError::FailedToLookupGateways { source })?;
 
-    // Exclude the entry gateway from the list of exit gateways for privacy reasons
-    exit_gateways.remove_gateway(&entry_gateway);
     let exit_gateway = nym_vpn
         .exit_point()
         .lookup_gateway(&exit_gateways)
+        .map_err(|source| GatewayDirectoryError::FailedToSelectExitGateway { source })?;
+
+    // Setup the gateway that we will use as the entry point
+    let mut entry_gateways = gateway_directory_client
+        .lookup_entry_gateways()
+        .await
+        .map_err(|source| GatewayDirectoryError::FailedToLookupGateways { source })?;
+
+    // Exclude the exit gateway from the list of entry gateways for privacy reasons
+    entry_gateways.remove_gateway(&exit_gateway);
+
+    let entry_gateway = nym_vpn
+        .entry_point()
+        .lookup_gateway(&entry_gateways)
         .map_err(|source| match source {
-            nym_gateway_directory::Error::NoMatchingExitGatewayForLocation {
+            nym_gateway_directory::Error::NoMatchingEntryGatewayForLocation {
                 requested_location,
                 available_countries: _,
             } if Some(requested_location.as_str())
-                == entry_gateway.two_letter_iso_country_code() =>
+                == exit_gateway.two_letter_iso_country_code() =>
             {
                 GatewayDirectoryError::SameEntryAndExitGatewayFromCountry {
                     requested_location: requested_location.to_string(),
                 }
             }
-            _ => GatewayDirectoryError::FailedToSelectExitGateway { source },
+            _ => GatewayDirectoryError::FailedToSelectEntryGateway { source },
         })?;
 
     info!("Found {} entry gateways", entry_gateways.len());

--- a/nym-vpn-core/nym-vpn-lib/src/tunnel_setup.rs
+++ b/nym-vpn-core/nym-vpn-lib/src/tunnel_setup.rs
@@ -428,31 +428,19 @@ async fn select_gateways(
     let exit_gateway = nym_vpn
         .exit_point()
         .lookup_gateway(&exit_gateways)
-        .map_err(|source| GatewayDirectoryError::FailedToSelectExitGateway { source });
-
-    let exit_gateway = match exit_gateway {
-        Ok(exit_gateway) => exit_gateway,
-        Err(error) => {
-            // If exit point was a country, and we just removed the only exit gateway in that
-            // country as it's used as entry point
-            match error {
-                GatewayDirectoryError::FailedToSelectExitGateway { ref source } => match source {
-                    nym_gateway_directory::Error::NoMatchingExitGatewayForLocation {
-                        requested_location,
-                        available_countries: _,
-                    } if Some(requested_location.as_str())
-                        == entry_gateway.two_letter_iso_country_code() =>
-                    {
-                        return Err(GatewayDirectoryError::SameEntryAndExitGatewayFromCountry {
-                            requested_location: requested_location.to_string(),
-                        });
-                    }
-                    _ => return Err(error),
-                },
-                _ => return Err(error),
+        .map_err(|source| match source {
+            nym_gateway_directory::Error::NoMatchingExitGatewayForLocation {
+                requested_location,
+                available_countries: _,
+            } if Some(requested_location.as_str())
+                == entry_gateway.two_letter_iso_country_code() =>
+            {
+                GatewayDirectoryError::SameEntryAndExitGatewayFromCountry {
+                    requested_location: requested_location.to_string(),
+                }
             }
-        }
-    };
+            _ => GatewayDirectoryError::FailedToSelectExitGateway { source },
+        })?;
 
     info!("Found {} entry gateways", entry_gateways.len());
     info!("Found {} exit gateways", exit_gateways.len());

--- a/proto/nym/vpn.proto
+++ b/proto/nym/vpn.proto
@@ -210,6 +210,9 @@ message Error {
 
     // Failing to lookup the exit gateway for a given location
     GATEWAY_DIRECTORY_EXIT_LOCATION = 16;
+
+    // Invalid configuration attempted, with the same entry and exit gateway
+    GATEWAY_DIRECTORY_SAME_ENTRY_AND_EXIT_GW = 17;
   }
 
   ErrorType kind = 1;


### PR DESCRIPTION
Add an error enum for invalid gateway selection configuration. Basically it will happen if you select the same location for both entry and exit, and there are not enough gateways to avoid using the same gw for both