### PR TITLE
Invert MacOS as_service flag

### DIFF
--- a/nym-vpn-core/crates/nym-vpnd/src/cli.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/cli.rs
@@ -52,7 +52,7 @@ pub(crate) struct Command {
     #[arg(long)]
     pub(crate) run_as_service: bool,
 
-    #[cfg(unix)]
+    #[cfg(target_os = "macos")]
     #[arg(long)]
     pub(crate) run_as_cli: bool,
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/cli.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/cli.rs
@@ -48,8 +48,13 @@ pub(crate) struct Command {
     #[arg(long)]
     pub(crate) start: bool,
 
+    #[cfg(windows)]
     #[arg(long)]
     pub(crate) run_as_service: bool,
+
+    #[cfg(unix)]
+    #[arg(long)]
+    pub(crate) run_as_cli: bool,
 }
 
 impl Command {

--- a/nym-vpn-core/crates/nym-vpnd/src/logging.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/logging.rs
@@ -5,13 +5,7 @@ use tracing_appender::non_blocking::WorkerGuard;
 
 use crate::service;
 
-pub fn setup_logging(_as_service: bool) {
-    #[cfg(target_os = "macos")]
-    if _as_service {
-        nym_vpn_lib::swift::init_logs();
-        return;
-    }
-
+pub fn setup_logging() {
     let filter = tracing_subscriber::EnvFilter::builder()
         .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
         .from_env()

--- a/nym-vpn-core/crates/nym-vpnd/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/main.rs
@@ -54,10 +54,23 @@ fn run_inner(args: CliArgs) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "macos")]
 fn run() -> Result<(), Box<dyn std::error::Error>> {
     let args = CliArgs::parse();
-    setup_logging(!args.command.run_as_cli);
+    if args.command.run_as_cli {
+        setup_logging();
+    } else {
+        nym_vpn_lib::swift::init_logs();
+    }
+    setup_env(args.config_env_file.as_ref());
+
+    run_inner(args)
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn run() -> Result<(), Box<dyn std::error::Error>> {
+    let args = CliArgs::parse();
+    setup_logging();
     setup_env(args.config_env_file.as_ref());
 
     run_inner(args)
@@ -71,7 +84,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     if args.command.is_any() {
         Ok(windows_service::start(args)?)
     } else {
-        setup_logging(false);
+        setup_logging();
         run_inner(args)
     }
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/main.rs
@@ -57,7 +57,7 @@ fn run_inner(args: CliArgs) -> Result<(), Box<dyn std::error::Error>> {
 #[cfg(unix)]
 fn run() -> Result<(), Box<dyn std::error::Error>> {
     let args = CliArgs::parse();
-    setup_logging(args.command.run_as_service);
+    setup_logging(!args.command.run_as_cli);
     setup_env(args.config_env_file.as_ref());
 
     run_inner(args)


### PR DESCRIPTION
As on MacOS the service is run without any flag and that can't be modified, we need to have an inverted flag, at least for this platform, which the default value (false) means running it as a service => `run_as_cli`