### PR TITLE
Convert compiler flags to uppercase

### DIFF
--- a/nym-vpn-core/Makefile
+++ b/nym-vpn-core/Makefile
@@ -45,8 +45,9 @@ build-deb-vpnc:
 	RUSTFLAGS="-L $(WG_TARGET_DIR)" cargo deb -p nym-vpnc
 
 build-vpn-lib-swift:	
-	$(eval RUSTFLAGS += $(foreach arch,$(IPHONEOS_ARCHS),RUSTFLAGS_$(arch)="-L $(WG_BUILD_DIR)/$(arch)"))
-	cd nym-vpn-lib && env $(RUSTFLAGS) cargo swift package --platforms ios --name NymVpnLib --release
+	$(eval RUSTFLAGS += $(foreach arch,$(IPHONEOS_ARCHS),CARGO_TARGET_$(shell echo '$(arch)' | tr '[:lower:]' '[:upper:]' | tr '-' '_')_RUSTFLAGS="-L $(WG_BUILD_DIR)/$(arch)"))
+	cd nym-vpn-lib; \
+	$(RUSTFLAGS) cargo swift package --platforms ios --name NymVpnLib --release
 
 generate-uniffi-swift:
 	cd nym-vpn-lib; \


### PR DESCRIPTION
`RUSTFLAGS_<target>` didn't seem to work on Apple mac, so after poking around a bit and switching to `CARGO_TARGET_<TARGET>_RUSTFLAGS`, the linker was finally happy. The script crafts target using `tr` and converts all `-` to `_` and then uppercases the whole thing to produce the correct env variable name.