### PR TITLE
Add support for custom min gateway performance threshold

### DIFF
--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
@@ -10,7 +10,7 @@ use tracing::error;
 use crate::{error::Result, AuthAddress, Country, Error, IpPacketRouterAddress};
 
 // Decimal between 0 and 1 representing the performance of a gateway, measured over 24h.
-type Perfomance = f64;
+type Performance = u8;
 
 #[derive(Clone, Debug)]
 pub struct Gateway {
@@ -22,7 +22,7 @@ pub struct Gateway {
     pub host: Option<nym_topology::NetworkAddress>,
     pub clients_ws_port: Option<u16>,
     pub clients_wss_port: Option<u16>,
-    pub performance: Option<Perfomance>,
+    pub performance: Option<Performance>,
 }
 
 impl Gateway {

--- a/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
@@ -22,6 +22,7 @@ use url::Url;
 pub struct Config {
     pub api_url: Url,
     pub nym_vpn_api_url: Option<Url>,
+    pub min_gateway_performance: Option<f64>,
 }
 
 impl Default for Config {
@@ -65,10 +66,11 @@ impl Config {
         Config {
             api_url: default_api_url,
             nym_vpn_api_url: Some(default_nym_vpn_api_url),
+            min_gateway_performance: None,
         }
     }
 
-    pub fn new_from_env() -> Self {
+    pub fn new_from_env(min_gateway_performance: Option<u8>) -> Self {
         let network = nym_sdk::NymNetworkDetails::new_from_env();
         let api_url = network
             .endpoints
@@ -80,18 +82,21 @@ impl Config {
         // The vpn api url is strictly not needed, so skip the expect here
         let nym_vpn_api_url = network.nym_vpn_api_url();
 
+        let min_gateway_performance = min_gateway_performance.map(|p| p as f64 / 100.0);
+
         Config {
             api_url,
             nym_vpn_api_url,
+            min_gateway_performance,
         }
     }
 
-    pub fn new_from_urls(api_url: Url, nym_vpn_api_url: Option<Url>) -> Self {
-        Config {
-            api_url,
-            nym_vpn_api_url,
-        }
-    }
+    // pub fn new_from_urls(api_url: Url, nym_vpn_api_url: Option<Url>) -> Self {
+    //     Config {
+    //         api_url,
+    //         nym_vpn_api_url,
+    //     }
+    // }
 
     pub fn api_url(&self) -> &Url {
         &self.api_url
@@ -108,6 +113,15 @@ impl Config {
 
     pub fn with_custom_nym_vpn_api_url(mut self, nym_vpn_api_url: Url) -> Self {
         self.nym_vpn_api_url = Some(nym_vpn_api_url);
+        self
+    }
+
+    pub fn min_gateway_performance(&self) -> Option<f64> {
+        self.min_gateway_performance
+    }
+
+    pub fn with_custom_min_gateway_performance(mut self, min_gateway_performance: f64) -> Self {
+        self.min_gateway_performance = Some(min_gateway_performance);
         self
     }
 }

--- a/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
@@ -18,6 +18,8 @@ use std::{fmt, net::IpAddr, time::Duration};
 use tracing::{debug, error, info};
 use url::Url;
 
+const DIRECTORY_CLIENT_TIMEOUT: Duration = Duration::from_secs(20);
+
 #[derive(Clone, Debug)]
 pub struct Config {
     pub api_url: Url,
@@ -131,7 +133,7 @@ impl GatewayClient {
                 nym_vpn_api_client::ClientBuilder::new(url)
                     .map_err(nym_vpn_api_client::VpnApiClientError::from)?
                     .with_user_agent(user_agent)
-                    .with_timeout(Duration::from_secs(10))
+                    .with_timeout(DIRECTORY_CLIENT_TIMEOUT)
                     .build()?,
             )
         } else {

--- a/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
+++ b/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
@@ -92,7 +92,7 @@ pub async fn probe(entry_point: EntryPoint) -> anyhow::Result<ProbeResult> {
 }
 
 async fn lookup_gateways() -> anyhow::Result<GatewayList> {
-    let gateway_config = GatewayDirectoryConfig::new_from_env();
+    let gateway_config = GatewayDirectoryConfig::new_from_env(None);
     info!("nym-api: {}", gateway_config.api_url());
     info!(
         "nym-vpn-api: {}",

--- a/nym-vpn-core/crates/nym-vpn-cli/src/commands.rs
+++ b/nym-vpn-core/crates/nym-vpn-cli/src/commands.rs
@@ -91,13 +91,11 @@ pub(crate) struct RunArgs {
     pub(crate) enable_credentials_mode: bool,
 
     /// Set the minimum performance level for mixnodes.
-    #[arg(long)]
+    #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]
     pub(crate) min_mixnode_performance: Option<u8>,
 
     // Set the minimum performance level for gateways.
-    // NOTE: hidden since it's not respected yet by the gateway directory client, and is only
-    // useful to testnet development.
-    #[arg(long, hide = true)]
+    #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]
     pub(crate) min_gateway_performance: Option<u8>,
 }
 

--- a/nym-vpn-core/crates/nym-vpn-cli/src/commands.rs
+++ b/nym-vpn-core/crates/nym-vpn-cli/src/commands.rs
@@ -91,7 +91,7 @@ pub(crate) struct RunArgs {
     pub(crate) enable_credentials_mode: bool,
 
     /// Set the minimum performance level for mixnodes.
-    #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]
+    #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100), hide = true)]
     pub(crate) min_mixnode_performance: Option<u8>,
 
     // Set the minimum performance level for gateways.

--- a/nym-vpn-core/crates/nym-vpn-cli/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpn-cli/src/main.rs
@@ -153,7 +153,7 @@ async fn run_vpn(args: commands::RunArgs, data_path: Option<PathBuf>) -> Result<
             disable_background_cover_traffic: args.disable_background_cover_traffic,
             enable_credentials_mode: args.enable_credentials_mode,
             min_mixnode_performance: args.min_mixnode_performance,
-            min_gateway_performance: None,
+            min_gateway_performance: args.min_gateway_performance,
         },
         data_path,
         gateway_config,

--- a/nym-vpn-core/crates/nym-vpn-cli/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpn-cli/src/main.rs
@@ -130,7 +130,7 @@ async fn run() -> Result<()> {
 
 async fn run_vpn(args: commands::RunArgs, data_path: Option<PathBuf>) -> Result<()> {
     // Setup gateway directory configuration
-    let gateway_config = GatewayConfig::new_from_env();
+    let gateway_config = GatewayConfig::new_from_env(args.min_gateway_performance);
     info!("nym-api: {}", gateway_config.api_url());
     info!(
         "nym-vpn-api: {}",

--- a/nym-vpn-core/crates/nym-vpnc/src/cli.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/cli.rs
@@ -27,10 +27,10 @@ pub(crate) enum Command {
     StoreAccount(StoreAccountArgs),
     ListenToStatus,
     ListenToStateChanges,
-    ListEntryGateways,
-    ListExitGateways,
-    ListEntryCountries,
-    ListExitCountries,
+    ListEntryGateways(ListEntryGatewaysArgs),
+    ListExitGateways(ListExitGatewaysArgs),
+    ListEntryCountries(ListEntryCountriesArgs),
+    ListExitCountries(ListExitCountriesArgs),
 }
 
 #[derive(Args)]
@@ -72,25 +72,30 @@ pub(crate) struct ConnectArgs {
     /// consider a mixnode for routing traffic.
     #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]
     pub(crate) min_mixnode_performance: Option<u8>,
+
+    /// An integer between 0 and 100 representing the minimum gateway performance required to
+    /// consider a gateway for routing traffic.
+    #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]
+    pub(crate) min_gateway_performance: Option<u8>,
 }
 
 #[derive(Args)]
 #[group(multiple = false)]
 pub(crate) struct CliEntry {
     /// Mixnet public ID of the entry gateway.
-    #[clap(long, alias = "entry-id")]
+    #[arg(long, alias = "entry-id")]
     pub(crate) entry_gateway_id: Option<String>,
 
     /// Auto-select entry gateway by country ISO.
-    #[clap(long, alias = "entry-country")]
+    #[arg(long, alias = "entry-country")]
     pub(crate) entry_gateway_country: Option<String>,
 
     /// Auto-select entry gateway by latency
-    #[clap(long, alias = "entry-fastest")]
+    #[arg(long, alias = "entry-fastest")]
     pub(crate) entry_gateway_low_latency: bool,
 
     /// Auto-select entry gateway randomly.
-    #[clap(long, alias = "entry-random")]
+    #[arg(long, alias = "entry-random")]
     pub(crate) entry_gateway_random: bool,
 }
 
@@ -157,6 +162,38 @@ pub(crate) struct StoreAccountArgs {
     /// The account mnemonic to be stored.
     #[arg(long)]
     pub(crate) mnemonic: String,
+}
+
+#[derive(Args)]
+pub(crate) struct ListEntryGatewaysArgs {
+    /// An integer between 0 and 100 representing the minimum gateway performance required to
+    /// consider a gateway for routing traffic.
+    #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]
+    pub(crate) min_gateway_performance: Option<u8>,
+}
+
+#[derive(Args)]
+pub(crate) struct ListExitGatewaysArgs {
+    /// An integer between 0 and 100 representing the minimum gateway performance required to
+    /// consider a gateway for routing traffic.
+    #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]
+    pub(crate) min_gateway_performance: Option<u8>,
+}
+
+#[derive(Args)]
+pub(crate) struct ListEntryCountriesArgs {
+    /// An integer between 0 and 100 representing the minimum gateway performance required to
+    /// consider a gateway for routing traffic.
+    #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]
+    pub(crate) min_gateway_performance: Option<u8>,
+}
+
+#[derive(Args)]
+pub(crate) struct ListExitCountriesArgs {
+    /// An integer between 0 and 100 representing the minimum gateway performance required to
+    /// consider a gateway for routing traffic.
+    #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]
+    pub(crate) min_gateway_performance: Option<u8>,
 }
 
 pub(crate) fn parse_entry_point(args: &ConnectArgs) -> Result<Option<EntryPoint>> {

--- a/nym-vpn-core/crates/nym-vpnc/src/cli.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/cli.rs
@@ -70,7 +70,7 @@ pub(crate) struct ConnectArgs {
 
     /// An integer between 0 and 100 representing the minimum mixnode performance required to
     /// consider a mixnode for routing traffic.
-    #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]
+    #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100), hide = true)]
     pub(crate) min_mixnode_performance: Option<u8>,
 
     /// An integer between 0 and 100 representing the minimum gateway performance required to

--- a/nym-vpn-core/crates/nym-vpnc/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/main.rs
@@ -42,10 +42,18 @@ async fn main() -> Result<()> {
         Command::StoreAccount(ref store_args) => store_account(client_type, store_args).await?,
         Command::ListenToStatus => listen_to_status(client_type).await?,
         Command::ListenToStateChanges => listen_to_state_changes(client_type).await?,
-        Command::ListEntryGateways => list_entry_gateways(client_type).await?,
-        Command::ListExitGateways => list_exit_gateways(client_type).await?,
-        Command::ListEntryCountries => list_entry_countries(client_type).await?,
-        Command::ListExitCountries => list_exit_countries(client_type).await?,
+        Command::ListEntryGateways(ref list_args) => {
+            list_entry_gateways(client_type, list_args).await?
+        }
+        Command::ListExitGateways(ref list_args) => {
+            list_exit_gateways(client_type, list_args).await?
+        }
+        Command::ListEntryCountries(ref list_args) => {
+            list_entry_countries(client_type, list_args).await?
+        }
+        Command::ListExitCountries(ref list_args) => {
+            list_exit_countries(client_type, list_args).await?
+        }
     }
     Ok(())
 }
@@ -64,6 +72,7 @@ async fn connect(client_type: ClientType, connect_args: &cli::ConnectArgs) -> Re
         disable_background_cover_traffic: connect_args.disable_background_cover_traffic,
         enable_credentials_mode: connect_args.enable_credentials_mode,
         min_mixnode_performance: connect_args.min_mixnode_performance.map(into_threshold),
+        min_gateway_performance: connect_args.min_gateway_performance.map(into_threshold),
     });
 
     let mut client = vpnd_client::get_client(client_type).await?;
@@ -173,9 +182,14 @@ async fn listen_to_state_changes(client_type: ClientType) -> Result<()> {
     Ok(())
 }
 
-async fn list_entry_gateways(client_type: ClientType) -> Result<()> {
+async fn list_entry_gateways(
+    client_type: ClientType,
+    list_args: &cli::ListEntryGatewaysArgs,
+) -> Result<()> {
     let mut client = vpnd_client::get_client(client_type).await?;
-    let request = tonic::Request::new(ListEntryGatewaysRequest {});
+    let request = tonic::Request::new(ListEntryGatewaysRequest {
+        min_gateway_performance: list_args.min_gateway_performance.map(into_threshold),
+    });
     let response = client.list_entry_gateways(request).await?.into_inner();
     println!("{:#?}", response);
 
@@ -191,9 +205,14 @@ async fn list_entry_gateways(client_type: ClientType) -> Result<()> {
     Ok(())
 }
 
-async fn list_exit_gateways(client_type: ClientType) -> Result<()> {
+async fn list_exit_gateways(
+    client_type: ClientType,
+    list_args: &cli::ListExitGatewaysArgs,
+) -> Result<()> {
     let mut client = vpnd_client::get_client(client_type).await?;
-    let request = tonic::Request::new(ListExitGatewaysRequest {});
+    let request = tonic::Request::new(ListExitGatewaysRequest {
+        min_gateway_performance: list_args.min_gateway_performance.map(into_threshold),
+    });
     let response = client.list_exit_gateways(request).await?.into_inner();
     println!("{:#?}", response);
 
@@ -209,17 +228,27 @@ async fn list_exit_gateways(client_type: ClientType) -> Result<()> {
     Ok(())
 }
 
-async fn list_entry_countries(client_type: ClientType) -> Result<()> {
+async fn list_entry_countries(
+    client_type: ClientType,
+    list_args: &cli::ListEntryCountriesArgs,
+) -> Result<()> {
     let mut client = vpnd_client::get_client(client_type).await?;
-    let request = tonic::Request::new(ListEntryCountriesRequest {});
+    let request = tonic::Request::new(ListEntryCountriesRequest {
+        min_gateway_performance: list_args.min_gateway_performance.map(into_threshold),
+    });
     let response = client.list_entry_countries(request).await?.into_inner();
     println!("{:#?}", response);
     Ok(())
 }
 
-async fn list_exit_countries(client_type: ClientType) -> Result<()> {
+async fn list_exit_countries(
+    client_type: ClientType,
+    list_args: &cli::ListExitCountriesArgs,
+) -> Result<()> {
     let mut client = vpnd_client::get_client(client_type).await?;
-    let request = tonic::Request::new(ListExitCountriesRequest {});
+    let request = tonic::Request::new(ListExitCountriesRequest {
+        min_gateway_performance: list_args.min_gateway_performance.map(into_threshold),
+    });
     let response = client.list_exit_countries(request).await?.into_inner();
     println!("{:#?}", response);
     Ok(())

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/connection_handler.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/connection_handler.rs
@@ -138,7 +138,7 @@ impl CommandInterfaceConnectionHandler {
 
     pub(crate) async fn handle_list_entry_gateways(
         &self,
-        min_gateway_performance: Option<f64>,
+        min_gateway_performance: Option<u8>,
     ) -> Result<Vec<gateway::Gateway>, ListGatewayError> {
         let gateways = directory_client(min_gateway_performance)?
             .lookup_entry_gateways()
@@ -150,7 +150,7 @@ impl CommandInterfaceConnectionHandler {
 
     pub(crate) async fn handle_list_exit_gateways(
         &self,
-        min_gateway_performance: Option<f64>,
+        min_gateway_performance: Option<u8>,
     ) -> Result<Vec<gateway::Gateway>, ListGatewayError> {
         let gateways = directory_client(min_gateway_performance)?
             .lookup_exit_gateways()
@@ -162,7 +162,7 @@ impl CommandInterfaceConnectionHandler {
 
     pub(crate) async fn handle_list_entry_countries(
         &self,
-        min_gateway_performance: Option<f64>,
+        min_gateway_performance: Option<u8>,
     ) -> Result<Vec<gateway::Country>, ListGatewayError> {
         let gateways = directory_client(min_gateway_performance)?
             .lookup_entry_countries()
@@ -174,7 +174,7 @@ impl CommandInterfaceConnectionHandler {
 
     pub(crate) async fn handle_list_exit_countries(
         &self,
-        min_gateway_performance: Option<f64>,
+        min_gateway_performance: Option<u8>,
     ) -> Result<Vec<gateway::Country>, ListGatewayError> {
         let gateways = directory_client(min_gateway_performance)?
             .lookup_exit_countries()
@@ -201,9 +201,8 @@ impl CommandInterfaceConnectionHandler {
 }
 
 fn directory_client(
-    min_gateway_performance: Option<f64>,
+    min_gateway_performance: Option<u8>,
 ) -> Result<GatewayClient, ListGatewayError> {
-    let min_gateway_performance = min_gateway_performance.map(|p| (p * 100.0).round() as u8);
     let user_agent = bin_info_local_vergen!().into();
     let directory_config =
         nym_vpn_lib::gateway_directory::Config::new_from_env(min_gateway_performance);

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/connection_handler.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/connection_handler.rs
@@ -196,9 +196,12 @@ impl CommandInterfaceConnectionHandler {
     }
 }
 
-fn directory_client() -> Result<GatewayClient, ListGatewayError> {
+fn directory_client(
+    min_gateway_performance: Option<f64>,
+) -> Result<GatewayClient, ListGatewayError> {
     let user_agent = bin_info_local_vergen!().into();
-    let directory_config = nym_vpn_lib::gateway_directory::Config::new_from_env();
+    let directory_config =
+        nym_vpn_lib::gateway_directory::Config::new_from_env(min_gateway_performance);
     GatewayClient::new(directory_config, user_agent)
         .map_err(|error| ListGatewayError::CreateGatewayDirectoryClient { error })
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/connection_handler.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/connection_handler.rs
@@ -138,8 +138,9 @@ impl CommandInterfaceConnectionHandler {
 
     pub(crate) async fn handle_list_entry_gateways(
         &self,
+        min_gateway_performance: Option<f64>,
     ) -> Result<Vec<gateway::Gateway>, ListGatewayError> {
-        let gateways = directory_client()?
+        let gateways = directory_client(min_gateway_performance)?
             .lookup_entry_gateways()
             .await
             .map_err(|error| ListGatewayError::GetEntryGateways { error })?;
@@ -149,8 +150,9 @@ impl CommandInterfaceConnectionHandler {
 
     pub(crate) async fn handle_list_exit_gateways(
         &self,
+        min_gateway_performance: Option<f64>,
     ) -> Result<Vec<gateway::Gateway>, ListGatewayError> {
-        let gateways = directory_client()?
+        let gateways = directory_client(min_gateway_performance)?
             .lookup_exit_gateways()
             .await
             .map_err(|error| ListGatewayError::GetExitGateways { error })?;
@@ -160,8 +162,9 @@ impl CommandInterfaceConnectionHandler {
 
     pub(crate) async fn handle_list_entry_countries(
         &self,
+        min_gateway_performance: Option<f64>,
     ) -> Result<Vec<gateway::Country>, ListGatewayError> {
-        let gateways = directory_client()?
+        let gateways = directory_client(min_gateway_performance)?
             .lookup_entry_countries()
             .await
             .map_err(|error| ListGatewayError::GetEntryGateways { error })?;
@@ -171,8 +174,9 @@ impl CommandInterfaceConnectionHandler {
 
     pub(crate) async fn handle_list_exit_countries(
         &self,
+        min_gateway_performance: Option<f64>,
     ) -> Result<Vec<gateway::Country>, ListGatewayError> {
-        let gateways = directory_client()?
+        let gateways = directory_client(min_gateway_performance)?
             .lookup_exit_countries()
             .await
             .map_err(|error| ListGatewayError::GetExitGateways { error })?;
@@ -199,6 +203,7 @@ impl CommandInterfaceConnectionHandler {
 fn directory_client(
     min_gateway_performance: Option<f64>,
 ) -> Result<GatewayClient, ListGatewayError> {
+    let min_gateway_performance = min_gateway_performance.map(|p| (p * 100.0).round() as u8);
     let user_agent = bin_info_local_vergen!().into();
     let directory_config =
         nym_vpn_lib::gateway_directory::Config::new_from_env(min_gateway_performance);

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/helpers.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/helpers.rs
@@ -78,3 +78,7 @@ pub(super) fn parse_exit_point(
         }
     })
 }
+
+pub(super) fn threshold_into_u8(threshold: nym_vpn_proto::Threshold) -> u8 {
+    threshold.min_performance.clamp(0, 100) as u8
+}

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -158,6 +158,7 @@ pub(crate) struct ConnectOptions {
     pub(crate) disable_background_cover_traffic: bool,
     pub(crate) enable_credentials_mode: bool,
     pub(crate) min_mixnode_performance: Option<u8>,
+    pub(crate) min_gateway_performance: Option<u8>,
 }
 
 #[derive(Debug)]
@@ -474,10 +475,12 @@ where
                 disable_background_cover_traffic: options.disable_background_cover_traffic,
                 enable_credentials_mode: options.enable_credentials_mode,
                 min_mixnode_performance: options.min_mixnode_performance,
-                min_gateway_performance: None,
+                min_gateway_performance: options.min_gateway_performance,
             },
             data_path: Some(self.data_dir.clone()),
-            gateway_config: gateway_directory::Config::new_from_env(),
+            gateway_config: gateway_directory::Config::new_from_env(
+                options.min_gateway_performance,
+            ),
             entry_point: config.entry_point.clone(),
             exit_point: config.exit_point.clone(),
             nym_ips: None,

--- a/nym-vpn-core/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-core/nym-vpn-lib/src/platform/mod.rs
@@ -318,6 +318,7 @@ async fn get_gateway_countries(
     let directory_config = nym_gateway_directory::Config {
         api_url,
         nym_vpn_api_url,
+        min_gateway_performance: None,
     };
     let directory_client = GatewayClient::new(directory_config, user_agent)?;
     let locations = if !exit_only {
@@ -368,6 +369,7 @@ async fn get_low_latency_entry_country(
     let config = nym_gateway_directory::Config {
         api_url,
         nym_vpn_api_url: vpn_api_url,
+        min_gateway_performance: None,
     };
     let user_agent = user_agent
         .map(nym_sdk::UserAgent::from)

--- a/nym-vpn-x/src-tauri/src/grpc/client.rs
+++ b/nym-vpn-x/src-tauri/src/grpc/client.rs
@@ -295,6 +295,7 @@ impl GrpcClient {
             enable_credentials_mode: false,
             dns,
             min_mixnode_performance: None,
+            min_gateway_performance: None,
         });
         let response = vpnd.vpn_connect(request).await.map_err(|e| {
             error!("grpc vpn_connect: {}", e);
@@ -346,7 +347,9 @@ impl GrpcClient {
         debug!("entry_countries");
         let mut vpnd = self.vpnd().await?;
 
-        let request = Request::new(ListEntryCountriesRequest {});
+        let request = Request::new(ListEntryCountriesRequest {
+            min_mixnode_performance: None,
+        });
         let response = vpnd.list_entry_countries(request).await.map_err(|e| {
             error!("grpc list_entry_countries: {}", e);
             VpndError::GrpcError(e)
@@ -372,7 +375,9 @@ impl GrpcClient {
         debug!("exit_countries");
         let mut vpnd = self.vpnd().await?;
 
-        let request = Request::new(ListExitCountriesRequest {});
+        let request = Request::new(ListExitCountriesRequest {
+            min_gateway_performance: None,
+        });
         let response = vpnd.list_exit_countries(request).await.map_err(|e| {
             error!("grpc list_exit_countries: {}", e);
             VpndError::GrpcError(e)

--- a/nym-vpn-x/src-tauri/src/grpc/client.rs
+++ b/nym-vpn-x/src-tauri/src/grpc/client.rs
@@ -348,7 +348,7 @@ impl GrpcClient {
         let mut vpnd = self.vpnd().await?;
 
         let request = Request::new(ListEntryCountriesRequest {
-            min_mixnode_performance: None,
+            min_gateway_performance: None,
         });
         let response = vpnd.list_entry_countries(request).await.map_err(|e| {
             error!("grpc list_entry_countries: {}", e);

--- a/proto/nym/vpn.proto
+++ b/proto/nym/vpn.proto
@@ -95,6 +95,7 @@ message ConnectRequest {
   bool disable_background_cover_traffic = 7;
   bool enable_credentials_mode = 8;
   Threshold min_mixnode_performance = 9;
+  Threshold min_gateway_performance = 10;
 }
 
 message ConnectResponse {
@@ -347,7 +348,10 @@ message EntryGateway {
   Probe last_probe = 3;
 }
 
-message ListEntryGatewaysRequest {}
+message ListEntryGatewaysRequest {
+  Threshold min_gateway_performance = 1;
+}
+
 message ListEntryGatewaysResponse {
   repeated EntryGateway gateways = 1;
 }
@@ -358,17 +362,26 @@ message ExitGateway {
   Probe last_probe = 3;
 }
 
-message ListExitGatewaysRequest {}
+message ListExitGatewaysRequest {
+  Threshold min_gateway_performance = 1;
+}
+
 message ListExitGatewaysResponse {
   repeated ExitGateway gateways = 1;
 }
 
-message ListEntryCountriesRequest {}
+message ListEntryCountriesRequest {
+  Threshold min_gateway_performance = 1;
+}
+
 message ListEntryCountriesResponse {
   repeated Location countries = 1;
 }
 
-message ListExitCountriesRequest {}
+message ListExitCountriesRequest {
+  Threshold min_gateway_performance = 1;
+}
+
 message ListExitCountriesResponse {
   repeated Location countries = 1;
 }


### PR DESCRIPTION
Add support for min-gateway-performance across all components in `nym-vpn-core`.