### PR TITLE
feat(vpnx): add network env file to config

### DIFF
--- a/nym-vpn-x/src-tauri/src/fs/config.rs
+++ b/nym-vpn-x/src-tauri/src/fs/config.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Default, Serialize, Deserialize, Debug, Clone)]
 pub struct AppConfig {
+    /// Path to a file to load a custom network environment
+    pub network_env_file: Option<PathBuf>,
     /// Unix socket path of gRPC endpoint in IPC mode
     pub grpc_socket_endpoint: Option<PathBuf>,
     /// Enable HTTP transport for gRPC connection

--- a/nym-vpn-x/src-tauri/src/main.rs
+++ b/nym-vpn-x/src-tauri/src/main.rs
@@ -111,8 +111,13 @@ async fn main() -> Result<()> {
     };
     debug!("app_config: {app_config:?}");
 
-    info!("network environment: mainnet");
-    defaults::setup_env::<PathBuf>(None);
+    if let Some(env_file) = &app_config.network_env_file {
+        info!("network environment: custom - {}", env_file.display());
+        defaults::setup_env(Some(env_file.clone()));
+    } else {
+        info!("network environment: mainnet");
+        defaults::setup_env::<PathBuf>(None);
+    }
 
     let app_state = AppState::try_from((&db, &app_config, &cli)).map_err(|e| {
         error!("failed to create app state from saved app data and config: {e}");


### PR DESCRIPTION
Add to the app config file a new field `network_env_file` to set a custom network env