### PR TITLE
Streamline logging on iOS

### DIFF
--- a/nym-vpn-apple/NymMixnetTunnel/PacketTunnelProvider.swift
+++ b/nym-vpn-apple/NymMixnetTunnel/PacketTunnelProvider.swift
@@ -17,7 +17,14 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
     override init() {
         LoggingSystem.bootstrap { label in
-            FileLogHandler(label: label)
+            let fileLogHandler = FileLogHandler(label: label)
+
+            #if DEBUG
+                let osLogHandler = OSLogHandler(subsystem: Bundle.main.bundleIdentifier!, category: label)
+                return MultiplexLogHandler([osLogHandler, fileLogHandler])
+            #else
+                return fileLogHandler
+            #endif
         }
     }
 

--- a/nym-vpn-apple/Services/Sources/Services/NymLogger/FileLogHandler.swift
+++ b/nym-vpn-apple/Services/Sources/Services/NymLogger/FileLogHandler.swift
@@ -9,8 +9,11 @@ public class FileLogHandler: LogHandler {
         self.label = label
     }
 
-    public var metadata = Logger.Metadata()
-    public var logLevel = Logger.Level.info
+    public var metadata = Logging.Logger.Metadata()
+    public var logLevel = Logging.Logger.Level.info
+
+    private let ioQueue = DispatchQueue(label: "FileLogHandler-queue", qos: .utility)
+    private var fileHandle: FileHandle?
 
     public static var logFileURL: URL? {
         let fileManager = FileManager.default
@@ -51,39 +54,47 @@ public class FileLogHandler: LogHandler {
             fullMetadata.merge(metadata) { $1 }
         }
 
-        let symbol: String
-        switch level {
+        var metadataOutput = fullMetadata.formatted()
+        if !metadataOutput.isEmpty {
+            metadataOutput = " " + metadataOutput
+        }
+
+        let logLine = "\(Date()) [\(label)] \(level.emoji) \(level)\(metadataOutput): \(message)\n"
+        let data = Data(logLine.utf8)
+
+        ioQueue.async {
+            if self.fileHandle == nil, let logFileURL = FileLogHandler.logFileURL {
+                self.fileHandle = try? FileHandle(forWritingTo: logFileURL)
+            }
+            try? self.fileHandle?.write(contentsOf: data)
+        }
+    }
+}
+
+extension Logging.Logger.Metadata {
+    func formatted() -> String {
+        map { key, value in "\(key)=\(value)" }
+            .joined(separator: " ")
+    }
+}
+
+extension Logging.Logger.Level {
+    var emoji: String {
+        switch self {
         case .trace:
-            symbol = "👀"
+            return "👀"
         case .debug:
-            symbol = "⌨️"
+            return "⌨️"
         case .info:
-            symbol = "ℹ"
+            return "ℹ"
         case .notice:
-            symbol = "📣"
+            return "📣"
         case .warning:
-            symbol = "⚠️"
+            return "⚠️"
         case .error:
-            symbol = "⛔️"
+            return "⛔️"
         case .critical:
-            symbol = "🔥"
-        }
-
-        let logLine = "\(Date()) [\(label)] \(symbol) \(level): \(message)\n"
-
-        guard let data = logLine.data(using: .utf8),
-              let logFileURL = FileLogHandler.logFileURL
-        else {
-            return
-        }
-
-        if FileManager.default.fileExists(atPath: logFileURL.path()) {
-            let fileHandle = try? FileHandle(forWritingTo: logFileURL)
-            _ = try? fileHandle?.seekToEnd()
-            try? fileHandle?.write(contentsOf: data)
-            try? fileHandle?.close()
-        } else {
-            try? data.write(to: logFileURL, options: .atomic)
+            return "🔥"
         }
     }
 }

--- a/nym-vpn-apple/Services/Sources/Services/NymLogger/OSLogHandler.swift
+++ b/nym-vpn-apple/Services/Sources/Services/NymLogger/OSLogHandler.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Logging
+import os
+
+public class OSLogHandler: LogHandler {
+    private let label: String
+    private let store: OSLog
+
+    public var metadata = Logging.Logger.Metadata()
+    public var logLevel = Logging.Logger.Level.info
+
+    public init(subsystem: String, category: String) {
+        self.label = category
+        self.store = OSLog(subsystem: subsystem, category: label)
+    }
+
+    public subscript(metadataKey key: String) -> Logging.Logger.Metadata.Value? {
+        get { metadata[key] }
+        set { metadata[key] = newValue }
+    }
+
+    public func log(
+        level: Logging.Logger.Level,
+        message: Logging.Logger.Message,
+        metadata: Logging.Logger.Metadata?,
+        file: String,
+        function: String,
+        line: UInt
+    ) {
+        var fullMetadata = self.metadata
+        if let metadata = metadata {
+            fullMetadata.merge(metadata) { $1 }
+        }
+
+        var metadataOutput = fullMetadata.formatted()
+        if !metadataOutput.isEmpty {
+            metadataOutput = metadataOutput + " "
+        }
+        let logLine = "\(metadataOutput)\(message)\n"
+
+        os_log("%{public}s", log: store, type: level.osLogType, "\(logLine)")
+    }
+}
+
+extension Logging.Logger.Level {
+    var osLogType: OSLogType {
+        switch self {
+        case .trace, .debug:
+            return .debug
+        case .info, .notice, .warning:
+            return .info
+        case .error, .critical:
+            return .error
+        }
+    }
+}

--- a/nym-vpn-apple/Services/Sources/Services/NymLogger/OSLogHandler.swift
+++ b/nym-vpn-apple/Services/Sources/Services/NymLogger/OSLogHandler.swift
@@ -34,7 +34,7 @@ public class OSLogHandler: LogHandler {
 
         var metadataOutput = fullMetadata.formatted()
         if !metadataOutput.isEmpty {
-            metadataOutput = metadataOutput + " "
+            metadataOutput += " "
         }
         let logLine = "\(metadataOutput)\(message)\n"
 


### PR DESCRIPTION
1. Streamline file logger by holding onto file descriptor instead of opening it on each log message, which is fairly slow.
2. Add os logger to make it easier to monitor log in real-time.