### PR TITLE
Add network info to info response

### DIFF
--- a/nym-vpn-core/crates/nym-vpnc/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/main.rs
@@ -102,7 +102,7 @@ async fn info(client_type: ClientType) -> Result<()> {
     let mut client = vpnd_client::get_client(client_type).await?;
     let request = tonic::Request::new(InfoRequest {});
     let response = client.info(request).await?.into_inner();
-    println!("{:?}", response);
+    println!("{:#?}", response);
 
     if let Some(Ok(utc_build_timestamp)) = response.build_timestamp.map(parse_offset_datetime) {
         println!("build timestamp (utc): {:?}", utc_build_timestamp);

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/info_response.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/info_response.rs
@@ -6,15 +6,45 @@ use nym_vpn_proto::InfoResponse;
 
 impl From<VpnServiceInfoResult> for InfoResponse {
     fn from(info: VpnServiceInfoResult) -> Self {
-        let build_timestamp = info.build_timestamp.map(|ts| prost_types::Timestamp {
-            seconds: ts.unix_timestamp(),
-            nanos: ts.nanosecond() as i32,
-        });
+        let build_timestamp = info.build_timestamp.map(offset_datetime_to_timestamp);
+
+        let endpoints = info
+            .endpoints
+            .into_iter()
+            .map(validator_details_to_endpoints)
+            .collect();
+
+        let nym_vpn_api_url = info.nym_vpn_api_url.map(string_to_url);
+
         InfoResponse {
             version: info.version,
             build_timestamp,
             triple: info.triple,
             git_commit: info.git_commit,
+            network_name: info.network_name,
+            endpoints,
+            nym_vpn_api_url,
         }
     }
+}
+
+fn offset_datetime_to_timestamp(datetime: time::OffsetDateTime) -> prost_types::Timestamp {
+    prost_types::Timestamp {
+        seconds: datetime.unix_timestamp(),
+        nanos: datetime.nanosecond() as i32,
+    }
+}
+
+fn validator_details_to_endpoints(
+    validator_details: nym_vpn_lib::nym_config::defaults::ValidatorDetails,
+) -> nym_vpn_proto::Endpoints {
+    nym_vpn_proto::Endpoints {
+        nyxd_url: Some(string_to_url(validator_details.nyxd_url)),
+        websocket_url: validator_details.websocket_url.map(string_to_url),
+        api_url: validator_details.api_url.map(string_to_url),
+    }
+}
+
+fn string_to_url(url: String) -> nym_vpn_proto::Url {
+    nym_vpn_proto::Url { url }
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -210,6 +210,9 @@ pub struct VpnServiceInfoResult {
     pub build_timestamp: Option<time::OffsetDateTime>,
     pub triple: String,
     pub git_commit: String,
+    pub network_name: String,
+    pub endpoints: Vec<nym_vpn_lib::nym_config::defaults::ValidatorDetails>,
+    pub nym_vpn_api_url: Option<String>,
 }
 
 impl fmt::Display for VpnServiceStatusResult {
@@ -556,12 +559,16 @@ where
     }
 
     async fn handle_info(&self) -> VpnServiceInfoResult {
+        let network = nym_vpn_lib::nym_config::defaults::NymNetworkDetails::new_from_env();
         let bin_info = nym_vpn_lib::bin_common::bin_info_local_vergen!();
         VpnServiceInfoResult {
             version: bin_info.build_version.to_string(),
             build_timestamp: time::OffsetDateTime::parse(bin_info.build_timestamp, &Rfc3339).ok(),
             triple: bin_info.cargo_triple.to_string(),
             git_commit: bin_info.commit_sha.to_string(),
+            network_name: network.network_name,
+            endpoints: network.endpoints,
+            nym_vpn_api_url: network.nym_vpn_api_url,
         }
     }
 

--- a/proto/nym/vpn.proto
+++ b/proto/nym/vpn.proto
@@ -59,6 +59,16 @@ message Dns {
   string ip = 1;
 }
 
+message Url {
+  string url = 1;
+}
+
+message Endpoints {
+  Url nyxd_url = 1;
+  Url websocket_url = 2;
+  Url api_url = 3;
+}
+
 message InfoRequest {}
 
 message InfoResponse {
@@ -66,6 +76,9 @@ message InfoResponse {
   google.protobuf.Timestamp build_timestamp = 2;
   string triple = 3;
   string git_commit = 4;
+  string network_name = 5;
+  repeated Endpoints endpoints = 6;
+  Url nym_vpn_api_url = 7;
 }
 
 message Threshold {


### PR DESCRIPTION
To allow the UI to make sure it's in sync with the background daemon, append network info to the info response