### PR TITLE
De-duplicate some task handling in nym-vpn-lib

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-cli/src/error.rs
+++ b/nym-vpn-core/crates/nym-vpn-cli/src/error.rs
@@ -27,8 +27,8 @@ pub(crate) enum Error {
     #[error("failed to parse encoded credential data")]
     FailedToParseEncodedCredentialData(#[source] bs58::decode::Error),
 
-    #[error(transparent)]
-    Boxed(#[from] Box<dyn std::error::Error + Send + Sync + 'static>),
+    #[error("{0}")]
+    VpnRun(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
 
     #[error("vpn task stopped unexpectedly")]
     UnexpectedStop,

--- a/nym-vpn-core/crates/nym-vpn-cli/src/error.rs
+++ b/nym-vpn-core/crates/nym-vpn-cli/src/error.rs
@@ -28,7 +28,7 @@ pub(crate) enum Error {
     FailedToParseEncodedCredentialData(#[source] bs58::decode::Error),
 
     #[error(transparent)]
-    BoxedError(#[from] Box<dyn std::error::Error + Send + Sync + 'static>),
+    Boxed(#[from] Box<dyn std::error::Error + Send + Sync + 'static>),
 
     #[error("vpn task stopped unexpectedly")]
     UnexpectedStop,

--- a/nym-vpn-core/crates/nym-vpn-cli/src/error.rs
+++ b/nym-vpn-core/crates/nym-vpn-cli/src/error.rs
@@ -26,6 +26,12 @@ pub(crate) enum Error {
 
     #[error("failed to parse encoded credential data")]
     FailedToParseEncodedCredentialData(#[source] bs58::decode::Error),
+
+    #[error(transparent)]
+    BoxedError(#[from] Box<dyn std::error::Error + Send + Sync + 'static>),
+
+    #[error("vpn task stopped unexpectedly")]
+    UnexpectedStop,
 }
 
 // Result type based on our error type

--- a/nym-vpn-core/crates/nym-vpn-cli/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpn-cli/src/main.rs
@@ -186,16 +186,14 @@ async fn run_vpn(args: commands::RunArgs, data_path: Option<PathBuf>) -> Result<
 
 async fn join_vpn_handle(handle: nym_vpn_lib::NymVpnHandle) -> Result<()> {
     match handle.vpn_exit_rx.await {
-        Ok(exit_msg) => match exit_msg {
-            nym_vpn_lib::NymVpnExitStatusMessage::Stopped => {
-                debug!("VPN stopped");
-                Ok(())
-            }
-            nym_vpn_lib::NymVpnExitStatusMessage::Failed(err) => {
-                debug!("VPN exited with error: {:?}", err);
-                Err(Error::BoxedError(err))
-            }
-        },
+        Ok(nym_vpn_lib::NymVpnExitStatusMessage::Stopped) => {
+            debug!("VPN stopped");
+            Ok(())
+        }
+        Ok(nym_vpn_lib::NymVpnExitStatusMessage::Failed(err)) => {
+            debug!("VPN exited with error: {:?}", err);
+            Err(Error::Boxed(err))
+        }
         Err(err) => {
             debug!("VPN exited with error: {:?}", err);
             Err(Error::UnexpectedStop)

--- a/nym-vpn-core/crates/nym-vpn-cli/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpn-cli/src/main.rs
@@ -192,7 +192,7 @@ async fn join_vpn_handle(handle: nym_vpn_lib::NymVpnHandle) -> Result<()> {
         }
         Ok(nym_vpn_lib::NymVpnExitStatusMessage::Failed(err)) => {
             debug!("VPN exited with error: {:?}", err);
-            Err(Error::Boxed(err))
+            Err(Error::VpnRun(err))
         }
         Err(err) => {
             debug!("VPN exited with error: {:?}", err);

--- a/nym-vpn-core/crates/nym-vpnd/src/service/start.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/start.rs
@@ -33,6 +33,11 @@ pub(crate) fn start_vpn_service(
                     error!("Failed to initialize VPN service: {:?}", err);
                 }
             }
+
+            // The task handling of the vpn libary is not yet integrated with the daemon task
+            // handling, so sleep here to give the mixnet client a sporting chance to flush data to
+            // storage.
+            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
         });
     })
 }

--- a/nym-vpn-core/nym-vpn-lib/src/tunnel_setup.rs
+++ b/nym-vpn-core/nym-vpn-lib/src/tunnel_setup.rs
@@ -379,6 +379,10 @@ pub async fn setup_tunnel(
 
     let tunnels_setup = match nym_vpn {
         SpecificVpn::Wg(vpn) => {
+
+            // HERE BE DRAGONS: these all can fail, including setup_mix_tunnel, and the
+            // mixnet_client is not disconnected when that happens!
+
             let entry_authenticator_address = entry
                 .authenticator_address
                 .ok_or(Error::AuthenticatorAddressNotFound)?;

--- a/nym-vpn-core/nym-vpn-lib/src/util.rs
+++ b/nym-vpn-core/nym-vpn-lib/src/util.rs
@@ -64,7 +64,7 @@ pub(crate) async fn wait_for_interrupt(
         handle_interrupt(route_manager, wireguard_waiting).await;
 
         info!("Waiting for tasks to finish... (Press ctrl-c to force)");
-        // TODO: this contains another signal handler that needs to be moved out out.
+        // TODO: this contains another signal handler that needs to be moved out.
         task_manager.wait_for_shutdown().await;
 
         info!("Stopping mixnet client");

--- a/nym-vpn-core/nym-vpn-lib/src/util.rs
+++ b/nym-vpn-core/nym-vpn-lib/src/util.rs
@@ -1,36 +1,19 @@
 // Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use crate::{error::*, tunnel_setup::WgTunnelSetup, vpn::NymVpnCtrlMessage};
 use futures::{channel::mpsc, StreamExt};
-use log::*;
 use talpid_routing::RouteManager;
+use tracing::{error, info};
 
-pub(crate) async fn wait_and_handle_interrupt(
-    task_manager: &mut nym_task::TaskManager,
-    route_manager: RouteManager,
-    wireguard_waiting: Option<[WgTunnelSetup; 2]>,
-) {
-    wait_for_interrupt(task_manager).await;
-    handle_interrupt(route_manager, wireguard_waiting).await;
-    log::info!("Waiting for tasks to finish... (Press ctrl-c to force)");
-    task_manager.wait_for_shutdown().await;
-}
+use crate::{
+    error::{Error, Result},
+    tunnel_setup::WgTunnelSetup,
+    vpn::NymVpnCtrlMessage,
+};
 
-pub(crate) async fn wait_for_interrupt(task_manager: &mut nym_task::TaskManager) {
-    let res = nym_task::wait_for_signal_and_error(task_manager).await;
-
-    log::info!("Sending shutdown");
-    task_manager.signal_shutdown().ok();
-
-    if let Err(e) = res {
-        error!("Could not wait for interrupts anymore - {e}. Shutting down the tunnel.");
-    }
-}
-
-pub(crate) async fn wait_for_interrupt_and_signal(
+pub(crate) async fn wait_for_interrupt(
     mut task_manager: Option<nym_task::TaskManager>,
-    mut vpn_ctrl_rx: mpsc::UnboundedReceiver<NymVpnCtrlMessage>,
+    mut vpn_ctrl_rx: Option<mpsc::UnboundedReceiver<NymVpnCtrlMessage>>,
     route_manager: RouteManager,
     wireguard_waiting: Option<[WgTunnelSetup; 2]>,
 ) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
@@ -41,29 +24,39 @@ pub(crate) async fn wait_for_interrupt_and_signal(
             std::future::pending().await
         }
     };
+
+    let vpn_ctrl_rx_wait = async {
+        if let Some(vpn_ctrl_rx) = &mut vpn_ctrl_rx {
+            vpn_ctrl_rx.next().await
+        } else {
+            std::future::pending().await
+        }
+    };
+
     let res = tokio::select! {
         biased;
-        message = vpn_ctrl_rx.next() => {
-            log::debug!("Received message: {:?}", message);
-            match message {
-                Some(NymVpnCtrlMessage::Stop) => {
-                    log::info!("Received stop message");
-                }
-                None => {
-                    log::info!("Channel closed, stopping");
-                }
+        Some(message) = vpn_ctrl_rx_wait => match message {
+            NymVpnCtrlMessage::Stop => {
+                log::info!("Received stop message");
+                Ok(())
             }
-            Ok(())
-        }
+        },
         Some(msg) = task_manager_wait => {
             log::info!("Task error: {:?}", msg);
             Err(msg)
         }
         _ = tokio::signal::ctrl_c() => {
+            // TODO: instead of this we should register a signal handler that when triggered would
+            // signal a shutdown, and then indirectly exiting this select.
             log::info!("Received SIGINT");
             Ok(())
         },
+        else => {
+            log::error!("Unexpected channel close when waiting for interrupt");
+            Ok(())
+        }
     };
+
     if let Some(mut task_manager) = task_manager {
         info!("Sending shutdown signal");
         task_manager.signal_shutdown().ok();
@@ -71,6 +64,7 @@ pub(crate) async fn wait_for_interrupt_and_signal(
         handle_interrupt(route_manager, wireguard_waiting).await;
 
         info!("Waiting for tasks to finish... (Press ctrl-c to force)");
+        // TODO: this contains another signal handler that needs to be moved out out.
         task_manager.wait_for_shutdown().await;
 
         info!("Stopping mixnet client");
@@ -110,6 +104,8 @@ pub(crate) async fn handle_interrupt(
 
 #[cfg(unix)]
 pub fn unix_has_root(binary_name: &str) -> Result<()> {
+    use tracing::debug;
+
     if nix::unistd::geteuid().is_root() {
         debug!("Root privileges acquired");
         Ok(())
@@ -122,6 +118,8 @@ pub fn unix_has_root(binary_name: &str) -> Result<()> {
 
 #[cfg(windows)]
 pub fn win_has_admin(binary_name: &str) -> Result<()> {
+    use tracing::debug;
+
     if is_elevated::is_elevated() {
         debug!("Admin privileges acquired");
         Ok(())

--- a/nym-vpn-core/nym-vpn-lib/src/vpn/base.rs
+++ b/nym-vpn-core/nym-vpn-lib/src/vpn/base.rs
@@ -22,7 +22,6 @@ use crate::platform::swift::OSTunProvider;
 use crate::{
     error::Result,
     tunnel_setup::{AllTunnelsSetup, TunnelSetup},
-    Error,
 };
 
 use super::{
@@ -156,93 +155,9 @@ impl SpecificVpn {
         }
     }
 
-    // Start the Nym VPN client, and wait for it to shutdown. The use case is in simple console
-    // applications where the main way to interact with the running process is to send SIGINT
-    // (ctrl-c)
-    pub async fn run(&mut self) -> Result<()> {
-        let mut task_manager = TaskManager::new(SHUTDOWN_TIMER_SECS).named("nym_vpn_lib");
-        info!("Setting up route manager");
-        let mut route_manager = crate::tunnel::setup_route_manager().await?;
-        let (mut firewall, mut dns_monitor) = crate::tunnel_setup::init_firewall_dns(
-            #[cfg(target_os = "linux")]
-            route_manager.handle()?,
-        )
-        .await?;
-        let tunnels = match crate::tunnel_setup::setup_tunnel(
-            self,
-            &mut task_manager,
-            &mut route_manager,
-            &mut dns_monitor,
-        )
-        .await
-        {
-            Ok(tunnels) => tunnels,
-            Err(e) => {
-                tokio::task::spawn_blocking(move || {
-                    dns_monitor
-                        .reset()
-                        .inspect_err(|err| {
-                            error!("Failed to reset dns monitor: {err}");
-                        })
-                        .ok();
-                    firewall
-                        .reset_policy()
-                        .inspect_err(|err| {
-                            error!("Failed to reset firewall policy: {err}");
-                        })
-                        .ok();
-                    drop(route_manager);
-                })
-                .await?;
-                return Err(e);
-            }
-        };
-        info!("Nym VPN is now running");
-
-        // Finished starting everything, now wait for mixnet client shutdown
-        match tunnels {
-            AllTunnelsSetup::Mix(_) => {
-                let _result =
-                    crate::util::wait_for_interrupt(Some(task_manager), None, route_manager, None)
-                        .await;
-
-                tokio::task::spawn_blocking(move || {
-                    dns_monitor.reset().inspect_err(|err| {
-                        error!("Failed to reset dns monitor: {err}");
-                    })
-                })
-                .await??;
-            }
-            AllTunnelsSetup::Wg { entry, exit } => {
-                let _result = crate::util::wait_for_interrupt(
-                    Some(task_manager),
-                    None,
-                    route_manager,
-                    Some([entry.specific_setup, exit.specific_setup]),
-                )
-                .await;
-
-                tokio::task::spawn_blocking(move || {
-                    dns_monitor.reset().inspect_err(|err| {
-                        error!("Failed to reset dns monitor: {err}");
-                    })
-                })
-                .await??;
-                firewall.reset_policy().map_err(|err| {
-                    error!("Failed to reset firewall policy: {err}");
-                    Error::FirewallError(err.to_string())
-                })?;
-            }
-        }
-
-        Ok(())
-    }
-
     // Start the Nym VPN client, but also listen for external messages to e.g. disconnect as well
-    // as reporting it's status on the provided channel. The usecase when the VPN is embedded in
-    // another application, or running as a background process with a graphical interface remote
-    // controlling it.
-    pub async fn run_and_listen(
+    // as reporting it's status on the provided channel.
+    pub async fn run(
         &mut self,
         mut vpn_status_tx: nym_task::StatusSender,
         vpn_ctrl_rx: mpsc::UnboundedReceiver<super::NymVpnCtrlMessage>,

--- a/nym-vpn-core/nym-vpn-lib/src/vpn/start.rs
+++ b/nym-vpn-core/nym-vpn-lib/src/vpn/start.rs
@@ -103,7 +103,7 @@ async fn run_nym_vpn(
     vpn_ctrl_rx: mpsc::UnboundedReceiver<NymVpnCtrlMessage>,
     vpn_exit_tx: oneshot::Sender<NymVpnExitStatusMessage>,
 ) {
-    match nym_vpn.run_and_listen(vpn_status_tx, vpn_ctrl_rx).await {
+    match nym_vpn.run(vpn_status_tx, vpn_ctrl_rx).await {
         Ok(()) => {
             info!("Nym VPN has shut down");
             vpn_exit_tx


### PR DESCRIPTION
This is the start of an attempt to simplify task handling in the vpn lib and move some of it away from the lib to the binary crate. This is PR is not a complete solution but a step in the right direction, I hope.

- Switch `nym-vpn-cli` to use to use the same task handling as the daemon and uniffi clients, so that we can de-duplicate some of the code in `nym-vpn-lib` that handles waiting for the running task and interrups and delete it.

- Put in a 1 sec sleep as a hack until the task handling in `nym-vpnd` is unified with `nym-vpn-lib`.

- Stop using `nym_task::wait_for_signal_and_error` to try to push signal handling one level up. This is not the endgoal, but should bring us one step closer.

- Handle a few failures that didn't disconnect the mixnet client in the wireguard path, and put in a note about what's missing.
