### PR TITLE
Remove the ctrl-c signal handler from nym-vpn-lib

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -5228,6 +5228,7 @@ dependencies = [
  "bs58 0.5.1",
  "clap",
  "dirs 5.0.1",
+ "futures",
  "ipnetwork",
  "nym-vpn-lib",
  "thiserror",

--- a/nym-vpn-core/crates/nym-vpn-cli/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-cli/Cargo.toml
@@ -14,6 +14,7 @@ anyhow.workspace = true
 bs58.workspace = true
 clap = { workspace = true, features = ["cargo", "derive"] }
 dirs.workspace = true
+futures.workspace = true
 ipnetwork.workspace = true
 thiserror.workspace = true
 time.workspace = true

--- a/nym-vpn-core/crates/nym-vpn-cli/src/error.rs
+++ b/nym-vpn-core/crates/nym-vpn-cli/src/error.rs
@@ -26,12 +26,6 @@ pub(crate) enum Error {
 
     #[error("failed to parse encoded credential data")]
     FailedToParseEncodedCredentialData(#[source] bs58::decode::Error),
-
-    #[error("{0}")]
-    VpnRun(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
-
-    #[error("vpn task stopped unexpectedly")]
-    UnexpectedStop,
 }
 
 // Result type based on our error type

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/start.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/start.rs
@@ -10,14 +10,14 @@ use tokio::sync::{
     mpsc::{UnboundedReceiver, UnboundedSender},
 };
 use tonic::transport::Server;
-use tracing::{debug, debug_span, info, info_span, trace, trace_span, Span};
+use tracing::{debug, debug_span, info, info_span, trace, trace_span, warn, Span};
 
 use super::{
     config::{default_socket_path, default_uri_addr},
     listener::CommandInterface,
     socket_stream::setup_socket_stream,
 };
-use crate::service::{VpnServiceCommand, VpnServiceStateChange};
+use crate::service::{VpnServiceCommand, VpnServiceDisconnectResult, VpnServiceStateChange};
 
 fn grpc_span(req: &http::Request<()>) -> Span {
     let service = req.uri().path().trim_start_matches('/');
@@ -170,6 +170,7 @@ pub(crate) fn start_command_interface(
             tokio::select! {
                 _ = task_manager.catch_interrupt() => {
                     info!("Caught interrupt");
+                    disconnect_vpn(&vpn_command_tx).await;
                 },
                 _ = event_rx.recv() => {
                     info!("Caught event stop");
@@ -177,6 +178,7 @@ pub(crate) fn start_command_interface(
                     task_manager.signal_shutdown().ok();
                     info!("Waiting for shutdown ...");
                     task_manager.wait_for_shutdown().await;
+                    disconnect_vpn(&vpn_command_tx).await;
                 }
             }
 
@@ -185,4 +187,24 @@ pub(crate) fn start_command_interface(
     });
 
     (handle, vpn_command_rx)
+}
+
+async fn disconnect_vpn(vpn_command_tx: &UnboundedSender<VpnServiceCommand>) {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    vpn_command_tx
+        .send(VpnServiceCommand::Disconnect(tx))
+        .unwrap();
+    info!("Sent stop command to VPN");
+    info!("Waiting for response");
+    match rx.await.unwrap() {
+        VpnServiceDisconnectResult::Success => {
+            info!("VPN disconnect command sent successfully");
+        }
+        VpnServiceDisconnectResult::NotRunning => {
+            info!("VPN can't stop - it's not running");
+        }
+        VpnServiceDisconnectResult::Fail(ref err) => {
+            warn!("VPN failed to send disconnect command: {err}");
+        }
+    };
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/service/error.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/error.rs
@@ -299,6 +299,8 @@ impl From<&nym_vpn_lib::Error> for ConnectionFailedError {
             | nym_vpn_lib::Error::AuthenticatorAddressNotFound
             | nym_vpn_lib::Error::NotEnoughBandwidth
             | nym_vpn_lib::Error::FailedToParseEntryGatewayIpv4(_)
+            | nym_vpn_lib::Error::NymVpnExitWithError(_)
+            | nym_vpn_lib::Error::NymVpnExitUnexpectedChannelClose
             | nym_vpn_lib::Error::BadWireguardEvent => {
                 ConnectionFailedError::Unhandled(format!("unhandled error: {err:#?}"))
             }

--- a/nym-vpn-core/nym-vpn-lib/src/error.rs
+++ b/nym-vpn-core/nym-vpn-lib/src/error.rs
@@ -47,6 +47,12 @@ pub enum Error {
     #[error("vpn errored on stop")]
     StopError,
 
+    #[error("{0}")]
+    NymVpnExitWithError(#[source] Box<dyn std::error::Error + Send + Sync>),
+
+    #[error("vpn exit listener channel unexpected close when listening")]
+    NymVpnExitUnexpectedChannelClose,
+
     #[cfg(any(unix, target_os = "android"))]
     #[error("{0}")]
     TunProvider(#[from] talpid_tunnel::tun_provider::Error),

--- a/nym-vpn-core/nym-vpn-lib/src/util.rs
+++ b/nym-vpn-core/nym-vpn-lib/src/util.rs
@@ -45,12 +45,6 @@ pub(crate) async fn wait_for_interrupt(
             log::info!("Task error: {:?}", msg);
             Err(msg)
         }
-        _ = tokio::signal::ctrl_c() => {
-            // TODO: instead of this we should register a signal handler that when triggered would
-            // signal a shutdown, and then indirectly exiting this select.
-            log::info!("Received SIGINT");
-            Ok(())
-        },
         else => {
             log::error!("Unexpected channel close when waiting for interrupt");
             Ok(())


### PR DESCRIPTION
Remove the Ctrl-C signal handler from `nym-vpn-lib` and instead start it from the cli crate, which in turns sends a stop signal that gets the whole shutdown procedure rolling

NOTE: there is still a second signal handler hidden in force to exit step
