### PR TITLE
feat(vpnx): handle startup errors

### DIFF
--- a/nym-vpn-x/package-lock.json
+++ b/nym-vpn-x/package-lock.json
@@ -32,6 +32,7 @@
         "@tauri-apps/cli": "^1.5.0",
         "@types/eslint__js": "^8.42.3",
         "@types/lodash-es": "^4.17.0",
+        "@types/node": "^22.5.0",
         "@types/react": "^18.2.37",
         "@types/react-dom": "^18.2.15",
         "@types/react-router-dom": "^5.3.3",
@@ -2524,6 +2525,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/lodash": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.0.tgz",
+      "integrity": "sha512-DkFrJOe+rfdHTqqMg0bSNlGlQ85hSoh2TPzZyhHsXnMtligRWpxUySiyw8FY14ITt24HVCiQPWxS3KO/QlGmWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
       }
     },
     "node_modules/@types/prop-types": {
@@ -7538,6 +7549,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.0",

--- a/nym-vpn-x/package.json
+++ b/nym-vpn-x/package.json
@@ -52,6 +52,7 @@
     "@tauri-apps/cli": "^1.5.0",
     "@types/eslint__js": "^8.42.3",
     "@types/lodash-es": "^4.17.0",
+    "@types/node": "^22.5.0",
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.15",
     "@types/react-router-dom": "^5.3.3",

--- a/nym-vpn-x/src-tauri/src/commands/country.rs
+++ b/nym-vpn-x/src-tauri/src/commands/country.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::sync::Arc;
 use tauri::State;
 use tracing::{debug, instrument};
@@ -26,17 +25,17 @@ pub async fn get_countries(
     debug!("get_countries");
     match node_type {
         NodeType::Entry => grpc.entry_countries().await.map_err(|e| {
-            BackendError::new_with_data(
+            BackendError::new_with_details(
                 "failed to fetch entry countries",
                 ErrorKey::GetEntryCountriesQuery,
-                HashMap::from([("details", e.to_string())]),
+                e.to_string(),
             )
         }),
         NodeType::Exit => grpc.exit_countries().await.map_err(|e| {
-            BackendError::new_with_data(
+            BackendError::new_with_details(
                 "failed to fetch exit countries",
                 ErrorKey::GetExitCountriesQuery,
-                HashMap::from([("details", e.to_string())]),
+                e.to_string(),
             )
         }),
     }

--- a/nym-vpn-x/src-tauri/src/commands/mod.rs
+++ b/nym-vpn-x/src-tauri/src/commands/mod.rs
@@ -6,5 +6,5 @@ pub mod daemon;
 pub mod db;
 pub mod fs;
 pub mod log;
-pub mod window;
 pub mod startup;
+pub mod window;

--- a/nym-vpn-x/src-tauri/src/commands/mod.rs
+++ b/nym-vpn-x/src-tauri/src/commands/mod.rs
@@ -7,3 +7,4 @@ pub mod db;
 pub mod fs;
 pub mod log;
 pub mod window;
+pub mod startup;

--- a/nym-vpn-x/src-tauri/src/commands/startup.rs
+++ b/nym-vpn-x/src-tauri/src/commands/startup.rs
@@ -1,6 +1,6 @@
 use tracing::{debug, instrument, trace};
 
-use crate::startup::{StartupError, STARTUP_ERROR};
+use crate::startup_error::{StartupError, STARTUP_ERROR};
 
 #[instrument(skip_all)]
 #[tauri::command]

--- a/nym-vpn-x/src-tauri/src/commands/startup.rs
+++ b/nym-vpn-x/src-tauri/src/commands/startup.rs
@@ -1,15 +1,12 @@
-use tracing::{debug, instrument};
+use tracing::{debug, instrument, trace};
 
-use crate::error::BackendError;
-use crate::startup::STARTUP_ERROR;
+use crate::startup::{StartupError, STARTUP_ERROR};
 
 #[instrument(skip_all)]
 #[tauri::command]
-pub fn startup_error() -> Result<String, BackendError> {
+pub fn startup_error() -> Option<StartupError> {
     debug!("startup_error");
-
-    Ok(STARTUP_ERROR
-        .get()
-        .cloned()
-        .unwrap_or_else(|| "No startup error found".to_string()))
+    STARTUP_ERROR.get().cloned().inspect(|e| {
+        trace!("{:#?}", e);
+    })
 }

--- a/nym-vpn-x/src-tauri/src/commands/startup.rs
+++ b/nym-vpn-x/src-tauri/src/commands/startup.rs
@@ -1,0 +1,15 @@
+use tracing::{debug, instrument};
+
+use crate::error::BackendError;
+use crate::startup::STARTUP_ERROR;
+
+#[instrument(skip_all)]
+#[tauri::command]
+pub fn startup_error() -> Result<String, BackendError> {
+    debug!("startup_error");
+
+    Ok(STARTUP_ERROR
+        .get()
+        .cloned()
+        .unwrap_or_else(|| "No startup error found".to_string()))
+}

--- a/nym-vpn-x/src-tauri/src/error.rs
+++ b/nym-vpn-x/src-tauri/src/error.rs
@@ -47,11 +47,19 @@ impl BackendError {
         }
     }
 
-    pub fn new_with_data(message: &str, key: ErrorKey, data: HashMap<&str, String>) -> Self {
+    pub fn _new_with_data(message: &str, key: ErrorKey, data: HashMap<&str, String>) -> Self {
         Self {
             message: message.to_string(),
             key,
             data: Some(data.into_iter().map(|(k, v)| (k.to_string(), v)).collect()),
+        }
+    }
+
+    pub fn new_with_details(message: &str, key: ErrorKey, details: String) -> Self {
+        Self {
+            message: message.to_string(),
+            key,
+            data: Some(HashMap::from([("details".to_string(), details)])),
         }
     }
 

--- a/nym-vpn-x/src-tauri/src/main.rs
+++ b/nym-vpn-x/src-tauri/src/main.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::cli::{db_command, Commands};
-use crate::startup::ErrorKey;
+use crate::startup_error::ErrorKey;
 use crate::window::AppWindow;
 use crate::{
     cli::{print_build_info, Cli},
@@ -42,7 +42,7 @@ mod events;
 mod fs;
 mod grpc;
 mod log;
-mod startup;
+mod startup_error;
 mod states;
 mod system_tray;
 mod vpn_status;
@@ -81,9 +81,9 @@ async fn main() -> Result<()> {
 
     info!("Creating k/v embedded db");
     let Ok(db) = Db::new().inspect_err(|e| {
-        startup::set_error(ErrorKey::from(e), Some(&e.to_string()));
+        startup_error::set_error(ErrorKey::from(e), Some(&e.to_string()));
     }) else {
-        startup::show_error_window()?;
+        startup_error::show_window()?;
         exit(1);
     };
 

--- a/nym-vpn-x/src-tauri/src/startup.rs
+++ b/nym-vpn-x/src-tauri/src/startup.rs
@@ -1,15 +1,15 @@
 use crate::commands::startup;
 use crate::db::DbError;
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
-use tauri::Manager;
-use tracing::{error, info, warn};
+use tracing::{info, warn};
 use ts_rs::TS;
 
 pub static STARTUP_ERROR: OnceCell<StartupError> = OnceCell::new();
-const ERROR_WIN_LABEL: &str = "error";
+const WIN_LABEL: &str = "error";
+const WIN_TITLE: &str = "NymVPN - Startup error";
 
 #[derive(Debug, Serialize, Deserialize, TS, Clone)]
 #[ts(export, export_to = "StartupErrorKey.ts")]
@@ -50,13 +50,22 @@ pub fn show_error_window() -> Result<()> {
         .setup(move |app| {
             info!("app setup");
 
-            let window = app
-                .get_window(ERROR_WIN_LABEL)
-                .ok_or_else(|| anyhow!("failed to get window {}", ERROR_WIN_LABEL))?;
-
-            window
-                .show()
-                .inspect_err(|e| error!("failed to show window {}: {}", ERROR_WIN_LABEL, e))?;
+            tauri::WindowBuilder::new(
+                app,
+                WIN_LABEL,
+                tauri::WindowUrl::App("src/error.html".into()),
+            )
+            .fullscreen(false)
+            .resizable(false)
+            .maximizable(false)
+            .visible(true)
+            .focused(true)
+            .inner_size(600.0, 560.0)
+            .min_inner_size(200.0, 340.0)
+            .max_inner_size(800.0, 1000.0)
+            .center()
+            .title(WIN_TITLE)
+            .build()?;
 
             Ok(())
         })

--- a/nym-vpn-x/src-tauri/src/startup.rs
+++ b/nym-vpn-x/src-tauri/src/startup.rs
@@ -1,0 +1,43 @@
+use anyhow::{anyhow, Result};
+use once_cell::sync::OnceCell;
+use tauri::Manager;
+use tracing::{error, info, warn};
+
+use crate::commands::startup;
+
+pub static STARTUP_ERROR: OnceCell<String> = OnceCell::new();
+const ERROR_WIN_LABEL: &str = "error";
+
+pub fn set_error(error: String) {
+    STARTUP_ERROR
+        .set(error)
+        .inspect_err(|_| {
+            warn!("failed to set startup error: already set");
+        })
+        .ok();
+}
+
+pub fn show_error_window() -> Result<()> {
+    let context = tauri::generate_context!();
+
+    info!("Starting tauri app");
+    tauri::Builder::default()
+        .setup(move |app| {
+            info!("app setup");
+
+            let window = app
+                .get_window(ERROR_WIN_LABEL)
+                .ok_or_else(|| anyhow!("failed to get window {}", ERROR_WIN_LABEL))?;
+
+            window
+                .show()
+                .inspect_err(|e| error!("failed to show window {}: {}", ERROR_WIN_LABEL, e))?;
+
+            Ok(())
+        })
+        .invoke_handler(tauri::generate_handler![startup::startup_error])
+        .run(context)
+        .expect("error while running tauri application");
+
+    Ok(())
+}

--- a/nym-vpn-x/src-tauri/src/startup_error.rs
+++ b/nym-vpn-x/src-tauri/src/startup_error.rs
@@ -42,7 +42,7 @@ pub fn set_error(key: ErrorKey, details: Option<&str>) {
         .ok();
 }
 
-pub fn show_error_window() -> Result<()> {
+pub fn show_window() -> Result<()> {
     let context = tauri::generate_context!();
 
     info!("Starting tauri app");

--- a/nym-vpn-x/src-tauri/tauri.conf.json
+++ b/nym-vpn-x/src-tauri/tauri.conf.json
@@ -81,6 +81,7 @@
     },
     "windows": [
       {
+        "label": "main",
         "fullscreen": false,
         "resizable": true,
         "visible": false,
@@ -93,6 +94,23 @@
         "minHeight": 346,
         "maxWidth": 600,
         "maxHeight": 1299,
+        "maximizable": false
+      },
+      {
+        "label": "error",
+        "url": "src/error.html",
+        "fullscreen": false,
+        "resizable": false,
+        "visible": false,
+        "center": true,
+        "title": "NymVPN",
+        "hiddenTitle": true,
+        "width": 600,
+        "height": 560,
+        "minWidth": 160,
+        "minHeight": 346,
+        "maxWidth": 800,
+        "maxHeight": 1000,
         "maximizable": false
       }
     ],

--- a/nym-vpn-x/src-tauri/tauri.conf.json
+++ b/nym-vpn-x/src-tauri/tauri.conf.json
@@ -95,23 +95,6 @@
         "maxWidth": 600,
         "maxHeight": 1299,
         "maximizable": false
-      },
-      {
-        "label": "error",
-        "url": "src/error.html",
-        "fullscreen": false,
-        "resizable": false,
-        "visible": false,
-        "center": true,
-        "title": "NymVPN",
-        "hiddenTitle": true,
-        "width": 600,
-        "height": 560,
-        "minWidth": 160,
-        "minHeight": 346,
-        "maxWidth": 800,
-        "maxHeight": 1000,
-        "maximizable": false
       }
     ],
     "systemTray": {

--- a/nym-vpn-x/src/error.html
+++ b/nym-vpn-x/src/error.html
@@ -1,0 +1,19 @@
+<!-- Entry point used in case of app startup failure -->
+<!doctype html>
+<html lang="en" class="text-[14px] tracking-wide">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/nym.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>NymVPN</title>
+    <link href="/src/styles.css" rel="stylesheet" />
+  </head>
+
+  <body class="h-screen overflow-hidden">
+    <div
+      id="root"
+      class="h-full font-sans flex flex-col min-w-64 bg-baltic-sea text-mercury-pinkish"
+    ></div>
+    <script type="module" src="/src/error.tsx"></script>
+  </body>
+</html>

--- a/nym-vpn-x/src/error.tsx
+++ b/nym-vpn-x/src/error.tsx
@@ -6,9 +6,21 @@ import clsx from 'clsx';
 import { invoke } from '@tauri-apps/api';
 import { exit } from '@tauri-apps/api/process';
 import { Button, MsIcon } from './ui';
+import { StartupError, StartupErrorKey } from './types';
+
+function getErrorText(key: StartupErrorKey) {
+  switch (key) {
+    case 'StartupOpenDb':
+      return 'Failed to open the application database.';
+    case 'StartupOpenDbLocked':
+      return 'It is likely that the application is already running. You cannot run multiple instances of the application at the same time.';
+    default:
+      return 'Unknown error';
+  }
+}
 
 (async () => {
-  const error = await invoke<string | undefined>('startup_error');
+  const error = await invoke<StartupError | undefined>('startup_error');
 
   ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
@@ -30,13 +42,14 @@ import { Button, MsIcon } from './ui';
           <p className="font-semibold">
             Something went wrong while loading the app.
           </p>
-          {error && (
+          {error && <p className="font-semibold">{getErrorText(error?.key)}</p>}
+          {error?.details && (
             <div className="overflow-auto overscroll-auto max-h-32 mt-4">
               <p
                 id="error-content"
                 className="italic text-mercury-mist cursor-auto select-text"
               >
-                {error}
+                {error.details}
               </p>
             </div>
           )}

--- a/nym-vpn-x/src/error.tsx
+++ b/nym-vpn-x/src/error.tsx
@@ -1,0 +1,56 @@
+// entry point for the error window
+
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import clsx from 'clsx';
+import { invoke } from '@tauri-apps/api';
+import { exit } from '@tauri-apps/api/process';
+import { Button, MsIcon } from './ui';
+
+(async () => {
+  const error = await invoke<string | undefined>('startup_error');
+
+  ReactDOM.createRoot(document.getElementById('root')!).render(
+    <React.StrictMode>
+      <div
+        className={clsx([
+          'flex flex-col items-center justify-between h-full p-8 gap-10 cursor-default select-none',
+        ])}
+      >
+        <div className="flex flex-col mt-auto">
+          <div className="flex flex-row items-center gap-2">
+            <MsIcon
+              className="text-2xl font-bold text-cement-feet"
+              icon={'error'}
+            />
+            <h1 className="text-xl font-semibold tracking-wider leading-loose">
+              Oops!
+            </h1>
+          </div>
+          <p className="font-semibold">
+            Something went wrong while loading the app.
+          </p>
+          {error && (
+            <div className="overflow-auto overscroll-auto max-h-32 mt-4">
+              <p
+                id="error-content"
+                className="italic text-mercury-mist cursor-auto select-text"
+              >
+                {error}
+              </p>
+            </div>
+          )}
+        </div>
+        <Button
+          color="cornflower"
+          onClick={() => {
+            exit(0);
+          }}
+          className="max-w-48 mt-auto"
+        >
+          Close
+        </Button>
+      </div>
+    </React.StrictMode>,
+  );
+})();

--- a/nym-vpn-x/src/hooks/useNotify.ts
+++ b/nym-vpn-x/src/hooks/useNotify.ts
@@ -43,7 +43,7 @@ function useNotify() {
       clearTimeout(id.current);
       id.current = setTimeout(() => {
         setLastNotification(null);
-      }, AntiSpamTimeout);
+      }, AntiSpamTimeout) as unknown as number;
     }
   }, [lastNotification]);
 

--- a/nym-vpn-x/src/types/tauri-ipc.ts
+++ b/nym-vpn-x/src/types/tauri-ipc.ts
@@ -6,6 +6,8 @@ export type BackendError = {
   data: Record<string, string> | null;
 };
 
+export type StartupError = { key: StartupErrorKey; details: string | null };
+
 export type Cli = {
   nosplash: boolean;
 };
@@ -64,6 +66,8 @@ export type BkdErrorKey =
   | 'UserNoBandwidth'
   | 'GetEntryCountriesQuery'
   | 'GetExitCountriesQuery';
+
+export type StartupErrorKey = 'StartupOpenDb' | 'StartupOpenDbLocked';
 
 export type ConnectionStateResponse = {
   state: ConnectionState;

--- a/nym-vpn-x/tailwind.config.ts
+++ b/nym-vpn-x/tailwind.config.ts
@@ -2,7 +2,7 @@ import type { Config } from 'tailwindcss';
 import defaultTheme from 'tailwindcss/defaultTheme';
 
 export default {
-  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  content: ['./index.html', './src/error.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     colors: {
       transparent: 'transparent',

--- a/nym-vpn-x/vite.config.ts
+++ b/nym-vpn-x/vite.config.ts
@@ -1,3 +1,4 @@
+import { resolve } from 'path';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react-swc';
 import svgr from 'vite-plugin-svgr';
@@ -23,6 +24,10 @@ export default defineConfig(async () => ({
   envPrefix: ['VITE_', 'TAURI_', 'APP_'],
   build: {
     rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        startupError: resolve(__dirname, 'src/error.html'),
+      },
       output: {
         manualChunks: {
           // put the following packages in their own chunk


### PR DESCRIPTION
Handle unrecoverable errors at app startup via a dedicated window.
That is, if during app initialization a blocking error occurs preventing the app to start normally, it will show a friendly user dialog with the underlying error details; as it could be read from logs.

<img src="https://github.com/user-attachments/assets/c1234825-1dce-4fbd-9d1e-61e4beab92e0" width="400px" />