### PR TITLE
wf(publish-vpnx): fix sha256sum paths

### DIFF
--- a/.github/workflows/publish-nym-vpn-x.yml
+++ b/.github/workflows/publish-nym-vpn-x.yml
@@ -105,11 +105,15 @@ jobs:
 
       - name: Generate checksums
         run: |
-          for f in ${{ env.UPLOAD_DIR_UBUNTU_22}}/*; do sha256sum ${f} > ${f}.sha256sum; done
-          for f in ${{ env.UPLOAD_DIR_WINDOWS}}/*; do sha256sum ${f} > ${f}.sha256sum; done
+          pushd ${{ env.UPLOAD_DIR_UBUNTU_22 }} || exit 1
+          for f in *; do sha256sum "$f" > "$f.sha256sum"; done
+          popd
+          pushd ${{ env.UPLOAD_DIR_WINDOWS }} || exit 1
+          for f in *; do sha256sum "$f" > "$f.sha256sum"; done
+          popd
           echo 'SHA256_CHECKSUMS<<EOF' >> $GITHUB_ENV
-          cat ${{ env.UPLOAD_DIR_UBUNTU_22}}/*.sha256sum >> $GITHUB_ENV
-          cat ${{ env.UPLOAD_DIR_WINDOWS}}/*.sha256sum >> $GITHUB_ENV
+          cat ${{ env.UPLOAD_DIR_UBUNTU_22 }}/*.sha256sum >> $GITHUB_ENV
+          cat ${{ env.UPLOAD_DIR_WINDOWS }}/*.sha256sum >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
 
       # - name: AppImage installer bump version


### PR DESCRIPTION
Recent changes introduced to workflows cause sha256sums outputs with bad path

```
4aa86debaa1ba474ac2b39ec4821017f2619004c0bfad86c3418eaadc0d00223  linux_artifacts/nymvpn-x_0.1.9-dev.AppImage
e40802a82a4e9e8b36b8129bd4c4afa0f93b67b9d4ef042af88f2993f0b9f87d  linux_artifacts/nymvpn-x_0.1.9-dev_amd64.deb
```

this PR fix it

```
4aa86debaa1ba474ac2b39ec4821017f2619004c0bfad86c3418eaadc0d00223  nymvpn-x_0.1.9-dev.AppImage
e40802a82a4e9e8b36b8129bd4c4afa0f93b67b9d4ef042af88f2993f0b9f87d  nymvpn-x_0.1.9-dev_amd64.deb
```