### PR TITLE
Fix leak when releasing a box

### DIFF
--- a/nym-vpn-core/crates/nym-wg-go/src/netstack.rs
+++ b/nym-vpn-core/crates/nym-wg-go/src/netstack.rs
@@ -148,7 +148,7 @@ impl Tunnel {
             self.handle = -1;
         }
 
-        if self.boxed_logger_ptr.is_null() {
+        if !self.boxed_logger_ptr.is_null() {
             unsafe {
                 let _ = Box::from_raw(self.boxed_logger_ptr);
             }

--- a/nym-vpn-core/crates/nym-wg-go/src/wireguard_go.rs
+++ b/nym-vpn-core/crates/nym-wg-go/src/wireguard_go.rs
@@ -135,7 +135,7 @@ impl Tunnel {
             self.handle = -1;
         }
 
-        if self.boxed_logger_ptr.is_null() {
+        if !self.boxed_logger_ptr.is_null() {
             unsafe {
                 let _ = Box::from_raw(self.boxed_logger_ptr);
             }


### PR DESCRIPTION
Seems like I made a mistake and put the inverse check before releasing the boxed value.