### PR TITLE
Make sure to pass nym_vpn_api_url

### DIFF
--- a/nym-vpn-core/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-core/nym-vpn-lib/src/platform/mod.rs
@@ -170,6 +170,7 @@ fn sync_run_vpn(config: VPNConfig) -> Result<NymVpn<MixnetVpn>, FFIError> {
     );
     debug!("Created new mixnet vpn");
     vpn.generic_config.gateway_config.api_url = config.api_url;
+    vpn.generic_config.gateway_config.nym_vpn_api_url = config.vpn_api_url;
     vpn.generic_config
         .data_path
         .clone_from(&config.credential_data_path);


### PR DESCRIPTION
We forgot to assign `nym_vpn_api_url` from `VPNConfig` which caused issues when running against canary environment. This tiny PR fixes this omission.