### PR TITLE
Translations update from Nym - Desktop

### DIFF
--- a/nym-vpn-x/src/i18n/hi/settings.json
+++ b/nym-vpn-x/src/i18n/hi/settings.json
@@ -27,5 +27,8 @@
   "add-credential-button": "कनेक्ट करने के लिए क्रेडेंशियल जोड़ें",
   "logs": {
     "title": "लॉग्स"
+  },
+  "entry-selector": {
+    "title": "प्रवेश स्थान चयनकर्ता"
   }
 }

--- a/nym-vpn-x/src/i18n/pt-BR/errors.json
+++ b/nym-vpn-x/src/i18n/pt-BR/errors.json
@@ -34,7 +34,7 @@
       "entry": "Falha ao pesquisar o gateway de entrada",
       "entry-id": "Falha ao procurar a identidade do gateway de entrada",
       "exit": "Falha ao procurar o gateway de saída",
-      "exit-location": "Falha ao procurar o gateway de entrada para um determinado local"
+      "exit-location": "Falha ao procurar o gateway de saída para um determinado local"
     },
     "ipr-connect": "Falha na conexão com o IPR"
   },

--- a/nym-vpn-x/src/i18n/tr/errors.json
+++ b/nym-vpn-x/src/i18n/tr/errors.json
@@ -13,7 +13,27 @@
   "connection": {
     "no-valid-credential": "Geçerli anahtar yok, lütfen önce bir anahtar ekleyin",
     "timeout": "Bağlantı zaman aşımı",
-    "bad-country-combination": "Desteklenmeyen ülke kombinasyonu, lütfen giriş veya çıkış ülkesini değiştirin"
+    "bad-country-combination": "Desteklenmeyen ülke kombinasyonu, lütfen giriş veya çıkış ülkesini değiştirin",
+    "gateway-lookup": {
+      "entry-id": "Entry gateway'i kimliği bulunamadı",
+      "exit-location": "Verilen konum için exit gateway bulunamadı",
+      "generic": "Gateway'ler bulunamadı",
+      "id": "Gateway kimliği bulunamadı",
+      "ipr": "IPR adresi bulunamadı",
+      "ip": "Gateway IP adresi bulunamadı",
+      "entry": "Entry gateway bulunamadı",
+      "entry-location": "Verilen konum için entry gateway bulunamadı",
+      "exit": "Exit gateway bulunamadı"
+    },
+    "mixnet": {
+      "timeout": "Mixnet bağlantı zaman aşımı",
+      "storage-path": "Mixnet için depolama yolları oluşturulamadı",
+      "default-storage": "Varsayılan depolama ile mixnet oluşturulamadı",
+      "build-client": "Mixnet istemcisi oluşturulamadı",
+      "connect": "Mixnet'e bağlanılamadı",
+      "entry-gateway": "Mixnet entry gateway'ine bağlanılamadı"
+    },
+    "ipr-connect": "IPR'ye bağlanılamadı"
   },
   "countries-request": {
     "entry": "Kullanılabilir entry node ülke bilgileri alınamadı",

--- a/nym-vpn-x/src/i18n/tr/settings.json
+++ b/nym-vpn-x/src/i18n/tr/settings.json
@@ -46,5 +46,10 @@
   "logs": {
     "title": "Günlükler",
     "desc": "Logları kopyala veya sil"
+  },
+  "info": {
+    "daemon-version": "Daemon sürümü",
+    "client-version": "İstemci sürümü",
+    "network-name": "Ağ"
   }
 }


### PR DESCRIPTION
Translations update from [Nym](https://weblate.nymte.ch) for [Nym/add-credential](https://weblate.nymte.ch/projects/nymvpn/linux-windows/add-credential/).


It also includes following components:

* [Nym/welcome](https://weblate.nymte.ch/projects/nymvpn/linux-windows/welcome/)

* [Nym/notifications](https://weblate.nymte.ch/projects/nymvpn/linux-windows/notifications/)

* [Nym/settings](https://weblate.nymte.ch/projects/nymvpn/linux-windows/settings/)

* [Nym/errors](https://weblate.nymte.ch/projects/nymvpn/linux-windows/errors/)

* [Nym/home](https://weblate.nymte.ch/projects/nymvpn/linux-windows/home/)

* [Nym/display](https://weblate.nymte.ch/projects/nymvpn/linux-windows/display/)

* [Nym/node-location](https://weblate.nymte.ch/projects/nymvpn/linux-windows/node-location/)

* [Nym/licenses](https://weblate.nymte.ch/projects/nymvpn/linux-windows/licenses/)

* [Nym/common](https://weblate.nymte.ch/projects/nymvpn/linux-windows/common/)

* [Nym/glossary](https://weblate.nymte.ch/projects/nymvpn/linux-windows/glossary/)

* [Nym/backend-messages](https://weblate.nymte.ch/projects/nymvpn/linux-windows/backend-messages/)



Current translation status:

![Weblate translation status](https://weblate.nymte.ch/widget/nymvpn/linux-windows/add-credential/horizontal-auto.svg)