### PR TITLE
build(vpn-x): fix js licenses gen

### DIFF
--- a/nym-vpn-x/package.json
+++ b/nym-vpn-x/package.json
@@ -25,7 +25,7 @@
     "tscheck": "tsc --noEmit",
     "tauri": "tauri",
     "gen:licenses": "run-p --aggregate-output gen:licenses:rust gen:licenses:js",
-    "gen:licenses:js": "npx license-checker-rseidelsohn --production --json > public/licenses-js.json",
+    "gen:licenses:js": "npx --yes license-checker-rseidelsohn@4.3.0 --production --json > public/licenses-js.json",
     "gen:licenses:rust": "cargo license -j --avoid-dev-deps --avoid-build-deps --manifest-path src-tauri/Cargo.toml > public/licenses-rust.json"
   },
   "dependencies": {


### PR DESCRIPTION
Pins `license-checker-rseidelsohn` to `4.3.0` because of https://github.com/RSeidelsohn/license-checker-rseidelsohn/issues/118

Should fix [build workflows](https://github.com/nymtech/nym-vpn-client/actions/workflows/publish-nym-vpn-x.yml)