### PR TITLE
Reset shutdown handle

### DIFF
--- a/nym-vpn-core/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-core/nym-vpn-lib/src/platform/mod.rs
@@ -118,11 +118,9 @@ async fn stop_and_reset_shutdown_handle() -> Result<(), FFIError> {
     Ok(())
 }
 
-async fn reset_shutdown_handle() -> Result<(), FFIError> {
-    let mut guard = VPN_SHUTDOWN_HANDLE.lock().await;
-    *guard = None;
+async fn reset_shutdown_handle() {
+    let _ = VPN_SHUTDOWN_HANDLE.lock().await.take();
     debug!("VPN shutdown handle reset");
-    Ok(())
 }
 
 async fn _async_run_vpn(vpn: SpecificVpn) -> Result<(Arc<Notify>, NymVpnHandle), FFIError> {
@@ -255,6 +253,8 @@ pub fn startVPN(config: VPNConfig) -> Result<(), FFIError> {
                 }
 
                 uniffi_set_listener_status(StatusEvent::Tun(TunStatus::Down));
+                RUNNING.store(false, Ordering::Relaxed);
+                reset_shutdown_handle().await;
             });
 
             let shutdown_handle = ShutdownHandle::CancellationToken {
@@ -326,9 +326,7 @@ async fn run_vpn(vpn: SpecificVpn) -> Result<(), FFIError> {
     match _async_run_vpn(vpn).await {
         Err(err) => {
             debug!("Stopping and resetting shutdown handle");
-            reset_shutdown_handle()
-                .await
-                .expect("Failed to reset shutdown handle");
+            reset_shutdown_handle().await;
             RUNNING.store(false, Ordering::Relaxed);
             error!("Could not start the VPN: {:?}", err);
             uniffi_set_listener_status(StatusEvent::Exit(ExitStatus::Failed {


### PR DESCRIPTION
This PR ensures that the shutdown handle is erased when two-hop tunnel exits for any reason.