### PR TITLE
Extract netstack/android related functions into individual file

### DIFF
--- a/wireguard/libwg/netstack_android.go
+++ b/wireguard/libwg/netstack_android.go
@@ -1,0 +1,39 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2018-2019 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
+ * Copyright (C) 2024 Nym Technologies SA <contact@nymtech.net>. All Rights Reserved.
+ */
+
+package main
+
+import "C"
+
+import "golang.zx2c4.com/wireguard/conn"
+
+//export wgNetGetSocketV4
+func wgNetGetSocketV4(tunnelHandle int32) int32 {
+	tunnel, err := netTunnelHandles.Get(tunnelHandle)
+	if err != nil {
+		return ERROR_GENERAL_FAILURE
+	}
+	peek := tunnel.Device.Bind().(conn.PeekLookAtSocketFd)
+	fd, err := peek.PeekLookAtSocketFd4()
+	if err != nil {
+		return ERROR_GENERAL_FAILURE
+	}
+	return int32(fd)
+}
+
+//export wgNetGetSocketV6
+func wgNetGetSocketV6(tunnelHandle int32) int32 {
+	tunnel, err := netTunnelHandles.Get(tunnelHandle)
+	if err != nil {
+		return ERROR_GENERAL_FAILURE
+	}
+	peek := tunnel.Device.Bind().(conn.PeekLookAtSocketFd)
+	fd, err := peek.PeekLookAtSocketFd6()
+	if err != nil {
+		return ERROR_GENERAL_FAILURE
+	}
+	return int32(fd)
+}

--- a/wireguard/libwg/netstack_mobile.go
+++ b/wireguard/libwg/netstack_mobile.go
@@ -184,36 +184,6 @@ func wgNetCloseConnectionThroughTunnel(udpForwarderHandle int32) {
 	(*udpForwarder).Close()
 }
 
-// todo: move wgNetGetSocket{V4,V6} to _android specific file.
-
-//export wgNetGetSocketV4
-func wgNetGetSocketV4(tunnelHandle int32) int32 {
-	tunnel, err := netTunnelHandles.Get(tunnelHandle)
-	if err != nil {
-		return ERROR_GENERAL_FAILURE
-	}
-	peek := tunnel.Device.Bind().(conn.PeekLookAtSocketFd)
-	fd, err := peek.PeekLookAtSocketFd4()
-	if err != nil {
-		return ERROR_GENERAL_FAILURE
-	}
-	return int32(fd)
-}
-
-//export wgNetGetSocketV6
-func wgNetGetSocketV6(tunnelHandle int32) int32 {
-	tunnel, err := netTunnelHandles.Get(tunnelHandle)
-	if err != nil {
-		return ERROR_GENERAL_FAILURE
-	}
-	peek := tunnel.Device.Bind().(conn.PeekLookAtSocketFd)
-	fd, err := peek.PeekLookAtSocketFd6()
-	if err != nil {
-		return ERROR_GENERAL_FAILURE
-	}
-	return int32(fd)
-}
-
 // Parse a list of comma-separated IP addresses into array of netip.Addr structs.
 func parseIPAddrs(input string) ([]netip.Addr, error) {
 	addrs := []netip.Addr{}


### PR DESCRIPTION
This makes sure that `wgNetGetSocketV4()` and `wgNetGetSocketV6` only compile for Android where we use them