### PR TITLE
Translations update from Nym - Desktop

### DIFF
--- a/nym-vpn-x/src/i18n/en/home.json
+++ b/nym-vpn-x/src/i18n/en/home.json
@@ -30,7 +30,7 @@
     "connected": "Disabled while connected to VPN",
     "connecting": "Disabled while connecting to VPN",
     "disconnecting": "Disabled while disconnecting from VPN",
-    "daemon-not-connected": "Disabled while not connected to VPN daemon"
+    "daemon-not-connected": "The NymVPN app is currently not connected to the NymVPN daemon."
   },
   "modes-dialog": {
     "title": "Mode selection",

--- a/nym-vpn-x/src/i18n/en/notifications.json
+++ b/nym-vpn-x/src/i18n/en/notifications.json
@@ -1,7 +1,7 @@
 {
   "vpn-tunnel-state": {
     "connected": "VPN tunnel connected",
-    "disconnected": "VPN tunnel disconnected",
+    "disconnected": "NymVPN has disconnected. To safeguard your privacy, please reconnect.",
     "failed": "VPN tunnel connection failed!"
   }
 }

--- a/nym-vpn-x/src/i18n/tr/home.json
+++ b/nym-vpn-x/src/i18n/tr/home.json
@@ -21,7 +21,7 @@
     "connected": "VPN bağlıyken devre dışı",
     "connecting": "VPN bağlantısı sırasında devre dışı bırakıldı",
     "disconnecting": "VPN'den bağlantı kesilirken devre dışı bırakıldı",
-    "daemon-not-connected": "VPN daemon'ına bağlı değilken devre dışı"
+    "daemon-not-connected": "NymVPN uygulaması şu anda NymVPN daemon'una bağlı değil."
   },
   "privacy-mode": {
     "title": "Anonim",


### PR DESCRIPTION
Translations update from [Nym](https://weblate.nymte.ch) for [Nym/add-credential](https://weblate.nymte.ch/projects/nymvpn/linux-windows/add-credential/).


It also includes following components:

* [Nym/welcome](https://weblate.nymte.ch/projects/nymvpn/linux-windows/welcome/)

* [Nym/notifications](https://weblate.nymte.ch/projects/nymvpn/linux-windows/notifications/)

* [Nym/settings](https://weblate.nymte.ch/projects/nymvpn/linux-windows/settings/)

* [Nym/errors](https://weblate.nymte.ch/projects/nymvpn/linux-windows/errors/)

* [Nym/home](https://weblate.nymte.ch/projects/nymvpn/linux-windows/home/)

* [Nym/display](https://weblate.nymte.ch/projects/nymvpn/linux-windows/display/)

* [Nym/node-location](https://weblate.nymte.ch/projects/nymvpn/linux-windows/node-location/)

* [Nym/licenses](https://weblate.nymte.ch/projects/nymvpn/linux-windows/licenses/)

* [Nym/common](https://weblate.nymte.ch/projects/nymvpn/linux-windows/common/)

* [Nym/glossary](https://weblate.nymte.ch/projects/nymvpn/linux-windows/glossary/)

* [Nym/backend-messages](https://weblate.nymte.ch/projects/nymvpn/linux-windows/backend-messages/)



Current translation status:

![Weblate translation status](https://weblate.nymte.ch/widget/nymvpn/linux-windows/add-credential/horizontal-auto.svg)