### PR TITLE
Translations update from Nym - Desktop

### DIFF
--- a/nym-vpn-x/src/i18n/en/add-credential.json
+++ b/nym-vpn-x/src/i18n/en/add-credential.json
@@ -1,7 +1,7 @@
 {
   "welcome": "Welcome!",
   "description1": "Enter your credential to get started",
-  "description2": "To generate a new credential, please use the link provided in the alpha phase invitation email.",
+  "description2": "To generate a new credential, please use the link provided in the beta test invitation email.",
   "input-label": "Credential",
   "add-button": "Add credential",
   "error": "Invalid credential",

--- a/nym-vpn-x/src/i18n/en/welcome.json
+++ b/nym-vpn-x/src/i18n/en/welcome.json
@@ -1,10 +1,10 @@
 {
   "title": {
     "part1": "Welcome",
-    "part2": "to NymVPN Alpha"
+    "part2": "to NymVPN beta"
   },
   "description": {
-    "part1": "Help us refine our app during the alpha phase!",
+    "part1": "Help us refine our app during the beta test!",
     "part2": "Your feedback is crucial",
     "part3": "for identifying and resolving issues. Opt-in for anonymous error monitoring",
     "part4": "and analytics, you can opt out anytime. Thanks for your support!"

--- a/nym-vpn-x/src/i18n/tr/notifications.json
+++ b/nym-vpn-x/src/i18n/tr/notifications.json
@@ -1,7 +1,7 @@
 {
   "vpn-tunnel-state": {
     "connected": "VPN tüneli bağlandı",
-    "disconnected": "VPN tünel bağlantısı kesildi",
+    "disconnected": "NymVPN bağlantısı kesildi. Gizliliğinizi korumak için lütfen yeniden bağlanın.",
     "failed": "VPN tünel bağlantısı başarısız oldu!"
   }
 }


### PR DESCRIPTION
Translations update from [Nym](https://weblate.nymte.ch) for [Nym/add-credential](https://weblate.nymte.ch/projects/nymvpn/linux-windows/add-credential/).


It also includes following components:

* [Nym/welcome](https://weblate.nymte.ch/projects/nymvpn/linux-windows/welcome/)

* [Nym/notifications](https://weblate.nymte.ch/projects/nymvpn/linux-windows/notifications/)

* [Nym/settings](https://weblate.nymte.ch/projects/nymvpn/linux-windows/settings/)

* [Nym/errors](https://weblate.nymte.ch/projects/nymvpn/linux-windows/errors/)

* [Nym/home](https://weblate.nymte.ch/projects/nymvpn/linux-windows/home/)

* [Nym/display](https://weblate.nymte.ch/projects/nymvpn/linux-windows/display/)

* [Nym/node-location](https://weblate.nymte.ch/projects/nymvpn/linux-windows/node-location/)

* [Nym/licenses](https://weblate.nymte.ch/projects/nymvpn/linux-windows/licenses/)

* [Nym/common](https://weblate.nymte.ch/projects/nymvpn/linux-windows/common/)

* [Nym/glossary](https://weblate.nymte.ch/projects/nymvpn/linux-windows/glossary/)

* [Nym/backend-messages](https://weblate.nymte.ch/projects/nymvpn/linux-windows/backend-messages/)



Current translation status:

![Weblate translation status](https://weblate.nymte.ch/widget/nymvpn/linux-windows/add-credential/horizontal-auto.svg)