### PR TITLE
Apple: Store current env selection in shared app settings

### DIFF
--- a/nym-vpn-apple/NymMixnetTunnel/PacketTunnelProvider.swift
+++ b/nym-vpn-apple/NymMixnetTunnel/PacketTunnelProvider.swift
@@ -70,7 +70,6 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
                 logger.debug("Tunnel is up.")
                 // Stop blocking startTunnel() to avoid being terminated due to system 60s timeout
                 return
-
             case .statusUpdate(.establishingConnection):
                 logger.debug("Tunnel is establishing connection.")
             case .statusUpdate(.down):

--- a/nym-vpn-apple/Services/Package.swift
+++ b/nym-vpn-apple/Services/Package.swift
@@ -38,7 +38,9 @@ let package = Package(
     targets: [
         .target(
             name: "AppSettings",
-            dependencies: [],
+            dependencies: [
+                "Constants"
+            ],
             path: "Sources/Services/AppSettings"
         ),
         .target(
@@ -49,6 +51,7 @@ let package = Package(
         .target(
             name: "ConfigurationManager",
             dependencies: [
+                "AppSettings",
                 "Constants",
                 "NymLogger"
             ],

--- a/nym-vpn-apple/Services/Sources/Services/AppSettings/AppSettings.swift
+++ b/nym-vpn-apple/Services/Sources/Services/AppSettings/AppSettings.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Constants
 
 public final class AppSettings: ObservableObject {
     public static let shared = AppSettings()
@@ -43,6 +44,12 @@ public final class AppSettings: ObservableObject {
     @AppStorage(AppSettingKey.lastConnectionIntent.rawValue)
     public var lastConnectionIntent: String?
 
+    @AppStorage(
+        AppSettingKey.currentEnv.rawValue,
+        store: UserDefaults(suiteName: Constants.groupID.rawValue)
+    )
+    public var currentEnv: String = "mainnet"
+
     // Observed values for view models
     @Published public var isEntryLocationSelectionOnPublisher = false
     @Published public var isErrorReportingOnPublisher = false
@@ -70,4 +77,5 @@ enum AppSettingKey: String {
     case exitCountry
     case connectionType
     case lastConnectionIntent
+    case currentEnv
 }


### PR DESCRIPTION
Store current env in app settings, for tunnel to be able to set values from correct source as well.