### PR TITLE
Translations update from Nym - Desktop

### DIFF
--- a/nym-vpn-x/src/i18n/pt-BR/add-credential.json
+++ b/nym-vpn-x/src/i18n/pt-BR/add-credential.json
@@ -1,7 +1,7 @@
 {
   "welcome": "Bem vindo!",
   "description1": "Digite sua credencial para começar",
-  "description2": "Para gerar uma nova credencial, use o link fornecido no e-mail de convite da fase alfa.",
+  "description2": "Resgate sua credencial e cole ou escaneie o código QR. Não tem um? Registre-se em nymvpn.com para obtê-la instantaneamente.",
   "input-label": "Credencial",
   "add-button": "Adicionar credencial",
   "error": "Credencial inválida",

--- a/nym-vpn-x/src/i18n/pt-BR/home.json
+++ b/nym-vpn-x/src/i18n/pt-BR/home.json
@@ -20,16 +20,16 @@
     "connected": "Desativado enquanto conectado à VPN",
     "connecting": "Desativado durante a conexão com a VPN",
     "disconnecting": "Desativado ao se desconectar da VPN",
-    "daemon-not-connected": "Desativado enquanto não estiver conectado ao daemon VPN"
+    "daemon-not-connected": "O aplicativo NymVPN não está conectado ao daemon NymVPN no momento."
   },
   "connection-time": "Tempo de conexão",
   "privacy-mode": {
     "desc": "Melhor para pagamentos, e-mails e mensagens",
-    "title": "Anônimo"
+    "title": "Anônimo (mixnet)"
   },
   "fast-mode": {
     "desc": "Melhor para pesquisar, trasmitir, compartilhar",
-    "title": "Rápido"
+    "title": "Rápido (WireGuard)"
   },
   "select-mode-label": "Selecionar modo",
   "modes-dialog": {
@@ -37,5 +37,6 @@
     "privacy-description": "Aproveite a privacidade de nível máximo ao rotear sua conexão por meio de 5 servidores via mixnet. Perfeito para lidar com segurança com pagamentos, emails e mensagens.",
     "fast-description": "Experimente a velocidade máxima com 2 servidores. Perfeito para navegação rápida, streaming e compartilhamento de arquivos.",
     "link": "Continuar lendo"
-  }
+  },
+  "windows-no-fast-mode": "Como estamos fazendo a transição do modo Fast para o WireGuard, essa opção está temporariamente indisponível."
 }

--- a/nym-vpn-x/src/i18n/pt-BR/notifications.json
+++ b/nym-vpn-x/src/i18n/pt-BR/notifications.json
@@ -1,7 +1,7 @@
 {
   "vpn-tunnel-state": {
     "connected": "Túnel VPN conectado",
-    "disconnected": "Túnel VPN desconectado",
+    "disconnected": "A NymVPN foi desconectada. Para proteger sua privacidade, reconecte-se.",
     "failed": "A conexão do túnel VPN falhou!"
   }
 }

--- a/nym-vpn-x/src/i18n/pt-BR/settings.json
+++ b/nym-vpn-x/src/i18n/pt-BR/settings.json
@@ -46,5 +46,10 @@
   "logs": {
     "title": "Registros",
     "desc": "Copiar ou excluir registros"
+  },
+  "info": {
+    "daemon-version": "Versão do Daemon",
+    "network-name": "Rede",
+    "client-version": "Versão do cliente"
   }
 }

--- a/nym-vpn-x/src/i18n/pt-BR/welcome.json
+++ b/nym-vpn-x/src/i18n/pt-BR/welcome.json
@@ -6,10 +6,10 @@
   },
   "title": {
     "part1": "Bem vindo",
-    "part2": "para NymVPN Alfa"
+    "part2": "para NymVPN beta"
   },
   "description": {
-    "part1": "Ajude-nos a refinar nosso aplicativo durante a fase alfa!",
+    "part1": "Ajude-nos a refinar nosso aplicativo durante o teste beta!",
     "part2": "Seu feedback é fundamental",
     "part3": "para identificar e resolver problemas. Opte pelo monitoramento anônimo de erros",
     "part4": "e análises, você pode cancelar a qualquer momento. Obrigado por seu apoio!"

--- a/nym-vpn-x/src/i18n/tr/add-credential.json
+++ b/nym-vpn-x/src/i18n/tr/add-credential.json
@@ -1,7 +1,7 @@
 {
   "welcome": "Hoş geldiniz!",
   "description1": "Başlamak için anahtarınızı girin",
-  "description2": "Yeni bir anahtar oluşturmak için lütfen alpha aşaması davet e-postasında verilen bağlantıyı kullanın.",
+  "description2": "Giriş bilgilerinizi kullanarak giriş yapın, ardından QR kodunu yapıştırın veya tarayın. Henüz giriş bilginiz yok mu? Anında almak için nymvpn.com adresinden kaydolun.",
   "input-label": "Anahtar",
   "add-button": "Anahtarı ekle",
   "error": "Geçersiz anahtar",

--- a/nym-vpn-x/src/i18n/tr/home.json
+++ b/nym-vpn-x/src/i18n/tr/home.json
@@ -24,11 +24,11 @@
     "daemon-not-connected": "NymVPN uygulaması şu anda NymVPN daemon'una bağlı değil."
   },
   "privacy-mode": {
-    "title": "Anonim",
+    "title": "Anonim (mixnet)",
     "desc": "Ödemeler, e-postalar, mesajlar için en iyisi"
   },
   "fast-mode": {
-    "title": "Hızlı",
+    "title": "Hızlı (WireGuard)",
     "desc": "İnternet tarama, yayın, paylaşım için en iyisi"
   },
   "select-mode-label": "Mod seçin",
@@ -37,5 +37,6 @@
     "privacy-description": "Bağlantınızı mixnet üzerinden 5 sunucuya yönlendirerek maksimum düzeyde gizliliğin tadını çıkarın. Ödemeleri, e-postaları ve mesajları güvenli bir şekilde yönetmek için mükemmeldir.",
     "fast-description": "Maksimum hızı 2 sunucu bağlantısıyla deneyimleyin. Hızlı tarama, yayın izleme ve dosya paylaşımı için mükemmeldir.",
     "link": "Okumaya devam edin"
-  }
+  },
+  "windows-no-fast-mode": "Hızlı mod WireGuard'a geçirken, bu seçenek geçici olarak kullanılamamaktadır."
 }

--- a/nym-vpn-x/src/i18n/tr/welcome.json
+++ b/nym-vpn-x/src/i18n/tr/welcome.json
@@ -1,7 +1,7 @@
 {
   "title": {
     "part1": "Hoş geldiniz",
-    "part2": "NymVPN Alpha'ya"
+    "part2": "NymVPN Beta'ya"
   },
   "experimental": "Bu deneysel yazılımdır. Şu anda güçlü anonimlik için buna güvenmeyin.",
   "tos": {
@@ -11,7 +11,7 @@
   },
   "continue-button": "Devam et",
   "description": {
-    "part1": "Alpha aşamasında uygulamamızı geliştirmemize yardımcı olun!",
+    "part1": "Beta test uygulamamızı geliştirmemize yardımcı olun!",
     "part2": "Geribildiriminiz çok önemli",
     "part3": "Sorunları tespit etmek ve çözmek için. Anonim hata izleme seçeneğini tercih et",
     "part4": "ve analizler, istediğiniz zaman vazgeçebilirsiniz. Desteğiniz için teşekkürler!"


### PR DESCRIPTION
Translations update from [Nym](https://weblate.nymte.ch) for [Nym/add-credential](https://weblate.nymte.ch/projects/nymvpn/linux-windows/add-credential/).


It also includes following components:

* [Nym/welcome](https://weblate.nymte.ch/projects/nymvpn/linux-windows/welcome/)

* [Nym/notifications](https://weblate.nymte.ch/projects/nymvpn/linux-windows/notifications/)

* [Nym/settings](https://weblate.nymte.ch/projects/nymvpn/linux-windows/settings/)

* [Nym/errors](https://weblate.nymte.ch/projects/nymvpn/linux-windows/errors/)

* [Nym/home](https://weblate.nymte.ch/projects/nymvpn/linux-windows/home/)

* [Nym/display](https://weblate.nymte.ch/projects/nymvpn/linux-windows/display/)

* [Nym/node-location](https://weblate.nymte.ch/projects/nymvpn/linux-windows/node-location/)

* [Nym/licenses](https://weblate.nymte.ch/projects/nymvpn/linux-windows/licenses/)

* [Nym/common](https://weblate.nymte.ch/projects/nymvpn/linux-windows/common/)

* [Nym/glossary](https://weblate.nymte.ch/projects/nymvpn/linux-windows/glossary/)

* [Nym/backend-messages](https://weblate.nymte.ch/projects/nymvpn/linux-windows/backend-messages/)



Current translation status:

![Weblate translation status](https://weblate.nymte.ch/widget/nymvpn/linux-windows/add-credential/horizontal-auto.svg)