### PR TITLE
Install go for mac and win release builds

### DIFF
--- a/.github/workflows/build-nym-vpn-core-mac.yml
+++ b/.github/workflows/build-nym-vpn-core-mac.yml
@@ -60,7 +60,7 @@ jobs:
         env:
           RUSTFLAGS: "-L ${{ env.WG_GO_LIB_PATH }}"
         run: |
-          cargo build --${{ env.CARGO_TARGET }} --target x86_64-apple-darwin
+          cargo build --${{ env.CARGO_TARGET }} --target x86_64-apple-darwin --workspace --exclude nym-gateway-probe
           ls -la target/x86_64-apple-darwin/release/ || true
 
       - name: Build nym-vpnd with extra flags (native)

--- a/.github/workflows/build-nym-vpn-core-mac.yml
+++ b/.github/workflows/build-nym-vpn-core-mac.yml
@@ -88,7 +88,9 @@ jobs:
           lipo -create -output ${{ env.UPLOAD_DIR_MAC }}/nym-vpn-cli ${{ env.SRC_NATIVE_BINARY }}/nym-vpn-cli ${{ env.SRC_X86_64_BINARY }}/nym-vpn-cli
           lipo -create -output ${{ env.UPLOAD_DIR_MAC }}/nym-vpnc ${{ env.SRC_NATIVE_BINARY }}/nym-vpnc ${{ env.SRC_X86_64_BINARY }}/nym-vpnc
           lipo -create -output ${{ env.UPLOAD_DIR_MAC }}/nym-vpnd ${{ env.SRC_NATIVE_BINARY }}/nym-vpnd ${{ env.SRC_X86_64_BINARY }}/nym-vpnd
-          lipo -create -output ${{ env.UPLOAD_DIR_MAC }}/nym-gateway-probe ${{ env.SRC_NATIVE_BINARY }}/nym-gateway-probe ${{ env.SRC_X86_64_BINARY }}/nym-gateway-probe
+          #lipo -create -output ${{ env.UPLOAD_DIR_MAC }}/nym-gateway-probe ${{ env.SRC_NATIVE_BINARY }}/nym-gateway-probe ${{ env.SRC_X86_64_BINARY }}/nym-gateway-probe
+          # Native only for nym-gateway-probe
+          cp ${{ env.SRC_NATIVE_BINARY }}/nym-gateway-probe ${{ env.UPLOAD_DIR_MAC }}/nym-gateway-probe
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-nym-vpn-core-mac.yml
+++ b/.github/workflows/build-nym-vpn-core-mac.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Install rust toolchain
+      - name: Install Rust toolchain
         uses: brndnmtthws/rust-action-rustup@v1
         with:
           toolchain: stable
@@ -30,6 +30,11 @@ jobs:
       - name: Install extra arch apple
         run: |
           rustup target add x86_64-apple-darwin
+
+      - name: Install Go toochain
+        uses: actions/setup-go@v5
+        with:
+          go-version: "stable"
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3

--- a/.github/workflows/build-nym-vpn-core-windows.yml
+++ b/.github/workflows/build-nym-vpn-core-windows.yml
@@ -36,11 +36,16 @@ jobs:
       - name: Setup MSBuild.exe
         uses: microsoft/setup-msbuild@v2
 
-      - name: Install rust toolchain
+      - name: Install Rust toolchain
         uses: brndnmtthws/rust-action-rustup@v1
         with:
           toolchain: stable
           components: rustfmt, clippy
+
+      - name: Install Go toolchain
+        uses: actions/setup-go@v5
+        with:
+          go-version: "stable"
 
       - name: Download wireguard-go-windows artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/build-wireguard-go-deb.yml
+++ b/.github/workflows/build-wireguard-go-deb.yml
@@ -17,7 +17,10 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: "stable"
+          # With "stable" here build fails with version mismatch "1.23.1 vs
+          # 1.23.0". So setting it to explicit version as a quick hack to
+          # unblock release builds
+          go-version: 1.23.0
           cache-dependency-path: "**/go.sum"
 
       - name: Build wireguard

--- a/.github/workflows/build-wireguard-go-linux.yml
+++ b/.github/workflows/build-wireguard-go-linux.yml
@@ -15,11 +15,17 @@ jobs:
       - name: Checkout nym-vpn-client
         uses: actions/checkout@v4
 
+      - name: Check Go version
+        run: go version
+
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: "stable"
+          go-version: 1.23
           # cache-dependency-path: "**/go.sum"
+
+      - name: Check Go version
+        run: go version
 
       - name: Build wireguard
         run: ./wireguard/build-wireguard-go.sh

--- a/.github/workflows/build-wireguard-go-linux.yml
+++ b/.github/workflows/build-wireguard-go-linux.yml
@@ -15,17 +15,14 @@ jobs:
       - name: Checkout nym-vpn-client
         uses: actions/checkout@v4
 
-      - name: Check Go version
-        run: go version
-
       - name: Install Go
         uses: actions/setup-go@v5
         with:
+          # With "stable" here build fails with version mismatch "1.23.1 vs
+          # 1.23.0". So setting it to explicit version as a quick hack to
+          # unblock release builds
           go-version: 1.23.0
           cache-dependency-path: "**/go.sum"
-
-      - name: Check Go version
-        run: go version
 
       - name: Build wireguard
         run: ./wireguard/build-wireguard-go.sh

--- a/.github/workflows/build-wireguard-go-linux.yml
+++ b/.github/workflows/build-wireguard-go-linux.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: 1.23
+          cache-dependency-path: ""
           # cache-dependency-path: "**/go.sum"
 
       - name: Check Go version

--- a/.github/workflows/build-wireguard-go-linux.yml
+++ b/.github/workflows/build-wireguard-go-linux.yml
@@ -21,9 +21,8 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23
-          cache-dependency-path: ""
-          # cache-dependency-path: "**/go.sum"
+          go-version: 1.23.0
+          cache-dependency-path: "**/go.sum"
 
       - name: Check Go version
         run: go version

--- a/.github/workflows/build-wireguard-go-linux.yml
+++ b/.github/workflows/build-wireguard-go-linux.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "stable"
-          cache-dependency-path: "**/go.sum"
+          # cache-dependency-path: "**/go.sum"
 
       - name: Build wireguard
         run: ./wireguard/build-wireguard-go.sh

--- a/.github/workflows/ci-nym-vpn-core-cargo-deny.yml
+++ b/.github/workflows/ci-nym-vpn-core-cargo-deny.yml
@@ -7,15 +7,19 @@ on:
       - 'nym-vpn-core/**/Cargo.toml'
 jobs:
   cargo-deny:
-    runs-on: arc-ubuntu-22.04
+    runs-on: arc-ubuntu-22.04-dind
     steps:
       - uses: actions/checkout@v4
-      - run: |
-          sudo apt-get update && sudo apt-get install -y curl gcc git
+      # - run: |
+      #     sudo apt-get update && sudo apt-get install -y curl gcc git
       - uses: dtolnay/rust-toolchain@stable
       # The cargo-deny action uses docker which we currently can't run on
       # arc-ubuntu-22.04, so we have to build manually for now
-      - run: cargo install --locked cargo-deny
-      - run: |
-          cd nym-vpn-core
-          cargo deny --all-features check licenses bans sources
+      # - run: cargo install --locked cargo-deny
+      # - run: |
+      #     cd nym-vpn-core
+      - uses: EmbarkStudios/cargo-deny-action@v1
+        with:
+          manifest-path: ./nym-vpn-core/Cargo.toml
+          command: check licenses bans sources
+          arguments: --all-features  cargo deny --all-features check licenses bans sources

--- a/.github/workflows/ci-nym-vpn-core-cargo-deny.yml
+++ b/.github/workflows/ci-nym-vpn-core-cargo-deny.yml
@@ -10,14 +10,7 @@ jobs:
     runs-on: arc-ubuntu-22.04-dind
     steps:
       - uses: actions/checkout@v4
-      # - run: |
-      #     sudo apt-get update && sudo apt-get install -y curl gcc git
       - uses: dtolnay/rust-toolchain@stable
-      # The cargo-deny action uses docker which we currently can't run on
-      # arc-ubuntu-22.04, so we have to build manually for now
-      # - run: cargo install --locked cargo-deny
-      # - run: |
-      #     cd nym-vpn-core
       - uses: EmbarkStudios/cargo-deny-action@v1
         with:
           manifest-path: ./nym-vpn-core/Cargo.toml

--- a/.github/workflows/ci-nym-vpn-core-cargo-deny.yml
+++ b/.github/workflows/ci-nym-vpn-core-cargo-deny.yml
@@ -22,4 +22,4 @@ jobs:
         with:
           manifest-path: ./nym-vpn-core/Cargo.toml
           command: check licenses bans sources
-          arguments: --all-features  cargo deny --all-features check licenses bans sources
+          arguments: --all-features

--- a/.github/workflows/ci-nym-vpn-core-cargo-deny.yml
+++ b/.github/workflows/ci-nym-vpn-core-cargo-deny.yml
@@ -3,8 +3,6 @@ on:
   pull_request:
     paths:
       - "nym-vpn-core/**"
-  workflow_dispatch:
-
 jobs:
   cargo-deny:
     runs-on: arc-ubuntu-22.04
@@ -15,12 +13,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       # The cargo-deny action uses docker which we currently can't run on
       # arc-ubuntu-22.04, so we have to build manually for now
-      # - run: cargo install --locked cargo-deny
-      # - run: |
-      #     cd nym-vpn-core
-      #     cargo deny --all-features check licenses bans sources
-      - uses: EmbarkStudios/cargo-deny-action@v1
-        with:
-          manifest-path: ./nym-vpn-core/Cargo.toml
-          command: check licenses bans sources
-          arguments: --all-features
+      - run: cargo install --locked cargo-deny
+      - run: |
+          cd nym-vpn-core
+          cargo deny --all-features check licenses bans sources

--- a/.github/workflows/ci-nym-vpn-core-cargo-deny.yml
+++ b/.github/workflows/ci-nym-vpn-core-cargo-deny.yml
@@ -15,7 +15,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       # The cargo-deny action uses docker which we currently can't run on
       # arc-ubuntu-22.04, so we have to build manually for now
-      - run: cargo install --locked cargo-deny
-      - run: |
-          cd nym-vpn-core
-          cargo deny --all-features check licenses bans sources
+      # - run: cargo install --locked cargo-deny
+      # - run: |
+      #     cd nym-vpn-core
+      #     cargo deny --all-features check licenses bans sources
+      - uses: EmbarkStudios/cargo-deny-action@v1
+        with:
+          manifest-path: ./nym-vpn-core/Cargo.toml
+          command: check licenses bans sources
+          arguments: --all-features

--- a/.github/workflows/ci-nym-vpn-core-cargo-deny.yml
+++ b/.github/workflows/ci-nym-vpn-core-cargo-deny.yml
@@ -1,8 +1,10 @@
 name: ci-nym-vpn-core-cargo-deny
 on:
+  workflow_dispatch:
   pull_request:
     paths:
-      - "nym-vpn-core/**"
+      - 'nym-vpn-core/**/Cargo.lock'
+      - 'nym-vpn-core/**/Cargo.toml'
 jobs:
   cargo-deny:
     runs-on: arc-ubuntu-22.04

--- a/.github/workflows/publish-nym-vpn-core.yml
+++ b/.github/workflows/publish-nym-vpn-core.yml
@@ -90,6 +90,10 @@ jobs:
       - if: github.event_name == 'push'
         run: echo "TAG_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
 
+      - name: Set tag
+        id: set_tag
+        run: echo "tag=${{ env.TAG_NAME }}" >> "$GITHUB_OUTPUT"
+
       - name: Generate checksums and create tar.gz archive per platform
         run: |
           ARCHIVE_LINUX=nym-vpn-core-v${{ steps.workspace-version.outputs.metadata }}_linux_x86_64


### PR DESCRIPTION
Fix release builds for nym-vpn-core

- Install Go toolchain on windows and mac
- Workaround for  Go version mismatch error for the wireguard build on linux

Also

- Narrow file triggers for cargo-deny to only Cargo.toml and Cargo.lock files
- Fix bug where gen-hashes was generating hashes for all releases on each run
- Switch cargo-deny CI build to use the new arc dind runner

Successful build: https://github.com/nymtech/nym-vpn-client/actions/runs/10749859761