### PR TITLE
Fix go toolchain on linux

### DIFF
--- a/.github/workflows/build-nym-vpn-android.yml
+++ b/.github/workflows/build-nym-vpn-android.yml
@@ -85,11 +85,23 @@ jobs:
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
+
       # Native build dependencies
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version: "stable"
+
+      - name: Override GOROOT and GOTOOLDIR
+        if: contains(matrix.os, 'ubuntu')
+        run: |
+          echo "Setting correct GOROOT and GOTOOLDIR"
+          unset GOROOT
+          unset GOTOOLDIR
+          export GOROOT=$(go env GOROOT)
+          export GOTOOLDIR=$(go env GOTOOLDIR)
+          echo "GOROOT=$GOROOT" >> $GITHUB_ENV
+          echo "GOTOOLDIR=$GOTOOLDIR" >> $GITHUB_ENV
 
       - name: Add rust stable toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/build-nym-vpn-android.yml
+++ b/.github/workflows/build-nym-vpn-android.yml
@@ -93,7 +93,6 @@ jobs:
           go-version: "stable"
 
       - name: Override GOROOT and GOTOOLDIR
-        if: contains(matrix.os, 'ubuntu')
         run: |
           echo "Setting correct GOROOT and GOTOOLDIR"
           unset GOROOT

--- a/.github/workflows/build-wireguard-go-android.yml
+++ b/.github/workflows/build-wireguard-go-android.yml
@@ -1,5 +1,10 @@
 name: build-wireguard-go-android
-on: [workflow_dispatch, workflow_call]
+on:
+  workflow_dispatch:
+  workflow_call:
+  pull_request:
+    paths:
+      - ".github/workflows/build-wireguard-go-android.yml"
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/build-wireguard-go-deb.yml
+++ b/.github/workflows/build-wireguard-go-deb.yml
@@ -33,8 +33,6 @@ jobs:
 
       - name: Build wireguard
         run: |
-          unset GOROOT
-          unset GOTOOLDIR
           ./wireguard/build-wireguard-go.sh
 
       - name: Upload artifacts

--- a/.github/workflows/build-wireguard-go-deb.yml
+++ b/.github/workflows/build-wireguard-go-deb.yml
@@ -34,14 +34,6 @@ jobs:
           export GOTOOLDIR=$(go env GOTOOLDIR)
           echo "GOROOT=$GOROOT" >> $GITHUB_ENV
           echo "GOTOOLDIR=$GOTOOLDIR" >> $GITHUB_ENV
-          echo $GOROOT
-          echo $GOTOOLDIR
-
-      - name: Verify Go version, GOROOT, and GOTOOLDIR
-        run: |
-          go version
-          echo "GOROOT is set to: $GOROOT"
-          echo "GOTOOLDIR is set to: $GOTOOLDIR"
 
       - name: Build wireguard
         run: |

--- a/.github/workflows/build-wireguard-go-deb.yml
+++ b/.github/workflows/build-wireguard-go-deb.yml
@@ -32,6 +32,8 @@ jobs:
           export GOTOOLDIR=$(go env GOTOOLDIR)
           echo "GOROOT=$GOROOT" >> $GITHUB_ENV
           echo "GOTOOLDIR=$GOTOOLDIR" >> $GITHUB_ENV
+          echo $GOROOT
+          echo $GOTOOLDIR
 
       - name: Verify Go version, GOROOT, and GOTOOLDIR
         run: |

--- a/.github/workflows/build-wireguard-go-deb.yml
+++ b/.github/workflows/build-wireguard-go-deb.yml
@@ -1,5 +1,10 @@
 name: build-wireguard-go-deb
-on: [workflow_dispatch, workflow_call]
+on:
+  workflow_dispatch:
+  workflow_call:
+  pull_request:
+    paths:
+      - ".github/workflows/build-wireguard-go-deb.yml"
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/build-wireguard-go-deb.yml
+++ b/.github/workflows/build-wireguard-go-deb.yml
@@ -28,6 +28,8 @@ jobs:
       - name: Override GOROOT and GOTOOLDIR
         run: |
           echo "Setting correct GOROOT and GOTOOLDIR"
+          unset GOROOT
+          unset GOTOOLDIR
           export GOROOT=$(go env GOROOT)
           export GOTOOLDIR=$(go env GOTOOLDIR)
           echo "GOROOT=$GOROOT" >> $GITHUB_ENV

--- a/.github/workflows/build-wireguard-go-deb.yml
+++ b/.github/workflows/build-wireguard-go-deb.yml
@@ -17,14 +17,14 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          # With "stable" here build fails with version mismatch "1.23.1 vs
-          # 1.23.0". So setting it to explicit version as a quick hack to
-          # unblock release builds
-          go-version: 1.23.0
+          go-version: "stable"
           cache-dependency-path: "**/go.sum"
 
       - name: Build wireguard
-        run: ./wireguard/build-wireguard-go.sh
+        run: |
+          unset GOROOT
+          unset GOTOOLDIR
+          ./wireguard/build-wireguard-go.sh
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-wireguard-go-deb.yml
+++ b/.github/workflows/build-wireguard-go-deb.yml
@@ -25,11 +25,19 @@ jobs:
           go-version: "stable"
           cache-dependency-path: "**/go.sum"
 
-      - name: Override GOROOT
+      - name: Override GOROOT and GOTOOLDIR
         run: |
-          echo "Setting correct GOROOT"
+          echo "Setting correct GOROOT and GOTOOLDIR"
           export GOROOT=$(go env GOROOT)
+          export GOTOOLDIR=$(go env GOTOOLDIR)
           echo "GOROOT=$GOROOT" >> $GITHUB_ENV
+          echo "GOTOOLDIR=$GOTOOLDIR" >> $GITHUB_ENV
+
+      - name: Verify Go version, GOROOT, and GOTOOLDIR
+        run: |
+          go version
+          echo "GOROOT is set to: $GOROOT"
+          echo "GOTOOLDIR is set to: $GOTOOLDIR"
 
       - name: Build wireguard
         run: |

--- a/.github/workflows/build-wireguard-go-deb.yml
+++ b/.github/workflows/build-wireguard-go-deb.yml
@@ -25,6 +25,12 @@ jobs:
           go-version: "stable"
           cache-dependency-path: "**/go.sum"
 
+      - name: Override GOROOT
+        run: |
+          echo "Setting correct GOROOT"
+          export GOROOT=$(go env GOROOT)
+          echo "GOROOT=$GOROOT" >> $GITHUB_ENV
+
       - name: Build wireguard
         run: |
           unset GOROOT

--- a/.github/workflows/build-wireguard-go-linux.yml
+++ b/.github/workflows/build-wireguard-go-linux.yml
@@ -21,6 +21,7 @@ jobs:
           echo $PATH
           ls -al /go
           ls -al /go/bin
+          rm -rf /usr/local/go
 
       - name: Install Go
         uses: actions/setup-go@v5

--- a/.github/workflows/build-wireguard-go-linux.yml
+++ b/.github/workflows/build-wireguard-go-linux.yml
@@ -34,8 +34,6 @@ jobs:
 
       - name: Build wireguard
         run: |
-          unset GOROOT
-          unset GOTOOLDIR
           ./wireguard/build-wireguard-go.sh
 
       - name: Upload artifacts

--- a/.github/workflows/build-wireguard-go-linux.yml
+++ b/.github/workflows/build-wireguard-go-linux.yml
@@ -26,6 +26,12 @@ jobs:
           go-version: "stable"
           cache-dependency-path: "**/go.sum"
 
+      - name: Override GOROOT
+        run: |
+          echo "Setting correct GOROOT"
+          export GOROOT=$(go env GOROOT)
+          echo "GOROOT=$GOROOT" >> $GITHUB_ENV
+
       - name: Build wireguard
         run: |
           unset GOROOT

--- a/.github/workflows/build-wireguard-go-linux.yml
+++ b/.github/workflows/build-wireguard-go-linux.yml
@@ -1,5 +1,10 @@
 name: build-wireguard-go-linux
-on: [workflow_dispatch, workflow_call]
+on:
+  workflow_dispatch:
+  workflow_call:
+  pull_request:
+    paths:
+      - ".github/workflows/build-wireguard-go-linux.yml"
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/build-wireguard-go-linux.yml
+++ b/.github/workflows/build-wireguard-go-linux.yml
@@ -15,38 +15,14 @@ jobs:
       - name: Checkout nym-vpn-client
         uses: actions/checkout@v4
 
-      - run: |
-          which go
-          go version
-          echo $PATH
-          ls -al /go
-          ls -al /go/bin
-          # rm -rf /usr/local/go
-
-      # - name: Remove system Go from PATH
-      #   run: |
-      #     echo "Current PATH: $PATH"
-      #     export PATH=$(echo "$PATH" | sed -e 's|:/usr/local/go/bin||g')
-      #     echo "Modified PATH: $PATH"
-      #     echo "PATH after modification: $PATH" >> $GITHUB_ENV
-
       - name: Install Go
         uses: actions/setup-go@v5
         with:
           go-version: "stable"
           cache-dependency-path: "**/go.sum"
 
-      - name: Clean Go build cache
-        working-directory: wireguard/libwg
-        run: go clean -cache -modcache -i -r
-
       - name: Build wireguard
         run: |
-          which go
-          go version
-          echo $PATH
-          ls -al /go
-          ls -al /go/bin
           unset GOROOT
           unset GOTOOLDIR
           ./wireguard/build-wireguard-go.sh

--- a/.github/workflows/build-wireguard-go-linux.yml
+++ b/.github/workflows/build-wireguard-go-linux.yml
@@ -27,6 +27,7 @@ jobs:
           cache-dependency-path: "**/go.sum"
 
       - name: Clean Go build cache
+        working-directory: wireguard-go/libwg
         run: go clean -cache -modcache -i -r
 
       - name: Build wireguard

--- a/.github/workflows/build-wireguard-go-linux.yml
+++ b/.github/workflows/build-wireguard-go-linux.yml
@@ -19,6 +19,8 @@ jobs:
           which go
           go version
           echo $PATH
+          ls -al /go
+          ls -al /go/bin
 
       - name: Install Go
         uses: actions/setup-go@v5

--- a/.github/workflows/build-wireguard-go-linux.yml
+++ b/.github/workflows/build-wireguard-go-linux.yml
@@ -15,14 +15,23 @@ jobs:
       - name: Checkout nym-vpn-client
         uses: actions/checkout@v4
 
+      - run: |
+          which go
+          go version
+          echo $PATH
+
       - name: Install Go
         uses: actions/setup-go@v5
         with:
           go-version: "stable"
           cache-dependency-path: "**/go.sum"
 
+      - name: Clean Go build cache
+        run: go clean -cache -modcache -i -r
+
       - name: Build wireguard
         run: |
+          which go
           go version
           echo $PATH
           ./wireguard/build-wireguard-go.sh

--- a/.github/workflows/build-wireguard-go-linux.yml
+++ b/.github/workflows/build-wireguard-go-linux.yml
@@ -27,7 +27,7 @@ jobs:
           cache-dependency-path: "**/go.sum"
 
       - name: Clean Go build cache
-        working-directory: wireguard-go/libwg
+        working-directory: wireguard/libwg
         run: go clean -cache -modcache -i -r
 
       - name: Build wireguard

--- a/.github/workflows/build-wireguard-go-linux.yml
+++ b/.github/workflows/build-wireguard-go-linux.yml
@@ -26,11 +26,15 @@ jobs:
           go-version: "stable"
           cache-dependency-path: "**/go.sum"
 
-      - name: Override GOROOT
+      - name: Override GOROOT and GOTOOLDIR
         run: |
-          echo "Setting correct GOROOT"
+          echo "Setting correct GOROOT and GOTOOLDIR"
+          unset GOROOT
+          unset GOTOOLDIR
           export GOROOT=$(go env GOROOT)
+          export GOTOOLDIR=$(go env GOTOOLDIR)
           echo "GOROOT=$GOROOT" >> $GITHUB_ENV
+          echo "GOTOOLDIR=$GOTOOLDIR" >> $GITHUB_ENV
 
       - name: Build wireguard
         run: |

--- a/.github/workflows/build-wireguard-go-linux.yml
+++ b/.github/workflows/build-wireguard-go-linux.yml
@@ -21,7 +21,14 @@ jobs:
           echo $PATH
           ls -al /go
           ls -al /go/bin
-          rm -rf /usr/local/go
+          # rm -rf /usr/local/go
+
+      - name: Remove system Go from PATH
+        run: |
+          echo "Current PATH: $PATH"
+          export PATH=$(echo "$PATH" | sed -e 's|:/usr/local/go/bin||g')
+          echo "Modified PATH: $PATH"
+          echo "PATH after modification: $PATH" >> $GITHUB_ENV
 
       - name: Install Go
         uses: actions/setup-go@v5

--- a/.github/workflows/build-wireguard-go-linux.yml
+++ b/.github/workflows/build-wireguard-go-linux.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          # With "stable" here build fails with version mismatch "1.23.1 vs
-          # 1.23.0". So setting it to explicit version as a quick hack to
-          # unblock release builds
-          go-version: 1.23.0
+          go-version: "stable"
           cache-dependency-path: "**/go.sum"
 
       - name: Build wireguard
-        run: ./wireguard/build-wireguard-go.sh
+        run: |
+          go version
+          echo $PATH
+          ./wireguard/build-wireguard-go.sh
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-wireguard-go-linux.yml
+++ b/.github/workflows/build-wireguard-go-linux.yml
@@ -23,12 +23,12 @@ jobs:
           ls -al /go/bin
           # rm -rf /usr/local/go
 
-      - name: Remove system Go from PATH
-        run: |
-          echo "Current PATH: $PATH"
-          export PATH=$(echo "$PATH" | sed -e 's|:/usr/local/go/bin||g')
-          echo "Modified PATH: $PATH"
-          echo "PATH after modification: $PATH" >> $GITHUB_ENV
+      # - name: Remove system Go from PATH
+      #   run: |
+      #     echo "Current PATH: $PATH"
+      #     export PATH=$(echo "$PATH" | sed -e 's|:/usr/local/go/bin||g')
+      #     echo "Modified PATH: $PATH"
+      #     echo "PATH after modification: $PATH" >> $GITHUB_ENV
 
       - name: Install Go
         uses: actions/setup-go@v5
@@ -45,6 +45,10 @@ jobs:
           which go
           go version
           echo $PATH
+          ls -al /go
+          ls -al /go/bin
+          unset GOROOT
+          unset GOTOOLDIR
           ./wireguard/build-wireguard-go.sh
 
       - name: Upload artifacts

--- a/.github/workflows/ci-nym-vpn-core.yml
+++ b/.github/workflows/ci-nym-vpn-core.yml
@@ -119,7 +119,6 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-
       - name: Setup MSBuild.exe
         if: contains(matrix.os, 'windows')
         uses: microsoft/setup-msbuild@v2
@@ -128,6 +127,8 @@ jobs:
         if: matrix.target != 'ios' && matrix.target != 'android'
         shell: bash
         run: |
+          unset GOROOT
+          unset GOTOOLDIR
           ./wireguard/build-wireguard-go.sh
 
       - name: Build wireguard (iOS)

--- a/.github/workflows/ci-nym-vpn-core.yml
+++ b/.github/workflows/ci-nym-vpn-core.yml
@@ -113,6 +113,12 @@ jobs:
         with:
           go-version: "stable"
 
+      - name: Override GOROOT
+        run: |
+          echo "Setting correct GOROOT"
+          export GOROOT=$(go env GOROOT)
+          echo "GOROOT=$GOROOT" >> $GITHUB_ENV
+
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
         if: contains(matrix.os, 'macos') || contains(matrix.os, 'windows')

--- a/.github/workflows/ci-nym-vpn-core.yml
+++ b/.github/workflows/ci-nym-vpn-core.yml
@@ -133,8 +133,6 @@ jobs:
         if: matrix.target != 'ios' && matrix.target != 'android'
         shell: bash
         run: |
-          unset GOROOT
-          unset GOTOOLDIR
           ./wireguard/build-wireguard-go.sh
 
       - name: Build wireguard (iOS)

--- a/.github/workflows/ci-nym-vpn-core.yml
+++ b/.github/workflows/ci-nym-vpn-core.yml
@@ -113,11 +113,15 @@ jobs:
         with:
           go-version: "stable"
 
-      - name: Override GOROOT
+      - name: Override GOROOT and GOTOOLDIR
         run: |
-          echo "Setting correct GOROOT"
+          echo "Setting correct GOROOT and GOTOOLDIR"
+          unset GOROOT
+          unset GOTOOLDIR
           export GOROOT=$(go env GOROOT)
+          export GOTOOLDIR=$(go env GOTOOLDIR)
           echo "GOROOT=$GOROOT" >> $GITHUB_ENV
+          echo "GOTOOLDIR=$GOTOOLDIR" >> $GITHUB_ENV
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3

--- a/.github/workflows/ci-nym-vpn-core.yml
+++ b/.github/workflows/ci-nym-vpn-core.yml
@@ -114,6 +114,7 @@ jobs:
           go-version: "stable"
 
       - name: Override GOROOT and GOTOOLDIR
+        if: contains(matrix.os, 'ubuntu')
         run: |
           echo "Setting correct GOROOT and GOTOOLDIR"
           unset GOROOT

--- a/wireguard/build-wireguard-go.sh
+++ b/wireguard/build-wireguard-go.sh
@@ -133,6 +133,8 @@ function create_folder_and_build {
     target_triple_dir="../../build/lib/$1"
 
     mkdir -p $target_triple_dir
+    echo $PATH
+    go version
     go build -trimpath -v -o $target_triple_dir/libwg.a -buildmode c-archive
 }
 

--- a/wireguard/build-wireguard-go.sh
+++ b/wireguard/build-wireguard-go.sh
@@ -133,14 +133,12 @@ function create_folder_and_build {
     target_triple_dir="../../build/lib/$1"
 
     mkdir -p $target_triple_dir
-    echo $PATH
-    go version
     go build -trimpath -v -o $target_triple_dir/libwg.a -buildmode c-archive
 }
 
 function build_macos_universal {
     patch_darwin_goruntime
-    
+
     export CGO_ENABLED=1
     export MACOSX_DEPLOYMENT_TARGET=10.13
 
@@ -167,7 +165,7 @@ function build_ios {
 
     export CGO_ENABLED=1
     export IPHONEOS_DEPLOYMENT_TARGET=16.0
-    
+
     pushd libwg
 
     echo "🍎 Building for ios/aarch64"
@@ -209,7 +207,7 @@ function build_ios {
     mkdir -p "../../build/lib/universal-apple-ios-sim/"
     lipo -create -output "../../build/lib/universal-apple-ios-sim/libwg.a"  "../../build/lib/x86_64-apple-ios/libwg.a" "../../build/lib/aarch64-apple-ios-sim/libwg.a"
     cp "../../build/lib/aarch64-apple-ios/libwg.h" "../../build/lib/universal-apple-ios-sim/libwg.h"
-    
+
     popd
 }
 


### PR DESCRIPTION
Fix go toolchain on the arc runners by overriding GOROOT and GOTOOLDIR. These were set to the system installed version of go which is a different version, leading to version mismatch errors
