### PR TITLE
Use new vpn-api gateway directory

### DIFF
--- a/.github/workflows/ci-nym-vpn-android.yml
+++ b/.github/workflows/ci-nym-vpn-android.yml
@@ -35,9 +35,6 @@ jobs:
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
 
-      - name: Install NDK
-        run: sdkmanager "ndk;26.3.11579264"
-
       - name: Run ktlint
         run: ./gradlew ktlintCheck
 

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
@@ -196,11 +196,11 @@ impl TryFrom<nym_vpn_api_client::response::NymDirectoryGateway> for Gateway {
             identity,
             location: Some(gateway.location.into()),
             ipr_address: gateway
-                .ipr_address
-                .and_then(|ipr| IpPacketRouterAddress::try_from_base58_string(&ipr).ok()),
+                .ip_packet_router
+                .and_then(|ipr| IpPacketRouterAddress::try_from_base58_string(&ipr.address).ok()),
             authenticator_address: gateway
-                .authenticator_address
-                .and_then(|auth| AuthAddress::try_from_base58_string(&auth).ok()),
+                .authenticator
+                .and_then(|auth| AuthAddress::try_from_base58_string(&auth.address).ok()),
             last_probe: gateway.last_probe.map(Probe::from),
             host,
             clients_ws_port: Some(gateway.entry.ws_port),

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
@@ -63,6 +63,10 @@ impl Gateway {
         self.ipr_address.is_some()
     }
 
+    pub fn has_authenticator_address(&self) -> bool {
+        self.authenticator_address.is_some()
+    }
+
     pub fn clients_address_no_tls(&self) -> Option<String> {
         match (&self.host, &self.clients_ws_port) {
             (Some(host), Some(port)) => Some(format!("ws://{}:{}", host, port)),
@@ -341,6 +345,15 @@ impl GatewayList {
             .gateways
             .into_iter()
             .filter(Gateway::has_ipr_address)
+            .collect();
+        Self::new(gw)
+    }
+
+    pub fn into_vpn_gateways(self) -> GatewayList {
+        let gw = self
+            .gateways
+            .into_iter()
+            .filter(Gateway::has_authenticator_address)
             .collect();
         Self::new(gw)
     }

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
@@ -1,6 +1,8 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use std::{net::IpAddr, str::FromStr};
+
 use itertools::Itertools;
 use nym_sdk::mixnet::NodeIdentity;
 use nym_topology::IntoGatewayNode;
@@ -12,7 +14,7 @@ use crate::{error::Result, AuthAddress, Country, Error, IpPacketRouterAddress};
 // Decimal between 0 and 1 representing the performance of a gateway, measured over 24h.
 type Performance = u8;
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct Gateway {
     pub identity: NodeIdentity,
     pub location: Option<Location>,
@@ -23,6 +25,22 @@ pub struct Gateway {
     pub clients_ws_port: Option<u16>,
     pub clients_wss_port: Option<u16>,
     pub performance: Option<Performance>,
+}
+
+impl std::fmt::Debug for Gateway {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Gateway")
+            .field("identity", &self.identity.to_base58_string())
+            .field("location", &self.location)
+            .field("ipr_address", &self.ipr_address)
+            .field("authenticator_address", &self.authenticator_address)
+            .field("last_probe", &self.last_probe)
+            .field("host", &self.host)
+            .field("clients_ws_port", &self.clients_ws_port)
+            .field("clients_wss_port", &self.clients_wss_port)
+            .field("performance", &self.performance)
+            .finish()
+    }
 }
 
 impl Gateway {
@@ -154,16 +172,40 @@ impl TryFrom<nym_vpn_api_client::response::NymDirectoryGateway> for Gateway {
                     source,
                 }
             })?;
+
+        let host = gateway
+            .entry
+            .hostname
+            .map(nym_topology::NetworkAddress::Hostname)
+            .or(gateway
+                .ip_addresses
+                .first()
+                .cloned()
+                .and_then(|ip| IpAddr::from_str(&ip).ok())
+                .map(nym_topology::NetworkAddress::IpAddr));
+
+        let performance = gateway
+            .performance
+            .parse::<f64>()
+            .map(|p| p * 100.0)
+            .map(|p| p.round() as u8)
+            .map(|p| p.clamp(0, 100))
+            .ok();
+
         Ok(Gateway {
             identity,
             location: Some(gateway.location.into()),
-            ipr_address: None,
-            authenticator_address: None,
+            ipr_address: gateway
+                .ipr_address
+                .and_then(|ipr| IpPacketRouterAddress::try_from_base58_string(&ipr).ok()),
+            authenticator_address: gateway
+                .authenticator_address
+                .and_then(|auth| AuthAddress::try_from_base58_string(&auth).ok()),
             last_probe: gateway.last_probe.map(Probe::from),
-            host: None,
-            clients_ws_port: None,
-            clients_wss_port: None,
-            performance: None,
+            host,
+            clients_ws_port: Some(gateway.entry.ws_port),
+            clients_wss_port: gateway.entry.wss_port,
+            performance,
         })
     }
 }

--- a/nym-vpn-core/crates/nym-gateway-directory/src/error.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/error.rs
@@ -42,6 +42,9 @@ pub enum Error {
     #[error("missing ip packet router address for gateway")]
     MissingIpPacketRouterAddress,
 
+    #[error("missing hostname or ip address for gateway")]
+    MissingHostnameOrIpAddress { gateway_identity: String },
+
     #[error("no matching gateway found: {requested_identity}")]
     NoMatchingGateway { requested_identity: String },
 

--- a/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
@@ -3,8 +3,7 @@
 
 use std::{fmt, net::IpAddr};
 
-use nym_sdk::{mixnet::Recipient, UserAgent};
-use nym_topology::IntoGatewayNode;
+use nym_sdk::UserAgent;
 use nym_validator_client::{models::DescribedGateway, nym_nodes::SkimmedNode, NymApiClient};
 use tracing::{debug, error, info};
 use url::Url;
@@ -16,7 +15,7 @@ use crate::{
     },
     error::Result,
     helpers::try_resolve_hostname,
-    AuthAddress, Error, IpPacketRouterAddress,
+    Error,
 };
 
 #[derive(Clone, Debug)]
@@ -230,12 +229,6 @@ impl GatewayClient {
                 })
                 .collect();
 
-            // Lookup the IPR and authenticator addresses from the nym-api as a temporary hack until
-            // the nymvpn.com endpoints are updated to also include these fields.
-            let described_gateways = self.lookup_described_gateways().await?;
-            let basic_gw = self.api_client.get_basic_gateways(None).await.unwrap();
-            append_ipr_and_authenticator_addresses(&mut gateways, described_gateways);
-            append_performance(&mut gateways, basic_gw);
             filter_on_min_performance(&mut gateways, self.min_gateway_performance);
             Ok(GatewayList::new(gateways))
         } else {
@@ -257,12 +250,6 @@ impl GatewayClient {
                 })
                 .collect();
 
-            // Lookup the IPR and authenticator addresses from the nym-api as a temporary hack until
-            // the nymvpn.com endpoints are updated to also include these fields.
-            let described_gateways = self.lookup_described_gateways().await?;
-            let basic_gw = self.api_client.get_basic_gateways(None).await.unwrap();
-            append_ipr_and_authenticator_addresses(&mut entry_gateways, described_gateways);
-            append_performance(&mut entry_gateways, basic_gw);
             filter_on_min_performance(&mut entry_gateways, self.min_gateway_performance);
             Ok(GatewayList::new(entry_gateways))
         } else {
@@ -284,12 +271,6 @@ impl GatewayClient {
                 })
                 .collect();
 
-            // Lookup the IPR and authenticator addresses from the nym-api as a temporary hack until
-            // the nymvpn.com endpoints are updated to also include these fields.
-            let described_gateways = self.lookup_described_gateways().await?;
-            let basic_gw = self.api_client.get_basic_gateways(None).await.unwrap();
-            append_ipr_and_authenticator_addresses(&mut exit_gateways, described_gateways);
-            append_performance(&mut exit_gateways, basic_gw);
             filter_on_min_performance(&mut exit_gateways, self.min_gateway_performance);
             Ok(GatewayList::new(exit_gateways))
         } else {
@@ -348,43 +329,6 @@ impl GatewayClient {
             self.lookup_exit_gateways_from_nym_api()
                 .await
                 .map(GatewayList::into_countries)
-        }
-    }
-}
-
-// Append the IPR and authenticator addresses to the gateways. This is a temporary hack until the
-// nymvpn.com endpoints are updated to also include these fields.
-fn append_ipr_and_authenticator_addresses(
-    gateways: &mut [Gateway],
-    described_gateways: Vec<DescribedGateway>,
-) {
-    for gateway in gateways.iter_mut() {
-        if let Some(described_gateway) = described_gateways
-            .iter()
-            .find(|dg| dg.identity() == gateway.identity().to_base58_string())
-        {
-            gateway.ipr_address = described_gateway
-                .self_described
-                .clone()
-                .and_then(|d| d.ip_packet_router)
-                .map(|ipr| ipr.address)
-                .and_then(|address| IpPacketRouterAddress::try_from_base58_string(&address).ok());
-            gateway.authenticator_address = described_gateway
-                .self_described
-                .clone()
-                .and_then(|d| d.authenticator)
-                .map(|auth| auth.address)
-                .and_then(|address| Recipient::try_from_base58_string(address).ok())
-                .map(|r| AuthAddress(Some(r)));
-            let gateway_node = nym_topology::gateway::Node::try_from(described_gateway).unwrap();
-            gateway.host = Some(gateway_node.host);
-            gateway.clients_ws_port = Some(gateway_node.clients_ws_port);
-            gateway.clients_wss_port = gateway_node.clients_wss_port;
-        } else {
-            error!(
-                "Failed to find described gateway for gateway with identity {}",
-                gateway.identity()
-            );
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
@@ -383,6 +383,37 @@ impl VpnApiClient {
             .map_err(VpnApiClientError::FailedToGetGateways)
     }
 
+    pub async fn get_vpn_gateways(&self) -> Result<NymDirectoryGatewaysResponse> {
+        self.inner
+            .get_json(
+                &[
+                    routes::PUBLIC,
+                    routes::V1,
+                    routes::DIRECTORY,
+                    routes::GATEWAYS,
+                ],
+                &[("show_vpn_only", "true")],
+            )
+            .await
+            .map_err(VpnApiClientError::FailedToGetVpnGateways)
+    }
+
+    pub async fn get_vpn_gateway_countries(&self) -> Result<NymDirectoryGatewayCountriesResponse> {
+        self.inner
+            .get_json(
+                &[
+                    routes::PUBLIC,
+                    routes::V1,
+                    routes::DIRECTORY,
+                    routes::GATEWAYS,
+                    routes::COUNTRIES,
+                ],
+                &[("show_vpn_only", "true")],
+            )
+            .await
+            .map_err(VpnApiClientError::FailedToGetVpnGatewayCountries)
+    }
+
     pub async fn get_gateway_countries(&self) -> Result<NymDirectoryGatewayCountriesResponse> {
         self.inner
             .get_json(

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
@@ -408,7 +408,7 @@ impl VpnApiClient {
                     routes::GATEWAYS,
                     routes::COUNTRIES,
                 ],
-                &[("show_vpn_only", "true")],
+                &[(routes::SHOW_VPN_ONLY, "true")],
             )
             .await
             .map_err(VpnApiClientError::FailedToGetVpnGatewayCountries)

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
@@ -372,9 +372,8 @@ impl VpnApiClient {
         self.inner
             .get_json(
                 &[
-                    // Add public/v1 to the path once the api is updated
-                    //routes::PUBLIC,
-                    //routes::V1,
+                    routes::PUBLIC,
+                    routes::V1,
                     routes::DIRECTORY,
                     routes::GATEWAYS,
                 ],
@@ -388,9 +387,8 @@ impl VpnApiClient {
         self.inner
             .get_json(
                 &[
-                    // Add public/v1 to the path once the api is updated
-                    //routes::PUBLIC,
-                    //routes::V1,
+                    routes::PUBLIC,
+                    routes::V1,
                     routes::DIRECTORY,
                     routes::GATEWAYS,
                     routes::COUNTRIES,
@@ -405,9 +403,8 @@ impl VpnApiClient {
         self.inner
             .get_json(
                 &[
-                    // Add public/v1 to the path once the api is updated
-                    //routes::PUBLIC,
-                    //routes::V1,
+                    routes::PUBLIC,
+                    routes::V1,
                     routes::DIRECTORY,
                     routes::GATEWAYS,
                     routes::ENTRY,
@@ -424,9 +421,8 @@ impl VpnApiClient {
         self.inner
             .get_json(
                 &[
-                    // Add public/v1 to the path once the api is updated
-                    //routes::PUBLIC,
-                    //routes::V1,
+                    routes::PUBLIC,
+                    routes::V1,
                     routes::DIRECTORY,
                     routes::GATEWAYS,
                     routes::ENTRY,
@@ -442,9 +438,8 @@ impl VpnApiClient {
         self.inner
             .get_json(
                 &[
-                    // Add public/v1 to the path once the api is updated
-                    //routes::PUBLIC,
-                    //routes::V1,
+                    routes::PUBLIC,
+                    routes::V1,
                     routes::DIRECTORY,
                     routes::GATEWAYS,
                     routes::EXIT,
@@ -459,9 +454,8 @@ impl VpnApiClient {
         self.inner
             .get_json(
                 &[
-                    // Add public/v1 to the path once the api is updated
-                    //routes::PUBLIC,
-                    //routes::V1,
+                    routes::PUBLIC,
+                    routes::V1,
                     routes::DIRECTORY,
                     routes::GATEWAYS,
                     routes::EXIT,

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
@@ -392,7 +392,7 @@ impl VpnApiClient {
                     routes::DIRECTORY,
                     routes::GATEWAYS,
                 ],
-                &[("show_vpn_only", "true")],
+                &[(routes::SHOW_VPN_ONLY, "true")],
             )
             .await
             .map_err(VpnApiClientError::FailedToGetVpnGateways)

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/error.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/error.rs
@@ -66,6 +66,12 @@ pub enum VpnApiClientError {
 
     #[error("failed to get exit gateway countries")]
     FailedToGetExitGatewayCountries(#[source] HttpClientError<UnexpectedError>),
+
+    #[error("failed to get vpn gateways")]
+    FailedToGetVpnGateways(#[source] HttpClientError<UnexpectedError>),
+
+    #[error("failed to get vpn gateway countries")]
+    FailedToGetVpnGatewayCountries(#[source] HttpClientError<UnexpectedError>),
 }
 
 pub type Result<T> = std::result::Result<T, VpnApiClientError>;

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
@@ -211,13 +211,13 @@ impl IntoIterator for NymDirectoryGatewaysResponse {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct NymDirectoryGateway {
     pub identity_key: String,
+    pub ip_packet_router: Option<IpPacketRouter>,
+    pub authenticator: Option<Authenticator>,
     pub location: Location,
     pub last_probe: Option<Probe>,
     pub ip_addresses: Vec<String>,
     pub entry: EntryInformation,
     pub performance: String,
-    pub ipr_address: Option<String>,
-    pub authenticator_address: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -225,6 +225,16 @@ pub struct EntryInformation {
     pub hostname: Option<String>,
     pub ws_port: u16,
     pub wss_port: Option<u16>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct IpPacketRouter {
+    pub address: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Authenticator {
+    pub address: String,
 }
 
 impl NymDirectoryGateway {

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
@@ -213,6 +213,18 @@ pub struct NymDirectoryGateway {
     pub identity_key: String,
     pub location: Location,
     pub last_probe: Option<Probe>,
+    pub ip_addresses: Vec<String>,
+    pub entry: EntryInformation,
+    pub performance: String,
+    pub ipr_address: Option<String>,
+    pub authenticator_address: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct EntryInformation {
+    pub hostname: Option<String>,
+    pub ws_port: u16,
+    pub wss_port: Option<u16>,
 }
 
 impl NymDirectoryGateway {

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/routes.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/routes.rs
@@ -14,3 +14,5 @@ pub(crate) const GATEWAYS: &str = "gateways";
 pub(crate) const COUNTRIES: &str = "countries";
 pub(crate) const ENTRY: &str = "entry";
 pub(crate) const EXIT: &str = "exit";
+
+pub(crate) const SHOW_VPN_ONLY: &str = "show_vpn_only";

--- a/nym-vpn-core/crates/nym-vpn-cli/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpn-cli/src/main.rs
@@ -158,12 +158,7 @@ async fn run() -> Result<()> {
 
 async fn run_vpn(args: commands::RunArgs, data_path: Option<PathBuf>) -> Result<()> {
     // Setup gateway directory configuration
-    let gateway_config = GatewayConfig::new_from_env(args.min_gateway_performance)
-        .with_custom_nym_vpn_api_url(
-            "https://nym-dot-com-git-feature-directory-gws-nyx-network-staging.vercel.app/api"
-                .parse()
-                .unwrap(),
-        );
+    let gateway_config = GatewayConfig::new_from_env(args.min_gateway_performance);
 
     info!("nym-api: {}", gateway_config.api_url());
     info!(

--- a/nym-vpn-core/crates/nym-vpn-cli/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpn-cli/src/main.rs
@@ -158,7 +158,13 @@ async fn run() -> Result<()> {
 
 async fn run_vpn(args: commands::RunArgs, data_path: Option<PathBuf>) -> Result<()> {
     // Setup gateway directory configuration
-    let gateway_config = GatewayConfig::new_from_env(args.min_gateway_performance);
+    let gateway_config = GatewayConfig::new_from_env(args.min_gateway_performance)
+        .with_custom_nym_vpn_api_url(
+            "https://nym-dot-com-git-feature-directory-gws-nyx-network-staging.vercel.app/api"
+                .parse()
+                .unwrap(),
+        );
+
     info!("nym-api: {}", gateway_config.api_url());
     info!(
         "nym-vpn-api: {}",

--- a/nym-vpn-core/crates/nym-vpn-lib/src/mobile/runner.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/mobile/runner.rs
@@ -209,11 +209,9 @@ impl WgTunnelRunner {
     }
 
     async fn select_gateways(&self) -> Result<SelectedGateways> {
-        // The set of exit gateways is smaller than the set of entry gateways, so we start by selecting
-        // the exit gateway and then filter out the exit gateway from the set of entry gateways.
         let all_gateways = self
             .gateway_directory_client
-            .lookup_all_gateways()
+            .lookup_vpn_gateways()
             .await
             .map_err(|source| GatewayDirectoryError::FailedToLookupGateways { source })?;
         let mut entry_gateways = all_gateways.clone();

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_setup.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_setup.rs
@@ -447,7 +447,7 @@ async fn select_gateways(
         (entry_gateways, exit_gateways)
     } else {
         let all_gateways = gateway_directory_client
-            .lookup_all_gateways()
+            .lookup_vpn_gateways()
             .await
             .map_err(|source| GatewayDirectoryError::FailedToLookupGateways { source })?;
         (all_gateways.clone(), all_gateways)

--- a/nym-vpn-core/crates/nym-vpn-lib/uniffi/nym_vpn_lib.kt
+++ b/nym-vpn-core/crates/nym-vpn-lib/uniffi/nym_vpn_lib.kt
@@ -797,6 +797,8 @@ internal open class UniffiVTableCallbackInterfaceTunnelStatusListener(
 
 
 
+
+
 // A JNA Library to expose the extern-C FFI definitions.
 // This is an implementation detail which will be called internally by the public API.
 
@@ -851,6 +853,8 @@ internal interface UniffiLib : Library {
     fun uniffi_nym_vpn_lib_fn_func_getlowlatencyentrycountry(`apiUrl`: RustBuffer.ByValue,`vpnApiUrl`: RustBuffer.ByValue,`harbourMasterUrl`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
     fun uniffi_nym_vpn_lib_fn_func_getlowlatencyentrycountryuseragent(`apiUrl`: RustBuffer.ByValue,`vpnApiUrl`: RustBuffer.ByValue,`harbourMasterUrl`: RustBuffer.ByValue,`userAgent`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+    ): RustBuffer.ByValue
+    fun uniffi_nym_vpn_lib_fn_func_getvpncountries(`apiUrl`: RustBuffer.ByValue,`nymVpnApiUrl`: RustBuffer.ByValue,`userAgent`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
     fun uniffi_nym_vpn_lib_fn_func_importcredential(`credential`: RustBuffer.ByValue,`path`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
@@ -980,6 +984,8 @@ internal interface UniffiLib : Library {
     ): Short
     fun uniffi_nym_vpn_lib_checksum_func_getlowlatencyentrycountryuseragent(
     ): Short
+    fun uniffi_nym_vpn_lib_checksum_func_getvpncountries(
+    ): Short
     fun uniffi_nym_vpn_lib_checksum_func_importcredential(
     ): Short
     fun uniffi_nym_vpn_lib_checksum_func_initlogger(
@@ -1029,6 +1035,9 @@ private fun uniffiCheckApiChecksums(lib: UniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_nym_vpn_lib_checksum_func_getlowlatencyentrycountryuseragent() != 14102.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_nym_vpn_lib_checksum_func_getvpncountries() != 17864.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_nym_vpn_lib_checksum_func_importcredential() != 49505.toShort()) {
@@ -3925,6 +3934,16 @@ public object FfiConverterTypeUrl: FfiConverter<Url, RustBuffer.ByValue> {
     uniffiRustCallWithError(VpnException) { _status ->
     UniffiLib.INSTANCE.uniffi_nym_vpn_lib_fn_func_getlowlatencyentrycountryuseragent(
         FfiConverterTypeUrl.lower(`apiUrl`),FfiConverterOptionalTypeUrl.lower(`vpnApiUrl`),FfiConverterOptionalTypeUrl.lower(`harbourMasterUrl`),FfiConverterTypeUserAgent.lower(`userAgent`),_status)
+}
+    )
+    }
+    
+
+    @Throws(VpnException::class) fun `getVpnCountries`(`apiUrl`: Url, `nymVpnApiUrl`: Url?, `userAgent`: UserAgent?): List<Location> {
+            return FfiConverterSequenceTypeLocation.lift(
+    uniffiRustCallWithError(VpnException) { _status ->
+    UniffiLib.INSTANCE.uniffi_nym_vpn_lib_fn_func_getvpncountries(
+        FfiConverterTypeUrl.lower(`apiUrl`),FfiConverterOptionalTypeUrl.lower(`nymVpnApiUrl`),FfiConverterOptionalTypeUserAgent.lower(`userAgent`),_status)
 }
     )
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/uniffi/nym_vpn_lib.swift
+++ b/nym-vpn-core/crates/nym-vpn-lib/uniffi/nym_vpn_lib.swift
@@ -3761,6 +3761,15 @@ public func getLowLatencyEntryCountryUserAgent(apiUrl: Url, vpnApiUrl: Url?, har
     )
 })
 }
+public func getVpnCountries(apiUrl: Url, nymVpnApiUrl: Url?, userAgent: UserAgent?)throws  -> [Location] {
+    return try  FfiConverterSequenceTypeLocation.lift(try rustCallWithError(FfiConverterTypeVpnError.lift) {
+    uniffi_nym_vpn_lib_fn_func_getvpncountries(
+        FfiConverterTypeUrl.lower(apiUrl),
+        FfiConverterOptionTypeUrl.lower(nymVpnApiUrl),
+        FfiConverterOptionTypeUserAgent.lower(userAgent),$0
+    )
+})
+}
 public func importCredential(credential: String, path: String)throws  -> Date? {
     return try  FfiConverterOptionTimestamp.lift(try rustCallWithError(FfiConverterTypeVpnError.lift) {
     uniffi_nym_vpn_lib_fn_func_importcredential(
@@ -3811,6 +3820,9 @@ private var initializationResult: InitializationResult {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_nym_vpn_lib_checksum_func_getlowlatencyentrycountryuseragent() != 14102) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_nym_vpn_lib_checksum_func_getvpncountries() != 17864) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_nym_vpn_lib_checksum_func_importcredential() != 49505) {

--- a/nym-vpn-core/crates/nym-vpnc/src/cli.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/cli.rs
@@ -30,8 +30,10 @@ pub(crate) enum Command {
     ListenToStateChanges,
     ListEntryGateways(ListEntryGatewaysArgs),
     ListExitGateways(ListExitGatewaysArgs),
+    ListVpnGateways(ListVpnGatewaysArgs),
     ListEntryCountries(ListEntryCountriesArgs),
     ListExitCountries(ListExitCountriesArgs),
+    ListVpnCountries(ListVpnCountriesArgs),
 }
 
 #[derive(Args)]
@@ -182,6 +184,14 @@ pub(crate) struct ListExitGatewaysArgs {
 }
 
 #[derive(Args)]
+pub(crate) struct ListVpnGatewaysArgs {
+    /// An integer between 0 and 100 representing the minimum gateway performance required to
+    /// consider a gateway for routing traffic.
+    #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]
+    pub(crate) min_gateway_performance: Option<u8>,
+}
+
+#[derive(Args)]
 pub(crate) struct ListEntryCountriesArgs {
     /// An integer between 0 and 100 representing the minimum gateway performance required to
     /// consider a gateway for routing traffic.
@@ -191,6 +201,14 @@ pub(crate) struct ListEntryCountriesArgs {
 
 #[derive(Args)]
 pub(crate) struct ListExitCountriesArgs {
+    /// An integer between 0 and 100 representing the minimum gateway performance required to
+    /// consider a gateway for routing traffic.
+    #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]
+    pub(crate) min_gateway_performance: Option<u8>,
+}
+
+#[derive(Args)]
+pub(crate) struct ListVpnCountriesArgs {
     /// An integer between 0 and 100 representing the minimum gateway performance required to
     /// consider a gateway for routing traffic.
     #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]

--- a/nym-vpn-core/crates/nym-vpnc/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/main.rs
@@ -6,7 +6,8 @@ use clap::Parser;
 use nym_vpn_proto::{
     ConnectRequest, DisconnectRequest, Empty, ImportUserCredentialRequest, InfoRequest,
     ListEntryCountriesRequest, ListEntryGatewaysRequest, ListExitCountriesRequest,
-    ListExitGatewaysRequest, StatusRequest, StoreAccountRequest,
+    ListExitGatewaysRequest, ListVpnCountriesRequest, ListVpnGatewaysRequest, StatusRequest,
+    StoreAccountRequest,
 };
 use protobuf_conversion::into_threshold;
 use vpnd_client::ClientType;
@@ -48,11 +49,17 @@ async fn main() -> Result<()> {
         Command::ListExitGateways(ref list_args) => {
             list_exit_gateways(client_type, list_args).await?
         }
+        Command::ListVpnGateways(ref list_args) => {
+            list_vpn_gateways(client_type, list_args).await?
+        }
         Command::ListEntryCountries(ref list_args) => {
             list_entry_countries(client_type, list_args).await?
         }
         Command::ListExitCountries(ref list_args) => {
             list_exit_countries(client_type, list_args).await?
+        }
+        Command::ListVpnCountries(ref list_args) => {
+            list_vpn_countries(client_type, list_args).await?
         }
     }
     Ok(())
@@ -228,6 +235,19 @@ async fn list_exit_gateways(
     Ok(())
 }
 
+async fn list_vpn_gateways(
+    client_type: ClientType,
+    list_args: &cli::ListVpnGatewaysArgs,
+) -> Result<()> {
+    let mut client = vpnd_client::get_client(client_type).await?;
+    let request = tonic::Request::new(ListVpnGatewaysRequest {
+        min_gateway_performance: list_args.min_gateway_performance.map(into_threshold),
+    });
+    let response = client.list_vpn_gateways(request).await?.into_inner();
+    println!("{:#?}", response);
+    Ok(())
+}
+
 async fn list_entry_countries(
     client_type: ClientType,
     list_args: &cli::ListEntryCountriesArgs,
@@ -250,6 +270,19 @@ async fn list_exit_countries(
         min_gateway_performance: list_args.min_gateway_performance.map(into_threshold),
     });
     let response = client.list_exit_countries(request).await?.into_inner();
+    println!("{:#?}", response);
+    Ok(())
+}
+
+async fn list_vpn_countries(
+    client_type: ClientType,
+    list_args: &cli::ListVpnCountriesArgs,
+) -> Result<()> {
+    let mut client = vpnd_client::get_client(client_type).await?;
+    let request = tonic::Request::new(ListVpnCountriesRequest {
+        min_gateway_performance: list_args.min_gateway_performance.map(into_threshold),
+    });
+    let response = client.list_vpn_countries(request).await?.into_inner();
     println!("{:#?}", response);
     Ok(())
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/connection_handler.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/connection_handler.rs
@@ -160,6 +160,18 @@ impl CommandInterfaceConnectionHandler {
         Ok(gateways.into_iter().map(gateway::Gateway::from).collect())
     }
 
+    pub(crate) async fn handle_list_vpn_gateways(
+        &self,
+        min_gateway_performance: Option<u8>,
+    ) -> Result<Vec<gateway::Gateway>, ListGatewayError> {
+        let gateways = directory_client(min_gateway_performance)?
+            .lookup_vpn_gateways()
+            .await
+            .map_err(|error| ListGatewayError::GetEntryGateways { error })?;
+
+        Ok(gateways.into_iter().map(gateway::Gateway::from).collect())
+    }
+
     pub(crate) async fn handle_list_entry_countries(
         &self,
         min_gateway_performance: Option<u8>,
@@ -180,6 +192,18 @@ impl CommandInterfaceConnectionHandler {
             .lookup_exit_countries()
             .await
             .map_err(|error| ListGatewayError::GetExitGateways { error })?;
+
+        Ok(gateways.into_iter().map(gateway::Country::from).collect())
+    }
+
+    pub(crate) async fn handle_list_vpn_countries(
+        &self,
+        min_gateway_performance: Option<u8>,
+    ) -> Result<Vec<gateway::Country>, ListGatewayError> {
+        let gateways = directory_client(min_gateway_performance)?
+            .lookup_vpn_countries()
+            .await
+            .map_err(|error| ListGatewayError::GetEntryGateways { error })?;
 
         Ok(gateways.into_iter().map(gateway::Country::from).collect())
     }

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/gateway.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/gateway.rs
@@ -94,3 +94,13 @@ impl From<gateway::Country> for nym_vpn_proto::Location {
         }
     }
 }
+
+impl From<gateway::Gateway> for nym_vpn_proto::VpnGateway {
+    fn from(gateway: gateway::Gateway) -> Self {
+        let id = Some(nym_vpn_proto::Gateway {
+            id: gateway.identity_key.to_string(),
+        });
+        let location = gateway.location.map(nym_vpn_proto::Location::from);
+        nym_vpn_proto::VpnGateway { id, location }
+    }
+}

--- a/proto/nym/vpn.proto
+++ b/proto/nym/vpn.proto
@@ -391,6 +391,19 @@ message ListExitGatewaysResponse {
   repeated ExitGateway gateways = 1;
 }
 
+message VpnGateway {
+  Gateway id = 1;
+  Location location = 2;
+}
+
+message ListVpnGatewaysRequest {
+  Threshold min_gateway_performance = 1;
+}
+
+message ListVpnGatewaysResponse {
+  repeated VpnGateway gateways = 1;
+}
+
 message ListEntryCountriesRequest {
   Threshold min_gateway_performance = 1;
 }
@@ -404,6 +417,14 @@ message ListExitCountriesRequest {
 }
 
 message ListExitCountriesResponse {
+  repeated Location countries = 1;
+}
+
+message ListVpnCountriesRequest {
+  Threshold min_gateway_performance = 1;
+}
+
+message ListVpnCountriesResponse {
   repeated Location countries = 1;
 }
 
@@ -476,8 +497,10 @@ service NymVpnd {
 
   rpc ListEntryGateways (ListEntryGatewaysRequest) returns (ListEntryGatewaysResponse) {}
   rpc ListExitGateways (ListExitGatewaysRequest) returns (ListExitGatewaysResponse) {}
+  rpc ListVpnGateways (ListVpnGatewaysRequest) returns (ListVpnGatewaysResponse) {}
   rpc ListEntryCountries (ListEntryCountriesRequest) returns (ListEntryCountriesResponse) {}
   rpc ListExitCountries (ListExitCountriesRequest) returns (ListExitCountriesResponse) {}
+  rpc ListVpnCountries (ListVpnCountriesRequest) returns (ListVpnCountriesResponse) {}
 
   // Unstable
   rpc StoreAccount (StoreAccountRequest) returns (StoreAccountResponse) {}


### PR DESCRIPTION
Use the new gateway directory endpoints in the nym-vpn-api

- [x] Add vpn-api client calls to fetch vpn gateways and countries
- [x] Remove calls to nym-api and polyfill step
- [x] Add vpn gateway list
- [x] Add vpn country list
- [x] Add to daemon API
- [x] Add to uniffi API
