### PR TITLE
fix(vpn-x): wrong vpn mode state

### DIFF
--- a/nym-vpn-x/src/pages/home/NetworkModeSelect.tsx
+++ b/nym-vpn-x/src/pages/home/NetworkModeSelect.tsx
@@ -11,6 +11,7 @@ import { useThrottle } from '../../hooks';
 import { HomeThrottleDelay } from '../../constants';
 import MsIcon from '../../ui/MsIcon';
 import ModeDetailsDialog from './ModeDetailsDialog';
+import { S_STATE } from '../../static';
 
 const os = type();
 
@@ -136,6 +137,7 @@ function NetworkModeSelect() {
       />
       <div className="select-none" onClick={handleDisabledState}>
         <RadioGroup
+          key={`_${S_STATE.vpnModeInit}`}
           defaultValue={state.vpnMode}
           options={vpnModes}
           onChange={handleNetworkModeChange}

--- a/nym-vpn-x/src/state/init.ts
+++ b/nym-vpn-x/src/state/init.ts
@@ -23,6 +23,7 @@ import {
   WindowSize,
 } from '../types';
 import fireRequests, { TauriReq } from './helper';
+import { S_STATE } from '../static';
 
 // initialize connection state
 const getInitialConnectionState = async () => {
@@ -158,6 +159,7 @@ export async function initFirstBatch(dispatch: StateDispatch) {
     request: () => kvGet<VpnMode>('VpnMode'),
     onFulfilled: (vpnMode) => {
       dispatch({ type: 'set-vpn-mode', mode: vpnMode || DefaultVpnMode });
+      S_STATE.vpnModeInit = true;
     },
   };
 

--- a/nym-vpn-x/src/static.ts
+++ b/nym-vpn-x/src/static.ts
@@ -1,0 +1,4 @@
+// global state managed out of the React tree
+export const S_STATE = {
+  vpnModeInit: false,
+};


### PR DESCRIPTION
To avoid bad state initialization, force the vpn mode Select component to re-render and reset whenever the initial db query is done