### PR TITLE
Finish support of the new gateway directory API

### DIFF
--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/data/GatewayRepository.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/data/GatewayRepository.kt
@@ -18,5 +18,7 @@ interface GatewayRepository {
 
 	suspend fun getExitCountries(): Set<Country>
 
+	suspend fun setWgCountries(it: Set<Country>)
+
 	val gatewayFlow: Flow<Gateways>
 }

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/data/datastore/DataStoreGatewayRepository.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/data/datastore/DataStoreGatewayRepository.kt
@@ -14,6 +14,7 @@ class DataStoreGatewayRepository(private val dataStoreManager: DataStoreManager)
 		val LOW_LATENCY_ENTRY_COUNTRY = stringPreferencesKey("LOW_LATENCY_ENTRY_COUNTRY")
 		val ENTRY_COUNTRIES = stringPreferencesKey("ENTRY_COUNTRIES")
 		val EXIT_COUNTRIES = stringPreferencesKey("EXIT_COUNTRIES")
+		val WG_COUNTRIES = stringPreferencesKey("WG_COUNTRIES")
 	}
 
 	override suspend fun getLowLatencyEntryCountry(): Country? {
@@ -43,6 +44,10 @@ class DataStoreGatewayRepository(private val dataStoreManager: DataStoreManager)
 		return Country.fromCollectionString(countries)
 	}
 
+	override suspend fun setWgCountries(countries: Set<Country>) {
+		dataStoreManager.saveToDataStore(WG_COUNTRIES, countries.toString())
+	}
+
 	override val gatewayFlow: Flow<Gateways> =
 		dataStoreManager.preferencesFlow.map { prefs ->
 			prefs?.let { pref ->
@@ -51,6 +56,7 @@ class DataStoreGatewayRepository(private val dataStoreManager: DataStoreManager)
 						lowLatencyEntryCountry = Country.from(pref[LOW_LATENCY_ENTRY_COUNTRY]),
 						exitCountries = Country.fromCollectionString(pref[EXIT_COUNTRIES]),
 						entryCountries = Country.fromCollectionString(pref[ENTRY_COUNTRIES]),
+						wgCountries = Country.fromCollectionString(pref[WG_COUNTRIES]),
 					)
 				} catch (e: IllegalArgumentException) {
 					Timber.e(e)

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/data/domain/Gateways.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/data/domain/Gateways.kt
@@ -6,4 +6,5 @@ data class Gateways(
 	val lowLatencyEntryCountry: Country? = null,
 	val entryCountries: Set<Country> = emptySet(),
 	val exitCountries: Set<Country> = emptySet(),
+	val wgCountries: Set<Country> = emptySet(),
 )

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/service/country/CountryCacheService.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/service/country/CountryCacheService.kt
@@ -5,5 +5,7 @@ interface CountryCacheService {
 
 	suspend fun updateEntryCountriesCache(): Result<Unit>
 
+	suspend fun updateWgCountriesCache(): Result<Unit>
+
 	suspend fun updateLowLatencyEntryCountryCache(): Result<Unit>
 }

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/service/country/CountryDataStoreCacheService.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/service/country/CountryDataStoreCacheService.kt
@@ -3,6 +3,7 @@ package net.nymtech.nymvpn.service.country
 import net.nymtech.nymvpn.data.GatewayRepository
 import net.nymtech.nymvpn.module.qualifiers.Native
 import net.nymtech.nymvpn.service.gateway.GatewayService
+import nym_vpn_lib.GatewayType
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -12,7 +13,7 @@ class CountryDataStoreCacheService @Inject constructor(
 ) : CountryCacheService {
 	override suspend fun updateExitCountriesCache(): Result<Unit> {
 		return runCatching {
-			gatewayService.getCountries(true).onSuccess {
+			gatewayService.getCountries(GatewayType.MIXNET_EXIT).onSuccess {
 				gatewayRepository.setExitCountries(it)
 			}
 		}
@@ -20,8 +21,16 @@ class CountryDataStoreCacheService @Inject constructor(
 
 	override suspend fun updateEntryCountriesCache(): Result<Unit> {
 		return runCatching {
-			gatewayService.getCountries(false).onSuccess {
+			gatewayService.getCountries(GatewayType.MIXNET_ENTRY).onSuccess {
 				gatewayRepository.setEntryCountries(it)
+			}
+		}
+	}
+
+	override suspend fun updateWgCountriesCache(): Result<Unit> {
+		return kotlin.runCatching {
+			gatewayService.getCountries(GatewayType.WG).onSuccess {
+				gatewayRepository.setWgCountries(it)
 			}
 		}
 	}

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/service/gateway/GatewayApiService.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/service/gateway/GatewayApiService.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import net.nymtech.nymvpn.module.qualifiers.IoDispatcher
 import net.nymtech.vpn.model.Country
+import nym_vpn_lib.GatewayType
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -19,14 +20,17 @@ class GatewayApiService @Inject constructor(
 		}
 	}
 
-	override suspend fun getCountries(exitOnly: Boolean): Result<Set<Country>> {
+	override suspend fun getCountries(type: GatewayType): Result<Set<Country>> {
 		Timber.d("Getting countries from nym api")
 		return safeApiCall {
 			withContext(ioDispatcher) {
-				val countries = if (exitOnly) {
-					gatewayApi.getAllExitGatewayTwoCharacterCountryCodes()
-				} else {
-					gatewayApi.getAllEntryGatewayTwoCharacterCountryCodes()
+				val countries = when (type) {
+					GatewayType.MIXNET_ENTRY -> gatewayApi.getAllEntryGatewayTwoCharacterCountryCodes()
+					GatewayType.MIXNET_EXIT -> gatewayApi.getAllExitGatewayTwoCharacterCountryCodes()
+					GatewayType.WG -> {
+						Timber.w("Not implemented for VPN")
+						emptyList()
+					}
 				}
 				countries.map { Country(it) }.toSet()
 			}

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/service/gateway/GatewayLibService.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/service/gateway/GatewayLibService.kt
@@ -6,6 +6,7 @@ import net.nymtech.nymvpn.data.SettingsRepository
 import net.nymtech.nymvpn.module.qualifiers.IoDispatcher
 import net.nymtech.vpn.NymApi
 import net.nymtech.vpn.model.Country
+import nym_vpn_lib.GatewayType
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -23,12 +24,12 @@ class GatewayLibService @Inject constructor(
 		}
 	}
 
-	override suspend fun getCountries(exitOnly: Boolean): Result<Set<Country>> {
+	override suspend fun getCountries(type: GatewayType): Result<Set<Country>> {
 		return runCatching {
 			withContext(ioDispatcher) {
 				val env = settingsRepository.getEnvironment()
 				Timber.d("Getting countries from lib api")
-				nymApi.gateways(exitOnly, env)
+				nymApi.gateways(type, env)
 			}
 		}
 	}

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/service/gateway/GatewayService.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/service/gateway/GatewayService.kt
@@ -1,8 +1,9 @@
 package net.nymtech.nymvpn.service.gateway
 
 import net.nymtech.vpn.model.Country
+import nym_vpn_lib.GatewayType
 
 interface GatewayService {
 	suspend fun getLowLatencyCountry(): Result<Country>
-	suspend fun getCountries(exitOnly: Boolean): Result<Set<Country>>
+	suspend fun getCountries(type: GatewayType): Result<Set<Country>>
 }

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/SplashActivity.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/SplashActivity.kt
@@ -62,6 +62,12 @@ class SplashActivity : ComponentActivity() {
 					Timber.d("Entry countries updated")
 				}.onFailure { Timber.w("Failed to get entry countries: ${it.message}") }
 			}
+			launch {
+				Timber.d("Updating entry country cache")
+				countryCacheService.updateWgCountriesCache().onSuccess {
+					Timber.d("Wg countries updated")
+				}.onFailure { Timber.w("Failed to get wg countries: ${it.message}") }
+			}
 		}
 
 		lifecycleScope.launch {

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/hop/HopScreen.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/hop/HopScreen.kt
@@ -53,6 +53,8 @@ import net.nymtech.nymvpn.util.extensions.go
 import net.nymtech.nymvpn.util.extensions.openWebUrl
 import net.nymtech.nymvpn.util.extensions.scaledHeight
 import net.nymtech.nymvpn.util.extensions.scaledWidth
+import net.nymtech.vpn.backend.Tunnel
+import nym_vpn_lib.GatewayType
 import java.text.Collator
 
 @Composable
@@ -69,9 +71,20 @@ fun HopScreen(
 	val currentLocale = ConfigurationCompat.getLocales(context.resources.configuration)[0]
 	val collator = Collator.getInstance(currentLocale)
 
-	val countries = when (gatewayLocation) {
-		GatewayLocation.EXIT -> appUiState.gateways.exitCountries
-		GatewayLocation.ENTRY -> appUiState.gateways.entryCountries
+	val gatewayType = when (appUiState.settings.vpnMode) {
+		Tunnel.Mode.FIVE_HOP_MIXNET -> {
+			when (gatewayLocation) {
+				GatewayLocation.EXIT -> GatewayType.MIXNET_EXIT
+				GatewayLocation.ENTRY -> GatewayType.MIXNET_ENTRY
+			}
+		}
+		Tunnel.Mode.TWO_HOP_MIXNET -> GatewayType.WG
+	}
+
+	val countries = when (gatewayType) {
+		GatewayType.MIXNET_ENTRY -> appUiState.gateways.entryCountries
+		GatewayType.MIXNET_EXIT -> appUiState.gateways.exitCountries
+		GatewayType.WG -> appUiState.gateways.wgCountries
 	}
 
 	val selectedCountry = when (gatewayLocation) {
@@ -91,7 +104,7 @@ fun HopScreen(
 	val displayCountries = if (uiState.query.isBlank()) allCountries else queriedCountries
 
 	LaunchedEffect(Unit) {
-		viewModel.updateCountryCache(gatewayLocation)
+		viewModel.updateCountryCache(gatewayType)
 	}
 
 	Modal(show = appUiState.showLocationTooltip, onDismiss = { appViewModel.onToggleShowLocationTooltip() }, title = {

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/hop/HopViewModel.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/hop/HopViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.launch
 import net.nymtech.nymvpn.data.SettingsRepository
 import net.nymtech.nymvpn.service.country.CountryCacheService
 import net.nymtech.vpn.model.Country
+import nym_vpn_lib.GatewayType
 import javax.inject.Inject
 
 @HiltViewModel
@@ -32,10 +33,11 @@ constructor(
 		}
 	}
 
-	fun updateCountryCache(gatewayLocation: GatewayLocation) = viewModelScope.launch {
-		when (gatewayLocation) {
-			GatewayLocation.ENTRY -> countryCacheService.updateEntryCountriesCache()
-			GatewayLocation.EXIT -> countryCacheService.updateExitCountriesCache()
+	fun updateCountryCache(type: GatewayType) = viewModelScope.launch {
+		when (type) {
+			GatewayType.MIXNET_ENTRY -> countryCacheService.updateEntryCountriesCache()
+			GatewayType.MIXNET_EXIT -> countryCacheService.updateExitCountriesCache()
+			GatewayType.WG -> countryCacheService.updateWgCountriesCache()
 		}
 	}
 

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/environment/EnvironmentViewModel.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/environment/EnvironmentViewModel.kt
@@ -30,6 +30,9 @@ constructor(
 			launch {
 				cacheService.updateEntryCountriesCache()
 			}
+			launch {
+				cacheService.updateWgCountriesCache()
+			}
 		} else {
 			SnackbarController.showMessage(StringValue.DynamicString("Tunnel must be down"))
 		}

--- a/nym-vpn-android/nym-vpn-client/src/main/java/net/nymtech/vpn/NymApi.kt
+++ b/nym-vpn-android/nym-vpn-client/src/main/java/net/nymtech/vpn/NymApi.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import net.nymtech.vpn.backend.Tunnel
 import net.nymtech.vpn.model.Country
+import nym_vpn_lib.GatewayType
 import nym_vpn_lib.UserAgent
 import nym_vpn_lib.getGatewayCountries
 
@@ -11,9 +12,9 @@ class NymApi(
 	private val ioDispatcher: CoroutineDispatcher,
 	private val userAgent: UserAgent,
 ) {
-	suspend fun gateways(exitOnly: Boolean, environment: Tunnel.Environment): Set<Country> {
+	suspend fun gateways(type: GatewayType, environment: Tunnel.Environment): Set<Country> {
 		return withContext(ioDispatcher) {
-			getGatewayCountries(environment.apiUrl, environment.nymVpnApiUrl, exitOnly, userAgent).map {
+			getGatewayCountries(environment.apiUrl, environment.nymVpnApiUrl, type, userAgent, null).map {
 				Country(isoCode = it.twoLetterIsoCountryCode)
 			}.toSet()
 		}

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -5386,6 +5386,7 @@ dependencies = [
  "bip39",
  "bs58 0.5.1",
  "chrono",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=b7baff1)",
  "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=b7baff1)",
  "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?rev=b7baff1)",
  "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=b7baff1)",

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -5412,6 +5412,7 @@ dependencies = [
  "is_elevated",
  "nix 0.29.0",
  "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=b7baff1)",
+ "nym-vpn-api-client",
  "nym-vpn-lib",
  "thiserror",
  "time",

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -119,6 +119,7 @@ nym-authenticator-requests = { git = "https://github.com/nymtech/nym", rev = "b7
 nym-bin-common = { git = "https://github.com/nymtech/nym", rev = "b7baff1" }
 nym-client-core = { git = "https://github.com/nymtech/nym", rev = "b7baff1" }
 nym-config = { git = "https://github.com/nymtech/nym", rev = "b7baff1" }
+nym-contracts-common = { git = "https://github.com/nymtech/nym", rev = "b7baff1" }
 nym-crypto = { git = "https://github.com/nymtech/nym", rev = "b7baff1" }
 nym-http-api-client = { git = "https://github.com/nymtech/nym", rev = "b7baff1" }
 nym-ip-packet-requests = { git = "https://github.com/nymtech/nym", rev = "b7baff1" }

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
@@ -420,16 +420,16 @@ impl nym_client_core::init::helpers::ConnectableGateway for Gateway {
 
 #[derive(Debug, Clone)]
 pub enum GatewayType {
-    Entry,
-    Exit,
+    MixnetEntry,
+    MixnetExit,
     Vpn,
 }
 
 impl fmt::Display for GatewayType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            GatewayType::Entry => write!(f, "entry"),
-            GatewayType::Exit => write!(f, "exit"),
+            GatewayType::MixnetEntry => write!(f, "mixnet entry"),
+            GatewayType::MixnetExit => write!(f, "mixnet exit"),
             GatewayType::Vpn => write!(f, "vpn"),
         }
     }
@@ -438,8 +438,8 @@ impl fmt::Display for GatewayType {
 impl From<nym_vpn_api_client::types::GatewayType> for GatewayType {
     fn from(gateway_type: nym_vpn_api_client::types::GatewayType) -> Self {
         match gateway_type {
-            nym_vpn_api_client::types::GatewayType::Entry => GatewayType::Entry,
-            nym_vpn_api_client::types::GatewayType::Exit => GatewayType::Exit,
+            nym_vpn_api_client::types::GatewayType::MixnetEntry => GatewayType::MixnetEntry,
+            nym_vpn_api_client::types::GatewayType::MixnetExit => GatewayType::MixnetExit,
             nym_vpn_api_client::types::GatewayType::Vpn => GatewayType::Vpn,
         }
     }
@@ -448,8 +448,8 @@ impl From<nym_vpn_api_client::types::GatewayType> for GatewayType {
 impl From<GatewayType> for nym_vpn_api_client::types::GatewayType {
     fn from(gateway_type: GatewayType) -> Self {
         match gateway_type {
-            GatewayType::Entry => nym_vpn_api_client::types::GatewayType::Entry,
-            GatewayType::Exit => nym_vpn_api_client::types::GatewayType::Exit,
+            GatewayType::MixnetEntry => nym_vpn_api_client::types::GatewayType::MixnetEntry,
+            GatewayType::MixnetExit => nym_vpn_api_client::types::GatewayType::MixnetExit,
             GatewayType::Vpn => nym_vpn_api_client::types::GatewayType::Vpn,
         }
     }

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{net::IpAddr, str::FromStr};
+use std::{fmt, net::IpAddr, str::FromStr};
 
 use itertools::Itertools;
 use nym_sdk::mixnet::NodeIdentity;
@@ -25,8 +25,8 @@ pub struct Gateway {
     pub mixnet_performance: Option<Percent>,
 }
 
-impl std::fmt::Debug for Gateway {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for Gateway {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Gateway")
             .field("identity", &self.identity.to_base58_string())
             .field("location", &self.location)
@@ -415,5 +415,42 @@ impl nym_client_core::init::helpers::ConnectableGateway for Gateway {
 
     fn is_wss(&self) -> bool {
         self.clients_address_tls().is_some()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum GatewayType {
+    Entry,
+    Exit,
+    Vpn,
+}
+
+impl fmt::Display for GatewayType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            GatewayType::Entry => write!(f, "entry"),
+            GatewayType::Exit => write!(f, "exit"),
+            GatewayType::Vpn => write!(f, "vpn"),
+        }
+    }
+}
+
+impl From<nym_vpn_api_client::types::GatewayType> for GatewayType {
+    fn from(gateway_type: nym_vpn_api_client::types::GatewayType) -> Self {
+        match gateway_type {
+            nym_vpn_api_client::types::GatewayType::Entry => GatewayType::Entry,
+            nym_vpn_api_client::types::GatewayType::Exit => GatewayType::Exit,
+            nym_vpn_api_client::types::GatewayType::Vpn => GatewayType::Vpn,
+        }
+    }
+}
+
+impl From<GatewayType> for nym_vpn_api_client::types::GatewayType {
+    fn from(gateway_type: GatewayType) -> Self {
+        match gateway_type {
+            GatewayType::Entry => nym_vpn_api_client::types::GatewayType::Entry,
+            GatewayType::Exit => nym_vpn_api_client::types::GatewayType::Exit,
+            GatewayType::Vpn => nym_vpn_api_client::types::GatewayType::Vpn,
+        }
     }
 }

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
@@ -222,6 +222,10 @@ fn string_fraction_into_percentage_u8(s: &str) -> Option<u8> {
         .ok()
 }
 
+fn percentage_u8_to_string_fraction(p: u8) -> String {
+    (p as f64 / 100.0).clamp(0.0, 1.0).to_string()
+}
+
 impl TryFrom<nym_validator_client::models::DescribedGateway> for Gateway {
     type Error = Error;
 

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
@@ -422,7 +422,7 @@ impl nym_client_core::init::helpers::ConnectableGateway for Gateway {
 pub enum GatewayType {
     MixnetEntry,
     MixnetExit,
-    Vpn,
+    Wg,
 }
 
 impl fmt::Display for GatewayType {
@@ -430,7 +430,7 @@ impl fmt::Display for GatewayType {
         match self {
             GatewayType::MixnetEntry => write!(f, "mixnet entry"),
             GatewayType::MixnetExit => write!(f, "mixnet exit"),
-            GatewayType::Vpn => write!(f, "vpn"),
+            GatewayType::Wg => write!(f, "vpn"),
         }
     }
 }
@@ -440,7 +440,7 @@ impl From<nym_vpn_api_client::types::GatewayType> for GatewayType {
         match gateway_type {
             nym_vpn_api_client::types::GatewayType::MixnetEntry => GatewayType::MixnetEntry,
             nym_vpn_api_client::types::GatewayType::MixnetExit => GatewayType::MixnetExit,
-            nym_vpn_api_client::types::GatewayType::Vpn => GatewayType::Vpn,
+            nym_vpn_api_client::types::GatewayType::Wg => GatewayType::Wg,
         }
     }
 }
@@ -450,7 +450,7 @@ impl From<GatewayType> for nym_vpn_api_client::types::GatewayType {
         match gateway_type {
             GatewayType::MixnetEntry => nym_vpn_api_client::types::GatewayType::MixnetEntry,
             GatewayType::MixnetExit => nym_vpn_api_client::types::GatewayType::MixnetExit,
-            GatewayType::Vpn => nym_vpn_api_client::types::GatewayType::Vpn,
+            GatewayType::Wg => nym_vpn_api_client::types::GatewayType::Wg,
         }
     }
 }

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
@@ -6,6 +6,7 @@ use std::{net::IpAddr, str::FromStr};
 use itertools::Itertools;
 use nym_sdk::mixnet::NodeIdentity;
 use nym_topology::IntoGatewayNode;
+use nym_vpn_api_client::types::Percent;
 use rand::seq::IteratorRandom;
 use tracing::error;
 
@@ -13,6 +14,7 @@ use crate::{error::Result, AuthAddress, Country, Error, IpPacketRouterAddress};
 
 // Decimal between 0 and 1 representing the performance of a gateway, measured over 24h.
 type Performance = u8;
+// type Performance = nym_vpn_api_client::types::Percent;
 
 #[derive(Clone)]
 pub struct Gateway {
@@ -222,9 +224,9 @@ fn string_fraction_into_percentage_u8(s: &str) -> Option<u8> {
         .ok()
 }
 
-fn percentage_u8_to_string_fraction(p: u8) -> String {
-    (p as f64 / 100.0).clamp(0.0, 1.0).to_string()
-}
+// fn percentage_u8_to_string_fraction(p: u8) -> String {
+//     (p as f64 / 100.0).clamp(0.0, 1.0).to_string()
+// }
 
 impl TryFrom<nym_validator_client::models::DescribedGateway> for Gateway {
     type Error = Error;

--- a/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
@@ -221,7 +221,7 @@ impl GatewayClient {
         match gw_type {
             GatewayType::MixnetEntry => self.lookup_entry_gateways_from_nym_api().await,
             GatewayType::MixnetExit => self.lookup_exit_gateways_from_nym_api().await,
-            GatewayType::Vpn => self.lookup_vpn_gateways_from_nym_api().await,
+            GatewayType::Wg => self.lookup_vpn_gateways_from_nym_api().await,
         }
     }
 

--- a/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
@@ -5,6 +5,7 @@ use std::{fmt, net::IpAddr};
 
 use nym_sdk::UserAgent;
 use nym_validator_client::{models::DescribedGateway, nym_nodes::SkimmedNode, NymApiClient};
+use nym_vpn_api_client::types::GatewayMinPerformance;
 use tracing::{debug, error, info};
 use url::Url;
 
@@ -22,7 +23,7 @@ use crate::{
 pub struct Config {
     pub api_url: Url,
     pub nym_vpn_api_url: Option<Url>,
-    pub min_gateway_performance: Option<u8>,
+    pub min_gateway_performance: Option<GatewayMinPerformance>,
 }
 
 impl Default for Config {
@@ -120,7 +121,9 @@ impl Config {
 pub struct GatewayClient {
     api_client: NymApiClient,
     nym_vpn_api_client: Option<nym_vpn_api_client::VpnApiClient>,
-    min_gateway_performance: Option<u8>,
+    // min_gateway_performance: Option<u8>,
+    vpn_min_performance: Option<u8>,
+    mixnet_min_performance: Option<u8>,
 }
 
 impl GatewayClient {

--- a/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
@@ -5,7 +5,7 @@ use std::{fmt, net::IpAddr};
 
 use nym_sdk::UserAgent;
 use nym_validator_client::{models::DescribedGateway, nym_nodes::SkimmedNode, NymApiClient};
-use nym_vpn_api_client::types::GatewayMinPerformance;
+use nym_vpn_api_client::types::{GatewayMinPerformance, Percent};
 use tracing::{debug, error, info};
 use url::Url;
 
@@ -136,6 +136,18 @@ impl GatewayClient {
             nym_vpn_api_client,
             min_gateway_performance: config.min_gateway_performance,
         })
+    }
+
+    pub fn mixnet_min_performance(&self) -> Option<Percent> {
+        self.min_gateway_performance
+            .as_ref()
+            .and_then(|min_performance| min_performance.mixnet_min_performance)
+    }
+
+    pub fn vpn_min_performance(&self) -> Option<Percent> {
+        self.min_gateway_performance
+            .as_ref()
+            .and_then(|min_performance| min_performance.vpn_min_performance)
     }
 
     async fn lookup_described_gateways(&self) -> Result<Vec<DescribedGateway>> {

--- a/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
@@ -108,7 +108,7 @@ impl Config {
         self
     }
 
-    pub fn with_custom_min_gateway_performance(
+    pub fn with_min_gateway_performance(
         mut self,
         min_gateway_performance: GatewayMinPerformance,
     ) -> Self {

--- a/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
@@ -168,7 +168,7 @@ impl GatewayClient {
 
     pub async fn lookup_low_latency_entry_gateway(&self) -> Result<Gateway> {
         debug!("Fetching low latency entry gateway...");
-        let gateways = self.lookup_gateways(GatewayType::Entry).await?;
+        let gateways = self.lookup_gateways(GatewayType::MixnetEntry).await?;
         gateways.random_low_latency_gateway().await
     }
 
@@ -219,8 +219,8 @@ impl GatewayClient {
 
     pub async fn lookup_gateways_from_nym_api(&self, gw_type: GatewayType) -> Result<GatewayList> {
         match gw_type {
-            GatewayType::Entry => self.lookup_entry_gateways_from_nym_api().await,
-            GatewayType::Exit => self.lookup_exit_gateways_from_nym_api().await,
+            GatewayType::MixnetEntry => self.lookup_entry_gateways_from_nym_api().await,
+            GatewayType::MixnetExit => self.lookup_exit_gateways_from_nym_api().await,
             GatewayType::Vpn => self.lookup_vpn_gateways_from_nym_api().await,
         }
     }
@@ -358,7 +358,10 @@ mod test {
     async fn lookup_gateways_in_nym_vpn_api() {
         let config = Config::new_mainnet();
         let client = GatewayClient::new(config, user_agent()).unwrap();
-        let gateways = client.lookup_gateways(GatewayType::Exit).await.unwrap();
+        let gateways = client
+            .lookup_gateways(GatewayType::MixnetExit)
+            .await
+            .unwrap();
         assert!(!gateways.is_empty());
     }
 }

--- a/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
@@ -358,7 +358,7 @@ fn append_performance(
             .iter()
             .find(|bgw| bgw.ed25519_identity_pubkey == gateway.identity().to_base58_string())
         {
-            gateway.performance = Some(basic_gw.performance);
+            gateway.mixnet_performance = Some(basic_gw.performance);
         } else {
             error!(
                 "Failed to find skimmed node for gateway with identity {}",
@@ -375,7 +375,7 @@ fn filter_on_mixnet_min_performance(
     if let Some(min_performance) = min_gateway_performance {
         if let Some(mixnet_min_performance) = min_performance.mixnet_min_performance {
             gateways.retain(|gateway| {
-                gateway.performance.unwrap_or_default() >= mixnet_min_performance
+                gateway.mixnet_performance.unwrap_or_default() >= mixnet_min_performance
             });
         }
     }

--- a/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
@@ -362,7 +362,7 @@ fn append_performance(
             .iter()
             .find(|bgw| bgw.ed25519_identity_pubkey == gateway.identity().to_base58_string())
         {
-            gateway.performance = Some(basic_gw.performance.round_to_integer());
+            gateway.performance = Some(basic_gw.performance);
         } else {
             error!(
                 "Failed to find skimmed node for gateway with identity {}",
@@ -379,7 +379,7 @@ fn filter_on_mixnet_min_performance(
     if let Some(min_performance) = min_gateway_performance {
         if let Some(mixnet_min_performance) = min_performance.mixnet_min_performance {
             gateways.retain(|gateway| {
-                gateway.performance.unwrap_or(0) >= mixnet_min_performance.round_to_integer()
+                gateway.performance.unwrap_or_default() >= mixnet_min_performance
             });
         }
     }

--- a/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
@@ -265,7 +265,7 @@ impl GatewayClient {
         if let Some(nym_vpn_api_client) = &self.nym_vpn_api_client {
             info!("Fetching gateways from nym-vpn-api...");
             let gateways: Vec<_> = nym_vpn_api_client
-                .get_gateways_kind(gw_type.into(), self.min_gateway_performance.clone())
+                .get_gateways_by_type(gw_type.into(), self.min_gateway_performance.clone())
                 .await?
                 .into_iter()
                 .filter_map(|gw| {
@@ -284,7 +284,7 @@ impl GatewayClient {
         if let Some(nym_vpn_api_client) = &self.nym_vpn_api_client {
             info!("Fetching entry countries from nym-vpn-api...");
             Ok(nym_vpn_api_client
-                .get_gateway_countries_kind(gw_type.into(), self.min_gateway_performance.clone())
+                .get_gateway_countries_by_type(gw_type.into(), self.min_gateway_performance.clone())
                 .await?
                 .into_iter()
                 .map(Country::from)
@@ -358,7 +358,7 @@ mod test {
     async fn lookup_gateways_in_nym_vpn_api() {
         let config = Config::new_mainnet();
         let client = GatewayClient::new(config, user_agent()).unwrap();
-        let gateways = client.lookup_exit_gateways().await.unwrap();
+        let gateways = client.lookup_gateways(GatewayType::Exit).await.unwrap();
         assert!(!gateways.is_empty());
     }
 }

--- a/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
@@ -108,10 +108,6 @@ impl Config {
         self
     }
 
-    pub fn min_gateway_performance(&self) -> Option<&GatewayMinPerformance> {
-        self.min_gateway_performance.as_ref()
-    }
-
     pub fn with_custom_min_gateway_performance(
         mut self,
         min_gateway_performance: GatewayMinPerformance,

--- a/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
@@ -71,7 +71,7 @@ impl Config {
         }
     }
 
-    pub fn new_from_env(min_gateway_performance: Option<GatewayMinPerformance>) -> Self {
+    pub fn new_from_env() -> Self {
         let network = nym_sdk::NymNetworkDetails::new_from_env();
         let api_url = network
             .endpoints
@@ -86,7 +86,7 @@ impl Config {
         Config {
             api_url,
             nym_vpn_api_url,
-            min_gateway_performance,
+            min_gateway_performance: None,
         }
     }
 

--- a/nym-vpn-core/crates/nym-gateway-directory/src/lib.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/lib.rs
@@ -8,6 +8,7 @@ mod helpers;
 
 pub use nym_sdk::mixnet::{NodeIdentity, Recipient};
 pub use nym_validator_client::models::DescribedGateway;
+pub use nym_vpn_api_client::types::{GatewayMinPerformance, Percent};
 
 pub use crate::{
     entries::{

--- a/nym-vpn-core/crates/nym-gateway-directory/src/lib.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/lib.rs
@@ -16,7 +16,7 @@ pub use crate::{
         country::Country,
         entry_point::EntryPoint,
         exit_point::ExitPoint,
-        gateway::{Entry, Exit, Gateway, GatewayList, Location, Probe, ProbeOutcome},
+        gateway::{Entry, Exit, Gateway, GatewayList, GatewayType, Location, Probe, ProbeOutcome},
         ipr_addresses::IpPacketRouterAddress,
     },
     error::Error,

--- a/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
+++ b/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
@@ -237,7 +237,7 @@ async fn wg_probe(
 }
 
 async fn lookup_gateways() -> anyhow::Result<GatewayList> {
-    let gateway_config = GatewayDirectoryConfig::new_from_env(None);
+    let gateway_config = GatewayDirectoryConfig::new_from_env();
     info!("nym-api: {}", gateway_config.api_url());
     info!(
         "nym-vpn-api: {}",

--- a/nym-vpn-core/crates/nym-vpn-api-client/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-api-client/Cargo.toml
@@ -13,6 +13,7 @@ base64-url.workspace = true
 bip39 = { workspace = true, features = ["zeroize"] }
 bs58.workspace = true
 chrono.workspace = true
+nym-contracts-common.workspace = true
 nym-crypto = { workspace = true, features = ["asymmetric"] }
 nym-http-api-client.workspace = true
 nym-validator-client.workspace = true

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
@@ -585,7 +585,6 @@ mod tests {
             .get_gateways(Some(GatewayMinPerformance::default()))
             .await
             .unwrap();
-        dbg!(&response);
         assert!(!response.into_inner().is_empty());
     }
 

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
@@ -19,7 +19,7 @@ use crate::{
         NymVpnSubscriptionResponse, NymVpnSubscriptionsResponse, NymVpnZkNym, NymVpnZkNymResponse,
     },
     routes,
-    types::{Device, GatewayMinPerformance, VpnApiAccount},
+    types::{Device, GatewayMinPerformance, GatewayType, VpnApiAccount},
 };
 
 pub(crate) const DEVICE_AUTHORIZATION_HEADER: &str = "x-device-authorization";
@@ -384,6 +384,30 @@ impl VpnApiClient {
             )
             .await
             .map_err(VpnApiClientError::FailedToGetGateways)
+    }
+
+    pub async fn get_gateways_kind(
+        &self,
+        kind: GatewayType,
+        min_performance: Option<GatewayMinPerformance>,
+    ) -> Result<NymDirectoryGatewaysResponse> {
+        match kind {
+            GatewayType::Entry => self.get_entry_gateways(min_performance).await,
+            GatewayType::Exit => self.get_exit_gateways(min_performance).await,
+            GatewayType::Vpn => self.get_vpn_gateways(min_performance).await,
+        }
+    }
+
+    pub async fn get_gateway_countries_kind(
+        &self,
+        kind: GatewayType,
+        min_performance: Option<GatewayMinPerformance>,
+    ) -> Result<NymDirectoryGatewayCountriesResponse> {
+        match kind {
+            GatewayType::Entry => self.get_entry_gateway_countries(min_performance).await,
+            GatewayType::Exit => self.get_exit_gateway_countries(min_performance).await,
+            GatewayType::Vpn => self.get_vpn_gateway_countries(min_performance).await,
+        }
     }
 
     pub async fn get_vpn_gateways(

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
@@ -392,8 +392,8 @@ impl VpnApiClient {
         min_performance: Option<GatewayMinPerformance>,
     ) -> Result<NymDirectoryGatewaysResponse> {
         match kind {
-            GatewayType::Entry => self.get_entry_gateways(min_performance).await,
-            GatewayType::Exit => self.get_exit_gateways(min_performance).await,
+            GatewayType::MixnetEntry => self.get_entry_gateways(min_performance).await,
+            GatewayType::MixnetExit => self.get_exit_gateways(min_performance).await,
             GatewayType::Vpn => self.get_vpn_gateways(min_performance).await,
         }
     }
@@ -404,8 +404,8 @@ impl VpnApiClient {
         min_performance: Option<GatewayMinPerformance>,
     ) -> Result<NymDirectoryGatewayCountriesResponse> {
         match kind {
-            GatewayType::Entry => self.get_entry_gateway_countries(min_performance).await,
-            GatewayType::Exit => self.get_exit_gateway_countries(min_performance).await,
+            GatewayType::MixnetEntry => self.get_entry_gateway_countries(min_performance).await,
+            GatewayType::MixnetExit => self.get_exit_gateway_countries(min_performance).await,
             GatewayType::Vpn => self.get_vpn_gateway_countries(min_performance).await,
         }
     }

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
@@ -394,7 +394,7 @@ impl VpnApiClient {
         match kind {
             GatewayType::MixnetEntry => self.get_entry_gateways(min_performance).await,
             GatewayType::MixnetExit => self.get_exit_gateways(min_performance).await,
-            GatewayType::Vpn => self.get_vpn_gateways(min_performance).await,
+            GatewayType::Wg => self.get_vpn_gateways(min_performance).await,
         }
     }
 
@@ -406,7 +406,7 @@ impl VpnApiClient {
         match kind {
             GatewayType::MixnetEntry => self.get_entry_gateway_countries(min_performance).await,
             GatewayType::MixnetExit => self.get_exit_gateway_countries(min_performance).await,
-            GatewayType::Vpn => self.get_vpn_gateway_countries(min_performance).await,
+            GatewayType::Wg => self.get_vpn_gateway_countries(min_performance).await,
         }
     }
 

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
@@ -370,14 +370,20 @@ impl VpnApiClient {
 
     pub async fn get_gateways(
         &self,
-        threshold: Option<u8>,
+        mixnet_min_performance: Option<u8>,
+        vpn_min_performance: Option<u8>,
     ) -> Result<NymDirectoryGatewaysResponse> {
         let mut params = vec![];
-        if let Some(threshold) = threshold {
-            let mixnet_min_performance = percentage_u8_to_string_fraction(threshold);
+        if let Some(threshold) = mixnet_min_performance {
             params.push((
                 routes::MIXNET_MIN_PERFORMANCE,
-                mixnet_min_performance.as_str(),
+                percentage_u8_to_string_fraction(threshold),
+            ));
+        };
+        if let Some(threshold) = vpn_min_performance {
+            params.push((
+                routes::MIXNET_MIN_PERFORMANCE,
+                percentage_u8_to_string_fraction(threshold),
             ));
         };
 
@@ -529,6 +535,31 @@ impl VpnApiClient {
             .map_err(VpnApiClientError::FailedToGetExitGatewayCountries)
     }
 }
+
+// #[derive(Clone, Default)]
+// struct GatewayMinPerformance {
+//     mixnet_min_performance: Option<rust_decimal::Decimal>,
+//     vpn_min_performance: Option<rust_decimal::Decimal>,
+// }
+
+// impl GatewayMinPerformance {
+//     
+// }
+
+// #[derive(Copy, Clone, Debug)]
+// struct Threshold {
+//     threshold: u8,
+// }
+//
+// impl Threshold {
+//     fn from_string(s: &str) -> Result<Self> {
+//         s.parse::<f64>()
+//             .map(|p| p * 100.0)
+//             .map(|p| p.round() as u8)
+//             .map(|p| p.clamp(0, 100))
+//             .map(|threshold| Self { threshold })
+//     }
+// }
 
 fn percentage_u8_to_string_fraction(p: u8) -> String {
     (p as f64 / 100.0).clamp(0.0, 1.0).to_string()

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
@@ -386,7 +386,7 @@ impl VpnApiClient {
             .map_err(VpnApiClientError::FailedToGetGateways)
     }
 
-    pub async fn get_gateways_kind(
+    pub async fn get_gateways_by_type(
         &self,
         kind: GatewayType,
         min_performance: Option<GatewayMinPerformance>,
@@ -398,7 +398,7 @@ impl VpnApiClient {
         }
     }
 
-    pub async fn get_gateway_countries_kind(
+    pub async fn get_gateway_countries_by_type(
         &self,
         kind: GatewayType,
         min_performance: Option<GatewayMinPerformance>,

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
@@ -368,7 +368,19 @@ impl VpnApiClient {
 
     // GATEWAYS
 
-    pub async fn get_gateways(&self) -> Result<NymDirectoryGatewaysResponse> {
+    pub async fn get_gateways(
+        &self,
+        threshold: Option<u8>,
+    ) -> Result<NymDirectoryGatewaysResponse> {
+        let mut params = vec![];
+        if let Some(threshold) = threshold {
+            let mixnet_min_performance = percentage_u8_to_string_fraction(threshold);
+            params.push((
+                routes::MIXNET_MIN_PERFORMANCE,
+                mixnet_min_performance.as_str(),
+            ));
+        };
+
         self.inner
             .get_json(
                 &[
@@ -377,13 +389,16 @@ impl VpnApiClient {
                     routes::DIRECTORY,
                     routes::GATEWAYS,
                 ],
-                NO_PARAMS,
+                &params,
             )
             .await
             .map_err(VpnApiClientError::FailedToGetGateways)
     }
 
-    pub async fn get_vpn_gateways(&self) -> Result<NymDirectoryGatewaysResponse> {
+    pub async fn get_vpn_gateways(
+        &self,
+        threshold: Option<u8>,
+    ) -> Result<NymDirectoryGatewaysResponse> {
         self.inner
             .get_json(
                 &[
@@ -398,7 +413,10 @@ impl VpnApiClient {
             .map_err(VpnApiClientError::FailedToGetVpnGateways)
     }
 
-    pub async fn get_vpn_gateway_countries(&self) -> Result<NymDirectoryGatewayCountriesResponse> {
+    pub async fn get_vpn_gateway_countries(
+        &self,
+        threshold: Option<u8>,
+    ) -> Result<NymDirectoryGatewayCountriesResponse> {
         self.inner
             .get_json(
                 &[
@@ -414,7 +432,10 @@ impl VpnApiClient {
             .map_err(VpnApiClientError::FailedToGetVpnGatewayCountries)
     }
 
-    pub async fn get_gateway_countries(&self) -> Result<NymDirectoryGatewayCountriesResponse> {
+    pub async fn get_gateway_countries(
+        &self,
+        threshold: Option<u8>,
+    ) -> Result<NymDirectoryGatewayCountriesResponse> {
         self.inner
             .get_json(
                 &[
@@ -430,7 +451,10 @@ impl VpnApiClient {
             .map_err(VpnApiClientError::FailedToGetGatewayCountries)
     }
 
-    pub async fn get_entry_gateways(&self) -> Result<NymDirectoryGatewaysResponse> {
+    pub async fn get_entry_gateways(
+        &self,
+        threshold: Option<u8>,
+    ) -> Result<NymDirectoryGatewaysResponse> {
         self.inner
             .get_json(
                 &[
@@ -448,6 +472,7 @@ impl VpnApiClient {
 
     pub async fn get_entry_gateway_countries(
         &self,
+        threshold: Option<u8>,
     ) -> Result<NymDirectoryGatewayCountriesResponse> {
         self.inner
             .get_json(
@@ -465,7 +490,10 @@ impl VpnApiClient {
             .map_err(VpnApiClientError::FailedToGetEntryGatewayCountries)
     }
 
-    pub async fn get_exit_gateways(&self) -> Result<NymDirectoryGatewaysResponse> {
+    pub async fn get_exit_gateways(
+        &self,
+        threshold: Option<u8>,
+    ) -> Result<NymDirectoryGatewaysResponse> {
         self.inner
             .get_json(
                 &[
@@ -481,7 +509,10 @@ impl VpnApiClient {
             .map_err(VpnApiClientError::FailedToGetExitGateways)
     }
 
-    pub async fn get_exit_gateway_countries(&self) -> Result<NymDirectoryGatewayCountriesResponse> {
+    pub async fn get_exit_gateway_countries(
+        &self,
+        threshold: Option<u8>,
+    ) -> Result<NymDirectoryGatewayCountriesResponse> {
         self.inner
             .get_json(
                 &[
@@ -497,6 +528,10 @@ impl VpnApiClient {
             .await
             .map_err(VpnApiClientError::FailedToGetExitGatewayCountries)
     }
+}
+
+fn percentage_u8_to_string_fraction(p: u8) -> String {
+    (p as f64 / 100.0).clamp(0.0, 1.0).to_string()
 }
 
 #[cfg(test)]

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
@@ -582,7 +582,7 @@ mod tests {
     async fn get_gateways() {
         let client = VpnApiClient::new(BASE_URL.parse().unwrap(), user_agent()).unwrap();
         let response = client
-            .get_gateways(GatewayMinPerformance::default())
+            .get_gateways(Some(GatewayMinPerformance::default()))
             .await
             .unwrap();
         dbg!(&response);
@@ -592,27 +592,21 @@ mod tests {
     #[tokio::test]
     async fn get_entry_gateways() {
         let client = VpnApiClient::new(BASE_URL.parse().unwrap(), user_agent()).unwrap();
-        let response = client
-            .get_entry_gateways(GatewayMinPerformance::default())
-            .await
-            .unwrap();
+        let response = client.get_entry_gateways(None).await.unwrap();
         assert!(!response.into_inner().is_empty());
     }
 
     #[tokio::test]
     async fn get_exit_gateways() {
         let client = VpnApiClient::new(BASE_URL.parse().unwrap(), user_agent()).unwrap();
-        let response = client
-            .get_entry_gateways(GatewayMinPerformance::default())
-            .await
-            .unwrap();
+        let response = client.get_entry_gateways(None).await.unwrap();
         assert!(!response.into_inner().is_empty());
     }
 
     #[tokio::test]
     async fn get_gateway_countries() {
         let client = VpnApiClient::new(BASE_URL.parse().unwrap(), user_agent()).unwrap();
-        let response = client.get_gateway_countries().await.unwrap();
+        let response = client.get_gateway_countries(None).await.unwrap();
         dbg!(&response);
         assert!(!response.into_inner().is_empty());
     }
@@ -620,14 +614,14 @@ mod tests {
     #[tokio::test]
     async fn get_entry_gateway_countries() {
         let client = VpnApiClient::new(BASE_URL.parse().unwrap(), user_agent()).unwrap();
-        let response = client.get_entry_gateway_countries().await.unwrap();
+        let response = client.get_entry_gateway_countries(None).await.unwrap();
         assert!(!response.into_inner().is_empty());
     }
 
     #[tokio::test]
     async fn get_exit_gateway_countries() {
         let client = VpnApiClient::new(BASE_URL.parse().unwrap(), user_agent()).unwrap();
-        let response = client.get_exit_gateway_countries().await.unwrap();
+        let response = client.get_exit_gateway_countries(None).await.unwrap();
         assert!(!response.into_inner().is_empty());
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/error.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/error.rs
@@ -1,6 +1,7 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use nym_contracts_common::ContractsCommonError;
 use nym_http_api_client::HttpClientError;
 
 use crate::response::{NymErrorResponse, UnexpectedError};
@@ -72,6 +73,9 @@ pub enum VpnApiClientError {
 
     #[error("failed to get vpn gateway countries")]
     FailedToGetVpnGatewayCountries(#[source] HttpClientError<UnexpectedError>),
+
+    #[error("invalud percent value")]
+    InvalidPercentValue(#[source] ContractsCommonError),
 }
 
 pub type Result<T> = std::result::Result<T, VpnApiClientError>;

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
@@ -3,6 +3,7 @@
 
 use std::fmt;
 
+use nym_contracts_common::Percent;
 use serde::{Deserialize, Serialize};
 
 const MAX_PROBE_RESULT_AGE_MINUTES: i64 = 60;
@@ -217,7 +218,7 @@ pub struct NymDirectoryGateway {
     pub last_probe: Option<Probe>,
     pub ip_addresses: Vec<String>,
     pub entry: EntryInformation,
-    pub performance: String,
+    pub performance: Percent,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
@@ -218,6 +218,8 @@ pub struct NymDirectoryGateway {
     pub last_probe: Option<Probe>,
     pub ip_addresses: Vec<String>,
     pub entry: EntryInformation,
+    // The performance data here originates from the nym-api, and is effectively mixnet performance
+    // at the time of writing this
     pub performance: Percent,
 }
 
@@ -287,6 +289,7 @@ impl Probe {
 pub struct ProbeOutcome {
     pub as_entry: Entry,
     pub as_exit: Option<Exit>,
+    pub wg: Option<WgProbeResults>,
 }
 
 impl ProbeOutcome {
@@ -320,6 +323,16 @@ pub struct Exit {
     pub can_route_ip_external_v4: bool,
     pub can_route_ip_v6: bool,
     pub can_route_ip_external_v6: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename = "wg")]
+pub struct WgProbeResults {
+    pub can_register: bool,
+    pub can_handshake: bool,
+    pub can_resolve_dns: bool,
+    pub ping_hosts_performance: f32,
+    pub ping_ips_performance: f32,
 }
 
 fn is_recently_updated(last_updated_utc: &str) -> bool {

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/routes.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/routes.rs
@@ -16,3 +16,5 @@ pub(crate) const ENTRY: &str = "entry";
 pub(crate) const EXIT: &str = "exit";
 
 pub(crate) const SHOW_VPN_ONLY: &str = "show_vpn_only";
+pub(crate) const VPN_MIN_PERFORMANCE: &str = "vpn_min_performance";
+pub(crate) const MIXNET_MIN_PERFORMANCE: &str = "mixnet_min_performance";

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/types.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/types.rs
@@ -108,3 +108,10 @@ impl GatewayMinPerformance {
         params
     }
 }
+
+#[derive(Clone, Debug)]
+pub enum GatewayType {
+    Entry,
+    Exit,
+    Vpn,
+}

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/types.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/types.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use nym_crypto::asymmetric::ed25519;
 use nym_validator_client::{signing::signer::OfflineSigner as _, DirectSecp256k1HdWallet};
 
-use crate::jwt::Jwt;
+use crate::{jwt::Jwt, VpnApiClientError};
 
 pub struct VpnApiAccount {
     wallet: DirectSecp256k1HdWallet,
@@ -73,6 +73,24 @@ pub struct GatewayMinPerformance {
 }
 
 impl GatewayMinPerformance {
+    pub fn from_percentage_values(
+        mixnet_min_performance: Option<u64>,
+        vpn_min_performance: Option<u64>,
+    ) -> Result<Self, VpnApiClientError> {
+        let mixnet_min_performance = mixnet_min_performance
+            .map(Percent::from_percentage_value)
+            .transpose()
+            .map_err(VpnApiClientError::InvalidPercentValue)?;
+        let vpn_min_performance = vpn_min_performance
+            .map(Percent::from_percentage_value)
+            .transpose()
+            .map_err(VpnApiClientError::InvalidPercentValue)?;
+        Ok(Self {
+            mixnet_min_performance,
+            vpn_min_performance,
+        })
+    }
+
     pub(crate) fn to_param(&self) -> Vec<(String, String)> {
         let mut params = vec![];
         if let Some(threshold) = self.mixnet_min_performance {

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/types.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/types.rs
@@ -111,7 +111,7 @@ impl GatewayMinPerformance {
 
 #[derive(Clone, Debug)]
 pub enum GatewayType {
-    Entry,
-    Exit,
+    MixnetEntry,
+    MixnetExit,
     Vpn,
 }

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/types.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/types.rs
@@ -1,9 +1,10 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+pub use nym_contracts_common::Percent;
+
 use std::sync::Arc;
 
-use nym_contracts_common::Percent;
 use nym_crypto::asymmetric::ed25519;
 use nym_validator_client::{signing::signer::OfflineSigner as _, DirectSecp256k1HdWallet};
 

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/types.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/types.rs
@@ -3,6 +3,7 @@
 
 use std::sync::Arc;
 
+use nym_contracts_common::Percent;
 use nym_crypto::asymmetric::ed25519;
 use nym_validator_client::{signing::signer::OfflineSigner as _, DirectSecp256k1HdWallet};
 
@@ -61,5 +62,30 @@ impl From<ed25519::KeyPair> for Device {
         Self {
             keypair: Arc::new(keypair),
         }
+    }
+}
+
+#[derive(Clone, Default, Debug)]
+pub struct GatewayMinPerformance {
+    pub mixnet_min_performance: Option<Percent>,
+    pub vpn_min_performance: Option<Percent>,
+}
+
+impl GatewayMinPerformance {
+    pub(crate) fn to_param(&self) -> Vec<(String, String)> {
+        let mut params = vec![];
+        if let Some(threshold) = self.mixnet_min_performance {
+            params.push((
+                crate::routes::MIXNET_MIN_PERFORMANCE.to_string(),
+                threshold.to_string(),
+            ));
+        };
+        if let Some(threshold) = self.vpn_min_performance {
+            params.push((
+                crate::routes::VPN_MIN_PERFORMANCE.to_string(),
+                threshold.to_string(),
+            ));
+        };
+        params
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/types.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/types.rs
@@ -113,5 +113,5 @@ impl GatewayMinPerformance {
 pub enum GatewayType {
     MixnetEntry,
     MixnetExit,
-    Vpn,
+    Wg,
 }

--- a/nym-vpn-core/crates/nym-vpn-cli/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-cli/Cargo.toml
@@ -22,7 +22,9 @@ tokio = { workspace = true, features = ["process", "rt-multi-thread", "fs", "syn
 tracing-subscriber.workspace = true
 tracing.workspace = true
 
+nym-vpn-api-client = { path = "../nym-vpn-api-client" }
 nym-vpn-lib = { path = "../nym-vpn-lib" }
+
 nym-bin-common.workspace = true
 
 [target.'cfg(unix)'.dependencies]

--- a/nym-vpn-core/crates/nym-vpn-cli/src/commands.rs
+++ b/nym-vpn-core/crates/nym-vpn-cli/src/commands.rs
@@ -96,7 +96,11 @@ pub(crate) struct RunArgs {
 
     // Set the minimum performance level for gateways.
     #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]
-    pub(crate) min_gateway_performance: Option<u8>,
+    pub(crate) min_gateway_mixnet_performance: Option<u8>,
+
+    // Set the minimum performance level for VPN gateways.
+    #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]
+    pub(crate) min_gateway_vpn_performance: Option<u8>,
 }
 
 #[derive(Args)]

--- a/nym-vpn-core/crates/nym-vpn-cli/src/error.rs
+++ b/nym-vpn-core/crates/nym-vpn-cli/src/error.rs
@@ -34,6 +34,9 @@ pub(crate) enum Error {
     #[cfg(windows)]
     #[error("administrator privileges required, try rerunning with administrator privileges: `runas /user:Administrator {binary_name} run`")]
     AdminPrivilegesRequired { binary_name: String },
+
+    #[error("failed to setup gateway minimum performance threshold: {0}")]
+    FailedToSetupGatewayPerformanceThresholds(#[source] nym_vpn_api_client::VpnApiClientError),
 }
 
 // Result type based on our error type

--- a/nym-vpn-core/crates/nym-vpn-cli/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpn-cli/src/main.rs
@@ -160,8 +160,8 @@ async fn run() -> Result<()> {
 async fn run_vpn(args: commands::RunArgs, data_path: Option<PathBuf>) -> Result<()> {
     // Setup gateway directory configuration
     let min_gateway_performance = GatewayMinPerformance::from_percentage_values(
-        args.min_mixnode_performance.map(u64::from),
-        args.min_gateway_performance.map(u64::from),
+        args.min_gateway_mixnet_performance.map(u64::from),
+        args.min_gateway_vpn_performance.map(u64::from),
     )
     .map_err(Error::FailedToSetupGatewayPerformanceThresholds)?;
 
@@ -190,7 +190,7 @@ async fn run_vpn(args: commands::RunArgs, data_path: Option<PathBuf>) -> Result<
             disable_background_cover_traffic: args.disable_background_cover_traffic,
             enable_credentials_mode: args.enable_credentials_mode,
             min_mixnode_performance: args.min_mixnode_performance,
-            min_gateway_performance: args.min_gateway_performance,
+            min_gateway_performance: args.min_gateway_mixnet_performance,
         },
         data_path,
         gateway_config,

--- a/nym-vpn-core/crates/nym-vpn-cli/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpn-cli/src/main.rs
@@ -166,10 +166,11 @@ async fn run_vpn(args: commands::RunArgs, data_path: Option<PathBuf>) -> Result<
     let vpn_min_performance = args
         .min_gateway_performance
         .map(|p| Percent::from_percentage_value(p as u64).unwrap());
-    let gateway_config = GatewayConfig::new_from_env(Some(GatewayMinPerformance {
-        mixnet_min_performance,
-        vpn_min_performance,
-    }));
+    let gateway_config =
+        GatewayConfig::new_from_env().with_custom_min_gateway_performance(GatewayMinPerformance {
+            mixnet_min_performance,
+            vpn_min_performance,
+        });
 
     info!("nym-api: {}", gateway_config.api_url());
     info!(

--- a/nym-vpn-core/crates/nym-vpn-lib/src/mobile/runner.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/mobile/runner.rs
@@ -219,7 +219,7 @@ impl WgTunnelRunner {
 
         let all_gateways = self
             .gateway_directory_client
-            .lookup_gateways(GatewayType::Vpn)
+            .lookup_gateways(nym_gateway_directory::GatewayType::Vpn)
             .await
             .map_err(|source| GatewayDirectoryError::FailedToLookupGateways { source })?;
         let mut entry_gateways = all_gateways.clone();
@@ -262,7 +262,7 @@ impl WgTunnelRunner {
                 .two_letter_iso_country_code()
                 .map_or_else(|| "unknown".to_string(), |code| code.to_string()),
             entry_gateway
-                .performance
+                .mixnet_performance
                 .map_or_else(|| "unknown".to_string(), |perf| perf.to_string()),
         );
         tracing::info!(
@@ -272,7 +272,7 @@ impl WgTunnelRunner {
                 .two_letter_iso_country_code()
                 .map_or_else(|| "unknown".to_string(), |code| code.to_string()),
             entry_gateway
-                .performance
+                .mixnet_performance
                 .map_or_else(|| "unknown".to_string(), |perf| perf.to_string()),
         );
         tracing::info!(

--- a/nym-vpn-core/crates/nym-vpn-lib/src/mobile/runner.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/mobile/runner.rs
@@ -209,6 +209,14 @@ impl WgTunnelRunner {
     }
 
     async fn select_gateways(&self) -> Result<SelectedGateways> {
+        if let Some(min_mixnet_performance) = self.gateway_directory_client.mixnet_min_performance()
+        {
+            tracing::info!("Using min mixnet gateway performance: {min_mixnet_performance}");
+        }
+        if let Some(min_vpn_performance) = self.gateway_directory_client.vpn_min_performance() {
+            tracing::info!("Using min vpn gateway performance: {min_vpn_performance}");
+        }
+
         let all_gateways = self
             .gateway_directory_client
             .lookup_vpn_gateways()

--- a/nym-vpn-core/crates/nym-vpn-lib/src/mobile/runner.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/mobile/runner.rs
@@ -219,7 +219,7 @@ impl WgTunnelRunner {
 
         let all_gateways = self
             .gateway_directory_client
-            .lookup_gateways(nym_gateway_directory::GatewayType::Vpn)
+            .lookup_gateways(nym_gateway_directory::GatewayType::Wg)
             .await
             .map_err(|source| GatewayDirectoryError::FailedToLookupGateways { source })?;
         let mut entry_gateways = all_gateways.clone();

--- a/nym-vpn-core/crates/nym-vpn-lib/src/mobile/runner.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/mobile/runner.rs
@@ -219,7 +219,7 @@ impl WgTunnelRunner {
 
         let all_gateways = self
             .gateway_directory_client
-            .lookup_vpn_gateways()
+            .lookup_gateways(GatewayType::Vpn)
             .await
             .map_err(|source| GatewayDirectoryError::FailedToLookupGateways { source })?;
         let mut entry_gateways = all_gateways.clone();

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
@@ -22,7 +22,6 @@ use std::{
 
 use lazy_static::lazy_static;
 use log::*;
-use nym_gateway_directory::GatewayType;
 use talpid_core::mpsc::Sender;
 use tokio::{
     runtime::Runtime,
@@ -44,8 +43,9 @@ use crate::{
     gateway_directory::GatewayClient,
     platform::status_listener::VpnServiceStatusListener,
     uniffi_custom_impls::{
-        BandwidthStatus, ConnectionStatus, EntryPoint, ExitPoint, ExitStatus, Location,
-        NymVpnStatus, StatusEvent, TunStatus, UserAgent,
+        BandwidthStatus, ConnectionStatus, EntryPoint, ExitPoint, ExitStatus,
+        GatewayMinPerformance, GatewayType, Location, NymVpnStatus, StatusEvent, TunStatus,
+        UserAgent,
     },
     vpn::{
         spawn_nym_vpn, MixnetVpn, NymVpn, NymVpnCtrlMessage, NymVpnExitStatusMessage, NymVpnHandle,
@@ -415,72 +415,40 @@ async fn stop_vpn() -> Result<(), VpnError> {
 pub fn getGatewayCountries(
     api_url: Url,
     nym_vpn_api_url: Option<Url>,
-    exit_only: bool,
+    gw_type: GatewayType,
     user_agent: Option<UserAgent>,
+    min_gateway_performance: Option<GatewayMinPerformance>,
 ) -> Result<Vec<Location>, VpnError> {
     RUNTIME.block_on(get_gateway_countries(
         api_url,
         nym_vpn_api_url,
-        exit_only,
+        gw_type,
         user_agent,
+        min_gateway_performance,
     ))
 }
 
 async fn get_gateway_countries(
     api_url: Url,
     nym_vpn_api_url: Option<Url>,
-    exit_only: bool,
+    gw_type: GatewayType,
     user_agent: Option<UserAgent>,
+    min_gateway_performance: Option<GatewayMinPerformance>,
 ) -> Result<Vec<Location>, VpnError> {
     let user_agent = user_agent
         .map(nym_sdk::UserAgent::from)
         .unwrap_or_else(|| nym_bin_common::bin_info_local_vergen!().into());
+    let min_gateway_performance = min_gateway_performance.map(|p| p.try_into()).transpose()?;
     let directory_config = nym_gateway_directory::Config {
         api_url,
         nym_vpn_api_url,
-        min_gateway_performance: None,
+        min_gateway_performance,
     };
-    let directory_client = GatewayClient::new(directory_config, user_agent)?;
-    let locations = if !exit_only {
-        directory_client
-            .lookup_countries(GatewayType::MixnetEntry)
-            .await
-    } else {
-        directory_client
-            .lookup_countries(GatewayType::MixnetExit)
-            .await
-    }?;
-    Ok(locations.into_iter().map(Location::from).collect())
-}
-
-// Add an additional method to preserve backwards compatibility for a bit, so that we can use add
-// this functionality before all apps are ready
-#[allow(non_snake_case)]
-#[uniffi::export]
-pub fn getVpnCountries(
-    api_url: Url,
-    nym_vpn_api_url: Option<Url>,
-    user_agent: Option<UserAgent>,
-) -> Result<Vec<Location>, VpnError> {
-    RUNTIME.block_on(get_vpn_countries(api_url, nym_vpn_api_url, user_agent))
-}
-
-async fn get_vpn_countries(
-    api_url: Url,
-    nym_vpn_api_url: Option<Url>,
-    user_agent: Option<UserAgent>,
-) -> Result<Vec<Location>, VpnError> {
-    let user_agent = user_agent
-        .map(nym_sdk::UserAgent::from)
-        .unwrap_or_else(|| nym_bin_common::bin_info_local_vergen!().into());
-    let directory_config = nym_gateway_directory::Config {
-        api_url,
-        nym_vpn_api_url,
-        min_gateway_performance: None,
-    };
-    let directory_client = GatewayClient::new(directory_config, user_agent)?;
-    let locations = directory_client.lookup_countries(GatewayType::Vpn).await?;
-    Ok(locations.into_iter().map(Location::from).collect())
+    GatewayClient::new(directory_config, user_agent)?
+        .lookup_countries(gw_type.into())
+        .await
+        .map(|countries| countries.into_iter().map(Location::from).collect())
+        .map_err(VpnError::from)
 }
 
 #[allow(non_snake_case)]
@@ -488,28 +456,11 @@ async fn get_vpn_countries(
 pub fn getLowLatencyEntryCountry(
     api_url: Url,
     vpn_api_url: Option<Url>,
-    harbour_master_url: Option<Url>,
-) -> Result<Location, VpnError> {
-    RUNTIME.block_on(get_low_latency_entry_country(
-        api_url,
-        vpn_api_url,
-        harbour_master_url,
-        None,
-    ))
-}
-
-#[allow(non_snake_case)]
-#[uniffi::export]
-pub fn getLowLatencyEntryCountryUserAgent(
-    api_url: Url,
-    vpn_api_url: Option<Url>,
-    harbour_master_url: Option<Url>,
     user_agent: UserAgent,
 ) -> Result<Location, VpnError> {
     RUNTIME.block_on(get_low_latency_entry_country(
         api_url,
         vpn_api_url,
-        harbour_master_url,
         Some(user_agent),
     ))
 }
@@ -517,7 +468,6 @@ pub fn getLowLatencyEntryCountryUserAgent(
 async fn get_low_latency_entry_country(
     api_url: Url,
     vpn_api_url: Option<Url>,
-    _harbour_master_url: Option<Url>,
     user_agent: Option<UserAgent>,
 ) -> Result<Location, VpnError> {
     let config = nym_gateway_directory::Config {
@@ -528,17 +478,17 @@ async fn get_low_latency_entry_country(
     let user_agent = user_agent
         .map(nym_sdk::UserAgent::from)
         .unwrap_or_else(|| nym_bin_common::bin_info_local_vergen!().into());
-    let gateway_client = GatewayClient::new(config, user_agent)?;
-    let gateway = gateway_client.lookup_low_latency_entry_gateway().await?;
-    let country = gateway
-        .location
-        // Using LibError here keep existing behaviour and not make any changes to FFIError
-        .ok_or(VpnError::InternalError {
-            details: "gateway does not contain a two character country ISO".to_string(),
-        })?
-        .into();
 
-    Ok(country)
+    GatewayClient::new(config, user_agent)?
+        .lookup_low_latency_entry_gateway()
+        .await
+        .map_err(VpnError::from)
+        .and_then(|gateway| {
+            gateway.location.ok_or(VpnError::InternalError {
+                details: "gateway does not contain a two character country ISO".to_string(),
+            })
+        })
+        .map(Location::from)
 }
 
 #[uniffi::export(with_foreign)]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
@@ -22,6 +22,7 @@ use std::{
 
 use lazy_static::lazy_static;
 use log::*;
+use nym_gateway_directory::GatewayType;
 use talpid_core::mpsc::Sender;
 use tokio::{
     runtime::Runtime,
@@ -441,9 +442,9 @@ async fn get_gateway_countries(
     };
     let directory_client = GatewayClient::new(directory_config, user_agent)?;
     let locations = if !exit_only {
-        directory_client.lookup_entry_countries().await
+        directory_client.lookup_countries(GatewayType::Entry).await
     } else {
-        directory_client.lookup_exit_countries().await
+        directory_client.lookup_countries(GatewayType::Exit).await
     }?;
     Ok(locations.into_iter().map(Location::from).collect())
 }
@@ -474,7 +475,7 @@ async fn get_vpn_countries(
         min_gateway_performance: None,
     };
     let directory_client = GatewayClient::new(directory_config, user_agent)?;
-    let locations = directory_client.lookup_vpn_countries().await?;
+    let locations = directory_client.lookup_countries(GatewayType::Vpn).await?;
     Ok(locations.into_iter().map(Location::from).collect())
 }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
@@ -442,9 +442,13 @@ async fn get_gateway_countries(
     };
     let directory_client = GatewayClient::new(directory_config, user_agent)?;
     let locations = if !exit_only {
-        directory_client.lookup_countries(GatewayType::Entry).await
+        directory_client
+            .lookup_countries(GatewayType::MixnetEntry)
+            .await
     } else {
-        directory_client.lookup_countries(GatewayType::Exit).await
+        directory_client
+            .lookup_countries(GatewayType::MixnetExit)
+            .await
     }?;
     Ok(locations.into_iter().map(Location::from).collect())
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_setup.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_setup.rs
@@ -418,6 +418,13 @@ async fn select_gateways(
     gateway_directory_client: &GatewayClient,
     nym_vpn: &SpecificVpn,
 ) -> std::result::Result<SelectedGateways, GatewayDirectoryError> {
+    if let Some(min_mixnet_performance) = gateway_directory_client.mixnet_min_performance() {
+        info!("Using min mixnet gateway performance: {min_mixnet_performance}");
+    }
+    if let Some(min_vpn_performance) = gateway_directory_client.vpn_min_performance() {
+        info!("Using min vpn gateway performance: {min_vpn_performance}");
+    }
+
     // The set of exit gateways is smaller than the set of entry gateways, so we start by selecting
     // the exit gateway and then filter out the exit gateway from the set of entry gateways.
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_setup.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_setup.rs
@@ -10,7 +10,7 @@ use futures::{
 use ipnetwork::IpNetwork;
 use log::*;
 use nym_authenticator_client::AuthClient;
-use nym_gateway_directory::{AuthAddresses, GatewayClient, IpPacketRouterAddress};
+use nym_gateway_directory::{AuthAddresses, GatewayClient, GatewayType, IpPacketRouterAddress};
 use nym_task::TaskManager;
 use nym_wg_gateway_client::WgGatewayClient;
 use talpid_core::dns::DnsMonitor;
@@ -431,18 +431,18 @@ async fn select_gateways(
     let (mut entry_gateways, exit_gateways) = if let SpecificVpn::Mix(_) = nym_vpn {
         // Setup the gateway that we will use as the exit point
         let exit_gateways = gateway_directory_client
-            .lookup_exit_gateways()
+            .lookup_gateways(GatewayType::Exit)
             .await
             .map_err(|source| GatewayDirectoryError::FailedToLookupGateways { source })?;
         // Setup the gateway that we will use as the entry point
         let entry_gateways = gateway_directory_client
-            .lookup_entry_gateways()
+            .lookup_gateways(GatewayType::Entry)
             .await
             .map_err(|source| GatewayDirectoryError::FailedToLookupGateways { source })?;
         (entry_gateways, exit_gateways)
     } else {
         let all_gateways = gateway_directory_client
-            .lookup_vpn_gateways()
+            .lookup_gateways(GatewayType::Vpn)
             .await
             .map_err(|source| GatewayDirectoryError::FailedToLookupGateways { source })?;
         (all_gateways.clone(), all_gateways)

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_setup.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_setup.rs
@@ -431,12 +431,12 @@ async fn select_gateways(
     let (mut entry_gateways, exit_gateways) = if let SpecificVpn::Mix(_) = nym_vpn {
         // Setup the gateway that we will use as the exit point
         let exit_gateways = gateway_directory_client
-            .lookup_gateways(GatewayType::Exit)
+            .lookup_gateways(GatewayType::MixnetExit)
             .await
             .map_err(|source| GatewayDirectoryError::FailedToLookupGateways { source })?;
         // Setup the gateway that we will use as the entry point
         let entry_gateways = gateway_directory_client
-            .lookup_gateways(GatewayType::Entry)
+            .lookup_gateways(GatewayType::MixnetEntry)
             .await
             .map_err(|source| GatewayDirectoryError::FailedToLookupGateways { source })?;
         (entry_gateways, exit_gateways)

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_setup.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_setup.rs
@@ -442,7 +442,7 @@ async fn select_gateways(
         (entry_gateways, exit_gateways)
     } else {
         let all_gateways = gateway_directory_client
-            .lookup_gateways(GatewayType::Vpn)
+            .lookup_gateways(GatewayType::Wg)
             .await
             .map_err(|source| GatewayDirectoryError::FailedToLookupGateways { source })?;
         (all_gateways.clone(), all_gateways)

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_setup.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_setup.rs
@@ -476,7 +476,7 @@ async fn select_gateways(
             .two_letter_iso_country_code()
             .map_or_else(|| "unknown".to_string(), |code| code.to_string()),
         entry_gateway
-            .performance
+            .mixnet_performance
             .map_or_else(|| "unknown".to_string(), |perf| perf.to_string()),
     );
     info!(
@@ -486,7 +486,7 @@ async fn select_gateways(
             .two_letter_iso_country_code()
             .map_or_else(|| "unknown".to_string(), |code| code.to_string()),
         entry_gateway
-            .performance
+            .mixnet_performance
             .map_or_else(|| "unknown".to_string(), |perf| perf.to_string()),
     );
     info!(

--- a/nym-vpn-core/crates/nym-vpn-lib/src/uniffi_custom_impls.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/uniffi_custom_impls.rs
@@ -245,6 +245,60 @@ impl From<nym_gateway_directory::Country> for Location {
     }
 }
 
+#[derive(uniffi::Enum)]
+pub enum GatewayType {
+    MixnetEntry,
+    MixnetExit,
+    Wg,
+}
+
+impl From<GatewayType> for nym_gateway_directory::GatewayType {
+    fn from(value: GatewayType) -> Self {
+        match value {
+            GatewayType::MixnetEntry => nym_gateway_directory::GatewayType::MixnetEntry,
+            GatewayType::MixnetExit => nym_gateway_directory::GatewayType::MixnetExit,
+            GatewayType::Wg => nym_gateway_directory::GatewayType::Wg,
+        }
+    }
+}
+
+#[derive(uniffi::Record)]
+pub struct GatewayMinPerformance {
+    mixnet_min_performance: Option<u64>,
+    vpn_min_performance: Option<u64>,
+}
+
+impl TryFrom<GatewayMinPerformance> for nym_gateway_directory::GatewayMinPerformance {
+    type Error = VpnError;
+
+    fn try_from(value: GatewayMinPerformance) -> Result<Self, Self::Error> {
+        let mixnet_min_performance = value
+            .mixnet_min_performance
+            .map(|p| {
+                nym_gateway_directory::Percent::from_percentage_value(p).map_err(|_| {
+                    VpnError::InternalError {
+                        details: "Invalid mixnet min performance percentage".to_string(),
+                    }
+                })
+            })
+            .transpose()?;
+        let vpn_min_performance = value
+            .vpn_min_performance
+            .map(|p| {
+                nym_gateway_directory::Percent::from_percentage_value(p).map_err(|_| {
+                    VpnError::InternalError {
+                        details: "Invalid vpn min performance percentage".to_string(),
+                    }
+                })
+            })
+            .transpose()?;
+        Ok(nym_gateway_directory::GatewayMinPerformance {
+            mixnet_min_performance,
+            vpn_min_performance,
+        })
+    }
+}
+
 #[derive(uniffi::Record)]
 pub struct UserAgent {
     // The name of the application

--- a/nym-vpn-core/crates/nym-vpn-lib/uniffi/nym_vpn_lib.kt
+++ b/nym-vpn-core/crates/nym-vpn-lib/uniffi/nym_vpn_lib.kt
@@ -795,10 +795,6 @@ internal open class UniffiVTableCallbackInterfaceTunnelStatusListener(
 
 
 
-
-
-
-
 // A JNA Library to expose the extern-C FFI definitions.
 // This is an implementation detail which will be called internally by the public API.
 
@@ -848,13 +844,9 @@ internal interface UniffiLib : Library {
     ): Unit
     fun uniffi_nym_vpn_lib_fn_func_checkcredential(`credential`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
-    fun uniffi_nym_vpn_lib_fn_func_getgatewaycountries(`apiUrl`: RustBuffer.ByValue,`nymVpnApiUrl`: RustBuffer.ByValue,`exitOnly`: Byte,`userAgent`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+    fun uniffi_nym_vpn_lib_fn_func_getgatewaycountries(`apiUrl`: RustBuffer.ByValue,`nymVpnApiUrl`: RustBuffer.ByValue,`gwType`: RustBuffer.ByValue,`userAgent`: RustBuffer.ByValue,`minGatewayPerformance`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
-    fun uniffi_nym_vpn_lib_fn_func_getlowlatencyentrycountry(`apiUrl`: RustBuffer.ByValue,`vpnApiUrl`: RustBuffer.ByValue,`harbourMasterUrl`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
-    ): RustBuffer.ByValue
-    fun uniffi_nym_vpn_lib_fn_func_getlowlatencyentrycountryuseragent(`apiUrl`: RustBuffer.ByValue,`vpnApiUrl`: RustBuffer.ByValue,`harbourMasterUrl`: RustBuffer.ByValue,`userAgent`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
-    ): RustBuffer.ByValue
-    fun uniffi_nym_vpn_lib_fn_func_getvpncountries(`apiUrl`: RustBuffer.ByValue,`nymVpnApiUrl`: RustBuffer.ByValue,`userAgent`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+    fun uniffi_nym_vpn_lib_fn_func_getlowlatencyentrycountry(`apiUrl`: RustBuffer.ByValue,`vpnApiUrl`: RustBuffer.ByValue,`userAgent`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
     fun uniffi_nym_vpn_lib_fn_func_importcredential(`credential`: RustBuffer.ByValue,`path`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
@@ -982,10 +974,6 @@ internal interface UniffiLib : Library {
     ): Short
     fun uniffi_nym_vpn_lib_checksum_func_getlowlatencyentrycountry(
     ): Short
-    fun uniffi_nym_vpn_lib_checksum_func_getlowlatencyentrycountryuseragent(
-    ): Short
-    fun uniffi_nym_vpn_lib_checksum_func_getvpncountries(
-    ): Short
     fun uniffi_nym_vpn_lib_checksum_func_importcredential(
     ): Short
     fun uniffi_nym_vpn_lib_checksum_func_initlogger(
@@ -1028,16 +1016,10 @@ private fun uniffiCheckApiChecksums(lib: UniffiLib) {
     if (lib.uniffi_nym_vpn_lib_checksum_func_checkcredential() != 1684.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_nym_vpn_lib_checksum_func_getgatewaycountries() != 18771.toShort()) {
+    if (lib.uniffi_nym_vpn_lib_checksum_func_getgatewaycountries() != 41607.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_nym_vpn_lib_checksum_func_getlowlatencyentrycountry() != 27206.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_nym_vpn_lib_checksum_func_getlowlatencyentrycountryuseragent() != 14102.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_nym_vpn_lib_checksum_func_getvpncountries() != 17864.toShort()) {
+    if (lib.uniffi_nym_vpn_lib_checksum_func_getlowlatencyentrycountry() != 12628.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_nym_vpn_lib_checksum_func_importcredential() != 49505.toShort()) {
@@ -1170,6 +1152,26 @@ public object FfiConverterInt: FfiConverter<Int, Int> {
 
     override fun write(value: Int, buf: ByteBuffer) {
         buf.putInt(value)
+    }
+}
+
+public object FfiConverterULong: FfiConverter<ULong, Long> {
+    override fun lift(value: Long): ULong {
+        return value.toULong()
+    }
+
+    override fun read(buf: ByteBuffer): ULong {
+        return lift(buf.getLong())
+    }
+
+    override fun lower(value: ULong): Long {
+        return value.toLong()
+    }
+
+    override fun allocationSize(value: ULong) = 8UL
+
+    override fun write(value: ULong, buf: ByteBuffer) {
+        buf.putLong(value.toLong())
     }
 }
 
@@ -2107,6 +2109,35 @@ public object FfiConverterTypeDnsSettings: FfiConverterRustBuffer<DnsSettings> {
 
 
 
+data class GatewayMinPerformance (
+    var `mixnetMinPerformance`: kotlin.ULong?, 
+    var `vpnMinPerformance`: kotlin.ULong?
+) {
+    
+    companion object
+}
+
+public object FfiConverterTypeGatewayMinPerformance: FfiConverterRustBuffer<GatewayMinPerformance> {
+    override fun read(buf: ByteBuffer): GatewayMinPerformance {
+        return GatewayMinPerformance(
+            FfiConverterOptionalULong.read(buf),
+            FfiConverterOptionalULong.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: GatewayMinPerformance) = (
+            FfiConverterOptionalULong.allocationSize(value.`mixnetMinPerformance`) +
+            FfiConverterOptionalULong.allocationSize(value.`vpnMinPerformance`)
+    )
+
+    override fun write(value: GatewayMinPerformance, buf: ByteBuffer) {
+            FfiConverterOptionalULong.write(value.`mixnetMinPerformance`, buf)
+            FfiConverterOptionalULong.write(value.`vpnMinPerformance`, buf)
+    }
+}
+
+
+
 data class Ipv4Settings (
     /**
      * IPv4 addresses that will be set on tunnel interface.
@@ -2810,6 +2841,34 @@ public object FfiConverterTypeExitStatus : FfiConverterRustBuffer<ExitStatus>{
 
 
 
+
+enum class GatewayType {
+    
+    MIXNET_ENTRY,
+    MIXNET_EXIT,
+    WG;
+    companion object
+}
+
+
+public object FfiConverterTypeGatewayType: FfiConverterRustBuffer<GatewayType> {
+    override fun read(buf: ByteBuffer) = try {
+        GatewayType.values()[buf.getInt() - 1]
+    } catch (e: IndexOutOfBoundsException) {
+        throw RuntimeException("invalid enum value, something is very wrong!!", e)
+    }
+
+    override fun allocationSize(value: GatewayType) = 4UL
+
+    override fun write(value: GatewayType, buf: ByteBuffer) {
+        buf.putInt(value.ordinal + 1)
+    }
+}
+
+
+
+
+
 sealed class Ipv4Route {
     
     /**
@@ -3221,6 +3280,35 @@ public object FfiConverterTypeVpnError : FfiConverterRustBuffer<VpnException> {
 
 
 
+public object FfiConverterOptionalULong: FfiConverterRustBuffer<kotlin.ULong?> {
+    override fun read(buf: ByteBuffer): kotlin.ULong? {
+        if (buf.get().toInt() == 0) {
+            return null
+        }
+        return FfiConverterULong.read(buf)
+    }
+
+    override fun allocationSize(value: kotlin.ULong?): ULong {
+        if (value == null) {
+            return 1UL
+        } else {
+            return 1UL + FfiConverterULong.allocationSize(value)
+        }
+    }
+
+    override fun write(value: kotlin.ULong?, buf: ByteBuffer) {
+        if (value == null) {
+            buf.put(0)
+        } else {
+            buf.put(1)
+            FfiConverterULong.write(value, buf)
+        }
+    }
+}
+
+
+
+
 public object FfiConverterOptionalTimestamp: FfiConverterRustBuffer<java.time.Instant?> {
     override fun read(buf: ByteBuffer): java.time.Instant? {
         if (buf.get().toInt() == 0) {
@@ -3301,6 +3389,35 @@ public object FfiConverterOptionalTypeDnsSettings: FfiConverterRustBuffer<DnsSet
         } else {
             buf.put(1)
             FfiConverterTypeDnsSettings.write(value, buf)
+        }
+    }
+}
+
+
+
+
+public object FfiConverterOptionalTypeGatewayMinPerformance: FfiConverterRustBuffer<GatewayMinPerformance?> {
+    override fun read(buf: ByteBuffer): GatewayMinPerformance? {
+        if (buf.get().toInt() == 0) {
+            return null
+        }
+        return FfiConverterTypeGatewayMinPerformance.read(buf)
+    }
+
+    override fun allocationSize(value: GatewayMinPerformance?): ULong {
+        if (value == null) {
+            return 1UL
+        } else {
+            return 1UL + FfiConverterTypeGatewayMinPerformance.allocationSize(value)
+        }
+    }
+
+    override fun write(value: GatewayMinPerformance?, buf: ByteBuffer) {
+        if (value == null) {
+            buf.put(0)
+        } else {
+            buf.put(1)
+            FfiConverterTypeGatewayMinPerformance.write(value, buf)
         }
     }
 }
@@ -3909,41 +4026,21 @@ public object FfiConverterTypeUrl: FfiConverter<Url, RustBuffer.ByValue> {
     }
     
 
-    @Throws(VpnException::class) fun `getGatewayCountries`(`apiUrl`: Url, `nymVpnApiUrl`: Url?, `exitOnly`: kotlin.Boolean, `userAgent`: UserAgent?): List<Location> {
+    @Throws(VpnException::class) fun `getGatewayCountries`(`apiUrl`: Url, `nymVpnApiUrl`: Url?, `gwType`: GatewayType, `userAgent`: UserAgent?, `minGatewayPerformance`: GatewayMinPerformance?): List<Location> {
             return FfiConverterSequenceTypeLocation.lift(
     uniffiRustCallWithError(VpnException) { _status ->
     UniffiLib.INSTANCE.uniffi_nym_vpn_lib_fn_func_getgatewaycountries(
-        FfiConverterTypeUrl.lower(`apiUrl`),FfiConverterOptionalTypeUrl.lower(`nymVpnApiUrl`),FfiConverterBoolean.lower(`exitOnly`),FfiConverterOptionalTypeUserAgent.lower(`userAgent`),_status)
+        FfiConverterTypeUrl.lower(`apiUrl`),FfiConverterOptionalTypeUrl.lower(`nymVpnApiUrl`),FfiConverterTypeGatewayType.lower(`gwType`),FfiConverterOptionalTypeUserAgent.lower(`userAgent`),FfiConverterOptionalTypeGatewayMinPerformance.lower(`minGatewayPerformance`),_status)
 }
     )
     }
     
 
-    @Throws(VpnException::class) fun `getLowLatencyEntryCountry`(`apiUrl`: Url, `vpnApiUrl`: Url?, `harbourMasterUrl`: Url?): Location {
+    @Throws(VpnException::class) fun `getLowLatencyEntryCountry`(`apiUrl`: Url, `vpnApiUrl`: Url?, `userAgent`: UserAgent): Location {
             return FfiConverterTypeLocation.lift(
     uniffiRustCallWithError(VpnException) { _status ->
     UniffiLib.INSTANCE.uniffi_nym_vpn_lib_fn_func_getlowlatencyentrycountry(
-        FfiConverterTypeUrl.lower(`apiUrl`),FfiConverterOptionalTypeUrl.lower(`vpnApiUrl`),FfiConverterOptionalTypeUrl.lower(`harbourMasterUrl`),_status)
-}
-    )
-    }
-    
-
-    @Throws(VpnException::class) fun `getLowLatencyEntryCountryUserAgent`(`apiUrl`: Url, `vpnApiUrl`: Url?, `harbourMasterUrl`: Url?, `userAgent`: UserAgent): Location {
-            return FfiConverterTypeLocation.lift(
-    uniffiRustCallWithError(VpnException) { _status ->
-    UniffiLib.INSTANCE.uniffi_nym_vpn_lib_fn_func_getlowlatencyentrycountryuseragent(
-        FfiConverterTypeUrl.lower(`apiUrl`),FfiConverterOptionalTypeUrl.lower(`vpnApiUrl`),FfiConverterOptionalTypeUrl.lower(`harbourMasterUrl`),FfiConverterTypeUserAgent.lower(`userAgent`),_status)
-}
-    )
-    }
-    
-
-    @Throws(VpnException::class) fun `getVpnCountries`(`apiUrl`: Url, `nymVpnApiUrl`: Url?, `userAgent`: UserAgent?): List<Location> {
-            return FfiConverterSequenceTypeLocation.lift(
-    uniffiRustCallWithError(VpnException) { _status ->
-    UniffiLib.INSTANCE.uniffi_nym_vpn_lib_fn_func_getvpncountries(
-        FfiConverterTypeUrl.lower(`apiUrl`),FfiConverterOptionalTypeUrl.lower(`nymVpnApiUrl`),FfiConverterOptionalTypeUserAgent.lower(`userAgent`),_status)
+        FfiConverterTypeUrl.lower(`apiUrl`),FfiConverterOptionalTypeUrl.lower(`vpnApiUrl`),FfiConverterTypeUserAgent.lower(`userAgent`),_status)
 }
     )
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/uniffi/nym_vpn_lib.swift
+++ b/nym-vpn-core/crates/nym-vpn-lib/uniffi/nym_vpn_lib.swift
@@ -408,6 +408,19 @@ fileprivate struct FfiConverterUInt16: FfiConverterPrimitive {
     }
 }
 
+fileprivate struct FfiConverterUInt64: FfiConverterPrimitive {
+    typealias FfiType = UInt64
+    typealias SwiftType = UInt64
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> UInt64 {
+        return try lift(readInt(&buf))
+    }
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        writeInt(&buf, lower(value))
+    }
+}
+
 fileprivate struct FfiConverterInt64: FfiConverterPrimitive {
     typealias FfiType = Int64
     typealias SwiftType = Int64
@@ -1263,6 +1276,63 @@ public func FfiConverterTypeDnsSettings_lift(_ buf: RustBuffer) throws -> DnsSet
 
 public func FfiConverterTypeDnsSettings_lower(_ value: DnsSettings) -> RustBuffer {
     return FfiConverterTypeDnsSettings.lower(value)
+}
+
+
+public struct GatewayMinPerformance {
+    public var mixnetMinPerformance: UInt64?
+    public var vpnMinPerformance: UInt64?
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(mixnetMinPerformance: UInt64?, vpnMinPerformance: UInt64?) {
+        self.mixnetMinPerformance = mixnetMinPerformance
+        self.vpnMinPerformance = vpnMinPerformance
+    }
+}
+
+
+
+extension GatewayMinPerformance: Equatable, Hashable {
+    public static func ==(lhs: GatewayMinPerformance, rhs: GatewayMinPerformance) -> Bool {
+        if lhs.mixnetMinPerformance != rhs.mixnetMinPerformance {
+            return false
+        }
+        if lhs.vpnMinPerformance != rhs.vpnMinPerformance {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(mixnetMinPerformance)
+        hasher.combine(vpnMinPerformance)
+    }
+}
+
+
+public struct FfiConverterTypeGatewayMinPerformance: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> GatewayMinPerformance {
+        return
+            try GatewayMinPerformance(
+                mixnetMinPerformance: FfiConverterOptionUInt64.read(from: &buf), 
+                vpnMinPerformance: FfiConverterOptionUInt64.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: GatewayMinPerformance, into buf: inout [UInt8]) {
+        FfiConverterOptionUInt64.write(value.mixnetMinPerformance, into: &buf)
+        FfiConverterOptionUInt64.write(value.vpnMinPerformance, into: &buf)
+    }
+}
+
+
+public func FfiConverterTypeGatewayMinPerformance_lift(_ buf: RustBuffer) throws -> GatewayMinPerformance {
+    return try FfiConverterTypeGatewayMinPerformance.lift(buf)
+}
+
+public func FfiConverterTypeGatewayMinPerformance_lower(_ value: GatewayMinPerformance) -> RustBuffer {
+    return FfiConverterTypeGatewayMinPerformance.lower(value)
 }
 
 
@@ -2358,6 +2428,68 @@ extension ExitStatus: Equatable, Hashable {}
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 
+public enum GatewayType {
+    
+    case mixnetEntry
+    case mixnetExit
+    case wg
+}
+
+
+public struct FfiConverterTypeGatewayType: FfiConverterRustBuffer {
+    typealias SwiftType = GatewayType
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> GatewayType {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+        
+        case 1: return .mixnetEntry
+        
+        case 2: return .mixnetExit
+        
+        case 3: return .wg
+        
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: GatewayType, into buf: inout [UInt8]) {
+        switch value {
+        
+        
+        case .mixnetEntry:
+            writeInt(&buf, Int32(1))
+        
+        
+        case .mixnetExit:
+            writeInt(&buf, Int32(2))
+        
+        
+        case .wg:
+            writeInt(&buf, Int32(3))
+        
+        }
+    }
+}
+
+
+public func FfiConverterTypeGatewayType_lift(_ buf: RustBuffer) throws -> GatewayType {
+    return try FfiConverterTypeGatewayType.lift(buf)
+}
+
+public func FfiConverterTypeGatewayType_lower(_ value: GatewayType) -> RustBuffer {
+    return FfiConverterTypeGatewayType.lower(value)
+}
+
+
+
+extension GatewayType: Equatable, Hashable {}
+
+
+
+// Note that we don't yet support `indirect` for enums.
+// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+
 public enum Ipv4Route {
     
     /**
@@ -2817,6 +2949,27 @@ extension VpnError: Equatable, Hashable {}
 
 extension VpnError: Error { }
 
+fileprivate struct FfiConverterOptionUInt64: FfiConverterRustBuffer {
+    typealias SwiftType = UInt64?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterUInt64.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterUInt64.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
 fileprivate struct FfiConverterOptionTimestamp: FfiConverterRustBuffer {
     typealias SwiftType = Date?
 
@@ -2896,6 +3049,27 @@ fileprivate struct FfiConverterOptionTypeDnsSettings: FfiConverterRustBuffer {
         switch try readInt(&buf) as Int8 {
         case 0: return nil
         case 1: return try FfiConverterTypeDnsSettings.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+fileprivate struct FfiConverterOptionTypeGatewayMinPerformance: FfiConverterRustBuffer {
+    typealias SwiftType = GatewayMinPerformance?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeGatewayMinPerformance.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeGatewayMinPerformance.read(from: &buf)
         default: throw UniffiInternalError.unexpectedOptionalTag
         }
     }
@@ -3732,41 +3906,23 @@ public func checkCredential(credential: String)throws  -> Date? {
     )
 })
 }
-public func getGatewayCountries(apiUrl: Url, nymVpnApiUrl: Url?, exitOnly: Bool, userAgent: UserAgent?)throws  -> [Location] {
+public func getGatewayCountries(apiUrl: Url, nymVpnApiUrl: Url?, gwType: GatewayType, userAgent: UserAgent?, minGatewayPerformance: GatewayMinPerformance?)throws  -> [Location] {
     return try  FfiConverterSequenceTypeLocation.lift(try rustCallWithError(FfiConverterTypeVpnError.lift) {
     uniffi_nym_vpn_lib_fn_func_getgatewaycountries(
         FfiConverterTypeUrl.lower(apiUrl),
         FfiConverterOptionTypeUrl.lower(nymVpnApiUrl),
-        FfiConverterBool.lower(exitOnly),
-        FfiConverterOptionTypeUserAgent.lower(userAgent),$0
+        FfiConverterTypeGatewayType.lower(gwType),
+        FfiConverterOptionTypeUserAgent.lower(userAgent),
+        FfiConverterOptionTypeGatewayMinPerformance.lower(minGatewayPerformance),$0
     )
 })
 }
-public func getLowLatencyEntryCountry(apiUrl: Url, vpnApiUrl: Url?, harbourMasterUrl: Url?)throws  -> Location {
+public func getLowLatencyEntryCountry(apiUrl: Url, vpnApiUrl: Url?, userAgent: UserAgent)throws  -> Location {
     return try  FfiConverterTypeLocation.lift(try rustCallWithError(FfiConverterTypeVpnError.lift) {
     uniffi_nym_vpn_lib_fn_func_getlowlatencyentrycountry(
         FfiConverterTypeUrl.lower(apiUrl),
         FfiConverterOptionTypeUrl.lower(vpnApiUrl),
-        FfiConverterOptionTypeUrl.lower(harbourMasterUrl),$0
-    )
-})
-}
-public func getLowLatencyEntryCountryUserAgent(apiUrl: Url, vpnApiUrl: Url?, harbourMasterUrl: Url?, userAgent: UserAgent)throws  -> Location {
-    return try  FfiConverterTypeLocation.lift(try rustCallWithError(FfiConverterTypeVpnError.lift) {
-    uniffi_nym_vpn_lib_fn_func_getlowlatencyentrycountryuseragent(
-        FfiConverterTypeUrl.lower(apiUrl),
-        FfiConverterOptionTypeUrl.lower(vpnApiUrl),
-        FfiConverterOptionTypeUrl.lower(harbourMasterUrl),
         FfiConverterTypeUserAgent.lower(userAgent),$0
-    )
-})
-}
-public func getVpnCountries(apiUrl: Url, nymVpnApiUrl: Url?, userAgent: UserAgent?)throws  -> [Location] {
-    return try  FfiConverterSequenceTypeLocation.lift(try rustCallWithError(FfiConverterTypeVpnError.lift) {
-    uniffi_nym_vpn_lib_fn_func_getvpncountries(
-        FfiConverterTypeUrl.lower(apiUrl),
-        FfiConverterOptionTypeUrl.lower(nymVpnApiUrl),
-        FfiConverterOptionTypeUserAgent.lower(userAgent),$0
     )
 })
 }
@@ -3813,16 +3969,10 @@ private var initializationResult: InitializationResult {
     if (uniffi_nym_vpn_lib_checksum_func_checkcredential() != 1684) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_nym_vpn_lib_checksum_func_getgatewaycountries() != 18771) {
+    if (uniffi_nym_vpn_lib_checksum_func_getgatewaycountries() != 41607) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_nym_vpn_lib_checksum_func_getlowlatencyentrycountry() != 27206) {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if (uniffi_nym_vpn_lib_checksum_func_getlowlatencyentrycountryuseragent() != 14102) {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if (uniffi_nym_vpn_lib_checksum_func_getvpncountries() != 17864) {
+    if (uniffi_nym_vpn_lib_checksum_func_getlowlatencyentrycountry() != 12628) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_nym_vpn_lib_checksum_func_importcredential() != 49505) {

--- a/nym-vpn-core/crates/nym-vpnc/src/cli.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/cli.rs
@@ -174,6 +174,10 @@ pub(crate) struct StoreAccountArgs {
 
 #[derive(Args)]
 pub(crate) struct ListGatewaysArgs {
+    /// Display additional information about the gateways.
+    #[arg(long, short)]
+    pub(crate) verbose: bool,
+
     /// An integer between 0 and 100 representing the minimum gateway performance required to
     /// consider a gateway for routing traffic.
     #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]

--- a/nym-vpn-core/crates/nym-vpnc/src/cli.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/cli.rs
@@ -28,12 +28,12 @@ pub(crate) enum Command {
     StoreAccount(StoreAccountArgs),
     ListenToStatus,
     ListenToStateChanges,
-    ListEntryGateways(ListEntryGatewaysArgs),
-    ListExitGateways(ListExitGatewaysArgs),
-    ListVpnGateways(ListVpnGatewaysArgs),
-    ListEntryCountries(ListEntryCountriesArgs),
-    ListExitCountries(ListExitCountriesArgs),
-    ListVpnCountries(ListVpnCountriesArgs),
+    ListEntryGateways(ListGatewaysArgs),
+    ListExitGateways(ListGatewaysArgs),
+    ListVpnGateways(ListGatewaysArgs),
+    ListEntryCountries(ListCountriesArgs),
+    ListExitCountries(ListCountriesArgs),
+    ListVpnCountries(ListCountriesArgs),
 }
 
 #[derive(Args)]
@@ -173,51 +173,29 @@ pub(crate) struct StoreAccountArgs {
 }
 
 #[derive(Args)]
-pub(crate) struct ListEntryGatewaysArgs {
+pub(crate) struct ListGatewaysArgs {
     /// An integer between 0 and 100 representing the minimum gateway performance required to
     /// consider a gateway for routing traffic.
     #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]
-    pub(crate) min_gateway_performance: Option<u8>,
+    pub(crate) min_mixnet_performance: Option<u8>,
+
+    /// An integer between 0 and 100 representing the minimum gateway performance required to
+    /// consider a gateway for routing traffic.
+    #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]
+    pub(crate) min_vpn_performance: Option<u8>,
 }
 
 #[derive(Args)]
-pub(crate) struct ListExitGatewaysArgs {
+pub(crate) struct ListCountriesArgs {
     /// An integer between 0 and 100 representing the minimum gateway performance required to
     /// consider a gateway for routing traffic.
     #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]
-    pub(crate) min_gateway_performance: Option<u8>,
-}
+    pub(crate) min_mixnet_performance: Option<u8>,
 
-#[derive(Args)]
-pub(crate) struct ListVpnGatewaysArgs {
     /// An integer between 0 and 100 representing the minimum gateway performance required to
     /// consider a gateway for routing traffic.
     #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]
-    pub(crate) min_gateway_performance: Option<u8>,
-}
-
-#[derive(Args)]
-pub(crate) struct ListEntryCountriesArgs {
-    /// An integer between 0 and 100 representing the minimum gateway performance required to
-    /// consider a gateway for routing traffic.
-    #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]
-    pub(crate) min_gateway_performance: Option<u8>,
-}
-
-#[derive(Args)]
-pub(crate) struct ListExitCountriesArgs {
-    /// An integer between 0 and 100 representing the minimum gateway performance required to
-    /// consider a gateway for routing traffic.
-    #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]
-    pub(crate) min_gateway_performance: Option<u8>,
-}
-
-#[derive(Args)]
-pub(crate) struct ListVpnCountriesArgs {
-    /// An integer between 0 and 100 representing the minimum gateway performance required to
-    /// consider a gateway for routing traffic.
-    #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]
-    pub(crate) min_gateway_performance: Option<u8>,
+    pub(crate) min_vpn_performance: Option<u8>,
 }
 
 pub(crate) fn parse_entry_point(args: &ConnectArgs) -> Result<Option<EntryPoint>> {

--- a/nym-vpn-core/crates/nym-vpnc/src/cli.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/cli.rs
@@ -79,7 +79,12 @@ pub(crate) struct ConnectArgs {
     /// An integer between 0 and 100 representing the minimum gateway performance required to
     /// consider a gateway for routing traffic.
     #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]
-    pub(crate) min_gateway_performance: Option<u8>,
+    pub(crate) min_gateway_mixnet_performance: Option<u8>,
+
+    /// An integer between 0 and 100 representing the minimum gateway performance required to
+    /// consider a gateway for routing traffic.
+    #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]
+    pub(crate) min_gateway_vpn_performance: Option<u8>,
 }
 
 #[derive(Args)]

--- a/nym-vpn-core/crates/nym-vpnc/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/main.rs
@@ -49,7 +49,7 @@ async fn main() -> Result<()> {
             list_gateways(client_type, list_args, GatewayType::MixnetExit).await?
         }
         Command::ListVpnGateways(ref list_args) => {
-            list_gateways(client_type, list_args, GatewayType::Vpn).await?
+            list_gateways(client_type, list_args, GatewayType::Wg).await?
         }
         Command::ListEntryCountries(ref list_args) => {
             list_countries(client_type, list_args, GatewayType::MixnetEntry).await?
@@ -58,7 +58,7 @@ async fn main() -> Result<()> {
             list_countries(client_type, list_args, GatewayType::MixnetExit).await?
         }
         Command::ListVpnCountries(ref list_args) => {
-            list_countries(client_type, list_args, GatewayType::Vpn).await?
+            list_countries(client_type, list_args, GatewayType::Wg).await?
         }
     }
     Ok(())

--- a/nym-vpn-core/crates/nym-vpnc/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/main.rs
@@ -4,9 +4,8 @@
 use anyhow::Result;
 use clap::Parser;
 use nym_vpn_proto::{
-    list_countries_request::ListCountriesType, list_gateways_request::ListGatewaysType,
-    ConnectRequest, DisconnectRequest, Empty, ImportUserCredentialRequest, InfoRequest,
-    ListCountriesRequest, ListGatewaysRequest, StatusRequest, StoreAccountRequest,
+    ConnectRequest, DisconnectRequest, Empty, GatewayType, ImportUserCredentialRequest,
+    InfoRequest, ListCountriesRequest, ListGatewaysRequest, StatusRequest, StoreAccountRequest,
 };
 use protobuf_conversion::into_threshold;
 use vpnd_client::ClientType;
@@ -197,7 +196,7 @@ async fn list_entry_gateways(
 ) -> Result<()> {
     let mut client = vpnd_client::get_client(client_type).await?;
     let request = tonic::Request::new(ListGatewaysRequest {
-        kind: ListGatewaysType::Entry as i32,
+        kind: GatewayType::Entry as i32,
         min_mixnet_performance: list_args.min_mixnet_performance.map(into_threshold),
         min_vpn_performance: list_args.min_vpn_performance.map(into_threshold),
     });
@@ -222,7 +221,7 @@ async fn list_exit_gateways(
 ) -> Result<()> {
     let mut client = vpnd_client::get_client(client_type).await?;
     let request = tonic::Request::new(ListGatewaysRequest {
-        kind: ListGatewaysType::Exit as i32,
+        kind: GatewayType::Exit as i32,
         min_mixnet_performance: list_args.min_mixnet_performance.map(into_threshold),
         min_vpn_performance: list_args.min_vpn_performance.map(into_threshold),
     });
@@ -247,7 +246,7 @@ async fn list_vpn_gateways(
 ) -> Result<()> {
     let mut client = vpnd_client::get_client(client_type).await?;
     let request = tonic::Request::new(ListGatewaysRequest {
-        kind: ListGatewaysType::Vpn as i32,
+        kind: GatewayType::Vpn as i32,
         min_mixnet_performance: list_args.min_mixnet_performance.map(into_threshold),
         min_vpn_performance: list_args.min_vpn_performance.map(into_threshold),
     });
@@ -262,7 +261,7 @@ async fn list_entry_countries(
 ) -> Result<()> {
     let mut client = vpnd_client::get_client(client_type).await?;
     let request = tonic::Request::new(ListCountriesRequest {
-        kind: ListCountriesType::Entry as i32,
+        kind: GatewayType::Entry as i32,
         min_mixnet_performance: list_args.min_mixnet_performance.map(into_threshold),
         min_vpn_performance: list_args.min_vpn_performance.map(into_threshold),
     });
@@ -277,7 +276,7 @@ async fn list_exit_countries(
 ) -> Result<()> {
     let mut client = vpnd_client::get_client(client_type).await?;
     let request = tonic::Request::new(ListCountriesRequest {
-        kind: ListCountriesType::Exit as i32,
+        kind: GatewayType::Exit as i32,
         min_mixnet_performance: list_args.min_mixnet_performance.map(into_threshold),
         min_vpn_performance: list_args.min_vpn_performance.map(into_threshold),
     });
@@ -292,7 +291,7 @@ async fn list_vpn_countries(
 ) -> Result<()> {
     let mut client = vpnd_client::get_client(client_type).await?;
     let request = tonic::Request::new(ListCountriesRequest {
-        kind: ListCountriesType::Vpn as i32,
+        kind: GatewayType::Vpn as i32,
         min_mixnet_performance: list_args.min_mixnet_performance.map(into_threshold),
         min_vpn_performance: list_args.min_vpn_performance.map(into_threshold),
     });

--- a/nym-vpn-core/crates/nym-vpnc/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/main.rs
@@ -4,10 +4,9 @@
 use anyhow::Result;
 use clap::Parser;
 use nym_vpn_proto::{
+    list_countries_request::ListCountriesType, list_gateways_request::ListGatewaysType,
     ConnectRequest, DisconnectRequest, Empty, ImportUserCredentialRequest, InfoRequest,
-    ListEntryCountriesRequest, ListEntryGatewaysRequest, ListExitCountriesRequest,
-    ListExitGatewaysRequest, ListVpnCountriesRequest, ListVpnGatewaysRequest, StatusRequest,
-    StoreAccountRequest,
+    ListCountriesRequest, ListGatewaysRequest, StatusRequest, StoreAccountRequest,
 };
 use protobuf_conversion::into_threshold;
 use vpnd_client::ClientType;
@@ -197,11 +196,12 @@ async fn list_entry_gateways(
     list_args: &cli::ListGatewaysArgs,
 ) -> Result<()> {
     let mut client = vpnd_client::get_client(client_type).await?;
-    let request = tonic::Request::new(ListEntryGatewaysRequest {
+    let request = tonic::Request::new(ListGatewaysRequest {
+        kind: ListGatewaysType::Entry as i32,
         min_mixnet_performance: list_args.min_mixnet_performance.map(into_threshold),
         min_vpn_performance: list_args.min_vpn_performance.map(into_threshold),
     });
-    let response = client.list_entry_gateways(request).await?.into_inner();
+    let response = client.list_gateways(request).await?.into_inner();
     println!("{:#?}", response);
 
     // TODO: support a flag that enables brief output
@@ -221,11 +221,12 @@ async fn list_exit_gateways(
     list_args: &cli::ListGatewaysArgs,
 ) -> Result<()> {
     let mut client = vpnd_client::get_client(client_type).await?;
-    let request = tonic::Request::new(ListExitGatewaysRequest {
+    let request = tonic::Request::new(ListGatewaysRequest {
+        kind: ListGatewaysType::Exit as i32,
         min_mixnet_performance: list_args.min_mixnet_performance.map(into_threshold),
         min_vpn_performance: list_args.min_vpn_performance.map(into_threshold),
     });
-    let response = client.list_exit_gateways(request).await?.into_inner();
+    let response = client.list_gateways(request).await?.into_inner();
     println!("{:#?}", response);
 
     // TODO: support a flag that enables brief output
@@ -245,11 +246,12 @@ async fn list_vpn_gateways(
     list_args: &cli::ListGatewaysArgs,
 ) -> Result<()> {
     let mut client = vpnd_client::get_client(client_type).await?;
-    let request = tonic::Request::new(ListVpnGatewaysRequest {
+    let request = tonic::Request::new(ListGatewaysRequest {
+        kind: ListGatewaysType::Vpn as i32,
         min_mixnet_performance: list_args.min_mixnet_performance.map(into_threshold),
         min_vpn_performance: list_args.min_vpn_performance.map(into_threshold),
     });
-    let response = client.list_vpn_gateways(request).await?.into_inner();
+    let response = client.list_gateways(request).await?.into_inner();
     println!("{:#?}", response);
     Ok(())
 }
@@ -259,11 +261,12 @@ async fn list_entry_countries(
     list_args: &cli::ListCountriesArgs,
 ) -> Result<()> {
     let mut client = vpnd_client::get_client(client_type).await?;
-    let request = tonic::Request::new(ListEntryCountriesRequest {
+    let request = tonic::Request::new(ListCountriesRequest {
+        kind: ListCountriesType::Entry as i32,
         min_mixnet_performance: list_args.min_mixnet_performance.map(into_threshold),
         min_vpn_performance: list_args.min_vpn_performance.map(into_threshold),
     });
-    let response = client.list_entry_countries(request).await?.into_inner();
+    let response = client.list_countries(request).await?.into_inner();
     println!("{:#?}", response);
     Ok(())
 }
@@ -273,11 +276,12 @@ async fn list_exit_countries(
     list_args: &cli::ListCountriesArgs,
 ) -> Result<()> {
     let mut client = vpnd_client::get_client(client_type).await?;
-    let request = tonic::Request::new(ListExitCountriesRequest {
+    let request = tonic::Request::new(ListCountriesRequest {
+        kind: ListCountriesType::Exit as i32,
         min_mixnet_performance: list_args.min_mixnet_performance.map(into_threshold),
         min_vpn_performance: list_args.min_vpn_performance.map(into_threshold),
     });
-    let response = client.list_exit_countries(request).await?.into_inner();
+    let response = client.list_countries(request).await?.into_inner();
     println!("{:#?}", response);
     Ok(())
 }
@@ -287,11 +291,12 @@ async fn list_vpn_countries(
     list_args: &cli::ListCountriesArgs,
 ) -> Result<()> {
     let mut client = vpnd_client::get_client(client_type).await?;
-    let request = tonic::Request::new(ListVpnCountriesRequest {
+    let request = tonic::Request::new(ListCountriesRequest {
+        kind: ListCountriesType::Vpn as i32,
         min_mixnet_performance: list_args.min_mixnet_performance.map(into_threshold),
         min_vpn_performance: list_args.min_vpn_performance.map(into_threshold),
     });
-    let response = client.list_vpn_countries(request).await?.into_inner();
+    let response = client.list_countries(request).await?.into_inner();
     println!("{:#?}", response);
     Ok(())
 }

--- a/nym-vpn-core/crates/nym-vpnc/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/main.rs
@@ -43,19 +43,19 @@ async fn main() -> Result<()> {
         Command::ListenToStatus => listen_to_status(client_type).await?,
         Command::ListenToStateChanges => listen_to_state_changes(client_type).await?,
         Command::ListEntryGateways(ref list_args) => {
-            list_gateways(client_type, list_args, GatewayType::Entry).await?
+            list_gateways(client_type, list_args, GatewayType::MixnetEntry).await?
         }
         Command::ListExitGateways(ref list_args) => {
-            list_gateways(client_type, list_args, GatewayType::Exit).await?
+            list_gateways(client_type, list_args, GatewayType::MixnetExit).await?
         }
         Command::ListVpnGateways(ref list_args) => {
             list_gateways(client_type, list_args, GatewayType::Vpn).await?
         }
         Command::ListEntryCountries(ref list_args) => {
-            list_countries(client_type, list_args, GatewayType::Entry).await?
+            list_countries(client_type, list_args, GatewayType::MixnetEntry).await?
         }
         Command::ListExitCountries(ref list_args) => {
-            list_countries(client_type, list_args, GatewayType::Exit).await?
+            list_countries(client_type, list_args, GatewayType::MixnetExit).await?
         }
         Command::ListVpnCountries(ref list_args) => {
             list_countries(client_type, list_args, GatewayType::Vpn).await?

--- a/nym-vpn-core/crates/nym-vpnc/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/main.rs
@@ -79,7 +79,8 @@ async fn connect(client_type: ClientType, connect_args: &cli::ConnectArgs) -> Re
         disable_background_cover_traffic: connect_args.disable_background_cover_traffic,
         enable_credentials_mode: connect_args.enable_credentials_mode,
         min_mixnode_performance: connect_args.min_mixnode_performance.map(into_threshold),
-        min_gateway_performance: connect_args.min_gateway_performance.map(into_threshold),
+        min_gateway_mixnet_performance: connect_args.min_gateway_mixnet_performance.map(into_threshold),
+        min_gateway_vpn_performance: connect_args.min_gateway_vpn_performance.map(into_threshold),
     });
 
     let mut client = vpnd_client::get_client(client_type).await?;

--- a/nym-vpn-core/crates/nym-vpnc/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/main.rs
@@ -79,7 +79,9 @@ async fn connect(client_type: ClientType, connect_args: &cli::ConnectArgs) -> Re
         disable_background_cover_traffic: connect_args.disable_background_cover_traffic,
         enable_credentials_mode: connect_args.enable_credentials_mode,
         min_mixnode_performance: connect_args.min_mixnode_performance.map(into_threshold),
-        min_gateway_mixnet_performance: connect_args.min_gateway_mixnet_performance.map(into_threshold),
+        min_gateway_mixnet_performance: connect_args
+            .min_gateway_mixnet_performance
+            .map(into_threshold),
         min_gateway_vpn_performance: connect_args.min_gateway_vpn_performance.map(into_threshold),
     });
 
@@ -192,11 +194,12 @@ async fn listen_to_state_changes(client_type: ClientType) -> Result<()> {
 
 async fn list_entry_gateways(
     client_type: ClientType,
-    list_args: &cli::ListEntryGatewaysArgs,
+    list_args: &cli::ListGatewaysArgs,
 ) -> Result<()> {
     let mut client = vpnd_client::get_client(client_type).await?;
     let request = tonic::Request::new(ListEntryGatewaysRequest {
-        min_gateway_performance: list_args.min_gateway_performance.map(into_threshold),
+        min_mixnet_performance: list_args.min_mixnet_performance.map(into_threshold),
+        min_vpn_performance: list_args.min_vpn_performance.map(into_threshold),
     });
     let response = client.list_entry_gateways(request).await?.into_inner();
     println!("{:#?}", response);
@@ -215,11 +218,12 @@ async fn list_entry_gateways(
 
 async fn list_exit_gateways(
     client_type: ClientType,
-    list_args: &cli::ListExitGatewaysArgs,
+    list_args: &cli::ListGatewaysArgs,
 ) -> Result<()> {
     let mut client = vpnd_client::get_client(client_type).await?;
     let request = tonic::Request::new(ListExitGatewaysRequest {
-        min_gateway_performance: list_args.min_gateway_performance.map(into_threshold),
+        min_mixnet_performance: list_args.min_mixnet_performance.map(into_threshold),
+        min_vpn_performance: list_args.min_vpn_performance.map(into_threshold),
     });
     let response = client.list_exit_gateways(request).await?.into_inner();
     println!("{:#?}", response);
@@ -238,11 +242,12 @@ async fn list_exit_gateways(
 
 async fn list_vpn_gateways(
     client_type: ClientType,
-    list_args: &cli::ListVpnGatewaysArgs,
+    list_args: &cli::ListGatewaysArgs,
 ) -> Result<()> {
     let mut client = vpnd_client::get_client(client_type).await?;
     let request = tonic::Request::new(ListVpnGatewaysRequest {
-        min_gateway_performance: list_args.min_gateway_performance.map(into_threshold),
+        min_mixnet_performance: list_args.min_mixnet_performance.map(into_threshold),
+        min_vpn_performance: list_args.min_vpn_performance.map(into_threshold),
     });
     let response = client.list_vpn_gateways(request).await?.into_inner();
     println!("{:#?}", response);
@@ -251,11 +256,12 @@ async fn list_vpn_gateways(
 
 async fn list_entry_countries(
     client_type: ClientType,
-    list_args: &cli::ListEntryCountriesArgs,
+    list_args: &cli::ListCountriesArgs,
 ) -> Result<()> {
     let mut client = vpnd_client::get_client(client_type).await?;
     let request = tonic::Request::new(ListEntryCountriesRequest {
-        min_gateway_performance: list_args.min_gateway_performance.map(into_threshold),
+        min_mixnet_performance: list_args.min_mixnet_performance.map(into_threshold),
+        min_vpn_performance: list_args.min_vpn_performance.map(into_threshold),
     });
     let response = client.list_entry_countries(request).await?.into_inner();
     println!("{:#?}", response);
@@ -264,11 +270,12 @@ async fn list_entry_countries(
 
 async fn list_exit_countries(
     client_type: ClientType,
-    list_args: &cli::ListExitCountriesArgs,
+    list_args: &cli::ListCountriesArgs,
 ) -> Result<()> {
     let mut client = vpnd_client::get_client(client_type).await?;
     let request = tonic::Request::new(ListExitCountriesRequest {
-        min_gateway_performance: list_args.min_gateway_performance.map(into_threshold),
+        min_mixnet_performance: list_args.min_mixnet_performance.map(into_threshold),
+        min_vpn_performance: list_args.min_vpn_performance.map(into_threshold),
     });
     let response = client.list_exit_countries(request).await?.into_inner();
     println!("{:#?}", response);
@@ -277,11 +284,12 @@ async fn list_exit_countries(
 
 async fn list_vpn_countries(
     client_type: ClientType,
-    list_args: &cli::ListVpnCountriesArgs,
+    list_args: &cli::ListCountriesArgs,
 ) -> Result<()> {
     let mut client = vpnd_client::get_client(client_type).await?;
     let request = tonic::Request::new(ListVpnCountriesRequest {
-        min_gateway_performance: list_args.min_gateway_performance.map(into_threshold),
+        min_mixnet_performance: list_args.min_mixnet_performance.map(into_threshold),
+        min_vpn_performance: list_args.min_vpn_performance.map(into_threshold),
     });
     let response = client.list_vpn_countries(request).await?.into_inner();
     println!("{:#?}", response);

--- a/nym-vpn-core/crates/nym-vpnc/src/protobuf_conversion.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/protobuf_conversion.rs
@@ -109,7 +109,7 @@ pub(crate) fn into_gateway_type(gateway_type: GatewayType) -> nym_vpn_proto::Gat
     match gateway_type {
         GatewayType::MixnetEntry => nym_vpn_proto::GatewayType::MixnetEntry,
         GatewayType::MixnetExit => nym_vpn_proto::GatewayType::MixnetExit,
-        GatewayType::Wg => nym_vpn_proto::GatewayType::Vpn,
+        GatewayType::Wg => nym_vpn_proto::GatewayType::Wg,
     }
 }
 

--- a/nym-vpn-core/crates/nym-vpnc/src/protobuf_conversion.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/protobuf_conversion.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use nym_gateway_directory::{EntryPoint, ExitPoint, NodeIdentity, Recipient};
+use nym_gateway_directory::{EntryPoint, ExitPoint, GatewayType, NodeIdentity, Recipient};
 
 fn new_entry_node_gateway(identity: &NodeIdentity) -> nym_vpn_proto::EntryNode {
     nym_vpn_proto::EntryNode {
@@ -102,6 +102,14 @@ pub(crate) fn ipaddr_into_string(ip: std::net::IpAddr) -> nym_vpn_proto::Dns {
 pub(crate) fn into_threshold(performance: u8) -> nym_vpn_proto::Threshold {
     nym_vpn_proto::Threshold {
         min_performance: performance.into(),
+    }
+}
+
+pub(crate) fn into_gateway_type(gateway_type: GatewayType) -> nym_vpn_proto::GatewayType {
+    match gateway_type {
+        GatewayType::Entry => nym_vpn_proto::GatewayType::Entry,
+        GatewayType::Exit => nym_vpn_proto::GatewayType::Exit,
+        GatewayType::Vpn => nym_vpn_proto::GatewayType::Vpn,
     }
 }
 

--- a/nym-vpn-core/crates/nym-vpnc/src/protobuf_conversion.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/protobuf_conversion.rs
@@ -109,7 +109,7 @@ pub(crate) fn into_gateway_type(gateway_type: GatewayType) -> nym_vpn_proto::Gat
     match gateway_type {
         GatewayType::MixnetEntry => nym_vpn_proto::GatewayType::MixnetEntry,
         GatewayType::MixnetExit => nym_vpn_proto::GatewayType::MixnetExit,
-        GatewayType::Vpn => nym_vpn_proto::GatewayType::Vpn,
+        GatewayType::Wg => nym_vpn_proto::GatewayType::Vpn,
     }
 }
 

--- a/nym-vpn-core/crates/nym-vpnc/src/protobuf_conversion.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/protobuf_conversion.rs
@@ -107,8 +107,8 @@ pub(crate) fn into_threshold(performance: u8) -> nym_vpn_proto::Threshold {
 
 pub(crate) fn into_gateway_type(gateway_type: GatewayType) -> nym_vpn_proto::GatewayType {
     match gateway_type {
-        GatewayType::Entry => nym_vpn_proto::GatewayType::Entry,
-        GatewayType::Exit => nym_vpn_proto::GatewayType::Exit,
+        GatewayType::MixnetEntry => nym_vpn_proto::GatewayType::MixnetEntry,
+        GatewayType::MixnetExit => nym_vpn_proto::GatewayType::MixnetExit,
         GatewayType::Vpn => nym_vpn_proto::GatewayType::Vpn,
     }
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/connection_handler.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/connection_handler.rs
@@ -1,8 +1,9 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use nym_vpn_api_client::response::{
-    NymVpnAccountSummaryResponse, NymVpnDevice, NymVpnZkNym, NymVpnZkNymResponse,
+use nym_vpn_api_client::{
+    response::{NymVpnAccountSummaryResponse, NymVpnDevice, NymVpnZkNym, NymVpnZkNymResponse},
+    types::GatewayMinPerformance,
 };
 use nym_vpn_lib::gateway_directory::{EntryPoint, ExitPoint, GatewayClient};
 use time::OffsetDateTime;
@@ -138,7 +139,8 @@ impl CommandInterfaceConnectionHandler {
 
     pub(crate) async fn handle_list_entry_gateways(
         &self,
-        min_gateway_performance: Option<u8>,
+        // min_gateway_performance: Option<u8>,
+        min_gateway_performance: GatewayMinPerformance,
     ) -> Result<Vec<gateway::Gateway>, ListGatewayError> {
         let gateways = directory_client(min_gateway_performance)?
             .lookup_entry_gateways()
@@ -150,7 +152,8 @@ impl CommandInterfaceConnectionHandler {
 
     pub(crate) async fn handle_list_exit_gateways(
         &self,
-        min_gateway_performance: Option<u8>,
+        // min_gateway_performance: Option<u8>,
+        min_gateway_performance: GatewayMinPerformance,
     ) -> Result<Vec<gateway::Gateway>, ListGatewayError> {
         let gateways = directory_client(min_gateway_performance)?
             .lookup_exit_gateways()
@@ -162,7 +165,8 @@ impl CommandInterfaceConnectionHandler {
 
     pub(crate) async fn handle_list_vpn_gateways(
         &self,
-        min_gateway_performance: Option<u8>,
+        // min_gateway_performance: Option<u8>,
+        min_gateway_performance: GatewayMinPerformance,
     ) -> Result<Vec<gateway::Gateway>, ListGatewayError> {
         let gateways = directory_client(min_gateway_performance)?
             .lookup_vpn_gateways()
@@ -174,7 +178,8 @@ impl CommandInterfaceConnectionHandler {
 
     pub(crate) async fn handle_list_entry_countries(
         &self,
-        min_gateway_performance: Option<u8>,
+        // min_gateway_performance: Option<u8>,
+        min_gateway_performance: GatewayMinPerformance,
     ) -> Result<Vec<gateway::Country>, ListGatewayError> {
         let gateways = directory_client(min_gateway_performance)?
             .lookup_entry_countries()
@@ -186,7 +191,8 @@ impl CommandInterfaceConnectionHandler {
 
     pub(crate) async fn handle_list_exit_countries(
         &self,
-        min_gateway_performance: Option<u8>,
+        // min_gateway_performance: Option<u8>,
+        min_gateway_performance: GatewayMinPerformance,
     ) -> Result<Vec<gateway::Country>, ListGatewayError> {
         let gateways = directory_client(min_gateway_performance)?
             .lookup_exit_countries()
@@ -198,7 +204,8 @@ impl CommandInterfaceConnectionHandler {
 
     pub(crate) async fn handle_list_vpn_countries(
         &self,
-        min_gateway_performance: Option<u8>,
+        // min_gateway_performance: Option<u8>,
+        min_gateway_performance: GatewayMinPerformance,
     ) -> Result<Vec<gateway::Country>, ListGatewayError> {
         let gateways = directory_client(min_gateway_performance)?
             .lookup_vpn_countries()
@@ -264,11 +271,12 @@ impl CommandInterfaceConnectionHandler {
 }
 
 fn directory_client(
-    min_gateway_performance: Option<u8>,
+    // min_gateway_performance: Option<u8>,
+    min_gateway_performance: GatewayMinPerformance,
 ) -> Result<GatewayClient, ListGatewayError> {
     let user_agent = nym_bin_common::bin_info_local_vergen!().into();
     let directory_config =
-        nym_vpn_lib::gateway_directory::Config::new_from_env(min_gateway_performance);
+        nym_vpn_lib::gateway_directory::Config::new_from_env(Some(min_gateway_performance));
     GatewayClient::new(directory_config, user_agent)
         .map_err(|error| ListGatewayError::CreateGatewayDirectoryClient { error })
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/connection_handler.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/connection_handler.rs
@@ -271,12 +271,11 @@ impl CommandInterfaceConnectionHandler {
 }
 
 fn directory_client(
-    // min_gateway_performance: Option<u8>,
     min_gateway_performance: GatewayMinPerformance,
 ) -> Result<GatewayClient, ListGatewayError> {
     let user_agent = nym_bin_common::bin_info_local_vergen!().into();
-    let directory_config =
-        nym_vpn_lib::gateway_directory::Config::new_from_env(Some(min_gateway_performance));
+    let directory_config = nym_vpn_lib::gateway_directory::Config::new_from_env()
+        .with_custom_min_gateway_performance(min_gateway_performance);
     GatewayClient::new(directory_config, user_agent)
         .map_err(|error| ListGatewayError::CreateGatewayDirectoryClient { error })
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/connection_handler.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/connection_handler.rs
@@ -275,7 +275,7 @@ fn directory_client(
 ) -> Result<GatewayClient, ListGatewayError> {
     let user_agent = nym_bin_common::bin_info_local_vergen!().into();
     let directory_config = nym_vpn_lib::gateway_directory::Config::new_from_env()
-        .with_custom_min_gateway_performance(min_gateway_performance);
+        .with_min_gateway_performance(min_gateway_performance);
     GatewayClient::new(directory_config, user_agent)
         .map_err(|error| ListGatewayError::CreateGatewayDirectoryClient { error })
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/connection_handler.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/connection_handler.rs
@@ -139,7 +139,6 @@ impl CommandInterfaceConnectionHandler {
 
     pub(crate) async fn handle_list_entry_gateways(
         &self,
-        // min_gateway_performance: Option<u8>,
         min_gateway_performance: GatewayMinPerformance,
     ) -> Result<Vec<gateway::Gateway>, ListGatewayError> {
         let gateways = directory_client(min_gateway_performance)?
@@ -152,7 +151,6 @@ impl CommandInterfaceConnectionHandler {
 
     pub(crate) async fn handle_list_exit_gateways(
         &self,
-        // min_gateway_performance: Option<u8>,
         min_gateway_performance: GatewayMinPerformance,
     ) -> Result<Vec<gateway::Gateway>, ListGatewayError> {
         let gateways = directory_client(min_gateway_performance)?
@@ -165,7 +163,6 @@ impl CommandInterfaceConnectionHandler {
 
     pub(crate) async fn handle_list_vpn_gateways(
         &self,
-        // min_gateway_performance: Option<u8>,
         min_gateway_performance: GatewayMinPerformance,
     ) -> Result<Vec<gateway::Gateway>, ListGatewayError> {
         let gateways = directory_client(min_gateway_performance)?
@@ -178,7 +175,6 @@ impl CommandInterfaceConnectionHandler {
 
     pub(crate) async fn handle_list_entry_countries(
         &self,
-        // min_gateway_performance: Option<u8>,
         min_gateway_performance: GatewayMinPerformance,
     ) -> Result<Vec<gateway::Country>, ListGatewayError> {
         let gateways = directory_client(min_gateway_performance)?
@@ -191,7 +187,6 @@ impl CommandInterfaceConnectionHandler {
 
     pub(crate) async fn handle_list_exit_countries(
         &self,
-        // min_gateway_performance: Option<u8>,
         min_gateway_performance: GatewayMinPerformance,
     ) -> Result<Vec<gateway::Country>, ListGatewayError> {
         let gateways = directory_client(min_gateway_performance)?
@@ -204,7 +199,6 @@ impl CommandInterfaceConnectionHandler {
 
     pub(crate) async fn handle_list_vpn_countries(
         &self,
-        // min_gateway_performance: Option<u8>,
         min_gateway_performance: GatewayMinPerformance,
     ) -> Result<Vec<gateway::Country>, ListGatewayError> {
         let gateways = directory_client(min_gateway_performance)?

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/helpers.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/helpers.rs
@@ -1,6 +1,7 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use nym_vpn_api_client::types::Percent;
 use nym_vpn_lib::{
     gateway_directory::{EntryPoint, ExitPoint},
     NodeIdentity, Recipient,
@@ -79,6 +80,6 @@ pub(super) fn parse_exit_point(
     })
 }
 
-pub(super) fn threshold_into_u8(threshold: nym_vpn_proto::Threshold) -> u8 {
-    threshold.min_performance.clamp(0, 100) as u8
+pub(super) fn threshold_into_percent(threshold: nym_vpn_proto::Threshold) -> Percent {
+    Percent::from_percentage_value(threshold.min_performance.clamp(0, 100) as u64).unwrap()
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
@@ -289,9 +289,10 @@ impl NymVpnd for CommandInterface {
             mixnet_min_performance: min_mixnet_performance,
             vpn_min_performance: min_vpn_performance,
         };
+        let gw_type = crate::command_interface::protobuf::gateway::into_gateway_type(kind);
 
         let gateways = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
-            .handle_list_gateways(kind, min_gateway_performance)
+            .handle_list_gateways(gw_type, min_gateway_performance)
             .await
             .map_err(|err| {
                 let msg = format!("Failed to list gateways: {:?}", err);
@@ -326,6 +327,8 @@ impl NymVpnd for CommandInterface {
             error!(msg);
             tonic::Status::invalid_argument(msg)
         })?;
+        let gw_type =
+            crate::command_interface::protobuf::gateway::from_country_into_gateway_type(kind);
 
         let min_mixnet_performance = request.min_mixnet_performance.map(threshold_into_percent);
         let min_vpn_performance = request.min_vpn_performance.map(threshold_into_percent);
@@ -336,7 +339,7 @@ impl NymVpnd for CommandInterface {
         };
 
         let countries = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
-            .handle_list_countries(kind, min_gateway_performance)
+            .handle_list_countries(gw_type, min_gateway_performance)
             .await
             .map_err(|err| {
                 let msg = format!("Failed to list entry countries: {:?}", err);

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
@@ -28,7 +28,7 @@ use tracing::{error, info};
 use super::{
     connection_handler::CommandInterfaceConnectionHandler,
     error::CommandInterfaceError,
-    helpers::{parse_entry_point, parse_exit_point, threshold_into_u8},
+    helpers::{parse_entry_point, parse_exit_point, threshold_into_percent},
     status_broadcaster::ConnectionStatusBroadcaster,
 };
 use crate::service::{
@@ -280,8 +280,7 @@ impl NymVpnd for CommandInterface {
         let min_gateway_performance = request
             .into_inner()
             .min_gateway_performance
-            .map(threshold_into_u8)
-            .map(|p| Percent::from_percentage_value(p as u64).unwrap());
+            .map(threshold_into_percent);
 
         let min_gateway_performance = GatewayMinPerformance {
             mixnet_min_performance: min_gateway_performance,
@@ -320,8 +319,7 @@ impl NymVpnd for CommandInterface {
         let min_gateway_performance = request
             .into_inner()
             .min_gateway_performance
-            .map(threshold_into_u8)
-            .map(|p| Percent::from_percentage_value(p as u64).unwrap());
+            .map(threshold_into_percent);
 
         let min_gateway_performance = GatewayMinPerformance {
             mixnet_min_performance: None,
@@ -360,8 +358,7 @@ impl NymVpnd for CommandInterface {
         let min_gateway_performance = request
             .into_inner()
             .min_gateway_performance
-            .map(threshold_into_u8)
-            .map(|p| Percent::from_percentage_value(p as u64).unwrap());
+            .map(threshold_into_percent);
 
         let min_gateway_performance = GatewayMinPerformance {
             mixnet_min_performance: min_gateway_performance,
@@ -400,8 +397,7 @@ impl NymVpnd for CommandInterface {
         let min_gateway_performance = request
             .into_inner()
             .min_gateway_performance
-            .map(threshold_into_u8)
-            .map(|p| Percent::from_percentage_value(p as u64).unwrap());
+            .map(threshold_into_percent);
 
         let min_gateway_performance = GatewayMinPerformance {
             mixnet_min_performance: min_gateway_performance,
@@ -440,8 +436,7 @@ impl NymVpnd for CommandInterface {
         let min_gateway_performance = request
             .into_inner()
             .min_gateway_performance
-            .map(threshold_into_u8)
-            .map(|p| Percent::from_percentage_value(p as u64).unwrap());
+            .map(threshold_into_percent);
 
         let min_gateway_performance = GatewayMinPerformance {
             mixnet_min_performance: min_gateway_performance,
@@ -480,8 +475,7 @@ impl NymVpnd for CommandInterface {
         let min_gateway_performance = request
             .into_inner()
             .min_gateway_performance
-            .map(threshold_into_u8)
-            .map(|p| Percent::from_percentage_value(p as u64).unwrap());
+            .map(threshold_into_percent);
 
         let min_gateway_performance = GatewayMinPerformance {
             mixnet_min_performance: None,
@@ -656,6 +650,14 @@ impl TryFrom<ConnectRequest> for ConnectOptions {
             })
             .transpose()?;
 
+        let min_mixnode_performance = request.min_mixnode_performance.map(threshold_into_percent);
+        let min_gateway_mixnet_performance = request
+            .min_gateway_mixnet_performance
+            .map(threshold_into_percent);
+        let min_gateway_vpn_performance = request
+            .min_gateway_vpn_performance
+            .map(threshold_into_percent);
+
         Ok(ConnectOptions {
             dns,
             disable_routing: request.disable_routing,
@@ -663,8 +665,9 @@ impl TryFrom<ConnectRequest> for ConnectOptions {
             enable_poisson_rate: request.enable_poisson_rate,
             disable_background_cover_traffic: request.disable_background_cover_traffic,
             enable_credentials_mode: request.enable_credentials_mode,
-            min_mixnode_performance: request.min_mixnode_performance.map(threshold_into_u8),
-            min_gateway_performance: request.min_gateway_performance.map(threshold_into_u8),
+            min_mixnode_performance,
+            min_gateway_mixnet_performance,
+            min_gateway_vpn_performance,
         })
     }
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use futures::{stream::BoxStream, StreamExt};
+use nym_vpn_api_client::types::{GatewayMinPerformance, Percent};
 use nym_vpn_proto::{
     nym_vpnd_server::NymVpnd, AccountError, ConnectRequest, ConnectResponse, ConnectionStateChange,
     ConnectionStatusUpdate, DisconnectRequest, DisconnectResponse, Empty, GetAccountSummaryRequest,
@@ -279,7 +280,13 @@ impl NymVpnd for CommandInterface {
         let min_gateway_performance = request
             .into_inner()
             .min_gateway_performance
-            .map(threshold_into_u8);
+            .map(threshold_into_u8)
+            .map(|p| Percent::from_percentage_value(p as u64).unwrap());
+
+        let min_gateway_performance = GatewayMinPerformance {
+            mixnet_min_performance: min_gateway_performance,
+            vpn_min_performance: None,
+        };
 
         let entry_gateways = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
             .handle_list_entry_gateways(min_gateway_performance)
@@ -313,7 +320,13 @@ impl NymVpnd for CommandInterface {
         let min_gateway_performance = request
             .into_inner()
             .min_gateway_performance
-            .map(threshold_into_u8);
+            .map(threshold_into_u8)
+            .map(|p| Percent::from_percentage_value(p as u64).unwrap());
+
+        let min_gateway_performance = GatewayMinPerformance {
+            mixnet_min_performance: None,
+            vpn_min_performance: min_gateway_performance,
+        };
 
         let gateways = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
             .handle_list_vpn_gateways(min_gateway_performance)
@@ -347,7 +360,13 @@ impl NymVpnd for CommandInterface {
         let min_gateway_performance = request
             .into_inner()
             .min_gateway_performance
-            .map(threshold_into_u8);
+            .map(threshold_into_u8)
+            .map(|p| Percent::from_percentage_value(p as u64).unwrap());
+
+        let min_gateway_performance = GatewayMinPerformance {
+            mixnet_min_performance: min_gateway_performance,
+            vpn_min_performance: None,
+        };
 
         let exit_gateways = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
             .handle_list_exit_gateways(min_gateway_performance)
@@ -381,7 +400,13 @@ impl NymVpnd for CommandInterface {
         let min_gateway_performance = request
             .into_inner()
             .min_gateway_performance
-            .map(threshold_into_u8);
+            .map(threshold_into_u8)
+            .map(|p| Percent::from_percentage_value(p as u64).unwrap());
+
+        let min_gateway_performance = GatewayMinPerformance {
+            mixnet_min_performance: min_gateway_performance,
+            vpn_min_performance: None,
+        };
 
         let countries = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
             .handle_list_entry_countries(min_gateway_performance)
@@ -415,7 +440,13 @@ impl NymVpnd for CommandInterface {
         let min_gateway_performance = request
             .into_inner()
             .min_gateway_performance
-            .map(threshold_into_u8);
+            .map(threshold_into_u8)
+            .map(|p| Percent::from_percentage_value(p as u64).unwrap());
+
+        let min_gateway_performance = GatewayMinPerformance {
+            mixnet_min_performance: min_gateway_performance,
+            vpn_min_performance: None,
+        };
 
         let countries = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
             .handle_list_exit_countries(min_gateway_performance)
@@ -449,7 +480,13 @@ impl NymVpnd for CommandInterface {
         let min_gateway_performance = request
             .into_inner()
             .min_gateway_performance
-            .map(threshold_into_u8);
+            .map(threshold_into_u8)
+            .map(|p| Percent::from_percentage_value(p as u64).unwrap());
+
+        let min_gateway_performance = GatewayMinPerformance {
+            mixnet_min_performance: None,
+            vpn_min_performance: min_gateway_performance,
+        };
 
         let countries = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
             .handle_list_vpn_countries(min_gateway_performance)

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use futures::{stream::BoxStream, StreamExt};
-use nym_vpn_api_client::types::{GatewayMinPerformance, Percent};
+use nym_vpn_api_client::types::GatewayMinPerformance;
 use nym_vpn_proto::{
     nym_vpnd_server::NymVpnd, AccountError, ConnectRequest, ConnectResponse, ConnectionStateChange,
     ConnectionStatusUpdate, DisconnectRequest, DisconnectResponse, Empty, GetAccountSummaryRequest,
@@ -277,14 +277,15 @@ impl NymVpnd for CommandInterface {
     ) -> Result<tonic::Response<ListEntryGatewaysResponse>, tonic::Status> {
         info!("Got list entry gateways request: {:?}", request);
 
-        let min_gateway_performance = request
-            .into_inner()
-            .min_gateway_performance
-            .map(threshold_into_percent);
+        let request = request.into_inner();
+
+        let min_mixnet_performance = request.min_mixnet_performance.map(threshold_into_percent);
+
+        let min_vpn_performance = request.min_vpn_performance.map(threshold_into_percent);
 
         let min_gateway_performance = GatewayMinPerformance {
-            mixnet_min_performance: min_gateway_performance,
-            vpn_min_performance: None,
+            mixnet_min_performance: min_mixnet_performance,
+            vpn_min_performance: min_vpn_performance,
         };
 
         let entry_gateways = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
@@ -316,14 +317,15 @@ impl NymVpnd for CommandInterface {
     ) -> Result<tonic::Response<ListVpnGatewaysResponse>, tonic::Status> {
         info!("Got list VPN gateways request: {request:?}");
 
-        let min_gateway_performance = request
-            .into_inner()
-            .min_gateway_performance
-            .map(threshold_into_percent);
+        let request = request.into_inner();
+
+        let min_mixnet_performance = request.min_mixnet_performance.map(threshold_into_percent);
+
+        let min_vpn_performance = request.min_vpn_performance.map(threshold_into_percent);
 
         let min_gateway_performance = GatewayMinPerformance {
-            mixnet_min_performance: None,
-            vpn_min_performance: min_gateway_performance,
+            mixnet_min_performance: min_mixnet_performance,
+            vpn_min_performance: min_vpn_performance,
         };
 
         let gateways = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
@@ -355,14 +357,15 @@ impl NymVpnd for CommandInterface {
     ) -> Result<tonic::Response<ListExitGatewaysResponse>, tonic::Status> {
         info!("Got list exit gateways request: {:?}", request);
 
-        let min_gateway_performance = request
-            .into_inner()
-            .min_gateway_performance
-            .map(threshold_into_percent);
+        let request = request.into_inner();
+
+        let min_mixnet_performance = request.min_mixnet_performance.map(threshold_into_percent);
+
+        let min_vpn_performance = request.min_vpn_performance.map(threshold_into_percent);
 
         let min_gateway_performance = GatewayMinPerformance {
-            mixnet_min_performance: min_gateway_performance,
-            vpn_min_performance: None,
+            mixnet_min_performance: min_mixnet_performance,
+            vpn_min_performance: min_vpn_performance,
         };
 
         let exit_gateways = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
@@ -394,14 +397,15 @@ impl NymVpnd for CommandInterface {
     ) -> Result<tonic::Response<ListEntryCountriesResponse>, tonic::Status> {
         info!("Got list entry countries request: {request:?}");
 
-        let min_gateway_performance = request
-            .into_inner()
-            .min_gateway_performance
-            .map(threshold_into_percent);
+        let request = request.into_inner();
+
+        let min_mixnet_performance = request.min_mixnet_performance.map(threshold_into_percent);
+
+        let min_vpn_performance = request.min_vpn_performance.map(threshold_into_percent);
 
         let min_gateway_performance = GatewayMinPerformance {
-            mixnet_min_performance: min_gateway_performance,
-            vpn_min_performance: None,
+            mixnet_min_performance: min_mixnet_performance,
+            vpn_min_performance: min_vpn_performance,
         };
 
         let countries = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
@@ -433,14 +437,15 @@ impl NymVpnd for CommandInterface {
     ) -> Result<tonic::Response<ListExitCountriesResponse>, tonic::Status> {
         info!("Got list exit countries request: {request:?}");
 
-        let min_gateway_performance = request
-            .into_inner()
-            .min_gateway_performance
-            .map(threshold_into_percent);
+        let request = request.into_inner();
+
+        let min_mixnet_performance = request.min_mixnet_performance.map(threshold_into_percent);
+
+        let min_vpn_performance = request.min_vpn_performance.map(threshold_into_percent);
 
         let min_gateway_performance = GatewayMinPerformance {
-            mixnet_min_performance: min_gateway_performance,
-            vpn_min_performance: None,
+            mixnet_min_performance: min_mixnet_performance,
+            vpn_min_performance: min_vpn_performance,
         };
 
         let countries = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
@@ -472,14 +477,15 @@ impl NymVpnd for CommandInterface {
     ) -> Result<tonic::Response<ListVpnCountriesResponse>, tonic::Status> {
         info!("Got list VPN countries request: {request:?}");
 
-        let min_gateway_performance = request
-            .into_inner()
-            .min_gateway_performance
-            .map(threshold_into_percent);
+        let request = request.into_inner();
+
+        let min_mixnet_performance = request.min_mixnet_performance.map(threshold_into_percent);
+
+        let min_vpn_performance = request.min_vpn_performance.map(threshold_into_percent);
 
         let min_gateway_performance = GatewayMinPerformance {
-            mixnet_min_performance: None,
-            vpn_min_performance: min_gateway_performance,
+            mixnet_min_performance: min_mixnet_performance,
+            vpn_min_performance: min_vpn_performance,
         };
 
         let countries = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/gateway.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/gateway.rs
@@ -89,8 +89,8 @@ impl From<gateway::Country> for nym_vpn_proto::Location {
 pub(crate) fn into_gateway_type(gateway_type: nym_vpn_proto::GatewayType) -> Option<GatewayType> {
     match gateway_type {
         nym_vpn_proto::GatewayType::Unspecified => None,
-        nym_vpn_proto::GatewayType::Entry => Some(GatewayType::Entry),
-        nym_vpn_proto::GatewayType::Exit => Some(GatewayType::Exit),
+        nym_vpn_proto::GatewayType::MixnetEntry => Some(GatewayType::MixnetEntry),
+        nym_vpn_proto::GatewayType::MixnetExit => Some(GatewayType::MixnetExit),
         nym_vpn_proto::GatewayType::Vpn => Some(GatewayType::Vpn),
     }
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/gateway.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/gateway.rs
@@ -62,29 +62,14 @@ impl From<gateway::Probe> for nym_vpn_proto::Probe {
     }
 }
 
-impl From<gateway::Gateway> for nym_vpn_proto::EntryGateway {
+impl From<gateway::Gateway> for nym_vpn_proto::GatewayResponse {
     fn from(gateway: gateway::Gateway) -> Self {
         let id = Some(nym_vpn_proto::Gateway {
             id: gateway.identity_key.to_string(),
         });
         let location = gateway.location.map(nym_vpn_proto::Location::from);
         let last_probe = gateway.last_probe.map(nym_vpn_proto::Probe::from);
-        nym_vpn_proto::EntryGateway {
-            id,
-            location,
-            last_probe,
-        }
-    }
-}
-
-impl From<gateway::Gateway> for nym_vpn_proto::ExitGateway {
-    fn from(gateway: gateway::Gateway) -> Self {
-        let id = Some(nym_vpn_proto::Gateway {
-            id: gateway.identity_key.to_string(),
-        });
-        let location = gateway.location.map(nym_vpn_proto::Location::from);
-        let last_probe = gateway.last_probe.map(nym_vpn_proto::Probe::from);
-        nym_vpn_proto::ExitGateway {
+        nym_vpn_proto::GatewayResponse {
             id,
             location,
             last_probe,
@@ -96,21 +81,6 @@ impl From<gateway::Country> for nym_vpn_proto::Location {
     fn from(country: gateway::Country) -> Self {
         nym_vpn_proto::Location {
             two_letter_iso_country_code: country.iso_code().to_string(),
-        }
-    }
-}
-
-impl From<gateway::Gateway> for nym_vpn_proto::VpnGateway {
-    fn from(gateway: gateway::Gateway) -> Self {
-        let id = Some(nym_vpn_proto::Gateway {
-            id: gateway.identity_key.to_string(),
-        });
-        let location = gateway.location.map(nym_vpn_proto::Location::from);
-        let last_probe = gateway.last_probe.map(nym_vpn_proto::Probe::from);
-        nym_vpn_proto::VpnGateway {
-            id,
-            location,
-            last_probe,
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/gateway.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/gateway.rs
@@ -91,6 +91,6 @@ pub(crate) fn into_gateway_type(gateway_type: nym_vpn_proto::GatewayType) -> Opt
         nym_vpn_proto::GatewayType::Unspecified => None,
         nym_vpn_proto::GatewayType::MixnetEntry => Some(GatewayType::MixnetEntry),
         nym_vpn_proto::GatewayType::MixnetExit => Some(GatewayType::MixnetExit),
-        nym_vpn_proto::GatewayType::Vpn => Some(GatewayType::Wg),
+        nym_vpn_proto::GatewayType::Wg => Some(GatewayType::Wg),
     }
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/gateway.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/gateway.rs
@@ -38,7 +38,12 @@ impl From<gateway::ProbeOutcome> for nym_vpn_proto::ProbeOutcome {
     fn from(outcome: gateway::ProbeOutcome) -> Self {
         let as_entry = Some(nym_vpn_proto::AsEntry::from(outcome.as_entry));
         let as_exit = outcome.as_exit.map(nym_vpn_proto::AsExit::from);
-        nym_vpn_proto::ProbeOutcome { as_entry, as_exit }
+        let wg = None;
+        nym_vpn_proto::ProbeOutcome {
+            as_entry,
+            as_exit,
+            wg,
+        }
     }
 }
 
@@ -101,6 +106,11 @@ impl From<gateway::Gateway> for nym_vpn_proto::VpnGateway {
             id: gateway.identity_key.to_string(),
         });
         let location = gateway.location.map(nym_vpn_proto::Location::from);
-        nym_vpn_proto::VpnGateway { id, location }
+        let last_probe = gateway.last_probe.map(nym_vpn_proto::Probe::from);
+        nym_vpn_proto::VpnGateway {
+            id,
+            location,
+            last_probe,
+        }
     }
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/gateway.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/gateway.rs
@@ -2,9 +2,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use nym_vpn_lib::gateway_directory::GatewayType;
-use nym_vpn_proto::{
-    list_countries_request::ListCountriesType, list_gateways_request::ListGatewaysType,
-};
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
 use crate::types::gateway;
@@ -89,24 +86,11 @@ impl From<gateway::Country> for nym_vpn_proto::Location {
     }
 }
 
-pub(crate) fn into_gateway_type(gateway_type: ListGatewaysType) -> GatewayType {
+pub(crate) fn into_gateway_type(gateway_type: nym_vpn_proto::GatewayType) -> Option<GatewayType> {
     match gateway_type {
-        ListGatewaysType::ListGatewayTypeUnspecified => {
-            todo!();
-        }
-        ListGatewaysType::Entry => GatewayType::Entry,
-        ListGatewaysType::Exit => GatewayType::Exit,
-        ListGatewaysType::Vpn => GatewayType::Vpn,
-    }
-}
-
-pub(crate) fn from_country_into_gateway_type(gateway_type: ListCountriesType) -> GatewayType {
-    match gateway_type {
-        ListCountriesType::ListGatewayTypeUnspecified => {
-            todo!();
-        }
-        ListCountriesType::Entry => GatewayType::Entry,
-        ListCountriesType::Exit => GatewayType::Exit,
-        ListCountriesType::Vpn => GatewayType::Vpn,
+        nym_vpn_proto::GatewayType::Unspecified => None,
+        nym_vpn_proto::GatewayType::Entry => Some(GatewayType::Entry),
+        nym_vpn_proto::GatewayType::Exit => Some(GatewayType::Exit),
+        nym_vpn_proto::GatewayType::Vpn => Some(GatewayType::Vpn),
     }
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/gateway.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/gateway.rs
@@ -91,6 +91,6 @@ pub(crate) fn into_gateway_type(gateway_type: nym_vpn_proto::GatewayType) -> Opt
         nym_vpn_proto::GatewayType::Unspecified => None,
         nym_vpn_proto::GatewayType::MixnetEntry => Some(GatewayType::MixnetEntry),
         nym_vpn_proto::GatewayType::MixnetExit => Some(GatewayType::MixnetExit),
-        nym_vpn_proto::GatewayType::Vpn => Some(GatewayType::Vpn),
+        nym_vpn_proto::GatewayType::Vpn => Some(GatewayType::Wg),
     }
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/gateway.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/gateway.rs
@@ -1,6 +1,10 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use nym_vpn_lib::gateway_directory::GatewayType;
+use nym_vpn_proto::{
+    list_countries_request::ListCountriesType, list_gateways_request::ListGatewaysType,
+};
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
 use crate::types::gateway;
@@ -82,5 +86,27 @@ impl From<gateway::Country> for nym_vpn_proto::Location {
         nym_vpn_proto::Location {
             two_letter_iso_country_code: country.iso_code().to_string(),
         }
+    }
+}
+
+pub(crate) fn into_gateway_type(gateway_type: ListGatewaysType) -> GatewayType {
+    match gateway_type {
+        ListGatewaysType::ListGatewayTypeUnspecified => {
+            todo!();
+        }
+        ListGatewaysType::Entry => GatewayType::Entry,
+        ListGatewaysType::Exit => GatewayType::Exit,
+        ListGatewaysType::Vpn => GatewayType::Vpn,
+    }
+}
+
+pub(crate) fn from_country_into_gateway_type(gateway_type: ListCountriesType) -> GatewayType {
+    match gateway_type {
+        ListCountriesType::ListGatewayTypeUnspecified => {
+            todo!();
+        }
+        ListCountriesType::Entry => GatewayType::Entry,
+        ListCountriesType::Exit => GatewayType::Exit,
+        ListCountriesType::Vpn => GatewayType::Vpn,
     }
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -15,7 +15,7 @@ use futures::{
 };
 use nym_vpn_api_client::{
     response::{NymVpnAccountSummaryResponse, NymVpnDevice, NymVpnZkNym, NymVpnZkNymResponse},
-    types::{GatewayMinPerformance, VpnApiAccount},
+    types::{GatewayMinPerformance, Percent, VpnApiAccount},
 };
 use nym_vpn_lib::{
     credentials::import_credential,
@@ -172,8 +172,9 @@ pub(crate) struct ConnectOptions {
     pub(crate) enable_poisson_rate: bool,
     pub(crate) disable_background_cover_traffic: bool,
     pub(crate) enable_credentials_mode: bool,
-    pub(crate) min_mixnode_performance: Option<u8>,
-    pub(crate) min_gateway_performance: Option<u8>,
+    pub(crate) min_mixnode_performance: Option<Percent>,
+    pub(crate) min_gateway_mixnet_performance: Option<Percent>,
+    pub(crate) min_gateway_vpn_performance: Option<Percent>,
 }
 
 #[derive(Debug)]
@@ -484,15 +485,9 @@ where
 
         info!("Using config: {}", config);
 
-        let min_gateway_performance = match GatewayMinPerformance::from_percentage_values(
-            options.min_mixnode_performance.map(u64::from),
-            options.min_gateway_performance.map(u64::from),
-        ) {
-            Ok(min_gateway_performance) => min_gateway_performance,
-            Err(err) => {
-                self.shared_vpn_state.set(VpnState::NotConnected);
-                return VpnServiceConnectResult::Fail(err.to_string());
-            }
+        let min_gateway_performance = GatewayMinPerformance {
+            mixnet_min_performance: options.min_gateway_mixnet_performance,
+            vpn_min_performance: options.min_gateway_vpn_performance,
         };
 
         let gateway_config = gateway_directory::Config::new_from_env()
@@ -503,8 +498,12 @@ where
                 enable_poisson_rate: options.enable_poisson_rate,
                 disable_background_cover_traffic: options.disable_background_cover_traffic,
                 enable_credentials_mode: options.enable_credentials_mode,
-                min_mixnode_performance: options.min_mixnode_performance,
-                min_gateway_performance: options.min_gateway_performance,
+                min_mixnode_performance: options
+                    .min_mixnode_performance
+                    .map(|p| p.round_to_integer()),
+                min_gateway_performance: options
+                    .min_gateway_mixnet_performance
+                    .map(|p| p.round_to_integer()),
             },
             data_path: Some(self.data_dir.clone()),
             gateway_config,

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -494,6 +494,8 @@ where
             mixnet_min_performance,
             vpn_min_performance,
         };
+        let gateway_config = gateway_directory::Config::new_from_env()
+            .with_custom_min_gateway_performance(min_gateway_performance);
 
         let generic_config = GenericNymVpnConfig {
             mixnet_client_config: MixnetClientConfig {
@@ -504,7 +506,7 @@ where
                 min_gateway_performance: options.min_gateway_performance,
             },
             data_path: Some(self.data_dir.clone()),
-            gateway_config: gateway_directory::Config::new_from_env(Some(min_gateway_performance)),
+            gateway_config,
             entry_point: config.entry_point.clone(),
             exit_point: config.exit_point.clone(),
             nym_ips: None,

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -15,7 +15,7 @@ use futures::{
 };
 use nym_vpn_api_client::{
     response::{NymVpnAccountSummaryResponse, NymVpnDevice, NymVpnZkNym, NymVpnZkNymResponse},
-    types::VpnApiAccount,
+    types::{GatewayMinPerformance, Percent, VpnApiAccount},
 };
 use nym_vpn_lib::{
     credentials::import_credential,
@@ -484,6 +484,17 @@ where
 
         info!("Using config: {}", config);
 
+        let mixnet_min_performance = options
+            .min_mixnode_performance
+            .map(|p| Percent::from_percentage_value(p as u64).unwrap());
+        let vpn_min_performance = options
+            .min_gateway_performance
+            .map(|p| Percent::from_percentage_value(p as u64).unwrap());
+        let min_gateway_performance = GatewayMinPerformance {
+            mixnet_min_performance,
+            vpn_min_performance,
+        };
+
         let generic_config = GenericNymVpnConfig {
             mixnet_client_config: MixnetClientConfig {
                 enable_poisson_rate: options.enable_poisson_rate,
@@ -493,9 +504,7 @@ where
                 min_gateway_performance: options.min_gateway_performance,
             },
             data_path: Some(self.data_dir.clone()),
-            gateway_config: gateway_directory::Config::new_from_env(
-                options.min_gateway_performance,
-            ),
+            gateway_config: gateway_directory::Config::new_from_env(Some(min_gateway_performance)),
             entry_point: config.entry_point.clone(),
             exit_point: config.exit_point.clone(),
             nym_ips: None,

--- a/proto/nym/vpn.proto
+++ b/proto/nym/vpn.proto
@@ -95,7 +95,8 @@ message ConnectRequest {
   bool disable_background_cover_traffic = 7;
   bool enable_credentials_mode = 8;
   Threshold min_mixnode_performance = 9;
-  Threshold min_gateway_performance = 10;
+  Threshold min_gateway_mixnet_performance = 10;
+  Threshold min_gateway_vpn_performance = 11;
 }
 
 message ConnectResponse {

--- a/proto/nym/vpn.proto
+++ b/proto/nym/vpn.proto
@@ -354,9 +354,18 @@ message AsExit {
   bool can_route_ip_external_v6 = 5;
 }
 
+message WgProbeResult {
+  bool can_register = 1;
+  bool can_handshake = 2;
+  bool can_resolve_dns = 3;
+  float ping_hosts_performance = 4;
+  float ping_ips_performance = 5;
+}
+
 message ProbeOutcome {
   AsEntry as_entry = 1;
   AsExit as_exit = 2;
+  WgProbeResult wg = 3;
 }
 
 message Probe {
@@ -371,7 +380,8 @@ message EntryGateway {
 }
 
 message ListEntryGatewaysRequest {
-  Threshold min_gateway_performance = 1;
+  Threshold min_mixnet_performance = 1;
+  Threshold min_vpn_performance = 2;
 }
 
 message ListEntryGatewaysResponse {
@@ -385,7 +395,8 @@ message ExitGateway {
 }
 
 message ListExitGatewaysRequest {
-  Threshold min_gateway_performance = 1;
+  Threshold min_mixnet_performance = 1;
+  Threshold min_vpn_performance = 2;
 }
 
 message ListExitGatewaysResponse {
@@ -395,10 +406,12 @@ message ListExitGatewaysResponse {
 message VpnGateway {
   Gateway id = 1;
   Location location = 2;
+  Probe last_probe = 3;
 }
 
 message ListVpnGatewaysRequest {
-  Threshold min_gateway_performance = 1;
+  Threshold min_mixnet_performance = 1;
+  Threshold min_vpn_performance = 2;
 }
 
 message ListVpnGatewaysResponse {
@@ -406,7 +419,8 @@ message ListVpnGatewaysResponse {
 }
 
 message ListEntryCountriesRequest {
-  Threshold min_gateway_performance = 1;
+  Threshold min_mixnet_performance = 1;
+  Threshold min_vpn_performance = 2;
 }
 
 message ListEntryCountriesResponse {
@@ -414,7 +428,8 @@ message ListEntryCountriesResponse {
 }
 
 message ListExitCountriesRequest {
-  Threshold min_gateway_performance = 1;
+  Threshold min_mixnet_performance = 1;
+  Threshold min_vpn_performance = 2;
 }
 
 message ListExitCountriesResponse {
@@ -422,7 +437,8 @@ message ListExitCountriesResponse {
 }
 
 message ListVpnCountriesRequest {
-  Threshold min_gateway_performance = 1;
+  Threshold min_mixnet_performance = 1;
+  Threshold min_vpn_performance = 2;
 }
 
 message ListVpnCountriesResponse {

--- a/proto/nym/vpn.proto
+++ b/proto/nym/vpn.proto
@@ -384,7 +384,7 @@ enum GatewayType {
   GATEWAY_TYPE_UNSPECIFIED = 0;
   MIXNET_ENTRY = 1;
   MIXNET_EXIT = 2;
-  VPN = 3;
+  WG = 3;
 }
 
 message ListGatewaysRequest {

--- a/proto/nym/vpn.proto
+++ b/proto/nym/vpn.proto
@@ -373,75 +373,41 @@ message Probe {
   ProbeOutcome outcome = 2;
 }
 
-message EntryGateway {
+message GatewayResponse {
   Gateway id = 1;
   Location location = 2;
   Probe last_probe = 3;
 }
 
-message ListEntryGatewaysRequest {
-  Threshold min_mixnet_performance = 1;
-  Threshold min_vpn_performance = 2;
+message ListGatewaysRequest {
+  enum ListGatewaysType {
+    LIST_GATEWAY_TYPE_UNSPECIFIED = 0;
+    ENTRY = 1;
+    EXIT = 2;
+    VPN = 3;
+  }
+  ListGatewaysType kind = 1;
+  Threshold min_mixnet_performance = 2;
+  Threshold min_vpn_performance = 3;
 }
 
-message ListEntryGatewaysResponse {
-  repeated EntryGateway gateways = 1;
+message ListGatewaysResponse {
+  repeated GatewayResponse gateways = 1;
 }
 
-message ExitGateway {
-  Gateway id = 1;
-  Location location = 2;
-  Probe last_probe = 3;
+message ListCountriesRequest {
+  enum ListCountriesType {
+    LIST_GATEWAY_TYPE_UNSPECIFIED = 0;
+    ENTRY = 1;
+    EXIT = 2;
+    VPN = 3;
+  }
+  ListCountriesType kind = 1;
+  Threshold min_mixnet_performance = 2;
+  Threshold min_vpn_performance = 3;
 }
 
-message ListExitGatewaysRequest {
-  Threshold min_mixnet_performance = 1;
-  Threshold min_vpn_performance = 2;
-}
-
-message ListExitGatewaysResponse {
-  repeated ExitGateway gateways = 1;
-}
-
-message VpnGateway {
-  Gateway id = 1;
-  Location location = 2;
-  Probe last_probe = 3;
-}
-
-message ListVpnGatewaysRequest {
-  Threshold min_mixnet_performance = 1;
-  Threshold min_vpn_performance = 2;
-}
-
-message ListVpnGatewaysResponse {
-  repeated VpnGateway gateways = 1;
-}
-
-message ListEntryCountriesRequest {
-  Threshold min_mixnet_performance = 1;
-  Threshold min_vpn_performance = 2;
-}
-
-message ListEntryCountriesResponse {
-  repeated Location countries = 1;
-}
-
-message ListExitCountriesRequest {
-  Threshold min_mixnet_performance = 1;
-  Threshold min_vpn_performance = 2;
-}
-
-message ListExitCountriesResponse {
-  repeated Location countries = 1;
-}
-
-message ListVpnCountriesRequest {
-  Threshold min_mixnet_performance = 1;
-  Threshold min_vpn_performance = 2;
-}
-
-message ListVpnCountriesResponse {
+message ListCountriesResponse {
   repeated Location countries = 1;
 }
 
@@ -512,12 +478,8 @@ service NymVpnd {
   rpc ListenToConnectionStateChanges (Empty) returns (stream ConnectionStateChange) {}
   rpc ListenToConnectionStatus (Empty) returns (stream ConnectionStatusUpdate) {}
 
-  rpc ListEntryGateways (ListEntryGatewaysRequest) returns (ListEntryGatewaysResponse) {}
-  rpc ListExitGateways (ListExitGatewaysRequest) returns (ListExitGatewaysResponse) {}
-  rpc ListVpnGateways (ListVpnGatewaysRequest) returns (ListVpnGatewaysResponse) {}
-  rpc ListEntryCountries (ListEntryCountriesRequest) returns (ListEntryCountriesResponse) {}
-  rpc ListExitCountries (ListExitCountriesRequest) returns (ListExitCountriesResponse) {}
-  rpc ListVpnCountries (ListVpnCountriesRequest) returns (ListVpnCountriesResponse) {}
+  rpc ListGateways (ListGatewaysRequest) returns (ListGatewaysResponse) {}
+  rpc ListCountries (ListCountriesRequest) returns (ListCountriesResponse) {}
 
   // Unstable
   rpc StoreAccount (StoreAccountRequest) returns (StoreAccountResponse) {}

--- a/proto/nym/vpn.proto
+++ b/proto/nym/vpn.proto
@@ -379,14 +379,15 @@ message GatewayResponse {
   Probe last_probe = 3;
 }
 
+enum GatewayType {
+  GATEWAY_TYPE_UNSPECIFIED = 0;
+  ENTRY = 1;
+  EXIT = 2;
+  VPN = 3;
+}
+
 message ListGatewaysRequest {
-  enum ListGatewaysType {
-    LIST_GATEWAY_TYPE_UNSPECIFIED = 0;
-    ENTRY = 1;
-    EXIT = 2;
-    VPN = 3;
-  }
-  ListGatewaysType kind = 1;
+  GatewayType kind = 1;
   Threshold min_mixnet_performance = 2;
   Threshold min_vpn_performance = 3;
 }
@@ -396,13 +397,7 @@ message ListGatewaysResponse {
 }
 
 message ListCountriesRequest {
-  enum ListCountriesType {
-    LIST_GATEWAY_TYPE_UNSPECIFIED = 0;
-    ENTRY = 1;
-    EXIT = 2;
-    VPN = 3;
-  }
-  ListCountriesType kind = 1;
+  GatewayType kind = 1;
   Threshold min_mixnet_performance = 2;
   Threshold min_vpn_performance = 3;
 }

--- a/proto/nym/vpn.proto
+++ b/proto/nym/vpn.proto
@@ -94,6 +94,7 @@ message ConnectRequest {
   bool enable_poisson_rate = 6;
   bool disable_background_cover_traffic = 7;
   bool enable_credentials_mode = 8;
+  // Optional thresholds
   Threshold min_mixnode_performance = 9;
   Threshold min_gateway_mixnet_performance = 10;
   Threshold min_gateway_vpn_performance = 11;
@@ -388,6 +389,7 @@ enum GatewayType {
 
 message ListGatewaysRequest {
   GatewayType kind = 1;
+  // Optional thresholds
   Threshold min_mixnet_performance = 2;
   Threshold min_vpn_performance = 3;
 }
@@ -398,6 +400,7 @@ message ListGatewaysResponse {
 
 message ListCountriesRequest {
   GatewayType kind = 1;
+  // Optional thresholds
   Threshold min_mixnet_performance = 2;
   Threshold min_vpn_performance = 3;
 }

--- a/proto/nym/vpn.proto
+++ b/proto/nym/vpn.proto
@@ -382,8 +382,8 @@ message GatewayResponse {
 
 enum GatewayType {
   GATEWAY_TYPE_UNSPECIFIED = 0;
-  ENTRY = 1;
-  EXIT = 2;
+  MIXNET_ENTRY = 1;
+  MIXNET_EXIT = 2;
   VPN = 3;
 }
 


### PR DESCRIPTION
Finish support of the new gateway directory API on nymvpn.com.
Support setting the mixnet and vpn performance threshold parameters for the gateway directory.
Update grpc API.

The changes to the uniffi API is split out into https://github.com/nymtech/nym-vpn-client/pull/1155

**NOTE**: breaks the grpc API for getting gateways and countries