### PR TITLE
Fix handling errors sent in channels

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -5559,6 +5559,7 @@ dependencies = [
  "http 0.2.12",
  "maplit",
  "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=3f922cc0)",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=b7baff1)",
  "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=b7baff1)",
  "nym-task",
  "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=b7baff1)",

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -5445,6 +5445,7 @@ dependencies = [
  "nym-authenticator-client",
  "nym-authenticator-requests",
  "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=3f922cc0)",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=b7baff1)",
  "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=b7baff1)",
  "nym-client-core",
  "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=b7baff1)",

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -22,6 +22,7 @@ members = [
 # For local development
 # [patch."https://github.com/nymtech/nym"]
 # nym-authenticator-requests = { path = "../../nym/common/authenticator-requests" }
+# nym-bandwidth-controller = { path = "../../nym/common/bandwidth-controller" }
 # nym-bin-common = { path = "../../nym/common/bin-common" }
 # nym-client-core = { path = "../../nym/common/client-core" }
 # nym-config = { path = "../../nym/common/config" }
@@ -116,6 +117,7 @@ talpid-types = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = 
 talpid-wireguard = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "95fb001fb" }
 
 nym-authenticator-requests = { git = "https://github.com/nymtech/nym", rev = "b7baff1" }
+nym-bandwidth-controller = { git = "https://github.com/nymtech/nym", rev = "b7baff1" }
 nym-bin-common = { git = "https://github.com/nymtech/nym", rev = "b7baff1" }
 nym-client-core = { git = "https://github.com/nymtech/nym", rev = "b7baff1" }
 nym-config = { git = "https://github.com/nymtech/nym", rev = "b7baff1" }
@@ -137,5 +139,3 @@ nym-credential-storage-pre-ecash = { git = "https://github.com/nymtech/nym", rev
 nym-credentials-pre-ecash = { git = "https://github.com/nymtech/nym", rev = "3f922cc0", package = "nym-credentials" }
 nym-id-pre-ecash = { git = "https://github.com/nymtech/nym", rev = "3f922cc0", package = "nym-id" }
 nym-bandwidth-controller-pre-ecash = { git = "https://github.com/nymtech/nym", rev = "3f922cc0", package = "nym-bandwidth-controller" }
-
-nym-bandwidth-controller = { git = "https://github.com/nymtech/nym", rev = "b7baff1" }

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -137,3 +137,5 @@ nym-credential-storage-pre-ecash = { git = "https://github.com/nymtech/nym", rev
 nym-credentials-pre-ecash = { git = "https://github.com/nymtech/nym", rev = "3f922cc0", package = "nym-credentials" }
 nym-id-pre-ecash = { git = "https://github.com/nymtech/nym", rev = "3f922cc0", package = "nym-id" }
 nym-bandwidth-controller-pre-ecash = { git = "https://github.com/nymtech/nym", rev = "3f922cc0", package = "nym-bandwidth-controller" }
+
+nym-bandwidth-controller = { git = "https://github.com/nymtech/nym", rev = "b7baff1" }

--- a/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
@@ -60,6 +60,7 @@ talpid-wireguard.workspace = true
 
 nym-authenticator-requests.workspace = true
 nym-bandwidth-controller-pre-ecash.workspace = true
+nym-bandwidth-controller.workspace = true
 nym-bin-common.workspace = true
 nym-client-core.workspace = true
 nym-config.workspace = true

--- a/nym-vpn-core/crates/nym-vpn-lib/src/error.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/error.rs
@@ -65,6 +65,10 @@ pub enum Error {
     #[cfg(target_os = "ios")]
     #[error("failed to run wireguard tunnel")]
     RunTunnel(#[from] crate::mobile::Error),
+
+    // Messages sent through the task manager from the nym-wg-gateway-client
+    #[error(transparent)]
+    WgGatewayClientMessage(#[from] nym_wg_gateway_client::ErrorMessage),
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/error.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/error.rs
@@ -65,10 +65,6 @@ pub enum Error {
     #[cfg(target_os = "ios")]
     #[error("failed to run wireguard tunnel")]
     RunTunnel(#[from] crate::mobile::Error),
-
-    // Messages sent through the task manager from the nym-wg-gateway-client
-    #[error(transparent)]
-    WgGatewayClientMessage(#[from] nym_wg_gateway_client::ErrorMessage),
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/event.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/event.rs
@@ -1,0 +1,23 @@
+// Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use std::path::PathBuf;
+
+// For sending status events that the status listener listens to(!)
+// Again I'd like to re-iterate that we should create a separte trait for this instead of
+// piggybacking on the error trait. Once we can depend on the latest rev of the mono repo it will
+// be possible to make this change.
+#[derive(Debug, thiserror::Error)]
+pub enum WgTunnelErrorEvent {
+    #[error("failed to create dir {path}: {source}")]
+    CreateDir {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[error("failed to start wireguard monitor: {0}")]
+    WireguardMonitor(#[source] talpid_wireguard::Error),
+
+    #[error("failed to send shutdown message to wireguard tunnel")]
+    SendWireguardShutdown,
+}

--- a/nym-vpn-core/crates/nym-vpn-lib/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/lib.rs
@@ -9,6 +9,7 @@ pub mod util;
 
 mod bandwidth_controller;
 mod error;
+mod event;
 mod mixnet;
 #[cfg(any(target_os = "ios", target_os = "android"))]
 mod mobile;
@@ -45,6 +46,7 @@ pub use nym_wg_gateway_client as wg_gateway_client;
 pub use crate::platform::swift;
 pub use crate::{
     error::{Error, GatewayDirectoryError, SetupMixTunnelError, SetupWgTunnelError},
+    event::WgTunnelErrorEvent,
     mixnet::MixnetError,
     vpn::{
         spawn_nym_vpn, spawn_nym_vpn_with_new_runtime, GenericNymVpnConfig, MixnetClientConfig,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/status_listener.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/status_listener.rs
@@ -1,7 +1,8 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use nym_bandwidth_controller_pre_ecash::BandwidthStatusMessage;
+use nym_bandwidth_controller::BandwidthStatusMessage;
+use nym_bandwidth_controller_pre_ecash::BandwidthStatusMessage as LegacyBandwidthStatusMessage;
 use nym_connection_monitor::ConnectionMonitorStatus;
 use nym_task::{
     manager::{SentStatus, TaskStatus},
@@ -37,6 +38,10 @@ impl VpnServiceStatusListener {
         }
 
         if let Some(message) = status_update.downcast_ref::<BandwidthStatusMessage>() {
+            uniffi_set_listener_status(StatusEvent::Bandwidth(message.into()))
+        }
+
+        if let Some(message) = status_update.downcast_ref::<LegacyBandwidthStatusMessage>() {
             uniffi_set_listener_status(StatusEvent::Bandwidth(message.into()))
         }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/uniffi_custom_impls.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/uniffi_custom_impls.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
+use nym_bandwidth_controller::BandwidthStatusMessage as LegacyBandwidthStatusMessage;
 use nym_bandwidth_controller_pre_ecash::BandwidthStatusMessage;
 use nym_connection_monitor::ConnectionMonitorStatus;
 use nym_gateway_directory::{EntryPoint as GwEntryPoint, ExitPoint as GwExitPoint};
@@ -525,6 +526,19 @@ impl From<&BandwidthStatusMessage> for BandwidthStatus {
                 }
             }
             BandwidthStatusMessage::NoBandwidth => BandwidthStatus::NoBandwidth,
+        }
+    }
+}
+
+impl From<&LegacyBandwidthStatusMessage> for BandwidthStatus {
+    fn from(value: &LegacyBandwidthStatusMessage) -> Self {
+        match value {
+            LegacyBandwidthStatusMessage::RemainingBandwidth(bandwidth) => {
+                BandwidthStatus::RemainingBandwidth {
+                    bandwidth: *bandwidth,
+                }
+            }
+            LegacyBandwidthStatusMessage::NoBandwidth => BandwidthStatus::NoBandwidth,
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/util.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/util.rs
@@ -38,7 +38,8 @@ pub(crate) async fn wait_for_interrupt(
             }
         },
         Some(msg) = task_manager_wait => {
-            log::info!("Task error: {:?}", msg);
+            log::info!("Task error: {}", msg);
+            log::debug!("Task error: {:?}", msg);
             Err(msg)
         }
         else => {

--- a/nym-vpn-core/crates/nym-vpnd/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpnd/Cargo.toml
@@ -44,6 +44,7 @@ talpid-wireguard.workspace = true
 
 # Nym monorepo
 nym-bandwidth-controller-pre-ecash.workspace = true
+nym-bandwidth-controller.workspace = true
 nym-bin-common.workspace = true
 nym-task.workspace = true
 nym-validator-client.workspace = true

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/error.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/error.rs
@@ -69,6 +69,13 @@ impl From<ConnectionFailedError> for ProtoError {
                     "reason".to_string() => reason.clone(),
                 },
             },
+            ConnectionFailedError::UnhandledExit(ref reason) => ProtoError {
+                kind: ErrorType::UnhandledExit as i32,
+                message: err.to_string(),
+                details: hashmap! {
+                    "reason".to_string() => reason.clone(),
+                },
+            },
             ConnectionFailedError::InternalError(ref reason) => ProtoError {
                 kind: ErrorType::Internal as i32,
                 message: err.to_string(),

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/status_update.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/status_update.rs
@@ -1,6 +1,8 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use nym_bandwidth_controller::BandwidthStatusMessage;
+use nym_bandwidth_controller_pre_ecash::BandwidthStatusMessage as LegacyBandwidthStatusMessage;
 use nym_vpn_lib::{connection_monitor::ConnectionMonitorStatus, NymVpnStatusMessage};
 use nym_vpn_proto::{connection_status_update::StatusType, ConnectionStatusUpdate};
 
@@ -84,19 +86,17 @@ pub(crate) fn status_update_from_monitor_status(
 }
 
 pub(crate) fn status_update_from_bandwidth_status_message(
-    status: &nym_bandwidth_controller::BandwidthStatusMessage,
+    status: &BandwidthStatusMessage,
 ) -> ConnectionStatusUpdate {
     match status {
-        nym_bandwidth_controller::BandwidthStatusMessage::RemainingBandwidth(amount) => {
-            ConnectionStatusUpdate {
-                kind: StatusType::RemainingBandwidth as i32,
-                message: status.to_string(),
-                details: maplit::hashmap! {
-                    "amount".to_string() => amount.to_string(),
-                },
-            }
-        }
-        nym_bandwidth_controller::BandwidthStatusMessage::NoBandwidth => ConnectionStatusUpdate {
+        BandwidthStatusMessage::RemainingBandwidth(amount) => ConnectionStatusUpdate {
+            kind: StatusType::RemainingBandwidth as i32,
+            message: status.to_string(),
+            details: maplit::hashmap! {
+                "amount".to_string() => amount.to_string(),
+            },
+        },
+        BandwidthStatusMessage::NoBandwidth => ConnectionStatusUpdate {
             kind: StatusType::NoBandwidth as i32,
             message: status.to_string(),
             details: Default::default(),
@@ -106,25 +106,21 @@ pub(crate) fn status_update_from_bandwidth_status_message(
 
 // Temporary while we depend on a pre-cash rev of the bandwidth controller
 pub(crate) fn status_update_from_bandwidth_status_message_legacy(
-    status: &nym_bandwidth_controller_pre_ecash::BandwidthStatusMessage,
+    status: &LegacyBandwidthStatusMessage,
 ) -> ConnectionStatusUpdate {
     match status {
-        nym_bandwidth_controller_pre_ecash::BandwidthStatusMessage::RemainingBandwidth(amount) => {
-            ConnectionStatusUpdate {
-                kind: StatusType::RemainingBandwidth as i32,
-                message: status.to_string(),
-                details: maplit::hashmap! {
-                    "amount".to_string() => amount.to_string(),
-                },
-            }
-        }
-        nym_bandwidth_controller_pre_ecash::BandwidthStatusMessage::NoBandwidth => {
-            ConnectionStatusUpdate {
-                kind: StatusType::NoBandwidth as i32,
-                message: status.to_string(),
-                details: Default::default(),
-            }
-        }
+        LegacyBandwidthStatusMessage::RemainingBandwidth(amount) => ConnectionStatusUpdate {
+            kind: StatusType::RemainingBandwidth as i32,
+            message: status.to_string(),
+            details: maplit::hashmap! {
+                "amount".to_string() => amount.to_string(),
+            },
+        },
+        LegacyBandwidthStatusMessage::NoBandwidth => ConnectionStatusUpdate {
+            kind: StatusType::NoBandwidth as i32,
+            message: status.to_string(),
+            details: Default::default(),
+        },
     }
 }
 

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/status_update.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/status_update.rs
@@ -104,6 +104,7 @@ pub(crate) fn status_update_from_bandwidth_status_message(
     }
 }
 
+// Temporary while we depend on a pre-cash rev of the bandwidth controller
 pub(crate) fn status_update_from_bandwidth_status_message_legacy(
     status: &nym_bandwidth_controller_pre_ecash::BandwidthStatusMessage,
 ) -> ConnectionStatusUpdate {

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/status_update.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/status_update.rs
@@ -111,7 +111,7 @@ pub(crate) fn status_update_from_bandwidth_status_message_legacy(
         nym_bandwidth_controller_pre_ecash::BandwidthStatusMessage::RemainingBandwidth(amount) => {
             ConnectionStatusUpdate {
                 kind: StatusType::RemainingBandwidth as i32,
-                internal: status.to_string(),
+                message: status.to_string(),
                 details: maplit::hashmap! {
                     "amount".to_string() => amount.to_string(),
                 },
@@ -120,7 +120,7 @@ pub(crate) fn status_update_from_bandwidth_status_message_legacy(
         nym_bandwidth_controller_pre_ecash::BandwidthStatusMessage::NoBandwidth => {
             ConnectionStatusUpdate {
                 kind: StatusType::NoBandwidth as i32,
-                internal: status.to_string(),
+                message: status.to_string(),
                 details: Default::default(),
             }
         }

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/status_update.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/status_update.rs
@@ -127,3 +127,13 @@ pub(crate) fn status_update_from_bandwidth_status_message_legacy(
         }
     }
 }
+
+pub(crate) fn status_update_from_wg_tunnel_error_event(
+    status: &nym_vpn_lib::WgTunnelErrorEvent,
+) -> ConnectionStatusUpdate {
+    ConnectionStatusUpdate {
+        kind: StatusType::WgTunnelError as i32,
+        message: status.to_string(),
+        details: Default::default(),
+    }
+}

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/status_update.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/status_update.rs
@@ -1,7 +1,6 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use nym_bandwidth_controller_pre_ecash::BandwidthStatusMessage;
 use nym_vpn_lib::{connection_monitor::ConnectionMonitorStatus, NymVpnStatusMessage};
 use nym_vpn_proto::{connection_status_update::StatusType, ConnectionStatusUpdate};
 
@@ -85,20 +84,43 @@ pub(crate) fn status_update_from_monitor_status(
 }
 
 pub(crate) fn status_update_from_bandwidth_status_message(
-    status: &BandwidthStatusMessage,
+    status: &nym_bandwidth_controller::BandwidthStatusMessage,
 ) -> ConnectionStatusUpdate {
     match status {
-        BandwidthStatusMessage::RemainingBandwidth(amount) => ConnectionStatusUpdate {
+        nym_bandwidth_controller::BandwidthStatusMessage::RemainingBandwidth(amount) => ConnectionStatusUpdate {
             kind: StatusType::RemainingBandwidth as i32,
             message: status.to_string(),
             details: maplit::hashmap! {
                 "amount".to_string() => amount.to_string(),
             },
         },
-        BandwidthStatusMessage::NoBandwidth => ConnectionStatusUpdate {
+        nym_bandwidth_controller::BandwidthStatusMessage::NoBandwidth => ConnectionStatusUpdate {
             kind: StatusType::NoBandwidth as i32,
             message: status.to_string(),
             details: Default::default(),
         },
+    }
+}
+
+pub(crate) fn status_update_from_bandwidth_status_message_legacy(
+    status: &nym_bandwidth_controller_pre_ecash::BandwidthStatusMessage,
+) -> ConnectionStatusUpdate {
+    match status {
+        nym_bandwidth_controller_pre_ecash::BandwidthStatusMessage::RemainingBandwidth(amount) => {
+            ConnectionStatusUpdate {
+                kind: StatusType::RemainingBandwidth as i32,
+                internal: status.to_string(),
+                details: maplit::hashmap! {
+                    "amount".to_string() => amount.to_string(),
+                },
+            }
+        }
+        nym_bandwidth_controller_pre_ecash::BandwidthStatusMessage::NoBandwidth => {
+            ConnectionStatusUpdate {
+                kind: StatusType::NoBandwidth as i32,
+                internal: status.to_string(),
+                details: Default::default(),
+            }
+        }
     }
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/status_update.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/status_update.rs
@@ -87,13 +87,15 @@ pub(crate) fn status_update_from_bandwidth_status_message(
     status: &nym_bandwidth_controller::BandwidthStatusMessage,
 ) -> ConnectionStatusUpdate {
     match status {
-        nym_bandwidth_controller::BandwidthStatusMessage::RemainingBandwidth(amount) => ConnectionStatusUpdate {
-            kind: StatusType::RemainingBandwidth as i32,
-            message: status.to_string(),
-            details: maplit::hashmap! {
-                "amount".to_string() => amount.to_string(),
-            },
-        },
+        nym_bandwidth_controller::BandwidthStatusMessage::RemainingBandwidth(amount) => {
+            ConnectionStatusUpdate {
+                kind: StatusType::RemainingBandwidth as i32,
+                message: status.to_string(),
+                details: maplit::hashmap! {
+                    "amount".to_string() => amount.to_string(),
+                },
+            }
+        }
         nym_bandwidth_controller::BandwidthStatusMessage::NoBandwidth => ConnectionStatusUpdate {
             kind: StatusType::NoBandwidth as i32,
             message: status.to_string(),

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/status_broadcaster.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/status_broadcaster.rs
@@ -67,6 +67,7 @@ impl ConnectionStatusBroadcaster {
             } else if let Some(message) = status_update.downcast_ref::<BandwidthStatusMessage>() {
                 self.handle_bandwidth_status_message(message);
             } else {
+                tracing::warn!("Received unknown status update: {:?}", status_update);
                 self.status_tx
                     .send(ConnectionStatusUpdate {
                         kind: StatusType::Unknown as i32,

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/status_broadcaster.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/status_broadcaster.rs
@@ -2,14 +2,18 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use futures::StreamExt;
-use nym_vpn_lib::{connection_monitor::ConnectionMonitorStatus, NymVpnStatusMessage};
+use nym_bandwidth_controller::BandwidthStatusMessage;
+use nym_bandwidth_controller_pre_ecash::BandwidthStatusMessage as LegacyBandwidthStatusMessage;
+use nym_vpn_lib::{
+    connection_monitor::ConnectionMonitorStatus, NymVpnStatusMessage, WgTunnelErrorEvent,
+};
 use nym_vpn_proto::{connection_status_update::StatusType, ConnectionStatusUpdate};
 use tracing::debug;
 
 use super::protobuf::status_update::{
     status_update_from_bandwidth_status_message,
     status_update_from_bandwidth_status_message_legacy, status_update_from_monitor_status,
-    status_update_from_status_message,
+    status_update_from_status_message, status_update_from_wg_tunnel_error_event,
 };
 
 pub(super) struct ConnectionStatusBroadcaster {
@@ -46,10 +50,7 @@ impl ConnectionStatusBroadcaster {
             .ok();
     }
 
-    fn handle_bandwidth_status_message(
-        &self,
-        message: &nym_bandwidth_controller::BandwidthStatusMessage,
-    ) {
+    fn handle_bandwidth_status_message(&self, message: &BandwidthStatusMessage) {
         self.status_tx
             .send(status_update_from_bandwidth_status_message(message))
             .ok();
@@ -61,6 +62,12 @@ impl ConnectionStatusBroadcaster {
     ) {
         self.status_tx
             .send(status_update_from_bandwidth_status_message_legacy(message))
+            .ok();
+    }
+
+    fn handle_wg_tunnel_error_event(&self, message: &nym_vpn_lib::WgTunnelErrorEvent) {
+        self.status_tx
+            .send(status_update_from_wg_tunnel_error_event(message))
             .ok();
     }
 
@@ -76,14 +83,14 @@ impl ConnectionStatusBroadcaster {
                 self.handle_status_message(message);
             } else if let Some(message) = status_update.downcast_ref::<ConnectionMonitorStatus>() {
                 self.handle_connection_monitor_status(message);
-            } else if let Some(message) =
-                status_update.downcast_ref::<nym_bandwidth_controller::BandwidthStatusMessage>()
-            {
+            } else if let Some(message) = status_update.downcast_ref::<BandwidthStatusMessage>() {
                 self.handle_bandwidth_status_message(message);
-            } else if let Some(message) = status_update
-                .downcast_ref::<nym_bandwidth_controller_pre_ecash::BandwidthStatusMessage>(
-            ) {
+            } else if let Some(message) =
+                status_update.downcast_ref::<LegacyBandwidthStatusMessage>()
+            {
                 self.handle_bandwidth_status_message_legacy(message);
+            } else if let Some(message) = status_update.downcast_ref::<WgTunnelErrorEvent>() {
+                self.handle_wg_tunnel_error_event(message);
             } else {
                 tracing::warn!("Received unknown status update: {:?}", status_update);
                 self.status_tx

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/status_broadcaster.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/status_broadcaster.rs
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use futures::StreamExt;
-use nym_bandwidth_controller_pre_ecash::BandwidthStatusMessage;
 use nym_vpn_lib::{connection_monitor::ConnectionMonitorStatus, NymVpnStatusMessage};
 use nym_vpn_proto::{connection_status_update::StatusType, ConnectionStatusUpdate};
 use tracing::debug;
 
 use super::protobuf::status_update::{
-    status_update_from_bandwidth_status_message, status_update_from_monitor_status,
+    status_update_from_bandwidth_status_message,
+    status_update_from_bandwidth_status_message_legacy, status_update_from_monitor_status,
     status_update_from_status_message,
 };
 
@@ -46,9 +46,21 @@ impl ConnectionStatusBroadcaster {
             .ok();
     }
 
-    fn handle_bandwidth_status_message(&self, message: &BandwidthStatusMessage) {
+    fn handle_bandwidth_status_message(
+        &self,
+        message: &nym_bandwidth_controller::BandwidthStatusMessage,
+    ) {
         self.status_tx
             .send(status_update_from_bandwidth_status_message(message))
+            .ok();
+    }
+
+    fn handle_bandwidth_status_message_legacy(
+        &self,
+        message: &nym_bandwidth_controller_pre_ecash::BandwidthStatusMessage,
+    ) {
+        self.status_tx
+            .send(status_update_from_bandwidth_status_message_legacy(message))
             .ok();
     }
 
@@ -64,8 +76,14 @@ impl ConnectionStatusBroadcaster {
                 self.handle_status_message(message);
             } else if let Some(message) = status_update.downcast_ref::<ConnectionMonitorStatus>() {
                 self.handle_connection_monitor_status(message);
-            } else if let Some(message) = status_update.downcast_ref::<BandwidthStatusMessage>() {
+            } else if let Some(message) =
+                status_update.downcast_ref::<nym_bandwidth_controller::BandwidthStatusMessage>()
+            {
                 self.handle_bandwidth_status_message(message);
+            } else if let Some(message) = status_update
+                .downcast_ref::<nym_bandwidth_controller_pre_ecash::BandwidthStatusMessage>(
+            ) {
+                self.handle_bandwidth_status_message_legacy(message);
             } else {
                 tracing::warn!("Received unknown status update: {:?}", status_update);
                 self.status_tx

--- a/nym-vpn-core/crates/nym-vpnd/src/service/error.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/error.rs
@@ -379,9 +379,11 @@ impl From<&nym_vpn_lib::Error> for ConnectionFailedError {
                     authenticator_address,
                     source,
                 } => match source {
-                    WgGatewayClientError::OutOfBandwidth => ConnectionFailedError::OutOfBandwidth {
-                        gateway_id: gateway_id.clone(),
-                        authenticator_address: authenticator_address.clone(),
+                    WgGatewayClientError::OutOfBandwidth { gateway_id, authenticator_address } => {
+                        ConnectionFailedError::OutOfBandwidth {
+                            gateway_id: gateway_id.clone(),
+                            authenticator_address: authenticator_address.clone(),
+                        }
                     },
                     WgGatewayClientError::AuthenticatorClientError(auth_err) => match auth_err {
                         AuthenticatorClientError::TimeoutWaitingForConnectResponse => {

--- a/nym-vpn-core/crates/nym-vpnd/src/service/error.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/error.rs
@@ -497,15 +497,6 @@ impl From<&nym_vpn_lib::Error> for ConnectionFailedError {
             | nym_vpn_lib::Error::NymVpnExitUnexpectedChannelClose => {
                 ConnectionFailedError::InternalError(err.to_string())
             }
-            nym_vpn_lib::Error::WgGatewayClientMessage(wg_error_msg) => match wg_error_msg {
-                nym_vpn_lib::wg_gateway_client::ErrorMessage::OutOfBandwidth {
-                    gateway_id,
-                    authenticator_address,
-                } => ConnectionFailedError::OutOfBandwidth {
-                    gateway_id: gateway_id.clone(),
-                    authenticator_address: authenticator_address.clone(),
-                },
-            }
             #[cfg(unix)]
             nym_vpn_lib::Error::TunProvider(inner) => {
                 ConnectionFailedError::TunError { reason: inner.to_string() }
@@ -578,6 +569,20 @@ impl From<&nym_vpn_lib::GatewayDirectoryError> for ConnectionFailedError {
                     requested_location: requested_location.clone(),
                 }
             }
+        }
+    }
+}
+
+impl From<&nym_vpn_lib::wg_gateway_client::ErrorMessage> for ConnectionFailedError {
+    fn from(err: &nym_vpn_lib::wg_gateway_client::ErrorMessage) -> Self {
+        match err {
+            nym_vpn_lib::wg_gateway_client::ErrorMessage::OutOfBandwidth {
+                gateway_id,
+                authenticator_address,
+            } => ConnectionFailedError::OutOfBandwidth {
+                gateway_id: gateway_id.clone(),
+                authenticator_address: authenticator_address.clone(),
+            },
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/service/exit_listener.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/exit_listener.rs
@@ -41,9 +41,15 @@ impl VpnServiceExitListener {
                             .map(ConnectionFailedError::from);
 
                         // If None, try to cast to nym_wg_gateway_client::Error since we are
-                        // sending error events from that task.
-                        // NOTE: man we are really twisting the arm of the error handling here,
-                        // this is not good.
+                        // sending error `OutOfBandwidth` events from that task.
+                        //
+                        // NOTE: man this is nasty and we are really twisting the arm of the error
+                        // handling here, this is not good.
+                        //
+                        // We can't reuse the `From` error conversions because in this case the
+                        // error has not passed back up through the higher layers where it gets
+                        // wrapped in the appropriate wrapping type and its associated context.
+                        // Instead we construct the final connection failed error directly
                         let vpn_lib_err = vpn_lib_err.or_else(|| {
                             err.downcast_ref::<nym_vpn_lib::wg_gateway_client::Error>()
                                 .map(|err| match err {

--- a/nym-vpn-core/crates/nym-vpnd/src/service/exit_listener.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/exit_listener.rs
@@ -41,8 +41,14 @@ impl VpnServiceExitListener {
                             .map(ConnectionFailedError::from);
 
                         let connection_failed_err = match vpn_lib_err {
-                            Some(vpn_lib_err) => vpn_lib_err,
-                            None => ConnectionFailedError::Unhandled(err.to_string()),
+                            Some(vpn_lib_err) => {
+                                tracing::warn!("proper return error: {vpn_lib_err:#?}");
+                                vpn_lib_err
+                            },
+                            None => {
+                                tracing::warn!("unknown error type: {err:#?}");
+                                ConnectionFailedError::Unhandled(err.to_string())
+                            },
                         };
 
                         self.shared_vpn_state

--- a/nym-vpn-core/crates/nym-vpnd/src/service/exit_listener.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/exit_listener.rs
@@ -40,6 +40,12 @@ impl VpnServiceExitListener {
                             .downcast_ref::<nym_vpn_lib::Error>()
                             .map(ConnectionFailedError::from);
 
+                        // If not, try to downcast to ErrorMessage that is sent from
+                        // nym_wg_gateway_client.
+                        let vpn_lib_err = vpn_lib_err.or(err
+                            .downcast_ref::<nym_vpn_lib::wg_gateway_client::ErrorMessage>()
+                            .map(ConnectionFailedError::from));
+
                         let connection_failed_err = match vpn_lib_err {
                             Some(vpn_lib_err) => vpn_lib_err,
                             None => {

--- a/nym-vpn-core/crates/nym-vpnd/src/service/status_listener.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/status_listener.rs
@@ -82,19 +82,13 @@ impl VpnServiceStatusListener {
                 BandwidthStatusMessage::RemainingBandwidth(_) => {}
                 BandwidthStatusMessage::NoBandwidth => {}
             }
-        } else if let Some(msg) = msg.downcast_ref::<Box<BandwidthStatusMessage>>() {
-            info!("VPN bandwidth status (box): monitor status: {msg}");
-            match **msg {
-                BandwidthStatusMessage::RemainingBandwidth(_) => {}
-                BandwidthStatusMessage::NoBandwidth => {}
-            }
         } else if let Some(msg) =
-            msg.downcast_ref::<nym_bandwidth_controller_pre_ecash::BandwidthStatusMessage>()
+            msg.downcast_ref::<nym_bandwidth_controller::BandwidthStatusMessage>()
         {
             info!("Mixnet bandwidth status: monitor status: {msg}");
             match msg {
-                BandwidthStatusMessage::RemainingBandwidth(_) => {}
-                BandwidthStatusMessage::NoBandwidth => {}
+                nym_bandwidth_controller::BandwidthStatusMessage::RemainingBandwidth(_) => {}
+                nym_bandwidth_controller::BandwidthStatusMessage::NoBandwidth => {}
             }
         } else {
             tracing::warn!("VPN status: unknown: {msg}");

--- a/nym-vpn-core/crates/nym-vpnd/src/service/status_listener.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/status_listener.rs
@@ -85,7 +85,7 @@ impl VpnServiceStatusListener {
             info!("VPN error status: {msg}");
         } else {
             tracing::warn!("VPN status: unknown: {msg}");
-            tracing::warn!("{msg:#?}");
+            tracing::debug!("Unknown status message received: {msg:#?}");
         }
         msg
     }

--- a/nym-vpn-core/crates/nym-vpnd/src/service/status_listener.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/status_listener.rs
@@ -7,7 +7,7 @@ use nym_bandwidth_controller_pre_ecash::BandwidthStatusMessage as LegacyBandwidt
 use nym_task::StatusSender;
 use nym_vpn_lib::{
     connection_monitor::ConnectionMonitorStatus, NymVpnStatusMessage, SentStatus, StatusReceiver,
-    TaskStatus,
+    TaskStatus, WgTunnelErrorEvent,
 };
 use time::OffsetDateTime;
 use tracing::{debug, info};
@@ -81,6 +81,8 @@ impl VpnServiceStatusListener {
             info!("VPN bandwidth status: monitor status: {msg}");
         } else if let Some(msg) = msg.downcast_ref::<LegacyBandwidthStatusMessage>() {
             info!("VPN bandwidth status (legacy): monitor status: {msg}");
+        } else if let Some(msg) = msg.downcast_ref::<WgTunnelErrorEvent>() {
+            info!("VPN error status: {msg}");
         } else {
             tracing::warn!("VPN status: unknown: {msg}");
             tracing::warn!("{msg:#?}");

--- a/nym-vpn-core/crates/nym-vpnd/src/service/status_listener.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/status_listener.rs
@@ -82,8 +82,23 @@ impl VpnServiceStatusListener {
                 BandwidthStatusMessage::RemainingBandwidth(_) => {}
                 BandwidthStatusMessage::NoBandwidth => {}
             }
+        } else if let Some(msg) = msg.downcast_ref::<Box<BandwidthStatusMessage>>() {
+            info!("VPN bandwidth status (box): monitor status: {msg}");
+            match **msg {
+                BandwidthStatusMessage::RemainingBandwidth(_) => {}
+                BandwidthStatusMessage::NoBandwidth => {}
+            }
+        } else if let Some(msg) =
+            msg.downcast_ref::<nym_bandwidth_controller_pre_ecash::BandwidthStatusMessage>()
+        {
+            info!("Mixnet bandwidth status: monitor status: {msg}");
+            match msg {
+                BandwidthStatusMessage::RemainingBandwidth(_) => {}
+                BandwidthStatusMessage::NoBandwidth => {}
+            }
         } else {
-            info!("VPN status: unknown: {msg}");
+            tracing::warn!("VPN status: unknown: {msg}");
+            tracing::warn!("{msg:#?}");
         }
         msg
     }

--- a/nym-vpn-core/crates/nym-vpnd/src/service/status_listener.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/status_listener.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use futures::{SinkExt, StreamExt};
-use nym_bandwidth_controller_pre_ecash::BandwidthStatusMessage;
+use nym_bandwidth_controller::BandwidthStatusMessage;
+use nym_bandwidth_controller_pre_ecash::BandwidthStatusMessage as LegacyBandwidthStatusMessage;
 use nym_task::StatusSender;
 use nym_vpn_lib::{
     connection_monitor::ConnectionMonitorStatus, NymVpnStatusMessage, SentStatus, StatusReceiver,
@@ -78,18 +79,8 @@ impl VpnServiceStatusListener {
             info!("VPN connection monitor status: {msg}");
         } else if let Some(msg) = msg.downcast_ref::<BandwidthStatusMessage>() {
             info!("VPN bandwidth status: monitor status: {msg}");
-            match msg {
-                BandwidthStatusMessage::RemainingBandwidth(_) => {}
-                BandwidthStatusMessage::NoBandwidth => {}
-            }
-        } else if let Some(msg) =
-            msg.downcast_ref::<nym_bandwidth_controller::BandwidthStatusMessage>()
-        {
-            info!("Mixnet bandwidth status: monitor status: {msg}");
-            match msg {
-                nym_bandwidth_controller::BandwidthStatusMessage::RemainingBandwidth(_) => {}
-                nym_bandwidth_controller::BandwidthStatusMessage::NoBandwidth => {}
-            }
+        } else if let Some(msg) = msg.downcast_ref::<LegacyBandwidthStatusMessage>() {
+            info!("VPN bandwidth status (legacy): monitor status: {msg}");
         } else {
             tracing::warn!("VPN status: unknown: {msg}");
             tracing::warn!("{msg:#?}");

--- a/nym-vpn-core/crates/nym-wg-gateway-client/src/error.rs
+++ b/nym-vpn-core/crates/nym-wg-gateway-client/src/error.rs
@@ -1,6 +1,8 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use nym_gateway_directory::{NodeIdentity, Recipient};
+
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("received invalid response from gateway authenticator")]
@@ -15,8 +17,11 @@ pub enum Error {
     #[error("failed to parse entry gateway socket addr: {0}")]
     FailedToParseEntryGatewaySocketAddr(#[source] std::net::AddrParseError),
 
-    #[error("out of bandwidth")]
-    OutOfBandwidth,
+    #[error("out of bandwidth for gateway: `{gateway_id}`")]
+    OutOfBandwidth {
+        gateway_id: Box<NodeIdentity>,
+        authenticator_address: Box<Recipient>,
+    },
 }
 
 // Result type based on our error type

--- a/nym-vpn-core/crates/nym-wg-gateway-client/src/error.rs
+++ b/nym-vpn-core/crates/nym-wg-gateway-client/src/error.rs
@@ -16,7 +16,10 @@ pub enum Error {
 
     #[error("failed to parse entry gateway socket addr: {0}")]
     FailedToParseEntryGatewaySocketAddr(#[source] std::net::AddrParseError),
+}
 
+#[derive(Debug, thiserror::Error)]
+pub enum ErrorMessage {
     #[error("out of bandwidth for gateway: `{gateway_id}`")]
     OutOfBandwidth {
         gateway_id: Box<NodeIdentity>,

--- a/nym-vpn-core/crates/nym-wg-gateway-client/src/lib.rs
+++ b/nym-vpn-core/crates/nym-wg-gateway-client/src/lib.rs
@@ -247,7 +247,11 @@ impl WgGatewayClient {
                                     timeout_check_interval.next().await;
                                 }
                                 None => {
-                                    shutdown.send_we_stopped(Box::new(Error::OutOfBandwidth));
+                                    // TODO: try to return this error in the JoinHandle instead
+                                    shutdown.send_we_stopped(Box::new(Error::OutOfBandwidth {
+                                        gateway_id: Box::new(*self.auth_recipient.gateway()),
+                                        authenticator_address: Box::new(self.auth_recipient),
+                                    }));
                                 }
                             }
                         },

--- a/nym-vpn-core/crates/nym-wg-gateway-client/src/lib.rs
+++ b/nym-vpn-core/crates/nym-wg-gateway-client/src/lib.rs
@@ -10,7 +10,7 @@ use std::{
     time::Duration,
 };
 
-pub use error::Error;
+pub use error::{Error, ErrorMessage};
 use nym_authenticator_client::AuthClient;
 use nym_authenticator_requests::v1::response::{
     AuthenticatorResponseData, PendingRegistrationResponse, RegisteredResponse,
@@ -248,7 +248,7 @@ impl WgGatewayClient {
                                 }
                                 None => {
                                     // TODO: try to return this error in the JoinHandle instead
-                                    shutdown.send_we_stopped(Box::new(Error::OutOfBandwidth {
+                                    shutdown.send_we_stopped(Box::new(ErrorMessage::OutOfBandwidth {
                                         gateway_id: Box::new(*self.auth_recipient.gateway()),
                                         authenticator_address: Box::new(self.auth_recipient),
                                     }));

--- a/proto/nym/vpn.proto
+++ b/proto/nym/vpn.proto
@@ -201,8 +201,12 @@ message Error {
 
     // An error that was not explicitly handled by the vpn service. This should
     // not happen but it will while we iterate on mapping out all possible
-    // error that can happen
+    // errors
     UNHANDLED = 1;
+
+    // The vpn exiting with an error that isn't handled by the automatic
+    // conversion. If this happens it's a bug.
+    UNHANDLED_EXIT = 49;
 
     // An internal error that indicates a programmer error and should not
     // happen. If it did an invariant was probably broken at some point.

--- a/proto/nym/vpn.proto
+++ b/proto/nym/vpn.proto
@@ -184,6 +184,10 @@ message ConnectionStatusUpdate {
 
     // The user has run out of available bandwidth
     NO_BANDWIDTH = 13;
+
+    // Wireguard tunnel errors sent through the status channel. This error case
+    // will go away in the future.
+    WG_TUNNEL_ERROR = 14;
   }
 
   StatusType kind = 1;


### PR DESCRIPTION
Primarily this PR fixes that `OutOfBandwidth` errors were being snuck through without being properly caught by the daemon.

Fix bandwidth messages sent from the mixnet client not being caught. This was caused by not matching on the correct type, due to importing the same crate twice to support the freepass credential handling until ecash is merged.

Also wrap the errors sent through the status channel in a struct suitable for catching by the listener.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1186)
<!-- Reviewable:end -->
