### PR TITLE
Add user agent to proto requests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,5 +10,5 @@ build-wireguard-ios:
 	./wireguard/build-wireguard-go.sh --ios
 
 build-nym-vpn-core:
-	$(MAKE) -C nym-vpn-core
+	$(MAKE) -C nym-vpn-core build
 

--- a/nym-vpn-app/src-tauri/src/grpc/client.rs
+++ b/nym-vpn-app/src-tauri/src/grpc/client.rs
@@ -306,6 +306,7 @@ impl GrpcClient {
             disable_background_cover_traffic: false,
             enable_credentials_mode: false,
             dns,
+            user_agent: None,
             min_mixnode_performance: None,
             min_gateway_mixnet_performance: None,
             min_gateway_vpn_performance: None,
@@ -362,6 +363,7 @@ impl GrpcClient {
 
         let request = Request::new(ListCountriesRequest {
             kind: gw_type as i32,
+            user_agent: None,
             min_mixnet_performance: None,
             min_vpn_performance: None,
         });

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -5533,6 +5533,7 @@ dependencies = [
  "anyhow",
  "bs58 0.5.1",
  "clap",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=b7baff1)",
  "nym-gateway-directory",
  "nym-vpn-proto",
  "parity-tokio-ipc",

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -3721,6 +3721,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7709,6 +7718,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.30.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "windows",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9331,6 +9354,7 @@ dependencies = [
  "regex",
  "rustc_version",
  "rustversion",
+ "sysinfo",
  "time",
 ]
 
@@ -9578,6 +9602,16 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-core"

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -2877,7 +2877,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.52.0",
 ]
 
 [[package]]
@@ -5486,6 +5486,7 @@ dependencies = [
  "shadowsocks-service",
  "signature 2.2.0",
  "sqlx",
+ "sysinfo",
  "talpid-core",
  "talpid-platform-metadata",
  "talpid-routing",
@@ -5548,6 +5549,7 @@ dependencies = [
  "parity-tokio-ipc",
  "prost 0.12.6",
  "prost-types 0.12.6",
+ "sysinfo",
  "time",
  "tokio",
  "tonic 0.11.0",
@@ -5584,6 +5586,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
+ "sysinfo",
  "talpid-routing",
  "talpid-wireguard",
  "thiserror",
@@ -7719,15 +7722,15 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.30.13"
+version = "0.31.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
+checksum = "355dbe4f8799b304b05e1b0f05fc59b2a18d36645cf169607da45bde2f69a1be"
 dependencies = [
- "cfg-if",
  "core-foundation-sys",
  "libc",
+ "memchr",
  "ntapi",
- "once_cell",
+ "rayon",
  "windows",
 ]
 
@@ -9354,7 +9357,6 @@ dependencies = [
  "regex",
  "rustc_version",
  "rustversion",
- "sysinfo",
  "time",
 ]
 
@@ -9605,11 +9607,11 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.52.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
- "windows-core",
+ "windows-core 0.57.0",
  "windows-targets 0.52.6",
 ]
 
@@ -9618,6 +9620,49 @@ name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -71,6 +71,7 @@ lazy_static = "1.5.0"
 log = "0.4.22"
 maplit = "1.0.2"
 netdev = "0.29.0"
+nix = "0.29"
 parity-tokio-ipc = "0.9.0"
 pnet_packet = "0.35.0"
 prost = "0.12.6"
@@ -84,6 +85,7 @@ serde_json = "1.0"
 sha2 = "0.10"
 signature = "2.2.0"
 sqlx = "0.6.3"
+sysinfo = "0.31"
 tap = "1.0.1"
 tempfile = "3.12"
 thiserror = "1.0.63"
@@ -107,7 +109,6 @@ url = "2.5"
 vergen = { version = "8.3.1", default-features = false }
 x25519-dalek = "2.0"
 zeroize = "1.6.0"
-nix = "0.29"
 
 talpid-core = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "95fb001fb" }
 talpid-platform-metadata = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "95fb001fb" }

--- a/nym-vpn-core/Makefile
+++ b/nym-vpn-core/Makefile
@@ -11,26 +11,32 @@ IPHONEOS_ARCHS = aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios
 WG_BUILD_DIR = $(CURDIR)/../build/lib
 WG_TARGET_DIR = $(WG_BUILD_DIR)/$(ARCH)
 
-.PHONY: all deb fmt
+.PHONY: all deb fmt help
 
 # Main targets
-all: build
+all: help
 
-deb: build-deb-vpn-cli build-deb-vpnd build-deb-vpnc
+deb: build-deb-vpn-cli build-deb-vpnd build-deb-vpnc ## Build debian packages
 
 # Build targets
-build:
+build: ## Build the rust workspace
+	RUSTFLAGS="-L $(WG_TARGET_DIR)" cargo build
+
+build-release: ## Build the rust workspace in release mode
 	RUSTFLAGS="-L $(WG_TARGET_DIR)" cargo build --release
 
-build-mac:
+build-mac: ## Build the Rust workspace suitable for running the daemon
 	RUSTFLAGS="-L $(WG_TARGET_DIR) -C link-arg=-all_load -C link-arg=-ObjC -C link-arg=-sectcreate -C link-arg=__TEXT -C link-arg=__info_plist -C link-arg=$(CURDIR)/../nym-vpn-apple/Daemon/Info.plist -C link-arg=-sectcreate -C link-arg=__TEXT -C link-arg=__launchd_plist -C link-arg=$(CURDIR)/nym-vpn-apple/Daemon/Launchd.plist" cargo build --release
 
 # Linting targets
-clippy:
+clippy: ## Run clippy
 	cargo clippy --workspace -- -Dwarnings
 
-fmt:
+fmt: ## Run rustfmt
 	cargo fmt --all
+
+fmt-check: ## Check rustfmt
+	cargo fmt --all --check
 
 # Debian package builds
 build-deb-vpn-cli:
@@ -42,15 +48,17 @@ build-deb-vpnd:
 build-deb-vpnc:
 	RUSTFLAGS="-L $(WG_TARGET_DIR)" cargo deb -p nym-vpnc
 
-build-vpn-lib-swift:
+build-vpn-lib-swift: ## Rust cargo swift
 	$(eval RUSTFLAGS += $(foreach arch,$(IPHONEOS_ARCHS),CARGO_TARGET_$(shell echo '$(arch)' | tr '[:lower:]' '[:upper:]' | tr '-' '_')_RUSTFLAGS="-L $(WG_BUILD_DIR)/$(arch)"))
 	cd crates/nym-vpn-lib; \
 	$(RUSTFLAGS) cargo swift package --platforms ios --name NymVpnLib --release
 
-generate-uniffi-swift:
+generate-uniffi-swift: ## Generate uniffi for swift
 	RUSTFLAGS="-L $(WG_TARGET_DIR)" cargo run --bin uniffi-bindgen generate \
 		--library $(CURDIR)/target/aarch64-apple-ios/release/libnym_vpn_lib.a \
 		--language swift --out-dir uniffi -n
 
-# Just print detected architecture and stop
-print-info:
+print-info: ## Print detected architecture
+
+help:  ## Show this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)

--- a/nym-vpn-core/Makefile
+++ b/nym-vpn-core/Makefile
@@ -16,17 +16,17 @@ WG_TARGET_DIR = $(WG_BUILD_DIR)/$(ARCH)
 # Main targets
 all: help
 
-deb: build-deb-vpn-cli build-deb-vpnd build-deb-vpnc ## Build debian packages
-
 # Build targets
-build: ## Build the rust workspace
+build: ## Build the Rust workspace
 	RUSTFLAGS="-L $(WG_TARGET_DIR)" cargo build
 
-build-release: ## Build the rust workspace in release mode
+build-release: ## Build the Rust workspace in release mode
 	RUSTFLAGS="-L $(WG_TARGET_DIR)" cargo build --release
 
 build-mac: ## Build the Rust workspace suitable for running the daemon
 	RUSTFLAGS="-L $(WG_TARGET_DIR) -C link-arg=-all_load -C link-arg=-ObjC -C link-arg=-sectcreate -C link-arg=__TEXT -C link-arg=__info_plist -C link-arg=$(CURDIR)/../nym-vpn-apple/Daemon/Info.plist -C link-arg=-sectcreate -C link-arg=__TEXT -C link-arg=__launchd_plist -C link-arg=$(CURDIR)/nym-vpn-apple/Daemon/Launchd.plist" cargo build --release
+
+deb: build-deb-vpn-cli build-deb-vpnd build-deb-vpnc ## Build debian packages
 
 # Linting targets
 clippy: ## Run clippy

--- a/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
@@ -30,6 +30,7 @@ serde.workspace = true
 serde_json.workspace = true
 signature.workspace = true
 sqlx.workspace = true
+sysinfo.workspace = true
 tap.workspace = true
 thiserror.workspace = true
 time.workspace = true

--- a/nym-vpn-core/crates/nym-vpn-lib/src/mobile/runner.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/mobile/runner.rs
@@ -5,7 +5,6 @@ use nym_authenticator_client::AuthClient;
 use nym_gateway_directory::{
     AuthAddresses, EntryPoint, ExitPoint, Gateway, GatewayClient, Recipient,
 };
-use nym_sdk::UserAgent;
 use nym_task::TaskManager;
 use nym_wg_gateway_client::{GatewayData, WgGatewayClient};
 use nym_wg_go::{PrivateKey, PublicKey};

--- a/nym-vpn-core/crates/nym-vpn-lib/src/mobile/runner.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/mobile/runner.rs
@@ -77,7 +77,7 @@ pub struct WgTunnelRunner {
 
 impl WgTunnelRunner {
     pub fn new(config: VPNConfig, shutdown_token: CancellationToken) -> Result<Self> {
-        let user_agent = UserAgent::from(nym_bin_common::bin_info_local_vergen!());
+        let user_agent = crate::util::construct_user_agent();
         tracing::info!("User agent: {user_agent}");
 
         let generic_config = GenericNymVpnConfig {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
@@ -437,7 +437,7 @@ async fn get_gateway_countries(
 ) -> Result<Vec<Location>, VpnError> {
     let user_agent = user_agent
         .map(nym_sdk::UserAgent::from)
-        .unwrap_or_else(|| crate::util::construct_user_agent());
+        .unwrap_or_else(crate::util::construct_user_agent);
     let min_gateway_performance = min_gateway_performance.map(|p| p.try_into()).transpose()?;
     let directory_config = nym_gateway_directory::Config {
         api_url,
@@ -477,7 +477,7 @@ async fn get_low_latency_entry_country(
     };
     let user_agent = user_agent
         .map(nym_sdk::UserAgent::from)
-        .unwrap_or_else(|| crate::util::construct_user_agent());
+        .unwrap_or_else(crate::util::construct_user_agent);
 
     GatewayClient::new(config, user_agent)?
         .lookup_low_latency_entry_gateway()

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
@@ -437,7 +437,7 @@ async fn get_gateway_countries(
 ) -> Result<Vec<Location>, VpnError> {
     let user_agent = user_agent
         .map(nym_sdk::UserAgent::from)
-        .unwrap_or_else(|| nym_bin_common::bin_info_local_vergen!().into());
+        .unwrap_or_else(|| crate::util::construct_user_agent());
     let min_gateway_performance = min_gateway_performance.map(|p| p.try_into()).transpose()?;
     let directory_config = nym_gateway_directory::Config {
         api_url,
@@ -477,7 +477,7 @@ async fn get_low_latency_entry_country(
     };
     let user_agent = user_agent
         .map(nym_sdk::UserAgent::from)
-        .unwrap_or_else(|| nym_bin_common::bin_info_local_vergen!().into());
+        .unwrap_or_else(|| crate::util::construct_user_agent());
 
     GatewayClient::new(config, user_agent)?
         .lookup_low_latency_entry_gateway()

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_setup.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_setup.rs
@@ -349,9 +349,6 @@ pub(crate) async fn setup_tunnel(
     route_manager: &mut RouteManager,
     dns_monitor: &mut DnsMonitor,
 ) -> Result<AllTunnelsSetup> {
-    // The user agent is set on HTTP REST API calls, and ideally should identify the type of
-    // client. This means it needs to be set way higher in the call stack, but set a default for
-    // what we know here if we don't have anything.
     let user_agent = nym_vpn.user_agent().unwrap_or_else(|| {
         warn!("No user agent provided, using default");
         nym_bin_common::bin_info_local_vergen!().into()

--- a/nym-vpn-core/crates/nym-vpn-lib/src/util.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/util.rs
@@ -92,3 +92,17 @@ pub(crate) async fn handle_interrupt(
         error!("Error on exit tunnel handle {}", err);
     }
 }
+
+pub(crate) fn construct_user_agent() -> nym_sdk::UserAgent {
+    let bin_info = nym_bin_common::bin_info_local_vergen!();
+    let name = sysinfo::System::name().unwrap_or("unknown".to_string());
+    let os_long = sysinfo::System::long_os_version().unwrap_or("unknown".to_string());
+    let arch = sysinfo::System::cpu_arch().unwrap_or("unknown".to_string());
+    let platform = format!("{}; {}; {}", name, os_long, arch);
+    nym_sdk::UserAgent {
+        application: bin_info.binary_name.to_string(),
+        version: bin_info.build_version.to_string(),
+        platform,
+        git_commit: bin_info.commit_sha.to_string(),
+    }
+}

--- a/nym-vpn-core/crates/nym-vpnc/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpnc/Cargo.toml
@@ -16,6 +16,7 @@ clap = { workspace = true, features = ["derive"] }
 parity-tokio-ipc.workspace = true
 prost-types.workspace = true
 prost.workspace = true
+sysinfo.workspace = true
 time = { workspace = true, features = ["formatting"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"]}
 tonic.workspace = true
@@ -32,7 +33,6 @@ vergen = { workspace = true, default-features = false, features = [
     "gitcl",
     "rustc",
     "cargo",
-    "si",
 ] }
 
 # Debian

--- a/nym-vpn-core/crates/nym-vpnc/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpnc/Cargo.toml
@@ -21,6 +21,7 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"]}
 tonic.workspace = true
 tower.workspace = true
 
+nym-bin-common.workspace = true
 nym-gateway-directory = { path = "../nym-gateway-directory" }
 nym-vpn-proto = { path = "../nym-vpn-proto" }
 

--- a/nym-vpn-core/crates/nym-vpnc/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpnc/Cargo.toml
@@ -32,6 +32,7 @@ vergen = { workspace = true, default-features = false, features = [
     "gitcl",
     "rustc",
     "cargo",
+    "si",
 ] }
 
 # Debian

--- a/nym-vpn-core/crates/nym-vpnc/build.rs
+++ b/nym-vpn-core/crates/nym-vpnc/build.rs
@@ -9,6 +9,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .all_git()
         .all_rustc()
         .all_cargo()
+        .all_sysinfo()
         .emit()
         .expect("failed to extract build metadata");
     Ok(())

--- a/nym-vpn-core/crates/nym-vpnc/build.rs
+++ b/nym-vpn-core/crates/nym-vpnc/build.rs
@@ -9,7 +9,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .all_git()
         .all_rustc()
         .all_cargo()
-        .all_sysinfo()
         .emit()
         .expect("failed to extract build metadata");
     Ok(())

--- a/nym-vpn-core/crates/nym-vpnd/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpnd/Cargo.toml
@@ -25,6 +25,7 @@ prost.workspace = true
 reqwest = { workspace = true, default-features = false, features = ["rustls-tls"] }
 serde.workspace = true
 serde_json.workspace = true
+sysinfo.workspace = true
 thiserror.workspace = true
 time.workspace = true
 tokio = { workspace = true, features = ["full"]}

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
@@ -145,7 +145,7 @@ impl NymVpnd for CommandInterface {
             .user_agent
             .clone()
             .map(into_user_agent)
-            .unwrap_or_else(|| crate::util::construct_user_agent());
+            .unwrap_or_else(crate::util::construct_user_agent);
 
         let options = ConnectOptions::try_from(connect_request).map_err(|err| {
             error!("Failed to parse connect options: {:?}", err);
@@ -294,7 +294,7 @@ impl NymVpnd for CommandInterface {
         let user_agent = request
             .user_agent
             .map(into_user_agent)
-            .unwrap_or_else(|| crate::util::construct_user_agent());
+            .unwrap_or_else(crate::util::construct_user_agent);
 
         let min_mixnet_performance = request.min_mixnet_performance.map(threshold_into_percent);
         let min_vpn_performance = request.min_vpn_performance.map(threshold_into_percent);
@@ -347,7 +347,7 @@ impl NymVpnd for CommandInterface {
         let user_agent = request
             .user_agent
             .map(into_user_agent)
-            .unwrap_or_else(|| crate::util::construct_user_agent());
+            .unwrap_or_else(crate::util::construct_user_agent);
 
         let min_mixnet_performance = request.min_mixnet_performance.map(threshold_into_percent);
         let min_vpn_performance = request.min_vpn_performance.map(threshold_into_percent);

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/gateway.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/gateway.rs
@@ -94,3 +94,12 @@ pub(crate) fn into_gateway_type(gateway_type: nym_vpn_proto::GatewayType) -> Opt
         nym_vpn_proto::GatewayType::Wg => Some(GatewayType::Wg),
     }
 }
+
+pub(crate) fn into_user_agent(user_agent: nym_vpn_proto::UserAgent) -> nym_vpn_lib::UserAgent {
+    nym_vpn_lib::UserAgent {
+        application: user_agent.application,
+        version: user_agent.version,
+        platform: user_agent.platform,
+        git_commit: user_agent.git_commit,
+    }
+}

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/info_response.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/info_response.rs
@@ -21,6 +21,7 @@ impl From<VpnServiceInfoResult> for InfoResponse {
             version: info.version,
             build_timestamp,
             triple: info.triple,
+            platform: info.platform,
             git_commit: info.git_commit,
             network_name: info.network_name,
             endpoints,

--- a/nym-vpn-core/crates/nym-vpnd/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/main.rs
@@ -6,6 +6,7 @@ mod command_interface;
 mod logging;
 mod service;
 mod types;
+mod util;
 #[cfg(windows)]
 mod windows_service;
 

--- a/nym-vpn-core/crates/nym-vpnd/src/util.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/util.rs
@@ -1,0 +1,16 @@
+// Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+pub(crate) fn construct_user_agent() -> nym_vpn_lib::UserAgent {
+    let bin_info = nym_bin_common::bin_info_local_vergen!();
+    let name = sysinfo::System::name().unwrap_or("unknown".to_string());
+    let os_long = sysinfo::System::long_os_version().unwrap_or("unknown".to_string());
+    let arch = sysinfo::System::cpu_arch().unwrap_or("unknown".to_string());
+    let platform = format!("{}; {}; {}", name, os_long, arch);
+    nym_vpn_lib::UserAgent {
+        application: bin_info.binary_name.to_string(),
+        version: bin_info.build_version.to_string(),
+        platform,
+        git_commit: bin_info.commit_sha.to_string(),
+    }
+}

--- a/proto/nym/vpn.proto
+++ b/proto/nym/vpn.proto
@@ -63,6 +63,35 @@ message Url {
   string url = 1;
 }
 
+// Inspired by
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent
+// Forward slashes '/' are not valid
+message UserAgent {
+  // Example:
+  //    nym-vpn-app
+  //    nym-vpnd
+  //    nym-vpn-cli
+  string application = 1;
+  // Format: version[-optional] [(daemon version[-optional])]
+  // Example:
+  //    0.1.8
+  //    0.1.8-debug (0.1.6)
+  //    0.2.1-fdroid
+  string version = 2;
+  // Format: OS; OS version; CPU
+  // Example:
+  //    Windows NT 6.1; Win64; x64
+  //    Macintosh; Intel Mac OS X 14.6.1
+  //    iPad; U; CPU OS 3_2 like Mac OS X; en-us
+  string platform = 3;
+  // Format: git hash [(daemon git hash)]
+  // Commit hash should be at least 7 characters long
+  // Example:
+  //    4h9fk59 (4kdufle)
+  //    4h9fk59
+  string git_commit = 4;
+}
+
 message Endpoints {
   Url nyxd_url = 1;
   Url websocket_url = 2;
@@ -94,6 +123,7 @@ message ConnectRequest {
   bool enable_poisson_rate = 6;
   bool disable_background_cover_traffic = 7;
   bool enable_credentials_mode = 8;
+  UserAgent user_agent = 12;
   // Optional thresholds
   Threshold min_mixnode_performance = 9;
   Threshold min_gateway_mixnet_performance = 10;
@@ -452,6 +482,7 @@ enum GatewayType {
 
 message ListGatewaysRequest {
   GatewayType kind = 1;
+  UserAgent user_agent = 4;
   // Optional thresholds
   Threshold min_mixnet_performance = 2;
   Threshold min_vpn_performance = 3;
@@ -463,6 +494,7 @@ message ListGatewaysResponse {
 
 message ListCountriesRequest {
   GatewayType kind = 1;
+  UserAgent user_agent = 4;
   // Optional thresholds
   Threshold min_mixnet_performance = 2;
   Threshold min_vpn_performance = 3;

--- a/proto/nym/vpn.proto
+++ b/proto/nym/vpn.proto
@@ -104,6 +104,7 @@ message InfoResponse {
   string version = 1;
   google.protobuf.Timestamp build_timestamp = 2;
   string triple = 3;
+  string platform = 8;
   string git_commit = 4;
   string network_name = 5;
   repeated Endpoints endpoints = 6;


### PR DESCRIPTION
Resolves: NV-1923

- Add UserAgent to daemon connect and list grpc requests and pass it down the callstack
- Construct proper user agent in vpnc using sysinfo
- Update Makefile with help function
- Update Makefile to  make debug builds the default

The format follows NV-1855 with the addition that the version and git commit fields has an optional second value in brackets that indicates the version and commit for the daemon, when applicable.

Also the platform fields leaves out the brackets, since this is something added as part of the conversion to a string when passing it to reqwest

Also the platform field is being repurposed for system information. The plan is to add a system_info field to the UserAgent struct upstreams in the nym repo, but this will not trickle down here for a bit.

Example:
```rust
UserAgent {
    application: "nym-vpnc",
    version: "0.2.2-dev (0.2.2-dev)",
    platform: "Ubuntu; Linux 23.10 Ubuntu; x86_64",
    git_commit: "6dde4bd8bda00cce89bc2a0c75dac267d3451882 (ba519d1cefb65d48fe6997ec303932fbb31fe4c6)",
}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1191)
<!-- Reviewable:end -->

