### PR TITLE
Prevent gateway version mismatching

### DIFF
--- a/nym-vpn-app/src-tauri/Cargo.toml
+++ b/nym-vpn-app/src-tauri/Cargo.toml
@@ -47,7 +47,7 @@ rust_iso3166 = "0.1"
 dirs = "5.0.1"
 
 # nym deps
-nym-config = { git = "https://github.com/nymtech/nym", rev = "1627146" }
+nym-config = { git = "https://github.com/nymtech/nym", rev = "1f8dc3fca1834f00269ce561a6f34d9413b9b79d" }
 nym-vpn-proto = { path = "../../nym-vpn-core/crates/nym-vpn-proto" }
 
 # tauri deps

--- a/nym-vpn-app/src-tauri/Cargo.toml
+++ b/nym-vpn-app/src-tauri/Cargo.toml
@@ -47,7 +47,7 @@ rust_iso3166 = "0.1"
 dirs = "5.0.1"
 
 # nym deps
-nym-config = { git = "https://github.com/nymtech/nym", rev = "1f8dc3fca1834f00269ce561a6f34d9413b9b79d" }
+nym-config = { git = "https://github.com/nymtech/nym", rev = "c6545d8c13f46de3e815206f63a702b1c6b9a95e" }
 nym-vpn-proto = { path = "../../nym-vpn-core/crates/nym-vpn-proto" }
 
 # tauri deps

--- a/nym-vpn-app/src-tauri/Cargo.toml
+++ b/nym-vpn-app/src-tauri/Cargo.toml
@@ -47,7 +47,7 @@ rust_iso3166 = "0.1"
 dirs = "5.0.1"
 
 # nym deps
-nym-config = { git = "https://github.com/nymtech/nym", rev = "894e0bd" }
+nym-config = { git = "https://github.com/nymtech/nym", rev = "fabd48b" }
 nym-vpn-proto = { path = "../../nym-vpn-core/crates/nym-vpn-proto" }
 
 # tauri deps

--- a/nym-vpn-app/src-tauri/Cargo.toml
+++ b/nym-vpn-app/src-tauri/Cargo.toml
@@ -47,7 +47,7 @@ rust_iso3166 = "0.1"
 dirs = "5.0.1"
 
 # nym deps
-nym-config = { git = "https://github.com/nymtech/nym", rev = "c6545d8c13f46de3e815206f63a702b1c6b9a95e" }
+nym-config = { git = "https://github.com/nymtech/nym", rev = "894e0bd" }
 nym-vpn-proto = { path = "../../nym-vpn-core/crates/nym-vpn-proto" }
 
 # tauri deps

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -3680,7 +3680,7 @@ dependencies = [
 [[package]]
 name = "nym-api-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "bs58 0.5.1",
  "cosmrs 0.17.0-pre",
@@ -3688,11 +3688,11 @@ dependencies = [
  "ecdsa 0.16.9",
  "getset",
  "nym-compact-ecash",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-ecash-time",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-node-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-node-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-serde-helpers",
  "schemars",
  "serde",
@@ -3730,7 +3730,7 @@ dependencies = [
  "futures",
  "nym-authenticator-requests",
  "nym-sdk",
- "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "serde",
  "thiserror",
  "tokio",
@@ -3741,16 +3741,16 @@ dependencies = [
 [[package]]
 name = "nym-authenticator-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "base64 0.22.1",
  "bincode",
  "hmac",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-service-provider-requests-common",
  "nym-sphinx",
- "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "rand 0.8.5",
  "serde",
  "sha2 0.10.8",
@@ -3761,18 +3761,18 @@ dependencies = [
 [[package]]
 name = "nym-bandwidth-controller"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "bip39",
  "log",
- "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-ecash-contract-common",
  "nym-ecash-time",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "rand 0.8.5",
  "thiserror",
  "url",
@@ -3802,7 +3802,7 @@ dependencies = [
 [[package]]
 name = "nym-bin-common"
 version = "0.6.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "const-str",
  "log",
@@ -3831,7 +3831,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core"
 version = "1.1.15"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3844,28 +3844,28 @@ dependencies = [
  "hyper 1.4.1",
  "hyper-util",
  "log",
- "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-client-core-config-types",
  "nym-client-core-gateways-storage",
  "nym-client-core-surb-storage",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-country-group",
- "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-ecash-time",
  "nym-explorer-client",
  "nym-gateway-client",
  "nym-gateway-requests",
- "nym-id 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-id 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-metrics",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-nonexhaustive-delayqueue",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-sphinx",
  "nym-task",
  "nym-topology",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "serde",
@@ -3890,12 +3890,12 @@ dependencies = [
 [[package]]
 name = "nym-client-core-config-types"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "humantime-serde",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-country-group",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-sphinx-addressing",
  "nym-sphinx-params",
  "serde",
@@ -3906,12 +3906,12 @@ dependencies = [
 [[package]]
 name = "nym-client-core-gateways-storage"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "async-trait",
  "cosmrs 0.17.0-pre",
  "log",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-gateway-requests",
  "serde",
  "sqlx",
@@ -3925,12 +3925,12 @@ dependencies = [
 [[package]]
 name = "nym-client-core-surb-storage"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "async-trait",
  "dashmap",
  "log",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-sphinx",
  "nym-task",
  "sqlx",
@@ -3963,11 +3963,11 @@ dependencies = [
 [[package]]
 name = "nym-coconut-bandwidth-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
 ]
 
 [[package]]
@@ -3983,15 +3983,15 @@ dependencies = [
 [[package]]
 name = "nym-coconut-dkg-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-utils",
  "cw2",
  "cw4",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
 ]
 
 [[package]]
@@ -4011,7 +4011,7 @@ dependencies = [
 [[package]]
 name = "nym-compact-ecash"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "bincode",
  "bls12_381 0.8.0 (git+https://github.com/jstuczyn/bls12_381?branch=temp/experimental-serdect)",
@@ -4021,8 +4021,8 @@ dependencies = [
  "ff",
  "group",
  "itertools 0.12.1",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "rand 0.8.5",
  "serde",
  "sha2 0.9.9",
@@ -4033,12 +4033,12 @@ dependencies = [
 [[package]]
 name = "nym-config"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "dirs",
  "handlebars",
  "log",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "serde",
  "toml 0.8.19",
  "url",
@@ -4077,7 +4077,7 @@ dependencies = [
 [[package]]
 name = "nym-contracts-common"
 version = "0.5.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "bs58 0.5.1",
  "cosmwasm-schema",
@@ -4107,7 +4107,7 @@ dependencies = [
 [[package]]
 name = "nym-country-group"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "serde",
  "tracing",
@@ -4116,13 +4116,13 @@ dependencies = [
 [[package]]
 name = "nym-credential-storage"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "async-trait",
  "bincode",
  "log",
  "nym-compact-ecash",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-ecash-time",
  "serde",
  "sqlx",
@@ -4147,17 +4147,17 @@ dependencies = [
 [[package]]
 name = "nym-credential-utils"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "log",
- "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-client-core",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-ecash-time",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "thiserror",
  "time",
  "tokio",
@@ -4166,20 +4166,20 @@ dependencies = [
 [[package]]
 name = "nym-credentials"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "bincode",
  "bls12_381 0.8.0 (git+https://github.com/jstuczyn/bls12_381?branch=temp/experimental-serdect)",
  "cosmrs 0.17.0-pre",
  "log",
- "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-ecash-contract-common",
  "nym-ecash-time",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-serde-helpers",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "serde",
  "thiserror",
  "time",
@@ -4208,12 +4208,12 @@ dependencies = [
 [[package]]
 name = "nym-credentials-interface"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "bls12_381 0.8.0 (git+https://github.com/jstuczyn/bls12_381?branch=temp/experimental-serdect)",
  "nym-compact-ecash",
  "nym-ecash-time",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "rand 0.8.5",
  "serde",
  "strum",
@@ -4235,7 +4235,7 @@ dependencies = [
 [[package]]
 name = "nym-crypto"
 version = "0.4.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "aead 0.5.2",
  "aes 0.8.4",
@@ -4249,8 +4249,8 @@ dependencies = [
  "generic-array 0.14.7",
  "hkdf",
  "hmac",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "rand 0.8.5",
  "serde",
  "serde_bytes",
@@ -4311,21 +4311,21 @@ dependencies = [
 [[package]]
 name = "nym-ecash-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "bs58 0.5.1",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-controllers",
  "cw-utils",
- "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "thiserror",
 ]
 
 [[package]]
 name = "nym-ecash-time"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "nym-compact-ecash",
  "time",
@@ -4334,7 +4334,7 @@ dependencies = [
 [[package]]
 name = "nym-exit-policy"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "serde",
  "serde_json",
@@ -4356,11 +4356,11 @@ dependencies = [
 [[package]]
 name = "nym-explorer-api-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
- "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "schemars",
  "serde",
 ]
@@ -4368,7 +4368,7 @@ dependencies = [
 [[package]]
 name = "nym-explorer-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "log",
  "nym-explorer-api-requests",
@@ -4381,21 +4381,21 @@ dependencies = [
 [[package]]
 name = "nym-gateway-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "futures",
  "getrandom 0.2.15",
  "gloo-utils",
- "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-gateway-requests",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-sphinx",
  "nym-task",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "rand 0.8.5",
  "serde",
  "si-scale",
@@ -4424,10 +4424,10 @@ dependencies = [
  "hickory-resolver",
  "itertools 0.13.0",
  "nym-client-core",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-sdk",
  "nym-topology",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-vpn-api-client",
  "rand 0.8.5",
  "serde",
@@ -4456,18 +4456,18 @@ dependencies = [
  "log",
  "nym-authenticator-client",
  "nym-authenticator-requests",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-client-core",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-connection-monitor",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-gateway-directory",
  "nym-ip-packet-client",
  "nym-ip-packet-requests",
  "nym-sdk",
  "nym-task",
  "nym-topology",
- "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "pnet_packet",
  "rand 0.8.5",
  "rust2go",
@@ -4485,15 +4485,15 @@ dependencies = [
 [[package]]
 name = "nym-gateway-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "bs58 0.5.1",
  "futures",
  "generic-array 0.14.7",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-sphinx",
  "nym-task",
  "rand 0.8.5",
@@ -4511,7 +4511,7 @@ dependencies = [
 [[package]]
 name = "nym-group-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "cosmwasm-schema",
  "cw-controllers",
@@ -4537,7 +4537,7 @@ name = "nym-harbour-master-client"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "reqwest 0.11.27",
  "serde",
  "serde_json",
@@ -4548,11 +4548,11 @@ dependencies = [
 [[package]]
 name = "nym-http-api-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "async-trait",
  "http 1.1.0",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "reqwest 0.12.4",
  "serde",
  "serde_json",
@@ -4582,10 +4582,10 @@ dependencies = [
 [[package]]
 name = "nym-id"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
- "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "thiserror",
  "time",
  "tracing",
@@ -4624,12 +4624,12 @@ dependencies = [
 [[package]]
 name = "nym-ip-packet-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "bincode",
  "bytes",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-sphinx",
  "rand 0.8.5",
  "serde",
@@ -4642,7 +4642,7 @@ dependencies = [
 [[package]]
 name = "nym-metrics"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "dashmap",
  "lazy_static",
@@ -4653,7 +4653,7 @@ dependencies = [
 [[package]]
 name = "nym-mixnet-contract-common"
 version = "0.6.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "bs58 0.5.1",
  "cosmwasm-schema",
@@ -4661,7 +4661,7 @@ dependencies = [
  "cw-controllers",
  "humantime-serde",
  "log",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "schemars",
  "serde",
  "serde-json-wasm",
@@ -4692,7 +4692,7 @@ dependencies = [
 [[package]]
 name = "nym-multisig-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -4724,7 +4724,7 @@ dependencies = [
 [[package]]
 name = "nym-network-defaults"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "dotenvy",
  "log",
@@ -4753,18 +4753,18 @@ dependencies = [
 [[package]]
 name = "nym-node-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
  "celes",
  "humantime 2.1.0",
  "humantime-serde",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-exit-policy 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-exit-policy 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "schemars",
  "serde",
  "serde_json",
@@ -4796,7 +4796,7 @@ dependencies = [
 [[package]]
 name = "nym-nonexhaustive-delayqueue"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -4807,7 +4807,7 @@ dependencies = [
 [[package]]
 name = "nym-ordered-buffer"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "log",
  "thiserror",
@@ -4816,7 +4816,7 @@ dependencies = [
 [[package]]
 name = "nym-outfox"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "blake3",
  "chacha20 0.9.1",
@@ -4834,7 +4834,7 @@ dependencies = [
 [[package]]
 name = "nym-pemstore"
 version = "0.3.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "pem",
 ]
@@ -4850,7 +4850,7 @@ dependencies = [
 [[package]]
 name = "nym-sdk"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4864,15 +4864,15 @@ dependencies = [
  "http 1.1.0",
  "httpcodec",
  "log",
- "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-client-core",
- "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-credential-utils",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-gateway-requests",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-ordered-buffer",
  "nym-service-providers-common",
  "nym-socks5-client-core",
@@ -4880,7 +4880,7 @@ dependencies = [
  "nym-sphinx",
  "nym-task",
  "nym-topology",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "rand 0.8.5",
  "serde",
  "tap",
@@ -4899,7 +4899,7 @@ dependencies = [
 [[package]]
 name = "nym-serde-helpers"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "base64 0.22.1",
  "bs58 0.5.1",
@@ -4910,7 +4910,7 @@ dependencies = [
 [[package]]
 name = "nym-service-provider-requests-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "serde",
 ]
@@ -4918,11 +4918,11 @@ dependencies = [
 [[package]]
 name = "nym-service-providers-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "async-trait",
  "log",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-sphinx-anonymous-replies",
  "serde",
  "serde_json",
@@ -4932,25 +4932,25 @@ dependencies = [
 [[package]]
 name = "nym-socks5-client-core"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "anyhow",
  "dirs",
  "futures",
  "log",
- "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-client-core",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-service-providers-common",
  "nym-socks5-proxy-helpers",
  "nym-socks5-requests",
  "nym-sphinx",
  "nym-task",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "pin-project",
  "rand 0.8.5",
  "reqwest 0.12.4",
@@ -4965,7 +4965,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-proxy-helpers"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "bytes",
  "futures",
@@ -4980,11 +4980,11 @@ dependencies = [
 [[package]]
 name = "nym-socks5-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "bincode",
  "log",
- "nym-exit-policy 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-exit-policy 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-service-providers-common",
  "nym-sphinx-addressing",
  "serde",
@@ -4996,10 +4996,10 @@ dependencies = [
 [[package]]
 name = "nym-sphinx"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "log",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-metrics",
  "nym-sphinx-acknowledgements",
  "nym-sphinx-addressing",
@@ -5010,7 +5010,7 @@ dependencies = [
  "nym-sphinx-framing",
  "nym-sphinx-params",
  "nym-sphinx-routing",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-topology",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -5022,14 +5022,14 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-acknowledgements"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-sphinx-addressing",
  "nym-sphinx-params",
  "nym-sphinx-routing",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-topology",
  "rand 0.8.5",
  "thiserror",
@@ -5039,10 +5039,10 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-addressing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "serde",
  "thiserror",
 ]
@@ -5050,14 +5050,14 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-anonymous-replies"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "bs58 0.5.1",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-sphinx-addressing",
  "nym-sphinx-params",
  "nym-sphinx-routing",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-topology",
  "rand 0.8.5",
  "serde",
@@ -5068,15 +5068,15 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-chunking"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "dashmap",
  "log",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-metrics",
  "nym-sphinx-addressing",
  "nym-sphinx-params",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "rand 0.8.5",
  "serde",
  "thiserror",
@@ -5086,16 +5086,16 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-cover"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-sphinx-acknowledgements",
  "nym-sphinx-addressing",
  "nym-sphinx-chunking",
  "nym-sphinx-forwarding",
  "nym-sphinx-params",
  "nym-sphinx-routing",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-topology",
  "rand 0.8.5",
  "thiserror",
@@ -5104,23 +5104,23 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-forwarding"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "nym-outfox",
  "nym-sphinx-addressing",
  "nym-sphinx-params",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "thiserror",
 ]
 
 [[package]]
 name = "nym-sphinx-framing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "bytes",
  "nym-sphinx-params",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "thiserror",
  "tokio-util",
 ]
@@ -5128,10 +5128,10 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-params"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "serde",
  "thiserror",
 ]
@@ -5139,17 +5139,17 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-routing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "nym-sphinx-addressing",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "thiserror",
 ]
 
 [[package]]
 name = "nym-sphinx-types"
 version = "0.2.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "nym-outfox",
  "sphinx-packet",
@@ -5168,7 +5168,7 @@ dependencies = [
 [[package]]
 name = "nym-task"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "futures",
  "log",
@@ -5182,19 +5182,19 @@ dependencies = [
 [[package]]
 name = "nym-topology"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "async-trait",
  "bs58 0.5.1",
  "log",
- "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-sphinx-addressing",
  "nym-sphinx-routing",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "rand 0.8.5",
  "reqwest 0.12.4",
  "semver 1.0.23",
@@ -5206,7 +5206,7 @@ dependencies = [
 [[package]]
 name = "nym-validator-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5225,19 +5225,19 @@ dependencies = [
  "futures",
  "itertools 0.13.0",
  "log",
- "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-coconut-bandwidth-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-coconut-dkg-common 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-coconut-bandwidth-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-coconut-dkg-common 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-compact-ecash",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-ecash-contract-common",
- "nym-group-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-vesting-contract-common 0.7.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-group-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-vesting-contract-common 0.7.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "prost 0.12.6",
  "reqwest 0.12.4",
  "serde",
@@ -5302,12 +5302,12 @@ dependencies = [
 [[package]]
 name = "nym-vesting-contract-common"
 version = "0.7.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "serde",
  "thiserror",
 ]
@@ -5334,10 +5334,10 @@ dependencies = [
  "bip39",
  "bs58 0.5.1",
  "chrono",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "reqwest 0.11.27",
  "serde",
  "serde_json",
@@ -5359,7 +5359,7 @@ dependencies = [
  "ipnetwork",
  "is_elevated",
  "nix 0.29.0",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-vpn-api-client",
  "nym-vpn-lib",
  "thiserror",
@@ -5392,30 +5392,30 @@ dependencies = [
  "nix 0.29.0",
  "nym-authenticator-client",
  "nym-authenticator-requests",
- "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=3f922cc0)",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-client-core",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-connection-monitor",
  "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=3f922cc0)",
  "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=3f922cc0)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-gateway-directory",
  "nym-id 0.1.0 (git+https://github.com/nymtech/nym?rev=3f922cc0)",
  "nym-ip-packet-client",
  "nym-ip-packet-requests",
- "nym-node-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-node-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-sdk",
  "nym-task",
  "nym-topology",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-vpn-api-client",
  "nym-vpn-store",
  "nym-wg-gateway-client",
  "nym-wg-go",
- "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "oslog",
  "pnet_packet",
  "rand 0.8.5",
@@ -5462,9 +5462,9 @@ name = "nym-vpn-store"
 version = "0.1.0"
 dependencies = [
  "bip39",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "serde",
@@ -5482,7 +5482,7 @@ dependencies = [
  "anyhow",
  "bs58 0.5.1",
  "clap",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-gateway-directory",
  "nym-vpn-proto",
  "parity-tokio-ipc",
@@ -5508,11 +5508,11 @@ dependencies = [
  "futures",
  "http 0.2.12",
  "maplit",
- "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=3f922cc0)",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-task",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-vpn-api-client",
  "nym-vpn-lib",
  "nym-vpn-proto",
@@ -5551,13 +5551,13 @@ version = "0.2.3-dev"
 dependencies = [
  "nym-authenticator-client",
  "nym-authenticator-requests",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-gateway-directory",
- "nym-node-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-node-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-sdk",
- "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "rand 0.8.5",
  "talpid-types",
  "thiserror",
@@ -5582,12 +5582,12 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-types"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "base64 0.22.1",
  "log",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=1627146)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "serde",
  "thiserror",
  "x25519-dalek",
@@ -9422,7 +9422,7 @@ checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 [[package]]
 name = "wasm-utils"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1627146#1627146c0e28f46f2ee51f913443ecb5b513f15b"
+source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
 dependencies = [
  "futures",
  "getrandom 0.2.15",

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -3700,7 +3700,7 @@ dependencies = [
 [[package]]
 name = "nym-api-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "bs58 0.5.1",
  "cosmrs 0.17.0-pre",
@@ -3708,11 +3708,11 @@ dependencies = [
  "ecdsa 0.16.9",
  "getset",
  "nym-compact-ecash",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-ecash-time",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-node-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-node-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-serde-helpers",
  "schemars",
  "serde",
@@ -3730,7 +3730,7 @@ dependencies = [
  "futures",
  "nym-authenticator-requests",
  "nym-sdk",
- "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "serde",
  "thiserror",
  "tokio",
@@ -3741,16 +3741,16 @@ dependencies = [
 [[package]]
 name = "nym-authenticator-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "base64 0.22.1",
  "bincode",
  "hmac",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-service-provider-requests-common",
  "nym-sphinx",
- "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "rand 0.8.5",
  "serde",
  "sha2 0.10.8",
@@ -3781,18 +3781,18 @@ dependencies = [
 [[package]]
 name = "nym-bandwidth-controller"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "bip39",
  "log",
- "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-ecash-contract-common",
  "nym-ecash-time",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "rand 0.8.5",
  "thiserror",
  "url",
@@ -3816,7 +3816,7 @@ dependencies = [
 [[package]]
 name = "nym-bin-common"
 version = "0.6.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "const-str",
  "log",
@@ -3831,7 +3831,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core"
 version = "1.1.15"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3844,28 +3844,28 @@ dependencies = [
  "hyper 1.4.1",
  "hyper-util",
  "log",
- "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-client-core-config-types",
  "nym-client-core-gateways-storage",
  "nym-client-core-surb-storage",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-country-group",
- "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-ecash-time",
  "nym-explorer-client",
  "nym-gateway-client",
  "nym-gateway-requests",
- "nym-id 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-id 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-metrics",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-nonexhaustive-delayqueue",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-sphinx",
  "nym-task",
  "nym-topology",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "serde",
@@ -3890,12 +3890,12 @@ dependencies = [
 [[package]]
 name = "nym-client-core-config-types"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "humantime-serde",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-country-group",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-sphinx-addressing",
  "nym-sphinx-params",
  "serde",
@@ -3906,12 +3906,12 @@ dependencies = [
 [[package]]
 name = "nym-client-core-gateways-storage"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "async-trait",
  "cosmrs 0.17.0-pre",
  "log",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-gateway-requests",
  "serde",
  "sqlx",
@@ -3925,12 +3925,12 @@ dependencies = [
 [[package]]
 name = "nym-client-core-surb-storage"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "async-trait",
  "dashmap",
  "log",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-sphinx",
  "nym-task",
  "sqlx",
@@ -3973,11 +3973,11 @@ dependencies = [
 [[package]]
 name = "nym-coconut-bandwidth-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
 ]
 
 [[package]]
@@ -3997,21 +3997,21 @@ dependencies = [
 [[package]]
 name = "nym-coconut-dkg-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-utils",
  "cw2",
  "cw4",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
 ]
 
 [[package]]
 name = "nym-compact-ecash"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "bincode",
  "bls12_381 0.8.0 (git+https://github.com/jstuczyn/bls12_381?branch=temp/experimental-serdect)",
@@ -4021,8 +4021,8 @@ dependencies = [
  "ff",
  "group",
  "itertools 0.12.1",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "rand 0.8.5",
  "serde",
  "sha2 0.9.9",
@@ -4047,12 +4047,12 @@ dependencies = [
 [[package]]
 name = "nym-config"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "dirs",
  "handlebars",
  "log",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "serde",
  "toml 0.8.19",
  "url",
@@ -4092,7 +4092,7 @@ dependencies = [
 [[package]]
 name = "nym-contracts-common"
 version = "0.5.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "bs58 0.5.1",
  "cosmwasm-schema",
@@ -4107,7 +4107,7 @@ dependencies = [
 [[package]]
 name = "nym-country-group"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "serde",
  "tracing",
@@ -4129,13 +4129,13 @@ dependencies = [
 [[package]]
 name = "nym-credential-storage"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "async-trait",
  "bincode",
  "log",
  "nym-compact-ecash",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-ecash-time",
  "serde",
  "sqlx",
@@ -4147,17 +4147,17 @@ dependencies = [
 [[package]]
 name = "nym-credential-utils"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "log",
- "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-client-core",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-ecash-time",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "thiserror",
  "time",
  "tokio",
@@ -4185,20 +4185,20 @@ dependencies = [
 [[package]]
 name = "nym-credentials"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "bincode",
  "bls12_381 0.8.0 (git+https://github.com/jstuczyn/bls12_381?branch=temp/experimental-serdect)",
  "cosmrs 0.17.0-pre",
  "log",
- "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-ecash-contract-common",
  "nym-ecash-time",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-serde-helpers",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "serde",
  "thiserror",
  "time",
@@ -4219,12 +4219,12 @@ dependencies = [
 [[package]]
 name = "nym-credentials-interface"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "bls12_381 0.8.0 (git+https://github.com/jstuczyn/bls12_381?branch=temp/experimental-serdect)",
  "nym-compact-ecash",
  "nym-ecash-time",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "rand 0.8.5",
  "serde",
  "strum",
@@ -4261,7 +4261,7 @@ dependencies = [
 [[package]]
 name = "nym-crypto"
 version = "0.4.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "aead 0.5.2",
  "aes 0.8.4",
@@ -4275,8 +4275,8 @@ dependencies = [
  "generic-array 0.14.7",
  "hkdf",
  "hmac",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "rand 0.8.5",
  "serde",
  "serde_bytes",
@@ -4311,21 +4311,21 @@ dependencies = [
 [[package]]
 name = "nym-ecash-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "bs58 0.5.1",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-controllers",
  "cw-utils",
- "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "thiserror",
 ]
 
 [[package]]
 name = "nym-ecash-time"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "nym-compact-ecash",
  "time",
@@ -4344,7 +4344,7 @@ dependencies = [
 [[package]]
 name = "nym-exit-policy"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "serde",
  "serde_json",
@@ -4356,11 +4356,11 @@ dependencies = [
 [[package]]
 name = "nym-explorer-api-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
- "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "schemars",
  "serde",
 ]
@@ -4368,7 +4368,7 @@ dependencies = [
 [[package]]
 name = "nym-explorer-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "log",
  "nym-explorer-api-requests",
@@ -4381,21 +4381,21 @@ dependencies = [
 [[package]]
 name = "nym-gateway-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "futures",
  "getrandom 0.2.15",
  "gloo-utils",
- "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-gateway-requests",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-sphinx",
  "nym-task",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "rand 0.8.5",
  "serde",
  "si-scale",
@@ -4424,10 +4424,10 @@ dependencies = [
  "hickory-resolver",
  "itertools 0.13.0",
  "nym-client-core",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-sdk",
  "nym-topology",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-vpn-api-client",
  "rand 0.8.5",
  "serde",
@@ -4456,18 +4456,18 @@ dependencies = [
  "log",
  "nym-authenticator-client",
  "nym-authenticator-requests",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-client-core",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-connection-monitor",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-gateway-directory",
  "nym-ip-packet-client",
  "nym-ip-packet-requests",
  "nym-sdk",
  "nym-task",
  "nym-topology",
- "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "pnet_packet",
  "rand 0.8.5",
  "rust2go",
@@ -4485,15 +4485,15 @@ dependencies = [
 [[package]]
 name = "nym-gateway-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "bs58 0.5.1",
  "futures",
  "generic-array 0.14.7",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-sphinx",
  "nym-task",
  "rand 0.8.5",
@@ -4523,7 +4523,7 @@ dependencies = [
 [[package]]
 name = "nym-group-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "cosmwasm-schema",
  "cw-controllers",
@@ -4537,7 +4537,7 @@ name = "nym-harbour-master-client"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "reqwest 0.11.27",
  "serde",
  "serde_json",
@@ -4565,11 +4565,11 @@ dependencies = [
 [[package]]
 name = "nym-http-api-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "async-trait",
  "http 1.1.0",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "reqwest 0.12.4",
  "serde",
  "serde_json",
@@ -4595,10 +4595,10 @@ dependencies = [
 [[package]]
 name = "nym-id"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
- "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "thiserror",
  "time",
  "tracing",
@@ -4624,12 +4624,12 @@ dependencies = [
 [[package]]
 name = "nym-ip-packet-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "bincode",
  "bytes",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-sphinx",
  "rand 0.8.5",
  "serde",
@@ -4642,7 +4642,7 @@ dependencies = [
 [[package]]
 name = "nym-metrics"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "dashmap",
  "lazy_static",
@@ -4672,7 +4672,7 @@ dependencies = [
 [[package]]
 name = "nym-mixnet-contract-common"
 version = "0.6.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "bs58 0.5.1",
  "cosmwasm-schema",
@@ -4680,7 +4680,7 @@ dependencies = [
  "cw-controllers",
  "humantime-serde",
  "log",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "schemars",
  "serde",
  "serde-json-wasm",
@@ -4708,7 +4708,7 @@ dependencies = [
 [[package]]
 name = "nym-multisig-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -4740,7 +4740,7 @@ dependencies = [
 [[package]]
 name = "nym-network-defaults"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "dotenvy",
  "log",
@@ -4773,18 +4773,18 @@ dependencies = [
 [[package]]
 name = "nym-node-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
  "celes",
  "humantime 2.1.0",
  "humantime-serde",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-exit-policy 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-exit-policy 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "schemars",
  "serde",
  "serde_json",
@@ -4796,7 +4796,7 @@ dependencies = [
 [[package]]
 name = "nym-nonexhaustive-delayqueue"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -4807,7 +4807,7 @@ dependencies = [
 [[package]]
 name = "nym-ordered-buffer"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "log",
  "thiserror",
@@ -4816,7 +4816,7 @@ dependencies = [
 [[package]]
 name = "nym-outfox"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "blake3",
  "chacha20 0.9.1",
@@ -4842,7 +4842,7 @@ dependencies = [
 [[package]]
 name = "nym-pemstore"
 version = "0.3.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "pem",
 ]
@@ -4850,7 +4850,7 @@ dependencies = [
 [[package]]
 name = "nym-sdk"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4864,15 +4864,15 @@ dependencies = [
  "http 1.1.0",
  "httpcodec",
  "log",
- "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-client-core",
- "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-credential-utils",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-gateway-requests",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-ordered-buffer",
  "nym-service-providers-common",
  "nym-socks5-client-core",
@@ -4880,7 +4880,7 @@ dependencies = [
  "nym-sphinx",
  "nym-task",
  "nym-topology",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "rand 0.8.5",
  "serde",
  "tap",
@@ -4899,7 +4899,7 @@ dependencies = [
 [[package]]
 name = "nym-serde-helpers"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "base64 0.22.1",
  "bs58 0.5.1",
@@ -4910,7 +4910,7 @@ dependencies = [
 [[package]]
 name = "nym-service-provider-requests-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "serde",
 ]
@@ -4918,11 +4918,11 @@ dependencies = [
 [[package]]
 name = "nym-service-providers-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "async-trait",
  "log",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-sphinx-anonymous-replies",
  "serde",
  "serde_json",
@@ -4932,25 +4932,25 @@ dependencies = [
 [[package]]
 name = "nym-socks5-client-core"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "anyhow",
  "dirs",
  "futures",
  "log",
- "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-client-core",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-service-providers-common",
  "nym-socks5-proxy-helpers",
  "nym-socks5-requests",
  "nym-sphinx",
  "nym-task",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "pin-project",
  "rand 0.8.5",
  "reqwest 0.12.4",
@@ -4965,7 +4965,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-proxy-helpers"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "bytes",
  "futures",
@@ -4980,11 +4980,11 @@ dependencies = [
 [[package]]
 name = "nym-socks5-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "bincode",
  "log",
- "nym-exit-policy 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-exit-policy 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-service-providers-common",
  "nym-sphinx-addressing",
  "serde",
@@ -4996,10 +4996,10 @@ dependencies = [
 [[package]]
 name = "nym-sphinx"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "log",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-metrics",
  "nym-sphinx-acknowledgements",
  "nym-sphinx-addressing",
@@ -5010,7 +5010,7 @@ dependencies = [
  "nym-sphinx-framing",
  "nym-sphinx-params",
  "nym-sphinx-routing",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-topology",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -5022,14 +5022,14 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-acknowledgements"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-sphinx-addressing",
  "nym-sphinx-params",
  "nym-sphinx-routing",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-topology",
  "rand 0.8.5",
  "thiserror",
@@ -5039,10 +5039,10 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-addressing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "serde",
  "thiserror",
 ]
@@ -5050,14 +5050,14 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-anonymous-replies"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "bs58 0.5.1",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-sphinx-addressing",
  "nym-sphinx-params",
  "nym-sphinx-routing",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-topology",
  "rand 0.8.5",
  "serde",
@@ -5068,15 +5068,15 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-chunking"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "dashmap",
  "log",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-metrics",
  "nym-sphinx-addressing",
  "nym-sphinx-params",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "rand 0.8.5",
  "serde",
  "thiserror",
@@ -5086,16 +5086,16 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-cover"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-sphinx-acknowledgements",
  "nym-sphinx-addressing",
  "nym-sphinx-chunking",
  "nym-sphinx-forwarding",
  "nym-sphinx-params",
  "nym-sphinx-routing",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-topology",
  "rand 0.8.5",
  "thiserror",
@@ -5104,23 +5104,23 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-forwarding"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "nym-outfox",
  "nym-sphinx-addressing",
  "nym-sphinx-params",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "thiserror",
 ]
 
 [[package]]
 name = "nym-sphinx-framing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "bytes",
  "nym-sphinx-params",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "thiserror",
  "tokio-util",
 ]
@@ -5128,10 +5128,10 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-params"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "serde",
  "thiserror",
 ]
@@ -5139,10 +5139,10 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-routing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "nym-sphinx-addressing",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "thiserror",
 ]
 
@@ -5158,7 +5158,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-types"
 version = "0.2.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "nym-outfox",
  "sphinx-packet",
@@ -5168,7 +5168,7 @@ dependencies = [
 [[package]]
 name = "nym-task"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "futures",
  "log",
@@ -5182,19 +5182,19 @@ dependencies = [
 [[package]]
 name = "nym-topology"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "async-trait",
  "bs58 0.5.1",
  "log",
- "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-sphinx-addressing",
  "nym-sphinx-routing",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "rand 0.8.5",
  "reqwest 0.12.4",
  "semver 1.0.23",
@@ -5253,7 +5253,7 @@ dependencies = [
 [[package]]
 name = "nym-validator-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5272,19 +5272,19 @@ dependencies = [
  "futures",
  "itertools 0.13.0",
  "log",
- "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-coconut-bandwidth-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-coconut-dkg-common 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-coconut-bandwidth-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-coconut-dkg-common 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-compact-ecash",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-ecash-contract-common",
- "nym-group-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-vesting-contract-common 0.7.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-group-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-vesting-contract-common 0.7.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "prost 0.12.6",
  "reqwest 0.12.4",
  "serde",
@@ -5315,12 +5315,12 @@ dependencies = [
 [[package]]
 name = "nym-vesting-contract-common"
 version = "0.7.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "serde",
  "thiserror",
 ]
@@ -5334,10 +5334,10 @@ dependencies = [
  "bip39",
  "bs58 0.5.1",
  "chrono",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "reqwest 0.11.27",
  "serde",
  "serde_json",
@@ -5359,7 +5359,7 @@ dependencies = [
  "ipnetwork",
  "is_elevated",
  "nix 0.29.0",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-vpn-api-client",
  "nym-vpn-lib",
  "thiserror",
@@ -5393,29 +5393,29 @@ dependencies = [
  "nym-authenticator-client",
  "nym-authenticator-requests",
  "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=3f922cc0)",
- "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-client-core",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-connection-monitor",
  "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=3f922cc0)",
  "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=3f922cc0)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-gateway-directory",
  "nym-id 0.1.0 (git+https://github.com/nymtech/nym?rev=3f922cc0)",
  "nym-ip-packet-client",
  "nym-ip-packet-requests",
- "nym-node-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-node-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-sdk",
  "nym-task",
  "nym-topology",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-vpn-api-client",
  "nym-vpn-store",
  "nym-wg-gateway-client",
  "nym-wg-go",
- "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "oslog",
  "pnet_packet",
  "rand 0.8.5",
@@ -5462,9 +5462,9 @@ name = "nym-vpn-store"
 version = "0.1.0"
 dependencies = [
  "bip39",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "serde",
@@ -5482,7 +5482,7 @@ dependencies = [
  "anyhow",
  "bs58 0.5.1",
  "clap",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-gateway-directory",
  "nym-vpn-proto",
  "parity-tokio-ipc",
@@ -5509,10 +5509,10 @@ dependencies = [
  "http 0.2.12",
  "maplit",
  "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=3f922cc0)",
- "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-task",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-vpn-api-client",
  "nym-vpn-lib",
  "nym-vpn-proto",
@@ -5551,13 +5551,13 @@ version = "0.2.3-dev"
 dependencies = [
  "nym-authenticator-client",
  "nym-authenticator-requests",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-gateway-directory",
- "nym-node-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-node-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "nym-sdk",
- "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "rand 0.8.5",
  "talpid-types",
  "thiserror",
@@ -5598,12 +5598,12 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-types"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "base64 0.22.1",
  "log",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
  "serde",
  "thiserror",
  "x25519-dalek",
@@ -9422,7 +9422,7 @@ checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 [[package]]
 name = "wasm-utils"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
 dependencies = [
  "futures",
  "getrandom 0.2.15",

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -3700,7 +3700,7 @@ dependencies = [
 [[package]]
 name = "nym-api-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "bs58 0.5.1",
  "cosmrs 0.17.0-pre",
@@ -3708,11 +3708,11 @@ dependencies = [
  "ecdsa 0.16.9",
  "getset",
  "nym-compact-ecash",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-ecash-time",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-node-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-node-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-serde-helpers",
  "schemars",
  "serde",
@@ -3730,7 +3730,7 @@ dependencies = [
  "futures",
  "nym-authenticator-requests",
  "nym-sdk",
- "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "serde",
  "thiserror",
  "tokio",
@@ -3741,16 +3741,16 @@ dependencies = [
 [[package]]
 name = "nym-authenticator-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "base64 0.22.1",
  "bincode",
  "hmac",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-service-provider-requests-common",
  "nym-sphinx",
- "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "rand 0.8.5",
  "serde",
  "sha2 0.10.8",
@@ -3781,18 +3781,18 @@ dependencies = [
 [[package]]
 name = "nym-bandwidth-controller"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "bip39",
  "log",
- "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-ecash-contract-common",
  "nym-ecash-time",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "rand 0.8.5",
  "thiserror",
  "url",
@@ -3816,7 +3816,7 @@ dependencies = [
 [[package]]
 name = "nym-bin-common"
 version = "0.6.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "const-str",
  "log",
@@ -3831,7 +3831,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core"
 version = "1.1.15"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3844,28 +3844,28 @@ dependencies = [
  "hyper 1.4.1",
  "hyper-util",
  "log",
- "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-client-core-config-types",
  "nym-client-core-gateways-storage",
  "nym-client-core-surb-storage",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-country-group",
- "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-ecash-time",
  "nym-explorer-client",
  "nym-gateway-client",
  "nym-gateway-requests",
- "nym-id 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-id 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-metrics",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-nonexhaustive-delayqueue",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-sphinx",
  "nym-task",
  "nym-topology",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "serde",
@@ -3890,12 +3890,12 @@ dependencies = [
 [[package]]
 name = "nym-client-core-config-types"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "humantime-serde",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-country-group",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-sphinx-addressing",
  "nym-sphinx-params",
  "serde",
@@ -3906,12 +3906,12 @@ dependencies = [
 [[package]]
 name = "nym-client-core-gateways-storage"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "async-trait",
  "cosmrs 0.17.0-pre",
  "log",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-gateway-requests",
  "serde",
  "sqlx",
@@ -3925,12 +3925,12 @@ dependencies = [
 [[package]]
 name = "nym-client-core-surb-storage"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "async-trait",
  "dashmap",
  "log",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-sphinx",
  "nym-task",
  "sqlx",
@@ -3973,11 +3973,11 @@ dependencies = [
 [[package]]
 name = "nym-coconut-bandwidth-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
 ]
 
 [[package]]
@@ -3997,21 +3997,21 @@ dependencies = [
 [[package]]
 name = "nym-coconut-dkg-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-utils",
  "cw2",
  "cw4",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
 ]
 
 [[package]]
 name = "nym-compact-ecash"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "bincode",
  "bls12_381 0.8.0 (git+https://github.com/jstuczyn/bls12_381?branch=temp/experimental-serdect)",
@@ -4021,8 +4021,8 @@ dependencies = [
  "ff",
  "group",
  "itertools 0.12.1",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "rand 0.8.5",
  "serde",
  "sha2 0.9.9",
@@ -4047,12 +4047,12 @@ dependencies = [
 [[package]]
 name = "nym-config"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "dirs",
  "handlebars",
  "log",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "serde",
  "toml 0.8.19",
  "url",
@@ -4092,7 +4092,7 @@ dependencies = [
 [[package]]
 name = "nym-contracts-common"
 version = "0.5.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "bs58 0.5.1",
  "cosmwasm-schema",
@@ -4107,7 +4107,7 @@ dependencies = [
 [[package]]
 name = "nym-country-group"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "serde",
  "tracing",
@@ -4129,13 +4129,13 @@ dependencies = [
 [[package]]
 name = "nym-credential-storage"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "async-trait",
  "bincode",
  "log",
  "nym-compact-ecash",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-ecash-time",
  "serde",
  "sqlx",
@@ -4147,17 +4147,17 @@ dependencies = [
 [[package]]
 name = "nym-credential-utils"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "log",
- "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-client-core",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-ecash-time",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "thiserror",
  "time",
  "tokio",
@@ -4185,20 +4185,20 @@ dependencies = [
 [[package]]
 name = "nym-credentials"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "bincode",
  "bls12_381 0.8.0 (git+https://github.com/jstuczyn/bls12_381?branch=temp/experimental-serdect)",
  "cosmrs 0.17.0-pre",
  "log",
- "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-ecash-contract-common",
  "nym-ecash-time",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-serde-helpers",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "serde",
  "thiserror",
  "time",
@@ -4219,12 +4219,12 @@ dependencies = [
 [[package]]
 name = "nym-credentials-interface"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "bls12_381 0.8.0 (git+https://github.com/jstuczyn/bls12_381?branch=temp/experimental-serdect)",
  "nym-compact-ecash",
  "nym-ecash-time",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "rand 0.8.5",
  "serde",
  "strum",
@@ -4261,7 +4261,7 @@ dependencies = [
 [[package]]
 name = "nym-crypto"
 version = "0.4.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "aead 0.5.2",
  "aes 0.8.4",
@@ -4275,8 +4275,8 @@ dependencies = [
  "generic-array 0.14.7",
  "hkdf",
  "hmac",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "rand 0.8.5",
  "serde",
  "serde_bytes",
@@ -4311,21 +4311,21 @@ dependencies = [
 [[package]]
 name = "nym-ecash-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "bs58 0.5.1",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-controllers",
  "cw-utils",
- "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "thiserror",
 ]
 
 [[package]]
 name = "nym-ecash-time"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "nym-compact-ecash",
  "time",
@@ -4344,7 +4344,7 @@ dependencies = [
 [[package]]
 name = "nym-exit-policy"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "serde",
  "serde_json",
@@ -4356,11 +4356,11 @@ dependencies = [
 [[package]]
 name = "nym-explorer-api-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
- "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "schemars",
  "serde",
 ]
@@ -4368,7 +4368,7 @@ dependencies = [
 [[package]]
 name = "nym-explorer-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "log",
  "nym-explorer-api-requests",
@@ -4381,21 +4381,21 @@ dependencies = [
 [[package]]
 name = "nym-gateway-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "futures",
  "getrandom 0.2.15",
  "gloo-utils",
- "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-gateway-requests",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-sphinx",
  "nym-task",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "rand 0.8.5",
  "serde",
  "si-scale",
@@ -4424,10 +4424,10 @@ dependencies = [
  "hickory-resolver",
  "itertools 0.13.0",
  "nym-client-core",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-sdk",
  "nym-topology",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-vpn-api-client",
  "rand 0.8.5",
  "serde",
@@ -4456,18 +4456,18 @@ dependencies = [
  "log",
  "nym-authenticator-client",
  "nym-authenticator-requests",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-client-core",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-connection-monitor",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-gateway-directory",
  "nym-ip-packet-client",
  "nym-ip-packet-requests",
  "nym-sdk",
  "nym-task",
  "nym-topology",
- "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "pnet_packet",
  "rand 0.8.5",
  "rust2go",
@@ -4485,15 +4485,15 @@ dependencies = [
 [[package]]
 name = "nym-gateway-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "bs58 0.5.1",
  "futures",
  "generic-array 0.14.7",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-sphinx",
  "nym-task",
  "rand 0.8.5",
@@ -4523,7 +4523,7 @@ dependencies = [
 [[package]]
 name = "nym-group-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "cosmwasm-schema",
  "cw-controllers",
@@ -4537,7 +4537,7 @@ name = "nym-harbour-master-client"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "reqwest 0.11.27",
  "serde",
  "serde_json",
@@ -4565,11 +4565,11 @@ dependencies = [
 [[package]]
 name = "nym-http-api-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "async-trait",
  "http 1.1.0",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "reqwest 0.12.4",
  "serde",
  "serde_json",
@@ -4595,10 +4595,10 @@ dependencies = [
 [[package]]
 name = "nym-id"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
- "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "thiserror",
  "time",
  "tracing",
@@ -4624,12 +4624,12 @@ dependencies = [
 [[package]]
 name = "nym-ip-packet-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "bincode",
  "bytes",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-sphinx",
  "rand 0.8.5",
  "serde",
@@ -4642,7 +4642,7 @@ dependencies = [
 [[package]]
 name = "nym-metrics"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "dashmap",
  "lazy_static",
@@ -4672,7 +4672,7 @@ dependencies = [
 [[package]]
 name = "nym-mixnet-contract-common"
 version = "0.6.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "bs58 0.5.1",
  "cosmwasm-schema",
@@ -4680,7 +4680,7 @@ dependencies = [
  "cw-controllers",
  "humantime-serde",
  "log",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "schemars",
  "serde",
  "serde-json-wasm",
@@ -4708,7 +4708,7 @@ dependencies = [
 [[package]]
 name = "nym-multisig-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -4740,7 +4740,7 @@ dependencies = [
 [[package]]
 name = "nym-network-defaults"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "dotenvy",
  "log",
@@ -4773,18 +4773,18 @@ dependencies = [
 [[package]]
 name = "nym-node-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
  "celes",
  "humantime 2.1.0",
  "humantime-serde",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-exit-policy 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-exit-policy 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "schemars",
  "serde",
  "serde_json",
@@ -4796,7 +4796,7 @@ dependencies = [
 [[package]]
 name = "nym-nonexhaustive-delayqueue"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -4807,7 +4807,7 @@ dependencies = [
 [[package]]
 name = "nym-ordered-buffer"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "log",
  "thiserror",
@@ -4816,7 +4816,7 @@ dependencies = [
 [[package]]
 name = "nym-outfox"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "blake3",
  "chacha20 0.9.1",
@@ -4842,7 +4842,7 @@ dependencies = [
 [[package]]
 name = "nym-pemstore"
 version = "0.3.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "pem",
 ]
@@ -4850,7 +4850,7 @@ dependencies = [
 [[package]]
 name = "nym-sdk"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4864,15 +4864,15 @@ dependencies = [
  "http 1.1.0",
  "httpcodec",
  "log",
- "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-client-core",
- "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-credential-utils",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-gateway-requests",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-ordered-buffer",
  "nym-service-providers-common",
  "nym-socks5-client-core",
@@ -4880,7 +4880,7 @@ dependencies = [
  "nym-sphinx",
  "nym-task",
  "nym-topology",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "rand 0.8.5",
  "serde",
  "tap",
@@ -4899,7 +4899,7 @@ dependencies = [
 [[package]]
 name = "nym-serde-helpers"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "base64 0.22.1",
  "bs58 0.5.1",
@@ -4910,7 +4910,7 @@ dependencies = [
 [[package]]
 name = "nym-service-provider-requests-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "serde",
 ]
@@ -4918,11 +4918,11 @@ dependencies = [
 [[package]]
 name = "nym-service-providers-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "async-trait",
  "log",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-sphinx-anonymous-replies",
  "serde",
  "serde_json",
@@ -4932,25 +4932,25 @@ dependencies = [
 [[package]]
 name = "nym-socks5-client-core"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "anyhow",
  "dirs",
  "futures",
  "log",
- "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-client-core",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-service-providers-common",
  "nym-socks5-proxy-helpers",
  "nym-socks5-requests",
  "nym-sphinx",
  "nym-task",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "pin-project",
  "rand 0.8.5",
  "reqwest 0.12.4",
@@ -4965,7 +4965,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-proxy-helpers"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "bytes",
  "futures",
@@ -4980,11 +4980,11 @@ dependencies = [
 [[package]]
 name = "nym-socks5-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "bincode",
  "log",
- "nym-exit-policy 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-exit-policy 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-service-providers-common",
  "nym-sphinx-addressing",
  "serde",
@@ -4996,10 +4996,10 @@ dependencies = [
 [[package]]
 name = "nym-sphinx"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "log",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-metrics",
  "nym-sphinx-acknowledgements",
  "nym-sphinx-addressing",
@@ -5010,7 +5010,7 @@ dependencies = [
  "nym-sphinx-framing",
  "nym-sphinx-params",
  "nym-sphinx-routing",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-topology",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -5022,14 +5022,14 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-acknowledgements"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-sphinx-addressing",
  "nym-sphinx-params",
  "nym-sphinx-routing",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-topology",
  "rand 0.8.5",
  "thiserror",
@@ -5039,10 +5039,10 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-addressing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "serde",
  "thiserror",
 ]
@@ -5050,14 +5050,14 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-anonymous-replies"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "bs58 0.5.1",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-sphinx-addressing",
  "nym-sphinx-params",
  "nym-sphinx-routing",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-topology",
  "rand 0.8.5",
  "serde",
@@ -5068,15 +5068,15 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-chunking"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "dashmap",
  "log",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-metrics",
  "nym-sphinx-addressing",
  "nym-sphinx-params",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "rand 0.8.5",
  "serde",
  "thiserror",
@@ -5086,16 +5086,16 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-cover"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-sphinx-acknowledgements",
  "nym-sphinx-addressing",
  "nym-sphinx-chunking",
  "nym-sphinx-forwarding",
  "nym-sphinx-params",
  "nym-sphinx-routing",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-topology",
  "rand 0.8.5",
  "thiserror",
@@ -5104,23 +5104,23 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-forwarding"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "nym-outfox",
  "nym-sphinx-addressing",
  "nym-sphinx-params",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "thiserror",
 ]
 
 [[package]]
 name = "nym-sphinx-framing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "bytes",
  "nym-sphinx-params",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "thiserror",
  "tokio-util",
 ]
@@ -5128,10 +5128,10 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-params"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "serde",
  "thiserror",
 ]
@@ -5139,10 +5139,10 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-routing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "nym-sphinx-addressing",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "thiserror",
 ]
 
@@ -5158,7 +5158,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-types"
 version = "0.2.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "nym-outfox",
  "sphinx-packet",
@@ -5168,7 +5168,7 @@ dependencies = [
 [[package]]
 name = "nym-task"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "futures",
  "log",
@@ -5182,19 +5182,19 @@ dependencies = [
 [[package]]
 name = "nym-topology"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "async-trait",
  "bs58 0.5.1",
  "log",
- "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-sphinx-addressing",
  "nym-sphinx-routing",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "rand 0.8.5",
  "reqwest 0.12.4",
  "semver 1.0.23",
@@ -5253,7 +5253,7 @@ dependencies = [
 [[package]]
 name = "nym-validator-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5272,19 +5272,19 @@ dependencies = [
  "futures",
  "itertools 0.13.0",
  "log",
- "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-coconut-bandwidth-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-coconut-dkg-common 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-coconut-bandwidth-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-coconut-dkg-common 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-compact-ecash",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-ecash-contract-common",
- "nym-group-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-vesting-contract-common 0.7.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-group-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-vesting-contract-common 0.7.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "prost 0.12.6",
  "reqwest 0.12.4",
  "serde",
@@ -5315,12 +5315,12 @@ dependencies = [
 [[package]]
 name = "nym-vesting-contract-common"
 version = "0.7.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "serde",
  "thiserror",
 ]
@@ -5334,10 +5334,10 @@ dependencies = [
  "bip39",
  "bs58 0.5.1",
  "chrono",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "reqwest 0.11.27",
  "serde",
  "serde_json",
@@ -5359,7 +5359,7 @@ dependencies = [
  "ipnetwork",
  "is_elevated",
  "nix 0.29.0",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-vpn-api-client",
  "nym-vpn-lib",
  "thiserror",
@@ -5393,29 +5393,29 @@ dependencies = [
  "nym-authenticator-client",
  "nym-authenticator-requests",
  "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=3f922cc0)",
- "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-client-core",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-connection-monitor",
  "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=3f922cc0)",
  "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=3f922cc0)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-gateway-directory",
  "nym-id 0.1.0 (git+https://github.com/nymtech/nym?rev=3f922cc0)",
  "nym-ip-packet-client",
  "nym-ip-packet-requests",
- "nym-node-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-node-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-sdk",
  "nym-task",
  "nym-topology",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-vpn-api-client",
  "nym-vpn-store",
  "nym-wg-gateway-client",
  "nym-wg-go",
- "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "oslog",
  "pnet_packet",
  "rand 0.8.5",
@@ -5462,9 +5462,9 @@ name = "nym-vpn-store"
 version = "0.1.0"
 dependencies = [
  "bip39",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "serde",
@@ -5482,7 +5482,7 @@ dependencies = [
  "anyhow",
  "bs58 0.5.1",
  "clap",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-gateway-directory",
  "nym-vpn-proto",
  "parity-tokio-ipc",
@@ -5509,10 +5509,10 @@ dependencies = [
  "http 0.2.12",
  "maplit",
  "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=3f922cc0)",
- "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-task",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-vpn-api-client",
  "nym-vpn-lib",
  "nym-vpn-proto",
@@ -5551,13 +5551,13 @@ version = "0.2.3-dev"
 dependencies = [
  "nym-authenticator-client",
  "nym-authenticator-requests",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-gateway-directory",
- "nym-node-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-node-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "nym-sdk",
- "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "rand 0.8.5",
  "talpid-types",
  "thiserror",
@@ -5598,12 +5598,12 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-types"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "base64 0.22.1",
  "log",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=894e0bd)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=fabd48b)",
  "serde",
  "thiserror",
  "x25519-dalek",
@@ -9422,7 +9422,7 @@ checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 [[package]]
 name = "wasm-utils"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=894e0bd#894e0bd1bf58e6bf866e09b40b7aba71b2f84e2e"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "futures",
  "getrandom 0.2.15",

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -3680,32 +3680,6 @@ dependencies = [
 [[package]]
 name = "nym-api-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
-dependencies = [
- "bs58 0.5.1",
- "cosmrs 0.17.0-pre",
- "cosmwasm-std",
- "ecdsa 0.16.9",
- "getset",
- "nym-compact-ecash",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-ecash-time",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-node-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-serde-helpers",
- "schemars",
- "serde",
- "sha2 0.10.8",
- "tendermint 0.37.0",
- "thiserror",
- "time",
- "utoipa",
-]
-
-[[package]]
-name = "nym-api-requests"
-version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?rev=3f922cc0#3f922cc0aee9ce82472aadada2e7445ef7f03ca0"
 dependencies = [
  "bs58 0.5.1",
@@ -3724,13 +3698,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "nym-api-requests"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+dependencies = [
+ "bs58 0.5.1",
+ "cosmrs 0.17.0-pre",
+ "cosmwasm-std",
+ "ecdsa 0.16.9",
+ "getset",
+ "nym-compact-ecash",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-ecash-time",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-node-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-serde-helpers",
+ "schemars",
+ "serde",
+ "sha2 0.10.8",
+ "tendermint 0.37.0",
+ "thiserror",
+ "time",
+ "utoipa",
+]
+
+[[package]]
 name = "nym-authenticator-client"
 version = "0.1.0"
 dependencies = [
  "futures",
  "nym-authenticator-requests",
  "nym-sdk",
- "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "serde",
  "thiserror",
  "tokio",
@@ -3741,42 +3741,21 @@ dependencies = [
 [[package]]
 name = "nym-authenticator-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
  "base64 0.22.1",
  "bincode",
  "hmac",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-service-provider-requests-common",
  "nym-sphinx",
- "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "rand 0.8.5",
  "serde",
  "sha2 0.10.8",
  "thiserror",
  "x25519-dalek",
-]
-
-[[package]]
-name = "nym-bandwidth-controller"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
-dependencies = [
- "bip39",
- "log",
- "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-ecash-contract-common",
- "nym-ecash-time",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "rand 0.8.5",
- "thiserror",
- "url",
- "zeroize",
 ]
 
 [[package]]
@@ -3800,18 +3779,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "nym-bin-common"
-version = "0.6.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+name = "nym-bandwidth-controller"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
- "const-str",
+ "bip39",
  "log",
- "pretty_env_logger",
- "schemars",
- "semver 1.0.23",
- "serde",
- "utoipa",
- "vergen",
+ "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-ecash-contract-common",
+ "nym-ecash-time",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "rand 0.8.5",
+ "thiserror",
+ "url",
+ "zeroize",
 ]
 
 [[package]]
@@ -3829,9 +3814,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "nym-bin-common"
+version = "0.6.0"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+dependencies = [
+ "const-str",
+ "log",
+ "pretty_env_logger",
+ "schemars",
+ "semver 1.0.23",
+ "serde",
+ "utoipa",
+ "vergen",
+]
+
+[[package]]
 name = "nym-client-core"
 version = "1.1.15"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3844,28 +3844,28 @@ dependencies = [
  "hyper 1.4.1",
  "hyper-util",
  "log",
- "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-client-core-config-types",
  "nym-client-core-gateways-storage",
  "nym-client-core-surb-storage",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-country-group",
- "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-ecash-time",
  "nym-explorer-client",
  "nym-gateway-client",
  "nym-gateway-requests",
- "nym-id 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-id 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-metrics",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-nonexhaustive-delayqueue",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-sphinx",
  "nym-task",
  "nym-topology",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "serde",
@@ -3890,12 +3890,12 @@ dependencies = [
 [[package]]
 name = "nym-client-core-config-types"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
  "humantime-serde",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-country-group",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-sphinx-addressing",
  "nym-sphinx-params",
  "serde",
@@ -3906,12 +3906,12 @@ dependencies = [
 [[package]]
 name = "nym-client-core-gateways-storage"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
  "async-trait",
  "cosmrs 0.17.0-pre",
  "log",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-gateway-requests",
  "serde",
  "sqlx",
@@ -3925,12 +3925,12 @@ dependencies = [
 [[package]]
 name = "nym-client-core-surb-storage"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
  "async-trait",
  "dashmap",
  "log",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-sphinx",
  "nym-task",
  "sqlx",
@@ -3963,16 +3963,6 @@ dependencies = [
 [[package]]
 name = "nym-coconut-bandwidth-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
-dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
-]
-
-[[package]]
-name = "nym-coconut-bandwidth-contract-common"
-version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?rev=3f922cc0#3f922cc0aee9ce82472aadada2e7445ef7f03ca0"
 dependencies = [
  "cosmwasm-schema",
@@ -3981,17 +3971,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "nym-coconut-dkg-common"
+name = "nym-coconut-bandwidth-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-utils",
- "cw2",
- "cw4",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
 ]
 
 [[package]]
@@ -4009,9 +3995,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "nym-coconut-dkg-common"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-utils",
+ "cw2",
+ "cw4",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+]
+
+[[package]]
 name = "nym-compact-ecash"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
  "bincode",
  "bls12_381 0.8.0 (git+https://github.com/jstuczyn/bls12_381?branch=temp/experimental-serdect)",
@@ -4021,27 +4021,13 @@ dependencies = [
  "ff",
  "group",
  "itertools 0.12.1",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "rand 0.8.5",
  "serde",
  "sha2 0.9.9",
  "thiserror",
  "zeroize",
-]
-
-[[package]]
-name = "nym-config"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
-dependencies = [
- "dirs",
- "handlebars",
- "log",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "serde",
- "toml 0.8.19",
- "url",
 ]
 
 [[package]]
@@ -4055,6 +4041,20 @@ dependencies = [
  "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=3f922cc0)",
  "serde",
  "toml 0.7.8",
+ "url",
+]
+
+[[package]]
+name = "nym-config"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+dependencies = [
+ "dirs",
+ "handlebars",
+ "log",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "serde",
+ "toml 0.8.19",
  "url",
 ]
 
@@ -4077,7 +4077,7 @@ dependencies = [
 [[package]]
 name = "nym-contracts-common"
 version = "0.5.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=3f922cc0#3f922cc0aee9ce82472aadada2e7445ef7f03ca0"
 dependencies = [
  "bs58 0.5.1",
  "cosmwasm-schema",
@@ -4092,7 +4092,7 @@ dependencies = [
 [[package]]
 name = "nym-contracts-common"
 version = "0.5.0"
-source = "git+https://github.com/nymtech/nym?rev=3f922cc0#3f922cc0aee9ce82472aadada2e7445ef7f03ca0"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
  "bs58 0.5.1",
  "cosmwasm-schema",
@@ -4107,28 +4107,10 @@ dependencies = [
 [[package]]
 name = "nym-country-group"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
  "serde",
  "tracing",
-]
-
-[[package]]
-name = "nym-credential-storage"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
-dependencies = [
- "async-trait",
- "bincode",
- "log",
- "nym-compact-ecash",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-ecash-time",
- "serde",
- "sqlx",
- "thiserror",
- "tokio",
- "zeroize",
 ]
 
 [[package]]
@@ -4145,45 +4127,40 @@ dependencies = [
 ]
 
 [[package]]
-name = "nym-credential-utils"
+name = "nym-credential-storage"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
+ "async-trait",
+ "bincode",
  "log",
- "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-client-core",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-compact-ecash",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-ecash-time",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "serde",
+ "sqlx",
  "thiserror",
- "time",
  "tokio",
+ "zeroize",
 ]
 
 [[package]]
-name = "nym-credentials"
+name = "nym-credential-utils"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
- "bincode",
- "bls12_381 0.8.0 (git+https://github.com/jstuczyn/bls12_381?branch=temp/experimental-serdect)",
- "cosmrs 0.17.0-pre",
  "log",
- "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-ecash-contract-common",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-client-core",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-ecash-time",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-serde-helpers",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "serde",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "thiserror",
  "time",
- "zeroize",
+ "tokio",
 ]
 
 [[package]]
@@ -4206,19 +4183,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "nym-credentials-interface"
+name = "nym-credentials"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
+ "bincode",
  "bls12_381 0.8.0 (git+https://github.com/jstuczyn/bls12_381?branch=temp/experimental-serdect)",
- "nym-compact-ecash",
+ "cosmrs 0.17.0-pre",
+ "log",
+ "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-ecash-contract-common",
  "nym-ecash-time",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "rand 0.8.5",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-serde-helpers",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "serde",
- "strum",
  "thiserror",
  "time",
+ "zeroize",
 ]
 
 [[package]]
@@ -4233,31 +4217,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "nym-crypto"
-version = "0.4.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+name = "nym-credentials-interface"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
- "aead 0.5.2",
- "aes 0.8.4",
- "aes-gcm-siv",
- "blake3",
- "bs58 0.5.1",
- "cipher 0.4.4",
- "ctr 0.9.2",
- "digest 0.10.7",
- "ed25519-dalek",
- "generic-array 0.14.7",
- "hkdf",
- "hmac",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "bls12_381 0.8.0 (git+https://github.com/jstuczyn/bls12_381?branch=temp/experimental-serdect)",
+ "nym-compact-ecash",
+ "nym-ecash-time",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "rand 0.8.5",
  "serde",
- "serde_bytes",
- "subtle-encoding",
+ "strum",
  "thiserror",
- "x25519-dalek",
- "zeroize",
+ "time",
 ]
 
 [[package]]
@@ -4277,6 +4249,34 @@ dependencies = [
  "hmac",
  "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=3f922cc0)",
  "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=3f922cc0)",
+ "rand 0.8.5",
+ "serde",
+ "serde_bytes",
+ "subtle-encoding",
+ "thiserror",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
+name = "nym-crypto"
+version = "0.4.0"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+dependencies = [
+ "aead 0.5.2",
+ "aes 0.8.4",
+ "aes-gcm-siv",
+ "blake3",
+ "bs58 0.5.1",
+ "cipher 0.4.4",
+ "ctr 0.9.2",
+ "digest 0.10.7",
+ "ed25519-dalek",
+ "generic-array 0.14.7",
+ "hkdf",
+ "hmac",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "rand 0.8.5",
  "serde",
  "serde_bytes",
@@ -4311,36 +4311,24 @@ dependencies = [
 [[package]]
 name = "nym-ecash-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
  "bs58 0.5.1",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-controllers",
  "cw-utils",
- "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "thiserror",
 ]
 
 [[package]]
 name = "nym-ecash-time"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
  "nym-compact-ecash",
  "time",
-]
-
-[[package]]
-name = "nym-exit-policy"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
-dependencies = [
- "serde",
- "serde_json",
- "thiserror",
- "tracing",
- "utoipa",
 ]
 
 [[package]]
@@ -4354,13 +4342,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "nym-exit-policy"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+ "utoipa",
+]
+
+[[package]]
 name = "nym-explorer-api-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
- "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "schemars",
  "serde",
 ]
@@ -4368,7 +4368,7 @@ dependencies = [
 [[package]]
 name = "nym-explorer-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
  "log",
  "nym-explorer-api-requests",
@@ -4381,21 +4381,21 @@ dependencies = [
 [[package]]
 name = "nym-gateway-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
  "futures",
  "getrandom 0.2.15",
  "gloo-utils",
- "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-gateway-requests",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-sphinx",
  "nym-task",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "rand 0.8.5",
  "serde",
  "si-scale",
@@ -4424,10 +4424,10 @@ dependencies = [
  "hickory-resolver",
  "itertools 0.13.0",
  "nym-client-core",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-sdk",
  "nym-topology",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-vpn-api-client",
  "rand 0.8.5",
  "serde",
@@ -4456,18 +4456,18 @@ dependencies = [
  "log",
  "nym-authenticator-client",
  "nym-authenticator-requests",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-client-core",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-connection-monitor",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-gateway-directory",
  "nym-ip-packet-client",
  "nym-ip-packet-requests",
  "nym-sdk",
  "nym-task",
  "nym-topology",
- "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "pnet_packet",
  "rand 0.8.5",
  "rust2go",
@@ -4485,15 +4485,15 @@ dependencies = [
 [[package]]
 name = "nym-gateway-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
  "bs58 0.5.1",
  "futures",
  "generic-array 0.14.7",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-sphinx",
  "nym-task",
  "rand 0.8.5",
@@ -4511,7 +4511,7 @@ dependencies = [
 [[package]]
 name = "nym-group-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=3f922cc0#3f922cc0aee9ce82472aadada2e7445ef7f03ca0"
 dependencies = [
  "cosmwasm-schema",
  "cw-controllers",
@@ -4523,7 +4523,7 @@ dependencies = [
 [[package]]
 name = "nym-group-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=3f922cc0#3f922cc0aee9ce82472aadada2e7445ef7f03ca0"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
  "cosmwasm-schema",
  "cw-controllers",
@@ -4537,29 +4537,12 @@ name = "nym-harbour-master-client"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "reqwest 0.11.27",
  "serde",
  "serde_json",
  "thiserror",
  "tracing",
-]
-
-[[package]]
-name = "nym-http-api-client"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
-dependencies = [
- "async-trait",
- "http 1.1.0",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "reqwest 0.12.4",
- "serde",
- "serde_json",
- "thiserror",
- "tracing",
- "url",
- "wasmtimer",
 ]
 
 [[package]]
@@ -4580,16 +4563,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "nym-id"
+name = "nym-http-api-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
- "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "async-trait",
+ "http 1.1.0",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "reqwest 0.12.4",
+ "serde",
+ "serde_json",
  "thiserror",
- "time",
  "tracing",
- "zeroize",
+ "url",
+ "wasmtimer",
 ]
 
 [[package]]
@@ -4599,6 +4586,19 @@ source = "git+https://github.com/nymtech/nym?rev=3f922cc0#3f922cc0aee9ce82472aad
 dependencies = [
  "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=3f922cc0)",
  "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=3f922cc0)",
+ "thiserror",
+ "time",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "nym-id"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+dependencies = [
+ "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "thiserror",
  "time",
  "tracing",
@@ -4624,12 +4624,12 @@ dependencies = [
 [[package]]
 name = "nym-ip-packet-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
  "bincode",
  "bytes",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-sphinx",
  "rand 0.8.5",
  "serde",
@@ -4642,32 +4642,12 @@ dependencies = [
 [[package]]
 name = "nym-metrics"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
  "dashmap",
  "lazy_static",
  "log",
  "prometheus",
-]
-
-[[package]]
-name = "nym-mixnet-contract-common"
-version = "0.6.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
-dependencies = [
- "bs58 0.5.1",
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-controllers",
- "humantime-serde",
- "log",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "schemars",
- "serde",
- "serde-json-wasm",
- "serde_repr",
- "thiserror",
- "time",
 ]
 
 [[package]]
@@ -4690,19 +4670,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "nym-multisig-contract-common"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+name = "nym-mixnet-contract-common"
+version = "0.6.0"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
+ "bs58 0.5.1",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus",
- "cw-utils",
- "cw3",
- "cw4",
+ "cw-controllers",
+ "humantime-serde",
+ "log",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "schemars",
  "serde",
+ "serde-json-wasm",
+ "serde_repr",
  "thiserror",
+ "time",
 ]
 
 [[package]]
@@ -4722,16 +4706,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "nym-network-defaults"
+name = "nym-multisig-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
- "dotenvy",
- "log",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus",
+ "cw-utils",
+ "cw3",
+ "cw4",
  "schemars",
  "serde",
- "url",
- "utoipa",
+ "thiserror",
 ]
 
 [[package]]
@@ -4751,25 +4738,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "nym-node-requests"
+name = "nym-network-defaults"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
- "async-trait",
- "base64 0.22.1",
- "celes",
- "humantime 2.1.0",
- "humantime-serde",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-exit-policy 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "dotenvy",
+ "log",
  "schemars",
  "serde",
- "serde_json",
- "thiserror",
- "time",
+ "url",
  "utoipa",
 ]
 
@@ -4794,9 +4771,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "nym-node-requests"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "celes",
+ "humantime 2.1.0",
+ "humantime-serde",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-exit-policy 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "time",
+ "utoipa",
+]
+
+[[package]]
 name = "nym-nonexhaustive-delayqueue"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -4807,7 +4807,7 @@ dependencies = [
 [[package]]
 name = "nym-ordered-buffer"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
  "log",
  "thiserror",
@@ -4816,7 +4816,7 @@ dependencies = [
 [[package]]
 name = "nym-outfox"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
  "blake3",
  "chacha20 0.9.1",
@@ -4834,7 +4834,7 @@ dependencies = [
 [[package]]
 name = "nym-pemstore"
 version = "0.3.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=3f922cc0#3f922cc0aee9ce82472aadada2e7445ef7f03ca0"
 dependencies = [
  "pem",
 ]
@@ -4842,7 +4842,7 @@ dependencies = [
 [[package]]
 name = "nym-pemstore"
 version = "0.3.0"
-source = "git+https://github.com/nymtech/nym?rev=3f922cc0#3f922cc0aee9ce82472aadada2e7445ef7f03ca0"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
  "pem",
 ]
@@ -4850,7 +4850,7 @@ dependencies = [
 [[package]]
 name = "nym-sdk"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4864,15 +4864,15 @@ dependencies = [
  "http 1.1.0",
  "httpcodec",
  "log",
- "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-client-core",
- "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-credential-utils",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-gateway-requests",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-ordered-buffer",
  "nym-service-providers-common",
  "nym-socks5-client-core",
@@ -4880,7 +4880,7 @@ dependencies = [
  "nym-sphinx",
  "nym-task",
  "nym-topology",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "rand 0.8.5",
  "serde",
  "tap",
@@ -4899,7 +4899,7 @@ dependencies = [
 [[package]]
 name = "nym-serde-helpers"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
  "base64 0.22.1",
  "bs58 0.5.1",
@@ -4910,7 +4910,7 @@ dependencies = [
 [[package]]
 name = "nym-service-provider-requests-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
  "serde",
 ]
@@ -4918,11 +4918,11 @@ dependencies = [
 [[package]]
 name = "nym-service-providers-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
  "async-trait",
  "log",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-sphinx-anonymous-replies",
  "serde",
  "serde_json",
@@ -4932,25 +4932,25 @@ dependencies = [
 [[package]]
 name = "nym-socks5-client-core"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
  "anyhow",
  "dirs",
  "futures",
  "log",
- "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-client-core",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-service-providers-common",
  "nym-socks5-proxy-helpers",
  "nym-socks5-requests",
  "nym-sphinx",
  "nym-task",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "pin-project",
  "rand 0.8.5",
  "reqwest 0.12.4",
@@ -4965,7 +4965,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-proxy-helpers"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
  "bytes",
  "futures",
@@ -4980,11 +4980,11 @@ dependencies = [
 [[package]]
 name = "nym-socks5-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
  "bincode",
  "log",
- "nym-exit-policy 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-exit-policy 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-service-providers-common",
  "nym-sphinx-addressing",
  "serde",
@@ -4996,10 +4996,10 @@ dependencies = [
 [[package]]
 name = "nym-sphinx"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
  "log",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-metrics",
  "nym-sphinx-acknowledgements",
  "nym-sphinx-addressing",
@@ -5010,7 +5010,7 @@ dependencies = [
  "nym-sphinx-framing",
  "nym-sphinx-params",
  "nym-sphinx-routing",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-topology",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -5022,14 +5022,14 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-acknowledgements"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-sphinx-addressing",
  "nym-sphinx-params",
  "nym-sphinx-routing",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-topology",
  "rand 0.8.5",
  "thiserror",
@@ -5039,10 +5039,10 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-addressing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "serde",
  "thiserror",
 ]
@@ -5050,14 +5050,14 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-anonymous-replies"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
  "bs58 0.5.1",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-sphinx-addressing",
  "nym-sphinx-params",
  "nym-sphinx-routing",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-topology",
  "rand 0.8.5",
  "serde",
@@ -5068,15 +5068,15 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-chunking"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
  "dashmap",
  "log",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-metrics",
  "nym-sphinx-addressing",
  "nym-sphinx-params",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "rand 0.8.5",
  "serde",
  "thiserror",
@@ -5086,16 +5086,16 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-cover"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-sphinx-acknowledgements",
  "nym-sphinx-addressing",
  "nym-sphinx-chunking",
  "nym-sphinx-forwarding",
  "nym-sphinx-params",
  "nym-sphinx-routing",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-topology",
  "rand 0.8.5",
  "thiserror",
@@ -5104,23 +5104,23 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-forwarding"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
  "nym-outfox",
  "nym-sphinx-addressing",
  "nym-sphinx-params",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "thiserror",
 ]
 
 [[package]]
 name = "nym-sphinx-framing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
  "bytes",
  "nym-sphinx-params",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "thiserror",
  "tokio-util",
 ]
@@ -5128,10 +5128,10 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-params"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "serde",
  "thiserror",
 ]
@@ -5139,20 +5139,10 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-routing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
  "nym-sphinx-addressing",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "thiserror",
-]
-
-[[package]]
-name = "nym-sphinx-types"
-version = "0.2.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
-dependencies = [
- "nym-outfox",
- "sphinx-packet",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "thiserror",
 ]
 
@@ -5166,9 +5156,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nym-sphinx-types"
+version = "0.2.0"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+dependencies = [
+ "nym-outfox",
+ "sphinx-packet",
+ "thiserror",
+]
+
+[[package]]
 name = "nym-task"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
  "futures",
  "log",
@@ -5182,74 +5182,25 @@ dependencies = [
 [[package]]
 name = "nym-topology"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
  "async-trait",
  "bs58 0.5.1",
  "log",
- "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-sphinx-addressing",
  "nym-sphinx-routing",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "rand 0.8.5",
  "reqwest 0.12.4",
  "semver 1.0.23",
  "serde",
  "serde_json",
  "thiserror",
-]
-
-[[package]]
-name = "nym-validator-client"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
-dependencies = [
- "async-trait",
- "base64 0.22.1",
- "bip32",
- "bip39",
- "colored",
- "cosmrs 0.17.0-pre",
- "cosmwasm-std",
- "cw-controllers",
- "cw-utils",
- "cw2",
- "cw3",
- "cw4",
- "eyre",
- "flate2",
- "futures",
- "itertools 0.13.0",
- "log",
- "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-coconut-bandwidth-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-coconut-dkg-common 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-compact-ecash",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-ecash-contract-common",
- "nym-group-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-vesting-contract-common 0.7.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "prost 0.12.6",
- "reqwest 0.12.4",
- "serde",
- "serde_json",
- "sha2 0.9.9",
- "tendermint-rpc 0.37.0",
- "thiserror",
- "time",
- "tokio",
- "url",
- "wasmtimer",
- "zeroize",
 ]
 
 [[package]]
@@ -5300,16 +5251,52 @@ dependencies = [
 ]
 
 [[package]]
-name = "nym-vesting-contract-common"
-version = "0.7.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+name = "nym-validator-client"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
- "cosmwasm-schema",
+ "async-trait",
+ "base64 0.22.1",
+ "bip32",
+ "bip39",
+ "colored",
+ "cosmrs 0.17.0-pre",
  "cosmwasm-std",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "cw-controllers",
+ "cw-utils",
+ "cw2",
+ "cw3",
+ "cw4",
+ "eyre",
+ "flate2",
+ "futures",
+ "itertools 0.13.0",
+ "log",
+ "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-coconut-bandwidth-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-coconut-dkg-common 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-compact-ecash",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-ecash-contract-common",
+ "nym-group-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-vesting-contract-common 0.7.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "prost 0.12.6",
+ "reqwest 0.12.4",
  "serde",
+ "serde_json",
+ "sha2 0.9.9",
+ "tendermint-rpc 0.37.0",
  "thiserror",
+ "time",
+ "tokio",
+ "url",
+ "wasmtimer",
+ "zeroize",
 ]
 
 [[package]]
@@ -5326,6 +5313,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nym-vesting-contract-common"
+version = "0.7.0"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "nym-vpn-api-client"
 version = "0.1.0"
 dependencies = [
@@ -5334,10 +5334,10 @@ dependencies = [
  "bip39",
  "bs58 0.5.1",
  "chrono",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "reqwest 0.11.27",
  "serde",
  "serde_json",
@@ -5359,7 +5359,7 @@ dependencies = [
  "ipnetwork",
  "is_elevated",
  "nix 0.29.0",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-vpn-api-client",
  "nym-vpn-lib",
  "thiserror",
@@ -5392,30 +5392,30 @@ dependencies = [
  "nix 0.29.0",
  "nym-authenticator-client",
  "nym-authenticator-requests",
- "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=3f922cc0)",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-client-core",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-connection-monitor",
  "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?rev=3f922cc0)",
  "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?rev=3f922cc0)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-gateway-directory",
  "nym-id 0.1.0 (git+https://github.com/nymtech/nym?rev=3f922cc0)",
  "nym-ip-packet-client",
  "nym-ip-packet-requests",
- "nym-node-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-node-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-sdk",
  "nym-task",
  "nym-topology",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-vpn-api-client",
  "nym-vpn-store",
  "nym-wg-gateway-client",
  "nym-wg-go",
- "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "oslog",
  "pnet_packet",
  "rand 0.8.5",
@@ -5462,9 +5462,9 @@ name = "nym-vpn-store"
 version = "0.1.0"
 dependencies = [
  "bip39",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "serde",
@@ -5482,7 +5482,7 @@ dependencies = [
  "anyhow",
  "bs58 0.5.1",
  "clap",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-gateway-directory",
  "nym-vpn-proto",
  "parity-tokio-ipc",
@@ -5508,11 +5508,11 @@ dependencies = [
  "futures",
  "http 0.2.12",
  "maplit",
- "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
  "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=3f922cc0)",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-task",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-vpn-api-client",
  "nym-vpn-lib",
  "nym-vpn-proto",
@@ -5551,13 +5551,13 @@ version = "0.2.3-dev"
 dependencies = [
  "nym-authenticator-client",
  "nym-authenticator-requests",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-gateway-directory",
- "nym-node-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-node-requests 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "nym-sdk",
- "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
+ "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "rand 0.8.5",
  "talpid-types",
  "thiserror",
@@ -5582,20 +5582,6 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-types"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
-dependencies = [
- "base64 0.22.1",
- "log",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d)",
- "serde",
- "thiserror",
- "x25519-dalek",
-]
-
-[[package]]
-name = "nym-wireguard-types"
-version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?rev=3f922cc0#3f922cc0aee9ce82472aadada2e7445ef7f03ca0"
 dependencies = [
  "base64 0.21.7",
@@ -5604,6 +5590,20 @@ dependencies = [
  "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=3f922cc0)",
  "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?rev=3f922cc0)",
  "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=3f922cc0)",
+ "serde",
+ "thiserror",
+ "x25519-dalek",
+]
+
+[[package]]
+name = "nym-wireguard-types"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e)",
  "serde",
  "thiserror",
  "x25519-dalek",
@@ -9422,7 +9422,7 @@ checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 [[package]]
 name = "wasm-utils"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=1f8dc3fca1834f00269ce561a6f34d9413b9b79d#1f8dc3fca1834f00269ce561a6f34d9413b9b79d"
+source = "git+https://github.com/nymtech/nym?rev=c6545d8c13f46de3e815206f63a702b1c6b9a95e#c6545d8c13f46de3e815206f63a702b1c6b9a95e"
 dependencies = [
  "futures",
  "getrandom 0.2.15",

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -116,23 +116,23 @@ talpid-tunnel = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev =
 talpid-types = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "95fb001fb" }
 talpid-wireguard = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "95fb001fb" }
 
-nym-authenticator-requests = { git = "https://github.com/nymtech/nym", rev = "c6545d8c13f46de3e815206f63a702b1c6b9a95e" }
-nym-bandwidth-controller = { git = "https://github.com/nymtech/nym", rev = "c6545d8c13f46de3e815206f63a702b1c6b9a95e" }
-nym-bin-common = { git = "https://github.com/nymtech/nym", rev = "c6545d8c13f46de3e815206f63a702b1c6b9a95e" }
-nym-client-core = { git = "https://github.com/nymtech/nym", rev = "c6545d8c13f46de3e815206f63a702b1c6b9a95e" }
-nym-config = { git = "https://github.com/nymtech/nym", rev = "c6545d8c13f46de3e815206f63a702b1c6b9a95e" }
-nym-contracts-common = { git = "https://github.com/nymtech/nym", rev = "c6545d8c13f46de3e815206f63a702b1c6b9a95e" }
-nym-credentials-interface = { git = "https://github.com/nymtech/nym", rev = "c6545d8c13f46de3e815206f63a702b1c6b9a95e" }
-nym-crypto = { git = "https://github.com/nymtech/nym", rev = "c6545d8c13f46de3e815206f63a702b1c6b9a95e" }
-nym-http-api-client = { git = "https://github.com/nymtech/nym", rev = "c6545d8c13f46de3e815206f63a702b1c6b9a95e" }
-nym-ip-packet-requests = { git = "https://github.com/nymtech/nym", rev = "c6545d8c13f46de3e815206f63a702b1c6b9a95e" }
-nym-node-requests = { git = "https://github.com/nymtech/nym", rev = "c6545d8c13f46de3e815206f63a702b1c6b9a95e" }
-nym-pemstore = { git = "https://github.com/nymtech/nym", rev = "c6545d8c13f46de3e815206f63a702b1c6b9a95e" }
-nym-sdk = { git = "https://github.com/nymtech/nym", rev = "c6545d8c13f46de3e815206f63a702b1c6b9a95e" }
-nym-task = { git = "https://github.com/nymtech/nym", rev = "c6545d8c13f46de3e815206f63a702b1c6b9a95e" }
-nym-topology = { git = "https://github.com/nymtech/nym", rev = "c6545d8c13f46de3e815206f63a702b1c6b9a95e" }
-nym-validator-client = { git = "https://github.com/nymtech/nym", rev = "c6545d8c13f46de3e815206f63a702b1c6b9a95e" }
-nym-wireguard-types = { git = "https://github.com/nymtech/nym", rev = "c6545d8c13f46de3e815206f63a702b1c6b9a95e" }
+nym-authenticator-requests = { git = "https://github.com/nymtech/nym", rev = "894e0bd" }
+nym-bandwidth-controller = { git = "https://github.com/nymtech/nym", rev = "894e0bd" }
+nym-bin-common = { git = "https://github.com/nymtech/nym", rev = "894e0bd" }
+nym-client-core = { git = "https://github.com/nymtech/nym", rev = "894e0bd" }
+nym-config = { git = "https://github.com/nymtech/nym", rev = "894e0bd" }
+nym-contracts-common = { git = "https://github.com/nymtech/nym", rev = "894e0bd" }
+nym-credentials-interface = { git = "https://github.com/nymtech/nym", rev = "894e0bd" }
+nym-crypto = { git = "https://github.com/nymtech/nym", rev = "894e0bd" }
+nym-http-api-client = { git = "https://github.com/nymtech/nym", rev = "894e0bd" }
+nym-ip-packet-requests = { git = "https://github.com/nymtech/nym", rev = "894e0bd" }
+nym-node-requests = { git = "https://github.com/nymtech/nym", rev = "894e0bd" }
+nym-pemstore = { git = "https://github.com/nymtech/nym", rev = "894e0bd" }
+nym-sdk = { git = "https://github.com/nymtech/nym", rev = "894e0bd" }
+nym-task = { git = "https://github.com/nymtech/nym", rev = "894e0bd" }
+nym-topology = { git = "https://github.com/nymtech/nym", rev = "894e0bd" }
+nym-validator-client = { git = "https://github.com/nymtech/nym", rev = "894e0bd" }
+nym-wireguard-types = { git = "https://github.com/nymtech/nym", rev = "894e0bd" }
 
 # Pointing to before ecash was merged, for backwards compatibility and migration period
 

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -116,23 +116,23 @@ talpid-tunnel = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev =
 talpid-types = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "95fb001fb" }
 talpid-wireguard = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "95fb001fb" }
 
-nym-authenticator-requests = { git = "https://github.com/nymtech/nym", rev = "1627146" }
-nym-bandwidth-controller = { git = "https://github.com/nymtech/nym", rev = "1627146" }
-nym-bin-common = { git = "https://github.com/nymtech/nym", rev = "1627146" }
-nym-client-core = { git = "https://github.com/nymtech/nym", rev = "1627146" }
-nym-config = { git = "https://github.com/nymtech/nym", rev = "1627146" }
-nym-contracts-common = { git = "https://github.com/nymtech/nym", rev = "1627146" }
-nym-credentials-interface = { git = "https://github.com/nymtech/nym", rev = "1627146" }
-nym-crypto = { git = "https://github.com/nymtech/nym", rev = "1627146" }
-nym-http-api-client = { git = "https://github.com/nymtech/nym", rev = "1627146" }
-nym-ip-packet-requests = { git = "https://github.com/nymtech/nym", rev = "1627146" }
-nym-node-requests = { git = "https://github.com/nymtech/nym", rev = "1627146" }
-nym-pemstore = { git = "https://github.com/nymtech/nym", rev = "1627146" }
-nym-sdk = { git = "https://github.com/nymtech/nym", rev = "1627146" }
-nym-task = { git = "https://github.com/nymtech/nym", rev = "1627146" }
-nym-topology = { git = "https://github.com/nymtech/nym", rev = "1627146" }
-nym-validator-client = { git = "https://github.com/nymtech/nym", rev = "1627146" }
-nym-wireguard-types = { git = "https://github.com/nymtech/nym", rev = "1627146" }
+nym-authenticator-requests = { git = "https://github.com/nymtech/nym", rev = "1f8dc3fca1834f00269ce561a6f34d9413b9b79d" }
+nym-bandwidth-controller = { git = "https://github.com/nymtech/nym", rev = "1f8dc3fca1834f00269ce561a6f34d9413b9b79d" }
+nym-bin-common = { git = "https://github.com/nymtech/nym", rev = "1f8dc3fca1834f00269ce561a6f34d9413b9b79d" }
+nym-client-core = { git = "https://github.com/nymtech/nym", rev = "1f8dc3fca1834f00269ce561a6f34d9413b9b79d" }
+nym-config = { git = "https://github.com/nymtech/nym", rev = "1f8dc3fca1834f00269ce561a6f34d9413b9b79d" }
+nym-contracts-common = { git = "https://github.com/nymtech/nym", rev = "1f8dc3fca1834f00269ce561a6f34d9413b9b79d" }
+nym-credentials-interface = { git = "https://github.com/nymtech/nym", rev = "1f8dc3fca1834f00269ce561a6f34d9413b9b79d" }
+nym-crypto = { git = "https://github.com/nymtech/nym", rev = "1f8dc3fca1834f00269ce561a6f34d9413b9b79d" }
+nym-http-api-client = { git = "https://github.com/nymtech/nym", rev = "1f8dc3fca1834f00269ce561a6f34d9413b9b79d" }
+nym-ip-packet-requests = { git = "https://github.com/nymtech/nym", rev = "1f8dc3fca1834f00269ce561a6f34d9413b9b79d" }
+nym-node-requests = { git = "https://github.com/nymtech/nym", rev = "1f8dc3fca1834f00269ce561a6f34d9413b9b79d" }
+nym-pemstore = { git = "https://github.com/nymtech/nym", rev = "1f8dc3fca1834f00269ce561a6f34d9413b9b79d" }
+nym-sdk = { git = "https://github.com/nymtech/nym", rev = "1f8dc3fca1834f00269ce561a6f34d9413b9b79d" }
+nym-task = { git = "https://github.com/nymtech/nym", rev = "1f8dc3fca1834f00269ce561a6f34d9413b9b79d" }
+nym-topology = { git = "https://github.com/nymtech/nym", rev = "1f8dc3fca1834f00269ce561a6f34d9413b9b79d" }
+nym-validator-client = { git = "https://github.com/nymtech/nym", rev = "1f8dc3fca1834f00269ce561a6f34d9413b9b79d" }
+nym-wireguard-types = { git = "https://github.com/nymtech/nym", rev = "1f8dc3fca1834f00269ce561a6f34d9413b9b79d" }
 
 # Pointing to before ecash was merged, for backwards compatibility and migration period
 

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -116,23 +116,23 @@ talpid-tunnel = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev =
 talpid-types = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "95fb001fb" }
 talpid-wireguard = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "95fb001fb" }
 
-nym-authenticator-requests = { git = "https://github.com/nymtech/nym", rev = "894e0bd" }
-nym-bandwidth-controller = { git = "https://github.com/nymtech/nym", rev = "894e0bd" }
-nym-bin-common = { git = "https://github.com/nymtech/nym", rev = "894e0bd" }
-nym-client-core = { git = "https://github.com/nymtech/nym", rev = "894e0bd" }
-nym-config = { git = "https://github.com/nymtech/nym", rev = "894e0bd" }
-nym-contracts-common = { git = "https://github.com/nymtech/nym", rev = "894e0bd" }
-nym-credentials-interface = { git = "https://github.com/nymtech/nym", rev = "894e0bd" }
-nym-crypto = { git = "https://github.com/nymtech/nym", rev = "894e0bd" }
-nym-http-api-client = { git = "https://github.com/nymtech/nym", rev = "894e0bd" }
-nym-ip-packet-requests = { git = "https://github.com/nymtech/nym", rev = "894e0bd" }
-nym-node-requests = { git = "https://github.com/nymtech/nym", rev = "894e0bd" }
-nym-pemstore = { git = "https://github.com/nymtech/nym", rev = "894e0bd" }
-nym-sdk = { git = "https://github.com/nymtech/nym", rev = "894e0bd" }
-nym-task = { git = "https://github.com/nymtech/nym", rev = "894e0bd" }
-nym-topology = { git = "https://github.com/nymtech/nym", rev = "894e0bd" }
-nym-validator-client = { git = "https://github.com/nymtech/nym", rev = "894e0bd" }
-nym-wireguard-types = { git = "https://github.com/nymtech/nym", rev = "894e0bd" }
+nym-authenticator-requests = { git = "https://github.com/nymtech/nym", rev = "fabd48b" }
+nym-bandwidth-controller = { git = "https://github.com/nymtech/nym", rev = "fabd48b" }
+nym-bin-common = { git = "https://github.com/nymtech/nym", rev = "fabd48b" }
+nym-client-core = { git = "https://github.com/nymtech/nym", rev = "fabd48b" }
+nym-config = { git = "https://github.com/nymtech/nym", rev = "fabd48b" }
+nym-contracts-common = { git = "https://github.com/nymtech/nym", rev = "fabd48b" }
+nym-credentials-interface = { git = "https://github.com/nymtech/nym", rev = "fabd48b" }
+nym-crypto = { git = "https://github.com/nymtech/nym", rev = "fabd48b" }
+nym-http-api-client = { git = "https://github.com/nymtech/nym", rev = "fabd48b" }
+nym-ip-packet-requests = { git = "https://github.com/nymtech/nym", rev = "fabd48b" }
+nym-node-requests = { git = "https://github.com/nymtech/nym", rev = "fabd48b" }
+nym-pemstore = { git = "https://github.com/nymtech/nym", rev = "fabd48b" }
+nym-sdk = { git = "https://github.com/nymtech/nym", rev = "fabd48b" }
+nym-task = { git = "https://github.com/nymtech/nym", rev = "fabd48b" }
+nym-topology = { git = "https://github.com/nymtech/nym", rev = "fabd48b" }
+nym-validator-client = { git = "https://github.com/nymtech/nym", rev = "fabd48b" }
+nym-wireguard-types = { git = "https://github.com/nymtech/nym", rev = "fabd48b" }
 
 # Pointing to before ecash was merged, for backwards compatibility and migration period
 

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -116,23 +116,23 @@ talpid-tunnel = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev =
 talpid-types = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "95fb001fb" }
 talpid-wireguard = { git = "https://github.com/nymtech/nym-vpn-mullvad-libs", rev = "95fb001fb" }
 
-nym-authenticator-requests = { git = "https://github.com/nymtech/nym", rev = "1f8dc3fca1834f00269ce561a6f34d9413b9b79d" }
-nym-bandwidth-controller = { git = "https://github.com/nymtech/nym", rev = "1f8dc3fca1834f00269ce561a6f34d9413b9b79d" }
-nym-bin-common = { git = "https://github.com/nymtech/nym", rev = "1f8dc3fca1834f00269ce561a6f34d9413b9b79d" }
-nym-client-core = { git = "https://github.com/nymtech/nym", rev = "1f8dc3fca1834f00269ce561a6f34d9413b9b79d" }
-nym-config = { git = "https://github.com/nymtech/nym", rev = "1f8dc3fca1834f00269ce561a6f34d9413b9b79d" }
-nym-contracts-common = { git = "https://github.com/nymtech/nym", rev = "1f8dc3fca1834f00269ce561a6f34d9413b9b79d" }
-nym-credentials-interface = { git = "https://github.com/nymtech/nym", rev = "1f8dc3fca1834f00269ce561a6f34d9413b9b79d" }
-nym-crypto = { git = "https://github.com/nymtech/nym", rev = "1f8dc3fca1834f00269ce561a6f34d9413b9b79d" }
-nym-http-api-client = { git = "https://github.com/nymtech/nym", rev = "1f8dc3fca1834f00269ce561a6f34d9413b9b79d" }
-nym-ip-packet-requests = { git = "https://github.com/nymtech/nym", rev = "1f8dc3fca1834f00269ce561a6f34d9413b9b79d" }
-nym-node-requests = { git = "https://github.com/nymtech/nym", rev = "1f8dc3fca1834f00269ce561a6f34d9413b9b79d" }
-nym-pemstore = { git = "https://github.com/nymtech/nym", rev = "1f8dc3fca1834f00269ce561a6f34d9413b9b79d" }
-nym-sdk = { git = "https://github.com/nymtech/nym", rev = "1f8dc3fca1834f00269ce561a6f34d9413b9b79d" }
-nym-task = { git = "https://github.com/nymtech/nym", rev = "1f8dc3fca1834f00269ce561a6f34d9413b9b79d" }
-nym-topology = { git = "https://github.com/nymtech/nym", rev = "1f8dc3fca1834f00269ce561a6f34d9413b9b79d" }
-nym-validator-client = { git = "https://github.com/nymtech/nym", rev = "1f8dc3fca1834f00269ce561a6f34d9413b9b79d" }
-nym-wireguard-types = { git = "https://github.com/nymtech/nym", rev = "1f8dc3fca1834f00269ce561a6f34d9413b9b79d" }
+nym-authenticator-requests = { git = "https://github.com/nymtech/nym", rev = "c6545d8c13f46de3e815206f63a702b1c6b9a95e" }
+nym-bandwidth-controller = { git = "https://github.com/nymtech/nym", rev = "c6545d8c13f46de3e815206f63a702b1c6b9a95e" }
+nym-bin-common = { git = "https://github.com/nymtech/nym", rev = "c6545d8c13f46de3e815206f63a702b1c6b9a95e" }
+nym-client-core = { git = "https://github.com/nymtech/nym", rev = "c6545d8c13f46de3e815206f63a702b1c6b9a95e" }
+nym-config = { git = "https://github.com/nymtech/nym", rev = "c6545d8c13f46de3e815206f63a702b1c6b9a95e" }
+nym-contracts-common = { git = "https://github.com/nymtech/nym", rev = "c6545d8c13f46de3e815206f63a702b1c6b9a95e" }
+nym-credentials-interface = { git = "https://github.com/nymtech/nym", rev = "c6545d8c13f46de3e815206f63a702b1c6b9a95e" }
+nym-crypto = { git = "https://github.com/nymtech/nym", rev = "c6545d8c13f46de3e815206f63a702b1c6b9a95e" }
+nym-http-api-client = { git = "https://github.com/nymtech/nym", rev = "c6545d8c13f46de3e815206f63a702b1c6b9a95e" }
+nym-ip-packet-requests = { git = "https://github.com/nymtech/nym", rev = "c6545d8c13f46de3e815206f63a702b1c6b9a95e" }
+nym-node-requests = { git = "https://github.com/nymtech/nym", rev = "c6545d8c13f46de3e815206f63a702b1c6b9a95e" }
+nym-pemstore = { git = "https://github.com/nymtech/nym", rev = "c6545d8c13f46de3e815206f63a702b1c6b9a95e" }
+nym-sdk = { git = "https://github.com/nymtech/nym", rev = "c6545d8c13f46de3e815206f63a702b1c6b9a95e" }
+nym-task = { git = "https://github.com/nymtech/nym", rev = "c6545d8c13f46de3e815206f63a702b1c6b9a95e" }
+nym-topology = { git = "https://github.com/nymtech/nym", rev = "c6545d8c13f46de3e815206f63a702b1c6b9a95e" }
+nym-validator-client = { git = "https://github.com/nymtech/nym", rev = "c6545d8c13f46de3e815206f63a702b1c6b9a95e" }
+nym-wireguard-types = { git = "https://github.com/nymtech/nym", rev = "c6545d8c13f46de3e815206f63a702b1c6b9a95e" }
 
 # Pointing to before ecash was merged, for backwards compatibility and migration period
 

--- a/nym-vpn-core/crates/nym-authenticator-client/src/lib.rs
+++ b/nym-vpn-core/crates/nym-authenticator-client/src/lib.rs
@@ -1,9 +1,11 @@
 use std::{cmp::Ordering, sync::Arc, time::Duration};
 
+use nym_authenticator_requests::latest::VERSION as LATEST_VERSION;
 use nym_authenticator_requests::v1::{
     registration::InitMessage, request::AuthenticatorRequest, response::AuthenticatorResponse,
-    GatewayClient,
+    GatewayClient, VERSION as USED_VERSION,
 };
+
 use nym_sdk::mixnet::{
     MixnetClient, MixnetClientSender, MixnetMessageSender, Recipient, ReconstructedMessage,
     TransmissionLane,
@@ -16,7 +18,11 @@ mod error;
 
 pub use crate::error::{Error, Result};
 
-const USED_VERSION: u8 = 1;
+// We shouldn't get too much behind the latest version, or else it will be difficult
+// to support smooth version transitions. Right now, we support one unit of version
+// discrepancy between client and gateway, to account for the time a version moves
+// through the envs (qa, sandbox, mainnet).
+const _: () = assert!(USED_VERSION == LATEST_VERSION || USED_VERSION + 1 == LATEST_VERSION);
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(tag = "type", rename_all = "camelCase")]

--- a/nym-vpn-core/crates/nym-authenticator-client/src/lib.rs
+++ b/nym-vpn-core/crates/nym-authenticator-client/src/lib.rs
@@ -189,7 +189,7 @@ impl AuthClient {
                             let version = check_auth_message_version(&msg)?;
 
                             // Then we deserialize the message
-                            debug!("AuthClient: got message while waiting for connect response");
+                            debug!("AuthClient: got message while waiting for connect response with version {version}");
                             let ret = if version == USED_VERSION + 1 {
                                 nym_authenticator_requests::latest::response::AuthenticatorResponse::from_reconstructed_message(&msg).map(Into::into)
                             } else {
@@ -236,7 +236,7 @@ fn check_auth_message_version(message: &ReconstructedMessage) -> Result<u8> {
                         received: *version,
                     })
                 } else {
-                    Ok(*version + 1)
+                    Ok(*version)
                 }
             }
             Ordering::Less => Err(Error::ReceivedResponseWithOldVersion {


### PR DESCRIPTION
As gateways might get updated at different paces on different envs (qa, sandbox, mainnet), we should support at least two consecutive versions on the client side of the authenticator.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1213)
<!-- Reviewable:end -->
