### PR TITLE
feat(tauri-app): add user agent

### DIFF
--- a/nym-vpn-app/src-tauri/Cargo.lock
+++ b/nym-vpn-app/src-tauri/Cargo.lock
@@ -2995,21 +2995,21 @@ dependencies = [
 [[package]]
 name = "nym-config"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=b7baff1#b7baff1a79d19ff8729531b1b8b10510b68cd8ca"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "dirs",
  "handlebars",
  "log",
  "nym-network-defaults",
  "serde",
- "toml 0.7.8",
+ "toml 0.8.19",
  "url",
 ]
 
 [[package]]
 name = "nym-network-defaults"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?rev=b7baff1#b7baff1a79d19ff8729531b1b8b10510b68cd8ca"
+source = "git+https://github.com/nymtech/nym?rev=fabd48b#fabd48b7ea564df952abe058db93025a80a27f36"
 dependencies = [
  "dotenvy",
  "log",

--- a/nym-vpn-app/src-tauri/src/cli.rs
+++ b/nym-vpn-app/src-tauri/src/cli.rs
@@ -10,11 +10,6 @@ use tracing::{error, info};
 
 pub type ManagedCli = Arc<Cli>;
 
-// generate `crate::build_info` function that returns the data
-// collected during build time
-// see https://github.com/danielschemmel/build-info
-build_info::build_info!(fn build_info);
-
 #[derive(Parser, Serialize, Deserialize, Debug, Clone)]
 #[command(author, version, about, long_about = None)]
 pub struct Cli {
@@ -123,7 +118,7 @@ pub fn db_command(db: &Db, command: &DbCommands) -> Result<()> {
 }
 
 pub fn print_build_info(package_info: &PackageInfo) {
-    let info = build_info();
+    let info = crate::build_info();
 
     print!(
         r"app name:      {}

--- a/nym-vpn-app/src-tauri/src/db.rs
+++ b/nym-vpn-app/src-tauri/src/db.rs
@@ -113,9 +113,9 @@ impl Db {
             }
         })?;
         if db.was_recovered() {
-            info!("sled db recovered");
+            info!("using existing db at {}", &path.display());
         } else {
-            info!("new sled db created");
+            info!("new db created at {}", &path.display());
         }
         Ok(Self { db, path })
     }

--- a/nym-vpn-app/src-tauri/src/grpc/client.rs
+++ b/nym-vpn-app/src-tauri/src/grpc/client.rs
@@ -80,7 +80,7 @@ impl GrpcClient {
             user_agent: UserAgent {
                 application: pkg.name.clone(),
                 version: pkg.version.to_string(),
-                platform: format!("{}-{}", OS, ARCH),
+                platform: format!("{}-{}-{}", OS, tauri_plugin_os::version(), ARCH),
                 git_commit,
             },
         };

--- a/nym-vpn-app/src-tauri/src/grpc/client.rs
+++ b/nym-vpn-app/src-tauri/src/grpc/client.rs
@@ -80,7 +80,7 @@ impl GrpcClient {
             user_agent: UserAgent {
                 application: pkg.name.clone(),
                 version: pkg.version.to_string(),
-                platform: format!("{}-{}-{}", OS, tauri_plugin_os::version(), ARCH),
+                platform: format!("{}; {}; {}", OS, tauri_plugin_os::version(), ARCH),
                 git_commit,
             },
         };

--- a/nym-vpn-app/src-tauri/src/grpc/client.rs
+++ b/nym-vpn-app/src-tauri/src/grpc/client.rs
@@ -1,3 +1,4 @@
+use std::env::consts::OS;
 use std::path::PathBuf;
 
 use anyhow::{anyhow, Result};
@@ -7,11 +8,11 @@ use nym_vpn_proto::{
     nym_vpnd_client::NymVpndClient, ConnectRequest, ConnectionStatus, DisconnectRequest, Dns,
     Empty, EntryNode, ExitNode, GatewayType, HealthCheckRequest, ImportUserCredentialRequest,
     ImportUserCredentialResponse, InfoRequest, InfoResponse, ListCountriesRequest, Location,
-    StatusRequest, StatusResponse,
+    StatusRequest, StatusResponse, UserAgent,
 };
 use parity_tokio_ipc::Endpoint as IpcEndpoint;
 use serde::{Deserialize, Serialize};
-use tauri::{AppHandle, Manager};
+use tauri::{AppHandle, Manager, PackageInfo};
 use thiserror::Error;
 use time::OffsetDateTime;
 use tokio::sync::mpsc;
@@ -59,13 +60,31 @@ pub enum VpndError {
 }
 
 #[derive(Debug, Default, Clone)]
-pub struct GrpcClient(Transport);
+pub struct GrpcClient {
+    transport: Transport,
+    user_agent: UserAgent,
+}
 
 impl GrpcClient {
     #[instrument(skip_all)]
-    pub fn new(config: &AppConfig, cli: &Cli) -> Self {
-        let client = GrpcClient(Transport::from((config, cli)));
-        match &client.0 {
+    pub fn new(config: &AppConfig, cli: &Cli, pkg: &PackageInfo) -> Self {
+        let git_commit = crate::build_info()
+            .version_control
+            .as_ref()
+            .and_then(|vc| vc.git())
+            .map(|g| g.commit_short_id.clone())
+            .unwrap_or_default();
+
+        let client = GrpcClient {
+            transport: Transport::from((config, cli)),
+            user_agent: UserAgent {
+                application: pkg.name.clone(),
+                version: pkg.version.to_string(),
+                platform: OS.to_string(),
+                git_commit,
+            },
+        };
+        match &client.transport {
             Transport::Http(endpoint) => {
                 info!("using grpc HTTP transport: {}", endpoint);
             }
@@ -79,7 +98,7 @@ impl GrpcClient {
     /// Get the Vpnd service client
     #[instrument(skip_all)]
     pub async fn vpnd(&self) -> Result<NymVpndClient<Channel>, VpndError> {
-        match &self.0 {
+        match &self.transport {
             Transport::Http(endpoint) => {
                 NymVpndClient::connect(endpoint.clone()).await.map_err(|e| {
                     warn!("failed to connect to the daemon: {}", e);
@@ -99,7 +118,7 @@ impl GrpcClient {
     /// Get the Health service client
     #[instrument(skip_all)]
     pub async fn health(&self) -> Result<HealthClient<Channel>, VpndError> {
-        match &self.0 {
+        match &self.transport {
             Transport::Http(endpoint) => {
                 HealthClient::connect(endpoint.clone()).await.map_err(|e| {
                     warn!("failed to connect to the daemon: {}", e);
@@ -306,7 +325,7 @@ impl GrpcClient {
             disable_background_cover_traffic: false,
             enable_credentials_mode: false,
             dns,
-            user_agent: None,
+            user_agent: Some(self.user_agent.clone()),
             min_mixnode_performance: None,
             min_gateway_mixnet_performance: None,
             min_gateway_vpn_performance: None,
@@ -363,7 +382,7 @@ impl GrpcClient {
 
         let request = Request::new(ListCountriesRequest {
             kind: gw_type as i32,
-            user_agent: None,
+            user_agent: Some(self.user_agent.clone()),
             min_mixnet_performance: None,
             min_vpn_performance: None,
         });

--- a/nym-vpn-app/src-tauri/src/grpc/client.rs
+++ b/nym-vpn-app/src-tauri/src/grpc/client.rs
@@ -1,4 +1,4 @@
-use std::env::consts::OS;
+use std::env::consts::{ARCH, OS};
 use std::path::PathBuf;
 
 use anyhow::{anyhow, Result};
@@ -80,7 +80,7 @@ impl GrpcClient {
             user_agent: UserAgent {
                 application: pkg.name.clone(),
                 version: pkg.version.to_string(),
-                platform: OS.to_string(),
+                platform: format!("{}-{}", OS, ARCH),
                 git_commit,
             },
         };

--- a/nym-vpn-app/src-tauri/src/main.rs
+++ b/nym-vpn-app/src-tauri/src/main.rs
@@ -59,6 +59,9 @@ const APP_CONFIG_FILE: &str = "config.toml";
 const ENV_APP_NOSPLASH: &str = "APP_NOSPLASH";
 const VPND_RETRY_INTERVAL: Duration = Duration::from_secs(2);
 
+// build time pkg data
+build_info::build_info!(fn build_info);
+
 #[tokio::main]
 async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
@@ -135,7 +138,7 @@ async fn main() -> Result<()> {
 
     let app_state = AppState::new(&db, &app_config, &cli);
 
-    let grpc = GrpcClient::new(&app_config, &cli);
+    let grpc = GrpcClient::new(&app_config, &cli, context.package_info());
 
     info!("Starting tauri app");
     tauri::Builder::default()


### PR DESCRIPTION
Set the `user_agent` info for the relevant grpc calls

NOTE: since proto3 `optional` label is still prohibited in the codebase (for bad reasons imo) user_agent's git hash will default to empty string if there is no available hash (very unlikely)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1236)
<!-- Reviewable:end -->
