### PR TITLE
APPLE: update macOS log file path to avoid data access alert

### DIFF
--- a/nym-vpn-apple/Services/Sources/Services/NymLogger/LogFileManager.swift
+++ b/nym-vpn-apple/Services/Sources/Services/NymLogger/LogFileManager.swift
@@ -24,14 +24,21 @@ public final class LogFileManager: ObservableObject {
 
     public func logFileURL(logFileType: LogFileType) -> URL? {
         let fileManager = FileManager.default
-        let logsDirectory = fileManager
+        var logsDirectory: URL?
+        #if os(macOS)
+        logsDirectory = try? fileManager
+            .url(for: .libraryDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+        #else
+        logsDirectory = fileManager
             .containerURL(
                 forSecurityApplicationGroupIdentifier: Constants.groupID.rawValue
-            )?
+            )
+        #endif
+
+        guard var logsDirectory else { return nil }
+        logsDirectory = logsDirectory
             .appendingPathComponent("net.nymtech.vpn")
             .appendingPathComponent("Logs")
-
-        guard let logsDirectory else { return nil }
 
         try? fileManager.createDirectory(at: logsDirectory, withIntermediateDirectories: true, attributes: nil)
         let fileName = "\(logFileType.rawValue)\(Constants.logFileName.rawValue)"


### PR DESCRIPTION
We can't use `~/Library/Containers` for macOS as that triggers the alert in screenshot below:

<img width="372" alt="Screenshot 2024-10-06 at 07 25 42" src="https://github.com/user-attachments/assets/493c2ae2-089c-48e7-a51d-a3ea2c3df98b">

Update log url for macOS to not trigger the alert.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1247)
<!-- Reviewable:end -->
