### PR TITLE
feat(tauri): add tauri single instance plugin

### DIFF
--- a/nym-vpn-app/src-tauri/Cargo.lock
+++ b/nym-vpn-app/src-tauri/Cargo.lock
@@ -3197,6 +3197,7 @@ dependencies = [
  "tauri-plugin-os",
  "tauri-plugin-process",
  "tauri-plugin-shell",
+ "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "thiserror",
  "time",
@@ -5415,6 +5416,21 @@ dependencies = [
  "tauri-plugin",
  "thiserror",
  "tokio",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a25ac834491d089699a2bc9266a662faf373c9f779f05a2235bc6e4d9e61769a"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror",
+ "windows-sys 0.59.0",
+ "zbus",
 ]
 
 [[package]]

--- a/nym-vpn-app/src-tauri/Cargo.toml
+++ b/nym-vpn-app/src-tauri/Cargo.toml
@@ -58,6 +58,7 @@ tauri-plugin-dialog = "2.0.1"
 tauri-plugin-process = "2.0.1"
 tauri-plugin-clipboard-manager = "2.0.1"
 tauri-plugin-updater = "2.0.1"
+tauri-plugin-single-instance = "2.0.1"
 
 [target."cfg(windows)".dependencies]
 windows = { version = "0.58.0", features = [

--- a/nym-vpn-app/src-tauri/src/cli.rs
+++ b/nym-vpn-app/src-tauri/src/cli.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::path::PathBuf;
 use std::str::FromStr;
+use strum::IntoEnumIterator;
 use tauri::PackageInfo;
 use tracing::{error, info};
 
@@ -91,6 +92,8 @@ pub enum Commands {
 
 #[derive(Subcommand, Serialize, Deserialize, Debug, Clone)]
 pub enum DbCommands {
+    /// List all keys
+    Keys,
     /// Get a key
     Get {
         #[arg()]
@@ -117,6 +120,13 @@ pub fn db_command(command: &DbCommands) -> Result<()> {
     })?;
 
     match command {
+        DbCommands::Keys => {
+            info!("cli db keys");
+            Key::iter().for_each(|key| {
+                println!("{key}");
+            });
+            Ok(())
+        }
         DbCommands::Get { key: k } => {
             info!("cli db get {k}");
             let key = Key::from_str(k).map_err(|_| anyhow!("invalid key"))?;

--- a/nym-vpn-app/src-tauri/src/cli.rs
+++ b/nym-vpn-app/src-tauri/src/cli.rs
@@ -122,9 +122,9 @@ pub fn db_command(command: &DbCommands) -> Result<()> {
     match command {
         DbCommands::Keys => {
             info!("cli db keys");
-            Key::iter().for_each(|key| {
+            for key in Key::iter() {
                 println!("{key}");
-            });
+            }
             Ok(())
         }
         DbCommands::Get { key: k } => {

--- a/nym-vpn-app/src-tauri/src/db.rs
+++ b/nym-vpn-app/src-tauri/src/db.rs
@@ -8,7 +8,7 @@ use std::{
     io,
     path::PathBuf,
 };
-use strum::{AsRefStr, EnumString};
+use strum::{AsRefStr, EnumIter, EnumString};
 use thiserror::Error;
 use tracing::{debug, error, info, instrument, warn};
 use ts_rs::TS;
@@ -20,7 +20,7 @@ const DB_DIR: &str = "db";
 pub type JsonValue = Value;
 
 #[allow(dead_code)]
-#[derive(Deserialize, Serialize, AsRefStr, EnumString, Debug, Clone, Copy, TS)]
+#[derive(Deserialize, Serialize, AsRefStr, EnumString, EnumIter, Debug, Clone, Copy, TS)]
 #[ts(export)]
 pub enum Key {
     #[strum(serialize = "monitoring")]

--- a/nym-vpn-app/src-tauri/src/main.rs
+++ b/nym-vpn-app/src-tauri/src/main.rs
@@ -94,6 +94,10 @@ async fn main() -> Result<()> {
     info!("app version: {}", pkg_info.version);
     info!("Starting tauri app");
     tauri::Builder::default()
+        .plugin(tauri_plugin_single_instance::init(|app, _, _| {
+            info!("an app instance is already running, focusing main window");
+            window::focus_main_window(app)
+        }))
         .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_dialog::init())


### PR DESCRIPTION
Add tauri [single-instance](https://v2.tauri.app/plugin/single-instance/) plugin to prevent launching multiple app instances -> if an instance is already running focus it (bringing the window ontop if needed)

#### misc

add `NymVPN db keys` cli cmd to list all keys of the embedded db

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1276)
<!-- Reviewable:end -->
