### PR TITLE
release nym-vpn-app v0.2.3

### DIFF
--- a/.pkg/linux/install
+++ b/.pkg/linux/install
@@ -35,8 +35,8 @@ BI="$ITL$BLD"
 ####
 
 # nym-vpn-app AppImage
-app_tag=nym-vpn-app-v0.2.2
-app_version=0.2.2
+app_tag=nym-vpn-app-v0.2.3
+app_version=0.2.3
 appimage_url="https://github.com/nymtech/nym-vpn-client/releases/download/$app_tag/nym-vpn_${app_version}_x64.AppImage"
 
 # nym-vpnd prebuilt binary

--- a/nym-vpn-app/package-lock.json
+++ b/nym-vpn-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nym-vpn-app",
-  "version": "0.2.3-dev",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nym-vpn-app",
-      "version": "0.2.3-dev",
+      "version": "0.2.3",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@headlessui/react": "^2.1.2",

--- a/nym-vpn-app/package-lock.json
+++ b/nym-vpn-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nym-vpn-app",
-  "version": "0.2.3",
+  "version": "0.2.4-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nym-vpn-app",
-      "version": "0.2.3",
+      "version": "0.2.4-dev",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@headlessui/react": "^2.1.2",

--- a/nym-vpn-app/package.json
+++ b/nym-vpn-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nym-vpn-app",
   "private": true,
-  "version": "0.2.3-dev",
+  "version": "0.2.3",
   "type": "module",
   "authors": [
     "pierre <dommerc.pierre@gmail.com>",

--- a/nym-vpn-app/package.json
+++ b/nym-vpn-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nym-vpn-app",
   "private": true,
-  "version": "0.2.3",
+  "version": "0.2.4-dev",
   "type": "module",
   "authors": [
     "pierre <dommerc.pierre@gmail.com>",

--- a/nym-vpn-app/src-tauri/Cargo.lock
+++ b/nym-vpn-app/src-tauri/Cargo.lock
@@ -3170,7 +3170,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-app"
-version = "0.2.3-dev"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "bs58",

--- a/nym-vpn-app/src-tauri/Cargo.lock
+++ b/nym-vpn-app/src-tauri/Cargo.lock
@@ -3170,7 +3170,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-app"
-version = "0.2.3"
+version = "0.2.4-dev"
 dependencies = [
  "anyhow",
  "bs58",

--- a/nym-vpn-app/src-tauri/Cargo.toml
+++ b/nym-vpn-app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nym-vpn-app"
-version = "0.2.3"
+version = "0.2.4-dev"
 description = "NymVPN desktop client"
 authors = [
     "Nym Technologies SA",

--- a/nym-vpn-app/src-tauri/Cargo.toml
+++ b/nym-vpn-app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nym-vpn-app"
-version = "0.2.3-dev"
+version = "0.2.3"
 description = "NymVPN desktop client"
 authors = [
     "Nym Technologies SA",


### PR DESCRIPTION
rust ci checks are expected to fail due to the recent breaking changes (nymtech/nym-vpn-client/pull/1282) introduced in the proto

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1288)
<!-- Reviewable:end -->
