### PR TITLE
Request zk-nym in account controller

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -4671,6 +4671,7 @@ dependencies = [
  "nym-http-api-client",
  "nym-vpn-api-client",
  "nym-vpn-store",
+ "reqwest 0.11.27",
  "thiserror",
  "tokio",
  "tokio-util",

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -4664,7 +4664,10 @@ dependencies = [
 name = "nym-vpn-account-controller"
 version = "0.2.5-dev"
 dependencies = [
+ "nym-compact-ecash",
  "nym-config",
+ "nym-credentials-interface",
+ "nym-ecash-time",
  "nym-http-api-client",
  "nym-vpn-api-client",
  "nym-vpn-store",
@@ -4684,8 +4687,11 @@ dependencies = [
  "bip39",
  "bs58",
  "chrono",
+ "nym-compact-ecash",
  "nym-contracts-common",
+ "nym-credentials-interface",
  "nym-crypto",
+ "nym-ecash-time",
  "nym-http-api-client",
  "nym-validator-client",
  "reqwest 0.11.27",

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -125,11 +125,13 @@ nym-authenticator-requests = { git = "https://github.com/nymtech/nym", rev = "e7
 nym-bandwidth-controller = { git = "https://github.com/nymtech/nym", rev = "e78040f0ecfc795691a800c72831bd7ba7a02b9c" }
 nym-bin-common = { git = "https://github.com/nymtech/nym", rev = "e78040f0ecfc795691a800c72831bd7ba7a02b9c" }
 nym-client-core = { git = "https://github.com/nymtech/nym", rev = "e78040f0ecfc795691a800c72831bd7ba7a02b9c" }
+nym-compact-ecash = { git = "https://github.com/nymtech/nym", rev = "e78040f0ecfc795691a800c72831bd7ba7a02b9c" }
 nym-config = { git = "https://github.com/nymtech/nym", rev = "e78040f0ecfc795691a800c72831bd7ba7a02b9c" }
 nym-contracts-common = { git = "https://github.com/nymtech/nym", rev = "e78040f0ecfc795691a800c72831bd7ba7a02b9c" }
 nym-credentials-interface = { git = "https://github.com/nymtech/nym", rev = "e78040f0ecfc795691a800c72831bd7ba7a02b9c" }
 nym-credential-storage = { git = "https://github.com/nymtech/nym", rev = "e78040f0ecfc795691a800c72831bd7ba7a02b9c" }
 nym-crypto = { git = "https://github.com/nymtech/nym", rev = "e78040f0ecfc795691a800c72831bd7ba7a02b9c" }
+nym-ecash-time = { git = "https://github.com/nymtech/nym", rev = "e78040f0ecfc795691a800c72831bd7ba7a02b9c" }
 nym-http-api-client = { git = "https://github.com/nymtech/nym", rev = "e78040f0ecfc795691a800c72831bd7ba7a02b9c" }
 nym-ip-packet-requests = { git = "https://github.com/nymtech/nym", rev = "e78040f0ecfc795691a800c72831bd7ba7a02b9c" }
 nym-node-requests = { git = "https://github.com/nymtech/nym", rev = "e78040f0ecfc795691a800c72831bd7ba7a02b9c" }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/Cargo.toml
@@ -9,7 +9,10 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+nym-compact-ecash.workspace = true
 nym-config.workspace = true
+nym-credentials-interface.workspace = true
+nym-ecash-time.workspace = true
 nym-http-api-client.workspace = true
 nym-vpn-api-client = { path = "../nym-vpn-api-client" }
 nym-vpn-store = { path = "../nym-vpn-store" }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/Cargo.toml
@@ -16,6 +16,7 @@ nym-ecash-time.workspace = true
 nym-http-api-client.workspace = true
 nym-vpn-api-client = { path = "../nym-vpn-api-client" }
 nym-vpn-store = { path = "../nym-vpn-store" }
+reqwest.workspace = true
 thiserror.workspace = true
 tokio-util.workspace = true
 tokio.workspace = true

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
@@ -270,7 +270,7 @@ where
             .await
             .map_err(Error::GetDevices)?;
 
-        tracing::info!("Registered devices: {:?}", devices);
+        tracing::info!("Registered devices: {:#?}", devices);
 
         // TODO: pagination
         let found_device = devices.items.iter().find(|device| {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
@@ -195,7 +195,7 @@ where
 
         // TODO: pagination
         for zknym in zknym.items {
-            tracing::info!("zk-nym: {:?}", zknym);
+            tracing::info!("zk-nym: {:#?}", zknym);
 
             let _blinded_shares = match zknym.status {
                 NymVpnZkNymStatus::Active => zknym.blinded_shares,

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
@@ -184,6 +184,9 @@ where
     async fn get_device_zk_nym(&self) -> Result<(), Error> {
         tracing::info!("Getting device zk-nym");
 
+        // Current pending zk-nym requests
+        tracing::info!("Pending zk-nym requests: {:#?}", self.pending_zk_nym);
+
         let account = self.load_account().await?;
         let device = self.load_device_keys().await?;
 

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/error.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/error.rs
@@ -1,14 +1,49 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use tokio::sync::mpsc::error::SendError;
+
+use crate::AccountCommand;
+
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("failed to get account summary")]
-    GetAccountSummary,
+    GetAccountSummary(#[source] nym_vpn_api_client::VpnApiClientError),
 
     #[error("missing API URL")]
     MissingApiUrl,
 
     #[error("invalid API URL")]
     InvalidApiUrl,
+
+    #[error("mnemonic store error")]
+    MnemonicStore {
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    #[error("key store error")]
+    KeyStore {
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    #[error("failed to register device")]
+    RegisterDevice(#[source] nym_vpn_api_client::VpnApiClientError),
+
+    #[error("failed to get devices")]
+    GetDevices(#[source] nym_vpn_api_client::VpnApiClientError),
+
+    #[error("failed to send account controller command")]
+    AccountCommandSend {
+        #[from]
+        source: SendError<AccountCommand>,
+    },
+
+    #[error("failed to construct withdrawal request")]
+    ConstructWithdrawalRequest(#[source] nym_compact_ecash::CompactEcashError),
+
+    #[error("failed to send get zk-nyms request")]
+    GetZkNyms(#[source] nym_vpn_api_client::VpnApiClientError),
+
+    #[error("failed to send request zk-nym request")]
+    RequestZkNym(#[source] nym_vpn_api_client::VpnApiClientError),
 }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/shared_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/shared_state.rs
@@ -40,23 +40,27 @@ impl SharedAccountState {
     }
 
     pub(crate) async fn set_mnemonic(&self, state: MnemonicState) {
+        let mut guard = self.inner.lock().await;
         tracing::info!("Setting mnemonic state to {:?}", state);
-        self.inner.lock().await.mnemonic = Some(state);
+        guard.mnemonic = Some(state);
     }
 
     pub(crate) async fn set_account(&self, state: RemoteAccountState) {
+        let mut guard = self.inner.lock().await;
         tracing::info!("Setting account state to {:?}", state);
-        self.inner.lock().await.account = Some(state);
+        guard.account = Some(state);
     }
 
     pub(crate) async fn set_subscription(&self, state: SubscriptionState) {
+        let mut guard = self.inner.lock().await;
         tracing::info!("Setting subscription state to {:?}", state);
-        self.inner.lock().await.subscription = Some(state);
+        guard.subscription = Some(state);
     }
 
     pub(crate) async fn set_device(&self, state: DeviceState) {
+        let mut guard = self.inner.lock().await;
         tracing::info!("Setting device state to {:?}", state);
-        self.inner.lock().await.device = Some(state);
+        guard.device = Some(state);
     }
 }
 

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/shared_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/shared_state.rs
@@ -32,6 +32,13 @@ impl SharedAccountState {
             && state.device == Some(DeviceState::Active)
     }
 
+    pub(crate) async fn is_ready_to_register_device(&self) -> bool {
+        let state = self.get().await;
+        state.mnemonic == Some(MnemonicState::Stored)
+            && state.account == Some(RemoteAccountState::Active)
+            && state.device == Some(DeviceState::NotRegistered)
+    }
+
     pub(crate) async fn set_mnemonic(&self, state: MnemonicState) {
         tracing::info!("Setting mnemonic state to {:?}", state);
         self.inner.lock().await.mnemonic = Some(state);

--- a/nym-vpn-core/crates/nym-vpn-api-client/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-api-client/Cargo.toml
@@ -14,8 +14,11 @@ base64-url.workspace = true
 bip39 = { workspace = true, features = ["zeroize"] }
 bs58.workspace = true
 chrono.workspace = true
+nym-compact-ecash.workspace = true
 nym-contracts-common.workspace = true
+nym-credentials-interface.workspace = true
 nym-crypto = { workspace = true, features = ["asymmetric"] }
+nym-ecash-time.workspace = true
 nym-http-api-client.workspace = true
 nym-validator-client.workspace = true
 reqwest = { workspace = true, features = ["rustls-tls", "json"] }

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
@@ -262,13 +262,15 @@ impl VpnApiClient {
         &self,
         account: &VpnApiAccount,
         device: &Device,
+        withdrawal_request: String,
+        ecash_pubkey: String,
+        ticketbook_type: String,
     ) -> Result<NymVpnZkNym> {
         let body = RequestZkNymRequestBody {
-            withdrawal_request: "todo!".to_string(),
-            ecash_pubkey: "todo!".to_string(),
-            ticketbook_type: "todo!".to_string(),
+            withdrawal_request,
+            ecash_pubkey,
+            ticketbook_type,
         };
-
         self.post_authorized(
             &[
                 routes::PUBLIC,

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
@@ -61,7 +61,10 @@ impl VpnApiClient {
             .bearer_auth(account.jwt().to_string());
 
         let request = match device {
-            Some(device) => request.header(DEVICE_AUTHORIZATION_HEADER, device.jwt().to_string()),
+            Some(device) => request.header(
+                DEVICE_AUTHORIZATION_HEADER,
+                format!("Bearer {}", device.jwt()),
+            ),
             None => request,
         };
 
@@ -109,7 +112,10 @@ impl VpnApiClient {
             .bearer_auth(account.jwt().to_string());
 
         let request = match device {
-            Some(device) => request.header(DEVICE_AUTHORIZATION_HEADER, device.jwt().to_string()),
+            Some(device) => request.header(
+                DEVICE_AUTHORIZATION_HEADER,
+                format!("Bearer {}", device.jwt()),
+            ),
             None => request,
         };
 

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
@@ -125,10 +125,10 @@ pub struct NymVpnZkNym {
     pub valid_from_utc: String,
     pub issued_bandwidth_in_gb: f64,
     pub blinded_shares: Vec<String>,
-    pub status: String,
+    pub status: NymVpnZkNymStatus,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum NymVpnZkNymStatus {
     Pending,

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/types/device.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/types/device.rs
@@ -3,6 +3,7 @@
 
 use std::{fmt, sync::Arc};
 
+use nym_compact_ecash::scheme::keygen::KeyPairUser;
 use nym_crypto::asymmetric::ed25519;
 use sha2::Digest as _;
 
@@ -33,6 +34,10 @@ impl Device {
 
     pub fn sign_identity_key(&self) -> DeviceSignature {
         self.sign(self.identity_key().to_base58_string())
+    }
+
+    pub fn create_ecash_keypair(&self) -> KeyPairUser {
+        KeyPairUser::new_seeded(self.keypair.private_key().to_bytes())
     }
 }
 

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/connection_handler.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/connection_handler.rs
@@ -4,7 +4,7 @@
 use nym_vpn_api_client::{
     response::{
         NymVpnAccountSummaryResponse, NymVpnDevice, NymVpnDevicesResponse, NymVpnSubscription,
-        NymVpnSubscriptionsResponse, NymVpnZkNymResponse,
+        NymVpnSubscriptionsResponse,
     },
     types::GatewayMinPerformance,
 };
@@ -234,7 +234,7 @@ impl CommandInterfaceConnectionHandler {
 
     pub(crate) async fn handle_get_device_zk_nyms(
         &self,
-    ) -> Result<Result<NymVpnZkNymResponse, AccountError>, VpnCommandSendError> {
+    ) -> Result<Result<(), AccountError>, VpnCommandSendError> {
         self.vpn_command_send(VpnServiceCommand::GetDeviceZkNyms)
             .await
     }

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/connection_handler.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/connection_handler.rs
@@ -4,7 +4,7 @@
 use nym_vpn_api_client::{
     response::{
         NymVpnAccountSummaryResponse, NymVpnDevice, NymVpnDevicesResponse, NymVpnSubscription,
-        NymVpnSubscriptionsResponse, NymVpnZkNym, NymVpnZkNymResponse,
+        NymVpnSubscriptionsResponse, NymVpnZkNymResponse,
     },
     types::GatewayMinPerformance,
 };
@@ -228,7 +228,7 @@ impl CommandInterfaceConnectionHandler {
 
     pub(crate) async fn handle_request_zk_nym(
         &self,
-    ) -> Result<Result<NymVpnZkNym, AccountError>, VpnCommandSendError> {
+    ) -> Result<Result<(), AccountError>, VpnCommandSendError> {
         self.vpn_command_send(VpnServiceCommand::RequestZkNym).await
     }
 

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
@@ -107,9 +107,8 @@ impl Drop for CommandInterface {
 impl NymVpnd for CommandInterface {
     async fn info(
         &self,
-        request: tonic::Request<InfoRequest>,
+        _request: tonic::Request<InfoRequest>,
     ) -> Result<tonic::Response<InfoResponse>, tonic::Status> {
-        info!("Got info request: {:?}", request);
 
         let info = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
             .handle_info()
@@ -176,10 +175,8 @@ impl NymVpnd for CommandInterface {
 
     async fn vpn_disconnect(
         &self,
-        request: tonic::Request<DisconnectRequest>,
+        _request: tonic::Request<DisconnectRequest>,
     ) -> Result<tonic::Response<DisconnectResponse>, tonic::Status> {
-        info!("Got disconnect request: {:?}", request);
-
         let status = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
             .handle_disconnect()
             .await;
@@ -195,8 +192,6 @@ impl NymVpnd for CommandInterface {
         &self,
         request: tonic::Request<StatusRequest>,
     ) -> Result<tonic::Response<StatusResponse>, tonic::Status> {
-        info!("Got status request: {:?}", request);
-
         let status = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
             .handle_status()
             .await;
@@ -356,8 +351,6 @@ impl NymVpnd for CommandInterface {
         &self,
         request: tonic::Request<StoreAccountRequest>,
     ) -> Result<tonic::Response<StoreAccountResponse>, tonic::Status> {
-        info!("Got store account request");
-
         let account = request.into_inner().mnemonic;
 
         let result = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
@@ -383,8 +376,6 @@ impl NymVpnd for CommandInterface {
         &self,
         _request: tonic::Request<IsAccountStoredRequest>,
     ) -> Result<tonic::Response<IsAccountStoredResponse>, tonic::Status> {
-        info!("Got is account stored request");
-
         let result = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
             .handle_is_account_stored()
             .await
@@ -413,8 +404,6 @@ impl NymVpnd for CommandInterface {
         &self,
         _request: tonic::Request<RemoveAccountRequest>,
     ) -> Result<tonic::Response<RemoveAccountResponse>, tonic::Status> {
-        info!("Got remove account request");
-
         let result = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
             .handle_remove_account()
             .await
@@ -439,8 +428,6 @@ impl NymVpnd for CommandInterface {
         &self,
         _request: tonic::Request<GetAccountSummaryRequest>,
     ) -> Result<tonic::Response<GetAccountSummaryResponse>, tonic::Status> {
-        info!("Got get account summary request");
-
         let result = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
             .handle_get_account_summary()
             .await
@@ -467,8 +454,6 @@ impl NymVpnd for CommandInterface {
         &self,
         _request: tonic::Request<GetDevicesRequest>,
     ) -> Result<tonic::Response<GetDevicesResponse>, tonic::Status> {
-        info!("Got get devices request");
-
         let result = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
             .handle_get_devices()
             .await
@@ -493,8 +478,6 @@ impl NymVpnd for CommandInterface {
         &self,
         _request: tonic::Request<RegisterDeviceRequest>,
     ) -> Result<tonic::Response<RegisterDeviceResponse>, tonic::Status> {
-        info!("Got register device request");
-
         let result = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
             .handle_register_device()
             .await
@@ -519,8 +502,6 @@ impl NymVpnd for CommandInterface {
         &self,
         _request: tonic::Request<RequestZkNymRequest>,
     ) -> Result<tonic::Response<RequestZkNymResponse>, tonic::Status> {
-        info!("Got request zk nym request");
-
         let result = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
             .handle_request_zk_nym()
             .await
@@ -545,8 +526,6 @@ impl NymVpnd for CommandInterface {
         &self,
         _request: tonic::Request<GetDeviceZkNymsRequest>,
     ) -> Result<tonic::Response<GetDeviceZkNymsResponse>, tonic::Status> {
-        info!("Got get device zk nyms request");
-
         let result = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
             .handle_get_device_zk_nyms()
             .await
@@ -573,8 +552,6 @@ impl NymVpnd for CommandInterface {
         &self,
         _request: tonic::Request<nym_vpn_proto::GetFreePassesRequest>,
     ) -> Result<tonic::Response<nym_vpn_proto::GetFreePassesResponse>, tonic::Status> {
-        info!("Got get free passes request");
-
         let result = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
             .handle_get_free_passes()
             .await
@@ -599,8 +576,6 @@ impl NymVpnd for CommandInterface {
         &self,
         request: tonic::Request<nym_vpn_proto::ApplyFreepassRequest>,
     ) -> Result<tonic::Response<nym_vpn_proto::ApplyFreepassResponse>, tonic::Status> {
-        info!("Got apply freepass request");
-
         let code = request.into_inner().code;
 
         let result = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
@@ -109,7 +109,6 @@ impl NymVpnd for CommandInterface {
         &self,
         _request: tonic::Request<InfoRequest>,
     ) -> Result<tonic::Response<InfoResponse>, tonic::Status> {
-
         let info = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
             .handle_info()
             .await;
@@ -190,7 +189,7 @@ impl NymVpnd for CommandInterface {
 
     async fn vpn_status(
         &self,
-        request: tonic::Request<StatusRequest>,
+        _request: tonic::Request<StatusRequest>,
     ) -> Result<tonic::Response<StatusResponse>, tonic::Status> {
         let status = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
             .handle_status()

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/error.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/error.rs
@@ -465,6 +465,11 @@ impl From<AccountError> for nym_vpn_proto::AccountError {
                 message: err.to_string(),
                 details: hashmap! {},
             },
+            AccountError::SendCommand { .. } => nym_vpn_proto::AccountError {
+                kind: AccountErrorType::Storage as i32,
+                message: err.to_string(),
+                details: hashmap! {},
+            },
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/service/error.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/error.rs
@@ -5,6 +5,7 @@ use nym_vpn_lib::{
     gateway_directory::Error as DirError, wg_gateway_client::Error as WgGatewayClientError,
     AuthenticatorClientError, GatewayDirectoryError, NodeIdentity, Recipient,
 };
+use tokio::sync::mpsc::error::SendError;
 use tracing::error;
 
 #[derive(Clone, Debug, thiserror::Error)]
@@ -559,7 +560,6 @@ pub enum AccountError {
 
     #[error("failed to send command")]
     SendCommand {
-        source:
-            Box<tokio::sync::mpsc::error::SendError<nym_vpn_account_controller::AccountCommand>>,
+        source: Box<SendError<nym_vpn_account_controller::AccountCommand>>,
     },
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/service/error.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/error.rs
@@ -556,4 +556,10 @@ pub enum AccountError {
 
     #[error("failed to get account summary")]
     FailedToGetAccountSummary,
+
+    #[error("failed to send command")]
+    SendCommand {
+        source:
+            Box<tokio::sync::mpsc::error::SendError<nym_vpn_account_controller::AccountCommand>>,
+    },
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -16,7 +16,7 @@ use futures::{
 use nym_vpn_api_client::{
     response::{
         NymVpnAccountSummaryResponse, NymVpnDevice, NymVpnDevicesResponse, NymVpnSubscription,
-        NymVpnSubscriptionsResponse, NymVpnZkNym, NymVpnZkNymResponse,
+        NymVpnSubscriptionsResponse, NymVpnZkNymResponse,
     },
     types::{GatewayMinPerformance, Percent, VpnApiAccount},
 };
@@ -142,7 +142,7 @@ pub enum VpnServiceCommand {
     GetAccountSummary(oneshot::Sender<Result<NymVpnAccountSummaryResponse, AccountError>>),
     GetDevices(oneshot::Sender<Result<NymVpnDevicesResponse, AccountError>>),
     RegisterDevice(oneshot::Sender<Result<NymVpnDevice, AccountError>>),
-    RequestZkNym(oneshot::Sender<Result<NymVpnZkNym, AccountError>>),
+    RequestZkNym(oneshot::Sender<Result<(), AccountError>>),
     GetDeviceZkNyms(oneshot::Sender<Result<NymVpnZkNymResponse, AccountError>>),
     GetFreePasses(oneshot::Sender<Result<NymVpnSubscriptionsResponse, AccountError>>),
     ApplyFreepass(
@@ -797,23 +797,12 @@ where
             .map_err(Into::into)
     }
 
-    async fn handle_request_zk_nym(&self) -> Result<NymVpnZkNym, AccountError> {
-        // Get account
-        let account = self.load_account().await?;
-
-        // Get device
-        let device_keypair = self.load_device_keys().await?.device_keypair();
-        let device = nym_vpn_api_client::types::Device::from(device_keypair);
-
-        // Setup client
-        let nym_vpn_api_url = get_nym_vpn_api_url()?;
-        let user_agent = crate::util::construct_user_agent();
-        let api_client = nym_vpn_api_client::VpnApiClient::new(nym_vpn_api_url, user_agent)?;
-
-        api_client
-            .request_zk_nym(&account, &device)
-            .await
-            .map_err(Into::into)
+    async fn handle_request_zk_nym(&self) -> Result<(), AccountError> {
+        self.account_command_tx
+            .send(AccountCommand::RequestZkNym)
+            .map_err(|err| AccountError::SendCommand {
+                source: Box::new(err),
+            })
     }
 
     async fn handle_get_device_zk_nyms(&self) -> Result<NymVpnZkNymResponse, AccountError> {


### PR DESCRIPTION
- Vpn account controller to automatically register devices once the account is stored
- Add functionality to request new zk-nyms and get current device zk-nyms


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1302)
<!-- Reviewable:end -->
