### PR TITLE
Move to v2 authenticator

### DIFF
--- a/nym-vpn-core/crates/nym-authenticator-client/src/lib.rs
+++ b/nym-vpn-core/crates/nym-authenticator-client/src/lib.rs
@@ -2,9 +2,11 @@ use std::{cmp::Ordering, sync::Arc, time::Duration};
 
 use nym_authenticator_requests::{
     latest::VERSION as LATEST_VERSION,
-    v1::{
-        registration::InitMessage, request::AuthenticatorRequest, response::AuthenticatorResponse,
-        GatewayClient, VERSION as USED_VERSION,
+    v2::{
+        registration::{FinalMessage, InitMessage},
+        request::AuthenticatorRequest,
+        response::AuthenticatorResponse,
+        VERSION as USED_VERSION,
     },
 };
 
@@ -30,7 +32,7 @@ const _: () = assert!(USED_VERSION == LATEST_VERSION || USED_VERSION + 1 == LATE
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum ClientMessage {
     Initial(InitMessage),
-    Final(GatewayClient),
+    Final(FinalMessage),
     Query(PeerPublicKey),
 }
 
@@ -148,7 +150,10 @@ impl AuthClient {
                 AuthenticatorRequest::new_query_request(peer_public_key, self.nym_address)
             }
         };
-        debug!("Sent connect request with version v{}", request.version);
+        debug!(
+            "Sent connect request with version v{}",
+            request.protocol.version
+        );
 
         self.mixnet_sender
             .send(nym_sdk::mixnet::InputMessage::new_regular(

--- a/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
+++ b/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
@@ -11,8 +11,8 @@ use dns_lookup::lookup_host;
 use futures::StreamExt;
 use netstack::{NetstackCall as _, NetstackCallImpl};
 use nym_authenticator_client::ClientMessage;
-use nym_authenticator_requests::v1::{
-    registration::{GatewayClient, InitMessage, RegistrationData},
+use nym_authenticator_requests::v2::{
+    registration::{FinalMessage, GatewayClient, InitMessage, RegistrationData},
     response::{AuthenticatorResponseData, PendingRegistrationResponse, RegisteredResponse},
 };
 use nym_config::defaults::NymNetworkDetails;
@@ -161,12 +161,15 @@ async fn wg_probe(
                 debug!("Verifying data");
                 gateway_data.verify(&private_key, nonce)?;
 
-                let finalized_message = ClientMessage::Final(GatewayClient::new(
-                    &private_key,
-                    gateway_data.pub_key().inner(),
-                    gateway_data.private_ip,
-                    nonce,
-                ));
+                let finalized_message = ClientMessage::Final(FinalMessage {
+                    gateway_client: GatewayClient::new(
+                        &private_key,
+                        gateway_data.pub_key().inner(),
+                        gateway_data.private_ip,
+                        nonce,
+                    ),
+                    credential: None,
+                });
                 let response = auth_client
                     .send(finalized_message, authenticator_address)
                     .await?;

--- a/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
@@ -148,7 +148,7 @@ impl<C, St: Storage> BandwidthController<C, St> {
         match wg_gateway_client.query_bandwidth().await {
             Err(e) => tracing::warn!("Error querying remaining bandwidth {:?}", e),
             Ok(Some(remaining_bandwidth)) => {
-                match update_dynamic_check_interval(remaining_bandwidth) {
+                match update_dynamic_check_interval(remaining_bandwidth as u64) {
                     Some(new_duration) => {
                         return Some(new_duration);
                     }


### PR DESCRIPTION
This will make the move to a credential based wireguard registration (v2), temporarily breaking mainnet compatibility until the aero release reaches mainnet. Test should be ran against testnets that contain aero or later gateways

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1311)
<!-- Reviewable:end -->
