### PR TITLE
Refresh account state and keep checking if we can register device

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
@@ -678,19 +678,19 @@ where
         self.update_verification_key()
             .await
             .inspect_err(|err| {
-                tracing::error!("Failed to update master verification key: {:#?}", err)
+                tracing::error!("Failed to update master verification key: {:?}", err)
             })
             .ok();
         self.update_coin_indices_signatures()
             .await
             .inspect_err(|err| {
-                tracing::error!("Failed to update coin indices signatures: {:#?}", err)
+                tracing::error!("Failed to update coin indices signatures: {:?}", err)
             })
             .ok();
         self.update_expiration_date_signatures()
             .await
             .inspect_err(|err| {
-                tracing::error!("Failed to update expiration date signatures: {:#?}", err)
+                tracing::error!("Failed to update expiration date signatures: {:?}", err)
             })
             .ok();
 
@@ -698,7 +698,7 @@ where
         let mut polling_timer = tokio::time::interval(Duration::from_millis(500));
 
         // Timer to periodically refresh the remote account state
-        let mut update_shared_account_state_timer = tokio::time::interval(Duration::from_secs(10));
+        let mut update_shared_account_state_timer = tokio::time::interval(Duration::from_secs(60));
 
         loop {
             tokio::select! {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/lib.rs
@@ -12,4 +12,4 @@ mod error;
 mod shared_state;
 
 pub use controller::{AccountCommand, AccountController};
-pub use shared_state::{AccountState, SharedAccountState};
+pub use shared_state::{AccountState, ReadyToConnect, SharedAccountState};

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/connection_handler.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/connection_handler.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use nym_vpn_account_controller::AccountState;
+use nym_vpn_account_controller::{AccountState, ReadyToConnect};
 use tokio::sync::{mpsc::UnboundedSender, oneshot};
 
 use nym_vpn_api_client::{
@@ -228,7 +228,7 @@ impl CommandInterfaceConnectionHandler {
 
     pub(crate) async fn handle_is_ready_to_connect(
         &self,
-    ) -> Result<Result<bool, AccountError>, VpnCommandSendError> {
+    ) -> Result<Result<ReadyToConnect, AccountError>, VpnCommandSendError> {
         self.vpn_command_send(VpnServiceCommand::IsReadyToConnect)
             .await
     }

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use futures::{stream::BoxStream, StreamExt};
+use nym_vpn_account_controller::ReadyToConnect;
 use tokio::sync::{broadcast, mpsc::UnboundedSender};
 
 use nym_vpn_api_client::types::GatewayMinPerformance;
@@ -621,7 +622,8 @@ impl NymVpnd for CommandInterface {
             .await
             .map_err(|err| {
                 tonic::Status::internal(format!("Failed to check if ready to connect: {err}"))
-            })?;
+            })?
+            .map(|ready| ready == ReadyToConnect::Ready);
 
         let response = IsReadyToConnectResponse {
             is_ready_to_connect: result.unwrap_or(false),

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -654,15 +654,6 @@ where
         connect_args: ConnectArgs,
         _user_agent: nym_vpn_lib::UserAgent, // todo: use user-agent!
     ) -> VpnServiceConnectResult {
-        match self.shared_account_state.is_ready_to_connect().await {
-            ReadyToConnect::Ready => {}
-            not_ready => {
-                let msg = format!("Not ready to connect: {:?}", not_ready);
-                tracing::info!(msg);
-                return VpnServiceConnectResult::Fail(msg);
-            }
-        }
-
         let ConnectArgs {
             entry,
             exit,


### PR DESCRIPTION
- Fix bug which caused 100% cpu usage
- Period refresh of remote account state
- Extend type that reports if we are ready to connect from bool to enum

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1332)
<!-- Reviewable:end -->
