### PR TITLE
Translations update from Nym - Desktop

### DIFF
--- a/nym-vpn-app/src/i18n/tr/add-credential.json
+++ b/nym-vpn-app/src/i18n/tr/add-credential.json
@@ -1,5 +1,5 @@
 {
-  "welcome": "Hoş geldiniz!",
+  "welcome": "NymVPN'e hoş geldiniz!",
   "description1": "Başlamak için giriş anahtarınızı girin",
   "description2": "Giriş anahtarınızı kullanarak giriş yapın, ardından QR kodunu yapıştırın veya tarayın. Henüz giriş bilginiz yok mu? Anında almak için nymvpn.com adresinden kaydolun.",
   "input-label": "Giriş anahtarı",

--- a/nym-vpn-app/src/i18n/tr/add-credential.json
+++ b/nym-vpn-app/src/i18n/tr/add-credential.json
@@ -5,5 +5,9 @@
   "input-label": "Giriş anahtarı",
   "login-button": "Giriş anahtarını ekle",
   "error": "Geçersiz giriş anahtarı",
-  "added-notification": "Giriş anahtarı başarıyla eklendi!"
+  "added-notification": "Giriş anahtarı başarıyla eklendi!",
+  "create-account": {
+    "text": "NymVPN'de yeni misiniz?",
+    "link": "Hesap oluştur"
+  }
 }

--- a/nym-vpn-app/src/i18n/tr/errors.json
+++ b/nym-vpn-app/src/i18n/tr/errors.json
@@ -77,5 +77,8 @@
     "routing": "Çıkış nodeu {{protocol}} trafiğini iletmiyor",
     "ping": "Çıkış nodeu {{protocol}} trafiği için ping başarısız oldu"
   },
-  "entry-node-routing": "Giriş nodeu trafiği iletmiyor (internet bağlantısı mı kesik?)"
+  "entry-node-routing": "Giriş nodeu trafiği iletmiyor (internet bağlantısı mı kesik?)",
+  "account": {
+    "invalid-recovery-phrase": "Geçersiz kurtarma ifadesi"
+  }
 }


### PR DESCRIPTION
Translations update from [Nym](https://weblate.nymte.ch) for [Nym/add-credential](https://weblate.nymte.ch/projects/nymvpn/linux-windows/add-credential/).


It also includes following components:

* [Nym/welcome](https://weblate.nymte.ch/projects/nymvpn/linux-windows/welcome/)

* [Nym/notifications](https://weblate.nymte.ch/projects/nymvpn/linux-windows/notifications/)

* [Nym/backend-messages](https://weblate.nymte.ch/projects/nymvpn/linux-windows/backend-messages/)

* [Nym/node-location](https://weblate.nymte.ch/projects/nymvpn/linux-windows/node-location/)

* [Nym/errors](https://weblate.nymte.ch/projects/nymvpn/linux-windows/errors/)

* [Nym/licenses](https://weblate.nymte.ch/projects/nymvpn/linux-windows/licenses/)

* [Nym/display](https://weblate.nymte.ch/projects/nymvpn/linux-windows/display/)

* [Nym/settings](https://weblate.nymte.ch/projects/nymvpn/linux-windows/settings/)

* [Nym/glossary](https://weblate.nymte.ch/projects/nymvpn/linux-windows/glossary/)

* [Nym/home](https://weblate.nymte.ch/projects/nymvpn/linux-windows/home/)

* [Nym/common](https://weblate.nymte.ch/projects/nymvpn/linux-windows/common/)



Current translation status:

![Weblate translation status](https://weblate.nymte.ch/widget/nymvpn/linux-windows/add-credential/horizontal-auto.svg)