### PR TITLE
Improve tun handling on mobile

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -426,7 +426,7 @@ pub enum Error {
 
     #[cfg(target_os = "ios")]
     #[error("failed to locate tun device")]
-    LocateTunDevice,
+    LocateTunDevice(std::io::Error),
 
     #[cfg(any(target_os = "ios", target_os = "android"))]
     #[error("failed to configure tunnel provider: {}", _0)]
@@ -488,7 +488,7 @@ impl Error {
             Self::ConfigureTunnelProvider(_) => ErrorStateReason::TunnelProvider,
 
             #[cfg(target_os = "ios")]
-            Self::LocateTunDevice => ErrorStateReason::TunDevice,
+            Self::LocateTunDevice(_) => ErrorStateReason::TunDevice,
 
             Self::ConnectWireguardTunnel(_) | Self::RunWireguardTunnel(_) => {
                 // todo: add detail


### PR DESCRIPTION
- ios: use `BorrowedFd::try_clone_to_owned()` to `dup()` the file descriptor and leave ownership of the original fd with the packet tunnel ([source](https://doc.rust-lang.org/src/std/os/fd/owned.rs.html#101-118))
- lib: ensure that the tun fd is closed properly in the event of error but before transferring ownership to `AsyncDevice`.

Note that this is different on Android where we transfer ownership of the tun fd and we want it to be owned and closed with the drop of `AsyncDevice`, so no changes there except `OwnedFd` ensures that if `AsyncDevice` cannot be created, the fd is properly closed at the time of exiting the function scope.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1378)
<!-- Reviewable:end -->
