### PR TITLE
Fix windows builds

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-cli/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpn-cli/src/main.rs
@@ -141,8 +141,6 @@ pub(crate) fn unix_has_root(binary_name: &str) -> Result<()> {
 
 #[cfg(windows)]
 pub(crate) fn win_has_admin(binary_name: &str) -> Result<()> {
-    use tracing::debug;
-
     if is_elevated::is_elevated() {
         tracing::debug!("Admin privileges acquired");
         Ok(())

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/route_handler.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/route_handler.rs
@@ -86,10 +86,6 @@ impl RouteHandler {
     }
 
     pub async fn stop(self) {
-        #[cfg(windows)]
-        self.route_manager.stop();
-
-        #[cfg(not(windows))]
         self.route_manager.stop().await;
 
         _ = tokio::task::spawn_blocking(|| drop(self.route_manager)).await;

--- a/nym-vpn-core/crates/nym-vpnd/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/main.rs
@@ -76,7 +76,7 @@ fn run() -> anyhow::Result<()> {
     if args.command.is_any() {
         Ok(windows_service::start(args)?)
     } else {
-        setup_logging(false);
+        logging::setup_logging(false);
         run_inner(args)
     }
 }

--- a/nym-vpn-core/crates/nym-wg-go/build.rs
+++ b/nym-vpn-core/crates/nym-wg-go/build.rs
@@ -29,11 +29,17 @@ fn main() {
 
     println!("cargo::rustc-link-search={}", build_dir.display());
 
+    let lib_prefix = if target_os.as_str() == "windows" {
+        "lib"
+    } else {
+        ""
+    };
+
     let link_type = match target_os.as_str() {
         "android" => "",
         "linux" | "macos" | "ios" => "=static",
-        "windows" => "dylib",
+        "windows" => "=dylib",
         _ => panic!("Unsupported platform: {}", target_os),
     };
-    println!("cargo:rustc-link-lib{}=wg", link_type);
+    println!("cargo:rustc-link-lib{}={}wg", link_type, lib_prefix);
 }

--- a/wireguard/build-wireguard-go.sh
+++ b/wireguard/build-wireguard-go.sh
@@ -37,21 +37,6 @@ function is_docker_build {
     return 0
 }
 
-
-function win_deduce_lib_executable_path {
-    msbuild_path="$(which msbuild.exe)"
-    msbuild_dir=$(dirname "$msbuild_path")
-    local arch="$(uname -m)"
-    local lib_target="hostx64/x64"
-    if [[ ("${arch}" == "arm64") ]]; then
-       lib_target="hostarm64/arm64"
-    fi
-
-    find "$msbuild_dir/../../../../" -name "lib.exe" | \
-            grep -i "$lib_target" | \
-            head -n1
-}
-
 function win_gather_export_symbols {
    grep -Eo "\/\/export \w+" libwg.go libwg_windows.go | cut -d' ' -f2
 }
@@ -64,9 +49,7 @@ function win_create_lib_file {
         printf "\t%s\n" "$symbol" >> exports.def
     done
 
-    lib_path="$(win_deduce_lib_executable_path)"
-
-    "$lib_path" \
+    lib.exe \
         "/def:exports.def" \
         "/out:libwg.lib" \
         "/machine:X64"
@@ -79,7 +62,11 @@ function build_windows {
         go build -trimpath -v -o libwg.dll -buildmode c-shared
         win_create_lib_file
 
-        target_dir=../../build/lib/x86_64-pc-windows-msvc/
+        local target_dir=../../build/lib/x86_64-pc-windows-msvc/
+        local arch="$(uname -m)"
+        if [[ ("${arch}" == "arm64") ]]; then
+            arch="aarch64"
+        fi
         mkdir -p $target_dir
         mv libwg.dll libwg.lib $target_dir
     popd

--- a/wireguard/build-wireguard-go.sh
+++ b/wireguard/build-wireguard-go.sh
@@ -63,10 +63,6 @@ function build_windows {
         win_create_lib_file
 
         local target_dir=../../build/lib/x86_64-pc-windows-msvc/
-        local arch="$(uname -m)"
-        if [[ ("${arch}" == "arm64") ]]; then
-            arch="aarch64"
-        fi
         mkdir -p $target_dir
         mv libwg.dll libwg.lib $target_dir
     popd

--- a/wireguard/build-wireguard-go.sh
+++ b/wireguard/build-wireguard-go.sh
@@ -41,9 +41,15 @@ function is_docker_build {
 function win_deduce_lib_executable_path {
     msbuild_path="$(which msbuild.exe)"
     msbuild_dir=$(dirname "$msbuild_path")
+    local arch="$(uname -m)"
+    local lib_target="hostx64/x64"
+    if [[ ("${arch}" == "arm64") ]]; then
+       lib_target="hostarm64/arm64"
+    fi
+
     find "$msbuild_dir/../../../../" -name "lib.exe" | \
-        grep -i "hostx64/x64" | \
-        head -n1
+            grep -i "$lib_target" | \
+            head -n1
 }
 
 function win_gather_export_symbols {


### PR DESCRIPTION
- Fixes to make windows service compile on windows
- Few tweaks for wireguard to adapt to current libwg interface

Wireguard on Windows will not work out of the box as more fixes need to be done but this PR at least should fix compilation for x86_64 and rust code.