### PR TITLE
chore(taurti): lock network env selector

### DIFF
--- a/.github/workflows/build-nym-vpn-app-linux.yml
+++ b/.github/workflows/build-nym-vpn-app-linux.yml
@@ -2,6 +2,12 @@ name: build-nym-vpn-app-linux
 on:
   workflow_dispatch:
   workflow_call:
+    inputs:
+      # set to true when it is a 'dev' build
+      dev_mode:
+        required: true
+        type: boolean
+        default: false
     secrets:
       TAURI_PRIVATE_KEY:
         required: true
@@ -92,6 +98,7 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
           APP_SENTRY_DSN: ${{ secrets.DESKTOP_JS_SENTRY_DSN }}
           # RUSTFLAGS: "-L ${{ env.WG_GO_LIB_PATH }}"
+          NETWORK_ENV_SELECT: ${{ inputs.dev_mode == true }}
         run: |
           if [ "${{ env.CARGO_TARGET }}" = "release" ]; then
             npm run tauri build

--- a/.github/workflows/build-nym-vpn-app-windows.yml
+++ b/.github/workflows/build-nym-vpn-app-windows.yml
@@ -2,6 +2,12 @@ name: build-nym-vpn-app-windows
 on:
   workflow_dispatch:
   workflow_call:
+    inputs:
+      # set to true when it is a 'dev' build
+      dev_mode:
+        required: true
+        type: boolean
+        default: false
     secrets:
       WINDOWS_SIGNING_PFX_BASE64:
         required: true
@@ -198,6 +204,7 @@ jobs:
           RUSTFLAGS: "-L ${{ env.TAURI_SRC }}/x86_64-pc-windows-msvc -L ${{ env.TAURI_SRC }} -Clink-args=/LIBPATH:${{ env.TAURI_SRC }}/x64-${{ env.CPP_BUILD_MODES }}"
           WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_SIGNING_PFX_BASE64 }}
           WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_SIGNING_PFX_PASSWORD }}
+          NETWORK_ENV_SELECT: ${{ inputs.dev_mode == true }}
         run: |
           if [ "${{ env.CARGO_TARGET }}" = "release" ]; then
             npm run tauri build

--- a/.github/workflows/publish-nym-vpn-app.yml
+++ b/.github/workflows/publish-nym-vpn-app.yml
@@ -12,12 +12,19 @@ on:
     tags:
       - nym-vpn-app-v[0-9]+.[0-9]+.[0-9]+*
 
+env:
+  DEV_MODE: ${{ github.event_name == 'schedule' || contains(github.ref_name, 'dev') || contains(github.ref_name, 'nightly') || contains(inputs.tag_name, 'dev') || contains(inputs.tag_name, 'nightly') }}
+
 jobs:
   build-nym-vpn-app-linux:
     uses: ./.github/workflows/build-nym-vpn-app-linux.yml
+    with:
+      dev_mode: ${{ env.DEV_MODE }}
     secrets: inherit
   build-nym-vpn-app-windows:
     uses: ./.github/workflows/build-nym-vpn-app-windows.yml
+    with:
+      dev_mode: ${{ env.DEV_MODE }}
     secrets: inherit
 
   generate-build-info-nym-vpn-app:

--- a/.github/workflows/publish-nym-vpn-app.yml
+++ b/.github/workflows/publish-nym-vpn-app.yml
@@ -12,19 +12,16 @@ on:
     tags:
       - nym-vpn-app-v[0-9]+.[0-9]+.[0-9]+*
 
-env:
-  DEV_MODE: ${{ github.event_name == 'schedule' || contains(github.ref_name, 'dev') || contains(github.ref_name, 'nightly') || contains(inputs.tag_name, 'dev') || contains(inputs.tag_name, 'nightly') }}
-
 jobs:
   build-nym-vpn-app-linux:
     uses: ./.github/workflows/build-nym-vpn-app-linux.yml
     with:
-      dev_mode: ${{ env.DEV_MODE }}
+      dev_mode: ${{ github.event_name == 'schedule' || contains(github.ref_name, 'dev') || contains(github.ref_name, 'nightly') || contains(inputs.tag_name, 'dev') || contains(inputs.tag_name, 'nightly') }}
     secrets: inherit
   build-nym-vpn-app-windows:
     uses: ./.github/workflows/build-nym-vpn-app-windows.yml
     with:
-      dev_mode: ${{ env.DEV_MODE }}
+      dev_mode: ${{ github.event_name == 'schedule' || contains(github.ref_name, 'dev') || contains(github.ref_name, 'nightly') || contains(inputs.tag_name, 'dev') || contains(inputs.tag_name, 'nightly') }}
     secrets: inherit
 
   generate-build-info-nym-vpn-app:

--- a/nym-vpn-app/src-tauri/src/commands/env.rs
+++ b/nym-vpn-app/src-tauri/src/commands/env.rs
@@ -1,0 +1,20 @@
+use crate::env::NETWORK_ENV_SELECT;
+use serde::Serialize;
+use tracing::{debug, instrument};
+use ts_rs::TS;
+
+#[derive(Serialize, Debug, Clone, TS)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[ts(export)]
+pub struct Env {
+    network_env_select: bool,
+}
+
+#[instrument(skip_all)]
+#[tauri::command]
+pub async fn env() -> Env {
+    debug!("env");
+    Env {
+        network_env_select: *NETWORK_ENV_SELECT,
+    }
+}

--- a/nym-vpn-app/src-tauri/src/commands/mod.rs
+++ b/nym-vpn-app/src-tauri/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod connection;
 pub mod country;
 pub mod daemon;
 pub mod db;
+pub mod env;
 pub mod fs;
 pub mod log;
 pub mod startup;

--- a/nym-vpn-app/src-tauri/src/env.rs
+++ b/nym-vpn-app/src-tauri/src/env.rs
@@ -1,0 +1,7 @@
+use once_cell::sync::Lazy;
+
+pub static NETWORK_ENV_SELECT: Lazy<bool> = Lazy::new(|| {
+    option_env!("NETWORK_ENV_SELECT")
+        .map(|v| v.to_lowercase() == "true" || v == "1")
+        .unwrap_or(false)
+});

--- a/nym-vpn-app/src-tauri/src/main.rs
+++ b/nym-vpn-app/src-tauri/src/main.rs
@@ -19,6 +19,7 @@ use clap::Parser;
 use commands::country as cmd_country;
 use commands::daemon as cmd_daemon;
 use commands::db as cmd_db;
+use commands::env as cmd_env;
 use commands::fs as cmd_fs;
 use commands::log as cmd_log;
 use commands::window as cmd_window;
@@ -38,6 +39,7 @@ mod cli;
 mod commands;
 mod country;
 mod db;
+mod env;
 mod envi;
 mod error;
 mod events;
@@ -239,6 +241,7 @@ async fn main() -> Result<()> {
             cmd_daemon::set_network,
             cmd_fs::log_dir,
             startup::startup_error,
+            cmd_env::env,
         ])
         // keep the app running in the background on window close request
         .on_window_event(|win, event| {

--- a/nym-vpn-app/src/main.tsx
+++ b/nym-vpn-app/src/main.tsx
@@ -12,6 +12,7 @@ import initSentry from './sentry';
 import { StartupError as TStartupError } from './types';
 import { StartupError } from './screens';
 import { init } from './log';
+import { S_STATE } from './static';
 
 // needed locales to load for dayjs
 import 'dayjs/locale/es';
@@ -46,6 +47,12 @@ dayjs.extend(duration);
     init();
   }
   console.info('starting UI');
+
+  const env = await invoke<Record<string, unknown>>('env');
+  if (env.NETWORK_ENV_SELECT === true) {
+    console.info('network env selector enabled');
+    S_STATE.networkEnvSelect = true;
+  }
 
   // check for unrecoverable errors
   const error = await invoke<TStartupError | undefined>('startup_error');

--- a/nym-vpn-app/src/screens/settings/info-data/InfoData.tsx
+++ b/nym-vpn-app/src/screens/settings/info-data/InfoData.tsx
@@ -5,6 +5,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { useMainState } from '../../../contexts';
 import { DaemonInfo, NetworkEnv } from '../../../types';
 import NetworkEnvSelect from './NetworkEnvSelect.tsx';
+import { S_STATE } from '../../../static';
 
 function InfoData() {
   const [daemonInfo, setDaemonInfo] = useState<DaemonInfo | undefined>();
@@ -52,13 +53,16 @@ function InfoData() {
           </p>
         </div>
       </div>
-      {daemonStatus === 'Ok' && daemonInfo && showEnvSelect && (
-        <NetworkEnvSelect
-          open={showEnvSelect}
-          onClose={() => setShowEnvSelect(false)}
-          current={daemonInfo.network as NetworkEnv}
-        />
-      )}
+      {S_STATE.networkEnvSelect &&
+        daemonStatus === 'Ok' &&
+        daemonInfo &&
+        showEnvSelect && (
+          <NetworkEnvSelect
+            open={showEnvSelect}
+            onClose={() => setShowEnvSelect(false)}
+            current={daemonInfo.network as NetworkEnv}
+          />
+        )}
     </>
   );
 }

--- a/nym-vpn-app/src/screens/settings/info-data/NetworkEnvSelect.tsx
+++ b/nym-vpn-app/src/screens/settings/info-data/NetworkEnvSelect.tsx
@@ -4,7 +4,7 @@ import { Description, Field, Label, Select } from '@headlessui/react';
 import { motion } from 'framer-motion';
 import { invoke } from '@tauri-apps/api/core';
 import { BackendError, NetworkEnv } from '../../../types';
-import { Button, Dialog } from '../../../ui';
+import { Button, Dialog, MsIcon } from '../../../ui';
 
 type NetworkOption = { value: NetworkEnv; label: string };
 
@@ -67,6 +67,10 @@ function NetworkEnvSelect({ open, onClose, current }: Props) {
               </option>
             ))}
           </Select>
+          <MsIcon
+            icon="keyboard_arrow_down"
+            className="absolute right-2 top-1/2 transform -translate-y-1/2 text-black/50 dark:text-white/60"
+          />
         </div>
       </Field>
       {error && (

--- a/nym-vpn-app/src/screens/settings/info-data/NetworkEnvSelect.tsx
+++ b/nym-vpn-app/src/screens/settings/info-data/NetworkEnvSelect.tsx
@@ -27,6 +27,7 @@ function NetworkEnvSelect({ open, onClose, current }: Props) {
   const handleOnSelect = async (network: NetworkEnv) => {
     setError(null);
     try {
+      console.info('setting network to', network);
       await invoke<void>('set_network', { network });
     } catch (e: unknown) {
       const error = e as BackendError;

--- a/nym-vpn-app/src/static.ts
+++ b/nym-vpn-app/src/static.ts
@@ -2,4 +2,5 @@
 export const S_STATE = {
   // Either the vpn mode has been initialized or not
   vpnModeInit: false,
+  networkEnvSelect: false,
 };


### PR DESCRIPTION
- lock network env selector behind an env variable set at compile time
- update GH workflows to set this env variable depending on the release type: set to true on nightly/dev builds, set to false on stable prod releases

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1396)
<!-- Reviewable:end -->
