### PR TITLE
libwg: Set correct architecture when building an import lib

### DIFF
--- a/wireguard/build-wireguard-go.sh
+++ b/wireguard/build-wireguard-go.sh
@@ -60,10 +60,18 @@ function win_create_lib_file {
         printf "\t%s\n" "$symbol" >> exports.def
     done
 
+    if is_win_arm64 $@; then
+        local arch="ARM64"
+    else
+        local arch="X64"
+    fi
+
+    echo "Creating lib for $arch"
+
     lib.exe \
         "/def:exports.def" \
         "/out:libwg.lib" \
-        "/machine:X64"
+        "/machine:$arch"
 }
 
 function build_windows {
@@ -84,7 +92,7 @@ function build_windows {
 
     pushd libwg
         go build -trimpath -v -o libwg.dll -buildmode c-shared
-        win_create_lib_file
+        win_create_lib_file $@
 
         local target_dir="../../build/lib/$arch-pc-windows-msvc/"
         echo "Copying files to $(realpath "$target_dir")"


### PR DESCRIPTION
Just a small omission on my side. This PR ensures that import library for the `libwg.dll` is built using the correct architecture.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1398)
<!-- Reviewable:end -->
