### PR TITLE
Gracefully shutdown task manager

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/connect.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/connect.rs
@@ -6,7 +6,6 @@ use std::{path::PathBuf, result::Result};
 use nym_config::defaults::NymNetworkDetails;
 use nym_sdk::mixnet::{MixnetClientBuilder, NodeIdentity, StoragePaths};
 use nym_vpn_store::mnemonic::MnemonicStorage as _;
-use tracing::{debug, info};
 
 use super::{MixnetError, SharedMixnetClient};
 use crate::{storage::VpnClientOnDiskStorage, MixnetClientConfig};
@@ -39,7 +38,7 @@ fn apply_mixnet_client_config(
         min_gateway_performance,
     } = mixnet_client_config;
 
-    info!(
+    tracing::info!(
         "mixnet client poisson rate limiting: {}",
         true_to_disabled(*disable_poisson_rate)
     );
@@ -47,7 +46,7 @@ fn apply_mixnet_client_config(
         .traffic
         .disable_main_poisson_packet_distribution = *disable_poisson_rate;
 
-    info!(
+    tracing::info!(
         "mixnet client background loop cover traffic stream: {}",
         true_to_disabled(*disable_background_cover_traffic)
     );
@@ -57,7 +56,7 @@ fn apply_mixnet_client_config(
     if let Some(min_mixnode_performance) = min_mixnode_performance {
         debug_config.topology.minimum_mixnode_performance = *min_mixnode_performance;
     }
-    info!(
+    tracing::info!(
         "mixnet client minimum mixnode performance: {}",
         debug_config.topology.minimum_mixnode_performance,
     );
@@ -65,7 +64,7 @@ fn apply_mixnet_client_config(
     if let Some(min_gateway_performance) = min_gateway_performance {
         debug_config.topology.minimum_gateway_performance = *min_gateway_performance;
     }
-    info!(
+    tracing::info!(
         "mixnet client minimum gateway performance: {}",
         debug_config.topology.minimum_gateway_performance,
     );
@@ -84,7 +83,7 @@ pub(crate) async fn setup_mixnet_client(
     let user_agent = nym_bin_common::bin_info_owned!().into();
 
     let mixnet_client = if let Some(path) = mixnet_client_key_storage_path {
-        debug!("Using custom key storage path: {:?}", path);
+        tracing::debug!("Using custom key storage path: {:?}", path);
 
         let storage = VpnClientOnDiskStorage::new(path.clone());
         match storage.is_mnemonic_stored().await {
@@ -118,7 +117,7 @@ pub(crate) async fn setup_mixnet_client(
             .await
             .map_err(map_mixnet_connect_error)?
     } else {
-        debug!("Using ephemeral key storage");
+        tracing::debug!("Using ephemeral key storage");
         MixnetClientBuilder::new_ephemeral()
             .with_user_agent(user_agent)
             .request_gateway(mixnet_entry_gateway.to_string())

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -392,7 +392,7 @@ impl TunnelStateMachine {
                 NextTunnelState::NewState((new_state_handler, new_state)) => {
                     self.current_state_handler = new_state_handler;
 
-                    tracing::debug!("New tunnel state: {:?}", new_state);
+                    tracing::debug!("New tunnel state: {}", new_state);
                     let _ = self.event_sender.send(TunnelEvent::NewState(new_state));
                 }
                 NextTunnelState::SameState(same_state) => {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -40,7 +40,6 @@ use crate::tunnel_state_machine::{
 };
 
 /// Default MTU for mixnet tun device.
-#[cfg(not(all(target_os = "ios", target_os = "android")))]
 const DEFAULT_TUN_MTU: u16 = if cfg!(any(target_os = "ios", target_os = "android")) {
     1280
 } else {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnecting_state.rs
@@ -62,10 +62,9 @@ impl DisconnectingState {
     }
 
     async fn on_tunnel_exit(
-        &self,
         result: Result<Option<Vec<AsyncDevice>>, JoinError>,
         shared_state: &mut SharedState,
-    ) -> NextTunnelState {
+    ) {
         #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
         shared_state.route_handler.remove_routes().await;
 
@@ -93,16 +92,6 @@ impl DisconnectingState {
         #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
         shared_state.route_handler.remove_routes().await;
         // todo: reset firewall
-
-        match self.after_disconnect {
-            ActionAfterDisconnect::Nothing => NextTunnelState::NewState(DisconnectedState::enter()),
-            ActionAfterDisconnect::Error(reason) => {
-                NextTunnelState::NewState(ErrorState::enter(reason))
-            }
-            ActionAfterDisconnect::Reconnect => {
-                NextTunnelState::NewState(ConnectingState::enter(shared_state))
-            }
-        }
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
@@ -110,13 +99,6 @@ impl DisconnectingState {
         if let Err(e) = dns_handler.reset() {
             tracing::error!("Failed to reset dns: {}", e);
         }
-    }
-
-    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-    async fn reset_on_cancel(shared_state: &mut SharedState) {
-        Self::reset_dns(&mut shared_state.dns_handler);
-        shared_state.route_handler.remove_routes().await;
-        // todo: reset firewall
     }
 }
 
@@ -130,12 +112,24 @@ impl TunnelStateHandler for DisconnectingState {
     ) -> NextTunnelState {
         tokio::select! {
             _ = shutdown_token.cancelled() => {
-                #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-                Self::reset_on_cancel(shared_state).await;
+                // Wait for tunnel to exit anyway because it's unsafe to drop the task manager.
+                let result = self.wait_handle.await;
+                Self::on_tunnel_exit(result, shared_state).await;
+
                 NextTunnelState::NewState(DisconnectedState::enter())
             }
             result = (&mut self.wait_handle) => {
-                self.on_tunnel_exit(result, shared_state).await
+                Self::on_tunnel_exit(result, shared_state).await;
+
+                match self.after_disconnect {
+                    ActionAfterDisconnect::Nothing => NextTunnelState::NewState(DisconnectedState::enter()),
+                    ActionAfterDisconnect::Error(reason) => {
+                        NextTunnelState::NewState(ErrorState::enter(reason))
+                    }
+                    ActionAfterDisconnect::Reconnect => {
+                        NextTunnelState::NewState(ConnectingState::enter(shared_state))
+                    }
+                }
             }
             Some(command) = command_rx.recv() => {
                 match command {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnecting_state.rs
@@ -63,15 +63,15 @@ impl DisconnectingState {
 
     async fn on_tunnel_exit(
         result: Result<Option<Vec<AsyncDevice>>, JoinError>,
-        shared_state: &mut SharedState,
+        _shared_state: &mut SharedState,
     ) {
         #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-        shared_state.route_handler.remove_routes().await;
+        _shared_state.route_handler.remove_routes().await;
 
         match result {
             Ok(Some(tun_devices)) => {
                 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-                if let Err(e) = shared_state.dns_handler.reset_before_interface_removal() {
+                if let Err(e) = _shared_state.dns_handler.reset_before_interface_removal() {
                     tracing::error!("Failed to reset dns before interface removal: {}", e);
                 }
                 tracing::debug!("Closing tunnel {} device(s).", tun_devices.len());
@@ -79,18 +79,18 @@ impl DisconnectingState {
             }
             Ok(None) => {
                 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-                Self::reset_dns(&mut shared_state.dns_handler);
+                Self::reset_dns(&mut _shared_state.dns_handler);
                 tracing::debug!("Tunnel device has already been closed.");
             }
             Err(e) => {
                 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-                Self::reset_dns(&mut shared_state.dns_handler);
+                Self::reset_dns(&mut _shared_state.dns_handler);
                 tracing::error!("Failed to join on tunnel handle: {}", e);
             }
         }
 
         #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-        shared_state.route_handler.remove_routes().await;
+        _shared_state.route_handler.remove_routes().await;
         // todo: reset firewall
     }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mixnet/connected_tunnel.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mixnet/connected_tunnel.rs
@@ -79,7 +79,7 @@ impl TunnelHandle {
     /// Cancel tunnel execution.
     pub fn cancel(&self) {
         if let Err(e) = self.task_manager.signal_shutdown() {
-            tracing::error!("Failed to signal shutdown: {}", e);
+            tracing::error!("Failed to signal task manager shutdown: {}", e);
         }
     }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
@@ -132,7 +132,7 @@ impl TunnelHandle {
         }
 
         if let Err(e) = self.task_manager.signal_shutdown() {
-            tracing::error!("Failed to signal shutdown: {}", e);
+            tracing::error!("Failed to signal task manager shutdown: {}", e);
         }
     }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/mobile.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/mobile.rs
@@ -228,7 +228,7 @@ impl TunnelHandle {
         self.shutdown_token.cancel();
 
         if let Err(e) = self.task_manager.signal_shutdown() {
-            tracing::error!("Failed to signal shutdown: {}", e);
+            tracing::error!("Failed to signal task manager shutdown: {}", e);
         }
     }
 


### PR DESCRIPTION
This PR introduces the cancellation token to `tunnel_state_machine::tunnel::connect_mixnet()` and ensures that the `TaskManager` is properly shutdown before the drop.

In more details:

- `CancellationToken::run_until_cancelled()` is used for gateway selection to bail as soon as cancellation arrives. The assumption that it's safe to do so with the gateway client. I am not all that familiar with it but I assume any network requests it performs at best will be cancelled on drop, and at worst ignored. I assume that those requests are non-mutating and side-effect free.
- `TaskManager` is created right after the gateways are selected. At this point we run a combination of `CancellationToken::run_until_cancelled(tokio::time::timeout(<Future>))`. There are no early returns here to ensure that we get the opportunity to shutdown the `TaskManager` before the drop.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1399)
<!-- Reviewable:end -->
