### PR TITLE
Run account controller on mobile

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -4540,6 +4540,7 @@ dependencies = [
  "nym-task",
  "nym-topology",
  "nym-validator-client",
+ "nym-vpn-account-controller",
  "nym-vpn-api-client",
  "nym-vpn-network-config",
  "nym-vpn-store",

--- a/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
@@ -68,6 +68,7 @@ nym-authenticator-client = { path = "../nym-authenticator-client" }
 nym-connection-monitor = { path = "../nym-connection-monitor" }
 nym-gateway-directory = { path = "../nym-gateway-directory" }
 nym-ip-packet-client = { path = "../nym-ip-packet-client" }
+nym-vpn-account-controller = { path = "../nym-vpn-account-controller" }
 nym-vpn-api-client = { path = "../nym-vpn-api-client" }
 nym-vpn-network-config = { path = "../nym-vpn-network-config" }
 nym-vpn-store = { path = "../nym-vpn-store" }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/account.rs
@@ -1,0 +1,198 @@
+// Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use std::{path::PathBuf, str::FromStr, sync::Arc};
+
+use nym_vpn_account_controller::{AccountCommand, ReadyToConnect, SharedAccountState};
+use nym_vpn_store::mnemonic::MnemonicStorage;
+use tokio::{sync::mpsc::UnboundedSender, task::JoinHandle};
+use tokio_util::sync::CancellationToken;
+
+use crate::uniffi_custom_impls::AccountStateSummary;
+
+use super::{error::VpnError, ACCOUNT_CONTROLLER_HANDLE};
+
+pub(super) async fn start_account_controller_inner(data_dir: PathBuf) -> Result<(), VpnError> {
+    let mut guard = ACCOUNT_CONTROLLER_HANDLE.lock().await;
+
+    if guard.is_none() {
+        let account_controller_handle = start_account_controller(data_dir).await?;
+        *guard = Some(account_controller_handle);
+        Ok(())
+    } else {
+        Err(VpnError::InvalidStateError {
+            details: "Account controller is already running.".to_owned(),
+        })
+    }
+}
+
+pub(super) async fn stop_account_controller_inner() -> Result<(), VpnError> {
+    let mut guard = ACCOUNT_CONTROLLER_HANDLE.lock().await;
+
+    match guard.take() {
+        Some(account_controller_handle) => {
+            account_controller_handle.shutdown_and_wait().await;
+            Ok(())
+        }
+        None => Err(VpnError::InvalidStateError {
+            details: "Account controller is not running.".to_owned(),
+        }),
+    }
+}
+
+pub(super) struct AccountControllerHandle {
+    command_sender: UnboundedSender<AccountCommand>,
+    shared_state: nym_vpn_account_controller::SharedAccountState,
+    handle: JoinHandle<()>,
+    shutdown_token: CancellationToken,
+}
+
+impl AccountControllerHandle {
+    fn send_command(&self, command: AccountCommand) {
+        if let Err(e) = self.command_sender.send(command) {
+            tracing::error!("Failed to send comamnd: {}", e);
+        }
+    }
+
+    async fn shutdown_and_wait(self) {
+        self.shutdown_token.cancel();
+
+        if let Err(e) = self.handle.await {
+            tracing::error!("Failed to join on account controller handle: {}", e);
+        }
+    }
+}
+
+pub(super) async fn send_account_command(command: AccountCommand) -> Result<(), VpnError> {
+    if let Some(guard) = &*ACCOUNT_CONTROLLER_HANDLE.lock().await {
+        guard.send_command(command);
+        Ok(())
+    } else {
+        Err(VpnError::InvalidStateError {
+            details: "Account controller is not running.".to_owned(),
+        })
+    }
+}
+
+async fn get_shared_account_state() -> Result<SharedAccountState, VpnError> {
+    if let Some(guard) = &*ACCOUNT_CONTROLLER_HANDLE.lock().await {
+        Ok(guard.shared_state.clone())
+    } else {
+        Err(VpnError::InvalidStateError {
+            details: "Account controller is not running.".to_owned(),
+        })
+    }
+}
+
+async fn is_account_ready_to_connect() -> Result<ReadyToConnect, VpnError> {
+    Ok(get_shared_account_state()
+        .await?
+        .is_ready_to_connect()
+        .await)
+}
+
+pub(super) async fn assert_account_ready_to_connect() -> Result<(), VpnError> {
+    match is_account_ready_to_connect().await? {
+        ReadyToConnect::Ready => Ok(()),
+        not_ready_to_connect => {
+            tracing::warn!("Not ready to connect: {:?}", not_ready_to_connect);
+            Err(VpnError::Account(not_ready_to_connect.into()))
+        }
+    }
+}
+
+async fn start_account_controller(data_dir: PathBuf) -> Result<AccountControllerHandle, VpnError> {
+    let storage = Arc::new(tokio::sync::Mutex::new(
+        crate::storage::VpnClientOnDiskStorage::new(data_dir.clone()),
+    ));
+    // TODO: pass in as argument
+    let user_agent = crate::util::construct_user_agent();
+    let shutdown_token = CancellationToken::new();
+    let account_controller = nym_vpn_account_controller::AccountController::new(
+        Arc::clone(&storage),
+        data_dir.clone(),
+        user_agent,
+        shutdown_token.child_token(),
+    )
+    .await;
+
+    let shared_account_state = account_controller.shared_state();
+    let account_command_tx = account_controller.command_tx();
+    let account_controller_handle = tokio::spawn(account_controller.run());
+
+    Ok(AccountControllerHandle {
+        command_sender: account_command_tx,
+        shared_state: shared_account_state,
+        handle: account_controller_handle,
+        shutdown_token,
+    })
+}
+
+fn setup_account_storage(path: &str) -> Result<crate::storage::VpnClientOnDiskStorage, VpnError> {
+    let path = PathBuf::from_str(path).map_err(|err| VpnError::InternalError {
+        details: err.to_string(),
+    })?;
+    Ok(crate::storage::VpnClientOnDiskStorage::new(path))
+}
+
+pub(super) async fn store_account_mnemonic(mnemonic: &str, path: &str) -> Result<(), VpnError> {
+    // TODO: store the mnemonic by sending a command to the account controller instead of directly
+    // interacting with the storage.
+
+    let storage = setup_account_storage(path)?;
+
+    let mnemonic = nym_vpn_store::mnemonic::Mnemonic::parse(mnemonic).map_err(|err| {
+        VpnError::InternalError {
+            details: err.to_string(),
+        }
+    })?;
+
+    storage
+        .store_mnemonic(mnemonic)
+        .await
+        .map_err(|err| VpnError::InternalError {
+            details: err.to_string(),
+        })?;
+
+    send_account_command(AccountCommand::UpdateSharedAccountState).await?;
+
+    Ok(())
+}
+
+pub(super) async fn is_account_mnemonic_stored(path: &str) -> Result<bool, VpnError> {
+    // TODO: query the mnemonic by sending a command to the account controller instead of directly
+    // interacting with the storage.
+
+    let storage = setup_account_storage(path)?;
+    storage
+        .is_mnemonic_stored()
+        .await
+        .map_err(|err| VpnError::InternalError {
+            details: err.to_string(),
+        })
+}
+
+pub(super) async fn remove_account_mnemonic(path: &str) -> Result<bool, VpnError> {
+    // TODO: remove the mnemonic by sending a command to the account controller instead of directly
+    // interacting with the storage.
+
+    let storage = setup_account_storage(path)?;
+    let is_account_removed_success =
+        storage
+            .remove_mnemonic()
+            .await
+            .map(|_| true)
+            .map_err(|err| VpnError::InternalError {
+                details: err.to_string(),
+            })?;
+
+    send_account_command(AccountCommand::UpdateSharedAccountState).await?;
+
+    Ok(is_account_removed_success)
+}
+
+pub(super) async fn get_account_summary() -> Result<AccountStateSummary, VpnError> {
+    let shared_account_state = get_shared_account_state().await?;
+    let account_state_summary = shared_account_state.lock().await.clone();
+    Ok(AccountStateSummary::from(account_state_summary))
+}

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/error.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/error.rs
@@ -21,8 +21,41 @@ pub enum VpnError {
     #[error("{details}")]
     InvalidStateError { details: String },
 
-    #[error("{details}")]
-    Account { details: String },
+    #[error("{0}")]
+    Account(AccountError),
+}
+
+#[derive(thiserror::Error, uniffi::Error, Debug, Clone, PartialEq)]
+pub enum AccountError {
+    #[error("account state is ready to connect")]
+    Ready,
+    #[error("no account stored")]
+    NoAccountStored,
+    #[error("account not active")]
+    AccountNotActive,
+    #[error("no active subscription")]
+    NoActiveSubscription,
+    #[error("device not registered")]
+    DeviceNotRegistered,
+    #[error("device not active")]
+    DeviceNotActive,
+}
+
+impl From<nym_vpn_account_controller::ReadyToConnect> for AccountError {
+    fn from(value: nym_vpn_account_controller::ReadyToConnect) -> Self {
+        match value {
+            nym_vpn_account_controller::ReadyToConnect::Ready => Self::Ready,
+            nym_vpn_account_controller::ReadyToConnect::NoMnemonicStored => Self::NoAccountStored,
+            nym_vpn_account_controller::ReadyToConnect::AccountNotActive => Self::AccountNotActive,
+            nym_vpn_account_controller::ReadyToConnect::NoActiveSubscription => {
+                Self::NoActiveSubscription
+            }
+            nym_vpn_account_controller::ReadyToConnect::DeviceNotRegistered => {
+                Self::DeviceNotRegistered
+            }
+            nym_vpn_account_controller::ReadyToConnect::DeviceNotActive => Self::DeviceNotActive,
+        }
+    }
 }
 
 impl From<crate::Error> for VpnError {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/error.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/error.rs
@@ -20,6 +20,9 @@ pub enum VpnError {
 
     #[error("{details}")]
     InvalidStateError { details: String },
+
+    #[error("{details}")]
+    Account { details: String },
 }
 
 impl From<crate::Error> for VpnError {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
@@ -291,6 +291,7 @@ async fn remove_account_mnemonic(path: &str) -> Result<bool, VpnError> {
 }
 
 #[allow(non_snake_case)]
+#[uniffi::export]
 pub fn getAccountSummary() -> Result<AccountStateSummary, VpnError> {
     RUNTIME.block_on(get_account_summary())
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
@@ -74,10 +74,8 @@ async fn start_vpn_inner(config: VPNConfig) -> Result<(), VpnError> {
     match shared_account_state.is_ready_to_connect().await {
         ReadyToConnect::Ready => {}
         not_ready_to_connect => {
-            tracing::info!("Not ready to connect: {:?}", not_ready_to_connect);
-            return Err(VpnError::Account {
-                details: not_ready_to_connect.to_string(),
-            });
+            tracing::warn!("Not ready to connect: {:?}", not_ready_to_connect);
+            return Err(VpnError::Account(not_ready_to_connect.into()));
         }
     }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
@@ -8,11 +8,13 @@ pub(crate) mod error;
 #[cfg(any(target_os = "ios", target_os = "macos"))]
 pub mod swift;
 
-use std::{env, path::PathBuf, str::FromStr, sync::Arc};
+mod account;
 
+use std::{env, path::PathBuf, sync::Arc};
+
+use account::AccountControllerHandle;
 use lazy_static::lazy_static;
 use log::*;
-use nym_vpn_account_controller::{AccountCommand, ReadyToConnect, SharedAccountState};
 use tokio::{
     runtime::Runtime,
     sync::{mpsc, Mutex},
@@ -22,7 +24,6 @@ use tokio_util::sync::CancellationToken;
 use url::Url;
 
 use nym_gateway_directory::Config as GatewayDirectoryConfig;
-use nym_vpn_store::mnemonic::MnemonicStorage as _;
 
 use self::error::VpnError;
 #[cfg(target_os = "android")]
@@ -59,7 +60,7 @@ async fn start_vpn_inner(config: VPNConfig) -> Result<(), VpnError> {
     // We want to move this check into the state machine so that it happens during the connecting
     // state instead. This would allow us more flexibility in waiting for the account to be ready
     // and handle errors in a unified manner.
-    assert_account_ready_to_connect().await?;
+    account::assert_account_ready_to_connect().await?;
 
     let mut guard = STATE_MACHINE_HANDLE.lock().await;
 
@@ -99,41 +100,15 @@ async fn stop_vpn_inner() -> Result<(), VpnError> {
 #[allow(non_snake_case)]
 #[uniffi::export]
 pub fn startAccountController(data_dir: String) -> Result<(), VpnError> {
-    RUNTIME.block_on(start_account_controller_inner(PathBuf::from(data_dir)))
-}
-
-async fn start_account_controller_inner(data_dir: PathBuf) -> Result<(), VpnError> {
-    let mut guard = ACCOUNT_CONTROLLER_HANDLE.lock().await;
-
-    if guard.is_none() {
-        let account_controller_handle = start_account_controller(data_dir).await?;
-        *guard = Some(account_controller_handle);
-        Ok(())
-    } else {
-        Err(VpnError::InvalidStateError {
-            details: "Account controller is already running.".to_owned(),
-        })
-    }
+    RUNTIME.block_on(account::start_account_controller_inner(PathBuf::from(
+        data_dir,
+    )))
 }
 
 #[allow(non_snake_case)]
 #[uniffi::export]
 pub fn stopAccountController() -> Result<(), VpnError> {
-    RUNTIME.block_on(stop_account_controller_inner())
-}
-
-async fn stop_account_controller_inner() -> Result<(), VpnError> {
-    let mut guard = ACCOUNT_CONTROLLER_HANDLE.lock().await;
-
-    match guard.take() {
-        Some(account_controller_handle) => {
-            account_controller_handle.shutdown_and_wait().await;
-            Ok(())
-        }
-        None => Err(VpnError::InvalidStateError {
-            details: "Account controller is not running.".to_owned(),
-        }),
-    }
+    RUNTIME.block_on(account::stop_account_controller_inner())
 }
 
 #[allow(non_snake_case)]
@@ -163,97 +138,28 @@ async fn fetch_environment(network_name: &str) -> Result<NetworkEnvironment, Vpn
         })
 }
 
-fn setup_account_storage(path: &str) -> Result<crate::storage::VpnClientOnDiskStorage, VpnError> {
-    let path = PathBuf::from_str(path).map_err(|err| VpnError::InternalError {
-        details: err.to_string(),
-    })?;
-    Ok(crate::storage::VpnClientOnDiskStorage::new(path))
-}
-
 #[allow(non_snake_case)]
 #[uniffi::export]
 pub fn storeAccountMnemonic(mnemonic: String, path: String) -> Result<(), VpnError> {
-    RUNTIME.block_on(store_account_mnemonic(&mnemonic, &path))
-}
-
-async fn store_account_mnemonic(mnemonic: &str, path: &str) -> Result<(), VpnError> {
-    // TODO: store the mnemonic by sending a command to the account controller instead of directly
-    // interacting with the storage.
-
-    let storage = setup_account_storage(path)?;
-
-    let mnemonic = nym_vpn_store::mnemonic::Mnemonic::parse(mnemonic).map_err(|err| {
-        VpnError::InternalError {
-            details: err.to_string(),
-        }
-    })?;
-
-    storage
-        .store_mnemonic(mnemonic)
-        .await
-        .map_err(|err| VpnError::InternalError {
-            details: err.to_string(),
-        })?;
-
-    send_account_command(AccountCommand::UpdateSharedAccountState).await?;
-
-    Ok(())
+    RUNTIME.block_on(account::store_account_mnemonic(&mnemonic, &path))
 }
 
 #[allow(non_snake_case)]
 #[uniffi::export]
 pub fn isAccountMnemonicStored(path: String) -> Result<bool, VpnError> {
-    RUNTIME.block_on(is_account_mnemonic_stored(&path))
-}
-
-async fn is_account_mnemonic_stored(path: &str) -> Result<bool, VpnError> {
-    // TODO: query the mnemonic by sending a command to the account controller instead of directly
-    // interacting with the storage.
-
-    let storage = setup_account_storage(path)?;
-    storage
-        .is_mnemonic_stored()
-        .await
-        .map_err(|err| VpnError::InternalError {
-            details: err.to_string(),
-        })
+    RUNTIME.block_on(account::is_account_mnemonic_stored(&path))
 }
 
 #[allow(non_snake_case)]
 #[uniffi::export]
 pub fn removeAccountMnemonic(path: String) -> Result<bool, VpnError> {
-    RUNTIME.block_on(remove_account_mnemonic(&path))
-}
-
-async fn remove_account_mnemonic(path: &str) -> Result<bool, VpnError> {
-    // TODO: remove the mnemonic by sending a command to the account controller instead of directly
-    // interacting with the storage.
-
-    let storage = setup_account_storage(path)?;
-    let is_account_removed_success =
-        storage
-            .remove_mnemonic()
-            .await
-            .map(|_| true)
-            .map_err(|err| VpnError::InternalError {
-                details: err.to_string(),
-            })?;
-
-    send_account_command(AccountCommand::UpdateSharedAccountState).await?;
-
-    Ok(is_account_removed_success)
+    RUNTIME.block_on(account::remove_account_mnemonic(&path))
 }
 
 #[allow(non_snake_case)]
 #[uniffi::export]
 pub fn getAccountSummary() -> Result<AccountStateSummary, VpnError> {
-    RUNTIME.block_on(get_account_summary())
-}
-
-async fn get_account_summary() -> Result<AccountStateSummary, VpnError> {
-    let shared_account_state = get_shared_account_state().await?;
-    let account_state_summary = shared_account_state.lock().await.clone();
-    Ok(AccountStateSummary::from(account_state_summary))
+    RUNTIME.block_on(account::get_account_summary())
 }
 
 #[allow(non_snake_case)]
@@ -351,94 +257,6 @@ pub struct VPNConfig {
 #[uniffi::export(with_foreign)]
 pub trait TunnelStatusListener: Send + Sync {
     fn on_event(&self, event: TunnelEvent);
-}
-
-struct AccountControllerHandle {
-    command_sender: mpsc::UnboundedSender<AccountCommand>,
-    shared_state: nym_vpn_account_controller::SharedAccountState,
-    handle: JoinHandle<()>,
-    shutdown_token: CancellationToken,
-}
-
-impl AccountControllerHandle {
-    fn send_command(&self, command: AccountCommand) {
-        if let Err(e) = self.command_sender.send(command) {
-            tracing::error!("Failed to send comamnd: {}", e);
-        }
-    }
-
-    async fn shutdown_and_wait(self) {
-        self.shutdown_token.cancel();
-
-        if let Err(e) = self.handle.await {
-            tracing::error!("Failed to join on account controller handle: {}", e);
-        }
-    }
-}
-
-async fn start_account_controller(data_dir: PathBuf) -> Result<AccountControllerHandle, VpnError> {
-    let storage = Arc::new(tokio::sync::Mutex::new(
-        crate::storage::VpnClientOnDiskStorage::new(data_dir.clone()),
-    ));
-    // TODO: pass in as argument
-    let user_agent = crate::util::construct_user_agent();
-    let shutdown_token = CancellationToken::new();
-    let account_controller = nym_vpn_account_controller::AccountController::new(
-        Arc::clone(&storage),
-        data_dir.clone(),
-        user_agent,
-        shutdown_token.child_token(),
-    )
-    .await;
-
-    let shared_account_state = account_controller.shared_state();
-    let account_command_tx = account_controller.command_tx();
-    let account_controller_handle = tokio::spawn(account_controller.run());
-
-    Ok(AccountControllerHandle {
-        command_sender: account_command_tx,
-        shared_state: shared_account_state,
-        handle: account_controller_handle,
-        shutdown_token,
-    })
-}
-
-async fn send_account_command(command: AccountCommand) -> Result<(), VpnError> {
-    if let Some(guard) = &*ACCOUNT_CONTROLLER_HANDLE.lock().await {
-        guard.send_command(command);
-        Ok(())
-    } else {
-        Err(VpnError::InvalidStateError {
-            details: "Account controller is not running.".to_owned(),
-        })
-    }
-}
-
-async fn get_shared_account_state() -> Result<SharedAccountState, VpnError> {
-    if let Some(guard) = &*ACCOUNT_CONTROLLER_HANDLE.lock().await {
-        Ok(guard.shared_state.clone())
-    } else {
-        Err(VpnError::InvalidStateError {
-            details: "Account controller is not running.".to_owned(),
-        })
-    }
-}
-
-async fn is_account_ready_to_connect() -> Result<ReadyToConnect, VpnError> {
-    Ok(get_shared_account_state()
-        .await?
-        .is_ready_to_connect()
-        .await)
-}
-
-async fn assert_account_ready_to_connect() -> Result<(), VpnError> {
-    match is_account_ready_to_connect().await? {
-        ReadyToConnect::Ready => Ok(()),
-        not_ready_to_connect => {
-            tracing::warn!("Not ready to connect: {:?}", not_ready_to_connect);
-            Err(VpnError::Account(not_ready_to_connect.into()))
-        }
-    }
 }
 
 struct StateMachineHandle {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
@@ -12,6 +12,7 @@ use std::{env, path::PathBuf, str::FromStr, sync::Arc};
 
 use lazy_static::lazy_static;
 use log::*;
+use nym_vpn_account_controller::ReadyToConnect;
 use tokio::{
     runtime::Runtime,
     sync::{mpsc, Mutex},
@@ -54,6 +55,28 @@ pub fn startVPN(config: VPNConfig) -> Result<(), VpnError> {
 }
 
 async fn start_vpn_inner(config: VPNConfig) -> Result<(), VpnError> {
+    let shared_account_state = {
+        let ac_guard = ACCOUNT_CONTROLLER_HANDLE.lock().await;
+
+        if let Some(ac_guard) = &*ac_guard {
+            ac_guard.shared_state.clone()
+        } else {
+            return Err(VpnError::InvalidStateError {
+                details: "Account controller is not running.".to_owned(),
+            });
+        }
+    };
+
+    match shared_account_state.is_ready_to_connect().await {
+        ReadyToConnect::Ready => {}
+        not_ready_to_connect => {
+            tracing::info!("Not ready to connect: {:?}", not_ready_to_connect);
+            return Err(VpnError::Account {
+                details: not_ready_to_connect.to_string(),
+            });
+        }
+    }
+
     let mut guard = STATE_MACHINE_HANDLE.lock().await;
 
     if guard.is_none() {
@@ -79,6 +102,7 @@ async fn stop_vpn_inner() -> Result<(), VpnError> {
 
     match guard.take() {
         Some(state_machine_handle) => {
+            // TODO: add timeout
             state_machine_handle.shutdown_and_wait().await;
             Ok(())
         }
@@ -220,20 +244,12 @@ async fn remove_account_mnemonic(path: &str) -> Result<bool, VpnError> {
         })
 }
 
-#[allow(non_snake_case, dead_code)]
-pub fn getAccountSummary(
-    path: String,
-    nym_vpn_api_url: Url,
-    user_agent: UserAgent,
-) -> Result<String, VpnError> {
+#[allow(non_snake_case)]
+pub fn getAccountSummary() -> Result<String, VpnError> {
     RUNTIME.block_on(get_account_summary(path, nym_vpn_api_url, user_agent))
 }
 
-async fn get_account_summary(
-    _path: String,
-    _nym_vpn_api_url: Url,
-    _user_agent: UserAgent,
-) -> Result<String, VpnError> {
+async fn get_account_summary() -> Result<String, VpnError> {
     let guard = ACCOUNT_CONTROLLER_HANDLE.lock().await;
 
     if let Some(guard) = &*guard {
@@ -371,7 +387,6 @@ impl AccountControllerHandle {
 }
 
 async fn start_account_controller(data_dir: PathBuf) -> Result<AccountControllerHandle, VpnError> {
-    // let data_path = config.credential_data_path.clone().unwrap();
     let storage = Arc::new(tokio::sync::Mutex::new(
         crate::storage::VpnClientOnDiskStorage::new(data_dir.clone()),
     ));
@@ -441,12 +456,8 @@ async fn start_state_machine(config: VPNConfig) -> Result<StateMachineHandle, Vp
         ..Default::default()
     };
 
-    // TODO: remove unwrap
-    let data_dir = config.credential_data_path.clone().unwrap();
-
     let nym_config = NymConfig {
-        // data_path: config.credential_data_path,
-        data_path: Some(data_dir.clone()),
+        data_path: config.credential_data_path,
         gateway_config,
     };
 
@@ -461,25 +472,6 @@ async fn start_state_machine(config: VPNConfig) -> Result<StateMachineHandle, Vp
         dns: DnsOptions::default(),
     };
 
-    let shutdown_token = CancellationToken::new();
-
-    // let data_path = config.credential_data_path.clone().unwrap();
-    //let storage = Arc::new(tokio::sync::Mutex::new(
-    //    crate::storage::VpnClientOnDiskStorage::new(data_dir.clone()),
-    //));
-    //// TODO: pass in as argument
-    //let user_agent = crate::util::construct_user_agent();
-    //let account_controller = nym_vpn_account_controller::AccountController::new(
-    //    Arc::clone(&storage),
-    //    data_dir.clone(),
-    //    user_agent,
-    //    shutdown_token.child_token(),
-    //)
-    //.await;
-    //let shared_account_state = account_controller.shared_state();
-    //let account_command_tx = account_controller.command_tx();
-    //let account_controller_handle = tokio::spawn(account_controller.run());
-
     let (command_sender, command_receiver) = mpsc::unbounded_channel();
     let (event_sender, mut event_receiver) = mpsc::unbounded_channel();
 
@@ -492,6 +484,7 @@ async fn start_state_machine(config: VPNConfig) -> Result<StateMachineHandle, Vp
         }
     });
 
+    let shutdown_token = CancellationToken::new();
     let state_machine_handle = TunnelStateMachine::spawn(
         command_receiver,
         event_sender,
@@ -507,10 +500,6 @@ async fn start_state_machine(config: VPNConfig) -> Result<StateMachineHandle, Vp
         state_machine_handle,
         event_broadcaster_handler,
         command_sender,
-
-        // account_command_sender: account_command_tx,
-        // account_shared_state: shared_account_state,
-        // account_controller_handle,
         shutdown_token,
     })
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
@@ -317,25 +317,21 @@ pub fn getLowLatencyEntryCountry(
     RUNTIME.block_on(get_low_latency_entry_country(
         api_url,
         vpn_api_url,
-        Some(user_agent),
+        user_agent,
     ))
 }
 
 async fn get_low_latency_entry_country(
     api_url: Url,
     vpn_api_url: Option<Url>,
-    user_agent: Option<UserAgent>,
+    user_agent: UserAgent,
 ) -> Result<Location, VpnError> {
     let config = nym_gateway_directory::Config {
         api_url,
         nym_vpn_api_url: vpn_api_url,
         min_gateway_performance: None,
     };
-    let user_agent = user_agent
-        .map(nym_sdk::UserAgent::from)
-        .unwrap_or_else(crate::util::construct_user_agent);
-
-    GatewayClient::new(config, user_agent)?
+    GatewayClient::new(config, user_agent.into())?
         .lookup_low_latency_entry_gateway()
         .await
         .map_err(VpnError::from)

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
@@ -14,7 +14,7 @@ use lazy_static::lazy_static;
 use log::*;
 use tokio::{
     runtime::Runtime,
-    sync::{mpsc, Mutex},
+    sync::{mpsc, Mutex, MutexGuard},
     task::JoinHandle,
 };
 use tokio_util::sync::CancellationToken;
@@ -189,34 +189,21 @@ pub fn getAccountSummary(
     RUNTIME.block_on(get_account_summary(path, nym_vpn_api_url, user_agent))
 }
 
-#[allow(dead_code)]
 async fn get_account_summary(
     path: String,
     nym_vpn_api_url: Url,
     user_agent: UserAgent,
 ) -> Result<String, VpnError> {
-    let storage = setup_account_storage(&path)?;
-    let account = storage
-        .load_mnemonic()
-        .await
-        .map(VpnApiAccount::from)
-        .map_err(|err| VpnError::InternalError {
-            details: err.to_string(),
-        })?;
+    let guard = STATE_MACHINE_HANDLE.lock().await;
 
-    let api_client = nym_vpn_api_client::VpnApiClient::new(nym_vpn_api_url, user_agent.into())?;
-
-    api_client
-        .get_account_summary(&account)
-        .await
-        .map_err(|err| VpnError::InternalError {
-            details: err.to_string(),
-        })
-        .and_then(|summary| {
-            serde_json::to_string(&summary).map_err(|err| VpnError::InternalError {
-                details: err.to_string(),
-            })
-        })
+    if let Some(guard) = &*guard {
+        let shared_account_state = guard.account_shared_state.lock().await.clone();
+        return Ok(shared_account_state.to_string());
+    } else {
+        return Err(VpnError::InvalidStateError {
+            details: "State machine is not running.".to_owned(),
+        });
+    }
 }
 
 #[allow(non_snake_case)]
@@ -324,6 +311,9 @@ struct StateMachineHandle {
     state_machine_handle: JoinHandle<()>,
     event_broadcaster_handler: JoinHandle<()>,
     command_sender: mpsc::UnboundedSender<TunnelCommand>,
+    account_command_sender: mpsc::UnboundedSender<nym_vpn_account_controller::AccountCommand>,
+    account_shared_state: nym_vpn_account_controller::SharedAccountState,
+    account_controller_handle: JoinHandle<()>,
     shutdown_token: CancellationToken,
 }
 
@@ -363,8 +353,12 @@ async fn start_state_machine(config: VPNConfig) -> Result<StateMachineHandle, Vp
         ..Default::default()
     };
 
+    // TODO: remove unwrap
+    let data_dir = config.credential_data_path.clone().unwrap();
+
     let nym_config = NymConfig {
-        data_path: config.credential_data_path,
+        // data_path: config.credential_data_path,
+        data_path: Some(data_dir.clone()),
         gateway_config,
     };
 
@@ -379,6 +373,25 @@ async fn start_state_machine(config: VPNConfig) -> Result<StateMachineHandle, Vp
         dns: DnsOptions::default(),
     };
 
+    let shutdown_token = CancellationToken::new();
+
+    // let data_path = config.credential_data_path.clone().unwrap();
+    let storage = Arc::new(tokio::sync::Mutex::new(
+        crate::storage::VpnClientOnDiskStorage::new(data_dir.clone()),
+    ));
+    // TODO: pass in as argument
+    let user_agent = crate::util::construct_user_agent();
+    let account_controller = nym_vpn_account_controller::AccountController::new(
+        Arc::clone(&storage),
+        data_dir.clone(),
+        user_agent,
+        shutdown_token.child_token(),
+    )
+    .await;
+    let shared_account_state = account_controller.shared_state();
+    let account_command_tx = account_controller.command_tx();
+    let account_controller_handle = tokio::spawn(account_controller.run());
+
     let (command_sender, command_receiver) = mpsc::unbounded_channel();
     let (event_sender, mut event_receiver) = mpsc::unbounded_channel();
 
@@ -391,7 +404,6 @@ async fn start_state_machine(config: VPNConfig) -> Result<StateMachineHandle, Vp
         }
     });
 
-    let shutdown_token = CancellationToken::new();
     let state_machine_handle = TunnelStateMachine::spawn(
         command_receiver,
         event_sender,
@@ -407,6 +419,11 @@ async fn start_state_machine(config: VPNConfig) -> Result<StateMachineHandle, Vp
         state_machine_handle,
         event_broadcaster_handler,
         command_sender,
+
+        account_command_sender: account_command_tx,
+        account_shared_state: shared_account_state,
+        account_controller_handle,
+
         shutdown_token,
     })
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
@@ -67,6 +67,10 @@ async fn start_vpn_inner(config: VPNConfig) -> Result<(), VpnError> {
         }
     };
 
+    // TODO: we do a pre-connect check here. This mirrors the logic in the daemon.
+    // We want to move this check into the state machine so that it happens during the connecting
+    // state instead. This would allow us more flexibility in waiting for the account to be ready
+    // and handle errors in a unified manner.
     match shared_account_state.is_ready_to_connect().await {
         ReadyToConnect::Ready => {}
         not_ready_to_connect => {
@@ -246,7 +250,7 @@ async fn remove_account_mnemonic(path: &str) -> Result<bool, VpnError> {
 
 #[allow(non_snake_case)]
 pub fn getAccountSummary() -> Result<String, VpnError> {
-    RUNTIME.block_on(get_account_summary(path, nym_vpn_api_url, user_agent))
+    RUNTIME.block_on(get_account_summary())
 }
 
 async fn get_account_summary() -> Result<String, VpnError> {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
@@ -37,8 +37,8 @@ use crate::{
         TunnelStateMachine, TunnelType,
     },
     uniffi_custom_impls::{
-        BandwidthStatus, ConnectionStatus, EntryPoint, ExitPoint, GatewayMinPerformance,
-        GatewayType, Location, NetworkEnvironment, TunStatus, UserAgent,
+        AccountStateSummary, BandwidthStatus, ConnectionStatus, EntryPoint, ExitPoint,
+        GatewayMinPerformance, GatewayType, Location, NetworkEnvironment, TunStatus, UserAgent,
     },
 };
 
@@ -249,16 +249,16 @@ async fn remove_account_mnemonic(path: &str) -> Result<bool, VpnError> {
 }
 
 #[allow(non_snake_case)]
-pub fn getAccountSummary() -> Result<String, VpnError> {
+pub fn getAccountSummary() -> Result<AccountStateSummary, VpnError> {
     RUNTIME.block_on(get_account_summary())
 }
 
-async fn get_account_summary() -> Result<String, VpnError> {
+async fn get_account_summary() -> Result<AccountStateSummary, VpnError> {
     let guard = ACCOUNT_CONTROLLER_HANDLE.lock().await;
 
     if let Some(guard) = &*guard {
         let shared_account_state = guard.shared_state.lock().await.clone();
-        Ok(shared_account_state.to_string())
+        Ok(AccountStateSummary::from(shared_account_state))
     } else {
         Err(VpnError::InvalidStateError {
             details: "Account controller is not running.".to_owned(),

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
@@ -14,14 +14,13 @@ use lazy_static::lazy_static;
 use log::*;
 use tokio::{
     runtime::Runtime,
-    sync::{mpsc, Mutex, MutexGuard},
+    sync::{mpsc, Mutex},
     task::JoinHandle,
 };
 use tokio_util::sync::CancellationToken;
 use url::Url;
 
 use nym_gateway_directory::Config as GatewayDirectoryConfig;
-use nym_vpn_api_client::types::VpnApiAccount;
 use nym_vpn_store::mnemonic::MnemonicStorage as _;
 
 use self::error::VpnError;
@@ -45,6 +44,7 @@ use crate::{
 lazy_static! {
     static ref RUNTIME: Runtime = Runtime::new().unwrap();
     static ref STATE_MACHINE_HANDLE: Mutex<Option<StateMachineHandle>> = Mutex::new(None);
+    static ref ACCOUNT_CONTROLLER_HANDLE: Mutex<Option<AccountControllerHandle>> = Mutex::new(None);
 }
 
 #[allow(non_snake_case)]
@@ -84,6 +84,46 @@ async fn stop_vpn_inner() -> Result<(), VpnError> {
         }
         None => Err(VpnError::InvalidStateError {
             details: "State machine is not running.".to_owned(),
+        }),
+    }
+}
+
+#[allow(non_snake_case)]
+#[uniffi::export]
+pub fn startAccountController(data_dir: String) -> Result<(), VpnError> {
+    RUNTIME.block_on(start_account_controller_inner(PathBuf::from(data_dir)))
+}
+
+async fn start_account_controller_inner(data_dir: PathBuf) -> Result<(), VpnError> {
+    let mut guard = ACCOUNT_CONTROLLER_HANDLE.lock().await;
+
+    if guard.is_none() {
+        let account_controller_handle = start_account_controller(data_dir).await?;
+        *guard = Some(account_controller_handle);
+        Ok(())
+    } else {
+        Err(VpnError::InvalidStateError {
+            details: "Account controller is already running.".to_owned(),
+        })
+    }
+}
+
+#[allow(non_snake_case)]
+#[uniffi::export]
+pub fn stopAccountController() -> Result<(), VpnError> {
+    RUNTIME.block_on(stop_account_controller_inner())
+}
+
+async fn stop_account_controller_inner() -> Result<(), VpnError> {
+    let mut guard = ACCOUNT_CONTROLLER_HANDLE.lock().await;
+
+    match guard.take() {
+        Some(account_controller_handle) => {
+            account_controller_handle.shutdown_and_wait().await;
+            Ok(())
+        }
+        None => Err(VpnError::InvalidStateError {
+            details: "Account controller is not running.".to_owned(),
         }),
     }
 }
@@ -190,19 +230,19 @@ pub fn getAccountSummary(
 }
 
 async fn get_account_summary(
-    path: String,
-    nym_vpn_api_url: Url,
-    user_agent: UserAgent,
+    _path: String,
+    _nym_vpn_api_url: Url,
+    _user_agent: UserAgent,
 ) -> Result<String, VpnError> {
-    let guard = STATE_MACHINE_HANDLE.lock().await;
+    let guard = ACCOUNT_CONTROLLER_HANDLE.lock().await;
 
     if let Some(guard) = &*guard {
-        let shared_account_state = guard.account_shared_state.lock().await.clone();
-        return Ok(shared_account_state.to_string());
+        let shared_account_state = guard.shared_state.lock().await.clone();
+        Ok(shared_account_state.to_string())
     } else {
-        return Err(VpnError::InvalidStateError {
-            details: "State machine is not running.".to_owned(),
-        });
+        Err(VpnError::InvalidStateError {
+            details: "Account controller is not running.".to_owned(),
+        })
     }
 }
 
@@ -307,13 +347,61 @@ pub trait TunnelStatusListener: Send + Sync {
     fn on_event(&self, event: TunnelEvent);
 }
 
+struct AccountControllerHandle {
+    command_sender: mpsc::UnboundedSender<nym_vpn_account_controller::AccountCommand>,
+    shared_state: nym_vpn_account_controller::SharedAccountState,
+    handle: JoinHandle<()>,
+    shutdown_token: CancellationToken,
+}
+
+impl AccountControllerHandle {
+    fn send_command(&self, command: nym_vpn_account_controller::AccountCommand) {
+        if let Err(e) = self.command_sender.send(command) {
+            tracing::error!("Failed to send comamnd: {}", e);
+        }
+    }
+
+    async fn shutdown_and_wait(self) {
+        self.shutdown_token.cancel();
+
+        if let Err(e) = self.handle.await {
+            tracing::error!("Failed to join on account controller handle: {}", e);
+        }
+    }
+}
+
+async fn start_account_controller(data_dir: PathBuf) -> Result<AccountControllerHandle, VpnError> {
+    // let data_path = config.credential_data_path.clone().unwrap();
+    let storage = Arc::new(tokio::sync::Mutex::new(
+        crate::storage::VpnClientOnDiskStorage::new(data_dir.clone()),
+    ));
+    // TODO: pass in as argument
+    let user_agent = crate::util::construct_user_agent();
+    let shutdown_token = CancellationToken::new();
+    let account_controller = nym_vpn_account_controller::AccountController::new(
+        Arc::clone(&storage),
+        data_dir.clone(),
+        user_agent,
+        shutdown_token.child_token(),
+    )
+    .await;
+
+    let shared_account_state = account_controller.shared_state();
+    let account_command_tx = account_controller.command_tx();
+    let account_controller_handle = tokio::spawn(account_controller.run());
+
+    Ok(AccountControllerHandle {
+        command_sender: account_command_tx,
+        shared_state: shared_account_state,
+        handle: account_controller_handle,
+        shutdown_token,
+    })
+}
+
 struct StateMachineHandle {
     state_machine_handle: JoinHandle<()>,
     event_broadcaster_handler: JoinHandle<()>,
     command_sender: mpsc::UnboundedSender<TunnelCommand>,
-    account_command_sender: mpsc::UnboundedSender<nym_vpn_account_controller::AccountCommand>,
-    account_shared_state: nym_vpn_account_controller::SharedAccountState,
-    account_controller_handle: JoinHandle<()>,
     shutdown_token: CancellationToken,
 }
 
@@ -376,21 +464,21 @@ async fn start_state_machine(config: VPNConfig) -> Result<StateMachineHandle, Vp
     let shutdown_token = CancellationToken::new();
 
     // let data_path = config.credential_data_path.clone().unwrap();
-    let storage = Arc::new(tokio::sync::Mutex::new(
-        crate::storage::VpnClientOnDiskStorage::new(data_dir.clone()),
-    ));
-    // TODO: pass in as argument
-    let user_agent = crate::util::construct_user_agent();
-    let account_controller = nym_vpn_account_controller::AccountController::new(
-        Arc::clone(&storage),
-        data_dir.clone(),
-        user_agent,
-        shutdown_token.child_token(),
-    )
-    .await;
-    let shared_account_state = account_controller.shared_state();
-    let account_command_tx = account_controller.command_tx();
-    let account_controller_handle = tokio::spawn(account_controller.run());
+    //let storage = Arc::new(tokio::sync::Mutex::new(
+    //    crate::storage::VpnClientOnDiskStorage::new(data_dir.clone()),
+    //));
+    //// TODO: pass in as argument
+    //let user_agent = crate::util::construct_user_agent();
+    //let account_controller = nym_vpn_account_controller::AccountController::new(
+    //    Arc::clone(&storage),
+    //    data_dir.clone(),
+    //    user_agent,
+    //    shutdown_token.child_token(),
+    //)
+    //.await;
+    //let shared_account_state = account_controller.shared_state();
+    //let account_command_tx = account_controller.command_tx();
+    //let account_controller_handle = tokio::spawn(account_controller.run());
 
     let (command_sender, command_receiver) = mpsc::unbounded_channel();
     let (event_sender, mut event_receiver) = mpsc::unbounded_channel();
@@ -420,10 +508,9 @@ async fn start_state_machine(config: VPNConfig) -> Result<StateMachineHandle, Vp
         event_broadcaster_handler,
         command_sender,
 
-        account_command_sender: account_command_tx,
-        account_shared_state: shared_account_state,
-        account_controller_handle,
-
+        // account_command_sender: account_command_tx,
+        // account_shared_state: shared_account_state,
+        // account_controller_handle,
         shutdown_token,
     })
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/uniffi_custom_impls.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/uniffi_custom_impls.rs
@@ -622,3 +622,120 @@ impl UniffiCustomTypeConverter for PathBuf {
         obj.display().to_string()
     }
 }
+
+#[derive(uniffi::Record, Clone, Default, PartialEq)]
+pub struct AccountStateSummary {
+    pub mnemonic: Option<MnemonicState>,
+    pub account: Option<AccountState>,
+    pub subscription: Option<SubscriptionState>,
+    pub device: Option<DeviceState>,
+    pub pending_zk_nym: bool,
+}
+
+impl From<nym_vpn_account_controller::AccountStateSummary> for AccountStateSummary {
+    fn from(value: nym_vpn_account_controller::AccountStateSummary) -> Self {
+        AccountStateSummary {
+            mnemonic: value.mnemonic.map(|m| m.into()),
+            account: value.account.map(|a| a.into()),
+            subscription: value.subscription.map(|s| s.into()),
+            device: value.device.map(|d| d.into()),
+            pending_zk_nym: value.pending_zk_nym,
+        }
+    }
+}
+
+#[derive(uniffi::Enum, Debug, Clone, PartialEq)]
+pub enum MnemonicState {
+    NotStored,
+    Stored,
+}
+
+impl From<nym_vpn_account_controller::shared_state::MnemonicState> for MnemonicState {
+    fn from(value: nym_vpn_account_controller::shared_state::MnemonicState) -> Self {
+        match value {
+            nym_vpn_account_controller::shared_state::MnemonicState::NotStored => {
+                MnemonicState::NotStored
+            }
+            nym_vpn_account_controller::shared_state::MnemonicState::Stored => {
+                MnemonicState::Stored
+            }
+        }
+    }
+}
+
+#[derive(uniffi::Enum, Debug, Clone, PartialEq)]
+pub enum AccountState {
+    NotRegistered,
+    Inactive,
+    Active,
+    DeleteMe,
+}
+
+impl From<nym_vpn_account_controller::shared_state::AccountState> for AccountState {
+    fn from(value: nym_vpn_account_controller::shared_state::AccountState) -> Self {
+        match value {
+            nym_vpn_account_controller::shared_state::AccountState::NotRegistered => {
+                AccountState::NotRegistered
+            }
+            nym_vpn_account_controller::shared_state::AccountState::Inactive => {
+                AccountState::Inactive
+            }
+            nym_vpn_account_controller::shared_state::AccountState::Active => AccountState::Active,
+            nym_vpn_account_controller::shared_state::AccountState::DeleteMe => {
+                AccountState::DeleteMe
+            }
+        }
+    }
+}
+
+#[derive(uniffi::Enum, Debug, Clone, PartialEq)]
+pub enum SubscriptionState {
+    NotActive,
+    Pending,
+    Complete,
+    Active,
+}
+
+impl From<nym_vpn_account_controller::shared_state::SubscriptionState> for SubscriptionState {
+    fn from(value: nym_vpn_account_controller::shared_state::SubscriptionState) -> Self {
+        match value {
+            nym_vpn_account_controller::shared_state::SubscriptionState::NotActive => {
+                SubscriptionState::NotActive
+            }
+            nym_vpn_account_controller::shared_state::SubscriptionState::Pending => {
+                SubscriptionState::Pending
+            }
+            nym_vpn_account_controller::shared_state::SubscriptionState::Complete => {
+                SubscriptionState::Complete
+            }
+            nym_vpn_account_controller::shared_state::SubscriptionState::Active => {
+                SubscriptionState::Active
+            }
+        }
+    }
+}
+
+#[derive(uniffi::Enum, Debug, Clone, PartialEq)]
+pub enum DeviceState {
+    NotRegistered,
+    Inactive,
+    Active,
+    DeleteMe,
+}
+
+impl From<nym_vpn_account_controller::shared_state::DeviceState> for DeviceState {
+    fn from(value: nym_vpn_account_controller::shared_state::DeviceState) -> Self {
+        match value {
+            nym_vpn_account_controller::shared_state::DeviceState::NotRegistered => {
+                DeviceState::NotRegistered
+            }
+            nym_vpn_account_controller::shared_state::DeviceState::Inactive => {
+                DeviceState::Inactive
+            }
+            nym_vpn_account_controller::shared_state::DeviceState::Active => DeviceState::Active,
+            nym_vpn_account_controller::shared_state::DeviceState::DeleteMe => {
+                DeviceState::DeleteMe
+            }
+        }
+    }
+}

--- a/nym-vpn-core/crates/nym-vpn-lib/uniffi/nym_vpn_lib.kt
+++ b/nym-vpn-core/crates/nym-vpn-lib/uniffi/nym_vpn_lib.kt
@@ -769,6 +769,8 @@ internal open class UniffiVTableCallbackInterfaceTunnelStatusListener(
 
 
 
+
+
 // A JNA Library to expose the extern-C FFI definitions.
 // This is an implementation detail which will be called internally by the public API.
 
@@ -808,6 +810,8 @@ internal interface UniffiLib : Library {
     ): Unit
     fun uniffi_nym_vpn_lib_fn_method_tunnelstatuslistener_on_event(`ptr`: Pointer,`event`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): Unit
+    fun uniffi_nym_vpn_lib_fn_func_fetchenvironment(`networkName`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+    ): RustBuffer.ByValue
     fun uniffi_nym_vpn_lib_fn_func_getgatewaycountries(`apiUrl`: RustBuffer.ByValue,`nymVpnApiUrl`: RustBuffer.ByValue,`gwType`: RustBuffer.ByValue,`userAgent`: RustBuffer.ByValue,`minGatewayPerformance`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
     fun uniffi_nym_vpn_lib_fn_func_getlowlatencyentrycountry(`apiUrl`: RustBuffer.ByValue,`vpnApiUrl`: RustBuffer.ByValue,`userAgent`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
@@ -940,6 +944,8 @@ internal interface UniffiLib : Library {
     ): Unit
     fun ffi_nym_vpn_lib_rust_future_complete_void(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
     ): Unit
+    fun uniffi_nym_vpn_lib_checksum_func_fetchenvironment(
+    ): Short
     fun uniffi_nym_vpn_lib_checksum_func_getgatewaycountries(
     ): Short
     fun uniffi_nym_vpn_lib_checksum_func_getlowlatencyentrycountry(
@@ -983,6 +989,9 @@ private fun uniffiCheckContractApiVersion(lib: UniffiLib) {
 
 @Suppress("UNUSED_PARAMETER")
 private fun uniffiCheckApiChecksums(lib: UniffiLib) {
+    if (lib.uniffi_nym_vpn_lib_checksum_func_fetchenvironment() != 34561.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_nym_vpn_lib_checksum_func_getgatewaycountries() != 41607.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -1099,6 +1108,26 @@ public object FfiConverterUShort: FfiConverter<UShort, Short> {
 
     override fun write(value: UShort, buf: ByteBuffer) {
         buf.putShort(value.toShort())
+    }
+}
+
+public object FfiConverterUInt: FfiConverter<UInt, Int> {
+    override fun lift(value: Int): UInt {
+        return value.toUInt()
+    }
+
+    override fun read(buf: ByteBuffer): UInt {
+        return lift(buf.getInt())
+    }
+
+    override fun lower(value: UInt): Int {
+        return value.toInt()
+    }
+
+    override fun allocationSize(value: UInt) = 4UL
+
+    override fun write(value: UInt, buf: ByteBuffer) {
+        buf.putInt(value.toInt())
     }
 }
 
@@ -1931,6 +1960,39 @@ public object FfiConverterTypeAccountStateSummary: FfiConverterRustBuffer<Accoun
 
 
 
+data class ChainDetails (
+    var `bech32AccountPrefix`: kotlin.String, 
+    var `mixDenom`: DenomDetails, 
+    var `stakeDenom`: DenomDetails
+) {
+    
+    companion object
+}
+
+public object FfiConverterTypeChainDetails: FfiConverterRustBuffer<ChainDetails> {
+    override fun read(buf: ByteBuffer): ChainDetails {
+        return ChainDetails(
+            FfiConverterString.read(buf),
+            FfiConverterTypeDenomDetails.read(buf),
+            FfiConverterTypeDenomDetails.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: ChainDetails) = (
+            FfiConverterString.allocationSize(value.`bech32AccountPrefix`) +
+            FfiConverterTypeDenomDetails.allocationSize(value.`mixDenom`) +
+            FfiConverterTypeDenomDetails.allocationSize(value.`stakeDenom`)
+    )
+
+    override fun write(value: ChainDetails, buf: ByteBuffer) {
+            FfiConverterString.write(value.`bech32AccountPrefix`, buf)
+            FfiConverterTypeDenomDetails.write(value.`mixDenom`, buf)
+            FfiConverterTypeDenomDetails.write(value.`stakeDenom`, buf)
+    }
+}
+
+
+
 data class ConnectionData (
     /**
      * Mixnet entry gateway
@@ -1975,6 +2037,39 @@ public object FfiConverterTypeConnectionData: FfiConverterRustBuffer<ConnectionD
             FfiConverterTypeBoxedNodeIdentity.write(value.`exitGateway`, buf)
             FfiConverterTypeOffsetDateTime.write(value.`connectedAt`, buf)
             FfiConverterTypeTunnelConnectionData.write(value.`tunnel`, buf)
+    }
+}
+
+
+
+data class DenomDetails (
+    var `base`: kotlin.String, 
+    var `display`: kotlin.String, 
+    var `displayExponent`: kotlin.UInt
+) {
+    
+    companion object
+}
+
+public object FfiConverterTypeDenomDetails: FfiConverterRustBuffer<DenomDetails> {
+    override fun read(buf: ByteBuffer): DenomDetails {
+        return DenomDetails(
+            FfiConverterString.read(buf),
+            FfiConverterString.read(buf),
+            FfiConverterUInt.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: DenomDetails) = (
+            FfiConverterString.allocationSize(value.`base`) +
+            FfiConverterString.allocationSize(value.`display`) +
+            FfiConverterUInt.allocationSize(value.`displayExponent`)
+    )
+
+    override fun write(value: DenomDetails, buf: ByteBuffer) {
+            FfiConverterString.write(value.`base`, buf)
+            FfiConverterString.write(value.`display`, buf)
+            FfiConverterUInt.write(value.`displayExponent`, buf)
     }
 }
 
@@ -2260,6 +2355,171 @@ public object FfiConverterTypeMixnetConnectionData: FfiConverterRustBuffer<Mixne
 
 
 /**
+ * Represents the nym network environment together with the environment specific to nym-vpn. These
+ * need to be exported to the environment (for now, until it's refactored internally in the nym
+ * crates) so that the client can have access to the necessary information.
+ *
+ * The list is as of today:
+ *
+ * NETWORK_NAME = nym_network::network_name
+ *
+ * BECH32_PREFIX = nym_network::chain_details::bech32_account_prefix
+ * MIX_DENOM = nym_network::chain_details::mix_denom::base
+ * MIX_DENOM_DISPLAY = nym_network::chain_details::mix_denom::display
+ * STAKE_DENOM = nym_network::chain_details::stake_denom::base
+ * STAKE_DENOM_DISPLAY = nym_network::chain_details::stake_denom::display
+ * DENOMS_EXPONENT = nym_network::chain_details::mix_denom::display_exponent
+ *
+ * MIXNET_CONTRACT_ADDRESS = nym_network::contracts::mixnet_contract_address
+ * VESTING_CONTRACT_ADDRESS = nym_network::contracts::vesting_contract_address
+ * GROUP_CONTRACT_ADDRESS = nym_network::contracts::group_contract_address
+ * ECASH_CONTRACT_ADDRESS = nym_network::contracts::ecash_contract_address
+ * MULTISIG_CONTRACT_ADDRESS = nym_network::contracts::multisig_contract_address
+ * COCONUT_DKG_CONTRACT_ADDRESS = nym_network::contracts::coconut_dkg_contract_address
+ *
+ * NYXD = nym_network::endpoints[0]::nyxd_url
+ * NYM_API = nym_network::endpoints[0]::api_url
+ * NYXD_WS = nym_network::endpoints[0]::websocket_url
+ *
+ * NYM_VPN_API = nym_vpn_network::nym_vpn_api_url
+ */
+data class NetworkEnvironment (
+    var `nymNetwork`: NymNetworkDetails, 
+    var `nymVpnNetwork`: NymVpnNetwork
+) {
+    
+    companion object
+}
+
+public object FfiConverterTypeNetworkEnvironment: FfiConverterRustBuffer<NetworkEnvironment> {
+    override fun read(buf: ByteBuffer): NetworkEnvironment {
+        return NetworkEnvironment(
+            FfiConverterTypeNymNetworkDetails.read(buf),
+            FfiConverterTypeNymVpnNetwork.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: NetworkEnvironment) = (
+            FfiConverterTypeNymNetworkDetails.allocationSize(value.`nymNetwork`) +
+            FfiConverterTypeNymVpnNetwork.allocationSize(value.`nymVpnNetwork`)
+    )
+
+    override fun write(value: NetworkEnvironment, buf: ByteBuffer) {
+            FfiConverterTypeNymNetworkDetails.write(value.`nymNetwork`, buf)
+            FfiConverterTypeNymVpnNetwork.write(value.`nymVpnNetwork`, buf)
+    }
+}
+
+
+
+data class NymContracts (
+    var `mixnetContractAddress`: kotlin.String?, 
+    var `vestingContractAddress`: kotlin.String?, 
+    var `ecashContractAddress`: kotlin.String?, 
+    var `groupContractAddress`: kotlin.String?, 
+    var `multisigContractAddress`: kotlin.String?, 
+    var `coconutDkgContractAddress`: kotlin.String?
+) {
+    
+    companion object
+}
+
+public object FfiConverterTypeNymContracts: FfiConverterRustBuffer<NymContracts> {
+    override fun read(buf: ByteBuffer): NymContracts {
+        return NymContracts(
+            FfiConverterOptionalString.read(buf),
+            FfiConverterOptionalString.read(buf),
+            FfiConverterOptionalString.read(buf),
+            FfiConverterOptionalString.read(buf),
+            FfiConverterOptionalString.read(buf),
+            FfiConverterOptionalString.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: NymContracts) = (
+            FfiConverterOptionalString.allocationSize(value.`mixnetContractAddress`) +
+            FfiConverterOptionalString.allocationSize(value.`vestingContractAddress`) +
+            FfiConverterOptionalString.allocationSize(value.`ecashContractAddress`) +
+            FfiConverterOptionalString.allocationSize(value.`groupContractAddress`) +
+            FfiConverterOptionalString.allocationSize(value.`multisigContractAddress`) +
+            FfiConverterOptionalString.allocationSize(value.`coconutDkgContractAddress`)
+    )
+
+    override fun write(value: NymContracts, buf: ByteBuffer) {
+            FfiConverterOptionalString.write(value.`mixnetContractAddress`, buf)
+            FfiConverterOptionalString.write(value.`vestingContractAddress`, buf)
+            FfiConverterOptionalString.write(value.`ecashContractAddress`, buf)
+            FfiConverterOptionalString.write(value.`groupContractAddress`, buf)
+            FfiConverterOptionalString.write(value.`multisigContractAddress`, buf)
+            FfiConverterOptionalString.write(value.`coconutDkgContractAddress`, buf)
+    }
+}
+
+
+
+data class NymNetworkDetails (
+    var `networkName`: kotlin.String, 
+    var `chainDetails`: ChainDetails, 
+    var `endpoints`: List<ValidatorDetails>, 
+    var `contracts`: NymContracts
+) {
+    
+    companion object
+}
+
+public object FfiConverterTypeNymNetworkDetails: FfiConverterRustBuffer<NymNetworkDetails> {
+    override fun read(buf: ByteBuffer): NymNetworkDetails {
+        return NymNetworkDetails(
+            FfiConverterString.read(buf),
+            FfiConverterTypeChainDetails.read(buf),
+            FfiConverterSequenceTypeValidatorDetails.read(buf),
+            FfiConverterTypeNymContracts.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: NymNetworkDetails) = (
+            FfiConverterString.allocationSize(value.`networkName`) +
+            FfiConverterTypeChainDetails.allocationSize(value.`chainDetails`) +
+            FfiConverterSequenceTypeValidatorDetails.allocationSize(value.`endpoints`) +
+            FfiConverterTypeNymContracts.allocationSize(value.`contracts`)
+    )
+
+    override fun write(value: NymNetworkDetails, buf: ByteBuffer) {
+            FfiConverterString.write(value.`networkName`, buf)
+            FfiConverterTypeChainDetails.write(value.`chainDetails`, buf)
+            FfiConverterSequenceTypeValidatorDetails.write(value.`endpoints`, buf)
+            FfiConverterTypeNymContracts.write(value.`contracts`, buf)
+    }
+}
+
+
+
+data class NymVpnNetwork (
+    var `nymVpnApiUrl`: kotlin.String
+) {
+    
+    companion object
+}
+
+public object FfiConverterTypeNymVpnNetwork: FfiConverterRustBuffer<NymVpnNetwork> {
+    override fun read(buf: ByteBuffer): NymVpnNetwork {
+        return NymVpnNetwork(
+            FfiConverterString.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: NymVpnNetwork) = (
+            FfiConverterString.allocationSize(value.`nymVpnApiUrl`)
+    )
+
+    override fun write(value: NymVpnNetwork, buf: ByteBuffer) {
+            FfiConverterString.write(value.`nymVpnApiUrl`, buf)
+    }
+}
+
+
+
+/**
  * Tunnel + network settings
  */
 data class TunnelNetworkSettings (
@@ -2422,6 +2682,39 @@ public object FfiConverterTypeVPNConfig: FfiConverterRustBuffer<VpnConfig> {
 
 
 
+data class ValidatorDetails (
+    var `nyxdUrl`: kotlin.String, 
+    var `websocketUrl`: kotlin.String?, 
+    var `apiUrl`: kotlin.String?
+) {
+    
+    companion object
+}
+
+public object FfiConverterTypeValidatorDetails: FfiConverterRustBuffer<ValidatorDetails> {
+    override fun read(buf: ByteBuffer): ValidatorDetails {
+        return ValidatorDetails(
+            FfiConverterString.read(buf),
+            FfiConverterOptionalString.read(buf),
+            FfiConverterOptionalString.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: ValidatorDetails) = (
+            FfiConverterString.allocationSize(value.`nyxdUrl`) +
+            FfiConverterOptionalString.allocationSize(value.`websocketUrl`) +
+            FfiConverterOptionalString.allocationSize(value.`apiUrl`)
+    )
+
+    override fun write(value: ValidatorDetails, buf: ByteBuffer) {
+            FfiConverterString.write(value.`nyxdUrl`, buf)
+            FfiConverterOptionalString.write(value.`websocketUrl`, buf)
+            FfiConverterOptionalString.write(value.`apiUrl`, buf)
+    }
+}
+
+
+
 data class WireguardConnectionData (
     var `entry`: WireguardNode, 
     var `exit`: WireguardNode
@@ -2514,6 +2807,117 @@ public object FfiConverterTypeWireguardNode: FfiConverterRustBuffer<WireguardNod
             FfiConverterTypeIpv4Addr.write(value.`privateIpv4`, buf)
     }
 }
+
+
+
+sealed class AccountError {
+    
+    object Ready : AccountError()
+    
+    
+    object NoAccountStored : AccountError()
+    
+    
+    object AccountNotActive : AccountError()
+    
+    
+    object NoActiveSubscription : AccountError()
+    
+    
+    object DeviceNotRegistered : AccountError()
+    
+    
+    object DeviceNotActive : AccountError()
+    
+    
+
+    
+    companion object
+}
+
+public object FfiConverterTypeAccountError : FfiConverterRustBuffer<AccountError>{
+    override fun read(buf: ByteBuffer): AccountError {
+        return when(buf.getInt()) {
+            1 -> AccountError.Ready
+            2 -> AccountError.NoAccountStored
+            3 -> AccountError.AccountNotActive
+            4 -> AccountError.NoActiveSubscription
+            5 -> AccountError.DeviceNotRegistered
+            6 -> AccountError.DeviceNotActive
+            else -> throw RuntimeException("invalid enum value, something is very wrong!!")
+        }
+    }
+
+    override fun allocationSize(value: AccountError) = when(value) {
+        is AccountError.Ready -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+            )
+        }
+        is AccountError.NoAccountStored -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+            )
+        }
+        is AccountError.AccountNotActive -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+            )
+        }
+        is AccountError.NoActiveSubscription -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+            )
+        }
+        is AccountError.DeviceNotRegistered -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+            )
+        }
+        is AccountError.DeviceNotActive -> {
+            // Add the size for the Int that specifies the variant plus the size needed for all fields
+            (
+                4UL
+            )
+        }
+    }
+
+    override fun write(value: AccountError, buf: ByteBuffer) {
+        when(value) {
+            is AccountError.Ready -> {
+                buf.putInt(1)
+                Unit
+            }
+            is AccountError.NoAccountStored -> {
+                buf.putInt(2)
+                Unit
+            }
+            is AccountError.AccountNotActive -> {
+                buf.putInt(3)
+                Unit
+            }
+            is AccountError.NoActiveSubscription -> {
+                buf.putInt(4)
+                Unit
+            }
+            is AccountError.DeviceNotRegistered -> {
+                buf.putInt(5)
+                Unit
+            }
+            is AccountError.DeviceNotActive -> {
+                buf.putInt(6)
+                Unit
+            }
+        }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
+    }
+}
+
+
 
 
 
@@ -3874,10 +4278,10 @@ sealed class VpnException: Exception() {
     
     class Account(
         
-        val `details`: kotlin.String
+        val ``: AccountError
         ) : VpnException() {
         override val message
-            get() = "details=${ `details` }"
+            get() = "=${ `` }"
     }
     
 
@@ -3910,7 +4314,7 @@ public object FfiConverterTypeVpnError : FfiConverterRustBuffer<VpnException> {
                 FfiConverterString.read(buf),
                 )
             7 -> VpnException.Account(
-                FfiConverterString.read(buf),
+                FfiConverterTypeAccountError.read(buf),
                 )
             else -> throw RuntimeException("invalid error enum value, something is very wrong!!")
         }
@@ -3950,7 +4354,7 @@ public object FfiConverterTypeVpnError : FfiConverterRustBuffer<VpnException> {
             is VpnException.Account -> (
                 // Add the size for the Int that specifies the variant plus the size needed for all fields
                 4UL
-                + FfiConverterString.allocationSize(value.`details`)
+                + FfiConverterTypeAccountError.allocationSize(value.``)
             )
         }
     }
@@ -3988,7 +4392,7 @@ public object FfiConverterTypeVpnError : FfiConverterRustBuffer<VpnException> {
             }
             is VpnException.Account -> {
                 buf.putInt(7)
-                FfiConverterString.write(value.`details`, buf)
+                FfiConverterTypeAccountError.write(value.``, buf)
                 Unit
             }
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
@@ -4021,6 +4425,35 @@ public object FfiConverterOptionalULong: FfiConverterRustBuffer<kotlin.ULong?> {
         } else {
             buf.put(1)
             FfiConverterULong.write(value, buf)
+        }
+    }
+}
+
+
+
+
+public object FfiConverterOptionalString: FfiConverterRustBuffer<kotlin.String?> {
+    override fun read(buf: ByteBuffer): kotlin.String? {
+        if (buf.get().toInt() == 0) {
+            return null
+        }
+        return FfiConverterString.read(buf)
+    }
+
+    override fun allocationSize(value: kotlin.String?): ULong {
+        if (value == null) {
+            return 1UL
+        } else {
+            return 1UL + FfiConverterString.allocationSize(value)
+        }
+    }
+
+    override fun write(value: kotlin.String?, buf: ByteBuffer) {
+        if (value == null) {
+            buf.put(0)
+        } else {
+            buf.put(1)
+            FfiConverterString.write(value, buf)
         }
     }
 }
@@ -4571,6 +5004,31 @@ public object FfiConverterSequenceTypeLocation: FfiConverterRustBuffer<List<Loca
 
 
 
+public object FfiConverterSequenceTypeValidatorDetails: FfiConverterRustBuffer<List<ValidatorDetails>> {
+    override fun read(buf: ByteBuffer): List<ValidatorDetails> {
+        val len = buf.getInt()
+        return List<ValidatorDetails>(len) {
+            FfiConverterTypeValidatorDetails.read(buf)
+        }
+    }
+
+    override fun allocationSize(value: List<ValidatorDetails>): ULong {
+        val sizeForLength = 4UL
+        val sizeForItems = value.map { FfiConverterTypeValidatorDetails.allocationSize(it) }.sum()
+        return sizeForLength + sizeForItems
+    }
+
+    override fun write(value: List<ValidatorDetails>, buf: ByteBuffer) {
+        buf.putInt(value.size)
+        value.iterator().forEach {
+            FfiConverterTypeValidatorDetails.write(it, buf)
+        }
+    }
+}
+
+
+
+
 public object FfiConverterSequenceTypeIpv4Route: FfiConverterRustBuffer<List<Ipv4Route>> {
     override fun read(buf: ByteBuffer): List<Ipv4Route> {
         val len = buf.getInt()
@@ -4872,6 +5330,16 @@ public object FfiConverterTypeUrl: FfiConverter<Url, RustBuffer.ByValue> {
         FfiConverterString.write(builtinValue, buf)
     }
 }
+    @Throws(VpnException::class) fun `fetchEnvironment`(`networkName`: kotlin.String): NetworkEnvironment {
+            return FfiConverterTypeNetworkEnvironment.lift(
+    uniffiRustCallWithError(VpnException) { _status ->
+    UniffiLib.INSTANCE.uniffi_nym_vpn_lib_fn_func_fetchenvironment(
+        FfiConverterString.lower(`networkName`),_status)
+}
+    )
+    }
+    
+
     @Throws(VpnException::class) fun `getGatewayCountries`(`apiUrl`: Url, `nymVpnApiUrl`: Url?, `gwType`: GatewayType, `userAgent`: UserAgent?, `minGatewayPerformance`: GatewayMinPerformance?): List<Location> {
             return FfiConverterSequenceTypeLocation.lift(
     uniffiRustCallWithError(VpnException) { _status ->

--- a/nym-vpn-core/crates/nym-vpn-lib/uniffi/nym_vpn_lib.kt
+++ b/nym-vpn-core/crates/nym-vpn-lib/uniffi/nym_vpn_lib.kt
@@ -767,6 +767,8 @@ internal open class UniffiVTableCallbackInterfaceTunnelStatusListener(
 
 
 
+
+
 // A JNA Library to expose the extern-C FFI definitions.
 // This is an implementation detail which will be called internally by the public API.
 
@@ -806,8 +808,6 @@ internal interface UniffiLib : Library {
     ): Unit
     fun uniffi_nym_vpn_lib_fn_method_tunnelstatuslistener_on_event(`ptr`: Pointer,`event`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): Unit
-    fun uniffi_nym_vpn_lib_fn_func_fetchenvironment(`networkName`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
-    ): RustBuffer.ByValue
     fun uniffi_nym_vpn_lib_fn_func_getgatewaycountries(`apiUrl`: RustBuffer.ByValue,`nymVpnApiUrl`: RustBuffer.ByValue,`gwType`: RustBuffer.ByValue,`userAgent`: RustBuffer.ByValue,`minGatewayPerformance`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
     fun uniffi_nym_vpn_lib_fn_func_getlowlatencyentrycountry(`apiUrl`: RustBuffer.ByValue,`vpnApiUrl`: RustBuffer.ByValue,`userAgent`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
@@ -818,7 +818,11 @@ internal interface UniffiLib : Library {
     ): Byte
     fun uniffi_nym_vpn_lib_fn_func_removeaccountmnemonic(`path`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): Byte
+    fun uniffi_nym_vpn_lib_fn_func_startaccountcontroller(`dataDir`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+    ): Unit
     fun uniffi_nym_vpn_lib_fn_func_startvpn(`config`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+    ): Unit
+    fun uniffi_nym_vpn_lib_fn_func_stopaccountcontroller(uniffi_out_err: UniffiRustCallStatus, 
     ): Unit
     fun uniffi_nym_vpn_lib_fn_func_stopvpn(uniffi_out_err: UniffiRustCallStatus, 
     ): Unit
@@ -936,8 +940,6 @@ internal interface UniffiLib : Library {
     ): Unit
     fun ffi_nym_vpn_lib_rust_future_complete_void(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
     ): Unit
-    fun uniffi_nym_vpn_lib_checksum_func_fetchenvironment(
-    ): Short
     fun uniffi_nym_vpn_lib_checksum_func_getgatewaycountries(
     ): Short
     fun uniffi_nym_vpn_lib_checksum_func_getlowlatencyentrycountry(
@@ -948,7 +950,11 @@ internal interface UniffiLib : Library {
     ): Short
     fun uniffi_nym_vpn_lib_checksum_func_removeaccountmnemonic(
     ): Short
+    fun uniffi_nym_vpn_lib_checksum_func_startaccountcontroller(
+    ): Short
     fun uniffi_nym_vpn_lib_checksum_func_startvpn(
+    ): Short
+    fun uniffi_nym_vpn_lib_checksum_func_stopaccountcontroller(
     ): Short
     fun uniffi_nym_vpn_lib_checksum_func_stopvpn(
     ): Short
@@ -977,9 +983,6 @@ private fun uniffiCheckContractApiVersion(lib: UniffiLib) {
 
 @Suppress("UNUSED_PARAMETER")
 private fun uniffiCheckApiChecksums(lib: UniffiLib) {
-    if (lib.uniffi_nym_vpn_lib_checksum_func_fetchenvironment() != 34561.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
     if (lib.uniffi_nym_vpn_lib_checksum_func_getgatewaycountries() != 41607.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -995,7 +998,13 @@ private fun uniffiCheckApiChecksums(lib: UniffiLib) {
     if (lib.uniffi_nym_vpn_lib_checksum_func_removeaccountmnemonic() != 51019.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_nym_vpn_lib_checksum_func_startaccountcontroller() != 34257.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_nym_vpn_lib_checksum_func_startvpn() != 55890.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_nym_vpn_lib_checksum_func_stopaccountcontroller() != 64683.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_nym_vpn_lib_checksum_func_stopvpn() != 59823.toShort()) {
@@ -1090,26 +1099,6 @@ public object FfiConverterUShort: FfiConverter<UShort, Short> {
 
     override fun write(value: UShort, buf: ByteBuffer) {
         buf.putShort(value.toShort())
-    }
-}
-
-public object FfiConverterUInt: FfiConverter<UInt, Int> {
-    override fun lift(value: Int): UInt {
-        return value.toUInt()
-    }
-
-    override fun read(buf: ByteBuffer): UInt {
-        return lift(buf.getInt())
-    }
-
-    override fun lower(value: UInt): Int {
-        return value.toInt()
-    }
-
-    override fun allocationSize(value: UInt) = 4UL
-
-    override fun write(value: UInt, buf: ByteBuffer) {
-        buf.putInt(value.toInt())
     }
 }
 
@@ -1901,34 +1890,42 @@ public object FfiConverterTypeTunnelStatusListener: FfiConverter<TunnelStatusLis
 
 
 
-data class ChainDetails (
-    var `bech32AccountPrefix`: kotlin.String, 
-    var `mixDenom`: DenomDetails, 
-    var `stakeDenom`: DenomDetails
+data class AccountStateSummary (
+    var `mnemonic`: MnemonicState?, 
+    var `account`: AccountState?, 
+    var `subscription`: SubscriptionState?, 
+    var `device`: DeviceState?, 
+    var `pendingZkNym`: kotlin.Boolean
 ) {
     
     companion object
 }
 
-public object FfiConverterTypeChainDetails: FfiConverterRustBuffer<ChainDetails> {
-    override fun read(buf: ByteBuffer): ChainDetails {
-        return ChainDetails(
-            FfiConverterString.read(buf),
-            FfiConverterTypeDenomDetails.read(buf),
-            FfiConverterTypeDenomDetails.read(buf),
+public object FfiConverterTypeAccountStateSummary: FfiConverterRustBuffer<AccountStateSummary> {
+    override fun read(buf: ByteBuffer): AccountStateSummary {
+        return AccountStateSummary(
+            FfiConverterOptionalTypeMnemonicState.read(buf),
+            FfiConverterOptionalTypeAccountState.read(buf),
+            FfiConverterOptionalTypeSubscriptionState.read(buf),
+            FfiConverterOptionalTypeDeviceState.read(buf),
+            FfiConverterBoolean.read(buf),
         )
     }
 
-    override fun allocationSize(value: ChainDetails) = (
-            FfiConverterString.allocationSize(value.`bech32AccountPrefix`) +
-            FfiConverterTypeDenomDetails.allocationSize(value.`mixDenom`) +
-            FfiConverterTypeDenomDetails.allocationSize(value.`stakeDenom`)
+    override fun allocationSize(value: AccountStateSummary) = (
+            FfiConverterOptionalTypeMnemonicState.allocationSize(value.`mnemonic`) +
+            FfiConverterOptionalTypeAccountState.allocationSize(value.`account`) +
+            FfiConverterOptionalTypeSubscriptionState.allocationSize(value.`subscription`) +
+            FfiConverterOptionalTypeDeviceState.allocationSize(value.`device`) +
+            FfiConverterBoolean.allocationSize(value.`pendingZkNym`)
     )
 
-    override fun write(value: ChainDetails, buf: ByteBuffer) {
-            FfiConverterString.write(value.`bech32AccountPrefix`, buf)
-            FfiConverterTypeDenomDetails.write(value.`mixDenom`, buf)
-            FfiConverterTypeDenomDetails.write(value.`stakeDenom`, buf)
+    override fun write(value: AccountStateSummary, buf: ByteBuffer) {
+            FfiConverterOptionalTypeMnemonicState.write(value.`mnemonic`, buf)
+            FfiConverterOptionalTypeAccountState.write(value.`account`, buf)
+            FfiConverterOptionalTypeSubscriptionState.write(value.`subscription`, buf)
+            FfiConverterOptionalTypeDeviceState.write(value.`device`, buf)
+            FfiConverterBoolean.write(value.`pendingZkNym`, buf)
     }
 }
 
@@ -1978,39 +1975,6 @@ public object FfiConverterTypeConnectionData: FfiConverterRustBuffer<ConnectionD
             FfiConverterTypeBoxedNodeIdentity.write(value.`exitGateway`, buf)
             FfiConverterTypeOffsetDateTime.write(value.`connectedAt`, buf)
             FfiConverterTypeTunnelConnectionData.write(value.`tunnel`, buf)
-    }
-}
-
-
-
-data class DenomDetails (
-    var `base`: kotlin.String, 
-    var `display`: kotlin.String, 
-    var `displayExponent`: kotlin.UInt
-) {
-    
-    companion object
-}
-
-public object FfiConverterTypeDenomDetails: FfiConverterRustBuffer<DenomDetails> {
-    override fun read(buf: ByteBuffer): DenomDetails {
-        return DenomDetails(
-            FfiConverterString.read(buf),
-            FfiConverterString.read(buf),
-            FfiConverterUInt.read(buf),
-        )
-    }
-
-    override fun allocationSize(value: DenomDetails) = (
-            FfiConverterString.allocationSize(value.`base`) +
-            FfiConverterString.allocationSize(value.`display`) +
-            FfiConverterUInt.allocationSize(value.`displayExponent`)
-    )
-
-    override fun write(value: DenomDetails, buf: ByteBuffer) {
-            FfiConverterString.write(value.`base`, buf)
-            FfiConverterString.write(value.`display`, buf)
-            FfiConverterUInt.write(value.`displayExponent`, buf)
     }
 }
 
@@ -2296,171 +2260,6 @@ public object FfiConverterTypeMixnetConnectionData: FfiConverterRustBuffer<Mixne
 
 
 /**
- * Represents the nym network environment together with the environment specific to nym-vpn. These
- * need to be exported to the environment (for now, until it's refactored internally in the nym
- * crates) so that the client can have access to the necessary information.
- *
- * The list is as of today:
- *
- * NETWORK_NAME = nym_network::network_name
- *
- * BECH32_PREFIX = nym_network::chain_details::bech32_account_prefix
- * MIX_DENOM = nym_network::chain_details::mix_denom::base
- * MIX_DENOM_DISPLAY = nym_network::chain_details::mix_denom::display
- * STAKE_DENOM = nym_network::chain_details::stake_denom::base
- * STAKE_DENOM_DISPLAY = nym_network::chain_details::stake_denom::display
- * DENOMS_EXPONENT = nym_network::chain_details::mix_denom::display_exponent
- *
- * MIXNET_CONTRACT_ADDRESS = nym_network::contracts::mixnet_contract_address
- * VESTING_CONTRACT_ADDRESS = nym_network::contracts::vesting_contract_address
- * GROUP_CONTRACT_ADDRESS = nym_network::contracts::group_contract_address
- * ECASH_CONTRACT_ADDRESS = nym_network::contracts::ecash_contract_address
- * MULTISIG_CONTRACT_ADDRESS = nym_network::contracts::multisig_contract_address
- * COCONUT_DKG_CONTRACT_ADDRESS = nym_network::contracts::coconut_dkg_contract_address
- *
- * NYXD = nym_network::endpoints[0]::nyxd_url
- * NYM_API = nym_network::endpoints[0]::api_url
- * NYXD_WS = nym_network::endpoints[0]::websocket_url
- *
- * NYM_VPN_API = nym_vpn_network::nym_vpn_api_url
- */
-data class NetworkEnvironment (
-    var `nymNetwork`: NymNetworkDetails, 
-    var `nymVpnNetwork`: NymVpnNetwork
-) {
-    
-    companion object
-}
-
-public object FfiConverterTypeNetworkEnvironment: FfiConverterRustBuffer<NetworkEnvironment> {
-    override fun read(buf: ByteBuffer): NetworkEnvironment {
-        return NetworkEnvironment(
-            FfiConverterTypeNymNetworkDetails.read(buf),
-            FfiConverterTypeNymVpnNetwork.read(buf),
-        )
-    }
-
-    override fun allocationSize(value: NetworkEnvironment) = (
-            FfiConverterTypeNymNetworkDetails.allocationSize(value.`nymNetwork`) +
-            FfiConverterTypeNymVpnNetwork.allocationSize(value.`nymVpnNetwork`)
-    )
-
-    override fun write(value: NetworkEnvironment, buf: ByteBuffer) {
-            FfiConverterTypeNymNetworkDetails.write(value.`nymNetwork`, buf)
-            FfiConverterTypeNymVpnNetwork.write(value.`nymVpnNetwork`, buf)
-    }
-}
-
-
-
-data class NymContracts (
-    var `mixnetContractAddress`: kotlin.String?, 
-    var `vestingContractAddress`: kotlin.String?, 
-    var `ecashContractAddress`: kotlin.String?, 
-    var `groupContractAddress`: kotlin.String?, 
-    var `multisigContractAddress`: kotlin.String?, 
-    var `coconutDkgContractAddress`: kotlin.String?
-) {
-    
-    companion object
-}
-
-public object FfiConverterTypeNymContracts: FfiConverterRustBuffer<NymContracts> {
-    override fun read(buf: ByteBuffer): NymContracts {
-        return NymContracts(
-            FfiConverterOptionalString.read(buf),
-            FfiConverterOptionalString.read(buf),
-            FfiConverterOptionalString.read(buf),
-            FfiConverterOptionalString.read(buf),
-            FfiConverterOptionalString.read(buf),
-            FfiConverterOptionalString.read(buf),
-        )
-    }
-
-    override fun allocationSize(value: NymContracts) = (
-            FfiConverterOptionalString.allocationSize(value.`mixnetContractAddress`) +
-            FfiConverterOptionalString.allocationSize(value.`vestingContractAddress`) +
-            FfiConverterOptionalString.allocationSize(value.`ecashContractAddress`) +
-            FfiConverterOptionalString.allocationSize(value.`groupContractAddress`) +
-            FfiConverterOptionalString.allocationSize(value.`multisigContractAddress`) +
-            FfiConverterOptionalString.allocationSize(value.`coconutDkgContractAddress`)
-    )
-
-    override fun write(value: NymContracts, buf: ByteBuffer) {
-            FfiConverterOptionalString.write(value.`mixnetContractAddress`, buf)
-            FfiConverterOptionalString.write(value.`vestingContractAddress`, buf)
-            FfiConverterOptionalString.write(value.`ecashContractAddress`, buf)
-            FfiConverterOptionalString.write(value.`groupContractAddress`, buf)
-            FfiConverterOptionalString.write(value.`multisigContractAddress`, buf)
-            FfiConverterOptionalString.write(value.`coconutDkgContractAddress`, buf)
-    }
-}
-
-
-
-data class NymNetworkDetails (
-    var `networkName`: kotlin.String, 
-    var `chainDetails`: ChainDetails, 
-    var `endpoints`: List<ValidatorDetails>, 
-    var `contracts`: NymContracts
-) {
-    
-    companion object
-}
-
-public object FfiConverterTypeNymNetworkDetails: FfiConverterRustBuffer<NymNetworkDetails> {
-    override fun read(buf: ByteBuffer): NymNetworkDetails {
-        return NymNetworkDetails(
-            FfiConverterString.read(buf),
-            FfiConverterTypeChainDetails.read(buf),
-            FfiConverterSequenceTypeValidatorDetails.read(buf),
-            FfiConverterTypeNymContracts.read(buf),
-        )
-    }
-
-    override fun allocationSize(value: NymNetworkDetails) = (
-            FfiConverterString.allocationSize(value.`networkName`) +
-            FfiConverterTypeChainDetails.allocationSize(value.`chainDetails`) +
-            FfiConverterSequenceTypeValidatorDetails.allocationSize(value.`endpoints`) +
-            FfiConverterTypeNymContracts.allocationSize(value.`contracts`)
-    )
-
-    override fun write(value: NymNetworkDetails, buf: ByteBuffer) {
-            FfiConverterString.write(value.`networkName`, buf)
-            FfiConverterTypeChainDetails.write(value.`chainDetails`, buf)
-            FfiConverterSequenceTypeValidatorDetails.write(value.`endpoints`, buf)
-            FfiConverterTypeNymContracts.write(value.`contracts`, buf)
-    }
-}
-
-
-
-data class NymVpnNetwork (
-    var `nymVpnApiUrl`: kotlin.String
-) {
-    
-    companion object
-}
-
-public object FfiConverterTypeNymVpnNetwork: FfiConverterRustBuffer<NymVpnNetwork> {
-    override fun read(buf: ByteBuffer): NymVpnNetwork {
-        return NymVpnNetwork(
-            FfiConverterString.read(buf),
-        )
-    }
-
-    override fun allocationSize(value: NymVpnNetwork) = (
-            FfiConverterString.allocationSize(value.`nymVpnApiUrl`)
-    )
-
-    override fun write(value: NymVpnNetwork, buf: ByteBuffer) {
-            FfiConverterString.write(value.`nymVpnApiUrl`, buf)
-    }
-}
-
-
-
-/**
  * Tunnel + network settings
  */
 data class TunnelNetworkSettings (
@@ -2623,39 +2422,6 @@ public object FfiConverterTypeVPNConfig: FfiConverterRustBuffer<VpnConfig> {
 
 
 
-data class ValidatorDetails (
-    var `nyxdUrl`: kotlin.String, 
-    var `websocketUrl`: kotlin.String?, 
-    var `apiUrl`: kotlin.String?
-) {
-    
-    companion object
-}
-
-public object FfiConverterTypeValidatorDetails: FfiConverterRustBuffer<ValidatorDetails> {
-    override fun read(buf: ByteBuffer): ValidatorDetails {
-        return ValidatorDetails(
-            FfiConverterString.read(buf),
-            FfiConverterOptionalString.read(buf),
-            FfiConverterOptionalString.read(buf),
-        )
-    }
-
-    override fun allocationSize(value: ValidatorDetails) = (
-            FfiConverterString.allocationSize(value.`nyxdUrl`) +
-            FfiConverterOptionalString.allocationSize(value.`websocketUrl`) +
-            FfiConverterOptionalString.allocationSize(value.`apiUrl`)
-    )
-
-    override fun write(value: ValidatorDetails, buf: ByteBuffer) {
-            FfiConverterString.write(value.`nyxdUrl`, buf)
-            FfiConverterOptionalString.write(value.`websocketUrl`, buf)
-            FfiConverterOptionalString.write(value.`apiUrl`, buf)
-    }
-}
-
-
-
 data class WireguardConnectionData (
     var `entry`: WireguardNode, 
     var `exit`: WireguardNode
@@ -2748,6 +2514,35 @@ public object FfiConverterTypeWireguardNode: FfiConverterRustBuffer<WireguardNod
             FfiConverterTypeIpv4Addr.write(value.`privateIpv4`, buf)
     }
 }
+
+
+
+
+enum class AccountState {
+    
+    NOT_REGISTERED,
+    INACTIVE,
+    ACTIVE,
+    DELETE_ME;
+    companion object
+}
+
+
+public object FfiConverterTypeAccountState: FfiConverterRustBuffer<AccountState> {
+    override fun read(buf: ByteBuffer) = try {
+        AccountState.values()[buf.getInt() - 1]
+    } catch (e: IndexOutOfBoundsException) {
+        throw RuntimeException("invalid enum value, something is very wrong!!", e)
+    }
+
+    override fun allocationSize(value: AccountState) = 4UL
+
+    override fun write(value: AccountState, buf: ByteBuffer) {
+        buf.putInt(value.ordinal + 1)
+    }
+}
+
+
 
 
 
@@ -3004,6 +2799,35 @@ public object FfiConverterTypeConnectionStatus: FfiConverterRustBuffer<Connectio
     override fun allocationSize(value: ConnectionStatus) = 4UL
 
     override fun write(value: ConnectionStatus, buf: ByteBuffer) {
+        buf.putInt(value.ordinal + 1)
+    }
+}
+
+
+
+
+
+
+enum class DeviceState {
+    
+    NOT_REGISTERED,
+    INACTIVE,
+    ACTIVE,
+    DELETE_ME;
+    companion object
+}
+
+
+public object FfiConverterTypeDeviceState: FfiConverterRustBuffer<DeviceState> {
+    override fun read(buf: ByteBuffer) = try {
+        DeviceState.values()[buf.getInt() - 1]
+    } catch (e: IndexOutOfBoundsException) {
+        throw RuntimeException("invalid enum value, something is very wrong!!", e)
+    }
+
+    override fun allocationSize(value: DeviceState) = 4UL
+
+    override fun write(value: DeviceState, buf: ByteBuffer) {
         buf.putInt(value.ordinal + 1)
     }
 }
@@ -3561,6 +3385,33 @@ public object FfiConverterTypeMixnetEvent : FfiConverterRustBuffer<MixnetEvent>{
 
 
 
+
+enum class MnemonicState {
+    
+    NOT_STORED,
+    STORED;
+    companion object
+}
+
+
+public object FfiConverterTypeMnemonicState: FfiConverterRustBuffer<MnemonicState> {
+    override fun read(buf: ByteBuffer) = try {
+        MnemonicState.values()[buf.getInt() - 1]
+    } catch (e: IndexOutOfBoundsException) {
+        throw RuntimeException("invalid enum value, something is very wrong!!", e)
+    }
+
+    override fun allocationSize(value: MnemonicState) = 4UL
+
+    override fun write(value: MnemonicState, buf: ByteBuffer) {
+        buf.putInt(value.ordinal + 1)
+    }
+}
+
+
+
+
+
 sealed class NymVpnStatus {
     
     data class MixConnectInfo(
@@ -3629,6 +3480,35 @@ public object FfiConverterTypeNymVpnStatus : FfiConverterRustBuffer<NymVpnStatus
                 Unit
             }
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
+    }
+}
+
+
+
+
+
+
+enum class SubscriptionState {
+    
+    NOT_ACTIVE,
+    PENDING,
+    COMPLETE,
+    ACTIVE;
+    companion object
+}
+
+
+public object FfiConverterTypeSubscriptionState: FfiConverterRustBuffer<SubscriptionState> {
+    override fun read(buf: ByteBuffer) = try {
+        SubscriptionState.values()[buf.getInt() - 1]
+    } catch (e: IndexOutOfBoundsException) {
+        throw RuntimeException("invalid enum value, something is very wrong!!", e)
+    }
+
+    override fun allocationSize(value: SubscriptionState) = 4UL
+
+    override fun write(value: SubscriptionState, buf: ByteBuffer) {
+        buf.putInt(value.ordinal + 1)
     }
 }
 
@@ -3992,6 +3872,14 @@ sealed class VpnException: Exception() {
             get() = "details=${ `details` }"
     }
     
+    class Account(
+        
+        val `details`: kotlin.String
+        ) : VpnException() {
+        override val message
+            get() = "details=${ `details` }"
+    }
+    
 
     companion object ErrorHandler : UniffiRustCallStatusErrorHandler<VpnException> {
         override fun lift(error_buf: RustBuffer.ByValue): VpnException = FfiConverterTypeVpnError.lift(error_buf)
@@ -4019,6 +3907,9 @@ public object FfiConverterTypeVpnError : FfiConverterRustBuffer<VpnException> {
                 )
             5 -> VpnException.OutOfBandwidth()
             6 -> VpnException.InvalidStateException(
+                FfiConverterString.read(buf),
+                )
+            7 -> VpnException.Account(
                 FfiConverterString.read(buf),
                 )
             else -> throw RuntimeException("invalid error enum value, something is very wrong!!")
@@ -4052,6 +3943,11 @@ public object FfiConverterTypeVpnError : FfiConverterRustBuffer<VpnException> {
                 4UL
             )
             is VpnException.InvalidStateException -> (
+                // Add the size for the Int that specifies the variant plus the size needed for all fields
+                4UL
+                + FfiConverterString.allocationSize(value.`details`)
+            )
+            is VpnException.Account -> (
                 // Add the size for the Int that specifies the variant plus the size needed for all fields
                 4UL
                 + FfiConverterString.allocationSize(value.`details`)
@@ -4090,6 +3986,11 @@ public object FfiConverterTypeVpnError : FfiConverterRustBuffer<VpnException> {
                 FfiConverterString.write(value.`details`, buf)
                 Unit
             }
+            is VpnException.Account -> {
+                buf.putInt(7)
+                FfiConverterString.write(value.`details`, buf)
+                Unit
+            }
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
     }
 
@@ -4120,35 +4021,6 @@ public object FfiConverterOptionalULong: FfiConverterRustBuffer<kotlin.ULong?> {
         } else {
             buf.put(1)
             FfiConverterULong.write(value, buf)
-        }
-    }
-}
-
-
-
-
-public object FfiConverterOptionalString: FfiConverterRustBuffer<kotlin.String?> {
-    override fun read(buf: ByteBuffer): kotlin.String? {
-        if (buf.get().toInt() == 0) {
-            return null
-        }
-        return FfiConverterString.read(buf)
-    }
-
-    override fun allocationSize(value: kotlin.String?): ULong {
-        if (value == null) {
-            return 1UL
-        } else {
-            return 1UL + FfiConverterString.allocationSize(value)
-        }
-    }
-
-    override fun write(value: kotlin.String?, buf: ByteBuffer) {
-        if (value == null) {
-            buf.put(0)
-        } else {
-            buf.put(1)
-            FfiConverterString.write(value, buf)
         }
     }
 }
@@ -4323,6 +4195,122 @@ public object FfiConverterOptionalTypeUserAgent: FfiConverterRustBuffer<UserAgen
         } else {
             buf.put(1)
             FfiConverterTypeUserAgent.write(value, buf)
+        }
+    }
+}
+
+
+
+
+public object FfiConverterOptionalTypeAccountState: FfiConverterRustBuffer<AccountState?> {
+    override fun read(buf: ByteBuffer): AccountState? {
+        if (buf.get().toInt() == 0) {
+            return null
+        }
+        return FfiConverterTypeAccountState.read(buf)
+    }
+
+    override fun allocationSize(value: AccountState?): ULong {
+        if (value == null) {
+            return 1UL
+        } else {
+            return 1UL + FfiConverterTypeAccountState.allocationSize(value)
+        }
+    }
+
+    override fun write(value: AccountState?, buf: ByteBuffer) {
+        if (value == null) {
+            buf.put(0)
+        } else {
+            buf.put(1)
+            FfiConverterTypeAccountState.write(value, buf)
+        }
+    }
+}
+
+
+
+
+public object FfiConverterOptionalTypeDeviceState: FfiConverterRustBuffer<DeviceState?> {
+    override fun read(buf: ByteBuffer): DeviceState? {
+        if (buf.get().toInt() == 0) {
+            return null
+        }
+        return FfiConverterTypeDeviceState.read(buf)
+    }
+
+    override fun allocationSize(value: DeviceState?): ULong {
+        if (value == null) {
+            return 1UL
+        } else {
+            return 1UL + FfiConverterTypeDeviceState.allocationSize(value)
+        }
+    }
+
+    override fun write(value: DeviceState?, buf: ByteBuffer) {
+        if (value == null) {
+            buf.put(0)
+        } else {
+            buf.put(1)
+            FfiConverterTypeDeviceState.write(value, buf)
+        }
+    }
+}
+
+
+
+
+public object FfiConverterOptionalTypeMnemonicState: FfiConverterRustBuffer<MnemonicState?> {
+    override fun read(buf: ByteBuffer): MnemonicState? {
+        if (buf.get().toInt() == 0) {
+            return null
+        }
+        return FfiConverterTypeMnemonicState.read(buf)
+    }
+
+    override fun allocationSize(value: MnemonicState?): ULong {
+        if (value == null) {
+            return 1UL
+        } else {
+            return 1UL + FfiConverterTypeMnemonicState.allocationSize(value)
+        }
+    }
+
+    override fun write(value: MnemonicState?, buf: ByteBuffer) {
+        if (value == null) {
+            buf.put(0)
+        } else {
+            buf.put(1)
+            FfiConverterTypeMnemonicState.write(value, buf)
+        }
+    }
+}
+
+
+
+
+public object FfiConverterOptionalTypeSubscriptionState: FfiConverterRustBuffer<SubscriptionState?> {
+    override fun read(buf: ByteBuffer): SubscriptionState? {
+        if (buf.get().toInt() == 0) {
+            return null
+        }
+        return FfiConverterTypeSubscriptionState.read(buf)
+    }
+
+    override fun allocationSize(value: SubscriptionState?): ULong {
+        if (value == null) {
+            return 1UL
+        } else {
+            return 1UL + FfiConverterTypeSubscriptionState.allocationSize(value)
+        }
+    }
+
+    override fun write(value: SubscriptionState?, buf: ByteBuffer) {
+        if (value == null) {
+            buf.put(0)
+        } else {
+            buf.put(1)
+            FfiConverterTypeSubscriptionState.write(value, buf)
         }
     }
 }
@@ -4576,31 +4564,6 @@ public object FfiConverterSequenceTypeLocation: FfiConverterRustBuffer<List<Loca
         buf.putInt(value.size)
         value.iterator().forEach {
             FfiConverterTypeLocation.write(it, buf)
-        }
-    }
-}
-
-
-
-
-public object FfiConverterSequenceTypeValidatorDetails: FfiConverterRustBuffer<List<ValidatorDetails>> {
-    override fun read(buf: ByteBuffer): List<ValidatorDetails> {
-        val len = buf.getInt()
-        return List<ValidatorDetails>(len) {
-            FfiConverterTypeValidatorDetails.read(buf)
-        }
-    }
-
-    override fun allocationSize(value: List<ValidatorDetails>): ULong {
-        val sizeForLength = 4UL
-        val sizeForItems = value.map { FfiConverterTypeValidatorDetails.allocationSize(it) }.sum()
-        return sizeForLength + sizeForItems
-    }
-
-    override fun write(value: List<ValidatorDetails>, buf: ByteBuffer) {
-        buf.putInt(value.size)
-        value.iterator().forEach {
-            FfiConverterTypeValidatorDetails.write(it, buf)
         }
     }
 }
@@ -4909,16 +4872,6 @@ public object FfiConverterTypeUrl: FfiConverter<Url, RustBuffer.ByValue> {
         FfiConverterString.write(builtinValue, buf)
     }
 }
-    @Throws(VpnException::class) fun `fetchEnvironment`(`networkName`: kotlin.String): NetworkEnvironment {
-            return FfiConverterTypeNetworkEnvironment.lift(
-    uniffiRustCallWithError(VpnException) { _status ->
-    UniffiLib.INSTANCE.uniffi_nym_vpn_lib_fn_func_fetchenvironment(
-        FfiConverterString.lower(`networkName`),_status)
-}
-    )
-    }
-    
-
     @Throws(VpnException::class) fun `getGatewayCountries`(`apiUrl`: Url, `nymVpnApiUrl`: Url?, `gwType`: GatewayType, `userAgent`: UserAgent?, `minGatewayPerformance`: GatewayMinPerformance?): List<Location> {
             return FfiConverterSequenceTypeLocation.lift(
     uniffiRustCallWithError(VpnException) { _status ->
@@ -4967,11 +4920,29 @@ public object FfiConverterTypeUrl: FfiConverter<Url, RustBuffer.ByValue> {
     }
     
 
+    @Throws(VpnException::class) fun `startAccountController`(`dataDir`: kotlin.String)
+        = 
+    uniffiRustCallWithError(VpnException) { _status ->
+    UniffiLib.INSTANCE.uniffi_nym_vpn_lib_fn_func_startaccountcontroller(
+        FfiConverterString.lower(`dataDir`),_status)
+}
+    
+    
+
     @Throws(VpnException::class) fun `startVpn`(`config`: VpnConfig)
         = 
     uniffiRustCallWithError(VpnException) { _status ->
     UniffiLib.INSTANCE.uniffi_nym_vpn_lib_fn_func_startvpn(
         FfiConverterTypeVPNConfig.lower(`config`),_status)
+}
+    
+    
+
+    @Throws(VpnException::class) fun `stopAccountController`()
+        = 
+    uniffiRustCallWithError(VpnException) { _status ->
+    UniffiLib.INSTANCE.uniffi_nym_vpn_lib_fn_func_stopaccountcontroller(
+        _status)
 }
     
     

--- a/nym-vpn-core/crates/nym-vpn-lib/uniffi/nym_vpn_lib.kt
+++ b/nym-vpn-core/crates/nym-vpn-lib/uniffi/nym_vpn_lib.kt
@@ -771,6 +771,8 @@ internal open class UniffiVTableCallbackInterfaceTunnelStatusListener(
 
 
 
+
+
 // A JNA Library to expose the extern-C FFI definitions.
 // This is an implementation detail which will be called internally by the public API.
 
@@ -811,6 +813,8 @@ internal interface UniffiLib : Library {
     fun uniffi_nym_vpn_lib_fn_method_tunnelstatuslistener_on_event(`ptr`: Pointer,`event`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): Unit
     fun uniffi_nym_vpn_lib_fn_func_fetchenvironment(`networkName`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+    ): RustBuffer.ByValue
+    fun uniffi_nym_vpn_lib_fn_func_getaccountsummary(uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
     fun uniffi_nym_vpn_lib_fn_func_getgatewaycountries(`apiUrl`: RustBuffer.ByValue,`nymVpnApiUrl`: RustBuffer.ByValue,`gwType`: RustBuffer.ByValue,`userAgent`: RustBuffer.ByValue,`minGatewayPerformance`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
@@ -946,6 +950,8 @@ internal interface UniffiLib : Library {
     ): Unit
     fun uniffi_nym_vpn_lib_checksum_func_fetchenvironment(
     ): Short
+    fun uniffi_nym_vpn_lib_checksum_func_getaccountsummary(
+    ): Short
     fun uniffi_nym_vpn_lib_checksum_func_getgatewaycountries(
     ): Short
     fun uniffi_nym_vpn_lib_checksum_func_getlowlatencyentrycountry(
@@ -990,6 +996,9 @@ private fun uniffiCheckContractApiVersion(lib: UniffiLib) {
 @Suppress("UNUSED_PARAMETER")
 private fun uniffiCheckApiChecksums(lib: UniffiLib) {
     if (lib.uniffi_nym_vpn_lib_checksum_func_fetchenvironment() != 34561.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_nym_vpn_lib_checksum_func_getaccountsummary() != 13465.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_nym_vpn_lib_checksum_func_getgatewaycountries() != 41607.toShort()) {
@@ -5335,6 +5344,16 @@ public object FfiConverterTypeUrl: FfiConverter<Url, RustBuffer.ByValue> {
     uniffiRustCallWithError(VpnException) { _status ->
     UniffiLib.INSTANCE.uniffi_nym_vpn_lib_fn_func_fetchenvironment(
         FfiConverterString.lower(`networkName`),_status)
+}
+    )
+    }
+    
+
+    @Throws(VpnException::class) fun `getAccountSummary`(): AccountStateSummary {
+            return FfiConverterTypeAccountStateSummary.lift(
+    uniffiRustCallWithError(VpnException) { _status ->
+    UniffiLib.INSTANCE.uniffi_nym_vpn_lib_fn_func_getaccountsummary(
+        _status)
 }
     )
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/uniffi/nym_vpn_lib.swift
+++ b/nym-vpn-core/crates/nym-vpn-lib/uniffi/nym_vpn_lib.swift
@@ -5915,6 +5915,12 @@ public func fetchEnvironment(networkName: String)throws  -> NetworkEnvironment {
     )
 })
 }
+public func getAccountSummary()throws  -> AccountStateSummary {
+    return try  FfiConverterTypeAccountStateSummary.lift(try rustCallWithError(FfiConverterTypeVpnError.lift) {
+    uniffi_nym_vpn_lib_fn_func_getaccountsummary($0
+    )
+})
+}
 public func getGatewayCountries(apiUrl: Url, nymVpnApiUrl: Url?, gwType: GatewayType, userAgent: UserAgent?, minGatewayPerformance: GatewayMinPerformance?)throws  -> [Location] {
     return try  FfiConverterSequenceTypeLocation.lift(try rustCallWithError(FfiConverterTypeVpnError.lift) {
     uniffi_nym_vpn_lib_fn_func_getgatewaycountries(
@@ -6000,6 +6006,9 @@ private var initializationResult: InitializationResult {
         return InitializationResult.contractVersionMismatch
     }
     if (uniffi_nym_vpn_lib_checksum_func_fetchenvironment() != 34561) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_nym_vpn_lib_checksum_func_getaccountsummary() != 13465) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_nym_vpn_lib_checksum_func_getgatewaycountries() != 41607) {

--- a/nym-vpn-core/crates/nym-vpn-lib/uniffi/nym_vpn_lib.swift
+++ b/nym-vpn-core/crates/nym-vpn-lib/uniffi/nym_vpn_lib.swift
@@ -408,19 +408,6 @@ fileprivate struct FfiConverterUInt16: FfiConverterPrimitive {
     }
 }
 
-fileprivate struct FfiConverterUInt32: FfiConverterPrimitive {
-    typealias FfiType = UInt32
-    typealias SwiftType = UInt32
-
-    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> UInt32 {
-        return try lift(readInt(&buf))
-    }
-
-    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
-        writeInt(&buf, lower(value))
-    }
-}
-
 fileprivate struct FfiConverterUInt64: FfiConverterPrimitive {
     typealias FfiType = UInt64
     typealias SwiftType = UInt64
@@ -1042,68 +1029,84 @@ public func FfiConverterTypeTunnelStatusListener_lower(_ value: TunnelStatusList
 }
 
 
-public struct ChainDetails {
-    public var bech32AccountPrefix: String
-    public var mixDenom: DenomDetails
-    public var stakeDenom: DenomDetails
+public struct AccountStateSummary {
+    public var mnemonic: MnemonicState?
+    public var account: AccountState?
+    public var subscription: SubscriptionState?
+    public var device: DeviceState?
+    public var pendingZkNym: Bool
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(bech32AccountPrefix: String, mixDenom: DenomDetails, stakeDenom: DenomDetails) {
-        self.bech32AccountPrefix = bech32AccountPrefix
-        self.mixDenom = mixDenom
-        self.stakeDenom = stakeDenom
+    public init(mnemonic: MnemonicState?, account: AccountState?, subscription: SubscriptionState?, device: DeviceState?, pendingZkNym: Bool) {
+        self.mnemonic = mnemonic
+        self.account = account
+        self.subscription = subscription
+        self.device = device
+        self.pendingZkNym = pendingZkNym
     }
 }
 
 
 
-extension ChainDetails: Equatable, Hashable {
-    public static func ==(lhs: ChainDetails, rhs: ChainDetails) -> Bool {
-        if lhs.bech32AccountPrefix != rhs.bech32AccountPrefix {
+extension AccountStateSummary: Equatable, Hashable {
+    public static func ==(lhs: AccountStateSummary, rhs: AccountStateSummary) -> Bool {
+        if lhs.mnemonic != rhs.mnemonic {
             return false
         }
-        if lhs.mixDenom != rhs.mixDenom {
+        if lhs.account != rhs.account {
             return false
         }
-        if lhs.stakeDenom != rhs.stakeDenom {
+        if lhs.subscription != rhs.subscription {
+            return false
+        }
+        if lhs.device != rhs.device {
+            return false
+        }
+        if lhs.pendingZkNym != rhs.pendingZkNym {
             return false
         }
         return true
     }
 
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(bech32AccountPrefix)
-        hasher.combine(mixDenom)
-        hasher.combine(stakeDenom)
+        hasher.combine(mnemonic)
+        hasher.combine(account)
+        hasher.combine(subscription)
+        hasher.combine(device)
+        hasher.combine(pendingZkNym)
     }
 }
 
 
-public struct FfiConverterTypeChainDetails: FfiConverterRustBuffer {
-    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ChainDetails {
+public struct FfiConverterTypeAccountStateSummary: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AccountStateSummary {
         return
-            try ChainDetails(
-                bech32AccountPrefix: FfiConverterString.read(from: &buf), 
-                mixDenom: FfiConverterTypeDenomDetails.read(from: &buf), 
-                stakeDenom: FfiConverterTypeDenomDetails.read(from: &buf)
+            try AccountStateSummary(
+                mnemonic: FfiConverterOptionTypeMnemonicState.read(from: &buf), 
+                account: FfiConverterOptionTypeAccountState.read(from: &buf), 
+                subscription: FfiConverterOptionTypeSubscriptionState.read(from: &buf), 
+                device: FfiConverterOptionTypeDeviceState.read(from: &buf), 
+                pendingZkNym: FfiConverterBool.read(from: &buf)
         )
     }
 
-    public static func write(_ value: ChainDetails, into buf: inout [UInt8]) {
-        FfiConverterString.write(value.bech32AccountPrefix, into: &buf)
-        FfiConverterTypeDenomDetails.write(value.mixDenom, into: &buf)
-        FfiConverterTypeDenomDetails.write(value.stakeDenom, into: &buf)
+    public static func write(_ value: AccountStateSummary, into buf: inout [UInt8]) {
+        FfiConverterOptionTypeMnemonicState.write(value.mnemonic, into: &buf)
+        FfiConverterOptionTypeAccountState.write(value.account, into: &buf)
+        FfiConverterOptionTypeSubscriptionState.write(value.subscription, into: &buf)
+        FfiConverterOptionTypeDeviceState.write(value.device, into: &buf)
+        FfiConverterBool.write(value.pendingZkNym, into: &buf)
     }
 }
 
 
-public func FfiConverterTypeChainDetails_lift(_ buf: RustBuffer) throws -> ChainDetails {
-    return try FfiConverterTypeChainDetails.lift(buf)
+public func FfiConverterTypeAccountStateSummary_lift(_ buf: RustBuffer) throws -> AccountStateSummary {
+    return try FfiConverterTypeAccountStateSummary.lift(buf)
 }
 
-public func FfiConverterTypeChainDetails_lower(_ value: ChainDetails) -> RustBuffer {
-    return FfiConverterTypeChainDetails.lower(value)
+public func FfiConverterTypeAccountStateSummary_lower(_ value: AccountStateSummary) -> RustBuffer {
+    return FfiConverterTypeAccountStateSummary.lower(value)
 }
 
 
@@ -1201,71 +1204,6 @@ public func FfiConverterTypeConnectionData_lift(_ buf: RustBuffer) throws -> Con
 
 public func FfiConverterTypeConnectionData_lower(_ value: ConnectionData) -> RustBuffer {
     return FfiConverterTypeConnectionData.lower(value)
-}
-
-
-public struct DenomDetails {
-    public var base: String
-    public var display: String
-    public var displayExponent: UInt32
-
-    // Default memberwise initializers are never public by default, so we
-    // declare one manually.
-    public init(base: String, display: String, displayExponent: UInt32) {
-        self.base = base
-        self.display = display
-        self.displayExponent = displayExponent
-    }
-}
-
-
-
-extension DenomDetails: Equatable, Hashable {
-    public static func ==(lhs: DenomDetails, rhs: DenomDetails) -> Bool {
-        if lhs.base != rhs.base {
-            return false
-        }
-        if lhs.display != rhs.display {
-            return false
-        }
-        if lhs.displayExponent != rhs.displayExponent {
-            return false
-        }
-        return true
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(base)
-        hasher.combine(display)
-        hasher.combine(displayExponent)
-    }
-}
-
-
-public struct FfiConverterTypeDenomDetails: FfiConverterRustBuffer {
-    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> DenomDetails {
-        return
-            try DenomDetails(
-                base: FfiConverterString.read(from: &buf), 
-                display: FfiConverterString.read(from: &buf), 
-                displayExponent: FfiConverterUInt32.read(from: &buf)
-        )
-    }
-
-    public static func write(_ value: DenomDetails, into buf: inout [UInt8]) {
-        FfiConverterString.write(value.base, into: &buf)
-        FfiConverterString.write(value.display, into: &buf)
-        FfiConverterUInt32.write(value.displayExponent, into: &buf)
-    }
-}
-
-
-public func FfiConverterTypeDenomDetails_lift(_ buf: RustBuffer) throws -> DenomDetails {
-    return try FfiConverterTypeDenomDetails.lift(buf)
-}
-
-public func FfiConverterTypeDenomDetails_lower(_ value: DenomDetails) -> RustBuffer {
-    return FfiConverterTypeDenomDetails.lower(value)
 }
 
 
@@ -1820,303 +1758,6 @@ public func FfiConverterTypeMixnetConnectionData_lower(_ value: MixnetConnection
 
 
 /**
- * Represents the nym network environment together with the environment specific to nym-vpn. These
- * need to be exported to the environment (for now, until it's refactored internally in the nym
- * crates) so that the client can have access to the necessary information.
- *
- * The list is as of today:
- *
- * NETWORK_NAME = nym_network::network_name
- *
- * BECH32_PREFIX = nym_network::chain_details::bech32_account_prefix
- * MIX_DENOM = nym_network::chain_details::mix_denom::base
- * MIX_DENOM_DISPLAY = nym_network::chain_details::mix_denom::display
- * STAKE_DENOM = nym_network::chain_details::stake_denom::base
- * STAKE_DENOM_DISPLAY = nym_network::chain_details::stake_denom::display
- * DENOMS_EXPONENT = nym_network::chain_details::mix_denom::display_exponent
- *
- * MIXNET_CONTRACT_ADDRESS = nym_network::contracts::mixnet_contract_address
- * VESTING_CONTRACT_ADDRESS = nym_network::contracts::vesting_contract_address
- * GROUP_CONTRACT_ADDRESS = nym_network::contracts::group_contract_address
- * ECASH_CONTRACT_ADDRESS = nym_network::contracts::ecash_contract_address
- * MULTISIG_CONTRACT_ADDRESS = nym_network::contracts::multisig_contract_address
- * COCONUT_DKG_CONTRACT_ADDRESS = nym_network::contracts::coconut_dkg_contract_address
- *
- * NYXD = nym_network::endpoints[0]::nyxd_url
- * NYM_API = nym_network::endpoints[0]::api_url
- * NYXD_WS = nym_network::endpoints[0]::websocket_url
- *
- * NYM_VPN_API = nym_vpn_network::nym_vpn_api_url
- */
-public struct NetworkEnvironment {
-    public var nymNetwork: NymNetworkDetails
-    public var nymVpnNetwork: NymVpnNetwork
-
-    // Default memberwise initializers are never public by default, so we
-    // declare one manually.
-    public init(nymNetwork: NymNetworkDetails, nymVpnNetwork: NymVpnNetwork) {
-        self.nymNetwork = nymNetwork
-        self.nymVpnNetwork = nymVpnNetwork
-    }
-}
-
-
-
-extension NetworkEnvironment: Equatable, Hashable {
-    public static func ==(lhs: NetworkEnvironment, rhs: NetworkEnvironment) -> Bool {
-        if lhs.nymNetwork != rhs.nymNetwork {
-            return false
-        }
-        if lhs.nymVpnNetwork != rhs.nymVpnNetwork {
-            return false
-        }
-        return true
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(nymNetwork)
-        hasher.combine(nymVpnNetwork)
-    }
-}
-
-
-public struct FfiConverterTypeNetworkEnvironment: FfiConverterRustBuffer {
-    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> NetworkEnvironment {
-        return
-            try NetworkEnvironment(
-                nymNetwork: FfiConverterTypeNymNetworkDetails.read(from: &buf), 
-                nymVpnNetwork: FfiConverterTypeNymVpnNetwork.read(from: &buf)
-        )
-    }
-
-    public static func write(_ value: NetworkEnvironment, into buf: inout [UInt8]) {
-        FfiConverterTypeNymNetworkDetails.write(value.nymNetwork, into: &buf)
-        FfiConverterTypeNymVpnNetwork.write(value.nymVpnNetwork, into: &buf)
-    }
-}
-
-
-public func FfiConverterTypeNetworkEnvironment_lift(_ buf: RustBuffer) throws -> NetworkEnvironment {
-    return try FfiConverterTypeNetworkEnvironment.lift(buf)
-}
-
-public func FfiConverterTypeNetworkEnvironment_lower(_ value: NetworkEnvironment) -> RustBuffer {
-    return FfiConverterTypeNetworkEnvironment.lower(value)
-}
-
-
-public struct NymContracts {
-    public var mixnetContractAddress: String?
-    public var vestingContractAddress: String?
-    public var ecashContractAddress: String?
-    public var groupContractAddress: String?
-    public var multisigContractAddress: String?
-    public var coconutDkgContractAddress: String?
-
-    // Default memberwise initializers are never public by default, so we
-    // declare one manually.
-    public init(mixnetContractAddress: String?, vestingContractAddress: String?, ecashContractAddress: String?, groupContractAddress: String?, multisigContractAddress: String?, coconutDkgContractAddress: String?) {
-        self.mixnetContractAddress = mixnetContractAddress
-        self.vestingContractAddress = vestingContractAddress
-        self.ecashContractAddress = ecashContractAddress
-        self.groupContractAddress = groupContractAddress
-        self.multisigContractAddress = multisigContractAddress
-        self.coconutDkgContractAddress = coconutDkgContractAddress
-    }
-}
-
-
-
-extension NymContracts: Equatable, Hashable {
-    public static func ==(lhs: NymContracts, rhs: NymContracts) -> Bool {
-        if lhs.mixnetContractAddress != rhs.mixnetContractAddress {
-            return false
-        }
-        if lhs.vestingContractAddress != rhs.vestingContractAddress {
-            return false
-        }
-        if lhs.ecashContractAddress != rhs.ecashContractAddress {
-            return false
-        }
-        if lhs.groupContractAddress != rhs.groupContractAddress {
-            return false
-        }
-        if lhs.multisigContractAddress != rhs.multisigContractAddress {
-            return false
-        }
-        if lhs.coconutDkgContractAddress != rhs.coconutDkgContractAddress {
-            return false
-        }
-        return true
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(mixnetContractAddress)
-        hasher.combine(vestingContractAddress)
-        hasher.combine(ecashContractAddress)
-        hasher.combine(groupContractAddress)
-        hasher.combine(multisigContractAddress)
-        hasher.combine(coconutDkgContractAddress)
-    }
-}
-
-
-public struct FfiConverterTypeNymContracts: FfiConverterRustBuffer {
-    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> NymContracts {
-        return
-            try NymContracts(
-                mixnetContractAddress: FfiConverterOptionString.read(from: &buf), 
-                vestingContractAddress: FfiConverterOptionString.read(from: &buf), 
-                ecashContractAddress: FfiConverterOptionString.read(from: &buf), 
-                groupContractAddress: FfiConverterOptionString.read(from: &buf), 
-                multisigContractAddress: FfiConverterOptionString.read(from: &buf), 
-                coconutDkgContractAddress: FfiConverterOptionString.read(from: &buf)
-        )
-    }
-
-    public static func write(_ value: NymContracts, into buf: inout [UInt8]) {
-        FfiConverterOptionString.write(value.mixnetContractAddress, into: &buf)
-        FfiConverterOptionString.write(value.vestingContractAddress, into: &buf)
-        FfiConverterOptionString.write(value.ecashContractAddress, into: &buf)
-        FfiConverterOptionString.write(value.groupContractAddress, into: &buf)
-        FfiConverterOptionString.write(value.multisigContractAddress, into: &buf)
-        FfiConverterOptionString.write(value.coconutDkgContractAddress, into: &buf)
-    }
-}
-
-
-public func FfiConverterTypeNymContracts_lift(_ buf: RustBuffer) throws -> NymContracts {
-    return try FfiConverterTypeNymContracts.lift(buf)
-}
-
-public func FfiConverterTypeNymContracts_lower(_ value: NymContracts) -> RustBuffer {
-    return FfiConverterTypeNymContracts.lower(value)
-}
-
-
-public struct NymNetworkDetails {
-    public var networkName: String
-    public var chainDetails: ChainDetails
-    public var endpoints: [ValidatorDetails]
-    public var contracts: NymContracts
-
-    // Default memberwise initializers are never public by default, so we
-    // declare one manually.
-    public init(networkName: String, chainDetails: ChainDetails, endpoints: [ValidatorDetails], contracts: NymContracts) {
-        self.networkName = networkName
-        self.chainDetails = chainDetails
-        self.endpoints = endpoints
-        self.contracts = contracts
-    }
-}
-
-
-
-extension NymNetworkDetails: Equatable, Hashable {
-    public static func ==(lhs: NymNetworkDetails, rhs: NymNetworkDetails) -> Bool {
-        if lhs.networkName != rhs.networkName {
-            return false
-        }
-        if lhs.chainDetails != rhs.chainDetails {
-            return false
-        }
-        if lhs.endpoints != rhs.endpoints {
-            return false
-        }
-        if lhs.contracts != rhs.contracts {
-            return false
-        }
-        return true
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(networkName)
-        hasher.combine(chainDetails)
-        hasher.combine(endpoints)
-        hasher.combine(contracts)
-    }
-}
-
-
-public struct FfiConverterTypeNymNetworkDetails: FfiConverterRustBuffer {
-    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> NymNetworkDetails {
-        return
-            try NymNetworkDetails(
-                networkName: FfiConverterString.read(from: &buf), 
-                chainDetails: FfiConverterTypeChainDetails.read(from: &buf), 
-                endpoints: FfiConverterSequenceTypeValidatorDetails.read(from: &buf), 
-                contracts: FfiConverterTypeNymContracts.read(from: &buf)
-        )
-    }
-
-    public static func write(_ value: NymNetworkDetails, into buf: inout [UInt8]) {
-        FfiConverterString.write(value.networkName, into: &buf)
-        FfiConverterTypeChainDetails.write(value.chainDetails, into: &buf)
-        FfiConverterSequenceTypeValidatorDetails.write(value.endpoints, into: &buf)
-        FfiConverterTypeNymContracts.write(value.contracts, into: &buf)
-    }
-}
-
-
-public func FfiConverterTypeNymNetworkDetails_lift(_ buf: RustBuffer) throws -> NymNetworkDetails {
-    return try FfiConverterTypeNymNetworkDetails.lift(buf)
-}
-
-public func FfiConverterTypeNymNetworkDetails_lower(_ value: NymNetworkDetails) -> RustBuffer {
-    return FfiConverterTypeNymNetworkDetails.lower(value)
-}
-
-
-public struct NymVpnNetwork {
-    public var nymVpnApiUrl: String
-
-    // Default memberwise initializers are never public by default, so we
-    // declare one manually.
-    public init(nymVpnApiUrl: String) {
-        self.nymVpnApiUrl = nymVpnApiUrl
-    }
-}
-
-
-
-extension NymVpnNetwork: Equatable, Hashable {
-    public static func ==(lhs: NymVpnNetwork, rhs: NymVpnNetwork) -> Bool {
-        if lhs.nymVpnApiUrl != rhs.nymVpnApiUrl {
-            return false
-        }
-        return true
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(nymVpnApiUrl)
-    }
-}
-
-
-public struct FfiConverterTypeNymVpnNetwork: FfiConverterRustBuffer {
-    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> NymVpnNetwork {
-        return
-            try NymVpnNetwork(
-                nymVpnApiUrl: FfiConverterString.read(from: &buf)
-        )
-    }
-
-    public static func write(_ value: NymVpnNetwork, into buf: inout [UInt8]) {
-        FfiConverterString.write(value.nymVpnApiUrl, into: &buf)
-    }
-}
-
-
-public func FfiConverterTypeNymVpnNetwork_lift(_ buf: RustBuffer) throws -> NymVpnNetwork {
-    return try FfiConverterTypeNymVpnNetwork.lift(buf)
-}
-
-public func FfiConverterTypeNymVpnNetwork_lower(_ value: NymVpnNetwork) -> RustBuffer {
-    return FfiConverterTypeNymVpnNetwork.lower(value)
-}
-
-
-/**
  * Represents a default network route used by the system.
  */
 public struct OsDefaultPath {
@@ -2452,71 +2093,6 @@ public func FfiConverterTypeVPNConfig_lower(_ value: VpnConfig) -> RustBuffer {
 }
 
 
-public struct ValidatorDetails {
-    public var nyxdUrl: String
-    public var websocketUrl: String?
-    public var apiUrl: String?
-
-    // Default memberwise initializers are never public by default, so we
-    // declare one manually.
-    public init(nyxdUrl: String, websocketUrl: String?, apiUrl: String?) {
-        self.nyxdUrl = nyxdUrl
-        self.websocketUrl = websocketUrl
-        self.apiUrl = apiUrl
-    }
-}
-
-
-
-extension ValidatorDetails: Equatable, Hashable {
-    public static func ==(lhs: ValidatorDetails, rhs: ValidatorDetails) -> Bool {
-        if lhs.nyxdUrl != rhs.nyxdUrl {
-            return false
-        }
-        if lhs.websocketUrl != rhs.websocketUrl {
-            return false
-        }
-        if lhs.apiUrl != rhs.apiUrl {
-            return false
-        }
-        return true
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(nyxdUrl)
-        hasher.combine(websocketUrl)
-        hasher.combine(apiUrl)
-    }
-}
-
-
-public struct FfiConverterTypeValidatorDetails: FfiConverterRustBuffer {
-    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ValidatorDetails {
-        return
-            try ValidatorDetails(
-                nyxdUrl: FfiConverterString.read(from: &buf), 
-                websocketUrl: FfiConverterOptionString.read(from: &buf), 
-                apiUrl: FfiConverterOptionString.read(from: &buf)
-        )
-    }
-
-    public static func write(_ value: ValidatorDetails, into buf: inout [UInt8]) {
-        FfiConverterString.write(value.nyxdUrl, into: &buf)
-        FfiConverterOptionString.write(value.websocketUrl, into: &buf)
-        FfiConverterOptionString.write(value.apiUrl, into: &buf)
-    }
-}
-
-
-public func FfiConverterTypeValidatorDetails_lift(_ buf: RustBuffer) throws -> ValidatorDetails {
-    return try FfiConverterTypeValidatorDetails.lift(buf)
-}
-
-public func FfiConverterTypeValidatorDetails_lower(_ value: ValidatorDetails) -> RustBuffer {
-    return FfiConverterTypeValidatorDetails.lower(value)
-}
-
-
 public struct WireguardConnectionData {
     public var entry: WireguardNode
     public var exit: WireguardNode
@@ -2702,6 +2278,75 @@ public func FfiConverterTypeWireguardNode_lift(_ buf: RustBuffer) throws -> Wire
 public func FfiConverterTypeWireguardNode_lower(_ value: WireguardNode) -> RustBuffer {
     return FfiConverterTypeWireguardNode.lower(value)
 }
+
+// Note that we don't yet support `indirect` for enums.
+// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+
+public enum AccountState {
+    
+    case notRegistered
+    case inactive
+    case active
+    case deleteMe
+}
+
+
+public struct FfiConverterTypeAccountState: FfiConverterRustBuffer {
+    typealias SwiftType = AccountState
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AccountState {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+        
+        case 1: return .notRegistered
+        
+        case 2: return .inactive
+        
+        case 3: return .active
+        
+        case 4: return .deleteMe
+        
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: AccountState, into buf: inout [UInt8]) {
+        switch value {
+        
+        
+        case .notRegistered:
+            writeInt(&buf, Int32(1))
+        
+        
+        case .inactive:
+            writeInt(&buf, Int32(2))
+        
+        
+        case .active:
+            writeInt(&buf, Int32(3))
+        
+        
+        case .deleteMe:
+            writeInt(&buf, Int32(4))
+        
+        }
+    }
+}
+
+
+public func FfiConverterTypeAccountState_lift(_ buf: RustBuffer) throws -> AccountState {
+    return try FfiConverterTypeAccountState.lift(buf)
+}
+
+public func FfiConverterTypeAccountState_lower(_ value: AccountState) -> RustBuffer {
+    return FfiConverterTypeAccountState.lower(value)
+}
+
+
+
+extension AccountState: Equatable, Hashable {}
+
+
 
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
@@ -3061,6 +2706,75 @@ public func FfiConverterTypeConnectionStatus_lower(_ value: ConnectionStatus) ->
 
 
 extension ConnectionStatus: Equatable, Hashable {}
+
+
+
+// Note that we don't yet support `indirect` for enums.
+// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+
+public enum DeviceState {
+    
+    case notRegistered
+    case inactive
+    case active
+    case deleteMe
+}
+
+
+public struct FfiConverterTypeDeviceState: FfiConverterRustBuffer {
+    typealias SwiftType = DeviceState
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> DeviceState {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+        
+        case 1: return .notRegistered
+        
+        case 2: return .inactive
+        
+        case 3: return .active
+        
+        case 4: return .deleteMe
+        
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: DeviceState, into buf: inout [UInt8]) {
+        switch value {
+        
+        
+        case .notRegistered:
+            writeInt(&buf, Int32(1))
+        
+        
+        case .inactive:
+            writeInt(&buf, Int32(2))
+        
+        
+        case .active:
+            writeInt(&buf, Int32(3))
+        
+        
+        case .deleteMe:
+            writeInt(&buf, Int32(4))
+        
+        }
+    }
+}
+
+
+public func FfiConverterTypeDeviceState_lift(_ buf: RustBuffer) throws -> DeviceState {
+    return try FfiConverterTypeDeviceState.lift(buf)
+}
+
+public func FfiConverterTypeDeviceState_lower(_ value: DeviceState) -> RustBuffer {
+    return FfiConverterTypeDeviceState.lower(value)
+}
+
+
+
+extension DeviceState: Equatable, Hashable {}
 
 
 
@@ -3657,6 +3371,61 @@ extension MixnetEvent: Equatable, Hashable {}
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 
+public enum MnemonicState {
+    
+    case notStored
+    case stored
+}
+
+
+public struct FfiConverterTypeMnemonicState: FfiConverterRustBuffer {
+    typealias SwiftType = MnemonicState
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MnemonicState {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+        
+        case 1: return .notStored
+        
+        case 2: return .stored
+        
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: MnemonicState, into buf: inout [UInt8]) {
+        switch value {
+        
+        
+        case .notStored:
+            writeInt(&buf, Int32(1))
+        
+        
+        case .stored:
+            writeInt(&buf, Int32(2))
+        
+        }
+    }
+}
+
+
+public func FfiConverterTypeMnemonicState_lift(_ buf: RustBuffer) throws -> MnemonicState {
+    return try FfiConverterTypeMnemonicState.lift(buf)
+}
+
+public func FfiConverterTypeMnemonicState_lower(_ value: MnemonicState) -> RustBuffer {
+    return FfiConverterTypeMnemonicState.lower(value)
+}
+
+
+
+extension MnemonicState: Equatable, Hashable {}
+
+
+
+// Note that we don't yet support `indirect` for enums.
+// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+
 public enum NymVpnStatus {
     
     case mixConnectInfo(mixConnectionInfo: MixConnectionInfo, mixExitConnectionInfo: MixExitConnectionInfo
@@ -3811,6 +3580,75 @@ public func FfiConverterTypeOSPathStatus_lower(_ value: OsPathStatus) -> RustBuf
 
 
 extension OsPathStatus: Equatable, Hashable {}
+
+
+
+// Note that we don't yet support `indirect` for enums.
+// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+
+public enum SubscriptionState {
+    
+    case notActive
+    case pending
+    case complete
+    case active
+}
+
+
+public struct FfiConverterTypeSubscriptionState: FfiConverterRustBuffer {
+    typealias SwiftType = SubscriptionState
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SubscriptionState {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+        
+        case 1: return .notActive
+        
+        case 2: return .pending
+        
+        case 3: return .complete
+        
+        case 4: return .active
+        
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: SubscriptionState, into buf: inout [UInt8]) {
+        switch value {
+        
+        
+        case .notActive:
+            writeInt(&buf, Int32(1))
+        
+        
+        case .pending:
+            writeInt(&buf, Int32(2))
+        
+        
+        case .complete:
+            writeInt(&buf, Int32(3))
+        
+        
+        case .active:
+            writeInt(&buf, Int32(4))
+        
+        }
+    }
+}
+
+
+public func FfiConverterTypeSubscriptionState_lift(_ buf: RustBuffer) throws -> SubscriptionState {
+    return try FfiConverterTypeSubscriptionState.lift(buf)
+}
+
+public func FfiConverterTypeSubscriptionState_lower(_ value: SubscriptionState) -> RustBuffer {
+    return FfiConverterTypeSubscriptionState.lower(value)
+}
+
+
+
+extension SubscriptionState: Equatable, Hashable {}
 
 
 
@@ -4168,6 +4006,8 @@ public enum VpnError {
     case OutOfBandwidth
     case InvalidStateError(details: String
     )
+    case Account(details: String
+    )
 }
 
 
@@ -4195,6 +4035,9 @@ public struct FfiConverterTypeVpnError: FfiConverterRustBuffer {
             )
         case 5: return .OutOfBandwidth
         case 6: return .InvalidStateError(
+            details: try FfiConverterString.read(from: &buf)
+            )
+        case 7: return .Account(
             details: try FfiConverterString.read(from: &buf)
             )
 
@@ -4237,6 +4080,11 @@ public struct FfiConverterTypeVpnError: FfiConverterRustBuffer {
             writeInt(&buf, Int32(6))
             FfiConverterString.write(details, into: &buf)
             
+        
+        case let .Account(details):
+            writeInt(&buf, Int32(7))
+            FfiConverterString.write(details, into: &buf)
+            
         }
     }
 }
@@ -4262,27 +4110,6 @@ fileprivate struct FfiConverterOptionUInt64: FfiConverterRustBuffer {
         switch try readInt(&buf) as Int8 {
         case 0: return nil
         case 1: return try FfiConverterUInt64.read(from: &buf)
-        default: throw UniffiInternalError.unexpectedOptionalTag
-        }
-    }
-}
-
-fileprivate struct FfiConverterOptionString: FfiConverterRustBuffer {
-    typealias SwiftType = String?
-
-    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
-        guard let value = value else {
-            writeInt(&buf, Int8(0))
-            return
-        }
-        writeInt(&buf, Int8(1))
-        FfiConverterString.write(value, into: &buf)
-    }
-
-    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
-        switch try readInt(&buf) as Int8 {
-        case 0: return nil
-        case 1: return try FfiConverterString.read(from: &buf)
         default: throw UniffiInternalError.unexpectedOptionalTag
         }
     }
@@ -4430,6 +4257,90 @@ fileprivate struct FfiConverterOptionTypeUserAgent: FfiConverterRustBuffer {
         switch try readInt(&buf) as Int8 {
         case 0: return nil
         case 1: return try FfiConverterTypeUserAgent.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+fileprivate struct FfiConverterOptionTypeAccountState: FfiConverterRustBuffer {
+    typealias SwiftType = AccountState?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeAccountState.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeAccountState.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+fileprivate struct FfiConverterOptionTypeDeviceState: FfiConverterRustBuffer {
+    typealias SwiftType = DeviceState?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeDeviceState.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeDeviceState.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+fileprivate struct FfiConverterOptionTypeMnemonicState: FfiConverterRustBuffer {
+    typealias SwiftType = MnemonicState?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeMnemonicState.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeMnemonicState.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+fileprivate struct FfiConverterOptionTypeSubscriptionState: FfiConverterRustBuffer {
+    typealias SwiftType = SubscriptionState?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeSubscriptionState.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeSubscriptionState.read(from: &buf)
         default: throw UniffiInternalError.unexpectedOptionalTag
         }
     }
@@ -4621,28 +4532,6 @@ fileprivate struct FfiConverterSequenceTypeLocation: FfiConverterRustBuffer {
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
             seq.append(try FfiConverterTypeLocation.read(from: &buf))
-        }
-        return seq
-    }
-}
-
-fileprivate struct FfiConverterSequenceTypeValidatorDetails: FfiConverterRustBuffer {
-    typealias SwiftType = [ValidatorDetails]
-
-    public static func write(_ value: [ValidatorDetails], into buf: inout [UInt8]) {
-        let len = Int32(value.count)
-        writeInt(&buf, len)
-        for item in value {
-            FfiConverterTypeValidatorDetails.write(item, into: &buf)
-        }
-    }
-
-    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [ValidatorDetails] {
-        let len: Int32 = try readInt(&buf)
-        var seq = [ValidatorDetails]()
-        seq.reserveCapacity(Int(len))
-        for _ in 0 ..< len {
-            seq.append(try FfiConverterTypeValidatorDetails.read(from: &buf))
         }
         return seq
     }
@@ -5388,13 +5277,6 @@ private func uniffiForeignFutureFree(handle: UInt64) {
 public func uniffiForeignFutureHandleCountNymVpnLib() -> Int {
     UNIFFI_FOREIGN_FUTURE_HANDLE_MAP.count
 }
-public func fetchEnvironment(networkName: String)throws  -> NetworkEnvironment {
-    return try  FfiConverterTypeNetworkEnvironment.lift(try rustCallWithError(FfiConverterTypeVpnError.lift) {
-    uniffi_nym_vpn_lib_fn_func_fetchenvironment(
-        FfiConverterString.lower(networkName),$0
-    )
-})
-}
 public func getGatewayCountries(apiUrl: Url, nymVpnApiUrl: Url?, gwType: GatewayType, userAgent: UserAgent?, minGatewayPerformance: GatewayMinPerformance?)throws  -> [Location] {
     return try  FfiConverterSequenceTypeLocation.lift(try rustCallWithError(FfiConverterTypeVpnError.lift) {
     uniffi_nym_vpn_lib_fn_func_getgatewaycountries(
@@ -5434,9 +5316,20 @@ public func removeAccountMnemonic(path: String)throws  -> Bool {
     )
 })
 }
+public func startAccountController(dataDir: String)throws  {try rustCallWithError(FfiConverterTypeVpnError.lift) {
+    uniffi_nym_vpn_lib_fn_func_startaccountcontroller(
+        FfiConverterString.lower(dataDir),$0
+    )
+}
+}
 public func startVpn(config: VpnConfig)throws  {try rustCallWithError(FfiConverterTypeVpnError.lift) {
     uniffi_nym_vpn_lib_fn_func_startvpn(
         FfiConverterTypeVPNConfig.lower(config),$0
+    )
+}
+}
+public func stopAccountController()throws  {try rustCallWithError(FfiConverterTypeVpnError.lift) {
+    uniffi_nym_vpn_lib_fn_func_stopaccountcontroller($0
     )
 }
 }
@@ -5468,9 +5361,6 @@ private var initializationResult: InitializationResult {
     if bindings_contract_version != scaffolding_contract_version {
         return InitializationResult.contractVersionMismatch
     }
-    if (uniffi_nym_vpn_lib_checksum_func_fetchenvironment() != 34561) {
-        return InitializationResult.apiChecksumMismatch
-    }
     if (uniffi_nym_vpn_lib_checksum_func_getgatewaycountries() != 41607) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -5486,7 +5376,13 @@ private var initializationResult: InitializationResult {
     if (uniffi_nym_vpn_lib_checksum_func_removeaccountmnemonic() != 51019) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_nym_vpn_lib_checksum_func_startaccountcontroller() != 34257) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_nym_vpn_lib_checksum_func_startvpn() != 55890) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_nym_vpn_lib_checksum_func_stopaccountcontroller() != 64683) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_nym_vpn_lib_checksum_func_stopvpn() != 59823) {


### PR DESCRIPTION
Initial work and the minimal implementation to run account controller on mobile.

- Add functions to start/stop the account controller
- When connecting, check the account state
- Add functions to query the current account state
- Trigger account state refresh after storing or removing recovery phrase

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1410)
<!-- Reviewable:end -->
