### PR TITLE
wg: Capture IPv6 traffic

### DIFF
--- a/nym-vpn-core/crates/nym-routing/src/unix/mod.rs
+++ b/nym-vpn-core/crates/nym-routing/src/unix/mod.rs
@@ -271,13 +271,10 @@ impl RouteManagerHandle {
 
     /// Ensure that packets are routed using the correct tables.
     #[cfg(target_os = "linux")]
-    pub async fn create_routing_rules(&self, enable_ipv6: bool) -> Result<(), Error> {
+    pub async fn create_routing_rules(&self) -> Result<(), Error> {
         let (response_tx, response_rx) = oneshot::channel();
         self.tx
-            .unbounded_send(RouteManagerCommand::CreateRoutingRules(
-                enable_ipv6,
-                response_tx,
-            ))
+            .unbounded_send(RouteManagerCommand::CreateRoutingRules(true, response_tx))
             .map_err(|_| Error::RouteManagerDown)?;
         response_rx
             .await

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/route_handler.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/route_handler.rs
@@ -53,7 +53,7 @@ impl RouteHandler {
         let routes = Self::get_routes(routing_config);
 
         #[cfg(target_os = "linux")]
-        self.route_manager.create_routing_rules(true).await?;
+        self.route_manager.create_routing_rules().await?;
 
         self.route_manager.add_routes(routes).await?;
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -52,19 +52,18 @@ const DEFAULT_TUN_MTU: u16 = if cfg!(any(target_os = "ios", target_os = "android
 } else {
     1500
 };
-
-#[cfg(any(target_os = "linux", target_os = "macos"))]
-/// Entry IPv6 address (ULA) used by WireGuard, currently not routable.
-const WG_ENTRY_IPV6_ADDR: Ipv6Addr = Ipv6Addr::new(
-    0xfdcc, 0x9fc0, 0xe75a, 0x53c3, 0xfa25, 0x241f, 0x21c0, 0x70d0,
-);
-
 #[cfg(any(
     target_os = "linux",
     target_os = "macos",
     target_os = "android",
     target_os = "ios"
 ))]
+/// Entry IPv6 address (ULA) used by WireGuard, currently not routable.
+const WG_ENTRY_IPV6_ADDR: Ipv6Addr = Ipv6Addr::new(
+    0xfdcc, 0x9fc0, 0xe75a, 0x53c3, 0xfa25, 0x241f, 0x21c0, 0x70d0,
+);
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 /// Exit IPv6 address (ULA) used by WireGuard, currently not routable.
 const WG_EXIT_IPV6_ADDR: Ipv6Addr = Ipv6Addr::new(
     0xfdcc, 0x9fc0, 0xe75a, 0x53c3, 0x72a5, 0xf352, 0x5475, 0x4160,
@@ -399,7 +398,7 @@ impl ConnectingState {
                         .expect("ipv4 to ipnetwork/32"),
                 ),
                 IpNetwork::V6(
-                    Ipv6Network::new(WG_EXIT_IPV6_ADDR, 128).expect("ipv6 to ipnetwork/128"),
+                    Ipv6Network::new(WG_ENTRY_IPV6_ADDR, 128).expect("ipv6 to ipnetwork/128"),
                 ),
             ],
             remote_addresses: vec![conn_data.entry.endpoint.ip()],

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
-use std::net::Ipv4Addr;
-#[cfg(unix)]
-use std::net::Ipv6Addr;
+use std::net::{Ipv4Addr, Ipv6Addr};
 #[cfg(any(target_os = "android", target_os = "ios"))]
 use std::os::fd::{AsRawFd, IntoRawFd};
 #[cfg(target_os = "android")]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -256,7 +256,6 @@ impl ConnectingState {
             tracing::debug!("Created tun device: {}", tun_name);
 
             let routing_config = RoutingConfig::Mixnet {
-                enable_ipv6: true,
                 tun_name: tun_name.clone(),
                 entry_gateway_address: assigned_addresses.entry_mixnet_gateway_ip,
                 #[cfg(target_os = "linux")]
@@ -327,7 +326,6 @@ impl ConnectingState {
         let exit_tun_name = "nym1".to_owned();
 
         let routing_config = RoutingConfig::Wireguard {
-            enable_ipv6: true,
             #[cfg(unix)]
             entry_tun_name,
             #[cfg(unix)]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -1,6 +1,8 @@
 // Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+use std::net::Ipv4Addr;
 #[cfg(any(
     target_os = "linux",
     target_os = "macos",
@@ -8,8 +10,6 @@
     target_os = "android"
 ))]
 use std::net::Ipv6Addr;
-#[cfg(any(target_os = "linux", target_os = "macos"))]
-use std::net::{Ipv4Addr, Ipv6Addr};
 #[cfg(any(target_os = "android", target_os = "ios"))]
 use std::os::fd::{AsRawFd, IntoRawFd};
 #[cfg(target_os = "android")]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
@@ -52,7 +52,7 @@ impl ConnectedTunnel {
     }
 
     pub fn exit_mtu(&self) -> u16 {
-        // 1440 - 80 (ipv6+wg header)
+        // 1420 - 80 (ipv6+wg header)
         1340
     }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
@@ -47,13 +47,13 @@ impl ConnectedTunnel {
     }
 
     pub fn entry_mtu(&self) -> u16 {
-        // 1500 - 60 (ipv4+wg header)
-        1440
+        // 1500 - 80 (ipv6+wg header)
+        1420
     }
 
     pub fn exit_mtu(&self) -> u16 {
         // 1440 - 80 (ipv6+wg header)
-        1360
+        1340
     }
 
     pub fn run(


### PR DESCRIPTION
- Configure wireguard tun adapters with unique local addresses (ULA)
- Enable IPv6 routing
- Wireguard configuration is set to: `allowed_ips=0.0.0.0/0, ::0/0` but we do not list the ipv6 addresses set on tun interfaces which makes me wonder if wg will simply drop all ipv6 as it would not be able to route it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1422)
<!-- Reviewable:end -->
