### PR TITLE
APPLE: add reset vpn profile to settings

### DIFF
--- a/nym-vpn-apple/NymMixnetTunnel/PacketTunnelProvider+TunnelStatusListener.swift
+++ b/nym-vpn-apple/NymMixnetTunnel/PacketTunnelProvider+TunnelStatusListener.swift
@@ -23,15 +23,7 @@ extension PacketTunnelProvider: TunnelStatusListener {
         // todo: implement
     }
 
-    func onExitStatusChange(status: ExitStatus) {
-        switch status {
-        case .failure(let error):
-            logger.error("onExitStatus: \(error.localizedDescription) after: \(connectionDuration())")
-            scheduleDisconnectNotification()
-        case .stopped:
-            logger.info("onExitStatus: Tunnel stopped after: \(connectionDuration())")
-        }
-    }
+    func onExitStatusChange(status: ExitStatus) {}
 
     func onTunStatusChange(status: TunStatus) {
         eventContinuation.yield(.statusUpdate(status))
@@ -53,6 +45,7 @@ private extension PacketTunnelProvider {
     func updateTunnelState(with tunnelState: TunnelState) {
         switch tunnelState {
         case let .error(errorStateReason):
+            scheduleDisconnectNotification()
             updateLastError(with: errorStateReason)
         default:
             break

--- a/nym-vpn-apple/Services/Sources/Services/ConnectionManager/ConnectionManager.swift
+++ b/nym-vpn-apple/Services/Sources/Services/ConnectionManager/ConnectionManager.swift
@@ -241,6 +241,13 @@ private extension ConnectionManager {
 }
 #endif
 
+// MARK: - Reset VPN profile -
+public extension ConnectionManager {
+    func resetVpnProfile() {
+        tunnelsManager.resetVpnProfile()
+    }
+}
+
 // MARK: - Connection -
 #if os(iOS)
 private extension ConnectionManager {
@@ -410,20 +417,11 @@ private extension ConnectionManager {
 
     func updateCountries() {
         Task { @MainActor in
-            if appSettings.isEntryLocationSelectionOn {
-                updateCountriesEntryExit()
-            } else {
-                updateCountriesExitOnly()
-            }
+            updateConnectionHops()
         }
     }
 
-    func updateCountriesEntryExit() {
-        entryGateway = connectionStorage.entryGateway()
-        exitRouter = connectionStorage.exitRouter()
-    }
-
-    func updateCountriesExitOnly() {
+    func updateConnectionHops() {
         entryGateway = connectionStorage.entryGateway()
         exitRouter = connectionStorage.exitRouter()
     }

--- a/nym-vpn-apple/Settings/Package.swift
+++ b/nym-vpn-apple/Settings/Package.swift
@@ -31,6 +31,7 @@ let package = Package(
                 .product(name: "AppSettings", package: "Services"),
                 .product(name: "AppVersionProvider", package: "ServicesMutual"),
                 .product(name: "Constants", package: "Services"),
+                .product(name: "ConnectionManager", package: "Services"),
                 .product(name: "CredentialsManager", package: "Services"),
                 .product(name: "Device", package: "Services"),
                 .product(name: "ExternalLinkManager", package: "Services"),

--- a/nym-vpn-apple/Settings/Sources/Settings/Support/ResetVPNProfileDialog.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/Support/ResetVPNProfileDialog.swift
@@ -1,0 +1,95 @@
+import SwiftUI
+import Theme
+import UIComponents
+
+struct ResetVPNProfileDialog: View {
+    @ObservedObject private var viewModel: ResetVPNProfileDialogViewModel
+
+    init(viewModel: ResetVPNProfileDialogViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        ZStack {
+            Rectangle()
+                .foregroundColor(.black)
+                .opacity(0.3)
+                .background(Color.clear)
+                .contentShape(Rectangle())
+
+            HStack {
+                Spacer()
+                    .frame(width: 40)
+
+                VStack {
+                    Spacer()
+                        .frame(height: 16)
+                    title()
+                    subtitle()
+                    HStack {
+                        Spacer()
+                        yesButton()
+
+                        Spacer()
+                            .frame(width: 16)
+
+                        noButton()
+                        Spacer()
+                    }
+                    .padding(24)
+                }
+                .background(NymColor.modeInfoViewBackground)
+                .cornerRadius(16)
+
+                Spacer()
+                    .frame(width: 40)
+            }
+        }
+        .edgesIgnoringSafeArea(.all)
+    }
+}
+
+private extension ResetVPNProfileDialog {
+    @ViewBuilder
+    func title() -> some View {
+        Text(viewModel.resetVpnProfileTitle)
+            .textStyle(NymTextStyle.Label.Huge.bold)
+            .foregroundStyle(NymColor.sysOnSurface)
+            .multilineTextAlignment(.center)
+
+        Spacer()
+            .frame(height: 16)
+    }
+
+    @ViewBuilder
+    func subtitle() -> some View {
+        Text(viewModel.resetVpnProfileSubtitle)
+            .foregroundStyle(NymColor.modeInfoViewDescription)
+            .textStyle(.Body.Medium.regular)
+            .multilineTextAlignment(.center)
+            .padding(EdgeInsets(top: 0, leading: 24, bottom: 0, trailing: 24))
+    }
+
+    @ViewBuilder
+    func yesButton() -> some View {
+        GenericButton(title: viewModel.yesLocalizedString)
+            .onTapGesture {
+#if os(iOS)
+                viewModel.impactGenerator.success()
+#endif
+                viewModel.action()
+                viewModel.isDisplayed = false
+            }
+    }
+
+    @ViewBuilder
+    func noButton() -> some View {
+        GenericButton(title: viewModel.noLocalizedString, borderOnly: true)
+            .onTapGesture {
+#if os(iOS)
+                viewModel.impactGenerator.impact()
+#endif
+                viewModel.isDisplayed = false
+            }
+    }
+}

--- a/nym-vpn-apple/Settings/Sources/Settings/Support/ResetVPNProfileDialogViewModel.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/Support/ResetVPNProfileDialogViewModel.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+#if os(iOS)
+import ImpactGenerator
+#endif
+
+final class ResetVPNProfileDialogViewModel: ObservableObject {
+#if os(iOS)
+    let impactGenerator: ImpactGenerator
+#endif
+    let resetVpnProfileTitle = "settings.resetVpnProfileTitle".localizedString
+    let resetVpnProfileSubtitle = "settings.resetVpnProfileSubtitle".localizedString
+    let yesLocalizedString = "logs.yes".localizedString
+    let noLocalizedString = "logs.no".localizedString
+
+    let action: () -> Void
+
+    @Binding var isDisplayed: Bool
+
+#if os(iOS)
+    init(
+        isDisplayed: Binding<Bool>,
+        impactGenerator: ImpactGenerator = ImpactGenerator.shared,
+        action: @escaping () -> Void
+    ) {
+        _isDisplayed = isDisplayed
+        self.impactGenerator = impactGenerator
+        self.action = action
+    }
+#endif
+#if os(macOS)
+    init(isDisplayed: Binding<Bool>, action: @escaping () -> Void) {
+        _isDisplayed = isDisplayed
+        self.action = action
+    }
+#endif
+}

--- a/nym-vpn-apple/Settings/Sources/Settings/Support/SupportView.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/Support/SupportView.swift
@@ -5,10 +5,10 @@ import Theme
 import UIComponents
 
 struct SupportView: View {
-    @State private var viewModel: SupportViewModel
+    @StateObject private var viewModel: SupportViewModel
 
     init(viewModel: SupportViewModel) {
-        _viewModel = State(initialValue: viewModel)
+        _viewModel = StateObject(wrappedValue: viewModel)
     }
 
     var body: some View {
@@ -23,6 +23,18 @@ struct SupportView: View {
         .navigationBarBackButtonHidden(true)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .ignoresSafeArea(edges: [.bottom])
+        .overlay {
+            if viewModel.isResetVPNProfileDisplayed {
+                ResetVPNProfileDialog(
+                    viewModel: ResetVPNProfileDialogViewModel(
+                        isDisplayed: $viewModel.isResetVPNProfileDisplayed,
+                        action: {
+                            viewModel.resetVPNProfile()
+                        }
+                    )
+                )
+            }
+        }
         .background {
             NymColor.background
                 .ignoresSafeArea()

--- a/nym-vpn-apple/Theme/Sources/Theme/Resources/Localizable.xcstrings
+++ b/nym-vpn-apple/Theme/Sources/Theme/Resources/Localizable.xcstrings
@@ -1233,6 +1233,39 @@
         }
       }
     },
+    "settings.resetVpnProfileSubtitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "NymVPN profile will be deleted from your device.\n\nIf connected: deleting VPN profile will disconnect you from VPN."
+          }
+        }
+      }
+    },
+    "settings.resetVpnProfileTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reset VPN profile?"
+          }
+        }
+      }
+    },
+    "settings.support.resetVpnProfile" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reset VPN profile"
+          }
+        }
+      }
+    },
     "stop" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/nym-vpn-apple/UIComponents/Sources/UIComponents/Buttons/HopButton/HopButtonViewModel.swift
+++ b/nym-vpn-apple/UIComponents/Sources/UIComponents/Buttons/HopButton/HopButtonViewModel.swift
@@ -42,6 +42,12 @@ private extension HopButtonViewModel {
             self?.updateData()
         }
         .store(in: &cancellables)
+
+        connectionManager.$connectionType.sink { [weak self] _ in
+            guard self?.hopType == .exit else { return }
+            self?.updateData()
+        }
+        .store(in: &cancellables)
     }
 }
 


### PR DESCRIPTION
Add reset vpn profile.
Replace notification from `onExitStatusChange(status: ExitStatus)` to  `updateTunnelState(with tunnelState: TunnelState)`.
Fix tunnel error event, not getting received on profile install.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1426)
<!-- Reviewable:end -->
