### PR TITLE
Wireguard Build Script Update

### DIFF
--- a/.github/workflows/ci-nym-vpn-core-ios.yml
+++ b/.github/workflows/ci-nym-vpn-core-ios.yml
@@ -46,9 +46,6 @@ jobs:
           version: "21.12" # 3.21.12: the version on ubuntu 24.04. Don't change this!
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install script dependencies
-        run: brew install gnu-getopt
-
       - name: Build wireguard
         shell: bash
         run: |

--- a/.github/workflows/ci-nym-vpn-core-ios.yml
+++ b/.github/workflows/ci-nym-vpn-core-ios.yml
@@ -46,6 +46,9 @@ jobs:
           version: "21.12" # 3.21.12: the version on ubuntu 24.04. Don't change this!
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install script dependencies
+        run: brew install gnu-getopt
+
       - name: Build wireguard
         shell: bash
         run: |

--- a/.github/workflows/ci-nym-vpn-core-macos.yml
+++ b/.github/workflows/ci-nym-vpn-core-macos.yml
@@ -24,7 +24,7 @@ jobs:
           rm -rf ./* || true
           rm -rf ./.??* || true
           ls -la ./
-      
+
       - name: Checkout repo
         uses: actions/checkout@v4
 
@@ -44,6 +44,9 @@ jobs:
         with:
           version: "21.12" # 3.21.12: the version on ubuntu 24.04. Don't change this!
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install script dependencies
+        run: brew install gnu-getopt
 
       - name: Build wireguard
         shell: bash

--- a/.github/workflows/ci-nym-vpn-core-macos.yml
+++ b/.github/workflows/ci-nym-vpn-core-macos.yml
@@ -45,9 +45,6 @@ jobs:
           version: "21.12" # 3.21.12: the version on ubuntu 24.04. Don't change this!
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install script dependencies
-        run: brew install gnu-getopt
-
       - name: Build wireguard
         shell: bash
         run: |

--- a/wireguard/build-wireguard-go.sh
+++ b/wireguard/build-wireguard-go.sh
@@ -10,34 +10,24 @@ IS_IOS_BUILD=false
 IS_DOCKER_BUILD=true
 
 function parseArgs {
-    if stringContain "Darwin" "$(uname -s)"; then
-        # Mac builds require gnu-getopt because regular macos getopt doesn't allow long args. -_-
-        # This could be avoided using something like `getopts` instead, but then we don't
-        # have the ability to use long options which pre-date this script change.
-        # > brew install gnu-getopt
-        echo "using gnu-getopt"
-        export PATH="/opt/homebrew/opt/gnu-getopt/bin:$PATH"
-    fi
-
-    which getopt
-    TEMP=$(getopt -o --long android,no-docker,ios \
-                  -n 'build-wireguard-go.sh' -- "$@")
-
-    if [ $? != 0 ]; then
-        echo "encountered an error parsing args"
-        exit 2
-    fi
-
-    # Note the quotes around '$TEMP': they are essential!
-    eval set -- "$TEMP"
-
-    while true; do
-      case "$1" in
-        "--android" ) IS_ANDROID_BUILD=true; shift ;;
-        "--ios" ) IS_IOS_BUILD=true; shift ;;
-        "--no-docker" ) IS_DOCKER_BUILD=false; shift ;;
+    for arg in "$@"; do
+      case "$arg" in
+        # handle --android option
+        "--android" )
+            IS_ANDROID_BUILD=true;
+            shift ;;
+        # handle --ios option
+        "--ios" )
+            IS_IOS_BUILD=true;
+            shift ;;
+        # handle --no-docker option
+        "--no-docker" )
+            IS_DOCKER_BUILD=false;
+            shift ;;
+        # if we receive "--" consider everything after to be inner arguments
         -- ) shift; break ;;
-        * ) break ;;
+        # any other args before "--" are improper
+        *) echo "Unsupported argument: $arg" && exit 2 ;;
       esac
     done
 


### PR DESCRIPTION
Modify the script used to build the wrapped wireguard go library to use variables and `getopt`.

On mac (and mac-adjacent platforms) `getopt` has different behavior which doesn't handle long options - one simple answer is to use the `gnu-getopt` package which I have added to the mac CI build script

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1432)
<!-- Reviewable:end -->
