### PR TITLE
Reconnect on error

### DIFF
--- a/nym-vpn-core/Makefile
+++ b/nym-vpn-core/Makefile
@@ -47,10 +47,17 @@ build-vpn-lib-swift: ## Rust cargo swift
 	cd crates/nym-vpn-lib; \
 	cargo swift package --platforms ios --name NymVpnLib --release
 
-generate-uniffi-swift: ## Generate uniffi for swift
+generate-uniffi-ios: ## Generate uniffi for ios
 	cargo run --bin uniffi-bindgen generate \
 		--library $(CURDIR)/target/aarch64-apple-ios/release/libnym_vpn_lib.a \
-		--language swift --out-dir uniffi -n
+		--language swift --out-dir crates/nym-vpn-lib/uniffi -n
+
+generate-uniffi-android: ## Generate uniffi for android
+	cargo run --bin uniffi-bindgen generate \
+		--library $(CURDIR)/target/armv7-linux-androideabi/release/libnym_vpn_lib.so \
+		--language kotlin --out-dir crates/nym-vpn-lib/uniffi -n
+	mv crates/nym-vpn-lib/uniffi/nym_vpn_lib/nym_vpn_lib.kt crates/nym-vpn-lib/uniffi
+	rm -rf crates/nym-vpn-lib/uniffi/nym_vpn_lib/
 
 print-info: ## Print detected architecture
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
@@ -360,7 +360,7 @@ impl From<&TunnelState> for TunStatus {
     fn from(value: &TunnelState) -> Self {
         // TODO: this cannot be accurate so we must switch frontends to use TunnelState instead! But for now that will do.
         match value {
-            TunnelState::Connecting => Self::EstablishingConnection,
+            TunnelState::Connecting { .. } => Self::EstablishingConnection,
             TunnelState::Connected { .. } => Self::Up,
             TunnelState::Disconnecting { .. } => Self::Disconnecting,
             TunnelState::Disconnected => Self::Down,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/dns_handler.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/dns_handler.rs
@@ -102,6 +102,7 @@ impl DnsHandlerHandle {
                     else => break
                 }
             }
+            tracing::debug!("Exiting dns handler loop");
         });
 
         Ok((Self { tx }, join_handle))

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -333,6 +333,15 @@ pub enum TunnelEvent {
     MixnetState(MixnetEvent),
 }
 
+impl fmt::Display for TunnelEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NewState(new_state) => new_state.fmt(f),
+            Self::MixnetState(event) => event.fmt(f),
+        }
+    }
+}
+
 #[derive(Debug, Copy, Clone, uniffi::Enum)]
 pub enum MixnetEvent {
     Bandwidth(BandwidthEvent),

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -217,6 +217,7 @@ pub struct WireguardConnectionData {
     pub exit: WireguardNode,
 }
 
+/// Public enum describing the tunnel state
 #[derive(Debug, Clone, Eq, PartialEq, uniffi::Enum)]
 pub enum TunnelState {
     Disconnected,
@@ -250,6 +251,7 @@ impl From<PrivateTunnelState> for TunnelState {
     }
 }
 
+/// Private enum describing the tunnel state
 #[derive(Debug, Clone)]
 enum PrivateTunnelState {
     Disconnected,
@@ -265,27 +267,39 @@ enum PrivateTunnelState {
     Error(ErrorStateReason),
 }
 
+/// Public enum describing action to perform after disconnect
 #[derive(Debug, Clone, Copy, Eq, PartialEq, uniffi::Enum)]
 pub enum ActionAfterDisconnect {
+    /// Do nothing after disconnect
     Nothing,
+
+    /// Reconnect after disconnect
     Reconnect,
-    Error(ErrorStateReason),
+
+    /// Enter error state
+    Error,
 }
 
 impl From<PrivateActionAfterDisconnect> for ActionAfterDisconnect {
     fn from(value: PrivateActionAfterDisconnect) -> Self {
         match value {
-            PrivateActionAfterDisconnect::Error(reason) => Self::Error(reason),
+            PrivateActionAfterDisconnect::Error(_) => Self::Error,
             PrivateActionAfterDisconnect::Nothing => Self::Nothing,
             PrivateActionAfterDisconnect::Reconnect { .. } => Self::Reconnect,
         }
     }
 }
 
+/// Private enum describing action to perform after disconnect
 #[derive(Debug, Clone)]
 enum PrivateActionAfterDisconnect {
+    /// Do nothing after disconnect
     Nothing,
+
+    /// Reconnect after disconnect, providing the retry attempt counter
     Reconnect { retry_attempt: u32 },
+
+    /// Enter error state
     Error(ErrorStateReason),
 }
 
@@ -617,7 +631,7 @@ impl fmt::Display for TunnelState {
             Self::Disconnecting { after_disconnect } => match after_disconnect {
                 ActionAfterDisconnect::Nothing => f.write_str("Disconnecting"),
                 ActionAfterDisconnect::Reconnect => f.write_str("Disconnecting to reconnect"),
-                ActionAfterDisconnect::Error(_) => f.write_str("Disconnecting because of an error"),
+                ActionAfterDisconnect::Error => f.write_str("Disconnecting because of an error"),
             },
             Self::Error(reason) => {
                 write!(f, "Error state: {:?}", reason)

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -409,6 +409,7 @@ impl TunnelStateMachine {
         let (dns_handler, dns_handler_task) = DnsHandlerHandle::spawn(
             #[cfg(target_os = "linux")]
             &route_handler,
+            shutdown_token.child_token(),
         )
         .map_err(Error::CreateDnsHandler)?;
         //let firewall_handler = FirewallHandler::new().map_err(Error::CreateFirewallHandler)?;

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -494,7 +494,7 @@ pub enum Error {
 
     #[cfg(target_os = "ios")]
     #[error("failed to locate tun device")]
-    LocateTunDevice(std::io::Error),
+    LocateTunDevice(#[source] std::io::Error),
 
     #[cfg(any(target_os = "ios", target_os = "android"))]
     #[error("failed to configure tunnel provider: {}", _0)]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/route_handler.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/route_handler.rs
@@ -33,6 +33,7 @@ pub enum RoutingConfig {
     },
 }
 
+#[derive(Debug, Clone)]
 pub struct RouteHandler {
     route_manager: RouteManagerHandle,
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
@@ -64,7 +64,7 @@ impl TunnelStateHandler for ConnectedState {
             Some(monitor_event) = self.monitor_event_receiver.recv() => {
                 match monitor_event {
                     TunnelMonitorEvent::Down(reason) => {
-                        let after_disconnect = reason.map(PrivateActionAfterDisconnect::Error).unwrap_or(PrivateActionAfterDisconnect::Nothing);
+                        let after_disconnect = reason.map(PrivateActionAfterDisconnect::Error).unwrap_or(PrivateActionAfterDisconnect::Reconnect { retry_attempt: 0 });
 
                         NextTunnelState::NewState(DisconnectingState::enter(after_disconnect, self.monitor_handle, shared_state))
                     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
@@ -5,24 +5,30 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 use crate::tunnel_state_machine::{
-    states::DisconnectingState, tunnel::any_tunnel_handle::AnyTunnelHandle, ActionAfterDisconnect,
-    ConnectionData, ErrorStateReason, NextTunnelState, SharedState, TunnelCommand, TunnelState,
-    TunnelStateHandler,
+    states::DisconnectingState,
+    tunnel_monitor::{TunnelMonitorEvent, TunnelMonitorEventReceiver, TunnelMonitorHandle},
+    ConnectionData, NextTunnelState, PrivateActionAfterDisconnect, PrivateTunnelState, SharedState,
+    TunnelCommand, TunnelStateHandler,
 };
 
 pub struct ConnectedState {
-    tunnel_handle: AnyTunnelHandle,
+    monitor_handle: TunnelMonitorHandle,
+    monitor_event_receiver: TunnelMonitorEventReceiver,
 }
 
 impl ConnectedState {
     pub fn enter(
         connection_data: ConnectionData,
-        tunnel_handle: AnyTunnelHandle,
+        monitor_handle: TunnelMonitorHandle,
+        monitor_event_receiver: TunnelMonitorEventReceiver,
         _shared_state: &mut SharedState,
-    ) -> (Box<dyn TunnelStateHandler>, TunnelState) {
+    ) -> (Box<dyn TunnelStateHandler>, PrivateTunnelState) {
         (
-            Box::new(Self { tunnel_handle }),
-            TunnelState::Connected { connection_data },
+            Box::new(Self {
+                monitor_handle,
+                monitor_event_receiver,
+            }),
+            PrivateTunnelState::Connected { connection_data },
         )
     }
 }
@@ -37,34 +43,33 @@ impl TunnelStateHandler for ConnectedState {
     ) -> NextTunnelState {
         tokio::select! {
             _ = shutdown_token.cancelled() => {
-                NextTunnelState::NewState(DisconnectingState::enter(ActionAfterDisconnect::Nothing, Some(self.tunnel_handle), shared_state))
+                NextTunnelState::NewState(DisconnectingState::enter(PrivateActionAfterDisconnect::Nothing, self.monitor_handle, shared_state))
             }
             Some(command) = command_rx.recv() => {
                 match command {
                     TunnelCommand::Connect => NextTunnelState::SameState(self),
                     TunnelCommand::Disconnect => {
-                        NextTunnelState::NewState(DisconnectingState::enter(ActionAfterDisconnect::Nothing, Some(self.tunnel_handle) , shared_state))
+                        NextTunnelState::NewState(DisconnectingState::enter(PrivateActionAfterDisconnect::Nothing, self.monitor_handle , shared_state))
                     },
                     TunnelCommand::SetTunnelSettings(tunnel_settings) => {
                         if shared_state.tunnel_settings == tunnel_settings {
                             NextTunnelState::SameState(self)
                         } else {
                             shared_state.tunnel_settings = tunnel_settings;
-                            NextTunnelState::NewState(DisconnectingState::enter(ActionAfterDisconnect::Reconnect, Some(self.tunnel_handle), shared_state))
+                            NextTunnelState::NewState(DisconnectingState::enter(PrivateActionAfterDisconnect::Reconnect { retry_attempt: 0 }, self.monitor_handle, shared_state))
                         }
                     }
                 }
             }
-            maybe_error = self.tunnel_handle.recv_error() => {
-                match maybe_error {
-                    Some(error) => {
-                        tracing::error!("Tunnel error: {}", error);
-                        // todo: handle error
-                        NextTunnelState::SameState(self)
+            Some(monitor_event) = self.monitor_event_receiver.recv() => {
+                match monitor_event {
+                    TunnelMonitorEvent::Down(reason) => {
+                        let after_disconnect = reason.map(PrivateActionAfterDisconnect::Error).unwrap_or(PrivateActionAfterDisconnect::Nothing);
+
+                        NextTunnelState::NewState(DisconnectingState::enter(after_disconnect, self.monitor_handle, shared_state))
                     }
-                    None => {
-                        tracing::info!("Tunnel went down unexpectedly.");
-                        NextTunnelState::NewState(DisconnectingState::enter(ActionAfterDisconnect::Error(ErrorStateReason::TunnelDown), Some(self.tunnel_handle), shared_state))
+                    _ => {
+                        NextTunnelState::SameState(self)
                     }
                 }
             }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -1,564 +1,59 @@
 // Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
-use std::net::Ipv4Addr;
-#[cfg(any(
-    target_os = "linux",
-    target_os = "macos",
-    target_os = "ios",
-    target_os = "android"
-))]
-use std::net::Ipv6Addr;
-#[cfg(any(target_os = "android", target_os = "ios"))]
-use std::os::fd::{AsRawFd, IntoRawFd};
-#[cfg(target_os = "android")]
-use std::os::fd::{FromRawFd, OwnedFd};
-
-use futures::{
-    future::{BoxFuture, Fuse, FusedFuture},
-    FutureExt,
-};
-#[cfg(any(target_os = "ios", target_os = "android"))]
-use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
-use nym_gateway_directory::GatewayMinPerformance;
-use time::OffsetDateTime;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
-use tun::AsyncDevice;
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-use tun::Device;
 
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-use nym_ip_packet_requests::IpPair;
-
-#[cfg(any(target_os = "ios", target_os = "android"))]
-use crate::tunnel_provider;
-#[cfg(target_os = "linux")]
-use crate::tunnel_state_machine::default_interface::DefaultInterface;
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-use crate::tunnel_state_machine::{route_handler::RoutingConfig, tun_ipv6};
 use crate::tunnel_state_machine::{
     states::{ConnectedState, DisconnectingState},
-    tunnel::{self, any_tunnel_handle::AnyTunnelHandle, ConnectedMixnet, MixnetConnectOptions},
-    ActionAfterDisconnect, ConnectionData, Error, MixnetConnectionData, NextTunnelState, Result,
-    SharedState, TunnelCommand, TunnelConnectionData, TunnelState, TunnelStateHandler, TunnelType,
-    WireguardConnectionData, WireguardNode,
+    tunnel::SelectedGateways,
+    tunnel_monitor::{
+        TunnelMonitor, TunnelMonitorEvent, TunnelMonitorEventReceiver, TunnelMonitorHandle,
+    },
+    NextTunnelState, PrivateActionAfterDisconnect, PrivateTunnelState, SharedState, TunnelCommand,
+    TunnelStateHandler,
 };
-
-/// Default MTU for mixnet tun device.
-const DEFAULT_TUN_MTU: u16 = if cfg!(any(target_os = "ios", target_os = "android")) {
-    1280
-} else {
-    1500
-};
-#[cfg(any(
-    target_os = "linux",
-    target_os = "macos",
-    target_os = "android",
-    target_os = "ios"
-))]
-/// Entry IPv6 address (ULA) used by WireGuard, currently not routable.
-const WG_ENTRY_IPV6_ADDR: Ipv6Addr = Ipv6Addr::new(
-    0xfdcc, 0x9fc0, 0xe75a, 0x53c3, 0xfa25, 0x241f, 0x21c0, 0x70d0,
-);
-
-#[cfg(any(target_os = "linux", target_os = "macos"))]
-/// Exit IPv6 address (ULA) used by WireGuard, currently not routable.
-const WG_EXIT_IPV6_ADDR: Ipv6Addr = Ipv6Addr::new(
-    0xfdcc, 0x9fc0, 0xe75a, 0x53c3, 0x72a5, 0xf352, 0x5475, 0x4160,
-);
-
-type ConnectFut = BoxFuture<'static, tunnel::Result<ConnectedMixnet>>;
 
 pub struct ConnectingState {
-    /// Fused future connecting the mixnet client.
-    connect_fut: Fuse<ConnectFut>,
-
-    /// Cancellation token used by `connect_fut`.
-    connect_cancel_token: CancellationToken,
+    monitor_handle: TunnelMonitorHandle,
+    monitor_event_receiver: TunnelMonitorEventReceiver,
+    retry_attempt: u32,
+    selected_gateways: Option<SelectedGateways>,
 }
 
 impl ConnectingState {
-    pub fn enter(shared_state: &mut SharedState) -> (Box<dyn TunnelStateHandler>, TunnelState) {
-        let gateway_performance_options = shared_state.tunnel_settings.gateway_performance_options;
-
-        let gateway_min_performance = GatewayMinPerformance::from_percentage_values(
-            gateway_performance_options
-                .mixnet_min_performance
-                .map(u64::from),
-            gateway_performance_options
-                .vpn_min_performance
-                .map(u64::from),
+    pub fn enter(
+        retry_attempt: u32,
+        selected_gateways: Option<SelectedGateways>,
+        shared_state: &mut SharedState,
+    ) -> (Box<dyn TunnelStateHandler>, PrivateTunnelState) {
+        let (monitor_event_sender, monitor_event_receiver) = mpsc::unbounded_channel();
+        let monitor_handle = TunnelMonitor::start(
+            retry_attempt,
+            selected_gateways.clone(),
+            monitor_event_sender,
+            shared_state.mixnet_event_sender.clone(),
+            #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+            shared_state.route_handler.clone(),
+            #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+            shared_state.dns_handler.clone(),
+            #[cfg(any(target_os = "ios", target_os = "android"))]
+            shared_state.tun_provider.clone(),
+            shared_state.nym_config.clone(),
+            shared_state.tunnel_settings.clone(),
         );
-
-        let mut gateway_config = shared_state.nym_config.gateway_config.clone();
-        match gateway_min_performance {
-            Ok(gateway_min_performance) => {
-                gateway_config =
-                    gateway_config.with_min_gateway_performance(gateway_min_performance);
-            }
-            Err(e) => {
-                tracing::error!(
-                    "Invalid gateway performance values. Will carry on with initial values. Error: {}"
-                , e);
-            }
-        }
-
-        let connect_options = MixnetConnectOptions {
-            data_path: shared_state.nym_config.data_path.clone(),
-            gateway_config,
-            mixnet_client_config: shared_state.tunnel_settings.mixnet_client_config.clone(),
-            tunnel_type: shared_state.tunnel_settings.tunnel_type,
-            enable_credentials_mode: shared_state.tunnel_settings.enable_credentials_mode,
-            entry_point: shared_state.tunnel_settings.entry_point.clone(),
-            exit_point: shared_state.tunnel_settings.exit_point.clone(),
-            user_agent: None, // todo: provide user-agent
-        };
-
-        let connect_cancel_token = CancellationToken::new();
-        let connect_fut =
-            tunnel::connect_mixnet(connect_options, connect_cancel_token.child_token())
-                .boxed()
-                .fuse();
 
         (
             Box::new(Self {
-                connect_fut,
-                connect_cancel_token,
+                monitor_handle,
+                monitor_event_receiver,
+                retry_attempt,
+                selected_gateways,
             }),
-            TunnelState::Connecting,
+            PrivateTunnelState::Connecting {
+                connection_data: None,
+            },
         )
-    }
-
-    async fn on_connect_mixnet_client(
-        result: tunnel::Result<ConnectedMixnet>,
-        shared_state: &mut SharedState,
-    ) -> NextTunnelState {
-        match result.map_err(Error::ConnectMixnetClient) {
-            Ok(mut connected_mixnet) => {
-                shared_state.status_listener_handle = Some(
-                    connected_mixnet
-                        .start_event_listener(shared_state.mixnet_event_sender.clone())
-                        .await,
-                );
-
-                match Self::start_tunnel(connected_mixnet, shared_state).await {
-                    Ok((conn_data, tunnel_handle)) => NextTunnelState::NewState(
-                        ConnectedState::enter(conn_data, tunnel_handle, shared_state),
-                    ),
-                    Err(e) => {
-                        tracing::error!("Failed to start the tunnel: {}", e);
-
-                        NextTunnelState::NewState(DisconnectingState::enter(
-                            ActionAfterDisconnect::Error(e.error_state_reason()),
-                            None,
-                            shared_state,
-                        ))
-                    }
-                }
-            }
-            Err(e) => {
-                tracing::error!("Failed to connect mixnet client: {}", e);
-                NextTunnelState::NewState(DisconnectingState::enter(
-                    ActionAfterDisconnect::Error(e.error_state_reason()),
-                    None,
-                    shared_state,
-                ))
-            }
-        }
-    }
-
-    async fn on_cancel(
-        self,
-        after_disconnect: ActionAfterDisconnect,
-        shared_state: &mut SharedState,
-    ) -> NextTunnelState {
-        self.connect_cancel_token.cancel();
-
-        if !self.connect_fut.is_terminated() {
-            if let Ok(connected_mixnet) = self.connect_fut.await {
-                connected_mixnet.dispose().await;
-            }
-        }
-        NextTunnelState::NewState(DisconnectingState::enter(
-            after_disconnect,
-            None,
-            shared_state,
-        ))
-    }
-
-    async fn start_tunnel(
-        connected_mixnet: ConnectedMixnet,
-        shared_state: &mut SharedState,
-    ) -> Result<(ConnectionData, AnyTunnelHandle)> {
-        let selected_gateways = connected_mixnet.selected_gateways().clone();
-        let (tunnel_conn_data, tunnel_handle) = match shared_state.tunnel_settings.tunnel_type {
-            TunnelType::Mixnet => Self::start_mixnet_tunnel(connected_mixnet, shared_state).await?,
-            TunnelType::Wireguard => {
-                Self::start_wireguard_tunnel(connected_mixnet, shared_state).await?
-            }
-        };
-
-        let conn_data = ConnectionData {
-            entry_gateway: Box::new(*selected_gateways.entry.identity()),
-            exit_gateway: Box::new(*selected_gateways.exit.identity()),
-            connected_at: OffsetDateTime::now_utc(),
-            tunnel: tunnel_conn_data,
-        };
-
-        Ok((conn_data, tunnel_handle))
-    }
-
-    async fn start_mixnet_tunnel(
-        connected_mixnet: ConnectedMixnet,
-        shared_state: &mut SharedState,
-    ) -> Result<(TunnelConnectionData, AnyTunnelHandle)> {
-        let interface_addrs = shared_state
-            .tunnel_settings
-            .mixnet_tunnel_options
-            .interface_addrs;
-
-        let connected_tunnel = connected_mixnet
-            .connect_mixnet_tunnel(interface_addrs)
-            .await
-            .map_err(Error::ConnectMixnetTunnel)?;
-        let assigned_addresses = connected_tunnel.assigned_addresses();
-
-        let mtu: u16 = shared_state
-            .tunnel_settings
-            .mixnet_tunnel_options
-            .mtu
-            .unwrap_or(DEFAULT_TUN_MTU);
-
-        #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-        let tun_device = Self::create_mixnet_device(assigned_addresses.interface_addresses, mtu)?;
-
-        #[cfg(any(target_os = "ios", target_os = "android"))]
-        let tun_device = {
-            let packet_tunnel_settings = tunnel_provider::tunnel_settings::TunnelSettings {
-                dns_servers: shared_state.tunnel_settings.dns.ip_addresses().to_vec(),
-                interface_addresses: vec![
-                    IpNetwork::V4(
-                        Ipv4Network::new(assigned_addresses.interface_addresses.ipv4, 32)
-                            .expect("ipv4/32 to ipnetwork"),
-                    ),
-                    IpNetwork::V6(
-                        Ipv6Network::new(assigned_addresses.interface_addresses.ipv6, 128)
-                            .expect("ipv6/128 addr to ipnetwork"),
-                    ),
-                ],
-                remote_addresses: vec![assigned_addresses.entry_mixnet_gateway_ip],
-                mtu,
-            };
-
-            let tun_device = Self::create_tun_device(packet_tunnel_settings, shared_state).await?;
-            tracing::debug!("Created tun device");
-            tun_device
-        };
-
-        #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-        {
-            let tun_name = tun_device
-                .get_ref()
-                .name()
-                .map_err(Error::GetTunDeviceName)?;
-
-            tracing::debug!("Created tun device: {}", tun_name);
-
-            let routing_config = RoutingConfig::Mixnet {
-                tun_name: tun_name.clone(),
-                entry_gateway_address: assigned_addresses.entry_mixnet_gateway_ip,
-                #[cfg(target_os = "linux")]
-                physical_interface: DefaultInterface::current()?,
-            };
-
-            Self::set_routes(routing_config, shared_state).await?;
-            Self::set_dns(&tun_name, shared_state)?;
-        }
-
-        let tunnel_conn_data = TunnelConnectionData::Mixnet(MixnetConnectionData {
-            nym_address: Box::new(assigned_addresses.mixnet_client_address),
-            exit_ipr: Box::new(assigned_addresses.exit_mix_addresses.0),
-            ipv4: assigned_addresses.interface_addresses.ipv4,
-            ipv6: assigned_addresses.interface_addresses.ipv6,
-        });
-
-        let tunnel_handle = AnyTunnelHandle::from(connected_tunnel.run(tun_device).await);
-
-        Ok((tunnel_conn_data, tunnel_handle))
-    }
-
-    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-    async fn start_wireguard_tunnel(
-        connected_mixnet: ConnectedMixnet,
-        shared_state: &mut SharedState,
-    ) -> Result<(TunnelConnectionData, AnyTunnelHandle)> {
-        let connected_tunnel = connected_mixnet
-            .connect_wireguard_tunnel(shared_state.tunnel_settings.enable_credentials_mode)
-            .await
-            .map_err(Error::ConnectWireguardTunnel)?;
-        let conn_data = connected_tunnel.connection_data();
-
-        #[cfg(unix)]
-        let entry_tun = Self::create_wireguard_device(
-            IpPair {
-                ipv4: conn_data.entry.private_ipv4,
-                ipv6: WG_ENTRY_IPV6_ADDR,
-            },
-            None,
-            connected_tunnel.entry_mtu(),
-        )?;
-        #[cfg(unix)]
-        let entry_tun_name = entry_tun
-            .get_ref()
-            .name()
-            .map_err(Error::GetTunDeviceName)?;
-        #[cfg(unix)]
-        tracing::info!("Created entry tun device: {}", entry_tun_name);
-
-        #[cfg(unix)]
-        let exit_tun = Self::create_wireguard_device(
-            IpPair {
-                ipv4: conn_data.exit.private_ipv4,
-                ipv6: WG_EXIT_IPV6_ADDR,
-            },
-            Some(conn_data.entry.private_ipv4),
-            connected_tunnel.exit_mtu(),
-        )?;
-        #[cfg(unix)]
-        let exit_tun_name = exit_tun.get_ref().name().map_err(Error::GetTunDeviceName)?;
-        #[cfg(unix)]
-        tracing::info!("Created exit tun device: {}", exit_tun_name);
-
-        #[cfg(windows)]
-        let entry_tun_name = "nym0".to_owned();
-        #[cfg(windows)]
-        let exit_tun_name = "nym1".to_owned();
-
-        let routing_config = RoutingConfig::Wireguard {
-            #[cfg(unix)]
-            entry_tun_name,
-            #[cfg(unix)]
-            exit_tun_name: exit_tun_name.clone(),
-            #[cfg(windows)]
-            entry_tun_name: entry_tun_name.clone(),
-            #[cfg(windows)]
-            exit_tun_name: exit_tun_name.clone(),
-            entry_gateway_address: conn_data.entry.endpoint.ip(),
-            exit_gateway_address: conn_data.exit.endpoint.ip(),
-            #[cfg(target_os = "linux")]
-            physical_interface: DefaultInterface::current()?,
-        };
-
-        Self::set_routes(routing_config, shared_state).await?;
-        Self::set_dns(&exit_tun_name, shared_state)?;
-
-        let tunnel_conn_data = TunnelConnectionData::Wireguard(WireguardConnectionData {
-            entry: WireguardNode::from(conn_data.entry.clone()),
-            exit: WireguardNode::from(conn_data.exit.clone()),
-        });
-
-        let tunnel_handle = connected_tunnel
-            .run(
-                #[cfg(unix)]
-                entry_tun,
-                #[cfg(unix)]
-                exit_tun,
-                #[cfg(windows)]
-                &entry_tun_name,
-                #[cfg(windows)]
-                &exit_tun_name,
-                shared_state.tunnel_settings.dns.ip_addresses().to_vec(),
-            )
-            .map_err(Error::RunWireguardTunnel)?;
-
-        let any_tunnel_handle = AnyTunnelHandle::from(tunnel_handle);
-
-        Ok((tunnel_conn_data, any_tunnel_handle))
-    }
-
-    #[cfg(any(target_os = "ios", target_os = "android"))]
-    async fn start_wireguard_tunnel(
-        connected_mixnet: ConnectedMixnet,
-        shared_state: &mut SharedState,
-    ) -> Result<(TunnelConnectionData, AnyTunnelHandle)> {
-        let connected_tunnel = connected_mixnet
-            .connect_wireguard_tunnel(shared_state.tunnel_settings.enable_credentials_mode)
-            .await
-            .map_err(Error::ConnectWireguardTunnel)?;
-
-        let conn_data = connected_tunnel.connection_data();
-
-        let packet_tunnel_settings = tunnel_provider::tunnel_settings::TunnelSettings {
-            dns_servers: shared_state.tunnel_settings.dns.ip_addresses().to_vec(),
-            interface_addresses: vec![
-                IpNetwork::V4(
-                    Ipv4Network::new(conn_data.entry.private_ipv4, 32)
-                        .expect("ipv4 to ipnetwork/32"),
-                ),
-                IpNetwork::V6(
-                    Ipv6Network::new(WG_ENTRY_IPV6_ADDR, 128).expect("ipv6 to ipnetwork/128"),
-                ),
-            ],
-            remote_addresses: vec![conn_data.entry.endpoint.ip()],
-            mtu: connected_tunnel.exit_mtu(),
-        };
-
-        let tun_device = Self::create_tun_device(packet_tunnel_settings, shared_state).await?;
-
-        tracing::info!("Created tun device");
-
-        let tunnel_conn_data = TunnelConnectionData::Wireguard(WireguardConnectionData {
-            entry: WireguardNode::from(conn_data.entry.clone()),
-            exit: WireguardNode::from(conn_data.exit.clone()),
-        });
-
-        let tunnel_handle = connected_tunnel
-            .run(
-                tun_device,
-                shared_state.tunnel_settings.dns.ip_addresses().to_vec(),
-                #[cfg(any(target_os = "ios", target_os = "android"))]
-                shared_state.tun_provider.clone(),
-            )
-            .map_err(Error::RunWireguardTunnel)?;
-
-        let any_tunnel_handle = AnyTunnelHandle::from(tunnel_handle);
-
-        Ok((tunnel_conn_data, any_tunnel_handle))
-    }
-
-    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-    fn set_dns(tun_name: &str, shared_state: &mut SharedState) -> Result<()> {
-        let dns_servers = shared_state.tunnel_settings.dns.ip_addresses();
-
-        shared_state
-            .dns_handler
-            .set(tun_name, dns_servers)
-            .map_err(Error::SetDns)
-    }
-
-    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-    async fn set_routes(
-        routing_config: RoutingConfig,
-        shared_state: &mut SharedState,
-    ) -> Result<()> {
-        #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-        shared_state
-            .route_handler
-            .add_routes(routing_config)
-            .await
-            .map_err(Error::AddRoutes)?;
-
-        Ok(())
-    }
-
-    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-    fn create_mixnet_device(interface_addresses: IpPair, mtu: u16) -> Result<AsyncDevice> {
-        let mut tun_config = tun::Configuration::default();
-
-        tun_config
-            .address(interface_addresses.ipv4)
-            .mtu(i32::from(mtu))
-            .up();
-
-        #[cfg(target_os = "linux")]
-        tun_config.platform(|platform_config| {
-            platform_config.packet_information(false);
-        });
-
-        let tun_device = tun::create_as_async(&tun_config).map_err(Error::CreateTunDevice)?;
-
-        let tun_name = tun_device
-            .get_ref()
-            .name()
-            .map_err(Error::GetTunDeviceName)?;
-
-        tun_ipv6::set_ipv6_addr(&tun_name, interface_addresses.ipv6)
-            .map_err(Error::SetTunDeviceIpv6Addr)?;
-
-        Ok(tun_device)
-    }
-
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
-    fn create_wireguard_device(
-        interface_addresses: IpPair,
-        destination: Option<Ipv4Addr>,
-        mtu: u16,
-    ) -> Result<AsyncDevice> {
-        let mut tun_config = tun::Configuration::default();
-
-        tun_config
-            .address(interface_addresses.ipv4)
-            .netmask(Ipv4Addr::BROADCAST)
-            .mtu(i32::from(mtu))
-            .up();
-
-        if let Some(destination) = destination {
-            tun_config.destination(destination);
-        }
-
-        #[cfg(target_os = "linux")]
-        tun_config.platform(|platform_config| {
-            platform_config.packet_information(false);
-        });
-
-        let tun_device = tun::create_as_async(&tun_config).map_err(Error::CreateTunDevice)?;
-
-        let tun_name = tun_device
-            .get_ref()
-            .name()
-            .map_err(Error::GetTunDeviceName)?;
-
-        tun_ipv6::set_ipv6_addr(&tun_name, interface_addresses.ipv6)
-            .map_err(Error::SetTunDeviceIpv6Addr)?;
-
-        Ok(tun_device)
-    }
-
-    #[cfg(any(target_os = "ios", target_os = "android"))]
-    async fn create_tun_device(
-        packet_tunnel_settings: tunnel_provider::tunnel_settings::TunnelSettings,
-        shared_state: &mut SharedState,
-    ) -> Result<AsyncDevice> {
-        #[cfg(target_os = "ios")]
-        let owned_tun_fd =
-            tunnel_provider::ios::interface::get_tun_fd().map_err(Error::LocateTunDevice)?;
-
-        #[cfg(target_os = "android")]
-        let owned_tun_fd = {
-            let raw_tun_fd = shared_state
-                .tun_provider
-                .configure_tunnel(packet_tunnel_settings.into_tunnel_network_settings())
-                .map_err(|e| Error::ConfigureTunnelProvider(e.to_string()))?;
-            unsafe { OwnedFd::from_raw_fd(raw_tun_fd) }
-        };
-
-        let mut tun_config = tun::Configuration::default();
-        tun_config.raw_fd(owned_tun_fd.as_raw_fd());
-        #[cfg(target_os = "android")]
-        {
-            #[cfg(target_os = "linux")]
-            tun_config.platform(|platform_config| {
-                platform_config.packet_information(false);
-            });
-        }
-
-        #[cfg(target_os = "ios")]
-        {
-            shared_state
-                .tun_provider
-                .set_tunnel_network_settings(packet_tunnel_settings.into_tunnel_network_settings())
-                .await
-                .map_err(|e| Error::ConfigureTunnelProvider(e.to_string()))?
-        }
-
-        let device = tun::create_as_async(&tun_config).map_err(Error::CreateTunDevice)?;
-
-        // Consume the owned fd, since the device is now responsible for closing the underlying raw fd.
-        let _ = owned_tun_fd.into_raw_fd();
-
-        Ok(device)
     }
 }
 
@@ -572,23 +67,59 @@ impl TunnelStateHandler for ConnectingState {
     ) -> NextTunnelState {
         tokio::select! {
             _ = shutdown_token.cancelled() => {
-                self.on_cancel(ActionAfterDisconnect::Nothing, shared_state).await
+                NextTunnelState::NewState(DisconnectingState::enter(
+                    PrivateActionAfterDisconnect::Nothing,
+                    self.monitor_handle,
+                    shared_state,
+                ))
             }
-            result = &mut self.connect_fut => {
-                Self::on_connect_mixnet_client(result, shared_state).await
+           Some(monitor_event) = self.monitor_event_receiver.recv() => {
+            match monitor_event {
+                TunnelMonitorEvent::InitializingClient => {
+                    NextTunnelState::SameState(self)
+                }
+                TunnelMonitorEvent::EstablishingTunnel(conn_data) => {
+                    NextTunnelState::NewState((self, PrivateTunnelState::Connecting { connection_data: Some(conn_data) }))
+                }
+                TunnelMonitorEvent::SelectedGateways(new_gateways) => {
+                    self.selected_gateways = Some(new_gateways);
+                    NextTunnelState::SameState(self)
+                }
+                TunnelMonitorEvent::Up(conn_data) => {
+                    NextTunnelState::NewState(ConnectedState::enter(conn_data, self.monitor_handle, self.monitor_event_receiver, shared_state))
+                }
+                TunnelMonitorEvent::Down(reason) => {
+                    if let Some(reason) = reason {
+                        NextTunnelState::NewState(DisconnectingState::enter(PrivateActionAfterDisconnect::Error(reason), self.monitor_handle, shared_state))
+                    } else {
+                        #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+                        shared_state.route_handler.remove_routes().await;
+
+                        NextTunnelState::NewState(ConnectingState::enter( self.retry_attempt.saturating_add(1), self.selected_gateways, shared_state))
+                    }
+                }
             }
+           }
             Some(command) = command_rx.recv() => {
                 match command {
                     TunnelCommand::Connect => NextTunnelState::SameState(self),
                     TunnelCommand::Disconnect => {
-                        self.on_cancel(ActionAfterDisconnect::Nothing, shared_state).await
+                        NextTunnelState::NewState(DisconnectingState::enter(
+                            PrivateActionAfterDisconnect::Nothing,
+                            self.monitor_handle,
+                            shared_state,
+                        ))
                     },
                     TunnelCommand::SetTunnelSettings(tunnel_settings) => {
                         if shared_state.tunnel_settings == tunnel_settings {
                             NextTunnelState::SameState(self)
                         } else {
                             shared_state.tunnel_settings = tunnel_settings;
-                            self.on_cancel(ActionAfterDisconnect::Reconnect, shared_state).await
+                            NextTunnelState::NewState(DisconnectingState::enter(
+                                PrivateActionAfterDisconnect::Reconnect { retry_attempt: 0 },
+                                self.monitor_handle,
+                                shared_state,
+                            ))
                         }
                     }
                 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -79,10 +79,10 @@ impl TunnelStateHandler for ConnectingState {
                     NextTunnelState::SameState(self)
                 }
                 TunnelMonitorEvent::EstablishingTunnel(conn_data) => {
-                    NextTunnelState::NewState((self, PrivateTunnelState::Connecting { connection_data: Some(conn_data) }))
+                    NextTunnelState::NewState((self, PrivateTunnelState::Connecting { connection_data: Some(*conn_data) }))
                 }
                 TunnelMonitorEvent::SelectedGateways(new_gateways) => {
-                    self.selected_gateways = Some(new_gateways);
+                    self.selected_gateways = Some(*new_gateways);
                     NextTunnelState::SameState(self)
                 }
                 TunnelMonitorEvent::Up(conn_data) => {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnected_state.rs
@@ -5,15 +5,15 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 use crate::tunnel_state_machine::{
-    states::ConnectingState, NextTunnelState, SharedState, TunnelCommand, TunnelState,
+    states::ConnectingState, NextTunnelState, PrivateTunnelState, SharedState, TunnelCommand,
     TunnelStateHandler,
 };
 
 pub struct DisconnectedState;
 
 impl DisconnectedState {
-    pub fn enter() -> (Box<dyn TunnelStateHandler>, TunnelState) {
-        (Box::new(Self), TunnelState::Disconnected)
+    pub fn enter() -> (Box<dyn TunnelStateHandler>, PrivateTunnelState) {
+        (Box::new(Self), PrivateTunnelState::Disconnected)
     }
 }
 
@@ -32,7 +32,7 @@ impl TunnelStateHandler for DisconnectedState {
             Some(command) = command_rx.recv() => {
                 match command {
                     TunnelCommand::Connect => {
-                        NextTunnelState::NewState(ConnectingState::enter(shared_state))
+                        NextTunnelState::NewState(ConnectingState::enter(0, None, shared_state))
                     },
                     TunnelCommand::Disconnect => NextTunnelState::SameState(self),
                     TunnelCommand::SetTunnelSettings(tunnel_settings) => {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
@@ -6,14 +6,15 @@ use tokio_util::sync::CancellationToken;
 
 use crate::tunnel_state_machine::{
     states::{ConnectingState, DisconnectedState},
-    ErrorStateReason, NextTunnelState, SharedState, TunnelCommand, TunnelState, TunnelStateHandler,
+    ErrorStateReason, NextTunnelState, PrivateTunnelState, SharedState, TunnelCommand,
+    TunnelStateHandler,
 };
 
 pub struct ErrorState;
 
 impl ErrorState {
-    pub fn enter(reason: ErrorStateReason) -> (Box<dyn TunnelStateHandler>, TunnelState) {
-        (Box::new(Self), TunnelState::Error(reason))
+    pub fn enter(reason: ErrorStateReason) -> (Box<dyn TunnelStateHandler>, PrivateTunnelState) {
+        (Box::new(Self), PrivateTunnelState::Error(reason))
     }
 }
 
@@ -32,7 +33,7 @@ impl TunnelStateHandler for ErrorState {
             Some(command) = command_rx.recv() => {
                 match command {
                     TunnelCommand::Connect => {
-                        NextTunnelState::NewState(ConnectingState::enter(shared_state))
+                        NextTunnelState::NewState(ConnectingState::enter(0, None, shared_state))
                     },
                     TunnelCommand::Disconnect => NextTunnelState::NewState(DisconnectedState::enter()),
                     TunnelCommand::SetTunnelSettings(tunnel_settings) => {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
@@ -85,7 +85,7 @@ impl ConnectedTunnel {
             #[cfg(windows)]
             entry_tun_name,
         )
-        .map_err(Error::StartWireguard)?;
+        .map_err(Error::Wireguard)?;
 
         let exit_tunnel = wireguard_go::Tunnel::start(
             wg_exit_config.into_wireguard_config(),
@@ -94,7 +94,7 @@ impl ConnectedTunnel {
             #[cfg(windows)]
             exit_tun_name,
         )
-        .map_err(Error::StartWireguard)?;
+        .map_err(Error::Wireguard)?;
 
         Ok(TunnelHandle {
             task_manager: self.task_manager,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -1,0 +1,665 @@
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+use std::net::Ipv4Addr;
+#[cfg(any(
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "android"
+))]
+use std::net::Ipv6Addr;
+#[cfg(any(target_os = "android", target_os = "ios"))]
+use std::os::fd::{AsRawFd, IntoRawFd};
+#[cfg(target_os = "android")]
+use std::os::fd::{FromRawFd, OwnedFd};
+use std::{cmp, sync::Arc, time::Duration};
+
+#[cfg(any(target_os = "ios", target_os = "android"))]
+use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
+use nym_gateway_directory::GatewayMinPerformance;
+use time::OffsetDateTime;
+use tokio::{sync::mpsc, task::JoinHandle};
+use tokio_util::sync::CancellationToken;
+use tun::AsyncDevice;
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+use tun::Device;
+
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+use nym_ip_packet_requests::IpPair;
+
+#[cfg(target_os = "linux")]
+use super::default_interface::DefaultInterface;
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+use super::{dns_handler::DnsHandlerHandle, route_handler::RouteHandler};
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+use super::{route_handler::RoutingConfig, tun_ipv6};
+use super::{
+    tunnel::{
+        self, any_tunnel_handle::AnyTunnelHandle, ConnectedMixnet, MixnetConnectOptions,
+        SelectedGateways,
+    },
+    ConnectionData, Error, ErrorStateReason, MixnetConnectionData, MixnetEvent, NymConfig, Result,
+    TunnelConnectionData, TunnelSettings, TunnelType, WireguardConnectionData, WireguardNode,
+};
+#[cfg(any(target_os = "ios", target_os = "android"))]
+use crate::tunnel_provider;
+#[cfg(target_os = "android")]
+use crate::tunnel_provider::android::AndroidTunProvider;
+#[cfg(target_os = "ios")]
+use crate::tunnel_provider::ios::OSTunProvider;
+
+/// Default MTU for mixnet tun device.
+const DEFAULT_TUN_MTU: u16 = if cfg!(any(target_os = "ios", target_os = "android")) {
+    1280
+} else {
+    1500
+};
+#[cfg(any(
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "android",
+    target_os = "ios"
+))]
+/// Entry IPv6 address (ULA) used by WireGuard, currently not routable.
+const WG_ENTRY_IPV6_ADDR: Ipv6Addr = Ipv6Addr::new(
+    0xfdcc, 0x9fc0, 0xe75a, 0x53c3, 0xfa25, 0x241f, 0x21c0, 0x70d0,
+);
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+/// Exit IPv6 address (ULA) used by WireGuard, currently not routable.
+const WG_EXIT_IPV6_ADDR: Ipv6Addr = Ipv6Addr::new(
+    0xfdcc, 0x9fc0, 0xe75a, 0x53c3, 0x72a5, 0xf352, 0x5475, 0x4160,
+);
+
+pub type TunnelMonitorEventReceiver = mpsc::UnboundedReceiver<TunnelMonitorEvent>;
+
+/// Initial delay between retry attempts.
+const INITIAL_WAIT_DELAY: Duration = Duration::from_secs(2);
+
+/// Wait delay multiplier used for each subsequent retry attempt.
+const DELAY_MULTIPLIER: u32 = 2;
+
+/// Max wait delay between retry attempts.
+const MAX_WAIT_DELAY: Duration = Duration::from_secs(15);
+
+#[derive(Debug, Clone)]
+pub enum TunnelMonitorEvent {
+    /// Initializing mixnet client
+    InitializingClient,
+
+    /// Selected gateways
+    SelectedGateways(SelectedGateways),
+
+    /// Establishing tunnel connection
+    EstablishingTunnel(ConnectionData),
+
+    /// Tunnel is up
+    Up(ConnectionData),
+
+    /// Tunnel went down
+    Down(Option<ErrorStateReason>),
+}
+
+pub struct TunnelMonitorHandle {
+    cancel_token: CancellationToken,
+    join_handle: JoinHandle<Vec<AsyncDevice>>,
+}
+
+impl TunnelMonitorHandle {
+    pub fn cancel(&self) {
+        self.cancel_token.cancel();
+    }
+
+    pub async fn wait(self) -> Vec<AsyncDevice> {
+        self.join_handle
+            .await
+            .inspect_err(|e| {
+                tracing::error!("Failed to join on tunnel monitor handle: {}", e);
+            })
+            .unwrap_or_default()
+    }
+}
+
+pub struct TunnelMonitor {
+    monitor_event_sender: mpsc::UnboundedSender<TunnelMonitorEvent>,
+    mixnet_event_sender: mpsc::UnboundedSender<MixnetEvent>,
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+    route_handler: RouteHandler,
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+    dns_handler: DnsHandlerHandle,
+    #[cfg(target_os = "ios")]
+    tun_provider: Arc<dyn OSTunProvider>,
+    #[cfg(target_os = "android")]
+    tun_provider: Arc<dyn AndroidTunProvider>,
+    nym_config: NymConfig,
+    tunnel_settings: TunnelSettings,
+    cancel_token: CancellationToken,
+}
+
+impl TunnelMonitor {
+    pub fn start(
+        retry_attempt: u32,
+        selected_gateways: Option<SelectedGateways>,
+        monitor_event_sender: mpsc::UnboundedSender<TunnelMonitorEvent>,
+        mixnet_event_sender: mpsc::UnboundedSender<MixnetEvent>,
+        #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+        route_handler: RouteHandler,
+        #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+        dns_handler: DnsHandlerHandle,
+        #[cfg(target_os = "ios")] tun_provider: Arc<dyn OSTunProvider>,
+        #[cfg(target_os = "android")] tun_provider: Arc<dyn AndroidTunProvider>,
+        nym_config: NymConfig,
+        tunnel_settings: TunnelSettings,
+    ) -> TunnelMonitorHandle {
+        let cancel_token = CancellationToken::new();
+        let tunnel_monitor = Self {
+            monitor_event_sender,
+            mixnet_event_sender,
+            #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+            route_handler,
+            #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+            dns_handler,
+            #[cfg(any(target_os = "ios", target_os = "android"))]
+            tun_provider,
+            nym_config,
+            tunnel_settings,
+            cancel_token: cancel_token.clone(),
+        };
+        let join_handle = tokio::spawn(tunnel_monitor.run(retry_attempt, selected_gateways));
+
+        TunnelMonitorHandle {
+            cancel_token,
+            join_handle,
+        }
+    }
+
+    async fn run(
+        mut self,
+        retry_attempt: u32,
+        selected_gateways: Option<SelectedGateways>,
+    ) -> Vec<AsyncDevice> {
+        self.run_inner(retry_attempt, selected_gateways)
+            .await
+            .inspect_err(|e| {
+                self.send_event(TunnelMonitorEvent::Down(e.error_state_reason()));
+            })
+            .unwrap_or_default()
+    }
+
+    async fn run_inner(
+        &mut self,
+        retry_attempt: u32,
+        selected_gateways: Option<SelectedGateways>,
+    ) -> Result<Vec<AsyncDevice>> {
+        if retry_attempt > 0 {
+            let delay = wait_delay(retry_attempt);
+            tracing::debug!("Waiting for {}s before connecting.", delay.as_secs());
+            if self
+                .cancel_token
+                .run_until_cancelled(tokio::time::sleep(delay))
+                .await
+                .is_none()
+            {
+                return Ok(vec![]);
+            }
+        }
+
+        self.send_event(TunnelMonitorEvent::InitializingClient);
+
+        let gateway_performance_options = self.tunnel_settings.gateway_performance_options;
+        let gateway_min_performance = GatewayMinPerformance::from_percentage_values(
+            gateway_performance_options
+                .mixnet_min_performance
+                .map(u64::from),
+            gateway_performance_options
+                .vpn_min_performance
+                .map(u64::from),
+        );
+
+        let mut gateway_config = self.nym_config.gateway_config.clone();
+        match gateway_min_performance {
+            Ok(gateway_min_performance) => {
+                gateway_config =
+                    gateway_config.with_min_gateway_performance(gateway_min_performance);
+            }
+            Err(e) => {
+                tracing::error!(
+                    "Invalid gateway performance values. Will carry on with initial values. Error: {}"
+                , e);
+            }
+        }
+
+        let selected_gateways = if let Some(selected_gateways) = selected_gateways {
+            selected_gateways
+        } else {
+            let new_gateways = tunnel::select_gateways(
+                gateway_config.clone(),
+                self.tunnel_settings.tunnel_type,
+                self.tunnel_settings.entry_point.clone(),
+                self.tunnel_settings.exit_point.clone(),
+                None, // todo: provider user agent
+                self.cancel_token.child_token(),
+            )
+            .await?;
+
+            self.send_event(TunnelMonitorEvent::SelectedGateways(new_gateways.clone()));
+
+            new_gateways
+        };
+
+        let connect_options = MixnetConnectOptions {
+            data_path: self.nym_config.data_path.clone(),
+            gateway_config,
+            mixnet_client_config: self.tunnel_settings.mixnet_client_config.clone(),
+            tunnel_type: self.tunnel_settings.tunnel_type,
+            enable_credentials_mode: self.tunnel_settings.enable_credentials_mode,
+            selected_gateways: selected_gateways.clone(),
+            user_agent: None, // todo: provide user-agent
+        };
+
+        let mut connected_mixnet =
+            tunnel::connect_mixnet(connect_options, self.cancel_token.child_token()).await?;
+
+        let status_listener_handle = connected_mixnet
+            .start_event_listener(self.mixnet_event_sender.clone())
+            .await;
+
+        let selected_gateways = connected_mixnet.selected_gateways().clone();
+        let (tunnel_conn_data, mut tunnel_handle) = match self.tunnel_settings.tunnel_type {
+            TunnelType::Mixnet => self.start_mixnet_tunnel(connected_mixnet).await?,
+            TunnelType::Wireguard => self.start_wireguard_tunnel(connected_mixnet).await?,
+        };
+
+        let conn_data = ConnectionData {
+            entry_gateway: Box::new(*selected_gateways.entry.identity()),
+            exit_gateway: Box::new(*selected_gateways.exit.identity()),
+            connected_at: None,
+            tunnel: tunnel_conn_data,
+        };
+        self.send_event(TunnelMonitorEvent::EstablishingTunnel(conn_data.clone()));
+
+        // todo: do initial ping
+
+        let conn_data = ConnectionData {
+            connected_at: Some(OffsetDateTime::now_utc()),
+            ..conn_data
+        };
+        self.send_event(TunnelMonitorEvent::Up(conn_data));
+
+        loop {
+            tokio::select! {
+                _ = self.cancel_token.cancelled() => {
+                    break;
+                }
+                e = tunnel_handle.recv_error() => {
+                    tracing::error!("Received mixnet client error: {:?}", e);
+                    // todo: handle error
+                }
+            }
+        }
+
+        tracing::debug!("Wait for tunnel to exit");
+        tunnel_handle.cancel();
+
+        let tun_devices = tunnel_handle
+            .wait()
+            .await
+            .inspect_err(|e| {
+                tracing::error!("Failed to gracefully shutdown the tunnel: {}", e);
+            })
+            .unwrap_or_default();
+
+        tracing::debug!("Wait for status listener to exit");
+        if let Err(e) = status_listener_handle.await {
+            tracing::error!("Failed to join on status listener: {}", e);
+        }
+
+        Ok(tun_devices)
+    }
+
+    fn send_event(&mut self, event: TunnelMonitorEvent) {
+        if let Err(e) = self.monitor_event_sender.send(event) {
+            tracing::error!("Failed to send event: {}", e);
+        }
+    }
+
+    async fn start_mixnet_tunnel(
+        &mut self,
+        connected_mixnet: ConnectedMixnet,
+    ) -> Result<(TunnelConnectionData, AnyTunnelHandle)> {
+        let interface_addrs = self.tunnel_settings.mixnet_tunnel_options.interface_addrs;
+
+        let connected_tunnel = connected_mixnet
+            .connect_mixnet_tunnel(interface_addrs)
+            .await?;
+        let assigned_addresses = connected_tunnel.assigned_addresses();
+
+        let mtu: u16 = self
+            .tunnel_settings
+            .mixnet_tunnel_options
+            .mtu
+            .unwrap_or(DEFAULT_TUN_MTU);
+
+        #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+        let tun_device = Self::create_mixnet_device(assigned_addresses.interface_addresses, mtu)?;
+
+        #[cfg(any(target_os = "ios", target_os = "android"))]
+        let tun_device = {
+            let packet_tunnel_settings = tunnel_provider::tunnel_settings::TunnelSettings {
+                dns_servers: self.tunnel_settings.dns.ip_addresses().to_vec(),
+                interface_addresses: vec![
+                    IpNetwork::V4(
+                        Ipv4Network::new(assigned_addresses.interface_addresses.ipv4, 32)
+                            .expect("ipv4/32 to ipnetwork"),
+                    ),
+                    IpNetwork::V6(
+                        Ipv6Network::new(assigned_addresses.interface_addresses.ipv6, 128)
+                            .expect("ipv6/128 addr to ipnetwork"),
+                    ),
+                ],
+                remote_addresses: vec![assigned_addresses.entry_mixnet_gateway_ip],
+                mtu,
+            };
+
+            let tun_device = self.create_tun_device(packet_tunnel_settings).await?;
+            tracing::debug!("Created tun device");
+            tun_device
+        };
+
+        #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+        {
+            let tun_name = tun_device
+                .get_ref()
+                .name()
+                .map_err(Error::GetTunDeviceName)?;
+
+            tracing::debug!("Created tun device: {}", tun_name);
+
+            let routing_config = RoutingConfig::Mixnet {
+                tun_name: tun_name.clone(),
+                entry_gateway_address: assigned_addresses.entry_mixnet_gateway_ip,
+                #[cfg(target_os = "linux")]
+                physical_interface: DefaultInterface::current()?,
+            };
+
+            self.set_routes(routing_config).await?;
+            self.set_dns(&tun_name).await?;
+        }
+
+        let tunnel_conn_data = TunnelConnectionData::Mixnet(MixnetConnectionData {
+            nym_address: Box::new(assigned_addresses.mixnet_client_address),
+            exit_ipr: Box::new(assigned_addresses.exit_mix_addresses.0),
+            ipv4: assigned_addresses.interface_addresses.ipv4,
+            ipv6: assigned_addresses.interface_addresses.ipv6,
+        });
+
+        let tunnel_handle = AnyTunnelHandle::from(connected_tunnel.run(tun_device).await);
+
+        Ok((tunnel_conn_data, tunnel_handle))
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+    async fn start_wireguard_tunnel(
+        &mut self,
+        connected_mixnet: ConnectedMixnet,
+    ) -> Result<(TunnelConnectionData, AnyTunnelHandle)> {
+        let connected_tunnel = connected_mixnet
+            .connect_wireguard_tunnel(self.tunnel_settings.enable_credentials_mode)
+            .await?;
+        let conn_data = connected_tunnel.connection_data();
+
+        #[cfg(unix)]
+        let entry_tun = Self::create_wireguard_device(
+            IpPair {
+                ipv4: conn_data.entry.private_ipv4,
+                ipv6: WG_ENTRY_IPV6_ADDR,
+            },
+            None,
+            connected_tunnel.entry_mtu(),
+        )?;
+        #[cfg(unix)]
+        let entry_tun_name = entry_tun
+            .get_ref()
+            .name()
+            .map_err(Error::GetTunDeviceName)?;
+        #[cfg(unix)]
+        tracing::info!("Created entry tun device: {}", entry_tun_name);
+
+        #[cfg(unix)]
+        let exit_tun = Self::create_wireguard_device(
+            IpPair {
+                ipv4: conn_data.exit.private_ipv4,
+                ipv6: WG_EXIT_IPV6_ADDR,
+            },
+            Some(conn_data.entry.private_ipv4),
+            connected_tunnel.exit_mtu(),
+        )?;
+        #[cfg(unix)]
+        let exit_tun_name = exit_tun.get_ref().name().map_err(Error::GetTunDeviceName)?;
+        #[cfg(unix)]
+        tracing::info!("Created exit tun device: {}", exit_tun_name);
+
+        #[cfg(windows)]
+        let entry_tun_name = "nym0".to_owned();
+        #[cfg(windows)]
+        let exit_tun_name = "nym1".to_owned();
+
+        let routing_config = RoutingConfig::Wireguard {
+            #[cfg(unix)]
+            entry_tun_name,
+            #[cfg(unix)]
+            exit_tun_name: exit_tun_name.clone(),
+            #[cfg(windows)]
+            entry_tun_name: entry_tun_name.clone(),
+            #[cfg(windows)]
+            exit_tun_name: exit_tun_name.clone(),
+            entry_gateway_address: conn_data.entry.endpoint.ip(),
+            exit_gateway_address: conn_data.exit.endpoint.ip(),
+            #[cfg(target_os = "linux")]
+            physical_interface: DefaultInterface::current()?,
+        };
+
+        self.set_routes(routing_config).await?;
+        self.set_dns(&exit_tun_name).await?;
+
+        let tunnel_conn_data = TunnelConnectionData::Wireguard(WireguardConnectionData {
+            entry: WireguardNode::from(conn_data.entry.clone()),
+            exit: WireguardNode::from(conn_data.exit.clone()),
+        });
+
+        let tunnel_handle = connected_tunnel.run(
+            #[cfg(unix)]
+            entry_tun,
+            #[cfg(unix)]
+            exit_tun,
+            #[cfg(windows)]
+            &entry_tun_name,
+            #[cfg(windows)]
+            &exit_tun_name,
+            self.tunnel_settings.dns.ip_addresses().to_vec(),
+        )?;
+
+        let any_tunnel_handle = AnyTunnelHandle::from(tunnel_handle);
+
+        Ok((tunnel_conn_data, any_tunnel_handle))
+    }
+
+    #[cfg(any(target_os = "ios", target_os = "android"))]
+    async fn start_wireguard_tunnel(
+        &self,
+        connected_mixnet: ConnectedMixnet,
+    ) -> Result<(TunnelConnectionData, AnyTunnelHandle)> {
+        let connected_tunnel = connected_mixnet
+            .connect_wireguard_tunnel(self.tunnel_settings.enable_credentials_mode)
+            .await?;
+
+        let conn_data = connected_tunnel.connection_data();
+
+        let packet_tunnel_settings = tunnel_provider::tunnel_settings::TunnelSettings {
+            dns_servers: self.tunnel_settings.dns.ip_addresses().to_vec(),
+            interface_addresses: vec![
+                IpNetwork::V4(
+                    Ipv4Network::new(conn_data.entry.private_ipv4, 32)
+                        .expect("ipv4 to ipnetwork/32"),
+                ),
+                IpNetwork::V6(
+                    Ipv6Network::new(WG_ENTRY_IPV6_ADDR, 128).expect("ipv6 to ipnetwork/128"),
+                ),
+            ],
+            remote_addresses: vec![conn_data.entry.endpoint.ip()],
+            mtu: connected_tunnel.exit_mtu(),
+        };
+
+        let tun_device = self.create_tun_device(packet_tunnel_settings).await?;
+
+        tracing::info!("Created tun device");
+
+        let tunnel_conn_data = TunnelConnectionData::Wireguard(WireguardConnectionData {
+            entry: WireguardNode::from(conn_data.entry.clone()),
+            exit: WireguardNode::from(conn_data.exit.clone()),
+        });
+
+        let tunnel_handle = connected_tunnel.run(
+            tun_device,
+            self.tunnel_settings.dns.ip_addresses().to_vec(),
+            #[cfg(any(target_os = "ios", target_os = "android"))]
+            self.tun_provider.clone(),
+        )?;
+
+        let any_tunnel_handle = AnyTunnelHandle::from(tunnel_handle);
+
+        Ok((tunnel_conn_data, any_tunnel_handle))
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+    async fn set_dns(&mut self, tun_name: &str) -> Result<()> {
+        let dns_servers = self.tunnel_settings.dns.ip_addresses().to_vec();
+
+        self.dns_handler
+            .set(tun_name.to_owned(), dns_servers)
+            .await
+            .map_err(Error::SetDns)
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+    async fn set_routes(&mut self, routing_config: RoutingConfig) -> Result<()> {
+        self.route_handler
+            .add_routes(routing_config)
+            .await
+            .map_err(Error::AddRoutes)?;
+
+        Ok(())
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+    fn create_mixnet_device(interface_addresses: IpPair, mtu: u16) -> Result<AsyncDevice> {
+        let mut tun_config = tun::Configuration::default();
+
+        tun_config
+            .address(interface_addresses.ipv4)
+            .mtu(i32::from(mtu))
+            .up();
+
+        #[cfg(target_os = "linux")]
+        tun_config.platform(|platform_config| {
+            platform_config.packet_information(false);
+        });
+
+        let tun_device = tun::create_as_async(&tun_config).map_err(Error::CreateTunDevice)?;
+
+        let tun_name = tun_device
+            .get_ref()
+            .name()
+            .map_err(Error::GetTunDeviceName)?;
+
+        tun_ipv6::set_ipv6_addr(&tun_name, interface_addresses.ipv6)
+            .map_err(Error::SetTunDeviceIpv6Addr)?;
+
+        Ok(tun_device)
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    fn create_wireguard_device(
+        interface_addresses: IpPair,
+        destination: Option<Ipv4Addr>,
+        mtu: u16,
+    ) -> Result<AsyncDevice> {
+        let mut tun_config = tun::Configuration::default();
+
+        tun_config
+            .address(interface_addresses.ipv4)
+            .netmask(Ipv4Addr::BROADCAST)
+            .mtu(i32::from(mtu))
+            .up();
+
+        if let Some(destination) = destination {
+            tun_config.destination(destination);
+        }
+
+        #[cfg(target_os = "linux")]
+        tun_config.platform(|platform_config| {
+            platform_config.packet_information(false);
+        });
+
+        let tun_device = tun::create_as_async(&tun_config).map_err(Error::CreateTunDevice)?;
+
+        let tun_name = tun_device
+            .get_ref()
+            .name()
+            .map_err(Error::GetTunDeviceName)?;
+
+        tun_ipv6::set_ipv6_addr(&tun_name, interface_addresses.ipv6)
+            .map_err(Error::SetTunDeviceIpv6Addr)?;
+
+        Ok(tun_device)
+    }
+
+    #[cfg(any(target_os = "ios", target_os = "android"))]
+    async fn create_tun_device(
+        &self,
+        packet_tunnel_settings: tunnel_provider::tunnel_settings::TunnelSettings,
+    ) -> Result<AsyncDevice> {
+        #[cfg(target_os = "ios")]
+        let owned_tun_fd =
+            tunnel_provider::ios::interface::get_tun_fd().map_err(Error::LocateTunDevice)?;
+
+        #[cfg(target_os = "android")]
+        let owned_tun_fd = {
+            let raw_tun_fd = self
+                .tun_provider
+                .configure_tunnel(packet_tunnel_settings.into_tunnel_network_settings())
+                .map_err(|e| Error::ConfigureTunnelProvider(e.to_string()))?;
+            unsafe { OwnedFd::from_raw_fd(raw_tun_fd) }
+        };
+
+        let mut tun_config = tun::Configuration::default();
+        tun_config.raw_fd(owned_tun_fd.as_raw_fd());
+        #[cfg(target_os = "android")]
+        {
+            #[cfg(target_os = "linux")]
+            tun_config.platform(|platform_config| {
+                platform_config.packet_information(false);
+            });
+        }
+
+        #[cfg(target_os = "ios")]
+        {
+            self.tun_provider
+                .set_tunnel_network_settings(packet_tunnel_settings.into_tunnel_network_settings())
+                .await
+                .map_err(|e| Error::ConfigureTunnelProvider(e.to_string()))?
+        }
+
+        let device = tun::create_as_async(&tun_config).map_err(Error::CreateTunDevice)?;
+
+        // Consume the owned fd, since the device is now responsible for closing the underlying raw fd.
+        let _ = owned_tun_fd.into_raw_fd();
+
+        Ok(device)
+    }
+}
+
+fn wait_delay(retry_attempt: u32) -> Duration {
+    let multiplier = retry_attempt.saturating_mul(DELAY_MULTIPLIER);
+    let delay = INITIAL_WAIT_DELAY.saturating_mul(multiplier);
+    cmp::min(delay, MAX_WAIT_DELAY)
+}

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -633,10 +633,6 @@ impl TunnelMonitor {
 
         let mut tun_config = tun::Configuration::default();
         tun_config.raw_fd(owned_tun_fd.as_raw_fd());
-        #[cfg(target_os = "android")]
-        tun_config.platform(|platform_config| {
-            platform_config.packet_information(false);
-        });
 
         #[cfg(target_os = "ios")]
         {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -634,12 +634,9 @@ impl TunnelMonitor {
         let mut tun_config = tun::Configuration::default();
         tun_config.raw_fd(owned_tun_fd.as_raw_fd());
         #[cfg(target_os = "android")]
-        {
-            #[cfg(target_os = "linux")]
-            tun_config.platform(|platform_config| {
-                platform_config.packet_information(false);
-            });
-        }
+        tun_config.platform(|platform_config| {
+            platform_config.packet_information(false);
+        });
 
         #[cfg(target_os = "ios")]
         {

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -521,11 +521,11 @@ where
             }
         }
 
-        tracing::info!("Exiting vpn service run loop");
-
         if let Err(e) = self.state_machine_handle.await {
             tracing::error!("Failed to join on state machine handle: {}", e);
         }
+
+        tracing::info!("Exiting vpn service run loop");
 
         Ok(())
     }

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -494,7 +494,7 @@ where
                     self.handle_service_command(command).await;
                 }
                 Some(event) = self.event_receiver.recv() => {
-                    tracing::info!("Tunnel event: {:?}", event);
+                    tracing::info!("Tunnel event: {}", event);
                     match event {
                         TunnelEvent::NewState(new_state) => {
                             self.tunnel_state = new_state.clone();


### PR DESCRIPTION
This is a draft PR for introducing a reconnection loop into the state machine. 

Most of tunnel related functions have been moved from the state machine into `TunnelMonitor`, exposing an event channel to the state machine.

Connecting state gained the connection metadata alas there is no self-ping yet to determine if the tunnel is functional so the connected states comes right after it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1453)
<!-- Reviewable:end -->
