### PR TITLE
Avoid rewriting user defaults on setup

### DIFF
--- a/nym-vpn-apple/Services/Sources/Services/ConfigurationManager/ConfigurationManager.swift
+++ b/nym-vpn-apple/Services/Sources/Services/ConfigurationManager/ConfigurationManager.swift
@@ -64,18 +64,9 @@ public final class ConfigurationManager {
 #endif
 
     public func setup() throws {
-        guard let env = Env(rawValue: appSettings.currentEnv)
-        else {
-            logger.error("Cannot load current env var from: \(appSettings.currentEnv)")
-            currentEnv = fallbackEnv
-            return
-        }
-        currentEnv = env
 #if os(iOS)
         try setEnvVariables(for: currentEnv)
-#endif
-
-#if os(macOS)
+#elseif os(macOS)
         try setDaemonEnvironmentVariables()
 #endif
     }


### PR DESCRIPTION
Prevents the loop where currentEnv overwrites the env in user defaults causing race conditions when called from multiple processes at the same time

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1482)
<!-- Reviewable:end -->
