### PR TITLE
Wait for account to be ready to connect

### DIFF
--- a/nym-vpn-app/src-tauri/src/error.rs
+++ b/nym-vpn-app/src-tauri/src/error.rs
@@ -200,6 +200,7 @@ pub enum ErrorKey {
     NoActiveSubscription,
     DeviceNotRegistered,
     DeviceNotActive,
+    ReadyToConnectPending,
     // Forwarded from proto `connection_status_update::StatusType`
     EntryGatewayNotRouting,
     ExitRouterPingIpv4,
@@ -309,6 +310,7 @@ impl From<ConnectRequestErrorType> for ErrorKey {
             ConnectRequestErrorType::NoActiveSubscription => ErrorKey::NoActiveSubscription,
             ConnectRequestErrorType::DeviceNotRegistered => ErrorKey::DeviceNotRegistered,
             ConnectRequestErrorType::DeviceNotActive => ErrorKey::DeviceNotActive,
+            ConnectRequestErrorType::Pending => ErrorKey::ReadyToConnectPending,
         }
     }
 }

--- a/nym-vpn-app/src/hooks/useI18nError.ts
+++ b/nym-vpn-app/src/hooks/useI18nError.ts
@@ -123,6 +123,8 @@ function useI18nError() {
           return t('account.device.not-registered');
         case 'DeviceNotActive':
           return t('account.device.not-active');
+        case 'ReadyToConnectPending':
+          return t('connection.ready-to-connect');
         case 'EntryGatewayNotRouting':
           return t('entry-node-routing');
         case 'ExitRouterPingIpv4':

--- a/nym-vpn-app/src/i18n/en/errors.json
+++ b/nym-vpn-app/src/i18n/en/errors.json
@@ -66,7 +66,8 @@
     },
     "add-ipv6-route": "Failed to add ipv6 default route to capture ipv6 traffic",
     "tun-device": "Tun device failed",
-    "routing": "Routing failed"
+    "routing": "Routing failed",
+    "ready-to-connect": "It was not yet possible to determine if we are ready to connect during the check"
   },
   "account": {
     "invalid-recovery-phrase": "Invalid recovery phrase",

--- a/nym-vpn-app/src/types/tauri-ipc.ts
+++ b/nym-vpn-app/src/types/tauri-ipc.ts
@@ -85,6 +85,7 @@ export type ErrorKey =
   | 'NoActiveSubscription'
   | 'DeviceNotRegistered'
   | 'DeviceNotActive'
+  | 'ReadyToConnectPending'
   | 'EntryGatewayNotRouting'
   | 'ExitRouterPingIpv4'
   | 'ExitRouterPingIpv6'

--- a/nym-vpn-app/src/ui/TopBar.tsx
+++ b/nym-vpn-app/src/ui/TopBar.tsx
@@ -27,9 +27,7 @@ type NavLocation = {
   noBackground?: boolean;
 };
 
-type NavBarData = {
-  [key in Routes]: NavLocation;
-};
+type NavBarData = Record<Routes, NavLocation>;
 
 export default function TopBar() {
   const location = useLocation();

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/account.rs
@@ -1,7 +1,7 @@
 // Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{path::PathBuf, str::FromStr, sync::Arc};
+use std::{path::PathBuf, str::FromStr, sync::Arc, time::Duration};
 
 use nym_vpn_account_controller::{AccountCommand, ReadyToConnect, SharedAccountState};
 use nym_vpn_store::{keys::KeyStore, mnemonic::MnemonicStorage};
@@ -84,8 +84,8 @@ impl AccountControllerHandle {
         }
     }
 
-    async fn is_ready_to_connect(&self) -> ReadyToConnect {
-        self.shared_state.is_ready_to_connect().await
+    async fn wait_for_ready_to_connect(&self, timeout: Duration) -> Option<ReadyToConnect> {
+        self.shared_state.wait_for_ready_to_connect(timeout).await
     }
 
     async fn shutdown_and_wait(self) {
@@ -118,9 +118,12 @@ async fn get_shared_account_state() -> Result<SharedAccountState, VpnError> {
     }
 }
 
-async fn is_account_ready_to_connect() -> Result<ReadyToConnect, VpnError> {
+async fn wait_for_account_ready_to_connect(timeout: Duration) -> Result<ReadyToConnect, VpnError> {
     if let Some(guard) = &*ACCOUNT_CONTROLLER_HANDLE.lock().await {
-        Ok(guard.is_ready_to_connect().await)
+        guard
+            .wait_for_ready_to_connect(timeout)
+            .await
+            .ok_or(VpnError::AccountStatusUnknown)
     } else {
         Err(VpnError::InvalidStateError {
             details: "Account controller is not running.".to_owned(),
@@ -128,13 +131,14 @@ async fn is_account_ready_to_connect() -> Result<ReadyToConnect, VpnError> {
     }
 }
 
-pub(super) async fn assert_account_ready_to_connect() -> Result<(), VpnError> {
-    match is_account_ready_to_connect().await? {
+pub(super) async fn assert_account_ready_to_connect(timeout: Duration) -> Result<(), VpnError> {
+    match wait_for_account_ready_to_connect(timeout).await? {
         ReadyToConnect::Ready => Ok(()),
-        not_ready_to_connect => {
-            tracing::warn!("Not ready to connect: {:?}", not_ready_to_connect);
-            Err(not_ready_to_connect.into())
-        }
+        ReadyToConnect::NoMnemonicStored => Err(VpnError::NoAccountStored),
+        ReadyToConnect::AccountNotActive => Err(VpnError::AccountNotActive),
+        ReadyToConnect::NoActiveSubscription => Err(VpnError::NoActiveSubscription),
+        ReadyToConnect::DeviceNotRegistered => Err(VpnError::AccountDeviceNotRegistered),
+        ReadyToConnect::DeviceNotActive => Err(VpnError::AccountDeviceNotActive),
     }
 }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/account.rs
@@ -168,8 +168,6 @@ pub(super) async fn store_account_mnemonic(mnemonic: &str, path: &str) -> Result
             details: err.to_string(),
         })?;
 
-    send_account_command(AccountCommand::UpdateSharedAccountState).await?;
-
     Ok(())
 }
 
@@ -200,8 +198,6 @@ pub(super) async fn remove_account_mnemonic(path: &str) -> Result<bool, VpnError
                 details: err.to_string(),
             })?;
 
-    send_account_command(AccountCommand::UpdateSharedAccountState).await?;
-
     Ok(is_account_removed_success)
 }
 
@@ -215,7 +211,11 @@ pub(super) async fn reset_device_identity(path: &str) -> Result<(), VpnError> {
         })
 }
 
-pub(super) async fn get_account_summary() -> Result<AccountStateSummary, VpnError> {
+pub(super) async fn update_account_state() -> Result<(), VpnError> {
+    send_account_command(AccountCommand::UpdateSharedAccountState).await
+}
+
+pub(super) async fn get_account_state() -> Result<AccountStateSummary, VpnError> {
     let shared_account_state = get_shared_account_state().await?;
     let account_state_summary = shared_account_state.lock().await.clone();
     Ok(AccountStateSummary::from(account_state_summary))

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/error.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/error.rs
@@ -38,6 +38,9 @@ pub enum VpnError {
 
     #[error("device not active")]
     AccountDeviceNotActive,
+
+    #[error("account status unknown")]
+    AccountStatusUnknown,
 }
 
 impl From<nym_vpn_account_controller::ReadyToConnect> for VpnError {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
@@ -165,8 +165,14 @@ pub fn resetDeviceIdentity(path: String) -> Result<(), VpnError> {
 
 #[allow(non_snake_case)]
 #[uniffi::export]
-pub fn getAccountSummary() -> Result<AccountStateSummary, VpnError> {
-    RUNTIME.block_on(account::get_account_summary())
+pub fn updateAccountState() -> Result<(), VpnError> {
+    RUNTIME.block_on(account::update_account_state())
+}
+
+#[allow(non_snake_case)]
+#[uniffi::export]
+pub fn getAccountState() -> Result<AccountStateSummary, VpnError> {
+    RUNTIME.block_on(account::get_account_state())
 }
 
 #[allow(non_snake_case)]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
@@ -60,7 +60,7 @@ async fn start_vpn_inner(config: VPNConfig) -> Result<(), VpnError> {
     // We want to move this check into the state machine so that it happens during the connecting
     // state instead. This would allow us more flexibility in waiting for the account to be ready
     // and handle errors in a unified manner.
-    let timeout = Duration::from_secs(5);
+    let timeout = Duration::from_secs(10);
     account::assert_account_ready_to_connect(timeout).await?;
 
     let mut guard = STATE_MACHINE_HANDLE.lock().await;

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
@@ -10,7 +10,7 @@ pub mod swift;
 
 mod account;
 
-use std::{env, path::PathBuf, sync::Arc};
+use std::{env, path::PathBuf, sync::Arc, time::Duration};
 
 use account::AccountControllerHandle;
 use lazy_static::lazy_static;
@@ -60,7 +60,8 @@ async fn start_vpn_inner(config: VPNConfig) -> Result<(), VpnError> {
     // We want to move this check into the state machine so that it happens during the connecting
     // state instead. This would allow us more flexibility in waiting for the account to be ready
     // and handle errors in a unified manner.
-    account::assert_account_ready_to_connect().await?;
+    let timeout = Duration::from_secs(5);
+    account::assert_account_ready_to_connect(timeout).await?;
 
     let mut guard = STATE_MACHINE_HANDLE.lock().await;
 

--- a/nym-vpn-core/crates/nym-vpn-lib/uniffi/nym_vpn_lib.swift
+++ b/nym-vpn-core/crates/nym-vpn-lib/uniffi/nym_vpn_lib.swift
@@ -2857,13 +2857,24 @@ extension AccountState: Equatable, Hashable {}
 
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+/**
+ * Public enum describing action to perform after disconnect
+ */
 
 public enum ActionAfterDisconnect {
     
+    /**
+     * Do nothing after disconnect
+     */
     case nothing
+    /**
+     * Reconnect after disconnect
+     */
     case reconnect
-    case error(ErrorStateReason
-    )
+    /**
+     * Enter error state
+     */
+    case error
 }
 
 
@@ -2878,8 +2889,7 @@ public struct FfiConverterTypeActionAfterDisconnect: FfiConverterRustBuffer {
         
         case 2: return .reconnect
         
-        case 3: return .error(try FfiConverterTypeErrorStateReason.read(from: &buf)
-        )
+        case 3: return .error
         
         default: throw UniffiInternalError.unexpectedEnumCase
         }
@@ -2897,10 +2907,9 @@ public struct FfiConverterTypeActionAfterDisconnect: FfiConverterRustBuffer {
             writeInt(&buf, Int32(2))
         
         
-        case let .error(v1):
+        case .error:
             writeInt(&buf, Int32(3))
-            FfiConverterTypeErrorStateReason.write(v1, into: &buf)
-            
+        
         }
     }
 }
@@ -3390,6 +3399,14 @@ public enum ErrorStateReason {
      */
     case sameEntryAndExitGateway
     /**
+     * Invalid country set for entry gateway
+     */
+    case invalidEntryGatewayCountry
+    /**
+     * Invalid country set for exit gateway
+     */
+    case invalidExitGatewayCountry
+    /**
      * Program errors that must not happen.
      */
     case `internal`
@@ -3415,7 +3432,11 @@ public struct FfiConverterTypeErrorStateReason: FfiConverterRustBuffer {
         
         case 6: return .sameEntryAndExitGateway
         
-        case 7: return .`internal`
+        case 7: return .invalidEntryGatewayCountry
+        
+        case 8: return .invalidExitGatewayCountry
+        
+        case 9: return .`internal`
         
         default: throw UniffiInternalError.unexpectedEnumCase
         }
@@ -3449,8 +3470,16 @@ public struct FfiConverterTypeErrorStateReason: FfiConverterRustBuffer {
             writeInt(&buf, Int32(6))
         
         
-        case .`internal`:
+        case .invalidEntryGatewayCountry:
             writeInt(&buf, Int32(7))
+        
+        
+        case .invalidExitGatewayCountry:
+            writeInt(&buf, Int32(8))
+        
+        
+        case .`internal`:
+            writeInt(&buf, Int32(9))
         
         }
     }
@@ -4339,6 +4368,9 @@ extension TunnelEvent: Equatable, Hashable {}
 
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+/**
+ * Public enum describing the tunnel state
+ */
 
 public enum TunnelState {
     
@@ -4502,6 +4534,7 @@ public enum VpnError {
     case NoActiveSubscription
     case AccountDeviceNotRegistered
     case AccountDeviceNotActive
+    case AccountStatusUnknown
 }
 
 
@@ -4537,6 +4570,7 @@ public struct FfiConverterTypeVpnError: FfiConverterRustBuffer {
         case 10: return .NoActiveSubscription
         case 11: return .AccountDeviceNotRegistered
         case 12: return .AccountDeviceNotActive
+        case 13: return .AccountStatusUnknown
 
          default: throw UniffiInternalError.unexpectedEnumCase
         }
@@ -4600,6 +4634,10 @@ public struct FfiConverterTypeVpnError: FfiConverterRustBuffer {
         
         case .AccountDeviceNotActive:
             writeInt(&buf, Int32(12))
+        
+        
+        case .AccountStatusUnknown:
+            writeInt(&buf, Int32(13))
         
         }
     }
@@ -5885,9 +5923,9 @@ public func fetchEnvironment(networkName: String)throws  -> NetworkEnvironment {
     )
 })
 }
-public func getAccountSummary()throws  -> AccountStateSummary {
+public func getAccountState()throws  -> AccountStateSummary {
     return try  FfiConverterTypeAccountStateSummary.lift(try rustCallWithError(FfiConverterTypeVpnError.lift) {
-    uniffi_nym_vpn_lib_fn_func_getaccountsummary($0
+    uniffi_nym_vpn_lib_fn_func_getaccountstate($0
     )
 })
 }
@@ -5965,6 +6003,11 @@ public func storeAccountMnemonic(mnemonic: String, path: String)throws  {try rus
     )
 }
 }
+public func updateAccountState()throws  {try rustCallWithError(FfiConverterTypeVpnError.lift) {
+    uniffi_nym_vpn_lib_fn_func_updateaccountstate($0
+    )
+}
+}
 
 private enum InitializationResult {
     case ok
@@ -5984,7 +6027,7 @@ private var initializationResult: InitializationResult {
     if (uniffi_nym_vpn_lib_checksum_func_fetchenvironment() != 34561) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_nym_vpn_lib_checksum_func_getaccountsummary() != 13465) {
+    if (uniffi_nym_vpn_lib_checksum_func_getaccountstate() != 12813) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_nym_vpn_lib_checksum_func_getgatewaycountries() != 41607) {
@@ -6018,6 +6061,9 @@ private var initializationResult: InitializationResult {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_nym_vpn_lib_checksum_func_storeaccountmnemonic() != 55674) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_nym_vpn_lib_checksum_func_updateaccountstate() != 33999) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_nym_vpn_lib_checksum_method_osdefaultpathobserver_on_default_path_change() != 43452) {

--- a/nym-vpn-core/crates/nym-vpnd/src/service/error.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/error.rs
@@ -6,6 +6,7 @@ use nym_vpn_lib::{
     gateway_directory::Error as DirError, tunnel_state_machine, GatewayDirectoryError,
     NodeIdentity, Recipient,
 };
+use serde::Serialize;
 use tokio::sync::mpsc::error::SendError;
 use tracing::error;
 
@@ -18,7 +19,47 @@ pub enum VpnServiceConnectError {
     Internal(String),
 
     #[error("failed to connect: {0}")]
-    Account(ReadyToConnect),
+    Account(AccountNotReady),
+
+    #[error("connection attempt cancelled")]
+    Cancel,
+}
+
+#[derive(Debug, thiserror::Error, Clone, PartialEq, Eq, Serialize)]
+pub enum AccountNotReady {
+    #[error("account status pending")]
+    Pending,
+    #[error("no recovery phrase stored")]
+    NoMnemonicStored,
+    #[error("account is not active")]
+    AccountNotActive,
+    #[error("no active subscription")]
+    NoActiveSubscription,
+    #[error("device is not registered")]
+    DeviceNotRegistered,
+    #[error("device is not active")]
+    DeviceNotActive,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum AcountNotReadyConversion {
+    #[error("invalid conversion")]
+    InvalidConversion,
+}
+
+impl TryFrom<ReadyToConnect> for AccountNotReady {
+    type Error = AcountNotReadyConversion;
+
+    fn try_from(err: ReadyToConnect) -> Result<Self, Self::Error> {
+        match err {
+            ReadyToConnect::Ready => Err(AcountNotReadyConversion::InvalidConversion),
+            ReadyToConnect::NoMnemonicStored => Ok(AccountNotReady::NoMnemonicStored),
+            ReadyToConnect::AccountNotActive => Ok(AccountNotReady::AccountNotActive),
+            ReadyToConnect::NoActiveSubscription => Ok(AccountNotReady::NoActiveSubscription),
+            ReadyToConnect::DeviceNotRegistered => Ok(AccountNotReady::DeviceNotRegistered),
+            ReadyToConnect::DeviceNotActive => Ok(AccountNotReady::DeviceNotActive),
+        }
+    }
 }
 
 // Failure to initiate the disconnect

--- a/nym-vpn-core/crates/nym-vpnd/src/service/mod.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/mod.rs
@@ -10,7 +10,7 @@ pub(crate) use config::{
     DEFAULT_GLOBAL_CONFIG_FILE, DEFAULT_LOG_FILE,
 };
 pub(crate) use error::{
-    AccountError, ConnectionFailedError, SetNetworkError, VpnServiceConnectError,
+    AccountError, AccountNotReady, ConnectionFailedError, SetNetworkError, VpnServiceConnectError,
     VpnServiceDisconnectError,
 };
 pub(crate) use vpn_service::{

--- a/proto/nym/vpn.proto
+++ b/proto/nym/vpn.proto
@@ -194,6 +194,10 @@ message ConnectRequestError {
     // NOTE: in the future we will try to re-active an inactive device on
     // connect
     DEVICE_NOT_ACTIVE = 6;
+
+    // It was not yet possible to determine if we are ready to connect during
+    // the check
+    PENDING = 7;
   }
 
   ConnectRequestErrorType kind = 1;


### PR DESCRIPTION
- Add wait_for_ready_to_connect and use in vpnd
- Switch uniffi start vpn to wait on ready to connect
- Split out the call to update the account controller when storing the mnemonic, so that it can be called when the account controller is not running

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1486)
<!-- Reviewable:end -->
