### PR TITLE
feat(tauri): memory cache

### DIFF
--- a/nym-vpn-app/src/cache/index.ts
+++ b/nym-vpn-app/src/cache/index.ts
@@ -1,0 +1,82 @@
+// simple memory cache
+
+export type Cached<T> = {
+  value: T;
+  // timestamp in ms
+  expiry?: number;
+};
+
+export type CKey = 'mn-entry-countries' | 'mn-exit-countries' | 'wg-countries';
+const cache = new Map<CKey, Cached<never>>();
+
+/**
+ * In-memory cache, with optional expiry
+ */
+export const MCache = {
+  /**
+   * Get a key
+   *
+   * @param key - Key
+   * @param stale - Accept stale (expired) data
+   * @returns The cached value if any
+   */
+  get: <T>(key: CKey, stale = false): T | null => {
+    const cached = cache.get(key);
+    if (!cached) {
+      console.log(`no cache data for [${key}]`);
+      return null;
+    }
+    if (!cached.expiry) {
+      console.log(`cache data [${key}]`, cached.value);
+      return cached.value as T;
+    }
+    if (Date.now() < cached.expiry) {
+      console.log(`cache data [${key}]`, cached.value);
+      return cached.value as T;
+    }
+    console.log(`cache data is stale [${key}]`);
+    if (stale) {
+      console.log(`cache data [${key}]`, cached.value);
+      cache.delete(key);
+      return cached.value as T;
+    }
+    cache.delete(key);
+    return null;
+  },
+  /**
+   * Set a key
+   *
+   * @param key - Key
+   * @param value - The date to cache
+   * @param ttl - The time to live from now in seconds
+   */
+  set: <T>(key: CKey, value: T, ttl?: number): void => {
+    if (!ttl) {
+      console.log(`set cache [${key}]`, value);
+      cache.set(key, { value: value as never });
+      return;
+    }
+    const expiry = Date.now() + ttl * 1000;
+    console.log(
+      `set cache [${key}], expiry ${new Date(expiry).toString()}`,
+      value,
+    );
+    cache.set(key, { value: value as never, expiry });
+  },
+  /**
+   * Remove a key
+   *
+   * @param key - Key
+   */
+  del: (key: CKey): void => {
+    console.log(`delete cache [${key}]`);
+    cache.delete(key);
+  },
+  /**
+   * Clear all cache
+   */
+  clear: (): void => {
+    console.log(`clear cache`);
+    cache.clear();
+  },
+} as const;

--- a/nym-vpn-app/src/constants.ts
+++ b/nym-vpn-app/src/constants.ts
@@ -42,5 +42,5 @@ export const NymDotComCanaryUrl =
   'https://nym-dot-com-git-deploy-canary-nyx-network-staging.vercel.app';
 export const NymDotComQAUrl =
   'https://nym-dot-com-git-deploy-qa-nyx-network-staging.vercel.app';
-export const CountryCacheDuration = 120000; // 2 minutes
+export const CountryCacheDuration = 120; // seconds
 export const HomeThrottleDelay = 6000;

--- a/nym-vpn-app/src/data/licenses.ts
+++ b/nym-vpn-app/src/data/licenses.ts
@@ -11,7 +11,9 @@ export async function getRustLicenses(): Promise<CodeDependency[] | undefined> {
     const response = await fetch(LicensesRust);
     json = (await response.json()) as RustLicensesJson;
   } catch (e) {
-    console.warn('Failed to fetch Rust licenses data', e);
+    if (import.meta.env.MODE === 'production') {
+      console.warn('Failed to fetch Rust licenses data', e);
+    }
     return;
   }
 
@@ -38,7 +40,9 @@ export async function getJsLicenses(): Promise<CodeDependency[] | undefined> {
     const response = await fetch(LicensesJs);
     json = (await response.json()) as JsLicensesJson;
   } catch (e) {
-    console.warn('Failed to fetch Js licenses data', e);
+    if (import.meta.env.MODE === 'production') {
+      console.warn('Failed to fetch Js licenses data', e);
+    }
     return;
   }
 

--- a/nym-vpn-app/src/screens/location/NodeLocation.tsx
+++ b/nym-vpn-app/src/screens/location/NodeLocation.tsx
@@ -32,8 +32,7 @@ function NodeLocation({ node }: { node: NodeHop }) {
     fastestNodeLocation,
     entryCountriesLoading,
     exitCountriesLoading,
-    fetchMxEntryCountries,
-    fetchMxExitCountries,
+    fetchMnCountries,
     fetchWgCountries,
     entryCountriesError,
     exitCountriesError,
@@ -58,22 +57,14 @@ function NodeLocation({ node }: { node: NodeHop }) {
   const dispatch = useMainDispatch() as StateDispatch;
   const navigate = useNavigate();
 
-  // request backend to refresh cache
+  // refresh cache (if stale)
   useEffect(() => {
-    if (vpnMode === 'Mixnet' && node === 'entry') {
-      fetchMxEntryCountries();
-    } else if (vpnMode === 'Mixnet' && node === 'exit') {
-      fetchMxExitCountries();
+    if (vpnMode === 'Mixnet') {
+      fetchMnCountries(node);
     } else {
       fetchWgCountries();
     }
-  }, [
-    node,
-    vpnMode,
-    fetchMxEntryCountries,
-    fetchMxExitCountries,
-    fetchWgCountries,
-  ]);
+  }, [node, vpnMode, fetchWgCountries, fetchMnCountries]);
 
   // update the UI country list whenever the country list or
   // fastest country change (likely from the backend)

--- a/nym-vpn-app/src/screens/settings/info-data/InfoData.tsx
+++ b/nym-vpn-app/src/screens/settings/info-data/InfoData.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import clsx from 'clsx';
 import { useTranslation } from 'react-i18next';
 import { useMainState } from '../../../contexts';
-import NetworkEnvSelect from './NetworkEnvSelect.tsx';
+import NetworkEnvSelect from './NetworkEnvSelect';
 import { S_STATE } from '../../../static';
 
 function InfoData() {

--- a/nym-vpn-app/src/state/reducer.ts
+++ b/nym-vpn-app/src/state/reducer.ts
@@ -93,11 +93,8 @@ export const initialState: AppState = {
   codeDepsRust: [],
   codeDepsJs: [],
   account: false,
-  fetchMxEntryCountries: async () => {
+  fetchMnCountries: async () => {
     /*  SCARECROW */
-  },
-  fetchMxExitCountries: async () => {
-    /* SCARECROW */
   },
   fetchWgCountries: async () => {
     /* SCARECROW */

--- a/nym-vpn-app/src/state/useTauriEvents.ts
+++ b/nym-vpn-app/src/state/useTauriEvents.ts
@@ -19,6 +19,7 @@ import {
   ProgressEvent,
   StatusUpdateEvent,
 } from '../constants';
+import { S_STATE } from '../static';
 
 function handleError(dispatch: StateDispatch, error?: BackendError | null) {
   if (!error) {
@@ -43,6 +44,9 @@ export function useTauriEvents(dispatch: StateDispatch) {
         try {
           const info = await invoke<DaemonInfo>('daemon_info');
           dispatch({ type: 'set-daemon-info', info });
+          if (info.network) {
+            S_STATE.networkEnvInit = true;
+          }
           const stored = await invoke<boolean | undefined>('is_account_stored');
           dispatch({ type: 'set-account', stored: stored || false });
         } catch (e: unknown) {

--- a/nym-vpn-app/src/static.ts
+++ b/nym-vpn-app/src/static.ts
@@ -2,5 +2,6 @@
 export const S_STATE = {
   // Either the vpn mode has been initialized or not
   vpnModeInit: false,
+  networkEnvInit: false,
   networkEnvSelect: false,
 };

--- a/nym-vpn-app/src/types/app-state.ts
+++ b/nym-vpn-app/src/types/app-state.ts
@@ -1,7 +1,7 @@
 import { Dispatch } from 'react';
 import { Dayjs } from 'dayjs';
 import { StateAction } from '../state';
-import { Country, NodeLocation, ThemeMode, UiTheme } from './common';
+import { Country, NodeHop, NodeLocation, ThemeMode, UiTheme } from './common';
 import { BackendError, ErrorKey, NetworkEnv } from './tauri-ipc';
 
 export type ConnectionState =
@@ -59,8 +59,7 @@ export type AppState = {
   codeDepsRust: CodeDependency[];
   // TODO just a boolean for now to indicate if the user has added an account
   account: boolean;
-  fetchMxEntryCountries: FetchMxCountriesFn;
-  fetchMxExitCountries: FetchMxCountriesFn;
+  fetchMnCountries: FetchMnCountriesFn;
   fetchWgCountries: FetchWgCountriesFn;
 };
 
@@ -82,7 +81,7 @@ export type ProgressEventPayload = {
 
 export type StateDispatch = Dispatch<StateAction>;
 
-export type FetchMxCountriesFn = () => Promise<void> | undefined;
+export type FetchMnCountriesFn = (node: NodeHop) => Promise<void> | undefined;
 export type FetchWgCountriesFn = () => Promise<void> | undefined;
 
 export type AppError = {


### PR DESCRIPTION
- implement a simple _in-memory_ cache system
- use it to cache country lists get from daemon with a _time to live_ of 2 minutes (avoid country list queries spam)
- drop previous throttle based system
- whenever daemon network env changes, the cache is cleared accordingly

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1496)
<!-- Reviewable:end -->
