### PR TITLE
Make netstack available on desktop too

### DIFF
--- a/nym-vpn-app/src-tauri/src/commands/connection.rs
+++ b/nym-vpn-app/src-tauri/src/commands/connection.rs
@@ -143,7 +143,7 @@ pub async fn connect(
 
     app.emit_connection_progress(ConnectProgressMsg::InitDone);
     match grpc
-        .vpn_connect(entry_node, exit_node, two_hop_mod, dns)
+        .vpn_connect(entry_node, exit_node, two_hop_mod, false, dns)
         .await
     {
         Ok(_) => Ok(ConnectionState::Connecting),

--- a/nym-vpn-app/src-tauri/src/commands/connection.rs
+++ b/nym-vpn-app/src-tauri/src/commands/connection.rs
@@ -140,10 +140,11 @@ pub async fn connect(
         info!("5-hop mode enabled");
         false
     };
+    let use_netstack_wireguard = false;
 
     app.emit_connection_progress(ConnectProgressMsg::InitDone);
     match grpc
-        .vpn_connect(entry_node, exit_node, two_hop_mod, false, dns)
+        .vpn_connect(entry_node, exit_node, two_hop_mod, use_netstack_wireguard, dns)
         .await
     {
         Ok(_) => Ok(ConnectionState::Connecting),

--- a/nym-vpn-app/src-tauri/src/commands/connection.rs
+++ b/nym-vpn-app/src-tauri/src/commands/connection.rs
@@ -144,7 +144,13 @@ pub async fn connect(
 
     app.emit_connection_progress(ConnectProgressMsg::InitDone);
     match grpc
-        .vpn_connect(entry_node, exit_node, two_hop_mod, use_netstack_wireguard, dns)
+        .vpn_connect(
+            entry_node,
+            exit_node,
+            two_hop_mod,
+            use_netstack_wireguard,
+            dns,
+        )
         .await
     {
         Ok(_) => Ok(ConnectionState::Connecting),

--- a/nym-vpn-app/src-tauri/src/grpc/client.rs
+++ b/nym-vpn-app/src-tauri/src/grpc/client.rs
@@ -343,6 +343,7 @@ impl GrpcClient {
         entry_node: EntryNode,
         exit_node: ExitNode,
         two_hop_mod: bool,
+        netstack: bool,
         dns: Option<Dns>,
     ) -> Result<(), VpndError> {
         debug!("vpn_connect");
@@ -353,6 +354,7 @@ impl GrpcClient {
             exit: Some(exit_node),
             disable_routing: false,
             enable_two_hop: two_hop_mod,
+            netstack,
             disable_poisson_rate: false,
             disable_background_cover_traffic: false,
             enable_credentials_mode: false,

--- a/nym-vpn-core/crates/nym-vpn-cli/src/commands.rs
+++ b/nym-vpn-core/crates/nym-vpn-cli/src/commands.rs
@@ -57,7 +57,7 @@ pub(crate) struct RunArgs {
     pub(crate) wireguard_mode: bool,
 
     /// Use wireguard with nestack for multihop.
-    #[arg(long, default_value_t = false)]
+    #[arg(long, requires = "wireguard_mode", default_value_t = false)]
     pub(crate) netstack: bool,
 
     /// The IPv4 address of the nym TUN device that wraps IP packets in sphinx packets.

--- a/nym-vpn-core/crates/nym-vpn-cli/src/commands.rs
+++ b/nym-vpn-core/crates/nym-vpn-cli/src/commands.rs
@@ -56,6 +56,10 @@ pub(crate) struct RunArgs {
     #[arg(long, default_value_t = false)]
     pub(crate) wireguard_mode: bool,
 
+    /// Use wireguard with nestack for multihop.
+    #[arg(long, default_value_t = false)]
+    pub(crate) netstack: bool,
+
     /// The IPv4 address of the nym TUN device that wraps IP packets in sphinx packets.
     #[arg(long, alias = "ipv4", value_parser = validate_ipv4, requires = "nym_ipv6")]
     pub(crate) nym_ipv4: Option<Ipv4Addr>,

--- a/nym-vpn-core/crates/nym-vpn-cli/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpn-cli/src/main.rs
@@ -18,7 +18,8 @@ use nym_vpn_lib::{
     nym_config::defaults::{setup_env, var_names},
     tunnel_state_machine::{
         DnsOptions, GatewayPerformanceOptions, MixnetTunnelOptions, NymConfig, TunnelCommand,
-        TunnelEvent, TunnelSettings, TunnelStateMachine, TunnelType,
+        TunnelEvent, TunnelSettings, TunnelStateMachine, TunnelType, WireguardMultihopMode,
+        WireguardTunnelOptions,
     },
     IpPair, MixnetClientConfig, NodeIdentity, Recipient,
 };
@@ -212,12 +213,21 @@ async fn run_vpn(args: commands::RunArgs, data_path: Option<PathBuf>) -> anyhow:
         gateway_config,
     };
 
+    let wireguard_tunnel_options = WireguardTunnelOptions {
+        multihop_mode: if args.netstack {
+            WireguardMultihopMode::Netstack
+        } else {
+            WireguardMultihopMode::TunTun
+        },
+    };
+
     let tunnel_settings = TunnelSettings {
         tunnel_type,
         enable_credentials_mode: args.enable_credentials_mode,
         mixnet_client_config: Some(mixnet_client_config),
         gateway_performance_options: GatewayPerformanceOptions::default(),
         mixnet_tunnel_options,
+        wireguard_tunnel_options,
         entry_point: Box::new(entry_point),
         exit_point: Box::new(exit_point),
         dns,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
@@ -35,7 +35,7 @@ use crate::{
     tunnel_state_machine::{
         BandwidthEvent, ConnectionEvent, DnsOptions, GatewayPerformanceOptions,
         MixnetTunnelOptions, NymConfig, TunnelCommand, TunnelEvent, TunnelSettings, TunnelState,
-        TunnelStateMachine, TunnelType,
+        TunnelStateMachine, TunnelType, WireguardTunnelOptions,
     },
     uniffi_custom_impls::{
         AccountStateSummary, BandwidthStatus, ConnectionStatus, EntryPoint, ExitPoint,
@@ -324,6 +324,7 @@ async fn start_state_machine(config: VPNConfig) -> Result<StateMachineHandle, Vp
         tunnel_type,
         enable_credentials_mode: false,
         mixnet_tunnel_options: MixnetTunnelOptions::default(),
+        wireguard_tunnel_options: WireguardTunnelOptions::default(),
         gateway_performance_options: GatewayPerformanceOptions::default(),
         mixnet_client_config: None,
         entry_point: Box::new(entry_point),

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -78,6 +78,9 @@ pub struct TunnelSettings {
     /// Mixnet tunnel options.
     pub mixnet_tunnel_options: MixnetTunnelOptions,
 
+    /// WireGuard tunnel options.
+    pub wireguard_tunnel_options: WireguardTunnelOptions,
+
     /// Overrides gateway config.
     pub gateway_performance_options: GatewayPerformanceOptions,
 
@@ -110,6 +113,35 @@ pub struct MixnetTunnelOptions {
     pub mtu: Option<u16>,
 }
 
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum WireguardMultihopMode {
+    /// Multihop using two tun devices to nest tunnels.
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+    TunTun,
+
+    /// Netstack based multihop.
+    Netstack,
+}
+
+impl Default for WireguardMultihopMode {
+    fn default() -> Self {
+        #[cfg(any(target_os = "ios", target_os = "android"))]
+        {
+            Self::Netstack
+        }
+
+        #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+        {
+            Self::TunTun
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
+pub struct WireguardTunnelOptions {
+    pub multihop_mode: WireguardMultihopMode,
+}
+
 #[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub enum DnsOptions {
     #[default]
@@ -133,6 +165,7 @@ impl Default for TunnelSettings {
             enable_credentials_mode: false,
             mixnet_tunnel_options: MixnetTunnelOptions::default(),
             mixnet_client_config: None,
+            wireguard_tunnel_options: WireguardTunnelOptions::default(),
             gateway_performance_options: GatewayPerformanceOptions::default(),
             entry_point: Box::new(EntryPoint::Random),
             exit_point: Box::new(ExitPoint::Random),

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
@@ -86,7 +86,7 @@ impl ConnectedTunnel {
             #[cfg(unix)]
             options.entry_tun.get_ref().as_raw_fd(),
             #[cfg(windows)]
-            entry_tun_name,
+            &options.entry_tun_name,
         )
         .map_err(Error::Wireguard)?;
 
@@ -95,7 +95,7 @@ impl ConnectedTunnel {
             #[cfg(unix)]
             options.exit_tun.get_ref().as_raw_fd(),
             #[cfg(windows)]
-            exit_tun_name,
+            &options.exit_tun_name,
         )
         .map_err(Error::Wireguard)?;
 
@@ -152,12 +152,16 @@ impl ConnectedTunnel {
         #[allow(unused_mut)]
         let mut exit_tunnel = wireguard_go::Tunnel::start(
             two_hop_config.exit.into_wireguard_config(),
+            #[cfg(unix)]
             options.exit_tun.get_ref().as_raw_fd(),
+            #[cfg(windows)]
+            &options.exit_tun_name,
         )?;
 
         Ok(TunnelHandle {
             task_manager: self.task_manager,
             internal_handle: InternalTunnelHandle::Netstack {
+                #[cfg(unix)]
                 exit_tun: options.exit_tun,
                 entry_wg_tunnel: Some(entry_tunnel),
                 exit_wg_tunnel: Some(exit_tunnel),

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
@@ -128,16 +128,7 @@ impl ConnectedTunnel {
             self.exit_mtu(),
         );
 
-        // Save entry peer so that we can re-resolve it and update wg config on network changes.
-        #[cfg(target_os = "ios")]
-        let orig_entry_peer = wg_entry_config.peer.clone();
-
-        #[allow(unused_mut)]
-        let mut two_hop_config = TwoHopConfig::new(wg_entry_config, wg_exit_config);
-
-        // iOS does not perform dns64 resolution by default. Do that manually.
-        #[cfg(target_os = "ios")]
-        two_hop_config.entry.peer.resolve_in_place()?;
+        let two_hop_config = TwoHopConfig::new(wg_entry_config, wg_exit_config);
 
         let mut entry_tunnel =
             netstack::Tunnel::start(two_hop_config.entry.into_netstack_config())?;

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
@@ -10,10 +10,13 @@ use tun::AsyncDevice;
 
 use nym_task::TaskManager;
 use nym_wg_gateway_client::WgGatewayClient;
-use nym_wg_go::wireguard_go;
+use nym_wg_go::{netstack, wireguard_go};
 
 use crate::{
-    tunnel_state_machine::tunnel::{wireguard::connector::ConnectionData, Error, Result},
+    tunnel_state_machine::tunnel::{
+        wireguard::{connector::ConnectionData, two_hop_config::TwoHopConfig},
+        Error, Result,
+    },
     wg_config::WgNodeConfig,
 };
 
@@ -56,32 +59,32 @@ impl ConnectedTunnel {
         1340
     }
 
-    pub fn run(
-        self,
-        #[cfg(unix)] entry_tun: AsyncDevice,
-        #[cfg(unix)] exit_tun: AsyncDevice,
-        #[cfg(windows)] entry_tun_name: &str,
-        #[cfg(windows)] exit_tun_name: &str,
-        dns: Vec<IpAddr>,
-    ) -> Result<TunnelHandle> {
+    pub fn run(self, options: TunnelOptions) -> Result<TunnelHandle> {
+        match options {
+            TunnelOptions::TunTun(tuntun_options) => self.run_using_tun_tun(tuntun_options),
+            TunnelOptions::Netstack(netstack_options) => self.run_using_netstack(netstack_options),
+        }
+    }
+
+    fn run_using_tun_tun(self, options: TunTunTunnelOptions) -> Result<TunnelHandle> {
         let wg_entry_config = WgNodeConfig::with_gateway_data(
             self.connection_data.entry.clone(),
             self.entry_gateway_client.keypair().private_key(),
-            dns.clone(),
+            options.dns.clone(),
             self.entry_mtu(),
         );
 
         let wg_exit_config = WgNodeConfig::with_gateway_data(
             self.connection_data.exit.clone(),
             self.exit_gateway_client.keypair().private_key(),
-            dns,
+            options.dns,
             self.exit_mtu(),
         );
 
         let entry_tunnel = wireguard_go::Tunnel::start(
             wg_entry_config.into_wireguard_config(),
             #[cfg(unix)]
-            entry_tun.get_ref().as_raw_fd(),
+            options.entry_tun.get_ref().as_raw_fd(),
             #[cfg(windows)]
             entry_tun_name,
         )
@@ -90,7 +93,7 @@ impl ConnectedTunnel {
         let exit_tunnel = wireguard_go::Tunnel::start(
             wg_exit_config.into_wireguard_config(),
             #[cfg(unix)]
-            exit_tun.get_ref().as_raw_fd(),
+            options.exit_tun.get_ref().as_raw_fd(),
             #[cfg(windows)]
             exit_tun_name,
         )
@@ -98,37 +101,174 @@ impl ConnectedTunnel {
 
         Ok(TunnelHandle {
             task_manager: self.task_manager,
-            #[cfg(unix)]
-            entry_tun,
-            #[cfg(unix)]
-            exit_tun,
-            entry_wg_tunnel: Some(entry_tunnel),
-            exit_wg_tunnel: Some(exit_tunnel),
+            internal_handle: InternalTunnelHandle::TunTun {
+                #[cfg(unix)]
+                entry_tun: options.entry_tun,
+                #[cfg(unix)]
+                exit_tun: options.exit_tun,
+                entry_wg_tunnel: Some(entry_tunnel),
+                exit_wg_tunnel: Some(exit_tunnel),
+            },
+            bandwidth_controller_handle: self.bandwidth_controller_handle,
+        })
+    }
+
+    fn run_using_netstack(self, options: NetstackTunnelOptions) -> Result<TunnelHandle> {
+        let wg_entry_config = WgNodeConfig::with_gateway_data(
+            self.connection_data.entry.clone(),
+            self.entry_gateway_client.keypair().private_key(),
+            options.dns.clone(),
+            self.entry_mtu(),
+        );
+
+        let wg_exit_config = WgNodeConfig::with_gateway_data(
+            self.connection_data.exit.clone(),
+            self.exit_gateway_client.keypair().private_key(),
+            options.dns,
+            self.exit_mtu(),
+        );
+
+        // Save entry peer so that we can re-resolve it and update wg config on network changes.
+        #[cfg(target_os = "ios")]
+        let orig_entry_peer = wg_entry_config.peer.clone();
+
+        #[allow(unused_mut)]
+        let mut two_hop_config = TwoHopConfig::new(wg_entry_config, wg_exit_config);
+
+        // iOS does not perform dns64 resolution by default. Do that manually.
+        #[cfg(target_os = "ios")]
+        two_hop_config.entry.peer.resolve_in_place()?;
+
+        let mut entry_tunnel =
+            netstack::Tunnel::start(two_hop_config.entry.into_netstack_config())?;
+
+        // Open connection to the exit node via entry node.
+        let exit_connection = entry_tunnel.open_connection(
+            two_hop_config.forwarder.listen_endpoint.port(),
+            two_hop_config.forwarder.client_port,
+            two_hop_config.forwarder.exit_endpoint,
+        )?;
+
+        #[allow(unused_mut)]
+        let mut exit_tunnel = wireguard_go::Tunnel::start(
+            two_hop_config.exit.into_wireguard_config(),
+            options.exit_tun.get_ref().as_raw_fd(),
+        )?;
+
+        Ok(TunnelHandle {
+            task_manager: self.task_manager,
+            internal_handle: InternalTunnelHandle::Netstack {
+                exit_tun: options.exit_tun,
+                entry_wg_tunnel: Some(entry_tunnel),
+                exit_wg_tunnel: Some(exit_tunnel),
+                exit_connection: Some(exit_connection),
+            },
             bandwidth_controller_handle: self.bandwidth_controller_handle,
         })
     }
 }
 
+pub enum TunnelOptions {
+    /// Multihop configured using two tun adapters.
+    TunTun(TunTunTunnelOptions),
+
+    /// Multihop using single tun adapter and netstack with local UDP forwarder to wrap tunnels.
+    Netstack(NetstackTunnelOptions),
+}
+
+/// Multihop configuration using two tun adapters.
+pub struct TunTunTunnelOptions {
+    /// Entry tunnel device.
+    #[cfg(unix)]
+    pub entry_tun: AsyncDevice,
+
+    /// Exit tunnel device.
+    #[cfg(unix)]
+    pub exit_tun: AsyncDevice,
+
+    /// Entry tunnel device name.
+    #[cfg(windows)]
+    pub entry_tun_name: String,
+
+    /// Exit tunnel device name.
+    #[cfg(windows)]
+    pub exit_tun_name: String,
+
+    /// In-tunnel DNS addresses
+    pub dns: Vec<IpAddr>,
+}
+
+/// Multihop configuration based on WireGuard/netstack.
+pub struct NetstackTunnelOptions {
+    /// Entry tunnel device.
+    #[cfg(unix)]
+    pub exit_tun: AsyncDevice,
+
+    /// Exit tunnel device name.
+    #[cfg(windows)]
+    pub exit_tun_name: String,
+
+    /// In-tunnel DNS addresses
+    pub dns: Vec<IpAddr>,
+}
+
+enum InternalTunnelHandle {
+    TunTun {
+        #[cfg(unix)]
+        entry_tun: AsyncDevice,
+        #[cfg(unix)]
+        exit_tun: AsyncDevice,
+        entry_wg_tunnel: Option<wireguard_go::Tunnel>,
+        exit_wg_tunnel: Option<wireguard_go::Tunnel>,
+    },
+    Netstack {
+        #[cfg(unix)]
+        exit_tun: AsyncDevice,
+        entry_wg_tunnel: Option<netstack::Tunnel>,
+        exit_wg_tunnel: Option<wireguard_go::Tunnel>,
+        exit_connection: Option<netstack::TunnelConnection>,
+    },
+}
+
 pub struct TunnelHandle {
     task_manager: TaskManager,
-    #[cfg(unix)]
-    entry_tun: AsyncDevice,
-    #[cfg(unix)]
-    exit_tun: AsyncDevice,
-    entry_wg_tunnel: Option<wireguard_go::Tunnel>,
-    exit_wg_tunnel: Option<wireguard_go::Tunnel>,
+    internal_handle: InternalTunnelHandle,
     bandwidth_controller_handle: JoinHandle<()>,
 }
 
 impl TunnelHandle {
     /// Close entry and exit WireGuard tunnels and signal mixnet facilities shutdown.
     pub fn cancel(&mut self) {
-        if let Some(entry_wg_tunnel) = self.entry_wg_tunnel.take() {
-            entry_wg_tunnel.stop();
-        }
+        match self.internal_handle {
+            InternalTunnelHandle::Netstack {
+                ref mut entry_wg_tunnel,
+                ref mut exit_wg_tunnel,
+                ref mut exit_connection,
+                ..
+            } => {
+                if let Some(exit_wg_tunnel) = exit_wg_tunnel.take() {
+                    exit_wg_tunnel.stop();
+                }
+                if let Some(exit_connection) = exit_connection.take() {
+                    exit_connection.close();
+                }
+                if let Some(entry_wg_tunnel) = entry_wg_tunnel.take() {
+                    entry_wg_tunnel.stop();
+                }
+            }
+            InternalTunnelHandle::TunTun {
+                ref mut entry_wg_tunnel,
+                ref mut exit_wg_tunnel,
+                ..
+            } => {
+                if let Some(entry_wg_tunnel) = entry_wg_tunnel.take() {
+                    entry_wg_tunnel.stop();
+                }
 
-        if let Some(exit_wg_tunnel) = self.exit_wg_tunnel.take() {
-            exit_wg_tunnel.stop();
+                if let Some(exit_wg_tunnel) = exit_wg_tunnel.take() {
+                    exit_wg_tunnel.stop();
+                }
+            }
         }
 
         if let Err(e) = self.task_manager.signal_shutdown() {
@@ -154,7 +294,18 @@ impl TunnelHandle {
 
         #[cfg(unix)]
         {
-            vec![self.entry_tun, self.exit_tun]
+            match self.internal_handle {
+                InternalTunnelHandle::Netstack { exit_tun, .. } => {
+                    vec![exit_tun]
+                }
+                InternalTunnelHandle::TunTun {
+                    entry_tun,
+                    exit_tun,
+                    ..
+                } => {
+                    vec![entry_tun, exit_tun]
+                }
+            }
         }
 
         #[cfg(windows)]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/mobile.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/mobile.rs
@@ -22,7 +22,10 @@ use crate::{
 };
 use crate::{
     tunnel_state_machine::tunnel::{
-        wireguard::{connector::ConnectionData, two_hop_config::TwoHopConfig},
+        wireguard::{
+            connector::ConnectionData,
+            two_hop_config::{TwoHopConfig, ENTRY_MTU, EXIT_MTU},
+        },
         Result,
     },
     wg_config::WgNodeConfig,
@@ -58,13 +61,12 @@ impl ConnectedTunnel {
     }
 
     pub fn entry_mtu(&self) -> u16 {
-        // exit mtu + 80 (ipv6 + wg overhead)
-        1360
+        ENTRY_MTU
     }
 
     pub fn exit_mtu(&self) -> u16 {
         // minimum mtu guaranteed by ipv6
-        1280
+        EXIT_MTU
     }
 
     pub fn run(

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/mod.rs
@@ -8,7 +8,9 @@ mod desktop;
 mod mobile;
 
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-pub use desktop::{ConnectedTunnel, TunnelHandle};
+pub use desktop::{
+    ConnectedTunnel, NetstackTunnelOptions, TunTunTunnelOptions, TunnelHandle, TunnelOptions,
+};
 
 #[cfg(any(target_os = "ios", target_os = "android"))]
 pub use mobile::{ConnectedTunnel, TunnelHandle};

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/mod.rs
@@ -6,5 +6,4 @@ pub mod connector;
 
 #[cfg(target_os = "ios")]
 pub mod dns64;
-#[cfg(any(target_os = "ios", target_os = "android"))]
 pub mod two_hop_config;

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/two_hop_config.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/two_hop_config.rs
@@ -7,6 +7,9 @@ use crate::wg_config::{WgInterface, WgNodeConfig, WgPeer};
 /// Minimum IPv6 MTU that the hosts should be ready to accept.
 pub const MIN_IPV6_MTU: u16 = 1280;
 
+/// Ethernet 2 mtu.
+pub const ETHERNET_V2_MTU: u16 = 1500;
+
 /// WG tunnel overhead (IPv6)
 pub const WG_TUNNEL_OVERHEAD: u16 = 80;
 
@@ -15,6 +18,14 @@ const UDP_FORWARDER_PORT: u16 = 34001;
 
 /// Local port used by exit tunnel when sending traffic to the udp forwarder.
 const EXIT_WG_CLIENT_PORT: u16 = 54001;
+
+pub const ENTRY_MTU: u16 = if cfg!(any(target_os = "ios", target_os = "android")) {
+    MIN_IPV6_MTU
+} else {
+    ETHERNET_V2_MTU - WG_TUNNEL_OVERHEAD
+};
+
+pub const EXIT_MTU: u16 = ENTRY_MTU - WG_TUNNEL_OVERHEAD;
 
 /// A struct that holds all configuration needed to setup the tunnels, tun device and forwarder.
 #[derive(Debug)]
@@ -54,8 +65,8 @@ impl TwoHopConfig {
         };
 
         // Since we collect the exit traffic on tun, the tun's mtu must be lesser than entry mtu.
-        let exit_mtu = MIN_IPV6_MTU;
-        let entry_mtu = exit_mtu + WG_TUNNEL_OVERHEAD;
+        let exit_mtu = EXIT_MTU;
+        let entry_mtu = ENTRY_MTU;
 
         let tun_config = TunConfig {
             addresses: exit.interface.addresses.clone(),

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -550,7 +550,7 @@ impl TunnelMonitor {
     }
 
     #[cfg(any(target_os = "ios", target_os = "android"))]
-    async fn start_wireguard_tunnel(
+    async fn start_wireguard_netstack_tunnel(
         &self,
         connected_mixnet: ConnectedMixnet,
     ) -> Result<(TunnelConnectionData, AnyTunnelHandle)> {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/wg_config.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/wg_config.rs
@@ -9,7 +9,6 @@ use nym_wg_gateway_client::GatewayData;
 use nym_wg_go::PeerEndpointUpdate;
 use nym_wg_go::{wireguard_go, PeerConfig, PrivateKey, PublicKey};
 
-#[cfg(any(target_os = "ios", target_os = "android"))]
 use nym_wg_go::netstack;
 
 #[derive(Debug)]
@@ -76,7 +75,6 @@ impl WgPeer {
 }
 
 impl WgNodeConfig {
-    #[cfg(any(target_os = "ios", target_os = "android"))]
     pub fn into_netstack_config(self) -> netstack::Config {
         netstack::Config {
             interface: netstack::InterfaceConfig {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/wg_config.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/wg_config.rs
@@ -76,6 +76,7 @@ impl WgPeer {
 
 impl WgNodeConfig {
     pub fn into_netstack_config(self) -> netstack::Config {
+        let allowed_ips = self.allowed_ips();
         netstack::Config {
             interface: netstack::InterfaceConfig {
                 private_key: self.interface.private_key,
@@ -89,16 +90,17 @@ impl WgNodeConfig {
                 mtu: self.interface.mtu,
             },
             peers: vec![PeerConfig {
-                // todo: limit to loopback?
-                allowed_ips: vec!["0.0.0.0/0".parse().unwrap(), "::/0".parse().unwrap()],
                 public_key: self.peer.public_key,
                 preshared_key: None,
                 endpoint: self.peer.endpoint,
+                // todo: limit to loopback?
+                allowed_ips,
             }],
         }
     }
 
     pub fn into_wireguard_config(self) -> wireguard_go::Config {
+        let allowed_ips = self.allowed_ips();
         wireguard_go::Config {
             interface: wireguard_go::InterfaceConfig {
                 listen_port: self.interface.listen_port,
@@ -111,9 +113,20 @@ impl WgNodeConfig {
                 public_key: self.peer.public_key,
                 preshared_key: None,
                 endpoint: self.peer.endpoint,
-                allowed_ips: vec!["0.0.0.0/0".parse().unwrap(), "::/0".parse().unwrap()],
+                allowed_ips,
             }],
         }
+    }
+
+    fn allowed_ips(&self) -> Vec<IpNetwork> {
+        let mut allowed_ips = vec![];
+        if self.interface.addresses.iter().any(|x| x.ip().is_ipv4()) {
+            allowed_ips.push("0.0.0.0/0".parse().unwrap());
+        }
+        if self.interface.addresses.iter().any(|x| x.ip().is_ipv6()) {
+            allowed_ips.push("::/0".parse().unwrap());
+        }
+        allowed_ips
     }
 }
 

--- a/nym-vpn-core/crates/nym-vpnc/src/cli.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/cli.rs
@@ -73,7 +73,7 @@ pub(crate) struct ConnectArgs {
     pub(crate) enable_two_hop: bool,
 
     /// Use netstack based implementation for two-hop wireguard.
-    #[arg(long)]
+    #[arg(long, requires = "enable_two_hop")]
     pub(crate) netstack: bool,
 
     /// Disable Poisson process rate limiting of outbound traffic.

--- a/nym-vpn-core/crates/nym-vpnc/src/cli.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/cli.rs
@@ -72,6 +72,10 @@ pub(crate) struct ConnectArgs {
     #[arg(long)]
     pub(crate) enable_two_hop: bool,
 
+    /// Use netstack based implementation for two-hop wireguard.
+    #[arg(long)]
+    pub(crate) netstack: bool,
+
     /// Disable Poisson process rate limiting of outbound traffic.
     #[arg(long, hide = true)]
     pub(crate) disable_poisson_rate: bool,

--- a/nym-vpn-core/crates/nym-vpnc/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/main.rs
@@ -114,6 +114,7 @@ async fn connect(client_type: ClientType, connect_args: &cli::ConnectArgs) -> Re
         dns: connect_args.dns.map(ipaddr_into_string),
         disable_routing: connect_args.disable_routing,
         enable_two_hop: connect_args.enable_two_hop,
+        netstack: connect_args.netstack,
         disable_poisson_rate: connect_args.disable_poisson_rate,
         disable_background_cover_traffic: connect_args.disable_background_cover_traffic,
         enable_credentials_mode: connect_args.enable_credentials_mode,

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
@@ -743,6 +743,7 @@ impl TryFrom<ConnectRequest> for ConnectOptions {
             dns,
             disable_routing: request.disable_routing,
             enable_two_hop: request.enable_two_hop,
+            netstack: request.netstack,
             disable_poisson_rate: request.disable_poisson_rate,
             disable_background_cover_traffic,
             enable_credentials_mode: request.enable_credentials_mode,

--- a/nym-vpn-core/crates/nym-wg-go/src/lib.rs
+++ b/nym-vpn-core/crates/nym-wg-go/src/lib.rs
@@ -1,7 +1,6 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-#[cfg(any(target_os = "ios", target_os = "android"))]
 pub mod netstack;
 pub mod uapi;
 pub mod wireguard_go;

--- a/proto/nym/vpn.proto
+++ b/proto/nym/vpn.proto
@@ -212,6 +212,7 @@ message ConnectRequest {
   Dns dns = 3;
   bool disable_routing = 4;
   bool enable_two_hop = 5;
+  bool netstack = 13;
   bool disable_poisson_rate = 6;
   bool disable_background_cover_traffic = 7;
   bool enable_credentials_mode = 8;

--- a/wireguard/build-wireguard-go.sh
+++ b/wireguard/build-wireguard-go.sh
@@ -27,7 +27,7 @@ function parseArgs {
             shift ;;
         # handle --arm64 option
         "--arm64" )
-            IS_WIN_ARM64=false;
+            IS_WIN_ARM64=true;
             shift ;;
         # if we receive "--" consider everything after to be inner arguments
         -- ) shift; break ;;
@@ -40,7 +40,7 @@ function parseArgs {
 }
 
 function win_gather_export_symbols {
-   grep -Eo "\/\/export \w+" libwg.go libwg_windows.go | cut -d' ' -f2
+   grep -Eo "\/\/export \w+" libwg.go libwg_windows.go netstack.go netstack_default.go | cut -d' ' -f2
 }
 
 function win_create_lib_file {

--- a/wireguard/libwg/netstack.go
+++ b/wireguard/libwg/netstack.go
@@ -1,0 +1,102 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2018-2019 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
+ * Copyright (C) 2024 Nym Technologies SA <contact@nymtech.net>. All Rights Reserved.
+ */
+
+package main
+
+import "C"
+
+import (
+	"net/netip"
+
+	"github.com/nymtech/nym-vpn-client/wireguard/libwg/container"
+	"github.com/nymtech/nym-vpn-client/wireguard/libwg/logging"
+	"github.com/nymtech/nym-vpn-client/wireguard/libwg/udp_forwarder"
+	"golang.zx2c4.com/wireguard/device"
+	"golang.zx2c4.com/wireguard/tun/netstack"
+)
+
+type NetTunnelHandle struct {
+	*device.Device
+	*netstack.Net
+	*device.Logger
+}
+
+var netTunnelHandles container.Container[NetTunnelHandle]
+var udpForwarders container.Container[*udp_forwarder.UDPForwarder]
+
+func init() {
+	netTunnelHandles = container.New[NetTunnelHandle]()
+	udpForwarders = container.New[*udp_forwarder.UDPForwarder]()
+}
+
+//export wgNetTurnOff
+func wgNetTurnOff(tunnelHandle int32) {
+	dev, err := netTunnelHandles.Remove(tunnelHandle)
+	if err != nil {
+		return
+	}
+	dev.Close()
+}
+
+//export wgNetGetConfig
+func wgNetGetConfig(tunnelHandle int32) *C.char {
+	device, err := netTunnelHandles.Get(tunnelHandle)
+	if err != nil {
+		return nil
+	}
+	settings, err := device.IpcGet()
+	if err != nil {
+		return nil
+	}
+	return C.CString(settings)
+}
+
+//export wgNetOpenConnectionThroughTunnel
+func wgNetOpenConnectionThroughTunnel(entryTunnelHandle int32, listenPort uint16, clientPort uint16, exitEndpointStr *C.char, logSink LogSink, logContext LogContext) int32 {
+	logger := logging.NewLogger(logSink, logContext)
+
+	dev, err := netTunnelHandles.Get(entryTunnelHandle)
+	if err != nil {
+		dev.Errorf("Invalid tunnel handle: %d", entryTunnelHandle)
+		return ERROR_GENERAL_FAILURE
+	}
+
+	exitEndpoint, err := netip.ParseAddrPort(C.GoString(exitEndpointStr))
+	if err != nil {
+		dev.Errorf("Failed to parse endpoint: %v", err)
+		return ERROR_GENERAL_FAILURE
+	}
+
+	forwarderConfig := udp_forwarder.UDPForwarderConfig{
+		ListenPort:   listenPort,
+		ClientPort:   clientPort,
+		ExitEndpoint: exitEndpoint,
+	}
+
+	udpForwarder, err := udp_forwarder.New(forwarderConfig, dev.Net, logger)
+	if err != nil {
+		dev.Errorf("Failed to create udp forwarder: %v", err)
+		return ERROR_GENERAL_FAILURE
+	}
+
+	forwarderHandle, err := udpForwarders.Insert(udpForwarder)
+	if err != nil {
+		dev.Errorf("Failed to store udp forwarder: %v", err)
+		udpForwarder.Close()
+		return ERROR_GENERAL_FAILURE
+	}
+
+	return forwarderHandle
+}
+
+//export wgNetCloseConnectionThroughTunnel
+func wgNetCloseConnectionThroughTunnel(udpForwarderHandle int32) {
+	udpForwarder, err := udpForwarders.Remove(udpForwarderHandle)
+	if err != nil {
+		return
+	}
+	(*udpForwarder).Close()
+}

--- a/wireguard/libwg/netstack_default.go
+++ b/wireguard/libwg/netstack_default.go
@@ -1,4 +1,4 @@
-//go:build ios || android
+//go:build (darwin || linux || windows) && !android && !ios
 
 /* SPDX-License-Identifier: MIT
  *
@@ -61,7 +61,6 @@ func wgNetTurnOn(localAddresses *C.char, dnsAddresses *C.char, mtu int, settings
 		return ERROR_GENERAL_FAILURE
 	}
 
-	dev.DisableSomeRoamingForBrokenMobileSemantics()
 	err = dev.Up()
 	if err != nil {
 		logger.Errorf("Failed to set device state to Up: %v", err)
@@ -71,7 +70,7 @@ func wgNetTurnOn(localAddresses *C.char, dnsAddresses *C.char, mtu int, settings
 
 	logger.Verbosef("Net device started")
 
-	i, err := netTunnelHandles.Insert(netTunnelHandle{dev, tnet, logger})
+	i, err := netTunnelHandles.Insert(NetTunnelHandle{dev, tnet, logger})
 	if err != nil {
 		logger.Errorf("Failed to store tunnel: %v", err)
 		dev.Close()

--- a/wireguard/libwg/netstack_mobile.go
+++ b/wireguard/libwg/netstack_mobile.go
@@ -71,7 +71,7 @@ func wgNetTurnOn(localAddresses *C.char, dnsAddresses *C.char, mtu int, settings
 
 	logger.Verbosef("Net device started")
 
-	i, err := netTunnelHandles.Insert(netTunnelHandle{dev, tnet, logger})
+	i, err := netTunnelHandles.Insert(NetTunnelHandle{dev, tnet, logger})
 	if err != nil {
 		logger.Errorf("Failed to store tunnel: %v", err)
 		dev.Close()


### PR DESCRIPTION
- Add wireguard/netstack tunnel on desktop too. This is useful for testing especially for mobile. You can enable the netstack tunnel by running `nym-vpnc connect --enable-two-hop --netstack`
- Set wg MTU to the following values on platforms:
  - desktop: entry = 1420, exit = 1360
  - mobile: entry = 1280, exit = 1200
  Note that wg tunnel overhead is 80 bytes for IPv6 and that at least 1280 must be handled by the hosts as mandated by the standard, so on mobile we stay at or below that value to avoid Path MTU discovery and/or fragmentation. In general we should do MTU discovery manually first but that's a bit out of scope for now.

Note that currently the main branch contains the authenticator v4 which is not deployed yet. So the best way to try this out is to switch to `am/investigating-ios` which has all the same changes but based off older revision of main branch.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1497)
<!-- Reviewable:end -->
