### PR TITLE
Add iOS generate uniffi

### DIFF
--- a/.github/workflows/ci-nym-vpn-core-ios.yml
+++ b/.github/workflows/ci-nym-vpn-core-ios.yml
@@ -61,6 +61,22 @@ jobs:
         run: |
           cargo build --verbose --target aarch64-apple-ios -p nym-vpn-lib
 
+      - name: Generate uniffi
+        working-directory: nym-vpn-core
+        run: |
+          cargo run --bin uniffi-bindgen generate \
+            --library target/aarch64-apple-ios/debug/libnym_vpn_lib.a  \
+            --config crates/nym-vpn-lib/uniffi.toml \
+            --language swift --out-dir build -n
+
+      - name: Upload generated uniffi file
+        if: steps.diff_ios.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: updated-uniffi-ios
+          path: nym-vpn-core/build/nym_vpn_lib.swift
+          retention-days: 1
+
       - name: Clippy
         working-directory: nym-vpn-core
         run: |


### PR DESCRIPTION
Let's remove the diff checks, but we need to generate uniffi for iOS for releases. It's quicker to add it here at the moment, than use release, go through whole build process and generate locally.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1510)
<!-- Reviewable:end -->
