### PR TITLE
iOS: add async support for ios path_observer

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_provider/ios/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_provider/ios/mod.rs
@@ -21,7 +21,7 @@ pub trait OSTunProvider: Send + Sync + std::fmt::Debug {
     ) -> Result<(), VpnError>;
 
     /// Set or unset the default path observer.
-    fn set_default_path_observer(
+    async fn set_default_path_observer(
         &self,
         observer: Option<Arc<dyn OSDefaultPathObserver>>,
     ) -> Result<(), VpnError>;

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/mobile.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/mobile.rs
@@ -138,6 +138,7 @@ impl ConnectedTunnel {
 
             tun_provider
                 .set_default_path_observer(Some(default_path_observer))
+                .await
                 .map_err(|e| Error::SetDefaultPathObserver(e.to_string()))?;
 
             default_path_rx
@@ -190,7 +191,7 @@ impl ConnectedTunnel {
 
             // Reset default path observer before exiting the event loop.
             #[cfg(target_os = "ios")]
-            let _ = tun_provider.set_default_path_observer(None);
+            let _ = tun_provider.set_default_path_observer(None).await;
 
             exit_tunnel.stop();
             exit_connection.close();

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -525,12 +525,17 @@ impl TunnelMonitor {
             exit: WireguardNode::from(conn_data.exit.clone()),
         });
 
-        let tunnel_handle = connected_tunnel.run(
-            tun_device,
-            self.tunnel_settings.dns.ip_addresses().to_vec(),
-            #[cfg(any(target_os = "ios", target_os = "android"))]
-            self.tun_provider.clone(),
-        )?;
+        #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+        let tunnel_handle =
+            connected_tunnel.run(tun_device, self.tunnel_settings.dns.ip_addresses().to_vec())?;
+        #[cfg(any(target_os = "ios", target_os = "android"))]
+        let tunnel_handle = connected_tunnel
+            .run(
+                tun_device,
+                self.tunnel_settings.dns.ip_addresses().to_vec(),
+                self.tun_provider.clone(),
+            )
+            .await?;
 
         let any_tunnel_handle = AnyTunnelHandle::from(tunnel_handle);
 


### PR DESCRIPTION
We need this so we could introduce the TunnelActor, which will improve error sending to UI.
Based on Andrei investigation branch.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1511)
<!-- Reviewable:end -->
