### PR TITLE
Rename init to configureLib

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
@@ -100,7 +100,7 @@ async fn stop_vpn_inner() -> Result<(), VpnError> {
 
 #[allow(non_snake_case)]
 #[uniffi::export]
-pub fn init(data_dir: String) -> Result<(), VpnError> {
+pub fn configureLib(data_dir: String) -> Result<(), VpnError> {
     init_logger();
     start_account_controller(data_dir)
 }


### PR DESCRIPTION
Rename conflicting `init` naming to `configureLib`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1523)
<!-- Reviewable:end -->
