### PR TITLE
Rebind netstack on network change

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/mobile.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/mobile.rs
@@ -177,6 +177,7 @@ impl ConnectedTunnel {
 
                         // Rebind wireguard-go on tun device.
                         exit_tunnel.bump_sockets();
+                        entry_tunnel.bump_sockets();
                     }
                     else => {
                         tracing::error!("Default path observer has been dropped. Exiting event loop.");

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/mobile.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/mobile.rs
@@ -166,8 +166,8 @@ impl ConnectedTunnel {
                                 let peer_update = resolved_peer.into_peer_endpoint_update();
 
                                 // Update wireguard-go configuration with re-resolved peer endpoints.
-                                if let Err(e) = exit_tunnel.update_peers(&[peer_update]) {
-                                    tracing::error!("Failed to update peers on network change: {}", e);
+                                if let Err(e) = entry_tunnel.update_peers(&[peer_update]) {
+                                   tracing::error!("Failed to update peers on network change: {}", e);
                                 }
                             }
                             Err(e) => {

--- a/nym-vpn-core/crates/nym-wg-go/src/netstack.rs
+++ b/nym-vpn-core/crates/nym-wg-go/src/netstack.rs
@@ -162,7 +162,7 @@ impl Tunnel {
         }
     }
 
-    /// Re-attach itself to the tun interface.
+    /// Re-attach itself to the new primary interface.
     ///
     /// Typically used on default route change.
     #[cfg(target_os = "ios")]

--- a/nym-vpn-core/crates/nym-wg-go/src/netstack.rs
+++ b/nym-vpn-core/crates/nym-wg-go/src/netstack.rs
@@ -161,6 +161,14 @@ impl Tunnel {
             self.handle = -1;
         }
     }
+
+    /// Re-attach itself to the tun interface.
+    ///
+    /// Typically used on default route change.
+    #[cfg(target_os = "ios")]
+    pub fn bump_sockets(&mut self) {
+        unsafe { wgNetBumpSockets(self.handle) }
+    }
 }
 
 impl Drop for Tunnel {
@@ -254,6 +262,8 @@ extern "C" {
     fn wgNetGetSocketV4(net_tunnel_handle: i32) -> i32;
     #[cfg(target_os = "android")]
     fn wgNetGetSocketV6(net_tunnel_handle: i32) -> i32;
+    #[cfg(target_os = "ios")]
+    fn wgNetBumpSockets(handle: i32);
 }
 
 /// Callback used by libwg to pass netstack logs.

--- a/wireguard/libwg/netstack_ios.go
+++ b/wireguard/libwg/netstack_ios.go
@@ -1,0 +1,30 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2018-2019 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
+ * Copyright (C) 2024 Nym Technologies SA <contact@nymtech.net>. All Rights Reserved.
+ */
+
+package main
+
+import "C"
+import "time"
+
+//export wgNetBumpSockets
+func wgNetBumpSockets(tunnelHandle int32) {
+	tunnel, err := netTunnelHandles.Get(tunnelHandle)
+	if err != nil {
+		return
+	}
+	go func() {
+		for i := 0; i < 10; i++ {
+			err := tunnel.Device.BindUpdate()
+			if err == nil {
+				tunnel.Device.SendKeepalivesToPeersWithCurrentKeypair()
+				return
+			}
+			tunnel.Logger.Errorf("Unable to update bind, try %d: %v", i+1, err)
+			time.Sleep(time.Second / 2)
+		}
+		tunnel.Logger.Errorf("Gave up trying to update bind; tunnel is likely dysfunctional")
+	}()
+}


### PR DESCRIPTION
- Make sure to rebind netstack socket to the new primary interface on network change
- Fix bug when entry tunnel peer was applied to exit tunnel by mistake

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1530)
<!-- Reviewable:end -->
