### PR TITLE
Dup tunnel descriptors for wireguard

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
@@ -76,6 +76,9 @@ nym-vpn-store = { path = "../nym-vpn-store" }
 nym-wg-gateway-client = { path = "../nym-wg-gateway-client" }
 nym-wg-go = { path = "../nym-wg-go" }
 
+[target.'cfg(unix)'.dependencies]
+nix = { workspace = true, features = ["socket", "net", "fs"] }
+
 [target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))'.dependencies]
 nym-routing = { path = "../nym-routing" }
 nym-dns = { path = "../nym-dns" }
@@ -84,14 +87,10 @@ nym-dns = { path = "../nym-dns" }
 android_logger = "0.14.1"
 err-derive = "0.3.1"
 jnix = { version = "=0.5.1", features = ["derive"] }
-nix = { workspace = true, features = ["socket", "net"] }
 rand.workspace = true
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 oslog = "0.2.0"
-
-[target.'cfg(target_os = "ios")'.dependencies]
-nix = { workspace = true, features = ["socket", "net"] }
 
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/dns_handler.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/dns_handler.rs
@@ -122,6 +122,7 @@ impl DnsHandlerHandle {
         .await
     }
 
+    #[allow(unused)]
     pub async fn reset(&mut self) -> Result<()> {
         let (reply_tx, reply_rx) = oneshot::channel();
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -372,6 +372,9 @@ pub enum ErrorStateReason {
     /// increase request, causing credential waste
     BadBandwidthIncrease,
 
+    /// Failure to duplicate tunnel file descriptor.
+    DuplicateTunFd,
+
     /// Program errors that must not happen.
     Internal,
 }
@@ -730,6 +733,7 @@ impl tunnel::Error {
                 source: WgGatewayClientError::NoRetry { .. },
                 ..
             }) => Some(ErrorStateReason::BadBandwidthIncrease),
+            Self::DupFd(_) => Some(ErrorStateReason::DuplicateTunFd),
             _ => None,
         }
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnecting_state.rs
@@ -66,13 +66,8 @@ impl DisconnectingState {
         #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
         _shared_state.route_handler.remove_routes().await;
 
-        tracing::debug!("Closing tunnel {} device(s).", tun_devices.len());
+        tracing::info!("Closing {} tunnel device(s).", tun_devices.len());
         tun_devices.clear();
-
-        #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-        if let Err(e) = _shared_state.dns_handler.reset().await {
-            tracing::error!("Failed to reset dns: {}", e);
-        }
 
         // todo: reset firewall
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
@@ -236,6 +236,9 @@ pub enum Error {
     #[error("WireGuard error: {0}")]
     Wireguard(#[from] nym_wg_go::Error),
 
+    #[error("failed to dup tunnel file descriptor: {0}")]
+    DupFd(#[source] std::io::Error),
+
     #[cfg(target_os = "ios")]
     #[error("failed to set default path observer: {0}")]
     SetDefaultPathObserver(String),

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
@@ -10,9 +10,11 @@ use nym_task::TaskManager;
 use nym_wg_gateway_client::WgGatewayClient;
 use nym_wg_go::{netstack, wireguard_go};
 
+#[cfg(unix)]
+use crate::tunnel_state_machine::tunnel::wireguard::fd::DupFd;
 use crate::{
     tunnel_state_machine::tunnel::{
-        wireguard::{connector::ConnectionData, fd::DupFd, two_hop_config::TwoHopConfig},
+        wireguard::{connector::ConnectionData, two_hop_config::TwoHopConfig},
         Error, Result,
     },
     wg_config::WgNodeConfig,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/fd.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/fd.rs
@@ -1,0 +1,38 @@
+use std::{
+    io,
+    os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd},
+};
+
+use nix::fcntl::{self, FcntlArg, OFlag};
+use tun::Device;
+
+pub trait DupFd {
+    /// Duplicate tunnel file descriptor pointing to the same file description as the original one.
+    /// Ensures that O_NONBLOCK is set.
+    fn dup_fd(&self) -> io::Result<OwnedFd>;
+}
+
+impl<T: Device + AsRawFd> DupFd for T {
+    fn dup_fd(&self) -> io::Result<OwnedFd> {
+        dup_fd(self.as_raw_fd())
+    }
+}
+
+fn dup_fd(raw_fd: RawFd) -> io::Result<OwnedFd> {
+    let dup_fd = unsafe { nix::libc::dup(raw_fd) };
+    if dup_fd == -1 {
+        return Err(io::Error::last_os_error());
+    }
+
+    let owned_fd = unsafe { OwnedFd::from_raw_fd(dup_fd) };
+
+    let flags = OFlag::from_bits_retain(fcntl::fcntl(owned_fd.as_raw_fd(), FcntlArg::F_GETFL)?);
+    if !flags.contains(OFlag::O_NONBLOCK) {
+        fcntl::fcntl(
+            owned_fd.as_raw_fd(),
+            FcntlArg::F_SETFL(flags | OFlag::O_NONBLOCK),
+        )?;
+    }
+
+    Ok(owned_fd)
+}

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/mod.rs
@@ -6,4 +6,6 @@ pub mod connector;
 
 #[cfg(target_os = "ios")]
 pub mod dns64;
+#[cfg(unix)]
+pub mod fd;
 pub mod two_hop_config;

--- a/nym-vpn-core/crates/nym-wg-go/src/wireguard_go.rs
+++ b/nym-vpn-core/crates/nym-wg-go/src/wireguard_go.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #[cfg(unix)]
-use std::os::unix::io::RawFd;
+use std::os::fd::{IntoRawFd, OwnedFd, RawFd};
 use std::{
     ffi::{c_char, c_void, CString},
     fmt,
@@ -79,7 +79,7 @@ impl Tunnel {
     /// Start new WireGuard tunnel
     pub fn start(
         config: Config,
-        #[cfg(not(windows))] tun_fd: RawFd,
+        #[cfg(not(windows))] tun_fd: OwnedFd,
         #[cfg(windows)] interface_name: &str,
     ) -> Result<Self> {
         let settings =
@@ -96,7 +96,7 @@ impl Tunnel {
                 i32::from(config.interface.mtu),
                 settings.as_ptr(),
                 #[cfg(not(windows))]
-                tun_fd,
+                tun_fd.into_raw_fd(),
                 wg_logger_callback,
                 std::ptr::null_mut(),
             )


### PR DESCRIPTION
- Duplicate tunnel file descriptors to prevent WireGuard from closing tunnel device. Instead tunnel devices are closed after routing table and dns are being reset to their original state. Based on my tests `dup()` works fine across the board, but I had issues with `fcntl()` on android.
- nym-wg-go: use `OwnedFd` which automatically closes the fd if it's being dropped before the ownership is transferred to wg-go, helpful with early returns and auto cleanup.
- Should prevent crash on Android

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1537)
<!-- Reviewable:end -->
