### PR TITLE
APPLE: fix typo in ConnectionStorage

### DIFF
--- a/nym-vpn-apple/Services/Sources/Services/ConnectionManager/ConnectionStorage.swift
+++ b/nym-vpn-apple/Services/Sources/Services/ConnectionManager/ConnectionStorage.swift
@@ -71,13 +71,13 @@ private extension ConnectionStorage {
         case .exit:
             if countriesManager.exitCountries.contains(where: { $0.code == "CH" }) {
                 return "CH"
-            } else if let country = countriesManager.entryCountries.first {
+            } else if let country = countriesManager.exitCountries.first {
                 return country.code
             }
         case .vpn:
             if countriesManager.vpnCountries.contains(where: { $0.code == "CH" }) {
                 return "CH"
-            } else if let country = countriesManager.entryCountries.first {
+            } else if let country = countriesManager.vpnCountries.first {
                 return country.code
             }
         }


### PR DESCRIPTION
Fix picking from wrong country pool.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1615)
<!-- Reviewable:end -->
