### PR TITLE
nym-vpn-app depends on latest RC for nym-vpnd

### DIFF
--- a/nym-vpn-app/src-tauri/tauri.conf.json
+++ b/nym-vpn-app/src-tauri/tauri.conf.json
@@ -35,7 +35,7 @@
     },
     "linux": {
       "deb": {
-        "depends": ["nym-vpnd (>= 0.2.0)"],
+        "depends": ["nym-vpnd (>= 1.0.0~rc.14)"],
         "conflicts": ["nymvpn-x"],
         "desktopTemplate": "./bundle/deb/main.desktop"
       }


### PR DESCRIPTION
Make `nym-vpn-app` depend on on the latest release candidate version of `nym-vpnd`

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1654)
<!-- Reviewable:end -->
