### PR TITLE
Gracefully shutdown connector with task manager

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -95,7 +95,7 @@ impl TunnelStateHandler for ConnectingState {
                         #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
                         shared_state.route_handler.remove_routes().await;
 
-                        NextTunnelState::NewState(ConnectingState::enter( self.retry_attempt.saturating_add(1), self.selected_gateways, shared_state))
+                        NextTunnelState::NewState(ConnectingState::enter(self.retry_attempt.saturating_add(1), self.selected_gateways, shared_state))
                     }
                 }
             }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mixnet/connector.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mixnet/connector.rs
@@ -11,7 +11,9 @@ use nym_task::TaskManager;
 use super::connected_tunnel::ConnectedTunnel;
 use crate::{
     mixnet::SharedMixnetClient,
-    tunnel_state_machine::tunnel::{gateway_selector::SelectedGateways, Error, Result},
+    tunnel_state_machine::tunnel::{
+        self, gateway_selector::SelectedGateways, AnyConnector, ConnectorError, Error, Result,
+    },
 };
 
 /// Struct holding addresses assigned by mixnet upon connect.
@@ -46,11 +48,41 @@ impl Connector {
         self,
         selected_gateways: SelectedGateways,
         nym_ips: Option<IpPair>,
-    ) -> Result<ConnectedTunnel> {
-        let mixnet_client_address = self.mixnet_client.nym_address().await;
+    ) -> Result<ConnectedTunnel, ConnectorError> {
+        let result = Self::connect_inner(
+            selected_gateways,
+            nym_ips,
+            self.mixnet_client.clone(),
+            &self.gateway_directory_client,
+        )
+        .await;
+
+        match result {
+            Ok(assigned_addresses) => Ok(ConnectedTunnel::new(
+                self.task_manager,
+                self.mixnet_client,
+                assigned_addresses,
+            )),
+            Err(e) => Err(ConnectorError::new(
+                e,
+                AnyConnector::Mixnet(Self::new(
+                    self.task_manager,
+                    self.mixnet_client,
+                    self.gateway_directory_client,
+                )),
+            )),
+        }
+    }
+
+    async fn connect_inner(
+        selected_gateways: SelectedGateways,
+        nym_ips: Option<IpPair>,
+        mixnet_client: SharedMixnetClient,
+        gateway_directory_client: &GatewayClient,
+    ) -> Result<AssignedAddresses> {
+        let mixnet_client_address = mixnet_client.nym_address().await;
         let gateway_used = mixnet_client_address.gateway().to_base58_string();
-        let entry_mixnet_gateway_ip: IpAddr = self
-            .gateway_directory_client
+        let entry_mixnet_gateway_ip: IpAddr = gateway_directory_client
             .lookup_gateway_ip(&gateway_used)
             .await
             .map_err(|source| Error::LookupGatewayIp {
@@ -60,23 +92,22 @@ impl Connector {
 
         let exit_mix_addresses = selected_gateways.exit.ipr_address.unwrap();
 
-        let mut ipr_client = IprClientConnect::new_from_inner(self.mixnet_client.inner()).await;
+        let mut ipr_client = IprClientConnect::new_from_inner(mixnet_client.inner()).await;
         let interface_addresses = ipr_client
             .connect(exit_mix_addresses.0, nym_ips)
             .await
             .map_err(Error::ConnectToIpPacketRouter)?;
 
-        let assigned_addresses = AssignedAddresses {
+        Ok(AssignedAddresses {
             entry_mixnet_gateway_ip,
             mixnet_client_address,
             exit_mix_addresses,
             interface_addresses,
-        };
+        })
+    }
 
-        Ok(ConnectedTunnel::new(
-            self.task_manager,
-            self.mixnet_client,
-            assigned_addresses,
-        ))
+    /// Gracefully shutdown task manager and consume the struct.
+    pub async fn dispose(self) {
+        tunnel::shutdown_task_manager(self.task_manager).await;
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
@@ -7,7 +7,7 @@ pub mod mixnet;
 mod status_listener;
 pub mod wireguard;
 
-use std::{path::PathBuf, time::Duration};
+use std::{error::Error as StdError, fmt, path::PathBuf, time::Duration};
 
 pub use gateway_selector::SelectedGateways;
 use nym_gateway_directory::{EntryPoint, ExitPoint, GatewayClient};
@@ -60,9 +60,17 @@ impl ConnectedMixnet {
             self.mixnet_client,
             self.gateway_directory_client,
         );
-        connector
+
+        match connector
             .connect(self.selected_gateways, interface_addresses)
             .await
+        {
+            Ok(connected_tunnel) => Ok(connected_tunnel),
+            Err(connector_error) => {
+                connector_error.connector.dispose().await;
+                Err(connector_error.error)
+            }
+        }
     }
 
     /// Creates a tunnel over WireGuard.
@@ -75,13 +83,21 @@ impl ConnectedMixnet {
             self.mixnet_client,
             self.gateway_directory_client,
         );
-        connector
+
+        match connector
             .connect(
                 enable_credentials_mode,
                 self.selected_gateways,
                 self.data_path,
             )
             .await
+        {
+            Ok(connected_tunnel) => Ok(connected_tunnel),
+            Err(connector_error) => {
+                connector_error.connector.dispose().await;
+                Err(connector_error.error)
+            }
+        }
     }
 
     /// Gracefully shutdown the mixnet client and consume the struct.
@@ -245,3 +261,53 @@ pub enum Error {
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Tunnel connector container.
+pub enum AnyConnector {
+    Mixnet(mixnet::connector::Connector),
+    Wireguard(wireguard::connector::Connector),
+}
+
+impl AnyConnector {
+    pub async fn dispose(self) {
+        match self {
+            Self::Mixnet(connector) => connector.dispose().await,
+            Self::Wireguard(connector) => connector.dispose().await,
+        }
+    }
+}
+
+/// Error returned when connector is unable to connect the tunnel.
+pub struct ConnectorError {
+    /// The error returned during the attempt to connect the tunnel.
+    pub error: Error,
+
+    /// The source connector.
+    pub connector: AnyConnector,
+}
+
+impl ConnectorError {
+    fn new(error: Error, connector: AnyConnector) -> Self {
+        Self { error, connector }
+    }
+}
+
+impl StdError for ConnectorError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        Some(&self.error)
+    }
+}
+
+impl fmt::Debug for ConnectorError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ConnectorError")
+            .field("error", &self.error)
+            .finish_non_exhaustive()
+    }
+}
+
+impl fmt::Display for ConnectorError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.error.fmt(f)
+    }
+}


### PR DESCRIPTION
This PR ensures that any early return in the consuming call to `connect()` the tunnel in the tunnel connectors doesn't cause the task manager to be dropped and instead returns a special `ConnectorError` that holds both the failure and the source connector that can either be reused or gracefully disposed. 

We don't care to reuse the connector, so a consuming call to `dispose()` ensures that the connector is properly cleaned up and task manager is properly shut down with all pending tasks completed before drop.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1655)
<!-- Reviewable:end -->
