### PR TITLE
Enable cover traffic for mobile

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
@@ -159,11 +159,7 @@ pub async fn connect_mixnet(
             // Always disable poisson process for outbound traffic in wireguard.
             mixnet_client_config.disable_poisson_rate = true;
             // Always disable background cover traffic in wireguard, except for android
-            if cfg!(target_os = "android") {
-                mixnet_client_config.disable_background_cover_traffic = false;
-            } else {
-                mixnet_client_config.disable_background_cover_traffic = true;
-            }
+            mixnet_client_config.disable_background_cover_traffic = !cfg!(target_os = "android");
         }
     };
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
@@ -158,8 +158,12 @@ pub async fn connect_mixnet(
         TunnelType::Wireguard => {
             // Always disable poisson process for outbound traffic in wireguard.
             mixnet_client_config.disable_poisson_rate = true;
-            // Always disable background cover traffic in wireguard.
-            mixnet_client_config.disable_background_cover_traffic = true;
+            // Always disable background cover traffic in wireguard, except for android
+            if cfg!(target_os = "android") {
+                mixnet_client_config.disable_background_cover_traffic = false;
+            } else {
+                mixnet_client_config.disable_background_cover_traffic = true;
+            }
         }
     };
 
@@ -172,6 +176,7 @@ pub async fn connect_mixnet(
             task_manager.subscribe_named("mixnet_client_main"),
             mixnet_client_config,
             options.enable_credentials_mode,
+            options.tunnel_type == TunnelType::Wireguard,
         ),
     );
 


### PR DESCRIPTION
In order to not kill the whole tunnel on mobile platforms like Android because the mixnet channel auto-shuts down when the tcp connection is unused, we do the same thing as on mixnet mode i.e. enable cover traffic, which basically keeps the websocket active permanently. This is a temporary solution, until we have a better way to treat the machine going to sleep.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1663)
<!-- Reviewable:end -->
