### PR TITLE
iOS: Block all traffic in error state

### DIFF
--- a/.github/workflows/ci-nym-vpn-core-ios.yml
+++ b/.github/workflows/ci-nym-vpn-core-ios.yml
@@ -9,6 +9,7 @@ on:
   workflow_dispatch:
 
 env:
+  IPHONEOS_DEPLOYMENT_TARGET: 16.0
   CARGO_TERM_COLOR: always
   AGENT_ISSELFHOSTED: 1 # https://github.com/actions/setup-go/issues/432
 

--- a/nym-vpn-apple/NymMixnetTunnel/TunnelActor.swift
+++ b/nym-vpn-apple/NymMixnetTunnel/TunnelActor.swift
@@ -85,7 +85,7 @@ actor TunnelActor {
         case .error:
             if canReassert {
                 // todo: remove once we properly handle error state
-                // tunnelProvider?.cancelTunnelWithError(PacketTunnelProviderError.errorState)
+                tunnelProvider?.cancelTunnelWithError(PacketTunnelProviderError.errorState)
             }
 
         case .disconnecting(.error):

--- a/nym-vpn-apple/NymMixnetTunnel/TunnelActor.swift
+++ b/nym-vpn-apple/NymMixnetTunnel/TunnelActor.swift
@@ -82,8 +82,15 @@ actor TunnelActor {
             }
             canReassert = true
 
+        case .error:
+            if canReassert {
+                // todo: remove once we properly handle error state
+                // tunnelProvider?.cancelTunnelWithError(PacketTunnelProviderError.errorState)
+            }
+
         case .disconnecting(.error):
             await NotificationMessages.scheduleDisconnectNotification()
+
         default:
             break
         }

--- a/nym-vpn-apple/Services/Sources/Services/Tunnels/Errors/PacketTunnelProviderError.swift
+++ b/nym-vpn-apple/Services/Sources/Services/Tunnels/Errors/PacketTunnelProviderError.swift
@@ -5,4 +5,7 @@ public enum PacketTunnelProviderError: String, Error {
     case backendStartFailure
     case noCredentialDataDir
     case startAccountController
+
+    /// Tunnel is cancelled because state machine entered error state.
+    case errorState
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_provider/tunnel_settings.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_provider/tunnel_settings.rs
@@ -128,14 +128,8 @@ impl TunnelSettings {
 
     fn split_ipnet_addrs(ipnet_addrs: Vec<IpNetwork>) -> (Vec<Ipv4Network>, Vec<Ipv6Network>) {
         ipnet_addrs.into_iter().partition_map(|addr| match addr {
-            IpNetwork::V4(address) => Either::Left(
-                Ipv4Network::new(address.ip(), address.prefix())
-                    .expect("failed to create ipv4 addr with /32 prefix"),
-            ),
-            IpNetwork::V6(address) => Either::Right(
-                Ipv6Network::new(address.ip(), address.prefix())
-                    .expect("failed to create ipv6 addr with /128 prefix"),
-            ),
+            IpNetwork::V4(address) => Either::Left(address),
+            IpNetwork::V6(address) => Either::Right(address),
         })
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_provider/tunnel_settings.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_provider/tunnel_settings.rs
@@ -123,17 +123,7 @@ impl TunnelSettings {
 
     #[cfg(target_os = "android")]
     fn bypass_addresses(remote_addresses: Vec<IpAddr>) -> Vec<IpNetwork> {
-        remote_addresses
-            .into_iter()
-            .map(|ip_addr| match ip_addr {
-                IpAddr::V4(addr) => {
-                    IpNetwork::V4(Ipv4Network::new(addr, 32).expect("remote_addr/32"))
-                }
-                IpAddr::V6(addr) => {
-                    IpNetwork::V6(Ipv6Network::new(addr, 128).expect("remote_addr/128"))
-                }
-            })
-            .collect()
+        remote_addresses.into_iter().map(IpNetwork::from).collect()
     }
 
     fn split_ipnet_addrs(ipnet_addrs: Vec<IpNetwork>) -> (Vec<Ipv4Network>, Vec<Ipv6Network>) {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnecting_state.rs
@@ -100,7 +100,7 @@ impl TunnelStateHandler for DisconnectingState {
                 match self.after_disconnect {
                     PrivateActionAfterDisconnect::Nothing => NextTunnelState::NewState(DisconnectedState::enter()),
                     PrivateActionAfterDisconnect::Error(reason) => {
-                        NextTunnelState::NewState(ErrorState::enter(reason))
+                        NextTunnelState::NewState(ErrorState::enter(reason, shared_state).await)
                     },
                     PrivateActionAfterDisconnect::Reconnect { retry_attempt } => {
                         NextTunnelState::NewState(ConnectingState::enter(retry_attempt, None, shared_state))

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
@@ -1,20 +1,67 @@
 // Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+#[cfg(target_os = "ios")]
+use std::{
+    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    sync::Arc,
+};
+
+#[cfg(target_os = "ios")]
+use ipnetwork::IpNetwork;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
+#[cfg(target_os = "ios")]
+use crate::tunnel_provider::{ios::OSTunProvider, tunnel_settings::TunnelSettings};
+#[cfg(target_os = "ios")]
+use crate::tunnel_state_machine::tunnel::wireguard::two_hop_config::MIN_IPV6_MTU;
 use crate::tunnel_state_machine::{
     states::{ConnectingState, DisconnectedState},
     ErrorStateReason, NextTunnelState, PrivateTunnelState, SharedState, TunnelCommand,
     TunnelStateHandler,
 };
 
+/// Interface addresses used as placeholders when in error state.
+#[cfg(target_os = "ios")]
+const BLOCKING_INTERFACE_ADDRS: [IpAddr; 2] = [
+    IpAddr::V4(Ipv4Addr::new(169, 254, 0, 10)),
+    IpAddr::V6(Ipv6Addr::new(
+        0xfdcc, 0x9fc0, 0xe75a, 0x53c3, 0xfa25, 0x241f, 0x21c0, 0x70d0,
+    )),
+];
+
 pub struct ErrorState;
 
 impl ErrorState {
-    pub fn enter(reason: ErrorStateReason) -> (Box<dyn TunnelStateHandler>, PrivateTunnelState) {
+    pub async fn enter(
+        reason: ErrorStateReason,
+        shared_state: &mut SharedState,
+    ) -> (Box<dyn TunnelStateHandler>, PrivateTunnelState) {
+        #[cfg(target_os = "ios")]
+        {
+            Self::set_blocking_network_settings(shared_state.tun_provider.clone()).await;
+        }
+
         (Box::new(Self), PrivateTunnelState::Error(reason))
+    }
+
+    /// Configure tunnel with dummy network settings consuming
+    #[cfg(target_os = "ios")]
+    async fn set_blocking_network_settings(tun_provider: Arc<dyn OSTunProvider>) {
+        let tunnel_network_settings = TunnelSettings {
+            remote_addresses: vec![],
+            interface_addresses: BLOCKING_INTERFACE_ADDRS.map(IpNetwork::from).to_vec(),
+            dns_servers: vec![],
+            mtu: MIN_IPV6_MTU,
+        };
+
+        if let Err(e) = tun_provider
+            .set_tunnel_network_settings(tunnel_network_settings.into_tunnel_network_settings())
+            .await
+        {
+            tracing::error!("Failed to set tunnel network settings: {}", e);
+        }
     }
 }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
@@ -36,11 +36,11 @@ pub struct ErrorState;
 impl ErrorState {
     pub async fn enter(
         reason: ErrorStateReason,
-        shared_state: &mut SharedState,
+        _shared_state: &mut SharedState,
     ) -> (Box<dyn TunnelStateHandler>, PrivateTunnelState) {
         #[cfg(target_os = "ios")]
         {
-            Self::set_blocking_network_settings(shared_state.tun_provider.clone()).await;
+            Self::set_blocking_network_settings(_shared_state.tun_provider.clone()).await;
         }
 
         (Box::new(Self), PrivateTunnelState::Error(reason))

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
@@ -46,7 +46,7 @@ impl ErrorState {
         (Box::new(Self), PrivateTunnelState::Error(reason))
     }
 
-    /// Configure tunnel with dummy network settings consuming
+    /// Configure tunnel with network settings blocking all traffic
     #[cfg(target_os = "ios")]
     async fn set_blocking_network_settings(tun_provider: Arc<dyn OSTunProvider>) {
         let tunnel_network_settings = TunnelSettings {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -504,13 +504,8 @@ impl TunnelMonitor {
         let packet_tunnel_settings = tunnel_provider::tunnel_settings::TunnelSettings {
             dns_servers: self.tunnel_settings.dns.ip_addresses().to_vec(),
             interface_addresses: vec![
-                IpNetwork::V4(
-                    Ipv4Network::new(conn_data.exit.private_ipv4, 32)
-                        .expect("ipv4 to ipnetwork/32"),
-                ),
-                IpNetwork::V6(
-                    Ipv6Network::new(WG_EXIT_IPV6_ADDR, 128).expect("ipv6 to ipnetwork/128"),
-                ),
+                IpNetwork::V4(Ipv4Network::from(conn_data.exit.private_ipv4)),
+                IpNetwork::V6(Ipv6Network::from(WG_EXIT_IPV6_ADDR)),
             ],
             remote_addresses: vec![conn_data.entry.endpoint.ip()],
             mtu: connected_tunnel.exit_mtu(),

--- a/nym-vpn-core/crates/nym-vpn-lib/src/wg_config.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/wg_config.rs
@@ -143,10 +143,7 @@ impl WgNodeConfig {
             interface: WgInterface {
                 listen_port: None,
                 private_key: PrivateKey::from(private_key.to_bytes()),
-                addresses: vec![IpNetwork::V4(
-                    Ipv4Network::new(gateway_data.private_ipv4, 32)
-                        .expect("private_ipv4/32 to ipnetwork"),
-                )],
+                addresses: vec![IpNetwork::V4(Ipv4Network::from(gateway_data.private_ipv4))],
                 dns,
                 mtu,
                 #[cfg(target_os = "linux")]


### PR DESCRIPTION
1. Set network settings blocking all traffic on iOS device in error state
2. As a workaround for now: cancel the packet tunnel in the event of error at runtime -- this is identical behaviour to android AFAIK. Ideally we should of course display an error and let the user exit error state but not yet..
3. Make sure to shutdown vpn and the lib on error to start the tunnel.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1669)
<!-- Reviewable:end -->
