### PR TITLE
wf: fix ci core windows

### DIFF
--- a/.github/workflows/build-nym-vpn-core-windows.yml
+++ b/.github/workflows/build-nym-vpn-core-windows.yml
@@ -36,10 +36,11 @@ jobs:
       - name: Setup MSBuild.exe
         uses: microsoft/setup-msbuild@v2
 
-      - name: Install Rust toolchain
-        uses: brndnmtthws/rust-action-rustup@v1
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          # TODO let's pin to 1.82.0 as in 1.83.0 the "build winfw.dll from mullvad" step fails
+          toolchain: 1.82.0
           components: rustfmt, clippy
 
       - name: Install Go toolchain

--- a/.github/workflows/ci-nym-vpn-core-windows.yml
+++ b/.github/workflows/ci-nym-vpn-core-windows.yml
@@ -32,9 +32,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install rust toolchain
-        uses: brndnmtthws/rust-action-rustup@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          # TODO let's pin to 1.82.0 as in 1.83.0 the step `Build winfw.dll from mullvad` fails
+          toolchain: 1.82.0
           components: rustfmt, clippy
 
       - name: Set env

--- a/.github/workflows/ci-nym-vpn-core-windows.yml
+++ b/.github/workflows/ci-nym-vpn-core-windows.yml
@@ -38,6 +38,10 @@ jobs:
           toolchain: 1.82.0
           components: rustfmt, clippy
 
+      - name: Install target i686-pc-windows-msvc
+        run: |
+          rustup target add i686-pc-windows-msvc
+
       - name: Set env
         shell: bash
         run: |


### PR DESCRIPTION
fix the rust toolchain install switching to proper gh action and pinning the toolchain to `1.82.0` as temp workaround

✓ ci run https://github.com/nymtech/nym-vpn-client/actions/runs/12074031200
✓ build run https://github.com/nymtech/nym-vpn-client/actions/runs/12074150425/job/33671669049

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1674)
<!-- Reviewable:end -->
