### PR TITLE
Support for wireguard-go on windows

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -4868,6 +4868,7 @@ dependencies = [
  "nym-vpn-store",
  "nym-wg-gateway-client",
  "nym-wg-go",
+ "nym-windows",
  "nym-wireguard-types",
  "oslog",
  "pnet_packet",
@@ -4889,6 +4890,7 @@ dependencies = [
  "uniffi",
  "url",
  "vergen",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5067,6 +5069,7 @@ dependencies = [
  "ipnetwork",
  "thiserror",
  "tracing",
+ "windows-sys 0.52.0",
  "x25519-dalek",
  "zeroize",
 ]

--- a/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
@@ -80,7 +80,13 @@ nym-wg-go = { path = "../nym-wg-go" }
 [target.'cfg(unix)'.dependencies]
 nix = { workspace = true, features = ["socket", "net", "fs"] }
 
-[target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))'.dependencies]
+[target.'cfg(windows)'.dependencies]
+windows-sys = { workspace = true, features = ["Win32_NetworkManagement_Ndis"] }
+nym-windows = { path = "../nym-windows" }
+nym-routing = { path = "../nym-routing" }
+nym-dns = { path = "../nym-dns" }
+
+[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 nym-routing = { path = "../nym-routing" }
 nym-dns = { path = "../nym-dns" }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -639,6 +639,7 @@ pub enum Error {
     #[error("failed to create tunnel device: {}", _0)]
     CreateTunDevice(#[source] tun::Error),
 
+    #[cfg(windows)]
     #[error("failed to setup wintun adapter: {}", _0)]
     SetupWintunAdapter(#[from] SetupWintunAdapterError),
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -639,6 +639,9 @@ pub enum Error {
     #[error("failed to create tunnel device: {}", _0)]
     CreateTunDevice(#[source] tun::Error),
 
+    #[error("failed to setup wintun adapter: {}", _0)]
+    SetupWintunAdapter(#[from] SetupWintunAdapterError),
+
     #[cfg(target_os = "ios")]
     #[error("failed to locate tun device")]
     LocateTunDevice(#[source] std::io::Error),
@@ -690,6 +693,9 @@ impl Error {
                 ErrorStateReason::TunDevice
             }
 
+            #[cfg(windows)]
+            Self::SetupWintunAdapter(_) => ErrorStateReason::TunDevice,
+
             Self::Tunnel(e) => e.error_state_reason()?,
 
             #[cfg(any(target_os = "ios", target_os = "android"))]
@@ -705,6 +711,23 @@ impl Error {
             Self::GetDefaultInterface(_) => ErrorStateReason::Internal,
         })
     }
+}
+
+/// Wintun adapter configuration error.
+#[cfg(windows)]
+#[derive(Debug, thiserror::Error)]
+pub enum SetupWintunAdapterError {
+    #[error("failed to set wintun adapter ipv4 address: {}", _0)]
+    SetIpv4Addr(#[source] nym_windows::net::Error),
+
+    #[error("failed to set wintun adapter ipv6 address: {}", _0)]
+    SetIpv6Addr(#[source] nym_windows::net::Error),
+
+    #[error("failed to set wintun adapter ipv4 gateway address: {}", _0)]
+    SetIpv4Gateway(#[source] nym_windows::net::Error),
+
+    #[error("failed to set wintun adapter ipv6 gateway address: {}", _0)]
+    SetIpv6Gateway(#[source] nym_windows::net::Error),
 }
 
 impl tunnel::Error {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
@@ -104,6 +104,7 @@ impl ConnectedTunnel {
             &options.exit_tun_name,
             #[cfg(windows)]
             &options.exit_tun_guid,
+            #[cfg(windows)]
             &options.wintun_tunnel_type,
         )
         .map_err(Error::Wireguard)?;

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
@@ -8,6 +8,8 @@ use tun::AsyncDevice;
 
 use nym_task::TaskManager;
 use nym_wg_gateway_client::WgGatewayClient;
+#[cfg(windows)]
+use nym_wg_go::wireguard_go::WintunInterface;
 use nym_wg_go::{netstack, wireguard_go};
 
 #[cfg(unix)]
@@ -87,6 +89,10 @@ impl ConnectedTunnel {
             options.entry_tun.get_ref().dup_fd().map_err(Error::DupFd)?,
             #[cfg(windows)]
             &options.entry_tun_name,
+            #[cfg(windows)]
+            &options.entry_tun_guid,
+            #[cfg(windows)]
+            &options.wintun_tunnel_type,
         )
         .map_err(Error::Wireguard)?;
 
@@ -96,6 +102,9 @@ impl ConnectedTunnel {
             options.exit_tun.get_ref().dup_fd().map_err(Error::DupFd)?,
             #[cfg(windows)]
             &options.exit_tun_name,
+            #[cfg(windows)]
+            &options.exit_tun_guid,
+            &options.wintun_tunnel_type,
         )
         .map_err(Error::Wireguard)?;
 
@@ -140,13 +149,16 @@ impl ConnectedTunnel {
             two_hop_config.forwarder.exit_endpoint,
         )?;
 
-        #[allow(unused_mut)]
-        let mut exit_tunnel = wireguard_go::Tunnel::start(
+        let exit_tunnel = wireguard_go::Tunnel::start(
             two_hop_config.exit.into_wireguard_config(),
             #[cfg(unix)]
             options.exit_tun.get_ref().dup_fd().map_err(Error::DupFd)?,
             #[cfg(windows)]
             &options.exit_tun_name,
+            #[cfg(windows)]
+            &options.exit_tun_guid,
+            #[cfg(windows)]
+            &options.wintun_tunnel_type,
         )?;
 
         Ok(TunnelHandle {
@@ -185,9 +197,21 @@ pub struct TunTunTunnelOptions {
     #[cfg(windows)]
     pub entry_tun_name: String,
 
+    /// Entry tunnel guid.
+    #[cfg(windows)]
+    pub entry_tun_guid: String,
+
     /// Exit tunnel device name.
     #[cfg(windows)]
     pub exit_tun_name: String,
+
+    /// Exit tunnel guid.
+    #[cfg(windows)]
+    pub exit_tun_guid: String,
+
+    /// Wintun tunnel type identifier.
+    #[cfg(windows)]
+    pub wintun_tunnel_type: String,
 
     /// In-tunnel DNS addresses
     pub dns: Vec<IpAddr>,
@@ -202,6 +226,14 @@ pub struct NetstackTunnelOptions {
     /// Exit tunnel device name.
     #[cfg(windows)]
     pub exit_tun_name: String,
+
+    /// Exit tunnel guid.
+    #[cfg(windows)]
+    pub exit_tun_guid: String,
+
+    /// Wintun tunnel type identifier.
+    #[cfg(windows)]
+    pub wintun_tunnel_type: String,
 
     /// In-tunnel DNS addresses
     pub dns: Vec<IpAddr>,
@@ -305,5 +337,33 @@ impl TunnelHandle {
 
         #[cfg(windows)]
         vec![]
+    }
+
+    /// Returns entry wintun interface descriptor when available.
+    /// Note: netstack based tunnel uses virtual adapter so it will always return `None`.
+    #[cfg(windows)]
+    pub fn entry_wintun_interface(&self) -> Option<&WintunInterface> {
+        match &self.internal_handle {
+            InternalTunnelHandle::Netstack { .. } => {
+                // Netstack tunnel does not use wintun interface.
+                None
+            }
+            InternalTunnelHandle::TunTun {
+                entry_wg_tunnel, ..
+            } => Some(entry_wg_tunnel.as_ref()?.wintun_interface()),
+        }
+    }
+
+    /// Returns exit wintun interface descriptor when available.
+    #[cfg(windows)]
+    pub fn exit_wintun_interface(&self) -> Option<&WintunInterface> {
+        match &self.internal_handle {
+            InternalTunnelHandle::Netstack { exit_wg_tunnel, .. } => {
+                Some(exit_wg_tunnel.as_ref()?.wintun_interface())
+            }
+            InternalTunnelHandle::TunTun { exit_wg_tunnel, .. } => {
+                Some(exit_wg_tunnel.as_ref()?.wintun_interface())
+            }
+        }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -381,14 +381,12 @@ impl TunnelMonitor {
             let packet_tunnel_settings = tunnel_provider::tunnel_settings::TunnelSettings {
                 dns_servers: self.tunnel_settings.dns.ip_addresses().to_vec(),
                 interface_addresses: vec![
-                    IpNetwork::V4(
-                        Ipv4Network::new(assigned_addresses.interface_addresses.ipv4, 32)
-                            .expect("ipv4/32 to ipnetwork"),
-                    ),
-                    IpNetwork::V6(
-                        Ipv6Network::new(assigned_addresses.interface_addresses.ipv6, 128)
-                            .expect("ipv6/128 addr to ipnetwork"),
-                    ),
+                    IpNetwork::V4(Ipv4Network::from(
+                        assigned_addresses.interface_addresses.ipv4,
+                    )),
+                    IpNetwork::V6(Ipv6Network::from(
+                        assigned_addresses.interface_addresses.ipv6,
+                    )),
                 ],
                 remote_addresses: vec![assigned_addresses.entry_mixnet_gateway_ip],
                 mtu,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -1,14 +1,14 @@
-#[cfg(windows)]
-use std::net::IpAddr;
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 use std::net::Ipv4Addr;
+#[cfg(windows)]
+use std::net::{IpAddr, Ipv6Addr};
 #[cfg(any(target_os = "android", target_os = "ios"))]
 use std::os::fd::{AsRawFd, IntoRawFd};
 #[cfg(target_os = "android")]
 use std::os::fd::{FromRawFd, OwnedFd};
 #[cfg(any(target_os = "android", target_os = "ios"))]
 use std::sync::Arc;
-use std::{cmp, net::Ipv6Addr, time::Duration};
+use std::{cmp, time::Duration};
 
 #[cfg(any(target_os = "ios", target_os = "android"))]
 use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
@@ -592,6 +592,7 @@ impl TunnelMonitor {
             dns: self.tunnel_settings.dns.ip_addresses().to_vec(),
         });
 
+        let tunnel_handle = connected_tunnel.run(tunnel_options)?;
         let any_tunnel_handle = AnyTunnelHandle::from(tunnel_handle);
 
         Ok((tunnel_conn_data, any_tunnel_handle))

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -511,7 +511,6 @@ impl TunnelMonitor {
 
         let tunnel_handle = connected_tunnel.run(tunnel_options)?;
 
-        // Patch routing config with actual interface name created by wireguard-go
         let wintun_exit_interface = tunnel_handle
             .exit_wintun_interface()
             .expect("failed to obtain wintun exit interface");

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -1,18 +1,14 @@
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(windows)]
+use std::net::IpAddr;
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 use std::net::Ipv4Addr;
-#[cfg(any(
-    target_os = "linux",
-    target_os = "macos",
-    target_os = "ios",
-    target_os = "android"
-))]
 #[cfg(any(target_os = "android", target_os = "ios"))]
 use std::os::fd::{AsRawFd, IntoRawFd};
 #[cfg(target_os = "android")]
 use std::os::fd::{FromRawFd, OwnedFd};
 #[cfg(any(target_os = "android", target_os = "ios"))]
 use std::sync::Arc;
-use std::{cmp, time::Duration};
+use std::{cmp, net::Ipv6Addr, time::Duration};
 
 #[cfg(any(target_os = "ios", target_os = "android"))]
 use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
@@ -23,12 +19,16 @@ use tokio_util::sync::CancellationToken;
 use tun::AsyncDevice;
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 use tun::Device;
+#[cfg(windows)]
+use windows_sys::Win32::NetworkManagement::Ndis::NET_LUID_LH;
 
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 use nym_ip_packet_requests::IpPair;
 
 #[cfg(target_os = "linux")]
 use super::default_interface::DefaultInterface;
+#[cfg(windows)]
+use super::SetupWintunAdapterError;
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 use super::{dns_handler::DnsHandlerHandle, route_handler::RouteHandler};
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
@@ -60,6 +60,33 @@ const DEFAULT_TUN_MTU: u16 = if cfg!(any(target_os = "ios", target_os = "android
 } else {
     1500
 };
+
+/// User-facing tunnel type identifier.
+#[cfg(windows)]
+const WINTUN_TUNNEL_TYPE: &str = "Nym";
+
+/// The user-facing name of wintun adapter.
+///
+/// Note that it refers to tunnel type because rust-tun uses the same name for adapter and
+/// tunnel type and there is no way to change that.
+#[cfg(windows)]
+const MIXNET_WINTUN_NAME: &str = WINTUN_TUNNEL_TYPE;
+
+/// The user-facing name of wintun adapter used as entry tunnel.
+#[cfg(windows)]
+const WG_ENTRY_WINTUN_NAME: &str = "WireGuard (entry)";
+
+/// The user-facing name of wintun adapter used as exit tunnel.
+#[cfg(windows)]
+const WG_EXIT_WINTUN_NAME: &str = "WireGuard (exit)";
+
+/// WireGuard entry adapter GUID.
+#[cfg(windows)]
+const WG_ENTRY_WINTUN_GUID: &str = "{AFE43773-E1F8-4EBB-8536-176AB86AFE9B}";
+
+/// WireGuard exit adapter GUID.
+#[cfg(windows)]
+const WG_EXIT_WINTUN_GUID: &str = "{AFE43773-E1F8-4EBB-8536-176AB86AFE9C}";
 
 pub type TunnelMonitorEventReceiver = mpsc::UnboundedReceiver<TunnelMonitorEvent>;
 
@@ -404,7 +431,7 @@ impl TunnelMonitor {
         Ok((tunnel_conn_data, tunnel_handle))
     }
 
-    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     async fn start_wireguard_netstack_tunnel(
         &mut self,
         connected_mixnet: ConnectedMixnet,
@@ -414,7 +441,6 @@ impl TunnelMonitor {
             .await?;
         let conn_data = connected_tunnel.connection_data();
 
-        #[cfg(unix)]
         let exit_tun = Self::create_wireguard_device(
             IpPair {
                 ipv4: conn_data.exit.private_ipv4,
@@ -423,13 +449,8 @@ impl TunnelMonitor {
             Some(conn_data.entry.private_ipv4),
             connected_tunnel.exit_mtu(),
         )?;
-        #[cfg(unix)]
         let exit_tun_name = exit_tun.get_ref().name().map_err(Error::GetTunDeviceName)?;
-        #[cfg(unix)]
         tracing::info!("Created exit tun device: {}", exit_tun_name);
-
-        #[cfg(windows)]
-        let exit_tun_name = "nym0".to_owned();
 
         let routing_config = RoutingConfig::WireguardNetstack {
             exit_tun_name: exit_tun_name.clone(),
@@ -447,10 +468,7 @@ impl TunnelMonitor {
         });
 
         let tunnel_options = TunnelOptions::Netstack(NetstackTunnelOptions {
-            #[cfg(unix)]
             exit_tun,
-            #[cfg(windows)]
-            exit_tun_name,
             dns: self.tunnel_settings.dns.ip_addresses().to_vec(),
         });
 
@@ -461,7 +479,71 @@ impl TunnelMonitor {
         Ok((tunnel_conn_data, any_tunnel_handle))
     }
 
-    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+    #[cfg(windows)]
+    async fn start_wireguard_netstack_tunnel(
+        &mut self,
+        connected_mixnet: ConnectedMixnet,
+    ) -> Result<(TunnelConnectionData, AnyTunnelHandle)> {
+        let connected_tunnel = connected_mixnet
+            .connect_wireguard_tunnel(self.tunnel_settings.enable_credentials_mode)
+            .await?;
+        let conn_data = connected_tunnel.connection_data();
+
+        let exit_adapter_config = WintunAdapterConfig {
+            interface_ipv4: conn_data.exit.private_ipv4,
+            interface_ipv6: conn_data.exit.private_ipv6,
+            gateway_ipv4: Some(conn_data.entry.private_ipv4),
+            gateway_ipv6: Some(conn_data.exit.private_ipv6),
+        };
+
+        let mut routing_config = RoutingConfig::WireguardNetstack {
+            exit_tun_name: WG_EXIT_WINTUN_NAME.to_owned(),
+            entry_gateway_address: conn_data.entry.endpoint.ip(),
+            #[cfg(target_os = "linux")]
+            physical_interface: DefaultInterface::current()?,
+        };
+
+        let tunnel_conn_data = TunnelConnectionData::Wireguard(WireguardConnectionData {
+            entry: WireguardNode::from(conn_data.entry.clone()),
+            exit: WireguardNode::from(conn_data.exit.clone()),
+        });
+
+        let tunnel_options = TunnelOptions::Netstack(NetstackTunnelOptions {
+            exit_tun_name: WG_EXIT_WINTUN_NAME.to_owned(),
+            exit_tun_guid: WG_EXIT_WINTUN_GUID.to_owned(),
+            wintun_tunnel_type: WINTUN_TUNNEL_TYPE.to_owned(),
+            dns: self.tunnel_settings.dns.ip_addresses().to_vec(),
+        });
+
+        let tunnel_handle = connected_tunnel.run(tunnel_options)?;
+
+        // Patch routing config with actual interface name created by wireguard-go
+        let wintun_exit_interface = tunnel_handle
+            .exit_wintun_interface()
+            .expect("failed to obtain wintun exit interface");
+
+        tracing::info!("Created wintun device: {}", wintun_exit_interface.name);
+
+        if let RoutingConfig::WireguardNetstack {
+            ref mut exit_tun_name,
+            ..
+        } = routing_config
+        {
+            *exit_tun_name = wintun_exit_interface.name.clone();
+        }
+
+        Self::setup_wintun_adapter(wintun_exit_interface.windows_luid(), exit_adapter_config)?;
+
+        // todo: make sure to shutdown tunnel_handle on failure!
+        self.set_routes(routing_config).await?;
+        self.set_dns(&wintun_exit_interface.name).await?;
+
+        let any_tunnel_handle = AnyTunnelHandle::from(tunnel_handle);
+
+        Ok((tunnel_conn_data, any_tunnel_handle))
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     async fn start_wireguard_tunnel(
         &mut self,
         connected_mixnet: ConnectedMixnet,
@@ -471,7 +553,6 @@ impl TunnelMonitor {
             .await?;
         let conn_data = connected_tunnel.connection_data();
 
-        #[cfg(unix)]
         let entry_tun = Self::create_wireguard_device(
             IpPair {
                 ipv4: conn_data.entry.private_ipv4,
@@ -480,15 +561,12 @@ impl TunnelMonitor {
             None,
             connected_tunnel.entry_mtu(),
         )?;
-        #[cfg(unix)]
         let entry_tun_name = entry_tun
             .get_ref()
             .name()
             .map_err(Error::GetTunDeviceName)?;
-        #[cfg(unix)]
         tracing::info!("Created entry tun device: {}", entry_tun_name);
 
-        #[cfg(unix)]
         let exit_tun = Self::create_wireguard_device(
             IpPair {
                 ipv4: conn_data.exit.private_ipv4,
@@ -497,31 +575,17 @@ impl TunnelMonitor {
             Some(conn_data.entry.private_ipv4),
             connected_tunnel.exit_mtu(),
         )?;
-        #[cfg(unix)]
         let exit_tun_name = exit_tun.get_ref().name().map_err(Error::GetTunDeviceName)?;
-        #[cfg(unix)]
         tracing::info!("Created exit tun device: {}", exit_tun_name);
 
-        #[cfg(windows)]
-        let entry_tun_name = "nym0".to_owned();
-        #[cfg(windows)]
-        let exit_tun_name = "nym1".to_owned();
-
         let routing_config = RoutingConfig::Wireguard {
-            #[cfg(unix)]
             entry_tun_name,
-            #[cfg(unix)]
-            exit_tun_name: exit_tun_name.clone(),
-            #[cfg(windows)]
-            entry_tun_name: entry_tun_name.clone(),
-            #[cfg(windows)]
             exit_tun_name: exit_tun_name.clone(),
             entry_gateway_address: conn_data.entry.endpoint.ip(),
             exit_gateway_address: conn_data.exit.endpoint.ip(),
             #[cfg(target_os = "linux")]
             physical_interface: DefaultInterface::current()?,
         };
-
         self.set_routes(routing_config).await?;
         self.set_dns(&exit_tun_name).await?;
 
@@ -531,22 +595,114 @@ impl TunnelMonitor {
         });
 
         let tunnel_options = TunnelOptions::TunTun(TunTunTunnelOptions {
-            #[cfg(unix)]
             entry_tun,
-            #[cfg(unix)]
             exit_tun,
-            #[cfg(windows)]
-            entry_tun_name,
-            #[cfg(windows)]
-            exit_tun_name,
+            dns: self.tunnel_settings.dns.ip_addresses().to_vec(),
+        });
+
+        let any_tunnel_handle = AnyTunnelHandle::from(tunnel_handle);
+
+        Ok((tunnel_conn_data, any_tunnel_handle))
+    }
+
+    #[cfg(windows)]
+    async fn start_wireguard_tunnel(
+        &mut self,
+        connected_mixnet: ConnectedMixnet,
+    ) -> Result<(TunnelConnectionData, AnyTunnelHandle)> {
+        let connected_tunnel = connected_mixnet
+            .connect_wireguard_tunnel(self.tunnel_settings.enable_credentials_mode)
+            .await?;
+        let conn_data = connected_tunnel.connection_data();
+
+        let mut routing_config = RoutingConfig::Wireguard {
+            entry_tun_name: WG_ENTRY_WINTUN_NAME.to_owned(),
+            exit_tun_name: WG_EXIT_WINTUN_NAME.to_owned(),
+            entry_gateway_address: conn_data.entry.endpoint.ip(),
+            exit_gateway_address: conn_data.exit.endpoint.ip(),
+        };
+        let entry_adapter_config = WintunAdapterConfig {
+            interface_ipv4: conn_data.entry.private_ipv4,
+            interface_ipv6: conn_data.entry.private_ipv6,
+            gateway_ipv4: None,
+            gateway_ipv6: None,
+        };
+        let exit_adapter_config = WintunAdapterConfig {
+            interface_ipv4: conn_data.exit.private_ipv4,
+            interface_ipv6: conn_data.exit.private_ipv6,
+            gateway_ipv4: Some(conn_data.entry.private_ipv4),
+            gateway_ipv6: Some(conn_data.entry.private_ipv6),
+        };
+
+        let tunnel_conn_data = TunnelConnectionData::Wireguard(WireguardConnectionData {
+            entry: WireguardNode::from(conn_data.entry.clone()),
+            exit: WireguardNode::from(conn_data.exit.clone()),
+        });
+
+        let tunnel_options = TunnelOptions::TunTun(TunTunTunnelOptions {
+            entry_tun_name: WG_ENTRY_WINTUN_NAME.to_owned(),
+            entry_tun_guid: WG_ENTRY_WINTUN_GUID.to_owned(),
+            exit_tun_name: WG_EXIT_WINTUN_NAME.to_owned(),
+            exit_tun_guid: WG_EXIT_WINTUN_GUID.to_owned(),
+            wintun_tunnel_type: WINTUN_TUNNEL_TYPE.to_owned(),
             dns: self.tunnel_settings.dns.ip_addresses().to_vec(),
         });
 
         let tunnel_handle = connected_tunnel.run(tunnel_options)?;
 
+        // Patch routing config with actual interface names created by wireguard-go
+        let wintun_entry_interface = tunnel_handle
+            .entry_wintun_interface()
+            .expect("failed to obtain wintun entry interface");
+        let wintun_exit_interface = tunnel_handle
+            .exit_wintun_interface()
+            .expect("failed to obtain wintun exit interface");
+
+        tracing::info!("Created entry tun device: {}", wintun_entry_interface.name);
+        tracing::info!("Created exit tun device: {}", wintun_exit_interface.name);
+
+        if let RoutingConfig::Wireguard {
+            ref mut entry_tun_name,
+            ref mut exit_tun_name,
+            ..
+        } = routing_config
+        {
+            *entry_tun_name = wintun_entry_interface.name.clone();
+            *exit_tun_name = wintun_exit_interface.name.clone();
+        }
+
+        Self::setup_wintun_adapter(wintun_entry_interface.windows_luid(), entry_adapter_config)?;
+        Self::setup_wintun_adapter(wintun_exit_interface.windows_luid(), exit_adapter_config)?;
+
+        // todo: make sure to shutdown tunnel_handle on failure!
+        self.set_routes(routing_config).await?;
+        self.set_dns(&wintun_exit_interface.name).await?;
+
         let any_tunnel_handle = AnyTunnelHandle::from(tunnel_handle);
 
         Ok((tunnel_conn_data, any_tunnel_handle))
+    }
+
+    #[cfg(windows)]
+    fn setup_wintun_adapter(luid: NET_LUID_LH, adapter_config: WintunAdapterConfig) -> Result<()> {
+        use nym_windows::net;
+
+        net::add_ip_address_for_interface(luid, IpAddr::V4(adapter_config.interface_ipv4))
+            .map_err(SetupWintunAdapterError::SetIpv4Addr)?;
+        net::add_ip_address_for_interface(luid, IpAddr::V6(adapter_config.interface_ipv6))
+            .map_err(SetupWintunAdapterError::SetIpv6Addr)?;
+
+        if let Some(gateway_ipv4) = adapter_config.gateway_ipv4 {
+            net::add_default_ipv4_gateway_for_interface(luid, gateway_ipv4)
+                .map_err(SetupWintunAdapterError::SetIpv4Gateway)?;
+        }
+
+        if let Some(gateway_ipv6) = adapter_config.gateway_ipv6 {
+            net::add_default_ipv6_gateway_for_interface(luid, gateway_ipv6)
+                .map_err(SetupWintunAdapterError::SetIpv6Gateway)?;
+        }
+
+        Ok(())
     }
 
     #[cfg(any(target_os = "ios", target_os = "android"))]
@@ -579,10 +735,6 @@ impl TunnelMonitor {
             exit: WireguardNode::from(conn_data.exit.clone()),
         });
 
-        #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-        let tunnel_handle =
-            connected_tunnel.run(tun_device, self.tunnel_settings.dns.ip_addresses().to_vec())?;
-        #[cfg(any(target_os = "ios", target_os = "android"))]
         let tunnel_handle = connected_tunnel
             .run(
                 tun_device,
@@ -619,6 +771,10 @@ impl TunnelMonitor {
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     fn create_mixnet_device(interface_addresses: IpPair, mtu: u16) -> Result<AsyncDevice> {
         let mut tun_config = tun::Configuration::default();
+
+        // rust-tun uses the same name for tunnel type.
+        #[cfg(windows)]
+        tun_config.name(MIXNET_WINTUN_NAME);
 
         tun_config
             .address(interface_addresses.ipv4)
@@ -721,4 +877,20 @@ fn wait_delay(retry_attempt: u32) -> Duration {
     let multiplier = retry_attempt.saturating_mul(DELAY_MULTIPLIER);
     let delay = INITIAL_WAIT_DELAY.saturating_mul(multiplier);
     cmp::min(delay, MAX_WAIT_DELAY)
+}
+
+/// Struct holding wintun adapter IP configuration.
+#[cfg(windows)]
+struct WintunAdapterConfig {
+    /// Interface IPv4 address.
+    interface_ipv4: Ipv4Addr,
+
+    /// Interface IPv6 address.
+    interface_ipv6: Ipv6Addr,
+
+    /// Default IPv4 gateway.
+    gateway_ipv4: Option<Ipv4Addr>,
+
+    /// Default IPv6 gateway.
+    gateway_ipv6: Option<Ipv6Addr>,
 }

--- a/nym-vpn-core/crates/nym-wg-go/Cargo.toml
+++ b/nym-vpn-core/crates/nym-wg-go/Cargo.toml
@@ -16,3 +16,6 @@ hex.workspace = true
 base64.workspace = true
 x25519-dalek = { workspace = true, features = ["static_secrets"] }
 zeroize.workspace = true
+
+[target.'cfg(windows)'.dependencies]
+windows-sys.workspace = true

--- a/nym-vpn-core/crates/nym-wg-go/Cargo.toml
+++ b/nym-vpn-core/crates/nym-wg-go/Cargo.toml
@@ -18,4 +18,4 @@ x25519-dalek = { workspace = true, features = ["static_secrets"] }
 zeroize.workspace = true
 
 [target.'cfg(windows)'.dependencies]
-windows-sys.workspace = true
+windows-sys = { workspace = true, features = ["Win32_NetworkManagement_Ndis"] }

--- a/nym-vpn-core/crates/nym-wg-go/src/lib.rs
+++ b/nym-vpn-core/crates/nym-wg-go/src/lib.rs
@@ -27,6 +27,14 @@ pub enum Error {
     #[error("interface name contains nul byte")]
     InterfaceNameContainsNulByte,
 
+    #[cfg(target_os = "windows")]
+    #[error("requested guid contains nul byte")]
+    RequestedGuidContainsNulByte,
+
+    #[cfg(target_os = "windows")]
+    #[error("wintun tunnel type contains nul byte")]
+    WintunTunnelTypeContainsNulByte,
+
     #[error("failed to start the tunnel (code: {})", _0)]
     StartTunnel(i32),
 

--- a/nym-vpn-core/crates/nym-wg-go/src/wireguard_go.rs
+++ b/nym-vpn-core/crates/nym-wg-go/src/wireguard_go.rs
@@ -102,7 +102,7 @@ pub struct Tunnel {
 impl Tunnel {
     /// Start new WireGuard tunnel
     #[cfg(not(windows))]
-    pub fn start(config: Config, tun_fd: RawFd) -> Result<Self> {
+    pub fn start(config: Config, tun_fd: OwnedFd) -> Result<Self> {
         let settings =
             CString::new(config.as_uapi_config()).map_err(|_| Error::ConfigContainsNulByte)?;
 
@@ -112,7 +112,7 @@ impl Tunnel {
                 #[cfg(any(target_os = "linux", target_os = "macos"))]
                 i32::from(config.interface.mtu),
                 settings.as_ptr(),
-                tun_fd,
+                tun_fd.into_raw_fd(),
                 wg_logger_callback,
                 std::ptr::null_mut(),
             )

--- a/nym-vpn-core/crates/nym-wg-go/src/wireguard_go.rs
+++ b/nym-vpn-core/crates/nym-wg-go/src/wireguard_go.rs
@@ -4,9 +4,12 @@
 #[cfg(unix)]
 use std::os::fd::{IntoRawFd, OwnedFd, RawFd};
 use std::{
-    ffi::{c_char, c_void, CString},
+    ffi::{c_char, c_void, CStr, CString},
     fmt,
 };
+
+#[cfg(windows)]
+use windows_sys::Win32::NetworkManagement::Ndis::NET_LUID_LH;
 
 use super::{
     uapi::UapiConfigBuilder, Error, LoggingCallback, PeerConfig, PeerEndpointUpdate, PrivateKey,
@@ -69,34 +72,47 @@ impl Config {
     }
 }
 
+/// Wintun interface created by wireguard-go
+#[cfg(windows)]
+#[derive(Debug, Clone)]
+pub struct WintunInterface {
+    /// Interface name.
+    pub name: String,
+
+    /// Interface LUID.
+    pub luid: u64,
+}
+
+#[cfg(windows)]
+impl WintunInterface {
+    pub fn windows_luid(&self) -> NET_LUID_LH {
+        // SAFETY: this is safe since NET_LUID_LH is a union represented by u64 value.
+        unsafe { std::mem::transmute(self.luid) }
+    }
+}
+
 /// Classic WireGuard tunnel.
 #[derive(Debug)]
 pub struct Tunnel {
     handle: i32,
+    #[cfg(windows)]
+    wintun_interface: WintunInterface,
 }
 
 impl Tunnel {
     /// Start new WireGuard tunnel
-    pub fn start(
-        config: Config,
-        #[cfg(not(windows))] tun_fd: OwnedFd,
-        #[cfg(windows)] interface_name: &str,
-    ) -> Result<Self> {
+    #[cfg(not(windows))]
+    pub fn start(config: Config, tun_fd: RawFd) -> Result<Self> {
         let settings =
             CString::new(config.as_uapi_config()).map_err(|_| Error::ConfigContainsNulByte)?;
-        #[cfg(windows)]
-        let interface_name =
-            CString::new(interface_name).map_err(|_| Error::InterfaceNameContainsNulByte)?;
+
         let handle = unsafe {
             wgTurnOn(
-                #[cfg(windows)]
-                interface_name.as_ptr(),
                 // note: not all platforms accept mtu = 0
                 #[cfg(any(target_os = "linux", target_os = "macos"))]
                 i32::from(config.interface.mtu),
                 settings.as_ptr(),
-                #[cfg(not(windows))]
-                tun_fd.into_raw_fd(),
+                tun_fd,
                 wg_logger_callback,
                 std::ptr::null_mut(),
             )
@@ -109,10 +125,80 @@ impl Tunnel {
         }
     }
 
+    #[cfg(windows)]
+    /// Start new WireGuard tunnel
+    pub fn start(
+        config: Config,
+        interface_name: &str,
+        requested_guid: &str,
+        wintun_tunnel_type: &str,
+    ) -> Result<Self> {
+        let settings =
+            CString::new(config.as_uapi_config()).map_err(|_| Error::ConfigContainsNulByte)?;
+        let interface_name_cstr =
+            CString::new(interface_name).map_err(|_| Error::InterfaceNameContainsNulByte)?;
+        let requested_guid_cstr =
+            CString::new(requested_guid).map_err(|_| Error::RequestedGuidContainsNulByte)?;
+        let wintun_tunnel_type_cstr =
+            CString::new(wintun_tunnel_type).map_err(|_| Error::WintunTunnelTypeContainsNulByte)?;
+
+        let mut out_interface_name: *mut c_char = std::ptr::null_mut();
+        let out_interface_name_ptr: *mut *mut c_char = &mut out_interface_name;
+
+        let mut out_interface_luid: u64 = 0;
+        let out_interface_luid_ptr: *mut u64 = &mut out_interface_luid;
+
+        let handle = unsafe {
+            wgTurnOn(
+                interface_name_cstr.as_ptr(),
+                requested_guid_cstr.as_ptr(),
+                wintun_tunnel_type_cstr.as_ptr(),
+                i32::from(config.interface.mtu),
+                settings.as_ptr(),
+                out_interface_name_ptr,
+                out_interface_luid_ptr,
+                wg_logger_callback,
+                std::ptr::null_mut(),
+            )
+        };
+
+        if handle >= 0 {
+            // SAFETY: libwg is expected to set a non-null value upon successful return.
+            let wintun_iface_name_cstr = unsafe { CStr::from_ptr(out_interface_name) };
+
+            // SAFETY: conversion must never fail.
+            let wintun_iface_name = wintun_iface_name_cstr
+                .to_str()
+                .expect("failed to convert cstring to str")
+                .to_owned();
+
+            let wintun_interface = WintunInterface {
+                name: wintun_iface_name,
+                luid: out_interface_luid,
+            };
+
+            // SAFETY: free C string allocated in Go using the correct deallocator.
+            unsafe { wgFreePtr(out_interface_name as *mut _) };
+
+            Ok(Self {
+                handle,
+                #[cfg(windows)]
+                wintun_interface,
+            })
+        } else {
+            Err(Error::StartTunnel(handle))
+        }
+    }
+
     /// Stop the tunnel.
     pub fn stop(mut self) {
         tracing::info!("Stopping the wg tunnel");
         self.stop_inner();
+    }
+
+    #[cfg(windows)]
+    pub fn wintun_interface(&self) -> &WintunInterface {
+        &self.wintun_interface
     }
 
     /// Re-attach itself to the tun interface.
@@ -155,31 +241,45 @@ impl Drop for Tunnel {
 }
 
 extern "C" {
-    // Start the tunnel.
+    /// Start the tunnel.
+    #[cfg(not(windows))]
     fn wgTurnOn(
-        #[cfg(windows)] interface_name: *const c_char,
         #[cfg(any(target_os = "linux", target_os = "macos"))] mtu: i32,
         settings: *const c_char,
-        #[cfg(not(windows))] fd: RawFd,
+        fd: RawFd,
         logging_callback: LoggingCallback,
         logging_context: *mut c_void,
     ) -> i32;
 
-    // Pass a handle that was created by wgTurnOn to stop a wireguard tunnel.
+    /// Start the tunnel.
+    #[cfg(windows)]
+    fn wgTurnOn(
+        interface_name: *const c_char,
+        requested_guid: *const c_char,
+        wintun_tunnel_type: *const c_char,
+        mtu: i32,
+        settings: *const c_char,
+        iface_name: *mut *mut c_char,
+        iface_luid: *mut u64,
+        logging_callback: LoggingCallback,
+        logging_context: *mut c_void,
+    ) -> i32;
+
+    /// Pass a handle that was created by wgTurnOn to stop a wireguard tunnel.
     fn wgTurnOff(handle: i32);
 
-    // Returns the config of the WireGuard interface.
+    /// Returns the config of the WireGuard interface.
     #[allow(unused)]
     fn wgGetConfig(handle: i32) -> *mut c_char;
 
-    // Sets the config of the WireGuard interface.
+    /// Sets the config of the WireGuard interface.
     fn wgSetConfig(handle: i32, settings: *const c_char) -> i32;
 
-    // Frees a pointer allocated by the go runtime - useful to free return value of wgGetConfig
+    /// Frees a pointer allocated by the go runtime - useful to free return value of wgGetConfig
     #[allow(unused)]
     fn wgFreePtr(ptr: *mut c_void);
 
-    // Re-attach wireguard-go to the tunnel interface.
+    /// Re-attach wireguard-go to the tunnel interface.
     #[cfg(target_os = "ios")]
     fn wgBumpSockets(handle: i32);
 }
@@ -195,7 +295,7 @@ pub unsafe extern "system" fn wg_logger_callback(
     _ctx: *mut c_void,
 ) {
     if !msg.is_null() {
-        let str = std::ffi::CStr::from_ptr(msg).to_string_lossy();
+        let str = CStr::from_ptr(msg).to_string_lossy();
         tracing::debug!("{}", str);
     }
 }

--- a/nym-vpn-core/crates/nym-wg-go/src/wireguard_go.rs
+++ b/nym-vpn-core/crates/nym-wg-go/src/wireguard_go.rs
@@ -182,7 +182,6 @@ impl Tunnel {
 
             Ok(Self {
                 handle,
-                #[cfg(windows)]
                 wintun_interface,
             })
         } else {

--- a/wireguard/README.md
+++ b/wireguard/README.md
@@ -56,3 +56,7 @@ It is forked from (https://github.com/mullvad/mullvadvpn-app) which maintains co
   - Build for x64: `./build-wireguard-go.sh`
   - Build for arm64: `./build-wireguard-go.sh --arm64`
 - Upon completion the compiled dll should be placed under `build/lib/{aarch64,x86_64}-pc-windows-msvc/libwg.dll`
+  
+  When developing you will need to copy `libwg.dll` with correct CPU architecture into `nym-vpn-core/target/debug`.
+  
+  Also make sure to obtain `wintun.dll` from [wintun.net](https://wintun.net/) and place it into `nym-vpn-core/target/debug`.

--- a/wireguard/libwg/README.md
+++ b/wireguard/libwg/README.md
@@ -6,18 +6,24 @@ It currently offers support for the following platforms:
 
 - Linux
 - macOS
-- Android
 - Windows
+- Android
+- iOS
 
 # Organization
 
-`libwg.go` has shared code that is used on all platforms.
+The library is split on classic wireguard using tun device and netstack-based implementation:
 
-`libwg_default.go` has default implementations for Linux-based systems.
-
-`libwg_android.go` has code specifically for Android.
-
-`libwg_windows.go` has code specifically for Windows.
+- `libwg.go` has shared code that is used on all platforms.
+- `libwg_mobile.go` has code shared between mobile platforms.
+- `libwg_default.go` has default implementations for macOS and Linux.
+- `libwg_android.go` has code specifically for Android.
+- `libwg_ios.go` has code specifically for iOS.
+- `netstack.go` has shared code that is used on all platforms.
+- `netstack_mobile.go` has code shared between mobile platforms.
+- `netstack_default.go` has default implementations for macOS, Linux, Windows.
+- `netstack_android.go` has code specifically for Android.
+- `netstack_ios.go` has code specifically for iOS.
 
 # Usage
 


### PR DESCRIPTION
This PR introduces initial support for wireguard-go on Windows:

- Fixes crash in libwg related to C->Go->C->Go roundtrip
- Creates wintun adapter using Go and later configures it using syscalls

Main differences:

- Unlike other platforms where we pass tun fd, on windows wireguard-go creates a wintun interface itself and configures MTU on it. We set the IP configuration using winapi syscalls using a network adapter id (luid) returned by wireguard-go.
- Since wireguard-go creates the wintun interface, we cannot set routing before starting the tunnel so the order in which system is being configured is distinct from other platforms.
- Due to the fact that wintun device is owned by wireguard-go, since we drop the tunnel before resetting the routing table, the error is printed in console saying that the routing manager couldn't clear all of the routes. I'll address that later.
- I have ideas how to refactor tunnel monitor because it has grown substantially, but not in this PR. We're really rushing to have something working asap.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1676)
<!-- Reviewable:end -->
