### PR TITLE
Drop devices before reconnect

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -3,6 +3,7 @@
 
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
+use tun::AsyncDevice;
 
 use crate::tunnel_state_machine::{
     states::{ConnectedState, DisconnectingState},
@@ -55,6 +56,21 @@ impl ConnectingState {
             },
         )
     }
+
+    async fn on_tunnel_exit(mut tun_devices: Vec<AsyncDevice>, _shared_state: &mut SharedState) {
+        #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+        {
+            if let Err(e) = _shared_state
+                .dns_handler
+                .reset_before_interface_removal()
+                .await
+            {
+                tracing::error!("Failed to reset dns before interface removal: {}", e);
+            }
+            _shared_state.route_handler.remove_routes().await;
+        }
+        tun_devices.clear();
+    }
 }
 
 #[async_trait::async_trait]
@@ -92,8 +108,8 @@ impl TunnelStateHandler for ConnectingState {
                     if let Some(reason) = reason {
                         NextTunnelState::NewState(DisconnectingState::enter(PrivateActionAfterDisconnect::Error(reason), self.monitor_handle, shared_state))
                     } else {
-                        #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-                        shared_state.route_handler.remove_routes().await;
+                        let tun_devices = self.monitor_handle.wait().await;
+                        Self::on_tunnel_exit(tun_devices, shared_state).await;
 
                         NextTunnelState::NewState(ConnectingState::enter(self.retry_attempt.saturating_add(1), self.selected_gateways, shared_state))
                     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnecting_state.rs
@@ -52,9 +52,6 @@ impl DisconnectingState {
 
     async fn on_tunnel_exit(mut tun_devices: Vec<AsyncDevice>, _shared_state: &mut SharedState) {
         #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-        _shared_state.route_handler.remove_routes().await;
-
-        #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
         if let Err(e) = _shared_state
             .dns_handler
             .reset_before_interface_removal()

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -564,7 +564,7 @@ impl TunnelMonitor {
             dns_servers: self.tunnel_settings.dns.ip_addresses().to_vec(),
             interface_addresses: vec![
                 IpNetwork::V4(Ipv4Network::from(conn_data.exit.private_ipv4)),
-                IpNetwork::V6(Ipv6Network::from(conn_data.exit_private_ipv6)),
+                IpNetwork::V6(Ipv6Network::from(conn_data.exit.private_ipv6)),
             ],
             remote_addresses: vec![conn_data.entry.endpoint.ip()],
             mtu: connected_tunnel.exit_mtu(),


### PR DESCRIPTION
- connecting: drop devices before reconnect, reset dns along with the routes
- disconnecting: remove duplicate call to reset routes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1682)
<!-- Reviewable:end -->
