### PR TITLE
Fix if condition in uniffi upload step

### DIFF
--- a/.github/workflows/ci-nym-vpn-core-ios.yml
+++ b/.github/workflows/ci-nym-vpn-core-ios.yml
@@ -71,7 +71,6 @@ jobs:
             --language swift --out-dir build -n
 
       - name: Upload generated uniffi file
-        if: steps.diff_ios.outcome == 'failure'
         uses: actions/upload-artifact@v4
         with:
           name: updated-uniffi-ios


### PR DESCRIPTION
There is no such step as `diff_ios` so the if condition `steps.diff_ios.outcome` is no longer valid. Let's make sure that that the upload only happens if "Generate Uniffi" step succeeds.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1683)
<!-- Reviewable:end -->
