### PR TITLE
Simon/bugfix wait for connected

### DIFF
--- a/nym-vpn-core/crates/nym-vpnc/src/cli.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/cli.rs
@@ -162,8 +162,7 @@ pub(crate) struct ConnectArgs {
     #[arg(long)]
     pub(crate) enable_two_hop: bool,
 
-    /// Enable two-hop wireguard traffic. This means that traffic jumps directly from entry gateway to
-    /// exit gateway using Wireguard protocol.
+    /// Blocks until the connection is established or failed
     #[arg(short, long)]
     pub(crate) wait_until_connected: bool,
 

--- a/nym-vpn-core/crates/nym-vpnc/src/cli.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/cli.rs
@@ -162,6 +162,11 @@ pub(crate) struct ConnectArgs {
     #[arg(long)]
     pub(crate) enable_two_hop: bool,
 
+    /// Enable two-hop wireguard traffic. This means that traffic jumps directly from entry gateway to
+    /// exit gateway using Wireguard protocol.
+    #[arg(short, long)]
+    pub(crate) wait_until_connected: bool,
+
     /// Use netstack based implementation for two-hop wireguard.
     #[arg(long, requires = "enable_two_hop")]
     pub(crate) netstack: bool,

--- a/nym-vpn-core/crates/nym-vpnc/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/main.rs
@@ -7,7 +7,7 @@ mod config;
 mod protobuf_conversion;
 mod vpnd_client;
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use clap::Parser;
 use cli::Internal;
 use itertools::Itertools;
@@ -208,8 +208,7 @@ async fn listen_until_connected_or_failed(opts: CliOptions) -> Result<()> {
             println!("Connected!");
             break;
         } else if response.status == nym_vpn_proto::ConnectionStatus::ConnectionFailed as i32 {
-            println!("Connection failed!");
-            break;
+            return Err(anyhow!("Connection failed"));
         }
     }
     Ok(())

--- a/nym-vpn-core/crates/nym-vpnc/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/main.rs
@@ -168,8 +168,13 @@ async fn connect(opts: CliOptions, connect_args: &cli::ConnectArgs) -> Result<()
     }
 
     if response.success {
+        if connect_args.wait_until_connected {
             println!("Successfully sent connect command, waiting for connected state");
             listen_until_connected_or_failed(opts).await
+        } else {
+            println!("Successfully sent connect command");
+            Ok(())
+        }
     } else if let Some(error) = response.error {
         let kind =
             nym_vpn_proto::connect_request_error::ConnectRequestErrorType::try_from(error.kind)
@@ -182,7 +187,7 @@ async fn connect(opts: CliOptions, connect_args: &cli::ConnectArgs) -> Result<()
     }
 }
 
-async fn listen_until_connected(opts: CliOptions) -> Result<()> {
+async fn listen_until_connected_or_failed(opts: CliOptions) -> Result<()> {
     let mut client = vpnd_client::get_client(opts.client_type).await?;
 
     let request = tonic::Request::new(StatusRequest {});

--- a/nym-vpn-core/crates/nym-vpnc/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/main.rs
@@ -168,8 +168,8 @@ async fn connect(opts: CliOptions, connect_args: &cli::ConnectArgs) -> Result<()
     }
 
     if response.success {
-        println!("Successfully sent connect command, waiting for connected state");
-        listen_until_connected(opts).await
+            println!("Successfully sent connect command, waiting for connected state");
+            listen_until_connected_or_failed(opts).await
     } else if let Some(error) = response.error {
         let kind =
             nym_vpn_proto::connect_request_error::ConnectRequestErrorType::try_from(error.kind)
@@ -201,6 +201,9 @@ async fn listen_until_connected(opts: CliOptions) -> Result<()> {
         println!("{:#?}", response);
         if response.status == nym_vpn_proto::ConnectionStatus::Connected as i32 {
             println!("Connected!");
+            break;
+        } else if response.status == nym_vpn_proto::ConnectionStatus::ConnectionFailed as i32 {
+            println!("Connection failed!");
             break;
         }
     }


### PR DESCRIPTION
- `listen_until_connected` is now `listen_until_connected_or_failed` and additionally returns upon reaching the `ConnectionFailed` state.
- `-w` to wait until connection is established or not. (Disabled by default, do we want it the other way around?)
- `listen_until_connected_or_failed` returns with an error, such that `nym-vpnc connect` has an error code of `1` if the connection failed

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1685)
<!-- Reviewable:end -->
