### PR TITLE
Cross Compile targetting windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,14 @@ build-wireguard-ios:
 build-nym-vpn-core:
 	$(MAKE) -C nym-vpn-core build
 
+# Used for cross compiling to target windows from linux
+# requires:
+#     binutils-mingw-w64 mingw-w64
+windows-cross: build-wireguard-windows build-nym-vpn-core-windows
+
+build-wireguard-windows:
+	./wireguard/build-wireguard-go.sh --windows-cross
+
+build-nym-vpn-core-windows:
+	$(MAKE) -C nym-vpn-core build-win-cross
+

--- a/nym-vpn-core/Makefile
+++ b/nym-vpn-core/Makefile
@@ -21,6 +21,9 @@ build-release: ## Build the Rust workspace in release mode
 build-mac: ## Build the Rust workspace suitable for running the daemon
 	RUSTFLAGS="-C link-arg=-all_load -C link-arg=-ObjC -C link-arg=-sectcreate -C link-arg=__TEXT -C link-arg=__info_plist -C link-arg=$(CURDIR)/../nym-vpn-apple/Daemon/Info.plist -C link-arg=-sectcreate -C link-arg=__TEXT -C link-arg=__launchd_plist -C link-arg=$(CURDIR)/../nym-vpn-apple/Daemon/Launchd.plist" cargo build --release --workspace --exclude nym-gateway-probe
 
+build-win-cross:
+	cargo build --target x86_64-pc-windows-gnu --release
+
 deb: build-deb-vpn-cli build-deb-vpnd build-deb-vpnc ## Build debian packages
 
 # Linting targets

--- a/wireguard/build-wireguard-go.sh
+++ b/wireguard/build-wireguard-go.sh
@@ -9,6 +9,7 @@ IS_ANDROID_BUILD=false
 IS_IOS_BUILD=false
 IS_DOCKER_BUILD=true
 IS_WIN_ARM64=false
+IS_WIN_CROSS_BUILD=false
 
 function parseArgs {
     for arg in "$@"; do
@@ -25,6 +26,10 @@ function parseArgs {
         "--no-docker" )
             IS_DOCKER_BUILD=false;
             shift ;;
+        # handle --windows option (allowing windows build from linux for example)
+        "--windows-cross" )
+            IS_WIN_CROSS_BUILD=true;
+            shift ;;
         # handle --arm64 option
         "--arm64" )
             IS_WIN_ARM64=true;
@@ -36,7 +41,7 @@ function parseArgs {
       esac
     done
 
-    echo "android:$IS_ANDROID_BUILD ios:$IS_IOS_BUILD docker:$IS_DOCKER_BUILD win_arm64:$IS_WIN_ARM64"
+    echo "android:$IS_ANDROID_BUILD ios:$IS_IOS_BUILD docker:$IS_DOCKER_BUILD windows:$IS_WIN_CROSS_BUILD win_arm64:$IS_WIN_ARM64"
 }
 
 function win_gather_export_symbols {
@@ -65,6 +70,28 @@ function win_create_lib_file {
         "/machine:$arch"
 }
 
+function win_create_lib_file_cross {
+    echo "LIBRARY libwg" > exports.def
+    echo "EXPORTS" >> exports.def
+
+    for symbol in $(win_gather_export_symbols); do
+        printf "\t%s\n" "$symbol" >> exports.def
+    done
+
+    if $IS_WIN_ARM64; then
+        printf "cross compiling for windows ARM is not supported"
+        # as of late 2024 aarch64-w64-mingw32-gcc is not upstreamed into mingw-w64
+        # so we cannot cross compile windows builds for arm architectures
+        exit 2
+    fi
+
+    local arch="i386:x86-64"
+
+    echo "Creating lib for $arch"
+
+    x86_64-w64-mingw32-dlltool --dllname libwg.dll --def exports.def --output-lib libwg.lib --machine "$arch"
+}
+
 function build_windows {
     export CGO_ENABLED=1
     export GOOS=windows
@@ -76,16 +103,26 @@ function build_windows {
     else
         local arch="x86_64"
         export GOARCH=amd64
-        export CC="x86_64-w64-mingw32-cc"
+        if $IS_WIN_CROSS_BUILD; then
+            export CC="x86_64-w64-mingw32-gcc"
+        else
+            export CC="x86_64-w64-mingw32-cc"
+        fi
     fi
 
     echo "Building wireguard-go for Windows ($arch)"
 
     pushd $LIB_DIR
         go build -trimpath -v -o libwg.dll -buildmode c-shared
-        win_create_lib_file
 
-        local target_dir="../../build/lib/$arch-pc-windows-msvc/"
+        if [ $# -eq 0 ] ; then
+            win_create_lib_file
+            local target_dir="../../build/lib/$arch-pc-windows-msvc/"
+        elif [ "$1" == "cross" ]; then
+            win_create_lib_file_cross
+            local target_dir="../../build/lib/$arch-pc-windows-gnu/"
+        fi
+
         echo "Copying files to $(realpath "$target_dir")"
         mkdir -p $target_dir
         mv libwg.dll libwg.lib $target_dir
@@ -245,6 +282,11 @@ function build_wireguard_go {
 
     if $IS_IOS_BUILD ; then
         build_ios $@
+        return
+    fi
+
+    if $IS_WIN_CROSS_BUILD ; then
+        build_windows "cross"
         return
     fi
 


### PR DESCRIPTION
PR adds support for cross compiling to target windows from unix (linux) envs. 

This came about while debugging windows builds in general, as cross compiling is easier for me than compiling in windows native. I figured I would make a PR in case this is useful to anyone else.

Some details: 
* using MSVC from non-Windows environments is a big hassle, so instead we target `x86_64-pc-windows-gnu`
* `x86_64-pc-windows-gnu` tools can be installed with `sudo apt-get install binutils-mingw-w64 mingw-w64` or your platforms equivalent.
* ARM64 cannot be built this way as `mingw-w64` doesn't yet have support for `aarch64-w64-mingw32-gcc`
  * There is probably a more involved way to cross compile targetting windows arm, but I am going to leave it as "unsupported" for now

:warning: I have not tested the produced binaries yet as I don't have access to a windows machine.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1689)
<!-- Reviewable:end -->
