### PR TITLE
APPLE: improve grpc health

### DIFF
--- a/nym-vpn-apple/ServicesMacOS/Sources/GRPCManager/GRPCManager.swift
+++ b/nym-vpn-apple/ServicesMacOS/Sources/GRPCManager/GRPCManager.swift
@@ -59,9 +59,9 @@ public final class GRPCManager: ObservableObject {
     }
 
     func setup() {
+        setupHealthObserver()
         setupListenToConnectionStateObserver()
         setupListenToConnectionStatusObserver()
-        setupHealthObserver()
     }
 
     // MARK: - Info -

--- a/nym-vpn-apple/ServicesMacOS/Sources/HelperInstallmanager/HelperInstallManager.swift
+++ b/nym-vpn-apple/ServicesMacOS/Sources/HelperInstallmanager/HelperInstallManager.swift
@@ -35,6 +35,6 @@ extension HelperInstallManager {
             daemonState = .unknown
             throw error
         }
-        try? await Task.sleep(for: .seconds(7))
+        try? await Task.sleep(for: .seconds(10))
     }
 }


### PR DESCRIPTION
Listen to health observer first.
Increase install timer to 10, to give more time for daemon to "warm up".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1696)
<!-- Reviewable:end -->
