### PR TITLE
Ensure device keys are available when storing the account recovery phrase in the uniffi API

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/account.rs
@@ -246,6 +246,13 @@ pub(super) async fn store_account_mnemonic(mnemonic: &str, path: &str) -> Result
             details: err.to_string(),
         })?;
 
+    storage
+        .init_keys(None)
+        .await
+        .map_err(|err| VpnError::InternalError {
+            details: err.to_string(),
+        })?;
+
     Ok(())
 }
 


### PR DESCRIPTION
When storing the account recovery phrase, generate the device key if it does not already exists. This matches the `nym-vpnd` behaviour

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1699)
<!-- Reviewable:end -->
