### PR TITLE
Fix build script failure on fresh run

### DIFF
--- a/wireguard/build-wireguard-go.sh
+++ b/wireguard/build-wireguard-go.sh
@@ -123,8 +123,8 @@ function build_windows {
             local target_dir="../../build/lib/$arch-pc-windows-gnu/"
         fi
 
-        echo "Copying files to $(realpath "$target_dir")"
         mkdir -p $target_dir
+        echo "Copying files to $(realpath "$target_dir")"
         mv libwg.dll libwg.lib $target_dir
     popd
 }


### PR DESCRIPTION
A call to `realpath` fails if the target directory does not exist yet. This PR simply shifts the order of `mkdir` and `realpath` to fix that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1703)
<!-- Reviewable:end -->
