### PR TITLE
Add getting devices and account usage to grpc API

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -4926,6 +4926,7 @@ dependencies = [
  "nym-gateway-directory",
  "nym-sdk",
  "nym-vpn-account-controller",
+ "nym-vpn-api-client",
  "nym-vpn-network-config",
  "nym-vpnd-types",
  "prost",

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commander.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commander.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use nym_vpn_api_client::response::{NymVpnAccountSummaryResponse, NymVpnDevice};
+use nym_vpn_api_client::response::{NymVpnAccountSummaryResponse, NymVpnDevice, NymVpnUsage};
 use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
@@ -45,10 +45,34 @@ impl AccountControllerCommander {
         rx.await.map_err(AccountCommandError::internal)?
     }
 
+    pub async fn get_usage(&self) -> Result<Vec<NymVpnUsage>, AccountCommandError> {
+        let (tx, rx) = ReturnSender::new();
+        self.command_tx
+            .send(AccountCommand::GetUsage(tx))
+            .map_err(AccountCommandError::internal)?;
+        rx.await.map_err(AccountCommandError::internal)?
+    }
+
     pub async fn register_device(&self) -> Result<NymVpnDevice, AccountCommandError> {
         let (tx, rx) = ReturnSender::new();
         self.command_tx
             .send(AccountCommand::RegisterDevice(Some(tx)))
+            .map_err(AccountCommandError::internal)?;
+        rx.await.map_err(AccountCommandError::internal)?
+    }
+
+    pub async fn get_devices(&self) -> Result<Vec<NymVpnDevice>, AccountCommandError> {
+        let (tx, rx) = ReturnSender::new();
+        self.command_tx
+            .send(AccountCommand::GetDevices(tx))
+            .map_err(AccountCommandError::internal)?;
+        rx.await.map_err(AccountCommandError::internal)?
+    }
+
+    pub async fn get_active_devices(&self) -> Result<Vec<NymVpnDevice>, AccountCommandError> {
+        let (tx, rx) = ReturnSender::new();
+        self.command_tx
+            .send(AccountCommand::GetActiveDevices(tx))
             .map_err(AccountCommandError::internal)?;
         rx.await.map_err(AccountCommandError::internal)?
     }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/mod.rs
@@ -13,7 +13,7 @@ pub use request_zknym::{
 
 use std::{collections::HashMap, fmt, sync::Arc};
 
-use nym_vpn_api_client::response::{NymVpnAccountSummaryResponse, NymVpnDevice};
+use nym_vpn_api_client::response::{NymVpnAccountSummaryResponse, NymVpnDevice, NymVpnUsage};
 use serde::{Deserialize, Serialize};
 use tokio::sync::oneshot;
 
@@ -163,7 +163,10 @@ pub enum AccountCommand {
     ResetAccount,
     UpdateAccountState(Option<ReturnSender<NymVpnAccountSummaryResponse>>),
     UpdateDeviceState(Option<ReturnSender<DeviceState>>),
+    GetUsage(ReturnSender<Vec<NymVpnUsage>>),
     RegisterDevice(Option<ReturnSender<NymVpnDevice>>),
+    GetDevices(ReturnSender<Vec<NymVpnDevice>>),
+    GetActiveDevices(ReturnSender<Vec<NymVpnDevice>>),
     RequestZkNym(Option<ReturnSender<RequestZkNymSuccessSummary>>),
     GetDeviceZkNym,
     GetZkNymsAvailableForDownload,

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/update_account.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/update_account.rs
@@ -4,6 +4,7 @@
 use std::sync::Arc;
 
 use nym_vpn_api_client::{response::NymVpnAccountSummaryResponse, types::VpnApiAccount};
+use tracing::Level;
 
 use crate::{
     commands::VpnApiEndpointFailure,
@@ -70,6 +71,7 @@ impl UpdateStateCommandHandler {
         fields(id = %self.id_str()),
         ret,
         err,
+        level = Level::DEBUG,
     )]
     pub(crate) async fn run_inner(
         self,

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/update_device.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/update_device.rs
@@ -7,6 +7,7 @@ use nym_vpn_api_client::{
     response::NymVpnDevicesResponse,
     types::{Device, VpnApiAccount},
 };
+use tracing::Level;
 
 use crate::{
     commands::VpnApiEndpointFailure,
@@ -79,6 +80,7 @@ impl UpdateDeviceStateCommandHandler {
         fields(id = %self.id_str()),
         ret,
         err,
+        level = Level::DEBUG,
     )]
     async fn run_inner(self) -> Result<DeviceState, AccountCommandError> {
         tracing::debug!("Running update device state command handler: {}", self.id);

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/error.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/error.rs
@@ -2,23 +2,11 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use tokio::sync::mpsc::error::SendError;
-use url::Url;
 
 use crate::commands::AccountCommand;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("failed to get account summary: {message}")]
-    GetAccountSummary {
-        message_id: Option<String>,
-        message: String,
-        base_url: Box<Url>,
-        source: Box<nym_vpn_api_client::VpnApiClientError>,
-    },
-
-    #[error("missing API URL")]
-    MissingApiUrl,
-
     #[error("failed to setup nym-vpn-api client")]
     SetupVpnApiClient(nym_vpn_api_client::VpnApiClientError),
 
@@ -40,13 +28,6 @@ pub enum Error {
 
     #[error("failed to setup credential storage")]
     SetupCredentialStorage(#[source] nym_sdk::Error),
-
-    #[error("failed to get devices: {message}")]
-    GetDevices {
-        message_id: Option<String>,
-        message: String,
-        response: Box<nym_vpn_api_client::response::NymErrorResponse>,
-    },
 
     #[error("failed to send account controller command")]
     AccountCommandSend {
@@ -72,15 +53,6 @@ pub enum Error {
     #[error("failed to send confirm zk-nym download")]
     ConfirmZkNymDownload(#[source] nym_vpn_api_client::VpnApiClientError),
 
-    #[error("unexepected response from nym-vpn-api: {0}")]
-    UnexpectedResponse(#[source] nym_vpn_api_client::VpnApiClientError),
-
-    #[error(transparent)]
-    HttpClient(#[from] nym_http_api_client::HttpClientError),
-
-    #[error("trying to use epoch before it's available")]
-    NoEpoch,
-
     #[error("failed to import zk-nym")]
     ImportZkNym(#[source] nym_compact_ecash::CompactEcashError),
 
@@ -89,9 +61,6 @@ pub enum Error {
 
     #[error("internal error: {0}")]
     Internal(String),
-
-    #[error(transparent)]
-    NymSdk(#[from] nym_sdk::Error),
 
     #[error("succesfull zknym response is missing blinded shares")]
     MissingBlindedShares,
@@ -105,9 +74,6 @@ pub enum Error {
     #[error("invalid verification key: {0}")]
     InvalidVerificationKey(#[source] nym_compact_ecash::CompactEcashError),
 
-    #[error("missing aggregated coin index signatures")]
-    MissingAggregatedCoinIndexSignatures,
-
     #[error("failed to deserialize blinded signature")]
     DeserializeBlindedSignature(nym_compact_ecash::CompactEcashError),
 
@@ -117,37 +83,15 @@ pub enum Error {
     #[error("decoded key missing index")]
     DecodedKeysMissingIndex,
 
-    #[error("invalid expiration date: {0}")]
-    InvalidExpirationDate(#[source] time::error::Parse),
-
     #[error("failed to aggregate wallets")]
     AggregateWallets(#[source] nym_compact_ecash::CompactEcashError),
 
-    #[error("failed to confirm zk-nym downloaded: {0}")]
-    ConfirmZkNymDownloaded(#[source] nym_vpn_api_client::VpnApiClientError),
-
     #[error("failed to parse ticket type: {0}")]
     ParseTicketType(String),
-
-    #[error("empty set of tickets")]
-    NoTickets,
-
-    #[error("error returned by channel: {0}")]
-    ErrorReturnedByChannel(String),
-
-    #[error("command already running")]
-    CommandAlreadyRunning(String),
-
-    #[error("timeout waiting for: {0}")]
-    Timeout(String),
 }
 
 impl Error {
     pub fn internal(msg: impl ToString) -> Self {
         Error::Internal(msg.to_string())
-    }
-
-    pub fn by_channel(msg: impl ToString) -> Self {
-        Error::ErrorReturnedByChannel(msg.to_string())
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
@@ -9,7 +9,7 @@ use nym_http_api_client::{HttpClientError, Params, PathSegments, UserAgent, NO_P
 use reqwest::Url;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
-use crate::response::NymVpnHealthResponse;
+use crate::response::{NymVpnHealthResponse, NymVpnUsagesResponse};
 use crate::{
     error::{Result, VpnApiClientError},
     request::{
@@ -635,6 +635,22 @@ impl VpnApiClient {
         )
         .await
         .map_err(VpnApiClientError::FailedToGetActiveSubscriptions)
+    }
+
+    pub async fn get_usage(&self, account: &VpnApiAccount) -> Result<NymVpnUsagesResponse> {
+        self.get_authorized(
+            &[
+                routes::PUBLIC,
+                routes::V1,
+                routes::ACCOUNT,
+                &account.id(),
+                routes::USAGE,
+            ],
+            account,
+            None,
+        )
+        .await
+        .map_err(VpnApiClientError::FailedToGetUsage)
     }
 
     // GATEWAYS

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/error.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/error.rs
@@ -94,8 +94,12 @@ pub enum VpnApiClientError {
     FailedToGetDirectoryZkNymsTicketbookPartialVerificationKeys(
         #[source] HttpClientError<ErrorMessage>,
     ),
+
     #[error("failed to get health")]
     FailedToGetHealth(#[source] HttpClientError<UnexpectedError>),
+
+    #[error("failed to get usage")]
+    FailedToGetUsage(#[source] HttpClientError<UnexpectedError>),
 }
 
 pub type Result<T> = std::result::Result<T, VpnApiClientError>;

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
@@ -230,6 +230,27 @@ pub struct NymVpnSubscriptionsResponse {
     pub items: Vec<NymVpnSubscription>,
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct NymVpnUsagesResponse {
+    pub total_items: u64,
+    pub page: u64,
+    pub page_size: u64,
+    pub items: Vec<NymVpnUsage>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct NymVpnUsage {
+    pub created_on_utc: String,
+    pub last_updated_utc: String,
+    pub id: String,
+    pub subscription_id: String,
+    pub valid_until_utc: String,
+    pub valid_from_utc: String,
+    pub bandwidth_allowance_gb: f64,
+    pub bandwidth_used_gb: f64,
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct NymDirectoryGatewaysResponse(Vec<NymDirectoryGateway>);
 

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/routes.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/routes.rs
@@ -12,6 +12,7 @@ pub(crate) const ZKNYM: &str = "zknym";
 pub(crate) const AVAILABLE: &str = "available";
 pub(crate) const FREEPASS: &str = "freepass";
 pub(crate) const SUBSCRIPTION: &str = "subscription";
+pub(crate) const USAGE: &str = "usage";
 pub(crate) const DIRECTORY: &str = "directory";
 pub(crate) const GATEWAYS: &str = "gateways";
 pub(crate) const COUNTRIES: &str = "countries";

--- a/nym-vpn-core/crates/nym-vpn-proto/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-proto/Cargo.toml
@@ -18,6 +18,7 @@ nym-config = { workspace = true, optional = true }
 nym-gateway-directory = { path = "../nym-gateway-directory", optional = true }
 nym-sdk = { workspace = true, optional = true }
 nym-vpn-account-controller = { path = "../nym-vpn-account-controller", optional = true }
+nym-vpn-api-client = { path = "../nym-vpn-api-client", optional = true }
 nym-vpn-network-config = { path = "../nym-vpn-network-config", optional = true }
 nym-vpnd-types = { path = "../nym-vpnd-types", optional = true }
 thiserror = { workspace = true, optional = true }
@@ -33,6 +34,7 @@ conversions = [
     "dep:nym-gateway-directory",
     "dep:nym-sdk",
     "dep:nym-vpn-account-controller",
+    "dep:nym-vpn-api-client",
     "dep:nym-vpn-network-config",
     "dep:nym-vpnd-types",
     "dep:thiserror",

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/into_proto/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/into_proto/account.rs
@@ -310,3 +310,55 @@ impl From<nym_vpn_account_controller::AccountStateSummary> for crate::AccountSta
         }
     }
 }
+
+impl From<nym_vpn_api_client::response::NymVpnUsage> for crate::AccountUsage {
+    fn from(usage: nym_vpn_api_client::response::NymVpnUsage) -> Self {
+        Self {
+            created_on_utc: usage.created_on_utc,
+            last_updated_utc: usage.last_updated_utc,
+            id: usage.id,
+            subscription_id: usage.subscription_id,
+            valid_until_utc: usage.valid_until_utc,
+            valid_from_utc: usage.valid_from_utc,
+            bandwidth_allowance_gb: usage.bandwidth_allowance_gb,
+            bandwidth_used_gb: usage.bandwidth_used_gb,
+        }
+    }
+}
+
+impl From<Vec<nym_vpn_api_client::response::NymVpnUsage>> for crate::AccountUsages {
+    fn from(usage: Vec<nym_vpn_api_client::response::NymVpnUsage>) -> Self {
+        Self {
+            account_usages: usage.into_iter().map(crate::AccountUsage::from).collect(),
+        }
+    }
+}
+
+impl From<nym_vpn_api_client::response::NymVpnDeviceStatus> for crate::DeviceStatus {
+    fn from(value: nym_vpn_api_client::response::NymVpnDeviceStatus) -> Self {
+        match value {
+            nym_vpn_api_client::response::NymVpnDeviceStatus::Active => Self::Active,
+            nym_vpn_api_client::response::NymVpnDeviceStatus::Inactive => Self::Inactive,
+            nym_vpn_api_client::response::NymVpnDeviceStatus::DeleteMe => Self::DeleteMe,
+        }
+    }
+}
+
+impl From<nym_vpn_api_client::response::NymVpnDevice> for crate::Device {
+    fn from(device: nym_vpn_api_client::response::NymVpnDevice) -> Self {
+        Self {
+            created_on_utc: device.created_on_utc,
+            last_updated_utc: device.last_updated_utc,
+            device_identity_key: device.device_identity_key,
+            status: crate::DeviceStatus::from(device.status) as i32,
+        }
+    }
+}
+
+impl From<Vec<nym_vpn_api_client::response::NymVpnDevice>> for crate::Devices {
+    fn from(devices: Vec<nym_vpn_api_client::response::NymVpnDevice>) -> Self {
+        Self {
+            devices: devices.into_iter().map(crate::Device::from).collect(),
+        }
+    }
+}

--- a/nym-vpn-core/crates/nym-vpnc/src/cli.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/cli.rs
@@ -97,6 +97,9 @@ pub(crate) enum Internal {
     /// Manually trigger an account sync with the nym-vpn-api.
     SyncAccountState,
 
+    /// Get the account usage from the nym-vpn-api.
+    GetAccountUsage,
+
     /// Evaluate the current state of the device and determine if it is ready to connect.
     IsReadyToConnect,
 
@@ -106,6 +109,12 @@ pub(crate) enum Internal {
 
     /// Register the device with your account.
     RegisterDevice,
+
+    /// Get the devices associated with the account.
+    GetDevices,
+
+    /// Get the active devices associated with the account.
+    GetActiveDevices,
 
     /// Manually request zknym credentials.
     RequestZkNym,

--- a/nym-vpn-core/crates/nym-vpnc/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/main.rs
@@ -16,12 +16,13 @@ use nym_vpn_proto::{
     ConfirmZkNymDownloadedRequest, ConnectRequest, DisconnectRequest, Empty,
     FetchRawAccountSummaryRequest, FetchRawDevicesRequest, ForgetAccountRequest,
     GetAccountIdentityRequest, GetAccountLinksRequest, GetAccountStateRequest,
-    GetAvailableTicketsRequest, GetDeviceIdentityRequest, GetDeviceZkNymsRequest,
-    GetFeatureFlagsRequest, GetSystemMessagesRequest, GetZkNymByIdRequest,
-    GetZkNymsAvailableForDownloadRequest, InfoRequest, InfoResponse, IsAccountStoredRequest,
-    IsReadyToConnectRequest, ListCountriesRequest, ListGatewaysRequest, RefreshAccountStateRequest,
-    RegisterDeviceRequest, RemoveAccountRequest, RequestZkNymRequest, ResetDeviceIdentityRequest,
-    SetNetworkRequest, StatusRequest, StoreAccountRequest, UserAgent,
+    GetAccountUsageRequest, GetActiveDevicesRequest, GetAvailableTicketsRequest,
+    GetDeviceIdentityRequest, GetDeviceZkNymsRequest, GetDevicesRequest, GetFeatureFlagsRequest,
+    GetSystemMessagesRequest, GetZkNymByIdRequest, GetZkNymsAvailableForDownloadRequest,
+    InfoRequest, InfoResponse, IsAccountStoredRequest, IsReadyToConnectRequest,
+    ListCountriesRequest, ListGatewaysRequest, RefreshAccountStateRequest, RegisterDeviceRequest,
+    RemoveAccountRequest, RequestZkNymRequest, ResetDeviceIdentityRequest, SetNetworkRequest,
+    StatusRequest, StoreAccountRequest, UserAgent,
 };
 use protobuf_conversion::into_gateway_type;
 use sysinfo::System;
@@ -87,6 +88,7 @@ async fn main() -> Result<()> {
             Internal::GetFeatureFlags => get_feature_flags(opts.client_type).await?,
             Internal::SyncAccountState => refresh_account_state(opts.client_type).await?,
             Internal::RemoveAccount => remove_account(opts.client_type).await?,
+            Internal::GetAccountUsage => get_account_usage(opts.client_type).await?,
             Internal::IsReadyToConnect => is_ready_to_connect(opts.client_type).await?,
             Internal::ListenToStatus => listen_to_status(opts.client_type).await?,
             Internal::ListenToStateChanges => listen_to_state_changes(opts.client_type).await?,
@@ -94,6 +96,8 @@ async fn main() -> Result<()> {
                 reset_device_identity(opts.client_type, args).await?
             }
             Internal::RegisterDevice => register_device(opts.client_type).await?,
+            Internal::GetDevices => get_devices(opts.client_type).await?,
+            Internal::GetActiveDevices => get_active_devices(opts.client_type).await?,
             Internal::RequestZkNym => request_zk_nym(opts.client_type).await?,
             Internal::GetDeviceZkNym => get_device_zk_nym(opts.client_type).await?,
             Internal::GetZkNymsAvailableForDownload => {
@@ -381,6 +385,14 @@ async fn remove_account(client_type: ClientType) -> Result<()> {
     Ok(())
 }
 
+async fn get_account_usage(client_type: ClientType) -> Result<()> {
+    let mut client = vpnd_client::get_client(client_type).await?;
+    let request = tonic::Request::new(GetAccountUsageRequest {});
+    let response = client.get_account_usage(request).await?.into_inner();
+    println!("{:#?}", response);
+    Ok(())
+}
+
 async fn forget_account(client_type: ClientType) -> Result<()> {
     let mut client = vpnd_client::get_client(client_type).await?;
     let request = tonic::Request::new(ForgetAccountRequest {});
@@ -483,6 +495,22 @@ async fn register_device(client_type: ClientType) -> Result<()> {
     let mut client = vpnd_client::get_client(client_type).await?;
     let request = tonic::Request::new(RegisterDeviceRequest {});
     let response = client.register_device(request).await?.into_inner();
+    println!("{:#?}", response);
+    Ok(())
+}
+
+async fn get_devices(client_type: ClientType) -> Result<()> {
+    let mut client = vpnd_client::get_client(client_type).await?;
+    let request = tonic::Request::new(GetDevicesRequest {});
+    let response = client.get_devices(request).await?.into_inner();
+    println!("{:#?}", response);
+    Ok(())
+}
+
+async fn get_active_devices(client_type: ClientType) -> Result<()> {
+    let mut client = vpnd_client::get_client(client_type).await?;
+    let request = tonic::Request::new(GetActiveDevicesRequest {});
+    let response = client.get_active_devices(request).await?.into_inner();
     println!("{:#?}", response);
     Ok(())
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/connection_handler.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/connection_handler.rs
@@ -6,7 +6,7 @@ use nym_vpn_network_config::{FeatureFlags, ParsedAccountLinks, SystemMessages};
 use tokio::sync::{mpsc::UnboundedSender, oneshot};
 
 use nym_vpn_api_client::{
-    response::{NymVpnAccountSummaryResponse, NymVpnDevicesResponse},
+    response::{NymVpnAccountSummaryResponse, NymVpnDevice, NymVpnDevicesResponse, NymVpnUsage},
     types::GatewayMinPerformance,
 };
 use nym_vpn_lib::gateway_directory::{EntryPoint, ExitPoint, GatewayClient, GatewayType};
@@ -189,6 +189,13 @@ impl CommandInterfaceConnectionHandler {
             .await
     }
 
+    pub(crate) async fn handle_get_account_usage(
+        &self,
+    ) -> Result<Result<Vec<NymVpnUsage>, AccountError>, VpnCommandSendError> {
+        self.send_and_wait(VpnServiceCommand::GetAccountUsage, ())
+            .await
+    }
+
     pub(crate) async fn handle_is_ready_to_connect(
         &self,
     ) -> Result<Result<ReadyToConnect, AccountError>, VpnCommandSendError> {
@@ -215,6 +222,19 @@ impl CommandInterfaceConnectionHandler {
         &self,
     ) -> Result<Result<(), AccountError>, VpnCommandSendError> {
         self.send_and_wait(VpnServiceCommand::RegisterDevice, ())
+            .await
+    }
+
+    pub(crate) async fn handle_get_devices(
+        &self,
+    ) -> Result<Result<Vec<NymVpnDevice>, AccountError>, VpnCommandSendError> {
+        self.send_and_wait(VpnServiceCommand::GetDevices, ()).await
+    }
+
+    pub(crate) async fn handle_get_active_devices(
+        &self,
+    ) -> Result<Result<Vec<NymVpnDevice>, AccountError>, VpnCommandSendError> {
+        self.send_and_wait(VpnServiceCommand::GetActiveDevices, ())
             .await
     }
 

--- a/proto/nym/vpn.proto
+++ b/proto/nym/vpn.proto
@@ -794,6 +794,29 @@ message GetAccountStateResponse {
 message RefreshAccountStateRequest {}
 message RefreshAccountStateResponse {}
 
+message AccountUsages {
+  repeated AccountUsage account_usages = 1;
+}
+
+message AccountUsage {
+  string created_on_utc = 1;
+  string last_updated_utc = 2;
+  string id = 3;
+  string subscription_id = 4;
+  string valid_until_utc = 5;
+  string valid_from_utc = 6;
+  double bandwidth_allowance_gb = 7;
+  double bandwidth_used_gb = 8;
+}
+
+message GetAccountUsageRequest {}
+message GetAccountUsageResponse {
+  oneof result {
+    AccountUsages account_usages = 1;
+    AccountError error = 2;
+  }
+}
+
 message FetchRawAccountSummaryRequest {}
 
 message FetchRawAccountSummaryResponse {
@@ -832,6 +855,40 @@ message RegisterDeviceRequest {}
 message RegisterDeviceResponse {
   string json = 1;
   AccountError error = 2;
+}
+
+enum DeviceStatus {
+  DEVICE_STATUS_UNSPECIFIED = 0;
+  DEVICE_STATUS_ACTIVE = 1;
+  DEVICE_STATUS_INACTIVE = 2;
+  DEVICE_STATUS_DELETE_ME = 3;
+}
+
+message Device {
+  string created_on_utc = 1;
+  string last_updated_utc = 2;
+  string device_identity_key = 3;
+  DeviceStatus status = 4;
+}
+
+message Devices {
+  repeated Device devices = 1;
+}
+
+message GetDevicesRequest {}
+message GetDevicesResponse {
+  oneof result {
+    Devices devices = 1;
+    AccountError error = 2;
+  }
+}
+
+message GetActiveDevicesRequest {}
+message GetActiveDevicesResponse {
+  oneof result {
+    Devices devices = 1;
+    AccountError error = 2;
+  }
 }
 
 message RequestZkNymRequest {}
@@ -1040,6 +1097,9 @@ service NymVpnd {
   // background. This command triggers a manual refresh.
   rpc RefreshAccountState (RefreshAccountStateRequest) returns (RefreshAccountStateResponse) {}
 
+  // Get the account usage from the nym-vpn-api
+  rpc GetAccountUsage (GetAccountUsageRequest) returns (GetAccountUsageResponse) {}
+
   // Check if the local account state is ready to connect
   rpc IsReadyToConnect (IsReadyToConnectRequest) returns (IsReadyToConnectResponse) {}
 
@@ -1051,6 +1111,12 @@ service NymVpnd {
 
   // Try to register the local device with the nym-vpn-api
   rpc RegisterDevice (RegisterDeviceRequest) returns (RegisterDeviceResponse) {}
+
+  // Get the list of devices associated with this account from the nym-vpn-api
+  rpc GetDevices (GetDevicesRequest) returns (GetDevicesResponse) {}
+
+  // Get the list of active devices associated with this account from the nym-vpn-api
+  rpc GetActiveDevices (GetActiveDevicesRequest) returns (GetActiveDevicesResponse) {}
 
   // Request new zk-nyms (ticketbooks) from the nym-vpn-api
   rpc RequestZkNym (RequestZkNymRequest) returns (RequestZkNymResponse) {}


### PR DESCRIPTION
Initial work on extending the _internal_ grpc API with functions to get the list of devices and the account usage(s)

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1716)
<!-- Reviewable:end -->
