### PR TITLE
win: bump wg socket on route change

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -5076,6 +5076,7 @@ dependencies = [
  "base64 0.22.1",
  "hex",
  "ipnetwork",
+ "nym-windows",
  "thiserror",
  "tracing",
  "windows-sys 0.52.0",

--- a/nym-vpn-core/crates/nym-routing/src/lib.rs
+++ b/nym-vpn-core/crates/nym-routing/src/lib.rs
@@ -18,7 +18,7 @@ pub mod debounce;
 mod imp;
 
 #[cfg(target_os = "windows")]
-pub use imp::{get_best_default_route, CallbackHandle, EventType, InterfaceAndGateway};
+pub use imp::{get_best_default_route, Callback, CallbackHandle, EventType, InterfaceAndGateway};
 
 #[cfg(not(target_os = "windows"))]
 #[path = "unix/mod.rs"]

--- a/nym-vpn-core/crates/nym-routing/src/windows/route_manager.rs
+++ b/nym-vpn-core/crates/nym-routing/src/windows/route_manager.rs
@@ -107,6 +107,7 @@ enum RecordEventType {
     AddRoute,
 }
 
+/// Default route monitor callback closure.
 pub type Callback = Box<dyn for<'a> Fn(RouteMonitorEventType<'a>, AddressFamily) + Send>;
 
 pub struct RouteManagerInternal {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/route_handler.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/route_handler.rs
@@ -4,8 +4,11 @@
 use std::{collections::HashSet, fmt, net::IpAddr};
 
 use ipnetwork::IpNetwork;
+
 #[cfg(not(target_os = "linux"))]
 use nym_routing::NetNode;
+#[cfg(windows)]
+pub use nym_routing::{Callback, CallbackHandle};
 use nym_routing::{Node, RequiredRoute, RouteManagerHandle};
 
 #[cfg(target_os = "linux")]
@@ -76,6 +79,17 @@ impl RouteHandler {
         if let Err(e) = self.route_manager.clear_routing_rules().await {
             tracing::error!("Failed to remove routing rules: {}", e);
         }
+    }
+
+    #[cfg(windows)]
+    pub async fn add_default_route_listener(
+        &mut self,
+        event_handler: Box<Callback>,
+    ) -> Result<CallbackHandle> {
+        self.route_manager
+            .add_default_route_change_callback(event_handler)
+            .await
+            .map_err(Error::from)
     }
 
     pub async fn stop(self) {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/route_handler.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/route_handler.rs
@@ -84,7 +84,7 @@ impl RouteHandler {
     #[cfg(windows)]
     pub async fn add_default_route_listener(
         &mut self,
-        event_handler: Box<Callback>,
+        event_handler: Callback,
     ) -> Result<CallbackHandle> {
         self.route_manager
             .add_default_route_change_callback(event_handler)

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -6,7 +6,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::tunnel_state_machine::{
     states::{ConnectedState, DisconnectingState},
-    tunnel::{tombstone::Tombstone, SelectedGateways},
+    tunnel::{SelectedGateways, Tombstone},
     tunnel_monitor::{
         TunnelMonitor, TunnelMonitorEvent, TunnelMonitorEventReceiver, TunnelMonitorHandle,
     },

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -68,6 +68,7 @@ impl ConnectingState {
             }
             _shared_state.route_handler.remove_routes().await;
         }
+        #[cfg(windows)]
         tombstone.wg_instances.clear();
         tombstone.tun_devices.clear();
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -3,11 +3,10 @@
 
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
-use tun::AsyncDevice;
 
 use crate::tunnel_state_machine::{
     states::{ConnectedState, DisconnectingState},
-    tunnel::SelectedGateways,
+    tunnel::{tombstone::Tombstone, SelectedGateways},
     tunnel_monitor::{
         TunnelMonitor, TunnelMonitorEvent, TunnelMonitorEventReceiver, TunnelMonitorHandle,
     },
@@ -57,7 +56,7 @@ impl ConnectingState {
         )
     }
 
-    async fn on_tunnel_exit(mut tun_devices: Vec<AsyncDevice>, _shared_state: &mut SharedState) {
+    async fn on_tunnel_exit(mut tombstone: Tombstone, _shared_state: &mut SharedState) {
         #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
         {
             if let Err(e) = _shared_state
@@ -69,7 +68,8 @@ impl ConnectingState {
             }
             _shared_state.route_handler.remove_routes().await;
         }
-        tun_devices.clear();
+        tombstone.wg_instances.clear();
+        tombstone.tun_devices.clear();
     }
 }
 
@@ -108,8 +108,8 @@ impl TunnelStateHandler for ConnectingState {
                     if let Some(reason) = reason {
                         NextTunnelState::NewState(DisconnectingState::enter(PrivateActionAfterDisconnect::Error(reason), self.monitor_handle, shared_state))
                     } else {
-                        let tun_devices = self.monitor_handle.wait().await;
-                        Self::on_tunnel_exit(tun_devices, shared_state).await;
+                        let tombstone = self.monitor_handle.wait().await;
+                        Self::on_tunnel_exit(tombstone, shared_state).await;
 
                         NextTunnelState::NewState(ConnectingState::enter(self.retry_attempt.saturating_add(1), self.selected_gateways, shared_state))
                     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnecting_state.rs
@@ -7,7 +7,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::tunnel_state_machine::{
     states::{ConnectingState, DisconnectedState, ErrorState},
-    tunnel::tombstone::Tombstone,
+    tunnel::Tombstone,
     tunnel_monitor::TunnelMonitorHandle,
     NextTunnelState, PrivateActionAfterDisconnect, PrivateTunnelState, SharedState, TunnelCommand,
     TunnelStateHandler,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnecting_state.rs
@@ -64,8 +64,9 @@ impl DisconnectingState {
         _shared_state.route_handler.remove_routes().await;
 
         tracing::info!("Closing {} tunnel device(s).", tombstone.tun_devices.len());
-        tombstone.tun_devices.clear();
+        #[cfg(windows)]
         tombstone.wg_instances.clear();
+        tombstone.tun_devices.clear();
 
         // todo: reset firewall
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnecting_state.rs
@@ -4,16 +4,16 @@
 use futures::future::{BoxFuture, Fuse, FutureExt};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
-use tun::AsyncDevice;
 
 use crate::tunnel_state_machine::{
     states::{ConnectingState, DisconnectedState, ErrorState},
+    tunnel::tombstone::Tombstone,
     tunnel_monitor::TunnelMonitorHandle,
     NextTunnelState, PrivateActionAfterDisconnect, PrivateTunnelState, SharedState, TunnelCommand,
     TunnelStateHandler,
 };
 
-type WaitHandle = BoxFuture<'static, Vec<AsyncDevice>>;
+type WaitHandle = BoxFuture<'static, Tombstone>;
 
 pub struct DisconnectingState {
     after_disconnect: PrivateActionAfterDisconnect,
@@ -50,7 +50,7 @@ impl DisconnectingState {
         )
     }
 
-    async fn on_tunnel_exit(mut tun_devices: Vec<AsyncDevice>, _shared_state: &mut SharedState) {
+    async fn on_tunnel_exit(mut tombstone: Tombstone, _shared_state: &mut SharedState) {
         #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
         if let Err(e) = _shared_state
             .dns_handler
@@ -63,8 +63,9 @@ impl DisconnectingState {
         #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
         _shared_state.route_handler.remove_routes().await;
 
-        tracing::info!("Closing {} tunnel device(s).", tun_devices.len());
-        tun_devices.clear();
+        tracing::info!("Closing {} tunnel device(s).", tombstone.tun_devices.len());
+        tombstone.tun_devices.clear();
+        tombstone.wg_instances.clear();
 
         // todo: reset firewall
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/any_tunnel_handle.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/any_tunnel_handle.rs
@@ -1,9 +1,7 @@
 // Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use super::{Error, Result};
-
-use tun::AsyncDevice;
+use super::{tombstone::Tombstone, Error, Result};
 
 use super::{
     mixnet::connected_tunnel::TunnelHandle as MixnetTunnelHandle,
@@ -48,17 +46,20 @@ impl AnyTunnelHandle {
         }
     }
 
-    pub async fn wait(self) -> Result<Vec<AsyncDevice>> {
+    pub async fn wait(self) -> Result<Tombstone> {
         match self {
             Self::Mixnet(handle) => match handle.wait().await {
-                Ok(Ok(device)) => Ok(vec![device]),
+                Ok(Ok(tombstone)) => Ok(tombstone),
                 Ok(Err(e)) => Err(Error::MixnetClient(e)),
                 Err(e) => {
                     tracing::error!("Failed to join on mixnet tunnel handle: {}", e);
-                    Ok(vec![])
+                    Ok(Tombstone::default())
                 }
             },
-            Self::Wireguard(handle) => Ok(handle.wait().await),
+            Self::Wireguard(handle) => handle.wait().await.or_else(|e| {
+                tracing::error!("Failed to join on wireguard tunnel handle: {}", e);
+                Ok(Tombstone::default())
+            }),
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/any_tunnel_handle.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/any_tunnel_handle.rs
@@ -1,7 +1,7 @@
 // Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use super::{tombstone::Tombstone, Error, Result};
+use super::{Error, Result, Tombstone};
 
 use super::{
     mixnet::connected_tunnel::TunnelHandle as MixnetTunnelHandle,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mixnet/connected_tunnel.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mixnet/connected_tunnel.rs
@@ -10,7 +10,10 @@ use tun::AsyncDevice;
 use nym_task::TaskManager;
 
 use super::connector::AssignedAddresses;
-use crate::mixnet::{MixnetError, SharedMixnetClient};
+use crate::{
+    mixnet::{MixnetError, SharedMixnetClient},
+    tunnel_state_machine::tunnel::tombstone::Tombstone,
+};
 
 /// Type representing a connected mixnet tunnel.
 pub struct ConnectedTunnel {
@@ -92,7 +95,9 @@ impl TunnelHandle {
     }
 
     /// Wait until the tunnel finished execution.
-    pub async fn wait(self) -> Result<Result<AsyncDevice, MixnetError>, JoinError> {
-        self.processor_handle.await
+    pub async fn wait(self) -> Result<Result<Tombstone, MixnetError>, JoinError> {
+        self.processor_handle
+            .await
+            .map(|result| result.map(Tombstone::with_tun_device))
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mixnet/connected_tunnel.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mixnet/connected_tunnel.rs
@@ -12,7 +12,7 @@ use nym_task::TaskManager;
 use super::connector::AssignedAddresses;
 use crate::{
     mixnet::{MixnetError, SharedMixnetClient},
-    tunnel_state_machine::tunnel::tombstone::Tombstone,
+    tunnel_state_machine::tunnel::Tombstone,
 };
 
 /// Type representing a connected mixnet tunnel.

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
@@ -1,11 +1,11 @@
 // Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-pub mod any_tunnel_handle;
+mod any_tunnel_handle;
 mod gateway_selector;
 pub mod mixnet;
 mod status_listener;
-pub mod tombstone;
+mod tombstone;
 pub mod wireguard;
 
 use std::{error::Error as StdError, fmt, net::IpAddr, path::PathBuf, time::Duration};
@@ -25,7 +25,9 @@ use crate::{
     bandwidth_controller::ReconnectMixnetClientData, mixnet::SharedMixnetClient,
     GatewayDirectoryError, MixnetClientConfig, MixnetError,
 };
+pub use any_tunnel_handle::AnyTunnelHandle;
 use status_listener::StatusListener;
+pub use tombstone::Tombstone;
 
 pub(crate) const MIXNET_CLIENT_STARTUP_TIMEOUT: Duration = Duration::from_secs(30);
 pub(crate) const TASK_MANAGER_SHUTDOWN_TIMER_SECS: u64 = 10;

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
@@ -5,6 +5,7 @@ pub mod any_tunnel_handle;
 mod gateway_selector;
 pub mod mixnet;
 mod status_listener;
+pub mod tombstone;
 pub mod wireguard;
 
 use std::{error::Error as StdError, fmt, net::IpAddr, path::PathBuf, time::Duration};
@@ -17,7 +18,7 @@ use nym_task::{TaskManager, TaskStatus};
 use tokio::{sync::mpsc, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
 
-use super::{MixnetEvent, TunnelType};
+use super::{route_handler, MixnetEvent, TunnelType};
 use crate::{
     bandwidth_controller::ReconnectMixnetClientData, mixnet::SharedMixnetClient,
     GatewayDirectoryError, MixnetClientConfig, MixnetError,
@@ -293,6 +294,10 @@ pub enum Error {
     #[cfg(target_os = "ios")]
     #[error("failed to set default path observer: {0}")]
     SetDefaultPathObserver(String),
+
+    #[cfg(windows)]
+    #[error("failed to add default route listener: {0}")]
+    AddDefaultRouteListener(#[source] route_handler::Error),
 
     #[error("connection cancelled")]
     Cancelled,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
@@ -18,7 +18,9 @@ use nym_task::{TaskManager, TaskStatus};
 use tokio::{sync::mpsc, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
 
-use super::{route_handler, MixnetEvent, TunnelType};
+#[cfg(windows)]
+use super::route_handler;
+use super::{MixnetEvent, TunnelType};
 use crate::{
     bandwidth_controller::ReconnectMixnetClientData, mixnet::SharedMixnetClient,
     GatewayDirectoryError, MixnetClientConfig, MixnetError,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/status_listener.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/status_listener.rs
@@ -30,9 +30,8 @@ impl StatusListener {
 
         while let Some(msg) = self.rx.next().await {
             if let Some(msg) = msg.as_any().downcast_ref::<TaskStatus>() {
-                tracing::info!("Received ignored TaskStatus message: {msg}");
+                tracing::debug!("Received ignored TaskStatus message: {msg}");
             } else if let Some(msg) = msg.as_any().downcast_ref::<ConnectionMonitorStatus>() {
-                tracing::info!("VPN connection monitor status: {msg}");
                 self.send_event(MixnetEvent::Connection(ConnectionEvent::from(msg)));
             } else if let Some(msg) = msg.as_any().downcast_ref::<BandwidthStatusMessage>() {
                 self.send_event(MixnetEvent::Bandwidth(BandwidthEvent::from(msg)));
@@ -40,12 +39,10 @@ impl StatusListener {
                 .as_any()
                 .downcast_ref::<MixnetBandwidthStatisticsEvent>()
             {
-                tracing::info!("Mixnet bandwidth: {msg}");
                 self.send_event(MixnetEvent::ConnectionStatistics(
                     ConnectionStatisticsEvent::from(msg),
                 ));
             } else {
-                tracing::warn!("VPN status: unknown: {msg}");
                 tracing::debug!("Unknown status message received: {msg}");
             }
         }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/tombstone.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/tombstone.rs
@@ -1,0 +1,21 @@
+use tun::AsyncDevice;
+
+/// Holds the remains of the mixnet or wireguard tunnel.
+#[derive(Default)]
+pub struct Tombstone {
+    /// Tunnel devices that are no longer in use by the tunnel.
+    pub tun_devices: Vec<tun::AsyncDevice>,
+
+    /// Wireguard tunnels that have not been shutdown yet because they own the tunnel device.
+    /// So we need to keep them around until after the routing table is reset. Windows only.
+    pub wg_instances: Vec<nym_wg_go::wireguard_go::Tunnel>,
+}
+
+impl Tombstone {
+    pub fn with_tun_device(tun_device: AsyncDevice) -> Self {
+        Self {
+            tun_devices: vec![tun_device],
+            ..Default::default()
+        }
+    }
+}

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/tombstone.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/tombstone.rs
@@ -7,7 +7,8 @@ pub struct Tombstone {
     pub tun_devices: Vec<tun::AsyncDevice>,
 
     /// Wireguard tunnels that have not been shutdown yet because they own the tunnel device.
-    /// So we need to keep them around until after the routing table is reset. Windows only.
+    /// These tunnels are kept around until after the routing table is reset. Windows only.
+    #[cfg(windows)]
     pub wg_instances: Vec<nym_wg_go::wireguard_go::Tunnel>,
 }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/tombstone.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/tombstone.rs
@@ -13,10 +13,26 @@ pub struct Tombstone {
 }
 
 impl Tombstone {
+    /// Convenience initializer that creates a tombstone with a single tunnel device.
     pub fn with_tun_device(tun_device: AsyncDevice) -> Self {
+        Self::with_tun_devices(vec![tun_device])
+    }
+
+    /// Creates a tombstone with tunnel devices.
+    pub fn with_tun_devices(tun_devices: Vec<AsyncDevice>) -> Self {
         Self {
-            tun_devices: vec![tun_device],
-            ..Default::default()
+            tun_devices: tun_devices,
+            #[cfg(windows)]
+            wg_instances: Vec::new(),
+        }
+    }
+
+    /// Creates a tombstone with wireguard tunnel instances.
+    #[cfg(windows)]
+    pub fn with_wg_instances(wg_instances: Vec<nym_wg_go::wireguard_go::Tunnel>) {
+        Self {
+            tun_devices: Vec::new(),
+            wg_instances,
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/tombstone.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/tombstone.rs
@@ -29,7 +29,7 @@ impl Tombstone {
 
     /// Creates a tombstone with wireguard tunnel instances.
     #[cfg(windows)]
-    pub fn with_wg_instances(wg_instances: Vec<nym_wg_go::wireguard_go::Tunnel>) {
+    pub fn with_wg_instances(wg_instances: Vec<nym_wg_go::wireguard_go::Tunnel>) -> Self {
         Self {
             tun_devices: Vec::new(),
             wg_instances,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/tombstone.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/tombstone.rs
@@ -21,7 +21,7 @@ impl Tombstone {
     /// Creates a tombstone with tunnel devices.
     pub fn with_tun_devices(tun_devices: Vec<AsyncDevice>) -> Self {
         Self {
-            tun_devices: tun_devices,
+            tun_devices,
             #[cfg(windows)]
             wg_instances: Vec::new(),
         }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
@@ -26,9 +26,8 @@ use crate::tunnel_state_machine::route_handler::RouteHandler;
 use crate::tunnel_state_machine::tunnel::wireguard::fd::DupFd;
 use crate::{
     tunnel_state_machine::tunnel::{
-        tombstone::Tombstone,
         wireguard::{connector::ConnectionData, two_hop_config::TwoHopConfig},
-        Error, Result,
+        Error, Result, Tombstone,
     },
     wg_config::WgNodeConfig,
 };

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
@@ -302,7 +302,7 @@ impl ConnectedTunnel {
 
         Ok(TunnelHandle {
             task_manager: self.task_manager,
-            shutdown_token: CancellationToken::new(),
+            shutdown_token,
             event_handler_task,
             bandwidth_controller_handle: self.bandwidth_controller_handle,
             #[cfg(windows)]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
@@ -3,21 +3,33 @@
 
 use std::{error::Error as StdError, net::IpAddr};
 
-use tokio::task::JoinHandle;
-use tun::AsyncDevice;
+use nym_routing::{Callback, EventType};
+use tokio::{
+    sync::mpsc,
+    task::{JoinError, JoinHandle},
+};
+use tokio_util::sync::CancellationToken;
 
+#[cfg(windows)]
+use nym_routing::CallbackHandle;
 use nym_task::TaskManager;
 use nym_wg_gateway_client::WgGatewayClient;
 #[cfg(windows)]
 use nym_wg_go::wireguard_go::WintunInterface;
 use nym_wg_go::{netstack, wireguard_go};
+#[cfg(windows)]
+use nym_windows::net::AddressFamily;
 
 #[cfg(unix)]
 use crate::tunnel_state_machine::tunnel::wireguard::fd::DupFd;
 use crate::{
-    tunnel_state_machine::tunnel::{
-        wireguard::{connector::ConnectionData, two_hop_config::TwoHopConfig},
-        Error, Result,
+    tunnel_state_machine::{
+        route_handler::RouteHandler,
+        tunnel::{
+            tombstone::Tombstone,
+            wireguard::{connector::ConnectionData, two_hop_config::TwoHopConfig},
+            Error, Result,
+        },
     },
     wg_config::WgNodeConfig,
 };
@@ -61,14 +73,24 @@ impl ConnectedTunnel {
         1340
     }
 
-    pub fn run(self, options: TunnelOptions) -> Result<TunnelHandle> {
+    pub async fn run(
+        self,
+        #[cfg(windows)] route_handler: RouteHandler,
+        options: TunnelOptions,
+    ) -> Result<TunnelHandle> {
         match options {
-            TunnelOptions::TunTun(tuntun_options) => self.run_using_tun_tun(tuntun_options),
+            TunnelOptions::TunTun(tuntun_options) => {
+                self.run_using_tun_tun(route_handler, tuntun_options).await
+            }
             TunnelOptions::Netstack(netstack_options) => self.run_using_netstack(netstack_options),
         }
     }
 
-    fn run_using_tun_tun(self, options: TunTunTunnelOptions) -> Result<TunnelHandle> {
+    async fn run_using_tun_tun(
+        self,
+        #[cfg(windows)] route_handler: RouteHandler,
+        options: TunTunTunnelOptions,
+    ) -> Result<TunnelHandle> {
         let wg_entry_config = WgNodeConfig::with_gateway_data(
             self.connection_data.entry.clone(),
             self.entry_gateway_client.keypair().private_key(),
@@ -83,7 +105,7 @@ impl ConnectedTunnel {
             self.exit_mtu(),
         );
 
-        let entry_tunnel = wireguard_go::Tunnel::start(
+        let mut entry_tunnel = wireguard_go::Tunnel::start(
             wg_entry_config.into_wireguard_config(),
             #[cfg(unix)]
             options.entry_tun.get_ref().dup_fd().map_err(Error::DupFd)?,
@@ -109,17 +131,64 @@ impl ConnectedTunnel {
         )
         .map_err(Error::Wireguard)?;
 
+        let shutdown_token = CancellationToken::new();
+        let child_shutdown_token = shutdown_token.child_token();
+
+        #[cfg(windows)]
+        let wintun_entry_interface = entry_tunnel.wintun_interface().clone();
+        #[cfg(windows)]
+        let wintun_exit_interface = exit_tunnel.wintun_interface().clone();
+
+        let event_handler_task = tokio::spawn(async move {
+            #[cfg(windows)]
+            {
+                let (default_route_tx, mut default_route_rx) = mpsc::unbounded_channel();
+                let _callback = Self::add_default_route_listener(route_handler, default_route_tx);
+
+                loop {
+                    tokio::select! {
+                        _ = child_shutdown_token.cancelled() => {
+                            tracing::debug!("Received tunnel shutdown event. Exiting event loop.");
+                            break
+                        }
+                        Some((interface_index, address_family)) = default_route_rx.recv() => {
+                            tracing::debug!("New default route: {} {}", interface_index, address_family);
+                            entry_tunnel.rebind_tunnel_socket(address_family, interface_index);
+                        }
+                        else => {
+                            tracing::error!("Default route listener has been dropped. Exiting event loop.");
+                            break;
+                        }
+                    }
+                }
+            }
+
+            #[cfg(not(windows))]
+            {
+                child_shutdown_token.cancelled().await;
+                tracing::debug!("Received tunnel shutdown event. Exiting event loop.");
+            }
+
+            Tombstone {
+                #[cfg(not(windows))]
+                tun_devices: vec![options.exit_tun, options.entry_tun],
+
+                #[cfg(windows)]
+                wg_instances: vec![exit_tunnel, entry_tunnel],
+
+                ..Default::default()
+            }
+        });
+
         Ok(TunnelHandle {
             task_manager: self.task_manager,
-            internal_handle: InternalTunnelHandle::TunTun {
-                #[cfg(unix)]
-                entry_tun: options.entry_tun,
-                #[cfg(unix)]
-                exit_tun: options.exit_tun,
-                entry_wg_tunnel: Some(entry_tunnel),
-                exit_wg_tunnel: Some(exit_tunnel),
-            },
+            shutdown_token,
+            event_handler_task,
             bandwidth_controller_handle: self.bandwidth_controller_handle,
+            #[cfg(windows)]
+            wintun_entry_interface: Some(wintun_entry_interface),
+            #[cfg(windows)]
+            wintun_exit_interface: Some(wintun_exit_interface),
         })
     }
 
@@ -162,17 +231,79 @@ impl ConnectedTunnel {
             &options.wintun_tunnel_type,
         )?;
 
+        #[cfg(windows)]
+        let wintun_exit_interface = exit_tunnel.wintun_interface().clone();
+
+        let shutdown_token = CancellationToken::new();
+        let child_shutdown_token = shutdown_token.child_token();
+
+        let event_handler_task = tokio::spawn(async move {
+            child_shutdown_token.cancelled().await;
+
+            entry_tunnel.stop();
+            exit_connection.close();
+
+            // Windows: do not drop exit tunnel as it owns the underlying tunnel device.
+            #[cfg(not(windows))]
+            exit_tunnel.stop();
+
+            Tombstone {
+                tun_devices: vec![
+                    #[cfg(not(windows))]
+                    options.exit_tun,
+                ],
+                wg_instances: vec![
+                    #[cfg(windows)]
+                    exit_tunnel,
+                ],
+            }
+        });
+
         Ok(TunnelHandle {
             task_manager: self.task_manager,
-            internal_handle: InternalTunnelHandle::Netstack {
-                #[cfg(unix)]
-                exit_tun: options.exit_tun,
-                entry_wg_tunnel: Some(entry_tunnel),
-                exit_wg_tunnel: Some(exit_tunnel),
-                exit_connection: Some(exit_connection),
-            },
+            shutdown_token: CancellationToken::new(),
+            event_handler_task,
             bandwidth_controller_handle: self.bandwidth_controller_handle,
+            #[cfg(windows)]
+            wintun_entry_interface: None,
+            #[cfg(windows)]
+            wintun_exit_interface: Some(wintun_exit_interface),
         })
+    }
+
+    #[cfg(windows)]
+    async fn add_default_route_listener(
+        mut route_handler: RouteHandler,
+        tx: mpsc::UnboundedSender<(u32, AddressFamily)>,
+    ) -> Result<CallbackHandle> {
+        let boxed_fn: Callback = Box::new(move |event, address_family| {
+            let result = match event {
+                EventType::Removed => {
+                    // Bind to blackhole when default route is no longer available.
+                    Ok(0)
+                }
+                EventType::Updated(interface_and_gateway)
+                | EventType::UpdatedDetails(interface_and_gateway) => {
+                    nym_windows::net::index_from_luid(&interface_and_gateway.iface)
+                }
+            };
+
+            match result {
+                Ok(interface_index) => {
+                    if let Err(e) = tx.send((interface_index, address_family)) {
+                        tracing::error!("Failed to send new default route over the channel: {}", e);
+                    }
+                }
+                Err(e) => {
+                    tracing::error!("Failed to convert luid to interface index: {}", e);
+                }
+            }
+        });
+
+        route_handler
+            .add_default_route_listener(Box::new(boxed_fn))
+            .await
+            .map_err(Error::AddDefaultRouteListener)
     }
 }
 
@@ -240,64 +371,21 @@ pub struct NetstackTunnelOptions {
     pub dns: Vec<IpAddr>,
 }
 
-enum InternalTunnelHandle {
-    TunTun {
-        #[cfg(unix)]
-        entry_tun: AsyncDevice,
-        #[cfg(unix)]
-        exit_tun: AsyncDevice,
-        entry_wg_tunnel: Option<wireguard_go::Tunnel>,
-        exit_wg_tunnel: Option<wireguard_go::Tunnel>,
-    },
-    Netstack {
-        #[cfg(unix)]
-        exit_tun: AsyncDevice,
-        entry_wg_tunnel: Option<netstack::Tunnel>,
-        exit_wg_tunnel: Option<wireguard_go::Tunnel>,
-        exit_connection: Option<netstack::TunnelConnection>,
-    },
-}
-
 pub struct TunnelHandle {
     task_manager: TaskManager,
-    internal_handle: InternalTunnelHandle,
+    shutdown_token: CancellationToken,
+    event_handler_task: JoinHandle<Tombstone>,
     bandwidth_controller_handle: JoinHandle<()>,
+    #[cfg(windows)]
+    wintun_entry_interface: Option<WintunInterface>,
+    #[cfg(windows)]
+    wintun_exit_interface: Option<WintunInterface>,
 }
 
 impl TunnelHandle {
     /// Close entry and exit WireGuard tunnels and signal mixnet facilities shutdown.
     pub fn cancel(&mut self) {
-        match self.internal_handle {
-            InternalTunnelHandle::Netstack {
-                ref mut entry_wg_tunnel,
-                ref mut exit_wg_tunnel,
-                ref mut exit_connection,
-                ..
-            } => {
-                if let Some(exit_wg_tunnel) = exit_wg_tunnel.take() {
-                    exit_wg_tunnel.stop();
-                }
-                if let Some(exit_connection) = exit_connection.take() {
-                    exit_connection.close();
-                }
-                if let Some(entry_wg_tunnel) = entry_wg_tunnel.take() {
-                    entry_wg_tunnel.stop();
-                }
-            }
-            InternalTunnelHandle::TunTun {
-                ref mut entry_wg_tunnel,
-                ref mut exit_wg_tunnel,
-                ..
-            } => {
-                if let Some(entry_wg_tunnel) = entry_wg_tunnel.take() {
-                    entry_wg_tunnel.stop();
-                }
-
-                if let Some(exit_wg_tunnel) = exit_wg_tunnel.take() {
-                    exit_wg_tunnel.stop();
-                }
-            }
-        }
+        self.shutdown_token.cancel();
 
         if let Err(e) = self.task_manager.signal_shutdown() {
             tracing::error!("Failed to signal task manager shutdown: {}", e);
@@ -314,57 +402,25 @@ impl TunnelHandle {
 
     /// Wait until the tunnel finished execution.
     ///
-    /// Returns a pair of tun devices no longer in use.
-    pub async fn wait(self) -> Vec<AsyncDevice> {
+    /// Returns a tombstone containing the no longer used tunnel devices and wireguard tunnels (on Windows).
+    pub async fn wait(self) -> Result<Tombstone, JoinError> {
         if let Err(e) = self.bandwidth_controller_handle.await {
             tracing::error!("Failed to join on bandwidth controller: {}", e);
         }
 
-        #[cfg(unix)]
-        {
-            match self.internal_handle {
-                InternalTunnelHandle::Netstack { exit_tun, .. } => {
-                    vec![exit_tun]
-                }
-                InternalTunnelHandle::TunTun {
-                    entry_tun,
-                    exit_tun,
-                    ..
-                } => {
-                    vec![entry_tun, exit_tun]
-                }
-            }
-        }
-
-        #[cfg(windows)]
-        vec![]
+        self.event_handler_task.await
     }
 
     /// Returns entry wintun interface descriptor when available.
     /// Note: netstack based tunnel uses virtual adapter so it will always return `None`.
     #[cfg(windows)]
     pub fn entry_wintun_interface(&self) -> Option<&WintunInterface> {
-        match &self.internal_handle {
-            InternalTunnelHandle::Netstack { .. } => {
-                // Netstack tunnel does not use wintun interface.
-                None
-            }
-            InternalTunnelHandle::TunTun {
-                entry_wg_tunnel, ..
-            } => Some(entry_wg_tunnel.as_ref()?.wintun_interface()),
-        }
+        self.wintun_entry_interface.as_ref()
     }
 
     /// Returns exit wintun interface descriptor when available.
     #[cfg(windows)]
     pub fn exit_wintun_interface(&self) -> Option<&WintunInterface> {
-        match &self.internal_handle {
-            InternalTunnelHandle::Netstack { exit_wg_tunnel, .. } => {
-                Some(exit_wg_tunnel.as_ref()?.wintun_interface())
-            }
-            InternalTunnelHandle::TunTun { exit_wg_tunnel, .. } => {
-                Some(exit_wg_tunnel.as_ref()?.wintun_interface())
-            }
-        }
+        self.wintun_exit_interface.as_ref()
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
@@ -184,10 +184,8 @@ impl ConnectedTunnel {
             Tombstone {
                 #[cfg(not(windows))]
                 tun_devices: vec![options.exit_tun, options.entry_tun],
-
                 #[cfg(windows)]
                 wg_instances: vec![exit_tunnel, entry_tunnel],
-
                 ..Default::default()
             }
         });
@@ -295,10 +293,8 @@ impl ConnectedTunnel {
                     #[cfg(not(windows))]
                     options.exit_tun,
                 ],
-                wg_instances: vec![
-                    #[cfg(windows)]
-                    exit_tunnel,
-                ],
+                #[cfg(windows)]
+                wg_instances: vec![exit_tunnel],
             }
         });
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/mobile.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/mobile.rs
@@ -5,7 +5,7 @@ use std::{error::Error as StdError, net::IpAddr, sync::Arc};
 
 #[cfg(target_os = "ios")]
 use tokio::sync::mpsc;
-use tokio::task::JoinHandle;
+use tokio::task::{JoinError, JoinHandle};
 use tokio_util::sync::CancellationToken;
 use tun::AsyncDevice;
 
@@ -216,7 +216,7 @@ impl ConnectedTunnel {
 pub struct TunnelHandle {
     task_manager: TaskManager,
     shutdown_token: CancellationToken,
-    event_loop_handle: JoinHandle<()>,
+    event_loop_handle: JoinHandle<Tombstone>,
     bandwidth_controller_handle: JoinHandle<()>,
 }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/mobile.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/mobile.rs
@@ -22,13 +22,12 @@ use crate::{
 };
 use crate::{
     tunnel_state_machine::tunnel::{
-        tombstone::Tombstone,
         wireguard::{
             connector::ConnectionData,
             fd::DupFd,
             two_hop_config::{TwoHopConfig, ENTRY_MTU, EXIT_MTU},
         },
-        Error, Result,
+        Error, Result, Tombstone,
     },
     wg_config::WgNodeConfig,
 };

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/mobile.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/mobile.rs
@@ -202,10 +202,7 @@ impl ConnectedTunnel {
             exit_connection.close();
             entry_tunnel.stop();
 
-            Tombstone {
-                tun_devices: vec![tun_device],
-                ..Default::default()
-            }
+            Tombstone::with_tun_device(tun_device)
         });
 
         Ok(TunnelHandle {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -477,7 +477,7 @@ impl TunnelMonitor {
             dns: self.tunnel_settings.dns.ip_addresses().to_vec(),
         });
 
-        let tunnel_handle = connected_tunnel.run(tunnel_options)?;
+        let tunnel_handle = connected_tunnel.run(tunnel_options).await?;
 
         let any_tunnel_handle = AnyTunnelHandle::from(tunnel_handle);
 
@@ -602,7 +602,7 @@ impl TunnelMonitor {
             dns: self.tunnel_settings.dns.ip_addresses().to_vec(),
         });
 
-        let tunnel_handle = connected_tunnel.run(tunnel_options)?;
+        let tunnel_handle = connected_tunnel.run(tunnel_options).await?;
         let any_tunnel_handle = AnyTunnelHandle::from(tunnel_handle);
 
         Ok((tunnel_conn_data, any_tunnel_handle))

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -31,8 +31,7 @@ use super::{dns_handler::DnsHandlerHandle, route_handler::RouteHandler};
 use super::{route_handler::RoutingConfig, tun_ipv6};
 use super::{
     tunnel::{
-        self, any_tunnel_handle::AnyTunnelHandle, tombstone::Tombstone, ConnectedMixnet,
-        MixnetConnectOptions, SelectedGateways,
+        self, AnyTunnelHandle, ConnectedMixnet, MixnetConnectOptions, SelectedGateways, Tombstone,
     },
     ConnectionData, Error, ErrorStateReason, MixnetConnectionData, MixnetEvent, NymConfig, Result,
     TunnelConnectionData, TunnelSettings, TunnelType, WireguardConnectionData, WireguardNode,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -498,7 +498,7 @@ impl TunnelMonitor {
             interface_ipv4: conn_data.exit.private_ipv4,
             interface_ipv6: conn_data.exit.private_ipv6,
             gateway_ipv4: Some(conn_data.entry.private_ipv4),
-            gateway_ipv6: Some(conn_data.exit.private_ipv6),
+            gateway_ipv6: Some(conn_data.entry.private_ipv6),
         };
 
         let tunnel_conn_data = TunnelConnectionData::Wireguard(WireguardConnectionData {

--- a/nym-vpn-core/crates/nym-wg-go/Cargo.toml
+++ b/nym-vpn-core/crates/nym-wg-go/Cargo.toml
@@ -19,3 +19,4 @@ zeroize.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = ["Win32_NetworkManagement_Ndis"] }
+nym-windows = { path = "../nym-windows" }

--- a/nym-vpn-core/crates/nym-wg-go/src/wireguard_go.rs
+++ b/nym-vpn-core/crates/nym-wg-go/src/wireguard_go.rs
@@ -273,7 +273,7 @@ extern "C" {
         logging_context: *mut c_void,
     ) -> i32;
 
-    /// Pass a handle that was created by wgTurnOn to stop a wireguard tunnel.
+    /// Pass a handle that was created by wgTurnOn to stop the wireguard tunnel.
     fn wgTurnOff(handle: i32);
 
     /// Returns the config of the WireGuard interface.

--- a/wireguard/build-wireguard-go.sh
+++ b/wireguard/build-wireguard-go.sh
@@ -41,7 +41,7 @@ function parseArgs {
       esac
     done
 
-    echo "android:$IS_ANDROID_BUILD ios:$IS_IOS_BUILD docker:$IS_DOCKER_BUILD windows:$IS_WIN_CROSS_BUILD win_arm64:$IS_WIN_ARM64"
+    echo "android:$IS_ANDROID_BUILD ios:$IS_IOS_BUILD docker:$IS_DOCKER_BUILD windows-cross:$IS_WIN_CROSS_BUILD win_arm64:$IS_WIN_ARM64"
 }
 
 function win_gather_export_symbols {

--- a/wireguard/build-wireguard-go.sh
+++ b/wireguard/build-wireguard-go.sh
@@ -45,7 +45,7 @@ function parseArgs {
 }
 
 function win_gather_export_symbols {
-   grep -Eo "\/\/export \w+" libwg.go libwg_windows.go netstack.go netstack_default.go | cut -d' ' -f2
+   grep -Eo "\/\/export \w+" libwg.go libwg_windows.go netstack.go netstack_default.go netstack_bind_windows.go | cut -d' ' -f2
 }
 
 function win_create_lib_file {

--- a/wireguard/build-wireguard-go.sh
+++ b/wireguard/build-wireguard-go.sh
@@ -26,7 +26,7 @@ function parseArgs {
         "--no-docker" )
             IS_DOCKER_BUILD=false;
             shift ;;
-        # handle --windows option (allowing windows build from linux for example)
+        # handle --windows-cross option (allowing windows build from linux for example)
         "--windows-cross" )
             IS_WIN_CROSS_BUILD=true;
             shift ;;

--- a/wireguard/libwg/netstack_bind_windows.go
+++ b/wireguard/libwg/netstack_bind_windows.go
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2024 Nym Technologies SA <contact@nymtech.net>. All Rights Reserved.
+ */
+
+package main
+
+import "C"
+import (
+	"golang.org/x/sys/windows"
+	"golang.zx2c4.com/wireguard/conn"
+)
+
+//export wgNetRebindTunnelSocket
+func wgNetRebindTunnelSocket(family uint16, interfaceIndex uint32) {
+	netTunnelHandles.ForEach(func(tunnel NetTunnelHandle) {
+		blackhole := (interfaceIndex == 0)
+		bind := tunnel.Device.Bind().(conn.BindSocketToInterface)
+
+		if family == windows.AF_INET {
+			tunnel.Logger.Verbosef("Binding v4 socket to interface %d (blackhole=%v)\n", interfaceIndex, blackhole)
+			err := bind.BindSocketToInterface4(interfaceIndex, blackhole)
+			if err != nil {
+				tunnel.Logger.Verbosef("%s\n", err)
+			}
+		} else if family == windows.AF_INET6 {
+			tunnel.Logger.Verbosef("Binding v6 socket to interface %d (blackhole=%v)\n", interfaceIndex, blackhole)
+			err := bind.BindSocketToInterface6(interfaceIndex, blackhole)
+			if err != nil {
+				tunnel.Logger.Verbosef("%s\n", err)
+			}
+		}
+	})
+}

--- a/wireguard/libwg/netstack_default.go
+++ b/wireguard/libwg/netstack_default.go
@@ -95,8 +95,6 @@ func wgNetSetConfig(tunnelHandle int32, settings *C.char) int64 {
 		return ERROR_GENERAL_FAILURE
 	}
 
-	dev.DisableSomeRoamingForBrokenMobileSemantics()
-
 	return 0
 }
 


### PR DESCRIPTION
- Add default route monitoring on windows and rebind tunnel socket on route change.
- Introduce `Tombstone` struct holding the remains of tunnel device or wireguard-go tunnels. 
  This struct unifies the return type of a tunnel handle at the end of its lifecycle.
  _On Windows_ where wireguard-go tunnels create and own the wintun interface, dropping the tunnel also drops the wintun adapter, which interferes with the routing table. Instead the tunnels that own the tunnel interface are kept alive, for a very brief moment, until the routing table and dns are fully reset.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1719)
<!-- Reviewable:end -->
