### PR TITLE
fixed clashing 'short' option names

### DIFF
--- a/nym-vpn-core/crates/nym-gateway-probe/src/run.rs
+++ b/nym-vpn-core/crates/nym-gateway-probe/src/run.rs
@@ -26,16 +26,16 @@ struct CliArgs {
     #[arg(long, short)]
     gateway: Option<String>,
 
-    #[arg(long, short)]
+    #[arg(long)]
     min_gateway_mixnet_performance: Option<u8>,
 
-    #[arg(long, short)]
+    #[arg(long)]
     min_gateway_vpn_performance: Option<u8>,
 
-    #[arg(long, short)]
+    #[arg(long)]
     only_wireguard: bool,
 
-    #[arg(long, short)]
+    #[arg(long)]
     no_log: bool,
 }
 


### PR DESCRIPTION
without it, the probe was crashing with
```
Command nym-gateway-probe: Short option names must be unique for each argument, but '-m' is in use by both 'min_gateway_mixnet_performance' and 'min_gateway_vpn_performance'
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1722)
<!-- Reviewable:end -->
