### PR TITLE
feat(tauri): add account id device id info and new zknym errors

### DIFF
--- a/nym-vpn-app/src-tauri/src/commands/account.rs
+++ b/nym-vpn-app/src-tauri/src/commands/account.rs
@@ -1,6 +1,6 @@
 use serde_json::Value as JsonValue;
 use tauri::State;
-use tracing::{error, info, instrument};
+use tracing::{error, info, instrument, warn};
 
 use crate::grpc::account_links::AccountLinks;
 use crate::grpc::client::ReadyToConnect;
@@ -103,4 +103,32 @@ pub async fn account_links(
         error!("failed to get account link: {e}");
         e.into()
     })
+}
+
+#[instrument(skip_all)]
+#[tauri::command]
+pub async fn get_account_id(grpc: State<'_, GrpcClient>) -> Result<String, BackendError> {
+    grpc.account_id()
+        .await
+        .map_err(|e| {
+            warn!("failed to get account id: {e}");
+            e.into()
+        })
+        .inspect(|id| {
+            info!("account id: {id}");
+        })
+}
+
+#[instrument(skip_all)]
+#[tauri::command]
+pub async fn get_device_id(grpc: State<'_, GrpcClient>) -> Result<String, BackendError> {
+    grpc.device_id()
+        .await
+        .map_err(|e| {
+            warn!("failed to get device id: {e}");
+            e.into()
+        })
+        .inspect(|id| {
+            info!("device id: {id}");
+        })
 }

--- a/nym-vpn-app/src-tauri/src/grpc/ready_to_connect.rs
+++ b/nym-vpn-app/src-tauri/src/grpc/ready_to_connect.rs
@@ -42,9 +42,6 @@ impl TryFrom<IsReadyToConnectResponseType> for ReadyToConnect {
             IsReadyToConnectResponseType::MaxDevicesReached => Ok(ReadyToConnect::NotReady(
                 "maximum number of device reached".to_string(),
             )),
-            IsReadyToConnectResponseType::DeviceRegistrationFailed => Ok(ReadyToConnect::NotReady(
-                "device registration failed".to_string(),
-            )),
         }
     }
 }

--- a/nym-vpn-app/src-tauri/src/main.rs
+++ b/nym-vpn-app/src-tauri/src/main.rs
@@ -234,6 +234,8 @@ async fn main() -> Result<()> {
             account::delete_account,
             account::forget_account,
             account::is_account_stored,
+            account::get_account_id,
+            account::get_device_id,
             account::get_account_info,
             account::account_links,
             account::ready_to_connect,

--- a/nym-vpn-app/src/cache/index.ts
+++ b/nym-vpn-app/src/cache/index.ts
@@ -1,13 +1,19 @@
-// simple memory cache
+// simple in-memory cache
 
-export type Cached<T> = {
+export type MCached<T> = {
   value: T;
   // timestamp in ms
   expiry?: number;
 };
 
-export type CKey = 'mn-entry-countries' | 'mn-exit-countries' | 'wg-countries';
-const cache = new Map<CKey, Cached<never>>();
+export type CKey =
+  | 'mn-entry-countries'
+  | 'mn-exit-countries'
+  | 'wg-countries'
+  | 'account-id'
+  | 'device-id';
+
+const cache = new Map<CKey, MCached<never>>();
 
 /**
  * In-memory cache, with optional expiry

--- a/nym-vpn-app/src/dev/setup.ts
+++ b/nym-vpn-app/src/dev/setup.ts
@@ -118,6 +118,18 @@ export function mockTauriIPC() {
       return new Promise<boolean>((resolve) => resolve(true));
     }
 
+    if (cmd === 'get_account_id') {
+      return new Promise<string>((resolve) =>
+        resolve('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'),
+      );
+    }
+
+    if (cmd === 'get_device_id') {
+      return new Promise<string>((resolve) =>
+        resolve('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'),
+      );
+    }
+
     // if (cmd === 'add_account') {
     //   return new Promise<boolean>((_, reject) => reject(new Error('nope')));
     // }

--- a/nym-vpn-app/src/hooks/useI18nError.ts
+++ b/nym-vpn-app/src/hooks/useI18nError.ts
@@ -127,6 +127,8 @@ function useI18nError() {
           return t('account.update-device');
         case 'ConnectRegisterDevice':
           return t('account.register-device');
+        case 'ConnectRequestZkNym':
+          return t('zknym.request-failed');
         case 'EntryGatewayNotRouting':
           return t('entry-node-routing');
         case 'ExitRouterPingIpv4':

--- a/nym-vpn-app/src/i18n/en/errors.json
+++ b/nym-vpn-app/src/i18n/en/errors.json
@@ -70,6 +70,9 @@
     "routing": "Routing failed",
     "ready-to-connect": "It was not yet possible to determine if we are ready to connect during the check"
   },
+  "zknym": {
+    "request-failed": "Requesting zk-nym failed"
+  },
   "account": {
     "invalid-recovery-phrase": "Invalid recovery phrase",
     "storage": "Storage backend error",

--- a/nym-vpn-app/src/i18n/en/settings.json
+++ b/nym-vpn-app/src/i18n/en/settings.json
@@ -46,6 +46,8 @@
   "info": {
     "client-version": "Client version",
     "daemon-version": "Daemon version",
-    "network-name": "Network"
+    "network-name": "Network",
+    "account-id": "Account ID",
+    "device-id": "Device ID"
   }
 }

--- a/nym-vpn-app/src/i18n/fr/settings.json
+++ b/nym-vpn-app/src/i18n/fr/settings.json
@@ -42,10 +42,12 @@
   "info": {
     "client-version": "Version du client",
     "daemon-version": "Version du daemon",
-    "network-name": "Réseau"
+    "network-name": "Réseau",
+    "account-id": "ID du compte",
+    "device-id": "ID de l'appareil"
   },
   "logout-confirmation": {
-    "title": "Etes-vous sûr ?",
+    "title": "Etes-vous sûr ?",
     "description": "Vous aurez besoin de votre phrase de récupération pour vous reconnecter."
   }
 }

--- a/nym-vpn-app/src/screens/login/Login.tsx
+++ b/nym-vpn-app/src/screens/login/Login.tsx
@@ -10,6 +10,7 @@ import { useI18nError } from '../../hooks';
 import { routes } from '../../router';
 import { BackendError, StateDispatch } from '../../types';
 import { Button, Link, PageAnim, TextArea } from '../../ui';
+import { MCache } from '../../cache';
 
 type AddError = {
   error: string;
@@ -48,6 +49,8 @@ function Login() {
           position: 'top',
           closeIcon: true,
         });
+        MCache.del('account-id');
+        MCache.del('device-id');
       })
       .catch((e: unknown) => {
         const eT = e as BackendError;

--- a/nym-vpn-app/src/screens/settings/Logout.tsx
+++ b/nym-vpn-app/src/screens/settings/Logout.tsx
@@ -10,6 +10,7 @@ import { Button, Dialog, MsIcon, SettingsMenuCard } from '../../ui';
 import { routes } from '../../router';
 import { BackendError, StateDispatch } from '../../types';
 import { useI18nError } from '../../hooks';
+import { MCache } from '../../cache';
 
 function Logout() {
   const [isOpen, setIsOpen] = useState(false);
@@ -32,6 +33,8 @@ function Logout() {
         text: t('logout.success', { ns: 'notifications' }),
         position: 'top',
       });
+      MCache.del('account-id');
+      MCache.del('device-id');
     } catch (e) {
       console.warn('failed to logout', e);
       push({

--- a/nym-vpn-app/src/screens/settings/info-data/AccountData.tsx
+++ b/nym-vpn-app/src/screens/settings/info-data/AccountData.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useState } from 'react';
+import clsx from 'clsx';
+import { writeText } from '@tauri-apps/plugin-clipboard-manager';
+import { invoke } from '@tauri-apps/api/core';
+import { useTranslation } from 'react-i18next';
+import { useMainState } from '../../../contexts';
+import { MCache } from '../../../cache';
+import { ButtonText } from '../../../ui';
+
+const IdsTimeToLive = 120; // sec
+
+function AccountData() {
+  const [accountId, setAccountId] = useState<string | null>(null);
+  const [deviceId, setDeviceId] = useState<string | null>(null);
+  const { account } = useMainState();
+
+  const { t } = useTranslation('settings');
+
+  const getAccountId = async () => {
+    const id = MCache.get<string>('account-id');
+    if (id) {
+      setAccountId(id);
+      return;
+    }
+    try {
+      const id = await invoke<string | null>('get_account_id');
+      setAccountId(id);
+      MCache.set('account-id', id, IdsTimeToLive);
+    } catch (e) {
+      console.warn('failed to get account id', e);
+      setAccountId(null);
+    }
+  };
+
+  const getDeviceId = async () => {
+    const id = MCache.get<string>('device-id');
+    if (id) {
+      setDeviceId(id);
+      return;
+    }
+    try {
+      const id = await invoke<string | null>('get_device_id');
+      setDeviceId(id);
+      MCache.set('device-id', id, IdsTimeToLive);
+    } catch (e) {
+      console.warn('failed to get device id', e);
+      setDeviceId(null);
+    }
+  };
+
+  useEffect(() => {
+    if (account) {
+      getAccountId();
+      getDeviceId();
+    }
+  }, [account]);
+
+  const copyToClipboard = async (text: string) => {
+    try {
+      await writeText(text);
+    } catch (e) {
+      console.error('failed to copy to clipboard', e);
+    }
+  };
+
+  if (!account) {
+    return null;
+  }
+
+  return (
+    <div className={clsx('mt-3')}>
+      {accountId && (
+        <div className={clsx('flex flex-row flex-nowrap gap-1')}>
+          <p className="text-nowrap">{t('info.account-id')}</p>
+          <ButtonText onClick={() => copyToClipboard(accountId)} truncate>
+            {accountId}
+          </ButtonText>
+        </div>
+      )}
+      {deviceId && (
+        <div className={clsx('flex flex-row flex-nowrap gap-1')}>
+          <p className="text-nowrap">{t('info.device-id')}</p>
+          <ButtonText onClick={() => copyToClipboard(deviceId)} truncate>
+            {deviceId}
+          </ButtonText>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default AccountData;

--- a/nym-vpn-app/src/screens/settings/info-data/InfoData.tsx
+++ b/nym-vpn-app/src/screens/settings/info-data/InfoData.tsx
@@ -1,38 +1,67 @@
 import { useState } from 'react';
 import clsx from 'clsx';
 import { useTranslation } from 'react-i18next';
+import { writeText } from '@tauri-apps/plugin-clipboard-manager';
 import { useMainState } from '../../../contexts';
 import NetworkEnvSelect from './NetworkEnvSelect';
 import { S_STATE } from '../../../static';
+import { ButtonText } from '../../../ui';
+import AccountData from './AccountData';
 
 function InfoData() {
   const [showEnvSelect, setShowEnvSelect] = useState(false);
-  const { version, daemonStatus, daemonVersion, networkEnv } = useMainState();
+  const { version, daemonStatus, daemonVersion, networkEnv, account } =
+    useMainState();
 
   const { t } = useTranslation('settings');
+
+  const copyToClipboard = async (text: string) => {
+    try {
+      await writeText(text);
+    } catch (e) {
+      console.error('failed to copy to clipboard', e);
+    }
+  };
 
   return (
     <>
       <div
         className={clsx([
+          'select-none',
           'flex grow flex-col justify-end text-comet/80 text-sm',
           'tracking-tight leading-tight font-semibold mb-4 cursor-default',
         ])}
       >
-        <p>{`${t('info.client-version')} ${version}`}</p>
-        <p>{daemonVersion && `${t('info.daemon-version')} ${daemonVersion}`}</p>
-        <div
-          onDoubleClick={() => {
-            setShowEnvSelect(!showEnvSelect);
-          }}
-        >
-          {networkEnv &&
-            networkEnv.length > 0 &&
-            `${t('info.network-name')} ${networkEnv}`}
+        <div className={clsx('flex flex-row flex-nowrap gap-1')}>
+          <p className="text-nowrap">{t('info.client-version')}</p>
+          <ButtonText onClick={() => copyToClipboard(version || '')} truncate>
+            {version}
+          </ButtonText>
         </div>
+        {daemonVersion && (
+          <div className={clsx('flex flex-row flex-nowrap gap-1')}>
+            <p className="text-nowrap">{t('info.daemon-version')}</p>
+            <ButtonText onClick={() => copyToClipboard(daemonVersion)} truncate>
+              {daemonVersion}
+            </ButtonText>
+          </div>
+        )}
+        {networkEnv && networkEnv.length > 0 && (
+          <div className={clsx('flex flex-row flex-nowrap gap-1')}>
+            <p className="text-nowrap">{t('info.network-name')}</p>
+            <ButtonText
+              onClick={() => copyToClipboard(networkEnv)}
+              onDoubleClick={() => setShowEnvSelect(!showEnvSelect)}
+              truncate
+            >
+              {networkEnv}
+            </ButtonText>
+          </div>
+        )}
+        {account && <AccountData />}
       </div>
       {S_STATE.networkEnvSelect &&
-        daemonStatus === 'Ok' &&
+        daemonStatus !== 'NotOk' &&
         networkEnv &&
         showEnvSelect && (
           <NetworkEnvSelect

--- a/nym-vpn-app/src/types/tauri-ipc.ts
+++ b/nym-vpn-app/src/types/tauri-ipc.ts
@@ -91,6 +91,7 @@ export type ErrorKey =
   | 'ConnectUpdateAccount'
   | 'ConnectUpdateDevice'
   | 'ConnectRegisterDevice'
+  | 'ConnectRequestZkNym'
   | 'EntryGatewayNotRouting'
   | 'ExitRouterPingIpv4'
   | 'ExitRouterPingIpv6'

--- a/nym-vpn-app/src/ui/ButtonIcon.tsx
+++ b/nym-vpn-app/src/ui/ButtonIcon.tsx
@@ -1,0 +1,49 @@
+// TODO _WIP_
+
+import clsx from 'clsx';
+import { Button as HuButton } from '@headlessui/react';
+import { MsIcon } from './index.ts';
+
+type ButtonIconProps = {
+  icon: string;
+  onClick: () => void;
+  disabled?: boolean;
+  className?: string;
+  iconClassName?: string;
+};
+
+function ButtonIcon({
+  onClick,
+  icon,
+  disabled,
+  className,
+  iconClassName,
+}: ButtonIconProps) {
+  return (
+    <HuButton
+      className={clsx([
+        'rounded-full w-10 h-10 min-w-10 min-h-10',
+        'text-white dark:text-mercury-mist bg-aluminium dark:bg-baltic-sea',
+        'data-[hover]:dark:text-white data-[hover]:dark:bg-baltic-sea-jaguar/80',
+        'focus:outline-none data-[focus]:ring-2 data-[focus]:ring-black data-[focus]:dark:ring-white',
+        'transition data-[disabled]:opacity-60 data-[active]:ring-0',
+        'shadow tracking-normal cursor-default',
+        className && className,
+      ])}
+      onClick={onClick}
+      disabled={disabled}
+    >
+      {
+        <MsIcon
+          icon={icon}
+          className={clsx([
+            'text-2xl w-10 h-10 min-w-10 min-h-10',
+            iconClassName,
+          ])}
+        />
+      }
+    </HuButton>
+  );
+}
+
+export default ButtonIcon;

--- a/nym-vpn-app/src/ui/ButtonText.tsx
+++ b/nym-vpn-app/src/ui/ButtonText.tsx
@@ -1,0 +1,56 @@
+import { ReactNode } from 'react';
+import clsx from 'clsx';
+import { Button as HuButton } from '@headlessui/react';
+
+type ButtonTextProps = {
+  children: ReactNode;
+  onClick?: () => void;
+  onDoubleClick?: () => void;
+  disabled?: boolean;
+  className?: string;
+  textClassName?: string;
+  truncate?: boolean;
+  colors?: 'rain';
+};
+
+function ButtonText({
+  onClick,
+  onDoubleClick,
+  children,
+  disabled,
+  className,
+  truncate,
+  colors = 'rain',
+}: ButtonTextProps) {
+  const getColors = () => {
+    switch (colors) {
+      case 'rain':
+        return [
+          'bg-blanc-nacre dark:bg-baltic-sea',
+          'data-[hover]:text-oil data-[hover]:bg-cement-feet/30',
+          'data-[hover]:dark:text-laughing-jack data-[hover]:dark:bg-baltic-sea-jaguar/80',
+        ];
+    }
+  };
+
+  return (
+    <HuButton
+      className={clsx([
+        'rounded-lg px-2',
+        'focus:outline-none data-[focus]:ring-0',
+        'transition data-[disabled]:opacity-60 data-[active]:ring-0',
+        'tracking-normal cursor-default',
+        truncate && 'overflow-hidden',
+        className && className,
+        ...getColors(),
+      ])}
+      onClick={onClick}
+      onDoubleClick={onDoubleClick}
+      disabled={disabled}
+    >
+      <div className={clsx(truncate && 'text-nowrap truncate')}>{children}</div>
+    </HuButton>
+  );
+}
+
+export default ButtonText;

--- a/nym-vpn-app/src/ui/index.ts
+++ b/nym-vpn-app/src/ui/index.ts
@@ -1,4 +1,6 @@
 export { default as Button } from './Button';
+export { default as ButtonIcon } from './ButtonIcon';
+export { default as ButtonText } from './ButtonText';
 export { default as Dialog } from './Dialog';
 export { default as MsIcon } from './MsIcon';
 export { default as DaemonDot } from './DaemonDot';
@@ -17,6 +19,8 @@ export { default as FlagIcon } from './FlagIcon';
 export { default as Notifications } from './Notifications';
 export { default as Link } from './Link';
 export * from './Button';
+export * from './ButtonIcon';
+export * from './ButtonText';
 export * from './Dialog';
 export * from './FlagIcon';
 export * from './MsIcon';


### PR DESCRIPTION
- show account ID and device ID (respectively when logged in, and device is registered) in the settings at the bottom
- left-click on the texts to copy into clipboard (useful to share/copy account IDs or app/daemon versions)
- handle new zk-nym errors and resync on latest proto
- localize zk-nym error + errors details in the UI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1726)
<!-- Reviewable:end -->
