### PR TITLE
Revert "Get entry gw IP early (#1718)"

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mixnet/connector.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mixnet/connector.rs
@@ -3,7 +3,7 @@
 
 use std::net::IpAddr;
 
-use nym_gateway_directory::{IpPacketRouterAddress, Recipient};
+use nym_gateway_directory::{GatewayClient, IpPacketRouterAddress, Recipient};
 use nym_ip_packet_client::IprClientConnect;
 use nym_ip_packet_requests::IpPair;
 use nym_sdk::mixnet::ConnectionStatsEvent;
@@ -29,19 +29,19 @@ pub struct AssignedAddresses {
 pub struct Connector {
     task_manager: TaskManager,
     mixnet_client: SharedMixnetClient,
-    gateway_host: IpAddr,
+    gateway_directory_client: GatewayClient,
 }
 
 impl Connector {
     pub fn new(
         task_manager: TaskManager,
         mixnet_client: SharedMixnetClient,
-        gateway_host: IpAddr,
+        gateway_directory_client: GatewayClient,
     ) -> Self {
         Self {
             task_manager,
             mixnet_client,
-            gateway_host,
+            gateway_directory_client,
         }
     }
 
@@ -54,7 +54,7 @@ impl Connector {
             selected_gateways,
             nym_ips,
             self.mixnet_client.clone(),
-            self.gateway_host,
+            &self.gateway_directory_client,
         )
         .await;
 
@@ -69,7 +69,7 @@ impl Connector {
                 AnyConnector::Mixnet(Self::new(
                     self.task_manager,
                     self.mixnet_client,
-                    self.gateway_host,
+                    self.gateway_directory_client,
                 )),
             )),
         }
@@ -79,9 +79,17 @@ impl Connector {
         selected_gateways: SelectedGateways,
         nym_ips: Option<IpPair>,
         mixnet_client: SharedMixnetClient,
-        entry_mixnet_gateway_ip: IpAddr,
+        gateway_directory_client: &GatewayClient,
     ) -> Result<AssignedAddresses> {
         let mixnet_client_address = mixnet_client.nym_address().await;
+        let gateway_used = mixnet_client_address.gateway().to_base58_string();
+        let entry_mixnet_gateway_ip: IpAddr = gateway_directory_client
+            .lookup_gateway_ip(&gateway_used)
+            .await
+            .map_err(|source| Error::LookupGatewayIp {
+                gateway_id: gateway_used,
+                source,
+            })?;
 
         let exit_mix_addresses = selected_gateways.exit.ipr_address.unwrap();
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
@@ -8,7 +8,7 @@ mod status_listener;
 mod tombstone;
 pub mod wireguard;
 
-use std::{error::Error as StdError, fmt, net::IpAddr, path::PathBuf, time::Duration};
+use std::{error::Error as StdError, fmt, path::PathBuf, time::Duration};
 
 pub use gateway_selector::SelectedGateways;
 use nym_gateway_directory::{EntryPoint, ExitPoint, GatewayClient};
@@ -34,7 +34,7 @@ pub(crate) const TASK_MANAGER_SHUTDOWN_TIMER_SECS: u64 = 10;
 
 pub struct ConnectedMixnet {
     task_manager: TaskManager,
-    gateway_host: IpAddr,
+    gateway_directory_client: GatewayClient,
     selected_gateways: SelectedGateways,
     data_path: Option<PathBuf>,
     mixnet_client: SharedMixnetClient,
@@ -73,7 +73,7 @@ impl ConnectedMixnet {
         let connector = mixnet::connector::Connector::new(
             self.task_manager,
             self.mixnet_client,
-            self.gateway_host,
+            self.gateway_directory_client,
         );
 
         match connector
@@ -96,7 +96,7 @@ impl ConnectedMixnet {
         let connector = wireguard::connector::Connector::new(
             self.task_manager,
             self.mixnet_client,
-            self.gateway_host,
+            self.gateway_directory_client,
         );
 
         match connector
@@ -182,15 +182,6 @@ pub async fn connect_mixnet(
         .unwrap_or(UserAgent::from(nym_bin_common::bin_info_local_vergen!()));
     let gateway_directory_client = GatewayClient::new(options.gateway_config, user_agent)
         .map_err(Error::CreateGatewayClient)?;
-    let gateway_id = options
-        .selected_gateways
-        .entry
-        .identity()
-        .to_base58_string();
-    let gateway_host = gateway_directory_client
-        .lookup_gateway_ip(&gateway_id)
-        .await
-        .map_err(|source| Error::LookupGatewayIp { gateway_id, source })?;
 
     match options.tunnel_type {
         TunnelType::Mixnet => {}
@@ -228,7 +219,7 @@ pub async fn connect_mixnet(
             task_manager,
             selected_gateways: options.selected_gateways,
             data_path: options.data_path,
-            gateway_host,
+            gateway_directory_client,
             mixnet_client,
             reconnect_mixnet_client_data,
         }),

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connector.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connector.rs
@@ -1,13 +1,13 @@
 // Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{net::IpAddr, path::PathBuf};
+use std::path::PathBuf;
 
 use tokio::task::JoinHandle;
 
 use nym_authenticator_client::AuthClient;
 use nym_credentials_interface::TicketType;
-use nym_gateway_directory::{AuthAddresses, Gateway};
+use nym_gateway_directory::{AuthAddresses, Gateway, GatewayClient};
 use nym_sdk::mixnet::{ConnectionStatsEvent, EphemeralCredentialStorage, StoragePaths};
 use nym_task::TaskManager;
 use nym_wg_gateway_client::{GatewayData, WgGatewayClient};
@@ -29,19 +29,19 @@ pub struct ConnectionData {
 pub struct Connector {
     task_manager: TaskManager,
     mixnet_client: SharedMixnetClient,
-    gateway_host: IpAddr,
+    gateway_directory_client: GatewayClient,
 }
 
 impl Connector {
     pub fn new(
         task_manager: TaskManager,
         mixnet_client: SharedMixnetClient,
-        gateway_host: IpAddr,
+        gateway_directory_client: GatewayClient,
     ) -> Self {
         Self {
             task_manager,
             mixnet_client,
-            gateway_host,
+            gateway_directory_client,
         }
     }
     pub async fn connect(
@@ -54,7 +54,7 @@ impl Connector {
         let result = Self::connect_inner(
             &self.task_manager,
             self.mixnet_client.clone(),
-            self.gateway_host,
+            &self.gateway_directory_client,
             enable_credentials_mode,
             selected_gateways,
             data_path,
@@ -75,7 +75,7 @@ impl Connector {
                 AnyConnector::Wireguard(Self::new(
                     self.task_manager,
                     self.mixnet_client,
-                    self.gateway_host,
+                    self.gateway_directory_client,
                 )),
             )),
         }
@@ -84,7 +84,7 @@ impl Connector {
     async fn connect_inner(
         task_manager: &TaskManager,
         mixnet_client: SharedMixnetClient,
-        gateway_host: IpAddr,
+        gateway_directory_client: &GatewayClient,
         enable_credentials_mode: bool,
         selected_gateways: SelectedGateways,
         data_path: Option<PathBuf>,
@@ -152,7 +152,7 @@ impl Connector {
                 .get_initial_bandwidth(
                     enable_credentials_mode,
                     TicketType::V1WireguardEntry,
-                    gateway_host,
+                    gateway_directory_client,
                     &mut wg_entry_gateway_client,
                 )
                 .await?;
@@ -160,7 +160,7 @@ impl Connector {
                 .get_initial_bandwidth(
                     enable_credentials_mode,
                     TicketType::V1WireguardExit,
-                    gateway_host,
+                    gateway_directory_client,
                     &mut wg_exit_gateway_client,
                 )
                 .await?;
@@ -181,7 +181,7 @@ impl Connector {
                 .get_initial_bandwidth(
                     enable_credentials_mode,
                     TicketType::V1WireguardEntry,
-                    gateway_host,
+                    gateway_directory_client,
                     &mut wg_entry_gateway_client,
                 )
                 .await?;
@@ -189,7 +189,7 @@ impl Connector {
                 .get_initial_bandwidth(
                     enable_credentials_mode,
                     TicketType::V1WireguardExit,
-                    gateway_host,
+                    gateway_directory_client,
                     &mut wg_exit_gateway_client,
                 )
                 .await?;


### PR DESCRIPTION
This reverts commit 46c20a0ec69f6cd587afeee18f48f67b918f68c2.

I hate doing reverts but this commit seemingly breaks wireguard-go which cannot handshake any longer. The assumption that the peer registration doesn't go through somehow. I don't mind us figuring out why but we're a bit constrained here right now and need to cut release soonish.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1728)
<!-- Reviewable:end -->
