### PR TITLE
Translations update from Nym - Desktop

### DIFF
--- a/nym-vpn-app/src/i18n/it/welcome.json
+++ b/nym-vpn-app/src/i18n/it/welcome.json
@@ -12,6 +12,8 @@
     "part1": "Aiutaci a migliorare la nostra app durante la fase beta!"
   },
   "tos": {
-    "part3": "."
+    "part3": ".",
+    "part1": "Continuando, accetti",
+    "part2": "e riconosci"
   }
 }

--- a/nym-vpn-app/src/i18n/pt-BR/backend-messages.json
+++ b/nym-vpn-app/src/i18n/pt-BR/backend-messages.json
@@ -1,6 +1,7 @@
 {
   "connection-progress": {
     "Initializing": "Inicializando o cliente Nym VPN…",
-    "InitDone": "Cliente Nym VPN inicializado"
+    "InitDone": "Cliente Nym VPN inicializado",
+    "Canceling": "Cancelando…"
   }
 }

--- a/nym-vpn-app/src/i18n/pt-BR/errors.json
+++ b/nym-vpn-app/src/i18n/pt-BR/errors.json
@@ -67,7 +67,8 @@
     "add-ipv6-route": "Falha ao adicionar a rota padrão ipv6 para capturar o tráfego ipv6",
     "tun-device": "Falha no dispositivo Tun",
     "routing": "Falha no roteamento",
-    "ready-to-connect": "Ainda não foi possível determinar se estamos prontos para nos conectar durante a verificação"
+    "ready-to-connect": "Ainda não foi possível determinar se estamos prontos para nos conectar durante a verificação",
+    "general": "Erro geral, verifique os registros para obter mais detalhes"
   },
   "countries-request": {
     "entry": "Falha ao buscar os países com nós de entrada disponíveis",
@@ -82,6 +83,13 @@
   "entry-node-routing": "O nó de entrada não está roteando o tráfego (a conexão com a Internet caiu?)",
   "account": {
     "invalid-recovery-phrase": "Frase de recuperação inválida",
-    "storage": "Erro no backend de armazenamento"
+    "storage": "Erro no backend de armazenamento",
+    "is-connected": "Não é possível continuar enquanto estiver conectado",
+    "maximum-registered-devices": "Falha no registro do dispositivo: o número máximo de dispositivos registrados foi atingido",
+    "update-device": "Falha na atualização do dispositivo",
+    "register-device": "Falha no registro do dispositivo",
+    "not-stored": "Nenhuma frase de recuperação de conta armazenada",
+    "no-device-stored": "Nenhuma chave de dispositivo armazenada",
+    "update": "Falha na atualização da conta"
   }
 }

--- a/nym-vpn-app/src/i18n/pt-BR/glossary.json
+++ b/nym-vpn-app/src/i18n/pt-BR/glossary.json
@@ -6,5 +6,6 @@
   "account": "conta",
   "cancel": "cancelar",
   "login": "fazer login",
-  "logout": "encerrar sessão"
+  "logout": "encerrar sessão",
+  "stop": "parar"
 }

--- a/nym-vpn-app/src/i18n/pt-BR/notifications.json
+++ b/nym-vpn-app/src/i18n/pt-BR/notifications.json
@@ -6,6 +6,7 @@
   },
   "logout": {
     "success": "Logout bem-sucedido",
-    "error": "Ocorreu um erro ao fazer o logout. Tente novamente."
-  }
+    "error": "Ocorreu um erro ao fazer o logout."
+  },
+  "daemon-not-compat": "A versão Daemon não é compatível com a versão do aplicativo! Versão do daemon: {{version}}, esperado: {{required}}. Atualize o aplicativo ou o daemon."
 }

--- a/nym-vpn-app/src/i18n/pt-PT/backend-messages.json
+++ b/nym-vpn-app/src/i18n/pt-PT/backend-messages.json
@@ -1,6 +1,7 @@
 {
   "connection-progress": {
     "Initializing": "Inicialização do cliente Nym VPN…",
-    "InitDone": "Cliente Nym VPN inicializado"
+    "InitDone": "Cliente Nym VPN inicializado",
+    "Canceling": "Cancelando…"
   }
 }

--- a/nym-vpn-app/src/i18n/pt-PT/errors.json
+++ b/nym-vpn-app/src/i18n/pt-PT/errors.json
@@ -67,7 +67,8 @@
     "tun-device": "Falha do dispositivo Tun",
     "unhandled-exit": "A VPN está a sair com um erro. É provável que seja um bug.",
     "add-ipv6-route": "Falha ao adicionar a rota predefinida ipv6 para capturar o tráfego ipv6",
-    "ready-to-connect": "Ainda não foi possível determinar se estamos prontos para nos ligarmos durante o controlo"
+    "ready-to-connect": "Ainda não foi possível determinar se estamos prontos para nos ligarmos durante o controlo",
+    "general": "Erro geral, verifique os registos para obter mais detalhes"
   },
   "countries-request": {
     "entry": "Falha ao procurar os países com nós de entrada disponíveis",
@@ -82,6 +83,13 @@
   },
   "account": {
     "invalid-recovery-phrase": "Frase de recuperação inválida",
-    "storage": "Erro de backend de armazenamento"
+    "storage": "Erro de backend de armazenamento",
+    "is-connected": "Não é possível prosseguir enquanto ligado",
+    "update": "Falha na atualização da conta",
+    "update-device": "Falha na atualização do dispositivo",
+    "register-device": "Falha no registo do dispositivo",
+    "no-device-stored": "Nenhuma chave de dispositivo armazenada",
+    "maximum-registered-devices": "Falha no registo do dispositivo: o número máximo de dispositivos registados foi atingido",
+    "not-stored": "Nenhuma frase de recuperação de conta armazenada"
   }
 }

--- a/nym-vpn-app/src/i18n/pt-PT/glossary.json
+++ b/nym-vpn-app/src/i18n/pt-PT/glossary.json
@@ -6,5 +6,6 @@
   "account": "conta",
   "cancel": "cancelar",
   "login": "login",
-  "logout": "Terminar sessão"
+  "logout": "Terminar sessão",
+  "stop": "parar"
 }

--- a/nym-vpn-app/src/i18n/pt-PT/notifications.json
+++ b/nym-vpn-app/src/i18n/pt-PT/notifications.json
@@ -6,6 +6,7 @@
   },
   "logout": {
     "success": "Terminar sessão com sucesso",
-    "error": "Ocorreu um erro ao terminar a sessão. Por favor, tente novamente."
-  }
+    "error": "Ocorreu um erro ao terminar a sessão."
+  },
+  "daemon-not-compat": "A versão Daemon não é compatível com a versão da aplicação! Versão daemon: {{version}}, esperado: {{required}}. Por favor, actualize a aplicação ou o daemon."
 }


### PR DESCRIPTION
Translations update from [Nym](https://weblate.nymte.ch) for [Nym/add-credential](https://weblate.nymte.ch/projects/nymvpn/linux-windows/add-credential/).


It also includes following components:

* [Nym/display](https://weblate.nymte.ch/projects/nymvpn/linux-windows/display/)

* [Nym/common](https://weblate.nymte.ch/projects/nymvpn/linux-windows/common/)

* [Nym/welcome](https://weblate.nymte.ch/projects/nymvpn/linux-windows/welcome/)

* [Nym/errors](https://weblate.nymte.ch/projects/nymvpn/linux-windows/errors/)

* [Nym/licenses](https://weblate.nymte.ch/projects/nymvpn/linux-windows/licenses/)

* [Nym/notifications](https://weblate.nymte.ch/projects/nymvpn/linux-windows/notifications/)

* [Nym/glossary](https://weblate.nymte.ch/projects/nymvpn/linux-windows/glossary/)

* [Nym/home](https://weblate.nymte.ch/projects/nymvpn/linux-windows/home/)

* [Nym/settings](https://weblate.nymte.ch/projects/nymvpn/linux-windows/settings/)

* [Nym/backend-messages](https://weblate.nymte.ch/projects/nymvpn/linux-windows/backend-messages/)

* [Nym/node-location](https://weblate.nymte.ch/projects/nymvpn/linux-windows/node-location/)



Current translation status:

![Weblate translation status](https://weblate.nymte.ch/widget/nymvpn/linux-windows/add-credential/horizontal-auto.svg)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1729)
<!-- Reviewable:end -->
