### PR TITLE
Remove dependency on ctr::cipher::zeroize

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -4799,6 +4799,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "zeroize",
 ]
 
 [[package]]

--- a/nym-vpn-core/crates/nym-vpn-api-client/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-api-client/Cargo.toml
@@ -32,8 +32,8 @@ strum.workspace = true
 strum_macros.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+zeroize.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
 bip39 = { workspace = true, features = ["zeroize"] }
-

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/types/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/types/account.rs
@@ -1,8 +1,9 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use zeroize::Zeroizing;
+
 use nym_compact_ecash::scheme::keygen::KeyPairUser;
-use nym_crypto::ctr::cipher::zeroize::Zeroizing;
 use nym_validator_client::{
     nyxd::bip32::DerivationPath, signing::signer::OfflineSigner as _, DirectSecp256k1HdWallet,
 };


### PR DESCRIPTION
Use our own `zeroize` instead of the one re-exported from `ctr::cipher::zeroize`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1771)
<!-- Reviewable:end -->
