### PR TITLE
Add default-members entry in nym-vpn-core workspace

### DIFF
--- a/.github/workflows/ci-nym-vpn-core-android.yml
+++ b/.github/workflows/ci-nym-vpn-core-android.yml
@@ -63,7 +63,7 @@ jobs:
       - name: rustfmt check
         working-directory: nym-vpn-core
         run: |
-          cargo fmt --check
+          cargo fmt --check --all
 
       - name: Build
         working-directory: nym-vpn-core

--- a/.github/workflows/ci-nym-vpn-core-ios.yml
+++ b/.github/workflows/ci-nym-vpn-core-ios.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Generate uniffi
         working-directory: nym-vpn-core
         run: |
-          cargo run --bin uniffi-bindgen generate \
+          cargo run -p uniffi-bindgen generate \
             --library target/aarch64-apple-ios/debug/libnym_vpn_lib.a  \
             --config crates/nym-vpn-lib/uniffi.toml \
             --language swift --out-dir build -n

--- a/.github/workflows/ci-nym-vpn-core-ios.yml
+++ b/.github/workflows/ci-nym-vpn-core-ios.yml
@@ -55,7 +55,7 @@ jobs:
       - name: rustfmt check
         working-directory: nym-vpn-core
         run: |
-          cargo fmt --check
+          cargo fmt --check --all
 
       - name: Build
         working-directory: nym-vpn-core

--- a/.github/workflows/ci-nym-vpn-core-linux.yml
+++ b/.github/workflows/ci-nym-vpn-core-linux.yml
@@ -48,20 +48,20 @@ jobs:
       - name: rustfmt check
         working-directory: nym-vpn-core
         run: |
-          cargo fmt --check
+          cargo fmt --check --all
 
       - name: Build
         working-directory: nym-vpn-core
         run: |
-          cargo build --verbose
+          cargo build --verbose --workspace
 
       - name: Run tests
         working-directory: nym-vpn-core
         run: |
-          cargo test --verbose
+          cargo test --verbose --workspace
 
       - name: Clippy
         working-directory: nym-vpn-core
         run: |
-          cargo clippy -- -Dwarnings
+          cargo clippy --workspace -- -Dwarnings
 

--- a/.github/workflows/ci-nym-vpn-core-macos.yml
+++ b/.github/workflows/ci-nym-vpn-core-macos.yml
@@ -53,14 +53,14 @@ jobs:
       - name: rustfmt check
         working-directory: nym-vpn-core
         run: |
-          cargo fmt --check
+          cargo fmt --check --all
 
       - name: Run tests
         working-directory: nym-vpn-core
         run: |
-          cargo test --verbose
+          cargo test --verbose --workspace
 
       - name: Clippy
         working-directory: nym-vpn-core
         run: |
-          cargo clippy -- -Dwarnings
+          cargo clippy --workspace -- -Dwarnings

--- a/.github/workflows/ci-nym-vpn-core-windows.yml
+++ b/.github/workflows/ci-nym-vpn-core-windows.yml
@@ -125,19 +125,19 @@ jobs:
       - name: rustfmt check
         working-directory: nym-vpn-core
         run: |
-          cargo fmt --check
+          cargo fmt --check --all
 
       - name: Build
         working-directory: nym-vpn-core
         run: |
-          cargo build --verbose
+          cargo build --verbose --workspace
 
       - name: Run tests
         working-directory: nym-vpn-core
         run: |
-          cargo test --verbose
+          cargo test --verbose --workspace
 
       - name: Clippy
         working-directory: nym-vpn-core
         run: |
-          cargo clippy -- -Dwarnings
+          cargo clippy --workspace -- -Dwarnings

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -27,6 +27,11 @@ members = [
     "crates/uniffi-bindgen",
 ]
 
+default-members = [
+    "crates/nym-vpnd",
+    "crates/nym-vpnc",
+]
+
 # For local development
 # [patch."https://github.com/nymtech/nym"]
 # nym-authenticator-requests = { path = "../../nym/common/authenticator-requests" }

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -28,8 +28,9 @@ members = [
 ]
 
 default-members = [
-    "crates/nym-vpnd",
     "crates/nym-vpnc",
+    "crates/nym-vpnd",
+    "crates/uniffi-bindgen",
 ]
 
 # For local development

--- a/nym-vpn-core/Makefile
+++ b/nym-vpn-core/Makefile
@@ -15,14 +15,20 @@ all: help
 #  Build targets
 # -----------------------------------------------------------------------------
 
-build: ## Build the Rust workspace
+build: ## Build the default crates in the Rust workspace
 	cargo build
 
-build-release: ## Build the Rust workspace in release mode
+build-all: ## Build all crates in the Rust workspace
+	cargo build --workspace
+
+build-release: ## Build the default crates in the Rust workspace in release mode
 	cargo build --release
 
+build-release-all: ## Build all the crates in the Rust workspace in release mode
+	cargo build --release --workspace
+
 build-mac: ## Build the Rust workspace suitable for running the daemon
-	RUSTFLAGS="-C link-arg=-all_load -C link-arg=-ObjC -C link-arg=-sectcreate -C link-arg=__TEXT -C link-arg=__info_plist -C link-arg=$(CURDIR)/../nym-vpn-apple/Daemon/Info.plist -C link-arg=-sectcreate -C link-arg=__TEXT -C link-arg=__launchd_plist -C link-arg=$(CURDIR)/../nym-vpn-apple/Daemon/Launchd.plist" cargo build --release --workspace --exclude nym-gateway-probe
+	RUSTFLAGS="-C link-arg=-all_load -C link-arg=-ObjC -C link-arg=-sectcreate -C link-arg=__TEXT -C link-arg=__info_plist -C link-arg=$(CURDIR)/../nym-vpn-apple/Daemon/Info.plist -C link-arg=-sectcreate -C link-arg=__TEXT -C link-arg=__launchd_plist -C link-arg=$(CURDIR)/../nym-vpn-apple/Daemon/Launchd.plist" cargo build --release
 
 build-win-cross:
 	cargo build --target x86_64-pc-windows-gnu --release


### PR DESCRIPTION
Add default-members to the `nym-vpn-core` workspace since usually people
only want to build the main binaries, and not bother with e.g
`nym-gateway-probe`.

Adding only `nym-vpnd` and `nym-vpnc`, but transitively most crates will
be built still.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1773)
<!-- Reviewable:end -->
