### PR TITLE
Improve android build

### DIFF
--- a/.github/workflows/build-nym-vpn-android.yml
+++ b/.github/workflows/build-nym-vpn-android.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Install deps
         run: |
-          sudo apt-get update && sudo apt-get install -y libdbus-1-dev libmnl-dev libnftnl-dev protobuf-compiler git curl gcc g++ make unzip
+          sudo apt-get update && sudo apt-get install -y libdbus-1-dev libmnl-dev libnftnl-dev protobuf-compiler git curl gcc g++ make unzip rsync
 
       # Here we need to decode keystore.jks from base64 string and place it
       # in the folder specified in the release signing configuration

--- a/.github/workflows/ci-nym-vpn-android.yml
+++ b/.github/workflows/ci-nym-vpn-android.yml
@@ -29,8 +29,8 @@ jobs:
           java-version: '17'
           cache: gradle
 
-      - name: Install unzip
-        run: sudo apt-get update && sudo apt-get install -y unzip
+      - name: Install deps
+        run: sudo apt-get update && sudo apt-get install -y unzip rsync
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3

--- a/.github/workflows/ci-nym-vpn-core-android.yml
+++ b/.github/workflows/ci-nym-vpn-core-android.yml
@@ -58,7 +58,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build wireguard
-        run: ./wireguard/libwg/build-android.sh
+        run: ./wireguard/build-wireguard-go.sh --android
 
       - name: rustfmt check
         working-directory: nym-vpn-core
@@ -68,7 +68,7 @@ jobs:
       - name: Build
         working-directory: nym-vpn-core
         run: |
-          cargo ndk  -t aarch64-linux-android -o ./build build -p nym-vpn-lib
+          cargo ndk -t aarch64-linux-android -o ./build build -p nym-vpn-lib
 
       - name: Clippy
         working-directory: nym-vpn-core

--- a/.github/workflows/ci-nym-vpn-core-android.yml
+++ b/.github/workflows/ci-nym-vpn-core-android.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev libmnl-dev libnftnl-dev protobuf-compiler git curl gcc g++ make unzip
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev libmnl-dev libnftnl-dev protobuf-compiler git curl gcc g++ make unzip rsync
 
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/nym-vpn-android/nym-vpn-client/src/main/scripts/build-libs.sh
+++ b/nym-vpn-android/nym-vpn-client/src/main/scripts/build-libs.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -euo pipefail
+
 # requires cargo, cargo-ndk and android NDK to be installed
 echo "Building WireGuard dep"
 echo "Working dir: $PWD"

--- a/nym-vpn-android/nym-vpn-client/src/main/scripts/build-libs.sh
+++ b/nym-vpn-android/nym-vpn-client/src/main/scripts/build-libs.sh
@@ -8,8 +8,7 @@ archDir=$(basename $1/toolchains/llvm/prebuilt/*/)
 echo "archdir: ${archDir}"
 export ANDROID_NDK_HOME="$1"
 export NDK_TOOLCHAIN_DIR="$1/toolchains/llvm/prebuilt/${archDir}/bin"
-bash $PWD/../../wireguard/build-wireguard-go.sh
-bash $PWD/../../wireguard/libwg/build-android.sh
+bash $PWD/../../wireguard/build-wireguard-go.sh --android
 echo "Building nym-vpn-lib dep"
 
 #fix emulators later

--- a/nym-vpn-android/nym-vpn-client/src/main/scripts/build-libs.sh
+++ b/nym-vpn-android/nym-vpn-client/src/main/scripts/build-libs.sh
@@ -16,13 +16,17 @@ echo "Building nym-vpn-lib dep"
 
 #fix emulators later
 #(cd $PWD/src/tools/nym-vpn-client/crates/nym-vpn-lib; cargo ndk -t armeabi-v7a -t arm64-v8a -t i686-linux-android -t x86_64-linux-android  -o ../../../main/jniLibs build --release)
-(cd $PWD/../../nym-vpn-core/crates/nym-vpn-lib; cargo ndk -t arm64-v8a -o ../../../nym-vpn-android/nym-vpn-client/src/main/jniLibs build --release)
+pushd $PWD/../../nym-vpn-core/crates/nym-vpn-lib
+cargo ndk -t arm64-v8a -o ../../../nym-vpn-android/nym-vpn-client/src/main/jniLibs build --release
+popd
 
-(cd $PWD/../../nym-vpn-core; cargo run --bin uniffi-bindgen generate --library ./target/aarch64-linux-android/release/libnym_vpn_lib.so  --language kotlin --out-dir ../nym-vpn-android/nym-vpn-client/src/main/java/net/nymtech/vpn -n)
+pushd $PWD/../../nym-vpn-core
+cargo run --bin uniffi-bindgen generate --library ./target/aarch64-linux-android/release/libnym_vpn_lib.so  --language kotlin --out-dir ../nym-vpn-android/nym-vpn-client/src/main/java/net/nymtech/vpn -n
+popd
+
 cargo license -j --avoid-dev-deps --current-dir ../../nym-vpn-core/crates/nym-vpn-lib --filter-platform aarch64-linux-android --avoid-build-deps > ./src/main/assets/licenses_rust.json
 
 mv $PWD/../../nym-vpn-android/app/build/extraJni/arm64-v8a/libwg.so $PWD/src/main/jniLibs/arm64-v8a/
 #mv $PWD/src/tools/nym-vpn-client/nym-vpn-android/app/build/extraJni/armeabi-v7a/libwg.so $PWD/src/main/jniLibs/armeabi-v7a/
 #mv $PWD/src/tools/nym-vpn-client/nym-vpn-android/app/build/extraJni/x86/libwg.so $PWD/src/main/jniLibs/x86/
 #mv $PWD/src/tools/nym-vpn-client/nym-vpn-android/app/build/extraJni/x86_64/libwg.so $PWD/src/main/jniLibs/x86_64/
-

--- a/nym-vpn-android/nym-vpn-client/src/main/scripts/build-libs.sh
+++ b/nym-vpn-android/nym-vpn-client/src/main/scripts/build-libs.sh
@@ -21,7 +21,8 @@ echo "Building nym-vpn-lib dep"
 (cd $PWD/../../nym-vpn-core; cargo run --bin uniffi-bindgen generate --library ./target/aarch64-linux-android/release/libnym_vpn_lib.so  --language kotlin --out-dir ../nym-vpn-android/nym-vpn-client/src/main/java/net/nymtech/vpn -n)
 cargo license -j --avoid-dev-deps --current-dir ../../nym-vpn-core/crates/nym-vpn-lib --filter-platform aarch64-linux-android --avoid-build-deps > ./src/main/assets/licenses_rust.json
 
-mv $PWD/../../android/app/build/extraJni/arm64-v8a/libwg.so $PWD/src/main/jniLibs/arm64-v8a/
-#mv $PWD/src/tools/nym-vpn-client/android/app/build/extraJni/armeabi-v7a/libwg.so $PWD/src/main/jniLibs/armeabi-v7a/
-#mv $PWD/src/tools/nym-vpn-client/android/app/build/extraJni/x86/libwg.so $PWD/src/main/jniLibs/x86/
-#mv $PWD/src/tools/nym-vpn-client/android/app/build/extraJni/x86_64/libwg.so $PWD/src/main/jniLibs/x86_64/
+mv $PWD/../../nym-vpn-android/app/build/extraJni/arm64-v8a/libwg.so $PWD/src/main/jniLibs/arm64-v8a/
+#mv $PWD/src/tools/nym-vpn-client/nym-vpn-android/app/build/extraJni/armeabi-v7a/libwg.so $PWD/src/main/jniLibs/armeabi-v7a/
+#mv $PWD/src/tools/nym-vpn-client/nym-vpn-android/app/build/extraJni/x86/libwg.so $PWD/src/main/jniLibs/x86/
+#mv $PWD/src/tools/nym-vpn-client/nym-vpn-android/app/build/extraJni/x86_64/libwg.so $PWD/src/main/jniLibs/x86_64/
+

--- a/nym-vpn-core/crates/nym-vpn-lib/README.md
+++ b/nym-vpn-core/crates/nym-vpn-lib/README.md
@@ -8,7 +8,7 @@ brew install go
 2. Build the wireguard-go dependency
 ```
 cd nym-vpn-lib
-NDK_TOOLCHAIN_DIR="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/<system arch>/bin" ../wireguard/libwg/build-android.sh
+NDK_TOOLCHAIN_DIR="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/<system arch>/bin" ../wireguard/build-wireguard-go.sh --android
 ```
 3. Install rustup
 ```

--- a/wireguard/build-wireguard-go.sh
+++ b/wireguard/build-wireguard-go.sh
@@ -281,12 +281,12 @@ function build_wireguard_go {
     parseArgs $@
 
     if $IS_ANDROID_BUILD ; then
-        build_android $@
+        build_android
         return
     fi
 
     if $IS_IOS_BUILD ; then
-        build_ios $@
+        build_ios
         return
     fi
 

--- a/wireguard/build-wireguard-go.sh
+++ b/wireguard/build-wireguard-go.sh
@@ -14,15 +14,12 @@ IS_WIN_CROSS_BUILD=false
 function parseArgs {
     for arg in "$@"; do
       case "$arg" in
-        # handle --android option
         "--android" )
             IS_ANDROID_BUILD=true;
             shift ;;
-        # handle --ios option
         "--ios" )
             IS_IOS_BUILD=true;
             shift ;;
-        # handle --no-docker option
         "--docker" )
             IS_DOCKER_BUILD=true;
             shift ;;
@@ -30,7 +27,6 @@ function parseArgs {
         "--windows-cross" )
             IS_WIN_CROSS_BUILD=true;
             shift ;;
-        # handle --arm64 option
         "--arm64" )
             IS_WIN_ARM64=true;
             shift ;;

--- a/wireguard/build-wireguard-go.sh
+++ b/wireguard/build-wireguard-go.sh
@@ -7,7 +7,7 @@ LIB_DIR="libwg"
 
 IS_ANDROID_BUILD=false
 IS_IOS_BUILD=false
-IS_DOCKER_BUILD=true
+IS_DOCKER_BUILD=false
 IS_WIN_ARM64=false
 IS_WIN_CROSS_BUILD=false
 
@@ -23,8 +23,8 @@ function parseArgs {
             IS_IOS_BUILD=true;
             shift ;;
         # handle --no-docker option
-        "--no-docker" )
-            IS_DOCKER_BUILD=false;
+        "--docker" )
+            IS_DOCKER_BUILD=true;
             shift ;;
         # handle --windows-cross option (allowing windows build from linux for example)
         "--windows-cross" )

--- a/wireguard/build-wireguard-go.sh
+++ b/wireguard/build-wireguard-go.sh
@@ -172,6 +172,7 @@ function build_android {
             --env ANDROID_NDK_HOME="/opt/android/android-ndk-r20b" \
             docker.io/pronebird1337/nymtech-android-app@sha256:$docker_image_hash
     else
+        patch_go_runtime
         ./$LIB_DIR/build-android.sh
     fi
 }
@@ -184,7 +185,7 @@ function create_folder_and_build {
 }
 
 function build_macos_universal {
-    patch_darwin_goruntime
+    patch_go_runtime
 
     export CGO_ENABLED=1
     export MACOSX_DEPLOYMENT_TARGET=10.13
@@ -208,7 +209,7 @@ function build_macos_universal {
 }
 
 function build_ios {
-    patch_darwin_goruntime
+    patch_go_runtime
 
     export CGO_ENABLED=1
     export IPHONEOS_DEPLOYMENT_TARGET=16.0
@@ -258,14 +259,22 @@ function build_ios {
     popd
 }
 
-function patch_darwin_goruntime {
-    echo "Patching goruntime..."
+function patch_go_runtime {
+    echo "Patching go runtime"
+
     BUILDDIR="$(pwd)/../build"
     REAL_GOROOT=$(go env GOROOT 2>/dev/null)
     export GOROOT="$BUILDDIR/goroot"
     mkdir -p "$GOROOT"
     rsync -a --delete --exclude=pkg/obj/go-build "$REAL_GOROOT/" "$GOROOT/"
-    cat $LIB_DIR/goruntime-boottime-over-monotonic-darwin.diff | patch -p1 -f -N -r- -d "$GOROOT"
+
+    if $IS_ANDROID_BUILD; then
+        local patch_file="$LIB_DIR/goruntime-boottime-over-monotonic.diff"
+    else
+        local patch_file="$LIB_DIR/goruntime-boottime-over-monotonic-darwin.diff"
+    fi
+    echo "Applying patch: $patch_file"
+    cat "$patch_file" | patch -p1 -f -N -r- -d "$GOROOT"
 }
 
 function build_wireguard_go {

--- a/wireguard/libwg/Android.mk
+++ b/wireguard/libwg/Android.mk
@@ -25,7 +25,7 @@ $(DESTDIR)/libwg.so:
 	mkdir -p $(DESTDIR)
 	go get -tags "linux android"
 	chmod -fR +w "$(GOPATH)/pkg/mod"
-	go build -tags "linux android" -ldflags="-X main.socketDirectory=/data/data/$(ANDROID_PACKAGE_NAME)/cache/wireguard" -v -o "$@" -buildmode c-shared
+	go build -tags "linux android" -ldflags="-X main.socketDirectory=/data/data/$(ANDROID_PACKAGE_NAME)/cache/wireguard" -trimpath -v -o "$@" -buildmode c-shared
 	rm -f $(DESTDIR)/libwg.h
 
 

--- a/wireguard/libwg/Android.mk
+++ b/wireguard/libwg/Android.mk
@@ -3,6 +3,7 @@
 # Copyright © 2017-2019 WireGuard LLC. All Rights Reserved.
 
 DESTDIR ?= $(CURDIR)/../../build/lib/$(RUST_TARGET_TRIPLE)
+ANDROID_PACKAGE_NAME ?= net.nymtech.nymvpn
 
 NDK_GO_ARCH_MAP_x86 := 386
 NDK_GO_ARCH_MAP_x86_64 := amd64

--- a/wireguard/libwg/Android.mk
+++ b/wireguard/libwg/Android.mk
@@ -20,13 +20,6 @@ export CGO_ENABLED := 1
 
 default: $(DESTDIR)/libwg.so
 
-GOBUILDARCH := $(NDK_GO_ARCH_MAP_$(shell uname -m))
-GOBUILDOS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
-GOBUILDVERSION := 1.22.6
-# TODO: Add checksum?
-GOBUILDTARBALL := https://go.dev/dl/go$(GOBUILDVERSION).$(GOBUILDOS)-$(GOBUILDARCH).tar.gz
-GOBUILDVERSION_NEEDED := go version go$(GOBUILDVERSION) $(GOBUILDOS)/$(GOBUILDARCH)
-
 $(DESTDIR)/libwg.so:
 	mkdir -p $(DESTDIR)
 	go get -tags "linux android"

--- a/wireguard/libwg/build-android.sh
+++ b/wireguard/libwg/build-android.sh
@@ -10,6 +10,9 @@ cd $script_dir
 export GOPATH=$script_dir/../../build/android-go-path/
 mkdir -p $GOPATH
 
+echo "GOPATH: $GOPATH"
+echo "GOROOT: $GOROOT"
+
 for arch in ${ARCHITECTURES:-armv7 aarch64 x86_64 i686}; do
     case "$arch" in
         "aarch64")

--- a/wireguard/libwg/build-android.sh
+++ b/wireguard/libwg/build-android.sh
@@ -14,33 +14,31 @@ for arch in ${ARCHITECTURES:-armv7 aarch64 x86_64 i686}; do
     case "$arch" in
         "aarch64")
             export ANDROID_C_COMPILER="${NDK_TOOLCHAIN_DIR}/aarch64-linux-android21-clang"
-            export ANDROID_STRIP_TOOL="${NDK_TOOLCHAIN_DIR}/aarch64-linux-android-strip"
             export RUST_TARGET_TRIPLE="aarch64-linux-android"
             export ANDROID_ABI="arm64-v8a"
             export ANDROID_ARCH_NAME="arm64"
             ;;
         "x86_64")
             export ANDROID_C_COMPILER="${NDK_TOOLCHAIN_DIR}/x86_64-linux-android21-clang"
-            export ANDROID_STRIP_TOOL="${NDK_TOOLCHAIN_DIR}/x86_64-linux-android-strip"
             export RUST_TARGET_TRIPLE="x86_64-linux-android"
             export ANDROID_ABI="x86_64"
             export ANDROID_ARCH_NAME="x86_64"
             ;;
         "armv7")
             export ANDROID_C_COMPILER="${NDK_TOOLCHAIN_DIR}/armv7a-linux-androideabi21-clang"
-            export ANDROID_STRIP_TOOL="${NDK_TOOLCHAIN_DIR}/arm-linux-androideabi-strip"
             export RUST_TARGET_TRIPLE="armv7-linux-androideabi"
             export ANDROID_ABI="armeabi-v7a"
             export ANDROID_ARCH_NAME="arm"
             ;;
         "i686")
             export ANDROID_C_COMPILER="${NDK_TOOLCHAIN_DIR}/i686-linux-android21-clang"
-            export ANDROID_STRIP_TOOL="${NDK_TOOLCHAIN_DIR}/i686-linux-android-strip"
             export RUST_TARGET_TRIPLE="i686-linux-android"
             export ANDROID_ABI="x86"
             export ANDROID_ARCH_NAME="x86"
             ;;
     esac
+    
+    export ANDROID_STRIP_TOOL="${NDK_TOOLCHAIN_DIR}/llvm-strip"
 
     # Build Wireguard-Go
     echo $(pwd)
@@ -59,10 +57,7 @@ for arch in ${ARCHITECTURES:-armv7 aarch64 x86_64 i686}; do
     # the directories afterwards
     mkdir -m 777 -p "$(dirname "$STRIPPED_LIB_PATH")"
 
-    cp "$UNSTRIPPED_LIB_PATH" "$STRIPPED_LIB_PATH"
-
-#    this is not available in the newer NDK
-#    $ANDROID_STRIP_TOOL --strip-unneeded --strip-debug -o "$STRIPPED_LIB_PATH" "$UNSTRIPPED_LIB_PATH"
+    $ANDROID_STRIP_TOOL --strip-unneeded --strip-debug -o "$STRIPPED_LIB_PATH" "$UNSTRIPPED_LIB_PATH"
 
     # Set permissions so that the build server can clean the outputs afterwards
     chmod 777 "$STRIPPED_LIB_PATH"

--- a/wireguard/libwg/build-android.sh
+++ b/wireguard/libwg/build-android.sh
@@ -54,7 +54,7 @@ for arch in ${ARCHITECTURES:-armv7 aarch64 x86_64 i686}; do
 
     # Strip and copy the libray to `android/build/extraJni/$ANDROID_ABI` to be able to build the APK
     UNSTRIPPED_LIB_PATH="../../build/lib/$RUST_TARGET_TRIPLE/libwg.so"
-    STRIPPED_LIB_PATH="../../android/app/build/extraJni/$ANDROID_ABI/libwg.so"
+    STRIPPED_LIB_PATH="../../nym-vpn-android/app/build/extraJni/$ANDROID_ABI/libwg.so"
 
     # Create the directories with RWX permissions for all users so that the build server can clean
     # the directories afterwards


### PR DESCRIPTION
### Changes to `build-wireguard-go.sh`:

-  Disable android builds using docker *by default*:
    - Use the following command to build for android in docker: `build-wireguard-go.sh --android --docker`
    - Omit `--docker` to build within the current environment: `build-wireguard-go.sh --android`
- Patch go runtime when building for `--android` without docker. Docker builds take care of patching golang as a part of `Dockerfile_AndroidPatchedGoruntime`, that's why docker runs `android-build.sh` directly.

### Changes to `Android.mk`

- Remove unused variables that were used for downloading the golang
- Set missing `ANDROID_PACKAGE_NAME` which is used in linker flags.
- Pass `-trimpath` to `go build` to strip local file system paths in crash logs/trace.

### Changes to `build-android.sh`

- Restore the use of strip tool on android which is now called `llvm-strip` to reduce binary size.
- Print `GOROOT` and `GOPATH` in the shell script for validation (both should point to custom folder within the build dir)


### Android build scripts and CI

- Use `build-wireguard-go.sh --android` instead of a combination of `build-wireguard-go.sh` and `build-android.sh` which is incorrect usage as the former builds libwg for current platform and the latter builds it for android.
- Migrate build output for wireguard-go from `android/app/build/extraJni` to `nym-vpn-android/app/build/extraJni`
- Error `build-libs.sh` on first error.
- Use `pushd` instead of sub-shelling in `build-libs.sh`. This is not critical but made it a bit easier to read long shell commands.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1791)
<!-- Reviewable:end -->
