### PR TITLE
Confine storage interation to the account controller

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -4737,6 +4737,7 @@ name = "nym-vpn-account-controller"
 version = "1.2.0-dev"
 dependencies = [
  "futures",
+ "nym-client-core",
  "nym-compact-ecash",
  "nym-config",
  "nym-credential-proxy-requests",
@@ -4750,6 +4751,7 @@ dependencies = [
  "nym-vpn-api-client",
  "nym-vpn-network-config",
  "nym-vpn-store",
+ "nym-wg-gateway-client",
  "reqwest 0.11.27",
  "serde",
  "serde_json",

--- a/nym-vpn-core/crates/nym-vpn-account-controller/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 
 [dependencies]
 futures.workspace = true
+nym-client-core.workspace = true
 nym-compact-ecash.workspace = true
 nym-config.workspace = true
 nym-credential-proxy-requests.workspace = true
@@ -23,6 +24,7 @@ nym-validator-client.workspace = true
 nym-vpn-api-client = { path = "../nym-vpn-api-client" }
 nym-vpn-network-config = { path = "../nym-vpn-network-config" }
 nym-vpn-store = { path = "../nym-vpn-store" }
+nym-wg-gateway-client = { path = "../nym-wg-gateway-client" }
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/mod.rs
@@ -88,6 +88,9 @@ pub enum AccountCommandError {
     #[error("failed to remove account files: {0}")]
     RemoveAccountFiles(String),
 
+    #[error("failed to init device keys: {0}")]
+    InitDeviceKeys(String),
+
     // Catch all for any other error
     #[error("general error: {0}")]
     General(String),

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/request_zknym.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/request_zknym.rs
@@ -84,6 +84,10 @@ impl WaitingRequestZkNymCommandHandler {
         }
     }
 
+    pub(crate) fn reset(&self) {
+        self.zk_nym_fails_in_a_row.store(0, Ordering::Relaxed);
+    }
+
     pub(crate) async fn max_fails_reached(&self) -> bool {
         self.zk_nym_fails_in_a_row.load(Ordering::Relaxed) >= ZK_NYM_MAX_FAILS
     }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
@@ -256,7 +256,16 @@ where
         self.account_storage
             .store_account(mnemonic)
             .await
-            .map_err(AccountCommandError::general)
+            .map_err(AccountCommandError::general)?;
+
+        self.update_mnemonic_state()
+            .await
+            .map_err(|_err| AccountCommandError::NoAccountStored)?;
+
+        // We don't need to wait for the sync to finish, so queue it up and return
+        self.queue_command(AccountCommand::SyncAccountState(None));
+
+        Ok(())
     }
 
     async fn handle_forget_account(&mut self) -> Result<(), AccountCommandError> {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
@@ -269,7 +269,7 @@ where
     }
 
     async fn handle_forget_account(&mut self) -> Result<(), AccountCommandError> {
-        tracing::warn!("REMOVING ACCOUNT AND ALL ASSOCIATED DATA");
+        tracing::info!("REMOVING ACCOUNT AND ALL ASSOCIATED DATA");
 
         // TODO: here we should put the controller in some sort of idle state, and wait for all
         // currently running operations to finish before proceeding with the reset

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
@@ -9,7 +9,7 @@ use nym_vpn_api_client::{
     types::VpnApiAccount,
 };
 use nym_vpn_network_config::Network;
-use nym_vpn_store::VpnStorage;
+use nym_vpn_store::{mnemonic::Mnemonic, VpnStorage};
 use tokio::{
     sync::mpsc::{UnboundedReceiver, UnboundedSender},
     task::{JoinError, JoinSet},
@@ -20,8 +20,8 @@ use crate::{
     commands::{
         register_device::RegisterDeviceCommandHandler,
         request_zknym::WaitingRequestZkNymCommandHandler,
-        update_account::WaitingUpdateAccountCommandHandler,
-        update_device::WaitingUpdateDeviceCommandHandler, AccountCommand, AccountCommandError,
+        sync_account::WaitingSyncAccountCommandHandler,
+        sync_device::WaitingSyncDeviceCommandHandler, AccountCommand, AccountCommandError,
         AccountCommandResult, Command, RunningCommands,
     },
     error::Error,
@@ -43,8 +43,12 @@ where
     // The storage used for the account and device keys
     account_storage: AccountStorage<S>,
 
-    // Storage used for credentials
+    // Storage used for credentials.
+    // It is an Option because we want to be able to close it when we reset the account.
     credential_storage: VpnCredentialStorage,
+
+    // The data directory where we store the account and device keys.
+    data_dir: PathBuf,
 
     // The API client used to interact with the nym-vpn-api
     vpn_api_client: nym_vpn_api_client::VpnApiClient,
@@ -65,11 +69,11 @@ where
     // Command tasks that are currently running
     running_command_tasks: JoinSet<AccountCommandResult>,
 
-    // Account update command handler state reused between runs
-    waiting_update_account_command_handler: WaitingUpdateAccountCommandHandler,
+    // Account sync command handler state reused between runs
+    waiting_sync_account_command_handler: WaitingSyncAccountCommandHandler,
 
-    // Device update command handler state reused between runs
-    waiting_update_device_command_handler: WaitingUpdateDeviceCommandHandler,
+    // Device sync command handler state reused between runs
+    waiting_sync_device_command_handler: WaitingSyncDeviceCommandHandler,
 
     // Zk-nym request command handler state reused between runs
     waiting_request_zknym_command_handler: WaitingRequestZkNymCommandHandler,
@@ -108,7 +112,7 @@ where
         // Generate the device keys if we don't already have them
         account_storage.init_keys().await?;
 
-        let credential_storage = VpnCredentialStorage::setup_from_path(data_dir).await?;
+        let credential_storage = VpnCredentialStorage::setup_from_path(data_dir.clone()).await?;
 
         let (command_tx, command_rx) = tokio::sync::mpsc::unbounded_channel();
 
@@ -117,10 +121,10 @@ where
             nym_vpn_api_client::VpnApiClient::new(network_env.vpn_api_url(), user_agent)
                 .map_err(Error::SetupVpnApiClient)?;
 
-        let waiting_update_account_command_handler =
-            WaitingUpdateAccountCommandHandler::new(account_state.clone(), vpn_api_client.clone());
-        let waiting_update_device_command_handler =
-            WaitingUpdateDeviceCommandHandler::new(account_state.clone(), vpn_api_client.clone());
+        let waiting_sync_account_command_handler =
+            WaitingSyncAccountCommandHandler::new(account_state.clone(), vpn_api_client.clone());
+        let waiting_sync_device_command_handler =
+            WaitingSyncDeviceCommandHandler::new(account_state.clone(), vpn_api_client.clone());
         let waiting_request_zknym_command_handler = WaitingRequestZkNymCommandHandler::new(
             credential_storage.clone(),
             account_state.clone(),
@@ -130,14 +134,15 @@ where
         Ok(AccountController {
             account_storage,
             credential_storage,
+            data_dir,
             vpn_api_client,
             account_state,
             command_rx,
             command_tx,
             running_commands: Default::default(),
             running_command_tasks: JoinSet::new(),
-            waiting_update_account_command_handler,
-            waiting_update_device_command_handler,
+            waiting_sync_account_command_handler,
+            waiting_sync_device_command_handler,
             waiting_request_zknym_command_handler,
             background_zk_nym_refresh: credentials_mode,
             cancel_token,
@@ -247,7 +252,66 @@ where
         Ok(())
     }
 
-    async fn handle_update_account_state(&mut self, command: AccountCommand) {
+    async fn handle_store_account(&self, mnemonic: Mnemonic) -> Result<(), AccountCommandError> {
+        self.account_storage
+            .store_account(mnemonic)
+            .await
+            .map_err(AccountCommandError::general)
+    }
+
+    async fn handle_forget_account(&mut self) -> Result<(), AccountCommandError> {
+        tracing::warn!("REMOVING ACCOUNT AND ALL ASSOCIATED DATA");
+
+        // TODO: here we should put the controller in some sort of idle state, and wait for all
+        // currently running operations to finish before proceeding with the reset
+
+        self.account_storage
+            .remove_account()
+            .await
+            .map_err(|source| {
+                tracing::error!("Failed to remove account: {source:?}");
+                AccountCommandError::RemoveAccount(source.to_string())
+            })?;
+
+        self.account_storage
+            .remove_device_keys()
+            .await
+            .map_err(|source| {
+                tracing::error!("Failed to remove device identity: {source:?}");
+                AccountCommandError::RemoveAccount(source.to_string())
+            })?;
+
+        self.credential_storage.reset().await.map_err(|source| {
+            tracing::error!("Failed to reset credential storage: {source:?}");
+            AccountCommandError::ResetCredentialStorage(source.to_string())
+        })?;
+
+        // Purge all files in the data directory that we are not explicitly deleting through it's
+        // owner. Ideally we should strive for this to be removed.
+        // If this fails, we still need to continue with the remaining steps
+        let remove_files_result = crate::util::remove_files_for_account(&self.data_dir)
+            .inspect_err(|err| {
+                tracing::error!("Failed to remove files for account: {err:?}");
+            });
+
+        // Once we have removed or reset all storage, we need to reset the account state
+        self.waiting_request_zknym_command_handler.reset();
+        self.account_state.reset().await;
+
+        // And conclude by syncing with the remote state
+        self.handle_sync_account_state(AccountCommand::SyncAccountState(None))
+            .await;
+
+        if remove_files_result.is_err() {
+            return Err(AccountCommandError::RemoveAccountFiles(
+                "Failed to remove files for account".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    async fn handle_sync_account_state(&mut self, command: AccountCommand) {
         let account = self
             .update_mnemonic_state()
             .await
@@ -261,14 +325,14 @@ where
             }
         };
 
-        let command_handler = self.waiting_update_account_command_handler.build(account);
+        let command_handler = self.waiting_sync_account_command_handler.build(account);
 
         if self.running_commands.add(command).await == Command::IsFirst {
             self.running_command_tasks.spawn(command_handler.run());
         }
     }
 
-    async fn handle_update_device_state(&mut self, command: AccountCommand) {
+    async fn handle_sync_device_state(&mut self, command: AccountCommand) {
         let account = self
             .update_mnemonic_state()
             .await
@@ -297,7 +361,7 @@ where
         };
 
         let command_handler = self
-            .waiting_update_device_command_handler
+            .waiting_sync_device_command_handler
             .build(account, device);
 
         if self.running_commands.add(command).await == Command::IsFirst {
@@ -318,6 +382,17 @@ where
             .map_err(AccountCommandError::general)?;
         tracing::info!("Usage: {:#?}", usage);
         Ok(usage.items)
+    }
+
+    async fn handle_get_device_identity(&self) -> Result<String, AccountCommandError> {
+        let device = self
+            .account_storage
+            .load_device_id()
+            .await
+            .map_err(|_err| AccountCommandError::NoDeviceStored)?;
+
+        tracing::info!("Device identity: {device:?}");
+        Ok(device)
     }
 
     async fn handle_register_device(&mut self, command: AccountCommand) {
@@ -508,17 +583,26 @@ where
     async fn handle_command(&mut self, command: AccountCommand) {
         tracing::info!("Received command: {}", command);
         match command {
-            AccountCommand::ResetAccount => {
-                self.account_state.reset().await;
+            AccountCommand::StoreAccount(result_tx, mnemonic) => {
+                let result = self.handle_store_account(mnemonic).await;
+                result_tx.send(result);
             }
-            AccountCommand::UpdateAccountState(_) => {
-                self.handle_update_account_state(command).await;
+            AccountCommand::ForgetAccount(result_tx) => {
+                let result = self.handle_forget_account().await;
+                result_tx.send(result);
             }
-            AccountCommand::UpdateDeviceState(_) => {
-                self.handle_update_device_state(command).await;
+            AccountCommand::SyncAccountState(_) => {
+                self.handle_sync_account_state(command).await;
+            }
+            AccountCommand::SyncDeviceState(_) => {
+                self.handle_sync_device_state(command).await;
             }
             AccountCommand::GetUsage(result_tx) => {
                 let result = self.handle_get_usage().await;
+                result_tx.send(result);
+            }
+            AccountCommand::GetDeviceIdentity(result_tx) => {
+                let result = self.handle_get_device_identity().await;
                 result_tx.send(result);
             }
             AccountCommand::RegisterDevice(_) => {
@@ -581,14 +665,14 @@ where
         };
 
         match result {
-            AccountCommandResult::UpdateAccountState(r) => {
-                tracing::debug!("Account state completed: {:?}", r);
+            AccountCommandResult::SyncAccountState(r) => {
+                tracing::debug!("Account sync task: {:?}", r);
                 let commands = self
                     .running_commands
-                    .remove(&AccountCommand::UpdateAccountState(None))
+                    .remove(&AccountCommand::SyncAccountState(None))
                     .await;
                 for command in commands {
-                    if let AccountCommand::UpdateAccountState(Some(tx)) = command {
+                    if let AccountCommand::SyncAccountState(Some(tx)) = command {
                         tx.send(r.clone());
                     }
                 }
@@ -597,14 +681,14 @@ where
                     self.request_zk_nym_if_ready().await.ok();
                 }
             }
-            AccountCommandResult::UpdateDeviceState(r) => {
-                tracing::debug!("Device state updated: {:?}", r);
+            AccountCommandResult::SyncDeviceState(r) => {
+                tracing::debug!("Device sync task: {:?}", r);
                 let commands = self
                     .running_commands
-                    .remove(&AccountCommand::UpdateDeviceState(None))
+                    .remove(&AccountCommand::SyncDeviceState(None))
                     .await;
                 for command in commands {
-                    if let AccountCommand::UpdateDeviceState(Some(tx)) = command {
+                    if let AccountCommand::SyncDeviceState(Some(tx)) = command {
                         tx.send(r.clone());
                     }
                 }
@@ -625,7 +709,7 @@ where
                     }
                 }
                 if r.is_ok() {
-                    self.queue_command(AccountCommand::UpdateAccountState(None));
+                    self.queue_command(AccountCommand::SyncAccountState(None));
                     self.request_zk_nym_if_ready().await.ok();
                 }
             }
@@ -689,8 +773,8 @@ where
         // so that we periodically check the results without interfering with other tasks
         let mut command_finish_timer = tokio::time::interval(Duration::from_millis(500));
 
-        // Timer to periodically refresh the remote account state
-        let mut update_account_state_timer = tokio::time::interval(ACCOUNT_UPDATE_INTERVAL);
+        // Timer to periodically sync the remote account state
+        let mut sync_account_state_timer = tokio::time::interval(ACCOUNT_UPDATE_INTERVAL);
 
         // Timer to periodically check if we need to request more zk-nyms
         let mut update_zk_nym_timer = tokio::time::interval(ZK_NYM_AUTOMATIC_REQUEST_INTERVAL);
@@ -707,10 +791,10 @@ where
                         self.handle_command_result(result).await;
                     }
                 }
-                // On a timer we want to refresh the account and device state
-                _ = update_account_state_timer.tick() => {
-                    self.queue_command(AccountCommand::UpdateAccountState(None));
-                    self.queue_command(AccountCommand::UpdateDeviceState(None));
+                // On a timer we want to sync the account and device state
+                _ = sync_account_state_timer.tick() => {
+                    self.queue_command(AccountCommand::SyncAccountState(None));
+                    self.queue_command(AccountCommand::SyncDeviceState(None));
                 }
                 // On a timer to check if we need to request more zk-nyms
                 _ = update_zk_nym_timer.tick() => {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/error.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/error.rs
@@ -88,6 +88,9 @@ pub enum Error {
 
     #[error("failed to parse ticket type: {0}")]
     ParseTicketType(String),
+
+    #[error("credential storage not initialized")]
+    CredentialStorageNotInitialized,
 }
 
 impl Error {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/shared_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/shared_state.rs
@@ -179,6 +179,19 @@ impl SharedAccountState {
         guard.request_zk_nym_result = Some(request);
     }
 
+    pub async fn is_account_stored(&self) -> bool {
+        self.lock()
+            .await
+            .mnemonic
+            .clone()
+            .map(|m| m.is_stored())
+            .unwrap_or(false)
+    }
+
+    pub async fn get_account_id(&self) -> Option<String> {
+        self.lock().await.mnemonic.clone().and_then(|m| m.id())
+    }
+
     pub(crate) async fn is_ready_to_register_device(&self) -> ReadyToRegisterDevice {
         self.lock().await.is_ready_to_register_device()
     }
@@ -234,6 +247,19 @@ pub enum MnemonicState {
 
     // The recovery phrase is stored locally
     Stored { id: String },
+}
+
+impl MnemonicState {
+    pub fn is_stored(&self) -> bool {
+        matches!(self, MnemonicState::Stored { .. })
+    }
+
+    pub fn id(&self) -> Option<String> {
+        match self {
+            MnemonicState::Stored { id } => Some(id.clone()),
+            MnemonicState::NotStored => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/storage.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/storage.rs
@@ -35,17 +35,6 @@ where
         Self { storage }
     }
 
-    pub(crate) async fn init_keys(&self) -> Result<(), Error> {
-        self.storage
-            .lock()
-            .await
-            .init_keys(None)
-            .await
-            .map_err(|err| Error::KeyStore {
-                source: Box::new(err),
-            })
-    }
-
     pub(crate) async fn store_account(&self, mnemonic: Mnemonic) -> Result<(), Error> {
         self.storage
             .lock()
@@ -82,6 +71,17 @@ where
 
     pub(crate) async fn load_account_id(&self) -> Result<String, Error> {
         self.load_account().await.map(|account| account.id())
+    }
+
+    pub(crate) async fn init_keys(&self) -> Result<(), Error> {
+        self.storage
+            .lock()
+            .await
+            .init_keys(None)
+            .await
+            .map_err(|err| Error::KeyStore {
+                source: Box::new(err),
+            })
     }
 
     pub(crate) async fn load_device_keys(&self) -> Result<Device, Error> {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/storage.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/storage.rs
@@ -1,7 +1,10 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{path::Path, sync::Arc};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use nym_compact_ecash::VerificationKeyAuth;
 use nym_credential_storage::persistent_storage::PersistentStorage as PersistentCredentialStorage;
@@ -10,9 +13,9 @@ use nym_credentials::{
     IssuedTicketBook,
 };
 use nym_credentials_interface::TicketType;
-use nym_sdk::mixnet::CredentialStorage;
+use nym_sdk::mixnet::{CredentialStorage, StoragePaths};
 use nym_vpn_api_client::types::{Device, VpnApiAccount};
-use nym_vpn_store::{keys::KeyStore, mnemonic::MnemonicStorage, VpnStorage};
+use nym_vpn_store::{mnemonic::Mnemonic, VpnStorage};
 
 use crate::{error::Error, AvailableTicketbooks};
 
@@ -43,22 +46,34 @@ where
             })
     }
 
-    // Load account and keep the error type
-    pub(crate) async fn load_account_from_storage(
-        &self,
-    ) -> Result<VpnApiAccount, <S as MnemonicStorage>::StorageError> {
+    pub(crate) async fn store_account(&self, mnemonic: Mnemonic) -> Result<(), Error> {
+        self.storage
+            .lock()
+            .await
+            .store_mnemonic(mnemonic)
+            .await
+            .map_err(|err| Error::MnemonicStore {
+                source: Box::new(err),
+            })
+    }
+
+    pub(crate) async fn load_account(&self) -> Result<VpnApiAccount, Error> {
         self.storage
             .lock()
             .await
             .load_mnemonic()
             .await
             .map(VpnApiAccount::from)
-            .inspect(|account| tracing::debug!("Loading account id: {}", account.id()))
+            .map_err(|err| Error::MnemonicStore {
+                source: Box::new(err),
+            })
     }
 
-    // Convenience function to load account and box the error
-    pub(crate) async fn load_account(&self) -> Result<VpnApiAccount, Error> {
-        self.load_account_from_storage()
+    pub(crate) async fn remove_account(&self) -> Result<(), Error> {
+        self.storage
+            .lock()
+            .await
+            .remove_mnemonic()
             .await
             .map_err(|err| Error::MnemonicStore {
                 source: Box::new(err),
@@ -69,10 +84,7 @@ where
         self.load_account().await.map(|account| account.id())
     }
 
-    // Load device keys and keep the error type
-    pub(crate) async fn load_device_keys_from_storage(
-        &self,
-    ) -> Result<Device, <S as KeyStore>::StorageError> {
+    pub(crate) async fn load_device_keys(&self) -> Result<Device, Error> {
         self.storage
             .lock()
             .await
@@ -82,12 +94,6 @@ where
             .inspect(|device| {
                 tracing::debug!("Loading device keys: {}", device.identity_key());
             })
-    }
-
-    // Convenience function to load device keys and box the error
-    pub(crate) async fn load_device_keys(&self) -> Result<Device, Error> {
-        self.load_device_keys_from_storage()
-            .await
             .map_err(|err| Error::KeyStore {
                 source: Box::new(err),
             })
@@ -98,23 +104,67 @@ where
             .await
             .map(|device| device.identity_key().to_string())
     }
+
+    pub(crate) async fn remove_device_keys(&self) -> Result<(), Error> {
+        self.storage
+            .lock()
+            .await
+            .remove_keys()
+            .await
+            .map_err(|err| Error::KeyStore {
+                source: Box::new(err),
+            })
+    }
 }
 
 #[derive(Clone)]
 pub(crate) struct VpnCredentialStorage {
     pub(crate) storage: Arc<tokio::sync::Mutex<PersistentCredentialStorage>>,
+    data_dir: PathBuf,
 }
 
 impl VpnCredentialStorage {
     pub(crate) async fn setup_from_path<P: AsRef<Path>>(data_dir: P) -> Result<Self, Error> {
         let storage_paths =
-            nym_sdk::mixnet::StoragePaths::new_from_dir(data_dir).map_err(Error::StoragePaths)?;
+            StoragePaths::new_from_dir(data_dir.as_ref()).map_err(Error::StoragePaths)?;
         let storage = storage_paths
             .persistent_credential_storage()
             .await
             .map_err(Error::SetupCredentialStorage)?;
         let storage = Arc::new(tokio::sync::Mutex::new(storage));
-        Ok(Self::from(storage))
+        Ok(Self {
+            storage,
+            data_dir: data_dir.as_ref().to_path_buf(),
+        })
+    }
+
+    pub(crate) async fn reset(&mut self) -> Result<(), Error> {
+        let mut guard = self.storage.lock().await;
+
+        // First we close the storage to ensure that all files are closed
+        guard.close().await;
+
+        // Calling close on the storage should be enough to ensure that all files are closed
+        // but just to be sure we wait a bit
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+        // Then we remove the credential database file
+        let storage_paths =
+            StoragePaths::new_from_dir(&self.data_dir).map_err(Error::StoragePaths)?;
+
+        std::fs::remove_file(&storage_paths.credential_database_path)
+            .inspect_err(|err| {
+                tracing::error!("Failed to remove file: {err:?}");
+            })
+            .ok();
+
+        // Finally we recreate the storage
+        *guard = storage_paths
+            .persistent_credential_storage()
+            .await
+            .map_err(Error::SetupCredentialStorage)?;
+
+        Ok(())
     }
 
     pub(crate) async fn insert_issued_ticketbook(
@@ -201,11 +251,5 @@ impl VpnCredentialStorage {
         self.get_available_ticketbooks()
             .await
             .map(|ticketbooks| ticketbooks.ticket_types_running_low())
-    }
-}
-
-impl From<Arc<tokio::sync::Mutex<PersistentCredentialStorage>>> for VpnCredentialStorage {
-    fn from(storage: Arc<tokio::sync::Mutex<PersistentCredentialStorage>>) -> Self {
-        Self { storage }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/util.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/util.rs
@@ -1,7 +1,25 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{ffi::OsStr, fs, path::Path};
+use std::{fs, path::Path};
+
+use nym_client_core::config::disk_persistence::{
+    DEFAULT_ACK_KEY_FILENAME, DEFAULT_GATEWAYS_DETAILS_DB_FILENAME,
+    DEFAULT_PRIVATE_ENCRYPTION_KEY_FILENAME, DEFAULT_PRIVATE_IDENTITY_KEY_FILENAME,
+    DEFAULT_PUBLIC_ENCRYPTION_KEY_FILENAME, DEFAULT_PUBLIC_IDENTITY_KEY_FILENAME,
+    DEFAULT_REPLY_SURB_DB_FILENAME,
+};
+use nym_vpn_store::keys::persistence::{
+    DEFAULT_PRIVATE_DEVICE_KEY_FILENAME, DEFAULT_PUBLIC_DEVICE_KEY_FILENAME,
+};
+use nym_wg_gateway_client::{
+    DEFAULT_FREE_PRIVATE_ENTRY_WIREGUARD_KEY_FILENAME,
+    DEFAULT_FREE_PRIVATE_EXIT_WIREGUARD_KEY_FILENAME,
+    DEFAULT_FREE_PUBLIC_ENTRY_WIREGUARD_KEY_FILENAME,
+    DEFAULT_FREE_PUBLIC_EXIT_WIREGUARD_KEY_FILENAME, DEFAULT_PRIVATE_ENTRY_WIREGUARD_KEY_FILENAME,
+    DEFAULT_PRIVATE_EXIT_WIREGUARD_KEY_FILENAME, DEFAULT_PUBLIC_ENTRY_WIREGUARD_KEY_FILENAME,
+    DEFAULT_PUBLIC_EXIT_WIREGUARD_KEY_FILENAME,
+};
 
 use crate::Error;
 
@@ -9,25 +27,49 @@ use crate::Error;
 // protect us against the names drifting out of sync.
 
 pub fn remove_files_for_account(data_dir: &Path) -> Result<(), Error> {
-    // Delete all files in data_dir that matches any of these patterns:
-    // *.sqlite
-    // *.pem
+    let device_key = [
+        DEFAULT_PRIVATE_DEVICE_KEY_FILENAME,
+        DEFAULT_PUBLIC_DEVICE_KEY_FILENAME,
+    ];
 
-    for file in fs::read_dir(data_dir).map_err(Error::internal)? {
-        let file = match file {
-            Ok(file) => file,
-            Err(err) => {
-                tracing::error!("failed to read file in data directory: {:?}", err);
-                continue;
-            }
-        };
+    let mixnet_keys = [
+        DEFAULT_PRIVATE_IDENTITY_KEY_FILENAME,
+        DEFAULT_PUBLIC_IDENTITY_KEY_FILENAME,
+        DEFAULT_PRIVATE_ENCRYPTION_KEY_FILENAME,
+        DEFAULT_PUBLIC_ENCRYPTION_KEY_FILENAME,
+        DEFAULT_ACK_KEY_FILENAME,
+    ];
 
-        if Some(OsStr::new("sqlite")) == file.path().extension()
-            || Some(OsStr::new("pem")) == file.path().extension()
-        {
-            tracing::info!("removing file: {:?}", file.path());
-            fs::remove_file(file.path())
-                .inspect_err(|err| tracing::error!("failed to remove file: {:?}", err))
+    let wireguard_keys = [
+        DEFAULT_PRIVATE_ENTRY_WIREGUARD_KEY_FILENAME,
+        DEFAULT_PUBLIC_ENTRY_WIREGUARD_KEY_FILENAME,
+        DEFAULT_PRIVATE_EXIT_WIREGUARD_KEY_FILENAME,
+        DEFAULT_PUBLIC_EXIT_WIREGUARD_KEY_FILENAME,
+        DEFAULT_FREE_PRIVATE_ENTRY_WIREGUARD_KEY_FILENAME,
+        DEFAULT_FREE_PUBLIC_ENTRY_WIREGUARD_KEY_FILENAME,
+        DEFAULT_FREE_PRIVATE_EXIT_WIREGUARD_KEY_FILENAME,
+        DEFAULT_FREE_PUBLIC_EXIT_WIREGUARD_KEY_FILENAME,
+    ];
+
+    let mixnet_db = [
+        DEFAULT_REPLY_SURB_DB_FILENAME,
+        DEFAULT_GATEWAYS_DETAILS_DB_FILENAME,
+    ];
+
+    let files_to_remove = device_key
+        .iter()
+        .chain(mixnet_keys.iter())
+        .chain(wireguard_keys.iter())
+        .chain(mixnet_db.iter());
+
+    for file in files_to_remove {
+        let file_path = data_dir.join(file);
+        if file_path.exists() {
+            tracing::info!("removing file: {:?}", file);
+            fs::remove_file(file_path)
+                .inspect_err(|err| {
+                    tracing::error!("failed to remove file: {err:?}");
+                })
                 .ok();
         }
     }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/util.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/util.rs
@@ -10,7 +10,6 @@ use crate::Error;
 
 pub fn remove_files_for_account(data_dir: &Path) -> Result<(), Error> {
     // Delete all files in data_dir that matches any of these patterns:
-    // credentials_database.db
     // *.sqlite
     // *.pem
 
@@ -23,8 +22,7 @@ pub fn remove_files_for_account(data_dir: &Path) -> Result<(), Error> {
             }
         };
 
-        if OsStr::new("credentials_database.db") == file.file_name()
-            || Some(OsStr::new("sqlite")) == file.path().extension()
+        if Some(OsStr::new("sqlite")) == file.path().extension()
             || Some(OsStr::new("pem")) == file.path().extension()
         {
             tracing::info!("removing file: {:?}", file.path());

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/account.rs
@@ -327,7 +327,7 @@ pub(crate) mod raw {
     }
 
     pub(crate) async fn forget_account_raw(path: &str) -> Result<(), VpnError> {
-        tracing::warn!("REMOVING ALL ACCOUNT AND DEVICE DATA IN: {path}");
+        tracing::info!("REMOVING ALL ACCOUNT AND DEVICE DATA IN: {path}");
 
         let path_buf =
             PathBuf::from_str(path).map_err(|err| VpnError::InvalidAccountStoragePath {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/account.rs
@@ -4,11 +4,14 @@
 use std::{path::PathBuf, str::FromStr, sync::Arc, time::Duration};
 
 use nym_vpn_account_controller::{
-    shared_state::DeviceState, AccountCommand, AccountControllerCommander, SharedAccountState,
+    shared_state::DeviceState, AccountControllerCommander, SharedAccountState,
 };
 use nym_vpn_api_client::{response::NymVpnAccountSummaryResponse, types::VpnApiAccount};
 use nym_vpn_network_config::Network;
-use nym_vpn_store::{keys::KeyStore, mnemonic::MnemonicStorage};
+use nym_vpn_store::{
+    keys::KeyStore,
+    mnemonic::{Mnemonic, MnemonicStorage},
+};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
@@ -93,12 +96,6 @@ pub(super) struct AccountControllerHandle {
 }
 
 impl AccountControllerHandle {
-    fn send_command(&self, command: AccountCommand) {
-        if let Err(e) = self.command_sender.send(command) {
-            tracing::error!("Failed to send comamnd: {}", e);
-        }
-    }
-
     async fn shutdown_and_wait(self) {
         self.shutdown_token.cancel();
 
@@ -108,24 +105,18 @@ impl AccountControllerHandle {
     }
 }
 
-pub(super) async fn send_account_command(command: AccountCommand) -> Result<(), VpnError> {
-    if let Some(guard) = &*ACCOUNT_CONTROLLER_HANDLE.lock().await {
-        guard.send_command(command);
-        Ok(())
-    } else {
-        Err(VpnError::InvalidStateError {
-            details: "Account controller is not running.".to_owned(),
-        })
-    }
+async fn is_account_controller_running() -> bool {
+    ACCOUNT_CONTROLLER_HANDLE.lock().await.is_some()
 }
 
-pub(super) async fn send_account_command_if_running(
-    command: AccountCommand,
-) -> Result<(), VpnError> {
-    if let Some(guard) = &*ACCOUNT_CONTROLLER_HANDLE.lock().await {
-        guard.send_command(command);
+async fn assert_account_controller_not_running() -> Result<(), VpnError> {
+    if is_account_controller_running().await {
+        Err(VpnError::InvalidStateError {
+            details: "Account controller is running.".to_owned(),
+        })
+    } else {
+        Ok(())
     }
-    Ok(())
 }
 
 async fn get_shared_account_state() -> Result<SharedAccountState, VpnError> {
@@ -195,139 +186,185 @@ pub(super) async fn wait_for_account_ready_to_connect(
     .map_err(VpnError::from)
 }
 
-fn setup_account_storage(path: &str) -> Result<crate::storage::VpnClientOnDiskStorage, VpnError> {
-    let path = PathBuf::from_str(path).map_err(|err| VpnError::InvalidAccountStoragePath {
+pub(super) async fn get_account_state() -> Result<AccountStateSummary, VpnError> {
+    let shared_account_state = get_shared_account_state().await?;
+    let account_state_summary = shared_account_state.lock().await.clone();
+    Ok(AccountStateSummary::from(account_state_summary))
+}
+
+pub(super) async fn update_account_state() -> Result<(), VpnError> {
+    get_command_sender()
+        .await?
+        .sync_account_state()
+        .await
+        .map_err(VpnError::from)
+        .map(|_| ())
+}
+
+pub(super) async fn store_account_mnemonic(mnemonic: &str) -> Result<(), VpnError> {
+    let mnemonic = Mnemonic::parse(mnemonic).map_err(|err| VpnError::InternalError {
         details: err.to_string(),
     })?;
-    Ok(crate::storage::VpnClientOnDiskStorage::new(path))
+
+    get_command_sender()
+        .await?
+        .store_account(mnemonic)
+        .await
+        .map_err(VpnError::from)
 }
 
-pub(super) async fn store_account_mnemonic(mnemonic: &str, path: &str) -> Result<(), VpnError> {
-    // TODO: store the mnemonic by sending a command to the account controller instead of directly
-    // interacting with the storage.
-
-    let storage = setup_account_storage(path)?;
-
-    let mnemonic = nym_vpn_store::mnemonic::Mnemonic::parse(mnemonic).map_err(|err| {
-        VpnError::InternalError {
-            details: err.to_string(),
-        }
-    })?;
-
-    storage
-        .store_mnemonic(mnemonic)
+pub(super) async fn forget_account() -> Result<(), VpnError> {
+    get_command_sender()
+        .await?
+        .forget_account()
         .await
-        .map_err(|err| VpnError::InternalError {
+        .map_err(VpnError::from)
+}
+
+pub(super) async fn get_account_id() -> Result<Option<String>, VpnError> {
+    Ok(get_shared_account_state().await?.get_account_id().await)
+}
+
+pub(super) async fn is_account_mnemonic_stored() -> Result<bool, VpnError> {
+    Ok(get_shared_account_state().await?.is_account_stored().await)
+}
+
+pub(super) async fn get_device_id() -> Result<String, VpnError> {
+    get_command_sender()
+        .await?
+        .get_device_identity()
+        .await
+        .map_err(VpnError::from)
+}
+
+// Raw API that does not interact with the account controller
+pub(crate) mod raw {
+    use std::path::Path;
+
+    use nym_sdk::mixnet::StoragePaths;
+
+    use super::*;
+
+    async fn setup_account_storage(
+        path: &str,
+    ) -> Result<crate::storage::VpnClientOnDiskStorage, VpnError> {
+        assert_account_controller_not_running().await?;
+        let path = PathBuf::from_str(path).map_err(|err| VpnError::InvalidAccountStoragePath {
+            details: err.to_string(),
+        })?;
+        Ok(crate::storage::VpnClientOnDiskStorage::new(path))
+    }
+
+    pub(crate) async fn store_account_mnemonic_raw(
+        mnemonic: &str,
+        path: &str,
+    ) -> Result<(), VpnError> {
+        let storage = setup_account_storage(path).await?;
+
+        let mnemonic = Mnemonic::parse(mnemonic).map_err(|err| VpnError::InternalError {
             details: err.to_string(),
         })?;
 
-    storage
-        .init_keys(None)
-        .await
-        .map_err(|err| VpnError::InternalError {
-            details: err.to_string(),
-        })?;
+        storage
+            .store_mnemonic(mnemonic)
+            .await
+            .map_err(|err| VpnError::InternalError {
+                details: err.to_string(),
+            })?;
 
-    Ok(())
-}
+        storage
+            .init_keys(None)
+            .await
+            .map_err(|err| VpnError::InternalError {
+                details: err.to_string(),
+            })?;
 
-pub(super) async fn is_account_mnemonic_stored(path: &str) -> Result<bool, VpnError> {
-    // TODO: query the mnemonic by sending a command to the account controller instead of directly
-    // interacting with the storage.
+        Ok(())
+    }
 
-    let storage = setup_account_storage(path)?;
-    storage
-        .is_mnemonic_stored()
-        .await
-        .map_err(|err| VpnError::InternalError {
-            details: err.to_string(),
-        })
-}
+    pub(crate) async fn is_account_mnemonic_stored_raw(path: &str) -> Result<bool, VpnError> {
+        let storage = setup_account_storage(path).await?;
+        storage
+            .is_mnemonic_stored()
+            .await
+            .map_err(|err| VpnError::InternalError {
+                details: err.to_string(),
+            })
+    }
 
-pub(super) async fn get_account_id(path: &str) -> Result<String, VpnError> {
-    let storage = setup_account_storage(path)?;
-    storage
-        .load_mnemonic()
-        .await
-        .map(VpnApiAccount::from)
-        .map(|account| account.id())
-        .map_err(|_err| VpnError::NoAccountStored)
-}
+    pub(crate) async fn get_account_id_raw(path: &str) -> Result<String, VpnError> {
+        let storage = setup_account_storage(path).await?;
+        storage
+            .load_mnemonic()
+            .await
+            .map(VpnApiAccount::from)
+            .map(|account| account.id())
+            .map_err(|_err| VpnError::NoAccountStored)
+    }
 
-pub(super) async fn remove_account_mnemonic(path: &str) -> Result<bool, VpnError> {
-    // TODO: remove the mnemonic by sending a command to the account controller instead of directly
-    // interacting with the storage.
-
-    let storage = setup_account_storage(path)?;
-    let is_account_removed_success =
+    async fn remove_account_mnemonic_raw(path: &str) -> Result<bool, VpnError> {
+        let storage = setup_account_storage(path).await?;
         storage
             .remove_mnemonic()
             .await
             .map(|_| true)
             .map_err(|err| VpnError::InternalError {
                 details: err.to_string(),
+            })
+    }
+
+    async fn remove_credential_storage_raw<P: AsRef<Path>>(path: P) -> Result<(), VpnError> {
+        let storage_paths =
+            StoragePaths::new_from_dir(&path).map_err(|err| VpnError::InternalError {
+                details: err.to_string(),
             })?;
 
-    Ok(is_account_removed_success)
-}
-
-pub(super) async fn forget_account(path: &str) -> Result<(), VpnError> {
-    tracing::warn!("REMOVING ALL ACCOUNT AND DEVICE DATA IN: {path}");
-
-    // First remove the files we own directly
-    remove_account_mnemonic(path).await?;
-    remove_device_identity(path).await?;
-
-    // Then remove the rest of the files, that we own indirectly
-    let path = PathBuf::from_str(path).map_err(|err| VpnError::InvalidAccountStoragePath {
-        details: err.to_string(),
-    })?;
-
-    nym_vpn_account_controller::util::remove_files_for_account(&path).map_err(|err| {
-        VpnError::InternalError {
-            details: err.to_string(),
-        }
-    })?;
-
-    send_account_command_if_running(AccountCommand::ResetAccount).await?;
-    Ok(())
-}
-
-pub(super) async fn get_device_id(path: &str) -> Result<String, VpnError> {
-    let storage = setup_account_storage(path)?;
-    storage
-        .load_keys()
-        .await
-        .map(|keys| keys.device_keypair().public_key().to_string())
-        .map_err(|_err| VpnError::NoDeviceIdentity)
-}
-
-pub(super) async fn reset_device_identity(path: &str) -> Result<(), VpnError> {
-    let storage = setup_account_storage(path)?;
-    storage
-        .reset_keys(None)
-        .await
-        .map_err(|err| VpnError::InternalError {
-            details: err.to_string(),
+        std::fs::remove_file(storage_paths.credential_database_path).map_err(|err| {
+            VpnError::InternalError {
+                details: err.to_string(),
+            }
         })
-}
+    }
 
-pub(super) async fn remove_device_identity(path: &str) -> Result<(), VpnError> {
-    let storage = setup_account_storage(path)?;
-    storage
-        .remove_keys()
-        .await
-        .map_err(|err| VpnError::InternalError {
-            details: err.to_string(),
-        })
-}
+    pub(crate) async fn forget_account_raw(path: &str) -> Result<(), VpnError> {
+        tracing::warn!("REMOVING ALL ACCOUNT AND DEVICE DATA IN: {path}");
 
-pub(super) async fn update_account_state() -> Result<(), VpnError> {
-    send_account_command(AccountCommand::UpdateAccountState(None)).await
-}
+        let path_buf =
+            PathBuf::from_str(path).map_err(|err| VpnError::InvalidAccountStoragePath {
+                details: err.to_string(),
+            })?;
 
-pub(super) async fn get_account_state() -> Result<AccountStateSummary, VpnError> {
-    let shared_account_state = get_shared_account_state().await?;
-    let account_state_summary = shared_account_state.lock().await.clone();
-    Ok(AccountStateSummary::from(account_state_summary))
+        // First remove the files we own directly
+        remove_account_mnemonic_raw(path).await?;
+        remove_device_identity_raw(path).await?;
+        remove_credential_storage_raw(&path_buf).await?;
+
+        // Then remove the rest of the files, that we own indirectly
+        nym_vpn_account_controller::util::remove_files_for_account(&path_buf).map_err(|err| {
+            VpnError::InternalError {
+                details: err.to_string(),
+            }
+        })?;
+
+        Ok(())
+    }
+
+    pub(crate) async fn get_device_id_raw(path: &str) -> Result<String, VpnError> {
+        let storage = setup_account_storage(path).await?;
+        storage
+            .load_keys()
+            .await
+            .map(|keys| keys.device_keypair().public_key().to_string())
+            .map_err(|_err| VpnError::NoDeviceIdentity)
+    }
+
+    pub(crate) async fn remove_device_identity_raw(path: &str) -> Result<(), VpnError> {
+        let storage = setup_account_storage(path).await?;
+        storage
+            .remove_keys()
+            .await
+            .map_err(|err| VpnError::InternalError {
+                details: err.to_string(),
+            })
+    }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/error.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/error.rs
@@ -140,14 +140,14 @@ impl From<nym_vpn_account_controller::AccountCommandError> for VpnError {
     fn from(value: nym_vpn_account_controller::AccountCommandError) -> Self {
         use nym_vpn_account_controller::AccountCommandError;
         match value {
-            AccountCommandError::UpdateAccountEndpointFailure(e) => {
+            AccountCommandError::SyncAccountEndpointFailure(e) => {
                 VpnError::UpdateAccountEndpointFailure {
                     details: e.message,
                     message_id: e.message_id,
                     code_reference_id: e.code_reference_id,
                 }
             }
-            AccountCommandError::UpdateDeviceEndpointFailure(e) => {
+            AccountCommandError::SyncDeviceEndpointFailure(e) => {
                 VpnError::UpdateDeviceEndpointFailure {
                     details: e.message,
                     message_id: e.message_id,
@@ -167,6 +167,12 @@ impl From<nym_vpn_account_controller::AccountCommandError> for VpnError {
             },
             AccountCommandError::NoAccountStored => VpnError::NoAccountStored,
             AccountCommandError::NoDeviceStored => VpnError::NoDeviceIdentity,
+            AccountCommandError::RemoveAccount(e) => VpnError::InternalError { details: e },
+            AccountCommandError::RemoveDeviceIdentity(e) => VpnError::InternalError { details: e },
+            AccountCommandError::ResetCredentialStorage(e) => {
+                VpnError::InternalError { details: e }
+            }
+            AccountCommandError::RemoveAccountFiles(e) => VpnError::InternalError { details: e },
             AccountCommandError::General(err) => VpnError::InternalError { details: err },
             AccountCommandError::Internal(err) => VpnError::InternalError { details: err },
         }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/error.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/error.rs
@@ -173,6 +173,7 @@ impl From<nym_vpn_account_controller::AccountCommandError> for VpnError {
                 VpnError::InternalError { details: e }
             }
             AccountCommandError::RemoveAccountFiles(e) => VpnError::InternalError { details: e },
+            AccountCommandError::InitDeviceKeys(e) => VpnError::InternalError { details: e },
             AccountCommandError::General(err) => VpnError::InternalError { details: err },
             AccountCommandError::Internal(err) => VpnError::InternalError { details: err },
         }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
@@ -155,7 +155,7 @@ pub fn shutdown() -> Result<(), VpnError> {
     RUNTIME.block_on(account::stop_account_controller_handle())
 }
 
-pub fn init_logger() {
+fn init_logger() {
     let log_level = env::var("RUST_LOG").unwrap_or("info".to_string());
     info!("Setting log level: {}", log_level);
     #[cfg(target_os = "ios")]
@@ -211,87 +211,93 @@ pub fn getSystemMessages() -> Result<Vec<SystemMessage>, VpnError> {
 /// Returns the account links for the current network environment
 #[allow(non_snake_case)]
 #[uniffi::export]
-pub fn getAccountLinks(account_store_path: &str, locale: &str) -> Result<AccountLinks, VpnError> {
-    RUNTIME.block_on(environment::get_account_links(account_store_path, locale))
+pub fn getAccountLinks(locale: &str) -> Result<AccountLinks, VpnError> {
+    RUNTIME.block_on(environment::get_account_links(locale))
 }
 
-/// Fetch the network environment details from the network name.
-/// This makes a network call. In normal operations you almost always want to use initEnvironment
-/// instead of this function.
+/// Returns the account links for the current network environment.
+/// This is a version that can be called when the account controller is not running.
 #[allow(non_snake_case)]
 #[uniffi::export]
-pub fn fetchEnvironment(network_name: &str) -> Result<NetworkEnvironment, VpnError> {
-    RUNTIME.block_on(environment::fetch_environment(network_name))
-}
-
-/// Feth the account links for the current network environment.
-/// This makes a network call. In normal operations you almost always want to use initEnvironment
-/// followed by getSystemMessages instead of this function.
-#[allow(non_snake_case)]
-#[uniffi::export]
-pub fn fetchSystemMessages(network_name: &str) -> Result<Vec<SystemMessage>, VpnError> {
-    RUNTIME.block_on(environment::fetch_system_messages(network_name))
-}
-
-/// Fetches the account links for the current network environment
-/// This makes a network call. In normal operations you almost always want to use initEnvironment
-/// followed by getAccountLinks instead of this function.
-#[allow(non_snake_case)]
-#[uniffi::export]
-pub fn fetchAccountLinks(
+pub fn getAccountLinksRaw(
     account_store_path: &str,
-    network_name: &str,
     locale: &str,
 ) -> Result<AccountLinks, VpnError> {
-    RUNTIME.block_on(environment::fetch_account_links(
+    RUNTIME.block_on(environment::get_account_links_raw(
         account_store_path,
-        network_name,
         locale,
     ))
 }
 
+/// Store the account mnemonic
 #[allow(non_snake_case)]
 #[uniffi::export]
-pub fn storeAccountMnemonic(mnemonic: String, path: String) -> Result<(), VpnError> {
-    RUNTIME.block_on(account::store_account_mnemonic(&mnemonic, &path))
+pub fn storeAccountMnemonic(mnemonic: String) -> Result<(), VpnError> {
+    RUNTIME.block_on(account::store_account_mnemonic(&mnemonic))
 }
 
+/// Store the account mnemonic
+/// This is a version that can be called when the account controller is not running.
 #[allow(non_snake_case)]
 #[uniffi::export]
-pub fn isAccountMnemonicStored(path: String) -> Result<bool, VpnError> {
-    RUNTIME.block_on(account::is_account_mnemonic_stored(&path))
+pub fn storeAccountMnemonicRaw(mnemonic: String, path: String) -> Result<(), VpnError> {
+    RUNTIME.block_on(account::raw::store_account_mnemonic_raw(&mnemonic, &path))
 }
 
+/// Check if the account mnemonic is stored
 #[allow(non_snake_case)]
 #[uniffi::export]
-pub fn removeAccountMnemonic(path: String) -> Result<bool, VpnError> {
-    RUNTIME.block_on(account::remove_account_mnemonic(&path))
+pub fn isAccountMnemonicStored() -> Result<bool, VpnError> {
+    RUNTIME.block_on(account::is_account_mnemonic_stored())
 }
 
+/// Check if the account mnemonic is stored
+/// This is a version that can be called when the account controller is not running.
 #[allow(non_snake_case)]
 #[uniffi::export]
-pub fn forgetAccount(path: String) -> Result<(), VpnError> {
-    RUNTIME.block_on(account::forget_account(&path))
+pub fn isAccountMnemonicStoredRaw(path: String) -> Result<bool, VpnError> {
+    RUNTIME.block_on(account::raw::is_account_mnemonic_stored_raw(&path))
 }
 
+/// Remove the account mnemonic and all associated keys and files
 #[allow(non_snake_case)]
 #[uniffi::export]
-pub fn resetDeviceIdentity(path: String) -> Result<(), VpnError> {
-    RUNTIME.block_on(account::reset_device_identity(&path))
+pub fn forgetAccount() -> Result<(), VpnError> {
+    RUNTIME.block_on(account::forget_account())
 }
 
+/// Remove the account mnemonic and all associated keys and files.
+/// This is a version that can be called when the account controller is not running.
 #[allow(non_snake_case)]
 #[uniffi::export]
-pub fn getDeviceIdentity(path: String) -> Result<String, VpnError> {
-    RUNTIME.block_on(account::get_device_id(&path))
+pub fn forgetAccountRaw(path: String) -> Result<(), VpnError> {
+    RUNTIME.block_on(account::raw::forget_account_raw(&path))
 }
 
+/// Get the device identity
+#[allow(non_snake_case)]
+#[uniffi::export]
+pub fn getDeviceIdentity() -> Result<String, VpnError> {
+    RUNTIME.block_on(account::get_device_id())
+}
+
+/// Get the device identity
+/// This is a version that can be called when the account controller is not running.
+#[allow(non_snake_case)]
+#[uniffi::export]
+pub fn getDeviceIdentityRaw(path: String) -> Result<String, VpnError> {
+    RUNTIME.block_on(account::raw::get_device_id_raw(&path))
+}
+
+/// This manually syncs the account state with the server. Normally this is done automatically, but
+/// this can be used to manually trigger a sync.
 #[allow(non_snake_case)]
 #[uniffi::export]
 pub fn updateAccountState() -> Result<(), VpnError> {
     RUNTIME.block_on(account::update_account_state())
 }
 
+/// Get the account state
 #[allow(non_snake_case)]
 #[uniffi::export]
 pub fn getAccountState() -> Result<AccountStateSummary, VpnError> {

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/into_proto/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/into_proto/account.rs
@@ -1,6 +1,14 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+impl From<Option<String>> for crate::AccountIdentity {
+    fn from(identity: Option<String>) -> Self {
+        Self {
+            account_identity: identity,
+        }
+    }
+}
+
 impl From<nym_vpn_account_controller::ReadyToConnect> for crate::IsReadyToConnectResponse {
     fn from(ready: nym_vpn_account_controller::ReadyToConnect) -> Self {
         use crate::is_ready_to_connect_response::IsReadyToConnectResponseType;

--- a/nym-vpn-core/crates/nym-vpn-store/src/keys/persistence/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-store/src/keys/persistence/mod.rs
@@ -4,4 +4,7 @@
 mod ephemeral;
 mod on_disk;
 
-pub use on_disk::{DeviceKeysPaths, OnDiskKeys, OnDiskKeysError};
+pub use on_disk::{
+    DeviceKeysPaths, OnDiskKeys, OnDiskKeysError, DEFAULT_PRIVATE_DEVICE_KEY_FILENAME,
+    DEFAULT_PUBLIC_DEVICE_KEY_FILENAME,
+};

--- a/nym-vpn-core/crates/nym-vpn-store/src/keys/persistence/on_disk.rs
+++ b/nym-vpn-core/crates/nym-vpn-store/src/keys/persistence/on_disk.rs
@@ -9,6 +9,9 @@ use rand::SeedableRng as _;
 
 use crate::keys::{DeviceKeys, KeyStore};
 
+pub const DEFAULT_PRIVATE_DEVICE_KEY_FILENAME: &str = "private_device.pem";
+pub const DEFAULT_PUBLIC_DEVICE_KEY_FILENAME: &str = "public_device.pem";
+
 #[derive(Debug, thiserror::Error)]
 pub enum OnDiskKeysError {
     #[error("unable to load keys")]
@@ -45,8 +48,8 @@ impl DeviceKeysPaths {
     pub fn new<P: AsRef<Path>>(base_data_directory: P) -> Self {
         let base_dir = base_data_directory.as_ref();
         DeviceKeysPaths {
-            private_device_key_file: base_dir.join("private_device.pem"),
-            public_device_key_file: base_dir.join("public_device.pem"),
+            private_device_key_file: base_dir.join(DEFAULT_PRIVATE_DEVICE_KEY_FILENAME),
+            public_device_key_file: base_dir.join(DEFAULT_PUBLIC_DEVICE_KEY_FILENAME),
         }
     }
 

--- a/nym-vpn-core/crates/nym-vpnc/src/cli.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/cli.rs
@@ -152,12 +152,6 @@ pub(crate) enum Internal {
     /// List the available zknym ticketbooks in the local credential store.
     GetAvailableTickets,
 
-    /// Fetch the account summary from the nym-vpn-api.
-    FetchRawAccountSummary,
-
-    /// Fetch the devices associated with the account from the nym-vpn-api.
-    FetchRawDevices,
-
     /// Listen the the status event stream from nym-vpnd.
     ListenToStatus,
 

--- a/nym-vpn-core/crates/nym-vpnc/src/cli.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/cli.rs
@@ -111,9 +111,6 @@ pub(crate) enum Internal {
     /// Get the list of feature flags provided by the nym-vpn-api.
     GetFeatureFlags,
 
-    /// Remove the stored account. This only removes the stored recovery phrase.
-    RemoveAccount,
-
     /// Manually trigger an account sync with the nym-vpn-api.
     SyncAccountState,
 

--- a/nym-vpn-core/crates/nym-vpnc/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/main.rs
@@ -21,8 +21,8 @@ use nym_vpn_proto::{
     GetSystemMessagesRequest, GetZkNymByIdRequest, GetZkNymsAvailableForDownloadRequest,
     InfoRequest, InfoResponse, IsAccountStoredRequest, IsReadyToConnectRequest,
     ListCountriesRequest, ListGatewaysRequest, RefreshAccountStateRequest, RegisterDeviceRequest,
-    RemoveAccountRequest, RequestZkNymRequest, ResetDeviceIdentityRequest, SetNetworkRequest,
-    StatusRequest, StoreAccountRequest, UserAgent,
+    RequestZkNymRequest, ResetDeviceIdentityRequest, SetNetworkRequest, StatusRequest,
+    StoreAccountRequest, UserAgent,
 };
 use protobuf_conversion::into_gateway_type;
 use sysinfo::System;
@@ -89,7 +89,6 @@ async fn main() -> Result<()> {
             Internal::GetSystemMessages => get_system_messages(opts.client_type).await?,
             Internal::GetFeatureFlags => get_feature_flags(opts.client_type).await?,
             Internal::SyncAccountState => refresh_account_state(opts.client_type).await?,
-            Internal::RemoveAccount => remove_account(opts.client_type).await?,
             Internal::GetAccountUsage => get_account_usage(opts.client_type).await?,
             Internal::IsReadyToConnect => is_ready_to_connect(opts.client_type).await?,
             Internal::ListenToStatus => listen_to_status(opts.client_type).await?,
@@ -382,14 +381,6 @@ async fn is_account_stored(client_type: ClientType) -> Result<()> {
     let mut client = vpnd_client::get_client(&client_type).await?;
     let request = tonic::Request::new(IsAccountStoredRequest {});
     let response = client.is_account_stored(request).await?.into_inner();
-    println!("{:#?}", response);
-    Ok(())
-}
-
-async fn remove_account(client_type: ClientType) -> Result<()> {
-    let mut client = vpnd_client::get_client(&client_type).await?;
-    let request = tonic::Request::new(RemoveAccountRequest {});
-    let response = client.remove_account(request).await?.into_inner();
     println!("{:#?}", response);
     Ok(())
 }

--- a/nym-vpn-core/crates/nym-vpnc/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/main.rs
@@ -13,8 +13,7 @@ use cli::Internal;
 use itertools::Itertools;
 use nym_gateway_directory::GatewayType;
 use nym_vpn_proto::{
-    ConfirmZkNymDownloadedRequest, ConnectRequest, DisconnectRequest, Empty,
-    FetchRawAccountSummaryRequest, FetchRawDevicesRequest, ForgetAccountRequest,
+    ConfirmZkNymDownloadedRequest, ConnectRequest, DisconnectRequest, Empty, ForgetAccountRequest,
     GetAccountIdentityRequest, GetAccountLinksRequest, GetAccountStateRequest,
     GetAccountUsageRequest, GetActiveDevicesRequest, GetAvailableTicketsRequest,
     GetDeviceIdentityRequest, GetDeviceZkNymsRequest, GetDevicesRequest, GetFeatureFlagsRequest,
@@ -109,8 +108,6 @@ async fn main() -> Result<()> {
                 confirm_zk_nym_downloaded(opts.client_type, args).await?
             }
             Internal::GetAvailableTickets => get_available_tickets(opts.client_type).await?,
-            Internal::FetchRawAccountSummary => fetch_raw_account_summary(opts.client_type).await?,
-            Internal::FetchRawDevices => fetch_raw_devices(opts.client_type).await?,
         },
     }
     Ok(())
@@ -447,25 +444,6 @@ async fn is_ready_to_connect(client_type: ClientType) -> Result<()> {
     let mut client = vpnd_client::get_client(&client_type).await?;
     let request = tonic::Request::new(IsReadyToConnectRequest {});
     let response = client.is_ready_to_connect(request).await?.into_inner();
-    println!("{:#?}", response);
-    Ok(())
-}
-
-async fn fetch_raw_account_summary(client_type: ClientType) -> Result<()> {
-    let mut client = vpnd_client::get_client(&client_type).await?;
-    let request = tonic::Request::new(FetchRawAccountSummaryRequest {});
-    let response = client
-        .fetch_raw_account_summary(request)
-        .await?
-        .into_inner();
-    println!("{:#?}", response);
-    Ok(())
-}
-
-async fn fetch_raw_devices(client_type: ClientType) -> Result<()> {
-    let mut client = vpnd_client::get_client(&client_type).await?;
-    let request = tonic::Request::new(FetchRawDevicesRequest {});
-    let response = client.fetch_raw_devices(request).await?.into_inner();
     println!("{:#?}", response);
     Ok(())
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/connection_handler.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/connection_handler.rs
@@ -6,7 +6,7 @@ use nym_vpn_network_config::{FeatureFlags, ParsedAccountLinks, SystemMessages};
 use tokio::sync::{mpsc::UnboundedSender, oneshot};
 
 use nym_vpn_api_client::{
-    response::{NymVpnAccountSummaryResponse, NymVpnDevice, NymVpnDevicesResponse, NymVpnUsage},
+    response::{NymVpnDevice, NymVpnUsage},
     types::GatewayMinPerformance,
 };
 use nym_vpn_lib::gateway_directory::{EntryPoint, ExitPoint, GatewayClient, GatewayType};
@@ -154,7 +154,7 @@ impl CommandInterfaceConnectionHandler {
 
     pub(crate) async fn handle_get_account_identity(
         &self,
-    ) -> Result<Result<String, AccountError>, VpnCommandSendError> {
+    ) -> Result<Result<Option<String>, AccountError>, VpnCommandSendError> {
         self.send_and_wait(VpnServiceCommand::GetAccountIdentity, ())
             .await
     }
@@ -271,20 +271,6 @@ impl CommandInterfaceConnectionHandler {
         &self,
     ) -> Result<Result<AvailableTicketbooks, AccountError>, VpnCommandSendError> {
         self.send_and_wait(VpnServiceCommand::GetAvailableTickets, ())
-            .await
-    }
-
-    pub(crate) async fn handle_fetch_raw_account_summary(
-        &self,
-    ) -> Result<Result<NymVpnAccountSummaryResponse, AccountError>, VpnCommandSendError> {
-        self.send_and_wait(VpnServiceCommand::FetchRawAccountSummary, ())
-            .await
-    }
-
-    pub(crate) async fn handle_fetch_raw_devices(
-        &self,
-    ) -> Result<Result<NymVpnDevicesResponse, AccountError>, VpnCommandSendError> {
-        self.send_and_wait(VpnServiceCommand::FetchRawDevices, ())
             .await
     }
 

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/connection_handler.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/connection_handler.rs
@@ -145,13 +145,6 @@ impl CommandInterfaceConnectionHandler {
             .await
     }
 
-    pub(crate) async fn handle_remove_account(
-        &self,
-    ) -> Result<Result<(), AccountError>, VpnCommandSendError> {
-        self.send_and_wait(VpnServiceCommand::RemoveAccount, ())
-            .await
-    }
-
     pub(crate) async fn handle_forget_account(
         &self,
     ) -> Result<Result<(), AccountError>, VpnCommandSendError> {

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
@@ -30,10 +30,9 @@ use nym_vpn_proto::{
     IsAccountStoredResponse, IsReadyToConnectRequest, IsReadyToConnectResponse,
     ListCountriesRequest, ListCountriesResponse, ListGatewaysRequest, ListGatewaysResponse,
     RefreshAccountStateRequest, RefreshAccountStateResponse, RegisterDeviceRequest,
-    RegisterDeviceResponse, RemoveAccountRequest, RemoveAccountResponse, RequestZkNymRequest,
-    RequestZkNymResponse, ResetDeviceIdentityRequest, ResetDeviceIdentityResponse,
-    SetNetworkRequest, SetNetworkResponse, StatusRequest, StatusResponse, StoreAccountRequest,
-    StoreAccountResponse,
+    RegisterDeviceResponse, RequestZkNymRequest, RequestZkNymResponse, ResetDeviceIdentityRequest,
+    ResetDeviceIdentityResponse, SetNetworkRequest, SetNetworkResponse, StatusRequest,
+    StatusResponse, StoreAccountRequest, StoreAccountResponse,
 };
 use zeroize::Zeroizing;
 
@@ -457,29 +456,6 @@ impl NymVpnd for CommandInterface {
         };
 
         tracing::debug!("Returning is account stored response");
-        Ok(tonic::Response::new(response))
-    }
-
-    async fn remove_account(
-        &self,
-        _request: tonic::Request<RemoveAccountRequest>,
-    ) -> Result<tonic::Response<RemoveAccountResponse>, tonic::Status> {
-        let result = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
-            .handle_remove_account()
-            .await?;
-
-        let response = match result {
-            Ok(()) => RemoveAccountResponse {
-                success: true,
-                error: None,
-            },
-            Err(err) => RemoveAccountResponse {
-                success: false,
-                error: Some(nym_vpn_proto::AccountError::from(err)),
-            },
-        };
-
-        tracing::debug!("Returning remove account response");
         Ok(tonic::Response::new(response))
     }
 

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
@@ -16,23 +16,21 @@ use nym_vpn_proto::{
     conversions::ConversionError, nym_vpnd_server::NymVpnd, AccountError,
     ConfirmZkNymDownloadedRequest, ConfirmZkNymDownloadedResponse, ConnectRequest, ConnectResponse,
     ConnectionStateChange, ConnectionStatusUpdate, DisconnectRequest, DisconnectResponse, Empty,
-    FetchRawAccountSummaryRequest, FetchRawAccountSummaryResponse, FetchRawDevicesRequest,
-    FetchRawDevicesResponse, ForgetAccountRequest, ForgetAccountResponse,
-    GetAccountIdentityRequest, GetAccountIdentityResponse, GetAccountLinksRequest,
-    GetAccountLinksResponse, GetAccountStateRequest, GetAccountStateResponse,
-    GetAccountUsageRequest, GetAccountUsageResponse, GetActiveDevicesRequest,
-    GetActiveDevicesResponse, GetAvailableTicketsRequest, GetAvailableTicketsResponse,
-    GetDeviceIdentityRequest, GetDeviceIdentityResponse, GetDeviceZkNymsRequest,
-    GetDeviceZkNymsResponse, GetDevicesRequest, GetDevicesResponse, GetFeatureFlagsRequest,
-    GetFeatureFlagsResponse, GetSystemMessagesRequest, GetSystemMessagesResponse,
-    GetZkNymByIdRequest, GetZkNymByIdResponse, GetZkNymsAvailableForDownloadRequest,
-    GetZkNymsAvailableForDownloadResponse, InfoRequest, InfoResponse, IsAccountStoredRequest,
-    IsAccountStoredResponse, IsReadyToConnectRequest, IsReadyToConnectResponse,
-    ListCountriesRequest, ListCountriesResponse, ListGatewaysRequest, ListGatewaysResponse,
-    RefreshAccountStateRequest, RefreshAccountStateResponse, RegisterDeviceRequest,
-    RegisterDeviceResponse, RequestZkNymRequest, RequestZkNymResponse, ResetDeviceIdentityRequest,
-    ResetDeviceIdentityResponse, SetNetworkRequest, SetNetworkResponse, StatusRequest,
-    StatusResponse, StoreAccountRequest, StoreAccountResponse,
+    ForgetAccountRequest, ForgetAccountResponse, GetAccountIdentityRequest,
+    GetAccountIdentityResponse, GetAccountLinksRequest, GetAccountLinksResponse,
+    GetAccountStateRequest, GetAccountStateResponse, GetAccountUsageRequest,
+    GetAccountUsageResponse, GetActiveDevicesRequest, GetActiveDevicesResponse,
+    GetAvailableTicketsRequest, GetAvailableTicketsResponse, GetDeviceIdentityRequest,
+    GetDeviceIdentityResponse, GetDeviceZkNymsRequest, GetDeviceZkNymsResponse, GetDevicesRequest,
+    GetDevicesResponse, GetFeatureFlagsRequest, GetFeatureFlagsResponse, GetSystemMessagesRequest,
+    GetSystemMessagesResponse, GetZkNymByIdRequest, GetZkNymByIdResponse,
+    GetZkNymsAvailableForDownloadRequest, GetZkNymsAvailableForDownloadResponse, InfoRequest,
+    InfoResponse, IsAccountStoredRequest, IsAccountStoredResponse, IsReadyToConnectRequest,
+    IsReadyToConnectResponse, ListCountriesRequest, ListCountriesResponse, ListGatewaysRequest,
+    ListGatewaysResponse, RefreshAccountStateRequest, RefreshAccountStateResponse,
+    RegisterDeviceRequest, RegisterDeviceResponse, RequestZkNymRequest, RequestZkNymResponse,
+    ResetDeviceIdentityRequest, ResetDeviceIdentityResponse, SetNetworkRequest, SetNetworkResponse,
+    StatusRequest, StatusResponse, StoreAccountRequest, StoreAccountResponse,
 };
 use zeroize::Zeroizing;
 
@@ -497,7 +495,9 @@ impl NymVpnd for CommandInterface {
         let response = match result {
             Ok(identity) => GetAccountIdentityResponse {
                 id: Some(
-                    nym_vpn_proto::get_account_identity_response::Id::AccountIdentity(identity),
+                    nym_vpn_proto::get_account_identity_response::Id::AccountIdentity(
+                        nym_vpn_proto::AccountIdentity::from(identity),
+                    ),
                 ),
             },
             Err(err) => GetAccountIdentityResponse {
@@ -884,52 +884,6 @@ impl NymVpnd for CommandInterface {
                 resp: Some(nym_vpn_proto::get_available_tickets_response::Resp::Error(
                     nym_vpn_proto::AccountError::from(err),
                 )),
-            },
-        };
-
-        Ok(tonic::Response::new(response))
-    }
-
-    async fn fetch_raw_account_summary(
-        &self,
-        _request: tonic::Request<FetchRawAccountSummaryRequest>,
-    ) -> Result<tonic::Response<FetchRawAccountSummaryResponse>, tonic::Status> {
-        let result = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
-            .handle_fetch_raw_account_summary()
-            .await?;
-
-        let response = match result {
-            Ok(summary) => FetchRawAccountSummaryResponse {
-                json: serde_json::to_string(&summary)
-                    .unwrap_or_else(|_| "failed to serialize".to_owned()),
-                error: None,
-            },
-            Err(err) => FetchRawAccountSummaryResponse {
-                json: err.to_string(),
-                error: Some(AccountError::from(err)),
-            },
-        };
-
-        Ok(tonic::Response::new(response))
-    }
-
-    async fn fetch_raw_devices(
-        &self,
-        _request: tonic::Request<FetchRawDevicesRequest>,
-    ) -> Result<tonic::Response<FetchRawDevicesResponse>, tonic::Status> {
-        let result = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
-            .handle_fetch_raw_devices()
-            .await?;
-
-        let response = match result {
-            Ok(devices) => FetchRawDevicesResponse {
-                json: serde_json::to_string(&devices)
-                    .unwrap_or_else(|_| "failed to serialize".to_owned()),
-                error: None,
-            },
-            Err(err) => FetchRawDevicesResponse {
-                json: err.to_string(),
-                error: Some(AccountError::from(err)),
             },
         };
 

--- a/nym-vpn-core/crates/nym-vpnd/src/service/error.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/error.rs
@@ -96,6 +96,7 @@ impl From<AccountCommandError> for AccountNotReady {
             AccountCommandError::RemoveDeviceIdentity(e) => AccountNotReady::General(e),
             AccountCommandError::ResetCredentialStorage(e) => AccountNotReady::General(e),
             AccountCommandError::RemoveAccountFiles(e) => AccountNotReady::General(e),
+            AccountCommandError::InitDeviceKeys(e) => AccountNotReady::General(e),
             AccountCommandError::General(err) => AccountNotReady::General(err),
             AccountCommandError::Internal(err) => AccountNotReady::Internal(err),
         }

--- a/nym-vpn-core/crates/nym-vpnd/src/service/error.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/error.rs
@@ -69,14 +69,12 @@ pub enum AccountNotReady {
 impl From<AccountCommandError> for AccountNotReady {
     fn from(err: AccountCommandError) -> Self {
         match err {
-            AccountCommandError::UpdateAccountEndpointFailure(e) => {
-                AccountNotReady::UpdateAccount {
-                    message: e.message,
-                    message_id: e.message_id,
-                    code_reference_id: e.code_reference_id,
-                }
-            }
-            AccountCommandError::UpdateDeviceEndpointFailure(e) => AccountNotReady::UpdateDevice {
+            AccountCommandError::SyncAccountEndpointFailure(e) => AccountNotReady::UpdateAccount {
+                message: e.message,
+                message_id: e.message_id,
+                code_reference_id: e.code_reference_id,
+            },
+            AccountCommandError::SyncDeviceEndpointFailure(e) => AccountNotReady::UpdateDevice {
                 message: e.message,
                 message_id: e.message_id,
                 code_reference_id: e.code_reference_id,
@@ -94,6 +92,10 @@ impl From<AccountCommandError> for AccountNotReady {
             } => AccountNotReady::RequestZkNym { failed },
             AccountCommandError::NoAccountStored => AccountNotReady::NoAccountStored,
             AccountCommandError::NoDeviceStored => AccountNotReady::NoDeviceStored,
+            AccountCommandError::RemoveAccount(e) => AccountNotReady::General(e),
+            AccountCommandError::RemoveDeviceIdentity(e) => AccountNotReady::General(e),
+            AccountCommandError::ResetCredentialStorage(e) => AccountNotReady::General(e),
+            AccountCommandError::RemoveAccountFiles(e) => AccountNotReady::General(e),
             AccountCommandError::General(err) => AccountNotReady::General(err),
             AccountCommandError::Internal(err) => AccountNotReady::Internal(err),
         }

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -930,7 +930,7 @@ where
         }
 
         let data_dir = self.data_dir.clone();
-        tracing::warn!(
+        tracing::info!(
             "REMOVING ALL ACCOUNT AND DEVICE DATA IN: {}",
             data_dir.display()
         );

--- a/nym-vpn-core/crates/nym-wg-gateway-client/src/lib.rs
+++ b/nym-vpn-core/crates/nym-wg-gateway-client/src/lib.rs
@@ -29,15 +29,18 @@ use tracing::{debug, error, info, warn};
 
 use crate::error::Result;
 
-const DEFAULT_PRIVATE_ENTRY_WIREGUARD_KEY_FILENAME: &str = "private_entry_wireguard.pem";
-const DEFAULT_PUBLIC_ENTRY_WIREGUARD_KEY_FILENAME: &str = "public_entry_wireguard.pem";
-const DEFAULT_PRIVATE_EXIT_WIREGUARD_KEY_FILENAME: &str = "private_exit_wireguard.pem";
-const DEFAULT_PUBLIC_EXIT_WIREGUARD_KEY_FILENAME: &str = "public_exit_wireguard.pem";
+pub const DEFAULT_PRIVATE_ENTRY_WIREGUARD_KEY_FILENAME: &str = "private_entry_wireguard.pem";
+pub const DEFAULT_PUBLIC_ENTRY_WIREGUARD_KEY_FILENAME: &str = "public_entry_wireguard.pem";
+pub const DEFAULT_PRIVATE_EXIT_WIREGUARD_KEY_FILENAME: &str = "private_exit_wireguard.pem";
+pub const DEFAULT_PUBLIC_EXIT_WIREGUARD_KEY_FILENAME: &str = "public_exit_wireguard.pem";
 
-const DEFAULT_FREE_PRIVATE_ENTRY_WIREGUARD_KEY_FILENAME: &str = "free_private_entry_wireguard.pem";
-const DEFAULT_FREE_PUBLIC_ENTRY_WIREGUARD_KEY_FILENAME: &str = "free_public_entry_wireguard.pem";
-const DEFAULT_FREE_PRIVATE_EXIT_WIREGUARD_KEY_FILENAME: &str = "free_private_exit_wireguard.pem";
-const DEFAULT_FREE_PUBLIC_EXIT_WIREGUARD_KEY_FILENAME: &str = "free_public_exit_wireguard.pem";
+pub const DEFAULT_FREE_PRIVATE_ENTRY_WIREGUARD_KEY_FILENAME: &str =
+    "free_private_entry_wireguard.pem";
+pub const DEFAULT_FREE_PUBLIC_ENTRY_WIREGUARD_KEY_FILENAME: &str =
+    "free_public_entry_wireguard.pem";
+pub const DEFAULT_FREE_PRIVATE_EXIT_WIREGUARD_KEY_FILENAME: &str =
+    "free_private_exit_wireguard.pem";
+pub const DEFAULT_FREE_PUBLIC_EXIT_WIREGUARD_KEY_FILENAME: &str = "free_public_exit_wireguard.pem";
 
 pub const TICKETS_TO_SPEND: u32 = 1;
 const RETRY_PERIOD: Duration = Duration::from_secs(30);

--- a/proto/nym/vpn.proto
+++ b/proto/nym/vpn.proto
@@ -627,11 +627,15 @@ message ForgetAccountResponse {
   AccountError error = 2;
 }
 
+message AccountIdentity {
+  optional string account_identity = 1;
+}
+
 message GetAccountIdentityRequest {}
 
 message GetAccountIdentityResponse {
   oneof id {
-    string account_identity = 1;
+    AccountIdentity account_identity = 1;
     AccountError error = 2;
   }
 }
@@ -808,20 +812,6 @@ message GetAccountUsageResponse {
     AccountUsages account_usages = 1;
     AccountError error = 2;
   }
-}
-
-message FetchRawAccountSummaryRequest {}
-
-message FetchRawAccountSummaryResponse {
-  string json = 1;
-  AccountError error = 2;
-}
-
-message FetchRawDevicesRequest {}
-
-message FetchRawDevicesResponse {
-  string json = 1;
-  AccountError error = 2;
 }
 
 message ResetDeviceIdentityRequest {
@@ -1125,14 +1115,5 @@ service NymVpnd {
 
   // Get the available tickets in the local credential store
   rpc GetAvailableTickets (GetAvailableTicketsRequest) returns (GetAvailableTicketsResponse) {}
-
-  // -- Delegated remote calls --
-  // These query the remote nym-vpn-api state directly
-
-  // Get the server side account summary directly from the nym-vpn-api
-  rpc FetchRawAccountSummary (FetchRawAccountSummaryRequest) returns (FetchRawAccountSummaryResponse) {}
-
-  // Get the list of devices directly from the nym-vpn-api
-  rpc FetchRawDevices (FetchRawDevicesRequest) returns (FetchRawDevicesResponse) {}
 }
 

--- a/proto/nym/vpn.proto
+++ b/proto/nym/vpn.proto
@@ -620,13 +620,6 @@ message IsAccountStoredResponse {
   }
 }
 
-message RemoveAccountRequest {}
-
-message RemoveAccountResponse {
-  bool success = 1;
-  AccountError error = 2;
-}
-
 message ForgetAccountRequest {}
 
 message ForgetAccountResponse {
@@ -1075,9 +1068,6 @@ service NymVpnd {
 
   // Check if the recovery phrase is stored
   rpc IsAccountStored (IsAccountStoredRequest) returns (IsAccountStoredResponse) {}
-
-  // Remove the recovery phrase from local storage
-  rpc RemoveAccount (RemoveAccountRequest) returns (RemoveAccountResponse) {}
 
   // Removes everything related to the account, including the device identity,
   // credential storage, mixnet keys, gateway registrations.


### PR DESCRIPTION
Confine storage interaction to the account controller.
This should fix a plethora of account and credential related issues plaguing the vpn client. 

NOTE: breaks compatibility for the uniffi API

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1805)
<!-- Reviewable:end -->
