### PR TITLE
Fix changed const values

### DIFF
--- a/nym-vpn-core/crates/nym-connection-monitor/src/icmp_beacon.rs
+++ b/nym-vpn-core/crates/nym-connection-monitor/src/icmp_beacon.rs
@@ -31,7 +31,7 @@ const ICMP_BEACON_PING_INTERVAL: Duration = Duration::from_millis(1000);
 // TODO: extract these from the ip-packet-router crate
 const ICMP_IPR_TUN_IP_V4: Ipv4Addr = Ipv4Addr::new(10, 0, 0, 1);
 // 2001:db8:a160::1
-const ICMP_IPR_TUN_IP_V6: Ipv6Addr = Ipv6Addr::new(0x2001, 0xdb8, 0xa160, 0, 0, 0, 0, 0x1);
+const ICMP_IPR_TUN_IP_V6: Ipv6Addr = Ipv6Addr::new(0xfc00, 0, 0, 0, 0, 0, 0, 0x1);
 
 // This can be anything really, we just want to check if the exit IPR can reach the internet
 // TODO: have a pool of IPs to ping

--- a/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
+++ b/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
@@ -413,7 +413,7 @@ async fn send_icmp_pings(
     let external_ip_v4 = Ipv4Addr::new(8, 8, 8, 8);
 
     // ipv6 addresses for testing
-    let ipr_tun_ip_v6 = Ipv6Addr::new(0x2001, 0xdb8, 0xa160, 0, 0, 0, 0, 0x1);
+    let ipr_tun_ip_v6 = Ipv6Addr::new(0xfc00, 0, 0, 0, 0, 0, 0, 0x1);
     let external_ip_v6 = Ipv6Addr::new(0x2001, 0x4860, 0x4860, 0, 0, 0, 0, 0x8888);
 
     info!("Sending ICMP echo requests to: {ipr_tun_ip_v4}, {ipr_tun_ip_v6}, {external_ip_v4}, {external_ip_v6}");


### PR DESCRIPTION
Following https://github.com/nymtech/nym/pull/5059 , some `const` values haven't been updated for the probe's hard-coded values

Temporary fix, until a more stable one, with shared `const`s from the monorepo, can be implemented (after reeses re-point)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1807)
<!-- Reviewable:end -->
