### PR TITLE
go: add flags to enable reproducible builds

### DIFF
--- a/wireguard/build-wireguard-go.sh
+++ b/wireguard/build-wireguard-go.sh
@@ -109,7 +109,7 @@ function build_windows {
     echo "Building wireguard-go for Windows ($arch)"
 
     pushd $LIB_DIR
-        go build -trimpath -v -o libwg.dll -buildmode c-shared
+        build_go -v -o libwg.dll -buildmode c-shared
 
         if [ $# -eq 0 ] ; then
             win_create_lib_file
@@ -141,7 +141,6 @@ function unix_target_triple {
         return 1
     fi
 }
-
 
 function build_unix {
     echo "Building wireguard-go for $1"
@@ -181,7 +180,12 @@ function create_folder_and_build {
     target_triple_dir="../../build/lib/$1"
 
     mkdir -p $target_triple_dir
-    go build -trimpath -v -o $target_triple_dir/libwg.a -buildmode c-archive
+    build_go -v -o $target_triple_dir/libwg.a -buildmode c-archive
+}
+
+# Runs `go build` prefixed with flags to enable reproducible builds.
+function build_go {
+    (set -x; go build -ldflags="-buildid=" -trimpath -buildvcs=false $@)
 }
 
 function build_macos_universal {

--- a/wireguard/libwg/Android.mk
+++ b/wireguard/libwg/Android.mk
@@ -25,7 +25,13 @@ $(DESTDIR)/libwg.so:
 	mkdir -p $(DESTDIR)
 	go get -tags "linux android"
 	chmod -fR +w "$(GOPATH)/pkg/mod"
-	go build -tags "linux android" -ldflags="-X main.socketDirectory=/data/data/$(ANDROID_PACKAGE_NAME)/cache/wireguard" -trimpath -v -o "$@" -buildmode c-shared
+	go build -tags "linux android" \
+		-ldflags="-X main.socketDirectory=/data/data/$(ANDROID_PACKAGE_NAME)/cache/wireguard -buildid=" \
+		-trimpath \
+		-buildvcs=false \
+		-v \
+		-o "$@" \
+		-buildmode c-shared
 	rm -f $(DESTDIR)/libwg.h
 
 


### PR DESCRIPTION
Verified SHA-256 sums between rebuilds using:

```sh
find ../build/lib -name '*-android' -exec shasum -a256 -b {}/libwg.so \;
c311f457ce9d8a665529b648b722f13ec89fa252e66ac5f1d2f678a2baf4f454 *../build/lib/aarch64-linux-android/libwg.so
c400c56d7cddb961a426e4871e9550bbcfbf84a628de31b05de15d8777ae029f *../build/lib/x86_64-linux-android/libwg.so
fac53310833bec44c9315dff19fe2ee0302b0f35e277b91cbcae374eb4ff000a *../build/lib/i686-linux-android/libwg.so
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1808)
<!-- Reviewable:end -->
