### PR TITLE
ci: rebuild libwg on changes

### DIFF
--- a/.github/workflows/build-wireguard-go-android.yml
+++ b/.github/workflows/build-wireguard-go-android.yml
@@ -4,6 +4,7 @@ on:
   workflow_call:
   pull_request:
     paths:
+      - "wireguard/**"
       - ".github/workflows/build-wireguard-go-android.yml"
 
 env:

--- a/.github/workflows/build-wireguard-go-deb.yml
+++ b/.github/workflows/build-wireguard-go-deb.yml
@@ -4,6 +4,7 @@ on:
   workflow_call:
   pull_request:
     paths:
+      - "wireguard/**"
       - ".github/workflows/build-wireguard-go-deb.yml"
 
 env:

--- a/.github/workflows/build-wireguard-go-ios.yml
+++ b/.github/workflows/build-wireguard-go-ios.yml
@@ -1,5 +1,11 @@
 name: build-wireguard-go-ios
-on: [workflow_dispatch, workflow_call]
+on:
+  workflow_dispatch:
+  workflow_call:
+  pull_request:
+    paths:
+      - "wireguard/**"
+      - ".github/workflows/build-wireguard-go-ios.yml"
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/build-wireguard-go-linux.yml
+++ b/.github/workflows/build-wireguard-go-linux.yml
@@ -4,6 +4,7 @@ on:
   workflow_call:
   pull_request:
     paths:
+      - "wireguard/**"
       - ".github/workflows/build-wireguard-go-linux.yml"
 
 env:

--- a/.github/workflows/build-wireguard-go-mac.yml
+++ b/.github/workflows/build-wireguard-go-mac.yml
@@ -1,5 +1,11 @@
 name: build-wireguard-go-mac
-on: [workflow_dispatch, workflow_call]
+on:
+  workflow_dispatch:
+  workflow_call:
+  pull_request:
+    paths:
+      - "wireguard/**"
+      - ".github/workflows/build-wireguard-go-mac.yml"
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/build-wireguard-go-windows.yml
+++ b/.github/workflows/build-wireguard-go-windows.yml
@@ -4,6 +4,7 @@ on:
   workflow_call:
   pull_request:
     paths:
+      - "wireguard/**"
       - ".github/workflows/build-wireguard-go-windows.yml"
 
 env:


### PR DESCRIPTION
Sending a PR concerning libwg does not bother to build it. This PR ensures that libwg is built for all platforms when anything within `wireguard/*` is changed.

You can witness it in the following PR: https://github.com/nymtech/nym-vpn-client/pull/1808

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1809)
<!-- Reviewable:end -->
