### PR TITLE
Add reproducible builds for rust codebase

### DIFF
--- a/nym-vpn-core/Makefile
+++ b/nym-vpn-core/Makefile
@@ -1,6 +1,9 @@
 # Detect the OS and architecture
 include platform.mk
 
+# Linker/compiler flags for producing reproducible output
+include reproducible_builds.mk
+
 # Minimum deployment targets for macOS and iOS
 # These environment variables are used by clang
 export MACOSX_DEPLOYMENT_TARGET = 10.13
@@ -22,16 +25,16 @@ build-all: ## Build all crates in the Rust workspace
 	cargo build --workspace
 
 build-release: ## Build the default crates in the Rust workspace in release mode
-	cargo build --release
+	$(ALL_IDEMPOTENT_FLAGS) cargo build --release
 
 build-release-all: ## Build all the crates in the Rust workspace in release mode
-	cargo build --release --workspace
+	$(ALL_IDEMPOTENT_FLAGS) cargo build --release --workspace
 
 build-mac: ## Build the Rust workspace suitable for running the daemon
-	RUSTFLAGS="-C link-arg=-all_load -C link-arg=-ObjC -C link-arg=-sectcreate -C link-arg=__TEXT -C link-arg=__info_plist -C link-arg=$(CURDIR)/../nym-vpn-apple/Daemon/Info.plist -C link-arg=-sectcreate -C link-arg=__TEXT -C link-arg=__launchd_plist -C link-arg=$(CURDIR)/../nym-vpn-apple/Daemon/Launchd.plist" cargo build --release
+	RUSTFLAGS="$(IDEMPOTENT_RUSTFLAGS) -C link-arg=-all_load -C link-arg=-ObjC -C link-arg=-sectcreate -C link-arg=__TEXT -C link-arg=__info_plist -C link-arg=$(CURDIR)/../nym-vpn-apple/Daemon/Info.plist -C link-arg=-sectcreate -C link-arg=__TEXT -C link-arg=__launchd_plist -C link-arg=$(CURDIR)/../nym-vpn-apple/Daemon/Launchd.plist" $(OTHER_IDEMPOTENT_FLAGS) cargo build --release
 
 build-win-cross:
-	cargo build --target x86_64-pc-windows-gnu --release
+	$(ALL_IDEMPOTENT_FLAGS) cargo build --target x86_64-pc-windows-gnu --release
 
 # -----------------------------------------------------------------------------
 #  Linting targets

--- a/nym-vpn-core/reproducible_builds.mk
+++ b/nym-vpn-core/reproducible_builds.mk
@@ -1,0 +1,22 @@
+# Project root redacted in reproducible builds
+PROJECT_ROOT = $(shell dirname $(CURDIR))
+
+# Rust compiler sysroot that typically points to ~/.rustup/toolchains/<toolchain>
+RUST_COMPILER_SYS_ROOT = $(shell rustc --print sysroot)
+
+# Rust flags used for redacting common paths in binaries
+IDEMPOTENT_RUSTFLAGS = --remap-path-prefix $(HOME)= --remap-path-prefix $(PROJECT_ROOT)= --remap-path-prefix $(RUST_COMPILER_SYS_ROOT)=
+
+# Disable build-id on Linux
+ifeq ($(OS),Linux)
+	IDEMPOTENT_RUSTFLAGS += -C link-args=-Wl,--build-id=none
+endif
+
+# Other environment variables that should be appeneded to cargo build
+# - SOURCE_DATE_EPOCH - set build timestamp to 1970
+# - VERGEN_IDEMPOTENT - force vergen to emit stable values
+# - VERGEN_GIT_BRANCH - make branch name idempotent to avoid catching detached head on some CI builds
+OTHER_IDEMPOTENT_FLAGS = SOURCE_DATE_EPOCH=0 VERGEN_IDEMPOTENT=1 VERGEN_GIT_BRANCH="VERGEN_IDEMPOTENT_OUTPUT"
+
+# Combined rust flags + all other flags.
+ALL_IDEMPOTENT_FLAGS = RUSTFLAGS="$(IDEMPOTENT_RUSTFLAGS)" $(OTHER_IDEMPOTENT_FLAGS)


### PR DESCRIPTION
This PR ensures that our release builds are reproducible by using the following set of techniques:

- Set `VERGEN_IDEMPOTENT` env variable. The following values are set to default and remain the same across rebuilds:
  - `VERGEN_BUILD_DATE` set to default
  - `VERGEN_BUILD_TIMESTAMP` set to default
  - `VERGEN_GIT_COMMIT_DATE` set to default
  - `VERGEN_GIT_COMMIT_TIMESTAMP` set to default
  Note that the warning is emitted to console during such builds.

- Set `VERGEN_GIT_BRANCH` to default because some CIs build from detached HEAD and others from branch etc and that results into different string being embedded into the binary.

- Set rust compiler flags to replace common paths in panic traces:
  - `$HOME` dir is redacted
  - Local filesystem project root is redacted
  - Rust compiler sysroot (typically `~/.rustup/toolchains/<toolchain>`) is redacted
  After running `strings nym-vpnd` a few times I couldn't find any other identifying strings so I assume these three should be sufficient for now but we should of course ensure that it all works properly on Windows too.

- Linker/compiler flags for reproducible builds are only passed in release builds.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1811)
<!-- Reviewable:end -->
