### PR TITLE
adjusted gateway probe to allow testing wireguard nodes that are not entries

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -214,7 +214,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -251,18 +251,18 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.84"
+version = "0.1.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1244b10dcd56c92219da4e14caa97e312079e185f04ba3eea25061561dc0a0"
+checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -502,7 +502,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -639,7 +639,7 @@ dependencies = [
  "pairing",
  "rand_core 0.6.4",
  "serde",
- "serdect 0.3.0-rc.0",
+ "serdect 0.3.0",
  "subtle 2.6.1",
  "zeroize",
 ]
@@ -776,16 +776,16 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.91",
+ "syn 2.0.95",
  "tempfile",
  "toml 0.8.19",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.5"
+version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31a0499c1dc64f458ad13872de75c0eb7e3fdb0e67964610c914b034fc5956e"
+checksum = "a012a0df96dd6d06ba9a1b29d6402d1a5d77c6befd2566afdc26e10603dc93d7"
 dependencies = [
  "shlex",
 ]
@@ -893,9 +893,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.23"
+version = "4.5.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
+checksum = "9560b07a799281c7e0958b9296854d6fafd4c5f31444a7e5bb1ad6dde5ccf1bd"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -903,9 +903,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.23"
+version = "4.5.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
+checksum = "874e0dd3eb68bf99058751ac9712f622e61e6f393a94f7128fa26e3f02f5c7cd"
 dependencies = [
  "anstream",
  "anstyle",
@@ -916,14 +916,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.18"
+version = "4.5.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -1235,7 +1235,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -1480,7 +1480,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -1646,7 +1646,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -1901,7 +1901,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -1994,7 +1994,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -2005,9 +2005,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "gloo-net"
@@ -2610,7 +2610,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -2856,9 +2856,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "lioness"
@@ -3229,7 +3229,7 @@ dependencies = [
 [[package]]
 name = "nym-api-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "bs58",
  "cosmrs",
@@ -3299,7 +3299,7 @@ dependencies = [
 [[package]]
 name = "nym-authenticator-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -3320,7 +3320,7 @@ dependencies = [
 [[package]]
 name = "nym-bandwidth-controller"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "bip39",
  "log",
@@ -3342,7 +3342,7 @@ dependencies = [
 [[package]]
 name = "nym-bin-common"
 version = "0.6.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "const-str",
  "log",
@@ -3356,7 +3356,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core"
 version = "1.1.15"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3417,7 +3417,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-config-types"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "humantime-serde",
  "nym-config",
@@ -3433,7 +3433,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-gateways-storage"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "async-trait",
  "cosmrs",
@@ -3452,7 +3452,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-surb-storage"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -3469,7 +3469,7 @@ dependencies = [
 [[package]]
 name = "nym-coconut-bandwidth-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -3479,7 +3479,7 @@ dependencies = [
 [[package]]
 name = "nym-coconut-dkg-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -3503,7 +3503,7 @@ dependencies = [
 [[package]]
 name = "nym-compact-ecash"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "bincode",
  "bls12_381",
@@ -3526,13 +3526,14 @@ dependencies = [
 [[package]]
 name = "nym-config"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "dirs",
  "handlebars",
  "log",
  "nym-network-defaults",
  "serde",
+ "thiserror 1.0.69",
  "toml 0.8.19",
  "url",
 ]
@@ -3557,7 +3558,7 @@ dependencies = [
 [[package]]
 name = "nym-contracts-common"
 version = "0.5.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -3572,7 +3573,7 @@ dependencies = [
 [[package]]
 name = "nym-country-group"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "serde",
  "tracing",
@@ -3581,7 +3582,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-proxy-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "async-trait",
  "nym-credentials",
@@ -3601,7 +3602,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-storage"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3619,7 +3620,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-utils"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "log",
  "nym-bandwidth-controller",
@@ -3638,7 +3639,7 @@ dependencies = [
 [[package]]
 name = "nym-credentials"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "bincode",
  "bls12_381",
@@ -3661,7 +3662,7 @@ dependencies = [
 [[package]]
 name = "nym-credentials-interface"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "bls12_381",
  "nym-compact-ecash",
@@ -3672,12 +3673,13 @@ dependencies = [
  "strum",
  "thiserror 1.0.69",
  "time",
+ "utoipa",
 ]
 
 [[package]]
 name = "nym-crypto"
 version = "0.4.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "aead",
  "aes",
@@ -3740,7 +3742,7 @@ dependencies = [
 [[package]]
 name = "nym-ecash-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -3754,7 +3756,7 @@ dependencies = [
 [[package]]
 name = "nym-ecash-time"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "nym-compact-ecash",
  "time",
@@ -3763,7 +3765,7 @@ dependencies = [
 [[package]]
 name = "nym-exit-policy"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "serde",
  "serde_json",
@@ -3775,7 +3777,7 @@ dependencies = [
 [[package]]
 name = "nym-explorer-api-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "nym-api-requests",
  "nym-contracts-common",
@@ -3787,7 +3789,7 @@ dependencies = [
 [[package]]
 name = "nym-explorer-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "nym-explorer-api-requests",
  "reqwest 0.12.4",
@@ -3800,7 +3802,7 @@ dependencies = [
 [[package]]
 name = "nym-gateway-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "futures",
  "getrandom 0.2.15",
@@ -3906,7 +3908,7 @@ dependencies = [
 [[package]]
 name = "nym-gateway-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "bs58",
  "futures",
@@ -3932,7 +3934,7 @@ dependencies = [
 [[package]]
 name = "nym-group-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "cosmwasm-schema",
  "cw-controllers",
@@ -3957,7 +3959,7 @@ dependencies = [
 [[package]]
 name = "nym-http-api-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "async-trait",
  "http 1.2.0",
@@ -3974,7 +3976,7 @@ dependencies = [
 [[package]]
 name = "nym-http-api-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "axum 0.7.9",
  "axum-client-ip",
@@ -3993,7 +3995,7 @@ dependencies = [
 [[package]]
 name = "nym-id"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "nym-credential-storage",
  "nym-credentials",
@@ -4023,7 +4025,7 @@ dependencies = [
 [[package]]
 name = "nym-ip-packet-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "bincode",
  "bytes",
@@ -4041,22 +4043,24 @@ dependencies = [
 [[package]]
 name = "nym-metrics"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "dashmap",
  "lazy_static",
- "log",
  "prometheus",
+ "tracing",
 ]
 
 [[package]]
 name = "nym-mixnet-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
+ "dashmap",
  "futures",
  "nym-sphinx",
  "tokio",
+ "tokio-stream",
  "tracing",
 ]
 
@@ -4072,7 +4076,7 @@ dependencies = [
 [[package]]
 name = "nym-mixnet-contract-common"
 version = "0.6.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -4088,12 +4092,13 @@ dependencies = [
  "serde_repr",
  "thiserror 1.0.69",
  "time",
+ "utoipa",
 ]
 
 [[package]]
 name = "nym-multisig-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -4109,7 +4114,7 @@ dependencies = [
 [[package]]
 name = "nym-network-defaults"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "cargo_metadata 0.18.1",
  "dotenvy",
@@ -4124,7 +4129,7 @@ dependencies = [
 [[package]]
 name = "nym-node-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4147,7 +4152,7 @@ dependencies = [
 [[package]]
 name = "nym-nonexhaustive-delayqueue"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -4158,7 +4163,7 @@ dependencies = [
 [[package]]
 name = "nym-ordered-buffer"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "log",
  "thiserror 1.0.69",
@@ -4167,7 +4172,7 @@ dependencies = [
 [[package]]
 name = "nym-outfox"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "blake3",
  "chacha20",
@@ -4185,7 +4190,7 @@ dependencies = [
 [[package]]
 name = "nym-pemstore"
 version = "0.3.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "pem",
 ]
@@ -4216,7 +4221,7 @@ dependencies = [
 [[package]]
 name = "nym-sdk"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4266,7 +4271,7 @@ dependencies = [
 [[package]]
 name = "nym-serde-helpers"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -4278,7 +4283,7 @@ dependencies = [
 [[package]]
 name = "nym-service-provider-requests-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "serde",
 ]
@@ -4286,7 +4291,7 @@ dependencies = [
 [[package]]
 name = "nym-service-providers-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "async-trait",
  "log",
@@ -4300,7 +4305,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-client-core"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4333,7 +4338,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-proxy-helpers"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "bytes",
  "futures",
@@ -4348,7 +4353,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "bincode",
  "log",
@@ -4364,7 +4369,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "log",
  "nym-crypto",
@@ -4390,7 +4395,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-acknowledgements"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "nym-crypto",
  "nym-pemstore",
@@ -4407,7 +4412,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-addressing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-types",
@@ -4418,7 +4423,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-anonymous-replies"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "bs58",
  "nym-crypto",
@@ -4436,7 +4441,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-chunking"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "dashmap",
  "log",
@@ -4454,7 +4459,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-cover"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-acknowledgements",
@@ -4472,7 +4477,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-forwarding"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "nym-outfox",
  "nym-sphinx-addressing",
@@ -4484,7 +4489,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-framing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "bytes",
  "log",
@@ -4501,7 +4506,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-params"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-types",
@@ -4512,7 +4517,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-routing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "nym-sphinx-addressing",
  "nym-sphinx-types",
@@ -4522,7 +4527,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-types"
 version = "0.2.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "nym-outfox",
  "sphinx-packet",
@@ -4532,7 +4537,7 @@ dependencies = [
 [[package]]
 name = "nym-statistics-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "futures",
  "log",
@@ -4554,7 +4559,7 @@ dependencies = [
 [[package]]
 name = "nym-task"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "futures",
  "log",
@@ -4568,7 +4573,7 @@ dependencies = [
 [[package]]
 name = "nym-ticketbooks-merkle"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "nym-credentials-interface",
  "nym-serde-helpers",
@@ -4577,18 +4582,16 @@ dependencies = [
  "serde",
  "sha2 0.10.8",
  "time",
+ "utoipa",
 ]
 
 [[package]]
 name = "nym-topology"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "async-trait",
- "bs58",
- "log",
  "nym-api-requests",
- "nym-bin-common",
  "nym-config",
  "nym-crypto",
  "nym-mixnet-contract-common",
@@ -4597,16 +4600,16 @@ dependencies = [
  "nym-sphinx-types",
  "rand 0.8.5",
  "reqwest 0.12.4",
- "semver",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+ "tracing",
 ]
 
 [[package]]
 name = "nym-validator-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4656,7 +4659,7 @@ dependencies = [
 [[package]]
 name = "nym-vesting-contract-common"
 version = "0.7.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -5011,7 +5014,7 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-types"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "base64 0.22.1",
  "log",
@@ -5258,7 +5261,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -5284,29 +5287,29 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
+checksum = "1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
+checksum = "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -5365,7 +5368,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -5439,36 +5442,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
+checksum = "483f8c21f64f3ea09fe0f30f5d48c3e8eefe5dac9129f0075f76593b4c1da705"
 dependencies = [
  "proc-macro2",
- "syn 2.0.91",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -5490,7 +5469,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -5544,7 +5523,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.91",
+ "syn 2.0.95",
  "tempfile",
 ]
 
@@ -5558,7 +5537,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -5590,9 +5569,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -5951,15 +5930,15 @@ dependencies = [
 
 [[package]]
 name = "rust2go"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb8398eed0838a26fda0a3eb2228c85e51b0f32206e97e687b8e79b1d34e8c2"
+checksum = "cedb3ca308113535deaf2e0cce0fe93bb53d5f4b1e571a13c701e5bca5b1c3ed"
 dependencies = [
  "bindgen",
  "rust2go-cli",
  "rust2go-convert",
  "rust2go-macro",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -5982,7 +5961,7 @@ checksum = "9e6cbc4f2ec83801d291d9285112d664ced769c3c141ae800bda677452d57ff3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -6000,7 +5979,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust2go-common",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -6026,9 +6005,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.42"
+version = "0.38.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
+checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -6122,9 +6101,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
@@ -6173,7 +6152,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -6199,7 +6178,7 @@ checksum = "7f81c2fde025af7e69b1d1420531c8a8811ca898919db177141a85313b1cb932"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -6242,9 +6221,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1863fd3768cd83c56a7f60faa4dc0d403f1b6df0a38c3c25f44b7894e45370d5"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -6294,7 +6273,7 @@ checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -6305,14 +6284,14 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.134"
+version = "1.0.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d"
+checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
 dependencies = [
  "itoa",
  "memchr",
@@ -6338,7 +6317,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -6387,9 +6366,9 @@ dependencies = [
 
 [[package]]
 name = "serdect"
-version = "0.3.0-rc.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a504c8ee181e3e594d84052f983d60afe023f4d94d050900be18062bbbf7b58"
+checksum = "f42f67da2385b51a5f9652db9c93d78aeaf7610bf5ec366080b6de810604af53"
 dependencies = [
  "base16ct",
  "serde",
@@ -6820,7 +6799,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -6863,9 +6842,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.91"
+version = "2.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53cbcb5a243bd33b7858b1d7f4aca2153490815872d86d955d6ea29f743c035"
+checksum = "46f71c0377baf4ef1cc3e3402ded576dccc315800fbc62dfc7fe04b009773b4a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6892,7 +6871,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -7134,7 +7113,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -7145,7 +7124,7 @@ checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -7219,9 +7198,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.42.0"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
+checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
 dependencies = [
  "backtrace",
  "bytes",
@@ -7247,13 +7226,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -7412,7 +7391,7 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -7535,7 +7514,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -7797,7 +7776,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5c400339a9d1d17be34257d0b407e91d64af335e5b4fa49f4bf28467fc8d635"
 dependencies = [
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -7828,7 +7807,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.91",
+ "syn 2.0.95",
  "toml 0.5.11",
  "uniffi_meta",
 ]
@@ -7943,9 +7922,9 @@ checksum = "133bf74f01486773317ddfcde8e2e20d2933cc3b68ab797e5d718bef996a81de"
 
 [[package]]
 name = "utoipa"
-version = "4.2.3"
+version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5afb1a60e207dca502682537fefcfd9921e71d0b83e9576060f09abc6efab23"
+checksum = "435c6f69ef38c9017b4b4eea965dfb91e71e53d869e896db40d1cf2441dd75c0"
 dependencies = [
  "indexmap 2.7.0",
  "serde",
@@ -7955,14 +7934,13 @@ dependencies = [
 
 [[package]]
 name = "utoipa-gen"
-version = "4.3.1"
+version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20c24e8ab68ff9ee746aad22d39b5535601e6416d1b0feeabf78be986a5c4392"
+checksum = "a77d306bc75294fd52f3e99b13ece67c02c1a2789190a6f31d32f736624326f7"
 dependencies = [
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -8066,7 +8044,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
  "wasm-bindgen-shared",
 ]
 
@@ -8101,7 +8079,7 @@ checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -8115,7 +8093,7 @@ checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
 [[package]]
 name = "wasm-utils"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2024.15-reeses#f7a7a8072fb74e53837ae9cb29a7471021549b2c"
+source = "git+https://github.com/nymtech/nym?rev=3d2914b3e5d707cd56e45508cfda6b656d483190#3d2914b3e5d707cd56e45508cfda6b656d483190"
 dependencies = [
  "futures",
  "getrandom 0.2.15",
@@ -8335,7 +8313,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -8346,7 +8324,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -8357,7 +8335,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -8368,7 +8346,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -8560,9 +8538,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.20"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+checksum = "39281189af81c07ec09db316b302a3e67bf9bd7cbf6c820b50e35fee9c2fa980"
 dependencies = [
  "memchr",
 ]
@@ -8650,7 +8628,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
  "synstructure",
 ]
 
@@ -8672,7 +8650,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -8692,7 +8670,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
  "synstructure",
 ]
 
@@ -8713,7 +8691,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -8735,5 +8713,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -168,27 +168,29 @@ windows-sys = "0.52"
 x25519-dalek = "2.0"
 zeroize = "1.6.0"
 
-nym-authenticator-requests = { git = "https://github.com/nymtech/nym", branch = "release/2024.15-reeses" }
-nym-bandwidth-controller = { git = "https://github.com/nymtech/nym", branch = "release/2024.15-reeses" }
-nym-bin-common = { git = "https://github.com/nymtech/nym", branch = "release/2024.15-reeses" }
-nym-client-core = { git = "https://github.com/nymtech/nym", branch = "release/2024.15-reeses" }
-nym-compact-ecash = { git = "https://github.com/nymtech/nym", branch = "release/2024.15-reeses" }
-nym-config = { git = "https://github.com/nymtech/nym", branch = "release/2024.15-reeses" }
-nym-contracts-common = { git = "https://github.com/nymtech/nym", branch = "release/2024.15-reeses" }
-nym-credential-proxy-requests = { git = "https://github.com/nymtech/nym", branch = "release/2024.15-reeses" }
-nym-credential-storage = { git = "https://github.com/nymtech/nym", branch = "release/2024.15-reeses" }
-nym-credentials = { git = "https://github.com/nymtech/nym", branch = "release/2024.15-reeses" }
-nym-credentials-interface = { git = "https://github.com/nymtech/nym", branch = "release/2024.15-reeses" }
-nym-crypto = { git = "https://github.com/nymtech/nym", branch = "release/2024.15-reeses" }
-nym-ecash-time = { git = "https://github.com/nymtech/nym", branch = "release/2024.15-reeses" }
-nym-http-api-client = { git = "https://github.com/nymtech/nym", branch = "release/2024.15-reeses" }
-nym-ip-packet-requests = { git = "https://github.com/nymtech/nym", branch = "release/2024.15-reeses" }
-nym-node-requests = { git = "https://github.com/nymtech/nym", branch = "release/2024.15-reeses" }
-nym-pemstore = { git = "https://github.com/nymtech/nym", branch = "release/2024.15-reeses" }
-nym-service-provider-requests-common = { git = "https://github.com/nymtech/nym", branch = "release/2024.15-reeses" }
-nym-sdk = { git = "https://github.com/nymtech/nym", branch = "release/2024.15-reeses" }
-nym-statistics-common = { git = "https://github.com/nymtech/nym", branch = "release/2024.15-reeses" }
-nym-task = { git = "https://github.com/nymtech/nym", branch = "release/2024.15-reeses" }
-nym-topology = { git = "https://github.com/nymtech/nym", branch = "release/2024.15-reeses" }
-nym-validator-client = { git = "https://github.com/nymtech/nym", branch = "release/2024.15-reeses" }
-nym-wireguard-types = { git = "https://github.com/nymtech/nym", branch = "release/2024.15-reeses" }
+# 3d2914b3e5d707cd56e45508cfda6b656d483190 points to the current develop (as of 08.01.25) that contains
+# needed changes to `NymTopology` that are going to be released in Hu
+nym-authenticator-requests = { git = "https://github.com/nymtech/nym", rev = "3d2914b3e5d707cd56e45508cfda6b656d483190" }
+nym-bandwidth-controller = { git = "https://github.com/nymtech/nym", rev = "3d2914b3e5d707cd56e45508cfda6b656d483190" }
+nym-bin-common = { git = "https://github.com/nymtech/nym", rev = "3d2914b3e5d707cd56e45508cfda6b656d483190" }
+nym-client-core = { git = "https://github.com/nymtech/nym", rev = "3d2914b3e5d707cd56e45508cfda6b656d483190" }
+nym-compact-ecash = { git = "https://github.com/nymtech/nym", rev = "3d2914b3e5d707cd56e45508cfda6b656d483190" }
+nym-config = { git = "https://github.com/nymtech/nym", rev = "3d2914b3e5d707cd56e45508cfda6b656d483190" }
+nym-contracts-common = { git = "https://github.com/nymtech/nym", rev = "3d2914b3e5d707cd56e45508cfda6b656d483190" }
+nym-credential-proxy-requests = { git = "https://github.com/nymtech/nym", rev = "3d2914b3e5d707cd56e45508cfda6b656d483190" }
+nym-credential-storage = { git = "https://github.com/nymtech/nym", rev = "3d2914b3e5d707cd56e45508cfda6b656d483190" }
+nym-credentials = { git = "https://github.com/nymtech/nym", rev = "3d2914b3e5d707cd56e45508cfda6b656d483190" }
+nym-credentials-interface = { git = "https://github.com/nymtech/nym", rev = "3d2914b3e5d707cd56e45508cfda6b656d483190" }
+nym-crypto = { git = "https://github.com/nymtech/nym", rev = "3d2914b3e5d707cd56e45508cfda6b656d483190" }
+nym-ecash-time = { git = "https://github.com/nymtech/nym", rev = "3d2914b3e5d707cd56e45508cfda6b656d483190" }
+nym-http-api-client = { git = "https://github.com/nymtech/nym", rev = "3d2914b3e5d707cd56e45508cfda6b656d483190" }
+nym-ip-packet-requests = { git = "https://github.com/nymtech/nym", rev = "3d2914b3e5d707cd56e45508cfda6b656d483190" }
+nym-node-requests = { git = "https://github.com/nymtech/nym", rev = "3d2914b3e5d707cd56e45508cfda6b656d483190" }
+nym-pemstore = { git = "https://github.com/nymtech/nym", rev = "3d2914b3e5d707cd56e45508cfda6b656d483190" }
+nym-service-provider-requests-common = { git = "https://github.com/nymtech/nym", rev = "3d2914b3e5d707cd56e45508cfda6b656d483190" }
+nym-sdk = { git = "https://github.com/nymtech/nym", rev = "3d2914b3e5d707cd56e45508cfda6b656d483190" }
+nym-statistics-common = { git = "https://github.com/nymtech/nym", rev = "3d2914b3e5d707cd56e45508cfda6b656d483190" }
+nym-task = { git = "https://github.com/nymtech/nym", rev = "3d2914b3e5d707cd56e45508cfda6b656d483190" }
+nym-topology = { git = "https://github.com/nymtech/nym", rev = "3d2914b3e5d707cd56e45508cfda6b656d483190" }
+nym-validator-client = { git = "https://github.com/nymtech/nym", rev = "3d2914b3e5d707cd56e45508cfda6b656d483190" }
+nym-wireguard-types = { git = "https://github.com/nymtech/nym", rev = "3d2914b3e5d707cd56e45508cfda6b656d483190" }

--- a/nym-vpn-core/crates/nym-authenticator-client/src/lib.rs
+++ b/nym-vpn-core/crates/nym-authenticator-client/src/lib.rs
@@ -735,22 +735,34 @@ impl From<u8> for AuthenticatorVersion {
     }
 }
 
-impl From<Option<String>> for AuthenticatorVersion {
-    fn from(value: Option<String>) -> Self {
+impl From<&str> for AuthenticatorVersion {
+    fn from(value: &str) -> Self {
+        let Ok(semver) = semver::Version::parse(value) else {
+            return Self::UNKNOWN;
+        };
+
+        semver.into()
+    }
+}
+
+impl From<Option<&String>> for AuthenticatorVersion {
+    fn from(value: Option<&String>) -> Self {
         match value {
             None => Self::UNKNOWN,
-            Some(value) => value.into(),
+            Some(value) => value.as_str().into(),
         }
     }
 }
 
 impl From<String> for AuthenticatorVersion {
     fn from(value: String) -> Self {
-        let Ok(semver) = semver::Version::parse(value.as_str()) else {
-            return Self::UNKNOWN;
-        };
+        Self::from(value.as_str())
+    }
+}
 
-        semver.into()
+impl From<Option<String>> for AuthenticatorVersion {
+    fn from(value: Option<String>) -> Self {
+        value.as_ref().into()
     }
 }
 

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/exit_point.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/exit_point.rs
@@ -53,9 +53,9 @@ impl ExitPoint {
                 let ipr_address = IpPacketRouterAddress(*address);
                 let gateway_address = ipr_address.gateway();
 
-                // Now fetch the gateway that the IPR is connected to, and override it's IPR address
+                // Now fetch the gateway that the IPR is connected to, and override its IPR address
                 let mut gateway = gateways
-                    .gateway_with_identity(gateway_address)
+                    .gateway_with_identity(&gateway_address)
                     .ok_or_else(|| Error::NoMatchingGateway {
                         requested_identity: gateway_address.to_string(),
                     })

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/ipr_addresses.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/ipr_addresses.rs
@@ -32,7 +32,7 @@ impl IpPacketRouterAddress {
         )?))
     }
 
-    pub fn gateway(&self) -> &NodeIdentity {
+    pub fn gateway(&self) -> NodeIdentity {
         self.0.gateway()
     }
 }

--- a/nym-vpn-core/crates/nym-gateway-directory/src/error.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/error.rs
@@ -36,6 +36,9 @@ pub enum Error {
     #[error("failed to lookup skimmed gateways: {0}")]
     FailedToLookupSkimmedGateways(#[source] nym_validator_client::ValidatorClientError),
 
+    #[error("failed to lookup skimmed nodes: {0}")]
+    FailedToLookupSkimmedNodes(#[source] nym_validator_client::ValidatorClientError),
+
     #[error("requested gateway not found in the remote list: {0}")]
     RequestedGatewayIdNotFound(String),
 
@@ -76,6 +79,9 @@ pub enum Error {
 
     #[error("failed to lookup gateway ip for gateway {0}")]
     FailedToLookupIp(String),
+
+    #[error("the provided gateway information is malformed")]
+    MalformedGateway,
 }
 
 // Result type based on our error type

--- a/nym-vpn-core/crates/nym-gateway-directory/src/lib.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/lib.rs
@@ -15,7 +15,9 @@ pub use crate::{
         country::Country,
         entry_point::EntryPoint,
         exit_point::ExitPoint,
-        gateway::{Entry, Exit, Gateway, GatewayList, GatewayType, Location, Probe, ProbeOutcome},
+        gateway::{
+            Entry, Exit, Gateway, GatewayList, GatewayType, Location, NymNode, Probe, ProbeOutcome,
+        },
         ipr_addresses::IpPacketRouterAddress,
     },
     error::Error,

--- a/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
+++ b/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
@@ -8,10 +8,9 @@ use std::{
 #[cfg(unix)]
 use std::{os::fd::RawFd, sync::Arc};
 
-use anyhow::bail;
+use anyhow::{anyhow, bail};
 use base64::{engine::general_purpose, Engine as _};
 use bytes::BytesMut;
-use dns_lookup::lookup_host;
 use futures::StreamExt;
 use nym_authenticator_client::{AuthenticatorResponse, AuthenticatorVersion, ClientMessage};
 use nym_authenticator_requests::{v2, v3, v4};
@@ -23,7 +22,7 @@ use nym_connection_monitor::self_ping_and_wait;
 use nym_gateway_directory::{
     AuthAddress, Config as GatewayDirectoryConfig, EntryPoint,
     GatewayClient as GatewayDirectoryClient, GatewayList, GatewayMinPerformance,
-    IpPacketRouterAddress,
+    IpPacketRouterAddress, NymNode,
 };
 use nym_ip_packet_client::IprClientConnect;
 use nym_ip_packet_requests::{
@@ -32,26 +31,77 @@ use nym_ip_packet_requests::{
     IpPair,
 };
 use nym_mixnet_client::SharedMixnetClient;
-use nym_sdk::mixnet::{MixnetClientBuilder, ReconstructedMessage};
+use nym_sdk::mixnet::{MixnetClientBuilder, NodeIdentity, ReconstructedMessage};
 use nym_wireguard_types::PeerPublicKey;
 use tokio_util::codec::Decoder;
 use tracing::*;
 use types::WgProbeResults;
+use crate::types::Entry;
 
 use crate::{
     icmp::{check_for_icmp_beacon_reply, icmp_identifier, send_ping_v4, send_ping_v6},
-    types::{Entry, Exit},
+    types::Exit,
 };
+
+use netstack::ffi::{NetstackCall as _, NetstackCallImpl, NetstackRequestGo};
+use netstack::NetstackRequest;
 
 mod error;
 mod icmp;
 mod netstack;
 mod types;
-use netstack::ffi::{NetstackCall as _, NetstackCallImpl, NetstackRequestGo};
-use netstack::NetstackRequest;
+
 
 pub use error::{Error, Result};
 pub use types::{IpPingReplies, ProbeOutcome, ProbeResult};
+
+#[derive(Default, Debug)]
+pub enum TestedNode {
+    #[default]
+    SameAsEntry,
+    Custom {
+        identity: NodeIdentity,
+    },
+}
+
+impl TestedNode {
+    pub fn is_same_as_entry(&self) -> bool {
+        matches!(self, TestedNode::SameAsEntry)
+    }
+}
+
+#[derive(Debug)]
+pub struct TestedNodeDetails {
+    identity: NodeIdentity,
+    exit_router_address: Option<IpPacketRouterAddress>,
+    authenticator_address: Option<AuthAddress>,
+    authenticator_version: AuthenticatorVersion,
+    ip_address: Option<IpAddr>,
+}
+
+impl From<&NymNode> for TestedNodeDetails {
+    fn from(node: &NymNode) -> Self {
+        TestedNodeDetails {
+            identity: node.identity,
+            exit_router_address: node.ipr_address,
+            authenticator_address: node.authenticator_address,
+            authenticator_version: AuthenticatorVersion::from(node.version.as_ref()),
+            ip_address: node.ips.first().copied(),
+        }
+    }
+}
+
+/// Obtain nym-node for testing
+pub async fn get_nym_node(identity: NodeIdentity) -> anyhow::Result<NymNode> {
+    let config = GatewayDirectoryConfig::new_from_env();
+    let user_agent = nym_bin_common::bin_info_local_vergen!().into();
+    let nodes_client = GatewayDirectoryClient::new(config.clone(), user_agent)?;
+    let nodes = nodes_client.lookup_all_nymnodes().await?;
+    let node = nodes
+        .node_with_identity(&identity)
+        .ok_or_else(|| anyhow!("did not find the specified node"))?;
+    Ok(node.clone())
+}
 
 pub async fn fetch_gateways(
     min_gateway_performance: GatewayMinPerformance,
@@ -66,6 +116,7 @@ pub async fn fetch_gateways_with_ipr(
         .await?
         .into_exit_gateways())
 }
+
 
 pub struct Probe {
     entrypoint: EntryPoint,
@@ -86,7 +137,9 @@ impl Probe {
 
     pub async fn probe(
         self,
-        min_gateway_performance: GatewayMinPerformance,
+        tested_node: TestedNode,
+    min_gateway_performance: GatewayMinPerformance,
+    ignore_egress_epoch_role: bool,
         only_wireguard: bool,
     ) -> anyhow::Result<ProbeResult> {
         let entry_point = self.entrypoint;
@@ -94,95 +147,127 @@ impl Probe {
         // Setup the entry gateways
         let gateways = lookup_gateways(min_gateway_performance).await?;
         let entry_gateway = entry_point.lookup_gateway(&gateways).await?;
-        let exit_router_address = entry_gateway.ipr_address;
-        let authenticator = entry_gateway.authenticator_address;
-        let gateway_host = entry_gateway.host.clone().unwrap();
-        let auth_version = AuthenticatorVersion::from(entry_gateway.version.clone());
-        let mixnet_entry_gateway_id = if only_wireguard {
-            *gateways.random_gateway().unwrap().identity()
-        } else {
-            *entry_gateway.identity()
+        let tested_entry = tested_node.is_same_as_entry();
+
+        let node_info: TestedNodeDetails = match tested_node {
+        TestedNode::Custom { identity } => {
+            let node = get_nym_node(identity).await?;
+            info!(
+                "testing node {} (via entry {})",
+                node.identity, entry_gateway.identity
+            );
+            (&node).into()
+        }
+        TestedNode::SameAsEntry => (&entry_gateway).into(),
         };
 
-        info!("Probing gateway: {entry_gateway:?}");
-        debug!("gateway_host: {}", gateway_host);
+    let mixnet_entry_gateway_id = entry_gateway.identity();
 
-        // Connect to the mixnet
+        info!("connecting to entry gateway: {entry_gateway:?}");
+        debug!(
+        "authenticator version: {:?}",
+        node_info.authenticator_version
+    );
+
+        // Connect to the mixnet via the entry gateway
         let mixnet_client = MixnetClientBuilder::new_ephemeral()
             .request_gateway(mixnet_entry_gateway_id.to_string())
             .network_details(NymNetworkDetails::new_from_env())
-            .debug_config(mixnet_debug_config(min_gateway_performance))
+            .debug_config(mixnet_debug_config(
+                min_gateway_performance,
+                ignore_egress_epoch_role,
+            ))
             .build()?
             .connect_to_mixnet()
             .await;
 
-        let mixnet_client = match mixnet_client {
-            Ok(mixnet_client) => mixnet_client,
-            Err(err) => {
-                error!("Failed to connect to mixnet: {err}");
-                return Ok(ProbeResult {
-                    gateway: mixnet_entry_gateway_id.to_string(),
-                    outcome: ProbeOutcome {
-                        as_entry: Entry::fail_to_connect(),
-                        as_exit: None,
-                        wg: None,
+    let mixnet_client = match mixnet_client {
+        Ok(mixnet_client) => mixnet_client,
+        Err(err) => {
+            error!("Failed to connect to mixnet: {err}");
+            return Ok(ProbeResult {
+                node: node_info.identity.to_string(),
+                used_entry: mixnet_entry_gateway_id.to_string(),
+                outcome: ProbeOutcome {
+                    as_entry: if tested_entry {
+                        Entry::fail_to_connect()
+                    } else {
+                        Entry::EntryFailure
                     },
-                });
-            }
-        };
+                    as_exit: None,
+                    wg: None,
+                },
+            });
+        }
+    };
 
-        let nym_address = mixnet_client.nym_address();
-        let entry_gateway = nym_address.gateway().to_base58_string();
+    let nym_address = *mixnet_client.nym_address();
+    let entry_gateway = nym_address.gateway().to_base58_string();
 
-        info!("Successfully connected to entry gateway: {entry_gateway}");
-        info!("Our nym address: {nym_address}");
+    info!("Successfully connected to entry gateway: {entry_gateway}");
+    info!("Our nym address: {nym_address}");
 
-        // Now that we have a connected mixnet client, we can start pinging
-        let shared_client = SharedMixnetClient::new(
-            mixnet_client,
-            #[cfg(unix)]
-            Arc::new(|_: RawFd| {}),
-        );
+    let shared_client = SharedMixnetClient::new(mixnet_client);
 
-        // Now that we have a connected mixnet client, we can start pinging
-        let outcome = do_ping(shared_client.clone(), exit_router_address).await;
-
-        let wg_outcome = if let Some(authenticator) = authenticator {
-            wg_probe(
-                authenticator,
-                shared_client.clone(),
-                &gateway_host,
-                auth_version,
-                self.amnezia_args,
-            )
-            .await
-            .unwrap_or_default()
-        } else {
-            WgProbeResults::default()
-        };
-
-        let mixnet_client = shared_client.lock().await.take().unwrap();
-        mixnet_client.disconnect().await;
-
-        // Disconnect the mixnet client gracefully
-        outcome.map(|mut outcome| {
-            outcome.wg = Some(wg_outcome);
-            ProbeResult {
-                gateway: entry_gateway.clone(),
-                outcome,
-            }
+    // Now that we have a connected mixnet client, we can start pinging
+    let outcome = if only_wireguard {
+        Ok(ProbeOutcome {
+            as_entry: if tested_entry {
+                Entry::success()
+            } else {
+                Entry::NotTested
+            },
+            as_exit: None,
+            wg: None,
         })
-    }
+    } else {
+        do_ping(
+            shared_client.clone(),
+            node_info.exit_router_address,
+            tested_entry,
+        )
+        .await
+    };
+
+    let wg_outcome = if let (Some(authenticator), Some(ip_address)) =
+        (node_info.authenticator_address, node_info.ip_address)
+    {
+        wg_probe(
+            authenticator,
+            shared_client.clone(),
+            ip_address,
+            node_info.authenticator_version,
+            self.amnezia_args,
+        )
+        .await
+        .unwrap_or_default()
+    } else {
+        WgProbeResults::default()
+    };
+
+    let mixnet_client = shared_client.lock().await.take().unwrap();
+    mixnet_client.disconnect().await;
+
+    // Disconnect the mixnet client gracefully
+    outcome.map(|mut outcome| {
+        outcome.wg = Some(wg_outcome);
+        ProbeResult {
+            node: node_info.identity.to_string(),
+            used_entry: mixnet_entry_gateway_id.to_string(),
+            outcome,
+        }
+    })
 }
 
 async fn wg_probe(
     authenticator: AuthAddress,
     shared_mixnet_client: SharedMixnetClient,
-    gateway_host: &nym_topology::NetworkAddress,
+    gateway_ip: IpAddr,
     auth_version: AuthenticatorVersion,
     awg_args: String,
 ) -> anyhow::Result<WgProbeResults> {
     let mut auth_client = nym_authenticator_client::AuthClient::new(shared_mixnet_client).await;
+    info!("attempting to use authenticator version {auth_version:?}");
 
     let mut rng = rand::thread_rng();
     let private_key = nym_crypto::asymmetric::encryption::PrivateKey::new(&mut rng);
@@ -199,12 +284,13 @@ async fn wg_probe(
         AuthenticatorVersion::V4 => ClientMessage::Initial(Box::new(
             v4::registration::InitMessage::new(authenticator_pub_key),
         )),
-        AuthenticatorVersion::UNKNOWN => bail!("Unknwon version number"),
+        AuthenticatorVersion::UNKNOWN => bail!("unknown version number"),
     };
 
     let mut wg_outcome = WgProbeResults::default();
 
     if let Some(authenticator_address) = authenticator.0 {
+        info!("connecting to authenticator: {authenticator_address}...");
         let response = auth_client
             .send(&init_message, authenticator_address)
             .await?;
@@ -251,7 +337,7 @@ async fn wg_probe(
                             credential: None,
                         }))
                     }
-                    AuthenticatorVersion::UNKNOWN => bail!("Unknwon version number"),
+                    AuthenticatorVersion::UNKNOWN => bail!("Unknown version number"),
                 };
                 let response = auth_client
                     .send(&finalized_message, authenticator_address)
@@ -282,21 +368,7 @@ async fn wg_probe(
             registered_data.wg_port(),
         );
 
-        let gateway_ip = match gateway_host {
-            nym_topology::NetworkAddress::Hostname(host) => lookup_host(host)?
-                .first()
-                .map(|ip| match ip {
-                    IpAddr::V4(ip) => ip.to_string(),
-                    IpAddr::V6(ip) => format!("[{}]", ip),
-                })
-                .unwrap_or_default(),
-            nym_topology::NetworkAddress::IpAddr(ip) => match ip {
-                IpAddr::V4(ip) => ip.to_string(),
-                IpAddr::V6(ip) => format!("[{}]", ip),
-            },
-        };
-
-        let wg_endpoint = format!("{}:{}", gateway_ip, registered_data.wg_port());
+        let wg_endpoint = format!("{gateway_ip}:{}", registered_data.wg_port());
 
         info!("Successfully registered with the gateway");
 
@@ -380,6 +452,7 @@ async fn lookup_gateways(
 
 fn mixnet_debug_config(
     min_gateway_performance: GatewayMinPerformance,
+    ignore_egress_epoch_role: bool,
 ) -> nym_client_core::config::DebugConfig {
     let mut debug_config = nym_client_core::config::DebugConfig::default();
     debug_config
@@ -390,12 +463,17 @@ fn mixnet_debug_config(
         debug_config.topology.minimum_gateway_performance =
             minimum_gateway_performance.round_to_integer();
     }
+    if ignore_egress_epoch_role {
+        debug_config.topology.ignore_egress_epoch_role = ignore_egress_epoch_role;
+    }
+
     debug_config
 }
 
 async fn do_ping(
     shared_mixnet_client: SharedMixnetClient,
     exit_router_address: Option<IpPacketRouterAddress>,
+    tested_entry: bool,
 ) -> anyhow::Result<ProbeOutcome> {
     // Step 1: confirm that the entry gateway is routing our mixnet traffic
     info!("Sending mixnet ping to ourselves to verify mixnet connection");
@@ -407,16 +485,26 @@ async fn do_ping(
     .is_err()
     {
         return Ok(ProbeOutcome {
-            as_entry: Entry::fail_to_route(),
+            as_entry: if tested_entry {
+                Entry::fail_to_connect()
+            } else {
+                Entry::EntryFailure
+            },
             as_exit: None,
             wg: None,
         });
     }
     info!("Successfully mixnet pinged ourselves");
 
+    let as_entry = if tested_entry {
+        Entry::success()
+    } else {
+        Entry::NotTested
+    };
+
     let Some(exit_router_address) = exit_router_address else {
         return Ok(ProbeOutcome {
-            as_entry: Entry::success(),
+            as_entry,
             as_exit: None,
             wg: None,
         });
@@ -430,7 +518,7 @@ async fn do_ping(
     let mut ipr_client = IprClientConnect::new(shared_mixnet_client.clone()).await;
     let Ok(our_ips) = ipr_client.connect(exit_router_address.0, None).await else {
         return Ok(ProbeOutcome {
-            as_entry: Entry::success(),
+            as_entry,
             as_exit: Some(Exit::fail_to_connect()),
             wg: None,
         });
@@ -440,7 +528,7 @@ async fn do_ping(
 
     // Step 3: perform ICMP connectivity checks for the exit gateway
     send_icmp_pings(shared_mixnet_client.clone(), our_ips, exit_router_address).await?;
-    listen_for_icmp_ping_replies(shared_mixnet_client.clone(), our_ips).await
+    listen_for_icmp_ping_replies(shared_mixnet_client.clone(), our_ips, as_entry).await
 }
 
 async fn send_icmp_pings(
@@ -503,6 +591,7 @@ async fn send_icmp_pings(
 async fn listen_for_icmp_ping_replies(
     shared_mixnet_client: SharedMixnetClient,
     our_ips: IpPair,
+    entry_result: Entry,
 ) -> anyhow::Result<ProbeOutcome> {
     // HACK: take it out of the shared mixnet client
     let mut mixnet_client = shared_mixnet_client.inner().lock().await.take().unwrap();
@@ -542,7 +631,7 @@ async fn listen_for_icmp_ping_replies(
         .replace(mixnet_client);
 
     Ok(ProbeOutcome {
-        as_entry: Entry::success(),
+        as_entry: entry_result,
         as_exit: Some(Exit {
             can_connect: true,
             can_route_ip_v4: registered_replies.ipr_tun_ip_v4,

--- a/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
+++ b/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
@@ -8,6 +8,7 @@ use std::{
 #[cfg(unix)]
 use std::{os::fd::RawFd, sync::Arc};
 
+use crate::types::Entry;
 use anyhow::{anyhow, bail};
 use base64::{engine::general_purpose, Engine as _};
 use bytes::BytesMut;
@@ -36,7 +37,6 @@ use nym_wireguard_types::PeerPublicKey;
 use tokio_util::codec::Decoder;
 use tracing::*;
 use types::WgProbeResults;
-use crate::types::Entry;
 
 use crate::{
     icmp::{check_for_icmp_beacon_reply, icmp_identifier, send_ping_v4, send_ping_v6},
@@ -50,7 +50,6 @@ mod error;
 mod icmp;
 mod netstack;
 mod types;
-
 
 pub use error::{Error, Result};
 pub use types::{IpPingReplies, ProbeOutcome, ProbeResult};
@@ -117,16 +116,17 @@ pub async fn fetch_gateways_with_ipr(
         .into_exit_gateways())
 }
 
-
 pub struct Probe {
     entrypoint: EntryPoint,
+    tested_node: TestedNode,
     amnezia_args: String,
 }
 
 impl Probe {
-    pub fn new(entrypoint: EntryPoint) -> Self {
+    pub fn new(entrypoint: EntryPoint, tested_node: TestedNode) -> Self {
         Self {
             entrypoint,
+            tested_node,
             amnezia_args: "".into(),
         }
     }
@@ -137,9 +137,8 @@ impl Probe {
 
     pub async fn probe(
         self,
-        tested_node: TestedNode,
-    min_gateway_performance: GatewayMinPerformance,
-    ignore_egress_epoch_role: bool,
+        min_gateway_performance: GatewayMinPerformance,
+        ignore_egress_epoch_role: bool,
         only_wireguard: bool,
     ) -> anyhow::Result<ProbeResult> {
         let entry_point = self.entrypoint;
@@ -147,27 +146,27 @@ impl Probe {
         // Setup the entry gateways
         let gateways = lookup_gateways(min_gateway_performance).await?;
         let entry_gateway = entry_point.lookup_gateway(&gateways).await?;
-        let tested_entry = tested_node.is_same_as_entry();
+        let tested_entry = self.tested_node.is_same_as_entry();
 
-        let node_info: TestedNodeDetails = match tested_node {
-        TestedNode::Custom { identity } => {
-            let node = get_nym_node(identity).await?;
-            info!(
-                "testing node {} (via entry {})",
-                node.identity, entry_gateway.identity
-            );
-            (&node).into()
-        }
-        TestedNode::SameAsEntry => (&entry_gateway).into(),
+        let node_info: TestedNodeDetails = match self.tested_node {
+            TestedNode::Custom { identity } => {
+                let node = get_nym_node(identity).await?;
+                info!(
+                    "testing node {} (via entry {})",
+                    node.identity, entry_gateway.identity
+                );
+                (&node).into()
+            }
+            TestedNode::SameAsEntry => (&entry_gateway).into(),
         };
 
-    let mixnet_entry_gateway_id = entry_gateway.identity();
+        let mixnet_entry_gateway_id = entry_gateway.identity();
 
         info!("connecting to entry gateway: {entry_gateway:?}");
         debug!(
-        "authenticator version: {:?}",
-        node_info.authenticator_version
-    );
+            "authenticator version: {:?}",
+            node_info.authenticator_version
+        );
 
         // Connect to the mixnet via the entry gateway
         let mixnet_client = MixnetClientBuilder::new_ephemeral()
@@ -181,82 +180,87 @@ impl Probe {
             .connect_to_mixnet()
             .await;
 
-    let mixnet_client = match mixnet_client {
-        Ok(mixnet_client) => mixnet_client,
-        Err(err) => {
-            error!("Failed to connect to mixnet: {err}");
-            return Ok(ProbeResult {
+        let mixnet_client = match mixnet_client {
+            Ok(mixnet_client) => mixnet_client,
+            Err(err) => {
+                error!("Failed to connect to mixnet: {err}");
+                return Ok(ProbeResult {
+                    node: node_info.identity.to_string(),
+                    used_entry: mixnet_entry_gateway_id.to_string(),
+                    outcome: ProbeOutcome {
+                        as_entry: if tested_entry {
+                            Entry::fail_to_connect()
+                        } else {
+                            Entry::EntryFailure
+                        },
+                        as_exit: None,
+                        wg: None,
+                    },
+                });
+            }
+        };
+
+        let nym_address = *mixnet_client.nym_address();
+        let entry_gateway = nym_address.gateway().to_base58_string();
+
+        info!("Successfully connected to entry gateway: {entry_gateway}");
+        info!("Our nym address: {nym_address}");
+
+        let shared_client = SharedMixnetClient::new(
+            mixnet_client,
+            #[cfg(unix)]
+            Arc::new(|_: RawFd| {}),
+        );
+
+        // Now that we have a connected mixnet client, we can start pinging
+        let outcome = if only_wireguard {
+            Ok(ProbeOutcome {
+                as_entry: if tested_entry {
+                    Entry::success()
+                } else {
+                    Entry::NotTested
+                },
+                as_exit: None,
+                wg: None,
+            })
+        } else {
+            do_ping(
+                shared_client.clone(),
+                node_info.exit_router_address,
+                tested_entry,
+            )
+            .await
+        };
+
+        let wg_outcome = if let (Some(authenticator), Some(ip_address)) =
+            (node_info.authenticator_address, node_info.ip_address)
+        {
+            wg_probe(
+                authenticator,
+                shared_client.clone(),
+                ip_address,
+                node_info.authenticator_version,
+                self.amnezia_args,
+            )
+            .await
+            .unwrap_or_default()
+        } else {
+            WgProbeResults::default()
+        };
+
+        let mixnet_client = shared_client.lock().await.take().unwrap();
+        mixnet_client.disconnect().await;
+
+        // Disconnect the mixnet client gracefully
+        outcome.map(|mut outcome| {
+            outcome.wg = Some(wg_outcome);
+            ProbeResult {
                 node: node_info.identity.to_string(),
                 used_entry: mixnet_entry_gateway_id.to_string(),
-                outcome: ProbeOutcome {
-                    as_entry: if tested_entry {
-                        Entry::fail_to_connect()
-                    } else {
-                        Entry::EntryFailure
-                    },
-                    as_exit: None,
-                    wg: None,
-                },
-            });
-        }
-    };
-
-    let nym_address = *mixnet_client.nym_address();
-    let entry_gateway = nym_address.gateway().to_base58_string();
-
-    info!("Successfully connected to entry gateway: {entry_gateway}");
-    info!("Our nym address: {nym_address}");
-
-    let shared_client = SharedMixnetClient::new(mixnet_client);
-
-    // Now that we have a connected mixnet client, we can start pinging
-    let outcome = if only_wireguard {
-        Ok(ProbeOutcome {
-            as_entry: if tested_entry {
-                Entry::success()
-            } else {
-                Entry::NotTested
-            },
-            as_exit: None,
-            wg: None,
+                outcome,
+            }
         })
-    } else {
-        do_ping(
-            shared_client.clone(),
-            node_info.exit_router_address,
-            tested_entry,
-        )
-        .await
-    };
-
-    let wg_outcome = if let (Some(authenticator), Some(ip_address)) =
-        (node_info.authenticator_address, node_info.ip_address)
-    {
-        wg_probe(
-            authenticator,
-            shared_client.clone(),
-            ip_address,
-            node_info.authenticator_version,
-            self.amnezia_args,
-        )
-        .await
-        .unwrap_or_default()
-    } else {
-        WgProbeResults::default()
-    };
-
-    let mixnet_client = shared_client.lock().await.take().unwrap();
-    mixnet_client.disconnect().await;
-
-    // Disconnect the mixnet client gracefully
-    outcome.map(|mut outcome| {
-        outcome.wg = Some(wg_outcome);
-        ProbeResult {
-            node: node_info.identity.to_string(),
-            used_entry: mixnet_entry_gateway_id.to_string(),
-            outcome,
-        }
-    })
+    }
 }
 
 async fn wg_probe(

--- a/nym-vpn-core/crates/nym-gateway-probe/src/netstack/ffi.rs
+++ b/nym-vpn-core/crates/nym-gateway-probe/src/netstack/ffi.rs
@@ -7,11 +7,11 @@ pub mod binding {
 
 #[derive(rust2go::R2G, Clone)]
 pub struct NetstackRequestGo {
-    wg_ip: String,
+    pub wg_ip: String,
     private_key: String,
     public_key: String,
     endpoint: String,
-    dns: String,
+    pub dns: String,
     ip_version: u8,
     ping_hosts: Vec<String>,
     ping_ips: Vec<String>,

--- a/nym-vpn-core/crates/nym-gateway-probe/src/run.rs
+++ b/nym-vpn-core/crates/nym-gateway-probe/src/run.rs
@@ -99,13 +99,12 @@ pub(crate) async fn run() -> anyhow::Result<ProbeResult> {
         TestedNode::SameAsEntry
     };
 
-    let mut trial = nym_gateway_probe::Probe::new(entry);
+    let mut trial = nym_gateway_probe::Probe::new(entry, test_point);
     if let Some(awg_args) = args.amnezia_args {
         trial.with_amnezia(&awg_args);
     }
     trial
         .probe(
-            test_point,
             min_gateway_performance,
             args.only_wireguard,
             args.ignore_egress_epoch_role,

--- a/nym-vpn-core/crates/nym-gateway-probe/src/run.rs
+++ b/nym-vpn-core/crates/nym-gateway-probe/src/run.rs
@@ -6,7 +6,8 @@ use clap::Parser;
 use nym_bin_common::bin_info;
 use nym_config::defaults::setup_env;
 use nym_gateway_directory::{EntryPoint, GatewayMinPerformance};
-use nym_gateway_probe::ProbeResult;
+use nym_gateway_probe::{ProbeResult, TestedNode};
+use nym_sdk::mixnet::NodeIdentity;
 use std::path::PathBuf;
 use std::sync::OnceLock;
 use tracing::*;
@@ -14,6 +15,13 @@ use tracing::*;
 fn pretty_build_info_static() -> &'static str {
     static PRETTY_BUILD_INFORMATION: OnceLock<String> = OnceLock::new();
     PRETTY_BUILD_INFORMATION.get_or_init(|| bin_info!().pretty_print())
+}
+
+fn validate_node_identity(s: &str) -> Result<NodeIdentity, String> {
+    match s.parse() {
+        Ok(cg) => Ok(cg),
+        Err(_) => Err(format!("failed to parse country group: {}", s)),
+    }
 }
 
 #[derive(Parser)]
@@ -24,8 +32,12 @@ struct CliArgs {
     config_env_file: Option<PathBuf>,
 
     /// The specific gateway specified by ID.
-    #[arg(long, short)]
-    gateway: Option<String>,
+    #[arg(long, short = 'g', alias = "gateway")]
+    entry_gateway: Option<String>,
+
+    /// Identity of the node to test
+    #[arg(long, short, value_parser = validate_node_identity)]
+    node: Option<NodeIdentity>,
 
     #[arg(long)]
     min_gateway_mixnet_performance: Option<u8>,
@@ -38,6 +50,9 @@ struct CliArgs {
 
     /// Disable logging during probe
     #[arg(long, short)]
+    ignore_egress_epoch_role: bool,
+
+    #[arg(long)]
     no_log: bool,
 
     /// Arguments to be appended to the wireguard config enabling amnezia-wg configuration
@@ -72,18 +87,29 @@ pub(crate) async fn run() -> anyhow::Result<ProbeResult> {
         args.min_gateway_vpn_performance.map(u64::from),
     )?;
 
-    let gateway = if let Some(gateway) = args.gateway {
+    let entry = if let Some(gateway) = args.entry_gateway {
         EntryPoint::from_base58_string(&gateway)?
     } else {
         fetch_random_gateway_with_ipr(min_gateway_performance).await?
     };
 
-    let mut trial = nym_gateway_probe::Probe::new(gateway);
+    let test_point = if let Some(node) = args.node {
+        TestedNode::Custom { identity: node }
+    } else {
+        TestedNode::SameAsEntry
+    };
+
+    let mut trial = nym_gateway_probe::Probe::new(entry);
     if let Some(awg_args) = args.amnezia_args {
         trial.with_amnezia(&awg_args);
     }
     trial
-        .probe(min_gateway_performance, args.only_wireguard)
+        .probe(
+            test_point,
+            min_gateway_performance,
+            args.only_wireguard,
+            args.ignore_egress_epoch_role,
+        )
         .await
 }
 
@@ -98,6 +124,6 @@ async fn fetch_random_gateway_with_ipr(
         .random_gateway()
         .ok_or(anyhow!("No gateways returned by nym-api"))?;
     Ok(EntryPoint::Gateway {
-        identity: *gateway.identity(),
+        identity: gateway.identity(),
     })
 }

--- a/nym-vpn-core/crates/nym-gateway-probe/src/types.rs
+++ b/nym-vpn-core/crates/nym-gateway-probe/src/types.rs
@@ -3,7 +3,8 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProbeResult {
-    pub gateway: String,
+    pub node: String,
+    pub used_entry: String,
     pub outcome: ProbeOutcome,
 }
 
@@ -39,32 +40,49 @@ pub struct WgProbeResults {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Entry {
-    pub can_connect: bool,
-    pub can_route: bool,
+#[serde(untagged)]
+pub enum Entry {
+    Tested(EntryTestResult),
+    NotTested,
+    EntryFailure,
+}
+
+impl From<EntryTestResult> for Entry {
+    fn from(value: EntryTestResult) -> Self {
+        Entry::Tested(value)
+    }
 }
 
 impl Entry {
     pub fn fail_to_connect() -> Self {
-        Self {
+        EntryTestResult {
             can_connect: false,
             can_route: false,
         }
+        .into()
     }
 
     pub fn fail_to_route() -> Self {
-        Self {
+        EntryTestResult {
             can_connect: true,
             can_route: false,
         }
+        .into()
     }
 
     pub fn success() -> Self {
-        Self {
+        EntryTestResult {
             can_connect: true,
             can_route: true,
         }
+        .into()
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EntryTestResult {
+    pub can_connect: bool,
+    pub can_route: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/nym-vpn-core/crates/nym-gateway-probe/src/types.rs
+++ b/nym-vpn-core/crates/nym-gateway-probe/src/types.rs
@@ -41,6 +41,7 @@ pub struct WgProbeResults {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
+#[allow(clippy::enum_variant_names)]
 pub enum Entry {
     Tested(EntryTestResult),
     NotTested,

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
@@ -1,13 +1,14 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::fmt;
-
 use chrono::{DateTime, Utc};
 use itertools::Itertools;
 use nym_contracts_common::Percent;
 use nym_credential_proxy_requests::api::v1::ticketbook::models::TicketbookWalletSharesResponse;
+use nym_validator_client::client::NodeId;
 use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::net::IpAddr;
 
 const MAX_PROBE_RESULT_AGE_MINUTES: i64 = 60;
 
@@ -271,12 +272,13 @@ impl IntoIterator for NymDirectoryGatewaysResponse {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct NymDirectoryGateway {
+    pub node_id: NodeId,
     pub identity_key: String,
     pub ip_packet_router: Option<IpPacketRouter>,
     pub authenticator: Option<Authenticator>,
     pub location: Location,
     pub last_probe: Option<Probe>,
-    pub ip_addresses: Vec<String>,
+    pub ip_addresses: Vec<IpAddr>,
     pub mix_port: u16,
     pub role: Role,
     pub entry: EntryInformation,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
@@ -184,11 +184,11 @@ impl ReconnectMixnetClientData {
         &self,
         #[cfg(unix)] connection_fd_callback: Arc<dyn Fn(RawFd) + Send + Sync>,
     ) -> Option<AuthClient> {
-        let entry_gateway = *self.options.selected_gateways.entry.identity();
+        let entry_gateway = self.options.selected_gateways.entry.identity();
         let mixnet_client = match tokio::time::timeout(
             MIXNET_CLIENT_STARTUP_TIMEOUT,
             crate::mixnet::setup_mixnet_client(
-                &entry_gateway,
+                entry_gateway,
                 &self.options.data_path,
                 self.bw_controller_task_manager
                     .subscribe_named("mixnet_client_main"),
@@ -270,7 +270,7 @@ impl<St: Storage> BandwidthController<St> {
         // First we need to register with the gateway to setup keys and IP assignment
         tracing::info!("Registering with wireguard gateway");
         let authenticator_address = wg_gateway_client.auth_recipient();
-        let gateway_id = *wg_gateway_client.auth_recipient().gateway();
+        let gateway_id = wg_gateway_client.auth_recipient().gateway();
         let gateway_host = gateway_client
             .lookup_gateway_ip(&gateway_id.to_base58_string())
             .await
@@ -305,7 +305,7 @@ impl<St: Storage> BandwidthController<St> {
         <St as Storage>::StorageError: Send + Sync + 'static,
     {
         let authenticator_address = wg_gateway_client.auth_recipient();
-        let gateway_id = *wg_gateway_client.auth_recipient().gateway();
+        let gateway_id = wg_gateway_client.auth_recipient().gateway();
         let remaining_bandwidth =
             WgGatewayClient::top_up_wireguard(wg_gateway_client, &self.inner, ticketbook_type)
                 .await
@@ -365,7 +365,7 @@ impl<St: Storage> BandwidthController<St> {
                             self.shutdown
                                 .send_we_stopped(Box::new(ErrorMessage::OutOfBandwidth {
                                     gateway_id: Box::new(
-                                        *wg_gateway_client.auth_recipient().gateway(),
+                                        wg_gateway_client.auth_recipient().gateway(),
                                     ),
                                     authenticator_address: Box::new(
                                         wg_gateway_client.auth_recipient(),

--- a/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/connect.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/connect.rs
@@ -79,7 +79,7 @@ fn apply_mixnet_client_config(
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn setup_mixnet_client(
-    mixnet_entry_gateway: &NodeIdentity,
+    mixnet_entry_gateway: NodeIdentity,
     mixnet_client_key_storage_path: &Option<PathBuf>,
     mut task_client: nym_task::TaskClient,
     mixnet_client_config: MixnetClientConfig,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_selector.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_selector.rs
@@ -72,7 +72,7 @@ pub async fn select_gateways(
 
     tracing::info!(
         "Using entry gateway: {}, location: {}, performance: {}",
-        *entry_gateway.identity(),
+        entry_gateway.identity(),
         entry_gateway
             .two_letter_iso_country_code()
             .map_or_else(|| "unknown".to_string(), |code| code.to_string()),
@@ -82,7 +82,7 @@ pub async fn select_gateways(
     );
     tracing::info!(
         "Using exit gateway: {}, location: {}, performance: {}",
-        *exit_gateway.identity(),
+        exit_gateway.identity(),
         exit_gateway
             .two_letter_iso_country_code()
             .map_or_else(|| "unknown".to_string(), |code| code.to_string()),

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -328,8 +328,8 @@ impl TunnelMonitor {
         };
 
         let conn_data = ConnectionData {
-            entry_gateway: Box::new(*selected_gateways.entry.identity()),
-            exit_gateway: Box::new(*selected_gateways.exit.identity()),
+            entry_gateway: Box::new(selected_gateways.entry.identity()),
+            exit_gateway: Box::new(selected_gateways.exit.identity()),
             connected_at: None,
             tunnel: tunnel_conn_data,
         };


### PR DESCRIPTION
this PR changes the behaviour of the gateway probe to allow for testing nodes that are **not** operating as entries (or maybe even not as exits). essentially the case of "I run a mixnode + wireguard" combo. currently it relies on this  branch of the monorepo: https://github.com/nymtech/nym/pull/5271

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1812)
<!-- Reviewable:end -->
