### PR TITLE
Trim newline from wireguard logs

### DIFF
--- a/nym-vpn-core/crates/nym-wg-go/src/netstack.rs
+++ b/nym-vpn-core/crates/nym-wg-go/src/netstack.rs
@@ -4,7 +4,7 @@
 #[cfg(target_os = "android")]
 use std::os::fd::RawFd;
 use std::{
-    ffi::{c_char, c_void, CString},
+    ffi::{c_char, c_void, CStr, CString},
     fmt,
     net::{IpAddr, SocketAddr},
 };
@@ -311,7 +311,8 @@ pub unsafe extern "system" fn wg_netstack_logger_callback(
     _ctx: *mut c_void,
 ) {
     if !msg.is_null() {
-        let str = std::ffi::CStr::from_ptr(msg).to_string_lossy();
-        tracing::debug!("{}", str);
+        let str = CStr::from_ptr(msg).to_string_lossy();
+        let trimmed_str = str.trim_end();
+        tracing::debug!("{}", trimmed_str);
     }
 }

--- a/nym-vpn-core/crates/nym-wg-go/src/wireguard_go.rs
+++ b/nym-vpn-core/crates/nym-wg-go/src/wireguard_go.rs
@@ -311,6 +311,7 @@ pub unsafe extern "system" fn wg_logger_callback(
 ) {
     if !msg.is_null() {
         let str = CStr::from_ptr(msg).to_string_lossy();
-        tracing::debug!("{}", str);
+        let trimmed_str = str.trim_end();
+        tracing::debug!("{}", trimmed_str);
     }
 }


### PR DESCRIPTION
Go backend sends logs with the trailing newline, then tracing adds one too. Let's trim the tail of the string received from WireGuard.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1825)
<!-- Reviewable:end -->
