### PR TITLE
Fix release build after adding default workspace members

### DIFF
--- a/.github/workflows/build-nym-vpn-core-deb.yml
+++ b/.github/workflows/build-nym-vpn-core-deb.yml
@@ -54,7 +54,6 @@ jobs:
         run: |
           cargo deb -p nym-vpnd
           cargo deb -p nym-vpnc
-          cargo deb -p nym-vpn-cli
           ls -la target/debian/ || true
 
       - name: Move things around to prepare for upload
@@ -64,7 +63,6 @@ jobs:
           mkdir ${{ env.UPLOAD_DIR_DEB }}
           cp -vpr ${{ env.SRC_BINARY }}/nym-vpnc_*_amd64.deb ${{ env.UPLOAD_DIR_DEB }}
           cp -vpr ${{ env.SRC_BINARY }}/nym-vpnd_*_amd64.deb ${{ env.UPLOAD_DIR_DEB }}
-          cp -vpr ${{ env.SRC_BINARY }}/nym-vpn-cli_*_amd64.deb ${{ env.UPLOAD_DIR_DEB }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-nym-vpn-core-linux.yml
+++ b/.github/workflows/build-nym-vpn-core-linux.yml
@@ -55,6 +55,7 @@ jobs:
           RUSTFLAGS: "-L ${{ env.WG_GO_LIB_PATH }}"
         run: |
           cargo build --${{ env.CARGO_TARGET }}
+          cargo build -p nym-gateway-probe --${{ env.CARGO_TARGET }}
           ls -la nym-vpn-core/target/release/ || true
 
       - name: Get rust version used for build
@@ -68,7 +69,6 @@ jobs:
         run: |
           mkdir ${{ env.UPLOAD_DIR_LINUX }}
           cp -vpr ${{ env.SRC_BINARY }}/nym-gateway-probe ${{ env.UPLOAD_DIR_LINUX }}
-          cp -vpr ${{ env.SRC_BINARY }}/nym-vpn-cli ${{ env.UPLOAD_DIR_LINUX }}
           cp -vpr ${{ env.SRC_BINARY }}/nym-vpnc ${{ env.UPLOAD_DIR_LINUX }}
           cp -vpr ${{ env.SRC_BINARY }}/nym-vpnd ${{ env.UPLOAD_DIR_LINUX }}
 

--- a/.github/workflows/build-nym-vpn-core-mac.yml
+++ b/.github/workflows/build-nym-vpn-core-mac.yml
@@ -75,7 +75,7 @@ jobs:
         env:
           RUSTFLAGS: "-L ${{ env.WG_GO_LIB_PATH }}"
         run: |
-          cargo build --${{ env.CARGO_TARGET }} --target x86_64-apple-darwin --workspace --exclude nym-gateway-probe
+          cargo build --${{ env.CARGO_TARGET }} --target x86_64-apple-darwin
           cargo build -p nym-gateway-probe --${{ env.CARGO_TARGET }}
           ls -la target/x86_64-apple-darwin/release/ || true
 

--- a/.github/workflows/build-nym-vpn-core-mac.yml
+++ b/.github/workflows/build-nym-vpn-core-mac.yml
@@ -66,8 +66,7 @@ jobs:
         env:
           RUSTFLAGS: "-L ${{ env.WG_GO_LIB_PATH }}"
         run: |
-          cargo build --${{ env.CARGO_TARGET }}
-          cargo build -p nym-gateway-probe --${{ env.CARGO_TARGET }}
+          cargo build -p nym-vpnc -p nym-gateway-probe --${{ env.CARGO_TARGET }}
           ls -la target/release/ || true
 
       - name: Build nym-vpn-core (x86_64)
@@ -75,8 +74,7 @@ jobs:
         env:
           RUSTFLAGS: "-L ${{ env.WG_GO_LIB_PATH }}"
         run: |
-          cargo build --${{ env.CARGO_TARGET }} --target x86_64-apple-darwin
-          cargo build -p nym-gateway-probe --${{ env.CARGO_TARGET }}
+          cargo build -p nym-vpnc --${{ env.CARGO_TARGET }} --target x86_64-apple-darwin
           ls -la target/x86_64-apple-darwin/release/ || true
 
       - name: Build nym-vpnd with extra flags (native)

--- a/.github/workflows/build-nym-vpn-core-mac.yml
+++ b/.github/workflows/build-nym-vpn-core-mac.yml
@@ -67,6 +67,7 @@ jobs:
           RUSTFLAGS: "-L ${{ env.WG_GO_LIB_PATH }}"
         run: |
           cargo build --${{ env.CARGO_TARGET }}
+          cargo build -p nym-gateway-probe --${{ env.CARGO_TARGET }}
           ls -la target/release/ || true
 
       - name: Build nym-vpn-core (x86_64)
@@ -75,6 +76,7 @@ jobs:
           RUSTFLAGS: "-L ${{ env.WG_GO_LIB_PATH }}"
         run: |
           cargo build --${{ env.CARGO_TARGET }} --target x86_64-apple-darwin --workspace --exclude nym-gateway-probe
+          cargo build -p nym-gateway-probe --${{ env.CARGO_TARGET }}
           ls -la target/x86_64-apple-darwin/release/ || true
 
       - name: Build nym-vpnd with extra flags (native)
@@ -99,7 +101,6 @@ jobs:
           SRC_X86_64_BINARY: nym-vpn-core/target/x86_64-apple-darwin/${{ env.CARGO_TARGET }}/
         run: |
           mkdir ${{ env.UPLOAD_DIR_MAC }}
-          lipo -create -output ${{ env.UPLOAD_DIR_MAC }}/nym-vpn-cli ${{ env.SRC_NATIVE_BINARY }}/nym-vpn-cli ${{ env.SRC_X86_64_BINARY }}/nym-vpn-cli
           lipo -create -output ${{ env.UPLOAD_DIR_MAC }}/nym-vpnc ${{ env.SRC_NATIVE_BINARY }}/nym-vpnc ${{ env.SRC_X86_64_BINARY }}/nym-vpnc
           lipo -create -output ${{ env.UPLOAD_DIR_MAC }}/nym-vpnd ${{ env.SRC_NATIVE_BINARY }}/nym-vpnd ${{ env.SRC_X86_64_BINARY }}/nym-vpnd
           #lipo -create -output ${{ env.UPLOAD_DIR_MAC }}/nym-gateway-probe ${{ env.SRC_NATIVE_BINARY }}/nym-gateway-probe ${{ env.SRC_X86_64_BINARY }}/nym-gateway-probe

--- a/.github/workflows/build-nym-vpn-core-windows.yml
+++ b/.github/workflows/build-nym-vpn-core-windows.yml
@@ -101,7 +101,6 @@ jobs:
           rm -rf ${{ env.UPLOAD_DIR_WINDOWS }} || true
           mkdir ${{ env.UPLOAD_DIR_WINDOWS }}
           #cp -vpr ${{ env.SRC_BINARY }}/nym-gateway-probe.exe ${{ env.UPLOAD_DIR_WINDOWS }}
-          cp -vpr ${{ env.SRC_BINARY }}/nym-vpn-cli.exe ${{ env.UPLOAD_DIR_WINDOWS }}
           cp -vpr ${{ env.SRC_BINARY }}/nym-vpnc.exe ${{ env.UPLOAD_DIR_WINDOWS }}
           cp -vpr ${{ env.SRC_BINARY }}/nym-vpnd.exe ${{ env.UPLOAD_DIR_WINDOWS }}
           cp -vpr nym-vpn-core/libwg.dll ${{ env.UPLOAD_DIR_WINDOWS }}


### PR DESCRIPTION
Nightly build is failing https://github.com/nymtech/nym-vpn-client/actions/runs/12424425633 after adding default workspace members. This PR skips the steps in the release workflows that refers to nym-vpn-cli since that is an internal component anyway

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1827)
<!-- Reviewable:end -->
