### PR TITLE
Read recovery phrase and set mnemonic state during init step

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/shared_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/shared_state.rs
@@ -116,9 +116,12 @@ impl fmt::Display for ReadyToConnect {
 }
 
 impl SharedAccountState {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(state: MnemonicState) -> Self {
+        let mut summary = AccountStateSummary::default();
+        tracing::info!("Setting mnemonic state to {:?}", state);
+        summary.mnemonic = Some(state);
         SharedAccountState {
-            inner: Arc::new(tokio::sync::Mutex::new(AccountStateSummary::default())),
+            inner: Arc::new(tokio::sync::Mutex::new(summary)),
         }
     }
 


### PR DESCRIPTION
When constructing the account controller, read the recovery phrase from
storage and initialize the mnemonic state to its correct value from the
start.

VPN-2713

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1867)
<!-- Reviewable:end -->
