### PR TITLE
core: api device removal on logout

### DIFF
--- a/.github/workflows/ci-nym-vpn-core-windows.yml
+++ b/.github/workflows/ci-nym-vpn-core-windows.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   build:
-    runs-on: custom-windows-11
+    runs-on: windows-latest
 
     steps:
       - name: "Cleanup working directory"

--- a/.github/workflows/ci-nym-vpn-core-windows.yml
+++ b/.github/workflows/ci-nym-vpn-core-windows.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: custom-windows-11
 
     steps:
       - name: "Cleanup working directory"

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/mod.rs
@@ -76,6 +76,9 @@ pub enum AccountCommandError {
     #[error("no device stored")]
     NoDeviceStored,
 
+    #[error("device registration is in progress")]
+    RegistrationInProgress,
+
     #[error("failed to remove account: {0}")]
     RemoveAccount(String),
 

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/mod.rs
@@ -79,6 +79,9 @@ pub enum AccountCommandError {
     #[error("failed to remove account: {0}")]
     RemoveAccount(String),
 
+    #[error("failed to remove device from nym vpn api")]
+    RemoveDeviceApiClientFailure,
+
     #[error("failed to remove device identity: {0}")]
     RemoveDeviceIdentity(String),
 

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/mod.rs
@@ -80,7 +80,7 @@ pub enum AccountCommandError {
     RemoveAccount(String),
 
     #[error("failed to remove device from nym vpn api: {0}")]
-    RemoveDeviceApiClientFailure(String),
+    UnregisterDeviceApiClientFailure(String),
 
     #[error("failed to remove device identity: {0}")]
     RemoveDeviceIdentity(String),

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/mod.rs
@@ -79,8 +79,8 @@ pub enum AccountCommandError {
     #[error("failed to remove account: {0}")]
     RemoveAccount(String),
 
-    #[error("failed to remove device from nym vpn api")]
-    RemoveDeviceApiClientFailure,
+    #[error("failed to remove device from nym vpn api: {0}")]
+    RemoveDeviceApiClientFailure(String),
 
     #[error("failed to remove device identity: {0}")]
     RemoveDeviceIdentity(String),

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
@@ -288,7 +288,7 @@ where
         // currently running operations to finish before proceeding with the reset
 
         //delete device from nym vpn api
-        self.delete_api_device().await?;
+        self.unregister_device_from_api().await?;
 
         self.account_storage
             .remove_account()
@@ -351,7 +351,7 @@ where
         Ok(())
     }
 
-    async fn delete_api_device(&self) -> Result<NymVpnDevice, AccountCommandError> {
+    async fn unregister_device_from_api(&self) -> Result<NymVpnDevice, AccountCommandError> {
         let device = self
             .account_storage
             .load_device_keys()
@@ -366,7 +366,7 @@ where
         self.vpn_api_client
             .update_device(&account, &device, DeviceStatus::DeleteMe)
             .await
-            .map_err(|_err| AccountCommandError::RemoveDeviceApiClientFailure(_err.to_string()))
+            .map_err(|err| AccountCommandError::UnregisterDeviceApiClientFailure(err.to_string()))
     }
 
     async fn handle_sync_account_state(&mut self, command: AccountCommand) {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
@@ -3,19 +3,6 @@
 
 use std::{path::PathBuf, sync::Arc, time::Duration};
 
-use nym_http_api_client::UserAgent;
-use nym_vpn_api_client::{
-    response::{NymVpnDevice, NymVpnUsage},
-    types::VpnApiAccount,
-};
-use nym_vpn_network_config::Network;
-use nym_vpn_store::{mnemonic::Mnemonic, VpnStorage};
-use tokio::{
-    sync::mpsc::{UnboundedReceiver, UnboundedSender},
-    task::{JoinError, JoinSet},
-};
-use tokio_util::sync::CancellationToken;
-
 use crate::{
     commands::{
         register_device::RegisterDeviceCommandHandler,
@@ -29,6 +16,19 @@ use crate::{
     storage::{AccountStorage, VpnCredentialStorage},
     AccountControllerCommander, AvailableTicketbooks,
 };
+use nym_http_api_client::UserAgent;
+use nym_vpn_api_client::types::DeviceStatus;
+use nym_vpn_api_client::{
+    response::{NymVpnDevice, NymVpnUsage},
+    types::VpnApiAccount,
+};
+use nym_vpn_network_config::Network;
+use nym_vpn_store::{mnemonic::Mnemonic, VpnStorage};
+use tokio::{
+    sync::mpsc::{UnboundedReceiver, UnboundedSender},
+    task::{JoinError, JoinSet},
+};
+use tokio_util::sync::CancellationToken;
 
 // The interval at which we automatically request zk-nyms
 const ZK_NYM_AUTOMATIC_REQUEST_INTERVAL: Duration = Duration::from_secs(6 * 60);
@@ -287,6 +287,9 @@ where
         // TODO: here we should put the controller in some sort of idle state, and wait for all
         // currently running operations to finish before proceeding with the reset
 
+        //delete device from nym vpn api
+        self.delete_api_device().await?;
+
         self.account_storage
             .remove_account()
             .await
@@ -346,6 +349,24 @@ where
         }
 
         Ok(())
+    }
+
+    async fn delete_api_device(&self) -> Result<NymVpnDevice, AccountCommandError> {
+        let device = self
+            .account_storage
+            .load_device_keys()
+            .await
+            .map_err(|_err| AccountCommandError::NoDeviceStored)?;
+
+        let account = self
+            .update_mnemonic_state()
+            .await
+            .map_err(|_err| AccountCommandError::NoAccountStored)?;
+
+        self.vpn_api_client
+            .update_device(&account, &device, DeviceStatus::DeleteMe)
+            .await
+            .map_err(|_err| AccountCommandError::NoDeviceStored)
     }
 
     async fn handle_sync_account_state(&mut self, command: AccountCommand) {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
@@ -352,13 +352,12 @@ where
     }
 
     async fn unregister_device_from_api(&self) -> Result<NymVpnDevice, AccountCommandError> {
-        match self.shared_state().is_ready_to_register_device().await {
-            ReadyToRegisterDevice::InProgress => {
-                return Err(AccountCommandError::Internal(
-                    "Device registration in progress".to_owned(),
-                ));
-            }
-            _ => {}
+        if self.shared_state().is_ready_to_register_device().await
+            == ReadyToRegisterDevice::InProgress
+        {
+            return Err(AccountCommandError::Internal(
+                "Device registration in progress".to_owned(),
+            ));
         }
 
         let device = self

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
@@ -366,7 +366,7 @@ where
         self.vpn_api_client
             .update_device(&account, &device, DeviceStatus::DeleteMe)
             .await
-            .map_err(|_err| AccountCommandError::RemoveDeviceApiClientFailure)
+            .map_err(|_err| AccountCommandError::RemoveDeviceApiClientFailure(_err.to_string()))
     }
 
     async fn handle_sync_account_state(&mut self, command: AccountCommand) {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
@@ -3,6 +3,19 @@
 
 use std::{path::PathBuf, sync::Arc, time::Duration};
 
+use nym_http_api_client::UserAgent;
+use nym_vpn_api_client::{
+    response::{NymVpnDevice, NymVpnUsage},
+    types::{DeviceStatus, VpnApiAccount},
+};
+use nym_vpn_network_config::Network;
+use nym_vpn_store::{mnemonic::Mnemonic, VpnStorage};
+use tokio::{
+    sync::mpsc::{UnboundedReceiver, UnboundedSender},
+    task::{JoinError, JoinSet},
+};
+use tokio_util::sync::CancellationToken;
+
 use crate::{
     commands::{
         register_device::RegisterDeviceCommandHandler,
@@ -16,19 +29,6 @@ use crate::{
     storage::{AccountStorage, VpnCredentialStorage},
     AccountControllerCommander, AvailableTicketbooks,
 };
-use nym_http_api_client::UserAgent;
-use nym_vpn_api_client::types::DeviceStatus;
-use nym_vpn_api_client::{
-    response::{NymVpnDevice, NymVpnUsage},
-    types::VpnApiAccount,
-};
-use nym_vpn_network_config::Network;
-use nym_vpn_store::{mnemonic::Mnemonic, VpnStorage};
-use tokio::{
-    sync::mpsc::{UnboundedReceiver, UnboundedSender},
-    task::{JoinError, JoinSet},
-};
-use tokio_util::sync::CancellationToken;
 
 // The interval at which we automatically request zk-nyms
 const ZK_NYM_AUTOMATIC_REQUEST_INTERVAL: Duration = Duration::from_secs(6 * 60);
@@ -355,9 +355,7 @@ where
         if self.shared_state().is_ready_to_register_device().await
             == ReadyToRegisterDevice::InProgress
         {
-            return Err(AccountCommandError::Internal(
-                "Device registration in progress".to_owned(),
-            ));
+            return Err(AccountCommandError::RegistrationInProgress);
         }
 
         let device = self

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
@@ -352,6 +352,15 @@ where
     }
 
     async fn unregister_device_from_api(&self) -> Result<NymVpnDevice, AccountCommandError> {
+        match self.shared_state().is_ready_to_register_device().await {
+            ReadyToRegisterDevice::InProgress => {
+                return Err(AccountCommandError::Internal(
+                    "Device registration in progress".to_owned(),
+                ));
+            }
+            _ => {}
+        }
+
         let device = self
             .account_storage
             .load_device_keys()

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
@@ -366,7 +366,7 @@ where
         self.vpn_api_client
             .update_device(&account, &device, DeviceStatus::DeleteMe)
             .await
-            .map_err(|_err| AccountCommandError::NoDeviceStored)
+            .map_err(|_err| AccountCommandError::RemoveDeviceApiClientFailure)
     }
 
     async fn handle_sync_account_state(&mut self, command: AccountCommand) {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/error.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/error.rs
@@ -176,6 +176,7 @@ impl From<nym_vpn_account_controller::AccountCommandError> for VpnError {
             AccountCommandError::InitDeviceKeys(e) => VpnError::InternalError { details: e },
             AccountCommandError::General(err) => VpnError::InternalError { details: err },
             AccountCommandError::Internal(err) => VpnError::InternalError { details: err },
+            AccountCommandError::RemoveDeviceApiClientFailure => { VpnError::VpnApiTimeout }
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/error.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/error.rs
@@ -176,7 +176,7 @@ impl From<nym_vpn_account_controller::AccountCommandError> for VpnError {
             AccountCommandError::InitDeviceKeys(e) => VpnError::InternalError { details: e },
             AccountCommandError::General(err) => VpnError::InternalError { details: err },
             AccountCommandError::Internal(err) => VpnError::InternalError { details: err },
-            AccountCommandError::RemoveDeviceApiClientFailure => { VpnError::VpnApiTimeout }
+            AccountCommandError::RemoveDeviceApiClientFailure(err) => { VpnError::InternalError { details: err } },
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/error.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/error.rs
@@ -176,7 +176,9 @@ impl From<nym_vpn_account_controller::AccountCommandError> for VpnError {
             AccountCommandError::InitDeviceKeys(e) => VpnError::InternalError { details: e },
             AccountCommandError::General(err) => VpnError::InternalError { details: err },
             AccountCommandError::Internal(err) => VpnError::InternalError { details: err },
-            AccountCommandError::RemoveDeviceApiClientFailure(err) => { VpnError::InternalError { details: err } },
+            AccountCommandError::RemoveDeviceApiClientFailure(err) => {
+                VpnError::InternalError { details: err }
+            }
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/error.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/error.rs
@@ -179,6 +179,9 @@ impl From<nym_vpn_account_controller::AccountCommandError> for VpnError {
             AccountCommandError::UnregisterDeviceApiClientFailure(err) => {
                 VpnError::InternalError { details: err }
             }
+            AccountCommandError::RegistrationInProgress => VpnError::InternalError {
+                details: value.to_string(),
+            },
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/error.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/error.rs
@@ -176,7 +176,7 @@ impl From<nym_vpn_account_controller::AccountCommandError> for VpnError {
             AccountCommandError::InitDeviceKeys(e) => VpnError::InternalError { details: e },
             AccountCommandError::General(err) => VpnError::InternalError { details: err },
             AccountCommandError::Internal(err) => VpnError::InternalError { details: err },
-            AccountCommandError::RemoveDeviceApiClientFailure(err) => {
+            AccountCommandError::UnregisterDeviceApiClientFailure(err) => {
                 VpnError::InternalError { details: err }
             }
         }

--- a/nym-vpn-core/crates/nym-vpnd/src/service/error.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/error.rs
@@ -99,6 +99,7 @@ impl From<AccountCommandError> for AccountNotReady {
             AccountCommandError::InitDeviceKeys(e) => AccountNotReady::General(e),
             AccountCommandError::General(err) => AccountNotReady::General(err),
             AccountCommandError::Internal(err) => AccountNotReady::Internal(err),
+            AccountCommandError::RemoveDeviceApiClientFailure(err) => { AccountNotReady::Internal(err) }
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/service/error.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/error.rs
@@ -102,6 +102,9 @@ impl From<AccountCommandError> for AccountNotReady {
             AccountCommandError::UnregisterDeviceApiClientFailure(err) => {
                 AccountNotReady::Internal(err)
             }
+            AccountCommandError::RegistrationInProgress => {
+                AccountNotReady::Internal(err.to_string())
+            }
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/service/error.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/error.rs
@@ -99,7 +99,7 @@ impl From<AccountCommandError> for AccountNotReady {
             AccountCommandError::InitDeviceKeys(e) => AccountNotReady::General(e),
             AccountCommandError::General(err) => AccountNotReady::General(err),
             AccountCommandError::Internal(err) => AccountNotReady::Internal(err),
-            AccountCommandError::RemoveDeviceApiClientFailure(err) => {
+            AccountCommandError::UnregisterDeviceApiClientFailure(err) => {
                 AccountNotReady::Internal(err)
             }
         }

--- a/nym-vpn-core/crates/nym-vpnd/src/service/error.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/error.rs
@@ -99,7 +99,9 @@ impl From<AccountCommandError> for AccountNotReady {
             AccountCommandError::InitDeviceKeys(e) => AccountNotReady::General(e),
             AccountCommandError::General(err) => AccountNotReady::General(err),
             AccountCommandError::Internal(err) => AccountNotReady::Internal(err),
-            AccountCommandError::RemoveDeviceApiClientFailure(err) => { AccountNotReady::Internal(err) }
+            AccountCommandError::RemoveDeviceApiClientFailure(err) => {
+                AccountNotReady::Internal(err)
+            }
         }
     }
 }


### PR DESCRIPTION
So, this will fail if they are offline and try to logout. I'm not sure if this is the proper behavior or if we should just let the api device become orphaned and still logout. 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1873)
<!-- Reviewable:end -->
