### PR TITLE
apple-network: add more useful methods for nw_path

### DIFF
--- a/nym-vpn-core/crates/nym-apple-network/src/interface.rs
+++ b/nym-vpn-core/crates/nym-apple-network/src/interface.rs
@@ -45,11 +45,22 @@ impl Interface {
 /// Types of network interfaces, based on their link layer media types.
 #[derive(Debug, Copy, Clone)]
 pub enum InterfaceType {
+    /// The network interface type used for communication over virtual networks or networks of unknown types.
     Other,
+
+    /// The network interface type used for communication over Wi-Fi networks.
     Wifi,
+
+    /// The network interface type used for communication over cellular networks.
     Cellular,
+
+    /// The network interface type used for communication over wired Ethernet networks.
     Wired,
+
+    /// The network interface type used for communication over local loopback networks.
     Loopback,
+
+    /// Interface type unknown to the crate.
     Unknown(nw_interface_type_t),
 }
 

--- a/nym-vpn-core/crates/nym-apple-network/src/path.rs
+++ b/nym-vpn-core/crates/nym-apple-network/src/path.rs
@@ -85,6 +85,31 @@ impl Path {
         unsafe { sys::nw_path_enumerate_gateways(self.inner.as_mut_ptr(), &block) };
         gateways.take()
     }
+
+    /// Checks whether the path can route IPv4 traffic.
+    pub fn supports_ipv4(&self) -> bool {
+        unsafe { sys::nw_path_has_ipv4(self.inner.as_mut_ptr()) }
+    }
+
+    /// Checks whether the path can route IPv6 traffic.
+    pub fn supports_ipv6(&self) -> bool {
+        unsafe { sys::nw_path_has_ipv6(self.inner.as_mut_ptr()) }
+    }
+
+    /// Checks whether the path has a DNS server configured.
+    pub fn supports_dns(&self) -> bool {
+        unsafe { sys::nw_path_has_dns(self.inner.as_mut_ptr()) }
+    }
+
+    /// Checks whether the path uses an interface in Low Data Mode.
+    pub fn is_constrained(&self) -> bool {
+        unsafe { sys::nw_path_is_constrained(self.inner.as_mut_ptr()) }
+    }
+
+    /// Checks whether the path uses an interface that is considered expensive, such as Cellular or a Personal Hotspot.
+    pub fn is_expensive(&self) -> bool {
+        unsafe { sys::nw_path_is_expensive(self.inner.as_mut_ptr()) }
+    }
 }
 
 impl PartialEq for Path {

--- a/nym-vpn-core/crates/nym-apple-network/src/path_monitor.rs
+++ b/nym-vpn-core/crates/nym-apple-network/src/path_monitor.rs
@@ -13,6 +13,7 @@ pub struct PathMonitor {
 }
 
 unsafe impl Send for PathMonitor {}
+unsafe impl Sync for PathMonitor {}
 
 impl Default for PathMonitor {
     fn default() -> Self {
@@ -42,7 +43,7 @@ impl PathMonitor {
     }
 
     /// Prohibit a path monitor from using a specific interface type.
-    pub fn prohibit_interface_type(&mut self, interface_type: &InterfaceType) {
+    pub fn prohibit_interface_type(&mut self, interface_type: InterfaceType) {
         unsafe {
             sys::nw_path_monitor_prohibit_interface_type(
                 self.inner.as_mut_ptr(),

--- a/nym-vpn-core/crates/nym-apple-network/src/sys.rs
+++ b/nym-vpn-core/crates/nym-apple-network/src/sys.rs
@@ -114,6 +114,12 @@ unsafe extern "C" {
         path: nw_path_t,
         enumerate_block: &nw_path_enumerate_gateways_block_t,
     );
+    pub fn nw_path_has_ipv4(path: nw_path_t) -> objc2::ffi::BOOL;
+    pub fn nw_path_has_ipv6(path: nw_path_t) -> objc2::ffi::BOOL;
+    pub fn nw_path_has_dns(path: nw_path_t) -> objc2::ffi::BOOL;
+    pub fn nw_path_is_constrained(path: nw_path_t) -> objc2::ffi::BOOL;
+    pub fn nw_path_is_expensive(path: nw_path_t) -> objc2::ffi::BOOL;
+
     pub fn nw_interface_get_type(interface: nw_interface_t) -> nw_interface_type_t;
     pub fn nw_interface_get_name(interface: nw_interface_t) -> *const c_char;
     pub fn nw_interface_get_index(interface: nw_interface_t) -> u32;


### PR DESCRIPTION
This PR adds a couple of additions to the apple network bindings, some of which we'll need in the follow up PR:

- Document `InterfaceType`
- Add methods to detect if the given network path supports IPv4, IPv6, etc.
- Make `PathMonitor + Sync` because the underlying type is thread safe.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1878)
<!-- Reviewable:end -->
