### PR TITLE
Exclude gateway probe for windows builds

### DIFF
--- a/.github/workflows/ci-nym-vpn-core-windows.yml
+++ b/.github/workflows/ci-nym-vpn-core-windows.yml
@@ -130,12 +130,12 @@ jobs:
       - name: Build
         working-directory: nym-vpn-core
         run: |
-          cargo build --verbose --workspace
+          cargo build --verbose --workspace --exclude nym-gateway-probe
 
       - name: Run tests
         working-directory: nym-vpn-core
         run: |
-          cargo test --verbose --workspace
+          cargo test --verbose --workspace --exclude nym-gateway-probe
 
       - name: Clippy
         working-directory: nym-vpn-core

--- a/.github/workflows/ci-nym-vpn-core-windows.yml
+++ b/.github/workflows/ci-nym-vpn-core-windows.yml
@@ -140,4 +140,4 @@ jobs:
       - name: Clippy
         working-directory: nym-vpn-core
         run: |
-          cargo clippy --workspace -- -Dwarnings
+          cargo clippy --workspace --exclude nym-gateway-probe -- -Dwarnings


### PR DESCRIPTION
Exclude `nym-gateway-probe` from the windows CI build

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1885)
<!-- Reviewable:end -->
