### PR TITLE
Set unique name identifiers of the calling process

### DIFF
--- a/nym-vpn-core/crates/nym-dns/src/macos.rs
+++ b/nym-vpn-core/crates/nym-dns/src/macos.rs
@@ -431,7 +431,7 @@ fn create_dynamic_store(state: Arc<Mutex<State>>) -> Result<SCDynamicStore> {
         info: update_trigger,
     };
 
-    let store = SCDynamicStoreBuilder::new("talpid-dns-monitor")
+    let store = SCDynamicStoreBuilder::new("nym-dns-monitor")
         .callback_context(callback_context)
         .build();
 

--- a/nym-vpn-core/crates/nym-routing/src/unix/macos/interface.rs
+++ b/nym-vpn-core/crates/nym-routing/src/unix/macos/interface.rs
@@ -109,8 +109,8 @@ impl From<DefaultRoute> for RouteMessage {
 
 impl PrimaryInterfaceMonitor {
     pub fn new() -> (Self, UnboundedReceiver<InterfaceEvent>) {
-        let store = SCDynamicStoreBuilder::new("talpid-routing").build();
-        let prefs = SCPreferences::default(&CFString::new("talpid-routing"));
+        let store = SCDynamicStoreBuilder::new("nym-routing").build();
+        let prefs = SCPreferences::default(&CFString::new("nym-routing"));
 
         let (tx, rx) = mpsc::unbounded();
         Self::start_listener(tx);
@@ -120,7 +120,7 @@ impl PrimaryInterfaceMonitor {
 
     fn start_listener(tx: UnboundedSender<InterfaceEvent>) {
         std::thread::spawn(|| {
-            let listener_store = SCDynamicStoreBuilder::new("talpid-routing-listener")
+            let listener_store = SCDynamicStoreBuilder::new("nym-routing-listener")
                 .callback_context(SCDynamicStoreCallBackContext {
                     callout: Self::store_change_handler,
                     info: tx,


### PR DESCRIPTION
Set unique name of the calling process when instantiating the dynamic store

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1886)
<!-- Reviewable:end -->
