### PR TITLE
fix: clippy

### DIFF
--- a/nym-vpn-core/crates/nym-dbus/src/systemd_resolved.rs
+++ b/nym-vpn-core/crates/nym-dbus/src/systemd_resolved.rs
@@ -212,8 +212,7 @@ impl SystemdResolved {
                     let parts = contents.trim().split(' ');
                     parts
                         .map(str::parse::<IpAddr>)
-                        .map(|maybe_ip| maybe_ip.map(|addr| addr.is_loopback()).unwrap_or(false))
-                        .any(|is_loopback| is_loopback)
+                        .any(|maybe_ip| maybe_ip.map(|addr| addr.is_loopback()).unwrap_or(false))
                 })
                 .unwrap_or(false);
 


### PR DESCRIPTION
Based on clippy suggestion:

```
warning: usage of `.map(...).any(identity)`
   --> crates/nym-dbus/src/systemd_resolved.rs:215:26
    |
215 |                           .map(|maybe_ip| maybe_ip.map(|addr| addr.is_loopback()).unwrap_or(false))
    |  __________________________^
216 | |                         .any(|is_loopback| is_loopback)
    | |_______________________________________________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#map_all_any_identity
    = note: `#[warn(clippy::map_all_any_identity)]` on by default
help: use `.any(...)` instead
    |
215 |                         .any(|maybe_ip| maybe_ip.map(|addr| addr.is_loopback()).unwrap_or(false))
    |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1887)
<!-- Reviewable:end -->
