### PR TITLE
Use official empty type in protobuf

### DIFF
--- a/nym-vpn-app/src-tauri/src/grpc/client.rs
+++ b/nym-vpn-app/src-tauri/src/grpc/client.rs
@@ -254,7 +254,7 @@ impl GrpcClient {
     pub async fn watch_vpn_state(&self, app: &AppHandle) -> Result<()> {
         let mut vpnd = self.vpnd().await?;
 
-        let request = Request::new(Empty {});
+        let request = Request::new(());
         let mut stream = vpnd
             .listen_to_connection_state_changes(request)
             .await
@@ -305,7 +305,7 @@ impl GrpcClient {
     pub async fn watch_vpn_connection_updates(&self, app: &AppHandle) -> Result<()> {
         let mut vpnd = self.vpnd().await?;
 
-        let request = Request::new(Empty {});
+        let request = Request::new(());
         let mut stream = vpnd
             .listen_to_connection_status(request)
             .await

--- a/nym-vpn-app/src-tauri/src/grpc/client.rs
+++ b/nym-vpn-app/src-tauri/src/grpc/client.rs
@@ -8,12 +8,9 @@ use nym_vpn_proto::{
     get_account_links_response::Res as AccountLinkRes,
     get_device_identity_response::Id as DeviceIdRes, health_check_response::ServingStatus,
     health_client::HealthClient, is_account_stored_response::Resp as IsAccountStoredResp,
-    nym_vpnd_client::NymVpndClient, ConnectRequest, ConnectionStatus, DisconnectRequest, Dns,
-    Empty, EntryNode, ExitNode, ForgetAccountRequest, GatewayType, GetAccountIdentityRequest,
-    GetAccountLinksRequest, GetDeviceIdentityRequest, GetFeatureFlagsRequest,
-    GetSystemMessagesRequest, HealthCheckRequest, InfoRequest, InfoResponse,
-    IsAccountStoredRequest, IsReadyToConnectRequest, ListCountriesRequest, Location,
-    SetNetworkRequest, StatusRequest, StatusResponse, StoreAccountRequest, UserAgent,
+    nym_vpnd_client::NymVpndClient, ConnectRequest, ConnectionStatus, Dns, EntryNode, ExitNode,
+    GatewayType, GetAccountLinksRequest, HealthCheckRequest, InfoResponse, ListCountriesRequest,
+    Location, SetNetworkRequest, StatusResponse, StoreAccountRequest, UserAgent,
 };
 use parity_tokio_ipc::Endpoint as IpcEndpoint;
 use tauri::{AppHandle, Manager, PackageInfo};
@@ -172,7 +169,7 @@ impl GrpcClient {
     pub async fn vpnd_info(&self, app: &AppHandle) -> Result<InfoResponse, VpndError> {
         let mut vpnd = self.vpnd().await?;
 
-        let request = Request::new(InfoRequest {});
+        let request = Request::new(());
         let response = vpnd
             .info(request)
             .await
@@ -211,7 +208,7 @@ impl GrpcClient {
     pub async fn vpn_status(&self) -> Result<StatusResponse, VpndError> {
         let mut vpnd = self.vpnd().await?;
 
-        let request = Request::new(StatusRequest {});
+        let request = Request::new(());
         let response = vpnd.vpn_status(request).await.map_err(|e| {
             error!("grpc: {}", e);
             VpndError::GrpcError(e)
@@ -396,7 +393,7 @@ impl GrpcClient {
     pub async fn vpn_disconnect(&self) -> Result<bool, VpndError> {
         let mut vpnd = self.vpnd().await?;
 
-        let request = Request::new(DisconnectRequest {});
+        let request = Request::new(());
         let response = vpnd.vpn_disconnect(request).await.map_err(|e| {
             error!("grpc: {}", e);
             VpndError::GrpcError(e)
@@ -439,7 +436,7 @@ impl GrpcClient {
     pub async fn forget_account(&self) -> Result<(), VpndError> {
         let mut vpnd = self.vpnd().await?;
 
-        let request = Request::new(ForgetAccountRequest {});
+        let request = Request::new(());
         let response = vpnd.forget_account(request).await.map_err(|e| {
             error!("grpc: {}", e);
             VpndError::GrpcError(e)
@@ -466,7 +463,7 @@ impl GrpcClient {
     pub async fn is_account_stored(&self) -> Result<bool, VpndError> {
         let mut vpnd = self.vpnd().await?;
 
-        let request = Request::new(IsAccountStoredRequest {});
+        let request = Request::new(());
         let response = vpnd.is_account_stored(request).await.map_err(|e| {
             error!("grpc: {}", e);
             VpndError::GrpcError(e)
@@ -487,7 +484,7 @@ impl GrpcClient {
     pub async fn is_ready_to_connect(&self) -> Result<ReadyToConnect, VpndError> {
         let mut vpnd = self.vpnd().await?;
 
-        let request = Request::new(IsReadyToConnectRequest {});
+        let request = Request::new(());
         let response = vpnd.is_ready_to_connect(request).await.map_err(|e| {
             error!("grpc: {}", e);
             VpndError::GrpcError(e)
@@ -506,7 +503,7 @@ impl GrpcClient {
     pub async fn account_id(&self) -> Result<Option<String>, VpndError> {
         let mut vpnd = self.vpnd().await?;
 
-        let request = Request::new(GetAccountIdentityRequest {});
+        let request = Request::new(());
         let response = vpnd
             .get_account_identity(request)
             .await
@@ -530,7 +527,7 @@ impl GrpcClient {
     pub async fn device_id(&self) -> Result<String, VpndError> {
         let mut vpnd = self.vpnd().await?;
 
-        let request = Request::new(GetDeviceIdentityRequest {});
+        let request = Request::new(());
         let response = vpnd
             .get_device_identity(request)
             .await
@@ -723,7 +720,7 @@ impl GrpcClient {
     pub async fn system_messages(&self) -> Result<Vec<SystemMessage>, VpndError> {
         let mut vpnd = self.vpnd().await?;
 
-        let request = Request::new(GetSystemMessagesRequest {});
+        let request = Request::new(());
         let response = vpnd.get_system_messages(request).await.map_err(|e| {
             error!("grpc: {}", e);
             VpndError::GrpcError(e)
@@ -738,7 +735,7 @@ impl GrpcClient {
     pub async fn feature_flags(&self) -> Result<FeatureFlags, VpndError> {
         let mut vpnd = self.vpnd().await?;
 
-        let request = Request::new(GetFeatureFlagsRequest {});
+        let request = Request::new(());
         let response = vpnd.get_feature_flags(request).await.map_err(|e| {
             error!("grpc: {}", e);
             VpndError::GrpcError(e)

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/decorations.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/decorations.rs
@@ -16,15 +16,13 @@ impl crate::EntryNode {
 
     pub fn new_random() -> Self {
         Self {
-            entry_node_enum: Some(crate::entry_node::EntryNodeEnum::Random(crate::Empty {})),
+            entry_node_enum: Some(crate::entry_node::EntryNodeEnum::Random(())),
         }
     }
 
     pub fn new_random_low_latency() -> Self {
         Self {
-            entry_node_enum: Some(crate::entry_node::EntryNodeEnum::RandomLowLatency(
-                crate::Empty {},
-            )),
+            entry_node_enum: Some(crate::entry_node::EntryNodeEnum::RandomLowLatency(())),
         }
     }
 
@@ -46,7 +44,7 @@ impl crate::ExitNode {
 
     pub fn new_random() -> Self {
         Self {
-            exit_node_enum: Some(crate::exit_node::ExitNodeEnum::Random(crate::Empty {})),
+            exit_node_enum: Some(crate::exit_node::ExitNodeEnum::Random(())),
         }
     }
 

--- a/nym-vpn-core/crates/nym-vpnc/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/main.rs
@@ -13,7 +13,7 @@ use cli::Internal;
 use itertools::Itertools;
 use nym_gateway_directory::GatewayType;
 use nym_vpn_proto::{
-    ConfirmZkNymDownloadedRequest, ConnectRequest, DisconnectRequest, Empty, ForgetAccountRequest,
+    ConfirmZkNymDownloadedRequest, ConnectRequest, DisconnectRequest, ForgetAccountRequest,
     GetAccountIdentityRequest, GetAccountLinksRequest, GetAccountStateRequest,
     GetAccountUsageRequest, GetActiveDevicesRequest, GetAvailableTicketsRequest,
     GetDeviceIdentityRequest, GetDeviceZkNymsRequest, GetDevicesRequest, GetFeatureFlagsRequest,
@@ -220,7 +220,7 @@ async fn listen_until_connected_or_failed(opts: CliOptions) -> Result<()> {
         return Ok(());
     }
 
-    let request = tonic::Request::new(Empty {});
+    let request = tonic::Request::new(());
     let mut stream = client
         .listen_to_connection_state_changes(request)
         .await?
@@ -268,7 +268,7 @@ async fn listen_until_disconnected(opts: CliOptions) -> Result<()> {
         return Ok(());
     }
 
-    let request = tonic::Request::new(Empty {});
+    let request = tonic::Request::new(());
     let mut stream = client
         .listen_to_connection_state_changes(request)
         .await?
@@ -556,7 +556,7 @@ async fn get_available_tickets(client_type: ClientType) -> Result<()> {
 
 async fn listen_to_status(client_type: ClientType) -> Result<()> {
     let mut client = vpnd_client::get_client(&client_type).await?;
-    let request = tonic::Request::new(Empty {});
+    let request = tonic::Request::new(());
     let mut stream = client
         .listen_to_connection_status(request)
         .await?
@@ -569,7 +569,7 @@ async fn listen_to_status(client_type: ClientType) -> Result<()> {
 
 async fn listen_to_state_changes(client_type: ClientType) -> Result<()> {
     let mut client = vpnd_client::get_client(&client_type).await?;
-    let request = tonic::Request::new(Empty {});
+    let request = tonic::Request::new(());
     let mut stream = client
         .listen_to_connection_state_changes(request)
         .await?

--- a/nym-vpn-core/crates/nym-vpnc/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/main.rs
@@ -13,15 +13,9 @@ use cli::Internal;
 use itertools::Itertools;
 use nym_gateway_directory::GatewayType;
 use nym_vpn_proto::{
-    ConfirmZkNymDownloadedRequest, ConnectRequest, DisconnectRequest, ForgetAccountRequest,
-    GetAccountIdentityRequest, GetAccountLinksRequest, GetAccountStateRequest,
-    GetAccountUsageRequest, GetActiveDevicesRequest, GetAvailableTicketsRequest,
-    GetDeviceIdentityRequest, GetDeviceZkNymsRequest, GetDevicesRequest, GetFeatureFlagsRequest,
-    GetSystemMessagesRequest, GetZkNymByIdRequest, GetZkNymsAvailableForDownloadRequest,
-    InfoRequest, InfoResponse, IsAccountStoredRequest, IsReadyToConnectRequest,
-    ListCountriesRequest, ListGatewaysRequest, RefreshAccountStateRequest, RegisterDeviceRequest,
-    RequestZkNymRequest, ResetDeviceIdentityRequest, SetNetworkRequest, StatusRequest,
-    StoreAccountRequest, UserAgent,
+    ConfirmZkNymDownloadedRequest, ConnectRequest, GetAccountLinksRequest, GetZkNymByIdRequest,
+    InfoResponse, ListCountriesRequest, ListGatewaysRequest, ResetDeviceIdentityRequest,
+    SetNetworkRequest, StoreAccountRequest, UserAgent,
 };
 use protobuf_conversion::into_gateway_type;
 use sysinfo::System;
@@ -144,7 +138,7 @@ async fn connect(opts: CliOptions, connect_args: &cli::ConnectArgs) -> Result<()
     let exit = cli::parse_exit_point(connect_args)?;
 
     let mut client = vpnd_client::get_client(&opts.client_type).await?;
-    let info_request = tonic::Request::new(InfoRequest {});
+    let info_request = tonic::Request::new(());
     let info = client.info(info_request).await?.into_inner();
     let user_agent = setup_user_agent(&opts, info);
 
@@ -213,7 +207,7 @@ fn handle_connect_failure(error: nym_vpn_proto::ConnectRequestError) -> Result<(
 async fn listen_until_connected_or_failed(opts: CliOptions) -> Result<()> {
     let mut client = vpnd_client::get_client(&opts.client_type).await?;
 
-    let request = tonic::Request::new(StatusRequest {});
+    let request = tonic::Request::new(());
     let response = client.vpn_status(request).await?.into_inner();
     if response.status == nym_vpn_proto::ConnectionStatus::Connected as i32 {
         println!("Connected!");
@@ -239,7 +233,7 @@ async fn listen_until_connected_or_failed(opts: CliOptions) -> Result<()> {
 
 async fn disconnect(opts: CliOptions) -> Result<()> {
     let mut client = vpnd_client::get_client(&opts.client_type.clone()).await?;
-    let request = tonic::Request::new(DisconnectRequest {});
+    let request = tonic::Request::new(());
     let response = client.vpn_disconnect(request).await?.into_inner();
 
     if opts.verbose {
@@ -258,7 +252,7 @@ async fn disconnect(opts: CliOptions) -> Result<()> {
 async fn listen_until_disconnected(opts: CliOptions) -> Result<()> {
     let mut client = vpnd_client::get_client(&opts.client_type).await?;
 
-    let request = tonic::Request::new(StatusRequest {});
+    let request = tonic::Request::new(());
     let response = client.vpn_status(request).await?.into_inner();
     if response.status == nym_vpn_proto::ConnectionStatus::NotConnected as i32 {
         println!("Disconnected!");
@@ -285,7 +279,7 @@ async fn listen_until_disconnected(opts: CliOptions) -> Result<()> {
 
 async fn status(opts: CliOptions) -> Result<()> {
     let mut client = vpnd_client::get_client(&opts.client_type).await?;
-    let request = tonic::Request::new(StatusRequest {});
+    let request = tonic::Request::new(());
     let response = client.vpn_status(request).await?.into_inner();
 
     if opts.verbose {
@@ -307,7 +301,7 @@ async fn status(opts: CliOptions) -> Result<()> {
 
 async fn info(client_type: ClientType) -> Result<()> {
     let mut client = vpnd_client::get_client(&client_type).await?;
-    let request = tonic::Request::new(InfoRequest {});
+    let request = tonic::Request::new(());
     let response = client.info(request).await?.into_inner();
     let info = nym_vpn_proto::conversions::InfoResponse::try_from(response)
         .context("failed to parse info response")?;
@@ -327,7 +321,7 @@ async fn set_network(client_type: ClientType, args: &cli::SetNetworkArgs) -> Res
 
 async fn get_system_messages(client_type: ClientType) -> Result<()> {
     let mut client = vpnd_client::get_client(&client_type).await?;
-    let request = tonic::Request::new(GetSystemMessagesRequest {});
+    let request = tonic::Request::new(());
     let response = client.get_system_messages(request).await?.into_inner();
     println!("{:#?}", response);
     Ok(())
@@ -335,7 +329,7 @@ async fn get_system_messages(client_type: ClientType) -> Result<()> {
 
 async fn get_feature_flags(client_type: ClientType) -> Result<()> {
     let mut client = vpnd_client::get_client(&client_type).await?;
-    let request = tonic::Request::new(GetFeatureFlagsRequest {});
+    let request = tonic::Request::new(());
     let response = client.get_feature_flags(request).await?.into_inner();
     println!("{:#?}", response);
     Ok(())
@@ -368,7 +362,7 @@ async fn store_account(opts: CliOptions, store_args: &cli::StoreAccountArgs) -> 
 
 async fn refresh_account_state(client_type: ClientType) -> Result<()> {
     let mut client = vpnd_client::get_client(&client_type).await?;
-    let request = tonic::Request::new(RefreshAccountStateRequest {});
+    let request = tonic::Request::new(());
     let response = client.refresh_account_state(request).await?.into_inner();
     println!("{:#?}", response);
     Ok(())
@@ -376,7 +370,7 @@ async fn refresh_account_state(client_type: ClientType) -> Result<()> {
 
 async fn is_account_stored(client_type: ClientType) -> Result<()> {
     let mut client = vpnd_client::get_client(&client_type).await?;
-    let request = tonic::Request::new(IsAccountStoredRequest {});
+    let request = tonic::Request::new(());
     let response = client.is_account_stored(request).await?.into_inner();
     println!("{:#?}", response);
     Ok(())
@@ -384,7 +378,7 @@ async fn is_account_stored(client_type: ClientType) -> Result<()> {
 
 async fn get_account_usage(client_type: ClientType) -> Result<()> {
     let mut client = vpnd_client::get_client(&client_type).await?;
-    let request = tonic::Request::new(GetAccountUsageRequest {});
+    let request = tonic::Request::new(());
     let response = client.get_account_usage(request).await?.into_inner();
     println!("{:#?}", response);
     Ok(())
@@ -392,7 +386,7 @@ async fn get_account_usage(client_type: ClientType) -> Result<()> {
 
 async fn forget_account(client_type: ClientType) -> Result<()> {
     let mut client = vpnd_client::get_client(&client_type).await?;
-    let request = tonic::Request::new(ForgetAccountRequest {});
+    let request = tonic::Request::new(());
     let response = client.forget_account(request).await?.into_inner();
     println!("{:#?}", response);
     Ok(())
@@ -400,7 +394,7 @@ async fn forget_account(client_type: ClientType) -> Result<()> {
 
 async fn get_account_id(client_type: ClientType) -> Result<()> {
     let mut client = vpnd_client::get_client(&client_type).await?;
-    let request = tonic::Request::new(GetAccountIdentityRequest {});
+    let request = tonic::Request::new(());
     let response = client.get_account_identity(request).await?.into_inner();
     println!("{:#?}", response);
     Ok(())
@@ -434,7 +428,7 @@ async fn get_account_links(opts: CliOptions, args: &cli::GetAccountLinksArgs) ->
 
 async fn get_account_state(client_type: ClientType) -> Result<()> {
     let mut client = vpnd_client::get_client(&client_type).await?;
-    let request = tonic::Request::new(GetAccountStateRequest {});
+    let request = tonic::Request::new(());
     let response = client.get_account_state(request).await?.into_inner();
     println!("{:#?}", response);
     Ok(())
@@ -442,7 +436,7 @@ async fn get_account_state(client_type: ClientType) -> Result<()> {
 
 async fn is_ready_to_connect(client_type: ClientType) -> Result<()> {
     let mut client = vpnd_client::get_client(&client_type).await?;
-    let request = tonic::Request::new(IsReadyToConnectRequest {});
+    let request = tonic::Request::new(());
     let response = client.is_ready_to_connect(request).await?.into_inner();
     println!("{:#?}", response);
     Ok(())
@@ -463,7 +457,7 @@ async fn reset_device_identity(
 
 async fn get_device_id(client_type: ClientType) -> Result<()> {
     let mut client = vpnd_client::get_client(&client_type).await?;
-    let request = tonic::Request::new(GetDeviceIdentityRequest {});
+    let request = tonic::Request::new(());
     let response = client.get_device_identity(request).await?.into_inner();
     println!("{:#?}", response);
     Ok(())
@@ -471,7 +465,7 @@ async fn get_device_id(client_type: ClientType) -> Result<()> {
 
 async fn register_device(client_type: ClientType) -> Result<()> {
     let mut client = vpnd_client::get_client(&client_type).await?;
-    let request = tonic::Request::new(RegisterDeviceRequest {});
+    let request = tonic::Request::new(());
     let response = client.register_device(request).await?.into_inner();
     println!("{:#?}", response);
     Ok(())
@@ -479,7 +473,7 @@ async fn register_device(client_type: ClientType) -> Result<()> {
 
 async fn get_devices(client_type: ClientType) -> Result<()> {
     let mut client = vpnd_client::get_client(&client_type).await?;
-    let request = tonic::Request::new(GetDevicesRequest {});
+    let request = tonic::Request::new(());
     let response = client.get_devices(request).await?.into_inner();
     println!("{:#?}", response);
     Ok(())
@@ -487,7 +481,7 @@ async fn get_devices(client_type: ClientType) -> Result<()> {
 
 async fn get_active_devices(client_type: ClientType) -> Result<()> {
     let mut client = vpnd_client::get_client(&client_type).await?;
-    let request = tonic::Request::new(GetActiveDevicesRequest {});
+    let request = tonic::Request::new(());
     let response = client.get_active_devices(request).await?.into_inner();
     println!("{:#?}", response);
     Ok(())
@@ -495,7 +489,7 @@ async fn get_active_devices(client_type: ClientType) -> Result<()> {
 
 async fn request_zk_nym(client_type: ClientType) -> Result<()> {
     let mut client = vpnd_client::get_client(&client_type).await?;
-    let request = tonic::Request::new(RequestZkNymRequest {});
+    let request = tonic::Request::new(());
     let response = client.request_zk_nym(request).await?.into_inner();
     println!("{:#?}", response);
     Ok(())
@@ -503,7 +497,7 @@ async fn request_zk_nym(client_type: ClientType) -> Result<()> {
 
 async fn get_device_zk_nym(client_type: ClientType) -> Result<()> {
     let mut client = vpnd_client::get_client(&client_type).await?;
-    let request = tonic::Request::new(GetDeviceZkNymsRequest {});
+    let request = tonic::Request::new(());
     let response = client.get_device_zk_nyms(request).await?.into_inner();
     println!("{:#?}", response);
     Ok(())
@@ -511,7 +505,7 @@ async fn get_device_zk_nym(client_type: ClientType) -> Result<()> {
 
 async fn get_zk_nyms_available_for_download(client_type: ClientType) -> Result<()> {
     let mut client = vpnd_client::get_client(&client_type).await?;
-    let request = tonic::Request::new(GetZkNymsAvailableForDownloadRequest {});
+    let request = tonic::Request::new(());
     let response = client
         .get_zk_nyms_available_for_download(request)
         .await?
@@ -548,7 +542,7 @@ async fn confirm_zk_nym_downloaded(
 
 async fn get_available_tickets(client_type: ClientType) -> Result<()> {
     let mut client = vpnd_client::get_client(&client_type).await?;
-    let request = tonic::Request::new(GetAvailableTicketsRequest {});
+    let request = tonic::Request::new(());
     let response = client.get_available_tickets(request).await?.into_inner();
     println!("{:#?}", response);
     Ok(())
@@ -587,7 +581,7 @@ async fn list_gateways(
 ) -> Result<()> {
     let mut client = vpnd_client::get_client(&opts.client_type).await?;
 
-    let info_request = tonic::Request::new(InfoRequest {});
+    let info_request = tonic::Request::new(());
     let info = client.info(info_request).await?.into_inner();
     let user_agent = setup_user_agent(&opts, info);
 
@@ -624,7 +618,7 @@ async fn list_countries(
 ) -> Result<()> {
     let mut client = vpnd_client::get_client(&opts.client_type).await?;
 
-    let info_request = tonic::Request::new(InfoRequest {});
+    let info_request = tonic::Request::new(());
     let info = client.info(info_request).await?.into_inner();
     let user_agent = setup_user_agent(&opts, info);
 

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
@@ -15,7 +15,7 @@ use nym_vpn_lib::tunnel_state_machine::MixnetEvent;
 use nym_vpn_proto::{
     conversions::ConversionError, nym_vpnd_server::NymVpnd, AccountError,
     ConfirmZkNymDownloadedRequest, ConfirmZkNymDownloadedResponse, ConnectRequest, ConnectResponse,
-    ConnectionStateChange, ConnectionStatusUpdate, DisconnectRequest, DisconnectResponse, Empty,
+    ConnectionStateChange, ConnectionStatusUpdate, DisconnectRequest, DisconnectResponse,
     ForgetAccountRequest, ForgetAccountResponse, GetAccountIdentityRequest,
     GetAccountIdentityResponse, GetAccountLinksRequest, GetAccountLinksResponse,
     GetAccountStateRequest, GetAccountStateResponse, GetAccountUsageRequest,
@@ -262,7 +262,7 @@ impl NymVpnd for CommandInterface {
 
     async fn listen_to_connection_status(
         &self,
-        request: tonic::Request<Empty>,
+        request: tonic::Request<()>,
     ) -> Result<tonic::Response<Self::ListenToConnectionStatusStream>, tonic::Status> {
         tracing::debug!("Got connection status stream request: {request:?}");
         let rx = self.status_rx.resubscribe();
@@ -284,7 +284,7 @@ impl NymVpnd for CommandInterface {
 
     async fn listen_to_connection_state_changes(
         &self,
-        request: tonic::Request<Empty>,
+        request: tonic::Request<()>,
     ) -> Result<tonic::Response<Self::ListenToConnectionStateChangesStream>, tonic::Status> {
         tracing::debug!("Got connection status stream request: {request:?}");
         let rx = self.vpn_state_changes_rx.resubscribe();

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
@@ -15,22 +15,17 @@ use nym_vpn_lib::tunnel_state_machine::MixnetEvent;
 use nym_vpn_proto::{
     conversions::ConversionError, nym_vpnd_server::NymVpnd, AccountError,
     ConfirmZkNymDownloadedRequest, ConfirmZkNymDownloadedResponse, ConnectRequest, ConnectResponse,
-    ConnectionStateChange, ConnectionStatusUpdate, DisconnectRequest, DisconnectResponse,
-    ForgetAccountRequest, ForgetAccountResponse, GetAccountIdentityRequest,
+    ConnectionStateChange, ConnectionStatusUpdate, DisconnectResponse, ForgetAccountResponse,
     GetAccountIdentityResponse, GetAccountLinksRequest, GetAccountLinksResponse,
-    GetAccountStateRequest, GetAccountStateResponse, GetAccountUsageRequest,
-    GetAccountUsageResponse, GetActiveDevicesRequest, GetActiveDevicesResponse,
-    GetAvailableTicketsRequest, GetAvailableTicketsResponse, GetDeviceIdentityRequest,
-    GetDeviceIdentityResponse, GetDeviceZkNymsRequest, GetDeviceZkNymsResponse, GetDevicesRequest,
-    GetDevicesResponse, GetFeatureFlagsRequest, GetFeatureFlagsResponse, GetSystemMessagesRequest,
-    GetSystemMessagesResponse, GetZkNymByIdRequest, GetZkNymByIdResponse,
-    GetZkNymsAvailableForDownloadRequest, GetZkNymsAvailableForDownloadResponse, InfoRequest,
-    InfoResponse, IsAccountStoredRequest, IsAccountStoredResponse, IsReadyToConnectRequest,
-    IsReadyToConnectResponse, ListCountriesRequest, ListCountriesResponse, ListGatewaysRequest,
-    ListGatewaysResponse, RefreshAccountStateRequest, RefreshAccountStateResponse,
-    RegisterDeviceRequest, RegisterDeviceResponse, RequestZkNymRequest, RequestZkNymResponse,
-    ResetDeviceIdentityRequest, ResetDeviceIdentityResponse, SetNetworkRequest, SetNetworkResponse,
-    StatusRequest, StatusResponse, StoreAccountRequest, StoreAccountResponse,
+    GetAccountStateResponse, GetAccountUsageResponse, GetActiveDevicesResponse,
+    GetAvailableTicketsResponse, GetDeviceIdentityResponse, GetDeviceZkNymsResponse,
+    GetDevicesResponse, GetFeatureFlagsResponse, GetSystemMessagesResponse, GetZkNymByIdRequest,
+    GetZkNymByIdResponse, GetZkNymsAvailableForDownloadResponse, InfoResponse,
+    IsAccountStoredResponse, IsReadyToConnectResponse, ListCountriesRequest, ListCountriesResponse,
+    ListGatewaysRequest, ListGatewaysResponse, RefreshAccountStateResponse, RegisterDeviceResponse,
+    RequestZkNymResponse, ResetDeviceIdentityRequest, ResetDeviceIdentityResponse,
+    SetNetworkRequest, SetNetworkResponse, StatusResponse, StoreAccountRequest,
+    StoreAccountResponse,
 };
 use zeroize::Zeroizing;
 
@@ -120,7 +115,7 @@ impl Drop for CommandInterface {
 impl NymVpnd for CommandInterface {
     async fn info(
         &self,
-        _request: tonic::Request<InfoRequest>,
+        _request: tonic::Request<()>,
     ) -> Result<tonic::Response<InfoResponse>, tonic::Status> {
         let info = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
             .handle_info()
@@ -152,7 +147,7 @@ impl NymVpnd for CommandInterface {
 
     async fn get_system_messages(
         &self,
-        _request: tonic::Request<GetSystemMessagesRequest>,
+        _request: tonic::Request<()>,
     ) -> Result<tonic::Response<GetSystemMessagesResponse>, tonic::Status> {
         tracing::debug!("Got get system messages request");
 
@@ -168,7 +163,7 @@ impl NymVpnd for CommandInterface {
 
     async fn get_feature_flags(
         &self,
-        _request: tonic::Request<GetFeatureFlagsRequest>,
+        _request: tonic::Request<()>,
     ) -> Result<tonic::Response<GetFeatureFlagsResponse>, tonic::Status> {
         tracing::debug!("Got get feature flags request");
 
@@ -231,7 +226,7 @@ impl NymVpnd for CommandInterface {
 
     async fn vpn_disconnect(
         &self,
-        _request: tonic::Request<DisconnectRequest>,
+        _request: tonic::Request<()>,
     ) -> Result<tonic::Response<DisconnectResponse>, tonic::Status> {
         let status = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
             .handle_disconnect()
@@ -246,7 +241,7 @@ impl NymVpnd for CommandInterface {
 
     async fn vpn_status(
         &self,
-        _request: tonic::Request<StatusRequest>,
+        _request: tonic::Request<()>,
     ) -> Result<tonic::Response<StatusResponse>, tonic::Status> {
         let status = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
             .handle_status()
@@ -434,7 +429,7 @@ impl NymVpnd for CommandInterface {
 
     async fn is_account_stored(
         &self,
-        _request: tonic::Request<IsAccountStoredRequest>,
+        _request: tonic::Request<()>,
     ) -> Result<tonic::Response<IsAccountStoredResponse>, tonic::Status> {
         let result = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
             .handle_is_account_stored()
@@ -459,7 +454,7 @@ impl NymVpnd for CommandInterface {
 
     async fn forget_account(
         &self,
-        _request: tonic::Request<ForgetAccountRequest>,
+        _request: tonic::Request<()>,
     ) -> Result<tonic::Response<ForgetAccountResponse>, tonic::Status> {
         let result = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
             .handle_forget_account()
@@ -482,7 +477,7 @@ impl NymVpnd for CommandInterface {
 
     async fn get_account_identity(
         &self,
-        _request: tonic::Request<GetAccountIdentityRequest>,
+        _request: tonic::Request<()>,
     ) -> Result<tonic::Response<GetAccountIdentityResponse>, tonic::Status> {
         let result = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
             .handle_get_account_identity()
@@ -541,7 +536,7 @@ impl NymVpnd for CommandInterface {
 
     async fn get_account_state(
         &self,
-        _request: tonic::Request<GetAccountStateRequest>,
+        _request: tonic::Request<()>,
     ) -> Result<tonic::Response<GetAccountStateResponse>, tonic::Status> {
         let result = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
             .handle_get_account_state()
@@ -566,7 +561,7 @@ impl NymVpnd for CommandInterface {
 
     async fn refresh_account_state(
         &self,
-        _request: tonic::Request<RefreshAccountStateRequest>,
+        _request: tonic::Request<()>,
     ) -> Result<tonic::Response<RefreshAccountStateResponse>, tonic::Status> {
         CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
             .handle_refresh_account_state()
@@ -580,7 +575,7 @@ impl NymVpnd for CommandInterface {
 
     async fn get_account_usage(
         &self,
-        _request: tonic::Request<GetAccountUsageRequest>,
+        _request: tonic::Request<()>,
     ) -> Result<tonic::Response<GetAccountUsageResponse>, tonic::Status> {
         let result = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
             .handle_get_account_usage()
@@ -608,7 +603,7 @@ impl NymVpnd for CommandInterface {
 
     async fn is_ready_to_connect(
         &self,
-        _request: tonic::Request<IsReadyToConnectRequest>,
+        _request: tonic::Request<()>,
     ) -> Result<tonic::Response<IsReadyToConnectResponse>, tonic::Status> {
         let result = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
             .handle_is_ready_to_connect()
@@ -656,7 +651,7 @@ impl NymVpnd for CommandInterface {
 
     async fn get_device_identity(
         &self,
-        _request: tonic::Request<GetDeviceIdentityRequest>,
+        _request: tonic::Request<()>,
     ) -> Result<tonic::Response<GetDeviceIdentityResponse>, tonic::Status> {
         let result = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
             .handle_get_device_identity()
@@ -678,7 +673,7 @@ impl NymVpnd for CommandInterface {
 
     async fn register_device(
         &self,
-        _request: tonic::Request<RegisterDeviceRequest>,
+        _request: tonic::Request<()>,
     ) -> Result<tonic::Response<RegisterDeviceResponse>, tonic::Status> {
         let result = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
             .handle_register_device()
@@ -702,7 +697,7 @@ impl NymVpnd for CommandInterface {
 
     async fn get_devices(
         &self,
-        _request: tonic::Request<GetDevicesRequest>,
+        _request: tonic::Request<()>,
     ) -> Result<tonic::Response<GetDevicesResponse>, tonic::Status> {
         let response = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
             .handle_get_devices()
@@ -722,7 +717,7 @@ impl NymVpnd for CommandInterface {
 
     async fn get_active_devices(
         &self,
-        _request: tonic::Request<GetActiveDevicesRequest>,
+        _request: tonic::Request<()>,
     ) -> Result<tonic::Response<GetActiveDevicesResponse>, tonic::Status> {
         let response = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
             .handle_get_active_devices()
@@ -742,7 +737,7 @@ impl NymVpnd for CommandInterface {
 
     async fn request_zk_nym(
         &self,
-        _request: tonic::Request<RequestZkNymRequest>,
+        _request: tonic::Request<()>,
     ) -> Result<tonic::Response<RequestZkNymResponse>, tonic::Status> {
         let result = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
             .handle_request_zk_nym()
@@ -766,7 +761,7 @@ impl NymVpnd for CommandInterface {
 
     async fn get_device_zk_nyms(
         &self,
-        _request: tonic::Request<GetDeviceZkNymsRequest>,
+        _request: tonic::Request<()>,
     ) -> Result<tonic::Response<GetDeviceZkNymsResponse>, tonic::Status> {
         let result = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
             .handle_get_device_zk_nyms()
@@ -790,7 +785,7 @@ impl NymVpnd for CommandInterface {
 
     async fn get_zk_nyms_available_for_download(
         &self,
-        _request: tonic::Request<GetZkNymsAvailableForDownloadRequest>,
+        _request: tonic::Request<()>,
     ) -> Result<tonic::Response<GetZkNymsAvailableForDownloadResponse>, tonic::Status> {
         let result = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
             .handle_get_zk_nyms_available_for_download()
@@ -860,7 +855,7 @@ impl NymVpnd for CommandInterface {
 
     async fn get_available_tickets(
         &self,
-        _request: tonic::Request<GetAvailableTicketsRequest>,
+        _request: tonic::Request<()>,
     ) -> Result<tonic::Response<GetAvailableTicketsResponse>, tonic::Status> {
         tracing::debug!("Got get available tickets request");
 

--- a/proto/nym/vpn.proto
+++ b/proto/nym/vpn.proto
@@ -138,8 +138,6 @@ message ValidatorDetails {
   Url api_url = 3;
 }
 
-message InfoRequest {}
-
 message InfoResponse {
   string version = 1;
   google.protobuf.Timestamp build_timestamp = 2;
@@ -181,13 +179,9 @@ message SystemMessage {
   map<string, string> properties = 3;
 }
 
-message GetSystemMessagesRequest {}
-
 message GetSystemMessagesResponse {
   repeated SystemMessage messages = 1;
 }
-
-message GetFeatureFlagsRequest {}
 
 message GetFeatureFlagsResponse {
   map<string, string> flags = 1;
@@ -265,7 +259,6 @@ message ConnectResponse {
   ConnectRequestError error = 2;
 }
 
-message DisconnectRequest {}
 message DisconnectResponse {
   bool success = 1;
 }
@@ -287,7 +280,6 @@ message ConnectionDetails {
   google.protobuf.Timestamp since = 4;
 }
 
-message StatusRequest {}
 message StatusResponse {
   ConnectionStatus status = 1;
   ConnectionDetails details = 2;
@@ -609,16 +601,12 @@ message StoreAccountResponse {
   AccountError error = 2;
 }
 
-message IsAccountStoredRequest {}
-
 message IsAccountStoredResponse {
   oneof resp {
     bool is_stored = 1;
     AccountError error = 2;
   }
 }
-
-message ForgetAccountRequest {}
 
 message ForgetAccountResponse {
   bool success = 1;
@@ -628,8 +616,6 @@ message ForgetAccountResponse {
 message AccountIdentity {
   optional string account_identity = 1;
 }
-
-message GetAccountIdentityRequest {}
 
 message GetAccountIdentityResponse {
   oneof id {
@@ -777,8 +763,6 @@ message AccountStateSummary {
   optional RequestZkNymResult request_zk_nym_result = 7;
 }
 
-message GetAccountStateRequest {}
-
 message GetAccountStateResponse {
   oneof result {
     AccountStateSummary account = 1;
@@ -786,7 +770,6 @@ message GetAccountStateResponse {
   }
 }
 
-message RefreshAccountStateRequest {}
 message RefreshAccountStateResponse {}
 
 message AccountUsages {
@@ -804,7 +787,6 @@ message AccountUsage {
   double bandwidth_used_gb = 8;
 }
 
-message GetAccountUsageRequest {}
 message GetAccountUsageResponse {
   oneof result {
     AccountUsages account_usages = 1;
@@ -822,16 +804,12 @@ message ResetDeviceIdentityResponse {
   AccountError error = 2;
 }
 
-message GetDeviceIdentityRequest {}
-
 message GetDeviceIdentityResponse {
   oneof id {
     string device_identity = 1;
     AccountError error = 2;
   }
 }
-
-message RegisterDeviceRequest {}
 
 message RegisterDeviceResponse {
   string json = 1;
@@ -856,7 +834,6 @@ message Devices {
   repeated Device devices = 1;
 }
 
-message GetDevicesRequest {}
 message GetDevicesResponse {
   oneof result {
     Devices devices = 1;
@@ -864,7 +841,6 @@ message GetDevicesResponse {
   }
 }
 
-message GetActiveDevicesRequest {}
 message GetActiveDevicesResponse {
   oneof result {
     Devices devices = 1;
@@ -872,21 +848,15 @@ message GetActiveDevicesResponse {
   }
 }
 
-message RequestZkNymRequest {}
-
 message RequestZkNymResponse {
   string json = 1;
   AccountError error = 2;
 }
 
-message GetDeviceZkNymsRequest {}
-
 message GetDeviceZkNymsResponse {
   string json = 1;
   AccountError error = 2;
 }
-
-message GetZkNymsAvailableForDownloadRequest {}
 
 message GetZkNymsAvailableForDownloadResponse {
   string json = 1;
@@ -940,16 +910,12 @@ message AvailableTickets {
   string vpn_exit_data_si = 12;
 }
 
-message GetAvailableTicketsRequest {}
-
 message GetAvailableTicketsResponse {
   oneof resp {
     AvailableTickets available_tickets = 1;
     AccountError error = 2;
   }
 }
-
-message IsReadyToConnectRequest {}
 
 message IsReadyToConnectResponse {
   enum IsReadyToConnectResponseType {
@@ -1013,25 +979,25 @@ message AccountError {
 
 service NymVpnd {
   // Get info regarding the nym-vpnd in general, like version etc.
-  rpc Info (InfoRequest) returns (InfoResponse) {}
+  rpc Info (google.protobuf.Empty) returns (InfoResponse) {}
 
   // Set the network. This requires a restart to take effect
   rpc SetNetwork (SetNetworkRequest) returns (SetNetworkResponse) {}
 
   // List messages fetched from nym-vpn-api
-  rpc GetSystemMessages (GetSystemMessagesRequest) returns (GetSystemMessagesResponse) {}
+  rpc GetSystemMessages (google.protobuf.Empty) returns (GetSystemMessagesResponse) {}
 
   // List the feature flags fetched from the nym-vpn-api
-  rpc GetFeatureFlags (GetFeatureFlagsRequest) returns (GetFeatureFlagsResponse) {}
+  rpc GetFeatureFlags (google.protobuf.Empty) returns (GetFeatureFlagsResponse) {}
 
   // Start the tunnel and connect
   rpc VpnConnect (ConnectRequest) returns (ConnectResponse) {}
 
   // Disconnect and stop the tunnel
-  rpc VpnDisconnect (DisconnectRequest) returns (DisconnectResponse) {}
+  rpc VpnDisconnect (google.protobuf.Empty) returns (DisconnectResponse) {}
 
   // Get the current tunnel and connection status
-  rpc VpnStatus (StatusRequest) returns (StatusResponse) {}
+  rpc VpnStatus (google.protobuf.Empty) returns (StatusResponse) {}
 
   // Listen for events that indicate that the connection state changes, such as
   // from Connecting -> Connected
@@ -1055,55 +1021,55 @@ service NymVpnd {
   rpc StoreAccount (StoreAccountRequest) returns (StoreAccountResponse) {}
 
   // Check if the recovery phrase is stored
-  rpc IsAccountStored (IsAccountStoredRequest) returns (IsAccountStoredResponse) {}
+  rpc IsAccountStored (google.protobuf.Empty) returns (IsAccountStoredResponse) {}
 
   // Removes everything related to the account, including the device identity,
   // credential storage, mixnet keys, gateway registrations.
-  rpc ForgetAccount (ForgetAccountRequest) returns (ForgetAccountResponse) {}
+  rpc ForgetAccount (google.protobuf.Empty) returns (ForgetAccountResponse) {}
 
   // Get the account identity of the locally stored recovery phrase
-  rpc GetAccountIdentity (GetAccountIdentityRequest) returns (GetAccountIdentityResponse) {}
+  rpc GetAccountIdentity (google.protobuf.Empty) returns (GetAccountIdentityResponse) {}
 
   // Get the set of account links for the user
   rpc GetAccountLinks (GetAccountLinksRequest) returns (GetAccountLinksResponse) {}
 
   // Query the account state, which is synced from the nym-vpn-api account, as it
   // is known and interpreted by nym-vpnd
-  rpc GetAccountState (GetAccountStateRequest) returns (GetAccountStateResponse) {}
+  rpc GetAccountState (google.protobuf.Empty) returns (GetAccountStateResponse) {}
 
   // The vpn client will periodically refresh the account state in the
   // background. This command triggers a manual refresh.
-  rpc RefreshAccountState (RefreshAccountStateRequest) returns (RefreshAccountStateResponse) {}
+  rpc RefreshAccountState (google.protobuf.Empty) returns (RefreshAccountStateResponse) {}
 
   // Get the account usage from the nym-vpn-api
-  rpc GetAccountUsage (GetAccountUsageRequest) returns (GetAccountUsageResponse) {}
+  rpc GetAccountUsage (google.protobuf.Empty) returns (GetAccountUsageResponse) {}
 
   // Check if the local account state is ready to connect
-  rpc IsReadyToConnect (IsReadyToConnectRequest) returns (IsReadyToConnectResponse) {}
+  rpc IsReadyToConnect (google.protobuf.Empty) returns (IsReadyToConnectResponse) {}
 
   // Reset the device identity
   rpc ResetDeviceIdentity (ResetDeviceIdentityRequest) returns (ResetDeviceIdentityResponse) {}
 
   // Get the device identity
-  rpc GetDeviceIdentity (GetDeviceIdentityRequest) returns (GetDeviceIdentityResponse) {}
+  rpc GetDeviceIdentity (google.protobuf.Empty) returns (GetDeviceIdentityResponse) {}
 
   // Try to register the local device with the nym-vpn-api
-  rpc RegisterDevice (RegisterDeviceRequest) returns (RegisterDeviceResponse) {}
+  rpc RegisterDevice (google.protobuf.Empty) returns (RegisterDeviceResponse) {}
 
   // Get the list of devices associated with this account from the nym-vpn-api
-  rpc GetDevices (GetDevicesRequest) returns (GetDevicesResponse) {}
+  rpc GetDevices (google.protobuf.Empty) returns (GetDevicesResponse) {}
 
   // Get the list of active devices associated with this account from the nym-vpn-api
-  rpc GetActiveDevices (GetActiveDevicesRequest) returns (GetActiveDevicesResponse) {}
+  rpc GetActiveDevices (google.protobuf.Empty) returns (GetActiveDevicesResponse) {}
 
   // Request new zk-nyms (ticketbooks) from the nym-vpn-api
-  rpc RequestZkNym (RequestZkNymRequest) returns (RequestZkNymResponse) {}
+  rpc RequestZkNym (google.protobuf.Empty) returns (RequestZkNymResponse) {}
 
   // List the zk-nyms associated with this device from the nym-vpn-api
-  rpc GetDeviceZkNyms (GetDeviceZkNymsRequest) returns (GetDeviceZkNymsResponse) {}
+  rpc GetDeviceZkNyms (google.protobuf.Empty) returns (GetDeviceZkNymsResponse) {}
 
   // List the zk-nyms available for download from the nym-vpn-api
-  rpc GetZkNymsAvailableForDownload (GetZkNymsAvailableForDownloadRequest) returns (GetZkNymsAvailableForDownloadResponse) {}
+  rpc GetZkNymsAvailableForDownload (google.protobuf.Empty) returns (GetZkNymsAvailableForDownloadResponse) {}
 
   // Get a zk-nym by its id from the nym-vpn-api
   rpc GetZkNymById (GetZkNymByIdRequest) returns (GetZkNymByIdResponse) {}
@@ -1112,6 +1078,6 @@ service NymVpnd {
   rpc ConfirmZkNymDownloaded (ConfirmZkNymDownloadedRequest) returns (ConfirmZkNymDownloadedResponse) {}
 
   // Get the available tickets in the local credential store
-  rpc GetAvailableTickets (GetAvailableTicketsRequest) returns (GetAvailableTicketsResponse) {}
+  rpc GetAvailableTickets (google.protobuf.Empty) returns (GetAvailableTicketsResponse) {}
 }
 

--- a/proto/nym/vpn.proto
+++ b/proto/nym/vpn.proto
@@ -2,7 +2,8 @@ syntax = "proto3";
 
 package nym.vpn;
 
-message Empty {}
+import "google/protobuf/empty.proto";
+import "google/protobuf/timestamp.proto";
 
 // Represents the identity of a gateway
 message Gateway {
@@ -24,8 +25,8 @@ message EntryNode {
   oneof entry_node_enum {
     Gateway gateway = 1;
     Location location = 2;
-    Empty random_low_latency = 3;
-    Empty random = 4;
+    google.protobuf.Empty random_low_latency = 3;
+    google.protobuf.Empty random = 4;
   }
 }
 
@@ -34,7 +35,7 @@ message ExitNode {
     Address address = 1;
     Gateway gateway = 2;
     Location location = 3;
-    Empty random = 4;
+    google.protobuf.Empty random = 4;
   }
 }
 
@@ -278,8 +279,6 @@ enum ConnectionStatus {
   DISCONNECTING = 5;
   CONNECTION_FAILED = 6;
 }
-
-import "google/protobuf/timestamp.proto";
 
 message ConnectionDetails {
   Gateway entry_gateway = 1;
@@ -1036,11 +1035,11 @@ service NymVpnd {
 
   // Listen for events that indicate that the connection state changes, such as
   // from Connecting -> Connected
-  rpc ListenToConnectionStateChanges (Empty) returns (stream ConnectionStateChange) {}
+  rpc ListenToConnectionStateChanges (google.protobuf.Empty) returns (stream ConnectionStateChange) {}
 
   // Listen for general status evens emitted by nym-vpnd, which in turn might
   // originate from elsewhere such as remote gateways.
-  rpc ListenToConnectionStatus (Empty) returns (stream ConnectionStatusUpdate) {}
+  rpc ListenToConnectionStatus (google.protobuf.Empty) returns (stream ConnectionStatusUpdate) {}
 
   // List the available gateways for the selected mode
   rpc ListGateways (ListGatewaysRequest) returns (ListGatewaysResponse) {}


### PR DESCRIPTION
- Replace our own `Empty` with `google.protobuf.Empty`.
- Use `()` in Rust in place of empty messages.
- Drop superfluous empty requests and replace them with `Empty`. The symmetry between request and response in protobuf can be seen as beauty, that's why the commit removing them is separate. However I propose that we only keep meaningful requests to have less types/code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1894)
<!-- Reviewable:end -->
