### PR TITLE
Fix type coercion of objc2::ffi::BOOL on x86_64

### DIFF
--- a/nym-vpn-core/crates/nym-apple-network/src/path.rs
+++ b/nym-vpn-core/crates/nym-apple-network/src/path.rs
@@ -43,6 +43,7 @@ impl Path {
     pub fn uses_interface_type(&self, interface_type: InterfaceType) -> bool {
         unsafe {
             sys::nw_path_uses_interface_type(self.inner.as_mut_ptr(), interface_type.as_raw())
+                == objc2::ffi::YES
         }
     }
 
@@ -88,33 +89,36 @@ impl Path {
 
     /// Checks whether the path can route IPv4 traffic.
     pub fn supports_ipv4(&self) -> bool {
-        unsafe { sys::nw_path_has_ipv4(self.inner.as_mut_ptr()) }
+        unsafe { sys::nw_path_has_ipv4(self.inner.as_mut_ptr()) == objc2::ffi::YES }
     }
 
     /// Checks whether the path can route IPv6 traffic.
     pub fn supports_ipv6(&self) -> bool {
-        unsafe { sys::nw_path_has_ipv6(self.inner.as_mut_ptr()) }
+        unsafe { sys::nw_path_has_ipv6(self.inner.as_mut_ptr()) == objc2::ffi::YES }
     }
 
     /// Checks whether the path has a DNS server configured.
     pub fn supports_dns(&self) -> bool {
-        unsafe { sys::nw_path_has_dns(self.inner.as_mut_ptr()) }
+        unsafe { sys::nw_path_has_dns(self.inner.as_mut_ptr()) == objc2::ffi::YES }
     }
 
     /// Checks whether the path uses an interface in Low Data Mode.
     pub fn is_constrained(&self) -> bool {
-        unsafe { sys::nw_path_is_constrained(self.inner.as_mut_ptr()) }
+        unsafe { sys::nw_path_is_constrained(self.inner.as_mut_ptr()) == objc2::ffi::YES }
     }
 
     /// Checks whether the path uses an interface that is considered expensive, such as Cellular or a Personal Hotspot.
     pub fn is_expensive(&self) -> bool {
-        unsafe { sys::nw_path_is_expensive(self.inner.as_mut_ptr()) }
+        unsafe { sys::nw_path_is_expensive(self.inner.as_mut_ptr()) == objc2::ffi::YES }
     }
 }
 
 impl PartialEq for Path {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { sys::nw_path_is_equal(self.inner.as_mut_ptr(), other.inner.as_mut_ptr()) }
+        unsafe {
+            sys::nw_path_is_equal(self.inner.as_mut_ptr(), other.inner.as_mut_ptr())
+                == objc2::ffi::YES
+        }
     }
 }
 


### PR DESCRIPTION
`objc2::ffi::BOOL` has different type on diff CPU architectures:
- ARM64 - `bool`
- x86_64 - `i8`

The simple fix to account for those differences is to compare against `objc2::ffi::YES`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1917)
<!-- Reviewable:end -->
