### PR TITLE
fix: nym vpn api deserialization

### DIFF
--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
@@ -15,7 +15,6 @@ pub type NymNode = Gateway;
 
 #[derive(Clone)]
 pub struct Gateway {
-    pub node_id: NodeId,
     pub identity: NodeIdentity,
     pub location: Option<Location>,
     pub ipr_address: Option<IpPacketRouterAddress>,
@@ -32,7 +31,6 @@ pub struct Gateway {
 impl fmt::Debug for Gateway {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Gateway")
-            .field("node_id", &self.node_id)
             .field("identity", &self.identity.to_base58_string())
             .field("location", &self.location)
             .field("ipr_address", &self.ipr_address)
@@ -47,10 +45,6 @@ impl fmt::Debug for Gateway {
 }
 
 impl Gateway {
-    pub fn node_id(&self) -> NodeId {
-        self.node_id
-    }
-
     pub fn identity(&self) -> NodeIdentity {
         self.identity
     }
@@ -231,7 +225,6 @@ impl TryFrom<nym_vpn_api_client::response::NymDirectoryGateway> for Gateway {
         let host = hostname.or(first_ip_address);
 
         Ok(Gateway {
-            node_id: gateway.node_id,
             identity,
             location: Some(gateway.location.into()),
             ipr_address,
@@ -301,7 +294,6 @@ impl TryFrom<nym_validator_client::models::NymNodeDescription> for Gateway {
         let clients_wss_port = entry_info.as_ref().and_then(|g| g.clients_wss_port);
         let ips = node_description.description.host_information.ip_address;
         Ok(Gateway {
-            node_id: gateway.node_id,
             identity,
             location,
             ipr_address,

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
@@ -431,6 +431,7 @@ impl IntoIterator for GatewayList {
 }
 
 impl nym_client_core::init::helpers::ConnectableGateway for Gateway {
+    #[allow(unconditional_recursion)]
     fn node_id(&self) -> NodeId {
         self.node_id()
     }

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
@@ -5,7 +5,6 @@ use chrono::{DateTime, Utc};
 use itertools::Itertools;
 use nym_contracts_common::Percent;
 use nym_credential_proxy_requests::api::v1::ticketbook::models::TicketbookWalletSharesResponse;
-use nym_validator_client::client::NodeId;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::net::IpAddr;

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
@@ -272,7 +272,6 @@ impl IntoIterator for NymDirectoryGatewaysResponse {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct NymDirectoryGateway {
-    pub node_id: NodeId,
     pub identity_key: String,
     pub ip_packet_router: Option<IpPacketRouter>,
     pub authenticator: Option<Authenticator>,


### PR DESCRIPTION
`node_id` breaks deserialization
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1919)
<!-- Reviewable:end -->
