### PR TITLE
Fix nym-offline-monitor compilation on android

### DIFF
--- a/nym-vpn-core/crates/nym-offline-monitor/src/android.rs
+++ b/nym-vpn-core/crates/nym-offline-monitor/src/android.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use tokio::sync::watch;
+use tokio_util::sync::CancellationToken;
 
 use super::Connectivity;
 
@@ -12,6 +13,17 @@ impl MonitorHandle {
     #[allow(clippy::unused_async)]
     pub async fn connectivity(&self) -> Connectivity {
         Connectivity::PresumeOnline
+    }
+}
+
+#[derive(Debug)]
+pub struct Error;
+
+impl std::error::Error for Error {}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Generic error")
     }
 }
 


### PR DESCRIPTION
This PR adds an error stub on android to fix compilation error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1925)
<!-- Reviewable:end -->
