### PR TITLE
Enable minimal Amnezia for all two-hop connections

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
@@ -116,6 +116,6 @@ vergen = { workspace = true, default-features = false, features = [
 ] }
 
 [features]
-default = []
+default = ["amnezia"]
 metrics-server = ["nym-client-core/metrics-server"]
 amnezia = ["nym-wg-go/amnezia"]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/wg_config.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/wg_config.rs
@@ -162,8 +162,7 @@ impl WgNodeConfig {
                 #[cfg(target_os = "linux")]
                 fwmark: None,
                 #[cfg(feature = "amnezia")]
-                // Even when enabled by feature flag amnezia is disabled by default.
-                azwg_config: None,
+                azwg_config: Some(AmneziaConfig::BASE),
             },
             peer: WgPeer {
                 public_key: PublicKey::from(*gateway_data.public_key.as_bytes()),


### PR DESCRIPTION
Leverage the previous changes to enable the minimal (backwards compatible) amnezia wireguard obfuscation by default.

As the goal of this PR is to enable amnezia by default, the place where the `AmneziaConfig` is instantiated now uses a real config so that calling clients don't need to configure the wireguard node themselves (i.e  using `.with_amnezia_config(...)`).

Disabling amnezia for a build is still as easy as excluding the `"amnezia"` flag from the `nym-vpn-lib` crate.  Or if we want to add something like a runtime toggle down the line this could be set with, for example, `.with_amnezia_config(AmneziaConfig::OFF)`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1926)
<!-- Reviewable:end -->
