### PR TITLE
Pass connectivity events on android

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -4164,6 +4164,7 @@ dependencies = [
 name = "nym-offline-monitor"
 version = "1.2.0-dev"
 dependencies = [
+ "async-trait",
  "debounced",
  "futures",
  "nym-apple-dispatch",

--- a/nym-vpn-core/crates/nym-offline-monitor/Cargo.toml
+++ b/nym-vpn-core/crates/nym-offline-monitor/Cargo.toml
@@ -24,3 +24,6 @@ nym-windows = { path = "../nym-windows" }
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 nym-apple-dispatch = { path = "../nym-apple-dispatch" }
 nym-apple-network = { path = "../nym-apple-network" }
+
+[target.'cfg(target_os = "android")'.dependencies]
+async-trait.workspace = true

--- a/nym-vpn-core/crates/nym-offline-monitor/src/android.rs
+++ b/nym-vpn-core/crates/nym-offline-monitor/src/android.rs
@@ -2,18 +2,41 @@
 // Copyright 2025 Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use tokio::sync::watch;
+use std::{sync::Arc, time::Duration};
+
+use tokio::sync::{watch, Mutex};
 use tokio_util::sync::CancellationToken;
 
 use super::Connectivity;
 
-pub struct MonitorHandle;
+/// Maximum duration to wait for the initial state from path monitor.
+const INITIAL_STATE_TIMEOUT: Duration = Duration::from_secs(1);
+
+pub struct MonitorHandle {
+    state: Arc<Mutex<Connectivity>>,
+}
 
 impl MonitorHandle {
-    #[allow(clippy::unused_async)]
-    pub async fn connectivity(&self) -> Connectivity {
-        Connectivity::PresumeOnline
+    fn new(state: Arc<Mutex<Connectivity>>) -> Self {
+        Self { state }
     }
+
+    pub async fn connectivity(&self) -> Connectivity {
+        *self.state.lock().await
+    }
+}
+
+#[async_trait::async_trait]
+pub trait NativeConnectivityAdapter: Send + Sync {
+    /// Wait for the next connectivity update.
+    ///
+    /// - Returns `None` when the event stream is exhausted.
+    /// - Returns `Some(true)` if connectivity is online, `Some(false)` if offline.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method must guarantee cancel safety.
+    async fn next_connectivity(&mut self) -> Option<bool>;
 }
 
 #[derive(Debug)]
@@ -29,9 +52,54 @@ impl std::fmt::Display for Error {
 
 #[allow(clippy::unused_async)]
 pub async fn spawn_monitor(
-    _sender: watch::Sender<Connectivity>,
-    _shutdown_token: CancellationToken,
+    sender: watch::Sender<Connectivity>,
+    mut connectivity_adapter: impl NativeConnectivityAdapter + 'static,
+    shutdown_token: CancellationToken,
 ) -> Result<MonitorHandle, Error> {
-    // todo: implement
-    Ok(MonitorHandle)
+    // Wait for initial state since path monitor should always send an update on start()
+    let initial_connectivity = tokio::time::timeout(INITIAL_STATE_TIMEOUT, connectivity_adapter.next_connectivity())
+        .await
+        .inspect_err(|_| {
+            tracing::warn!("Timed out receiving initial update from connectivity adapter. Default to presuming being online.");
+        })
+        .ok()
+        .flatten()
+        .map(|connected| {
+            Connectivity::Status { connected }
+        })
+        .unwrap_or(Connectivity::PresumeOnline);
+
+    tracing::info!("Initial connectivity: {:?}", initial_connectivity);
+
+    let state = Arc::new(Mutex::new(initial_connectivity));
+    let shared_state = state.clone();
+
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                _ = shutdown_token.cancelled() => {
+                    break;
+                }
+                Some(connected) = connectivity_adapter.next_connectivity() => {
+                    let mut state_guard = shared_state.lock().await;
+
+                    let connectivity = Connectivity::Status { connected };
+                    if *state_guard != connectivity {
+                        *state_guard = connectivity;
+                        tracing::info!("Connectivity changed: {:?}", connectivity);
+                        if sender.send(connectivity).is_err() {
+                            break;
+                        }
+                    }
+                }
+                else => {
+                    break;
+                }
+            }
+        }
+
+        tracing::debug!("Offline monitor exiting");
+    });
+
+    Ok(MonitorHandle::new(state))
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/android_connectivity_adapter.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/android_connectivity_adapter.rs
@@ -1,0 +1,58 @@
+use std::sync::Arc;
+
+use nym_offline_monitor::NativeConnectivityAdapter;
+use tokio::sync::mpsc;
+
+use crate::tunnel_provider::android::{AndroidTunProvider, ConnectivityObserver};
+
+/// Adapter bridging offline detection with native Android Connectivity Manager via uniffi.
+pub struct AndroidConnectivityAdapter {
+    rx: mpsc::UnboundedReceiver<bool>,
+    /// Inner connection observer that's being registered with `tun_provider`
+    inner: Option<Arc<InnerConnectionObserver>>,
+    /// Reference to `tun_provider` used for unregistering the observer on drop.
+    tun_provider: Arc<dyn AndroidTunProvider>,
+}
+
+impl AndroidConnectivityAdapter {
+    /// Create new connectivity adapter registering it with `tun_provider.`
+    /// Automatically unregisters the observer on drop.
+    pub fn new(tun_provider: Arc<dyn AndroidTunProvider>) -> Self {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let inner = Arc::new(InnerConnectionObserver { tx });
+        tun_provider.add_connectivity_observer(inner.clone());
+        Self {
+            rx,
+            inner: Some(inner),
+            tun_provider,
+        }
+    }
+}
+
+impl Drop for AndroidConnectivityAdapter {
+    fn drop(&mut self) {
+        self.inner
+            .take()
+            .map(|observer| self.tun_provider.remove_connectivity_observer(observer));
+    }
+}
+
+#[async_trait::async_trait]
+impl NativeConnectivityAdapter for AndroidConnectivityAdapter {
+    async fn next_connectivity(&mut self) -> Option<bool> {
+        self.rx.recv().await
+    }
+}
+
+#[derive(Debug)]
+struct InnerConnectionObserver {
+    tx: mpsc::UnboundedSender<bool>,
+}
+
+impl ConnectivityObserver for InnerConnectionObserver {
+    fn on_network_change(&self, is_online: bool) {
+        if let Err(e) = self.tx.send(is_online) {
+            tracing::warn!("Failed to send network change: {}", e);
+        }
+    }
+}

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -6,6 +6,8 @@ mod default_interface;
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 mod dns_handler;
 //mod firewall_handler;
+#[cfg(target_os = "android")]
+mod android_connectivity_adapter;
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 mod route_handler;
 mod states;
@@ -597,6 +599,8 @@ impl TunnelStateMachine {
         let offline_monitor = nym_offline_monitor::spawn_monitor(
             #[cfg(not(any(target_os = "android", target_os = "ios")))]
             route_handler.inner_handle(),
+            #[cfg(target_os = "android")]
+            android_connectivity_adapter::AndroidConnectivityAdapter::new(tun_provider.clone()),
             #[cfg(target_os = "linux")]
             Some(route_handler::TUNNEL_FWMARK),
         )


### PR DESCRIPTION
This PR adds a tiny adapter that passes connectivity events from uniffi into nym-offline-monitor

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1928)
<!-- Reviewable:end -->
