### PR TITLE
Skip revision in deb packages

### DIFF
--- a/nym-vpn-core/crates/nym-vpnc/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpnc/Cargo.toml
@@ -49,5 +49,6 @@ extended-description = '''NymVPN is a vpn service that uses the Nym mixnet.
 
 This package contains the nym-vpnc binary, which is a CLI application used to interact with the nym-vpnd daemon.'''
 recommends = "nym-vpnd"
+revision = ""
 maintainer-scripts = "debian"
 systemd-units = { enable = false }

--- a/nym-vpn-core/crates/nym-vpnd/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpnd/Cargo.toml
@@ -99,6 +99,7 @@ This package contains the nym-vpnd daemon binary, which runs as a background ser
 End-users should use either the CLI client, nym-vpnc, or the GUI client, nym-vpn-app.'''
 maintainer-scripts = "debian"
 recommends = "nym-vpnc"
+revision = ""
 
 [package.metadata.deb.systemd-units]
 unit-name = "nym-vpnd"


### PR DESCRIPTION
We never update the deb packages more frequently than the package version, so drop the revision number since it looks like a pre-release number for people used to standard semver

```
nym-vpnc_1.2.0~beta.0-1_amd64.deb -> nym-vpnc_1.2.0~beta.0_amd64.deb
```

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/1979)
<!-- Reviewable:end -->
