### PR TITLE
Move storage behind arc mutex to fix closing and reopening

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/credentials/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/credentials/mod.rs
@@ -63,6 +63,7 @@ impl VpnCredentialStorage {
         tracing::info!("Resetting credential storage");
 
         // First we close the storage to ensure that all files are closed
+        tracing::debug!("Closing credential storage");
         self.credential_storage.close().await;
 
         // Calling close on the storage should be enough to ensure that all files are closed
@@ -73,14 +74,18 @@ impl VpnCredentialStorage {
         let storage_paths =
             StoragePaths::new_from_dir(&self.data_dir).map_err(Error::StoragePaths)?;
 
+        tracing::debug!("Removing credential storage file");
         std::fs::remove_file(&storage_paths.credential_database_path)
             .map_err(Error::RemoveCredentialStorage)?;
 
         // Finally we recreate the storage
+        tracing::debug!("Recreating credential storage");
         self.credential_storage = storage_paths
             .persistent_credential_storage()
             .await
             .map_err(Error::SetupCredentialStorage)?;
+
+        tracing::info!("Credential storage reset completed");
 
         Ok(())
     }
@@ -88,6 +93,7 @@ impl VpnCredentialStorage {
     async fn reset_pending_request_storage(&mut self) -> Result<(), Error> {
         tracing::info!("Resetting pending request storage");
         self.pending_requests_storage.reset().await?;
+        tracing::info!("Pending request storage reset completed");
         Ok(())
     }
 

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/credentials/pending_credential_requests/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/credentials/pending_credential_requests/mod.rs
@@ -90,16 +90,6 @@ impl PendingCredentialRequestsStorage {
         tracing::debug!("Pending credential requests storage reset completed");
         *self = new_storage_manager;
 
-        self.clean_up_stale_requests()
-            .await
-            .inspect_err(|err| {
-                tracing::error!("Failed to clean up stale requests: {err:?}");
-            })
-            .inspect(|_| {
-                tracing::info!("Successfully cleaned up stale requests");
-            })
-            .ok();
-
         Ok(())
     }
 

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/credentials/pending_credential_requests/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/credentials/pending_credential_requests/mod.rs
@@ -42,10 +42,12 @@ impl PendingCredentialRequestsStorage {
             .create_if_missing(true)
             .log_statements(LevelFilter::Trace);
 
+        tracing::debug!("Connecting to the database");
         let connection_pool = sqlx::sqlite::SqlitePoolOptions::new()
             .connect_with(opts)
             .await?;
 
+        tracing::debug!("Setting file permissions on the database file");
         set_file_permission_owner_rw(&database_path)
             .map_err(
                 |source| PendingCredentialRequestsStorageError::FilePermissions {
@@ -58,6 +60,7 @@ impl PendingCredentialRequestsStorage {
             })
             .ok();
 
+        tracing::debug!("Running migrations");
         sqlx::migrate!("./migrations").run(&connection_pool).await?;
 
         Ok(Self {
@@ -68,6 +71,7 @@ impl PendingCredentialRequestsStorage {
 
     pub(crate) async fn reset(&mut self) -> Result<(), PendingCredentialRequestsStorageError> {
         // First we close the storage to ensure that all files are closed
+        tracing::debug!("Closing pending credential requests storage");
         self.storage_manager.close().await;
 
         // Calling close on the storage should be enough to ensure that all files
@@ -75,12 +79,26 @@ impl PendingCredentialRequestsStorage {
         tokio::time::sleep(Duration::from_secs(1)).await;
 
         // Then we remove the database file
+        tracing::debug!("Removing pending credential requests storage file");
         std::fs::remove_file(&self.database_path)
             .map_err(PendingCredentialRequestsStorageError::RemoveStorage)?;
 
         // Finally we recreate the storage
+        tracing::debug!("Recreating pending credential requests storage");
         let new_storage_manager = Self::init(&self.database_path).await?;
+
+        tracing::debug!("Pending credential requests storage reset completed");
         *self = new_storage_manager;
+
+        self.clean_up_stale_requests()
+            .await
+            .inspect_err(|err| {
+                tracing::error!("Failed to clean up stale requests: {err:?}");
+            })
+            .inspect(|_| {
+                tracing::info!("Successfully cleaned up stale requests");
+            })
+            .ok();
 
         Ok(())
     }


### PR DESCRIPTION
Logout closes the pending credential request storage connection pool and recreates the pool. However this is not shared across tasks. This PR moves the storage behind a arc mutex so that we only have a single pool

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2001)
<!-- Reviewable:end -->
