### PR TITLE
wf(tauri): stop app nightly builds

### DIFF
--- a/.github/workflows/publish-nym-vpn-app.yml
+++ b/.github/workflows/publish-nym-vpn-app.yml
@@ -1,7 +1,7 @@
 name: publish-nym-vpn-app
 on:
-  schedule:
-    - cron: "4 4 * * *"
+#  schedule:
+#    - cron: "4 4 * * *"
   workflow_dispatch:
     inputs:
       tag_name:


### PR DESCRIPTION
For some reason core nightly builds are not using the static `nym-vpn-core-nightly` tag anymore but a dynamic one, eg. `untagged-7701269101a8fa1829c9`
This prevent the scheduled nightly build of the app to pull core nightly for Windows as it fails

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2016)
<!-- Reviewable:end -->
