### PR TITLE
Handle cancellation when underlying channel(1) is congested

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
@@ -58,6 +58,7 @@ impl ConnectedMixnet {
     pub async fn start_event_listener(
         &mut self,
         event_sender: mpsc::UnboundedSender<MixnetEvent>,
+        cancel_token: CancellationToken,
     ) -> JoinHandle<()> {
         let (status_tx, status_rx) = futures::channel::mpsc::channel(10);
 
@@ -65,7 +66,7 @@ impl ConnectedMixnet {
             .start_status_listener(status_tx, TaskStatus::Ready)
             .await;
 
-        StatusListener::spawn(status_rx, event_sender)
+        StatusListener::spawn(status_rx, event_sender, cancel_token)
     }
 
     /// Creates a tunnel over Mixnet.

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -310,7 +310,10 @@ impl TunnelMonitor {
         }
 
         let status_listener_handle = connected_mixnet
-            .start_event_listener(self.mixnet_event_sender.clone())
+            .start_event_listener(
+                self.mixnet_event_sender.clone(),
+                self.cancel_token.child_token(),
+            )
             .await;
 
         let selected_gateways = connected_mixnet.selected_gateways().clone();


### PR DESCRIPTION
Due to mixnet facilities using a channel(1) to pass messages, the moment the network connection is unplugged, immediately creates a congestion which leads to `channel.send()` waiting for the previous message to be consumed. This is a draft PR that solves most of these issues. 

Although there is still one more issue left related to `start_status_listener()` never stopping to pass events even after termination.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2034)
<!-- Reviewable:end -->
