### PR TITLE
vpnc: move waiting for disconnect behind --wait flag

### DIFF
--- a/nym-vpn-core/crates/nym-vpnc/src/cli.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/cli.rs
@@ -182,7 +182,7 @@ pub struct ConnectArgs {
 
     /// Blocks until the connection is established or failed
     #[arg(short, long)]
-    pub wait_until_connected: bool,
+    pub wait: bool,
 
     /// Use netstack based implementation for two-hop wireguard.
     #[arg(long, requires = "enable_two_hop")]

--- a/nym-vpn-core/crates/nym-vpnc/src/cli.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/cli.rs
@@ -9,20 +9,20 @@ use nym_gateway_directory::{EntryPoint, ExitPoint, NodeIdentity, Recipient};
 
 #[derive(Parser)]
 #[clap(author = "Nymtech", version, about)]
-pub(crate) struct CliArgs {
+pub struct CliArgs {
     /// Use HTTP instead of socket file for IPC with the daemon.
     #[arg(long)]
-    pub(crate) http: bool,
+    pub http: bool,
 
     #[arg(long)]
-    pub(crate) verbose: bool,
+    pub verbose: bool,
 
     /// Override the default user agent string.
     #[arg(long, value_parser = parse_user_agent)]
-    pub(crate) user_agent: Option<nym_http_api_client::UserAgent>,
+    pub user_agent: Option<nym_http_api_client::UserAgent>,
 
     #[command(subcommand)]
-    pub(crate) command: Command,
+    pub command: Command,
 }
 
 // TODO: make use of the From<&str> implementation for UserAgent once that is available in the
@@ -42,7 +42,7 @@ fn parse_user_agent(user_agent: &str) -> Result<nym_http_api_client::UserAgent, 
 }
 
 #[derive(Subcommand)]
-pub(crate) enum Command {
+pub enum Command {
     /// Connect to the Nym network.
     Connect(ConnectArgs),
 
@@ -108,7 +108,7 @@ pub(crate) enum Command {
 }
 
 #[derive(Subcommand)]
-pub(crate) enum Internal {
+pub enum Internal {
     /// Get the list of system messages provided by the nym-vpn-api.
     GetSystemMessages,
 
@@ -158,176 +158,176 @@ pub(crate) enum Internal {
 }
 
 #[derive(Args)]
-pub(crate) struct ConnectArgs {
+pub struct ConnectArgs {
     #[command(flatten)]
-    pub(crate) entry: CliEntry,
+    pub entry: CliEntry,
 
     #[command(flatten)]
-    pub(crate) exit: CliExit,
+    pub exit: CliExit,
 
     /// Set the IP address of the DNS server to use.
     #[arg(long)]
-    pub(crate) dns: Option<IpAddr>,
+    pub dns: Option<IpAddr>,
 
     /// Disable routing all traffic through the nym TUN device. When the flag is set, the nym TUN
     /// device will be created, but to route traffic through it you will need to do it manually,
     /// e.g. ping -Itun0.
     #[arg(long)]
-    pub(crate) disable_routing: bool,
+    pub disable_routing: bool,
 
     /// Enable two-hop wireguard traffic. This means that traffic jumps directly from entry gateway to
     /// exit gateway using Wireguard protocol.
     #[arg(long)]
-    pub(crate) enable_two_hop: bool,
+    pub enable_two_hop: bool,
 
     /// Blocks until the connection is established or failed
     #[arg(short, long)]
-    pub(crate) wait_until_connected: bool,
+    pub wait_until_connected: bool,
 
     /// Use netstack based implementation for two-hop wireguard.
     #[arg(long, requires = "enable_two_hop")]
-    pub(crate) netstack: bool,
+    pub netstack: bool,
 
     /// Disable Poisson process rate limiting of outbound traffic.
     #[arg(long, hide = true)]
-    pub(crate) disable_poisson_rate: bool,
+    pub disable_poisson_rate: bool,
 
     /// Disable constant rate background loop cover traffic.
     #[arg(long, hide = true)]
-    pub(crate) disable_background_cover_traffic: bool,
+    pub disable_background_cover_traffic: bool,
 
     /// Enable credentials mode.
     #[arg(long)]
-    pub(crate) enable_credentials_mode: bool,
+    pub enable_credentials_mode: bool,
 
     /// An integer between 0 and 100 representing the minimum mixnode performance required to
     /// consider a mixnode for routing traffic.
     #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100), hide = true)]
-    pub(crate) min_mixnode_performance: Option<u8>,
+    pub min_mixnode_performance: Option<u8>,
 
     /// An integer between 0 and 100 representing the minimum gateway performance required to
     /// consider a gateway for routing traffic.
     #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]
-    pub(crate) min_gateway_mixnet_performance: Option<u8>,
+    pub min_gateway_mixnet_performance: Option<u8>,
 
     /// An integer between 0 and 100 representing the minimum gateway performance required to
     /// consider a gateway for routing traffic.
     #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]
-    pub(crate) min_gateway_vpn_performance: Option<u8>,
+    pub min_gateway_vpn_performance: Option<u8>,
 }
 
 #[derive(Args)]
 #[group(multiple = false)]
-pub(crate) struct CliEntry {
+pub struct CliEntry {
     /// Mixnet public ID of the entry gateway.
     #[arg(long, alias = "entry-id")]
-    pub(crate) entry_gateway_id: Option<String>,
+    pub entry_gateway_id: Option<String>,
 
     /// Auto-select entry gateway by country ISO.
     #[arg(long, alias = "entry-country")]
-    pub(crate) entry_gateway_country: Option<String>,
+    pub entry_gateway_country: Option<String>,
 
     /// Auto-select entry gateway by latency
     #[arg(long, alias = "entry-fastest")]
-    pub(crate) entry_gateway_low_latency: bool,
+    pub entry_gateway_low_latency: bool,
 
     /// Auto-select entry gateway randomly.
     #[arg(long, alias = "entry-random")]
-    pub(crate) entry_gateway_random: bool,
+    pub entry_gateway_random: bool,
 }
 
 #[derive(Args)]
 #[group(multiple = false)]
-pub(crate) struct CliExit {
+pub struct CliExit {
     /// Mixnet recipient address.
     #[clap(long, alias = "exit-address")]
-    pub(crate) exit_router_address: Option<String>,
+    pub exit_router_address: Option<String>,
 
     /// Mixnet public ID of the exit gateway.
     #[clap(long, alias = "exit-id")]
-    pub(crate) exit_gateway_id: Option<String>,
+    pub exit_gateway_id: Option<String>,
 
     /// Auto-select exit gateway by country ISO.
     #[clap(long, alias = "exit-country")]
-    pub(crate) exit_gateway_country: Option<String>,
+    pub exit_gateway_country: Option<String>,
 
     /// Auto-select exit gateway randomly.
     #[clap(long, alias = "exit-random")]
-    pub(crate) exit_gateway_random: bool,
+    pub exit_gateway_random: bool,
 }
 
 #[derive(Args)]
-pub(crate) struct SetNetworkArgs {
+pub struct SetNetworkArgs {
     /// The network to be set.
-    pub(crate) network: String,
+    pub network: String,
 }
 
 #[derive(Args)]
-pub(crate) struct StoreAccountArgs {
+pub struct StoreAccountArgs {
     /// The account mnemonic to be stored.
     #[arg(long)]
-    pub(crate) mnemonic: String,
+    pub mnemonic: String,
 }
 
 #[derive(Args)]
-pub(crate) struct GetAccountLinksArgs {
+pub struct GetAccountLinksArgs {
     /// The locale to be used.
     #[arg(long)]
-    pub(crate) locale: String,
+    pub locale: String,
 }
 
 #[derive(Args)]
-pub(crate) struct ListGatewaysArgs {
+pub struct ListGatewaysArgs {
     /// Display additional information about the gateways.
     #[arg(long, short)]
-    pub(crate) verbose: bool,
+    pub verbose: bool,
 
     /// An integer between 0 and 100 representing the minimum gateway performance required to
     /// consider a gateway for routing traffic.
     #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]
-    pub(crate) min_mixnet_performance: Option<u8>,
+    pub min_mixnet_performance: Option<u8>,
 
     /// An integer between 0 and 100 representing the minimum gateway performance required to
     /// consider a gateway for routing traffic.
     #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]
-    pub(crate) min_vpn_performance: Option<u8>,
+    pub min_vpn_performance: Option<u8>,
 }
 
 #[derive(Args)]
-pub(crate) struct ListCountriesArgs {
+pub struct ListCountriesArgs {
     /// An integer between 0 and 100 representing the minimum gateway performance required to
     /// consider a gateway for routing traffic.
     #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]
-    pub(crate) min_mixnet_performance: Option<u8>,
+    pub min_mixnet_performance: Option<u8>,
 
     /// An integer between 0 and 100 representing the minimum gateway performance required to
     /// consider a gateway for routing traffic.
     #[arg(long, value_parser = clap::value_parser!(u8).range(0..=100))]
-    pub(crate) min_vpn_performance: Option<u8>,
+    pub min_vpn_performance: Option<u8>,
 }
 
 #[derive(Args)]
-pub(crate) struct ResetDeviceIdentityArgs {
+pub struct ResetDeviceIdentityArgs {
     /// Reset the device identity using the given seed.
     #[arg(long)]
-    pub(crate) seed: Option<String>,
+    pub seed: Option<String>,
 }
 
 #[derive(Args)]
-pub(crate) struct GetZkNymByIdArgs {
+pub struct GetZkNymByIdArgs {
     /// The ID of the ZK Nym to fetch.
     #[arg(short, long)]
-    pub(crate) id: String,
+    pub id: String,
 }
 
 #[derive(Args)]
-pub(crate) struct ConfirmZkNymDownloadedArgs {
+pub struct ConfirmZkNymDownloadedArgs {
     /// The ID of the ZK Nym to confirm.
     #[arg(short, long)]
-    pub(crate) id: String,
+    pub id: String,
 }
 
-pub(crate) fn parse_entry_point(args: &ConnectArgs) -> Result<Option<EntryPoint>> {
+pub fn parse_entry_point(args: &ConnectArgs) -> Result<Option<EntryPoint>> {
     if let Some(ref entry_gateway_id) = args.entry.entry_gateway_id {
         Ok(Some(EntryPoint::Gateway {
             identity: NodeIdentity::from_base58_string(entry_gateway_id.clone())
@@ -346,7 +346,7 @@ pub(crate) fn parse_entry_point(args: &ConnectArgs) -> Result<Option<EntryPoint>
     }
 }
 
-pub(crate) fn parse_exit_point(args: &ConnectArgs) -> Result<Option<ExitPoint>> {
+pub fn parse_exit_point(args: &ConnectArgs) -> Result<Option<ExitPoint>> {
     if let Some(ref exit_router_address) = args.exit.exit_router_address {
         Ok(Some(ExitPoint::Address {
             address: Recipient::try_from_base58_string(exit_router_address.clone())

--- a/nym-vpn-core/crates/nym-vpnc/src/cli.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/cli.rs
@@ -47,7 +47,11 @@ pub enum Command {
     Connect(ConnectArgs),
 
     /// Disconnect from the Nym network.
-    Disconnect,
+    Disconnect {
+        /// Blocks until disconnected.
+        #[arg(long, default_value = "false", action = ArgAction::SetTrue)]
+        wait: bool,
+    },
 
     /// Get the current status of the connection.
     Status {

--- a/nym-vpn-core/crates/nym-vpnc/src/config.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/config.rs
@@ -3,7 +3,7 @@
 
 use std::path::{Path, PathBuf};
 
-pub(super) fn get_socket_path() -> PathBuf {
+pub fn get_socket_path() -> PathBuf {
     #[cfg(unix)]
     return Path::new("/var/run/nym-vpn.sock").to_path_buf();
 
@@ -11,6 +11,6 @@ pub(super) fn get_socket_path() -> PathBuf {
     return Path::new(r"\\.\pipe\nym-vpn").to_path_buf();
 }
 
-pub(crate) fn default_endpoint() -> String {
+pub fn default_endpoint() -> String {
     "http://[::1]:53181".to_string()
 }

--- a/nym-vpn-core/crates/nym-vpnc/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/main.rs
@@ -7,7 +7,7 @@ mod config;
 mod protobuf_conversion;
 mod vpnd_client;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{bail, Context, Result};
 use clap::Parser;
 use cli::Internal;
 use itertools::Itertools;
@@ -179,9 +179,9 @@ async fn connect(opts: CliOptions, connect_args: &cli::ConnectArgs) -> Result<()
 }
 
 async fn handle_connect_success(opts: CliOptions, connect_args: &cli::ConnectArgs) -> Result<()> {
-    if connect_args.wait_until_connected {
+    if connect_args.wait {
         println!("Successfully sent connect command, waiting for connected state");
-        listen_until_connected_or_failed(opts).await
+        wait_until_connected(opts).await
     } else {
         println!("Successfully sent connect command");
         Ok(())
@@ -202,7 +202,7 @@ fn handle_connect_failure(error: nym_vpn_proto::ConnectRequestError) -> Result<(
     Ok(())
 }
 
-async fn listen_until_connected_or_failed(opts: CliOptions) -> Result<()> {
+async fn wait_until_connected(opts: CliOptions) -> Result<()> {
     let mut client = vpnd_client::get_client(&opts.client_type).await?;
 
     let mut stream = client.listen_to_tunnel_state(()).await?.into_inner();
@@ -210,10 +210,21 @@ async fn listen_until_connected_or_failed(opts: CliOptions) -> Result<()> {
         let new_state = TunnelState::try_from(new_state)?;
         println!("{}", new_state);
 
-        if matches!(new_state, TunnelState::Connected { .. }) {
-            break;
-        } else if matches!(new_state, TunnelState::Error(_)) {
-            return Err(anyhow!("Connection failed"));
+        match new_state {
+            TunnelState::Connected { .. } => {
+                break;
+            }
+            TunnelState::Offline { reconnect } => {
+                if reconnect {
+                    println!("Device is offline. Waiting for network connectivity.");
+                } else {
+                    bail!("Device is offline");
+                }
+            }
+            TunnelState::Error(reason) => {
+                bail!("Tunnel entered error state {:?}", reason);
+            }
+            _ => {}
         }
     }
     Ok(())

--- a/nym-vpn-core/crates/nym-vpnc/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/main.rs
@@ -50,7 +50,7 @@ async fn main() -> Result<()> {
 
     match args.command {
         Command::Connect(ref connect_args) => connect(opts, connect_args).await?,
-        Command::Disconnect => disconnect(opts).await?,
+        Command::Disconnect { wait } => disconnect(opts, wait).await?,
         Command::Status { listen } => status(listen, opts).await?,
         Command::Info => info(opts.client_type).await?,
         Command::SetNetwork(ref args) => set_network(opts.client_type, args).await?,
@@ -180,7 +180,7 @@ async fn connect(opts: CliOptions, connect_args: &cli::ConnectArgs) -> Result<()
 
 async fn handle_connect_success(opts: CliOptions, connect_args: &cli::ConnectArgs) -> Result<()> {
     if connect_args.wait {
-        println!("Successfully sent connect command, waiting for connected state");
+        println!("Successfully sent connect command. Waiting until connected or failed.");
         wait_until_connected(opts).await
     } else {
         println!("Successfully sent connect command");
@@ -230,7 +230,7 @@ async fn wait_until_connected(opts: CliOptions) -> Result<()> {
     Ok(())
 }
 
-async fn disconnect(opts: CliOptions) -> Result<()> {
+async fn disconnect(opts: CliOptions, wait: bool) -> Result<()> {
     let mut client = vpnd_client::get_client(&opts.client_type.clone()).await?;
     let response = client.vpn_disconnect(()).await?.into_inner();
 
@@ -239,25 +239,34 @@ async fn disconnect(opts: CliOptions) -> Result<()> {
     }
 
     if response.success {
-        println!("Successfully sent disconnect command, waiting for disconnected state");
-        listen_until_disconnected(opts).await
+        if wait {
+            println!("Successfully sent disconnect command. Waiting until disconnected.");
+            wait_until_disconnected(opts).await
+        } else {
+            println!("Successfully sent disconnect command");
+            Ok(())
+        }
     } else {
         println!("Disconnect command failed");
         Ok(())
     }
 }
 
-async fn listen_until_disconnected(opts: CliOptions) -> Result<()> {
+async fn wait_until_disconnected(opts: CliOptions) -> Result<()> {
     let mut client = vpnd_client::get_client(&opts.client_type).await?;
-
     let mut stream = client.listen_to_tunnel_state(()).await?.into_inner();
-
     while let Some(new_state) = stream.message().await? {
         let new_state = TunnelState::try_from(new_state)?;
         println!("{}", new_state);
 
-        if matches!(new_state, TunnelState::Disconnected | TunnelState::Error(_)) {
-            break;
+        match new_state {
+            TunnelState::Disconnected | TunnelState::Offline { .. } => {
+                break;
+            }
+            TunnelState::Error(reason) => {
+                bail!("Tunnel entered error state: {:?}", reason)
+            }
+            _ => {}
         }
     }
     Ok(())

--- a/nym-vpn-core/crates/nym-vpnc/src/protobuf_conversion.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/protobuf_conversion.rs
@@ -3,7 +3,7 @@
 
 use nym_gateway_directory::{EntryPoint, ExitPoint, GatewayType};
 
-pub(crate) fn into_entry_point(entry: EntryPoint) -> nym_vpn_proto::EntryNode {
+pub fn into_entry_point(entry: EntryPoint) -> nym_vpn_proto::EntryNode {
     match entry {
         EntryPoint::Gateway { identity } => nym_vpn_proto::EntryNode::from(&identity),
         EntryPoint::Location { location } => nym_vpn_proto::EntryNode::new_from_location(&location),
@@ -12,7 +12,7 @@ pub(crate) fn into_entry_point(entry: EntryPoint) -> nym_vpn_proto::EntryNode {
     }
 }
 
-pub(crate) fn into_exit_point(exit: ExitPoint) -> nym_vpn_proto::ExitNode {
+pub fn into_exit_point(exit: ExitPoint) -> nym_vpn_proto::ExitNode {
     match exit {
         ExitPoint::Address { address } => nym_vpn_proto::ExitNode::from(&address),
         ExitPoint::Gateway { identity } => nym_vpn_proto::ExitNode::from(&identity),
@@ -21,7 +21,7 @@ pub(crate) fn into_exit_point(exit: ExitPoint) -> nym_vpn_proto::ExitNode {
     }
 }
 
-pub(crate) fn into_gateway_type(gateway_type: GatewayType) -> nym_vpn_proto::GatewayType {
+pub fn into_gateway_type(gateway_type: GatewayType) -> nym_vpn_proto::GatewayType {
     match gateway_type {
         GatewayType::MixnetEntry => nym_vpn_proto::GatewayType::MixnetEntry,
         GatewayType::MixnetExit => nym_vpn_proto::GatewayType::MixnetExit,

--- a/nym-vpn-core/crates/nym-vpnc/src/vpnd_client.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/vpnd_client.rs
@@ -11,14 +11,12 @@ use tonic::transport::{Channel as TonicChannel, Endpoint as TonicEndpoint};
 use crate::config;
 
 #[derive(Debug, Clone)]
-pub(crate) enum ClientType {
+pub enum ClientType {
     Http,
     Ipc,
 }
 
-pub(crate) async fn get_client(
-    client_type: &ClientType,
-) -> anyhow::Result<NymVpndClient<TonicChannel>> {
+pub async fn get_client(client_type: &ClientType) -> anyhow::Result<NymVpndClient<TonicChannel>> {
     match client_type {
         ClientType::Http => get_http_client().await,
         ClientType::Ipc => get_ipc_client().await,


### PR DESCRIPTION
- Move waiting for `disconnect` behind `--wait`
- Remove unusual for binary visibility levels such as `pub(super)` and `pub(crate)` and replace them with `pub`
- Rename `--wait-until-connected` in `connect` command to `--wait` to sync up with `disconnect`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2064)
<!-- Reviewable:end -->
