### PR TITLE
fix(tauri): handle correctly connected-at timestamp

### DIFF
--- a/nym-vpn-app/src-tauri/Cargo.lock
+++ b/nym-vpn-app/src-tauri/Cargo.lock
@@ -3091,7 +3091,7 @@ dependencies = [
 [[package]]
 name = "nym-bin-common"
 version = "0.6.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.2-hu#6e6675f7bffcc795f08a17c0e6d15c8a7cbcb829"
+source = "git+https://github.com/nymtech/nym?branch=2025.2-hu-fork#1e5f249275396f804ca8e866bff326b2c61fd2d5"
 dependencies = [
  "const-str",
  "log",
@@ -3103,7 +3103,7 @@ dependencies = [
 [[package]]
 name = "nym-http-api-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.2-hu#6e6675f7bffcc795f08a17c0e6d15c8a7cbcb829"
+source = "git+https://github.com/nymtech/nym?branch=2025.2-hu-fork#1e5f249275396f804ca8e866bff326b2c61fd2d5"
 dependencies = [
  "async-trait",
  "http 1.2.0",

--- a/nym-vpn-app/src-tauri/src/commands/tunnel.rs
+++ b/nym-vpn-app/src-tauri/src/commands/tunnel.rs
@@ -58,8 +58,8 @@ pub async fn connect(
     // release the lock
     drop(app_state);
 
-    info!("entry {}", entry.code);
-    info!("exit {}", exit.code);
+    info!("entry [{}]", entry.code);
+    info!("exit [{}]", exit.code);
     let two_hop_mod = if let VpnMode::TwoHop = vpn_mode {
         info!("mode [wg]");
         true

--- a/nym-vpn-app/src-tauri/src/grpc/mod.rs
+++ b/nym-vpn-app/src-tauri/src/grpc/mod.rs
@@ -6,6 +6,7 @@ pub mod feature_flags;
 mod node;
 pub mod ready_to_connect;
 pub mod system_message;
+mod timestamp;
 pub mod tunnel;
 mod version_check;
 pub mod vpnd_status;

--- a/nym-vpn-app/src-tauri/src/grpc/timestamp.rs
+++ b/nym-vpn-app/src-tauri/src/grpc/timestamp.rs
@@ -1,0 +1,12 @@
+use anyhow::Result;
+use nym_vpn_proto as p;
+use time::{Duration, OffsetDateTime};
+use tracing::{error, instrument};
+
+#[instrument]
+pub fn proto_timestamp_to_datetime(timestamp: p::Timestamp) -> Result<OffsetDateTime> {
+    let date_time = OffsetDateTime::from_unix_timestamp(timestamp.seconds)
+        .inspect_err(|e| error!("failed to parse timestamp [{}]: {}", timestamp.seconds, e))?;
+    // kinda overkill to get nanosec precision >_> but why not
+    Ok(date_time + Duration::nanoseconds(timestamp.nanos as i64))
+}

--- a/nym-vpn-app/src/types/tunnel.ts
+++ b/nym-vpn-app/src/types/tunnel.ts
@@ -47,7 +47,7 @@ export function isTunnelError(state: TunnelState): state is TunnelStateError {
 export type Tunnel = {
   entryGwId: string;
   exitGwId: string;
-  connectedAt: number | null;
+  connectedAt: number | null; // unix timestamp
   data: TunnelData;
 };
 

--- a/nym-vpn-core/crates/nym-vpn-proto/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/lib.rs
@@ -11,3 +11,6 @@ pub const VPN_FD_SET: &[u8] = tonic::include_file_descriptor_set!("vpn_descripto
 
 #[cfg(feature = "conversions")]
 pub mod conversions;
+
+// Re-export needed prost types
+pub use prost_types::Timestamp;


### PR DESCRIPTION
- remove useless conversion from proto timestamp into UTC datetime (for now)
- do not error log when `connected_at` field is null (while tunnel data is received during `connecting` state)
- add helper for future conversion btw proto timestamp and datetime

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2076)
<!-- Reviewable:end -->
