### PR TITLE
Don't generate debug symbols on CI

### DIFF
--- a/.github/workflows/ci-nym-vpn-core-linux.yml
+++ b/.github/workflows/ci-nym-vpn-core-linux.yml
@@ -42,8 +42,9 @@ jobs:
 
       # To avoid running out of disk space, skip generating debug symbols
       - name: Set debug to false
+        working-directory: nym-vpn-core
         run: |
-          sed -i.bak 's/\[profile.dev\]/\[profile.dev\]\ndebug = false/' Cargo.toml
+          sed -i.bak '1s/^/\[profile.dev\]\ndebug = false\n\n/' Cargo.toml
           git diff
 
       - name: Build wireguard

--- a/.github/workflows/ci-nym-vpn-core-linux.yml
+++ b/.github/workflows/ci-nym-vpn-core-linux.yml
@@ -40,6 +40,20 @@ jobs:
           version: "21.12" # 3.21.12: the version on ubuntu 24.04. Don't change this!
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      # To avoid running out of disk space, skip generating debug symbols
+      - name: Set debug to false (unix)
+        if: matrix.os == 'ubuntu-20.04' || matrix.os == 'macos-latest'
+        run: |
+          sed -i.bak 's/\[profile.dev\]/\[profile.dev\]\ndebug = false/' Cargo.toml
+          git diff
+
+      - name: Set debug to false (win)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          (Get-Content Cargo.toml) -replace '\[profile.dev\]', "`$&`ndebug = false" | Set-Content Cargo.toml
+          git diff
+
       - name: Build wireguard
         shell: bash
         run: |

--- a/.github/workflows/ci-nym-vpn-core-linux.yml
+++ b/.github/workflows/ci-nym-vpn-core-linux.yml
@@ -41,17 +41,9 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       # To avoid running out of disk space, skip generating debug symbols
-      - name: Set debug to false (unix)
-        if: matrix.os == 'ubuntu-20.04' || matrix.os == 'macos-latest'
+      - name: Set debug to false
         run: |
           sed -i.bak 's/\[profile.dev\]/\[profile.dev\]\ndebug = false/' Cargo.toml
-          git diff
-
-      - name: Set debug to false (win)
-        if: matrix.os == 'windows-latest'
-        shell: pwsh
-        run: |
-          (Get-Content Cargo.toml) -replace '\[profile.dev\]', "`$&`ndebug = false" | Set-Content Cargo.toml
           git diff
 
       - name: Build wireguard


### PR DESCRIPTION
To avoid running out of disk space during CI builds, disable debug
symbols

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2106)
<!-- Reviewable:end -->
