### PR TITLE
Promote tunnel state to info level

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -405,7 +405,7 @@ impl TunnelStateMachine {
                     self.current_state_handler = new_state_handler;
 
                     let state = TunnelState::from(new_state);
-                    tracing::debug!("New tunnel state: {}", state);
+                    tracing::info!("New tunnel state: {}", state);
                     let _ = self.event_sender.send(TunnelEvent::NewState(state));
                 }
                 NextTunnelState::SameState(same_state) => {


### PR DESCRIPTION
Debug log is very chatty and it was requested to print the tunnel state in logs to see what's going with the state machine without enabling the whole bunch of uninteresting logs. This PR simply promotes tunnel state logging to info level.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2124)
<!-- Reviewable:end -->
