### PR TITLE
tauri: nectarine.2 release

### DIFF
--- a/nym-vpn-app/src-tauri/Cargo.lock
+++ b/nym-vpn-app/src-tauri/Cargo.lock
@@ -3238,7 +3238,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-app"
-version = "1.3.0-nectarine.1"
+version = "1.3.0-nectarine.2"
 dependencies = [
  "anyhow",
  "build-info",

--- a/nym-vpn-app/src-tauri/Cargo.toml
+++ b/nym-vpn-app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nym-vpn-app"
-version = "1.3.0-nectarine.1"
+version = "1.3.0-nectarine.2"
 description = "NymVPN desktop client"
 authors = [
     "Nym Technologies SA",

--- a/nym-vpn-app/src-tauri/tauri.conf.json
+++ b/nym-vpn-app/src-tauri/tauri.conf.json
@@ -35,7 +35,7 @@
     },
     "linux": {
       "deb": {
-        "depends": ["nym-vpnd (>= 1.3.0~dev) | nym-vpnd (>= 1.3.0~beta.0)"],
+        "depends": ["nym-vpnd (>= 1.3.0~beta)"],
         "conflicts": ["nymvpn-x"],
         "desktopTemplate": "./bundle/deb/main.desktop"
       }


### PR DESCRIPTION
- bump version
- revert vpnd deb requirement to `"nym-vpnd (>= 1.3.0~beta)"`

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2133)
<!-- Reviewable:end -->
