### PR TITLE
Fix publish conditional in workflow

### DIFF
--- a/.github/workflows/publish-nym-vpn-core.yml
+++ b/.github/workflows/publish-nym-vpn-core.yml
@@ -186,7 +186,7 @@ jobs:
           echo 'EOF' >> $GITHUB_ENV
 
       - name: Publish release
-        if: ${{ inputs.publish == 'true' || inputs.publish == true || contains(env.TAG_NAME, 'nightly') }}
+        if: ${{ inputs.publish == 'true' || inputs.publish == true || contains(env.TAG_NAME, 'nightly') || github.event_name == 'push' }}
         run: |
           echo "Setting up the release notes"
           envsubst < "$GITHUB_WORKSPACE/.github/workflows/$NOTES_FILE" > "$RUNNER_TEMP/release-notes.md"


### PR DESCRIPTION
Fix the conditional that determines if the publish workflow should also enable the step for publishing to github, by making sure it's also true for release tags being pushed

We unconditionally always publish to our build archive.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2143)
<!-- Reviewable:end -->
