### PR TITLE
Automatically set tag when publishing nym-vpn-core

### DIFF
--- a/.github/workflows/build-nym-vpn-core-android.yml
+++ b/.github/workflows/build-nym-vpn-core-android.yml
@@ -71,7 +71,7 @@ jobs:
         run: cargo install --locked cargo-edit
 
       - name: Append timestamp if it's a dev version
-        run: ./scripts/append-timestamp-to-version.sh nym-vpn-core/Cargo.toml ${{ steps.workspace-version.outputs.output }}
+        run: ./scripts/append-timestamp-to-version.sh nym-vpn-core/Cargo.toml ${{ steps.workspace-version.outputs.metadata }}
 
       - name: Download wireguard-go artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/build-nym-vpn-core-deb.yml
+++ b/.github/workflows/build-nym-vpn-core-deb.yml
@@ -56,7 +56,7 @@ jobs:
         run: cargo install --locked cargo-edit
 
       - name: Append timestamp if it's a dev version
-        run: ./scripts/append-timestamp-to-version.sh nym-vpn-core/Cargo.toml ${{ steps.workspace-version.outputs.output }}
+        run: ./scripts/append-timestamp-to-version.sh nym-vpn-core/Cargo.toml ${{ steps.workspace-version.outputs.metadata }}
 
       - name: Download wireguard-go artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/build-nym-vpn-core-ios.yml
+++ b/.github/workflows/build-nym-vpn-core-ios.yml
@@ -57,7 +57,7 @@ jobs:
         run: cargo install --locked cargo-edit
 
       - name: Append timestamp if it's a dev version
-        run: ./scripts/append-timestamp-to-version.sh nym-vpn-core/Cargo.toml ${{ steps.workspace-version.outputs.output }}
+        run: ./scripts/append-timestamp-to-version.sh nym-vpn-core/Cargo.toml ${{ steps.workspace-version.outputs.metadata }}
 
       - name: Download wireguard-go artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/build-nym-vpn-core-linux.yml
+++ b/.github/workflows/build-nym-vpn-core-linux.yml
@@ -56,7 +56,7 @@ jobs:
         run: cargo install --locked cargo-edit
 
       - name: Append timestamp if it's a dev version
-        run: ./scripts/append-timestamp-to-version.sh nym-vpn-core/Cargo.toml ${{ steps.workspace-version.outputs.output }}
+        run: ./scripts/append-timestamp-to-version.sh nym-vpn-core/Cargo.toml ${{ steps.workspace-version.outputs.metadata }}
 
       - name: Download wireguard-go artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/build-nym-vpn-core-mac.yml
+++ b/.github/workflows/build-nym-vpn-core-mac.yml
@@ -76,7 +76,7 @@ jobs:
         run: cargo install --locked cargo-edit || true
 
       - name: Append timestamp if it's a dev version
-        run: ./scripts/append-timestamp-to-version.sh nym-vpn-core/Cargo.toml ${{ steps.workspace-version.outputs.output }}
+        run: ./scripts/append-timestamp-to-version.sh nym-vpn-core/Cargo.toml ${{ steps.workspace-version.outputs.metadata }}
 
       - name: Download wireguard-go artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/build-nym-vpn-core-windows.yml
+++ b/.github/workflows/build-nym-vpn-core-windows.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Append timestamp if it's a dev version
         shell: bash
-        run: ./scripts/append-timestamp-to-version.sh nym-vpn-core/Cargo.toml ${{ steps.workspace-version.outputs.output }}
+        run: ./scripts/append-timestamp-to-version.sh nym-vpn-core/Cargo.toml ${{ steps.workspace-version.outputs.metadata }}
 
       - name: Download wireguard-go-windows artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/generate-build-info-core.yml
+++ b/.github/workflows/generate-build-info-core.yml
@@ -43,7 +43,7 @@ jobs:
         run: cargo install --locked cargo-edit
 
       - name: Append timestamp if it's a dev version
-        run: ./scripts/append-timestamp-to-version.sh nym-vpn-core/Cargo.toml ${{ steps.workspace-version.outputs.output }}
+        run: ./scripts/append-timestamp-to-version.sh nym-vpn-core/Cargo.toml ${{ steps.workspace-version.outputs.metadata }}
 
       - name: Get package version nym-vpnc
         id: package-version-vpnc

--- a/.github/workflows/publish-nym-vpn-core.yml
+++ b/.github/workflows/publish-nym-vpn-core.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       publish_to_github:
-        description: "If the build should be published to github. Will only have an effect if the version is set to a non-pre-release version."
+        description: "If the build should be published to github. Only has an effect for pre-releases, if the version is not a pre-release then it will be automatically published."
         type: boolean
         default: false
         required: true
@@ -174,7 +174,7 @@ jobs:
           echo 'EOF' >> $GITHUB_ENV
 
       - name: Publish release
-        if: ${{ inputs.publish_to_github == 'true' || inputs.publish_to_github == true || github.event_name == 'push' }}
+        if: ${{ !contains(steps.workspace-version.outputs.metadata, '-') || inputs.publish_to_github == true || inputs.publish_to_github == 'true' }}
         run: |
           echo "Setting up the release notes"
           envsubst < "$GITHUB_WORKSPACE/.github/workflows/$NOTES_FILE" > "$RUNNER_TEMP/release-notes.md"
@@ -233,7 +233,7 @@ jobs:
           TARGET: ${{ secrets.CI_WWW_REMOTE_TARGET }}/builds/nym-vpn-client/nym-vpn-core
 
   gen-hashes:
-    if: ${{ inputs.publish_to_github == 'true' || inputs.publish_to_github == true || github.event_name == 'push' }}
+    if: ${{ !contains(steps.workspace-version.outputs.metadata, '-') || inputs.publish_to_github == true || inputs.publish_to_github == 'true' }}
     uses: ./.github/workflows/gen-hashes-json.yml
     needs: publish
     with:

--- a/.github/workflows/publish-nym-vpn-core.yml
+++ b/.github/workflows/publish-nym-vpn-core.yml
@@ -58,6 +58,7 @@ jobs:
       contents: write
     outputs:
       tag: ${{ steps.set_tag.outputs.tag }}
+      ok_to_publish: ${{ steps.determine-ok-to-publish.outputs.ok_to_publish }}
 
     steps:
       - name: Checkout repo
@@ -94,6 +95,21 @@ jobs:
 
       - name: Download artifacts
         uses: actions/download-artifact@v4
+
+      - name: Determine if we should publish
+        id: determine-ok-to-publish
+        run: |
+          version="${{ steps.workspace-version.outputs.metadata }}"
+          should_publish="false"
+          # If version does NOT contain '-' => stable => auto-publish
+          if [[ "$version" != *"-"* ]]; then
+            should_publish="true"
+          fi
+          # Or if the user explicitly sets publish_to_github
+          if [[ "${{ inputs.publish_to_github }}" == "true" ]]; then
+            should_publish="true"
+          fi
+          echo "ok_to_publish=$should_publish" >> "$GITHUB_OUTPUT"
 
       # Setup TAG_NAME, which is used as a general "name"
       - if: github.event_name == 'workflow_dispatch'
@@ -173,8 +189,8 @@ jobs:
           cat build-info/build-info.txt >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
 
-      - name: Publish release
-        if: ${{ !contains(steps.workspace-version.outputs.metadata, '-') || inputs.publish_to_github == true || inputs.publish_to_github == 'true' }}
+      - name: Publish release to github
+        if: ${{ steps.determine-ok-to-publish.outputs.ok_to_publish == 'true' }}
         run: |
           echo "Setting up the release notes"
           envsubst < "$GITHUB_WORKSPACE/.github/workflows/$NOTES_FILE" > "$RUNNER_TEMP/release-notes.md"
@@ -205,7 +221,7 @@ jobs:
           mkdir -p $OUTPUT_DIR
           echo $OUTPUT_DIR
 
-      - name: Prepare build output
+      - name: Prepare build output artifacts
         shell: bash
         run: |
           cp -v ${{ env.ARCHIVE_LINUX }}.tar.gz ${{ env.OUTPUT_DIR }} || true
@@ -233,9 +249,9 @@ jobs:
           TARGET: ${{ secrets.CI_WWW_REMOTE_TARGET }}/builds/nym-vpn-client/nym-vpn-core
 
   gen-hashes:
-    if: ${{ !contains(steps.workspace-version.outputs.metadata, '-') || inputs.publish_to_github == true || inputs.publish_to_github == 'true' }}
-    uses: ./.github/workflows/gen-hashes-json.yml
     needs: publish
+    if: ${{ needs.publish.outputs.ok_to_publish == 'true' }}
+    uses: ./.github/workflows/gen-hashes-json.yml
     with:
       release_tag: ${{ needs.publish.outputs.tag }}
     secrets: inherit

--- a/.github/workflows/publish-nym-vpn-core.yml
+++ b/.github/workflows/publish-nym-vpn-core.yml
@@ -162,10 +162,9 @@ jobs:
           fi
           echo 'EOF' >> $GITHUB_ENV
 
-      - name: Setting subject, prerelease and notes files
+      - name: Setting subject and notes files
         run: |
           (echo "SUBJECT=$TAG_NAME"
-           echo 'PRERELEASE='
            echo 'NOTES_FILE=release-notes/release-notes-core.md') >> $GITHUB_ENV
 
       - name: Build info
@@ -180,7 +179,7 @@ jobs:
           echo "Setting up the release notes"
           envsubst < "$GITHUB_WORKSPACE/.github/workflows/$NOTES_FILE" > "$RUNNER_TEMP/release-notes.md"
           echo "Creating the release"
-          gh release create $TAG_NAME ${{ env.PRERELEASE }} \
+          gh release create $TAG_NAME \
             --notes-file "$RUNNER_TEMP/release-notes.md" \
             --title "$SUBJECT" \
             --target $GITHUB_SHA

--- a/.github/workflows/publish-nym-vpn-core.yml
+++ b/.github/workflows/publish-nym-vpn-core.yml
@@ -4,11 +4,8 @@ on:
     - cron: "4 2 * * *"
   workflow_dispatch:
     inputs:
-      tag_name:
-        description: "Tag name for release"
-        required: false
-        default: nym-vpn-core-nightly
-      publish:
+      publish_to_github:
+        description: "If the build should be published to github. Will only have an effect if the version is set to a non-pre-release version."
         type: boolean
         default: false
         required: true
@@ -86,7 +83,7 @@ jobs:
       - name: Install cargo-edit
         run: cargo install --locked cargo-edit
 
-      - name: Append timestamp if it's a dev version
+      - name: Append timestamp if it's a pre-release version
         run: ./scripts/append-timestamp-to-version.sh nym-vpn-core/Cargo.toml ${{ steps.workspace-version-pre.outputs.output }}
 
       - name: Get nym-vpn-core workspace version (post-append)
@@ -100,7 +97,7 @@ jobs:
 
       # Setup TAG_NAME, which is used as a general "name"
       - if: github.event_name == 'workflow_dispatch'
-        run: echo "TAG_NAME=${{ github.event.inputs.tag_name }}" >> $GITHUB_ENV
+        run: echo "TAG_NAME=nym-vpn-core-v${{ steps.workspace-version.outputs.metadata }}" >> $GITHUB_ENV
       - if: github.event_name == 'schedule'
         run: echo 'TAG_NAME=nym-vpn-core-nightly' >> $GITHUB_ENV
       - if: github.event_name == 'push'
@@ -111,12 +108,14 @@ jobs:
         run: echo "tag=${{ env.TAG_NAME }}" >> "$GITHUB_OUTPUT"
 
       - name: Generate checksums and create tar.gz archive per platform
+        env:
+          BASENAME: nym-vpn-core-v${{ steps.workspace-version.outputs.metadata }}
         run: |
-          ARCHIVE_LINUX=nym-vpn-core-v${{ steps.workspace-version.outputs.metadata }}_linux_x86_64
-          ARCHIVE_MAC=nym-vpn-core-v${{ steps.workspace-version.outputs.metadata }}_macos_universal
-          ARCHIVE_ANDROID=nym-vpn-core-v${{ steps.workspace-version.outputs.metadata }}_android_aarch64
-          ARCHIVE_IOS=nym-vpn-core-v${{ steps.workspace-version.outputs.metadata }}_ios_universal
-          ARCHIVE_WINDOWS=nym-vpn-core-v${{ steps.workspace-version.outputs.metadata }}_windows_x86_64
+          ARCHIVE_LINUX=${BASENAME}_linux_x86_64
+          ARCHIVE_MAC=${BASENAME}_macos_universal
+          ARCHIVE_ANDROID=${BASENAME}_android_aarch64
+          ARCHIVE_IOS=${BASENAME}_ios_universal
+          ARCHIVE_WINDOWS=${BASENAME}_windows_x86_64
           echo "ARCHIVE_LINUX=${ARCHIVE_LINUX}" >> $GITHUB_ENV
           echo "ARCHIVE_MAC=${ARCHIVE_MAC}" >> $GITHUB_ENV
           echo "ARCHIVE_ANDROID=${ARCHIVE_ANDROID}" >> $GITHUB_ENV
@@ -164,16 +163,6 @@ jobs:
           echo 'EOF' >> $GITHUB_ENV
 
       - name: Setting subject, prerelease and notes files
-        if: ${{ contains(env.TAG_NAME, 'nightly') }}
-        run: |
-          (echo "SUBJECT=nym-vpn-core-v${{ steps.workspace-version.outputs.metadata }} nightly prerelease build";
-           echo 'PRERELEASE=--prerelease';
-           echo 'NOTES_FILE=release-notes/release-notes-core-nightly.md') >> $GITHUB_ENV
-          gh release delete nym-vpn-core-nightly --yes || true
-          git push origin :nym-vpn-core-nightly || true
-
-      - name: Removing --prerelease if needed
-        if: ${{ !contains(env.TAG_NAME, 'nightly') }}
         run: |
           (echo "SUBJECT=$TAG_NAME"
            echo 'PRERELEASE='
@@ -186,7 +175,7 @@ jobs:
           echo 'EOF' >> $GITHUB_ENV
 
       - name: Publish release
-        if: ${{ inputs.publish == 'true' || inputs.publish == true || contains(env.TAG_NAME, 'nightly') || github.event_name == 'push' }}
+        if: ${{ inputs.publish_to_github == 'true' || inputs.publish_to_github == true || github.event_name == 'push' }}
         run: |
           echo "Setting up the release notes"
           envsubst < "$GITHUB_WORKSPACE/.github/workflows/$NOTES_FILE" > "$RUNNER_TEMP/release-notes.md"
@@ -201,7 +190,7 @@ jobs:
           test -f ${{ env.ARCHIVE_IOS }}.zip &&         gh release upload $TAG_NAME ${{ env.ARCHIVE_IOS }}.zip ${{ env.ARCHIVE_IOS }}.zip.sha256sum
           test -f ${{ env.ARCHIVE_ANDROID }}.tar.gz &&  gh release upload $TAG_NAME ${{ env.ARCHIVE_ANDROID }}.tar.gz ${{ env.ARCHIVE_ANDROID }}.tar.gz.sha256sum
           test -f ${{ env.ARCHIVE_WINDOWS }}.zip &&     gh release upload $TAG_NAME ${{ env.ARCHIVE_WINDOWS }}.zip ${{ env.ARCHIVE_WINDOWS }}.zip.sha256sum
-          test -d ${{ env.UPLOAD_DIR_DEB }} &&   gh release upload $TAG_NAME ${{ env.UPLOAD_DIR_DEB}}/nym-vpn*_amd64.deb ${{ env.UPLOAD_DIR_DEB }}/nym-vpn*_amd64.deb.sha256sum
+          test -d ${{ env.UPLOAD_DIR_DEB }} &&          gh release upload $TAG_NAME ${{ env.UPLOAD_DIR_DEB}}/nym-vpn*_amd64.deb ${{ env.UPLOAD_DIR_DEB }}/nym-vpn*_amd64.deb.sha256sum
 
       # Upload to CI server
 
@@ -245,6 +234,7 @@ jobs:
           TARGET: ${{ secrets.CI_WWW_REMOTE_TARGET }}/builds/nym-vpn-client/nym-vpn-core
 
   gen-hashes:
+    if: ${{ inputs.publish_to_github == 'true' || inputs.publish_to_github == true || github.event_name == 'push' }}
     uses: ./.github/workflows/gen-hashes-json.yml
     needs: publish
     with:

--- a/.github/workflows/publish-nym-vpn-core.yml
+++ b/.github/workflows/publish-nym-vpn-core.yml
@@ -84,7 +84,7 @@ jobs:
         run: cargo install --locked cargo-edit
 
       - name: Append timestamp if it's a pre-release version
-        run: ./scripts/append-timestamp-to-version.sh nym-vpn-core/Cargo.toml ${{ steps.workspace-version-pre.outputs.output }}
+        run: ./scripts/append-timestamp-to-version.sh nym-vpn-core/Cargo.toml ${{ steps.workspace-version-pre.outputs.metadata }}
 
       - name: Get nym-vpn-core workspace version (post-append)
         id: workspace-version

--- a/.github/workflows/publish-nym-vpn-core.yml
+++ b/.github/workflows/publish-nym-vpn-core.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       publish_to_github:
-        description: "If the build should be published to github. Only has an effect for pre-releases, if the version is not a pre-release then it will be automatically published."
+        description: "If the build should be published to github. Only has an effect when the workspace version is a pre-release, if the version is not a pre-release then it will be automatically published."
         type: boolean
         default: false
         required: true

--- a/scripts/append-timestamp-to-version.sh
+++ b/scripts/append-timestamp-to-version.sh
@@ -24,7 +24,7 @@ fi
 
 echo "Current version is: $CURRENT_VERSION"
 
-# Check if the version ends with "-dev". If so, append a timestamp
+# Check if the version ends with a pre-release field. If so, append a timestamp
 if [[ "$CURRENT_VERSION" =~ (-dev|-alpha|-beta|-rc)$ ]]; then
     TIMESTAMP="$(date +'%Y%m%d%H%M')"
     NEW_VERSION="${CURRENT_VERSION}.${TIMESTAMP}"

--- a/scripts/append-timestamp-to-version.sh
+++ b/scripts/append-timestamp-to-version.sh
@@ -25,8 +25,8 @@ fi
 echo "Current version is: $CURRENT_VERSION"
 
 # Check if the version ends with "-dev". If so, append a timestamp
-if [[ "$CURRENT_VERSION" == *"-dev" ]]; then
-    TIMESTAMP="$(date +'%Y%m%d%H%M%S')"
+if [[ "$CURRENT_VERSION" =~ (-dev|-alpha|-beta|-rc)$ ]]; then
+    TIMESTAMP="$(date +'%Y%m%d%H%M')"
     NEW_VERSION="${CURRENT_VERSION}.${TIMESTAMP}"
 else
     NEW_VERSION="$CURRENT_VERSION"


### PR DESCRIPTION
To make publishing nym-vpn-core releases more automatic, we don't want to have to manually set the tag name. It should be pulled from the workspace version.
And we want to automatically create alpha and beta versions too, like we do for dev versions.

The intended workflow is:
- Release branch should have the version set to e.g. `1.3.0-beta` without the number.
- When we want to create a pre-release, we manually trigger the workflow. This will build and push a pre-release to the build server with the version `1.3.0-beta.1234`.
- When we want to create a release, we update the workspace version to `1.3.0` and manually trigger the workflow. This will build and push to the build server.

Releases are automatically published to github, while pre-releases are only published if the checkbox `publish_to_github` is checked.

Summary of changes:

- Use the workspace version automatically when publishing nym-vpn-core
- Extend script to also append versions number to beta, alpha and rc
- Don't publish nightly builds to github

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2163)
<!-- Reviewable:end -->
