### PR TITLE
Log the RTT estimated remote time of the vpn-api

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -4932,6 +4932,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "thiserror 2.0.11",
+ "time",
  "tokio",
  "tracing",
  "url",

--- a/nym-vpn-core/crates/nym-vpn-api-client/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-api-client/Cargo.toml
@@ -30,6 +30,7 @@ sha2.workspace = true
 strum.workspace = true
 strum_macros.workspace = true
 thiserror.workspace = true
+time = { workspace = true, features = ["serde-human-readable", "serde-well-known"] }
 tracing.workspace = true
 url.workspace = true
 zeroize.workspace = true

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
@@ -1,14 +1,13 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use chrono::{DateTime, Utc};
+use std::{collections::HashSet, fmt, net::IpAddr};
+
 use itertools::Itertools;
 use nym_contracts_common::Percent;
 use nym_credential_proxy_requests::api::v1::ticketbook::models::TicketbookWalletSharesResponse;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
-use std::fmt;
-use std::net::IpAddr;
+use time::OffsetDateTime;
 
 const MAX_PROBE_RESULT_AGE_MINUTES: i64 = 60;
 
@@ -64,7 +63,8 @@ pub struct NymVpnAccountSummaryFairUsage {
 #[serde(rename_all = "camelCase")]
 pub struct NymVpnHealthResponse {
     pub status: String,
-    pub timestamp_utc: DateTime<Utc>,
+    #[serde(with = "time::serde::rfc3339")]
+    pub timestamp_utc: OffsetDateTime,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/types/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/types/account.rs
@@ -97,18 +97,21 @@ impl VpnApiTime {
 
     // Local time minus remote time. Meaning if the value is positive, the local time is ahead
     // of the remote time.
-    pub fn skew(&self) -> Duration {
+    pub fn local_time_ahead_skew(&self) -> Duration {
         self.local_time - self.estimated_remote_time
     }
 
     pub fn is_synced(&self) -> bool {
-        self.skew().abs().whole_seconds() < MAX_ACCEPTABLE_SKEW_SECONDS
+        self.local_time_ahead_skew().abs().whole_seconds() < MAX_ACCEPTABLE_SKEW_SECONDS
     }
 
     pub fn estimate_remote_now(&self) -> OffsetDateTime {
-        tracing::debug!("Estimating remote now using skew: {}", self.skew());
-        let now = OffsetDateTime::now_utc();
-        now - self.skew()
+        tracing::debug!(
+            "Estimating remote now using (local time ahead) skew: {}",
+            self.local_time_ahead_skew()
+        );
+        let local_time_now = OffsetDateTime::now_utc();
+        local_time_now - self.local_time_ahead_skew()
     }
 
     pub fn estimate_remote_now_unix(&self) -> u128 {
@@ -123,7 +126,7 @@ impl fmt::Display for VpnApiTime {
             "Local time: {}, Remote time: {}, Skew: {}",
             self.local_time,
             self.estimated_remote_time,
-            self.skew(),
+            self.local_time_ahead_skew(),
         )
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/types/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/types/account.rs
@@ -1,10 +1,13 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use std::fmt;
+
 use nym_compact_ecash::scheme::keygen::KeyPairUser;
 use nym_validator_client::{
     nyxd::bip32::DerivationPath, signing::signer::OfflineSigner as _, DirectSecp256k1HdWallet,
 };
+use time::{Duration, OffsetDateTime};
 
 use crate::{error::Result, jwt::Jwt, VpnApiClientError};
 
@@ -25,9 +28,9 @@ impl VpnApiAccount {
         self.wallet.get_accounts().unwrap()[0].address().to_string()
     }
 
-    pub(crate) fn jwt(&self, vpn_api_unix_epoch: Option<i64>) -> Jwt {
-        match vpn_api_unix_epoch {
-            Some(epoch) => Jwt::new_secp256k1_synced(&self.wallet, epoch),
+    pub(crate) fn jwt(&self, remote_time: Option<VpnApiTime>) -> Jwt {
+        match remote_time {
+            Some(remote_time) => Jwt::new_secp256k1_synced(&self.wallet, remote_time),
             None => Jwt::new_secp256k1(&self.wallet),
         }
     }
@@ -55,6 +58,72 @@ fn cosmos_derivation_path() -> DerivationPath {
     nym_config::defaults::COSMOS_DERIVATION_PATH
         .parse()
         .unwrap()
+}
+
+#[derive(Clone, Debug)]
+pub struct VpnApiTime {
+    // The local time on the client.
+    pub local_time: OffsetDateTime,
+
+    // The estimated time on the remote server. Based on RTT, it's not guaranteed to be accurate.
+    pub estimated_remote_time: OffsetDateTime,
+}
+
+impl VpnApiTime {
+    pub fn from_estimated_remote_time(
+        local_time: OffsetDateTime,
+        estimated_remote_time: OffsetDateTime,
+    ) -> Self {
+        Self {
+            local_time,
+            estimated_remote_time,
+        }
+    }
+
+    pub fn from_remote_timestamp(
+        local_time_before_request: OffsetDateTime,
+        remote_timestamp: OffsetDateTime,
+        local_time_after_request: OffsetDateTime,
+    ) -> Self {
+        let rtt = local_time_after_request - local_time_before_request;
+        let estimated_remote_time = remote_timestamp + (rtt / 2);
+        Self {
+            local_time: local_time_before_request,
+            estimated_remote_time,
+        }
+    }
+
+    // Local time minus remote time. Meaning if the value is positive, the local time is ahead
+    // of the remote time.
+    pub fn skew(&self) -> Duration {
+        self.local_time - self.estimated_remote_time
+    }
+
+    pub fn is_synced(&self) -> bool {
+        self.skew().abs().whole_seconds() < 30
+    }
+
+    pub fn estimate_remote_now(&self) -> OffsetDateTime {
+        tracing::debug!("Estimating remote now using skew: {}", self.skew());
+        let now = OffsetDateTime::now_utc();
+        now - self.skew()
+    }
+
+    pub fn estimate_remote_now_unix(&self) -> u128 {
+        self.estimate_remote_now().unix_timestamp() as u128
+    }
+}
+
+impl fmt::Display for VpnApiTime {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "Local time: {}, Remote time: {}, Skew: {}",
+            self.local_time,
+            self.estimated_remote_time,
+            self.skew(),
+        )
+    }
 }
 
 #[cfg(test)]

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/types/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/types/account.rs
@@ -11,6 +11,8 @@ use time::{Duration, OffsetDateTime};
 
 use crate::{error::Result, jwt::Jwt, VpnApiClientError};
 
+const MAX_ACCEPTABLE_SKEW_SECONDS: i64 = 30;
+
 #[derive(Clone, Debug)]
 pub struct VpnApiAccount {
     wallet: DirectSecp256k1HdWallet,
@@ -100,7 +102,7 @@ impl VpnApiTime {
     }
 
     pub fn is_synced(&self) -> bool {
-        self.skew().abs().whole_seconds() < 30
+        self.skew().abs().whole_seconds() < MAX_ACCEPTABLE_SKEW_SECONDS
     }
 
     pub fn estimate_remote_now(&self) -> OffsetDateTime {

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/types/device.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/types/device.rs
@@ -8,6 +8,8 @@ use sha2::Digest as _;
 
 use crate::{jwt::Jwt, request::UpdateDeviceRequestStatus};
 
+use super::VpnApiTime;
+
 #[derive(Clone)]
 pub struct Device {
     keypair: Arc<ed25519::KeyPair>,
@@ -18,9 +20,9 @@ impl Device {
         self.keypair.public_key()
     }
 
-    pub(crate) fn jwt(&self, vpn_api_unix_epoch: Option<i64>) -> Jwt {
-        match vpn_api_unix_epoch {
-            Some(epoch) => Jwt::new_ecdsa_synced(&self.keypair, epoch),
+    pub(crate) fn jwt(&self, remote_time: Option<VpnApiTime>) -> Jwt {
+        match remote_time {
+            Some(remote_time) => Jwt::new_ecdsa_synced(&self.keypair, remote_time),
             None => Jwt::new_ecdsa(&self.keypair),
         }
     }

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/types/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/types/mod.rs
@@ -8,7 +8,7 @@ mod gateway;
 #[cfg(test)]
 mod test_fixtures;
 
-pub use account::VpnApiAccount;
+pub use account::{VpnApiAccount, VpnApiTime};
 pub use device::{Device, DeviceStatus};
 pub use gateway::{GatewayMinPerformance, GatewayType};
 


### PR DESCRIPTION
When syncing the account, also try to estimate the remote vpn-api time and log the results. If the skew is large enough, emit a warning.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2178)
<!-- Reviewable:end -->
