### PR TITLE
Move path dependencies to workspace as well

### DIFF
--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -102,6 +102,7 @@ hex = "0.4"
 http = "0.2.12"                                                     # version compatible with tonic
 inotify = "0.11"
 ipnetwork = "0.20"
+rs-release = "0.1.7"
 itertools = "0.13.0"
 lazy_static = "1.5.0"
 libc = "0.2"
@@ -179,6 +180,30 @@ winreg = "0.52"
 wmi = "0.14"
 x25519-dalek = "2.0"
 zeroize = "1.6.0"
+
+nym-apple-dispatch = { path = "crates/nym-apple-dispatch" }
+nym-apple-network = { path = "crates/nym-apple-network" }
+nym-authenticator-client = { path = "crates/nym-authenticator-client" }
+nym-common = { path = "crates/nym-common" }
+nym-connection-monitor = { path = "crates/nym-connection-monitor" }
+nym-dbus = { path = "crates/nym-dbus" }
+nym-dns = { path = "crates/nym-dns" }
+nym-gateway-directory = { path = "crates/nym-gateway-directory" }
+nym-ip-packet-client = { path = "crates/nym-ip-packet-client" }
+nym-mixnet-client = { path = "crates/nym-mixnet-client" }
+nym-offline-monitor = { path = "crates/nym-offline-monitor" }
+nym-routing = { path = "crates/nym-routing" }
+nym-vpn-account-controller = { path = "crates/nym-vpn-account-controller" }
+nym-vpn-api-client = { path = "crates/nym-vpn-api-client" }
+nym-vpn-lib = { path = "crates/nym-vpn-lib" }
+nym-vpn-lib-types = { path = "crates/nym-vpn-lib-types" }
+nym-vpn-network-config = { path = "crates/nym-vpn-network-config" }
+nym-vpn-proto = { path = "crates/nym-vpn-proto" }
+nym-vpn-store = { path = "crates/nym-vpn-store" }
+nym-vpnd-types = { path = "crates/nym-vpnd-types" }
+nym-wg-gateway-client = { path = "crates/nym-wg-gateway-client" }
+nym-wg-go = { path = "crates/nym-wg-go" }
+nym-windows = { path = "crates/nym-windows" }
 
 nym-authenticator-requests = { git = "https://github.com/nymtech/nym", branch = "release/2025.3-ruta-vpn-fork" }
 nym-api-requests = { git = "https://github.com/nymtech/nym", branch = "release/2025.3-ruta-vpn-fork" }

--- a/nym-vpn-core/crates/nym-apple-network/Cargo.toml
+++ b/nym-vpn-core/crates/nym-apple-network/Cargo.toml
@@ -15,4 +15,4 @@ objc2.workspace = true
 nix = { workspace = true, features = ["socket", "net"] }
 thiserror.workspace = true
 
-nym-apple-dispatch = { path = "../nym-apple-dispatch" }
+nym-apple-dispatch.workspace = true

--- a/nym-vpn-core/crates/nym-authenticator-client/Cargo.toml
+++ b/nym-vpn-core/crates/nym-authenticator-client/Cargo.toml
@@ -24,4 +24,4 @@ tracing-subscriber.workspace = true
 futures.workspace = true
 semver.workspace = true
 
-nym-mixnet-client = { path = "../nym-mixnet-client" }
+nym-mixnet-client = { workspace = true }

--- a/nym-vpn-core/crates/nym-dns/Cargo.toml
+++ b/nym-vpn-core/crates/nym-dns/Cargo.toml
@@ -19,9 +19,9 @@ tokio = { workspace = true, features = ["macros"] }
 futures.workspace = true
 triggered.workspace = true
 
-nym-routing = { path = "../nym-routing" }
-nym-dbus = { path = "../nym-dbus" }
-nym-common = { path = "../nym-common" }
+nym-routing = { workspace = true }
+nym-dbus = { workspace = true }
+nym-common = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 system-configuration.workspace = true
@@ -37,8 +37,8 @@ duct.workspace = true
 once_cell.workspace = true
 winreg = { workspace = true, features = ["transactions"] }
 
-nym-windows = { path = "../nym-windows" }
-nym-common = { path = "../nym-common" }
+nym-windows = { workspace = true }
+nym-common = { workspace = true }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 workspace = true

--- a/nym-vpn-core/crates/nym-firewall/Cargo.toml
+++ b/nym-vpn-core/crates/nym-firewall/Cargo.toml
@@ -14,8 +14,8 @@ libc.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
-nym-dns = { path = "../nym-dns" }
-nym-common = { path = "../nym-common" }
+nym-dns.workspace = true
+nym-common.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 pfctl.workspace = true
@@ -27,10 +27,9 @@ inotify.workspace = true
 resolv-conf.workspace = true
 nftnl = { workspace = true, features = ["nftnl-1-1-0"] }
 mnl = { workspace = true, features = ["mnl-1-0-4"] }
-nym-common = { path = "../nym-common" }
 
 [target.'cfg(windows)'.dependencies]
-nym-windows = { path = "../nym-windows" }
+nym-windows.workspace = true
 
 log.workspace = true
 wmi.workspace = true

--- a/nym-vpn-core/crates/nym-gateway-directory/Cargo.toml
+++ b/nym-vpn-core/crates/nym-gateway-directory/Cargo.toml
@@ -19,8 +19,8 @@ nym-http-api-client.workspace = true
 nym-sdk.workspace = true
 nym-topology.workspace = true
 nym-validator-client.workspace = true
-nym-vpn-api-client = { path = "../nym-vpn-api-client" }
-nym-vpn-network-config = { path = "../nym-vpn-network-config" }
+nym-vpn-api-client = { workspace = true }
+nym-vpn-network-config = { workspace = true }
 rand.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/nym-vpn-core/crates/nym-gateway-probe/Cargo.toml
+++ b/nym-vpn-core/crates/nym-gateway-probe/Cargo.toml
@@ -46,12 +46,12 @@ nym-bin-common.workspace = true
 nym-client-core.workspace = true
 nym-crypto.workspace = true
 nym-config.workspace = true
-nym-connection-monitor = { path = "../nym-connection-monitor" }
+nym-connection-monitor = { workspace = true }
 nym-credentials-interface.workspace = true
-nym-gateway-directory = { path = "../nym-gateway-directory" }
-nym-ip-packet-client = { path = "../nym-ip-packet-client" }
-nym-authenticator-client = { path = "../nym-authenticator-client" }
-nym-mixnet-client = { path = "../nym-mixnet-client" }
+nym-gateway-directory = { workspace = true }
+nym-ip-packet-client = { workspace = true }
+nym-authenticator-client = { workspace = true }
+nym-mixnet-client = { workspace = true }
 nym-wireguard-types.workspace = true
 nym-ip-packet-requests.workspace = true
 nym-sdk.workspace = true

--- a/nym-vpn-core/crates/nym-ip-packet-client/Cargo.toml
+++ b/nym-vpn-core/crates/nym-ip-packet-client/Cargo.toml
@@ -11,9 +11,9 @@ license.workspace = true
 [dependencies]
 bytes.workspace = true
 futures.workspace = true
-nym-gateway-directory = { path = "../nym-gateway-directory" }
+nym-gateway-directory = { workspace = true }
 nym-ip-packet-requests.workspace = true
-nym-mixnet-client = { path = "../nym-mixnet-client" }
+nym-mixnet-client = { workspace = true }
 nym-sdk.workspace = true
 thiserror.workspace = true
 tokio-util.workspace = true

--- a/nym-vpn-core/crates/nym-offline-monitor/Cargo.toml
+++ b/nym-vpn-core/crates/nym-offline-monitor/Cargo.toml
@@ -17,13 +17,13 @@ debounced.workspace = true
 tokio-stream.workspace = true
 tokio-util.workspace = true
 
-nym-common = { path = "../nym-common" }
-nym-routing = { path = "../nym-routing" }
-nym-windows = { path = "../nym-windows" }
+nym-common.workspace = true
+nym-routing.workspace = true
+nym-windows.workspace = true
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
-nym-apple-dispatch = { path = "../nym-apple-dispatch" }
-nym-apple-network = { path = "../nym-apple-network" }
+nym-apple-dispatch.workspace = true
+nym-apple-network.workspace = true
 
 [target.'cfg(target_os = "android")'.dependencies]
 async-trait.workspace = true

--- a/nym-vpn-core/crates/nym-platform-metadata/Cargo.toml
+++ b/nym-vpn-core/crates/nym-platform-metadata/Cargo.toml
@@ -13,8 +13,8 @@ default = ["network-manager"]
 network-manager = ["nym-dbus"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
-rs-release = "0.1.7"
-nym-dbus = { path = "../nym-dbus", optional = true }
+rs-release.workspace = true
+nym-dbus = { workspace = true, optional = true }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 workspace = true

--- a/nym-vpn-core/crates/nym-routing/Cargo.toml
+++ b/nym-vpn-core/crates/nym-routing/Cargo.toml
@@ -20,7 +20,7 @@ tokio = { workspace = true, features = [
 ] }
 
 [target.'cfg(not(target_os="android"))'.dependencies]
-nym-common = { path = "../nym-common" }
+nym-common.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc.workspace = true
@@ -36,7 +36,7 @@ nix = { workspace = true, features = ["socket", "fs", "net"] }
 system-configuration.workspace = true
 
 [target.'cfg(windows)'.dependencies]
-nym-windows = { path = "../nym-windows" }
+nym-windows.workspace = true
 widestring.workspace = true
 
 [target.'cfg(windows)'.dependencies.windows-sys]

--- a/nym-vpn-core/crates/nym-vpn-account-controller/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/Cargo.toml
@@ -22,11 +22,11 @@ nym-ecash-time.workspace = true
 nym-http-api-client.workspace = true
 nym-sdk.workspace = true
 nym-validator-client.workspace = true
-nym-vpn-api-client = { path = "../nym-vpn-api-client" }
-nym-vpn-lib-types = { path = "../nym-vpn-lib-types", features = ["nym-type-conversions"] }
-nym-vpn-network-config = { path = "../nym-vpn-network-config" }
-nym-vpn-store = { path = "../nym-vpn-store" }
-nym-wg-gateway-client = { path = "../nym-wg-gateway-client" }
+nym-vpn-api-client = { workspace = true }
+nym-vpn-lib-types = { workspace = true, features = ["nym-type-conversions"] }
+nym-vpn-network-config = { workspace = true }
+nym-vpn-store = { workspace = true }
+nym-wg-gateway-client = { workspace = true }
 serde.workspace = true
 serde_json.workspace = true
 si-scale.workspace = true

--- a/nym-vpn-core/crates/nym-vpn-lib-types/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/Cargo.toml
@@ -24,8 +24,8 @@ thiserror.workspace = true
 time.workspace = true
 
 nym-bandwidth-controller = { workspace = true, optional = true }
-nym-connection-monitor = { path = "../nym-connection-monitor", optional = true }
-nym-gateway-directory = { path = "../nym-gateway-directory", optional = true }
+nym-connection-monitor = { workspace = true, optional = true }
+nym-gateway-directory = { workspace = true, optional = true }
 nym-statistics-common = { workspace = true, optional = true }
-nym-vpn-api-client = { path = "../nym-vpn-api-client", optional = true }
-nym-wg-gateway-client = { path = "../nym-wg-gateway-client", optional = true }
+nym-vpn-api-client = { workspace = true, optional = true }
+nym-wg-gateway-client = { workspace = true, optional = true }

--- a/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
@@ -65,36 +65,34 @@ nym-topology.workspace = true
 nym-validator-client.workspace = true
 nym-wireguard-types.workspace = true
 
-nym-authenticator-client = { path = "../nym-authenticator-client" }
-nym-connection-monitor = { path = "../nym-connection-monitor" }
-nym-gateway-directory = { path = "../nym-gateway-directory" }
-nym-ip-packet-client = { path = "../nym-ip-packet-client" }
-nym-mixnet-client = { path = "../nym-mixnet-client" }
-nym-vpn-account-controller = { path = "../nym-vpn-account-controller" }
-nym-vpn-api-client = { path = "../nym-vpn-api-client" }
-nym-vpn-network-config = { path = "../nym-vpn-network-config" }
-nym-vpn-store = { path = "../nym-vpn-store" }
-nym-wg-gateway-client = { path = "../nym-wg-gateway-client" }
-nym-wg-go = { path = "../nym-wg-go" }
-nym-apple-network = { path = "../nym-apple-network" }
-nym-apple-dispatch = { path = "../nym-apple-dispatch" }
-nym-offline-monitor = { path = "../nym-offline-monitor" }
-nym-vpn-lib-types = { path = "../nym-vpn-lib-types", features = [
-    "nym-type-conversions",
-] }
+nym-authenticator-client.workspace = true
+nym-connection-monitor.workspace = true
+nym-gateway-directory.workspace = true
+nym-ip-packet-client.workspace = true
+nym-mixnet-client.workspace = true
+nym-vpn-account-controller.workspace = true
+nym-vpn-api-client.workspace = true
+nym-vpn-network-config.workspace = true
+nym-vpn-store.workspace = true
+nym-wg-gateway-client.workspace = true
+nym-wg-go.workspace = true
+nym-apple-network.workspace = true
+nym-apple-dispatch.workspace = true
+nym-offline-monitor.workspace = true
+nym-vpn-lib-types = { workspace = true, features = ["nym-type-conversions"] }
 
 [target.'cfg(unix)'.dependencies]
 nix = { workspace = true, features = ["socket", "net", "fs"] }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = ["Win32_NetworkManagement_Ndis"] }
-nym-windows = { path = "../nym-windows" }
-nym-routing = { path = "../nym-routing" }
-nym-dns = { path = "../nym-dns" }
+nym-windows.workspace = true
+nym-routing.workspace = true
+nym-dns.workspace = true
 
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
-nym-routing = { path = "../nym-routing" }
-nym-dns = { path = "../nym-dns" }
+nym-routing.workspace = true
+nym-dns.workspace = true
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_logger.workspace = true

--- a/nym-vpn-core/crates/nym-vpn-network-config/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-network-config/Cargo.toml
@@ -16,6 +16,7 @@ nym-api-requests.workspace = true
 nym-config.workspace = true
 nym-sdk.workspace = true
 nym-validator-client.workspace = true
+nym-vpn-api-client.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
@@ -24,8 +25,6 @@ tokio = { workspace = true, features = ["time", "macros"] }
 tokio-util.workspace = true
 tracing.workspace = true
 url = { workspace = true, features = ["serde"] }
-
-nym-vpn-api-client = { path = "../nym-vpn-api-client" }
 
 [build-dependencies]
 serde_json.workspace = true

--- a/nym-vpn-core/crates/nym-vpn-proto/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-proto/Cargo.toml
@@ -15,14 +15,14 @@ tonic-reflection.workspace = true
 tonic.workspace = true
 
 nym-config = { workspace = true, optional = true }
-nym-gateway-directory = { path = "../nym-gateway-directory", optional = true }
+nym-gateway-directory = { workspace = true, optional = true }
 nym-http-api-client.workspace = true
 nym-sdk = { workspace = true, optional = true }
-nym-vpn-account-controller = { path = "../nym-vpn-account-controller", optional = true }
-nym-vpn-api-client = { path = "../nym-vpn-api-client", optional = true }
-nym-vpn-network-config = { path = "../nym-vpn-network-config", optional = true }
-nym-vpnd-types = { path = "../nym-vpnd-types", optional = true }
-nym-vpn-lib-types = { path = "../nym-vpn-lib-types", optional = true }
+nym-vpn-account-controller = { workspace = true, optional = true }
+nym-vpn-api-client = { workspace = true, optional = true }
+nym-vpn-network-config = { workspace = true, optional = true }
+nym-vpnd-types = { workspace = true, optional = true }
+nym-vpn-lib-types = { workspace = true, optional = true }
 thiserror = { workspace = true, optional = true }
 time = { workspace = true, optional = true }
 url = { workspace = true, optional = true }

--- a/nym-vpn-core/crates/nym-vpnc/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpnc/Cargo.toml
@@ -24,12 +24,12 @@ tonic.workspace = true
 tower.workspace = true
 
 nym-bin-common.workspace = true
-nym-gateway-directory = { path = "../nym-gateway-directory" }
+nym-gateway-directory = { workspace = true }
 nym-http-api-client.workspace = true
-nym-vpn-network-config = { path = "../nym-vpn-network-config" }
-nym-vpn-proto = { path = "../nym-vpn-proto", features = ["conversions"] }
-nym-vpnd-types = { path = "../nym-vpnd-types" }
-nym-vpn-lib-types = { path = "../nym-vpn-lib-types" }
+nym-vpn-network-config = { workspace = true }
+nym-vpn-proto = { workspace = true, features = ["conversions"] }
+nym-vpnd-types = { workspace = true }
+nym-vpn-lib-types = { workspace = true }
 
 [build-dependencies]
 vergen = { workspace = true, default-features = false, features = [

--- a/nym-vpn-core/crates/nym-vpnd-types/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpnd-types/Cargo.toml
@@ -12,4 +12,4 @@ license.workspace = true
 nym-validator-client.workspace = true
 serde.workspace = true
 
-nym-vpn-lib = { path = "../nym-vpn-lib" }
+nym-vpn-lib = { workspace = true }

--- a/nym-vpn-core/crates/nym-vpnd/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpnd/Cargo.toml
@@ -55,14 +55,14 @@ nym-task.workspace = true
 nym-validator-client.workspace = true
 
 # Local crates
-nym-vpn-account-controller = { path = "../nym-vpn-account-controller" }
-nym-vpn-api-client = { path = "../nym-vpn-api-client" }
-nym-vpn-lib = { path = "../nym-vpn-lib" }
-nym-vpn-lib-types = { path = "../nym-vpn-lib-types" }
-nym-vpn-network-config = { path = "../nym-vpn-network-config" }
-nym-vpn-proto = { path = "../nym-vpn-proto", features = ["conversions"] }
-nym-vpn-store = { path = "../nym-vpn-store" }
-nym-vpnd-types = { path = "../nym-vpnd-types" }
+nym-vpn-account-controller = { workspace = true }
+nym-vpn-api-client = { workspace = true }
+nym-vpn-lib = { workspace = true }
+nym-vpn-lib-types = { workspace = true }
+nym-vpn-network-config = { workspace = true }
+nym-vpn-proto = { workspace = true, features = ["conversions"] }
+nym-vpn-store = { workspace = true }
+nym-vpnd-types = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 windows-service.workspace = true

--- a/nym-vpn-core/crates/nym-wg-gateway-client/Cargo.toml
+++ b/nym-vpn-core/crates/nym-wg-gateway-client/Cargo.toml
@@ -30,6 +30,6 @@ tokio-stream.workspace = true
 tracing.workspace = true
 si-scale.workspace = true
 
-nym-authenticator-client = { path = "../nym-authenticator-client" }
-nym-gateway-directory = { path = "../nym-gateway-directory" }
-nym-wg-go = { path = "../nym-wg-go" }
+nym-authenticator-client = { workspace = true }
+nym-gateway-directory = { workspace = true }
+nym-wg-go = { workspace = true }

--- a/nym-vpn-core/crates/nym-wg-go/Cargo.toml
+++ b/nym-vpn-core/crates/nym-wg-go/Cargo.toml
@@ -24,4 +24,4 @@ rand.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = ["Win32_NetworkManagement_Ndis"] }
-nym-windows = { path = "../nym-windows" }
+nym-windows.workspace = true

--- a/nym-vpn-core/crates/nym-windows/Cargo.toml
+++ b/nym-vpn-core/crates/nym-windows/Cargo.toml
@@ -13,7 +13,7 @@ futures.workspace = true
 tokio = { workspace = true, features = ["sync"] }
 tracing.workspace = true
 
-nym-common = { path = "../nym-common" }
+nym-common.workspace = true
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 workspace = true

--- a/nym-vpn-core/deny.toml
+++ b/nym-vpn-core/deny.toml
@@ -223,7 +223,7 @@ skip-tree = [
 
 [bans.workspace-dependencies]
 duplicates = "deny"
-include-path-dependencies = false
+include-path-dependencies = true
 unused = "deny"
 
 # This section is considered when running `cargo deny check sources`.


### PR DESCRIPTION
Run latest `cargo autoinherit`, which now also moves path dependencies to the workspace

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2182)
<!-- Reviewable:end -->
