### PR TITLE
feat(tauri): display vpn api error details in the UI

### DIFF
--- a/nym-vpn-app/src-tauri/src/grpc/client.rs
+++ b/nym-vpn-app/src-tauri/src/grpc/client.rs
@@ -217,7 +217,10 @@ impl GrpcClient {
             error!("failed to parse tunnel state: {}", e);
             VpndError::internal("failed to parse tunnel state")
         })?;
-        info!("tunnel state {}", tunnel);
+        match &tunnel {
+            TunnelState::Error(e) => warn!("tunnel error: {}", e),
+            _ => info!("tunnel state {}", tunnel),
+        }
         let s_state = app.state::<SharedAppState>();
         let mut app_state = s_state.lock().await;
         app_state.update_tunnel(app, tunnel.clone()).await?;
@@ -290,7 +293,10 @@ impl GrpcClient {
                 error!("failed to parse tunnel state: {}", e);
                 VpndError::internal("failed to parse tunnel state")
             })?;
-            info!("tunnel state {}", tunnel);
+            match &tunnel {
+                TunnelState::Error(e) => warn!("tunnel error: {}", e),
+                _ => info!("tunnel state {}", tunnel),
+            }
             let s_state = app.state::<SharedAppState>();
             let mut app_state = s_state.lock().await;
             app_state.update_tunnel(app, tunnel).await?;

--- a/nym-vpn-app/src/hooks/useI18nError.ts
+++ b/nym-vpn-app/src/hooks/useI18nError.ts
@@ -44,24 +44,28 @@ function useI18nError() {
             return t('sync-account', { reason: t('account.not-stored') });
           case 'sync-account-unexpected-response':
             return t('sync-account', {
-              reason: t('account.unexpected-response'),
+              reason: t('account.unexpected-response', { details: error.data }),
             });
           case 'sync-account-internal':
             return t('sync-account', { reason: t('account.internal') });
           case 'sync-account-vpn-api':
-            return t('sync-account', { reason: t('account.vpn-api') });
+            return t('sync-account', {
+              reason: t('account.vpn-api', { details: error.data }),
+            });
           case 'sync-device-no-account-stored':
             return t('sync-device', { reason: t('account.not-stored') });
           case 'sync-device-no-device-stored':
             return t('sync-device', { reason: t('account.no-device-stored') });
           case 'sync-device-unexpected-response':
             return t('sync-device', {
-              reason: t('account.unexpected-response'),
+              reason: t('account.unexpected-response', { details: error.data }),
             });
           case 'sync-device-internal':
             return t('sync-device', { reason: t('account.internal') });
           case 'sync-device-vpn-api':
-            return t('sync-device', { reason: t('account.vpn-api') });
+            return t('sync-device', {
+              reason: t('account.vpn-api', { details: error.data }),
+            });
           case 'register-device-no-account-stored':
             return t('register-device', { reason: t('account.not-stored') });
           case 'register-device-no-device-stored':
@@ -70,12 +74,14 @@ function useI18nError() {
             });
           case 'register-device-unexpected-response':
             return t('register-device', {
-              reason: t('account.unexpected-response'),
+              reason: t('account.unexpected-response', { details: error.data }),
             });
           case 'register-device-internal':
             return t('register-device', { reason: t('account.internal') });
           case 'register-device-vpn-api':
-            return t('register-device', { reason: t('account.vpn-api') });
+            return t('register-device', {
+              reason: t('account.vpn-api', { details: error.data }),
+            });
           case 'req-zknym-no-account-stored':
             return t('request-zknym', { reason: t('account.not-stored') });
           case 'req-zknym-no-device-stored':
@@ -84,14 +90,16 @@ function useI18nError() {
             });
           case 'req-zknym-unexpected-response':
             return t('request-zknym', {
-              reason: t('account.unexpected-response'),
+              reason: t('account.unexpected-response', { details: error.data }),
             });
           case 'req-zknym-storage':
             return t('request-zknym', { reason: t('account.storage') });
           case 'req-zknym-internal':
             return t('request-zknym', { reason: t('account.internal') });
           case 'req-zknym-vpn-api':
-            return t('request-zknym', { reason: t('account.vpn-api') });
+            return t('request-zknym', {
+              reason: t('account.vpn-api', { details: error.data }),
+            });
         }
 
         console.warn('unhandled tunnel error', error);

--- a/nym-vpn-app/src/i18n/en/errors.json
+++ b/nym-vpn-app/src/i18n/en/errors.json
@@ -26,9 +26,9 @@
     "is-connected": "Unable to proceed while connected",
     "not-stored": "no account stored",
     "no-device-stored": "no device stored",
-    "unexpected-response": "unexpected response",
+    "unexpected-response": "unexpected response: {{details}}",
     "internal": "internal error",
-    "vpn-api": "VPN API error"
+    "vpn-api": "VPN API error: {{details}}"
   },
   "sync-account": "Sync account: {{reason}}",
   "sync-device": "Sync device: {{reason}}",

--- a/nym-vpn-app/src/i18n/fr/errors.json
+++ b/nym-vpn-app/src/i18n/fr/errors.json
@@ -31,9 +31,9 @@
     "is-connected": "Impossible d'effectuer cette action lorsque connecté au VPN",
     "not-stored": "pas de compte stocké",
     "no-device-stored": "pas d'appareil stocké",
-    "unexpected-response": "réponse inattendue",
+    "unexpected-response": "réponse inattendue : {{details}}",
     "internal": "erreur interne",
-    "vpn-api": "erreur API VPN"
+    "vpn-api": "erreur API VPN : {{details}}"
   },
   "sync-account": "Synchronisation du compte : {{reason}}",
   "sync-device": "Synchronisation de l'appareil : {{reason}}",

--- a/nym-vpn-app/src/i18n/fr/errors.json
+++ b/nym-vpn-app/src/i18n/fr/errors.json
@@ -33,7 +33,7 @@
     "no-device-stored": "pas d'appareil stocké",
     "unexpected-response": "réponse inattendue : {{details}}",
     "internal": "erreur interne",
-    "vpn-api": "erreur API VPN : {{details}}"
+    "vpn-api": "erreur de l'API VPN : {{details}}"
   },
   "sync-account": "Synchronisation du compte : {{reason}}",
   "sync-device": "Synchronisation de l'appareil : {{reason}}",

--- a/nym-vpn-app/src/types/tunnel.ts
+++ b/nym-vpn-app/src/types/tunnel.ts
@@ -81,23 +81,23 @@ export type TunnelError =
   | { key: 'sync-account-no-account-stored'; data: boolean }
   | { key: 'sync-account-unexpected-response'; data: string }
   | { key: 'sync-account-internal'; data: string }
-  | { key: 'sync-account-vpn-api'; data: string | null }
+  | { key: 'sync-account-vpn-api'; data: string }
   | { key: 'sync-device-no-account-stored'; data: boolean }
   | { key: 'sync-device-no-device-stored'; data: boolean }
   | { key: 'sync-device-unexpected-response'; data: string }
   | { key: 'sync-device-internal'; data: string }
-  | { key: 'sync-device-vpn-api'; data: string | null }
+  | { key: 'sync-device-vpn-api'; data: string }
   | { key: 'register-device-no-account-stored'; data: boolean }
   | { key: 'register-device-no-device-stored'; data: boolean }
   | { key: 'register-device-unexpected-response'; data: string }
   | { key: 'register-device-internal'; data: string }
-  | { key: 'register-device-vpn-api'; data: string | null }
+  | { key: 'register-device-vpn-api'; data: string }
   | { key: 'req-zknym-no-account-stored'; data: boolean }
   | { key: 'req-zknym-no-device-stored'; data: boolean }
   | { key: 'req-zknym-unexpected-response'; data: string }
   | { key: 'req-zknym-storage'; data: string }
   | { key: 'req-zknym-internal'; data: string }
-  | { key: 'req-zknym-vpn-api'; data: string | null };
+  | { key: 'req-zknym-vpn-api'; data: string };
 
 export type TunnelStateEvent = {
   state: TunnelState;


### PR DESCRIPTION
- when there is a tunnel error originating from VpnAPI, forward the underlaying message and the message ID (if any), so it is displayed as additional details in the UI, along to the localized error message
- log any tunnel error at WARN level (to ease future debugging work)

NOTE: this is a first iteration to get minimum of details regarding VpnAPI errors, once a proper message ID mapping is available for vpn api errors, the plan would be to switch to it

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2204)
<!-- Reviewable:end -->
