### PR TITLE
Use cargo build --locked to catch lock file mismatch

### DIFF
--- a/.github/workflows/ci-nym-vpn-core-ios.yml
+++ b/.github/workflows/ci-nym-vpn-core-ios.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Build
         working-directory: nym-vpn-core
         run: |
-          cargo build --verbose --target aarch64-apple-ios -p nym-vpn-lib
+          cargo build --verbose --target aarch64-apple-ios -p nym-vpn-lib --locked
 
       - name: Generate uniffi
         working-directory: nym-vpn-core
@@ -80,4 +80,4 @@ jobs:
       - name: Clippy
         working-directory: nym-vpn-core
         run: |
-          cargo clippy --target aarch64-apple-ios -p nym-vpn-lib -- -Dwarnings
+          cargo clippy --target aarch64-apple-ios -p nym-vpn-lib --locked -- -Dwarnings

--- a/.github/workflows/ci-nym-vpn-core-linux.yml
+++ b/.github/workflows/ci-nym-vpn-core-linux.yml
@@ -60,15 +60,15 @@ jobs:
       - name: Build
         working-directory: nym-vpn-core
         run: |
-          cargo build --verbose --workspace
+          cargo build --verbose --workspace --locked
 
       - name: Run tests
         working-directory: nym-vpn-core
         run: |
-          cargo test --verbose --workspace
+          cargo test --verbose --workspace --locked
 
       - name: Clippy
         working-directory: nym-vpn-core
         run: |
-          cargo clippy --workspace -- -Dwarnings
+          cargo clippy --workspace --locked -- -Dwarnings
 

--- a/.github/workflows/ci-nym-vpn-core-macos.yml
+++ b/.github/workflows/ci-nym-vpn-core-macos.yml
@@ -58,9 +58,9 @@ jobs:
       - name: Run tests
         working-directory: nym-vpn-core
         run: |
-          cargo test --verbose --workspace
+          cargo test --verbose --workspace --locked
 
       - name: Clippy
         working-directory: nym-vpn-core
         run: |
-          cargo clippy --workspace -- -Dwarnings
+          cargo clippy --workspace --locked -- -Dwarnings

--- a/.github/workflows/ci-nym-vpn-core-windows.yml
+++ b/.github/workflows/ci-nym-vpn-core-windows.yml
@@ -130,14 +130,14 @@ jobs:
       - name: Build
         working-directory: nym-vpn-core
         run: |
-          cargo build --verbose --workspace --exclude nym-gateway-probe
+          cargo build --verbose --workspace --exclude nym-gateway-probe --locked
 
       - name: Run tests
         working-directory: nym-vpn-core
         run: |
-          cargo test --verbose --workspace --exclude nym-gateway-probe
+          cargo test --verbose --workspace --exclude nym-gateway-probe --locked
 
       - name: Clippy
         working-directory: nym-vpn-core
         run: |
-          cargo clippy --workspace --exclude nym-gateway-probe -- -Dwarnings
+          cargo clippy --workspace --exclude nym-gateway-probe --locked -- -Dwarnings


### PR DESCRIPTION
Build with `cargo build --locked` to catch lock file mismatch. In particular to give more confidence to dependabot changes

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2221)
<!-- Reviewable:end -->
