### PR TITLE
ci(tauri): update ci for dev builds

### DIFF
--- a/.github/workflows/build-nym-vpn-app-windows.yml
+++ b/.github/workflows/build-nym-vpn-app-windows.yml
@@ -8,7 +8,11 @@ on:
         type: boolean
         default: false
       core_release_tag:
-        description: "nym-vpn-core release tag to use for Windows build (as it bundles the daemon)"
+        description: "nym-vpn-core release tag from GH to use for Windows, to get the daemon"
+        required: false
+        type: string
+      core_artifact_url:
+        description: "direct nym-vpn-core artifact URL for Windows, to get the daemon"
         required: false
         type: string
       sign:
@@ -156,7 +160,7 @@ jobs:
           "core_release_tag=${{ inputs.core_release_tag }}" >> $env:GITHUB_ENV
 
       - name: Get nym-vpn-core release tag (latest stable)
-        if: ${{ !inputs.core_release_tag && !inputs.dev_mode }}
+        if: ${{ !inputs.core_release_tag && !inputs.core_artifact_url && !inputs.dev_mode }}
         run: |
           $release_tag = curl -sSL -H "Accept: application/vnd.github+json" `
             https://api.github.com/repos/nymtech/nym-vpn-client/releases |
@@ -165,7 +169,7 @@ jobs:
           "core_release_tag=$release_tag" >> $env:GITHUB_ENV
 
       - name: Get nym-vpn-core artifact url (latest dev)
-        if: ${{ !inputs.core_release_tag && inputs.dev_mode }}
+        if: ${{ !inputs.core_release_tag && !inputs.core_artifact_url && inputs.dev_mode }}
         shell: bash
         run: |
           latest=$(curl -s ${{ env.VPNCORE_DEV_BUILDS_URL }} \
@@ -187,6 +191,12 @@ jobs:
             yq '.assets.[] | select(.name | test("^nym-vpn-core-v.+_windows_x86_64\.zip$")) | .browser_download_url'
           echo "core_asset_url: $asset_url"
           "core_asset_url=$asset_url" >> $env:GITHUB_ENV
+
+      - name: Use nym-vpn-core artifact url from inputs
+        if: ${{ inputs.core_artifact_url }}
+        run: |
+          echo "core_asset_url: ${{ inputs.core_artifact_url }}"
+          "core_asset_url=${{ inputs.core_artifact_url }}" >> $env:GITHUB_ENV
 
       - name: Download nym-vpn-core artifact
         run: |

--- a/.github/workflows/build-nym-vpn-app-windows.yml
+++ b/.github/workflows/build-nym-vpn-app-windows.yml
@@ -76,7 +76,7 @@ jobs:
     runs-on: custom-windows-11
     env:
       CPP_BUILD_MODES: ${{ needs.build-mullvad-windows.outputs.CPP_BUILD_MODES }}
-      VPNCORE_DEV_BUILDS_URL: https://builds.ci.nymte.ch/nym-vpn-client/nym-vpn-core/develop
+      VPN_CORE_BUILDS_URL: https://${{ secrets.CI_WWW_REMOTE_HOST }}/nym-vpn-client/nym-vpn-core
     outputs:
       UPLOAD_DIR_WINDOWS: ${{ env.UPLOAD_DIR_WINDOWS }}
 
@@ -172,11 +172,11 @@ jobs:
         if: ${{ !inputs.core_release_tag && !inputs.core_artifact_url && inputs.dev_mode }}
         shell: bash
         run: |
-          latest=$(curl -s ${{ env.VPNCORE_DEV_BUILDS_URL }} \
+          latest=$(curl -s ${{ env.VPN_CORE_BUILDS_URL }}/develop \
               | grep -oP '(?<=<a href=")\d+/' \
               | sort -r \
               | head -n 1)
-          latest_url=${{ env.VPNCORE_DEV_BUILDS_URL }}/"$latest"
+          latest_url="${{ env.VPN_CORE_BUILDS_URL }}/develop/$latest"
           artifact=$(curl -s "$latest_url" \
               | grep -oP '(?<=^<a href=")nym-vpn-core-v.+_windows_x86_64\.zip(?=">)')
           artifact_url="$latest_url$artifact"

--- a/.github/workflows/build-nym-vpn-app-windows.yml
+++ b/.github/workflows/build-nym-vpn-app-windows.yml
@@ -72,6 +72,7 @@ jobs:
     runs-on: custom-windows-11
     env:
       CPP_BUILD_MODES: ${{ needs.build-mullvad-windows.outputs.CPP_BUILD_MODES }}
+      VPNCORE_DEV_BUILDS_URL: https://builds.ci.nymte.ch/nym-vpn-client/nym-vpn-core/develop
     outputs:
       UPLOAD_DIR_WINDOWS: ${{ env.UPLOAD_DIR_WINDOWS }}
 
@@ -154,7 +155,7 @@ jobs:
           echo "core_release_tag: ${{ inputs.core_release_tag }}"
           "core_release_tag=${{ inputs.core_release_tag }}" >> $env:GITHUB_ENV
 
-      - name: Get nym-vpn-core release tag
+      - name: Get nym-vpn-core release tag (latest stable)
         if: ${{ !inputs.core_release_tag && !inputs.dev_mode }}
         run: |
           $release_tag = curl -sSL -H "Accept: application/vnd.github+json" `
@@ -163,13 +164,23 @@ jobs:
           echo "core_release_tag: $release_tag"
           "core_release_tag=$release_tag" >> $env:GITHUB_ENV
 
-      - name: Get nym-vpn-core release tag (dev)
+      - name: Get nym-vpn-core artifact url (latest dev)
         if: ${{ !inputs.core_release_tag && inputs.dev_mode }}
+        shell: bash
         run: |
-          echo "core_release_tag: nym-vpn-core-nightly"
-          "core_release_tag=nym-vpn-core-nightly" >> $env:GITHUB_ENV
+          latest=$(curl -s ${{ env.VPNCORE_DEV_BUILDS_URL }} \
+              | grep -oP '(?<=<a href=")\d+/' \
+              | sort -r \
+              | head -n 1)
+          latest_url=${{ env.VPNCORE_DEV_BUILDS_URL }}/"$latest"
+          artifact=$(curl -s "$latest_url" \
+              | grep -oP '(?<=^<a href=")nym-vpn-core-v.+_windows_x86_64\.zip(?=">)')
+          artifact_url="$latest_url$artifact"
+          echo "$artifact_url"
+          echo "core_asset_url=$artifact_url" >> $GITHUB_ENV
 
-      - name: Get nym-vpn-core asset url
+      - name: Get nym-vpn-core artifact url (${{ env.core_release_tag }})
+        if: ${{ env.core_release_tag }}
         run: |
           $asset_url = curl -sSL -H "Accept: application/vnd.github+json" `
             https://api.github.com/repos/nymtech/nym-vpn-client/releases/tags/${{ env.core_release_tag }} |

--- a/.github/workflows/publish-nym-vpn-app.yml
+++ b/.github/workflows/publish-nym-vpn-app.yml
@@ -19,7 +19,11 @@ on:
         type: boolean
         default: false
       core_release_tag:
-        description: "nym-vpn-core release tag to use for Windows build (as it bundles the daemon)"
+        description: "nym-vpn-core release tag from GH to use for Windows, to get the daemon"
+        required: false
+        type: string
+      core_artifact_url:
+        description: "direct nym-vpn-core artifact URL for Windows, to get the daemon"
         required: false
         type: string
       windows_sign:
@@ -42,6 +46,7 @@ jobs:
     with:
       dev_mode: ${{ github.event_name == 'schedule' || contains(github.ref_name, 'dev') || contains(github.ref_name, 'nightly') || inputs.dev_mode == true  }}
       core_release_tag: ${{ inputs.core_release_tag }}
+      core_artifact_url: ${{ inputs.core_artifact_url }}
       sign: ${{ inputs.windows_sign == true }}
     secrets: inherit
 


### PR DESCRIPTION
- since any non-public builds are removed from GH, pull the dev builds from the external site
- add an optional input to the workflow allowing to pass a direct URL to vpn-core artifact for windows

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2222)
<!-- Reviewable:end -->
