### PR TITLE
Prevent error state when the tunnel is cancelled

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -556,7 +556,17 @@ impl tunnel::Error {
                 ..
             }) => Some(ErrorStateReason::BadBandwidthIncrease),
             Self::DupFd(_) => Some(ErrorStateReason::DuplicateTunFd),
-            _ => None,
+            Self::AuthenticationNotPossible(_)
+            | Self::AuthenticatorAddressNotFound
+            | Self::ConnectToIpPacketRouter(_)
+            | Self::LookupGatewayIp { .. }
+            | Self::MixnetClient(_)
+            | Self::SetupStoragePaths(_)
+            | Self::StartMixnetClientTimeout
+            | Self::CreateGatewayClient(_)
+            | Self::BandwidthController(_)
+            | Self::Wireguard(_)
+            | Self::Cancelled => None,
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -567,6 +567,10 @@ impl tunnel::Error {
             | Self::BandwidthController(_)
             | Self::Wireguard(_)
             | Self::Cancelled => None,
+            #[cfg(target_os = "ios")]
+            Self::ResolveDns64(_) => None,
+            #[cfg(windows)]
+            Self::AddDefaultRouteListener(_) => None,
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/status_listener.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/status_listener.rs
@@ -69,7 +69,9 @@ impl StatusListener {
 
     fn send_event(&self, event: MixnetEvent) {
         if let Err(e) = self.tx.send(event) {
-            tracing::error!("Failed to send event: {}", e);
+            if !self.cancel_token.is_cancelled() {
+                tracing::error!("Failed to send mixnet event: {}", e);
+            }
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -402,7 +402,9 @@ impl TunnelMonitor {
 
     fn send_event(&mut self, event: TunnelMonitorEvent) {
         if let Err(e) = self.monitor_event_sender.send(event) {
-            tracing::error!("Failed to send event: {}", e);
+            if !self.cancel_token.is_cancelled() {
+                tracing::error!("Failed to send monitor event: {}", e);
+            }
         }
     }
 


### PR DESCRIPTION
This PR ensures that state machine does not enter error state when the tunnel is cancelled. Also fixes the issue where "channel closed" error was printed upon cancellation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2231)
<!-- Reviewable:end -->
