### PR TITLE
feat(tauri): handle error state cancel action

### DIFF
--- a/nym-vpn-app/src-tauri/src/grpc/client.rs
+++ b/nym-vpn-app/src-tauri/src/grpc/client.rs
@@ -217,9 +217,9 @@ impl GrpcClient {
             error!("failed to parse tunnel state: {}", e);
             VpndError::internal("failed to parse tunnel state")
         })?;
-        match &tunnel {
-            TunnelState::Error(e) => warn!("tunnel error: {}", e),
-            _ => info!("tunnel state {}", tunnel),
+        info!("tunnel state [{}]", tunnel);
+        if let TunnelState::Error(e) = &tunnel {
+            warn!("tunnel error: {:?}", e);
         }
         let s_state = app.state::<SharedAppState>();
         let mut app_state = s_state.lock().await;
@@ -293,9 +293,9 @@ impl GrpcClient {
                 error!("failed to parse tunnel state: {}", e);
                 VpndError::internal("failed to parse tunnel state")
             })?;
-            match &tunnel {
-                TunnelState::Error(e) => warn!("tunnel error: {}", e),
-                _ => info!("tunnel state {}", tunnel),
+            info!("tunnel state [{}]", tunnel);
+            if let TunnelState::Error(e) = &tunnel {
+                warn!("tunnel error: {:?}", e);
             }
             let s_state = app.state::<SharedAppState>();
             let mut app_state = s_state.lock().await;

--- a/nym-vpn-app/src/i18n/fr/home.json
+++ b/nym-vpn-app/src/i18n/fr/home.json
@@ -6,7 +6,7 @@
     "disconnected": "Déconnecté",
     "connecting": "Connexion",
     "disconnecting": "Déconnexion",
-    "error": "Error",
+    "error": "Erreur",
     "offline": "Pas de connexion Internet"
   },
   "offline-message": "L'appareil n'est pas connecté à Internet",

--- a/nym-vpn-app/src/screens/home/ConnectionBadge.tsx
+++ b/nym-vpn-app/src/screens/home/ConnectionBadge.tsx
@@ -59,7 +59,7 @@ function ConnectionBadge({ state }: { state: TunnelState }) {
       animate={{ opacity: 1, scaleX: 1, translateY: 0 }}
       transition={{ duration: 0.1, ease: 'easeOut' }}
       className={clsx([
-        'flex justify-center items-center tracking-normal gap-4',
+        'flex justify-center items-center tracking-normal gap-4 min-w-36',
         ...statusBadgeDynStyles[state],
         'text-lg font-bold py-3 px-6 rounded-full tracking-normal',
       ])}

--- a/nym-vpn-app/src/screens/home/Home.tsx
+++ b/nym-vpn-app/src/screens/home/Home.tsx
@@ -33,7 +33,8 @@ function Home() {
     if (
       state === 'Connected' ||
       state === 'Connecting' ||
-      state === 'OfflineAutoReconnect'
+      state === 'OfflineAutoReconnect' ||
+      state === 'Error'
     ) {
       console.info('disconnect');
       if (state === 'Connecting') {
@@ -47,7 +48,7 @@ function Home() {
           console.warn('backend error:', e);
           dispatch({ type: 'set-error', error: e as BackendError });
         });
-    } else if (state === 'Disconnected' || state === 'Error') {
+    } else if (state === 'Disconnected') {
       console.info('connect');
       dispatch({ type: 'reset-error' });
       dispatch({ type: 'connect' });
@@ -74,11 +75,11 @@ function Home() {
 
   const getButtonText = useCallback(() => {
     const stop = capFirst(t('stop', { ns: 'glossary' }));
+    const cancel = capFirst(t('cancel', { ns: 'glossary' }));
     switch (state) {
       case 'Connected':
         return t('disconnect');
       case 'Disconnected':
-      case 'Error':
         return t('connect');
       case 'Connecting':
         return stop;
@@ -88,6 +89,8 @@ function Home() {
         return t('connect');
       case 'OfflineAutoReconnect':
         return stop;
+      case 'Error':
+        return cancel;
     }
   }, [state, t]);
 
@@ -102,6 +105,8 @@ function Home() {
       case 'Connected':
       case 'Disconnecting':
         return 'cornflower';
+      case 'Error':
+        return 'red';
       default:
         return 'gray';
     }

--- a/nym-vpn-app/src/ui/Button.tsx
+++ b/nym-vpn-app/src/ui/Button.tsx
@@ -7,7 +7,7 @@ export type ButtonProps = {
   children: ReactNode;
   onClick: () => void;
   disabled?: boolean;
-  color?: 'malachite' | 'cornflower' | 'gray';
+  color?: 'malachite' | 'cornflower' | 'gray' | 'red';
   outline?: boolean;
   className?: string;
   spinner?: boolean;
@@ -53,6 +53,11 @@ function Button({
           'bg-cornflower data-hover:bg-cornflower/85',
           'dark:data-hover:bg-cornflower/80',
         ];
+      case 'red':
+        return [
+          'bg-rouge-ecarlate data-hover:bg-rouge-ecarlate/85',
+          'dark:data-hover:bg-rouge-ecarlate/80',
+        ];
     }
   };
 
@@ -74,6 +79,8 @@ function Button({
         return 'text-dim-gray dark:text-dusty-grey';
       case 'cornflower':
         return 'text-cornflower';
+      case 'red':
+        return 'text-rouge-ecarlate';
     }
   };
 


### PR DESCRIPTION
- add a "Cancel" action when the tunnel enters the Error state, to allow the user to switch to 'Disconnected' state (so release firewall)
- improve tunnel state events logging

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2233)
<!-- Reviewable:end -->
