### PR TITLE
clippy: fix

### DIFF
--- a/nym-vpn-core/crates/nym-connection-monitor/src/packet_helpers.rs
+++ b/nym-vpn-core/crates/nym-connection-monitor/src/packet_helpers.rs
@@ -123,7 +123,7 @@ pub(crate) fn compute_ipv4_checksum(header: &Ipv4Packet) -> u16 {
     let mut sum = 0u32;
 
     for i in 0..len {
-        let word = (header.packet()[2 * i] as u32) << 8 | header.packet()[2 * i + 1] as u32;
+        let word = ((header.packet()[2 * i] as u32) << 8) | header.packet()[2 * i + 1] as u32;
         sum += word;
     }
 

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/from_proto/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/from_proto/tunnel_state.rs
@@ -137,7 +137,6 @@ impl TryFrom<ProtoTunnelState> for TunnelState {
             ProtoState::Error(ProtoError { error_state_reason }) => {
                 let reason = error_state_reason
                     .ok_or(ConversionError::NoValueSet("TunnelState.error"))
-                    .map(ProtoErrorStateReason::from)
                     .and_then(ErrorStateReason::try_from)?;
 
                 Self::Error(reason)


### PR DESCRIPTION
This PR fixes the following clippy warning and applied by clippy:

```warning: operator precedence can trip the unwary
   --> crates/nym-connection-monitor/src/packet_helpers.rs:126:20
    |
126 |         let word = (header.packet()[2 * i] as u32) << 8 | header.packet()[2 * i + 1] as u32;
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider parenthesizing your expression: `((header.packet()[2 * i] as u32) << 8) | header.packet()[2 * i + 1] as u32`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#precedence
    = note: `#[warn(clippy::precedence)]` on by default
```

and

```
warning: useless conversion to the same type: `tunnel_state::error::ErrorStateReason`
   --> crates/nym-vpn-proto/src/conversions/from_proto/tunnel_state.rs:139:77
    |
139 |                        .ok_or(ConversionError::NoValueSet("TunnelState.error"))
    |   _____________________________________________________________________________^
    |  |_____________________________________________________________________________|
140 | ||                     .map(ProtoErrorStateReason::from)
    | ||_____________________________________________________^
141 | |                      .and_then(ErrorStateReason::try_from)?;
    | |_____________________- help: consider removing
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion
    = note: `#[warn(clippy::useless_conversion)]` on by default

```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2254)
<!-- Reviewable:end -->
