### PR TITLE
Switch to `windows` in `nym-platform-metadata`

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -4003,7 +4003,6 @@ dependencies = [
  "tracing",
  "widestring",
  "windows 0.59.0",
- "windows-core 0.59.0",
  "windows-sys 0.59.0",
  "wmi",
 ]

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -4433,7 +4433,7 @@ version = "1.4.0-dev"
 dependencies = [
  "nym-dbus",
  "rs-release",
- "windows-sys 0.59.0",
+ "windows 0.59.0",
 ]
 
 [[package]]

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -172,7 +172,6 @@ which = { version = "7.0", default-features = false }
 widestring = "1.0"
 winapi = "0.3"
 windows = "0.59"
-windows-core = "0.59"
 windows-sys = "0.59"
 windows-service = "0.7.0"
 winreg = "0.52"

--- a/nym-vpn-core/crates/nym-firewall/Cargo.toml
+++ b/nym-vpn-core/crates/nym-firewall/Cargo.toml
@@ -33,7 +33,6 @@ nym-windows.workspace = true
 
 log.workspace = true
 wmi.workspace = true
-windows-core.workspace = true
 widestring.workspace = true
 
 [target.'cfg(windows)'.dependencies.windows-sys]

--- a/nym-vpn-core/crates/nym-firewall/src/windows/hyperv.rs
+++ b/nym-vpn-core/crates/nym-firewall/src/windows/hyperv.rs
@@ -2,11 +2,13 @@
 // Copyright 2025 Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use windows::Win32::System::{
-    Variant::VARIANT,
-    Wmi::{IWbemClassObject, WBEM_E_NOT_FOUND, WBEM_FLAG_RETURN_WBEM_COMPLETE},
+use windows::{
+    core::{BSTR, PCWSTR},
+    Win32::System::{
+        Variant::VARIANT,
+        Wmi::{IWbemClassObject, WBEM_E_NOT_FOUND, WBEM_FLAG_RETURN_WBEM_COMPLETE},
+    },
 };
-use windows_core::{BSTR, PCWSTR};
 use wmi::result_enumerator::IWbemClassWrapper;
 
 /// Name of the blocking Hyper-V rule.
@@ -33,13 +35,13 @@ pub enum Error {
     #[error("Failed to obtain Hyper-V rule class")]
     ObtainHyperVClass(#[source] wmi::WMIError),
     #[error("Failed to create new instance of Hyper-V rule class")]
-    NewRuleInstance(#[source] windows_core::Error),
+    NewRuleInstance(#[source] windows::core::Error),
     #[error("Failed to set rule setting: {0}")]
-    SetRuleKey(&'static str, #[source] windows_core::Error),
+    SetRuleKey(&'static str, #[source] windows::core::Error),
     #[error(r#"Failed to put the rule "{0}""#)]
-    PutInstance(&'static str, #[source] windows_core::Error),
+    PutInstance(&'static str, #[source] windows::core::Error),
     #[error(r#"Failed to delete rule "{0}""#)]
-    DeleteInstance(&'static str, #[source] windows_core::Error),
+    DeleteInstance(&'static str, #[source] windows::core::Error),
 }
 
 /// Initialize WMI connection to the ROOT\StandardCIMV2 namespace, which may be used for
@@ -186,7 +188,7 @@ fn remove_blocking_rule(
     }
 }
 
-fn map_deletion_err(element_name: &'static str, err: windows_core::Error) -> Result<(), Error> {
+fn map_deletion_err(element_name: &'static str, err: windows::core::Error) -> Result<(), Error> {
     if err.code().0 == WBEM_E_NOT_FOUND.0 {
         // If the rule doesn't exist, do nothing
         Ok(())

--- a/nym-vpn-core/crates/nym-platform-metadata/Cargo.toml
+++ b/nym-vpn-core/crates/nym-platform-metadata/Cargo.toml
@@ -16,7 +16,7 @@ network-manager = ["nym-dbus"]
 rs-release.workspace = true
 nym-dbus = { workspace = true, optional = true }
 
-[target.'cfg(windows)'.dependencies.windows-sys]
+[target.'cfg(windows)'.dependencies.windows]
 workspace = true
 features = [
     "Win32_Foundation",

--- a/nym-vpn-core/crates/nym-platform-metadata/src/windows.rs
+++ b/nym-vpn-core/crates/nym-platform-metadata/src/windows.rs
@@ -2,16 +2,15 @@
 // Copyright 2025 Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{
-    ffi::OsString,
-    io, iter,
-    mem::{self, MaybeUninit},
-    os::windows::ffi::OsStrExt,
-};
-use windows_sys::Win32::System::{
-    LibraryLoader::{GetModuleHandleW, GetProcAddress},
-    SystemInformation::OSVERSIONINFOEXW,
-    SystemServices::VER_NT_WORKSTATION,
+use std::mem::{self, MaybeUninit};
+
+use windows::{
+    core::{s, w},
+    Win32::System::{
+        LibraryLoader::{GetModuleHandleW, GetProcAddress},
+        SystemInformation::OSVERSIONINFOEXW,
+        SystemServices::VER_NT_WORKSTATION,
+    },
 };
 
 #[allow(non_camel_case_types)]
@@ -46,20 +45,10 @@ pub struct WindowsVersion {
 }
 
 impl WindowsVersion {
-    pub fn new() -> Result<WindowsVersion, io::Error> {
-        let module_name: Vec<u16> = OsString::from("ntdll")
-            .as_os_str()
-            .encode_wide()
-            .chain(iter::once(0u16))
-            .collect();
-
-        let ntdll = unsafe { GetModuleHandleW(module_name.as_ptr()) };
-        if ntdll.is_null() {
-            return Err(io::Error::last_os_error());
-        }
-
-        let function_address = unsafe { GetProcAddress(ntdll, b"RtlGetVersion\0" as *const u8) }
-            .ok_or_else(io::Error::last_os_error)?;
+    pub fn new() -> Result<WindowsVersion, windows::core::Error> {
+        let ntdll = unsafe { GetModuleHandleW(w!("ntdll"))? };
+        let function_address = unsafe { GetProcAddress(ntdll, s!("RtlGetVersion")) }
+            .ok_or_else(|| windows::core::Error::from_win32())?;
 
         let rtl_get_version: extern "stdcall" fn(*mut RTL_OSVERSIONINFOEXW) =
             unsafe { *(&function_address as *const _ as *const _) };

--- a/nym-vpn-core/crates/nym-platform-metadata/src/windows.rs
+++ b/nym-vpn-core/crates/nym-platform-metadata/src/windows.rs
@@ -48,7 +48,7 @@ impl WindowsVersion {
     pub fn new() -> Result<WindowsVersion, windows::core::Error> {
         let ntdll = unsafe { GetModuleHandleW(w!("ntdll"))? };
         let function_address = unsafe { GetProcAddress(ntdll, s!("RtlGetVersion")) }
-            .ok_or_else(|| windows::core::Error::from_win32())?;
+            .ok_or_else(windows::core::Error::from_win32)?;
 
         let rtl_get_version: extern "stdcall" fn(*mut RTL_OSVERSIONINFOEXW) =
             unsafe { *(&function_address as *const _ as *const _) };


### PR DESCRIPTION
- Switch from `windows-sys` to `windows` in `nym-platform-metadata`
- Remove reliance on `windows_core` as `windows` re-exports it via `windows::core` for better or for worse and we have `windows` nearly anywhere so I think it's ok if we stick to it for now.
- Refactor `WindowsVersion` to use `w!` and `s!` macros to produce wide or C-string respectively

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2258)
<!-- Reviewable:end -->
