### PR TITLE
Disable cover traffic for wireguard on Android

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
@@ -187,8 +187,8 @@ pub async fn connect_mixnet(
         TunnelType::Wireguard => {
             // Always disable poisson process for outbound traffic in wireguard.
             mixnet_client_config.disable_poisson_rate = true;
-            // Always disable background cover traffic in wireguard, except for android
-            mixnet_client_config.disable_background_cover_traffic = !cfg!(target_os = "android");
+            // Always disable background cover traffic in wireguard.
+            mixnet_client_config.disable_background_cover_traffic = false;
         }
     };
 


### PR DESCRIPTION
We should really stop running cover traffic.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2260)
<!-- Reviewable:end -->
