### PR TITLE
Update windows-service to 0.8

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -8775,13 +8775,13 @@ dependencies = [
 
 [[package]]
 name = "windows-service"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24d6bcc7f734a4091ecf8d7a64c5f7d7066f45585c1861eba06449909609c8a"
+checksum = "193cae8e647981c35bc947fdd57ba7928b1fa0d4a79305f6dd2dc55221ac35ac"
 dependencies = [
  "bitflags 2.8.0",
  "widestring",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -172,7 +172,7 @@ which = { version = "7.0", default-features = false }
 widestring = "1.0"
 winapi = "0.3"
 windows = "0.59"
-windows-service = "0.7.0"
+windows-service = "0.8.0"
 winreg = "0.52"
 wmi = "0.14"
 x25519-dalek = "2.0"


### PR DESCRIPTION
The only impact of this change that `windows-sys` in `windows-service` v0.8 has been bumped to v0.59

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2269)
<!-- Reviewable:end -->
