### PR TITLE
Enable workspace lints for panics and enable in a few crates

### DIFF
--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -75,6 +75,16 @@ documentation = "https://nymtech.net"
 edition = "2021"
 license = "GPL-3.0-only"
 
+[workspace.lints.clippy]
+unwrap_used = "deny"
+expect_used = "deny"
+todo = "deny"
+dbg_macro = "deny"
+exit = "deny"
+panic = "deny"
+unimplemented = "deny"
+unreachable = "deny"
+
 [workspace.dependencies]
 android_logger = "0.14.1"
 anyhow = "1.0.96"

--- a/nym-vpn-core/crates/nym-vpn-lib-types/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/Cargo.toml
@@ -8,6 +8,9 @@ documentation.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 nym-type-conversions = [
     "dep:nym-bandwidth-controller",

--- a/nym-vpn-core/crates/nym-vpn-store/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-store/Cargo.toml
@@ -8,6 +8,9 @@ documentation.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 bip39.workspace = true
 nym-crypto = { workspace = true, features = ["rand", "asymmetric"] }

--- a/nym-vpn-core/crates/nym-vpnd-types/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpnd-types/Cargo.toml
@@ -8,6 +8,9 @@ documentation.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 nym-validator-client.workspace = true
 serde.workspace = true


### PR DESCRIPTION
Similar to https://github.com/nymtech/nym/pull/5512, enable workspace lints for panics and add to a few crates

This should get the ball rolling for removing more panics from nym-vpn-core

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2280)
<!-- Reviewable:end -->
