### PR TITLE
Derive probe keys from known values

### DIFF
--- a/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
+++ b/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
@@ -23,6 +23,7 @@ use nym_config::defaults::{
 };
 use nym_connection_monitor::self_ping_and_wait;
 use nym_credentials_interface::TicketType;
+use nym_crypto::hkdf::DerivationMaterial;
 use nym_gateway_directory::{
     AuthAddress, Config as GatewayDirectoryConfig, EntryPoint,
     GatewayClient as GatewayDirectoryClient, GatewayList, GatewayMinPerformance,
@@ -88,6 +89,21 @@ pub struct NetstackArgs {
 
     #[arg(long, default_values_t = vec!["2001:4860:4860::8888".to_string(), "2606:4700:4700::1111".to_string(), "2620:fe::fe".to_string()])]
     netstack_ping_ips_v6: Vec<String>,
+}
+
+#[derive(Args)]
+pub struct DerivationMaterialArgs {
+    #[arg(
+        long,
+        default_value = "0000000000000000000000000000000000000000000000000000000000000000"
+    )]
+    pub master_key: String,
+
+    #[arg(
+        long,
+        default_value = "0000000000000000000000000000000000000000000000000000000000000000"
+    )]
+    pub salt: String,
 }
 
 #[derive(Args)]
@@ -192,12 +208,14 @@ impl Probe {
         gateway_config: GatewayDirectoryConfig,
         ignore_egress_epoch_role: bool,
         only_wireguard: bool,
+        derivation_material: DerivationMaterialArgs,
     ) -> anyhow::Result<ProbeResult> {
         let entry_point = self.entrypoint;
 
         // Setup the entry gateways
         let gateways = lookup_gateways(gateway_config.clone()).await?;
         let entry_gateway = entry_point.lookup_gateway(&gateways).await?;
+
         let tested_entry = self.tested_node.is_same_as_entry();
 
         let node_info: TestedNodeDetails = match self.tested_node {
@@ -213,6 +231,32 @@ impl Probe {
         };
 
         let mixnet_entry_gateway_id = entry_gateway.identity();
+
+        // Collapse gateway identity to a u32 index for the derivation material
+        let derivation_index = {
+            // If no index is provided, derive it from the gateway identity
+
+            // Use a simple hash of the identity string to create a u32 index
+            let identity_str = node_info.identity.to_string();
+            let mut hasher = std::collections::hash_map::DefaultHasher::new();
+            std::hash::Hash::hash(&identity_str, &mut hasher);
+            let hash = std::hash::Hasher::finish(&hasher);
+
+            // Convert the hash to a u32
+            let index = (hash % u32::MAX as u64) as u32;
+
+            info!(
+                "Derived index {} from gateway identity {}",
+                index, identity_str
+            );
+            index
+        };
+
+        let derivation_material = DerivationMaterial::new(
+            derivation_material.master_key,
+            derivation_index,
+            derivation_material.salt.as_bytes(),
+        );
 
         info!("connecting to entry gateway: {entry_gateway:?}");
         debug!(
@@ -230,6 +274,7 @@ impl Probe {
             ))
             .with_forget_me(ForgetMe::new_all())
             .credentials_mode(self.credentials_args.enable_credentials_mode)
+            .with_derivation_material(derivation_material)
             .build()?;
 
         if self.credentials_args.enable_credentials_mode {

--- a/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
+++ b/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
@@ -243,6 +243,10 @@ impl Probe {
             let hash = std::hash::Hasher::finish(&hasher);
 
             // Convert the hash to a u32
+            // Note: This modulo operation reduces the 64-bit hash to a 32-bit value,
+            // which increases collision probability. With u32::MAX (4.29 billion) possible values,
+            // by the birthday paradox, we'd expect a 50% chance of collision with ~65,000 gateways.
+            // For a small network of hundreds or thousands of gateways, collision risk is minimal.
             let index = (hash % u32::MAX as u64) as u32;
 
             info!(

--- a/nym-vpn-core/crates/nym-gateway-probe/src/run.rs
+++ b/nym-vpn-core/crates/nym-gateway-probe/src/run.rs
@@ -6,6 +6,7 @@ use clap::Parser;
 use nym_bin_common::bin_info;
 use nym_config::defaults::setup_env;
 use nym_gateway_directory::{EntryPoint, GatewayMinPerformance};
+use nym_gateway_probe::DerivationMaterialArgs;
 use nym_gateway_probe::{CredentialArgs, NetstackArgs, ProbeResult, TestedNode};
 use nym_sdk::mixnet::NodeIdentity;
 use std::path::PathBuf;
@@ -66,6 +67,9 @@ struct CliArgs {
     /// Arguments to manage credentials
     #[command(flatten)]
     credential_args: CredentialArgs,
+
+    #[command(flatten)]
+    derivation_material: DerivationMaterialArgs,
 }
 
 fn setup_logging() {
@@ -131,11 +135,13 @@ pub(crate) async fn run() -> anyhow::Result<ProbeResult> {
     if let Some(awg_args) = args.amnezia_args {
         trial.with_amnezia(&awg_args);
     }
+
     trial
         .probe(
             gateway_config,
             args.only_wireguard,
             args.ignore_egress_epoch_role,
+            args.derivation_material,
         )
         .await
 }


### PR DESCRIPTION
Adds two CLI args to derive probe keys. Both are set to default values so that existing setup continues to work, however it would be good to change them to something else. Key is derived from the master key and salt specified on the command line, and an index is derived from the tested node identity, this in practice means that all runs against the same node will have the same identity, and thats probably fine for now, it will make it easier to filter them out.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2332)
<!-- Reviewable:end -->
