### PR TITLE
Cleanup logging in account controller and add timings

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/mod.rs
@@ -110,7 +110,7 @@ impl AccountCommand {
     }
 
     pub fn return_no_account(self, error: Error) {
-        tracing::warn!("No account found: {error}");
+        tracing::debug!("No account found: {error}");
         match self {
             AccountCommand::SyncAccountState(Some(tx)) => {
                 tx.send(Err(SyncAccountError::NoAccountStored));
@@ -129,7 +129,7 @@ impl AccountCommand {
     }
 
     pub fn return_no_device(self, error: Error) {
-        tracing::warn!("No device found: {error}");
+        tracing::debug!("No device found: {error}");
         match self {
             AccountCommand::SyncDeviceState(Some(tx)) => {
                 tx.send(Err(SyncDeviceError::NoDeviceStored));

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/register_device.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/register_device.rs
@@ -107,7 +107,7 @@ pub(crate) async fn register_device(
                 .unwrap_or_else(RegisterDeviceError::unexpected_response)
         })?;
 
-    tracing::info!("Response: {:#?}", response);
+    tracing::debug!("Response: {:#?}", response);
     tracing::info!("Device registered: {}", response.device_identity_key);
     Ok(response)
 }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/request_zknym/request.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/request_zknym/request.rs
@@ -291,7 +291,7 @@ impl RequestZkNymTask {
             .map_err(|err| RequestZkNymError::CredentialStorage(err.to_string()))?
             .is_none()
         {
-            tracing::info!("Inserting coin index signatures for epoch: {epoch_id}",);
+            tracing::debug!("Inserting coin index signatures for epoch: {epoch_id}",);
             guard
                 .insert_coin_index_signatures(&aggregated_coin_index_signatures.signatures)
                 .await
@@ -349,7 +349,7 @@ impl RequestZkNymTask {
         response: &NymVpnZkNym,
         expiration_date: Date,
     ) -> Result<(), RequestZkNymError> {
-        tracing::info!("Importing attached keys and signatures, if available and needed");
+        tracing::debug!("Importing attached keys and signatures, if available and needed");
 
         let Some(ref shares) = response.blinded_shares else {
             return Err(RequestZkNymError::MissingBlindedShares);
@@ -463,7 +463,7 @@ impl RequestZkNymTask {
             return Err(RequestZkNymError::NoExpirationDateSignaturesInStorage);
         }
 
-        tracing::info!("Inserting issued zk-nym ticketbook");
+        tracing::debug!("Inserting issued zk-nym ticketbook");
         self.credential_storage
             .lock()
             .await
@@ -483,7 +483,7 @@ impl RequestZkNymTask {
         expiration_date: Date,
         request_info: &RequestInfo,
     ) -> Result<IssuedTicketBook, RequestZkNymError> {
-        tracing::info!("Unblinding and aggregating zk-nym shares");
+        tracing::debug!("Unblinding and aggregating zk-nym shares");
 
         let ecash_keypair = self
             .account
@@ -577,7 +577,7 @@ impl RequestZkNymTask {
     }
 
     async fn remove_pending_request(&self, id: &str) -> Result<(), RequestZkNymError> {
-        tracing::info!("Removing pending zk-nym request");
+        tracing::debug!("Removing pending zk-nym request");
         self.credential_storage
             .lock()
             .await

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/sync_account.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/sync_account.rs
@@ -97,7 +97,9 @@ impl SyncStateCommandHandler {
 }
 
 fn handle_remote_time(remote_time: VpnApiTime) {
-    if remote_time.is_synced() {
+    if remote_time.is_almost_same() {
+        tracing::debug!("{remote_time}");
+    } else if remote_time.is_acceptable_synced() {
         tracing::info!("{remote_time}");
     } else {
         tracing::warn!(

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/sync_device.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/sync_device.rs
@@ -136,7 +136,7 @@ async fn update_state(
     let new_device_state = if let Some(found_device) = found_device {
         DeviceState::from(found_device.status)
     } else {
-        tracing::info!("Our device is not registered");
+        tracing::debug!("Our device is not registered");
         DeviceState::NotRegistered
     };
 

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
@@ -216,11 +216,8 @@ where
                 Ok(account)
             }
             Err(err) => {
-                tracing::debug!("No account stored: {}", err);
-                self.account_state.reset().await;
-                self.account_state
-                    .set_mnemonic(MnemonicState::NotStored)
-                    .await;
+                tracing::debug!("No account stored: {err}");
+                self.account_state.reset_to(MnemonicState::NotStored).await;
                 Err(err)
             }
         }
@@ -664,7 +661,7 @@ where
     }
 
     async fn handle_command(&mut self, command: AccountCommand) {
-        tracing::info!("Received command: {}", command);
+        tracing::info!("← {}", command);
         match command {
             AccountCommand::StoreAccount(result_tx, mnemonic) => {
                 let result = self.handle_store_account(mnemonic).await;

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/credentials/pending_credential_requests/sqlite.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/credentials/pending_credential_requests/sqlite.rs
@@ -35,7 +35,7 @@ impl SqliteZkNymRequestsStorageManager {
         .execute(&self.connection_pool)
         .await?
         .rows_affected();
-        tracing::info!("Removed {} stale pending requests", affected);
+        tracing::debug!("Removed {} stale pending requests", affected);
         Ok(())
     }
 

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/ticketbooks.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/ticketbooks.rs
@@ -152,12 +152,14 @@ impl AvailableTicketbooks {
     }
 
     pub fn ticket_types_running_low(&self) -> Vec<TicketType> {
-        for ticket_type in self.ticket_types_above_threshold(0) {
-            tracing::info!(
-                "Remaining unexpired tickets for {ticket_type}: {}",
-                self.remaining_tickets(ticket_type)
-            );
-        }
+        let remaining_tickets = self
+            .ticket_types_above_threshold(0)
+            .into_iter()
+            .map(|ticket_type| format!("{ticket_type}: {}", self.remaining_tickets(ticket_type)))
+            .collect::<Vec<String>>()
+            .join(", ");
+        tracing::debug!("Remaining unexpired tickets: {remaining_tickets}");
+
         self.ticket_types_below_or_at_threshold(TICKET_NUMBER_THRESHOLD)
     }
 

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/types/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/types/account.rs
@@ -12,6 +12,7 @@ use time::{Duration, OffsetDateTime};
 use crate::{error::Result, jwt::Jwt, VpnApiClientError};
 
 const MAX_ACCEPTABLE_SKEW_SECONDS: i64 = 30;
+const SKEW_SECONDS_CONSIDERED_SAME: i64 = 2;
 
 #[derive(Clone, Debug)]
 pub struct VpnApiAccount {
@@ -101,7 +102,11 @@ impl VpnApiTime {
         self.local_time - self.estimated_remote_time
     }
 
-    pub fn is_synced(&self) -> bool {
+    pub fn is_almost_same(&self) -> bool {
+        self.local_time_ahead_skew().abs().whole_seconds() < SKEW_SECONDS_CONSIDERED_SAME
+    }
+
+    pub fn is_acceptable_synced(&self) -> bool {
         self.local_time_ahead_skew().abs().whole_seconds() < MAX_ACCEPTABLE_SKEW_SECONDS
     }
 

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/start.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/start.rs
@@ -42,7 +42,7 @@ fn grpc_span(req: &http::Request<()>) -> tracing::Span {
         tracing::debug!(target: "grpc_health", "← {} {:?}", method, req.body());
         return span;
     }
-    let span = tracing::info_span!("grpc_vpnd");
+    let span = tracing::info_span!("grpc_vpnd", req = method);
     tracing::info!(target: "grpc_vpnd", "← {} {:?}", method, req.body());
     span
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/logging.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/logging.rs
@@ -5,7 +5,8 @@ use tracing_appender::non_blocking::WorkerGuard;
 #[cfg(target_os = "macos")]
 use tracing_oslog::OsLogger;
 use tracing_subscriber::{
-    filter::LevelFilter, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer,
+    filter::LevelFilter, fmt::format::FmtSpan, layer::SubscriberExt, util::SubscriberInitExt,
+    EnvFilter, Layer,
 };
 
 use crate::service;
@@ -34,10 +35,8 @@ pub fn setup_logging(options: Options) -> Option<WorkerGuard> {
         let file_appender = tracing_appender::rolling::never(log_dir, service::DEFAULT_LOG_FILE);
         let (file_writer, worker_guard) = tracing_appender::non_blocking(file_appender);
         let file_layer = tracing_subscriber::fmt::layer()
-            // .with_timer(tracing_subscriber::fmt::time::time())
-            // .with_target(true)
             .compact()
-            .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
+            .with_span_events(FmtSpan::CLOSE)
             .with_writer(file_writer)
             .with_ansi(false);
         layers.push(file_layer.boxed());
@@ -48,10 +47,8 @@ pub fn setup_logging(options: Options) -> Option<WorkerGuard> {
 
     if options.enable_stdout_log {
         let console_layer = tracing_subscriber::fmt::layer()
-            // .with_timer(tracing_subscriber::fmt::time::time())
-            // .with_target(true)
             .compact()
-            .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
+            .with_span_events(FmtSpan::CLOSE)
             .with_ansi(true);
         layers.push(console_layer.boxed());
     }

--- a/nym-vpn-core/crates/nym-vpnd/src/logging.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/logging.rs
@@ -34,7 +34,10 @@ pub fn setup_logging(options: Options) -> Option<WorkerGuard> {
         let file_appender = tracing_appender::rolling::never(log_dir, service::DEFAULT_LOG_FILE);
         let (file_writer, worker_guard) = tracing_appender::non_blocking(file_appender);
         let file_layer = tracing_subscriber::fmt::layer()
+            // .with_timer(tracing_subscriber::fmt::time::time())
+            // .with_target(true)
             .compact()
+            .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
             .with_writer(file_writer)
             .with_ansi(false);
         layers.push(file_layer.boxed());
@@ -44,7 +47,12 @@ pub fn setup_logging(options: Options) -> Option<WorkerGuard> {
     };
 
     if options.enable_stdout_log {
-        let console_layer = tracing_subscriber::fmt::layer().compact().with_ansi(true);
+        let console_layer = tracing_subscriber::fmt::layer()
+            // .with_timer(tracing_subscriber::fmt::time::time())
+            // .with_target(true)
+            .compact()
+            .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
+            .with_ansi(true);
         layers.push(console_layer.boxed());
     }
 

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{net::IpAddr, path::PathBuf, sync::Arc};
+use std::{net::IpAddr, path::PathBuf, sync::Arc, time::Instant};
 
 use bip39::Mnemonic;
 use nym_vpn_network_config::{
@@ -41,6 +41,8 @@ use super::{
     error::{AccountError, Error, Result, SetNetworkError},
     VpnServiceConnectError, VpnServiceDisconnectError,
 };
+
+use tracing::{debug, info};
 
 // Seed used to generate device identity keys
 type Seed = [u8; 32];
@@ -492,6 +494,7 @@ where
         Ok(config)
     }
 
+    #[tracing::instrument(skip(self), level = "info", fields(time.unit = "ms"))]
     async fn handle_connect(
         &mut self,
         connect_args: ConnectArgs,
@@ -608,23 +611,27 @@ where
         }
     }
 
+    #[tracing::instrument(skip(self), level = "info", fields(time.unit = "ms"))]
     async fn handle_disconnect(&mut self) -> Result<(), VpnServiceDisconnectError> {
         self.command_sender
             .send(TunnelCommand::Disconnect)
             .map_err(|e| {
                 tracing::error!("Failed to send command to disconnect: {}", e);
-                VpnServiceDisconnectError::Internal("failed to send dicsonnect command".to_owned())
+                VpnServiceDisconnectError::Internal("failed to send disconnect command".to_owned())
             })
     }
 
+    #[tracing::instrument(skip(self), level = "info", fields(time.unit = "ms"))]
     fn handle_get_tunnel_state(&self) -> TunnelState {
         self.tunnel_state.borrow().to_owned()
     }
 
+    #[tracing::instrument(skip(self), level = "info", fields(time.unit = "ms"))]
     fn handle_subscribe_to_tunnel_state(&self) -> watch::Receiver<TunnelState> {
         self.tunnel_state.subscribe()
     }
 
+    #[tracing::instrument(skip(self), level = "info", fields(time.unit = "ms"))]
     async fn handle_info(&self) -> VpnServiceInfo {
         let bin_info = nym_bin_common::bin_info_local_vergen!();
 
@@ -639,13 +646,13 @@ where
         }
     }
 
+    #[tracing::instrument(skip(self), level = "info", fields(time.unit = "ms"))]
     async fn handle_set_network(&self, network: String) -> Result<(), SetNetworkError> {
         let mut global_config =
             GlobalConfigFile::read_from_file().map_err(|source| SetNetworkError::ReadConfig {
                 source: source.into(),
             })?;
 
-        // Manually restrict the set of possible network, until we handle this automatically
         let network_selected = NetworkEnvironments::try_from(network.as_str())
             .map_err(|_err| SetNetworkError::NetworkNotFound(network.to_owned()))?;
         global_config.network_name = network_selected.to_string();
@@ -656,27 +663,29 @@ where
                 source: source.into(),
             })?;
 
-        tracing::info!(
+        info!(
             "Network updated to: {} (SERVICE RESTART REQUIRED!)",
             network_selected
         );
-
         Ok(())
     }
 
+    #[tracing::instrument(skip(self), level = "info", fields(time.unit = "ms"))]
     async fn handle_get_system_messages(&self) -> SystemMessages {
         self.network_env.nym_vpn_network.system_messages.clone()
     }
 
+    #[tracing::instrument(skip(self), level = "info", fields(time.unit = "ms"))]
     async fn handle_get_feature_flags(&self) -> Option<FeatureFlags> {
         self.network_env.feature_flags.clone()
     }
 
+    #[tracing::instrument(skip(self, account), level = "info", fields(time.unit = "ms"))]
     async fn handle_store_account(
         &mut self,
         account: Zeroizing<String>,
     ) -> Result<(), AccountError> {
-        tracing::info!("Storing account");
+        info!("Storing account");
         let mnemonic = Mnemonic::parse::<&str>(account.as_ref())?;
         self.account_command_tx
             .store_account(mnemonic)
@@ -684,10 +693,12 @@ where
             .map_err(|source| AccountError::AccountCommandError { source })
     }
 
+    #[tracing::instrument(skip(self), level = "info", fields(time.unit = "ms"))]
     async fn handle_is_account_stored(&self) -> Result<bool, AccountError> {
         Ok(self.shared_account_state.is_account_stored().await)
     }
 
+    #[tracing::instrument(skip(self), level = "info", fields(time.unit = "ms"))]
     async fn handle_forget_account(&mut self) -> Result<(), AccountError> {
         if *self.tunnel_state.borrow() != TunnelState::Disconnected {
             return Err(AccountError::IsConnected);
@@ -705,10 +716,12 @@ where
             .map_err(|source| AccountError::AccountCommandError { source })
     }
 
+    #[tracing::instrument(skip(self), level = "info", fields(time.unit = "ms"))]
     async fn handle_get_account_identity(&self) -> Result<Option<String>, AccountError> {
         Ok(self.shared_account_state.get_account_id().await)
     }
 
+    #[tracing::instrument(skip(self), level = "info", fields(time.unit = "ms"))]
     async fn handle_get_account_links(
         &self,
         locale: String,
@@ -727,16 +740,19 @@ where
             })
     }
 
+    #[tracing::instrument(skip(self), level = "info", fields(time.unit = "ms"))]
     async fn handle_get_account_state(&self) -> Result<AccountStateSummary, AccountError> {
         Ok(self.shared_account_state.lock().await.clone())
     }
 
+    #[tracing::instrument(skip(self), level = "info", fields(time.unit = "ms"))]
     async fn handle_refresh_account_state(&self) -> Result<(), AccountError> {
         self.account_command_tx
             .send(AccountCommand::SyncAccountState(None))
             .map_err(|err| AccountError::AccountControllerError { source: err })
     }
 
+    #[tracing::instrument(skip(self), level = "info", fields(time.unit = "ms"))]
     async fn handle_get_usage(&self) -> Result<Vec<NymVpnUsage>, AccountError> {
         self.account_command_tx
             .get_usage()
@@ -744,6 +760,7 @@ where
             .map_err(|source| AccountError::AccountCommandError { source })
     }
 
+    #[tracing::instrument(skip(self), level = "info", fields(time.unit = "ms"))]
     async fn handle_reset_device_identity(
         &mut self,
         seed: Option<[u8; 32]>,
@@ -773,6 +790,7 @@ where
             .map_err(|source| AccountError::AccountControllerError { source })
     }
 
+    #[tracing::instrument(skip(self), level = "info", fields(time.unit = "ms"))]
     async fn handle_get_device_identity(&self) -> Result<String, AccountError> {
         self.account_command_tx
             .get_device_identity()

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -311,8 +311,8 @@ where
         loop {
             tokio::select! {
                 Some(command) = self.vpn_command_rx.recv() => {
-                    tracing::debug!("VPN: Received command: {command}");
-                    self.handle_service_command(command).await;
+                    tracing::debug!("Received command: {command}");
+                    self.handle_service_command_timed(command).await;
                 }
                 Some(event) = self.event_receiver.recv() => {
                     if let Err(e) = self.tunnel_event_tx.send(event.clone()) {
@@ -345,6 +345,16 @@ where
         tracing::info!("Exiting vpn service run loop");
 
         Ok(())
+    }
+
+    async fn handle_service_command_timed(&mut self, command: VpnServiceCommand) {
+        let start = Instant::now();
+        let command_str = command.to_string();
+        self.handle_service_command(command).await;
+        let elapsed = start.elapsed();
+        if elapsed.as_millis() > 100 {
+            tracing::warn!("{command_str} took {} ms to execute", elapsed.as_millis());
+        }
     }
 
     async fn handle_service_command(&mut self, command: VpnServiceCommand) {
@@ -492,7 +502,6 @@ where
         Ok(config)
     }
 
-    #[tracing::instrument(skip(self), level = "info", fields(time.unit = "ms"))]
     async fn handle_connect(
         &mut self,
         connect_args: ConnectArgs,
@@ -609,7 +618,6 @@ where
         }
     }
 
-    #[tracing::instrument(skip(self), level = "info", fields(time.unit = "ms"))]
     async fn handle_disconnect(&mut self) -> Result<(), VpnServiceDisconnectError> {
         self.command_sender
             .send(TunnelCommand::Disconnect)
@@ -619,17 +627,14 @@ where
             })
     }
 
-    #[tracing::instrument(skip(self), level = "info", fields(time.unit = "ms"))]
     fn handle_get_tunnel_state(&self) -> TunnelState {
         self.tunnel_state.borrow().to_owned()
     }
 
-    #[tracing::instrument(skip(self), level = "info", fields(time.unit = "ms"))]
     fn handle_subscribe_to_tunnel_state(&self) -> watch::Receiver<TunnelState> {
         self.tunnel_state.subscribe()
     }
 
-    #[tracing::instrument(skip(self), level = "info", fields(time.unit = "ms"))]
     async fn handle_info(&self) -> VpnServiceInfo {
         let bin_info = nym_bin_common::bin_info_local_vergen!();
 
@@ -644,7 +649,6 @@ where
         }
     }
 
-    #[tracing::instrument(skip(self), level = "info", fields(time.unit = "ms"))]
     async fn handle_set_network(&self, network: String) -> Result<(), SetNetworkError> {
         let mut global_config =
             GlobalConfigFile::read_from_file().map_err(|source| SetNetworkError::ReadConfig {
@@ -668,17 +672,14 @@ where
         Ok(())
     }
 
-    #[tracing::instrument(skip(self), level = "info", fields(time.unit = "ms"))]
     async fn handle_get_system_messages(&self) -> SystemMessages {
         self.network_env.nym_vpn_network.system_messages.clone()
     }
 
-    #[tracing::instrument(skip(self), level = "info", fields(time.unit = "ms"))]
     async fn handle_get_feature_flags(&self) -> Option<FeatureFlags> {
         self.network_env.feature_flags.clone()
     }
 
-    #[tracing::instrument(skip(self, account), level = "info", fields(time.unit = "ms"))]
     async fn handle_store_account(
         &mut self,
         account: Zeroizing<String>,
@@ -691,12 +692,10 @@ where
             .map_err(|source| AccountError::AccountCommandError { source })
     }
 
-    #[tracing::instrument(skip(self), level = "info", fields(time.unit = "ms"))]
     async fn handle_is_account_stored(&self) -> Result<bool, AccountError> {
         Ok(self.shared_account_state.is_account_stored().await)
     }
 
-    #[tracing::instrument(skip(self), level = "info", fields(time.unit = "ms"))]
     async fn handle_forget_account(&mut self) -> Result<(), AccountError> {
         if *self.tunnel_state.borrow() != TunnelState::Disconnected {
             return Err(AccountError::IsConnected);
@@ -714,12 +713,10 @@ where
             .map_err(|source| AccountError::AccountCommandError { source })
     }
 
-    #[tracing::instrument(skip(self), level = "info", fields(time.unit = "ms"))]
     async fn handle_get_account_identity(&self) -> Result<Option<String>, AccountError> {
         Ok(self.shared_account_state.get_account_id().await)
     }
 
-    #[tracing::instrument(skip(self), level = "info", fields(time.unit = "ms"))]
     async fn handle_get_account_links(
         &self,
         locale: String,
@@ -738,19 +735,16 @@ where
             })
     }
 
-    #[tracing::instrument(skip(self), level = "info", fields(time.unit = "ms"))]
     async fn handle_get_account_state(&self) -> Result<AccountStateSummary, AccountError> {
         Ok(self.shared_account_state.lock().await.clone())
     }
 
-    #[tracing::instrument(skip(self), level = "info", fields(time.unit = "ms"))]
     async fn handle_refresh_account_state(&self) -> Result<(), AccountError> {
         self.account_command_tx
             .send(AccountCommand::SyncAccountState(None))
             .map_err(|err| AccountError::AccountControllerError { source: err })
     }
 
-    #[tracing::instrument(skip(self), level = "info", fields(time.unit = "ms"))]
     async fn handle_get_usage(&self) -> Result<Vec<NymVpnUsage>, AccountError> {
         self.account_command_tx
             .get_usage()
@@ -758,7 +752,6 @@ where
             .map_err(|source| AccountError::AccountCommandError { source })
     }
 
-    #[tracing::instrument(skip(self), level = "info", fields(time.unit = "ms"))]
     async fn handle_reset_device_identity(
         &mut self,
         seed: Option<[u8; 32]>,
@@ -788,7 +781,6 @@ where
             .map_err(|source| AccountError::AccountControllerError { source })
     }
 
-    #[tracing::instrument(skip(self), level = "info", fields(time.unit = "ms"))]
     async fn handle_get_device_identity(&self) -> Result<String, AccountError> {
         self.account_command_tx
             .get_device_identity()

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -42,8 +42,6 @@ use super::{
     VpnServiceConnectError, VpnServiceDisconnectError,
 };
 
-use tracing::{debug, info};
-
 // Seed used to generate device identity keys
 type Seed = [u8; 32];
 
@@ -663,7 +661,7 @@ where
                 source: source.into(),
             })?;
 
-        info!(
+        tracing::info!(
             "Network updated to: {} (SERVICE RESTART REQUIRED!)",
             network_selected
         );
@@ -685,7 +683,7 @@ where
         &mut self,
         account: Zeroizing<String>,
     ) -> Result<(), AccountError> {
-        info!("Storing account");
+        tracing::info!("Storing account");
         let mnemonic = Mnemonic::parse::<&str>(account.as_ref())?;
         self.account_command_tx
             .store_account(mnemonic)

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -684,7 +684,6 @@ where
         &mut self,
         account: Zeroizing<String>,
     ) -> Result<(), AccountError> {
-        tracing::info!("Storing account");
         let mnemonic = Mnemonic::parse::<&str>(account.as_ref())?;
         self.account_command_tx
             .store_account(mnemonic)


### PR DESCRIPTION
- Fix: try to register device in the background even if there are no active subscriptions.
- Cleanup: remove lots of unnecessary logging at INFO level in the account controller
- Add timings on span close. Also a warning if any vpnd command takes a long time and blocks the select loop.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2339)
<!-- Reviewable:end -->
