### PR TITLE
clippy: fix

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/uniffi_custom_impls.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/uniffi_custom_impls.rs
@@ -633,7 +633,7 @@ pub enum AccountRegistered {
 impl From<nym_vpn_account_controller::shared_state::AccountRegistered> for AccountRegistered {
     fn from(value: nym_vpn_account_controller::shared_state::AccountRegistered) -> Self {
         match value {
-            nym_vpn_account_controller::shared_state::AccountRegistered::Registered { .. } => {
+            nym_vpn_account_controller::shared_state::AccountRegistered::Registered => {
                 AccountRegistered::Registered
             }
             nym_vpn_account_controller::shared_state::AccountRegistered::NotRegistered => {
@@ -653,13 +653,11 @@ pub enum AccountState {
 impl From<nym_vpn_account_controller::shared_state::AccountState> for AccountState {
     fn from(value: nym_vpn_account_controller::shared_state::AccountState) -> Self {
         match value {
-            nym_vpn_account_controller::shared_state::AccountState::Inactive { .. } => {
+            nym_vpn_account_controller::shared_state::AccountState::Inactive => {
                 AccountState::Inactive
             }
-            nym_vpn_account_controller::shared_state::AccountState::Active { .. } => {
-                AccountState::Active
-            }
-            nym_vpn_account_controller::shared_state::AccountState::DeleteMe { .. } => {
+            nym_vpn_account_controller::shared_state::AccountState::Active => AccountState::Active,
+            nym_vpn_account_controller::shared_state::AccountState::DeleteMe => {
                 AccountState::DeleteMe
             }
         }

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/account.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/protobuf/account.rs
@@ -86,7 +86,7 @@ impl From<AccountError> for nym_vpn_proto::AccountError {
                 message: err.to_string(),
                 details: hashmap! {},
             },
-            AccountError::FailedToGetAccountSummary { .. } => nym_vpn_proto::AccountError {
+            AccountError::FailedToGetAccountSummary => nym_vpn_proto::AccountError {
                 kind: AccountErrorType::Storage as i32,
                 message: err.to_string(),
                 details: hashmap! {},

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/start.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/start.rs
@@ -31,7 +31,7 @@ const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
 
 fn grpc_span(req: &http::Request<()>) -> tracing::Span {
     let service = req.uri().path().trim_start_matches('/');
-    let method = service.split('/').last().unwrap_or(service);
+    let method = service.split('/').next_back().unwrap_or(service);
     if service.contains("grpc.reflection.v1") {
         let span = tracing::trace_span!("grpc_reflection");
         tracing::trace!(target: "grpc_reflection", "← {} {:?}", method, req.body());


### PR DESCRIPTION
Fix the following clippy complaints originating from 1.86 nightly:

```
warning: struct pattern is not needed for a unit variant
   --> crates/nym-vpn-lib/src/platform/uniffi_custom_impls.rs:636:84
    |
636 |             nym_vpn_account_controller::shared_state::AccountRegistered::Registered { .. } => {
    |                                                                                    ^^^^^^^ help: remove the struct pattern
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unneeded_struct_pattern
    = note: `#[warn(clippy::unneeded_struct_pattern)]` on by default

warning: struct pattern is not needed for a unit variant
   --> crates/nym-vpn-lib/src/platform/uniffi_custom_impls.rs:656:77
    |
656 |             nym_vpn_account_controller::shared_state::AccountState::Inactive { .. } => {
    |                                                                             ^^^^^^^ help: remove the struct pattern
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unneeded_struct_pattern

warning: struct pattern is not needed for a unit variant
   --> crates/nym-vpn-lib/src/platform/uniffi_custom_impls.rs:659:75
    |
659 |             nym_vpn_account_controller::shared_state::AccountState::Active { .. } => {
    |                                                                           ^^^^^^^ help: remove the struct pattern
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unneeded_struct_pattern

warning: struct pattern is not needed for a unit variant
   --> crates/nym-vpn-lib/src/platform/uniffi_custom_impls.rs:662:77
    |
662 |             nym_vpn_account_controller::shared_state::AccountState::DeleteMe { .. } => {
    |                                                                             ^^^^^^^ help: remove the struct pattern
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unneeded_struct_pattern

warning: `nym-vpn-lib` (lib) generated 6 warnings (run `cargo clippy --fix --lib -p nym-vpn-lib` to apply 4 suggestions)
    Checking nym-vpnd-types v1.5.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpnd-types)
    Checking nym-vpn-proto v1.5.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpn-proto)
    Checking nym-vpnd v1.5.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpnd)
    Checking nym-vpnc v1.5.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpnc)
warning: struct pattern is not needed for a unit variant
  --> crates/nym-vpnd/src/command_interface/protobuf/account.rs:89:52
   |
89 |             AccountError::FailedToGetAccountSummary { .. } => nym_vpn_proto::AccountError {
   |                                                    ^^^^^^^ help: remove the struct pattern
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unneeded_struct_pattern
   = note: `#[warn(clippy::unneeded_struct_pattern)]` on by default

warning: called `Iterator::last` on a `DoubleEndedIterator`; this will needlessly iterate the entire iterator
  --> crates/nym-vpnd/src/command_interface/start.rs:34:37
   |
34 |     let method = service.split('/').last().unwrap_or(service);
   |                                     ^^^^^^ help: try: `next_back()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#double_ended_iterator_last
   = note: `#[warn(clippy::double_ended_iterator_last)]` on by default
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2351)
<!-- Reviewable:end -->
