### PR TITLE
refactor(tauri-react): extract gateways state into a dedicated context

### DIFF
--- a/nym-vpn-app/src/App.tsx
+++ b/nym-vpn-app/src/App.tsx
@@ -17,6 +17,7 @@ import router from './router';
 import './i18n/config';
 import { Cli } from './types';
 import { RouteLoading, ThemeSetter } from './ui';
+import { GatewaysProvider } from './contexts/gateways';
 
 let initialized = false;
 
@@ -64,13 +65,15 @@ function App() {
     <InAppNotificationProvider>
       <Toast.Provider>
         <MainStateProvider>
-          <ThemeSetter>
-            <DialogProvider>
-              <Suspense fallback={<RouteLoading />}>
-                <RouterProvider router={router} />
-              </Suspense>
-            </DialogProvider>
-          </ThemeSetter>
+          <GatewaysProvider>
+            <ThemeSetter>
+              <DialogProvider>
+                <Suspense fallback={<RouteLoading />}>
+                  <RouterProvider router={router} />
+                </Suspense>
+              </DialogProvider>
+            </ThemeSetter>
+          </GatewaysProvider>
         </MainStateProvider>
       </Toast.Provider>
     </InAppNotificationProvider>

--- a/nym-vpn-app/src/contexts/gateways/context.ts
+++ b/nym-vpn-app/src/contexts/gateways/context.ts
@@ -1,0 +1,22 @@
+import { createContext, useContext } from 'react';
+import { GatewaysState } from './types';
+
+export const initialState: GatewaysState = {
+  mxEntry: [],
+  mxExit: [],
+  wg: [],
+  mxEntryLoading: false,
+  mxExitLoading: false,
+  wgLoading: false,
+  mxEntryError: null,
+  mxExitError: null,
+  wgError: null,
+  fetch: async () => {
+    /*  SCARECROW */
+  },
+};
+
+export const GatewaysContext = createContext<GatewaysState>(initialState);
+export const useGateways = () => {
+  return useContext(GatewaysContext);
+};

--- a/nym-vpn-app/src/contexts/gateways/index.ts
+++ b/nym-vpn-app/src/contexts/gateways/index.ts
@@ -1,0 +1,3 @@
+export { default as GatewaysProvider } from './provider';
+export * from './context';
+export * from './types';

--- a/nym-vpn-app/src/contexts/gateways/provider.tsx
+++ b/nym-vpn-app/src/contexts/gateways/provider.tsx
@@ -1,0 +1,159 @@
+import { useCallback, useEffect, useMemo, useReducer } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import {
+  BackendError,
+  GatewayType,
+  GatewaysByCountry,
+  StateDispatch,
+} from '../../types';
+import { useMainDispatch, useMainState } from '../main';
+import { CCache } from '../../cache';
+import { DefaultCountry, GatewaysCacheDuration } from '../../constants';
+import { kvSet } from '../../kvStore';
+import { S_STATE } from '../../static';
+import { exists, getStateProps, gwTypeToCacheKey } from './util';
+import { GatewaysContext, initialState } from './context';
+import { reducer } from './reducer';
+import { GatewaysState } from './types';
+
+let initialized = false;
+
+type GatewaysStateProviderProps = {
+  children: React.ReactNode;
+};
+
+function GatewaysProvider({ children }: GatewaysStateProviderProps) {
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  const { entryNode, exitNode } = useMainState();
+  const mainDispatch = useMainDispatch() as StateDispatch;
+
+  const checkSelectedNode = useCallback(
+    async (gateways: GatewaysByCountry[], nodeType: 'entry' | 'exit') => {
+      const node = nodeType === 'entry' ? entryNode : exitNode;
+      if (!exists(node, gateways)) {
+        console.info(`[${nodeType}] node not available, swap to default`);
+        mainDispatch({
+          type: 'set-node',
+          payload: {
+            hop: nodeType,
+            node: DefaultCountry,
+          },
+        });
+        await kvSet(`${nodeType}-node`, DefaultCountry);
+        // TODO notify user
+      }
+    },
+    [mainDispatch, entryNode, exitNode],
+  );
+
+  // use cached values if any, otherwise query from daemon
+  const fetchGateways = useCallback(
+    async (nodeType: GatewayType) => {
+      const { loading } = getStateProps(nodeType);
+      if (state[loading]) {
+        return;
+      }
+      dispatch({
+        type: 'set-gateways-loading',
+        payload: {
+          type: nodeType,
+          loading: true,
+        },
+      });
+      const cacheKey = gwTypeToCacheKey(nodeType);
+      // first try to load from cache
+      let gateways = await CCache.get<GatewaysByCountry[]>(cacheKey);
+
+      // fallback to daemon query
+      if (!gateways) {
+        console.info(`fetching gateways for ${nodeType}`);
+        try {
+          gateways = await invoke<GatewaysByCountry[]>('get_gateways', {
+            nodeType,
+          });
+          await CCache.set(cacheKey, gateways, GatewaysCacheDuration);
+        } catch (e) {
+          console.warn(`Failed to fetch ${nodeType} gateways:`, e);
+          if (nodeType === 'mx-entry') {
+            // this also reset loading state
+            dispatch({
+              type: 'set-gateways-error',
+              payload: {
+                type: nodeType,
+                error: e as BackendError,
+              },
+            });
+          }
+        }
+      }
+      if (!gateways) {
+        console.warn(`no gateways found for ${nodeType}`);
+        gateways = [];
+      }
+      dispatch({
+        type: 'set-gateways',
+        payload: {
+          type: nodeType,
+          gateways,
+        },
+      });
+      dispatch({
+        type: 'reset-loading-and-error',
+        payload: {
+          type: nodeType,
+        },
+      });
+      if (nodeType === 'mx-entry') {
+        await checkSelectedNode(gateways, 'entry');
+      } else if (nodeType === 'mx-exit') {
+        await checkSelectedNode(gateways, 'exit');
+      } else {
+        // for wg check both entry and exit as they share the same gateways
+        await checkSelectedNode(gateways, 'entry');
+        await checkSelectedNode(gateways, 'exit');
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      checkSelectedNode,
+      state.mxEntryLoading,
+      state.mxExitLoading,
+      state.wgLoading,
+    ],
+  );
+
+  // init gateways on app start
+  useEffect(() => {
+    if (initialized) {
+      return;
+    }
+    initialized = true;
+    if (S_STATE.vpnModeAtStart === 'wg') {
+      fetchGateways('wg').then(() => {
+        console.info('[wg] gateways initialized');
+      });
+    } else {
+      fetchGateways('mx-entry').then(() => {
+        console.info('[mx-entry] gateways initialized');
+      });
+      fetchGateways('mx-exit').then(() => {
+        console.info('[mx-exit] gateways initialized');
+      });
+    }
+  }, [fetchGateways]);
+
+  const ctx = useMemo<GatewaysState>(
+    () => ({
+      ...state,
+      fetch: fetchGateways,
+    }),
+    [state, fetchGateways],
+  );
+
+  return (
+    <GatewaysContext.Provider value={ctx}>{children}</GatewaysContext.Provider>
+  );
+}
+
+export default GatewaysProvider;

--- a/nym-vpn-app/src/contexts/gateways/reducer.ts
+++ b/nym-vpn-app/src/contexts/gateways/reducer.ts
@@ -1,0 +1,58 @@
+import * as _ from 'lodash-es';
+import { AppError, GatewayType, GatewaysByCountry } from '../../types';
+import { getStateProps } from './util';
+import { GatewaysState } from './types';
+
+export type StateAction =
+  | {
+      type: 'set-gateways';
+      payload: { type: GatewayType; gateways: GatewaysByCountry[] };
+    }
+  | {
+      type: 'set-gateways-loading';
+      payload: { type: GatewayType; loading: boolean };
+    }
+  | {
+      type: 'set-gateways-error';
+      payload: { type: GatewayType; error: AppError | null };
+    }
+  | {
+      type: 'reset-loading-and-error';
+      payload: { type: GatewayType };
+    };
+
+export function reducer(
+  state: GatewaysState,
+  action: StateAction,
+): GatewaysState {
+  const { gateways, loading, error } = getStateProps(action.payload.type);
+
+  switch (action.type) {
+    case 'set-gateways': {
+      if (!_.isEqual(action.payload.gateways, state[gateways])) {
+        return {
+          ...state,
+          [gateways]: action.payload.gateways,
+        };
+      }
+      return state;
+    }
+    case 'set-gateways-loading':
+      return {
+        ...state,
+        [loading]: action.payload.loading,
+      };
+    case 'set-gateways-error':
+      return {
+        ...state,
+        [error]: action.payload.error,
+        [loading]: false,
+      };
+    case 'reset-loading-and-error':
+      return {
+        ...state,
+        [loading]: false,
+        [error]: null,
+      };
+  }
+}

--- a/nym-vpn-app/src/contexts/gateways/types.ts
+++ b/nym-vpn-app/src/contexts/gateways/types.ts
@@ -1,0 +1,18 @@
+import { AppError, GatewayType, GatewaysByCountry } from '../../types';
+
+export type FetchGatewaysFn = (
+  nodeType: GatewayType,
+) => Promise<void> | undefined;
+
+export type GatewaysState = {
+  mxEntry: GatewaysByCountry[];
+  mxExit: GatewaysByCountry[];
+  wg: GatewaysByCountry[];
+  mxEntryLoading: boolean;
+  mxExitLoading: boolean;
+  wgLoading: boolean;
+  mxEntryError?: AppError | null;
+  mxExitError?: AppError | null;
+  wgError?: AppError | null;
+  fetch: FetchGatewaysFn;
+};

--- a/nym-vpn-app/src/contexts/gateways/util.ts
+++ b/nym-vpn-app/src/contexts/gateways/util.ts
@@ -1,0 +1,58 @@
+import { CKey } from '../../cache';
+import {
+  Country,
+  Gateway,
+  GatewayType,
+  GatewaysByCountry,
+  isCountry,
+} from '../../types';
+import { GatewaysState } from './types';
+
+export function gwTypeToCacheKey(type: GatewayType): CKey {
+  if (type === 'wg') return 'cache-wg-gateways';
+  return `cache-${type}-gateways`;
+}
+
+type GatewaysKey = keyof Pick<GatewaysState, 'mxEntry' | 'mxExit' | 'wg'>;
+type LoadingKey = keyof Pick<
+  GatewaysState,
+  'mxEntryLoading' | 'mxExitLoading' | 'wgLoading'
+>;
+type ErrorKey = keyof Pick<
+  GatewaysState,
+  'mxEntryError' | 'mxExitError' | 'wgError'
+>;
+
+export function getStateProps(type: GatewayType): {
+  gateways: GatewaysKey;
+  loading: LoadingKey;
+  error: ErrorKey;
+} {
+  if (type === 'mx-entry') {
+    return {
+      gateways: 'mxEntry',
+      loading: 'mxEntryLoading',
+      error: 'mxEntryError',
+    };
+  }
+  if (type === 'mx-exit') {
+    return {
+      gateways: 'mxExit',
+      loading: 'mxExitLoading',
+      error: 'mxExitError',
+    };
+  }
+  return {
+    gateways: 'wg',
+    loading: 'wgLoading',
+    error: 'wgError',
+  };
+}
+
+// Check if a node exists in the gateways list
+export function exists(node: Country | Gateway, gateways: GatewaysByCountry[]) {
+  if (isCountry(node)) {
+    return gateways.some((g) => g.country.code === node.code);
+  }
+  return gateways.some((g) => g.gateways.some((gw) => gw.id === node.id));
+}

--- a/nym-vpn-app/src/contexts/index.ts
+++ b/nym-vpn-app/src/contexts/index.ts
@@ -2,3 +2,4 @@ export * from './main';
 export * from './in-app-notification';
 export * from './dialog';
 export * from './nodes';
+export * from './gateways';

--- a/nym-vpn-app/src/contexts/main/util.ts
+++ b/nym-vpn-app/src/contexts/main/util.ts
@@ -1,7 +1,0 @@
-import { GatewayType } from '../../types';
-import { CKey } from '../../cache';
-
-export function gwTypeToCacheKey(type: GatewayType): CKey {
-  if (type === 'wg') return 'cache-wg-gateways';
-  return `cache-${type}-gateways`;
-}

--- a/nym-vpn-app/src/i18n/en/node-location.json
+++ b/nym-vpn-app/src/i18n/en/node-location.json
@@ -1,5 +1,5 @@
 {
-  "loading": "Loading...",
+  "loading": "Loading…",
   "none-found": "No results found. Please try another search",
   "list-loading": "The location list is loading…",
   "selected": "Selected",

--- a/nym-vpn-app/src/i18n/fr/node-location.json
+++ b/nym-vpn-app/src/i18n/fr/node-location.json
@@ -2,7 +2,7 @@
   "selected": "Sélectionné",
   "search-country": "Rechercher un pays",
   "input-label": "Recherche",
-  "loading": "Chargement...",
+  "loading": "Chargement…",
   "none-found": "Pas de résultats, essayez une autre recherche",
   "list-loading": "Chargement de la liste des pays…",
   "location-not-available": {

--- a/nym-vpn-app/src/screens/home/NetworkModeSelect.tsx
+++ b/nym-vpn-app/src/screens/home/NetworkModeSelect.tsx
@@ -3,7 +3,7 @@ import { invoke } from '@tauri-apps/api/core';
 import clsx from 'clsx';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@headlessui/react';
-import { useMainDispatch, useMainState } from '../../contexts';
+import { useGateways, useMainDispatch, useMainState } from '../../contexts';
 import { StateDispatch, VpnMode } from '../../types';
 import { RadioGroup, RadioGroupOption } from '../../ui';
 import MsIcon from '../../ui/MsIcon';
@@ -12,8 +12,10 @@ import ModeDetailsDialog from './ModeDetailsDialog';
 import { useActionToast } from './util';
 
 function NetworkModeSelect() {
-  const { state, vpnMode, fetchGateways, daemonStatus } = useMainState();
+  const { state, vpnMode, daemonStatus } = useMainState();
   const dispatch = useMainDispatch() as StateDispatch;
+  const { fetch } = useGateways();
+
   const [isDialogModesOpen, setIsDialogModesOpen] = useState(false);
   const [loading, setLoading] = useState(false);
   const toast = useActionToast('mode-select');
@@ -28,10 +30,10 @@ function NetworkModeSelect() {
         dispatch({ type: 'set-vpn-mode', mode: value });
         console.info('vpn mode set to', value);
         if (value === 'mixnet') {
-          fetchGateways('mx-entry');
-          fetchGateways('mx-exit');
+          fetch('mx-entry');
+          fetch('mx-exit');
         } else {
-          fetchGateways('wg');
+          fetch('wg');
         }
       } catch (e) {
         console.warn(e);

--- a/nym-vpn-app/src/screens/home/TunnelState.tsx
+++ b/nym-vpn-app/src/screens/home/TunnelState.tsx
@@ -58,7 +58,7 @@ function TunnelState() {
   );
 
   return (
-    <div className="h-full min-h-52 flex flex-col justify-center items-center gap-y-2">
+    <div className="h-full min-h-52 flex flex-col justify-center items-center gap-y-2 cursor-default">
       <div className="flex flex-1 items-end cursor-default select-none">
         {showBadge && <ConnectionBadge state={state.state} />}
       </div>

--- a/nym-vpn-app/src/screens/node/Node.tsx
+++ b/nym-vpn-app/src/screens/node/Node.tsx
@@ -122,7 +122,11 @@ function Node({ node }: { node: NodeHop }) {
             label={t('input-label')}
           />
         </div>
-        {loading && <div>{t('loading')}</div>}
+        {loading && (
+          <div className="text-base text-dim-gray dark:text-mercury-mist">
+            {t('loading')}
+          </div>
+        )}
         {!loading && (
           <NodeList
             nodes={uiNodes}

--- a/nym-vpn-app/src/state/reducer.ts
+++ b/nym-vpn-app/src/state/reducer.ts
@@ -1,5 +1,4 @@
 import dayjs from 'dayjs';
-import * as _ from 'lodash-es';
 import {
   DefaultCountry,
   DefaultRootFontSize,
@@ -15,8 +14,6 @@ import {
   DaemonInfo,
   DaemonStatus,
   Gateway,
-  GatewayType,
-  GatewaysByCountry,
   NodeHop,
   ThemeMode,
   Tunnel,
@@ -54,18 +51,6 @@ export type StateAction =
   | { type: 'set-theme-mode'; mode: ThemeMode }
   | { type: 'system-theme-changed'; theme: UiTheme }
   | {
-      type: 'set-gateways';
-      payload: { type: GatewayType; gateways: GatewaysByCountry[] };
-    }
-  | {
-      type: 'set-gateways-loading';
-      payload: { type: GatewayType; loading: boolean };
-    }
-  | {
-      type: 'set-gateways-error';
-      payload: { type: GatewayType; error: AppError | null };
-    }
-  | {
       type: 'set-node';
       payload: { hop: NodeHop; node: Country | Gateway };
     }
@@ -94,19 +79,10 @@ export const initialState: AppState = {
   desktopNotifications: true,
   entryNode: DefaultCountry,
   exitNode: DefaultCountry,
-  mxEntryGateways: [],
-  mxExitGateways: [],
-  wgGateways: [],
-  mxEntryGatewaysLoading: true,
-  mxExitGatewaysLoading: true,
-  wgGatewaysLoading: true,
   rootFontSize: DefaultRootFontSize,
   codeDepsRust: [],
   codeDepsJs: [],
   account: false,
-  fetchGateways: async () => {
-    /*  SCARECROW */
-  },
 };
 
 export function reducer(state: AppState, action: StateAction): AppState {
@@ -157,39 +133,6 @@ export function reducer(state: AppState, action: StateAction): AppState {
       return {
         ...state,
         desktopNotifications: action.enabled,
-      };
-    case 'set-gateways': {
-      let prop: keyof AppState = 'wgGateways';
-      if (action.payload.type === 'mx-entry') {
-        prop = 'mxEntryGateways';
-      }
-      if (action.payload.type === 'mx-exit') {
-        prop = 'mxExitGateways';
-      }
-      if (!_.isEqual(action.payload.gateways, state[prop])) {
-        return {
-          ...state,
-          [prop]: action.payload.gateways,
-        };
-      }
-      return state;
-    }
-    case 'set-gateways-loading':
-      if (action.payload.type === 'mx-entry') {
-        return {
-          ...state,
-          mxEntryGatewaysLoading: action.payload.loading,
-        };
-      }
-      if (action.payload.type === 'mx-exit') {
-        return {
-          ...state,
-          mxExitGatewaysLoading: action.payload.loading,
-        };
-      }
-      return {
-        ...state,
-        wgGatewaysLoading: action.payload.loading,
       };
     case 'set-tunnel':
       return {
@@ -301,23 +244,6 @@ export function reducer(state: AppState, action: StateAction): AppState {
       return {
         ...state,
         codeDepsRust: action.dependencies,
-      };
-    case 'set-gateways-error':
-      if (action.payload.type === 'mx-entry') {
-        return {
-          ...state,
-          mxEntryGatewaysError: action.payload.error,
-        };
-      }
-      if (action.payload.type === 'mx-exit') {
-        return {
-          ...state,
-          mxExitGatewaysError: action.payload.error,
-        };
-      }
-      return {
-        ...state,
-        wgGatewaysError: action.payload.error,
       };
     case 'set-account-links':
       return {

--- a/nym-vpn-app/src/types/app-state.ts
+++ b/nym-vpn-app/src/types/app-state.ts
@@ -2,14 +2,7 @@ import { Dispatch } from 'react';
 import { Dayjs } from 'dayjs';
 import { StateAction } from '../state';
 import { Country, ThemeMode, UiTheme } from './common';
-import {
-  AccountLinks,
-  ErrorKey,
-  Gateway,
-  GatewayType,
-  GatewaysByCountry,
-  NetworkEnv,
-} from './tauri';
+import { AccountLinks, ErrorKey, Gateway, NetworkEnv } from './tauri';
 import { Tunnel, TunnelError } from './tunnel';
 
 export type TunnelState =
@@ -59,24 +52,12 @@ export type AppState = {
   desktopNotifications: boolean;
   entryNode: Country | Gateway;
   exitNode: Country | Gateway;
-  mxEntryGateways: GatewaysByCountry[];
-  mxExitGateways: GatewaysByCountry[];
-  wgGateways: GatewaysByCountry[];
-  mxEntryGatewaysLoading: boolean;
-  mxExitGatewaysLoading: boolean;
-  wgGatewaysLoading: boolean;
-  mxEntryGatewaysError?: AppError | null;
-  mxExitGatewaysError?: AppError | null;
-  wgGatewaysError?: AppError | null;
   rootFontSize: number;
   codeDepsJs: CodeDependency[];
   codeDepsRust: CodeDependency[];
   // TODO just a boolean for now to indicate if the user has added an account
   account: boolean;
   accountLinks?: AccountLinks | null;
-
-  // methods
-  fetchGateways: FetchGatewaysFn;
 };
 
 export type ConnectProgressMsg = 'Initializing' | 'InitDone' | 'Canceling';
@@ -86,10 +67,6 @@ export type ProgressEventPayload = {
 };
 
 export type StateDispatch = Dispatch<StateAction>;
-
-export type FetchGatewaysFn = (
-  nodeType: GatewayType,
-) => Promise<void> | undefined;
 
 export type AppError = {
   message: string;

--- a/nym-vpn-app/src/types/common.ts
+++ b/nym-vpn-app/src/types/common.ts
@@ -1,3 +1,5 @@
+import { Gateway } from './tauri';
+
 export type NodeHop = 'entry' | 'exit';
 
 export type UiTheme = 'Dark' | 'Light';
@@ -7,3 +9,5 @@ export type Country = {
   name: string;
   code: string;
 };
+
+export type SelectedNode = Country | Gateway;


### PR DESCRIPTION
- restore selected node autoswap logic; when a selected node is not available in the gatways list swap it to the default node
- fix gateways query loading state
- refactor: extract gateways state into its own context 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2358)
<!-- Reviewable:end -->
