### PR TITLE
daemon: add -v to enable debug, -vv for trace

### DIFF
--- a/nym-vpn-core/crates/nym-vpnd/src/cli.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/cli.rs
@@ -14,6 +14,10 @@ fn pretty_build_info_static() -> &'static str {
 #[derive(Parser, Clone, Debug)]
 #[clap(author = "Nymtech", version, about, long_version = pretty_build_info_static())]
 pub(crate) struct CliArgs {
+    /// Logging verbosity.
+    #[arg(long, short = 'v', action = clap::ArgAction::Count)]
+    pub verbose: u8,
+
     /// Path pointing to an env file describing the network.
     #[arg(short, long, value_parser = check_path)]
     pub(crate) config_env_file: Option<PathBuf>,
@@ -37,6 +41,16 @@ pub(crate) struct CliArgs {
 
     #[command(flatten)]
     pub(crate) command: Command,
+}
+
+impl CliArgs {
+    pub fn verbosity_level(&self) -> tracing::Level {
+        match self.verbose {
+            0 => tracing::Level::INFO,
+            1 => tracing::Level::DEBUG,
+            _ => tracing::Level::TRACE,
+        }
+    }
 }
 
 #[derive(Args, Debug, Clone)]

--- a/nym-vpn-core/crates/nym-vpnd/src/logging.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/logging.rs
@@ -1,17 +1,18 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use tracing::Level;
 use tracing_appender::non_blocking::WorkerGuard;
 #[cfg(target_os = "macos")]
 use tracing_oslog::OsLogger;
 use tracing_subscriber::{
-    filter::LevelFilter, fmt::format::FmtSpan, layer::SubscriberExt, util::SubscriberInitExt,
-    EnvFilter, Layer,
+    fmt::format::FmtSpan, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer,
 };
 
 use crate::service;
 
 pub struct Options {
+    pub verbosity_level: Level,
     pub enable_file_log: bool,
     pub enable_stdout_log: bool,
 }
@@ -39,7 +40,7 @@ static WARN_CRATES: &[&str; 1] = &["hickory_server"];
 
 pub fn setup_logging(options: Options) -> Option<WorkerGuard> {
     let mut env_filter = EnvFilter::builder()
-        .with_default_directive(LevelFilter::INFO.into())
+        .with_default_directive(options.verbosity_level.into())
         .from_env_lossy();
 
     for crate_name in INFO_CRATES {

--- a/nym-vpn-core/crates/nym-vpnd/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/main.rs
@@ -36,6 +36,7 @@ fn run() -> anyhow::Result<()> {
     }
 
     let options = logging::Options {
+        verbosity_level: args.verbosity_level(),
         enable_file_log: args.command.run_as_service,
         enable_stdout_log: true,
     };
@@ -62,6 +63,7 @@ fn run() -> anyhow::Result<()> {
         Ok(windows_service::start(args)?)
     } else {
         let options = logging::Options {
+            verbosity_level: args.verbosity_level(),
             enable_file_log: false,
             enable_stdout_log: true,
         };

--- a/nym-vpn-core/crates/nym-vpnd/src/windows_service/service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/windows_service/service.rs
@@ -207,6 +207,7 @@ pub(crate) fn start(args: CliArgs) -> Result<(), windows_service::Error> {
 
         println!("Configuring logging to file...");
         let _guard = logging::setup_logging(logging::Options {
+            verbosity_level: args.verbosity_level(),
             enable_file_log: true,
             enable_stdout_log: false,
         });


### PR DESCRIPTION
This PR adds a `-v` flag to the daemon to control verbosity level without using environment variables to improve ergonomics.

- Omitting `-v` is equivalent `INFO` log level
- `-v` - `DEBUG` log level
- `-vv` (or more 'v') - `TRACE`

I believe that `RUST_LOG` overrides this behaviour as `from_env_lossy()` should default to whatever is set in the env if present. I am not sure if that should be the other way around or not. This was a quick PR and it makes it easier to toggle log levels.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2368)
<!-- Reviewable:end -->
