### PR TITLE
firewall(linux): remove mullvad specific cleanup

### DIFF
--- a/nym-vpn-core/crates/nym-firewall/src/linux.rs
+++ b/nym-vpn-core/crates/nym-firewall/src/linux.rs
@@ -135,8 +135,6 @@ impl Firewall {
         batch.add(&table, nftnl::MsgType::Add);
         batch.add(&table, nftnl::MsgType::Del);
 
-        batch_deprecated_tables(&mut batch);
-
         let batch = batch.finalize();
 
         tracing::debug!("Removing table and chain from netfilter");
@@ -281,8 +279,6 @@ impl<'a> PolicyBatch<'a> {
     /// table and chains.
     pub fn new(table: &'a Table) -> Self {
         let mut batch = Batch::new();
-
-        batch_deprecated_tables(&mut batch);
 
         // Create the table if it does not exist and clear it otherwise.
         batch.add(table, nftnl::MsgType::Add);
@@ -1200,20 +1196,4 @@ fn lock_down_arp_ignore_sysctl() -> io::Result<()> {
         _ => tracing::trace!("Not locking down arp_ignore since it is set to {current_arp_ignore}"),
     }
     Ok(())
-}
-
-/// Tables that are no longer used but need to be deleted due to upgrades.
-/// This can be removed when upgrades from 2023.3 are no longer supported.
-fn batch_deprecated_tables(batch: &mut Batch) {
-    const MANGLE_TABLE_NAME_V4: &CStr = c"nymmangle4";
-    const MANGLE_TABLE_NAME_V6: &CStr = c"nymmangle6";
-
-    let tables = [
-        Table::new(&MANGLE_TABLE_NAME_V4, ProtoFamily::Ipv4),
-        Table::new(&MANGLE_TABLE_NAME_V6, ProtoFamily::Ipv6),
-    ];
-    for table in &tables {
-        batch.add(table, nftnl::MsgType::Add);
-        batch.add(table, nftnl::MsgType::Del);
-    }
 }


### PR DESCRIPTION
The mangle tables in question never existed in our release history or codebase. They are Mullvad specific therefore can be removed.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2384)
<!-- Reviewable:end -->
