### PR TITLE
Adapt winfw for our requirements

### DIFF
--- a/build-windows-modules.ps1
+++ b/build-windows-modules.ps1
@@ -1,6 +1,16 @@
 param (
-    [Parameter(Mandatory = $true)][string]$BuildConfiguration,
-    [Parameter(Mandatory = $true)][string]$Platform,
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('Release', 'Debug')]
+    # Build configuration
+    [string]$BuildConfiguration,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('x64', 'ARM64')]
+    # CPU architecture
+    [string]$Platform,
+
+    # Whether to copy compiled binaries to build\winfw
+    # In debug builds this also makes sure to copy winfw.dll to nym-vpn-core\target\debug
     [bool]$CopyToBuildDir = $False
 )
 
@@ -8,12 +18,20 @@ Write-Output "Compiling winfw in $BuildConfiguration for $Platform"
 
 MSBuild.exe /m .\nym-vpn-windows\winfw\winfw.sln /p:Configuration=$BuildConfiguration /p:Platform=$Platform
 
-$BuildDir = "$PSScriptRoot\nym-vpn-windows\winfw\bin\$Platform-$BuildConfiguration"
-$OutputDir = "$PSScriptRoot\build\winfw\$Platform-$BuildConfiguration"
-
 if ($CopyToBuildDir) {
+    $BuildDir = "$PSScriptRoot\nym-vpn-windows\winfw\bin\$Platform-$BuildConfiguration"
+    $OutputDir = "$PSScriptRoot\build\winfw\$Platform-$BuildConfiguration"
+    $RustTargetDir = "$PSScriptRoot\nym-vpn-core\target"
+    $RustBuildDir = "$RustTargetDir\$($BuildConfiguration.ToLower())"
+    $BaseLibPath = "$BuildDir\winfw"
+
+    # Copy winfw.{lib,dll} to build/libwf
     Write-Output "Copying winfw.{lib,dll} to $OutputDir"
     New-Item -ItemType Directory -Force -Path $OutputDir -Verbose
-    Copy-Item -Path $BuildDir\winfw.lib -Destination $OutputDir -Verbose
-    Copy-Item -Path $BuildDir\winfw.dll -Destination $OutputDir -Verbose
+    Copy-Item -Path "$BaseLibPath.lib" -Destination $OutputDir -Verbose
+    Copy-Item -Path "$BaseLibPath.dll" -Destination $OutputDir -Verbose
+
+    # Copy winfw.dll to target/<profile>
+    New-Item -ItemType Directory -Force -Path $RustBuildDir -Verbose
+    Copy-Item -Path "$BaseLibPath.dll" -Destination $RustBuildDir -Verbose
 }

--- a/nym-vpn-core/README.md
+++ b/nym-vpn-core/README.md
@@ -85,6 +85,6 @@ powershell -ExecutionPolicy Bypass -Command .\build-windows-modules.ps1 -BuildCo
 Options:
 - `<CONFIGURATION>` - build configuration, either `Debug` or `Release`.
 - `<ARCH>` - CPU architecture, either `x64` or `ARM64`.
-- `COPY_TO_BUILD_DIR` - Optional flag, that when set to `1` makes sure that compiled files are copied to `build/winfw/<ARCH>-<CONFIGURATION>`.
+- `COPY_TO_BUILD_DIR` - Optional flag, that when set to `1` makes sure that compiled files are copied to `build/winfw/<ARCH>-<CONFIGURATION>`. In debug builds, it also makes sure to copy `winfw.dll` to `target\debug`
 
 Note: the policy bypass for powershell scripts is only needed when running in the environment with restricted security policy.

--- a/nym-vpn-windows/winfw/src/winfw/fwcontext.cpp
+++ b/nym-vpn-windows/winfw/src/winfw/fwcontext.cpp
@@ -83,6 +83,8 @@ void AppendRelayRules
 	const std::vector<WinFwAllowedEndpoint> &relays
 )
 {
+	std::vector<multi::PermitVpnRelay::Endpoint> rule_endpoints;
+
 	for (const auto& relay : relays)
 	{
 		std::vector<std::wstring> relayClients;
@@ -107,14 +109,16 @@ void AppendRelayRules
 				: rules::multi::PermitVpnRelay::Sublayer::Baseline
 				);
 
-		ruleset.emplace_back(std::make_unique<multi::PermitVpnRelay>(
-			wfp::IpAddress(relay.endpoint.ip),
+		rule_endpoints.emplace_back(multi::PermitVpnRelay::Endpoint {
+			wfp::IpAddress(relay.endpoint.ip), 
 			relay.endpoint.port,
 			relay.endpoint.protocol,
 			relayClients,
 			sublayer
-		));
+		});
 	}
+
+	ruleset.emplace_back(std::make_unique<multi::PermitVpnRelay>(rule_endpoints));
 }
 
 //
@@ -126,6 +130,8 @@ void AppendAllowedEndpointRules
 	const std::vector<WinFwAllowedEndpoint> &endpoints
 )
 {
+	std::vector<baseline::PermitEndpoint::Endpoint> rule_endpoints;
+
 	for (const auto& endpoint : endpoints)
 	{
 		std::vector<std::wstring> clients;
@@ -134,13 +140,15 @@ void AppendAllowedEndpointRules
 			clients.push_back(endpoint.clients[i]);
 		}
 
-		ruleset.emplace_back(std::make_unique<baseline::PermitEndpoint>(
-			wfp::IpAddress(endpoint.endpoint.ip),
-			clients,
+		rule_endpoints.emplace_back(baseline::PermitEndpoint::Endpoint {
+			wfp::IpAddress(endpoint.endpoint.ip), 
 			endpoint.endpoint.port,
-			endpoint.endpoint.protocol
-		));
+			endpoint.endpoint.protocol,
+			clients
+		});
 	}
+
+	ruleset.emplace_back(std::make_unique<baseline::PermitEndpoint>(rule_endpoints));
 }
 
 void AppendNetBlockedRules(FwContext::Ruleset &ruleset)

--- a/nym-vpn-windows/winfw/src/winfw/fwcontext.cpp
+++ b/nym-vpn-windows/winfw/src/winfw/fwcontext.cpp
@@ -234,8 +234,9 @@ bool FwContext::applyPolicyConnecting
 		));
 	}
 
-	////////////////////////////////////////////
-	// ENTRY TUNNEL RULES
+	//
+	// Entry tunnel rules
+	//
 	if (entryTunnelIfaceAlias.has_value())
 	{
 		switch (allowedEntryTunnelTraffic.type)
@@ -243,10 +244,12 @@ bool FwContext::applyPolicyConnecting
 			case WinFwAllowedTunnelTrafficType::All:
 			{
 				ruleset.emplace_back(std::make_unique<baseline::PermitVpnTunnel>(
+					baseline::PermitVpnTunnel::InterfaceType::Entry,
 					*entryTunnelIfaceAlias,
 					std::nullopt
 				));
 				ruleset.emplace_back(std::make_unique<baseline::PermitVpnTunnelService>(
+					baseline::PermitVpnTunnel::InterfaceType::Entry,
 					*entryTunnelIfaceAlias,
 					std::nullopt
 				));
@@ -263,10 +266,12 @@ bool FwContext::applyPolicyConnecting
 						std::nullopt,
 				});
 				ruleset.emplace_back(std::make_unique<baseline::PermitVpnTunnel>(
+					baseline::PermitVpnTunnel::InterfaceType::Entry,
 					*entryTunnelIfaceAlias,
 					onlyEndpoint
 				));
 				ruleset.emplace_back(std::make_unique<baseline::PermitVpnTunnelService>(
+					baseline::PermitVpnTunnel::InterfaceType::Entry,
 					*entryTunnelIfaceAlias,
 					onlyEndpoint
 				));
@@ -287,10 +292,12 @@ bool FwContext::applyPolicyConnecting
 								})
 				});
 				ruleset.emplace_back(std::make_unique<baseline::PermitVpnTunnel>(
+							baseline::PermitVpnTunnel::InterfaceType::Entry,
 							*entryTunnelIfaceAlias,
 							endpoints
 							));
 				ruleset.emplace_back(std::make_unique<baseline::PermitVpnTunnelService>(
+							baseline::PermitVpnTunnel::InterfaceType::Entry,
 							*entryTunnelIfaceAlias,
 							endpoints
 							));
@@ -300,8 +307,9 @@ bool FwContext::applyPolicyConnecting
 		}
 	}
 
-	////////////////////////////////////////////
-	// EXIT TUNNEL RULES
+	//
+	// Exit tunnel rules
+	//
 	if (exitTunnelIfaceAlias.has_value())
 	{
 		switch (allowedExitTunnelTraffic.type)
@@ -309,10 +317,12 @@ bool FwContext::applyPolicyConnecting
 		case WinFwAllowedTunnelTrafficType::All:
 		{
 			ruleset.emplace_back(std::make_unique<baseline::PermitVpnTunnel>(
+				baseline::PermitVpnTunnel::InterfaceType::Exit,
 				*exitTunnelIfaceAlias,
 				std::nullopt
 			));
 			ruleset.emplace_back(std::make_unique<baseline::PermitVpnTunnelService>(
+				baseline::PermitVpnTunnel::InterfaceType::Exit,
 				*exitTunnelIfaceAlias,
 				std::nullopt
 			));
@@ -329,10 +339,12 @@ bool FwContext::applyPolicyConnecting
 					std::nullopt,
 				});
 			ruleset.emplace_back(std::make_unique<baseline::PermitVpnTunnel>(
+				baseline::PermitVpnTunnel::InterfaceType::Exit,
 				*exitTunnelIfaceAlias,
 				onlyEndpoint
 			));
 			ruleset.emplace_back(std::make_unique<baseline::PermitVpnTunnelService>(
+				baseline::PermitVpnTunnel::InterfaceType::Exit,
 				*exitTunnelIfaceAlias,
 				onlyEndpoint
 			));
@@ -353,10 +365,12 @@ bool FwContext::applyPolicyConnecting
 							})
 				});
 			ruleset.emplace_back(std::make_unique<baseline::PermitVpnTunnel>(
+				baseline::PermitVpnTunnel::InterfaceType::Exit,
 				*exitTunnelIfaceAlias,
 				endpoints
 			));
 			ruleset.emplace_back(std::make_unique<baseline::PermitVpnTunnelService>(
+				baseline::PermitVpnTunnel::InterfaceType::Exit,
 				*exitTunnelIfaceAlias,
 				endpoints
 			));
@@ -416,11 +430,13 @@ bool FwContext::applyPolicyConnected
 		}
 
 		ruleset.emplace_back(std::make_unique<baseline::PermitVpnTunnel>(
+			baseline::PermitVpnTunnel::InterfaceType::Exit,
 			exitTunnelIfaceAliasStr,
 			std::nullopt
 		));
 
 		ruleset.emplace_back(std::make_unique<baseline::PermitVpnTunnelService>(
+			baseline::PermitVpnTunnel::InterfaceType::Exit,
 			exitTunnelIfaceAliasStr,
 			std::nullopt
 		));
@@ -432,11 +448,13 @@ bool FwContext::applyPolicyConnected
 
 		
 		ruleset.emplace_back(std::make_unique<baseline::PermitVpnTunnel>(
+			baseline::PermitVpnTunnel::InterfaceType::Entry,
 			entryTunnelIfaceAliasStr,
 			std::nullopt
 		));
 
 		ruleset.emplace_back(std::make_unique<baseline::PermitVpnTunnelService>(
+			baseline::PermitVpnTunnel::InterfaceType::Entry,
 			entryTunnelIfaceAliasStr,
 			std::nullopt
 		));

--- a/nym-vpn-windows/winfw/src/winfw/mullvadguids.cpp
+++ b/nym-vpn-windows/winfw/src/winfw/mullvadguids.cpp
@@ -68,8 +68,18 @@ MullvadGuids::DetailedIdentityRegistry MullvadGuids::DetailedRegistry(IdentityQu
 	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitDhcp_Inbound_Response_Ipv6()));
 	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitDhcpServer_Inbound_Request_Ipv4()));
 	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitDhcpServer_Outbound_Response_Ipv4()));
-	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnRelay()));
-	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitEndpoint()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnRelay_Ipv4_1()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnRelay_Ipv6_1()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnRelay_Ipv4_2()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnRelay_Ipv6_2()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitEndpoint_Ipv4_1()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitEndpoint_Ipv6_1()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitEndpoint_Ipv4_2()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitEndpoint_Ipv6_2()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitEndpoint_Ipv4_3()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitEndpoint_Ipv6_3()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitEndpoint_Ipv4_4()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitEndpoint_Ipv6_4()));
 	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnel_Entry_Outbound_Ipv4_1()));
 	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnel_Entry_Outbound_Ipv6_1()));
 	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnel_Entry_Outbound_Ipv4_2()));
@@ -422,7 +432,7 @@ const GUID &MullvadGuids::Filter_Baseline_PermitDhcpServer_Outbound_Response_Ipv
 }
 
 //static
-const GUID &MullvadGuids::Filter_Baseline_PermitVpnRelay()
+const GUID &MullvadGuids::Filter_Baseline_PermitVpnRelay_Ipv4_1()
 {
 	// {93E92E50-FA3F-45D9-B576-8AB1233269A3}
 	static const GUID g = { 0x93e92e50,0xfa3f,0x45d9,{0xb5,0x76,0x8a,0xb1,0x23,0x32,0x69,0xa3} };
@@ -431,7 +441,36 @@ const GUID &MullvadGuids::Filter_Baseline_PermitVpnRelay()
 }
 
 //static
-const GUID &MullvadGuids::Filter_Baseline_PermitEndpoint()
+const GUID &MullvadGuids::Filter_Baseline_PermitVpnRelay_Ipv4_2()
+{
+	// {1F484D78-F9B8-43C1-9930-883EF830431F}
+	static const GUID g = { 0x1f484d78, 0xf9b8, 0x43c1, { 0x99, 0x30, 0x88, 0x3e, 0xf8, 0x30, 0x43, 0x1f } };
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::Filter_Baseline_PermitVpnRelay_Ipv6_1()
+{
+	// {2E0D95D2-530E-4D35-9BA8-50458B971B46}
+	static const GUID g = { 0x2e0d95d2, 0x530e, 0x4d35, { 0x9b, 0xa8, 0x50, 0x45, 0x8b, 0x97, 0x1b, 0x46 } };
+
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::Filter_Baseline_PermitVpnRelay_Ipv6_2()
+{
+	// {A9893597-4FCA-49BC-99A1-ED3FC44DEA82}
+	static const GUID g = { 0xa9893597, 0x4fca, 0x49bc, { 0x99, 0xa1, 0xed, 0x3f, 0xc4, 0x4d, 0xea, 0x82 } };
+
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::Filter_Baseline_PermitEndpoint_Ipv4_1()
 {
 	// {AF5716AA-D4E4-4E3E-9E85-E53AB4479338}
 	static const GUID g = { 0xaf5716aa,0xd4e4,0x4e3e,{0x9e,0x85,0xe5,0x3a,0xb4,0x47,0x93,0x38} };
@@ -440,6 +479,68 @@ const GUID &MullvadGuids::Filter_Baseline_PermitEndpoint()
 }
 
 //static
+const GUID &MullvadGuids::Filter_Baseline_PermitEndpoint_Ipv6_1()
+{
+	// {C88C848F-2DF9-4908-944D-DE550CAD325E}
+	static const GUID g = { 0xc88c848f,0x2df9,0x4908,{0x94,0x4d,0xde,0x55,0x0c,0xad,0x32,0x5e} };
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::Filter_Baseline_PermitEndpoint_Ipv4_2()
+{
+	// {1F1D87EC-6022-48C9-BDAA-224C428E30C0}
+	static const GUID g = { 0x1f1d87ec,0x6022,0x48c9,{0xbd,0xaa,0x22,0x4c,0x42,0x8e,0x30,0xc0} };
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::Filter_Baseline_PermitEndpoint_Ipv6_2()
+{
+	// {A8777D53-399B-418F-B24F-B03BAEABB68E}
+	static const GUID g = { 0xa8777d53,0x399b,0x418f,{0xb2,0x4f,0xb0,0x3b,0xae,0xab,0xb6,0x8e} };
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::Filter_Baseline_PermitEndpoint_Ipv4_3()
+{
+	// {CFDA4531-279D-4F4F-989C-93FB7C1C7AED}
+	static const GUID g = { 0xcfda4531,0x279d,0x4f4f,{0x98,0x9c,0x93,0xfb,0x7c,0x1c,0x7a,0xed} };
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::Filter_Baseline_PermitEndpoint_Ipv6_3()
+{
+	// {ECE12F4D-EA16-4672-A128-43BE87A2D9C9}
+	static const GUID g = { 0xece12f4d,0xea16,0x4672,{0xa1,0x28,0x43,0xbe,0x87,0xa2,0xd9,0xc9} };
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::Filter_Baseline_PermitEndpoint_Ipv4_4()
+{
+	// {7CB2CBA7-AF0A-43C8-B86E-86405FBC6352}
+	static const GUID g = { 0x7cb2cba7,0xaf0a,0x43c8,{0xb8,0x6e,0x86,0x40,0x5f,0xbc,0x63,0x52} };
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::Filter_Baseline_PermitEndpoint_Ipv6_4()
+{
+	// {A6674EDA-3AA6-4937-B2DC-FAE0B1AE83BE}
+	static const GUID g = { 0xa6674eda,0x3aa6,0x4937,{0xb2,0xdc,0xfa,0xe0,0xb1,0xae,0x83,0xbe} };
+
+	return g;
+}
+
 const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnel_Entry_Outbound_Ipv4_1()
 {
 	// {BCECE8D7-2BAA-40CE-A7E9-5A4044E24883}

--- a/nym-vpn-windows/winfw/src/winfw/mullvadguids.cpp
+++ b/nym-vpn-windows/winfw/src/winfw/mullvadguids.cpp
@@ -70,14 +70,22 @@ MullvadGuids::DetailedIdentityRegistry MullvadGuids::DetailedRegistry(IdentityQu
 	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitDhcpServer_Outbound_Response_Ipv4()));
 	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnRelay()));
 	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitEndpoint()));
-	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4_1()));
-	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6_1()));
-	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4_2()));
-	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6_2()));
-	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnelService_Ipv4_1()));
-	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnelService_Ipv6_1()));
-	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnelService_Ipv4_2()));
-	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnelService_Ipv6_2()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnel_Entry_Outbound_Ipv4_1()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnel_Entry_Outbound_Ipv6_1()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnel_Entry_Outbound_Ipv4_2()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnel_Entry_Outbound_Ipv6_2()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnel_Exit_Outbound_Ipv4_1()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnel_Exit_Outbound_Ipv6_1()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnel_Exit_Outbound_Ipv4_2()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnel_Exit_Outbound_Ipv6_2()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnelService_Entry_Ipv4_1()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnelService_Entry_Ipv6_1()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnelService_Entry_Ipv4_2()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnelService_Entry_Ipv6_2()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnelService_Exit_Ipv4_1()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnelService_Exit_Ipv6_1()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnelService_Exit_Ipv4_2()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnelService_Exit_Ipv6_2()));
 	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitNdp_Outbound_Router_Solicitation()));
 	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitNdp_Inbound_Router_Advertisement()));
 	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitNdp_Outbound_Neighbor_Solicitation()));
@@ -432,7 +440,40 @@ const GUID &MullvadGuids::Filter_Baseline_PermitEndpoint()
 }
 
 //static
-const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4_1()
+const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnel_Entry_Outbound_Ipv4_1()
+{
+	// {BCECE8D7-2BAA-40CE-A7E9-5A4044E24883}
+	static const GUID g = { 0xbcece8d7,0x2baa,0x40ce,{0xa7,0xe9,0x5a,0x40,0x44,0xe2,0x48,0x83} };
+
+	return g;
+}
+
+const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnel_Entry_Outbound_Ipv6_1()
+{
+	// {0DBD1D20-112E-4B56-946D-6AB3DAB722C9}
+	static const GUID g = { 0x0dbd1d20,0x112e,0x4b56,{0x94,0x6d,0x6a,0xb3,0xda,0xb7,0x22,0xc9} };
+
+	return g;
+}
+
+const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnel_Entry_Outbound_Ipv4_2()
+{
+	// {DCA44438-7942-4215-BD11-30DAE8EE0E03}
+	static const GUID g = { 0xdca44438,0x7942,0x4215,{0xbd,0x11,0x30,0xda,0xe8,0xee,0x0e,0x03} };
+
+	return g;
+}
+
+const GUID & MullvadGuids::Filter_Baseline_PermitVpnTunnel_Entry_Outbound_Ipv6_2()
+{
+	// {36862FAF-4AC0-4852-95A1-FF314F9F2F5B}
+	static const GUID g = { 0x36862faf,0x4ac0,0x4852,{0x95,0xa1,0xff,0x31,0x4f,0x9f,0x2f,0x5b} };
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnel_Exit_Outbound_Ipv4_1()
 {
 	// {C593D84F-9F07-429A-9B78-CE6CB4249EFC}
 	static const GUID g = { 0xc593d84f,0x9f07,0x429a,{0x9b,0x78,0xce,0x6c,0xb4,0x24,0x9e,0xfc} };
@@ -441,7 +482,7 @@ const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4_1()
 }
 
 //static
-const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6_1()
+const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnel_Exit_Outbound_Ipv6_1()
 {
 	// {04A39B8D-03DC-4C93-AE62-E3D6BA4178F3}
 	static const GUID g = { 0x04a39b8d,0x03dc,0x4c93,{0xae,0x62,0xe3,0xd6,0xba,0x41,0x78,0xf3} };
@@ -450,7 +491,7 @@ const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6_1()
 }
 
 //static
-const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4_2()
+const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnel_Exit_Outbound_Ipv4_2()
 {
 	// {67EE5B14-C670-47B7-B6C5-E9EE234C715E}
 	static const GUID g = { 0x67ee5b14,0xc670,0x47b7,{0xb6,0xc5,0xe9,0xee,0x23,0x4c,0x71,0x5e} };
@@ -459,7 +500,7 @@ const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4_2()
 }
 
 //static
-const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6_2()
+const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnel_Exit_Outbound_Ipv6_2()
 {
 	// {2C632BDB-F1AB-42C7-A7FE-91CE2DF74E9F}
 	static const GUID g = { 0x2c632bdb,0xf1ab,0x42c7,{0xa7,0xfe,0x91,0xce,0x2d,0xf7,0x4e,0x9f} };
@@ -468,7 +509,43 @@ const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6_2()
 }
 
 //static
-const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Ipv4_1()
+const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Entry_Ipv4_1()
+{
+	// {4A83F108-7008-4510-8EE3-900A7495CAAB}
+	static const GUID g = { 0x4a83f108,0x7008,0x4510,{0x8e,0xe3,0x90,0x0a,0x74,0x95,0xca,0xab} };
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Entry_Ipv6_1()
+{
+	// {652E1F33-4E01-4F27-B0B9-74912AA8F110}
+	static const GUID g = { 0x652e1f33,0x4e01,0x4f27,{0xb0,0xb9,0x74,0x91,0x2a,0xa8,0xf1,0x10} };
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Entry_Ipv4_2()
+{
+	// {0F2F41E9-6403-4A35-B9D0-D1784E400869}
+	static const GUID g = { 0x0f2f41e9,0x6403,0x4a35,{0xb9,0xd0,0xd1,0x78,0x4e,0x40,0x08,0x69} };
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Entry_Ipv6_2()
+{
+	// {D83633A3-E391-4391-AA85-8186B95DC363}
+	static const GUID g = { 0xd83633a3,0xe391,0x4391,{0xaa,0x85,0x81,0x86,0xb9,0x5d,0xc3,0x63} };
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Exit_Ipv4_1()
 {
 	// {9D857D88-211D-41DC-8A4C-1BC73474173C}
 	static const GUID g = { 0x9d857d88,0x211d,0x41dc,{0x8a,0x4c,0x1b,0xc7,0x34,0x74,0x17,0x3c} };
@@ -477,7 +554,7 @@ const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Ipv4_1()
 }
 
 //static
-const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Ipv6_1()
+const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Exit_Ipv6_1()
 {
 	// {32798A35-721E-4313-90EF-BC4CE42B00B3}
 	static const GUID g = { 0x32798a35,0x721e,0x4313,{0x90,0xef,0xbc,0x4c,0xe4,0x2b,0x00,0xb3} };
@@ -486,7 +563,7 @@ const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Ipv6_1()
 }
 
 //static
-const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Ipv4_2()
+const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Exit_Ipv4_2()
 {
 	// {BD6B5856-5F51-45E9-A4EB-B18202826191}
 	static const GUID g = { 0xbd6b5856,0x5f51,0x45e9,{0xa4,0xeb,0xb1,0x82,0x02,0x82,0x61,0x91} };
@@ -495,7 +572,7 @@ const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Ipv4_2()
 }
 
 //static
-const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Ipv6_2()
+const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Exit_Ipv6_2()
 {
 	// {131E52D0-502D-436F-B1A2-88A979CCBF9F}
 	static const GUID g = { 0x131e52d0,0x502d,0x436f,{0xb1,0xa2,0x88,0xa9,0x79,0xcc,0xbf,0x9f} };

--- a/nym-vpn-windows/winfw/src/winfw/mullvadguids.h
+++ b/nym-vpn-windows/winfw/src/winfw/mullvadguids.h
@@ -71,15 +71,25 @@ public:
 
 	static const GUID &Filter_Baseline_PermitEndpoint();
 
-	static const GUID &Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4_1();
-	static const GUID &Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6_1();
-	static const GUID &Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4_2();
-	static const GUID &Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6_2();
+	static const GUID &Filter_Baseline_PermitVpnTunnel_Entry_Outbound_Ipv4_1();
+	static const GUID &Filter_Baseline_PermitVpnTunnel_Entry_Outbound_Ipv6_1();
+	static const GUID &Filter_Baseline_PermitVpnTunnel_Entry_Outbound_Ipv4_2();
+	static const GUID &Filter_Baseline_PermitVpnTunnel_Entry_Outbound_Ipv6_2();
 
-	static const GUID &Filter_Baseline_PermitVpnTunnelService_Ipv4_1();
-	static const GUID &Filter_Baseline_PermitVpnTunnelService_Ipv6_1();
-	static const GUID &Filter_Baseline_PermitVpnTunnelService_Ipv4_2();
-	static const GUID &Filter_Baseline_PermitVpnTunnelService_Ipv6_2();
+	static const GUID &Filter_Baseline_PermitVpnTunnel_Exit_Outbound_Ipv4_1();
+	static const GUID &Filter_Baseline_PermitVpnTunnel_Exit_Outbound_Ipv6_1();
+	static const GUID &Filter_Baseline_PermitVpnTunnel_Exit_Outbound_Ipv4_2();
+	static const GUID &Filter_Baseline_PermitVpnTunnel_Exit_Outbound_Ipv6_2();
+
+	static const GUID &Filter_Baseline_PermitVpnTunnelService_Entry_Ipv4_1();
+	static const GUID &Filter_Baseline_PermitVpnTunnelService_Entry_Ipv6_1();
+	static const GUID &Filter_Baseline_PermitVpnTunnelService_Entry_Ipv4_2();
+	static const GUID &Filter_Baseline_PermitVpnTunnelService_Entry_Ipv6_2();
+
+	static const GUID &Filter_Baseline_PermitVpnTunnelService_Exit_Ipv4_1();
+	static const GUID &Filter_Baseline_PermitVpnTunnelService_Exit_Ipv6_1();
+	static const GUID &Filter_Baseline_PermitVpnTunnelService_Exit_Ipv4_2();
+	static const GUID &Filter_Baseline_PermitVpnTunnelService_Exit_Ipv6_2();
 
 	static const GUID &Filter_Baseline_PermitNdp_Outbound_Router_Solicitation();
 	static const GUID &Filter_Baseline_PermitNdp_Inbound_Router_Advertisement();

--- a/nym-vpn-windows/winfw/src/winfw/mullvadguids.h
+++ b/nym-vpn-windows/winfw/src/winfw/mullvadguids.h
@@ -67,9 +67,19 @@ public:
 	static const GUID &Filter_Baseline_PermitDhcpServer_Inbound_Request_Ipv4();
 	static const GUID &Filter_Baseline_PermitDhcpServer_Outbound_Response_Ipv4();
 
-	static const GUID &Filter_Baseline_PermitVpnRelay();
+	static const GUID &Filter_Baseline_PermitVpnRelay_Ipv4_1();
+	static const GUID &Filter_Baseline_PermitVpnRelay_Ipv4_2();
+	static const GUID &Filter_Baseline_PermitVpnRelay_Ipv6_1();
+	static const GUID &Filter_Baseline_PermitVpnRelay_Ipv6_2();
 
-	static const GUID &Filter_Baseline_PermitEndpoint();
+	static const GUID &Filter_Baseline_PermitEndpoint_Ipv4_1();
+	static const GUID &Filter_Baseline_PermitEndpoint_Ipv4_2();
+	static const GUID &Filter_Baseline_PermitEndpoint_Ipv4_3();
+	static const GUID &Filter_Baseline_PermitEndpoint_Ipv4_4();
+	static const GUID &Filter_Baseline_PermitEndpoint_Ipv6_1();
+	static const GUID &Filter_Baseline_PermitEndpoint_Ipv6_2();
+	static const GUID &Filter_Baseline_PermitEndpoint_Ipv6_3();
+	static const GUID &Filter_Baseline_PermitEndpoint_Ipv6_4();
 
 	static const GUID &Filter_Baseline_PermitVpnTunnel_Entry_Outbound_Ipv4_1();
 	static const GUID &Filter_Baseline_PermitVpnTunnel_Entry_Outbound_Ipv6_1();

--- a/nym-vpn-windows/winfw/src/winfw/rules/baseline/permitdns.cpp
+++ b/nym-vpn-windows/winfw/src/winfw/rules/baseline/permitdns.cpp
@@ -30,8 +30,10 @@ bool PermitDns::apply(IObjectInstaller &objectInstaller)
 		.permit();
 
 	wfp::ConditionBuilder conditionBuilder(FWPM_LAYER_ALE_AUTH_CONNECT_V4);
-
-	conditionBuilder.add_condition(ConditionPort::Remote(DNS_SERVER_PORT));
+	for (const auto& dnsPort : DNS_PORTS)
+	{
+		conditionBuilder.add_condition(ConditionPort::Remote(dnsPort));
+	}
 
 	if (false == objectInstaller.addFilter(filterBuilder, conditionBuilder))
 	{
@@ -48,7 +50,10 @@ bool PermitDns::apply(IObjectInstaller &objectInstaller)
 		.layer(FWPM_LAYER_ALE_AUTH_CONNECT_V6);
 
 	conditionBuilder.reset(FWPM_LAYER_ALE_AUTH_CONNECT_V6);
-	conditionBuilder.add_condition(ConditionPort::Remote(DNS_SERVER_PORT));
+	for (const auto& dnsPort : DNS_PORTS)
+	{
+		conditionBuilder.add_condition(ConditionPort::Remote(dnsPort));
+	}
 
 	return objectInstaller.addFilter(filterBuilder, conditionBuilder);
 }

--- a/nym-vpn-windows/winfw/src/winfw/rules/baseline/permitendpoint.cpp
+++ b/nym-vpn-windows/winfw/src/winfw/rules/baseline/permitendpoint.cpp
@@ -15,63 +15,122 @@ using namespace wfp::conditions;
 namespace rules::baseline
 {
 
-namespace
-{
+namespace {
+	// Maximum number of allowed endpoint per IP protocol version.
+	static const uint32_t MAX_ALLOWED_ENDPOINTS = 4;
 
-const GUID &OutboundLayerFromIp(const wfp::IpAddress &ip)
-{
-	switch (ip.type())
-	{
-		case wfp::IpAddress::Type::Ipv4: return FWPM_LAYER_ALE_AUTH_CONNECT_V4;
-		case wfp::IpAddress::Type::Ipv6: return FWPM_LAYER_ALE_AUTH_CONNECT_V6;
-		default:
-		{
-			THROW_ERROR("Missing case handler in switch clause");
-		}
+	static const GUID ENDPOINT_IPV4_GUIDS[MAX_ALLOWED_ENDPOINTS] = { 
+		MullvadGuids::Filter_Baseline_PermitEndpoint_Ipv4_1(),
+		MullvadGuids::Filter_Baseline_PermitEndpoint_Ipv4_2(),
+		MullvadGuids::Filter_Baseline_PermitEndpoint_Ipv4_3(),
+		MullvadGuids::Filter_Baseline_PermitEndpoint_Ipv4_4(),
 	};
-}
+
+	static const GUID ENDPOINT_IPV6_GUIDS[MAX_ALLOWED_ENDPOINTS] = {
+		MullvadGuids::Filter_Baseline_PermitEndpoint_Ipv6_1(),
+		MullvadGuids::Filter_Baseline_PermitEndpoint_Ipv6_2(),
+		MullvadGuids::Filter_Baseline_PermitEndpoint_Ipv6_3(),
+		MullvadGuids::Filter_Baseline_PermitEndpoint_Ipv6_4(),
+	};
 
 } // anonymous namespace
 
-PermitEndpoint::PermitEndpoint
-(
-	const wfp::IpAddress &address,
-	const std::vector<std::wstring> &clients,
-	uint16_t port,
-	WinFwProtocol protocol
-)
-	: m_address(address)
-	, m_clients(clients)
-	, m_port(port)
-	, m_protocol(protocol)
+PermitEndpoint::PermitEndpoint(const std::vector<Endpoint> endpoints)
+	: m_endpoints(endpoints)
 {
 }
 
 bool PermitEndpoint::apply(IObjectInstaller &objectInstaller)
 {
-	wfp::FilterBuilder filterBuilder;
-
 	//
 	// Permit outbound connections to endpoint.
 	//
 
+	uint32_t ipv4Count = 0;
+	uint32_t ipv6Count = 0;
+
+	for (auto endpoint: m_endpoints) {
+		switch (endpoint.ip.type()) {
+			case wfp::IpAddress::Type::Ipv4:
+				if (!AddIpv4EndpointFilter(endpoint, ENDPOINT_IPV4_GUIDS[ipv4Count], objectInstaller)) {
+					return false;
+				}
+
+				if (ipv4Count++ == MAX_ALLOWED_ENDPOINTS) {
+					THROW_ERROR("Exceeded max allowed endpoints (IPv4)");
+				}
+
+				break;
+
+			case wfp::IpAddress::Type::Ipv6:
+				if (!AddIpv6EndpointFilter(endpoint, ENDPOINT_IPV6_GUIDS[ipv6Count], objectInstaller)) {
+					return false;
+				}
+
+				if (ipv6Count++ == MAX_ALLOWED_ENDPOINTS) {
+					THROW_ERROR("Exceeded max allowed endpoints (IPv6)");
+				}
+
+				break;
+
+			default:
+			{
+				THROW_ERROR("Missing case handler in switch clause");
+			}
+		}
+	}
+
+	return true;
+}
+
+bool PermitEndpoint::AddIpv4EndpointFilter(const Endpoint &endpoint, const GUID &ipv4Guid, IObjectInstaller &objectInstaller) 
+{
+	wfp::FilterBuilder filterBuilder;
+
 	filterBuilder
-		.key(MullvadGuids::Filter_Baseline_PermitEndpoint())
-		.name(L"Permit outbound connections to a given endpoint")
+		.key(ipv4Guid)
+		.name(L"Permit outbound connections to a given endpoint (IPv4)")
 		.description(L"This filter is part of a rule that permits traffic to a specific endpoint")
 		.provider(MullvadGuids::Provider())
-		.layer(OutboundLayerFromIp(m_address))
+		.layer(FWPM_LAYER_ALE_AUTH_CONNECT_V4)
 		.sublayer(MullvadGuids::SublayerBaseline())
 		.weight(wfp::FilterBuilder::WeightClass::Max)
 		.permit();
 
-	wfp::ConditionBuilder conditionBuilder(OutboundLayerFromIp(m_address));
+	wfp::ConditionBuilder conditionBuilder(FWPM_LAYER_ALE_AUTH_CONNECT_V4);
 
-	conditionBuilder.add_condition(ConditionIp::Remote(m_address));
-	conditionBuilder.add_condition(ConditionPort::Remote(m_port));
-	conditionBuilder.add_condition(CreateProtocolCondition(m_protocol));
+	conditionBuilder.add_condition(ConditionIp::Remote(endpoint.ip));
+	conditionBuilder.add_condition(ConditionPort::Remote(endpoint.port));
+	conditionBuilder.add_condition(CreateProtocolCondition(endpoint.protocol));
 
-	for (const auto client : m_clients) {
+	for (const auto client : endpoint.clients) {
+		conditionBuilder.add_condition(std::make_unique<ConditionApplication>(client));
+	}
+
+	return objectInstaller.addFilter(filterBuilder, conditionBuilder);
+}
+
+bool PermitEndpoint::AddIpv6EndpointFilter(const Endpoint &endpoint, const GUID &ipv6Guid, IObjectInstaller &objectInstaller) 
+{
+	wfp::FilterBuilder filterBuilder;
+
+	filterBuilder
+		.key(ipv6Guid)
+		.name(L"Permit outbound connections to a given endpoint (IPv6)")
+		.description(L"This filter is part of a rule that permits traffic to a specific endpoint")
+		.provider(MullvadGuids::Provider())
+		.layer(FWPM_LAYER_ALE_AUTH_CONNECT_V6)
+		.sublayer(MullvadGuids::SublayerBaseline())
+		.weight(wfp::FilterBuilder::WeightClass::Max)
+		.permit();
+
+	wfp::ConditionBuilder conditionBuilder(FWPM_LAYER_ALE_AUTH_CONNECT_V6);
+
+	conditionBuilder.add_condition(ConditionIp::Remote(endpoint.ip));
+	conditionBuilder.add_condition(ConditionPort::Remote(endpoint.port));
+	conditionBuilder.add_condition(CreateProtocolCondition(endpoint.protocol));
+
+	for (const auto client : endpoint.clients) {
 		conditionBuilder.add_condition(std::make_unique<ConditionApplication>(client));
 	}
 

--- a/nym-vpn-windows/winfw/src/winfw/rules/baseline/permitendpoint.h
+++ b/nym-vpn-windows/winfw/src/winfw/rules/baseline/permitendpoint.h
@@ -5,6 +5,7 @@
 #include <libwfp/ipaddress.h>
 #include <vector>
 #include <string>
+#include <optional>
 
 namespace rules::baseline
 {
@@ -13,22 +14,22 @@ class PermitEndpoint : public IFirewallRule
 {
 public:
 
-	PermitEndpoint
-	(
-		const wfp::IpAddress &address,
-		const std::vector<std::wstring> &clients,
-		uint16_t port,
-		WinFwProtocol protocol
-	);
+	struct Endpoint {
+		wfp::IpAddress ip;
+		uint16_t port;
+		WinFwProtocol protocol;
+		std::vector<std::wstring> clients;
+	};
+
+	PermitEndpoint(const std::vector<Endpoint> endpoints);
 	
 	bool apply(IObjectInstaller &objectInstaller) override;
 
 private:
+	bool AddIpv4EndpointFilter(const Endpoint &endpoint, const GUID &ipv4Guid, IObjectInstaller &objectInstaller);
+	bool AddIpv6EndpointFilter(const Endpoint &endpoint, const GUID &ipv6Guid, IObjectInstaller &objectInstaller);
 
-	const wfp::IpAddress m_address;
-	const std::vector<std::wstring> m_clients;
-	const uint16_t m_port;
-	const WinFwProtocol m_protocol;
+	const std::vector<Endpoint> m_endpoints;
 };
 
 }

--- a/nym-vpn-windows/winfw/src/winfw/rules/baseline/permitvpntunnel.h
+++ b/nym-vpn-windows/winfw/src/winfw/rules/baseline/permitvpntunnel.h
@@ -13,6 +13,11 @@ class PermitVpnTunnel : public IFirewallRule
 {
 public:
 
+	enum InterfaceType {
+		Entry,
+		Exit,
+	};
+
 	struct Endpoint {
 		wfp::IpAddress ip;
 		uint16_t port;
@@ -25,6 +30,7 @@ public:
 	};
 
 	PermitVpnTunnel(
+		const InterfaceType interfaceType,
 		const std::wstring &tunnelInterfaceAlias,
 		const std::optional<Endpoints> &potentialEndpoints
 	);
@@ -32,8 +38,11 @@ public:
 	bool apply(IObjectInstaller &objectInstaller) override;
 
 private:
+	bool ApplyForEntryInterface(IObjectInstaller& objectInstaller);
+	bool ApplyForExitInterface(IObjectInstaller& objectInstaller);
 	bool AddEndpointFilter(const std::optional<Endpoint> &endpoint, const GUID &ipv4Guid, const GUID &ipv6Guid, IObjectInstaller &objectInstaller);
 
+	const InterfaceType m_interfaceType;
 	const std::wstring m_tunnelInterfaceAlias;
 	const std::optional<Endpoints> m_potentialEndpoints;
 };

--- a/nym-vpn-windows/winfw/src/winfw/rules/baseline/permitvpntunnelservice.h
+++ b/nym-vpn-windows/winfw/src/winfw/rules/baseline/permitvpntunnelservice.h
@@ -15,6 +15,7 @@ class PermitVpnTunnelService : public IFirewallRule
 public:
 
 	PermitVpnTunnelService(
+		const PermitVpnTunnel::InterfaceType interfaceType,
 		const std::wstring &tunnelInterfaceAlias,
 		const std::optional<PermitVpnTunnel::Endpoints> &potentialEndpoints
 	);
@@ -22,8 +23,11 @@ public:
 	bool apply(IObjectInstaller &objectInstaller) override;
 
 private:
+	bool ApplyForEntryInterface(IObjectInstaller& objectInstaller);
+	bool ApplyForExitInterface(IObjectInstaller& objectInstaller);
 	bool AddEndpointFilter(const std::optional<PermitVpnTunnel::Endpoint> &endpoint, const GUID &ipv4Guid, const GUID &ipv6Guid, IObjectInstaller &objectInstaller);
 
+	const PermitVpnTunnel::InterfaceType m_interfaceType;
 	const std::wstring m_tunnelInterfaceAlias;
 	const std::optional<PermitVpnTunnel::Endpoints> m_potentialEndpoints;
 };

--- a/nym-vpn-windows/winfw/src/winfw/rules/dns/permitnontunnel.cpp
+++ b/nym-vpn-windows/winfw/src/winfw/rules/dns/permitnontunnel.cpp
@@ -43,7 +43,10 @@ bool PermitNonTunnel::apply(IObjectInstaller &objectInstaller)
 
 		wfp::ConditionBuilder conditionBuilder(FWPM_LAYER_ALE_AUTH_CONNECT_V4);
 
-		conditionBuilder.add_condition(ConditionPort::Remote(DNS_SERVER_PORT));
+		for (const auto& dnsPort : DNS_PORTS)
+		{
+			conditionBuilder.add_condition(ConditionPort::Remote(dnsPort));
+		}
 
 		for (const auto &host : m_hostsIpv4)
 		{
@@ -82,7 +85,10 @@ bool PermitNonTunnel::apply(IObjectInstaller &objectInstaller)
 
 	wfp::ConditionBuilder conditionBuilder(FWPM_LAYER_ALE_AUTH_CONNECT_V6);
 
-	conditionBuilder.add_condition(ConditionPort::Remote(DNS_SERVER_PORT));
+	for (const auto& dnsPort : DNS_PORTS)
+	{
+		conditionBuilder.add_condition(ConditionPort::Remote(dnsPort));
+	}
 
 	for (const auto &host : m_hostsIpv6)
 	{

--- a/nym-vpn-windows/winfw/src/winfw/rules/dns/permittunnel.cpp
+++ b/nym-vpn-windows/winfw/src/winfw/rules/dns/permittunnel.cpp
@@ -43,7 +43,10 @@ bool PermitTunnel::apply(IObjectInstaller &objectInstaller)
 
 		wfp::ConditionBuilder conditionBuilder(FWPM_LAYER_ALE_AUTH_CONNECT_V4);
 
-		conditionBuilder.add_condition(ConditionPort::Remote(DNS_SERVER_PORT));
+		for (const auto &dnsPort: DNS_PORTS) 
+		{
+			conditionBuilder.add_condition(ConditionPort::Remote(dnsPort));
+		}
 		conditionBuilder.add_condition(ConditionInterface::Alias(m_tunnelInterfaceAlias));
 
 		for (const auto &host : m_hostsIpv4)
@@ -78,7 +81,10 @@ bool PermitTunnel::apply(IObjectInstaller &objectInstaller)
 
 	wfp::ConditionBuilder conditionBuilder(FWPM_LAYER_ALE_AUTH_CONNECT_V6);
 
-	conditionBuilder.add_condition(ConditionPort::Remote(DNS_SERVER_PORT));
+	for (const auto &dnsPort: DNS_PORTS) 
+	{
+		conditionBuilder.add_condition(ConditionPort::Remote(dnsPort));
+	}
 	conditionBuilder.add_condition(ConditionInterface::Alias(m_tunnelInterfaceAlias));
 
 	for (const auto &host : m_hostsIpv6)

--- a/nym-vpn-windows/winfw/src/winfw/rules/multi/permitvpnrelay.h
+++ b/nym-vpn-windows/winfw/src/winfw/rules/multi/permitvpnrelay.h
@@ -18,24 +18,24 @@ public:
 		Dns
 	};
 
-	PermitVpnRelay
-	(
-		const wfp::IpAddress &relay,
-		uint16_t relayPort,
-		WinFwProtocol protocol,
-		const std::vector<std::wstring> &relayClients,
-		Sublayer sublayer
-	);
+	struct Endpoint {
+		wfp::IpAddress ip;
+		uint16_t port;
+		WinFwProtocol protocol;
+		std::vector<std::wstring> clients;
+		Sublayer sublayer;
+	};
+
+	PermitVpnRelay(std::vector<Endpoint> endpoints);
 	
 	bool apply(IObjectInstaller &objectInstaller) override;
 
 private:
 
-	const wfp::IpAddress m_relay;
-	const uint16_t m_relayPort;
-	const WinFwProtocol m_protocol;
-	const std::vector<std::wstring> m_relayClients;
-	const Sublayer m_sublayer;
+	bool AddIpv4RelayFilter(const Endpoint& endpoint, const GUID& ipv4Guid, IObjectInstaller& objectInstaller);
+	bool AddIpv6RelayFilter(const Endpoint& endpoint, const GUID& ipv6Guid, IObjectInstaller& objectInstaller);
+
+	const std::vector<Endpoint> m_endpoints;
 };
 
 }

--- a/nym-vpn-windows/winfw/src/winfw/rules/ports.h
+++ b/nym-vpn-windows/winfw/src/winfw/rules/ports.h
@@ -14,6 +14,15 @@ enum Ports : uint16_t
 	DHCPV6_SERVER_PORT = 547,
 
 	DNS_SERVER_PORT = 53,
+	DNS_OVER_HTTPS_PORT = 443,
+	DNS_OVER_TLS_PORT = 853,
+};
+
+
+static const uint16_t DNS_PORTS[] = {
+	DNS_SERVER_PORT,
+	DNS_OVER_HTTPS_PORT,
+	DNS_OVER_TLS_PORT
 };
 
 }

--- a/nym-vpn-windows/winfw/src/winfw/winfw.cpp
+++ b/nym-vpn-windows/winfw/src/winfw/winfw.cpp
@@ -141,6 +141,58 @@ void LogDnsServers(const char* label, const std::vector<wfp::IpAddress>& dnsServ
 	g_logSink(MULLVAD_LOG_LEVEL_DEBUG, ss.str().c_str(), g_logSinkContext);
 }
 
+void LogAllowedEndpoints(const char *label, std::vector<WinFwAllowedEndpoint>& allowed_endpoints)
+{
+	if (nullptr == g_logSink)
+	{
+		return;
+	}
+
+	std::stringstream ss;
+	ss << label << ": ";
+	for (size_t i = 0; i < allowed_endpoints.size(); i++)
+	{
+		if (i > 0)
+		{
+			ss << ", ";
+		}
+		ss << common::string::ToAnsi(allowed_endpoints[i].endpoint.ip) << ":" << allowed_endpoints[i].endpoint.port << " ";
+
+		switch (allowed_endpoints[i].endpoint.protocol) {
+		case WinFwProtocol::Tcp:
+			ss << "tcp";
+			break;
+		case WinFwProtocol::Udp:
+			ss << "udp";
+			break;
+		default:
+			ss << "unknown";
+			break;
+		}
+	}
+	g_logSink(MULLVAD_LOG_LEVEL_DEBUG, ss.str().c_str(), g_logSinkContext);
+}
+
+void LogInterface(const char* label, std::optional<std::wstring>& iface) 
+{
+	if (nullptr == g_logSink)
+	{
+		return;
+	}
+
+	std::stringstream ss;
+	ss << label << ": ";
+
+	if (iface.has_value()) {
+		ss << common::string::ToAnsi(iface.value());
+	}
+	else {
+		ss << "unset";
+	}
+
+	g_logSink(MULLVAD_LOG_LEVEL_DEBUG, ss.str().c_str(), g_logSinkContext);
+}
+
 } // anonymous namespace
 
 WINFW_LINKAGE
@@ -350,7 +402,13 @@ WinFw_ApplyPolicyConnecting(
 		auto allowedEndpointOptVector = MakeOptionalVector(allowedEndpoints, numAllowedEndpoints);
 		auto nonTunnelDnsServerVector = MakeIpAddressVector(nonTunnelDnsServers, numNonTunnelDnsServers);
 
-		LogDnsServers("Non-tunnel DNS servers: ", nonTunnelDnsServerVector);
+		LogAllowedEndpoints("Relays", relayVector);
+		if (allowedEndpointOptVector.has_value()) {
+			LogAllowedEndpoints("AllowedEndpoints", allowedEndpointOptVector.value());
+		}
+		LogInterface("entryTunnelIface", entryTunnelIfaceAliasOptStr);
+		LogInterface("exitTunnelIface", exitTunnelIfaceAliasOptStr);
+		LogDnsServers("Non-tunnel DNS servers", nonTunnelDnsServerVector);
 
 		return g_fwContext->applyPolicyConnecting(
 			*settings,
@@ -430,11 +488,17 @@ WinFw_ApplyPolicyConnected(
 		auto entryTunnelIfaceAliasOptStr = MakeOptionalStr(entryTunnelIfaceAlias);
 		auto exitTunnelIfaceAliasOptStr = MakeOptionalStr(exitTunnelIfaceAlias);
 		auto allowedEndpointOptVector = MakeOptionalVector(allowedEndpoints, numAllowedEndpoints);
-		std::vector<wfp::IpAddress> nonTunnelDnsServerVector = MakeIpAddressVector(nonTunnelDnsServers, numNonTunnelDnsServers);
-		std::vector<wfp::IpAddress> tunnelDnsServersVector = MakeIpAddressVector(tunnelDnsServers, numTunnelDnsServers);
+		auto nonTunnelDnsServerVector = MakeIpAddressVector(nonTunnelDnsServers, numNonTunnelDnsServers);
+		auto tunnelDnsServersVector = MakeIpAddressVector(tunnelDnsServers, numTunnelDnsServers);
 
-		LogDnsServers("Non-tunnel DNS servers: ", nonTunnelDnsServerVector);
-		LogDnsServers("Tunnel DNS servers: ", tunnelDnsServersVector);
+		LogAllowedEndpoints("Relays", relayVector);
+		if (allowedEndpointOptVector.has_value()) {
+			LogAllowedEndpoints("Allowed endpoints", allowedEndpointOptVector.value());
+		}
+		LogInterface("Entry tunnel interface", entryTunnelIfaceAliasOptStr);
+		LogInterface("Exit tunnel interface", exitTunnelIfaceAliasOptStr);
+		LogDnsServers("Non-tunnel DNS servers", nonTunnelDnsServerVector);
+		LogDnsServers("Tunnel DNS servers", tunnelDnsServersVector);
 
 		return g_fwContext->applyPolicyConnected(
 			*settings,

--- a/nym-vpn-windows/winfw/src/winfw/winfw.cpp
+++ b/nym-vpn-windows/winfw/src/winfw/winfw.cpp
@@ -334,16 +334,6 @@ WinFw_ApplyPolicyConnecting(
 			THROW_ERROR("Invalid argument: settings");
 		}
 
-		if (nullptr == relays)
-		{
-			THROW_ERROR("Invalid argument: relays");
-		}
-
-		if (0 == numRelays)
-		{
-			THROW_ERROR("Invalid argument: numRelays");
-		}
-
 		if (nullptr == allowedEntryTunnelTraffic)
 		{
 			THROW_ERROR("Invalid argument: allowedEntryTunnelTraffic");

--- a/nym-vpn-windows/winfw/src/winfw/winfw.vcxproj
+++ b/nym-vpn-windows/winfw/src/winfw/winfw.vcxproj
@@ -213,7 +213,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;WINFW_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(ProjectDir)..\..\..\libshared\src\;$(ProjectDir)..\;$(ProjectDir)..\..\..\windows-libraries\src\;$(ProjectDir)..\..\..\libwfp\src\</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\..\..\libshared\src\;$(ProjectDir);$(ProjectDir)..\;$(ProjectDir)..\..\..\windows-libraries\src\;$(ProjectDir)..\..\..\libwfp\src\</AdditionalIncludeDirectories>
       <ObjectFileName>$(IntDir)%(RelativeDir)/</ObjectFileName>
     </ClCompile>
     <Link>
@@ -236,7 +236,7 @@
       <PreprocessorDefinitions>_DEBUG;WINFW_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(ProjectDir)..\..\..\libshared\src\;$(ProjectDir)..\;$(ProjectDir)..\..\..\windows-libraries\src\;$(ProjectDir)..\..\..\libwfp\src\</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\..\..\libshared\src\;$(ProjectDir);$(ProjectDir)..\;$(ProjectDir)..\..\..\windows-libraries\src\;$(ProjectDir)..\..\..\libwfp\src\</AdditionalIncludeDirectories>
       <ObjectFileName>$(IntDir)%(RelativeDir)/</ObjectFileName>
     </ClCompile>
     <Link>
@@ -259,7 +259,7 @@
       <PreprocessorDefinitions>_DEBUG;WINFW_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(ProjectDir)..\..\..\libshared\src\;$(ProjectDir)..\;$(ProjectDir)..\..\..\windows-libraries\src\;$(ProjectDir)..\..\..\libwfp\src\</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\..\..\libshared\src\;$(ProjectDir);$(ProjectDir)..\;$(ProjectDir)..\..\..\windows-libraries\src\;$(ProjectDir)..\..\..\libwfp\src\</AdditionalIncludeDirectories>
       <ObjectFileName>$(IntDir)%(RelativeDir)/</ObjectFileName>
     </ClCompile>
     <Link>
@@ -311,7 +311,7 @@
       <PreprocessorDefinitions>NDEBUG;WINFW_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(ProjectDir)..\..\..\libshared\src\;$(ProjectDir)..\;$(ProjectDir)..\..\..\windows-libraries\src\;$(ProjectDir)..\..\..\libwfp\src\</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\..\..\libshared\src\;$(ProjectDir);$(ProjectDir)..\;$(ProjectDir)..\..\..\windows-libraries\src\;$(ProjectDir)..\..\..\libwfp\src\</AdditionalIncludeDirectories>
       <ObjectFileName>$(IntDir)%(RelativeDir)/</ObjectFileName>
     </ClCompile>
     <Link>

--- a/nym-vpn-windows/winfw/src/winfw/winfw.vcxproj.filters
+++ b/nym-vpn-windows/winfw/src/winfw/winfw.vcxproj.filters
@@ -138,6 +138,7 @@
     <ClInclude Include="rules\dns\permitloopback.h">
       <Filter>rules\dns</Filter>
     </ClInclude>
+    <ClInclude Include="version.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="rules">


### PR DESCRIPTION
- `build-windows-modules.ps1`: Add parameter that enables auto-copy of `winfw.dll` into `target\debug` when developing
- Add `InterfaceType` describing entry and exit tunnel interfaces and use it to set up the second set of filters using unique GUIDs. This is important because we want individual rules match IP, port, transport and each but also we cannot install the filter with the same GUID twice so we have to swap GUIDs based on input parameters.
- Add option to configure up to 4 IP addresses in vpn relay filter. We use that for mixnet + wireguard endpoints.
- Add option to configure up to 8 IP addresses for allowed endpoints. We use that for APIs.
- Allow more DNS ports which should really be revamped to be stricter, alas not now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2389)
<!-- Reviewable:end -->
