### PR TITLE
libw: add DLL version info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ nym-vpn-core/crates/nym-vpn-lib/generated
 nym-vpn-apple/MixnetLibrary/Sources/MixnetLibrary/RustFramework.xcframework
 
 # Wireguard-go artifacts
+wireguard/libwg/versioninfo_windows.syso
 wireguard/libwg/exports.def
 wireguard/libwg/libwg.exp
 wireguard/libwg/libwg.h

--- a/nym-vpn-windows/winfw/src/winfw/version.h
+++ b/nym-vpn-windows/winfw/src/winfw/version.h
@@ -2,7 +2,7 @@
 #define VERSION_H
 
 #define MAJOR_VERSION 2025
-#define MINOR_VERSION 1
+#define MINOR_VERSION 4
 #define PATCH_VERSION 0
 #define PRODUCT_VERSION "1.0"
 

--- a/wireguard/build-wireguard-go.sh
+++ b/wireguard/build-wireguard-go.sh
@@ -109,6 +109,10 @@ function build_windows {
     echo "Building wireguard-go for Windows ($arch)"
 
     pushd $LIB_DIR
+        if [ $# -eq 0 ] ; then
+            win_create_versioninfo
+        fi
+
         build_go -v -o libwg.dll -buildmode c-shared
 
         if [ $# -eq 0 ] ; then
@@ -123,6 +127,11 @@ function build_windows {
         echo "Copying files to $(realpath "$target_dir")"
         mv libwg.dll libwg.lib $target_dir
     popd
+}
+
+function win_create_versioninfo {
+    echo "Compiling DLL version info (libwg.rc)"
+    windres -i libwg.rc -O coff -o versioninfo_windows.syso
 }
 
 function unix_target_triple {

--- a/wireguard/libwg/libwg.rc
+++ b/wireguard/libwg/libwg.rc
@@ -1,0 +1,25 @@
+#include "version.h"
+
+1 VERSIONINFO
+FILEVERSION     MAJOR_VERSION,MINOR_VERSION,PATCH_VERSION,0
+PRODUCTVERSION  MAJOR_VERSION,MINOR_VERSION,PATCH_VERSION,0
+BEGIN
+BLOCK "StringFileInfo"
+BEGIN
+    BLOCK "040904E4"
+    BEGIN
+        VALUE "CompanyName", "Nym Technologies SA"
+        VALUE "FileDescription", "Nym VPN WireGuard module"
+        VALUE "FileVersion", PRODUCT_VERSION
+        VALUE "InternalName", "libwg"
+        VALUE "LegalCopyright", "(c) 2025 Nym Technologies SA"
+        VALUE "OriginalFilename", "libwg.dll"
+        VALUE "ProductName", "Nym VPN"
+        VALUE "ProductVersion", PRODUCT_VERSION
+    END
+END
+BLOCK "VarFileInfo"
+BEGIN
+    VALUE "Translation", 0x409, 1252
+END
+END

--- a/wireguard/libwg/version.h
+++ b/wireguard/libwg/version.h
@@ -1,0 +1,9 @@
+#ifndef VERSION_H
+#define VERSION_H
+
+#define MAJOR_VERSION 2025
+#define MINOR_VERSION 4
+#define PATCH_VERSION 0
+#define PRODUCT_VERSION "1.0"
+
+#endif // VERSION_H


### PR DESCRIPTION
- This PR adds generation of version info metadata for `libwg.dll`
- Align `winfw.dll` metadata with `2025.4-papaya`

Ideally `version.h` should be autogenerated but we don't have capacity to do that right now.

![Screenshot 2025-03-08 at 14 18 36](https://github.com/user-attachments/assets/3318ccbb-15bf-4ea2-bdd3-29dc326b1b86)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2408)
<!-- Reviewable:end -->
