### PR TITLE
Wire up system_configuration statistics_recipient

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
@@ -608,6 +608,7 @@ pub struct SystemMessageResponse {
 pub struct SystemConfigurationResponse {
     pub mix_thresholds: ScoreThresholdsResponse,
     pub wg_thresholds: ScoreThresholdsResponse,
+    pub statistics_recipient: Option<String>,
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq)]

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/lib.rs
@@ -204,17 +204,6 @@ impl Network {
     pub fn get_feature_flag_stats_recipient(&self) -> Option<Recipient> {
         self.get_feature_flag("statistics", "recipient")
     }
-    //pub fn get_feature_flag_score_thresholds(&self) -> Option<ScoreThresholds> {
-    //    if let (Some(high), Some(medium), Some(low)) = (
-    //        self.get_feature_flag("score_threshold", "high"),
-    //        self.get_feature_flag("score_threshold", "medium"),
-    //        self.get_feature_flag("score_threshold", "low"),
-    //    ) {
-    //        Some(ScoreThresholds { high, medium, low })
-    //    } else {
-    //        None
-    //    }
-    //}
 }
 
 pub fn discover_networks(config_path: &Path) -> anyhow::Result<RegisteredNetworks> {

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/lib.rs
@@ -23,7 +23,7 @@ pub use network_compatibility::NetworkCompatibility;
 pub use nym_network::NymNetwork;
 use nym_sdk::mixnet::Recipient;
 pub use nym_vpn_network::NymVpnNetwork;
-use system_configuration::{ScoreThresholds, SystemConfiguration};
+use system_configuration::SystemConfiguration;
 pub use system_messages::{SystemMessage, SystemMessages};
 
 use discovery::Discovery;
@@ -204,18 +204,17 @@ impl Network {
     pub fn get_feature_flag_stats_recipient(&self) -> Option<Recipient> {
         self.get_feature_flag("statistics", "recipient")
     }
-
-    pub fn get_feature_flag_score_thresholds(&self) -> Option<ScoreThresholds> {
-        if let (Some(high), Some(medium), Some(low)) = (
-            self.get_feature_flag("score_threshold", "high"),
-            self.get_feature_flag("score_threshold", "medium"),
-            self.get_feature_flag("score_threshold", "low"),
-        ) {
-            Some(ScoreThresholds { high, medium, low })
-        } else {
-            None
-        }
-    }
+    //pub fn get_feature_flag_score_thresholds(&self) -> Option<ScoreThresholds> {
+    //    if let (Some(high), Some(medium), Some(low)) = (
+    //        self.get_feature_flag("score_threshold", "high"),
+    //        self.get_feature_flag("score_threshold", "medium"),
+    //        self.get_feature_flag("score_threshold", "low"),
+    //    ) {
+    //        Some(ScoreThresholds { high, medium, low })
+    //    } else {
+    //        None
+    //    }
+    //}
 }
 
 pub fn discover_networks(config_path: &Path) -> anyhow::Result<RegisteredNetworks> {

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/system_configuration.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/system_configuration.rs
@@ -17,8 +17,8 @@ impl fmt::Display for SystemConfiguration {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "mixnet score thresholds: {:?}\nwireguard score thresholds: {:?}",
-            self.mix_thresholds, self.wg_thresholds
+            "mixnet score thresholds: {:?}\nwireguard score thresholds: {:?}\nstatistics recipient: {:?}",
+            self.mix_thresholds, self.wg_thresholds, self.statistics_recipient
         )
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/system_configuration.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/system_configuration.rs
@@ -3,12 +3,14 @@
 
 use std::fmt;
 
+use nym_sdk::mixnet::Recipient;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SystemConfiguration {
     pub mix_thresholds: ScoreThresholds,
     pub wg_thresholds: ScoreThresholds,
+    pub statistics_recipient: Option<Recipient>,
 }
 
 impl fmt::Display for SystemConfiguration {

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -204,12 +204,12 @@ impl NymVpnService<nym_vpn_lib::storage::VpnClientOnDiskStorage> {
                             tracing::info!("VPN service has successfully exited");
                         }
                         Err(e) => {
-                            tracing::error!("VPN service has exited with error: {:?}", e);
+                            tracing::error!("VPN service has exited with error: {e:?}");
                         }
                     }
                 }
                 Err(err) => {
-                    tracing::error!("Failed to initialize VPN service: {:?}", err);
+                    tracing::error!("Failed to initialize VPN service: {err:?}");
                 }
             }
         })
@@ -235,7 +235,9 @@ impl NymVpnService<nym_vpn_lib::storage::VpnClientOnDiskStorage> {
         // Make sure the data dir exists
         super::config::create_data_dir(&data_dir).map_err(Error::ConfigSetup)?;
 
-        let statistics_recipient = network_env.get_feature_flag_stats_recipient();
+        let statistics_recipient = network_env
+            .system_configuration
+            .and_then(|config| config.statistics_recipient);
 
         let account_controller = AccountController::new(
             Arc::clone(&storage),


### PR DESCRIPTION
Wire up statistics_recipient in network configuration, if it is provided.

- **Parse statistics recipient from network configuration**
- **Set statistics recipient in uniffi**

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2419)
<!-- Reviewable:end -->
