### PR TITLE
Improve logging for forget_account and also delete corrupted files"

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/credentials/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/credentials/mod.rs
@@ -61,7 +61,7 @@ impl VpnCredentialStorage {
     }
 
     async fn reset_credential_storage(&mut self) -> Result<(), Error> {
-        tracing::info!("Resetting credential storage");
+        tracing::info!("Resetting credential storage by deleting and re-creating the storage");
 
         // First we close the storage to ensure that all files are closed
         tracing::debug!("Closing credential storage");
@@ -78,7 +78,7 @@ impl VpnCredentialStorage {
         tracing::debug!("Removing credential storage file");
         for path in storage_paths.credential_database_paths() {
             match std::fs::remove_file(&path) {
-                Ok(_) => tracing::trace!("Removed file: {}", path.display()),
+                Ok(_) => tracing::info!("Removed file: {}", path.display()),
                 Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
                     tracing::trace!("File not found, skipping: {}", path.display())
                 }
@@ -102,7 +102,7 @@ impl VpnCredentialStorage {
     }
 
     async fn reset_pending_request_storage(&mut self) -> Result<(), Error> {
-        tracing::info!("Resetting pending request storage");
+        tracing::info!("Resetting pending request storage by deleting and re-creating the storage");
         self.pending_requests_storage.reset().await?;
         tracing::info!("Pending request storage reset completed");
         Ok(())

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/credentials/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/credentials/mod.rs
@@ -77,10 +77,11 @@ impl VpnCredentialStorage {
 
         tracing::debug!("Removing credential storage file");
         for path in storage_paths.credential_database_paths() {
+            tracing::debug!("Attempting to remove file: {}", path.display());
             match std::fs::remove_file(&path) {
                 Ok(_) => tracing::info!("Removed file: {}", path.display()),
                 Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                    tracing::trace!("File not found, skipping: {}", path.display())
+                    tracing::debug!("File not found, skipping: {}", path.display())
                 }
                 Err(err) => {
                     tracing::error!("Failed to remove file {}: {err}", path.display());

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/credentials/pending_credential_requests/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/credentials/pending_credential_requests/mod.rs
@@ -82,6 +82,7 @@ impl PendingCredentialRequestsStorage {
         tracing::debug!("Removing pending credential requests storage file");
         std::fs::remove_file(&self.database_path)
             .map_err(PendingCredentialRequestsStorageError::RemoveStorage)?;
+        tracing::info!("Removed file: {}", self.database_path.display());
 
         // Finally we recreate the storage
         tracing::debug!("Recreating pending credential requests storage");

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/storage_cleanup.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/storage_cleanup.rs
@@ -114,7 +114,7 @@ fn get_list_of_corrupted_files(data_dir: &Path) -> Result<Vec<PathBuf>, Error> {
         .map_err(Error::StoragePaths)?
         .reply_surb_database_path;
 
-    if let Some(starts_with) = base_name.file_name().map(|bn| bn.to_string_lossy()) {
+    if let Some(starts_with) = base_name.file_name().and_then(|bn| bn.to_str()) {
         // Delete files of the form `base_name._[0-9]*.corrupted`
         let corrupted_files = fs::read_dir(data_dir)
             .map_err(Error::internal)?
@@ -122,7 +122,7 @@ fn get_list_of_corrupted_files(data_dir: &Path) -> Result<Vec<PathBuf>, Error> {
             .filter(|file| {
                 file.file_name()
                     .to_str()
-                    .map(|name| name.starts_with(&*starts_with))
+                    .map(|name| name.starts_with(starts_with))
                     .unwrap_or(false)
             })
             .filter(|file| {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/storage_cleanup.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/storage_cleanup.rs
@@ -63,7 +63,7 @@ pub fn remove_files_for_account(data_dir: &Path) -> Result<(), Error> {
     for file_path in files_to_remove {
         tracing::info!("Removing file: {}", file_path.display());
         match fs::remove_file(&file_path) {
-            Ok(_) => tracing::trace!("Removed file: {}", file_path.display()),
+            Ok(_) => tracing::info!("Removed file: {}", file_path.display()),
             Err(err) if err.kind() == io::ErrorKind::NotFound => {
                 tracing::trace!("File not found, skipping: {}", file_path.display());
             }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/storage_cleanup.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/storage_cleanup.rs
@@ -1,7 +1,10 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{fs, io, path::Path};
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+};
 
 use nym_sdk::mixnet::StoragePaths;
 use nym_vpn_store::keys::persistence::{
@@ -65,9 +68,32 @@ pub fn remove_files_for_account(data_dir: &Path) -> Result<(), Error> {
         match fs::remove_file(&file_path) {
             Ok(_) => tracing::info!("Removed file: {}", file_path.display()),
             Err(err) if err.kind() == io::ErrorKind::NotFound => {
-                tracing::trace!("File not found, skipping: {}", file_path.display());
+                tracing::debug!("File not found, skipping: {}", file_path.display());
             }
             Err(err) => tracing::error!("Failed to remove file {}: {err}", file_path.display()),
+        }
+    }
+
+    // For the persistent reply store we also have backups of corrupted files. They have the same
+    // filename as the original file, but appended with `_1234567890.corrupted`. Make sure to
+    // delete all of these as well.
+
+    let corrupted_files = get_list_of_corrupted_files(data_dir).inspect_err(|err| {
+        tracing::error!("Failed to get list of corrupted files: {err}");
+    });
+
+    if let Ok(corrupted_files) = corrupted_files {
+        for file in corrupted_files {
+            tracing::info!("Removing corrupted file: {}", file.display());
+            match fs::remove_file(&file) {
+                Ok(_) => tracing::info!("Removed corrupted file: {}", file.display()),
+                Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                    tracing::debug!("Corrupted file not found, skipping: {}", file.display());
+                }
+                Err(err) => {
+                    tracing::error!("Failed to remove corrupted file {}: {err}", file.display())
+                }
+            }
         }
     }
 
@@ -81,4 +107,34 @@ pub fn remove_files_for_account(data_dir: &Path) -> Result<(), Error> {
     }
 
     Ok(())
+}
+
+fn get_list_of_corrupted_files(data_dir: &Path) -> Result<Vec<PathBuf>, Error> {
+    let base_name = StoragePaths::new_from_dir(data_dir)
+        .map_err(Error::StoragePaths)?
+        .reply_surb_database_path;
+
+    if let Some(starts_with) = base_name.file_name().map(|bn| bn.to_string_lossy()) {
+        // Delete files of the form `base_name._[0-9]*.corrupted`
+        let corrupted_files = fs::read_dir(data_dir)
+            .map_err(Error::internal)?
+            .filter_map(|file| file.ok())
+            .filter(|file| {
+                file.file_name()
+                    .to_str()
+                    .map(|name| name.starts_with(&*starts_with))
+                    .unwrap_or(false)
+            })
+            .filter(|file| {
+                file.file_name()
+                    .to_str()
+                    .map(|name| name.ends_with(".corrupted"))
+                    .unwrap_or(false)
+            })
+            .map(|file| file.path())
+            .collect();
+        Ok(corrupted_files)
+    } else {
+        Ok(vec![])
+    }
 }


### PR DESCRIPTION
Improve logging to emphasize that credential db files are deleted as part of forget_account. They are reset to new, making the previous logging seem like they were missed. See e.g. this user reported issue https://github.com/nymtech/nym-vpn-client/issues/2262

Also while we're at it, make sure to delete corrupted backup files as well

Closes: #2262

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2426)
<!-- Reviewable:end -->
