### PR TITLE
windows: update service installation

### DIFF
--- a/nym-vpn-core/crates/nym-vpnd/src/windows_service/service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/windows_service/service.rs
@@ -175,7 +175,7 @@ pub(super) fn get_service_info() -> ServiceInfo {
     }
 }
 
-pub(crate) fn start(args: CliArgs) -> Result<(), windows_service::Error> {
+pub(crate) fn start(args: CliArgs) -> anyhow::Result<()> {
     if args.command.install {
         println!(
             "Processing request to install {} as a service...",


### PR DESCRIPTION
- Ensure that the service configuration is always updated upon service installation
- Create the service only if we the system reported that it does not exist
- Set failure actions to restart the service on failure

Recovery logic:

1. First restart after 3s
2. Second restart after 30s
3. Third restart after 10min

Reset the failure counter after 15min of running without failures.

Note that `ServiceAccess::START` permission is needed because we use `ServiceActionType::Restart` recovery action.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2436)
<!-- Reviewable:end -->
