### PR TITLE
Fix None response behaviour for bandwidth query

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
@@ -311,7 +311,9 @@ impl<St: Storage> BandwidthController<St> {
                             }
                         }
                     }
-                    Ok(None) => {}
+                    Ok(None) => {
+                        tracing::info!("Empty query for {} gadeway bandwidth check. This is normal, as long as it is not repeating for the same gateway", if entry {"entry".to_string()} else {"exit".to_string()});
+                    }
                 }
             }
         }


### PR DESCRIPTION
False negatives like
```
2025-03-07T09:28:42.485953Z  INFO nym_wg_gateway_client: Remaining wireguard bandwidth with gateway $GATEWAY_ID for today: 0 KB
2025-03-07T09:28:42.486029Z  WARN nym_wg_gateway_client: Remaining bandwidth is under 1 MB. The wireguard mode will get suspended after that until tomorrow, UTC time. The client might shutdown with timeout soon
```
that appear from time to time because of a data sync that happens on the gateway shouldn't be regarded as 0 bandwidth but rather as a needed retry

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2456)
<!-- Reviewable:end -->
