### PR TITLE
Start with initial 0 value instead of u64::MAX

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
@@ -373,11 +373,13 @@ mod tests {
     fn depletion_rate_slow() {
         let mut depletaion_rate = DepletionRate::default();
         let mut current_period = DEFAULT_BANDWIDTH_CHECK;
-        // the first check would force the big placeholder values to be replaced by the actual values
-        assert!(depletaion_rate
-            .update_dynamic_check_interval(current_period, BW_512MB)
-            .unwrap()
-            .is_none());
+        // the first check would force the placeholder values to be replaced by the actual values
+        assert_eq!(
+            depletaion_rate
+                .update_dynamic_check_interval(current_period, BW_512MB)
+                .unwrap(),
+            Some(DEFAULT_BANDWIDTH_CHECK)
+        );
 
         // simulate 1 byte/second depletion rate
         let consumed = current_period.as_secs() * 1;
@@ -392,11 +394,13 @@ mod tests {
     fn depletion_rate_fast() {
         let mut depletaion_rate = DepletionRate::default();
         let current_period = DEFAULT_BANDWIDTH_CHECK;
-        // the first check would force the big placeholder values to be replaced by the actual values
-        assert!(depletaion_rate
-            .update_dynamic_check_interval(current_period, BW_1GB)
-            .unwrap()
-            .is_none());
+        // the first check would force the placeholder values to be replaced by the actual values
+        assert_eq!(
+            depletaion_rate
+                .update_dynamic_check_interval(current_period, BW_1GB)
+                .unwrap(),
+            Some(DEFAULT_BANDWIDTH_CHECK)
+        );
 
         // simulate 128 MB/s depletion rate, so we would be depleted in the next 5 seconds after the function call (too fast)
         let consumed = current_period.as_secs() * BW_128MB;
@@ -411,11 +415,13 @@ mod tests {
         let mut depletaion_rate = DepletionRate::default();
         let mut current_period = DEFAULT_BANDWIDTH_CHECK;
         let mut current_bandwidth = BW_1GB;
-        // the first check would force the big placeholder values to be replaced by the actual values
-        assert!(depletaion_rate
-            .update_dynamic_check_interval(current_period, current_bandwidth)
-            .unwrap()
-            .is_none());
+        // the first check would force the placeholder values to be replaced by the actual values
+        assert_eq!(
+            depletaion_rate
+                .update_dynamic_check_interval(current_period, BW_1GB)
+                .unwrap(),
+            Some(DEFAULT_BANDWIDTH_CHECK)
+        );
 
         // simulate 1 KB/s depletion rate, constant
         for _ in 0..5 {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
@@ -88,7 +88,7 @@ impl Default for DepletionRate {
     fn default() -> Self {
         Self {
             current_depletion_rate: DEFAULT_BANDWIDTH_DEPLETION_RATE,
-            available_bandwidth: u64::MAX,
+            available_bandwidth: 0,
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
@@ -133,7 +133,9 @@ impl DepletionRate {
             estimated_depletion_secs
         );
 
-        let number_of_checks_before_depletion = estimated_depletion_secs / current_period.as_secs();
+        let number_of_checks_before_depletion = estimated_depletion_secs
+            .checked_div(current_period.as_secs())
+            .unwrap_or_default();
         // try and have at least 10 checks before depletion, to be on the safe side...
         if number_of_checks_before_depletion < 10 {
             return Ok(None);

--- a/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
@@ -371,11 +371,11 @@ mod tests {
 
     #[test]
     fn depletion_rate_slow() {
-        let mut depletaion_rate = DepletionRate::default();
+        let mut depletion_rate = DepletionRate::default();
         let mut current_period = DEFAULT_BANDWIDTH_CHECK;
         // the first check would force the placeholder values to be replaced by the actual values
         assert_eq!(
-            depletaion_rate
+            depletion_rate
                 .update_dynamic_check_interval(current_period, BW_512MB)
                 .unwrap(),
             Some(DEFAULT_BANDWIDTH_CHECK)
@@ -383,7 +383,7 @@ mod tests {
 
         // simulate 1 byte/second depletion rate
         let consumed = current_period.as_secs() * 1;
-        current_period = depletaion_rate
+        current_period = depletion_rate
             .update_dynamic_check_interval(current_period, BW_512MB - consumed)
             .unwrap()
             .unwrap();
@@ -392,11 +392,11 @@ mod tests {
 
     #[test]
     fn depletion_rate_fast() {
-        let mut depletaion_rate = DepletionRate::default();
+        let mut depletion_rate = DepletionRate::default();
         let current_period = DEFAULT_BANDWIDTH_CHECK;
         // the first check would force the placeholder values to be replaced by the actual values
         assert_eq!(
-            depletaion_rate
+            depletion_rate
                 .update_dynamic_check_interval(current_period, BW_1GB)
                 .unwrap(),
             Some(DEFAULT_BANDWIDTH_CHECK)
@@ -404,7 +404,7 @@ mod tests {
 
         // simulate 128 MB/s depletion rate, so we would be depleted in the next 5 seconds after the function call (too fast)
         let consumed = current_period.as_secs() * BW_128MB;
-        assert!(depletaion_rate
+        assert!(depletion_rate
             .update_dynamic_check_interval(current_period, BW_1GB - consumed)
             .unwrap()
             .is_none());
@@ -412,12 +412,12 @@ mod tests {
 
     #[test]
     fn depletion_rate_spike() {
-        let mut depletaion_rate = DepletionRate::default();
+        let mut depletion_rate = DepletionRate::default();
         let mut current_period = DEFAULT_BANDWIDTH_CHECK;
         let mut current_bandwidth = BW_1GB;
         // the first check would force the placeholder values to be replaced by the actual values
         assert_eq!(
-            depletaion_rate
+            depletion_rate
                 .update_dynamic_check_interval(current_period, BW_1GB)
                 .unwrap(),
             Some(DEFAULT_BANDWIDTH_CHECK)
@@ -426,7 +426,7 @@ mod tests {
         // simulate 1 KB/s depletion rate, constant
         for _ in 0..5 {
             current_bandwidth -= current_period.as_secs() * BW_1KB;
-            current_period = depletaion_rate
+            current_period = depletion_rate
                 .update_dynamic_check_interval(current_period, current_bandwidth)
                 .unwrap()
                 .unwrap();
@@ -436,7 +436,7 @@ mod tests {
         // spike a 1 MB/s depletion rate
         for _ in 0..24 {
             current_bandwidth -= current_period.as_secs() * BW_1MB;
-            current_period = depletaion_rate
+            current_period = depletion_rate
                 .update_dynamic_check_interval(current_period, current_bandwidth)
                 .unwrap()
                 .unwrap();
@@ -445,7 +445,7 @@ mod tests {
         }
 
         current_bandwidth -= current_period.as_secs() * BW_1MB;
-        let ret = depletaion_rate
+        let ret = depletion_rate
             .update_dynamic_check_interval(current_period, current_bandwidth)
             .unwrap();
         // when we get bellow a convinient dynamic threshold, we start reqwesting more bandwidth (returning None)


### PR DESCRIPTION
This means we don't do a preventive initial ticket spend

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2457)
<!-- Reviewable:end -->
