### PR TITLE
Increase the required number of zknyms before trying to connect

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commander.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commander.rs
@@ -190,10 +190,10 @@ impl AccountControllerCommander {
             .get_available_tickets()
             .await
             .map_err(|err| RequestZkNymError::CredentialStorage(err.to_string()))?
-            .is_all_ticket_types_above_threshold(0)
+            .is_all_ticket_types_above_soft_threshold()
         {
-            // If all ticket types are above zero, we're good to go. Additional ticketbooks will
-            // be requested in the background, but we should have enough to connect.
+            // If we have enough zk-nym ticketbooks, we can just return. Additional ticketbooks
+            // will be requested in the background later, if needed.
             return Ok(());
         }
 

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
@@ -34,7 +34,7 @@ use crate::{
 };
 
 // The interval at which we automatically request zk-nyms
-const ZK_NYM_AUTOMATIC_REQUEST_INTERVAL: Duration = Duration::from_secs(6 * 60);
+const ZK_NYM_AUTOMATIC_REQUEST_INTERVAL: Duration = Duration::from_secs(60);
 
 // The interval at which we update the account state
 const ACCOUNT_UPDATE_INTERVAL: Duration = Duration::from_secs(5 * 60);

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/credentials/pending_credential_requests/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/credentials/pending_credential_requests/mod.rs
@@ -32,9 +32,9 @@ impl PendingCredentialRequestsStorage {
     pub(crate) async fn init<P: AsRef<Path>>(
         database_path: P,
     ) -> Result<Self, PendingCredentialRequestsStorageError> {
-        tracing::info!(
-            "Setting up pending credential requests storage: {:?}",
-            database_path.as_ref().as_os_str()
+        tracing::debug!(
+            "Setting up pending credential requests storage: {}",
+            database_path.as_ref().display()
         );
 
         let opts = sqlx::sqlite::SqliteConnectOptions::new()

--- a/nym-vpn-core/crates/nym-vpnd/src/service/config.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/config.rs
@@ -161,7 +161,7 @@ where
     C: Serialize,
 {
     let config_str = toml::to_string(&config).unwrap();
-    tracing::info!("Creating config file at {}", file_path.display());
+    tracing::info!("Config file: {}", file_path.display());
 
     // Create path
     let config_dir = file_path
@@ -179,7 +179,7 @@ where
             file: file_path.clone(),
             error,
         })?;
-        tracing::info!("Config file created at {:?}", file_path.display());
+        tracing::info!("Config file created at {}", file_path.display());
     }
     Ok(config)
 }


### PR DESCRIPTION
Increase the number of required ticketbooks in storage before allowing to proceed with attempting to connect. Also reduce the interval time when the bakground check is triggered to 1 minute

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2459)
<!-- Reviewable:end -->
