### PR TITLE
vpnd: remove HTTP listener

### DIFF
--- a/nym-vpn-core/crates/nym-vpnd/src/cli.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/cli.rs
@@ -25,9 +25,6 @@ pub struct CliArgs {
     #[arg(short, long, hide = true)]
     pub network: Option<String>,
 
-    #[arg(long)]
-    pub disable_socket_listener: bool,
-
     /// Override the default user agent string.
     #[arg(long, value_parser = parse_user_agent)]
     pub user_agent: Option<nym_vpn_lib::UserAgent>,

--- a/nym-vpn-core/crates/nym-vpnd/src/cli.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/cli.rs
@@ -26,9 +26,6 @@ pub struct CliArgs {
     pub network: Option<String>,
 
     #[arg(long)]
-    pub enable_http_listener: bool,
-
-    #[arg(long)]
     pub disable_socket_listener: bool,
 
     /// Override the default user agent string.

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/config.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/config.rs
@@ -1,16 +1,13 @@
-use std::{
-    net::SocketAddr,
-    path::{Path, PathBuf},
-};
+use std::path::PathBuf;
 
 pub(super) fn default_socket_path() -> PathBuf {
     #[cfg(unix)]
-    return Path::new("/var/run/nym-vpn.sock").to_path_buf();
+    {
+        PathBuf::from("/var/run/nym-vpn.sock")
+    }
 
     #[cfg(windows)]
-    return Path::new(r"\\.\pipe\nym-vpn").to_path_buf();
-}
-
-pub(super) fn default_uri_addr() -> SocketAddr {
-    "[::1]:53181".parse().unwrap()
+    {
+        PathBuf::from(r"\\.\pipe\nym-vpn")
+    }
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
@@ -1,14 +1,9 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::path::PathBuf;
-
 use futures::{stream::BoxStream, StreamExt};
 use nym_vpn_network_config::{Network, NetworkCompatibility};
-use tokio::{
-    fs,
-    sync::{broadcast, mpsc::UnboundedSender},
-};
+use tokio::sync::{broadcast, mpsc::UnboundedSender};
 
 use nym_vpn_api_client::types::{GatewayMinPerformance, ScoreThresholds};
 use nym_vpn_lib_types::TunnelEvent;
@@ -44,40 +39,19 @@ pub(super) struct CommandInterface {
 
     // Broadcast tunnel events to our API endpoint listeners
     tunnel_event_rx: broadcast::Receiver<TunnelEvent>,
-
-    socket_path: PathBuf,
     network_env: Network,
 }
 
 impl CommandInterface {
-    pub(super) fn new_with_path(
+    pub(super) fn new(
         vpn_command_tx: UnboundedSender<VpnServiceCommand>,
         tunnel_event_rx: broadcast::Receiver<TunnelEvent>,
-        socket_path: PathBuf,
         network_env: Network,
     ) -> Self {
         Self {
             vpn_command_tx,
             tunnel_event_rx,
-            socket_path,
             network_env,
-        }
-    }
-
-    #[cfg(unix)]
-    pub(super) async fn remove_previous_socket_file(&self) {
-        match fs::remove_file(&self.socket_path).await {
-            Ok(_) => tracing::info!(
-                "Removed previous command interface socket: {}",
-                self.socket_path.display()
-            ),
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
-            Err(err) => {
-                tracing::error!(
-                    "Failed to remove previous command interface socket: {:?}",
-                    err
-                );
-            }
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
@@ -78,12 +78,6 @@ impl CommandInterface {
     }
 }
 
-impl Drop for CommandInterface {
-    fn drop(&mut self) {
-        self.remove_previous_socket_file();
-    }
-}
-
 #[tonic::async_trait]
 impl NymVpnd for CommandInterface {
     async fn info(

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
@@ -1,11 +1,7 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{
-    fs,
-    net::SocketAddr,
-    path::{Path, PathBuf},
-};
+use std::{fs, path::PathBuf};
 
 use futures::{stream::BoxStream, StreamExt};
 use nym_vpn_network_config::{Network, NetworkCompatibility};
@@ -39,11 +35,6 @@ use crate::{
     service::{ConnectOptions, VpnServiceCommand},
 };
 
-enum ListenerType {
-    Path(PathBuf),
-    Uri(#[allow(unused)] SocketAddr),
-}
-
 pub(super) struct CommandInterface {
     // Send commands to the VPN service
     vpn_command_tx: UnboundedSender<VpnServiceCommand>,
@@ -51,8 +42,7 @@ pub(super) struct CommandInterface {
     // Broadcast tunnel events to our API endpoint listeners
     tunnel_event_rx: broadcast::Receiver<TunnelEvent>,
 
-    listener: ListenerType,
-
+    socket_path: PathBuf,
     network_env: Network,
 }
 
@@ -60,45 +50,29 @@ impl CommandInterface {
     pub(super) fn new_with_path(
         vpn_command_tx: UnboundedSender<VpnServiceCommand>,
         tunnel_event_rx: broadcast::Receiver<TunnelEvent>,
-        socket_path: &Path,
+        socket_path: PathBuf,
         network_env: Network,
     ) -> Self {
         Self {
             vpn_command_tx,
             tunnel_event_rx,
-            listener: ListenerType::Path(socket_path.to_path_buf()),
-            network_env,
-        }
-    }
-
-    pub(super) fn new_with_uri(
-        vpn_command_tx: UnboundedSender<VpnServiceCommand>,
-        tunnel_event_rx: broadcast::Receiver<TunnelEvent>,
-        uri: SocketAddr,
-        network_env: Network,
-    ) -> Self {
-        Self {
-            vpn_command_tx,
-            tunnel_event_rx,
-            listener: ListenerType::Uri(uri),
+            socket_path,
             network_env,
         }
     }
 
     pub(super) fn remove_previous_socket_file(&self) {
-        if let ListenerType::Path(ref socket_path) = self.listener {
-            match fs::remove_file(socket_path) {
-                Ok(_) => tracing::info!(
-                    "Removed previous command interface socket: {:?}",
-                    socket_path
-                ),
-                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
-                Err(err) => {
-                    tracing::error!(
-                        "Failed to remove previous command interface socket: {:?}",
-                        err
-                    );
-                }
+        match fs::remove_file(&self.socket_path) {
+            Ok(_) => tracing::info!(
+                "Removed previous command interface socket: {}",
+                self.socket_path.display()
+            ),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => {
+                tracing::error!(
+                    "Failed to remove previous command interface socket: {:?}",
+                    err
+                );
             }
         }
     }

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
@@ -64,6 +64,7 @@ impl CommandInterface {
         }
     }
 
+    #[cfg(unix)]
     pub(super) async fn remove_previous_socket_file(&self) {
         match fs::remove_file(&self.socket_path).await {
             Ok(_) => tracing::info!(

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
@@ -1,11 +1,14 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{fs, path::PathBuf};
+use std::path::PathBuf;
 
 use futures::{stream::BoxStream, StreamExt};
 use nym_vpn_network_config::{Network, NetworkCompatibility};
-use tokio::sync::{broadcast, mpsc::UnboundedSender};
+use tokio::{
+    fs,
+    sync::{broadcast, mpsc::UnboundedSender},
+};
 
 use nym_vpn_api_client::types::{GatewayMinPerformance, ScoreThresholds};
 use nym_vpn_lib_types::TunnelEvent;
@@ -61,8 +64,8 @@ impl CommandInterface {
         }
     }
 
-    pub(super) fn remove_previous_socket_file(&self) {
-        match fs::remove_file(&self.socket_path) {
+    pub(super) async fn remove_previous_socket_file(&self) {
+        match fs::remove_file(&self.socket_path).await {
             Ok(_) => tracing::info!(
                 "Removed previous command interface socket: {}",
                 self.socket_path.display()

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/mod.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/mod.rs
@@ -9,4 +9,4 @@ mod listener;
 mod protobuf;
 mod start;
 
-pub use start::{start_command_interface, CommandInterfaceOptions};
+pub use start::start_command_interface;

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/start.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/start.rs
@@ -167,7 +167,7 @@ async fn remove_previous_socket_file(socket_path: &std::path::Path) {
     match tokio::fs::remove_file(socket_path).await {
         Ok(_) => tracing::info!(
             "Removed previous command interface socket: {}",
-            self.socket_path.display()
+            socket_path.display()
         ),
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
         Err(err) => {

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/start.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/start.rs
@@ -59,14 +59,11 @@ where
         .register_encoded_file_descriptor_set(VPN_FD_SET)
         .build_v1()
         .unwrap();
-    let command_interface = CommandInterface::new_with_path(
-        vpn_command_tx,
-        tunnel_event_rx,
-        socket_path.clone(),
-        network_env,
-    );
+    let command_interface = CommandInterface::new(vpn_command_tx, tunnel_event_rx, network_env);
+
+    // Remove previous socket file in case if the daemon crashed in the prior run and could not clean up the socket file.
     #[cfg(unix)]
-    command_interface.remove_previous_socket_file().await;
+    remove_previous_socket_file(&socket_path).await;
 
     // Wrap the unix socket into a stream that can be used by tonic
     let incoming = nym_ipc::server::create_incoming(socket_path).unwrap();
@@ -163,4 +160,21 @@ pub fn start_command_interface(
     });
 
     (handle, vpn_command_rx)
+}
+
+#[cfg(unix)]
+async fn remove_previous_socket_file(socket_path: &std::path::Path) {
+    match tokio::fs::remove_file(socket_path).await {
+        Ok(_) => tracing::info!(
+            "Removed previous command interface socket: {}",
+            self.socket_path.display()
+        ),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => {
+            tracing::error!(
+                "Failed to remove previous command interface socket: {:?}",
+                err
+            );
+        }
+    }
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/start.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/start.rs
@@ -65,7 +65,7 @@ where
         socket_path.clone(),
         network_env,
     );
-    command_interface.remove_previous_socket_file();
+    command_interface.remove_previous_socket_file().await;
 
     // Wrap the unix socket into a stream that can be used by tonic
     let incoming = nym_ipc::server::create_incoming(socket_path).unwrap();

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/start.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/start.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{net::SocketAddr, path::PathBuf, time::Duration};
+use std::{path::PathBuf, time::Duration};
 
 use futures::FutureExt;
 use nym_vpn_lib_types::TunnelEvent;
@@ -19,10 +19,7 @@ use tokio_util::sync::CancellationToken;
 use tonic::transport::Server;
 use tonic_health::pb::health_server::{Health, HealthServer};
 
-use super::{
-    config::{default_socket_path, default_uri_addr},
-    listener::CommandInterface,
-};
+use super::{config::default_socket_path, listener::CommandInterface};
 use crate::service::VpnServiceCommand;
 
 // If the shutdown signal is received, we give the listeners a little extra time to finish
@@ -46,34 +43,6 @@ fn grpc_span(req: &http::Request<()>) -> tracing::Span {
     span
 }
 
-async fn run_uri_listener<T>(
-    vpn_command_tx: UnboundedSender<VpnServiceCommand>,
-    tunnel_event_rx: broadcast::Receiver<TunnelEvent>,
-    addr: SocketAddr,
-    shutdown_token: CancellationToken,
-    health_service: HealthServer<T>,
-    network_env: Network,
-) -> Result<(), tonic::transport::Error>
-where
-    T: Health,
-{
-    tracing::info!("Starting HTTP listener on: {addr}");
-    let reflection_service = tonic_reflection::server::Builder::configure()
-        .register_encoded_file_descriptor_set(VPN_FD_SET)
-        .build_v1()
-        .unwrap();
-    let command_interface =
-        CommandInterface::new_with_uri(vpn_command_tx, tunnel_event_rx, addr, network_env);
-
-    Server::builder()
-        .trace_fn(grpc_span)
-        .add_service(health_service)
-        .add_service(reflection_service)
-        .add_service(NymVpndServer::new(command_interface))
-        .serve_with_shutdown(addr, shutdown_token.cancelled_owned())
-        .await
-}
-
 async fn run_socket_listener<T>(
     vpn_command_tx: UnboundedSender<VpnServiceCommand>,
     tunnel_event_rx: broadcast::Receiver<TunnelEvent>,
@@ -90,8 +59,12 @@ where
         .register_encoded_file_descriptor_set(VPN_FD_SET)
         .build_v1()
         .unwrap();
-    let command_interface =
-        CommandInterface::new_with_path(vpn_command_tx, tunnel_event_rx, &socket_path, network_env);
+    let command_interface = CommandInterface::new_with_path(
+        vpn_command_tx,
+        tunnel_event_rx,
+        socket_path.clone(),
+        network_env,
+    );
     command_interface.remove_previous_socket_file();
 
     // Wrap the unix socket into a stream that can be used by tonic
@@ -109,26 +82,6 @@ where
 #[derive(Default)]
 pub struct CommandInterfaceOptions {
     pub disable_socket_listener: bool,
-    pub enable_http_listener: bool,
-}
-
-async fn setup_health_service(
-    shutdown_token: CancellationToken,
-) -> (HealthServer<impl Health>, JoinHandle<()>) {
-    let (mut health_reporter, health_service) = tonic_health::server::health_reporter();
-    health_reporter
-        .set_serving::<NymVpndServer<CommandInterface>>()
-        .await;
-
-    let handle = tokio::spawn(async move {
-        shutdown_token.cancelled().await;
-        tracing::debug!("Reporting not serving on health service");
-        health_reporter
-            .set_not_serving::<NymVpndServer<CommandInterface>>()
-            .await;
-    });
-
-    (health_service, handle)
 }
 
 pub fn start_command_interface(
@@ -142,87 +95,81 @@ pub fn start_command_interface(
     let (vpn_command_tx, vpn_command_rx) = mpsc::unbounded_channel();
     let command_interface_options = command_interface_options.unwrap_or_default();
     let socket_path = default_socket_path();
-    let uri_addr = default_uri_addr();
 
     let handle = tokio::spawn(async move {
+        let (mut health_reporter, health_service) = tonic_health::server::health_reporter();
         let mut join_set = JoinSet::new();
 
-        let (health_service, health_service_handle) =
-            setup_health_service(shutdown_token.child_token()).await;
+        let child_token = shutdown_token.child_token();
+        join_set.spawn(async move {
+            health_reporter
+                .set_serving::<NymVpndServer<CommandInterface>>()
+                .await;
+
+            child_token.cancelled().await;
+
+            health_reporter
+                .set_not_serving::<NymVpndServer<CommandInterface>>()
+                .await;
+
+            tracing::info!("Health reporter has finished");
+        });
 
         if !command_interface_options.disable_socket_listener {
-            join_set.spawn(run_socket_listener(
-                vpn_command_tx.clone(),
-                tunnel_event_rx.resubscribe(),
-                socket_path.to_path_buf(),
-                shutdown_token.child_token(),
-                health_service.clone(),
-                network_env.clone(),
-            ));
+            let child_token = shutdown_token.child_token();
+            join_set.spawn(async move {
+                match run_socket_listener(
+                    vpn_command_tx.clone(),
+                    tunnel_event_rx.resubscribe(),
+                    socket_path,
+                    child_token,
+                    health_service.clone(),
+                    network_env.clone(),
+                )
+                .await
+                {
+                    Ok(()) => {
+                        tracing::info!("Socket listener has finished");
+                    }
+                    Err(e) => {
+                        tracing::error!("Socket listener exited with error: {}", e);
+                    }
+                }
+            });
         }
 
-        if command_interface_options.enable_http_listener {
-            join_set.spawn(run_uri_listener(
-                vpn_command_tx.clone(),
-                tunnel_event_rx.resubscribe(),
-                uri_addr,
-                shutdown_token.child_token(),
-                health_service,
-                network_env,
-            ));
+        let delayed_cancel = shutdown_token
+            .cancelled()
+            .then(|_| sleep(SHUTDOWN_TIMEOUT))
+            .fuse();
+        tokio::pin!(delayed_cancel);
+
+        loop {
+            tokio::select! {
+                _ = &mut delayed_cancel => {
+                    tracing::info!("Timed out while waiting for listeners to finish, shutting down");
+                    join_set.abort_all();
+                    break;
+                }
+                next_result = join_set.join_next() => {
+                    match next_result {
+                        Some(Ok(_)) => {
+                            continue;
+                        }
+                        Some(Err(e)) => {
+                            tracing::error!("Failed to join task: {}", e);
+                        }
+                        None => {
+                            tracing::info!("All listeners have finished, shutting down");
+                            break;
+                        }
+                    }
+                }
+            }
         }
 
-        wait_for_shutdown(shutdown_token, join_set, health_service_handle).await;
         tracing::info!("Command interface exiting");
     });
 
     (handle, vpn_command_rx)
-}
-
-async fn wait_for_shutdown(
-    shutdown_token: CancellationToken,
-    mut join_set: JoinSet<Result<(), tonic::transport::Error>>,
-    health_service_handle: JoinHandle<()>,
-) {
-    let delayed_cancel = shutdown_token
-        .cancelled()
-        .then(|_| sleep(SHUTDOWN_TIMEOUT))
-        .fuse();
-    tokio::pin!(delayed_cancel);
-
-    let mut i = 0;
-    loop {
-        tokio::select! {
-            _ = &mut delayed_cancel => {
-                tracing::info!("Shutdown timeout reached, cancelling all listeners");
-                join_set.abort_all();
-            }
-            result = join_set.join_next() => match result {
-                Some(result) => {
-                    i += 1;
-
-                    match result {
-                        Ok(Ok(_)) => {
-                            tracing::trace!("Listener ({i}) has finished.")
-                        }
-                        Ok(Err(e)) => {
-                            tracing::error!("Listener ({i}) exited with error: {e}");
-                        }
-                        Err(e) => {
-                            tracing::error!("Failed to join on listener ({i}): {e}");
-                        }
-                    }
-                },
-                None => {
-                    tracing::trace!("All listeners have finished");
-                    break;
-                }
-            }
-        }
-    }
-
-    health_service_handle
-        .await
-        .inspect_err(|e| tracing::error!("Failed to join on health reporter: {e}"))
-        .ok();
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/start.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/start.rs
@@ -80,22 +80,14 @@ where
         .await
 }
 
-#[derive(Default)]
-pub struct CommandInterfaceOptions {
-    pub disable_socket_listener: bool,
-}
-
 pub fn start_command_interface(
     tunnel_event_rx: broadcast::Receiver<TunnelEvent>,
-    command_interface_options: Option<CommandInterfaceOptions>,
     network_env: Network,
     shutdown_token: CancellationToken,
 ) -> (JoinHandle<()>, UnboundedReceiver<VpnServiceCommand>) {
     tracing::debug!("Starting command interface");
 
     let (vpn_command_tx, vpn_command_rx) = mpsc::unbounded_channel();
-    let command_interface_options = command_interface_options.unwrap_or_default();
-    let socket_path = default_socket_path();
 
     let handle = tokio::spawn(async move {
         let (mut health_reporter, health_service) = tonic_health::server::health_reporter();
@@ -116,28 +108,26 @@ pub fn start_command_interface(
             tracing::info!("Health reporter has finished");
         });
 
-        if !command_interface_options.disable_socket_listener {
-            let child_token = shutdown_token.child_token();
-            join_set.spawn(async move {
-                match run_socket_listener(
-                    vpn_command_tx.clone(),
-                    tunnel_event_rx.resubscribe(),
-                    socket_path,
-                    child_token,
-                    health_service.clone(),
-                    network_env.clone(),
-                )
-                .await
-                {
-                    Ok(()) => {
-                        tracing::info!("Socket listener has finished");
-                    }
-                    Err(e) => {
-                        tracing::error!("Socket listener exited with error: {}", e);
-                    }
+        let child_token = shutdown_token.child_token();
+        join_set.spawn(async move {
+            match run_socket_listener(
+                vpn_command_tx.clone(),
+                tunnel_event_rx.resubscribe(),
+                default_socket_path(),
+                child_token,
+                health_service.clone(),
+                network_env.clone(),
+            )
+            .await
+            {
+                Ok(()) => {
+                    tracing::info!("Socket listener has finished");
                 }
-            });
-        }
+                Err(e) => {
+                    tracing::error!("Socket listener exited with error: {}", e);
+                }
+            }
+        });
 
         let delayed_cancel = shutdown_token
             .cancelled()

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/start.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/start.rs
@@ -65,6 +65,7 @@ where
         socket_path.clone(),
         network_env,
     );
+    #[cfg(unix)]
     command_interface.remove_previous_socket_file().await;
 
     // Wrap the unix socket into a stream that can be used by tonic

--- a/nym-vpn-core/crates/nym-vpnd/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/main.rs
@@ -17,7 +17,7 @@ use service::NymVpnService;
 use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
 
-use crate::{cli::CliArgs, command_interface::CommandInterfaceOptions, config::GlobalConfigFile};
+use crate::{cli::CliArgs, config::GlobalConfigFile};
 
 fn main() -> anyhow::Result<()> {
     run()
@@ -115,9 +115,6 @@ async fn run_inner_async(args: CliArgs, network_env: Network) -> anyhow::Result<
 
     let (command_handle, vpn_command_rx) = command_interface::start_command_interface(
         tunnel_event_rx,
-        Some(CommandInterfaceOptions {
-            disable_socket_listener: args.disable_socket_listener,
-        }),
         network_env.clone(),
         shutdown_token.child_token(),
     );

--- a/nym-vpn-core/crates/nym-vpnd/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/main.rs
@@ -117,7 +117,6 @@ async fn run_inner_async(args: CliArgs, network_env: Network) -> anyhow::Result<
         tunnel_event_rx,
         Some(CommandInterfaceOptions {
             disable_socket_listener: args.disable_socket_listener,
-            enable_http_listener: args.enable_http_listener,
         }),
         network_env.clone(),
         shutdown_token.child_token(),

--- a/nym-vpn-core/crates/nym-vpnd/src/service/windows_service/mod.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/windows_service/mod.rs
@@ -180,7 +180,6 @@ async fn run_service_inner() -> anyhow::Result<()> {
     // Start the command interface that listens for commands from the outside
     let (command_handle, vpn_command_rx) = command_interface::start_command_interface(
         tunnel_event_rx,
-        None,
         network_env.clone(),
         shutdown_token.child_token(),
     );


### PR DESCRIPTION
1. Remove HTTP listener and `--enable-http-listener` CLI flag
2. Remove `--disable-socket-listener` CLI flag since the daemon without any management interface is not manageable.
3. Make `remove_previous_socket_file()` tokio friendly
4. Only remove previous socket file on unix platforms
5. `Uds` from `nym-ipc` already removes socket file on `Drop`, so we can stop doing that in management interface.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2468)
<!-- Reviewable:end -->
