### PR TITLE
core: refactor client error mapping

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -5044,6 +5044,7 @@ dependencies = [
  "nym-vpn-api-client",
  "nym-wg-gateway-client",
  "si-scale",
+ "strum_macros",
  "thiserror 2.0.12",
  "time",
 ]

--- a/nym-vpn-core/crates/nym-vpn-lib-types/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/Cargo.toml
@@ -32,4 +32,4 @@ nym-gateway-directory = { workspace = true, optional = true }
 nym-statistics-common = { workspace = true, optional = true }
 nym-vpn-api-client = { workspace = true, optional = true }
 nym-wg-gateway-client = { workspace = true, optional = true }
-strum_macros = "0.26.4"
+strum_macros = { workspace = true }

--- a/nym-vpn-core/crates/nym-vpn-lib-types/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/Cargo.toml
@@ -32,3 +32,4 @@ nym-gateway-directory = { workspace = true, optional = true }
 nym-statistics-common = { workspace = true, optional = true }
 nym-vpn-api-client = { workspace = true, optional = true }
 nym-wg-gateway-client = { workspace = true, optional = true }
+strum_macros = "0.26.4"

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
@@ -25,4 +25,6 @@ pub use tunnel_event::{
     BandwidthEvent, ConnectionEvent, ConnectionStatisticsEvent, MixnetEvent, SphinxPacketRates,
     TunnelEvent,
 };
-pub use tunnel_state::{ActionAfterDisconnect, ErrorStateReason, TunnelState, TunnelType};
+pub use tunnel_state::{
+    ActionAfterDisconnect, ClientErrorReason, ErrorStateReason, TunnelState, TunnelType,
+};

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
@@ -235,20 +235,9 @@ impl From<ErrorStateReason> for ClientErrorReason {
                 successes: _,
                 failed,
             } => {
-                for error in &failed {
-                    match error {
-                        RequestZkNymErrorReason::VpnApi(e) => {
-                            return ClientErrorReason::from(error.clone());
-                        }
-                        RequestZkNymErrorReason::UnexpectedVpnApiResponse { .. } => {
-                            return ClientErrorReason::from(error.clone());
-                        }
-                        _ => continue,
-                    }
-                }
-                // return just the first error so we don't have a potentially massive error message
+                // Return the first error if it exists, otherwise return a default error
                 if let Some(first_error) = failed.first() {
-                    Self::Api(first_error.to_string())
+                    ClientErrorReason::from(first_error.clone())
                 } else {
                     Self::Api("Empty failure list in RequestZkNymBundle".to_string())
                 }

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
@@ -215,9 +215,9 @@ pub enum ClientErrorReason {
     MaxDevicesReached,
     BandwidthExceeded,
     SubscriptionExpired,
-    Dns(String),
-    Api(String),
-    Internal(String),
+    Dns(Option<String>),
+    Api(Option<String>),
+    Internal(Option<String>),
 }
 
 impl From<ErrorStateReason> for ClientErrorReason {
@@ -226,7 +226,7 @@ impl From<ErrorStateReason> for ClientErrorReason {
             ErrorStateReason::SameEntryAndExitGateway => Self::SameEntryAndExitGateway,
             ErrorStateReason::InvalidEntryGatewayCountry => Self::InvalidEntryGatewayCountry,
             ErrorStateReason::InvalidExitGatewayCountry => Self::InvalidExitGatewayCountry,
-            ErrorStateReason::BadBandwidthIncrease => Self::Api(value.to_string()),
+            ErrorStateReason::BadBandwidthIncrease => Self::Api(Some(value.to_string())),
             ErrorStateReason::SyncAccount(err) => err.into(),
             ErrorStateReason::SyncDevice(err) => err.into(),
             ErrorStateReason::RegisterDevice(err) => err.into(),
@@ -239,18 +239,18 @@ impl From<ErrorStateReason> for ClientErrorReason {
                 if let Some(first_error) = failed.first() {
                     ClientErrorReason::from(first_error.clone())
                 } else {
-                    Self::Api("Empty failure list in RequestZkNymBundle".to_string())
+                    Self::Api(Some("Empty failure list in RequestZkNymBundle".to_string()))
                 }
             }
             ErrorStateReason::Firewall => Self::Firewall,
             ErrorStateReason::TunDevice
             | ErrorStateReason::TunnelProvider
-            | ErrorStateReason::DuplicateTunFd => Self::Internal(value.to_string()),
-            ErrorStateReason::Internal(message) => Self::Internal(message),
+            | ErrorStateReason::DuplicateTunFd => Self::Internal(Some(value.to_string())),
+            ErrorStateReason::Internal(message) => Self::Internal(Some(message)),
             ErrorStateReason::Routing => Self::Routing,
-            ErrorStateReason::ResolveGatewayAddrs => Self::Dns(value.to_string()),
-            ErrorStateReason::StartLocalDnsResolver => Self::Dns(value.to_string()),
-            ErrorStateReason::Dns => Self::Dns(value.to_string()),
+            ErrorStateReason::ResolveGatewayAddrs => Self::Dns(Some(value.to_string())),
+            ErrorStateReason::StartLocalDnsResolver => Self::Dns(Some(value.to_string())),
+            ErrorStateReason::Dns => Self::Dns(Some(value.to_string())),
         }
     }
 }
@@ -259,8 +259,8 @@ impl From<RequestZkNymErrorReason> for ClientErrorReason {
     fn from(error: RequestZkNymErrorReason) -> Self {
         match error {
             RequestZkNymErrorReason::VpnApi(e) => e.into(),
-            RequestZkNymErrorReason::UnexpectedVpnApiResponse(message) => Self::Api(message),
-            reason => Self::Internal(reason.to_string()),
+            RequestZkNymErrorReason::UnexpectedVpnApiResponse(message) => Self::Api(Some(message)),
+            reason => Self::Internal(Some(reason.to_string())),
         }
     }
 }
@@ -275,7 +275,7 @@ impl From<VpnApiErrorResponse> for ClientErrorReason {
                     None => error.message,
                     Some(id) => format!("{}, ID [{}]", error.message, id),
                 };
-                Self::Api(message)
+                Self::Api(Some(message))
             }
         }
     }
@@ -289,7 +289,7 @@ impl From<RegisterDeviceError> for ClientErrorReason {
         {
             Self::MaxDevicesReached
         } else {
-            Self::Api(value.to_string())
+            Self::Api(Some(value.to_string()))
         }
     }
 }
@@ -297,21 +297,21 @@ impl From<RegisterDeviceError> for ClientErrorReason {
 impl From<SyncAccountError> for ClientErrorReason {
     fn from(value: SyncAccountError) -> Self {
         match value {
-            SyncAccountError::NoAccountStored => Self::Internal(value.to_string()),
+            SyncAccountError::NoAccountStored => Self::Internal(Some(value.to_string())),
             SyncAccountError::SyncAccountEndpointFailure(response) => response.into(),
-            SyncAccountError::UnexpectedResponse(message) => Self::Internal(message),
-            SyncAccountError::Internal(message) => Self::Internal(message),
+            SyncAccountError::UnexpectedResponse(message) => Self::Internal(Some(message)),
+            SyncAccountError::Internal(message) => Self::Internal(Some(message)),
         }
     }
 }
 impl From<SyncDeviceError> for ClientErrorReason {
     fn from(value: SyncDeviceError) -> Self {
         match value {
-            SyncDeviceError::NoAccountStored => Self::Internal(value.to_string()),
-            SyncDeviceError::NoDeviceStored => Self::Internal(value.to_string()),
+            SyncDeviceError::NoAccountStored => Self::Internal(Some(value.to_string())),
+            SyncDeviceError::NoDeviceStored => Self::Internal(Some(value.to_string())),
             SyncDeviceError::SyncDeviceEndpointFailure(response) => response.into(),
-            SyncDeviceError::UnexpectedResponse(message) => Self::Internal(message),
-            SyncDeviceError::Internal(message) => Self::Internal(message),
+            SyncDeviceError::UnexpectedResponse(message) => Self::Internal(Some(message)),
+            SyncDeviceError::Internal(message) => Self::Internal(Some(message)),
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
@@ -13,6 +13,13 @@ use super::{
     connection_data::{ConnectionData, TunnelConnectionData},
 };
 
+const MAX_DEVICES_REACHED_MESSAGE_ID: &str =
+    "nym-vpn-website.public-api.register-device.max-devices-exceeded";
+const SUBSCRIPTION_EXPIRED_MESSAGE_ID: &str =
+    "nym-vpn-website.public-api.device.zk-nym.request_failed.no_active_subscription";
+const BANDWIDTH_LIMIT_REACHED_MESSAGE_ID: &str =
+    "nym-vpn-website.public-api.device.zk-nym.request_failed.fair_usage_used_for_month";
+
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum TunnelType {
     Mixnet,
@@ -196,6 +203,92 @@ pub enum ErrorStateReason {
 
     /// Program errors that must not happen.
     Internal(String),
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum ClientErrorReason {
+    Firewall,
+    Routing,
+    SameEntryAndExitGateway,
+    InvalidEntryGatewayCountry,
+    InvalidExitGatewayCountry,
+    MaxDevicesReached,
+    BandwidthExceeded,
+    SubscriptionExpired,
+    Dns(String),
+    Api(String),
+    Internal(String),
+}
+
+impl From<ErrorStateReason> for ClientErrorReason {
+    fn from(value: ErrorStateReason) -> Self {
+        match value {
+            ErrorStateReason::SameEntryAndExitGateway => Self::SameEntryAndExitGateway,
+            ErrorStateReason::InvalidEntryGatewayCountry => Self::InvalidEntryGatewayCountry,
+            ErrorStateReason::InvalidExitGatewayCountry => Self::InvalidExitGatewayCountry,
+            ErrorStateReason::BadBandwidthIncrease => Self::Api(value.to_string()),
+            ErrorStateReason::SyncAccount(err) => Self::Api(err.to_string()),
+            ErrorStateReason::SyncDevice(err) => Self::Api(err.to_string()),
+            ErrorStateReason::RegisterDevice(err) => {
+                if err
+                    .message_id()
+                    .is_some_and(|id| id.contains(MAX_DEVICES_REACHED_MESSAGE_ID))
+                {
+                    Self::MaxDevicesReached
+                } else {
+                    Self::Api(err.to_string())
+                }
+            }
+            ErrorStateReason::RequestZkNym(err) => match err {
+                RequestZkNymErrorReason::VpnApi(e) => match e.message_id.as_ref() {
+                    Some(id) if id.contains(BANDWIDTH_LIMIT_REACHED_MESSAGE_ID) => {
+                        Self::BandwidthExceeded
+                    }
+                    Some(id) if id.contains(SUBSCRIPTION_EXPIRED_MESSAGE_ID) => {
+                        Self::SubscriptionExpired
+                    }
+                    _ => Self::Api(e.message),
+                },
+                RequestZkNymErrorReason::UnexpectedVpnApiResponse(message) => Self::Api(message),
+                reason => Self::Internal(reason.to_string()),
+            },
+            ErrorStateReason::RequestZkNymBundle {
+                successes: _,
+                failed,
+            } => {
+                if let Some(RequestZkNymErrorReason::VpnApi(e)) = failed
+                    .iter()
+                    .find(|e| matches!(e, RequestZkNymErrorReason::VpnApi { .. }))
+                {
+                    return match e.message_id.as_ref() {
+                        Some(id) if id.contains(BANDWIDTH_LIMIT_REACHED_MESSAGE_ID) => {
+                            Self::BandwidthExceeded
+                        }
+                        Some(id) if id.contains(SUBSCRIPTION_EXPIRED_MESSAGE_ID) => {
+                            Self::SubscriptionExpired
+                        }
+                        _ => Self::Api(e.clone().message),
+                    };
+                }
+                if let Some(err) = failed
+                    .iter()
+                    .find(|e| matches!(e, RequestZkNymErrorReason::UnexpectedVpnApiResponse { .. }))
+                {
+                    return Self::Api(err.to_string());
+                }
+                Self::Internal(failed.into_iter().map(|e| e.to_string()).collect())
+            }
+            ErrorStateReason::Firewall => Self::Firewall,
+            ErrorStateReason::TunDevice
+            | ErrorStateReason::TunnelProvider
+            | ErrorStateReason::DuplicateTunFd
+            | ErrorStateReason::Dns => Self::Internal(value.to_string()),
+            ErrorStateReason::Internal(message) => Self::Internal(message),
+            ErrorStateReason::Routing => Self::Routing,
+            ErrorStateReason::ResolveGatewayAddrs => Self::Dns(value.to_string()),
+            ErrorStateReason::StartLocalDnsResolver => Self::Dns(value.to_string()),
+        }
+    }
 }
 
 impl fmt::Display for ErrorStateReason {

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
@@ -3,7 +3,7 @@
 
 use std::fmt;
 
-use crate::{RequestZkNymError, RequestZkNymErrorReason};
+use crate::{RequestZkNymError, RequestZkNymErrorReason, VpnApiErrorResponse};
 
 use super::{
     account::{
@@ -144,7 +144,7 @@ pub enum ActionAfterDisconnect {
     Error,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, strum_macros::AsRefStr)]
 pub enum ErrorStateReason {
     /// Issues related to firewall configuration.
     Firewall,
@@ -226,92 +226,103 @@ impl From<ErrorStateReason> for ClientErrorReason {
             ErrorStateReason::SameEntryAndExitGateway => Self::SameEntryAndExitGateway,
             ErrorStateReason::InvalidEntryGatewayCountry => Self::InvalidEntryGatewayCountry,
             ErrorStateReason::InvalidExitGatewayCountry => Self::InvalidExitGatewayCountry,
-            ErrorStateReason::BadBandwidthIncrease => Self::Api(value.to_string()),
-            ErrorStateReason::SyncAccount(err) => Self::Api(err.to_string()),
-            ErrorStateReason::SyncDevice(err) => Self::Api(err.to_string()),
-            ErrorStateReason::RegisterDevice(err) => {
-                if err
-                    .message_id()
-                    .is_some_and(|id| id.contains(MAX_DEVICES_REACHED_MESSAGE_ID))
-                {
-                    Self::MaxDevicesReached
-                } else {
-                    Self::Api(err.to_string())
-                }
-            }
-            ErrorStateReason::RequestZkNym(err) => match err {
-                RequestZkNymErrorReason::VpnApi(e) => match e.message_id.as_ref() {
-                    Some(id) if id.contains(BANDWIDTH_LIMIT_REACHED_MESSAGE_ID) => {
-                        Self::BandwidthExceeded
-                    }
-                    Some(id) if id.contains(SUBSCRIPTION_EXPIRED_MESSAGE_ID) => {
-                        Self::SubscriptionExpired
-                    }
-                    _ => Self::Api(e.message),
-                },
-                RequestZkNymErrorReason::UnexpectedVpnApiResponse(message) => Self::Api(message),
-                reason => Self::Internal(reason.to_string()),
-            },
+            ErrorStateReason::BadBandwidthIncrease => Self::Api(value.as_ref().to_string()),
+            ErrorStateReason::SyncAccount(err) => err.into(),
+            ErrorStateReason::SyncDevice(err) => err.into(),
+            ErrorStateReason::RegisterDevice(err) => err.into(),
+            ErrorStateReason::RequestZkNym(err) => err.into(),
             ErrorStateReason::RequestZkNymBundle {
                 successes: _,
                 failed,
             } => {
-                if let Some(RequestZkNymErrorReason::VpnApi(e)) = failed
-                    .iter()
-                    .find(|e| matches!(e, RequestZkNymErrorReason::VpnApi { .. }))
-                {
-                    return match e.message_id.as_ref() {
-                        Some(id) if id.contains(BANDWIDTH_LIMIT_REACHED_MESSAGE_ID) => {
-                            Self::BandwidthExceeded
+                for error in &failed {
+                    match error {
+                        RequestZkNymErrorReason::VpnApi(e) => {
+                            return ClientErrorReason::from(error.clone());
                         }
-                        Some(id) if id.contains(SUBSCRIPTION_EXPIRED_MESSAGE_ID) => {
-                            Self::SubscriptionExpired
+                        RequestZkNymErrorReason::UnexpectedVpnApiResponse { .. } => {
+                            return ClientErrorReason::from(error.clone());
                         }
-                        _ => Self::Api(e.clone().message),
-                    };
+                        _ => continue,
+                    }
                 }
-                if let Some(err) = failed
-                    .iter()
-                    .find(|e| matches!(e, RequestZkNymErrorReason::UnexpectedVpnApiResponse { .. }))
-                {
-                    return Self::Api(err.to_string());
+                // return just the first error so we don't have a potentially massive error message
+                if let Some(first_error) = failed.first() {
+                    Self::Api(first_error.to_string())
+                } else {
+                    Self::Api("Empty failure list in RequestZkNymBundle".to_string())
                 }
-                Self::Internal(failed.into_iter().map(|e| e.to_string()).collect())
             }
             ErrorStateReason::Firewall => Self::Firewall,
             ErrorStateReason::TunDevice
             | ErrorStateReason::TunnelProvider
-            | ErrorStateReason::DuplicateTunFd
-            | ErrorStateReason::Dns => Self::Internal(value.to_string()),
+            | ErrorStateReason::DuplicateTunFd => Self::Internal(value.as_ref().to_string()),
             ErrorStateReason::Internal(message) => Self::Internal(message),
             ErrorStateReason::Routing => Self::Routing,
-            ErrorStateReason::ResolveGatewayAddrs => Self::Dns(value.to_string()),
-            ErrorStateReason::StartLocalDnsResolver => Self::Dns(value.to_string()),
+            ErrorStateReason::ResolveGatewayAddrs => Self::Dns(value.as_ref().to_string()),
+            ErrorStateReason::StartLocalDnsResolver => Self::Dns(value.as_ref().to_string()),
+            ErrorStateReason::Dns => Self::Dns(value.as_ref().to_string()),
         }
     }
 }
 
-impl fmt::Display for ErrorStateReason {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            ErrorStateReason::Firewall => write!(f, "Firewall"),
-            ErrorStateReason::Routing => write!(f, "Routing"),
-            ErrorStateReason::Dns => write!(f, "Dns"),
-            ErrorStateReason::TunDevice => write!(f, "TunnelDevice"),
-            ErrorStateReason::TunnelProvider => write!(f, "TunnelProvider"),
-            ErrorStateReason::SameEntryAndExitGateway => write!(f, "SameEntryAndExitGateway"),
-            ErrorStateReason::InvalidEntryGatewayCountry => write!(f, "InvalidEntryGatewayCountry"),
-            ErrorStateReason::InvalidExitGatewayCountry => write!(f, "InvalidExitGatewayCountry"),
-            ErrorStateReason::BadBandwidthIncrease => write!(f, "BadBandwidthIncrease"),
-            ErrorStateReason::DuplicateTunFd => write!(f, "DuplicateTunFd"),
-            ErrorStateReason::SyncAccount(_) => write!(f, "SyncAccount"),
-            ErrorStateReason::SyncDevice(_) => write!(f, "SyncDevice"),
-            ErrorStateReason::RegisterDevice(_) => write!(f, "RequestZkNym"),
-            ErrorStateReason::RequestZkNym(_) => write!(f, "InvalidExitGatewayCountry"),
-            ErrorStateReason::RequestZkNymBundle { .. } => write!(f, "RequestZkNymBundle "),
-            ErrorStateReason::Internal(_) => write!(f, "Internal"),
-            ErrorStateReason::ResolveGatewayAddrs => write!(f, "ResolveGatewayAddrs"),
-            ErrorStateReason::StartLocalDnsResolver => write!(f, "StartLocalDnsResolver"),
+impl From<RequestZkNymErrorReason> for ClientErrorReason {
+    fn from(error: RequestZkNymErrorReason) -> Self {
+        match error {
+            RequestZkNymErrorReason::VpnApi(e) => e.into(),
+            RequestZkNymErrorReason::UnexpectedVpnApiResponse(message) => Self::Api(message),
+            reason => Self::Internal(reason.to_string()),
+        }
+    }
+}
+
+impl From<VpnApiErrorResponse> for ClientErrorReason {
+    fn from(error: VpnApiErrorResponse) -> Self {
+        match error.message_id.as_ref() {
+            Some(id) if id.contains(BANDWIDTH_LIMIT_REACHED_MESSAGE_ID) => Self::BandwidthExceeded,
+            Some(id) if id.contains(SUBSCRIPTION_EXPIRED_MESSAGE_ID) => Self::SubscriptionExpired,
+            _ => {
+                let message = match error.message_id {
+                    None => error.message,
+                    Some(id) => format!("{}, ID [{}]", error.message, id),
+                };
+                Self::Api(message)
+            }
+        }
+    }
+}
+
+impl From<RegisterDeviceError> for ClientErrorReason {
+    fn from(value: RegisterDeviceError) -> Self {
+        if value
+            .message_id()
+            .is_some_and(|id| id.contains(MAX_DEVICES_REACHED_MESSAGE_ID))
+        {
+            Self::MaxDevicesReached
+        } else {
+            Self::Api(value.to_string())
+        }
+    }
+}
+
+impl From<SyncAccountError> for ClientErrorReason {
+    fn from(value: SyncAccountError) -> Self {
+        match value {
+            SyncAccountError::NoAccountStored => Self::Internal(value.to_string()),
+            SyncAccountError::SyncAccountEndpointFailure(response) => response.into(),
+            SyncAccountError::UnexpectedResponse(message) => Self::Internal(message),
+            SyncAccountError::Internal(message) => Self::Internal(message),
+        }
+    }
+}
+impl From<SyncDeviceError> for ClientErrorReason {
+    fn from(value: SyncDeviceError) -> Self {
+        match value {
+            SyncDeviceError::NoAccountStored => Self::Internal(value.to_string()),
+            SyncDeviceError::NoDeviceStored => Self::Internal(value.to_string()),
+            SyncDeviceError::SyncDeviceEndpointFailure(response) => response.into(),
+            SyncDeviceError::UnexpectedResponse(message) => Self::Internal(message),
+            SyncDeviceError::Internal(message) => Self::Internal(message),
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
@@ -144,7 +144,7 @@ pub enum ActionAfterDisconnect {
     Error,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, strum_macros::AsRefStr)]
+#[derive(Debug, Clone, Eq, PartialEq, strum_macros::Display)]
 pub enum ErrorStateReason {
     /// Issues related to firewall configuration.
     Firewall,
@@ -226,7 +226,7 @@ impl From<ErrorStateReason> for ClientErrorReason {
             ErrorStateReason::SameEntryAndExitGateway => Self::SameEntryAndExitGateway,
             ErrorStateReason::InvalidEntryGatewayCountry => Self::InvalidEntryGatewayCountry,
             ErrorStateReason::InvalidExitGatewayCountry => Self::InvalidExitGatewayCountry,
-            ErrorStateReason::BadBandwidthIncrease => Self::Api(value.as_ref().to_string()),
+            ErrorStateReason::BadBandwidthIncrease => Self::Api(value.to_string()),
             ErrorStateReason::SyncAccount(err) => err.into(),
             ErrorStateReason::SyncDevice(err) => err.into(),
             ErrorStateReason::RegisterDevice(err) => err.into(),
@@ -245,12 +245,12 @@ impl From<ErrorStateReason> for ClientErrorReason {
             ErrorStateReason::Firewall => Self::Firewall,
             ErrorStateReason::TunDevice
             | ErrorStateReason::TunnelProvider
-            | ErrorStateReason::DuplicateTunFd => Self::Internal(value.as_ref().to_string()),
+            | ErrorStateReason::DuplicateTunFd => Self::Internal(value.to_string()),
             ErrorStateReason::Internal(message) => Self::Internal(message),
             ErrorStateReason::Routing => Self::Routing,
-            ErrorStateReason::ResolveGatewayAddrs => Self::Dns(value.as_ref().to_string()),
-            ErrorStateReason::StartLocalDnsResolver => Self::Dns(value.as_ref().to_string()),
-            ErrorStateReason::Dns => Self::Dns(value.as_ref().to_string()),
+            ErrorStateReason::ResolveGatewayAddrs => Self::Dns(value.to_string()),
+            ErrorStateReason::StartLocalDnsResolver => Self::Dns(value.to_string()),
+            ErrorStateReason::Dns => Self::Dns(value.to_string()),
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
@@ -46,7 +46,7 @@ pub enum TunnelState {
     },
 
     /// Tunnel is disconnected due to failure.
-    Error(ErrorStateReason),
+    Error(ClientErrorReason),
 
     /// Tunnel is disconnected, network connectivity is unavailable.
     Offline {

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
@@ -198,6 +198,31 @@ pub enum ErrorStateReason {
     Internal(String),
 }
 
+impl fmt::Display for ErrorStateReason {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            ErrorStateReason::Firewall => write!(f, "Firewall"),
+            ErrorStateReason::Routing => write!(f, "Routing"),
+            ErrorStateReason::Dns => write!(f, "Dns"),
+            ErrorStateReason::TunDevice => write!(f, "TunnelDevice"),
+            ErrorStateReason::TunnelProvider => write!(f, "TunnelProvider"),
+            ErrorStateReason::SameEntryAndExitGateway => write!(f, "SameEntryAndExitGateway"),
+            ErrorStateReason::InvalidEntryGatewayCountry => write!(f, "InvalidEntryGatewayCountry"),
+            ErrorStateReason::InvalidExitGatewayCountry => write!(f, "InvalidExitGatewayCountry"),
+            ErrorStateReason::BadBandwidthIncrease => write!(f, "BadBandwidthIncrease"),
+            ErrorStateReason::DuplicateTunFd => write!(f, "DuplicateTunFd"),
+            ErrorStateReason::SyncAccount(_) => write!(f, "SyncAccount"),
+            ErrorStateReason::SyncDevice(_) => write!(f, "SyncDevice"),
+            ErrorStateReason::RegisterDevice(_) => write!(f, "RequestZkNym"),
+            ErrorStateReason::RequestZkNym(_) => write!(f, "InvalidExitGatewayCountry"),
+            ErrorStateReason::RequestZkNymBundle { .. } => write!(f, "RequestZkNymBundle "),
+            ErrorStateReason::Internal(_) => write!(f, "Internal"),
+            ErrorStateReason::ResolveGatewayAddrs => write!(f, "ResolveGatewayAddrs"),
+            ErrorStateReason::StartLocalDnsResolver => write!(f, "StartLocalDnsResolver"),
+        }
+    }
+}
+
 impl From<SyncAccountError> for ErrorStateReason {
     fn from(value: SyncAccountError) -> Self {
         ErrorStateReason::SyncAccount(value)

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/uniffi_lib_types.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/uniffi_lib_types.rs
@@ -230,9 +230,9 @@ pub enum ErrorStateReason {
     MaxDevicesReached,
     BandwidthExceeded,
     SubscriptionExpired,
-    Dns(String),
-    Api(String),
-    Internal(String),
+    Dns(Option<String>),
+    Api(Option<String>),
+    Internal(Option<String>),
 }
 
 #[derive(thiserror::Error, uniffi::Error, Debug, Clone, PartialEq, Eq)]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/uniffi_lib_types.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/uniffi_lib_types.rs
@@ -8,12 +8,13 @@ use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 use nym_vpn_api_client::response::NymErrorResponse;
 use nym_vpn_lib_types::{
     ActionAfterDisconnect as CoreActionAfterDisconnect, BandwidthEvent as CoreBandwidthEvent,
-    ConnectionData as CoreConnectionData, ConnectionEvent as CoreConnectionEvent,
+    ClientErrorReason, ConnectionData as CoreConnectionData,
+    ConnectionEvent as CoreConnectionEvent,
     ConnectionStatisticsEvent as CoreConnectionStatisticsEvent,
-    ErrorStateReason as CoreErrorStateReason, ForgetAccountError as CoreForgetAccountError,
-    Gateway as CoreGateway, MixnetConnectionData as CoreMixnetConnectionData,
-    MixnetEvent as CoreMixnetEvent, NymAddress as CoreNymAddress,
-    RegisterDeviceError as CoreRegisterDeviceError, RequestZkNymError as CoreRequestZkNymError,
+    ForgetAccountError as CoreForgetAccountError, Gateway as CoreGateway,
+    MixnetConnectionData as CoreMixnetConnectionData, MixnetEvent as CoreMixnetEvent,
+    NymAddress as CoreNymAddress, RegisterDeviceError as CoreRegisterDeviceError,
+    RequestZkNymError as CoreRequestZkNymError,
     RequestZkNymErrorReason as CoreRequestZkNymErrorReason,
     RequestZkNymSuccess as CoreRequestZkNymSuccess, SphinxPacketRates as CoreSphinxPacketRates,
     StoreAccountError as CoreStoreAccountError, SyncAccountError as CoreSyncAccountError,
@@ -23,13 +24,6 @@ use nym_vpn_lib_types::{
     WireguardConnectionData as CoreWireguardConnectionData, WireguardNode as CoreWireguardNode,
 };
 use time::OffsetDateTime;
-
-const MAX_DEVICES_REACHED_MESSAGE_ID: &str =
-    "nym-vpn-website.public-api.register-device.max-devices-exceeded";
-const SUBSCRIPTION_EXPIRED_MESSAGE_ID: &str =
-    "nym-vpn-website.public-api.device.zk-nym.request_failed.no_active_subscription";
-const BANDWIDTH_LIMIT_REACHED_MESSAGE_ID: &str =
-    "nym-vpn-website.public-api.device.zk-nym.request_failed.fair_usage_used_for_month";
 
 #[derive(uniffi::Enum)]
 pub enum TunnelEvent {
@@ -77,7 +71,9 @@ impl From<CoreTunnelState> for TunnelState {
                 after_disconnect: ActionAfterDisconnect::from(after_disconnect),
             },
             CoreTunnelState::Disconnected => TunnelState::Disconnected,
-            CoreTunnelState::Error(reason) => TunnelState::Error(ErrorStateReason::from(reason)),
+            CoreTunnelState::Error(reason) => {
+                TunnelState::Error(ErrorStateReason::from(ClientErrorReason::from(reason)))
+            }
             CoreTunnelState::Offline { reconnect } => TunnelState::Offline { reconnect },
         }
     }
@@ -469,77 +465,20 @@ impl From<NymErrorResponse> for VpnApiErrorResponse {
     }
 }
 
-impl From<CoreErrorStateReason> for ErrorStateReason {
-    fn from(value: CoreErrorStateReason) -> Self {
+impl From<ClientErrorReason> for ErrorStateReason {
+    fn from(value: ClientErrorReason) -> Self {
         match value {
-            CoreErrorStateReason::SameEntryAndExitGateway => Self::SameEntryAndExitGateway,
-            CoreErrorStateReason::InvalidEntryGatewayCountry => Self::InvalidEntryGatewayCountry,
-            CoreErrorStateReason::InvalidExitGatewayCountry => Self::InvalidExitGatewayCountry,
-            CoreErrorStateReason::BadBandwidthIncrease => Self::Api(value.to_string()),
-            CoreErrorStateReason::SyncAccount(err) => Self::Api(err.to_string()),
-            CoreErrorStateReason::SyncDevice(err) => Self::Api(err.to_string()),
-            CoreErrorStateReason::RegisterDevice(err) => {
-                if err
-                    .message_id()
-                    .is_some_and(|id| id.contains(MAX_DEVICES_REACHED_MESSAGE_ID))
-                {
-                    Self::MaxDevicesReached
-                } else {
-                    Self::Api(err.to_string())
-                }
-            }
-            CoreErrorStateReason::RequestZkNym(err) => match err {
-                CoreRequestZkNymErrorReason::VpnApi(e) => match e.message_id.as_ref() {
-                    Some(id) if id.contains(BANDWIDTH_LIMIT_REACHED_MESSAGE_ID) => {
-                        Self::BandwidthExceeded
-                    }
-                    Some(id) if id.contains(SUBSCRIPTION_EXPIRED_MESSAGE_ID) => {
-                        Self::SubscriptionExpired
-                    }
-                    _ => Self::Api(e.message),
-                },
-                CoreRequestZkNymErrorReason::UnexpectedVpnApiResponse(message) => {
-                    Self::Api(message)
-                }
-                reason => Self::Internal(reason.to_string()),
-            },
-            CoreErrorStateReason::RequestZkNymBundle {
-                successes: _,
-                failed,
-            } => {
-                if let Some(CoreRequestZkNymErrorReason::VpnApi(e)) = failed
-                    .iter()
-                    .find(|e| matches!(e, CoreRequestZkNymErrorReason::VpnApi { .. }))
-                {
-                    return match e.message_id.as_ref() {
-                        Some(id) if id.contains(BANDWIDTH_LIMIT_REACHED_MESSAGE_ID) => {
-                            Self::BandwidthExceeded
-                        }
-                        Some(id) if id.contains(SUBSCRIPTION_EXPIRED_MESSAGE_ID) => {
-                            Self::SubscriptionExpired
-                        }
-                        _ => Self::Api(e.clone().message),
-                    };
-                }
-                if let Some(err) = failed.iter().find(|e| {
-                    matches!(
-                        e,
-                        CoreRequestZkNymErrorReason::UnexpectedVpnApiResponse { .. }
-                    )
-                }) {
-                    return Self::Api(err.to_string());
-                }
-                Self::Internal(failed.into_iter().map(|e| e.to_string()).collect())
-            }
-            CoreErrorStateReason::Firewall => Self::Firewall,
-            CoreErrorStateReason::Routing
-            | CoreErrorStateReason::TunDevice
-            | CoreErrorStateReason::TunnelProvider
-            | CoreErrorStateReason::DuplicateTunFd
-            | CoreErrorStateReason::Dns => Self::Internal(value.to_string()),
-            CoreErrorStateReason::Internal(message) => Self::Internal(message),
-            CoreErrorStateReason::ResolveGatewayAddrs => Self::Dns(value.to_string()),
-            CoreErrorStateReason::StartLocalDnsResolver => Self::Dns(value.to_string()),
+            ClientErrorReason::Firewall => Self::Firewall,
+            ClientErrorReason::Routing => Self::Routing,
+            ClientErrorReason::SameEntryAndExitGateway => Self::SameEntryAndExitGateway,
+            ClientErrorReason::InvalidEntryGatewayCountry => Self::InvalidEntryGatewayCountry,
+            ClientErrorReason::InvalidExitGatewayCountry => Self::InvalidExitGatewayCountry,
+            ClientErrorReason::MaxDevicesReached => Self::MaxDevicesReached,
+            ClientErrorReason::BandwidthExceeded => Self::BandwidthExceeded,
+            ClientErrorReason::SubscriptionExpired => Self::SubscriptionExpired,
+            ClientErrorReason::Dns(message) => Self::Dns(message),
+            ClientErrorReason::Api(message) => Self::Api(message),
+            ClientErrorReason::Internal(message) => Self::Internal(message),
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/uniffi_lib_types.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/uniffi_lib_types.rs
@@ -24,6 +24,13 @@ use nym_vpn_lib_types::{
 };
 use time::OffsetDateTime;
 
+const MAX_DEVICES_REACHED_MESSAGE_ID: &str =
+    "nym-vpn-website.public-api.register-device.max-devices-exceeded";
+const SUBSCRIPTION_EXPIRED_MESSAGE_ID: &str =
+    "nym-vpn-website.public-api.device.zk-nym.request_failed.no_active_subscription";
+const BANDWIDTH_LIMIT_REACHED_MESSAGE_ID: &str =
+    "nym-vpn-website.public-api.device.zk-nym.request_failed.fair_usage_used_for_month";
+
 #[derive(uniffi::Enum)]
 pub enum TunnelEvent {
     NewState(TunnelState),
@@ -223,24 +230,14 @@ impl From<CoreActionAfterDisconnect> for ActionAfterDisconnect {
 pub enum ErrorStateReason {
     Firewall,
     Routing,
-    Dns,
-    TunDevice,
-    TunnelProvider,
-    ResolveGatewayAddrs,
-    StartLocalDnsResolver,
     SameEntryAndExitGateway,
     InvalidEntryGatewayCountry,
     InvalidExitGatewayCountry,
-    BadBandwidthIncrease,
-    DuplicateTunFd,
-    SyncAccount(SyncAccountError),
-    SyncDevice(SyncDeviceError),
-    RegisterDevice(RegisterDeviceError),
-    RequestZkNym(RequestZkNymError),
-    RequestZkNymBundle {
-        successes: Vec<RequestZkNymSuccess>,
-        failed: Vec<RequestZkNymError>,
-    },
+    MaxDevicesReached,
+    BandwidthExceeded,
+    SubscriptionExpired,
+    Dns(String),
+    Api(String),
     Internal(String),
 }
 
@@ -475,32 +472,74 @@ impl From<NymErrorResponse> for VpnApiErrorResponse {
 impl From<CoreErrorStateReason> for ErrorStateReason {
     fn from(value: CoreErrorStateReason) -> Self {
         match value {
-            CoreErrorStateReason::Firewall => Self::Firewall,
-            CoreErrorStateReason::Routing => Self::Routing,
-            CoreErrorStateReason::Dns => Self::Dns,
-            CoreErrorStateReason::TunDevice => Self::TunDevice,
-            CoreErrorStateReason::TunnelProvider => Self::TunnelProvider,
-            CoreErrorStateReason::ResolveGatewayAddrs => Self::ResolveGatewayAddrs,
-            CoreErrorStateReason::StartLocalDnsResolver => Self::StartLocalDnsResolver,
             CoreErrorStateReason::SameEntryAndExitGateway => Self::SameEntryAndExitGateway,
             CoreErrorStateReason::InvalidEntryGatewayCountry => Self::InvalidEntryGatewayCountry,
             CoreErrorStateReason::InvalidExitGatewayCountry => Self::InvalidExitGatewayCountry,
-            CoreErrorStateReason::BadBandwidthIncrease => Self::BadBandwidthIncrease,
-            CoreErrorStateReason::DuplicateTunFd => Self::DuplicateTunFd,
-            CoreErrorStateReason::SyncAccount(err) => Self::SyncAccount(err.into()),
-            CoreErrorStateReason::SyncDevice(err) => Self::SyncDevice(err.into()),
-            CoreErrorStateReason::RegisterDevice(err) => Self::RegisterDevice(err.into()),
-            CoreErrorStateReason::RequestZkNym(err) => Self::RequestZkNym(err.into()),
-            CoreErrorStateReason::RequestZkNymBundle { successes, failed } => {
-                Self::RequestZkNymBundle {
-                    successes: successes
-                        .into_iter()
-                        .map(RequestZkNymSuccess::from)
-                        .collect(),
-                    failed: failed.into_iter().map(RequestZkNymError::from).collect(),
+            CoreErrorStateReason::BadBandwidthIncrease => Self::Api(value.to_string()),
+            CoreErrorStateReason::SyncAccount(err) => Self::Api(err.to_string()),
+            CoreErrorStateReason::SyncDevice(err) => Self::Api(err.to_string()),
+            CoreErrorStateReason::RegisterDevice(err) => {
+                if err
+                    .message_id()
+                    .is_some_and(|id| id.contains(MAX_DEVICES_REACHED_MESSAGE_ID))
+                {
+                    Self::MaxDevicesReached
+                } else {
+                    Self::Api(err.to_string())
                 }
             }
+            CoreErrorStateReason::RequestZkNym(err) => match err {
+                CoreRequestZkNymErrorReason::VpnApi(e) => match e.message_id.as_ref() {
+                    Some(id) if id.contains(BANDWIDTH_LIMIT_REACHED_MESSAGE_ID) => {
+                        Self::BandwidthExceeded
+                    }
+                    Some(id) if id.contains(SUBSCRIPTION_EXPIRED_MESSAGE_ID) => {
+                        Self::SubscriptionExpired
+                    }
+                    _ => Self::Api(e.message),
+                },
+                CoreRequestZkNymErrorReason::UnexpectedVpnApiResponse(message) => {
+                    Self::Api(message)
+                }
+                reason => Self::Internal(reason.to_string()),
+            },
+            CoreErrorStateReason::RequestZkNymBundle {
+                successes: _,
+                failed,
+            } => {
+                if let Some(CoreRequestZkNymErrorReason::VpnApi(e)) = failed
+                    .iter()
+                    .find(|e| matches!(e, CoreRequestZkNymErrorReason::VpnApi { .. }))
+                {
+                    return match e.message_id.as_ref() {
+                        Some(id) if id.contains(BANDWIDTH_LIMIT_REACHED_MESSAGE_ID) => {
+                            Self::BandwidthExceeded
+                        }
+                        Some(id) if id.contains(SUBSCRIPTION_EXPIRED_MESSAGE_ID) => {
+                            Self::SubscriptionExpired
+                        }
+                        _ => Self::Api(e.clone().message),
+                    };
+                }
+                if let Some(err) = failed.iter().find(|e| {
+                    matches!(
+                        e,
+                        CoreRequestZkNymErrorReason::UnexpectedVpnApiResponse { .. }
+                    )
+                }) {
+                    return Self::Api(err.to_string());
+                }
+                Self::Internal(failed.into_iter().map(|e| e.to_string()).collect())
+            }
+            CoreErrorStateReason::Firewall => Self::Firewall,
+            CoreErrorStateReason::Routing
+            | CoreErrorStateReason::TunDevice
+            | CoreErrorStateReason::TunnelProvider
+            | CoreErrorStateReason::DuplicateTunFd
+            | CoreErrorStateReason::Dns => Self::Internal(value.to_string()),
             CoreErrorStateReason::Internal(message) => Self::Internal(message),
+            CoreErrorStateReason::ResolveGatewayAddrs => Self::Dns(value.to_string()),
+            CoreErrorStateReason::StartLocalDnsResolver => Self::Dns(value.to_string()),
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/uniffi_lib_types.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/uniffi_lib_types.rs
@@ -71,9 +71,7 @@ impl From<CoreTunnelState> for TunnelState {
                 after_disconnect: ActionAfterDisconnect::from(after_disconnect),
             },
             CoreTunnelState::Disconnected => TunnelState::Disconnected,
-            CoreTunnelState::Error(reason) => {
-                TunnelState::Error(ErrorStateReason::from(ClientErrorReason::from(reason)))
-            }
+            CoreTunnelState::Error(reason) => TunnelState::Error(ErrorStateReason::from(reason)),
             CoreTunnelState::Offline { reconnect } => TunnelState::Offline { reconnect },
         }
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -39,8 +39,8 @@ use nym_firewall::{Firewall, FirewallArguments, InitialFirewallState};
 use nym_gateway_directory::{Config as GatewayDirectoryConfig, EntryPoint, ExitPoint, Recipient};
 use nym_sdk::UserAgent;
 use nym_vpn_lib_types::{
-    ActionAfterDisconnect, ConnectionData, ErrorStateReason, MixnetEvent, TunnelEvent, TunnelState,
-    TunnelType,
+    ActionAfterDisconnect, ClientErrorReason, ConnectionData, ErrorStateReason, MixnetEvent,
+    TunnelEvent, TunnelState, TunnelType,
 };
 use nym_wg_gateway_client::Error as WgGatewayClientError;
 
@@ -237,7 +237,7 @@ impl From<PrivateTunnelState> for TunnelState {
             PrivateTunnelState::Disconnecting { after_disconnect } => Self::Disconnecting {
                 after_disconnect: ActionAfterDisconnect::from(after_disconnect),
             },
-            PrivateTunnelState::Error(reason) => Self::Error(reason),
+            PrivateTunnelState::Error(reason) => Self::Error(ClientErrorReason::from(reason)),
             PrivateTunnelState::Offline { reconnect } => Self::Offline { reconnect },
         }
     }

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/from_proto/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/from_proto/tunnel_state.rs
@@ -41,28 +41,21 @@ impl From<ProtoActionAfterDisconnect> for ActionAfterDisconnect {
     }
 }
 
-impl TryFrom<ProtoError> for ClientErrorReason {
-    type Error = &'static str;
+impl From<ProtoError> for ClientErrorReason {
 
-    fn try_from(value: ProtoError) -> Result<Self, Self::Error> {
+    fn from(value: ProtoError) -> Self {
         match value.reason() {
-            ErrorStateReason::Firewall => Ok(ClientErrorReason::Firewall),
-            ErrorStateReason::Routing => Ok(ClientErrorReason::Routing),
-            ErrorStateReason::SameEntryAndExitGateway => {
-                Ok(ClientErrorReason::SameEntryAndExitGateway)
-            }
-            ErrorStateReason::InvalidEntryGatewayCountry => {
-                Ok(ClientErrorReason::InvalidEntryGatewayCountry)
-            }
-            ErrorStateReason::InvalidExitGatewayCountry => {
-                Ok(ClientErrorReason::InvalidExitGatewayCountry)
-            }
-            ErrorStateReason::MaxDevicesReached => Ok(ClientErrorReason::MaxDevicesReached),
-            ErrorStateReason::BandwidthExceeded => Ok(ClientErrorReason::BandwidthExceeded),
-            ErrorStateReason::SubscriptionExpired => Ok(ClientErrorReason::SubscriptionExpired),
-            ErrorStateReason::Dns => Ok(ClientErrorReason::Dns(value.detail)),
-            ErrorStateReason::Api => Ok(ClientErrorReason::Api(value.detail)),
-            ErrorStateReason::Internal => Ok(ClientErrorReason::Internal(value.detail)),
+            ErrorStateReason::Firewall => ClientErrorReason::Firewall,
+            ErrorStateReason::Routing => ClientErrorReason::Routing,
+            ErrorStateReason::SameEntryAndExitGateway => ClientErrorReason::SameEntryAndExitGateway,
+            ErrorStateReason::InvalidEntryGatewayCountry => ClientErrorReason::InvalidEntryGatewayCountry,
+            ErrorStateReason::InvalidExitGatewayCountry => ClientErrorReason::InvalidExitGatewayCountry,
+            ErrorStateReason::MaxDevicesReached => ClientErrorReason::MaxDevicesReached,
+            ErrorStateReason::BandwidthExceeded => ClientErrorReason::BandwidthExceeded,
+            ErrorStateReason::SubscriptionExpired => ClientErrorReason::SubscriptionExpired,
+            ErrorStateReason::Dns => ClientErrorReason::Dns(value.detail),
+            ErrorStateReason::Api => ClientErrorReason::Api(value.detail),
+            ErrorStateReason::Internal => ClientErrorReason::Internal(value.detail),
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/from_proto/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/from_proto/tunnel_state.rs
@@ -93,11 +93,7 @@ impl TryFrom<ProtoTunnelState> for TunnelState {
 
                 Self::Connected { connection_data }
             }
-            ProtoState::Error(error_state_reason) => {
-                let reason = ClientErrorReason::try_from(error_state_reason)
-                    .map_err(|_| ConversionError::NoValueSet("TunnelState.error"))?;
-                Self::Error(reason)
-            }
+            ProtoState::Error(error_state_reason) => Self::Error(error_state_reason.into()),
             ProtoState::Offline(ProtoOffline { reconnect }) => Self::Offline { reconnect },
         })
     }

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/from_proto/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/from_proto/tunnel_state.rs
@@ -42,14 +42,17 @@ impl From<ProtoActionAfterDisconnect> for ActionAfterDisconnect {
 }
 
 impl From<ProtoError> for ClientErrorReason {
-
     fn from(value: ProtoError) -> Self {
         match value.reason() {
             ErrorStateReason::Firewall => ClientErrorReason::Firewall,
             ErrorStateReason::Routing => ClientErrorReason::Routing,
             ErrorStateReason::SameEntryAndExitGateway => ClientErrorReason::SameEntryAndExitGateway,
-            ErrorStateReason::InvalidEntryGatewayCountry => ClientErrorReason::InvalidEntryGatewayCountry,
-            ErrorStateReason::InvalidExitGatewayCountry => ClientErrorReason::InvalidExitGatewayCountry,
+            ErrorStateReason::InvalidEntryGatewayCountry => {
+                ClientErrorReason::InvalidEntryGatewayCountry
+            }
+            ErrorStateReason::InvalidExitGatewayCountry => {
+                ClientErrorReason::InvalidExitGatewayCountry
+            }
             ErrorStateReason::MaxDevicesReached => ClientErrorReason::MaxDevicesReached,
             ErrorStateReason::BandwidthExceeded => ClientErrorReason::BandwidthExceeded,
             ErrorStateReason::SubscriptionExpired => ClientErrorReason::SubscriptionExpired,

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/from_proto/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/from_proto/tunnel_state.rs
@@ -60,18 +60,9 @@ impl TryFrom<ProtoError> for ClientErrorReason {
             ErrorStateReason::MaxDevicesReached => Ok(ClientErrorReason::MaxDevicesReached),
             ErrorStateReason::BandwidthExceeded => Ok(ClientErrorReason::BandwidthExceeded),
             ErrorStateReason::SubscriptionExpired => Ok(ClientErrorReason::SubscriptionExpired),
-            ErrorStateReason::Dns => match value.detail {
-                Some(detail) => Ok(ClientErrorReason::Dns(detail)),
-                None => Err("DNS variant missing a detail string"),
-            },
-            ErrorStateReason::Api => match value.detail {
-                Some(detail) => Ok(ClientErrorReason::Api(detail)),
-                None => Err("API variant missing detail string"),
-            },
-            ErrorStateReason::Internal => match value.detail {
-                Some(detail) => Ok(ClientErrorReason::Internal(detail)),
-                None => Err("Internal variant missing a detail string"),
-            },
+            ErrorStateReason::Dns => Ok(ClientErrorReason::Dns(value.detail)),
+            ErrorStateReason::Api => Ok(ClientErrorReason::Api(value.detail)),
+            ErrorStateReason::Internal => Ok(ClientErrorReason::Internal(value.detail)),
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/from_proto/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/from_proto/tunnel_state.rs
@@ -11,6 +11,7 @@ use nym_vpn_lib_types::{
     NymAddress, TunnelConnectionData, TunnelState, WireguardConnectionData, WireguardNode,
 };
 
+use crate::tunnel_state::ErrorStateReason;
 use crate::{
     conversions::ConversionError,
     tunnel_connection_data::{
@@ -44,28 +45,33 @@ impl TryFrom<ProtoError> for ClientErrorReason {
     type Error = &'static str;
 
     fn try_from(value: ProtoError) -> Result<Self, Self::Error> {
-        match value.reason {
-            0 => Ok(ClientErrorReason::Firewall),
-            1 => Ok(ClientErrorReason::Routing),
-            2 => Ok(ClientErrorReason::SameEntryAndExitGateway),
-            3 => Ok(ClientErrorReason::InvalidEntryGatewayCountry),
-            4 => Ok(ClientErrorReason::InvalidExitGatewayCountry),
-            5 => Ok(ClientErrorReason::MaxDevicesReached),
-            6 => Ok(ClientErrorReason::BandwidthExceeded),
-            7 => Ok(ClientErrorReason::SubscriptionExpired),
-            8 => match value.detail {
+        match value.reason() {
+            ErrorStateReason::Firewall => Ok(ClientErrorReason::Firewall),
+            ErrorStateReason::Routing => Ok(ClientErrorReason::Routing),
+            ErrorStateReason::SameEntryAndExitGateway => {
+                Ok(ClientErrorReason::SameEntryAndExitGateway)
+            }
+            ErrorStateReason::InvalidEntryGatewayCountry => {
+                Ok(ClientErrorReason::InvalidEntryGatewayCountry)
+            }
+            ErrorStateReason::InvalidExitGatewayCountry => {
+                Ok(ClientErrorReason::InvalidExitGatewayCountry)
+            }
+            ErrorStateReason::MaxDevicesReached => Ok(ClientErrorReason::MaxDevicesReached),
+            ErrorStateReason::BandwidthExceeded => Ok(ClientErrorReason::BandwidthExceeded),
+            ErrorStateReason::SubscriptionExpired => Ok(ClientErrorReason::SubscriptionExpired),
+            ErrorStateReason::Dns => match value.detail {
                 Some(detail) => Ok(ClientErrorReason::Dns(detail)),
-                None => Err("DNS variant requires a detail string"),
+                None => Err("DNS variant missing a detail string"),
             },
-            9 => match value.detail {
+            ErrorStateReason::Api => match value.detail {
                 Some(detail) => Ok(ClientErrorReason::Api(detail)),
-                None => Err("API variant requires a detail string"),
+                None => Err("API variant missing detail string"),
             },
-            10 => match value.detail {
+            ErrorStateReason::Internal => match value.detail {
                 Some(detail) => Ok(ClientErrorReason::Internal(detail)),
-                None => Err("Internal variant requires a detail string"),
+                None => Err("Internal variant missing a detail string"),
             },
-            _ => Err("Unknown ClientErrorReason value"),
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/from_proto/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/from_proto/tunnel_state.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use nym_vpn_lib_types::{
-    ActionAfterDisconnect, ConnectionData, ErrorStateReason, Gateway, MixnetConnectionData,
+    ActionAfterDisconnect, ClientErrorReason, ConnectionData, Gateway, MixnetConnectionData,
     NymAddress, TunnelConnectionData, TunnelState, WireguardConnectionData, WireguardNode,
 };
 
@@ -18,9 +18,7 @@ use crate::{
         Wireguard as ProtoWireguardConnectionDataVariant,
     },
     tunnel_state::{
-        error::ErrorStateReason as ProtoErrorStateReason,
-        ActionAfterDisconnect as ProtoActionAfterDisconnect,
-        BaseErrorStateReason as ProtoBaseErrorStateReason, Connected as ProtoConnected,
+        ActionAfterDisconnect as ProtoActionAfterDisconnect, Connected as ProtoConnected,
         Connecting as ProtoConnecting, Disconnected as ProtoDisconnected,
         Disconnecting as ProtoDisconnecting, Error as ProtoError, Offline as ProtoOffline,
         State as ProtoState,
@@ -42,66 +40,32 @@ impl From<ProtoActionAfterDisconnect> for ActionAfterDisconnect {
     }
 }
 
-impl TryFrom<ProtoErrorStateReason> for ErrorStateReason {
-    type Error = ConversionError;
+impl TryFrom<ProtoError> for ClientErrorReason {
+    type Error = &'static str;
 
-    fn try_from(value: ProtoErrorStateReason) -> Result<Self, Self::Error> {
-        Ok(match value {
-            ProtoErrorStateReason::BaseReason(reason) => {
-                let proto_base_reason = ProtoBaseErrorStateReason::try_from(reason)
-                    .map_err(|e| ConversionError::Decode("BaseErrorStateReason.base_reason", e))?;
-
-                Self::from(proto_base_reason)
-            }
-            ProtoErrorStateReason::SyncAccount(sync_account_error) => {
-                Self::SyncAccount(sync_account_error.try_into()?)
-            }
-            ProtoErrorStateReason::SyncDevice(sync_device_error) => {
-                Self::SyncDevice(sync_device_error.try_into()?)
-            }
-            ProtoErrorStateReason::RegisterDevice(register_device_error) => {
-                Self::RegisterDevice(register_device_error.try_into()?)
-            }
-            ProtoErrorStateReason::RequestZkNym(request_zk_nym_general_error) => {
-                Self::RequestZkNym(request_zk_nym_general_error.try_into()?)
-            }
-            ProtoErrorStateReason::RequestZkNymBundle(request_zk_nym_bundle) => {
-                let failures = request_zk_nym_bundle
-                    .failures
-                    .into_iter()
-                    .map(|outcome| outcome.try_into())
-                    .collect::<Result<Vec<_>, _>>()?;
-                Self::RequestZkNymBundle {
-                    successes: request_zk_nym_bundle
-                        .successes
-                        .into_iter()
-                        .map(Into::into)
-                        .collect(),
-                    failed: failures,
-                }
-            }
-        })
-    }
-}
-
-impl From<ProtoBaseErrorStateReason> for ErrorStateReason {
-    fn from(value: ProtoBaseErrorStateReason) -> Self {
-        match value {
-            ProtoBaseErrorStateReason::Firewall => Self::Firewall,
-            ProtoBaseErrorStateReason::Routing => Self::Routing,
-            ProtoBaseErrorStateReason::Dns => Self::Dns,
-            ProtoBaseErrorStateReason::TunDevice => Self::TunDevice,
-            ProtoBaseErrorStateReason::TunnelProvider => Self::TunnelProvider,
-            ProtoBaseErrorStateReason::ResolveGatewayAddrs => Self::ResolveGatewayAddrs,
-            ProtoBaseErrorStateReason::StartLocalDnsResolver => Self::StartLocalDnsResolver,
-            ProtoBaseErrorStateReason::SameEntryAndExitGateway => Self::SameEntryAndExitGateway,
-            ProtoBaseErrorStateReason::InvalidEntryGatewayCountry => {
-                Self::InvalidEntryGatewayCountry
-            }
-            ProtoBaseErrorStateReason::InvalidExitGatewayCountry => Self::InvalidExitGatewayCountry,
-            ProtoBaseErrorStateReason::BadBandwidthIncrease => Self::BadBandwidthIncrease,
-            ProtoBaseErrorStateReason::DuplicateTunFd => Self::DuplicateTunFd,
-            ProtoBaseErrorStateReason::Internal => Self::Internal("todo: fix me!".to_owned()),
+    fn try_from(value: ProtoError) -> Result<Self, Self::Error> {
+        match value.reason {
+            0 => Ok(ClientErrorReason::Firewall),
+            1 => Ok(ClientErrorReason::Routing),
+            2 => Ok(ClientErrorReason::SameEntryAndExitGateway),
+            3 => Ok(ClientErrorReason::InvalidEntryGatewayCountry),
+            4 => Ok(ClientErrorReason::InvalidExitGatewayCountry),
+            5 => Ok(ClientErrorReason::MaxDevicesReached),
+            6 => Ok(ClientErrorReason::BandwidthExceeded),
+            7 => Ok(ClientErrorReason::SubscriptionExpired),
+            8 => match value.detail {
+                Some(detail) => Ok(ClientErrorReason::Dns(detail)),
+                None => Err("DNS variant requires a detail string"),
+            },
+            9 => match value.detail {
+                Some(detail) => Ok(ClientErrorReason::Api(detail)),
+                None => Err("API variant requires a detail string"),
+            },
+            10 => match value.detail {
+                Some(detail) => Ok(ClientErrorReason::Internal(detail)),
+                None => Err("Internal variant requires a detail string"),
+            },
+            _ => Err("Unknown ClientErrorReason value"),
         }
     }
 }
@@ -136,11 +100,9 @@ impl TryFrom<ProtoTunnelState> for TunnelState {
 
                 Self::Connected { connection_data }
             }
-            ProtoState::Error(ProtoError { error_state_reason }) => {
-                let reason = error_state_reason
-                    .ok_or(ConversionError::NoValueSet("TunnelState.error"))
-                    .and_then(ErrorStateReason::try_from)?;
-
+            ProtoState::Error(error_state_reason) => {
+                let reason = ClientErrorReason::try_from(error_state_reason)
+                    .map_err(|_| ConversionError::NoValueSet("TunnelState.error"))?;
                 Self::Error(reason)
             }
             ProtoState::Offline(ProtoOffline { reconnect }) => Self::Offline { reconnect },

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/into_proto/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/into_proto/tunnel_state.rs
@@ -75,18 +75,9 @@ impl From<ClientErrorReason> for ProtoError {
                 reason: 7,
                 detail: None,
             },
-            ClientErrorReason::Dns(detail) => ProtoError {
-                reason: 8,
-                detail: Some(detail),
-            },
-            ClientErrorReason::Api(detail) => ProtoError {
-                reason: 9,
-                detail: Some(detail),
-            },
-            ClientErrorReason::Internal(detail) => ProtoError {
-                reason: 10,
-                detail: Some(detail),
-            },
+            ClientErrorReason::Dns(detail) => ProtoError { reason: 8, detail },
+            ClientErrorReason::Api(detail) => ProtoError { reason: 9, detail },
+            ClientErrorReason::Internal(detail) => ProtoError { reason: 10, detail },
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/into_proto/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/into_proto/tunnel_state.rs
@@ -8,6 +8,7 @@ use nym_vpn_lib_types::{
     WireguardConnectionData, WireguardNode,
 };
 
+use crate::tunnel_state::ErrorStateReason;
 use crate::{
     tunnel_connection_data::{
         Mixnet as ProtoMixnetConnectionDataVariant, State as ProtoTunnelConnectionDataState,
@@ -44,40 +45,49 @@ impl From<ClientErrorReason> for ProtoError {
     fn from(value: ClientErrorReason) -> Self {
         match value {
             ClientErrorReason::Firewall => ProtoError {
-                reason: 0,
+                reason: ErrorStateReason::Firewall.into(),
                 detail: None,
             },
             ClientErrorReason::Routing => ProtoError {
-                reason: 1,
+                reason: ErrorStateReason::Routing.into(),
                 detail: None,
             },
             ClientErrorReason::SameEntryAndExitGateway => ProtoError {
-                reason: 2,
+                reason: ErrorStateReason::SameEntryAndExitGateway.into(),
                 detail: None,
             },
             ClientErrorReason::InvalidEntryGatewayCountry => ProtoError {
-                reason: 3,
+                reason: ErrorStateReason::InvalidEntryGatewayCountry.into(),
                 detail: None,
             },
             ClientErrorReason::InvalidExitGatewayCountry => ProtoError {
-                reason: 4,
+                reason: ErrorStateReason::InvalidExitGatewayCountry.into(),
                 detail: None,
             },
             ClientErrorReason::MaxDevicesReached => ProtoError {
-                reason: 5,
+                reason: ErrorStateReason::MaxDevicesReached.into(),
                 detail: None,
             },
             ClientErrorReason::BandwidthExceeded => ProtoError {
-                reason: 6,
+                reason: ErrorStateReason::BandwidthExceeded.into(),
                 detail: None,
             },
             ClientErrorReason::SubscriptionExpired => ProtoError {
-                reason: 7,
+                reason: ErrorStateReason::SubscriptionExpired.into(),
                 detail: None,
             },
-            ClientErrorReason::Dns(detail) => ProtoError { reason: 8, detail },
-            ClientErrorReason::Api(detail) => ProtoError { reason: 9, detail },
-            ClientErrorReason::Internal(detail) => ProtoError { reason: 10, detail },
+            ClientErrorReason::Dns(detail) => ProtoError {
+                reason: ErrorStateReason::Dns.into(),
+                detail,
+            },
+            ClientErrorReason::Api(detail) => ProtoError {
+                reason: ErrorStateReason::Api.into(),
+                detail,
+            },
+            ClientErrorReason::Internal(detail) => ProtoError {
+                reason: ErrorStateReason::Internal.into(),
+                detail,
+            },
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/into_proto/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/into_proto/tunnel_state.rs
@@ -8,7 +8,6 @@ use nym_vpn_lib_types::{
     WireguardConnectionData, WireguardNode,
 };
 
-use crate::tunnel_state::ErrorStateReason;
 use crate::{
     tunnel_connection_data::{
         Mixnet as ProtoMixnetConnectionDataVariant, State as ProtoTunnelConnectionDataState,
@@ -17,8 +16,8 @@ use crate::{
     tunnel_state::{
         ActionAfterDisconnect as ProtoActionAfterDisconnect, Connected as ProtoConnected,
         Connecting as ProtoConnecting, Disconnected as ProtoDisconnected,
-        Disconnecting as ProtoDisconnecting, Error as ProtoError, Offline as ProtoOffline,
-        State as ProtoState,
+        Disconnecting as ProtoDisconnecting, Error as ProtoError, ErrorStateReason,
+        Offline as ProtoOffline, State as ProtoState,
     },
     Address as ProtoAddress, ConnectionData as ProtoConnectionData,
     ForgetAccountError as ProtoForgetAccountError, Gateway as ProtoGateway,

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/into_proto/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/into_proto/tunnel_state.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use nym_vpn_lib_types::{
-    ActionAfterDisconnect, ConnectionData, ErrorStateReason, ForgetAccountError, Gateway,
+    ActionAfterDisconnect, ClientErrorReason, ConnectionData, ForgetAccountError, Gateway,
     MixnetConnectionData, RegisterDeviceError, StoreAccountError, SyncAccountError,
     SyncDeviceError, TunnelConnectionData, TunnelState, VpnApiErrorResponse,
     WireguardConnectionData, WireguardNode,
@@ -14,9 +14,7 @@ use crate::{
         Wireguard as ProtoWireguardConnectionDataVariant,
     },
     tunnel_state::{
-        error::ErrorStateReason as ProtoErrorStateReason,
-        ActionAfterDisconnect as ProtoActionAfterDisconnect,
-        BaseErrorStateReason as ProtoBaseErrorStateReason, Connected as ProtoConnected,
+        ActionAfterDisconnect as ProtoActionAfterDisconnect, Connected as ProtoConnected,
         Connecting as ProtoConnecting, Disconnected as ProtoDisconnected,
         Disconnecting as ProtoDisconnecting, Error as ProtoError, Offline as ProtoOffline,
         State as ProtoState,
@@ -24,11 +22,10 @@ use crate::{
     Address as ProtoAddress, ConnectionData as ProtoConnectionData,
     ForgetAccountError as ProtoForgetAccountError, Gateway as ProtoGateway,
     MixnetConnectionData as ProtoMixnetConnectionData,
-    RegisterDeviceError as ProtoRegisterDeviceError, RequestZkNymBundle as ProtoRequestZkNymBundle,
-    RequestZkNymError as ProtoRequestZkNymError, RequestZkNymSuccess as ProtoRequestZkNymSuccess,
-    StoreAccountError as ProtoStoreAccountError, SyncAccountError as ProtoSyncAccountError,
-    SyncDeviceError as ProtoSyncDeviceError, TunnelConnectionData as ProtoTunnelConnectionData,
-    TunnelState as ProtoTunnelState, VpnApiErrorResponse as ProtoVpnApiErrorResponse,
+    RegisterDeviceError as ProtoRegisterDeviceError, StoreAccountError as ProtoStoreAccountError,
+    SyncAccountError as ProtoSyncAccountError, SyncDeviceError as ProtoSyncDeviceError,
+    TunnelConnectionData as ProtoTunnelConnectionData, TunnelState as ProtoTunnelState,
+    VpnApiErrorResponse as ProtoVpnApiErrorResponse,
     WireguardConnectionData as ProtoWireguardConnectionData, WireguardNode as ProtoWireguardNode,
 };
 
@@ -43,71 +40,53 @@ impl From<ActionAfterDisconnect> for ProtoActionAfterDisconnect {
     }
 }
 
-impl From<ErrorStateReason> for ProtoErrorStateReason {
-    fn from(value: ErrorStateReason) -> Self {
+impl From<ClientErrorReason> for ProtoError {
+    fn from(value: ClientErrorReason) -> Self {
         match value {
-            ErrorStateReason::Firewall => {
-                Self::BaseReason(ProtoBaseErrorStateReason::Firewall as i32)
-            }
-            ErrorStateReason::Routing => {
-                Self::BaseReason(ProtoBaseErrorStateReason::Routing as i32)
-            }
-            ErrorStateReason::Dns => Self::BaseReason(ProtoBaseErrorStateReason::Dns as i32),
-            ErrorStateReason::TunDevice => {
-                Self::BaseReason(ProtoBaseErrorStateReason::TunDevice as i32)
-            }
-            ErrorStateReason::TunnelProvider => {
-                Self::BaseReason(ProtoBaseErrorStateReason::TunnelProvider as i32)
-            }
-            ErrorStateReason::StartLocalDnsResolver => {
-                Self::BaseReason(ProtoBaseErrorStateReason::StartLocalDnsResolver as i32)
-            }
-            ErrorStateReason::ResolveGatewayAddrs => {
-                Self::BaseReason(ProtoBaseErrorStateReason::ResolveGatewayAddrs as i32)
-            }
-            ErrorStateReason::SameEntryAndExitGateway => {
-                Self::BaseReason(ProtoBaseErrorStateReason::SameEntryAndExitGateway as i32)
-            }
-            ErrorStateReason::InvalidEntryGatewayCountry => {
-                Self::BaseReason(ProtoBaseErrorStateReason::InvalidEntryGatewayCountry as i32)
-            }
-            ErrorStateReason::InvalidExitGatewayCountry => {
-                Self::BaseReason(ProtoBaseErrorStateReason::InvalidExitGatewayCountry as i32)
-            }
-            ErrorStateReason::BadBandwidthIncrease => {
-                Self::BaseReason(ProtoBaseErrorStateReason::BadBandwidthIncrease as i32)
-            }
-            ErrorStateReason::DuplicateTunFd => {
-                Self::BaseReason(ProtoBaseErrorStateReason::DuplicateTunFd as i32)
-            }
-            ErrorStateReason::Internal(_message) => {
-                // todo: pass error message!
-                Self::BaseReason(ProtoBaseErrorStateReason::Internal as i32)
-            }
-            ErrorStateReason::SyncAccount(sync_account_error) => {
-                Self::SyncAccount(sync_account_error.into())
-            }
-            ErrorStateReason::SyncDevice(sync_device_error) => {
-                Self::SyncDevice(sync_device_error.into())
-            }
-            ErrorStateReason::RegisterDevice(register_device_error) => {
-                Self::RegisterDevice(register_device_error.into())
-            }
-            ErrorStateReason::RequestZkNym(request_zk_nym_error) => {
-                Self::RequestZkNym(request_zk_nym_error.into())
-            }
-            ErrorStateReason::RequestZkNymBundle { successes, failed } => {
-                Self::RequestZkNymBundle(ProtoRequestZkNymBundle {
-                    successes: successes
-                        .into_iter()
-                        .map(ProtoRequestZkNymSuccess::from)
-                        .collect(),
-                    failures: failed
-                        .into_iter()
-                        .map(ProtoRequestZkNymError::from)
-                        .collect(),
-                })
-            }
+            ClientErrorReason::Firewall => ProtoError {
+                reason: 0,
+                detail: None,
+            },
+            ClientErrorReason::Routing => ProtoError {
+                reason: 1,
+                detail: None,
+            },
+            ClientErrorReason::SameEntryAndExitGateway => ProtoError {
+                reason: 2,
+                detail: None,
+            },
+            ClientErrorReason::InvalidEntryGatewayCountry => ProtoError {
+                reason: 3,
+                detail: None,
+            },
+            ClientErrorReason::InvalidExitGatewayCountry => ProtoError {
+                reason: 4,
+                detail: None,
+            },
+            ClientErrorReason::MaxDevicesReached => ProtoError {
+                reason: 5,
+                detail: None,
+            },
+            ClientErrorReason::BandwidthExceeded => ProtoError {
+                reason: 6,
+                detail: None,
+            },
+            ClientErrorReason::SubscriptionExpired => ProtoError {
+                reason: 7,
+                detail: None,
+            },
+            ClientErrorReason::Dns(detail) => ProtoError {
+                reason: 8,
+                detail: Some(detail),
+            },
+            ClientErrorReason::Api(detail) => ProtoError {
+                reason: 9,
+                detail: Some(detail),
+            },
+            ClientErrorReason::Internal(detail) => ProtoError {
+                reason: 10,
+                detail: Some(detail),
+            },
         }
     }
 }
@@ -294,9 +273,7 @@ impl From<TunnelState> for ProtoTunnelState {
                 })
             }
             TunnelState::Offline { reconnect } => ProtoState::Offline(ProtoOffline { reconnect }),
-            TunnelState::Error(reason) => ProtoState::Error(ProtoError {
-                error_state_reason: Some(ProtoErrorStateReason::from(reason)),
-            }),
+            TunnelState::Error(reason) => ProtoState::Error(ProtoError::from(reason)),
         };
 
         ProtoTunnelState {

--- a/proto/nym/vpn.proto
+++ b/proto/nym/vpn.proto
@@ -384,20 +384,18 @@ message TunnelConnectionData {
 }
 
 message TunnelState {
-  enum BaseErrorStateReason {
+  enum ErrorStateReason {
     FIREWALL = 0;
     ROUTING = 1;
-    DNS = 2;
-    TUN_DEVICE = 3;
-    TUNNEL_PROVIDER = 4;
-    SAME_ENTRY_AND_EXIT_GATEWAY = 5;
-    INVALID_ENTRY_GATEWAY_COUNTRY = 6;
-    INVALID_EXIT_GATEWAY_COUNTRY = 7;
-    BAD_BANDWIDTH_INCREASE = 8;
-    DUPLICATE_TUN_FD = 9;
+    SAME_ENTRY_AND_EXIT_GATEWAY = 2;
+    INVALID_ENTRY_GATEWAY_COUNTRY = 3;
+    INVALID_EXIT_GATEWAY_COUNTRY = 4;
+    MAX_DEVICES_REACHED = 5;
+    BANDWIDTH_EXCEEDED = 6;
+    SUBSCRIPTION_EXPIRED = 7;
+    DNS = 8;
+    API = 9;
     INTERNAL = 10;
-    RESOLVE_GATEWAY_ADDRS = 11;
-    START_LOCAL_DNS_RESOLVER = 12;
   }
 
   enum ActionAfterDisconnect {
@@ -418,14 +416,9 @@ message TunnelState {
     ActionAfterDisconnect after_disconnect = 1;
   }
   message Error {
-    oneof error_state_reason {
-      BaseErrorStateReason base_reason = 1;
-      SyncAccountError sync_account = 2;
-      SyncDeviceError sync_device = 3;
-      RegisterDeviceError register_device = 4;
-      RequestZkNymError request_zk_nym = 5;
-      RequestZkNymBundle request_zk_nym_bundle = 6;
-    }
+    ErrorStateReason reason = 1;
+    // for  errors with details like Dns, Api, Internal
+    optional string detail = 2;
   }
   message Offline {
     bool reconnect = 1;

--- a/proto/nym/vpn.proto
+++ b/proto/nym/vpn.proto
@@ -417,7 +417,7 @@ message TunnelState {
   }
   message Error {
     ErrorStateReason reason = 1;
-    // for  errors with details like Dns, Api, Internal
+    // for errors with details like Dns, Api, Internal
     optional string detail = 2;
   }
   message Offline {


### PR DESCRIPTION
* refactor errors that are exposed to clients
* single point of parsing for specific error cases relevant for clients from vpn api
* simplified errors with single location for errors consumed by clients
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2469)
<!-- Reviewable:end -->
