### PR TITLE
refactor(tauri): drop grpc health service

### DIFF
--- a/nym-vpn-app/src-tauri/src/commands/daemon.rs
+++ b/nym-vpn-app/src-tauri/src/commands/daemon.rs
@@ -23,15 +23,8 @@ pub enum NetworkEnv {
 #[tauri::command]
 pub async fn daemon_status(
     app_state: State<'_, SharedAppState>,
-    grpc_client: State<'_, GrpcClient>,
 ) -> Result<VpndStatus, BackendError> {
-    let status = grpc_client
-        .check(app_state.inner())
-        .await
-        .inspect_err(|e| {
-            warn!("failed to check daemon status: {:?}", e);
-        })
-        .unwrap_or(VpndStatus::Down);
+    let status = app_state.lock().await.vpnd_status.clone();
     debug!("daemon status: {:?}", status);
     Ok(status)
 }

--- a/nym-vpn-app/src-tauri/src/grpc/client.rs
+++ b/nym-vpn-app/src-tauri/src/grpc/client.rs
@@ -479,6 +479,7 @@ impl GrpcClient {
         Ok(gateways)
     }
 
+    #[instrument(skip(self, app))]
     pub async fn update_vpnd_state(
         &mut self,
         info: VpndInfo,

--- a/nym-vpn-app/src-tauri/src/grpc/client.rs
+++ b/nym-vpn-app/src-tauri/src/grpc/client.rs
@@ -2,15 +2,13 @@ use std::env::consts::{ARCH, OS};
 use std::path::PathBuf;
 
 use anyhow::{anyhow, Result};
-use nym_vpn_proto::tunnel_event::Event;
 use nym_vpn_proto::{
     get_account_identity_response::Id as AccountIdRes,
     get_account_links_response::Res as AccountLinkRes,
-    get_device_identity_response::Id as DeviceIdRes, health_check_response::ServingStatus,
-    health_client::HealthClient, is_account_stored_response::Resp as IsAccountStoredResp,
-    nym_vpnd_client::NymVpndClient, ConnectRequest, Dns, GetAccountLinksRequest,
-    HealthCheckRequest, InfoResponse, ListGatewaysRequest, Location, SetNetworkRequest,
-    StoreAccountRequest, UserAgent,
+    get_device_identity_response::Id as DeviceIdRes,
+    is_account_stored_response::Resp as IsAccountStoredResp, nym_vpnd_client::NymVpndClient,
+    tunnel_event::Event, ConnectRequest, Dns, GetAccountLinksRequest, ListGatewaysRequest,
+    Location, SetNetworkRequest, StoreAccountRequest, UserAgent,
 };
 use tauri::{AppHandle, Manager, PackageInfo};
 use tokio::sync::mpsc;
@@ -31,12 +29,10 @@ pub use crate::grpc::network::NetworkCompatVersions;
 
 use crate::cli::Cli;
 use crate::country::Country;
-use crate::env::VPND_COMPAT_REQ;
 use crate::error::BackendError;
 use crate::fs::config::AppConfig;
 use crate::{events::AppHandleEventEmitter, state::SharedAppState};
 
-const VPND_SERVICE: &str = "nym.vpn.NymVpnd";
 #[cfg(target_os = "linux")]
 const DEFAULT_SOCKET_PATH: &str = "/run/nym-vpn.sock";
 #[cfg(target_os = "macos")]
@@ -68,7 +64,7 @@ impl GrpcClient {
     }
 
     /// Create a user agent
-    pub fn user_agent(pkg: &PackageInfo, daemon_info: Option<&InfoResponse>) -> UserAgent {
+    pub fn user_agent(pkg: &PackageInfo, daemon_info: Option<&VpndInfo>) -> UserAgent {
         let app_git_commit = crate::build_info()
             .version_control
             .as_ref()
@@ -100,43 +96,9 @@ impl GrpcClient {
         Ok(NymVpndClient::new(channel))
     }
 
-    /// Get the Health service client
-    #[instrument(skip_all)]
-    pub async fn health(&self) -> Result<HealthClient<Channel>, VpndError> {
-        let channel = get_channel(self.socket.clone()).await.map_err(|e| {
-            warn!("failed to connect to the daemon: {}", e);
-            VpndError::FailedToConnectIpc(e)
-        })?;
-        Ok(HealthClient::new(channel))
-    }
-
-    /// Check the connection with the grpc server
-    #[instrument(skip_all)]
-    pub async fn check(&self, app_state: &SharedAppState) -> Result<VpndStatus> {
-        let mut health = self.health().await?;
-
-        let request = Request::new(HealthCheckRequest {
-            service: VPND_SERVICE.into(),
-        });
-        let response = health
-            .check(request)
-            .await
-            .inspect_err(|e| {
-                error!("health check failed: {}", e);
-            })?
-            .into_inner();
-        let serving = response.status();
-
-        let mut state = app_state.lock().await;
-        let status = self.get_vpnd_status(serving, state.vpnd_info.as_ref());
-        state.vpnd_status = status.clone();
-
-        Ok(status)
-    }
-
     /// Get daemon info
     #[instrument(skip_all)]
-    pub async fn vpnd_info(&self, app: &AppHandle) -> Result<InfoResponse, VpndError> {
+    pub async fn vpnd_info(&mut self) -> Result<VpndInfo, VpndError> {
         let mut vpnd = self.vpnd().await?;
 
         let request = Request::new(());
@@ -149,28 +111,15 @@ impl GrpcClient {
             })?
             .into_inner();
 
-        let app_state = app.state::<SharedAppState>();
-        let mut state = app_state.lock().await;
-        state.vpnd_info = Some(VpndInfo::from(&response));
-        Ok(response)
-    }
-
-    /// Update daemon info and user agent
-    #[instrument(skip_all)]
-    pub async fn update_vpnd_info(&mut self, app: &AppHandle) -> Result<VpndInfo, VpndError> {
-        let res = self.vpnd_info(app).await?;
-        let vpnd_info = VpndInfo::from(&res);
-        self.user_agent = GrpcClient::user_agent(&self.pkg_info, Some(&res));
-        info!("vpnd version: {}", res.version);
+        let info = VpndInfo::from(&response);
+        info!("vpnd UP");
         info!(
-            "network env: {}",
-            res.nym_network
-                .map(|n| n.network_name)
-                .unwrap_or_else(|| "unknown".to_string())
+            "vpnd version: {}, network env: {}",
+            info.version, info.network
         );
-        info!("updated user agent: {:?}", self.user_agent);
-
-        Ok(vpnd_info)
+        self.user_agent = GrpcClient::user_agent(&self.pkg_info, Some(&info));
+        info!("user agent: {:?}", self.user_agent);
+        Ok(info)
     }
 
     /// Get the current tunnel state and update the app state
@@ -530,99 +479,20 @@ impl GrpcClient {
         Ok(gateways)
     }
 
-    /// Watch the connection with the grpc server
-    #[instrument(skip_all)]
-    pub async fn watch(&mut self, app: &AppHandle) -> Result<()> {
-        let mut health = self.health().await?;
+    pub async fn update_vpnd_state(
+        &mut self,
+        info: VpndInfo,
+        app: &AppHandle,
+    ) -> Result<(), VpndError> {
+        let net_compat = self.network_compat().await.ok();
+
         let app_state = app.state::<SharedAppState>();
-
-        let request = Request::new(HealthCheckRequest {
-            service: VPND_SERVICE.into(),
-        });
-        let mut stream = health
-            .watch(request)
-            .await
-            .inspect_err(|e| {
-                error!("health check failed: {}", e);
-            })?
-            .into_inner();
-
-        let (tx, mut rx) = mpsc::channel(32);
-        tokio::spawn(async move {
-            loop {
-                match stream.message().await {
-                    Ok(Some(res)) => {
-                        tx.send(res.status()).await.unwrap();
-                    }
-                    Ok(None) => {
-                        warn!("watch health stream closed by the server");
-                        tx.send(ServingStatus::NotServing).await.unwrap();
-                        return;
-                    }
-                    Err(e) => {
-                        warn!("watch health stream get a grpc error: {}", e);
-                    }
-                }
-            }
-        });
-
-        while let Some(serving) = rx.recv().await {
-            debug!("health check status: {:?}", serving);
-            let mut vpnd_info = None;
-            if serving == ServingStatus::Serving {
-                vpnd_info = self.update_vpnd_info(app).await.ok();
-            }
-            let status = self.get_vpnd_status(serving, vpnd_info.as_ref());
-            app.emit_vpnd_status(status.clone());
-            if serving == ServingStatus::Serving {
-                let net_compat = self.network_compat().await.ok();
-                let mut state = app_state.lock().await;
-                state.set_network_compat(net_compat, &self.pkg_info.version, &vpnd_info);
-            }
-            let mut state = app_state.lock().await;
-            state.vpnd_status = status;
-        }
-
+        let mut state = app_state.lock().await;
+        state.vpnd_info = Some(info.clone());
+        state.set_vpnd_status(&info);
+        state.set_network_compat(net_compat, &self.pkg_info.version, &info);
+        app.emit_vpnd_status(state.vpnd_status.clone());
         Ok(())
-    }
-
-    #[instrument(skip(self))]
-    fn get_vpnd_status(&self, serving: ServingStatus, vpnd_info: Option<&VpndInfo>) -> VpndStatus {
-        if serving != ServingStatus::Serving {
-            return VpndStatus::Down;
-        }
-
-        let Some(ver_req) = VPND_COMPAT_REQ else {
-            warn!("env variable `VPND_COMPAT_REQ` is not set, skipping vpnd version compatibility check");
-            return VpndStatus::Ok(None);
-        };
-        let Some(info) = vpnd_info else {
-            // very unlikely to happen
-            error!("no vpnd info available, skipping vpnd version compatibility check");
-            return VpndStatus::Ok(None);
-        };
-        let Ok(ver) = VersionCheck::new(ver_req) else {
-            warn!("skipping vpnd version compatibility check");
-            return VpndStatus::Ok(Some(info.to_owned()));
-        };
-        let Ok(is_ok) = ver.check(&info.version) else {
-            warn!("skipping vpnd version compatibility check");
-            return VpndStatus::Ok(Some(info.to_owned()));
-        };
-
-        if !is_ok {
-            warn!(
-                "daemon version is not compatible with the client, required [{}], version [{}]",
-                ver_req, info.version
-            );
-            return VpndStatus::NonCompat {
-                current: info.clone(),
-                requirement: ver_req.to_string(),
-            };
-        }
-
-        info!("daemon version compatibility check OK");
-        VpndStatus::Ok(Some(info.to_owned()))
     }
 
     /// Set the network environment of the daemon.

--- a/nym-vpn-app/src-tauri/src/grpc/vpnd_status.rs
+++ b/nym-vpn-app/src-tauri/src/grpc/vpnd_status.rs
@@ -5,14 +5,15 @@ use serde::Serialize;
 use tracing::error;
 use ts_rs::TS;
 
-#[derive(Serialize, Default, Clone, Debug, TS)]
+#[derive(Serialize, Default, Clone, Debug, PartialEq, TS)]
 #[ts(export, export_to = "DaemonInfo.ts")]
 pub struct VpndInfo {
     pub version: String,
     pub network: String,
+    pub git_commit: String,
 }
 
-#[derive(Serialize, Default, Clone, Debug, TS)]
+#[derive(Serialize, Default, Clone, Debug, PartialEq, TS)]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
 pub enum VpndStatus {
@@ -39,6 +40,7 @@ impl From<&InfoResponse> for VpndInfo {
                 .as_ref()
                 .map(|network| network.network_name.to_owned())
                 .unwrap_or_else(|| "unknown".to_string()),
+            git_commit: info.git_commit.clone(),
         }
     }
 }

--- a/nym-vpn-app/src-tauri/src/main.rs
+++ b/nym-vpn-app/src-tauri/src/main.rs
@@ -165,11 +165,6 @@ async fn main() -> Result<()> {
 
             let pkg_info = app.package_info().clone();
             let grpc = GrpcClient::new(&app_config, &cli, &pkg_info);
-            let mut c_grpc = grpc.clone();
-            let handle = app.handle().clone();
-            tokio::spawn(async move {
-                c_grpc.update_vpnd_info(&handle).await.ok();
-            });
 
             app.manage(app_config);
             app.manage(grpc.clone());
@@ -180,30 +175,26 @@ async fn main() -> Result<()> {
                 debug!("splash screen disabled, showing main window");
                 app_window.no_splash();
             }
-
             tray::setup(app.handle())?;
 
             let handle = app.handle().clone();
             let mut c_grpc = grpc.clone();
             tokio::spawn(async move {
-                info!("starting vpnd health spy");
+                info!("starting vpnd spy");
                 loop {
-                    c_grpc.watch(&handle).await.ok();
-                    sleep(VPND_RETRY_INTERVAL).await;
-                    trace!("vpnd health spy retry");
-                }
-            });
-
-            let handle = app.handle().clone();
-            let c_grpc = grpc.clone();
-            tokio::spawn(async move {
-                info!("starting vpn tunnel spy");
-                loop {
-                    if c_grpc.tunnel_state(&handle).await.is_ok() {
+                    if let Ok(info) = c_grpc.vpnd_info().await {
+                        c_grpc.update_vpnd_state(info, &handle).await.ok();
+                        // initialize tunnel state
+                        c_grpc.tunnel_state(&handle).await.ok();
+                        info!("watching vpn tunnel events");
                         c_grpc.watch_tunnel_events(&handle).await.ok();
+                        // if the tunnel stream cuts off, that means vpnd is down
+                        AppState::vpnd_down(&handle).await;
+                    } else {
+                        AppState::vpnd_down(&handle).await;
                     }
                     sleep(VPND_RETRY_INTERVAL).await;
-                    trace!("vpn tunnel spy retry");
+                    trace!("vpnd spy retry");
                 }
             });
 

--- a/nym-vpn-app/src-tauri/src/main.rs
+++ b/nym-vpn-app/src-tauri/src/main.rs
@@ -71,8 +71,8 @@ async fn main() -> Result<()> {
     let _guard = log::setup_tracing(&cli).await?;
     trace!("cli args: {:#?}", cli);
 
-    #[cfg(unix)]
-    misc::nvidia_check();
+    #[cfg(any(target_os = "linux", target_os = "openbsd"))]
+    misc::linux_check();
 
     #[cfg(windows)]
     if cli.console {

--- a/nym-vpn-app/src-tauri/src/misc.rs
+++ b/nym-vpn-app/src-tauri/src/misc.rs
@@ -1,22 +1,26 @@
-#[cfg(unix)]
+#[cfg(any(target_os = "linux", target_os = "openbsd"))]
 use tracing::{info, warn};
 
-// under X11 with nvidia gpu, there is an upstream issue with
-// webkit dmabuf renderer
-// see https://github.com/tauri-apps/tauri/issues/9304
-#[cfg(unix)]
-pub fn nvidia_check() {
-    if std::fs::exists("/dev/nvidia0")
-        .inspect_err(|e| warn!("unable to check for nvidia gpu {}", e))
-        .unwrap_or(false)
-        && std::env::var("XDG_SESSION_TYPE")
-            .unwrap_or_default()
-            .to_lowercase()
-            == "x11"
+#[cfg(any(target_os = "linux", target_os = "openbsd"))]
+pub fn linux_check() {
+    if let Some(display_server) = std::env::var("XDG_SESSION_TYPE")
+        .inspect_err(|e| warn!("XDG_SESSION_TYPE not set or not valid: {e}"))
+        .ok()
+        .map(|s| s.to_lowercase())
     {
-        info!("X11 and nvidia gpu detected, disabling webkit dmabuf renderer");
-        unsafe {
-            std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+        info!("display server: {}", display_server);
+
+        // under X11 with nvidia gpu, there is an upstream issue with webkit dmabuf renderer
+        // see https://github.com/tauri-apps/tauri/issues/9304
+        if display_server == "x11"
+            && std::fs::exists("/dev/nvidia0")
+                .inspect_err(|e| warn!("unable to check for nvidia gpu {}", e))
+                .unwrap_or(false)
+        {
+            info!("nvidia gpu detected, disabling webkit dmabuf renderer");
+            unsafe {
+                std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+            }
         }
     }
 }

--- a/nym-vpn-app/src-tauri/src/state/app.rs
+++ b/nym-vpn-app/src-tauri/src/state/app.rs
@@ -1,12 +1,14 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Manager};
 use tracing::{debug, error, info, instrument, warn};
 use ts_rs::TS;
 
-use crate::env::DEV_MODE;
+use crate::env::{DEV_MODE, VPND_COMPAT_REQ};
 use crate::events::AppHandleEventEmitter;
 use crate::grpc::client::{NetworkCompatVersions, VersionCheck};
 use crate::grpc::tunnel::TunnelState;
+use crate::state::SharedAppState;
 use crate::{
     cli::Cli,
     db::{Db, Key},
@@ -77,11 +79,45 @@ impl AppState {
     }
 
     #[instrument(skip(self))]
+    pub fn set_vpnd_status(&mut self, info: &VpndInfo) {
+        let Some(ver_req) = VPND_COMPAT_REQ else {
+            warn!("env variable `VPND_COMPAT_REQ` is not set, skipping vpnd version compatibility check");
+            self.vpnd_status = VpndStatus::Ok(None);
+            return;
+        };
+        let Ok(ver) = VersionCheck::new(ver_req) else {
+            warn!("skipping vpnd version compatibility check");
+            self.vpnd_status = VpndStatus::Ok(Some(info.to_owned()));
+            return;
+        };
+        match ver.check(&info.version) {
+            Ok(true) => {
+                info!("daemon version compatibility check OK");
+                self.vpnd_status = VpndStatus::Ok(Some(info.to_owned()));
+            }
+            Ok(false) => {
+                warn!(
+                    "daemon version is not compatible with the client, required [{}], version [{}]",
+                    ver_req, info.version
+                );
+                self.vpnd_status = VpndStatus::NonCompat {
+                    current: info.clone(),
+                    requirement: ver_req.to_string(),
+                };
+            }
+            Err(_) => {
+                warn!("skipping vpnd version compatibility check");
+                self.vpnd_status = VpndStatus::Ok(Some(info.to_owned()));
+            }
+        }
+    }
+
+    #[instrument(skip(self))]
     pub fn set_network_compat(
         &mut self,
         network_compat: Option<NetworkCompatVersions>,
         pkg_version: &semver::Version,
-        vpnd_info: &Option<VpndInfo>,
+        info: &VpndInfo,
     ) {
         if *DEV_MODE {
             debug!("dev mode ON, skipping compatibility check");
@@ -92,16 +128,10 @@ impl AppState {
             warn!("no network compatibility data");
             return;
         };
-        let core_compat = if let Some(info) = vpnd_info {
-            let res = check_version(&compat.core, &info.version)
-                .inspect_err(|e| warn!("failed to check core version: {e}"))
-                .ok();
-            log_compat(&info.version, &compat.core, res, "core");
-            res
-        } else {
-            warn!("no vpnd info, skipping compatibility check for daemon");
-            None
-        };
+        let core_compat = check_version(&compat.core, &info.version)
+            .inspect_err(|e| warn!("failed to check core version: {e}"))
+            .ok();
+        log_compat(&info.version, &compat.core, core_compat, "core");
 
         let tauri_ver = pkg_version.to_string();
         let tauri_compat = check_version(&compat.tauri, &tauri_ver)
@@ -110,6 +140,17 @@ impl AppState {
 
         log_compat(&tauri_ver, &compat.tauri, tauri_compat, "tauri");
         self.network_compat = Some(NetworkCompat::new(core_compat, tauri_compat));
+    }
+
+    #[instrument(skip_all)]
+    pub async fn vpnd_down(app: &AppHandle) {
+        let app_state = app.state::<SharedAppState>();
+        let mut state = app_state.lock().await;
+        if state.vpnd_status != VpndStatus::Down {
+            warn!("vpnd DOWN");
+            state.vpnd_status = VpndStatus::Down;
+            app.emit_vpnd_status(state.vpnd_status.clone());
+        }
     }
 }
 

--- a/nym-vpn-app/src/contexts/main/provider.tsx
+++ b/nym-vpn-app/src/contexts/main/provider.tsx
@@ -8,6 +8,7 @@ import { S_STATE } from '../../static';
 import { CCache } from '../../cache';
 import { kvGet, kvSet } from '../../kvStore';
 import { useInAppNotify } from '../in-app-notification';
+import { daemonStatusUpdate } from '../../state/helper';
 import { MainDispatchContext, MainStateContext } from './context';
 import { initialState, reducer } from './reducer';
 
@@ -32,11 +33,12 @@ function MainStateProvider({ children }: Props) {
       return;
     }
     initialized = true;
+    daemonStatusUpdate(S_STATE.vpnd, dispatch, push);
 
     // this first batch is needed to ensure the app is fully
     // initialized and ready, once done splash screen is removed
     // and the UI is shown
-    initFirstBatch(dispatch, push).then(async () => {
+    initFirstBatch(dispatch).then(async () => {
       console.log('init of 1st batch done');
       dispatch({ type: 'init-done' });
       const args = await invoke<Cli>(`cli_args`);
@@ -85,7 +87,7 @@ function MainStateProvider({ children }: Props) {
   }, [networkEnv]);
 
   useEffect(() => {
-    if (S_STATE.systemMessageInit) {
+    if (S_STATE.systemMessageInit || state.daemonStatus === 'down') {
       return;
     }
     S_STATE.systemMessageInit = true;
@@ -108,7 +110,7 @@ function MainStateProvider({ children }: Props) {
       }
     };
     querySystemMessages();
-  }, [push]);
+  }, [push, state.daemonStatus]);
 
   return (
     <MainStateContext.Provider value={state}>

--- a/nym-vpn-app/src/main.tsx
+++ b/nym-vpn-app/src/main.tsx
@@ -12,7 +12,12 @@ import App from './App';
 import { mockTauriIPC } from './dev/setup';
 import { kvGet } from './kvStore';
 import initSentry from './sentry';
-import { StartupError as TStartupError, ThemeMode, VpnMode } from './types';
+import {
+  StartupError as TStartupError,
+  ThemeMode,
+  VpnMode,
+  VpndStatus,
+} from './types';
 import { StartupError } from './screens';
 import { init } from './log';
 import { DefaultVpnMode } from './constants';
@@ -82,6 +87,8 @@ async function setSplashTheme(window: WebviewWindow) {
     S_STATE.devMode = true;
   }
 
+  S_STATE.vpnd =
+    (await invoke<VpndStatus | undefined>('daemon_status')) || 'down';
   S_STATE.vpnModeAtStart = (await kvGet<VpnMode>('vpn-mode')) || DefaultVpnMode;
 
   // check for unrecoverable errors

--- a/nym-vpn-app/src/static.ts
+++ b/nym-vpn-app/src/static.ts
@@ -1,7 +1,10 @@
 // global state managed out of the React tree
-import { VpnMode } from './types';
+import { VpnMode, VpndStatus } from './types';
 
 export type SState = {
+  // the connection status with the daemon at startup
+  vpnd: VpndStatus;
+  // either the vpn mode has been initialized or not
   vpnModeInit: boolean;
   vpnModeAtStart: VpnMode;
   systemMessageInit: boolean;
@@ -9,7 +12,7 @@ export type SState = {
 };
 
 export const S_STATE: SState = {
-  // Either the vpn mode has been initialized or not
+  vpnd: 'down',
   vpnModeInit: false,
   vpnModeAtStart: 'wg',
   systemMessageInit: false,


### PR DESCRIPTION
- drop HealthService usage
- rely on `VpndInfo` and `ListenToEvents` rpces as health checks
- update js to prevent some grpc calls when daemon is down
- log the display server on Linux

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2471)
<!-- Reviewable:end -->
