### PR TITLE
Fix initial flag value for new discovery file

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-network-config/build.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/build.rs
@@ -58,9 +58,23 @@ fn default_mainnet_discovery() {
     let nym_vpn_api_url = json_value["nym_vpn_api_url"]
         .as_str()
         .expect("Failed to parse nym_vpn_api_url");
+    let credential_mode = json_value["feature_flags"]
+        .as_object()
+        .expect("Failed to parse feature_flags")
+        .get("zkNyms")
+        .expect("Failed to find zkNyms value")
+        .as_object()
+        .expect("Failed to parse zkNyms")
+        .get("credentialMode")
+        .expect("Failed to find credentialMode")
+        .as_str()
+        .expect("Failed to parse credentialMode");
 
     let generated_code = format!(
         r#"
+        use std::collections::HashMap;
+        use crate::FlagValue;
+
         impl Default for Discovery {{
             #[allow(clippy::expect_used)]
             fn default() -> Self {{
@@ -69,7 +83,21 @@ fn default_mainnet_discovery() {
                     nym_api_url: "{nym_api_url}".parse().expect("Failed to parse NYM API URL"),
                     nym_vpn_api_url: "{nym_vpn_api_url}".parse().expect("Failed to parse NYM VPN API URL"),
                     account_management: Default::default(),
-                    feature_flags: Default::default(),
+                    feature_flags: Some(
+                        FeatureFlags {{
+                            flags: HashMap::from(
+                                [
+                                    (
+                                        "zkNyms".to_string(), FlagValue::Group(
+                                            HashMap::from(
+                                                [("credentialMode".to_string(), "{credential_mode}".to_string())]
+                                            )
+                                        )    
+                                    )
+                                ]
+                            )
+                        }}
+                    ),
                     system_configuration: Default::default(),
                     system_messages: Default::default(),
                     network_compatibility: Default::default(),

--- a/nym-vpn-core/crates/nym-vpn-network-config/default/mainnet_discovery.json
+++ b/nym-vpn-core/crates/nym-vpn-network-config/default/mainnet_discovery.json
@@ -1,5 +1,10 @@
 {
   "network_name": "mainnet",
   "nym_api_url": "https://validator.nymtech.net/api/",
-  "nym_vpn_api_url": "https://nymvpn.com/api/"
+  "nym_vpn_api_url": "https://nymvpn.com/api/",
+  "feature_flags": {
+    "zkNyms": {
+      "credentialMode": "true"
+    }
+  }
 }


### PR DESCRIPTION
When the discovery file is initially created, the populated default value for zk-nym enable is false, and that value doesn't get updated until the next daemon restart, if that happens after 60 seconds (is considered stale).
Since moving to default zk-nym enabled, we should also make this true in the default values of the initial file

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2481)
<!-- Reviewable:end -->
