### PR TITLE
add llvm-dev libclang-dev clang to readme prerequisites

### DIFF
--- a/nym-vpn-core/crates/nym-gateway-probe/README.md
+++ b/nym-vpn-core/crates/nym-gateway-probe/README.md
@@ -12,7 +12,7 @@ preferred platform.
 
 Install required dependencies
 ```sh
-sudo apt install libdbus-1-dev libmnl-dev libnftnl-dev protobuf-compiler
+sudo apt install libdbus-1-dev libmnl-dev libnftnl-dev protobuf-compiler llvm-dev libclang-dev clang
 ```
 
 Build the wireguard library


### PR DESCRIPTION
Added missing dependencies to readme commands after running into issue building the probe on a clean Ubuntu 22 VM.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2496)
<!-- Reviewable:end -->
