### PR TITLE
chore: disable dependabot on tauri

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,15 +51,3 @@ updates:
           - "*"
         update-types:
           - "patch"
-  - package-ecosystem: cargo
-    directory: /nym-vpn-app/src-tauri
-    schedule:
-      interval: weekly
-    assignees:
-      - "doums"
-    groups:
-      patch-updates:
-        patterns:
-          - "*"
-        update-types:
-          - "patch"


### PR DESCRIPTION
It is completely broken and generate annoying noises (bad PRs + notification spam). 
It is mixing `nym-vpn-core` workspace dependencies with tauri's deps for some reason. As I don't have time to debug it, for now lets drop it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2509)
<!-- Reviewable:end -->
