### PR TITLE
Set max_retransmissions to zero for IP-over-sphinx

### DIFF
--- a/nym-vpn-core/crates/nym-connection-monitor/src/icmp_beacon.rs
+++ b/nym-vpn-core/crates/nym-connection-monitor/src/icmp_beacon.rs
@@ -175,17 +175,15 @@ impl IcmpConnectionBeacon {
 fn wrap_in_mixnet_message(recipient: Recipient, bundled_packets: Bytes) -> Result<InputMessage> {
     let packet = IpPacketRequest::new_data_request(bundled_packets).to_bytes()?;
     let surbs = 0;
-    Ok(create_input_message(recipient, packet, surbs))
-}
-
-fn create_input_message(recipient: Recipient, data: Vec<u8>, surbs: u32) -> InputMessage {
-    nym_sdk::mixnet::InputMessage::new_anonymous(
+    let mixnet_message = nym_sdk::mixnet::InputMessage::new_anonymous(
         recipient,
-        data,
+        packet,
         surbs,
         TransmissionLane::General,
         None,
     )
+    .with_max_retransmissions(Some(0));
+    Ok(mixnet_message)
 }
 
 pub enum IcmpBeaconReply {

--- a/nym-vpn-core/crates/nym-connection-monitor/src/icmp_beacon.rs
+++ b/nym-vpn-core/crates/nym-connection-monitor/src/icmp_beacon.rs
@@ -182,7 +182,7 @@ fn wrap_in_mixnet_message(recipient: Recipient, bundled_packets: Bytes) -> Resul
         TransmissionLane::General,
         None,
     )
-    .with_max_retransmissions(Some(0));
+    .with_max_retransmissions(0);
     Ok(mixnet_message)
 }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/processor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/processor.rs
@@ -331,13 +331,10 @@ impl MixnetMessageSinkTranslator for ToIprDataRequest {
         // sphinx packets that carry the actual data, since we try to keep the payload for IP
         // traffic contained within a single sphinx packet.
         let surbs = 0;
-        Ok(InputMessage::new_anonymous(
-            self.recipient,
-            packet,
-            surbs,
-            lane,
-            packet_type,
-        ))
+        Ok(
+            InputMessage::new_anonymous(self.recipient, packet, surbs, lane, packet_type)
+                .with_max_retransmissions(0),
+        )
     }
 }
 


### PR DESCRIPTION
Disable retransmissions of mixnet messages carrying IP packets.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2513)
<!-- Reviewable:end -->
