### PR TITLE
Include fair usage in account summary

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/shared_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/shared_state.rs
@@ -296,8 +296,8 @@ pub struct DeviceSummary {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct FairUsage {
-    pub used_gb: Option<f64>,
-    pub limit_gb: Option<f64>,
+    pub used_gb: u64,
+    pub limit_gb: u64,
     pub resets_on_utc: Option<String>,
 }
 

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
@@ -56,8 +56,8 @@ pub struct NymVpnAccountSummaryDevices {
 // These fields have the substring 'GB' in them, meaning we can't use `rename_all = "camelCase"`
 // like for the other structs
 pub struct NymVpnAccountSummaryFairUsage {
-    pub usedGB: Option<f64>,
-    pub limitGB: Option<f64>,
+    pub usedGB: u64,
+    pub limitGB: u64,
     pub resetsOnUtc: Option<String>,
 }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/uniffi_custom_impls.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/uniffi_custom_impls.rs
@@ -712,8 +712,8 @@ impl From<nym_vpn_account_controller::shared_state::DeviceSummary> for DeviceSum
 
 #[derive(uniffi::Record, Debug, Clone, PartialEq)]
 pub struct FairUsage {
-    pub used_gb: Option<f64>,
-    pub limit_gb: Option<f64>,
+    pub used_gb: u64,
+    pub limit_gb: u64,
     pub resets_on_utc: Option<String>,
 }
 

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/into_proto/account_shared_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/into_proto/account_shared_state.rs
@@ -3,8 +3,8 @@
 
 use nym_vpn_account_controller::{
     shared_state::{
-        AccountRegistered, AccountState, AccountSummary, DeviceState, DeviceSummary, MnemonicState,
-        RegisterDeviceResult, RequestZkNymResult, SubscriptionState,
+        AccountRegistered, AccountState, AccountSummary, DeviceState, DeviceSummary, FairUsage,
+        MnemonicState, RegisterDeviceResult, RequestZkNymResult, SubscriptionState,
     },
     AccountStateSummary,
 };
@@ -14,7 +14,7 @@ use crate::{
         account_state_summary::{
             account_summary::{
                 AccountState as ProtoAccountState, DeviceSummary as ProtoDeviceSummary,
-                SubscriptionState as ProtoSubscriptionState,
+                FairUsageState as ProtoFairUsageState, SubscriptionState as ProtoSubscriptionState,
             },
             AccountRegistered as ProtoAccountRegistered, AccountSummary as ProtoAccountSummary,
             DeviceState as ProtoDeviceState, MnemonicState as ProtoMnemonicState,
@@ -75,12 +75,23 @@ impl From<DeviceSummary> for ProtoDeviceSummary {
     }
 }
 
+impl From<FairUsage> for ProtoFairUsageState {
+    fn from(fair_usage: FairUsage) -> Self {
+        Self {
+            used_gb: fair_usage.used_gb,
+            limit_gb: fair_usage.limit_gb,
+            resets_on_utc: fair_usage.resets_on_utc,
+        }
+    }
+}
+
 impl From<AccountSummary> for ProtoAccountSummary {
     fn from(account_summary: AccountSummary) -> Self {
         Self {
             account: ProtoAccountState::from(account_summary.account) as i32,
             subscription: ProtoSubscriptionState::from(account_summary.subscription) as i32,
             device_summary: Some(ProtoDeviceSummary::from(account_summary.device_summary)),
+            fair_usage: Some(ProtoFairUsageState::from(account_summary.fair_usage)),
         }
     }
 }

--- a/proto/nym/account.proto
+++ b/proto/nym/account.proto
@@ -181,9 +181,16 @@ message GetAccountStateResponse {
         uint64 remaining = 3;
       }
 
+      message FairUsageState {
+        uint64 limit_gb = 1;
+        uint64 used_gb = 2;
+        optional string resets_on_utc = 3;
+      }
+
       AccountState account = 1;
       SubscriptionState subscription = 2;
       DeviceSummary device_summary = 3;
+      FairUsageState fair_usage = 4;
     }
 
     enum DeviceState {


### PR DESCRIPTION
I noticed fair usage was not included in the gRPC and uniffi account summary response. Include it since we already keep track of it internally.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2533)
<!-- Reviewable:end -->
