### PR TITLE
Remove google dns

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -4920,6 +4920,7 @@ dependencies = [
  "debounced",
  "futures",
  "hickory-proto",
+ "hickory-resolver",
  "hickory-server",
  "ipnetwork",
  "itertools 0.13.0",

--- a/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
@@ -16,6 +16,10 @@ async-trait.workspace = true
 bincode.workspace = true
 bytes.workspace = true
 futures.workspace = true
+hickory-resolver = { workspace = true, features = [
+    "dns-over-tls",
+    "dns-over-https",
+] }
 ipnetwork.workspace = true
 itertools.workspace = true
 lazy_static.workspace = true

--- a/nym-vpn-core/crates/nym-vpn-lib/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/lib.rs
@@ -15,7 +15,9 @@ pub mod tunnel_provider;
 pub mod tunnel_state_machine;
 mod wg_config;
 
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::{net::IpAddr, sync::LazyLock};
+
+use hickory_resolver::config::NameServerConfigGroup;
 
 // Re-export some our nym dependencies
 pub use nym_authenticator_client::Error as AuthenticatorClientError;
@@ -40,18 +42,20 @@ pub use crate::{
     mixnet::MixnetError,
 };
 
-pub const DEFAULT_DNS_SERVERS: [IpAddr; 8] = [
-    // Quad 9
-    IpAddr::V4(Ipv4Addr::new(9, 9, 9, 9)),
-    IpAddr::V4(Ipv4Addr::new(149, 112, 112, 112)),
-    IpAddr::V6(Ipv6Addr::new(0x2620, 0x00fe, 0, 0, 0, 0, 0, 0x00fe)),
-    IpAddr::V6(Ipv6Addr::new(0x2620, 0x00fe, 0, 0, 0, 0, 0x00fe, 0x0009)),
-    // Cloudflare
-    IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)),
-    IpAddr::V4(Ipv4Addr::new(1, 0, 0, 1)),
-    IpAddr::V6(Ipv6Addr::new(0x2606, 0x4700, 0x4700, 0, 0, 0, 0, 0x1111)),
-    IpAddr::V6(Ipv6Addr::new(0x2606, 0x4700, 0x4700, 0, 0, 0, 0, 0x1001)),
-];
+static DEFAULT_DNS_SERVERS_CONFIG: LazyLock<NameServerConfigGroup> = LazyLock::new(|| {
+    let mut name_servers = NameServerConfigGroup::quad9_tls();
+    name_servers.merge(NameServerConfigGroup::quad9_https());
+    name_servers.merge(NameServerConfigGroup::cloudflare_tls());
+    name_servers.merge(NameServerConfigGroup::cloudflare_https());
+    name_servers
+});
+
+pub static DEFAULT_DNS_SERVERS: LazyLock<Vec<IpAddr>> = LazyLock::new(|| {
+    DEFAULT_DNS_SERVERS_CONFIG
+        .iter()
+        .map(|ns| ns.socket_addr.ip())
+        .collect()
+});
 
 #[derive(Clone, Default, Debug, Eq, PartialEq)]
 pub struct MixnetClientConfig {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/lib.rs
@@ -40,12 +40,7 @@ pub use crate::{
     mixnet::MixnetError,
 };
 
-pub const DEFAULT_DNS_SERVERS: [IpAddr; 12] = [
-    // Google Public DNS
-    IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)),
-    IpAddr::V4(Ipv4Addr::new(8, 8, 4, 4)),
-    IpAddr::V6(Ipv6Addr::new(0x2001, 0x4860, 0x4860, 0, 0, 0, 0, 0x8888)),
-    IpAddr::V6(Ipv6Addr::new(0x2001, 0x4860, 0x4860, 0, 0, 0, 0, 0x8844)),
+pub const DEFAULT_DNS_SERVERS: [IpAddr; 8] = [
     // Quad 9
     IpAddr::V4(Ipv4Addr::new(9, 9, 9, 9)),
     IpAddr::V4(Ipv4Addr::new(149, 112, 112, 112)),


### PR DESCRIPTION
- Remove Google Public DNS due to privacy concerns
- Use hickory to obtain IPs for the reminder of IPs

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2558)
<!-- Reviewable:end -->
