### PR TITLE
Skip attempting to register device when connecting with pre-existing ticketbooks

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -508,11 +508,6 @@ impl TunnelMonitor {
             self.account_controller_tx
                 .send(AccountCommand::SyncDeviceState(None))
                 .ok();
-
-            self.send_event(TunnelMonitorEvent::RegisteringDevice);
-            self.account_controller_tx
-                .send(AccountCommand::RegisterDevice(None))
-                .ok();
         } else {
             // If we don't have ticket stored, go through the steps one by one, syncing and
             // registering and getting credentials.


### PR DESCRIPTION
As a workaround for the vpn-api currently returning an error when a
device attempts to re-register a device, skip registering the device as
part of connecting with pre-existing zknyms.

The completion of the device sync vpn-api call should trigger a register
device call if needed. It will be slower, but should be ok in the end.

This cherry-picks #2559 onto `release/2025.5-quince`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2560)
<!-- Reviewable:end -->
