### PR TITLE
Register entry and exit wireguard gateways in parallel

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -3331,7 +3331,6 @@ dependencies = [
 [[package]]
 name = "nym-api-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "bs58",
  "cosmrs",
@@ -3401,7 +3400,6 @@ dependencies = [
 [[package]]
 name = "nym-authenticator-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -3422,7 +3420,6 @@ dependencies = [
 [[package]]
 name = "nym-bandwidth-controller"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "bip39",
  "log",
@@ -3444,7 +3441,6 @@ dependencies = [
 [[package]]
 name = "nym-bin-common"
 version = "0.6.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "const-str",
  "log",
@@ -3459,7 +3455,6 @@ dependencies = [
 [[package]]
 name = "nym-client-core"
 version = "1.1.15"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3521,7 +3516,6 @@ dependencies = [
 [[package]]
 name = "nym-client-core-config-types"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "humantime-serde",
  "nym-config",
@@ -3537,7 +3531,6 @@ dependencies = [
 [[package]]
 name = "nym-client-core-gateways-storage"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "async-trait",
  "cosmrs",
@@ -3556,7 +3549,6 @@ dependencies = [
 [[package]]
 name = "nym-client-core-surb-storage"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -3573,7 +3565,6 @@ dependencies = [
 [[package]]
 name = "nym-coconut-bandwidth-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -3583,7 +3574,6 @@ dependencies = [
 [[package]]
 name = "nym-coconut-dkg-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -3606,7 +3596,6 @@ dependencies = [
 [[package]]
 name = "nym-compact-ecash"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "bincode",
  "bls12_381",
@@ -3629,7 +3618,6 @@ dependencies = [
 [[package]]
 name = "nym-config"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "dirs",
  "handlebars",
@@ -3661,7 +3649,6 @@ dependencies = [
 [[package]]
 name = "nym-contracts-common"
 version = "0.5.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -3676,7 +3663,6 @@ dependencies = [
 [[package]]
 name = "nym-country-group"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "serde",
  "tracing",
@@ -3685,7 +3671,6 @@ dependencies = [
 [[package]]
 name = "nym-credential-proxy-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "async-trait",
  "nym-credentials",
@@ -3705,7 +3690,6 @@ dependencies = [
 [[package]]
 name = "nym-credential-storage"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3723,7 +3707,6 @@ dependencies = [
 [[package]]
 name = "nym-credential-utils"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "log",
  "nym-bandwidth-controller",
@@ -3742,7 +3725,6 @@ dependencies = [
 [[package]]
 name = "nym-credentials"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "bincode",
  "bls12_381",
@@ -3765,7 +3747,6 @@ dependencies = [
 [[package]]
 name = "nym-credentials-interface"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "bls12_381",
  "nym-compact-ecash",
@@ -3782,7 +3763,6 @@ dependencies = [
 [[package]]
 name = "nym-crypto"
 version = "0.4.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "aead",
  "aes",
@@ -3845,7 +3825,6 @@ dependencies = [
 [[package]]
 name = "nym-ecash-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -3859,7 +3838,6 @@ dependencies = [
 [[package]]
 name = "nym-ecash-time"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "nym-compact-ecash",
  "time",
@@ -3868,7 +3846,6 @@ dependencies = [
 [[package]]
 name = "nym-exit-policy"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "serde",
  "serde_json",
@@ -3880,7 +3857,6 @@ dependencies = [
 [[package]]
 name = "nym-explorer-api-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "nym-api-requests",
  "nym-contracts-common",
@@ -3892,7 +3868,6 @@ dependencies = [
 [[package]]
 name = "nym-explorer-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "nym-explorer-api-requests",
  "reqwest 0.12.14",
@@ -3925,7 +3900,6 @@ dependencies = [
 [[package]]
 name = "nym-gateway-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "futures",
  "getrandom 0.2.15",
@@ -4023,7 +3997,6 @@ dependencies = [
 [[package]]
 name = "nym-gateway-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "bs58",
  "futures",
@@ -4052,7 +4025,6 @@ dependencies = [
 [[package]]
 name = "nym-group-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "cosmwasm-schema",
  "cw-controllers",
@@ -4076,7 +4048,6 @@ dependencies = [
 [[package]]
 name = "nym-http-api-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4098,7 +4069,6 @@ dependencies = [
 [[package]]
 name = "nym-http-api-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "axum",
  "axum-client-ip",
@@ -4118,7 +4088,6 @@ dependencies = [
 [[package]]
 name = "nym-id"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "nym-credential-storage",
  "nym-credentials",
@@ -4146,7 +4115,6 @@ dependencies = [
 [[package]]
 name = "nym-ip-packet-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "bincode",
  "bytes",
@@ -4187,7 +4155,6 @@ dependencies = [
 [[package]]
 name = "nym-metrics"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "dashmap",
  "lazy_static",
@@ -4198,7 +4165,6 @@ dependencies = [
 [[package]]
 name = "nym-mixnet-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "dashmap",
  "futures",
@@ -4219,7 +4185,6 @@ dependencies = [
 [[package]]
 name = "nym-mixnet-contract-common"
 version = "0.6.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -4241,7 +4206,6 @@ dependencies = [
 [[package]]
 name = "nym-multisig-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -4257,7 +4221,6 @@ dependencies = [
 [[package]]
 name = "nym-network-defaults"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "cargo_metadata 0.18.1",
  "dotenvy",
@@ -4272,7 +4235,6 @@ dependencies = [
 [[package]]
 name = "nym-node-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "async-trait",
  "celes",
@@ -4295,7 +4257,6 @@ dependencies = [
 [[package]]
 name = "nym-nonexhaustive-delayqueue"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -4325,7 +4286,6 @@ dependencies = [
 [[package]]
 name = "nym-ordered-buffer"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "log",
  "thiserror 2.0.12",
@@ -4334,7 +4294,6 @@ dependencies = [
 [[package]]
 name = "nym-outfox"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "blake3",
  "chacha20",
@@ -4352,7 +4311,6 @@ dependencies = [
 [[package]]
 name = "nym-pemstore"
 version = "0.3.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "pem",
  "tracing",
@@ -4393,7 +4351,6 @@ dependencies = [
 [[package]]
 name = "nym-sdk"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4447,7 +4404,6 @@ dependencies = [
 [[package]]
 name = "nym-serde-helpers"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -4459,7 +4415,6 @@ dependencies = [
 [[package]]
 name = "nym-service-provider-requests-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "serde",
  "thiserror 2.0.12",
@@ -4468,7 +4423,6 @@ dependencies = [
 [[package]]
 name = "nym-service-providers-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "async-trait",
  "log",
@@ -4482,7 +4436,6 @@ dependencies = [
 [[package]]
 name = "nym-socks5-client-core"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4515,7 +4468,6 @@ dependencies = [
 [[package]]
 name = "nym-socks5-proxy-helpers"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "bytes",
  "futures",
@@ -4530,7 +4482,6 @@ dependencies = [
 [[package]]
 name = "nym-socks5-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "bincode",
  "log",
@@ -4546,7 +4497,6 @@ dependencies = [
 [[package]]
 name = "nym-sphinx"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "log",
  "nym-crypto",
@@ -4572,7 +4522,6 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-acknowledgements"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "nym-crypto",
  "nym-pemstore",
@@ -4589,7 +4538,6 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-addressing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-types",
@@ -4600,7 +4548,6 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-anonymous-replies"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "bs58",
  "nym-crypto",
@@ -4618,7 +4565,6 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-chunking"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "dashmap",
  "log",
@@ -4636,7 +4582,6 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-cover"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-acknowledgements",
@@ -4654,7 +4599,6 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-forwarding"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "nym-outfox",
  "nym-sphinx-addressing",
@@ -4666,7 +4610,6 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-framing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "bytes",
  "log",
@@ -4683,7 +4626,6 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-params"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-types",
@@ -4694,7 +4636,6 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-routing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "nym-sphinx-addressing",
  "nym-sphinx-types",
@@ -4704,7 +4645,6 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-types"
 version = "0.2.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "nym-outfox",
  "sphinx-packet",
@@ -4714,7 +4654,6 @@ dependencies = [
 [[package]]
 name = "nym-statistics-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "futures",
  "log",
@@ -4737,7 +4676,6 @@ dependencies = [
 [[package]]
 name = "nym-task"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "cfg-if",
  "futures",
@@ -4754,7 +4692,6 @@ dependencies = [
 [[package]]
 name = "nym-ticketbooks-merkle"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "nym-credentials-interface",
  "nym-serde-helpers",
@@ -4769,7 +4706,6 @@ dependencies = [
 [[package]]
 name = "nym-topology"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "async-trait",
  "nym-api-requests",
@@ -4790,7 +4726,6 @@ dependencies = [
 [[package]]
 name = "nym-validator-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4840,7 +4775,6 @@ dependencies = [
 [[package]]
 name = "nym-vesting-contract-common"
 version = "0.7.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -5184,7 +5118,6 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-types"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "base64 0.22.1",
  "log",
@@ -8304,7 +8237,6 @@ dependencies = [
 [[package]]
 name = "wasm-utils"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#0f6ec8610eb34177f68693795b6eb83602c09f81"
 dependencies = [
  "futures",
  "getrandom 0.2.15",

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -3331,6 +3331,7 @@ dependencies = [
 [[package]]
 name = "nym-api-requests"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "bs58",
  "cosmrs",
@@ -3402,6 +3403,7 @@ dependencies = [
 [[package]]
 name = "nym-authenticator-requests"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -3422,6 +3424,7 @@ dependencies = [
 [[package]]
 name = "nym-bandwidth-controller"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "bip39",
  "log",
@@ -3443,6 +3446,7 @@ dependencies = [
 [[package]]
 name = "nym-bin-common"
 version = "0.6.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "const-str",
  "log",
@@ -3457,6 +3461,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core"
 version = "1.1.15"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3518,6 +3523,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-config-types"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "humantime-serde",
  "nym-config",
@@ -3533,6 +3539,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-gateways-storage"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "async-trait",
  "cosmrs",
@@ -3551,6 +3558,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-surb-storage"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -3567,6 +3575,7 @@ dependencies = [
 [[package]]
 name = "nym-coconut-bandwidth-contract-common"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -3576,6 +3585,7 @@ dependencies = [
 [[package]]
 name = "nym-coconut-dkg-common"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -3598,6 +3608,7 @@ dependencies = [
 [[package]]
 name = "nym-compact-ecash"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "bincode",
  "bls12_381",
@@ -3620,6 +3631,7 @@ dependencies = [
 [[package]]
 name = "nym-config"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "dirs",
  "handlebars",
@@ -3651,6 +3663,7 @@ dependencies = [
 [[package]]
 name = "nym-contracts-common"
 version = "0.5.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -3665,6 +3678,7 @@ dependencies = [
 [[package]]
 name = "nym-country-group"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "serde",
  "tracing",
@@ -3673,6 +3687,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-proxy-requests"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "async-trait",
  "nym-credentials",
@@ -3692,6 +3707,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-storage"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3709,6 +3725,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-utils"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "log",
  "nym-bandwidth-controller",
@@ -3727,6 +3744,7 @@ dependencies = [
 [[package]]
 name = "nym-credentials"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "bincode",
  "bls12_381",
@@ -3749,6 +3767,7 @@ dependencies = [
 [[package]]
 name = "nym-credentials-interface"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "bls12_381",
  "nym-compact-ecash",
@@ -3765,6 +3784,7 @@ dependencies = [
 [[package]]
 name = "nym-crypto"
 version = "0.4.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "aead",
  "aes",
@@ -3827,6 +3847,7 @@ dependencies = [
 [[package]]
 name = "nym-ecash-contract-common"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -3840,6 +3861,7 @@ dependencies = [
 [[package]]
 name = "nym-ecash-time"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "nym-compact-ecash",
  "time",
@@ -3848,6 +3870,7 @@ dependencies = [
 [[package]]
 name = "nym-exit-policy"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "serde",
  "serde_json",
@@ -3859,6 +3882,7 @@ dependencies = [
 [[package]]
 name = "nym-explorer-api-requests"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "nym-api-requests",
  "nym-contracts-common",
@@ -3870,6 +3894,7 @@ dependencies = [
 [[package]]
 name = "nym-explorer-client"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "nym-explorer-api-requests",
  "reqwest 0.12.14",
@@ -3902,6 +3927,7 @@ dependencies = [
 [[package]]
 name = "nym-gateway-client"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "futures",
  "getrandom 0.2.15",
@@ -3999,6 +4025,7 @@ dependencies = [
 [[package]]
 name = "nym-gateway-requests"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "bs58",
  "futures",
@@ -4027,6 +4054,7 @@ dependencies = [
 [[package]]
 name = "nym-group-contract-common"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "cosmwasm-schema",
  "cw-controllers",
@@ -4050,6 +4078,7 @@ dependencies = [
 [[package]]
 name = "nym-http-api-client"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4071,6 +4100,7 @@ dependencies = [
 [[package]]
 name = "nym-http-api-common"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "axum",
  "axum-client-ip",
@@ -4090,6 +4120,7 @@ dependencies = [
 [[package]]
 name = "nym-id"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "nym-credential-storage",
  "nym-credentials",
@@ -4117,6 +4148,7 @@ dependencies = [
 [[package]]
 name = "nym-ip-packet-requests"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "bincode",
  "bytes",
@@ -4157,6 +4189,7 @@ dependencies = [
 [[package]]
 name = "nym-metrics"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "dashmap",
  "lazy_static",
@@ -4167,6 +4200,7 @@ dependencies = [
 [[package]]
 name = "nym-mixnet-client"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "dashmap",
  "futures",
@@ -4187,6 +4221,7 @@ dependencies = [
 [[package]]
 name = "nym-mixnet-contract-common"
 version = "0.6.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -4208,6 +4243,7 @@ dependencies = [
 [[package]]
 name = "nym-multisig-contract-common"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -4223,6 +4259,7 @@ dependencies = [
 [[package]]
 name = "nym-network-defaults"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "cargo_metadata 0.18.1",
  "dotenvy",
@@ -4237,6 +4274,7 @@ dependencies = [
 [[package]]
 name = "nym-node-requests"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "async-trait",
  "celes",
@@ -4259,6 +4297,7 @@ dependencies = [
 [[package]]
 name = "nym-nonexhaustive-delayqueue"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -4288,6 +4327,7 @@ dependencies = [
 [[package]]
 name = "nym-ordered-buffer"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "log",
  "thiserror 2.0.12",
@@ -4296,6 +4336,7 @@ dependencies = [
 [[package]]
 name = "nym-outfox"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "blake3",
  "chacha20",
@@ -4313,6 +4354,7 @@ dependencies = [
 [[package]]
 name = "nym-pemstore"
 version = "0.3.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "pem",
  "tracing",
@@ -4353,6 +4395,7 @@ dependencies = [
 [[package]]
 name = "nym-sdk"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4406,6 +4449,7 @@ dependencies = [
 [[package]]
 name = "nym-serde-helpers"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -4417,6 +4461,7 @@ dependencies = [
 [[package]]
 name = "nym-service-provider-requests-common"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "serde",
  "thiserror 2.0.12",
@@ -4425,6 +4470,7 @@ dependencies = [
 [[package]]
 name = "nym-service-providers-common"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "async-trait",
  "log",
@@ -4438,6 +4484,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-client-core"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4470,6 +4517,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-proxy-helpers"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "bytes",
  "futures",
@@ -4484,6 +4532,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-requests"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "bincode",
  "log",
@@ -4499,6 +4548,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "log",
  "nym-crypto",
@@ -4524,6 +4574,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-acknowledgements"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "nym-crypto",
  "nym-pemstore",
@@ -4540,6 +4591,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-addressing"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-types",
@@ -4550,6 +4602,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-anonymous-replies"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "bs58",
  "nym-crypto",
@@ -4567,6 +4620,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-chunking"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "dashmap",
  "log",
@@ -4584,6 +4638,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-cover"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-acknowledgements",
@@ -4601,6 +4656,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-forwarding"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "nym-outfox",
  "nym-sphinx-addressing",
@@ -4612,6 +4668,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-framing"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "bytes",
  "log",
@@ -4628,6 +4685,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-params"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-types",
@@ -4638,6 +4696,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-routing"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "nym-sphinx-addressing",
  "nym-sphinx-types",
@@ -4647,6 +4706,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-types"
 version = "0.2.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "nym-outfox",
  "sphinx-packet",
@@ -4656,6 +4716,7 @@ dependencies = [
 [[package]]
 name = "nym-statistics-common"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "futures",
  "log",
@@ -4678,6 +4739,7 @@ dependencies = [
 [[package]]
 name = "nym-task"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "cfg-if",
  "futures",
@@ -4694,6 +4756,7 @@ dependencies = [
 [[package]]
 name = "nym-ticketbooks-merkle"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "nym-credentials-interface",
  "nym-serde-helpers",
@@ -4708,6 +4771,7 @@ dependencies = [
 [[package]]
 name = "nym-topology"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "async-trait",
  "nym-api-requests",
@@ -4728,6 +4792,7 @@ dependencies = [
 [[package]]
 name = "nym-validator-client"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4777,6 +4842,7 @@ dependencies = [
 [[package]]
 name = "nym-vesting-contract-common"
 version = "0.7.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -5120,6 +5186,7 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-types"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "base64 0.22.1",
  "log",
@@ -8239,6 +8306,7 @@ dependencies = [
 [[package]]
 name = "wasm-utils"
 version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.5-chokito#82e82943aa14e530ab4eb3aaab28ce86d47e5298"
 dependencies = [
  "futures",
  "getrandom 0.2.15",

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -3384,6 +3384,7 @@ name = "nym-authenticator-client"
 version = "1.7.0-beta"
 dependencies = [
  "bincode",
+ "futures",
  "nym-authenticator-requests",
  "nym-credentials-interface",
  "nym-crypto",
@@ -3394,6 +3395,7 @@ dependencies = [
  "semver",
  "thiserror 2.0.12",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -42,32 +42,32 @@ default-members = [
 ]
 
 # For local development
-[patch."https://github.com/nymtech/nym"]
-nym-authenticator-requests = { path = "../../nym/common/authenticator-requests" }
-nym-api-requests = { path = "../../nym/nym-api/nym-api-requests" }
-nym-bandwidth-controller = { path = "../../nym/common/bandwidth-controller" }
-nym-bin-common = { path = "../../nym/common/bin-common" }
-nym-client-core = { path = "../../nym/common/client-core" }
-nym-compact-ecash = { path = "../../nym/common/nym_offline_compact_ecash" }
-nym-config = { path = "../../nym/common/config" }
-nym-contracts-common = { path = "../../nym/common/cosmwasm-smart-contracts/contracts-common" }
-nym-credential-proxy-requests = { path = "../../nym/nym-credential-proxy/nym-credential-proxy-requests" }
-nym-credential-storage = { path = "../../nym/common/credential-storage" }
-nym-credentials = { path = "../../nym/common/credentials" }
-nym-credentials-interface = { path = "../../nym/common/credentials-interface" }
-nym-crypto = { path = "../../nym/common/crypto" }
-nym-ecash-time = { path = "../../nym/common/ecash-time" }
-nym-http-api-client = { path = "../../nym/common/http-api-client" }
-nym-ip-packet-requests = { path = "../../nym/common/ip-packet-requests" }
-nym-node-requests = { path = "../../nym/nym-node/nym-node-requests" }
-nym-pemstore = { path = "../../nym/common/pemstore" }
-nym-service-provider-requests-common = { path = "../../nym/common/service-provider-requests-common" }
-nym-sdk = { path = "../../nym/sdk/rust/nym-sdk" }
-nym-statistics-common = { path = "../../nym/common/statistics" }
-nym-task = { path = "../../nym/common/task" }
-nym-topology = { path = "../../nym/common/topology" }
-nym-validator-client = { path = "../../nym/common/client-libs/validator-client" }
-nym-wireguard-types = { path = "../../nym/common/wireguard-types" }
+# [patch."https://github.com/nymtech/nym"]
+# nym-authenticator-requests = { path = "../../nym/common/authenticator-requests" }
+# nym-api-requests = { path = "../../nym/nym-api/nym-api-requests" }
+# nym-bandwidth-controller = { path = "../../nym/common/bandwidth-controller" }
+# nym-bin-common = { path = "../../nym/common/bin-common" }
+# nym-client-core = { path = "../../nym/common/client-core" }
+# nym-compact-ecash = { path = "../../nym/common/nym_offline_compact_ecash" }
+# nym-config = { path = "../../nym/common/config" }
+# nym-contracts-common = { path = "../../nym/common/cosmwasm-smart-contracts/contracts-common" }
+# nym-credential-proxy-requests = { path = "../../nym/nym-credential-proxy/nym-credential-proxy-requests" }
+# nym-credential-storage = { path = "../../nym/common/credential-storage" }
+# nym-credentials = { path = "../../nym/common/credentials" }
+# nym-credentials-interface = { path = "../../nym/common/credentials-interface" }
+# nym-crypto = { path = "../../nym/common/crypto" }
+# nym-ecash-time = { path = "../../nym/common/ecash-time" }
+# nym-http-api-client = { path = "../../nym/common/http-api-client" }
+# nym-ip-packet-requests = { path = "../../nym/common/ip-packet-requests" }
+# nym-node-requests = { path = "../../nym/nym-node/nym-node-requests" }
+# nym-pemstore = { path = "../../nym/common/pemstore" }
+# nym-service-provider-requests-common = { path = "../../nym/common/service-provider-requests-common" }
+# nym-sdk = { path = "../../nym/sdk/rust/nym-sdk" }
+# nym-statistics-common = { path = "../../nym/common/statistics" }
+# nym-task = { path = "../../nym/common/task" }
+# nym-topology = { path = "../../nym/common/topology" }
+# nym-validator-client = { path = "../../nym/common/client-libs/validator-client" }
+# nym-wireguard-types = { path = "../../nym/common/wireguard-types" }
 
 [workspace.package]
 version = "1.7.0-beta"

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -42,32 +42,32 @@ default-members = [
 ]
 
 # For local development
-# [patch."https://github.com/nymtech/nym"]
-# nym-authenticator-requests = { path = "../../nym/common/authenticator-requests" }
-# nym-api-requests = { path = "../../nym/nym-api/nym-api-requests" }
-# nym-bandwidth-controller = { path = "../../nym/common/bandwidth-controller" }
-# nym-bin-common = { path = "../../nym/common/bin-common" }
-# nym-client-core = { path = "../../nym/common/client-core" }
-# nym-compact-ecash = { path = "../../nym/common/nym_offline_compact_ecash" }
-# nym-config = { path = "../../nym/common/config" }
-# nym-contracts-common = { path = "../../nym/common/cosmwasm-smart-contracts/contracts-common" }
-# nym-credential-proxy-requests = { path = "../../nym/nym-credential-proxy/nym-credential-proxy-requests" }
-# nym-credential-storage = { path = "../../nym/common/credential-storage" }
-# nym-credentials = { path = "../../nym/common/credentials" }
-# nym-credentials-interface = { path = "../../nym/common/credentials-interface" }
-# nym-crypto = { path = "../../nym/common/crypto" }
-# nym-ecash-time = { path = "../../nym/common/ecash-time" }
-# nym-http-api-client = { path = "../../nym/common/http-api-client" }
-# nym-ip-packet-requests = { path = "../../nym/common/ip-packet-requests" }
-# nym-node-requests = { path = "../../nym/nym-node/nym-node-requests" }
-# nym-pemstore = { path = "../../nym/common/pemstore" }
-# nym-service-provider-requests-common = { path = "../../nym/common/service-provider-requests-common" }
-# nym-sdk = { path = "../../nym/sdk/rust/nym-sdk" }
-# nym-statistics-common = { path = "../../nym/common/statistics" }
-# nym-task = { path = "../../nym/common/task" }
-# nym-topology = { path = "../../nym/common/topology" }
-# nym-validator-client = { path = "../../nym/common/client-libs/validator-client" }
-# nym-wireguard-types = { path = "../../nym/common/wireguard-types" }
+[patch."https://github.com/nymtech/nym"]
+nym-authenticator-requests = { path = "../../nym/common/authenticator-requests" }
+nym-api-requests = { path = "../../nym/nym-api/nym-api-requests" }
+nym-bandwidth-controller = { path = "../../nym/common/bandwidth-controller" }
+nym-bin-common = { path = "../../nym/common/bin-common" }
+nym-client-core = { path = "../../nym/common/client-core" }
+nym-compact-ecash = { path = "../../nym/common/nym_offline_compact_ecash" }
+nym-config = { path = "../../nym/common/config" }
+nym-contracts-common = { path = "../../nym/common/cosmwasm-smart-contracts/contracts-common" }
+nym-credential-proxy-requests = { path = "../../nym/nym-credential-proxy/nym-credential-proxy-requests" }
+nym-credential-storage = { path = "../../nym/common/credential-storage" }
+nym-credentials = { path = "../../nym/common/credentials" }
+nym-credentials-interface = { path = "../../nym/common/credentials-interface" }
+nym-crypto = { path = "../../nym/common/crypto" }
+nym-ecash-time = { path = "../../nym/common/ecash-time" }
+nym-http-api-client = { path = "../../nym/common/http-api-client" }
+nym-ip-packet-requests = { path = "../../nym/common/ip-packet-requests" }
+nym-node-requests = { path = "../../nym/nym-node/nym-node-requests" }
+nym-pemstore = { path = "../../nym/common/pemstore" }
+nym-service-provider-requests-common = { path = "../../nym/common/service-provider-requests-common" }
+nym-sdk = { path = "../../nym/sdk/rust/nym-sdk" }
+nym-statistics-common = { path = "../../nym/common/statistics" }
+nym-task = { path = "../../nym/common/task" }
+nym-topology = { path = "../../nym/common/topology" }
+nym-validator-client = { path = "../../nym/common/client-libs/validator-client" }
+nym-wireguard-types = { path = "../../nym/common/wireguard-types" }
 
 [workspace.package]
 version = "1.7.0-beta"

--- a/nym-vpn-core/crates/nym-authenticator-client/Cargo.toml
+++ b/nym-vpn-core/crates/nym-authenticator-client/Cargo.toml
@@ -9,16 +9,18 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+bincode.workspace = true
+futures.workspace = true
 nym-authenticator-requests.workspace = true
 nym-credentials-interface.workspace = true
 nym-crypto.workspace = true
-nym-service-provider-requests-common.workspace = true
 nym-sdk.workspace = true
+nym-service-provider-requests-common.workspace = true
 nym-wireguard-types.workspace = true
-bincode.workspace = true
-tracing.workspace = true
-thiserror.workspace = true
-tokio.workspace = true
 semver.workspace = true
+thiserror.workspace = true
+tokio-util.workspace = true
+tokio.workspace = true
+tracing.workspace = true
 
 nym-mixnet-client = { workspace = true }

--- a/nym-vpn-core/crates/nym-authenticator-client/Cargo.toml
+++ b/nym-vpn-core/crates/nym-authenticator-client/Cargo.toml
@@ -14,6 +14,7 @@ futures.workspace = true
 nym-authenticator-requests.workspace = true
 nym-credentials-interface.workspace = true
 nym-crypto.workspace = true
+nym-mixnet-client = { workspace = true }
 nym-sdk.workspace = true
 nym-service-provider-requests-common.workspace = true
 nym-wireguard-types.workspace = true
@@ -22,5 +23,3 @@ thiserror.workspace = true
 tokio-util.workspace = true
 tokio.workspace = true
 tracing.workspace = true
-
-nym-mixnet-client = { workspace = true }

--- a/nym-vpn-core/crates/nym-authenticator-client/src/lib.rs
+++ b/nym-vpn-core/crates/nym-authenticator-client/src/lib.rs
@@ -4,7 +4,6 @@ use std::{
     time::Duration,
 };
 
-use futures::StreamExt;
 use nym_authenticator_requests::{
     v2, v3, v4,
     v5::{self, registration::IpPair},
@@ -12,20 +11,22 @@ use nym_authenticator_requests::{
 
 use nym_credentials_interface::CredentialSpendingData;
 use nym_crypto::asymmetric::x25519::PrivateKey;
-use nym_mixnet_client::SharedMixnetClient;
 use nym_sdk::mixnet::{
     ClientStatsEvents, ClientStatsSender, IncludedSurbs, MixnetClientSender, MixnetMessageSender,
     Recipient, ReconstructedMessage, TransmissionLane,
 };
 use nym_service_provider_requests_common::ServiceProviderType;
 use nym_wireguard_types::PeerPublicKey;
-use tokio::{sync::broadcast, task::JoinHandle};
-use tokio_util::sync::CancellationToken;
+use tokio::sync::broadcast;
 use tracing::{debug, error};
 
 mod error;
+mod mixnet_listener;
 
-pub use crate::error::{Error, Result};
+pub use crate::{
+    error::{Error, Result},
+    mixnet_listener::{AuthClientsMixnetListener, AuthClientsMixnetListenerHandle},
+};
 
 pub trait Versionable {
     fn version(&self) -> AuthenticatorVersion;
@@ -1193,114 +1194,5 @@ fn create_input_message(
             TransmissionLane::General,
             None,
         ),
-    }
-}
-
-// The WgGatewayMixnetListener listens to mixnet messages and rebroadcasts them to the
-// WgGatewayClients, or whoever else is interested.
-pub struct WgGatewayMixnetListener {
-    mixnet_client: SharedMixnetClient,
-    message_broadcast: broadcast::Sender<ReconstructedMessage>,
-
-    // Listen to cancel from the outside world
-    external_cancel_token: CancellationToken,
-
-    // Cancel this task, returning to initial state so it can be restarted
-    cancel_token: CancellationToken,
-}
-
-impl WgGatewayMixnetListener {
-    pub fn new(
-        mixnet_client: SharedMixnetClient,
-        external_cancel_token: CancellationToken,
-    ) -> Self {
-        let (message_broadcast, _) = broadcast::channel(100);
-        let cancel_token = CancellationToken::new();
-        Self {
-            mixnet_client,
-            message_broadcast,
-            external_cancel_token,
-            cancel_token,
-        }
-    }
-
-    pub fn subscribe(&self) -> broadcast::Receiver<ReconstructedMessage> {
-        self.message_broadcast.subscribe()
-    }
-
-    async fn run(self) {
-        let mut mixnet_client = self.mixnet_client.lock().await.take().unwrap();
-        loop {
-            tokio::select! {
-                _ = self.external_cancel_token.cancelled() => {
-                    tracing::info!("Mixnet listener shutting down");
-                    break;
-                }
-                _ = self.cancel_token.cancelled() => {
-                    tracing::info!("Mixnet listener stopping and returning to initial state");
-                    break;
-                }
-                event = mixnet_client.next() => {
-                    match event {
-                        Some(event) => {
-                            if let Err(err) = self.message_broadcast.send(event) {
-                                tracing::error!("Failed to broadcast mixnet message: {err}");
-                            }
-                        }
-                        None => {
-                            tracing::error!("Mixnet client stream ended unexpectedly");
-                            break;
-                        }
-                    }
-                }
-            }
-        }
-        self.mixnet_client.lock().await.replace(mixnet_client);
-    }
-
-    pub fn start(self) -> WgGatewayMixnetListenerHandle {
-        let mixnet_client = self.mixnet_client.clone();
-        let message_broadcast = self.message_broadcast.clone();
-        let external_canel_token = self.external_cancel_token.clone();
-        let cancel_token = self.cancel_token.clone();
-
-        let handle = tokio::spawn(self.run());
-
-        WgGatewayMixnetListenerHandle {
-            mixnet_client,
-            message_broadcast,
-            external_canel_token,
-            cancel_token,
-            handle,
-        }
-    }
-}
-
-pub struct WgGatewayMixnetListenerHandle {
-    mixnet_client: SharedMixnetClient,
-    message_broadcast: broadcast::Sender<ReconstructedMessage>,
-    external_canel_token: CancellationToken,
-    cancel_token: CancellationToken,
-    handle: JoinHandle<()>,
-}
-
-impl WgGatewayMixnetListenerHandle {
-    pub async fn cancel(self) -> WgGatewayMixnetListener {
-        self.cancel_token.cancel();
-        if let Err(err) = self.handle.await {
-            tracing::error!("Error while waiting for mixnet listener to stop: {err}");
-        }
-        WgGatewayMixnetListener {
-            mixnet_client: self.mixnet_client,
-            message_broadcast: self.message_broadcast,
-            external_cancel_token: self.external_canel_token,
-            cancel_token: CancellationToken::new(),
-        }
-    }
-
-    pub async fn wait(self) {
-        if let Err(err) = self.handle.await {
-            tracing::error!("Error while waiting for mixnet listener to stop: {err}");
-        }
     }
 }

--- a/nym-vpn-core/crates/nym-authenticator-client/src/lib.rs
+++ b/nym-vpn-core/crates/nym-authenticator-client/src/lib.rs
@@ -18,6 +18,7 @@ use nym_sdk::mixnet::{
 };
 use nym_service_provider_requests_common::ServiceProviderType;
 use nym_wireguard_types::PeerPublicKey;
+use tokio::sync::broadcast;
 use tracing::{debug, error};
 
 mod error;
@@ -1019,16 +1020,31 @@ impl From<semver::Version> for AuthenticatorVersion {
     }
 }
 
-#[derive(Clone)]
 pub struct AuthClient {
     mixnet_client: SharedMixnetClient,
+    mixnet_listener: broadcast::Receiver<ReconstructedMessage>,
     mixnet_sender: MixnetClientSender,
     stats_sender: ClientStatsSender,
     nym_address: Recipient,
 }
 
+impl Clone for AuthClient {
+    fn clone(&self) -> Self {
+        Self {
+            mixnet_client: self.mixnet_client.clone(),
+            mixnet_listener: self.mixnet_listener.resubscribe(),
+            mixnet_sender: self.mixnet_sender.clone(),
+            stats_sender: self.stats_sender.clone(),
+            nym_address: self.nym_address,
+        }
+    }
+}
+
 impl AuthClient {
-    pub async fn new(mixnet_client: SharedMixnetClient) -> Self {
+    pub async fn new(
+        mixnet_client: SharedMixnetClient,
+        mixnet_listener: broadcast::Receiver<ReconstructedMessage>,
+    ) -> Self {
         let mixnet_sender = mixnet_client.lock().await.as_ref().unwrap().split_sender();
         let nym_address = *mixnet_client
             .inner()
@@ -1045,6 +1061,7 @@ impl AuthClient {
             .stats_events_reporter();
         Self {
             mixnet_client,
+            mixnet_listener,
             mixnet_sender,
             stats_sender,
             nym_address,
@@ -1072,21 +1089,12 @@ impl AuthClient {
         message: &ClientMessage,
         authenticator_address: Recipient,
     ) -> Result<AuthenticatorResponse> {
-        // Connecting is basically synchronous from the perspective of the mixnet client, so it's safe
-        // to just grab ahold of the mutex and keep it until we get the response.
-        // This needs to sit here, before sending the request and dropped after getting the response,
-        // so that it doesn't interfere with message to the other gateway (entry/exit).
-        let mut mixnet_client_handle = self.mixnet_client.lock().await;
-        if mixnet_client_handle.is_none() {
-            return Err(Error::UnableToGetMixnetHandle);
-        }
         let request_id = self
             .send_connect_request(message, authenticator_address)
             .await?;
 
         debug!("Waiting for reply...");
-        self.listen_for_connect_response(request_id, mixnet_client_handle.as_mut().unwrap())
-            .await
+        self.listen_for_connect_response(request_id).await
     }
 
     async fn send_connect_request(
@@ -1116,9 +1124,8 @@ impl AuthClient {
     }
 
     async fn listen_for_connect_response(
-        &self,
+        &mut self,
         request_id: u64,
-        mixnet_client: &mut MixnetClient,
     ) -> Result<AuthenticatorResponse> {
         let timeout = tokio::time::sleep(Duration::from_secs(10));
         tokio::pin!(timeout);
@@ -1129,38 +1136,36 @@ impl AuthClient {
                     error!("Timed out waiting for reply to connect request");
                     return Err(Error::TimeoutWaitingForConnectResponse);
                 }
-                msgs = mixnet_client.wait_for_messages() => match msgs {
-                    None => {
+                msg = self.mixnet_listener.recv() => match msg {
+                    Err(_) => {
                         return Err(Error::NoMixnetMessagesReceived);
                     }
-                    Some(msgs) => {
-                        for msg in msgs {
-                            if !check_if_authenticator_message(&msg) {
-                                debug!("Received non-authenticator message while waiting for connect response");
-                                continue;
-                            }
-                            // Confirm that the version is correct
-                            let version = check_auth_message_version(&msg)?;
+                    Ok(msg) => {
+                        if !check_if_authenticator_message(&msg) {
+                            debug!("Received non-authenticator message while waiting for connect response");
+                            continue;
+                        }
+                        // Confirm that the version is correct
+                        let version = check_auth_message_version(&msg)?;
 
-                            // Then we deserialize the message
-                            debug!("AuthClient: got message while waiting for connect response with version {version:?}");
-                            let ret: Result<AuthenticatorResponse> = match version {
-                                AuthenticatorVersion::V2 => v2::response::AuthenticatorResponse::from_reconstructed_message(&msg).map(Into::into).map_err(Into::into),
-                                AuthenticatorVersion::V3 => v3::response::AuthenticatorResponse::from_reconstructed_message(&msg).map(Into::into).map_err(Into::into),
-                                AuthenticatorVersion::V4 => v4::response::AuthenticatorResponse::from_reconstructed_message(&msg).map(Into::into).map_err(Into::into),
-                                AuthenticatorVersion::V5 => v5::response::AuthenticatorResponse::from_reconstructed_message(&msg).map(Into::into).map_err(Into::into),
-                                AuthenticatorVersion::UNKNOWN => Err(Error::UnknownVersion),
-                            };
-                            let Ok(response) = ret else {
-                                // This is ok, it's likely just one of our self-pings
-                                debug!("Failed to deserialize reconstructed message");
-                                continue;
-                            };
+                        // Then we deserialize the message
+                        debug!("AuthClient: got message while waiting for connect response with version {version:?}");
+                        let ret: Result<AuthenticatorResponse> = match version {
+                            AuthenticatorVersion::V2 => v2::response::AuthenticatorResponse::from_reconstructed_message(&msg).map(Into::into).map_err(Into::into),
+                            AuthenticatorVersion::V3 => v3::response::AuthenticatorResponse::from_reconstructed_message(&msg).map(Into::into).map_err(Into::into),
+                            AuthenticatorVersion::V4 => v4::response::AuthenticatorResponse::from_reconstructed_message(&msg).map(Into::into).map_err(Into::into),
+                            AuthenticatorVersion::V5 => v5::response::AuthenticatorResponse::from_reconstructed_message(&msg).map(Into::into).map_err(Into::into),
+                            AuthenticatorVersion::UNKNOWN => Err(Error::UnknownVersion),
+                        };
+                        let Ok(response) = ret else {
+                            // This is ok, it's likely just one of our self-pings
+                            debug!("Failed to deserialize reconstructed message");
+                            continue;
+                        };
 
-                            if response.id() == request_id {
-                                debug!("Got response with matching id");
-                                return Ok(response);
-                            }
+                        if response.id() == request_id {
+                            debug!("Got response with matching id");
+                            return Ok(response);
                         }
                     }
                 }

--- a/nym-vpn-core/crates/nym-authenticator-client/src/lib.rs
+++ b/nym-vpn-core/crates/nym-authenticator-client/src/lib.rs
@@ -1057,16 +1057,6 @@ impl AuthClient {
         }
     }
 
-    //pub async fn new_from(mixnet_interaction: MixnetInteraction) -> Self {
-    //    Self::new(
-    //        mixnet_interaction.sender,
-    //        mixnet_interaction.receiver,
-    //        mixnet_interaction.stats_sender,
-    //        mixnet_interaction.our_nym_address,
-    //    )
-    //    .await
-    //}
-    //
     pub async fn send(
         &mut self,
         message: &ClientMessage,

--- a/nym-vpn-core/crates/nym-authenticator-client/src/lib.rs
+++ b/nym-vpn-core/crates/nym-authenticator-client/src/lib.rs
@@ -25,8 +25,7 @@ mod mixnet_listener;
 pub use crate::{
     error::{Error, Result},
     mixnet_listener::{
-        AuthClientMixnetListener, AuthClientMixnetListenerHandle, MixnetInteraction,
-        MixnetMessageBroadcastReceiver,
+        AuthClientMixnetListener, AuthClientMixnetListenerHandle, MixnetMessageBroadcastReceiver,
     },
 };
 
@@ -1058,16 +1057,16 @@ impl AuthClient {
         }
     }
 
-    pub async fn new_from(mixnet_interaction: MixnetInteraction) -> Self {
-        Self::new(
-            mixnet_interaction.sender,
-            mixnet_interaction.receiver,
-            mixnet_interaction.stats_sender,
-            mixnet_interaction.our_nym_address,
-        )
-        .await
-    }
-
+    //pub async fn new_from(mixnet_interaction: MixnetInteraction) -> Self {
+    //    Self::new(
+    //        mixnet_interaction.sender,
+    //        mixnet_interaction.receiver,
+    //        mixnet_interaction.stats_sender,
+    //        mixnet_interaction.our_nym_address,
+    //    )
+    //    .await
+    //}
+    //
     pub async fn send(
         &mut self,
         message: &ClientMessage,

--- a/nym-vpn-core/crates/nym-authenticator-client/src/lib.rs
+++ b/nym-vpn-core/crates/nym-authenticator-client/src/lib.rs
@@ -14,8 +14,8 @@ use nym_credentials_interface::CredentialSpendingData;
 use nym_crypto::asymmetric::x25519::PrivateKey;
 use nym_mixnet_client::SharedMixnetClient;
 use nym_sdk::mixnet::{
-    ClientStatsEvents, ClientStatsSender, IncludedSurbs, MixnetClient, MixnetClientSender,
-    MixnetMessageSender, Recipient, ReconstructedMessage, TransmissionLane,
+    ClientStatsEvents, ClientStatsSender, IncludedSurbs, MixnetClientSender, MixnetMessageSender,
+    Recipient, ReconstructedMessage, TransmissionLane,
 };
 use nym_service_provider_requests_common::ServiceProviderType;
 use nym_wireguard_types::PeerPublicKey;
@@ -1023,55 +1023,36 @@ impl From<semver::Version> for AuthenticatorVersion {
 }
 
 pub struct AuthClient {
-    mixnet_client: SharedMixnetClient,
     mixnet_listener: broadcast::Receiver<ReconstructedMessage>,
     mixnet_sender: MixnetClientSender,
     stats_sender: ClientStatsSender,
-    nym_address: Recipient,
+    our_nym_address: Recipient,
 }
 
 impl Clone for AuthClient {
     fn clone(&self) -> Self {
         Self {
-            mixnet_client: self.mixnet_client.clone(),
             mixnet_listener: self.mixnet_listener.resubscribe(),
             mixnet_sender: self.mixnet_sender.clone(),
             stats_sender: self.stats_sender.clone(),
-            nym_address: self.nym_address,
+            our_nym_address: self.our_nym_address,
         }
     }
 }
 
 impl AuthClient {
     pub async fn new(
-        mixnet_client: SharedMixnetClient,
+        mixnet_sender: MixnetClientSender,
         mixnet_listener: broadcast::Receiver<ReconstructedMessage>,
+        stats_sender: ClientStatsSender,
+        our_nym_address: Recipient,
     ) -> Self {
-        let mixnet_sender = mixnet_client.lock().await.as_ref().unwrap().split_sender();
-        let nym_address = *mixnet_client
-            .inner()
-            .lock()
-            .await
-            .as_ref()
-            .unwrap()
-            .nym_address();
-        let stats_sender = mixnet_client
-            .lock()
-            .await
-            .as_ref()
-            .unwrap()
-            .stats_events_reporter();
         Self {
-            mixnet_client,
             mixnet_listener,
             mixnet_sender,
             stats_sender,
-            nym_address,
+            our_nym_address,
         }
-    }
-
-    pub fn mixnet_client(&self) -> SharedMixnetClient {
-        self.mixnet_client.clone()
     }
 
     pub async fn send(
@@ -1104,7 +1085,7 @@ impl AuthClient {
         message: &ClientMessage,
         authenticator_address: Recipient,
     ) -> Result<u64> {
-        let (data, request_id) = message.bytes(self.nym_address)?;
+        let (data, request_id) = message.bytes(self.our_nym_address)?;
 
         // We use 20 surbs for the connect request because typically the
         // authenticator mixnet client on the nym-node is configured to have a min
@@ -1306,12 +1287,20 @@ pub struct WgGatewayMixnetListenerHandle {
 impl WgGatewayMixnetListenerHandle {
     pub async fn cancel(self) -> WgGatewayMixnetListener {
         self.cancel_token.cancel();
-        self.handle.await.unwrap();
+        if let Err(err) = self.handle.await {
+            tracing::error!("Error while waiting for mixnet listener to stop: {err}");
+        }
         WgGatewayMixnetListener {
             mixnet_client: self.mixnet_client,
             message_broadcast: self.message_broadcast,
             external_cancel_token: self.external_canel_token,
             cancel_token: CancellationToken::new(),
+        }
+    }
+
+    pub async fn wait(self) {
+        if let Err(err) = self.handle.await {
+            tracing::error!("Error while waiting for mixnet listener to stop: {err}");
         }
     }
 }

--- a/nym-vpn-core/crates/nym-authenticator-client/src/lib.rs
+++ b/nym-vpn-core/crates/nym-authenticator-client/src/lib.rs
@@ -4,6 +4,7 @@ use std::{
     time::Duration,
 };
 
+use futures::StreamExt;
 use nym_authenticator_requests::{
     v2, v3, v4,
     v5::{self, registration::IpPair},
@@ -18,7 +19,8 @@ use nym_sdk::mixnet::{
 };
 use nym_service_provider_requests_common::ServiceProviderType;
 use nym_wireguard_types::PeerPublicKey;
-use tokio::sync::broadcast;
+use tokio::{sync::broadcast, task::JoinHandle};
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, error};
 
 mod error;
@@ -1210,5 +1212,106 @@ fn create_input_message(
             TransmissionLane::General,
             None,
         ),
+    }
+}
+
+// The WgGatewayMixnetListener listens to mixnet messages and rebroadcasts them to the
+// WgGatewayClients, or whoever else is interested.
+pub struct WgGatewayMixnetListener {
+    mixnet_client: SharedMixnetClient,
+    message_broadcast: broadcast::Sender<ReconstructedMessage>,
+
+    // Listen to cancel from the outside world
+    external_cancel_token: CancellationToken,
+
+    // Cancel this task, returning to initial state so it can be restarted
+    cancel_token: CancellationToken,
+}
+
+impl WgGatewayMixnetListener {
+    pub fn new(
+        mixnet_client: SharedMixnetClient,
+        external_cancel_token: CancellationToken,
+    ) -> Self {
+        let (message_broadcast, _) = broadcast::channel(100);
+        let cancel_token = CancellationToken::new();
+        Self {
+            mixnet_client,
+            message_broadcast,
+            external_cancel_token,
+            cancel_token,
+        }
+    }
+
+    pub fn subscribe(&self) -> broadcast::Receiver<ReconstructedMessage> {
+        self.message_broadcast.subscribe()
+    }
+
+    async fn run(self) {
+        let mut mixnet_client = self.mixnet_client.lock().await.take().unwrap();
+        loop {
+            tokio::select! {
+                _ = self.external_cancel_token.cancelled() => {
+                    tracing::info!("Mixnet listener shutting down");
+                    break;
+                }
+                _ = self.cancel_token.cancelled() => {
+                    tracing::info!("Mixnet listener stopping and returning to initial state");
+                    break;
+                }
+                event = mixnet_client.next() => {
+                    match event {
+                        Some(event) => {
+                            if let Err(err) = self.message_broadcast.send(event) {
+                                tracing::error!("Failed to broadcast mixnet message: {err}");
+                            }
+                        }
+                        None => {
+                            tracing::error!("Mixnet client stream ended unexpectedly");
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        self.mixnet_client.lock().await.replace(mixnet_client);
+    }
+
+    pub fn start(self) -> WgGatewayMixnetListenerHandle {
+        let mixnet_client = self.mixnet_client.clone();
+        let message_broadcast = self.message_broadcast.clone();
+        let external_canel_token = self.external_cancel_token.clone();
+        let cancel_token = self.cancel_token.clone();
+
+        let handle = tokio::spawn(self.run());
+
+        WgGatewayMixnetListenerHandle {
+            mixnet_client,
+            message_broadcast,
+            external_canel_token,
+            cancel_token,
+            handle,
+        }
+    }
+}
+
+pub struct WgGatewayMixnetListenerHandle {
+    mixnet_client: SharedMixnetClient,
+    message_broadcast: broadcast::Sender<ReconstructedMessage>,
+    external_canel_token: CancellationToken,
+    cancel_token: CancellationToken,
+    handle: JoinHandle<()>,
+}
+
+impl WgGatewayMixnetListenerHandle {
+    pub async fn cancel(self) -> WgGatewayMixnetListener {
+        self.cancel_token.cancel();
+        self.handle.await.unwrap();
+        WgGatewayMixnetListener {
+            mixnet_client: self.mixnet_client,
+            message_broadcast: self.message_broadcast,
+            external_cancel_token: self.external_canel_token,
+            cancel_token: CancellationToken::new(),
+        }
     }
 }

--- a/nym-vpn-core/crates/nym-authenticator-client/src/lib.rs
+++ b/nym-vpn-core/crates/nym-authenticator-client/src/lib.rs
@@ -17,7 +17,6 @@ use nym_sdk::mixnet::{
 };
 use nym_service_provider_requests_common::ServiceProviderType;
 use nym_wireguard_types::PeerPublicKey;
-use tokio::sync::broadcast;
 use tracing::{debug, error};
 
 mod error;
@@ -25,7 +24,10 @@ mod mixnet_listener;
 
 pub use crate::{
     error::{Error, Result},
-    mixnet_listener::{AuthClientsMixnetListener, AuthClientsMixnetListenerHandle},
+    mixnet_listener::{
+        AuthClientMixnetListener, AuthClientMixnetListenerHandle, MixnetInteraction,
+        MixnetMessageBroadcastReceiver,
+    },
 };
 
 pub trait Versionable {
@@ -1024,7 +1026,7 @@ impl From<semver::Version> for AuthenticatorVersion {
 }
 
 pub struct AuthClient {
-    mixnet_listener: broadcast::Receiver<ReconstructedMessage>,
+    mixnet_listener: MixnetMessageBroadcastReceiver,
     mixnet_sender: MixnetClientSender,
     stats_sender: ClientStatsSender,
     our_nym_address: Recipient,
@@ -1044,7 +1046,7 @@ impl Clone for AuthClient {
 impl AuthClient {
     pub async fn new(
         mixnet_sender: MixnetClientSender,
-        mixnet_listener: broadcast::Receiver<ReconstructedMessage>,
+        mixnet_listener: MixnetMessageBroadcastReceiver,
         stats_sender: ClientStatsSender,
         our_nym_address: Recipient,
     ) -> Self {
@@ -1054,6 +1056,16 @@ impl AuthClient {
             stats_sender,
             our_nym_address,
         }
+    }
+
+    pub async fn new_from(mixnet_interaction: MixnetInteraction) -> Self {
+        Self::new(
+            mixnet_interaction.sender,
+            mixnet_interaction.receiver,
+            mixnet_interaction.stats_sender,
+            mixnet_interaction.our_nym_address,
+        )
+        .await
     }
 
     pub async fn send(

--- a/nym-vpn-core/crates/nym-authenticator-client/src/mixnet_listener.rs
+++ b/nym-vpn-core/crates/nym-authenticator-client/src/mixnet_listener.rs
@@ -29,18 +29,19 @@ pub struct AuthClientsMixnetListener {
 }
 
 impl AuthClientsMixnetListener {
-    pub fn new(
-        mixnet_client: SharedMixnetClient,
-        external_cancel_token: Option<CancellationToken>,
-    ) -> Self {
+    pub fn new(mixnet_client: SharedMixnetClient) -> Self {
         let (message_broadcast, _) = broadcast::channel(100);
-        let external_cancel_token = external_cancel_token.unwrap_or_else(CancellationToken::new);
         Self {
             mixnet_client,
             message_broadcast,
-            external_cancel_token,
+            external_cancel_token: CancellationToken::new(),
             internal_cancel_token: CancellationToken::new(),
         }
+    }
+
+    pub fn with_external_cancel_token(mut self, external_cancel_token: CancellationToken) -> Self {
+        self.external_cancel_token = external_cancel_token;
+        self
     }
 
     pub fn subscribe(&self) -> broadcast::Receiver<ReconstructedMessage> {

--- a/nym-vpn-core/crates/nym-authenticator-client/src/mixnet_listener.rs
+++ b/nym-vpn-core/crates/nym-authenticator-client/src/mixnet_listener.rs
@@ -19,8 +19,8 @@ pub type MixnetMessageBroadcastReceiver = broadcast::Receiver<Arc<ReconstructedM
 // While it is running, it has a lock on the shared mixnet client. This is the reason it's
 // designed to be able to start and stop, so that the lock can be released when it's not needed.
 //
-// NOTE: this comes at the cost of cloning all incoming messages, meaning this is not intended for
-// high data rate applications. Only for controll messages like the ones used by the authenticator.
+// NOTE: this is potentially bit wasteful. Ideally we should have proper channels where the
+// recipient only gets messages they're interested in.
 pub struct AuthClientMixnetListener {
     // The shared mixnet client that we're listening to
     mixnet_client: SharedMixnetClient,

--- a/nym-vpn-core/crates/nym-authenticator-client/src/mixnet_listener.rs
+++ b/nym-vpn-core/crates/nym-authenticator-client/src/mixnet_listener.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use futures::StreamExt;
 use nym_mixnet_client::SharedMixnetClient;
-use nym_sdk::mixnet::{ClientStatsSender, MixnetClientSender, Recipient, ReconstructedMessage};
+use nym_sdk::mixnet::ReconstructedMessage;
 use tokio::{sync::broadcast, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
 
@@ -113,12 +113,11 @@ pub struct AuthClientMixnetListenerHandle {
 
 impl AuthClientMixnetListenerHandle {
     pub async fn new_auth_client(&self) -> AuthClient {
-        AuthClient::new_from(
-            MixnetInteraction::new(
-                self.mixnet_client.clone(),
-                self.message_broadcast.subscribe(),
-            )
-            .await,
+        AuthClient::new(
+            self.mixnet_client.split_sender().await,
+            self.message_broadcast.subscribe(),
+            self.mixnet_client.stats_sender().await,
+            self.mixnet_client.nym_address().await,
         )
         .await
     }
@@ -143,28 +142,6 @@ impl AuthClientMixnetListenerHandle {
     pub async fn wait(self) {
         if let Err(err) = self.handle.await {
             tracing::error!("Error while waiting for auth clients mixnet listener to stop: {err}");
-        }
-    }
-}
-
-// Bundle the components used to interact with the mixnet
-pub struct MixnetInteraction {
-    pub sender: MixnetClientSender,
-    pub receiver: MixnetMessageBroadcastReceiver,
-    pub stats_sender: ClientStatsSender,
-    pub our_nym_address: Recipient,
-}
-
-impl MixnetInteraction {
-    pub async fn new(
-        shared_mixnet_client: SharedMixnetClient,
-        receiver: MixnetMessageBroadcastReceiver,
-    ) -> Self {
-        Self {
-            sender: shared_mixnet_client.split_sender().await,
-            receiver,
-            stats_sender: shared_mixnet_client.stats_sender().await,
-            our_nym_address: shared_mixnet_client.nym_address().await,
         }
     }
 }

--- a/nym-vpn-core/crates/nym-authenticator-client/src/mixnet_listener.rs
+++ b/nym-vpn-core/crates/nym-authenticator-client/src/mixnet_listener.rs
@@ -1,11 +1,18 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use std::sync::Arc;
+
 use futures::StreamExt;
 use nym_mixnet_client::SharedMixnetClient;
-use nym_sdk::mixnet::ReconstructedMessage;
+use nym_sdk::mixnet::{ClientStatsSender, MixnetClientSender, Recipient, ReconstructedMessage};
 use tokio::{sync::broadcast, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
+
+use crate::AuthClient;
+
+pub type MixnetMessageBroadcastSender = broadcast::Sender<Arc<ReconstructedMessage>>;
+pub type MixnetMessageBroadcastReceiver = broadcast::Receiver<Arc<ReconstructedMessage>>;
 
 // The AuthClientsMixnetListener listens to mixnet messages and rebroadcasts them to the
 // AuthClients, or whoever else is interested.
@@ -14,12 +21,12 @@ use tokio_util::sync::CancellationToken;
 //
 // NOTE: this comes at the cost of cloning all incoming messages, meaning this is not intended for
 // high data rate applications. Only for controll messages like the ones used by the authenticator.
-pub struct AuthClientsMixnetListener {
+pub struct AuthClientMixnetListener {
     // The shared mixnet client that we're listening to
     mixnet_client: SharedMixnetClient,
 
     // Broadcast channel for the messages that we re-broadcast to the AuthClients
-    message_broadcast: broadcast::Sender<ReconstructedMessage>,
+    message_broadcast: MixnetMessageBroadcastSender,
 
     // Listen to cancel from the outside world
     external_cancel_token: CancellationToken,
@@ -28,7 +35,7 @@ pub struct AuthClientsMixnetListener {
     internal_cancel_token: CancellationToken,
 }
 
-impl AuthClientsMixnetListener {
+impl AuthClientMixnetListener {
     pub fn new(mixnet_client: SharedMixnetClient) -> Self {
         let (message_broadcast, _) = broadcast::channel(100);
         Self {
@@ -44,7 +51,7 @@ impl AuthClientsMixnetListener {
         self
     }
 
-    pub fn subscribe(&self) -> broadcast::Receiver<ReconstructedMessage> {
+    pub fn subscribe(&self) -> MixnetMessageBroadcastReceiver {
         self.message_broadcast.subscribe()
     }
 
@@ -63,7 +70,7 @@ impl AuthClientsMixnetListener {
                 event = mixnet_client.next() => {
                     match event {
                         Some(event) => {
-                            if let Err(err) = self.message_broadcast.send(event) {
+                            if let Err(err) = self.message_broadcast.send(Arc::new(event)) {
                                 tracing::error!("Failed to broadcast mixnet message: {err}");
                             }
                         }
@@ -78,7 +85,7 @@ impl AuthClientsMixnetListener {
         self.mixnet_client.lock().await.replace(mixnet_client);
     }
 
-    pub fn start(self) -> AuthClientsMixnetListenerHandle {
+    pub fn start(self) -> AuthClientMixnetListenerHandle {
         let mixnet_client = self.mixnet_client.clone();
         let message_broadcast = self.message_broadcast.clone();
         let external_canel_token = self.external_cancel_token.clone();
@@ -86,7 +93,7 @@ impl AuthClientsMixnetListener {
 
         let handle = tokio::spawn(self.run());
 
-        AuthClientsMixnetListenerHandle {
+        AuthClientMixnetListenerHandle {
             mixnet_client,
             message_broadcast,
             external_canel_token,
@@ -96,25 +103,36 @@ impl AuthClientsMixnetListener {
     }
 }
 
-pub struct AuthClientsMixnetListenerHandle {
+pub struct AuthClientMixnetListenerHandle {
     mixnet_client: SharedMixnetClient,
-    message_broadcast: broadcast::Sender<ReconstructedMessage>,
+    message_broadcast: MixnetMessageBroadcastSender,
     external_canel_token: CancellationToken,
     cancel_token: CancellationToken,
     handle: JoinHandle<()>,
 }
 
-impl AuthClientsMixnetListenerHandle {
-    pub fn subscribe(&self) -> broadcast::Receiver<ReconstructedMessage> {
+impl AuthClientMixnetListenerHandle {
+    pub async fn new_auth_client(&self) -> AuthClient {
+        AuthClient::new_from(
+            MixnetInteraction::new(
+                self.mixnet_client.clone(),
+                self.message_broadcast.subscribe(),
+            )
+            .await,
+        )
+        .await
+    }
+
+    pub fn subscribe(&self) -> MixnetMessageBroadcastReceiver {
         self.message_broadcast.subscribe()
     }
 
-    pub async fn cancel(self) -> AuthClientsMixnetListener {
+    pub async fn cancel(self) -> AuthClientMixnetListener {
         self.cancel_token.cancel();
         if let Err(err) = self.handle.await {
             tracing::error!("Error while waiting for auth clients mixnet listener to stop: {err}");
         }
-        AuthClientsMixnetListener {
+        AuthClientMixnetListener {
             mixnet_client: self.mixnet_client,
             message_broadcast: self.message_broadcast,
             external_cancel_token: self.external_canel_token,
@@ -125,6 +143,28 @@ impl AuthClientsMixnetListenerHandle {
     pub async fn wait(self) {
         if let Err(err) = self.handle.await {
             tracing::error!("Error while waiting for auth clients mixnet listener to stop: {err}");
+        }
+    }
+}
+
+// Bundle the components used to interact with the mixnet
+pub struct MixnetInteraction {
+    pub sender: MixnetClientSender,
+    pub receiver: MixnetMessageBroadcastReceiver,
+    pub stats_sender: ClientStatsSender,
+    pub our_nym_address: Recipient,
+}
+
+impl MixnetInteraction {
+    pub async fn new(
+        shared_mixnet_client: SharedMixnetClient,
+        receiver: MixnetMessageBroadcastReceiver,
+    ) -> Self {
+        Self {
+            sender: shared_mixnet_client.split_sender().await,
+            receiver,
+            stats_sender: shared_mixnet_client.stats_sender().await,
+            our_nym_address: shared_mixnet_client.nym_address().await,
         }
     }
 }

--- a/nym-vpn-core/crates/nym-authenticator-client/src/mixnet_listener.rs
+++ b/nym-vpn-core/crates/nym-authenticator-client/src/mixnet_listener.rs
@@ -1,0 +1,129 @@
+// Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use futures::StreamExt;
+use nym_mixnet_client::SharedMixnetClient;
+use nym_sdk::mixnet::ReconstructedMessage;
+use tokio::{sync::broadcast, task::JoinHandle};
+use tokio_util::sync::CancellationToken;
+
+// The AuthClientsMixnetListener listens to mixnet messages and rebroadcasts them to the
+// AuthClients, or whoever else is interested.
+// While it is running, it has a lock on the shared mixnet client. This is the reason it's
+// designed to be able to start and stop, so that the lock can be released when it's not needed.
+//
+// NOTE: this comes at the cost of cloning all incoming messages, meaning this is not intended for
+// high data rate applications. Only for controll messages like the ones used by the authenticator.
+pub struct AuthClientsMixnetListener {
+    // The shared mixnet client that we're listening to
+    mixnet_client: SharedMixnetClient,
+
+    // Broadcast channel for the messages that we re-broadcast to the AuthClients
+    message_broadcast: broadcast::Sender<ReconstructedMessage>,
+
+    // Listen to cancel from the outside world
+    external_cancel_token: CancellationToken,
+
+    // Cancel this task, returning to initial state so it can be restarted
+    internal_cancel_token: CancellationToken,
+}
+
+impl AuthClientsMixnetListener {
+    pub fn new(
+        mixnet_client: SharedMixnetClient,
+        external_cancel_token: Option<CancellationToken>,
+    ) -> Self {
+        let (message_broadcast, _) = broadcast::channel(100);
+        let external_cancel_token = external_cancel_token.unwrap_or_else(CancellationToken::new);
+        Self {
+            mixnet_client,
+            message_broadcast,
+            external_cancel_token,
+            internal_cancel_token: CancellationToken::new(),
+        }
+    }
+
+    pub fn subscribe(&self) -> broadcast::Receiver<ReconstructedMessage> {
+        self.message_broadcast.subscribe()
+    }
+
+    async fn run(self) {
+        let mut mixnet_client = self.mixnet_client.lock().await.take().unwrap();
+        loop {
+            tokio::select! {
+                _ = self.external_cancel_token.cancelled() => {
+                    tracing::info!("Mixnet listener shutting down");
+                    break;
+                }
+                _ = self.internal_cancel_token.cancelled() => {
+                    tracing::info!("Mixnet listener stopping and returning to initial state");
+                    break;
+                }
+                event = mixnet_client.next() => {
+                    match event {
+                        Some(event) => {
+                            if let Err(err) = self.message_broadcast.send(event) {
+                                tracing::error!("Failed to broadcast mixnet message: {err}");
+                            }
+                        }
+                        None => {
+                            tracing::error!("Mixnet client stream ended unexpectedly");
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        self.mixnet_client.lock().await.replace(mixnet_client);
+    }
+
+    pub fn start(self) -> AuthClientsMixnetListenerHandle {
+        let mixnet_client = self.mixnet_client.clone();
+        let message_broadcast = self.message_broadcast.clone();
+        let external_canel_token = self.external_cancel_token.clone();
+        let cancel_token = self.internal_cancel_token.clone();
+
+        let handle = tokio::spawn(self.run());
+
+        AuthClientsMixnetListenerHandle {
+            mixnet_client,
+            message_broadcast,
+            external_canel_token,
+            cancel_token,
+            handle,
+        }
+    }
+}
+
+pub struct AuthClientsMixnetListenerHandle {
+    mixnet_client: SharedMixnetClient,
+    message_broadcast: broadcast::Sender<ReconstructedMessage>,
+    external_canel_token: CancellationToken,
+    cancel_token: CancellationToken,
+    handle: JoinHandle<()>,
+}
+
+impl AuthClientsMixnetListenerHandle {
+    pub fn subscribe(&self) -> broadcast::Receiver<ReconstructedMessage> {
+        self.message_broadcast.subscribe()
+    }
+
+    pub async fn cancel(self) -> AuthClientsMixnetListener {
+        self.cancel_token.cancel();
+        if let Err(err) = self.handle.await {
+            tracing::error!("Error while waiting for auth clients mixnet listener to stop: {err}");
+        }
+        AuthClientsMixnetListener {
+            mixnet_client: self.mixnet_client,
+            message_broadcast: self.message_broadcast,
+            external_cancel_token: self.external_canel_token,
+            internal_cancel_token: CancellationToken::new(),
+        }
+    }
+
+    pub async fn wait(self) {
+        if let Err(err) = self.handle.await {
+            tracing::error!("Error while waiting for auth clients mixnet listener to stop: {err}");
+        }
+    }
+}

--- a/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
+++ b/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
@@ -15,7 +15,7 @@ use bytes::BytesMut;
 use clap::Args;
 use futures::StreamExt;
 use nym_authenticator_client::{
-    AuthClientsMixnetListener, AuthenticatorResponse, AuthenticatorVersion, ClientMessage,
+    AuthClientMixnetListener, AuthenticatorResponse, AuthenticatorVersion, ClientMessage,
 };
 use nym_authenticator_requests::{v2, v3, v4, v5};
 use nym_client_core::config::ForgetMe;
@@ -41,7 +41,6 @@ use nym_ip_packet_requests::{
 use nym_mixnet_client::SharedMixnetClient;
 use nym_sdk::mixnet::{MixnetClientBuilder, NodeIdentity, ReconstructedMessage};
 use nym_wireguard_types::PeerPublicKey;
-use tokio::sync::broadcast;
 use tokio_util::{codec::Decoder, sync::CancellationToken};
 use tracing::*;
 use types::WgProbeResults;
@@ -314,14 +313,12 @@ impl Probe {
             (node_info.authenticator_address, node_info.ip_address)
         {
             // Start the mixnet listener that the auth clients use to receive messages.
-            let mixnet_listener_task =
-                AuthClientsMixnetListener::new(shared_client.clone()).start();
-            let mixnet_listener = mixnet_listener_task.subscribe();
+            let mixnet_listener_task = AuthClientMixnetListener::new(shared_client.clone()).start();
+            let auth_client = mixnet_listener_task.new_auth_client().await;
 
             let outcome = wg_probe(
                 authenticator,
-                shared_client.clone(),
-                mixnet_listener,
+                auth_client,
                 ip_address,
                 node_info.authenticator_version,
                 self.amnezia_args,
@@ -337,8 +334,7 @@ impl Probe {
             WgProbeResults::default()
         };
 
-        let mixnet_client = shared_client.lock().await.take().unwrap();
-        mixnet_client.disconnect().await;
+        shared_client.disconnect().await;
 
         // Disconnect the mixnet client gracefully
         outcome.map(|mut outcome| {
@@ -354,23 +350,12 @@ impl Probe {
 
 async fn wg_probe(
     authenticator: AuthAddress,
-    shared_mixnet_client: SharedMixnetClient,
-    mixnet_listener: broadcast::Receiver<ReconstructedMessage>,
+    mut auth_client: nym_authenticator_client::AuthClient,
     gateway_ip: IpAddr,
     auth_version: AuthenticatorVersion,
     awg_args: String,
     netstack_args: NetstackArgs,
 ) -> anyhow::Result<WgProbeResults> {
-    let mixnet_sender = shared_mixnet_client.split_sender().await;
-    let stats_sender = shared_mixnet_client.stats_sender().await;
-    let our_nym_address = shared_mixnet_client.nym_address().await;
-    let mut auth_client = nym_authenticator_client::AuthClient::new(
-        mixnet_sender,
-        mixnet_listener,
-        stats_sender,
-        our_nym_address,
-    )
-    .await;
     info!("attempting to use authenticator version {auth_version:?}");
 
     let mut rng = rand::thread_rng();

--- a/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
+++ b/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
@@ -315,7 +315,7 @@ impl Probe {
         {
             // Start the mixnet listener that the auth clients use to receive messages.
             let mixnet_listener_task =
-                AuthClientsMixnetListener::new(shared_client.clone(), None).start();
+                AuthClientsMixnetListener::new(shared_client.clone()).start();
             let mixnet_listener = mixnet_listener_task.subscribe();
 
             let outcome = wg_probe(

--- a/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
+++ b/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
@@ -15,7 +15,7 @@ use bytes::BytesMut;
 use clap::Args;
 use futures::StreamExt;
 use nym_authenticator_client::{
-    AuthenticatorResponse, AuthenticatorVersion, ClientMessage, WgGatewayMixnetListener,
+    AuthClientsMixnetListener, AuthenticatorResponse, AuthenticatorVersion, ClientMessage,
 };
 use nym_authenticator_requests::{v2, v3, v4, v5};
 use nym_client_core::config::ForgetMe;
@@ -314,11 +314,9 @@ impl Probe {
             (node_info.authenticator_address, node_info.ip_address)
         {
             // Start the mixnet listener that the auth clients use to receive messages.
-            let cancel_token = CancellationToken::new();
-            let wg_gw_mixnet_listener =
-                WgGatewayMixnetListener::new(shared_client.clone(), cancel_token);
-            let mixnet_listener = wg_gw_mixnet_listener.subscribe();
-            let wg_gw_mixnet_listener_handle = wg_gw_mixnet_listener.start();
+            let mixnet_listener_task =
+                AuthClientsMixnetListener::new(shared_client.clone(), None).start();
+            let mixnet_listener = mixnet_listener_task.subscribe();
 
             let outcome = wg_probe(
                 authenticator,
@@ -332,7 +330,7 @@ impl Probe {
             .await
             .unwrap_or_default();
 
-            let _ = wg_gw_mixnet_listener_handle.cancel().await;
+            let _ = mixnet_listener_task.cancel().await;
 
             outcome
         } else {

--- a/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
+++ b/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
@@ -363,8 +363,16 @@ async fn wg_probe(
     awg_args: String,
     netstack_args: NetstackArgs,
 ) -> anyhow::Result<WgProbeResults> {
-    let mut auth_client =
-        nym_authenticator_client::AuthClient::new(shared_mixnet_client, mixnet_listener).await;
+    let mixnet_sender = shared_mixnet_client.split_sender().await;
+    let stats_sender = shared_mixnet_client.stats_sender().await;
+    let our_nym_address = shared_mixnet_client.nym_address().await;
+    let mut auth_client = nym_authenticator_client::AuthClient::new(
+        mixnet_sender,
+        mixnet_listener,
+        stats_sender,
+        our_nym_address,
+    )
+    .await;
     info!("attempting to use authenticator version {auth_version:?}");
 
     let mut rng = rand::thread_rng();

--- a/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
+++ b/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
@@ -14,7 +14,9 @@ use base64::{engine::general_purpose, Engine as _};
 use bytes::BytesMut;
 use clap::Args;
 use futures::StreamExt;
-use nym_authenticator_client::{AuthenticatorResponse, AuthenticatorVersion, ClientMessage};
+use nym_authenticator_client::{
+    AuthenticatorResponse, AuthenticatorVersion, ClientMessage, WgGatewayMixnetListener,
+};
 use nym_authenticator_requests::{v2, v3, v4, v5};
 use nym_client_core::config::ForgetMe;
 use nym_config::defaults::{
@@ -39,6 +41,7 @@ use nym_ip_packet_requests::{
 use nym_mixnet_client::SharedMixnetClient;
 use nym_sdk::mixnet::{MixnetClientBuilder, NodeIdentity, ReconstructedMessage};
 use nym_wireguard_types::PeerPublicKey;
+use tokio::sync::broadcast;
 use tokio_util::{codec::Decoder, sync::CancellationToken};
 use tracing::*;
 use types::WgProbeResults;
@@ -310,16 +313,28 @@ impl Probe {
         let wg_outcome = if let (Some(authenticator), Some(ip_address)) =
             (node_info.authenticator_address, node_info.ip_address)
         {
-            wg_probe(
+            // Start the mixnet listener that the auth clients use to receive messages.
+            let cancel_token = CancellationToken::new();
+            let wg_gw_mixnet_listener =
+                WgGatewayMixnetListener::new(shared_client.clone(), cancel_token);
+            let mixnet_listener = wg_gw_mixnet_listener.subscribe();
+            let wg_gw_mixnet_listener_handle = wg_gw_mixnet_listener.start();
+
+            let outcome = wg_probe(
                 authenticator,
                 shared_client.clone(),
+                mixnet_listener,
                 ip_address,
                 node_info.authenticator_version,
                 self.amnezia_args,
                 self.netstack_args,
             )
             .await
-            .unwrap_or_default()
+            .unwrap_or_default();
+
+            let _ = wg_gw_mixnet_listener_handle.cancel().await;
+
+            outcome
         } else {
             WgProbeResults::default()
         };
@@ -342,12 +357,14 @@ impl Probe {
 async fn wg_probe(
     authenticator: AuthAddress,
     shared_mixnet_client: SharedMixnetClient,
+    mixnet_listener: broadcast::Receiver<ReconstructedMessage>,
     gateway_ip: IpAddr,
     auth_version: AuthenticatorVersion,
     awg_args: String,
     netstack_args: NetstackArgs,
 ) -> anyhow::Result<WgProbeResults> {
-    let mut auth_client = nym_authenticator_client::AuthClient::new(shared_mixnet_client).await;
+    let mut auth_client =
+        nym_authenticator_client::AuthClient::new(shared_mixnet_client, mixnet_listener).await;
     info!("attempting to use authenticator version {auth_version:?}");
 
     let mut rng = rand::thread_rng();

--- a/nym-vpn-core/crates/nym-mixnet-client/src/lib.rs
+++ b/nym-vpn-core/crates/nym-mixnet-client/src/lib.rs
@@ -6,7 +6,8 @@ use std::os::fd::RawFd;
 use std::sync::Arc;
 
 use nym_sdk::mixnet::{
-    ed25519, ClientStatsEvents, MixnetClient, MixnetClientSender, MixnetMessageSender, Recipient,
+    ed25519, ClientStatsEvents, ClientStatsSender, MixnetClient, MixnetClientSender,
+    MixnetMessageSender, Recipient,
 };
 
 #[derive(Clone)]
@@ -47,6 +48,10 @@ impl SharedMixnetClient {
 
     pub async fn split_sender(&self) -> MixnetClientSender {
         self.lock().await.as_ref().unwrap().split_sender()
+    }
+
+    pub async fn stats_sender(&self) -> ClientStatsSender {
+        self.lock().await.as_ref().unwrap().stats_events_reporter()
     }
 
     pub async fn send_stats_event(&self, event: ClientStatsEvents) {

--- a/nym-vpn-core/crates/nym-mixnet-client/src/lib.rs
+++ b/nym-vpn-core/crates/nym-mixnet-client/src/lib.rs
@@ -77,6 +77,13 @@ impl SharedMixnetClient {
         self.connection_fd_callback.clone()
     }
 
+    // If the mixnet client does NOT have an external task manager, call this method to disconnect.
+    pub async fn disconnect(&self) {
+        let mixnet_client = self.lock().await.take().unwrap();
+        mixnet_client.disconnect().await;
+    }
+
+    // If the mixnet does have an external task manager, call this method to dispose.
     pub async fn dispose(self) {
         // A mixnet client that has an external task manager is dropped to disconnect.
         self.lock().await.take();

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
@@ -28,7 +28,10 @@ use crate::tunnel_state_machine::route_handler::TUNNEL_FWMARK;
 use crate::tunnel_state_machine::tunnel::wireguard::fd::DupFd;
 use crate::{
     tunnel_state_machine::tunnel::{
-        wireguard::{connector::ConnectionData, two_hop_config::TwoHopConfig},
+        wireguard::{
+            connector::{ConnectionData, WgGatewayMixnetListenerHandle},
+            two_hop_config::TwoHopConfig,
+        },
         Error, Result, Tombstone,
     },
     wg_config::WgNodeConfig,
@@ -40,6 +43,7 @@ pub struct ConnectedTunnel {
     exit_gateway_client: WgGatewayClient,
     connection_data: ConnectionData,
     bandwidth_controller_handle: JoinHandle<()>,
+    wg_gw_mixnet_listener_handle: WgGatewayMixnetListenerHandle,
 }
 
 impl ConnectedTunnel {
@@ -49,6 +53,7 @@ impl ConnectedTunnel {
         exit_gateway_client: WgGatewayClient,
         connection_data: ConnectionData,
         bandwidth_controller_handle: JoinHandle<()>,
+        wg_gw_mixnet_listener_handle: WgGatewayMixnetListenerHandle,
     ) -> Self {
         Self {
             task_manager,
@@ -56,6 +61,7 @@ impl ConnectedTunnel {
             exit_gateway_client,
             connection_data,
             bandwidth_controller_handle,
+            wg_gw_mixnet_listener_handle,
         }
     }
 
@@ -203,6 +209,7 @@ impl ConnectedTunnel {
             shutdown_token,
             event_handler_task,
             bandwidth_controller_handle: self.bandwidth_controller_handle,
+            wg_gw_mixnet_listener_handle: self.wg_gw_mixnet_listener_handle,
             #[cfg(windows)]
             wintun_entry_interface: Some(wintun_entry_interface),
             #[cfg(windows)]
@@ -315,6 +322,7 @@ impl ConnectedTunnel {
             shutdown_token,
             event_handler_task,
             bandwidth_controller_handle: self.bandwidth_controller_handle,
+            wg_gw_mixnet_listener_handle: self.wg_gw_mixnet_listener_handle,
             #[cfg(windows)]
             wintun_entry_interface: None,
             #[cfg(windows)]
@@ -438,6 +446,7 @@ pub struct TunnelHandle {
     shutdown_token: CancellationToken,
     event_handler_task: JoinHandle<Tombstone>,
     bandwidth_controller_handle: JoinHandle<()>,
+    wg_gw_mixnet_listener_handle: WgGatewayMixnetListenerHandle,
     #[cfg(windows)]
     wintun_entry_interface: Option<WintunInterface>,
     #[cfg(windows)]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
@@ -3,7 +3,7 @@
 
 use std::{error::Error as StdError, net::IpAddr};
 
-use nym_authenticator_client::WgGatewayMixnetListenerHandle;
+use nym_authenticator_client::AuthClientsMixnetListenerHandle;
 #[cfg(windows)]
 use tokio::sync::mpsc;
 use tokio::task::{JoinError, JoinHandle};
@@ -41,7 +41,7 @@ pub struct ConnectedTunnel {
     exit_gateway_client: WgGatewayClient,
     connection_data: ConnectionData,
     bandwidth_controller_handle: JoinHandle<()>,
-    wg_gw_mixnet_listener_handle: WgGatewayMixnetListenerHandle,
+    auth_clients_mixnet_listener_handle: AuthClientsMixnetListenerHandle,
 }
 
 impl ConnectedTunnel {
@@ -51,7 +51,7 @@ impl ConnectedTunnel {
         exit_gateway_client: WgGatewayClient,
         connection_data: ConnectionData,
         bandwidth_controller_handle: JoinHandle<()>,
-        wg_gw_mixnet_listener_handle: WgGatewayMixnetListenerHandle,
+        auth_clients_mixnet_listener_handle: AuthClientsMixnetListenerHandle,
     ) -> Self {
         Self {
             task_manager,
@@ -59,7 +59,7 @@ impl ConnectedTunnel {
             exit_gateway_client,
             connection_data,
             bandwidth_controller_handle,
-            wg_gw_mixnet_listener_handle,
+            auth_clients_mixnet_listener_handle,
         }
     }
 
@@ -207,7 +207,7 @@ impl ConnectedTunnel {
             shutdown_token,
             event_handler_task,
             bandwidth_controller_handle: self.bandwidth_controller_handle,
-            wg_gw_mixnet_listener_handle: self.wg_gw_mixnet_listener_handle,
+            auth_clients_mixnet_listener_handle: self.auth_clients_mixnet_listener_handle,
             #[cfg(windows)]
             wintun_entry_interface: Some(wintun_entry_interface),
             #[cfg(windows)]
@@ -320,7 +320,7 @@ impl ConnectedTunnel {
             shutdown_token,
             event_handler_task,
             bandwidth_controller_handle: self.bandwidth_controller_handle,
-            wg_gw_mixnet_listener_handle: self.wg_gw_mixnet_listener_handle,
+            auth_clients_mixnet_listener_handle: self.auth_clients_mixnet_listener_handle,
             #[cfg(windows)]
             wintun_entry_interface: None,
             #[cfg(windows)]
@@ -444,7 +444,7 @@ pub struct TunnelHandle {
     shutdown_token: CancellationToken,
     event_handler_task: JoinHandle<Tombstone>,
     bandwidth_controller_handle: JoinHandle<()>,
-    wg_gw_mixnet_listener_handle: WgGatewayMixnetListenerHandle,
+    auth_clients_mixnet_listener_handle: AuthClientsMixnetListenerHandle,
     #[cfg(windows)]
     wintun_entry_interface: Option<WintunInterface>,
     #[cfg(windows)]
@@ -477,7 +477,10 @@ impl TunnelHandle {
             tracing::error!("Failed to join on bandwidth controller: {}", e);
         }
 
-        self.wg_gw_mixnet_listener_handle.wait().await;
+        // No need to call cancel on auth_clients_mixnet_listener_handle as its external
+        // cancel_token should already be cancelled by the time we reach this point.
+        // We just need to wait for the task to finish.
+        self.auth_clients_mixnet_listener_handle.wait().await;
 
         self.event_handler_task.await
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
@@ -3,7 +3,7 @@
 
 use std::{error::Error as StdError, net::IpAddr};
 
-use nym_authenticator_client::AuthClientsMixnetListenerHandle;
+use nym_authenticator_client::AuthClientMixnetListenerHandle;
 #[cfg(windows)]
 use tokio::sync::mpsc;
 use tokio::task::{JoinError, JoinHandle};
@@ -41,7 +41,7 @@ pub struct ConnectedTunnel {
     exit_gateway_client: WgGatewayClient,
     connection_data: ConnectionData,
     bandwidth_controller_handle: JoinHandle<()>,
-    auth_clients_mixnet_listener_handle: AuthClientsMixnetListenerHandle,
+    auth_client_mixnet_listener_handle: AuthClientMixnetListenerHandle,
 }
 
 impl ConnectedTunnel {
@@ -51,7 +51,7 @@ impl ConnectedTunnel {
         exit_gateway_client: WgGatewayClient,
         connection_data: ConnectionData,
         bandwidth_controller_handle: JoinHandle<()>,
-        auth_clients_mixnet_listener_handle: AuthClientsMixnetListenerHandle,
+        auth_client_mixnet_listener_handle: AuthClientMixnetListenerHandle,
     ) -> Self {
         Self {
             task_manager,
@@ -59,7 +59,7 @@ impl ConnectedTunnel {
             exit_gateway_client,
             connection_data,
             bandwidth_controller_handle,
-            auth_clients_mixnet_listener_handle,
+            auth_client_mixnet_listener_handle,
         }
     }
 
@@ -207,7 +207,7 @@ impl ConnectedTunnel {
             shutdown_token,
             event_handler_task,
             bandwidth_controller_handle: self.bandwidth_controller_handle,
-            auth_clients_mixnet_listener_handle: self.auth_clients_mixnet_listener_handle,
+            auth_client_mixnet_listener_handle: self.auth_client_mixnet_listener_handle,
             #[cfg(windows)]
             wintun_entry_interface: Some(wintun_entry_interface),
             #[cfg(windows)]
@@ -320,7 +320,7 @@ impl ConnectedTunnel {
             shutdown_token,
             event_handler_task,
             bandwidth_controller_handle: self.bandwidth_controller_handle,
-            auth_clients_mixnet_listener_handle: self.auth_clients_mixnet_listener_handle,
+            auth_client_mixnet_listener_handle: self.auth_client_mixnet_listener_handle,
             #[cfg(windows)]
             wintun_entry_interface: None,
             #[cfg(windows)]
@@ -444,7 +444,7 @@ pub struct TunnelHandle {
     shutdown_token: CancellationToken,
     event_handler_task: JoinHandle<Tombstone>,
     bandwidth_controller_handle: JoinHandle<()>,
-    auth_clients_mixnet_listener_handle: AuthClientsMixnetListenerHandle,
+    auth_client_mixnet_listener_handle: AuthClientMixnetListenerHandle,
     #[cfg(windows)]
     wintun_entry_interface: Option<WintunInterface>,
     #[cfg(windows)]
@@ -480,7 +480,7 @@ impl TunnelHandle {
         // No need to call cancel on auth_clients_mixnet_listener_handle as its external
         // cancel_token should already be cancelled by the time we reach this point.
         // We just need to wait for the task to finish.
-        self.auth_clients_mixnet_listener_handle.wait().await;
+        self.auth_client_mixnet_listener_handle.wait().await;
 
         self.event_handler_task.await
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
@@ -477,6 +477,8 @@ impl TunnelHandle {
             tracing::error!("Failed to join on bandwidth controller: {}", e);
         }
 
+        self.wg_gw_mixnet_listener_handle.wait().await;
+
         self.event_handler_task.await
     }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
@@ -3,6 +3,7 @@
 
 use std::{error::Error as StdError, net::IpAddr};
 
+use nym_authenticator_client::WgGatewayMixnetListenerHandle;
 #[cfg(windows)]
 use tokio::sync::mpsc;
 use tokio::task::{JoinError, JoinHandle};
@@ -28,10 +29,7 @@ use crate::tunnel_state_machine::route_handler::TUNNEL_FWMARK;
 use crate::tunnel_state_machine::tunnel::wireguard::fd::DupFd;
 use crate::{
     tunnel_state_machine::tunnel::{
-        wireguard::{
-            connector::{ConnectionData, WgGatewayMixnetListenerHandle},
-            two_hop_config::TwoHopConfig,
-        },
+        wireguard::{connector::ConnectionData, two_hop_config::TwoHopConfig},
         Error, Result, Tombstone,
     },
     wg_config::WgNodeConfig,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connector.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connector.rs
@@ -4,15 +4,18 @@
 use std::path::PathBuf;
 
 use nym_vpn_network_config::Network;
-use tokio::task::JoinHandle;
+use tokio::{sync::broadcast, task::JoinHandle};
 
 use nym_authenticator_client::AuthClient;
 use nym_credentials_interface::TicketType;
 use nym_gateway_directory::{AuthAddresses, Gateway, GatewayClient};
 use nym_mixnet_client::SharedMixnetClient;
-use nym_sdk::mixnet::{ConnectionStatsEvent, EphemeralCredentialStorage, StoragePaths};
+use nym_sdk::mixnet::{
+    ConnectionStatsEvent, EphemeralCredentialStorage, ReconstructedMessage, StoragePaths,
+};
 use nym_task::TaskManager;
 use nym_wg_gateway_client::{GatewayData, WgGatewayClient};
+use tokio_stream::StreamExt;
 use tokio_util::sync::CancellationToken;
 
 use super::connected_tunnel::ConnectedTunnel;
@@ -73,6 +76,7 @@ impl Connector {
                 connect_result.exit_gateway_client,
                 connect_result.connection_data,
                 connect_result.bandwidth_controller_handle,
+                connect_result.wg_gateway_mixnet_listener_handle,
             )),
             Err(e) => Err(ConnectorError::new(
                 e,
@@ -107,7 +111,13 @@ impl Connector {
         tracing::debug!("Entry gateway version: {entry_version}");
         let exit_version = selected_gateways.exit.version.clone().into();
         tracing::debug!("Exit gateway version: {exit_version}");
-        let auth_client = AuthClient::new(mixnet_client).await;
+
+        let wg_gateway_mixnet_listener =
+            WgGatewayMixnetListener::new(mixnet_client.clone(), cancel_token.child_token());
+        let mixnet_listener = wg_gateway_mixnet_listener.subscribe();
+        let wg_gateway_mixnet_listener_handle = wg_gateway_mixnet_listener.start();
+
+        let auth_client = AuthClient::new(mixnet_client, mixnet_listener).await;
 
         let mut wg_entry_gateway_client = if enable_credentials_mode {
             WgGatewayClient::new_free_entry(
@@ -168,12 +178,9 @@ impl Connector {
                 gateway_directory_client,
                 &mut wg_exit_gateway_client,
             );
-            let entry = cancel_token
-                .run_until_cancelled(entry_fut)
-                .await
-                .ok_or(tunnel::Error::Cancelled)??;
-            let exit = cancel_token
-                .run_until_cancelled(exit_fut)
+
+            let (entry, exit) = cancel_token
+                .run_until_cancelled(async { tokio::try_join!(entry_fut, exit_fut) })
                 .await
                 .ok_or(tunnel::Error::Cancelled)??;
 
@@ -222,6 +229,7 @@ impl Connector {
             exit_gateway_client: wg_exit_gateway_client,
             connection_data,
             bandwidth_controller_handle,
+            wg_gateway_mixnet_listener_handle,
         })
     }
 
@@ -250,4 +258,103 @@ struct ConnectResult {
     exit_gateway_client: WgGatewayClient,
     connection_data: ConnectionData,
     bandwidth_controller_handle: JoinHandle<()>,
+    wg_gateway_mixnet_listener_handle: WgGatewayMixnetListenerHandle,
+}
+
+// The WgGatewayMixnetListener listens to mixnet messages and rebroadcasts them to the
+// WgGatewayClients, or whoever else is interested.
+struct WgGatewayMixnetListener {
+    mixnet_client: SharedMixnetClient,
+    message_broadcast: broadcast::Sender<ReconstructedMessage>,
+
+    // Listen to cancel from the outside world
+    external_cancel_token: CancellationToken,
+
+    // Cancel this task, returning to initial state so it can be restarted
+    cancel_token: CancellationToken,
+}
+
+impl WgGatewayMixnetListener {
+    fn new(mixnet_client: SharedMixnetClient, external_cancel_token: CancellationToken) -> Self {
+        let (message_broadcast, _) = broadcast::channel(100);
+        let cancel_token = CancellationToken::new();
+        Self {
+            mixnet_client,
+            message_broadcast,
+            external_cancel_token,
+            cancel_token,
+        }
+    }
+
+    fn subscribe(&self) -> broadcast::Receiver<ReconstructedMessage> {
+        self.message_broadcast.subscribe()
+    }
+
+    async fn run(self) {
+        let mut mixnet_client = self.mixnet_client.lock().await.take().unwrap();
+        loop {
+            tokio::select! {
+                _ = self.external_cancel_token.cancelled() => {
+                    tracing::info!("Mixnet listener shutting down");
+                    break;
+                }
+                _ = self.cancel_token.cancelled() => {
+                    tracing::info!("Mixnet listener stopping and returning to initial state");
+                    break;
+                }
+                event = mixnet_client.next() => {
+                    match event {
+                        Some(event) => {
+                            if let Err(err) = self.message_broadcast.send(event) {
+                                tracing::error!("Failed to broadcast mixnet message: {err}");
+                            }
+                        }
+                        None => {
+                            tracing::error!("Mixnet client stream ended unexpectedly");
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        self.mixnet_client.lock().await.replace(mixnet_client);
+    }
+
+    fn start(self) -> WgGatewayMixnetListenerHandle {
+        let mixnet_client = self.mixnet_client.clone();
+        let message_broadcast = self.message_broadcast.clone();
+        let external_canel_token = self.external_cancel_token.clone();
+        let cancel_token = self.cancel_token.clone();
+
+        let handle = tokio::spawn(self.run());
+
+        WgGatewayMixnetListenerHandle {
+            mixnet_client,
+            message_broadcast,
+            external_canel_token,
+            cancel_token,
+            handle,
+        }
+    }
+}
+
+pub(super) struct WgGatewayMixnetListenerHandle {
+    mixnet_client: SharedMixnetClient,
+    message_broadcast: broadcast::Sender<ReconstructedMessage>,
+    external_canel_token: CancellationToken,
+    cancel_token: CancellationToken,
+    handle: JoinHandle<()>,
+}
+
+impl WgGatewayMixnetListenerHandle {
+    pub(super) async fn cancel(self) -> WgGatewayMixnetListener {
+        self.cancel_token.cancel();
+        self.handle.await.unwrap();
+        WgGatewayMixnetListener {
+            mixnet_client: self.mixnet_client,
+            message_broadcast: self.message_broadcast,
+            external_cancel_token: self.external_canel_token,
+            cancel_token: CancellationToken::new(),
+        }
+    }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connector.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connector.rs
@@ -6,9 +6,7 @@ use std::path::PathBuf;
 use nym_vpn_network_config::Network;
 use tokio::task::JoinHandle;
 
-use nym_authenticator_client::{
-    AuthClient, AuthClientsMixnetListener, AuthClientsMixnetListenerHandle,
-};
+use nym_authenticator_client::{AuthClientMixnetListener, AuthClientMixnetListenerHandle};
 use nym_credentials_interface::TicketType;
 use nym_gateway_directory::{AuthAddresses, Gateway, GatewayClient};
 use nym_mixnet_client::SharedMixnetClient;
@@ -75,7 +73,7 @@ impl Connector {
                 connect_result.exit_gateway_client,
                 connect_result.connection_data,
                 connect_result.bandwidth_controller_handle,
-                connect_result.auth_clients_mixnet_listener_handle,
+                connect_result.auth_client_mixnet_listener_handle,
             )),
             Err(e) => Err(ConnectorError::new(
                 e,
@@ -111,20 +109,13 @@ impl Connector {
         let exit_version = selected_gateways.exit.version.clone().into();
         tracing::debug!("Exit gateway version: {exit_version}");
 
-        // Start the auth clients mixnet listener, which will listen for incoming messages from the
+        // Start the auth client mixnet listener, which will listen for incoming messages from the
         // mixnet and rebroadcast them to the auth clients.
-        let auth_clients_mixnet_listener_handle =
-            AuthClientsMixnetListener::new(mixnet_client.clone())
-                .with_external_cancel_token(cancel_token.clone())
-                .start();
+        let mixnet_listener = AuthClientMixnetListener::new(mixnet_client.clone())
+            .with_external_cancel_token(cancel_token.clone())
+            .start();
 
-        let auth_client = AuthClient::new(
-            mixnet_client.split_sender().await,
-            auth_clients_mixnet_listener_handle.subscribe(),
-            mixnet_client.stats_sender().await,
-            mixnet_client.nym_address().await,
-        )
-        .await;
+        let auth_client = mixnet_listener.new_auth_client().await;
 
         let mut wg_entry_gateway_client = if enable_credentials_mode {
             WgGatewayClient::new_free_entry(
@@ -236,7 +227,7 @@ impl Connector {
             exit_gateway_client: wg_exit_gateway_client,
             connection_data,
             bandwidth_controller_handle,
-            auth_clients_mixnet_listener_handle,
+            auth_client_mixnet_listener_handle: mixnet_listener,
         })
     }
 
@@ -265,5 +256,5 @@ struct ConnectResult {
     exit_gateway_client: WgGatewayClient,
     connection_data: ConnectionData,
     bandwidth_controller_handle: JoinHandle<()>,
-    auth_clients_mixnet_listener_handle: AuthClientsMixnetListenerHandle,
+    auth_client_mixnet_listener_handle: AuthClientMixnetListenerHandle,
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connector.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connector.rs
@@ -111,14 +111,16 @@ impl Connector {
         let exit_version = selected_gateways.exit.version.clone().into();
         tracing::debug!("Exit gateway version: {exit_version}");
 
+        // Start the auth clients mixnet listener, which will listen for incoming messages from the
+        // mixnet and rebroadcast them to the auth clients.
         let auth_clients_mixnet_listener_handle =
-            AuthClientsMixnetListener::new(mixnet_client.clone(), cancel_token.child_token())
+            AuthClientsMixnetListener::new(mixnet_client.clone())
+                .with_external_cancel_token(cancel_token.clone())
                 .start();
-        let mixnet_listener = auth_clients_mixnet_listener_handle.subscribe();
 
         let auth_client = AuthClient::new(
             mixnet_client.split_sender().await,
-            mixnet_listener,
+            auth_clients_mixnet_listener_handle.subscribe(),
             mixnet_client.stats_sender().await,
             mixnet_client.nym_address().await,
         )

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connector.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connector.rs
@@ -4,7 +4,7 @@
 use std::path::PathBuf;
 
 use nym_vpn_network_config::Network;
-use tokio::{sync::broadcast, task::JoinHandle};
+use tokio::task::JoinHandle;
 
 use nym_authenticator_client::{
     AuthClient, WgGatewayMixnetListener, WgGatewayMixnetListenerHandle,
@@ -12,12 +12,9 @@ use nym_authenticator_client::{
 use nym_credentials_interface::TicketType;
 use nym_gateway_directory::{AuthAddresses, Gateway, GatewayClient};
 use nym_mixnet_client::SharedMixnetClient;
-use nym_sdk::mixnet::{
-    ConnectionStatsEvent, EphemeralCredentialStorage, ReconstructedMessage, StoragePaths,
-};
+use nym_sdk::mixnet::{ConnectionStatsEvent, EphemeralCredentialStorage, StoragePaths};
 use nym_task::TaskManager;
 use nym_wg_gateway_client::{GatewayData, WgGatewayClient};
-use tokio_stream::StreamExt;
 use tokio_util::sync::CancellationToken;
 
 use super::connected_tunnel::ConnectedTunnel;
@@ -119,7 +116,16 @@ impl Connector {
         let mixnet_listener = wg_gateway_mixnet_listener.subscribe();
         let wg_gateway_mixnet_listener_handle = wg_gateway_mixnet_listener.start();
 
-        let auth_client = AuthClient::new(mixnet_client, mixnet_listener).await;
+        let mixnet_sender = mixnet_client.split_sender().await;
+        let stats_sender = mixnet_client.stats_sender().await;
+        let our_nym_address = mixnet_client.nym_address().await;
+        let auth_client = AuthClient::new(
+            mixnet_sender,
+            mixnet_listener,
+            stats_sender,
+            our_nym_address,
+        )
+        .await;
 
         let mut wg_entry_gateway_client = if enable_credentials_mode {
             WgGatewayClient::new_free_entry(

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connector.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connector.rs
@@ -7,7 +7,7 @@ use nym_vpn_network_config::Network;
 use tokio::task::JoinHandle;
 
 use nym_authenticator_client::{
-    AuthClient, WgGatewayMixnetListener, WgGatewayMixnetListenerHandle,
+    AuthClient, AuthClientsMixnetListener, AuthClientsMixnetListenerHandle,
 };
 use nym_credentials_interface::TicketType;
 use nym_gateway_directory::{AuthAddresses, Gateway, GatewayClient};
@@ -75,7 +75,7 @@ impl Connector {
                 connect_result.exit_gateway_client,
                 connect_result.connection_data,
                 connect_result.bandwidth_controller_handle,
-                connect_result.wg_gateway_mixnet_listener_handle,
+                connect_result.auth_clients_mixnet_listener_handle,
             )),
             Err(e) => Err(ConnectorError::new(
                 e,
@@ -111,19 +111,16 @@ impl Connector {
         let exit_version = selected_gateways.exit.version.clone().into();
         tracing::debug!("Exit gateway version: {exit_version}");
 
-        let wg_gateway_mixnet_listener =
-            WgGatewayMixnetListener::new(mixnet_client.clone(), cancel_token.child_token());
-        let mixnet_listener = wg_gateway_mixnet_listener.subscribe();
-        let wg_gateway_mixnet_listener_handle = wg_gateway_mixnet_listener.start();
+        let auth_clients_mixnet_listener_handle =
+            AuthClientsMixnetListener::new(mixnet_client.clone(), cancel_token.child_token())
+                .start();
+        let mixnet_listener = auth_clients_mixnet_listener_handle.subscribe();
 
-        let mixnet_sender = mixnet_client.split_sender().await;
-        let stats_sender = mixnet_client.stats_sender().await;
-        let our_nym_address = mixnet_client.nym_address().await;
         let auth_client = AuthClient::new(
-            mixnet_sender,
+            mixnet_client.split_sender().await,
             mixnet_listener,
-            stats_sender,
-            our_nym_address,
+            mixnet_client.stats_sender().await,
+            mixnet_client.nym_address().await,
         )
         .await;
 
@@ -237,7 +234,7 @@ impl Connector {
             exit_gateway_client: wg_exit_gateway_client,
             connection_data,
             bandwidth_controller_handle,
-            wg_gateway_mixnet_listener_handle,
+            auth_clients_mixnet_listener_handle,
         })
     }
 
@@ -266,5 +263,5 @@ struct ConnectResult {
     exit_gateway_client: WgGatewayClient,
     connection_data: ConnectionData,
     bandwidth_controller_handle: JoinHandle<()>,
-    wg_gateway_mixnet_listener_handle: WgGatewayMixnetListenerHandle,
+    auth_clients_mixnet_listener_handle: AuthClientsMixnetListenerHandle,
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connector.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connector.rs
@@ -6,7 +6,9 @@ use std::path::PathBuf;
 use nym_vpn_network_config::Network;
 use tokio::{sync::broadcast, task::JoinHandle};
 
-use nym_authenticator_client::AuthClient;
+use nym_authenticator_client::{
+    AuthClient, WgGatewayMixnetListener, WgGatewayMixnetListenerHandle,
+};
 use nym_credentials_interface::TicketType;
 use nym_gateway_directory::{AuthAddresses, Gateway, GatewayClient};
 use nym_mixnet_client::SharedMixnetClient;
@@ -259,102 +261,4 @@ struct ConnectResult {
     connection_data: ConnectionData,
     bandwidth_controller_handle: JoinHandle<()>,
     wg_gateway_mixnet_listener_handle: WgGatewayMixnetListenerHandle,
-}
-
-// The WgGatewayMixnetListener listens to mixnet messages and rebroadcasts them to the
-// WgGatewayClients, or whoever else is interested.
-struct WgGatewayMixnetListener {
-    mixnet_client: SharedMixnetClient,
-    message_broadcast: broadcast::Sender<ReconstructedMessage>,
-
-    // Listen to cancel from the outside world
-    external_cancel_token: CancellationToken,
-
-    // Cancel this task, returning to initial state so it can be restarted
-    cancel_token: CancellationToken,
-}
-
-impl WgGatewayMixnetListener {
-    fn new(mixnet_client: SharedMixnetClient, external_cancel_token: CancellationToken) -> Self {
-        let (message_broadcast, _) = broadcast::channel(100);
-        let cancel_token = CancellationToken::new();
-        Self {
-            mixnet_client,
-            message_broadcast,
-            external_cancel_token,
-            cancel_token,
-        }
-    }
-
-    fn subscribe(&self) -> broadcast::Receiver<ReconstructedMessage> {
-        self.message_broadcast.subscribe()
-    }
-
-    async fn run(self) {
-        let mut mixnet_client = self.mixnet_client.lock().await.take().unwrap();
-        loop {
-            tokio::select! {
-                _ = self.external_cancel_token.cancelled() => {
-                    tracing::info!("Mixnet listener shutting down");
-                    break;
-                }
-                _ = self.cancel_token.cancelled() => {
-                    tracing::info!("Mixnet listener stopping and returning to initial state");
-                    break;
-                }
-                event = mixnet_client.next() => {
-                    match event {
-                        Some(event) => {
-                            if let Err(err) = self.message_broadcast.send(event) {
-                                tracing::error!("Failed to broadcast mixnet message: {err}");
-                            }
-                        }
-                        None => {
-                            tracing::error!("Mixnet client stream ended unexpectedly");
-                            break;
-                        }
-                    }
-                }
-            }
-        }
-        self.mixnet_client.lock().await.replace(mixnet_client);
-    }
-
-    fn start(self) -> WgGatewayMixnetListenerHandle {
-        let mixnet_client = self.mixnet_client.clone();
-        let message_broadcast = self.message_broadcast.clone();
-        let external_canel_token = self.external_cancel_token.clone();
-        let cancel_token = self.cancel_token.clone();
-
-        let handle = tokio::spawn(self.run());
-
-        WgGatewayMixnetListenerHandle {
-            mixnet_client,
-            message_broadcast,
-            external_canel_token,
-            cancel_token,
-            handle,
-        }
-    }
-}
-
-pub(super) struct WgGatewayMixnetListenerHandle {
-    mixnet_client: SharedMixnetClient,
-    message_broadcast: broadcast::Sender<ReconstructedMessage>,
-    external_canel_token: CancellationToken,
-    cancel_token: CancellationToken,
-    handle: JoinHandle<()>,
-}
-
-impl WgGatewayMixnetListenerHandle {
-    pub(super) async fn cancel(self) -> WgGatewayMixnetListener {
-        self.cancel_token.cancel();
-        self.handle.await.unwrap();
-        WgGatewayMixnetListener {
-            mixnet_client: self.mixnet_client,
-            message_broadcast: self.message_broadcast,
-            external_cancel_token: self.external_canel_token,
-            cancel_token: CancellationToken::new(),
-        }
-    }
 }


### PR DESCRIPTION
Register with entry and exit gateway in parallel to speed up time-to-connect.

Create a mixnet listener that broadcasts the mixnet messages to the auth clients

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2576)
<!-- Reviewable:end -->
