### PR TITLE
Test using ExtendedPacket to fit Wireguard registration in one Packet

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -4948,6 +4948,7 @@ dependencies = [
  "nym-offline-monitor",
  "nym-routing",
  "nym-sdk",
+ "nym-sphinx-params",
  "nym-statistics-common",
  "nym-task",
  "nym-validator-client",

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -63,6 +63,7 @@ default-members = [
 # nym-pemstore = { path = "../../nym/common/pemstore" }
 # nym-service-provider-requests-common = { path = "../../nym/common/service-provider-requests-common" }
 # nym-sdk = { path = "../../nym/sdk/rust/nym-sdk" }
+# nym-sphinx-params = { path = "../../nym/sdk/rust/nymsphinx/params" }
 # nym-statistics-common = { path = "../../nym/common/statistics" }
 # nym-task = { path = "../../nym/common/task" }
 # nym-topology = { path = "../../nym/common/topology" }
@@ -235,6 +236,7 @@ nym-pemstore = { git = "https://github.com/nymtech/nym", branch = "release/2025.
 nym-service-provider-requests-common = { git = "https://github.com/nymtech/nym", branch = "release/2025.5-chokito" }
 nym-sdk = { git = "https://github.com/nymtech/nym", branch = "release/2025.5-chokito" }
 nym-statistics-common = { git = "https://github.com/nymtech/nym", branch = "release/2025.5-chokito" }
+nym-sphinx-params = { git = "https://github.com/nymtech/nym", branch = "release/2025.5-chokito" }
 nym-task = { git = "https://github.com/nymtech/nym", branch = "release/2025.5-chokito" }
 nym-topology = { git = "https://github.com/nymtech/nym", branch = "release/2025.5-chokito" }
 nym-validator-client = { git = "https://github.com/nymtech/nym", branch = "release/2025.5-chokito" }

--- a/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
@@ -65,6 +65,7 @@ nym-ip-packet-client.workspace = true
 nym-macos.workspace = true
 nym-mixnet-client.workspace = true
 nym-offline-monitor.workspace = true
+nym-sphinx-params.workspace = true
 nym-vpn-account-controller.workspace = true
 nym-vpn-api-client.workspace = true
 nym-vpn-lib-types = { workspace = true, features = ["nym-type-conversions"] }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/lib.rs
@@ -34,6 +34,7 @@ pub use nym_task::{
     StatusReceiver,
 };
 pub use nym_wg_gateway_client as wg_gateway_client;
+pub use nym_sphinx_params::PacketSize;
 
 #[cfg(any(target_os = "ios", target_os = "macos"))]
 pub use crate::platform::swift;
@@ -70,6 +71,10 @@ pub struct MixnetClientConfig {
 
     /// The minimum performance of gateways to use.
     pub min_gateway_performance: Option<u8>,
+
+    /// Specifies the packet size used for sent messages.
+    /// Do not override it unless you understand the consequences of that change.
+    pub primary_packet_size: Option<PacketSize>,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/lib.rs
@@ -29,12 +29,12 @@ pub use nym_sdk::{
     mixnet::{NodeIdentity, Recipient, StoragePaths},
     UserAgent,
 };
+pub use nym_sphinx_params::PacketSize;
 pub use nym_task::{
     event::{SentStatus, TaskStatus},
     StatusReceiver,
 };
 pub use nym_wg_gateway_client as wg_gateway_client;
-pub use nym_sphinx_params::PacketSize;
 
 #[cfg(any(target_os = "ios", target_os = "macos"))]
 pub use crate::platform::swift;

--- a/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/connect.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/connect.rs
@@ -43,6 +43,7 @@ fn apply_mixnet_client_config(
         disable_background_cover_traffic,
         min_mixnode_performance,
         min_gateway_performance,
+        primary_packet_size,
     } = mixnet_client_config;
 
     tracing::info!(
@@ -73,6 +74,14 @@ fn apply_mixnet_client_config(
     }
     tracing::info!(
         "mixnet client minimum gateway performance: {}",
+        debug_config.topology.minimum_gateway_performance,
+    );
+
+    if let Some(packet_size) = primary_packet_size {
+        debug_config.traffic.primary_packet_size = *packet_size;
+    }
+    tracing::debug!(
+        "mixnet client primary sphinx packet size: {}",
         debug_config.topology.minimum_gateway_performance,
     );
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
@@ -200,6 +200,8 @@ pub async fn connect_mixnet(
             mixnet_client_config.disable_poisson_rate = true;
             // Always disable background cover traffic in wireguard.
             mixnet_client_config.disable_background_cover_traffic = false;
+            // try larger packet size to reduce the number of packets used for control channel;
+            mixnet_client_config.primary_packet_size = Some(nym_sphinx_params::PacketSize::ExtendedPacket32);
         }
     };
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
@@ -201,7 +201,8 @@ pub async fn connect_mixnet(
             // Always disable background cover traffic in wireguard.
             mixnet_client_config.disable_background_cover_traffic = false;
             // try larger packet size to reduce the number of packets used for control channel;
-            mixnet_client_config.primary_packet_size = Some(nym_sphinx_params::PacketSize::ExtendedPacket32);
+            mixnet_client_config.primary_packet_size =
+                Some(nym_sphinx_params::PacketSize::ExtendedPacket32);
         }
     };
 

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -600,6 +600,7 @@ where
             min_gateway_performance: options
                 .min_gateway_mixnet_performance
                 .map(|p| p.round_to_integer()),
+            primary_packet_size: None,
         };
 
         let tunnel_type = if options.enable_two_hop {


### PR DESCRIPTION
Modify mixnet connections created for the purpose of registering wireguard peers to use a larger size primary message for sphinx packets so fewer need to be sent to complete the handshake. 

In total it looks like we send ~2 kB worth of data + 20 surbs (per destination) for a total message size of around around 24k

| Packet Size      |  Packets per Msg |  Waste (approx)  per Msg   |
| ------------- | ------------- | ------------- |
| 2 | 15-16 | <1k |
| 8 | 4 | ~7.5k |
| 16 | 2 | ~8k |
| 32 | 1 | ~8k |

```
### RegularPacket
2025-03-27T15:32:35.926273Z TRACE nym_sphinx::message: Padding repliable 0.06 kiB data message with 20 reply surbs attached from TW2iNFcqJcw1n34MFSrRHj: 23360 of raw plaintext bytes are required. They're going to be put into 15 sphinx packets with 700 bytes of leftover space. 2.9% of packet capacity is going to be wasted.
2025-03-27T15:32:38.320015Z TRACE nym_sphinx::message: Padding repliable 1.33 kiB data message with 20 reply surbs attached from TW2iNFcqJcw1n34MFSrRHj: 24661 of raw plaintext bytes are required. They're going to be put into 16 sphinx packets with 1003 bytes of leftover space. 3.9% of packet capacity is going to be wasted. 

### ExtendedPacket8
2025-03-27T20:05:14.885142Z TRACE nym_sphinx::message: Padding repliable 0.06 kiB data message with 20 reply surbs attached from QyobC8gRBz4TNo4PcPSbdq: 23360 of raw plaintext bytes are required. They're going to be put into 4 sphinx packets with 7632 bytes of leftover space. 24.6% of packet capacity is going to be wasted.
2025-03-27T20:05:21.611227Z TRACE nym_sphinx::message: Padding repliable 1.33 kiB data message with 20 reply surbs attached from JgmzHYVeavB1KNTQ7LgNc2: 24661 of raw plaintext bytes are required. They're going to be put into 4 sphinx packets with 6331 bytes of leftover space. 20.4% of packet capacity is going to be wasted.

### ExtendedPacket16
2025-03-27T19:22:57.677111Z TRACE nym_sphinx::message: Padding repliable 0.06 kiB data message with 20 reply surbs attached from WY46zdrA294YF6ZWTGJcak: 23360 of raw plaintext bytes are required. They're going to be put into 2 sphinx packets with 8520 bytes of leftover space. 26.7% of packet capacity is going to be wasted.
2025-03-27T19:22:57.607705Z TRACE nym_sphinx::message: Padding repliable 0.06 kiB data message with 20 reply surbs attached from HaX29sqGt5ctC8xyhexsfi: 23360 of raw plaintext bytes are required. They're going to be put into 2 sphinx packets with 8520 bytes of leftover space. 26.7% of packet capacity is going to be wasted.

### ExtendedPacket32
2025-03-27T19:34:34.006026Z TRACE nym_sphinx::message: Padding repliable 0.06 kiB data message with 20 reply surbs attached from R7no5CoNg9iW7n63Z4bP8K: 23360 of raw plaintext bytes are required. They're going to be put into 1 sphinx packets with 8964 bytes of leftover space. 27.7% of packet capacity is going to be wasted.
2025-03-27T19:34:36.114714Z TRACE nym_sphinx::message: Padding repliable 1.33 kiB data message with 20 reply surbs attached from UsR2Bft8rXeM5DyG7Sujac: 24661 of raw plaintext bytes are required. They're going to be put into 1 sphinx packets with 7663 bytes of leftover space. 23.7% of packet capacity is going to be wasted.
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2578)
<!-- Reviewable:end -->
