### PR TITLE
Remove unimplemented disable routing flag

### DIFF
--- a/nym-vpn-app/src-tauri/src/grpc/client.rs
+++ b/nym-vpn-app/src-tauri/src/grpc/client.rs
@@ -263,7 +263,6 @@ impl GrpcClient {
         let request = Request::new(ConnectRequest {
             entry: Some(entry_node.into()),
             exit: Some(exit_node.into()),
-            disable_routing: false,
             enable_two_hop: two_hop_mod,
             netstack,
             disable_poisson_rate: false,

--- a/nym-vpn-core/crates/nym-vpnc/src/cli.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/cli.rs
@@ -170,12 +170,6 @@ pub struct ConnectArgs {
     #[arg(long)]
     pub dns: Option<IpAddr>,
 
-    /// Disable routing all traffic through the nym TUN device. When the flag is set, the nym TUN
-    /// device will be created, but to route traffic through it you will need to do it manually,
-    /// e.g. ping -Itun0.
-    #[arg(long)]
-    pub disable_routing: bool,
-
     /// Enable two-hop wireguard traffic. This means that traffic jumps directly from entry gateway to
     /// exit gateway using Wireguard protocol.
     #[arg(long)]

--- a/nym-vpn-core/crates/nym-vpnc/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/main.rs
@@ -143,7 +143,6 @@ async fn connect(opts: CliOptions, connect_args: &cli::ConnectArgs) -> Result<()
         entry: entry.map(into_entry_point),
         exit: exit.map(into_exit_point),
         dns: connect_args.dns.map(nym_vpn_proto::Dns::from),
-        disable_routing: connect_args.disable_routing,
         enable_two_hop: connect_args.enable_two_hop,
         netstack: connect_args.netstack,
         disable_poisson_rate: connect_args.disable_poisson_rate,

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
@@ -954,7 +954,6 @@ impl TryFrom<ConnectRequest> for ConnectOptions {
 
         Ok(ConnectOptions {
             dns,
-            disable_routing: request.disable_routing,
             enable_two_hop: request.enable_two_hop,
             netstack: request.netstack,
             disable_poisson_rate: request.disable_poisson_rate,

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -108,7 +108,6 @@ pub struct ConnectArgs {
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct ConnectOptions {
     pub dns: Option<IpAddr>,
-    pub disable_routing: bool,
     pub enable_two_hop: bool,
     pub netstack: bool,
     pub disable_poisson_rate: bool,

--- a/proto/nym/vpn.proto
+++ b/proto/nym/vpn.proto
@@ -229,7 +229,6 @@ message ConnectRequest {
   EntryNode entry = 1;
   ExitNode exit = 2;
   Dns dns = 3;
-  bool disable_routing = 4;
   bool enable_two_hop = 5;
   bool netstack = 13;
   bool disable_poisson_rate = 6;


### PR DESCRIPTION
The disable_routing parameter was never implemented following the switch
to the state machine setup, so let's just remove it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2585)
<!-- Reviewable:end -->
