### PR TITLE
Add offline monitor to account controller

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -4962,6 +4962,7 @@ dependencies = [
  "nym-credentials-interface",
  "nym-ecash-time",
  "nym-http-api-client",
+ "nym-offline-monitor",
  "nym-sdk",
  "nym-vpn-api-client",
  "nym-vpn-lib-types",

--- a/nym-vpn-core/crates/nym-offline-monitor/src/lib.rs
+++ b/nym-vpn-core/crates/nym-offline-monitor/src/lib.rs
@@ -64,10 +64,6 @@ impl MonitorHandle {
         }
     }
 
-    pub fn subscribe(&self) -> watch::Receiver<Connectivity> {
-        self.rx.clone()
-    }
-
     /// Returns next connectivity status once changed.
     ///
     /// # Cancel safety
@@ -80,6 +76,11 @@ impl MonitorHandle {
         } else {
             None
         }
+    }
+
+    /// Returns a receiver that will be notified when the connectivity status changes.
+    pub fn subscribe(&self) -> watch::Receiver<Connectivity> {
+        self.rx.clone()
     }
 }
 
@@ -144,9 +145,14 @@ pub enum Connectivity {
 }
 
 impl Connectivity {
-    pub fn presume_offline() -> Self {
+    /// Create a new `Connectivity` instance that presumes the host is offline until
+    /// proven otherwise.
+    pub fn new_presume_offline() -> Self {
         #[cfg(not(target_os = "android"))]
-        return Connectivity::Status { ipv4: false, ipv6: false };
+        return Connectivity::Status {
+            ipv4: false,
+            ipv6: false,
+        };
 
         #[cfg(target_os = "android")]
         return Connectivity::Status { connected: false };

--- a/nym-vpn-core/crates/nym-offline-monitor/src/lib.rs
+++ b/nym-vpn-core/crates/nym-offline-monitor/src/lib.rs
@@ -64,6 +64,10 @@ impl MonitorHandle {
         }
     }
 
+    pub fn subscribe(&self) -> watch::Receiver<Connectivity> {
+        self.rx.clone()
+    }
+
     /// Returns next connectivity status once changed.
     ///
     /// # Cancel safety
@@ -140,6 +144,14 @@ pub enum Connectivity {
 }
 
 impl Connectivity {
+    pub fn presume_offline() -> Self {
+        #[cfg(not(target_os = "android"))]
+        return Connectivity::Status { ipv4: false, ipv6: false };
+
+        #[cfg(target_os = "android")]
+        return Connectivity::Status { connected: false };
+    }
+
     /// Inverse of [`Connectivity::is_offline`].
     pub fn is_online(&self) -> bool {
         !self.is_offline()

--- a/nym-vpn-core/crates/nym-offline-monitor/src/lib.rs
+++ b/nym-vpn-core/crates/nym-offline-monitor/src/lib.rs
@@ -2,7 +2,10 @@
 // Copyright 2025 Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::sync::{Arc, LazyLock};
+use std::{
+    fmt,
+    sync::{Arc, LazyLock},
+};
 
 use nym_common::ErrorExt;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
@@ -41,6 +44,14 @@ pub struct MonitorHandle {
     inner: Arc<Option<imp::MonitorHandle>>,
     rx: watch::Receiver<Connectivity>,
     _shutdown_drop_guard: Arc<DropGuard>,
+}
+
+impl fmt::Debug for MonitorHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MonitorHandle")
+            .field("rx", &self.rx)
+            .finish()
+    }
 }
 
 impl MonitorHandle {

--- a/nym-vpn-core/crates/nym-offline-monitor/src/lib.rs
+++ b/nym-vpn-core/crates/nym-offline-monitor/src/lib.rs
@@ -50,7 +50,7 @@ impl fmt::Debug for MonitorHandle {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MonitorHandle")
             .field("rx", &self.rx)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
@@ -87,11 +87,6 @@ impl MonitorHandle {
         } else {
             None
         }
-    }
-
-    /// Returns a receiver that will be notified when the connectivity status changes.
-    pub fn subscribe(&self) -> watch::Receiver<Connectivity> {
-        self.rx.clone()
     }
 }
 

--- a/nym-vpn-core/crates/nym-vpn-account-controller/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/Cargo.toml
@@ -17,6 +17,7 @@ nym-credentials-interface.workspace = true
 nym-credentials.workspace = true
 nym-ecash-time.workspace = true
 nym-http-api-client.workspace = true
+nym-offline-monitor.workspace = true
 nym-sdk.workspace = true
 nym-vpn-api-client = { workspace = true }
 nym-vpn-lib-types = { workspace = true, features = ["nym-type-conversions"] }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commander.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commander.rs
@@ -142,13 +142,13 @@ impl AccountControllerCommander {
         rx.await.map_err(AccountCommandError::internal)?
     }
 
-    pub async fn register_offline_watch(
+    pub async fn register_offline_monitor(
         &self,
-        offline_watch: MonitorHandle,
+        offline_monitor: MonitorHandle,
     ) -> Result<(), AccountCommandError> {
         let (tx, rx) = ReturnSender::new();
         self.command_tx
-            .send(AccountCommand::RegisterOfflineWatch(tx, offline_watch))
+            .send(AccountCommand::RegisterOfflineMonitor(tx, offline_monitor))
             .map_err(AccountCommandError::internal)?;
         rx.await.map_err(AccountCommandError::internal)?
     }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commander.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commander.rs
@@ -3,13 +3,13 @@
 
 use std::net::SocketAddr;
 
-use nym_offline_monitor::Connectivity;
+use nym_offline_monitor::MonitorHandle;
 use nym_vpn_api_client::response::{NymVpnAccountSummaryResponse, NymVpnDevice, NymVpnUsage};
 use nym_vpn_lib_types::{
     AccountCommandError, RegisterDeviceError, RequestZkNymError, SyncAccountError, SyncDeviceError,
 };
 use nym_vpn_store::mnemonic::Mnemonic;
-use tokio::sync::{mpsc::UnboundedSender, watch};
+use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
     commands::{request_zknym::RequestZkNymSummary, AccountCommand, ReturnSender},
@@ -144,7 +144,7 @@ impl AccountControllerCommander {
 
     pub async fn register_offline_watch(
         &self,
-        offline_watch: watch::Receiver<Connectivity>,
+        offline_watch: MonitorHandle,
     ) -> Result<(), AccountCommandError> {
         let (tx, rx) = ReturnSender::new();
         self.command_tx

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commander.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commander.rs
@@ -3,12 +3,13 @@
 
 use std::net::SocketAddr;
 
+use nym_offline_monitor::Connectivity;
 use nym_vpn_api_client::response::{NymVpnAccountSummaryResponse, NymVpnDevice, NymVpnUsage};
 use nym_vpn_lib_types::{
     AccountCommandError, RegisterDeviceError, RequestZkNymError, SyncAccountError, SyncDeviceError,
 };
 use nym_vpn_store::mnemonic::Mnemonic;
-use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::{mpsc::UnboundedSender, watch};
 
 use crate::{
     commands::{request_zknym::RequestZkNymSummary, AccountCommand, ReturnSender},
@@ -137,6 +138,17 @@ impl AccountControllerCommander {
         let (tx, rx) = ReturnSender::new();
         self.command_tx
             .send(AccountCommand::SetStaticApiAddresses(tx, static_addresses))
+            .map_err(AccountCommandError::internal)?;
+        rx.await.map_err(AccountCommandError::internal)?
+    }
+
+    pub async fn register_offline_watch(
+        &self,
+        offline_watch: watch::Receiver<Connectivity>,
+    ) -> Result<(), AccountCommandError> {
+        let (tx, rx) = ReturnSender::new();
+        self.command_tx
+            .send(AccountCommand::RegisterOfflineWatch(tx, offline_watch))
             .map_err(AccountCommandError::internal)?;
         rx.await.map_err(AccountCommandError::internal)?
     }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/mod.rs
@@ -6,7 +6,7 @@ pub(crate) mod request_zknym;
 pub(crate) mod sync_account;
 pub(crate) mod sync_device;
 
-use nym_offline_monitor::Connectivity;
+use nym_offline_monitor::MonitorHandle;
 use nym_vpn_lib_types::{
     AccountCommandError, RegisterDeviceError, RequestZkNymError, SyncAccountError, SyncDeviceError,
 };
@@ -16,7 +16,7 @@ use request_zknym::RequestZkNymSummary;
 use std::{collections::HashMap, net::SocketAddr, sync::Arc};
 
 use nym_vpn_api_client::response::{NymVpnAccountSummaryResponse, NymVpnDevice, NymVpnUsage};
-use tokio::sync::{oneshot, watch};
+use tokio::sync::oneshot;
 
 use crate::{shared_state::DeviceState, AvailableTicketbooks, Error};
 
@@ -103,10 +103,7 @@ pub enum AccountCommand {
         ReturnSender<(), AccountCommandError>,
         Option<Vec<SocketAddr>>,
     ),
-    RegisterOfflineWatch(
-        ReturnSender<(), AccountCommandError>,
-        watch::Receiver<Connectivity>,
-    ),
+    RegisterOfflineWatch(ReturnSender<(), AccountCommandError>, MonitorHandle),
 }
 
 impl AccountCommand {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/mod.rs
@@ -103,7 +103,7 @@ pub enum AccountCommand {
         ReturnSender<(), AccountCommandError>,
         Option<Vec<SocketAddr>>,
     ),
-    RegisterOfflineWatch(ReturnSender<(), AccountCommandError>, MonitorHandle),
+    RegisterOfflineMonitor(ReturnSender<(), AccountCommandError>, MonitorHandle),
 }
 
 impl AccountCommand {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod request_zknym;
 pub(crate) mod sync_account;
 pub(crate) mod sync_device;
 
+use nym_offline_monitor::Connectivity;
 use nym_vpn_lib_types::{
     AccountCommandError, RegisterDeviceError, RequestZkNymError, SyncAccountError, SyncDeviceError,
 };
@@ -15,7 +16,7 @@ use request_zknym::RequestZkNymSummary;
 use std::{collections::HashMap, net::SocketAddr, sync::Arc};
 
 use nym_vpn_api_client::response::{NymVpnAccountSummaryResponse, NymVpnDevice, NymVpnUsage};
-use tokio::sync::oneshot;
+use tokio::sync::{oneshot, watch};
 
 use crate::{shared_state::DeviceState, AvailableTicketbooks, Error};
 
@@ -102,6 +103,10 @@ pub enum AccountCommand {
         ReturnSender<(), AccountCommandError>,
         Option<Vec<SocketAddr>>,
     ),
+    RegisterOfflineWatch(
+        ReturnSender<(), AccountCommandError>,
+        watch::Receiver<Connectivity>,
+    ),
 }
 
 impl AccountCommand {
@@ -139,6 +144,25 @@ impl AccountCommand {
             }
             AccountCommand::RequestZkNym(Some(tx)) => {
                 tx.send(Err(RequestZkNymError::NoDeviceStored));
+            }
+            _ => {}
+        }
+    }
+
+    pub fn return_no_connectivity(self) {
+        tracing::debug!("No connectivity");
+        match self {
+            AccountCommand::SyncAccountState(Some(tx)) => {
+                tx.send(Err(SyncAccountError::internal("No connectivity")));
+            }
+            AccountCommand::SyncDeviceState(Some(tx)) => {
+                tx.send(Err(SyncDeviceError::internal("No connectivity")));
+            }
+            AccountCommand::RegisterDevice(Some(tx)) => {
+                tx.send(Err(RegisterDeviceError::internal("No connectivity")));
+            }
+            AccountCommand::RequestZkNym(Some(tx)) => {
+                tx.send(Err(RequestZkNymError::internal("No connectivity")));
             }
             _ => {}
         }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/connectivity.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/connectivity.rs
@@ -8,9 +8,9 @@ use nym_offline_monitor::{Connectivity, MonitorHandle};
 use crate::{AccountCommand, AccountControllerCommander};
 
 #[derive(Debug, thiserror::Error)]
-pub enum OfflineMonitorError {
-    #[error("offline watch already registered")]
-    WatchAlreadyRegistered,
+pub enum OfflineWatchError {
+    #[error("offline monitor already registered")]
+    MonitorAlreadyRegistered,
 }
 
 pub(super) struct OfflineWatch {
@@ -48,17 +48,17 @@ impl OfflineWatch {
         !self.is_online()
     }
 
-    pub(super) fn register_offline_watch(
+    pub(super) fn register_offline_monitor(
         &mut self,
-        offline_watch: MonitorHandle,
-    ) -> Result<(), OfflineMonitorError> {
+        offline_monitor: MonitorHandle,
+    ) -> Result<(), OfflineWatchError> {
         if self.task.is_some() {
-            return Err(OfflineMonitorError::WatchAlreadyRegistered);
+            return Err(OfflineWatchError::MonitorAlreadyRegistered);
         }
 
         let offline_watch_task = OfflineWatchTask::new(
             self.connectivity.clone(),
-            offline_watch,
+            offline_monitor,
             self.commander.clone(),
         );
         let handle = tokio::spawn(offline_watch_task.run());

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/connectivity.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/connectivity.rs
@@ -3,8 +3,7 @@
 
 use std::{sync::Arc, time::Duration};
 
-use nym_offline_monitor::Connectivity;
-use tokio::sync::watch;
+use nym_offline_monitor::{Connectivity, MonitorHandle};
 
 use crate::{AccountCommand, AccountControllerCommander};
 
@@ -51,7 +50,7 @@ impl OfflineWatch {
 
     pub(super) fn register_offline_watch(
         &mut self,
-        offline_watch: watch::Receiver<Connectivity>,
+        offline_watch: MonitorHandle,
     ) -> Result<(), OfflineMonitorError> {
         if self.task.is_some() {
             return Err(OfflineMonitorError::WatchAlreadyRegistered);
@@ -85,14 +84,14 @@ impl OfflineWatch {
 
 struct OfflineWatchTask {
     connectivity: Arc<std::sync::Mutex<Connectivity>>,
-    offline_watch: watch::Receiver<Connectivity>,
+    offline_watch: MonitorHandle,
     commander: AccountControllerCommander,
 }
 
 impl OfflineWatchTask {
     fn new(
         connectivity: Arc<std::sync::Mutex<Connectivity>>,
-        offline_watch: watch::Receiver<Connectivity>,
+        offline_watch: MonitorHandle,
         commander: AccountControllerCommander,
     ) -> Self {
         Self {
@@ -129,16 +128,13 @@ impl OfflineWatchTask {
         }
     }
 
-    fn update_state_from_watch(&self) {
-        let new_state = *self.offline_watch.borrow();
-        self.update_state(new_state);
-    }
-
     async fn run(mut self) {
         tracing::info!("Starting offline watch task");
-        self.update_state_from_watch();
-        while self.offline_watch.changed().await.is_ok() {
-            self.update_state_from_watch();
+        let initial_state = self.offline_watch.connectivity().await;
+        self.update_state(initial_state);
+
+        while let Some(state) = self.offline_watch.next().await {
+            self.update_state(state);
         }
         tracing::info!("Offline watch task has finished");
     }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/connectivity.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/connectivity.rs
@@ -1,126 +1,65 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{sync::Arc, time::Duration};
-
 use nym_offline_monitor::{Connectivity, MonitorHandle};
 
 use crate::{AccountCommand, AccountControllerCommander};
 
-#[derive(Debug, thiserror::Error)]
-pub enum OfflineWatchError {
-    #[error("offline monitor already registered")]
-    MonitorAlreadyRegistered,
-}
-
 pub(super) struct OfflineWatch {
-    // The current connectivity state.
-    connectivity: Arc<std::sync::Mutex<Connectivity>>,
+    // The handle to the offline monitor, used for receiving connectivity changes.
+    handle: Option<MonitorHandle>,
 
     // The account controller commander, used for sending commands to the account controller that
     // are triggered by connectivity changes.
     commander: AccountControllerCommander,
 
-    // The task that monitors the connectivity state and updates the `connectivity` field.
-    task: Option<tokio::task::JoinHandle<()>>,
+    // The last known connectivity state, used to determine any possible actions that should be
+    // taken depending on the connectivity change.
+    last_state: Connectivity,
 }
 
 impl OfflineWatch {
     pub(super) fn new(commander: AccountControllerCommander, initial_state: Connectivity) -> Self {
-        let connectivity = Arc::new(std::sync::Mutex::new(initial_state));
-        let task = None;
-
         Self {
-            connectivity,
+            handle: None,
             commander,
-            task,
+            last_state: initial_state,
         }
     }
 
     pub(super) fn is_online(&self) -> bool {
-        self.connectivity
-            .lock()
-            .map(|c| c.is_online())
-            .unwrap_or(false)
+        self.last_state.is_online()
     }
 
     pub(super) fn is_offline(&self) -> bool {
         !self.is_online()
     }
 
-    pub(super) fn register_offline_monitor(
-        &mut self,
-        offline_monitor: MonitorHandle,
-    ) -> Result<(), OfflineWatchError> {
-        if self.task.is_some() {
-            return Err(OfflineWatchError::MonitorAlreadyRegistered);
-        }
-
-        let offline_watch_task = OfflineWatchTask::new(
-            self.connectivity.clone(),
-            offline_monitor,
-            self.commander.clone(),
+    pub(super) async fn register_offline_monitor(&mut self, offline_monitor: MonitorHandle) {
+        self.last_state = offline_monitor.connectivity().await;
+        tracing::info!(
+            "Registering offline monitor with initial state: {:?}",
+            self.last_state
         );
-        let handle = tokio::spawn(offline_watch_task.run());
 
-        self.task = Some(handle);
-
-        Ok(())
+        if self.handle.replace(offline_monitor).is_some() {
+            tracing::info!("Registering offline monitor replaced an existing one");
+        }
     }
 
-    pub(super) async fn wait(&mut self, timeout: Duration) {
-        if let Some(mut task) = self.task.take() {
-            tokio::select! {
-                _ = &mut task => (),
-                _ = tokio::time::sleep(timeout) => {
-                    tracing::error!("Offline watch task did not finish within the specified timeout");
-                },
-            }
+    pub(super) async fn next(&mut self) -> Option<Connectivity> {
+        if let Some(handle) = self.handle.as_mut() {
+            handle.next().await
         } else {
-            tracing::error!("Tried to wait for offline watch task, but it was not registered");
-        }
-    }
-}
-
-struct OfflineWatchTask {
-    connectivity: Arc<std::sync::Mutex<Connectivity>>,
-    offline_watch: MonitorHandle,
-    commander: AccountControllerCommander,
-}
-
-impl OfflineWatchTask {
-    fn new(
-        connectivity: Arc<std::sync::Mutex<Connectivity>>,
-        offline_watch: MonitorHandle,
-        commander: AccountControllerCommander,
-    ) -> Self {
-        Self {
-            connectivity,
-            offline_watch,
-            commander,
+            std::future::pending().await
         }
     }
 
-    fn signal_went_online_to_controller(&self) {
-        self.commander
-            .send(AccountCommand::SyncAccountState(None))
-            .inspect_err(|e| tracing::error!("{e}"))
-            .ok();
-        self.commander
-            .send(AccountCommand::SyncDeviceState(None))
-            .inspect_err(|e| tracing::error!("{e}"))
-            .ok();
-    }
-
-    fn update_state(&self, new_state: Connectivity) {
-        if let Ok(mut connectivity) = self
-            .connectivity
-            .lock()
-            .inspect_err(|e| tracing::error!("failed to acquire lock: {e:?}"))
-        {
-            let old_state = *connectivity;
-            *connectivity = new_state;
-            tracing::info!("Connectivity state changed from {old_state:?} to {new_state:?}",);
+    pub(super) async fn handle_changed_connectivity(&mut self, new_state: Connectivity) {
+        if new_state != self.last_state {
+            let old_state = self.last_state;
+            self.last_state = new_state;
+            tracing::info!("Connectivity state changed from {old_state:?} to {new_state:?}");
 
             if new_state.is_online() && old_state.is_offline() {
                 self.signal_went_online_to_controller();
@@ -128,14 +67,14 @@ impl OfflineWatchTask {
         }
     }
 
-    async fn run(mut self) {
-        tracing::info!("Starting offline watch task");
-        let initial_state = self.offline_watch.connectivity().await;
-        self.update_state(initial_state);
-
-        while let Some(state) = self.offline_watch.next().await {
-            self.update_state(state);
-        }
-        tracing::info!("Offline watch task has finished");
+    fn signal_went_online_to_controller(&self) {
+        let _ = self
+            .commander
+            .send(AccountCommand::SyncAccountState(None))
+            .inspect_err(|e| tracing::error!("{e}"));
+        let _ = self
+            .commander
+            .send(AccountCommand::SyncDeviceState(None))
+            .inspect_err(|e| tracing::error!("{e}"));
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/connectivity.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/connectivity.rs
@@ -1,0 +1,145 @@
+// Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use std::{sync::Arc, time::Duration};
+
+use nym_offline_monitor::Connectivity;
+use tokio::{sync::watch, task::JoinError};
+
+use crate::{AccountCommand, AccountControllerCommander};
+
+#[derive(Debug, thiserror::Error)]
+pub enum OfflineMonitorError {
+    #[error("offline watch already registered")]
+    WatchAlreadyRegistered,
+}
+
+pub(super) struct OfflineWatch {
+    // The current connectivity state.
+    connectivity: Arc<std::sync::Mutex<Connectivity>>,
+
+    // The account controller commander, used for sending commands to the account controller that
+    // are triggered by connectivity changes.
+    commander: AccountControllerCommander,
+
+    // The task that monitors the connectivity state and updates the `connectivity` field.
+    task: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl OfflineWatch {
+    pub(super) fn new(commander: AccountControllerCommander, initial_state: Connectivity) -> Self {
+        let connectivity = Arc::new(std::sync::Mutex::new(initial_state));
+        let task = None;
+
+        Self {
+            connectivity,
+            commander,
+            task,
+        }
+    }
+
+    pub(super) fn is_oneline(&self) -> bool {
+        self.connectivity
+            .lock()
+            .map(|c| c.is_online())
+            .unwrap_or(false)
+    }
+
+    pub(super) fn is_offline(&self) -> bool {
+        !self.is_oneline()
+    }
+
+    pub(super) fn register_offline_watch(
+        &mut self,
+        offline_watch: watch::Receiver<Connectivity>,
+    ) -> Result<(), OfflineMonitorError> {
+        if self.task.is_some() {
+            return Err(OfflineMonitorError::WatchAlreadyRegistered);
+        }
+
+        let offline_watch_task = OfflineWatchTask::new(
+            self.connectivity.clone(),
+            offline_watch,
+            self.commander.clone(),
+        );
+        let handle = tokio::spawn(offline_watch_task.run());
+
+        self.task = Some(handle);
+
+        Ok(())
+    }
+
+    pub(super) async fn wait(&mut self, timeout: Duration) {
+        if let Some(mut task) = self.task.take() {
+            tokio::select! {
+                _ = &mut task => (),
+                _ = tokio::time::sleep(timeout) => {
+                    tracing::error!("Offline watch task did not finish within the specified timeout");
+                },
+            }
+        } else {
+            tracing::error!("Tried to wait for offline watch task, but it was not registered");
+        }
+    }
+}
+
+struct OfflineWatchTask {
+    connectivity: Arc<std::sync::Mutex<Connectivity>>,
+    offline_watch: watch::Receiver<Connectivity>,
+    commander: AccountControllerCommander,
+}
+
+impl OfflineWatchTask {
+    fn new(
+        connectivity: Arc<std::sync::Mutex<Connectivity>>,
+        offline_watch: watch::Receiver<Connectivity>,
+        commander: AccountControllerCommander,
+    ) -> Self {
+        Self {
+            connectivity,
+            offline_watch,
+            commander,
+        }
+    }
+
+    fn signal_went_online_to_controller(&self) {
+        self.commander
+            .send(AccountCommand::SyncAccountState(None))
+            .inspect_err(|e| tracing::error!("{e}"))
+            .ok();
+        self.commander
+            .send(AccountCommand::SyncDeviceState(None))
+            .inspect_err(|e| tracing::error!("{e}"))
+            .ok();
+    }
+
+    fn update_state(&self, new_state: Connectivity) {
+        if let Ok(mut connectivity) = self
+            .connectivity
+            .lock()
+            .inspect_err(|e| tracing::error!("failed to acquire lock: {e:?}"))
+        {
+            let old_state = *connectivity;
+            *connectivity = new_state;
+            tracing::info!("Connectivity state changed from {old_state:?} to {new_state:?}",);
+
+            if new_state.is_online() && old_state.is_offline() {
+                self.signal_went_online_to_controller();
+            }
+        }
+    }
+
+    fn update_state_from_watch(&self) {
+        let new_state = *self.offline_watch.borrow();
+        self.update_state(new_state);
+    }
+
+    async fn run(mut self) {
+        tracing::info!("Starting offline watch task");
+        self.update_state_from_watch();
+        while self.offline_watch.changed().await.is_ok() {
+            self.update_state_from_watch();
+        }
+        tracing::info!("Offline watch task has finished");
+    }
+}

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/connectivity.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/connectivity.rs
@@ -4,7 +4,7 @@
 use std::{sync::Arc, time::Duration};
 
 use nym_offline_monitor::Connectivity;
-use tokio::{sync::watch, task::JoinError};
+use tokio::sync::watch;
 
 use crate::{AccountCommand, AccountControllerCommander};
 
@@ -38,7 +38,7 @@ impl OfflineWatch {
         }
     }
 
-    pub(super) fn is_oneline(&self) -> bool {
+    pub(super) fn is_online(&self) -> bool {
         self.connectivity
             .lock()
             .map(|c| c.is_online())
@@ -46,7 +46,7 @@ impl OfflineWatch {
     }
 
     pub(super) fn is_offline(&self) -> bool {
-        !self.is_oneline()
+        !self.is_online()
     }
 
     pub(super) fn register_offline_watch(

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
@@ -4,6 +4,7 @@
 use std::{path::PathBuf, sync::Arc, time::Duration};
 
 use nym_http_api_client::UserAgent;
+use nym_offline_monitor::Connectivity;
 use nym_vpn_api_client::{
     response::{NymVpnAccountResponse, NymVpnDevice, NymVpnUsage},
     types::{DeviceStatus, VpnApiAccount},
@@ -14,7 +15,10 @@ use nym_vpn_lib_types::{
 use nym_vpn_network_config::Network;
 use nym_vpn_store::{mnemonic::Mnemonic, VpnStorage};
 use tokio::{
-    sync::mpsc::{UnboundedReceiver, UnboundedSender},
+    sync::{
+        mpsc::{UnboundedReceiver, UnboundedSender},
+        watch,
+    },
     task::{JoinError, JoinSet},
 };
 use tokio_util::sync::CancellationToken;
@@ -89,6 +93,9 @@ where
 
     // User agent used by api client.
     user_agent: UserAgent,
+
+    connectivity: Arc<std::sync::Mutex<Connectivity>>,
+    offline_watch: Option<watch::Receiver<Connectivity>>,
 }
 
 impl<S> AccountController<S>
@@ -167,6 +174,9 @@ where
             background_zk_nym_refresh: credentials_mode,
             cancel_token,
             user_agent,
+            // connectivity: Arc::new(std::sync::Mutex::new(Connectivity::PresumeOnline)),
+            connectivity: Arc::new(std::sync::Mutex::new(Connectivity::presume_offline())),
+            offline_watch: None,
         })
     }
 
@@ -251,7 +261,19 @@ where
             .map_err(AccountCommandError::internal)
     }
 
+    fn is_online(&self) -> bool {
+        self.connectivity
+            .lock()
+            .map(|c| c.is_online())
+            .unwrap_or(false)
+    }
+
     async fn request_zk_nym_if_ready(&self) {
+        if !self.is_online() {
+            tracing::info!("Not requesting zk-nym as we are offline");
+            return;
+        }
+
         if !self.is_background_zk_nym_refresh_active().await {
             return;
         }
@@ -431,6 +453,12 @@ where
             }
         };
 
+        if !self.is_online() {
+            tracing::info!("Not syncing account state as we are offline");
+            command.return_no_connectivity();
+            return;
+        }
+
         let command_handler = self.waiting_sync_account_command_handler.build(account);
 
         if self.running_commands.add(command).await == Command::IsFirst {
@@ -454,6 +482,12 @@ where
                 return;
             }
         };
+
+        if !self.is_online() {
+            tracing::info!("Not syncing device state as we are offline");
+            command.return_no_connectivity();
+            return;
+        }
 
         let command_handler = self
             .waiting_sync_device_command_handler
@@ -510,6 +544,12 @@ where
                 return;
             }
         };
+
+        if !self.is_online() {
+            tracing::info!("Not registering device as we are offline");
+            command.return_no_connectivity();
+            return;
+        }
 
         let command_handler = RegisterDeviceCommandHandler::new(
             account,
@@ -679,6 +719,14 @@ where
 
     async fn handle_command(&mut self, command: AccountCommand) {
         tracing::info!("← {}", command);
+        //if let Ok(connectivity) = self.connectivity.lock() {
+        //    if connectivity.is_offline() {
+        //        tracing::warn!("Ignoring command as we are offline");
+        //        command.return_no_connectivity();
+        //        return;
+        //    }
+        //}
+
         match command {
             AccountCommand::StoreAccount(result_tx, mnemonic) => {
                 let result = self.handle_store_account(mnemonic).await;
@@ -774,6 +822,46 @@ where
                         ))
                     }),
                 );
+            }
+            AccountCommand::RegisterOfflineWatch(result_tx, offline_watch) => {
+                if self.offline_watch.is_some() {
+                    result_tx.send(Err(AccountCommandError::internal(
+                        "offline watch already registered",
+                    )));
+                    return;
+                }
+
+                self.offline_watch = Some(offline_watch);
+
+                // Spawn task that monitors the offline watch and sets the connectivity state
+                let mut offline_watch = self.offline_watch.clone().unwrap();
+                let connectivity = self.connectivity.clone();
+                let commander = self.commander();
+                tokio::spawn(async move {
+                    tracing::info!("Starting offline watch task");
+                    let initial_state = *offline_watch.borrow();
+                    tracing::info!("Before setting initial connectivity state: {connectivity:?}");
+                    tracing::info!("Initial connectivity state: {initial_state:?}");
+                    *connectivity.lock().unwrap() = initial_state;
+                    tracing::info!("After setting initial connectivity state: {connectivity:?}");
+                    if initial_state.is_online() {
+                        let _ = commander.send(AccountCommand::SyncAccountState(None));
+                        let _ = commander.send(AccountCommand::SyncDeviceState(None));
+                    }
+
+                    while offline_watch.changed().await.is_ok() {
+                        let new_state = *offline_watch.borrow();
+                        let mut connectivity = connectivity.lock().unwrap();
+                        tracing::error!("Connectivity changed to: {new_state:?}");
+                        *connectivity = new_state;
+
+                        if new_state.is_online() {
+                            let _ = commander.send(AccountCommand::SyncAccountState(None));
+                            let _ = commander.send(AccountCommand::SyncDeviceState(None));
+                        }
+                    }
+                });
+                result_tx.send(Ok(()));
             }
         };
     }
@@ -896,8 +984,11 @@ where
         // so that we periodically check the results without interfering with other tasks
         let mut command_finish_timer = tokio::time::interval(Duration::from_millis(500));
 
-        // Timer to periodically sync the remote account state
+        // Timer to periodically sync the remote account state.
+        // Call tick() once to start the timer immediately. We don't want the first sync to happen
+        // immediately, so we wait for the first tick to happen.
         let mut sync_account_state_timer = tokio::time::interval(ACCOUNT_UPDATE_INTERVAL);
+        sync_account_state_timer.tick().await;
 
         // Timer to periodically check if we need to request more zk-nyms
         let mut update_zk_nym_timer = tokio::time::interval(ZK_NYM_AUTOMATIC_REQUEST_INTERVAL);
@@ -916,8 +1007,11 @@ where
                 }
                 // On a timer we want to sync the account and device state
                 _ = sync_account_state_timer.tick() => {
-                    self.queue_command(AccountCommand::SyncAccountState(None));
-                    self.queue_command(AccountCommand::SyncDeviceState(None));
+                    if self.is_online() {
+                        tracing::info!("Timed sync of account and device state");
+                        self.queue_command(AccountCommand::SyncAccountState(None));
+                        self.queue_command(AccountCommand::SyncDeviceState(None));
+                    }
                 }
                 // On a timer to check if we need to request more zk-nyms
                 _ = update_zk_nym_timer.tick() => {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
@@ -106,6 +106,7 @@ where
         user_agent: UserAgent,
         credentials_mode: Option<bool>,
         network_env: Network,
+        initial_connectivity: Option<Connectivity>,
         cancel_token: CancellationToken,
     ) -> Result<Self, Error> {
         let credentials_mode = credentials_mode.unwrap_or_else(|| {
@@ -161,7 +162,7 @@ where
                 command_tx: command_tx.clone(),
                 shared_state: account_state.clone(),
             },
-            Connectivity::new_presume_offline(),
+            initial_connectivity.unwrap_or(Connectivity::new_presume_offline()),
         );
 
         Ok(AccountController {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
@@ -813,10 +813,10 @@ where
                     }),
                 );
             }
-            AccountCommand::RegisterOfflineWatch(result_tx, offline_watch) => {
+            AccountCommand::RegisterOfflineMonitor(result_tx, offline_watch) => {
                 let res = self
                     .offline_watch
-                    .register_offline_watch(offline_watch)
+                    .register_offline_monitor(offline_watch)
                     .map_err(|e| {
                         AccountCommandError::internal(format!(
                             "Failed to register offline watch: {e}"

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
@@ -175,7 +175,7 @@ where
             cancel_token,
             user_agent,
             // connectivity: Arc::new(std::sync::Mutex::new(Connectivity::PresumeOnline)),
-            connectivity: Arc::new(std::sync::Mutex::new(Connectivity::presume_offline())),
+            connectivity: Arc::new(std::sync::Mutex::new(Connectivity::new_presume_offline())),
             offline_watch: None,
         })
     }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
@@ -15,10 +15,7 @@ use nym_vpn_lib_types::{
 use nym_vpn_network_config::Network;
 use nym_vpn_store::{mnemonic::Mnemonic, VpnStorage};
 use tokio::{
-    sync::{
-        mpsc::{UnboundedReceiver, UnboundedSender},
-        watch,
-    },
+    sync::mpsc::{UnboundedReceiver, UnboundedSender},
     task::{JoinError, JoinSet},
 };
 use tokio_util::sync::CancellationToken;
@@ -31,6 +28,7 @@ use crate::{
         sync_device::WaitingSyncDeviceCommandHandler, AccountCommand, AccountCommandResult,
         Command, RunningCommands,
     },
+    connectivity::OfflineWatch,
     error::Error,
     shared_state::{MnemonicState, ReadyToRegisterDevice, ReadyToRequestZkNym, SharedAccountState},
     storage::{AccountStorage, VpnCredentialStorage},
@@ -94,8 +92,9 @@ where
     // User agent used by api client.
     user_agent: UserAgent,
 
-    connectivity: Arc<std::sync::Mutex<Connectivity>>,
-    offline_watch: Option<watch::Receiver<Connectivity>>,
+    // connectivity: Arc<std::sync::Mutex<Connectivity>>,
+    // offline_watch: Option<watch::Receiver<Connectivity>>,
+    offline_watch: OfflineWatch,
 }
 
 impl<S> AccountController<S>
@@ -158,6 +157,14 @@ where
             vpn_api_client.clone(),
         );
 
+        let offline_watch = OfflineWatch::new(
+            AccountControllerCommander {
+                command_tx: command_tx.clone(),
+                shared_state: account_state.clone(),
+            },
+            Connectivity::new_presume_offline(),
+        );
+
         Ok(AccountController {
             account_storage,
             credential_storage,
@@ -174,9 +181,7 @@ where
             background_zk_nym_refresh: credentials_mode,
             cancel_token,
             user_agent,
-            // connectivity: Arc::new(std::sync::Mutex::new(Connectivity::PresumeOnline)),
-            connectivity: Arc::new(std::sync::Mutex::new(Connectivity::new_presume_offline())),
-            offline_watch: None,
+            offline_watch,
         })
     }
 
@@ -261,15 +266,8 @@ where
             .map_err(AccountCommandError::internal)
     }
 
-    fn is_online(&self) -> bool {
-        self.connectivity
-            .lock()
-            .map(|c| c.is_online())
-            .unwrap_or(false)
-    }
-
     async fn request_zk_nym_if_ready(&self) {
-        if !self.is_online() {
+        if self.offline_watch.is_offline() {
             tracing::info!("Not requesting zk-nym as we are offline");
             return;
         }
@@ -453,7 +451,7 @@ where
             }
         };
 
-        if !self.is_online() {
+        if self.offline_watch.is_offline() {
             tracing::info!("Not syncing account state as we are offline");
             command.return_no_connectivity();
             return;
@@ -483,7 +481,7 @@ where
             }
         };
 
-        if !self.is_online() {
+        if self.offline_watch.is_offline() {
             tracing::info!("Not syncing device state as we are offline");
             command.return_no_connectivity();
             return;
@@ -545,7 +543,7 @@ where
             }
         };
 
-        if !self.is_online() {
+        if self.offline_watch.is_offline() {
             tracing::info!("Not registering device as we are offline");
             command.return_no_connectivity();
             return;
@@ -719,14 +717,6 @@ where
 
     async fn handle_command(&mut self, command: AccountCommand) {
         tracing::info!("← {}", command);
-        //if let Ok(connectivity) = self.connectivity.lock() {
-        //    if connectivity.is_offline() {
-        //        tracing::warn!("Ignoring command as we are offline");
-        //        command.return_no_connectivity();
-        //        return;
-        //    }
-        //}
-
         match command {
             AccountCommand::StoreAccount(result_tx, mnemonic) => {
                 let result = self.handle_store_account(mnemonic).await;
@@ -824,44 +814,15 @@ where
                 );
             }
             AccountCommand::RegisterOfflineWatch(result_tx, offline_watch) => {
-                if self.offline_watch.is_some() {
-                    result_tx.send(Err(AccountCommandError::internal(
-                        "offline watch already registered",
-                    )));
-                    return;
-                }
-
-                self.offline_watch = Some(offline_watch);
-
-                // Spawn task that monitors the offline watch and sets the connectivity state
-                let mut offline_watch = self.offline_watch.clone().unwrap();
-                let connectivity = self.connectivity.clone();
-                let commander = self.commander();
-                tokio::spawn(async move {
-                    tracing::info!("Starting offline watch task");
-                    let initial_state = *offline_watch.borrow();
-                    tracing::info!("Before setting initial connectivity state: {connectivity:?}");
-                    tracing::info!("Initial connectivity state: {initial_state:?}");
-                    *connectivity.lock().unwrap() = initial_state;
-                    tracing::info!("After setting initial connectivity state: {connectivity:?}");
-                    if initial_state.is_online() {
-                        let _ = commander.send(AccountCommand::SyncAccountState(None));
-                        let _ = commander.send(AccountCommand::SyncDeviceState(None));
-                    }
-
-                    while offline_watch.changed().await.is_ok() {
-                        let new_state = *offline_watch.borrow();
-                        let mut connectivity = connectivity.lock().unwrap();
-                        tracing::error!("Connectivity changed to: {new_state:?}");
-                        *connectivity = new_state;
-
-                        if new_state.is_online() {
-                            let _ = commander.send(AccountCommand::SyncAccountState(None));
-                            let _ = commander.send(AccountCommand::SyncDeviceState(None));
-                        }
-                    }
-                });
-                result_tx.send(Ok(()));
+                let res = self
+                    .offline_watch
+                    .register_offline_watch(offline_watch)
+                    .map_err(|e| {
+                        AccountCommandError::internal(format!(
+                            "Failed to register offline watch: {e}"
+                        ))
+                    });
+                result_tx.send(res);
             }
         };
     }
@@ -1007,7 +968,7 @@ where
                 }
                 // On a timer we want to sync the account and device state
                 _ = sync_account_state_timer.tick() => {
-                    if self.is_online() {
+                    if self.offline_watch.is_online() {
                         tracing::info!("Timed sync of account and device state");
                         self.queue_command(AccountCommand::SyncAccountState(None));
                         self.queue_command(AccountCommand::SyncDeviceState(None));

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
@@ -92,8 +92,7 @@ where
     // User agent used by api client.
     user_agent: UserAgent,
 
-    // connectivity: Arc<std::sync::Mutex<Connectivity>>,
-    // offline_watch: Option<watch::Receiver<Connectivity>>,
+    // Keep track of offline state
     offline_watch: OfflineWatch,
 }
 
@@ -913,6 +912,8 @@ where
                 },
             }
         }
+
+        self.offline_watch.wait(Duration::from_secs(5)).await;
     }
 
     async fn print_info(&self) {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
@@ -814,15 +814,10 @@ where
                 );
             }
             AccountCommand::RegisterOfflineMonitor(result_tx, offline_watch) => {
-                let res = self
-                    .offline_watch
+                self.offline_watch
                     .register_offline_monitor(offline_watch)
-                    .map_err(|e| {
-                        AccountCommandError::internal(format!(
-                            "Failed to register offline watch: {e}"
-                        ))
-                    });
-                result_tx.send(res);
+                    .await;
+                result_tx.send(Ok(()));
             }
         };
     }
@@ -913,8 +908,6 @@ where
                 },
             }
         }
-
-        self.offline_watch.wait(Duration::from_secs(5)).await;
     }
 
     async fn print_info(&self) {
@@ -983,6 +976,9 @@ where
                 _ = self.cancel_token.cancelled() => {
                     tracing::trace!("Received cancellation signal");
                     break;
+                }
+                Some(connectivity) = self.offline_watch.next() => {
+                    self.offline_watch.handle_changed_connectivity(connectivity).await;
                 }
                 else => {
                     tracing::debug!("Account controller channel closed");

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/lib.rs
@@ -12,6 +12,7 @@ pub mod storage_cleanup;
 
 mod commander;
 mod commands;
+mod connectivity;
 mod controller;
 mod error;
 mod storage;

--- a/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
@@ -319,7 +319,7 @@ impl<St: Storage> BandwidthController<St> {
                         }
                     }
                     Ok(None) => {
-                        tracing::info!("Empty query for {} gadeway bandwidth check. This is normal, as long as it is not repeating for the same gateway", if entry {"entry".to_string()} else {"exit".to_string()});
+                        tracing::info!("Empty query for {} gateway bandwidth check. This is normal, as long as it is not repeating for the same gateway", if entry {"entry".to_string()} else {"exit".to_string()});
                     }
                 }
             }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/account.rs
@@ -3,6 +3,7 @@
 
 use std::{path::PathBuf, str::FromStr, sync::Arc, time::Duration};
 
+use nym_offline_monitor::Connectivity;
 use nym_vpn_account_controller::{
     shared_state::DeviceState, AccountControllerCommander, SharedAccountState,
 };
@@ -63,12 +64,19 @@ async fn start_account_controller(
     // TODO: pass in as argument
     let user_agent = crate::util::construct_user_agent();
     let shutdown_token = CancellationToken::new();
+
+    // Since the offline monitor is only started later, together with the state machine. Assume
+    // online.
+    // TODO: the whole mobile API should be refactored to start the state machine on init.
+    let initial_connectivity = Connectivity::PresumeOnline;
+
     let account_controller = nym_vpn_account_controller::AccountController::new(
         Arc::clone(&storage),
         data_dir.clone(),
         user_agent,
         credential_mode,
         network_env,
+        Some(initial_connectivity),
         shutdown_token.child_token(),
     )
     .await

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -432,7 +432,7 @@ impl TunnelStateMachine {
 
         let offline_watch = offline_monitor.clone();
         account_command_tx
-            .register_offline_watch(offline_watch)
+            .register_offline_monitor(offline_watch)
             .await
             .inspect_err(|err| tracing::error!("Failed to register offline watch: {}", err))
             .ok();

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -430,7 +430,7 @@ impl TunnelStateMachine {
         )
         .await;
 
-        let offline_watch = offline_monitor.subscribe();
+        let offline_watch = offline_monitor.clone();
         account_command_tx
             .register_offline_watch(offline_watch)
             .await

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -430,6 +430,13 @@ impl TunnelStateMachine {
         )
         .await;
 
+        let offline_watch = offline_monitor.subscribe();
+        account_command_tx
+            .register_offline_watch(offline_watch)
+            .await
+            .inspect_err(|err| tracing::error!("Failed to register offline watch: {}", err))
+            .ok();
+
         let (mixnet_event_sender, mixnet_event_receiver) = mpsc::unbounded_channel();
 
         #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -262,6 +262,7 @@ impl NymVpnService<nym_vpn_lib::storage::VpnClientOnDiskStorage> {
             user_agent.clone(),
             None,
             network_env.clone(),
+            None,
             shutdown_token.child_token(),
         )
         .await


### PR DESCRIPTION
- Monitor offline state in account controller.
- Don't schedule background tasks while offline

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2595)
<!-- Reviewable:end -->
