### PR TITLE
fix: clippy

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
@@ -9,38 +9,38 @@
 //!
 //! 1. Initialize the environment: `initEnvironment(..)` or `initFallbackMainnetEnvironment`.
 //!
-//!     This is required to set the network environment details.
+//!    This is required to set the network environment details.
 //!
 //! 2. Initialise the library: `configureLib(..)`.
 //!
-//!     This sets up the logger and starts the account controller that runs in the background and
-//!     manages the account state.
+//!    This sets up the logger and starts the account controller that runs in the background and
+//!    manages the account state.
 //!
 //! 3. At this point we can interact with the vpn-api and the account controller to do things like:
 //!
-//!     - Get gateway countries: `getGatewayCountries(..)`.
-//!     - Store the account mnemonic: `storeAccountMnemonic(..)`.
-//!     - Get the account state: `getAccountState()`.
-//!     - Get system messages: `getSystemMessages()`.
-//!     - Get account links: `getAccountLinks(..)`.
-//!     - ...
+//!    - Get gateway countries: `getGatewayCountries(..)`.
+//!    - Store the account mnemonic: `storeAccountMnemonic(..)`.
+//!    - Get the account state: `getAccountState()`.
+//!    - Get system messages: `getSystemMessages()`.
+//!    - Get account links: `getAccountLinks(..)`.
+//!    - ...
 //!
 //! 3. Start the VPN: `startVPN(..)`.
 //!
-//!     This will:
+//!    This will:
 //!
-//!     1. Check if the account is ready to connect.
-//!     2. Request zknym credentials if needed.
-//!     3. Start the VPN state machine.
+//!    1. Check if the account is ready to connect.
+//!    2. Request zknym credentials if needed.
+//!    3. Start the VPN state machine.
 //!
 //! 4. Stop the VPN: `stopVPN()`.
 //!
-//!     This will stop the VPN state machine.
+//!    This will stop the VPN state machine.
 //!
 //! 5. Shutdown the library: `shutdown()`.
 //!
-//!     This will stop the account controller and clean up any resources, including make sure there
-//!     are no open DB connections.
+//!    This will stop the account controller and clean up any resources, including make sure there
+//!    are no open DB connections.
 
 #[cfg(target_os = "android")]
 pub mod android;
@@ -63,12 +63,13 @@ use nym_vpn_api_client::types::ScoreThresholds;
 use tokio::{runtime::Runtime, sync::Mutex};
 
 use self::error::VpnError;
-use crate::gateway_directory::GatewayClient;
-use crate::platform::uniffi_custom_impls::NetworkCompatibility;
 #[cfg(target_os = "android")]
 use crate::tunnel_provider::android::AndroidTunProvider;
 #[cfg(target_os = "ios")]
 use crate::tunnel_provider::ios::OSTunProvider;
+use crate::{
+    gateway_directory::GatewayClient, platform::uniffi_custom_impls::NetworkCompatibility,
+};
 use state_machine::StateMachineHandle;
 use uniffi_custom_impls::{
     AccountLinks, AccountStateSummary, EntryPoint, ExitPoint, GatewayInfo, GatewayMinPerformance,

--- a/nym-vpn-core/crates/nym-wg-go/src/amnezia.rs
+++ b/nym-vpn-core/crates/nym-wg-go/src/amnezia.rs
@@ -39,7 +39,7 @@ const BASE: AmneziaConfig = AmneziaConfig {
 /// - S1 — S1 < 1280; S1 + 56 ≠ S2; recommended range is from 15 to 150 inclusive
 /// - S2 — S2 < 1280; recommended range is from 15 to 150 inclusive
 /// - H1/H2/H3/H4 — must be unique among each other;
-///     recommended range is from 5 to 2_147_483_647  (2^31 - 1   i.e. signed 32 bit int) inclusive
+///   recommended range is from 5 to 2_147_483_647  (2^31 - 1   i.e. signed 32 bit int) inclusive
 ///
 /// Note: changes to S1, S2, H1, H2, H3, and H4 are required to match between client
 /// and server. The connection will not work otherwise.
@@ -132,7 +132,7 @@ impl AmneziaConfig {
     /// - S1 — S1 < 1280; S1 + 56 ≠ S2; recommended range is from 15 to 150 inclusive
     /// - S2 — S2 < 1280; recommended range is from 15 to 150 inclusive
     /// - H1/H2/H3/H4 — must be unique among each other;
-    ///     recommended range is from 5 to 2_147_483_647  (2^31 - 1   i.e. signed 32 bit int) inclusive
+    ///   recommended range is from 5 to 2_147_483_647  (2^31 - 1   i.e. signed 32 bit int) inclusive
     pub fn validate(&self) -> bool {
         if self.junk_pkt_count > 128
             || self.junk_pkt_max_size > 1280


### PR DESCRIPTION
This PR fixes the following clippy complaint:

```
$ nym-vpn-core % cargo clippy -p nym-wg-go -F amnezia
warning: doc list item overindented
  --> crates/nym-wg-go/src/amnezia.rs:42:5
   |
42 | ///     recommended range is from 5 to 2_147_483_647  (2^31 - 1   i.e. signed 32 bit int) inclusive
   |     ^^^^ help: try using `  ` (2 spaces)
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_overindented_list_items
   = note: `#[warn(clippy::doc_overindented_list_items)]` on by default

warning: doc list item overindented
   --> crates/nym-wg-go/src/amnezia.rs:135:9
    |
135 |     ///     recommended range is from 5 to 2_147_483_647  (2^31 - 1   i.e. signed 32 bit int) inclusive
    |         ^^^^ help: try using `  ` (2 spaces)
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_overindented_list_items

warning: `nym-wg-go` (lib) generated 2 warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.11s

```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2610)
<!-- Reviewable:end -->
