### PR TITLE
Disable default features for nym-credential-proxy-requests

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -434,8 +434,6 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.6.0",
- "hyper-util",
  "itoa",
  "matchit",
  "memchr",
@@ -444,26 +442,10 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "serde_json",
- "serde_path_to_error",
- "serde_urlencoded",
  "sync_wrapper 1.0.2",
- "tokio",
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum-client-ip"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eefda7e2b27e1bda4d6fa8a06b50803b8793769045918bc37ad062d48a6efac"
-dependencies = [
- "axum",
- "forwarded-header-value",
- "serde",
 ]
 
 [[package]]
@@ -484,7 +466,6 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -1975,16 +1956,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "forwarded-header-value"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8835f84f38484cc86f110a805655697908257fb9a7af005234060891557198e9"
-dependencies = [
- "nonempty",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "fs-err"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3394,12 +3365,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nonempty"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
-
-[[package]]
 name = "ntapi"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3846,7 +3811,6 @@ dependencies = [
  "nym-credentials",
  "nym-credentials-interface",
  "nym-http-api-client",
- "nym-http-api-common",
  "nym-serde-helpers",
  "reqwest 0.12.14",
  "schemars",
@@ -4248,26 +4212,6 @@ dependencies = [
  "tracing",
  "url",
  "wasmtimer",
-]
-
-[[package]]
-name = "nym-http-api-common"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.6-chuckles#f1d3c333911cfb54e8f9f5c19506956acc280b96"
-dependencies = [
- "axum",
- "axum-client-ip",
- "bytes",
- "colored",
- "futures",
- "mime",
- "serde",
- "serde_json",
- "serde_yaml",
- "subtle 2.6.1",
- "tower 0.5.2",
- "tracing",
- "zeroize",
 ]
 
 [[package]]
@@ -6754,16 +6698,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_path_to_error"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
-dependencies = [
- "itoa",
- "serde",
-]
-
-[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6793,19 +6727,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap 2.8.0",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
 ]
 
 [[package]]
@@ -7866,7 +7787,6 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -8261,12 +8181,6 @@ dependencies = [
  "crypto-common",
  "subtle 2.6.1",
 ]
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -51,7 +51,7 @@ default-members = [
 # nym-compact-ecash = { path = "../../nym/common/nym_offline_compact_ecash" }
 # nym-config = { path = "../../nym/common/config" }
 # nym-contracts-common = { path = "../../nym/common/cosmwasm-smart-contracts/contracts-common" }
-# nym-credential-proxy-requests = { path = "../../nym/nym-credential-proxy/nym-credential-proxy-requests" }
+# nym-credential-proxy-requests = { path = "../../nym/nym-credential-proxy/nym-credential-proxy-requests", default-features = false }
 # nym-credential-storage = { path = "../../nym/common/credential-storage" }
 # nym-credentials = { path = "../../nym/common/credentials" }
 # nym-credentials-interface = { path = "../../nym/common/credentials-interface" }
@@ -222,7 +222,7 @@ nym-client-core = { git = "https://github.com/nymtech/nym", branch = "release/20
 nym-compact-ecash = { git = "https://github.com/nymtech/nym", branch = "release/2025.6-chuckles" }
 nym-config = { git = "https://github.com/nymtech/nym", branch = "release/2025.6-chuckles" }
 nym-contracts-common = { git = "https://github.com/nymtech/nym", branch = "release/2025.6-chuckles" }
-nym-credential-proxy-requests = { git = "https://github.com/nymtech/nym", branch = "release/2025.6-chuckles" }
+nym-credential-proxy-requests = { git = "https://github.com/nymtech/nym", branch = "release/2025.6-chuckles", default-features = false }
 nym-credential-storage = { git = "https://github.com/nymtech/nym", branch = "release/2025.6-chuckles" }
 nym-credentials = { git = "https://github.com/nymtech/nym", branch = "release/2025.6-chuckles" }
 nym-credentials-interface = { git = "https://github.com/nymtech/nym", branch = "release/2025.6-chuckles" }


### PR DESCRIPTION
`nym-credential-proxy-requests` brings a lot of unneeded stuff along with it like `axum`. As per Andrew's suggestion, disabling default-features should lighten up the dependency tree.

Consider this, without the patch:

```
% cargo tree -i axum
axum v0.7.9
├── axum-client-ip v0.6.1
│   └── nym-http-api-common v0.1.0 (https://github.com/nymtech/nym?branch=release%2F2025.6-chuckles#f1d3c333)
│       └── nym-credential-proxy-requests v0.1.0 (https://github.com/nymtech/nym?branch=release%2F2025.6-chuckles#f1d3c333)
│           ├── nym-vpn-account-controller v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpn-account-controller)
│           │   ├── nym-vpn-lib v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpn-lib)
│           │   │   ├── nym-vpnd v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpnd)
│           │   │   └── nym-vpnd-types v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpnd-types)
│           │   │       ├── nym-vpn-proto v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpn-proto)
│           │   │       │   ├── nym-vpnc v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpnc)
│           │   │       │   └── nym-vpnd v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpnd)
│           │   │       ├── nym-vpnc v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpnc)
│           │   │       └── nym-vpnd v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpnd)
│           │   ├── nym-vpn-proto v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpn-proto) (*)
│           │   └── nym-vpnd v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpnd)
│           └── nym-vpn-api-client v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpn-api-client)
│               ├── nym-gateway-directory v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-gateway-directory)
│               │   ├── nym-ip-packet-client v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-ip-packet-client)
│               │   │   └── nym-vpn-lib v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpn-lib) (*)
│               │   ├── nym-vpn-lib v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpn-lib) (*)
│               │   ├── nym-vpn-lib-types v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpn-lib-types)
│               │   │   ├── nym-vpn-account-controller v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpn-account-controller) (*)
│               │   │   ├── nym-vpn-lib v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpn-lib) (*)
│               │   │   ├── nym-vpn-proto v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpn-proto) (*)
│               │   │   ├── nym-vpnc v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpnc)
│               │   │   └── nym-vpnd v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpnd)
│               │   ├── nym-vpn-proto v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpn-proto) (*)
│               │   ├── nym-vpnc v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpnc)
│               │   └── nym-wg-gateway-client v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-wg-gateway-client)
│               │       ├── nym-vpn-account-controller v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpn-account-controller) (*)
│               │       ├── nym-vpn-lib v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpn-lib) (*)
│               │       └── nym-vpn-lib-types v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpn-lib-types) (*)
│               ├── nym-vpn-account-controller v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpn-account-controller) (*)
│               ├── nym-vpn-lib v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpn-lib) (*)
│               ├── nym-vpn-lib-types v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpn-lib-types) (*)
│               ├── nym-vpn-network-config v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpn-network-config)
│               │   ├── nym-vpn-account-controller v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpn-account-controller) (*)
│               │   ├── nym-vpn-lib v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpn-lib) (*)
│               │   ├── nym-vpn-proto v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpn-proto) (*)
│               │   ├── nym-vpnc v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpnc)
│               │   └── nym-vpnd v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpnd)
│               ├── nym-vpn-proto v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpn-proto) (*)
│               └── nym-vpnd v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpnd)
├── nym-http-api-common v0.1.0 (https://github.com/nymtech/nym?branch=release%2F2025.6-chuckles#f1d3c333) (*)
└── tonic v0.12.3
    ├── nym-ipc v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-ipc)
    │   ├── nym-vpnc v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpnc)
    │   └── nym-vpnd v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpnd)
    ├── nym-vpn-proto v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpn-proto) (*)
    ├── nym-vpnc v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpnc)
    ├── nym-vpnd v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpnd)
    └── tonic-reflection v0.12.3
        └── nym-vpnd v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpnd)
```

and after disabling default features:

```
% cargo tree -i axum
axum v0.7.9
└── tonic v0.12.3
    ├── nym-ipc v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-ipc)
    │   ├── nym-vpnc v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpnc)
    │   └── nym-vpnd v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpnd)
    ├── nym-vpn-proto v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpn-proto)
    │   ├── nym-vpnc v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpnc)
    │   └── nym-vpnd v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpnd)
    ├── nym-vpnc v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpnc)
    ├── nym-vpnd v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpnd)
    └── tonic-reflection v0.12.3
        └── nym-vpnd v1.7.0-beta (/Users/pronebird/Nym/nym-vpn-client/nym-vpn-core/crates/nym-vpnd)
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2621)
<!-- Reviewable:end -->
