### PR TITLE
ci: fix windows

### DIFF
--- a/.github/workflows/build-nym-vpn-core-windows.yml
+++ b/.github/workflows/build-nym-vpn-core-windows.yml
@@ -58,6 +58,7 @@ jobs:
           subcommand: workspace.package.version --entry nym-vpn-core
 
       - name: Install cargo-edit
+        shell: bash
         run: cargo install --locked cargo-edit || true
 
       - name: Append timestamp if it's a dev version


### PR DESCRIPTION
`|| true` does not work with pwsh which is probably default on windows CI. So let's duct tape that by switching to bash shell for that particular step.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2624)
<!-- Reviewable:end -->
