### PR TITLE
send 20 surbs in init message and only one after

### DIFF
--- a/nym-vpn-core/crates/nym-authenticator-client/src/lib.rs
+++ b/nym-vpn-core/crates/nym-authenticator-client/src/lib.rs
@@ -1097,7 +1097,10 @@ impl AuthClient {
         // threshold of 10 surbs that it reserves for itself to request additional
         // surbs.
         let surbs = if message.use_surbs() {
-            IncludedSurbs::new(20)
+            match &message {
+                ClientMessage::Initial(_) => IncludedSurbs::new(20),
+                _ => IncludedSurbs::new(1),
+            }
         } else {
             IncludedSurbs::ExposeSelfAddress
         };


### PR DESCRIPTION
Reduce the number of SURBs send in Wireguard mode.

In general this assumes that our first message to the gateway must be an `InitialMessage`

After Change.
```
Padding repliable 0.06 kiB data message with 20 reply surbs attached from 8sQ1X9ai44xqy7BTqBKrGs: 23360 of raw plaintext bytes are required. They're going to be put into 15 sphinx packets with 700 bytes of leftover space. 2.9% of packet capacity is going to be wasted.    
Padding repliable 0.06 kiB data message with 20 reply surbs attached from KzRd619sWt8T4kUCJMC23n: 23360 of raw plaintext bytes are required. They're going to be put into 15 sphinx packets with 700 bytes of leftover space. 2.9% of packet capacity is going to be wasted.    
Padding repliable 1.33 kiB data message with 1 reply surbs attached from 8sQ1X9ai44xqy7BTqBKrGs: 2545 of raw plaintext bytes are required. They're going to be put into 2 sphinx packets with 663 bytes of leftover space. 20.7% of packet capacity is going to be wasted.    
Padding repliable 1.33 kiB data message with 1 reply surbs attached from KzRd619sWt8T4kUCJMC23n: 2545 of raw plaintext bytes are required. They're going to be put into 2 sphinx packets with 663 bytes of leftover space. 20.7% of packet capacity is going to be wasted.    
Padding repliable 0.06 kiB data message with 1 reply surbs attached from KzRd619sWt8T4kUCJMC23n: 1244 of raw plaintext bytes are required. They're going to be put into 1 sphinx packets with 360 bytes of leftover space. 22.4% of packet capacity is going to be wasted.    
Padding repliable 0.06 kiB data message with 1 reply surbs attached from 8sQ1X9ai44xqy7BTqBKrGs: 1244 of raw plaintext bytes are required. They're going to be put into 1 sphinx packets with 360 bytes of leftover space. 22.4% of packet capacity is going to be wasted.    
Padding repliable 0.06 kiB data message with 1 reply surbs attached from KzRd619sWt8T4kUCJMC23n: 1244 of raw plaintext bytes are required. They're going to be put into 1 sphinx packets with 360 bytes of leftover space. 22.4% of packet capacity is going to be wasted.    
Padding repliable 0.06 kiB data message with 1 reply surbs attached from 8sQ1X9ai44xqy7BTqBKrGs: 1244 of raw plaintext bytes are required. They're going to be put into 1 sphinx packets with 360 bytes of leftover space. 22.4% of packet capacity is going to be wasted. 
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2628)
<!-- Reviewable:end -->
