### PR TITLE
Use fwmark for linux

### DIFF
--- a/nym-vpn-core/crates/nym-firewall/src/linux.rs
+++ b/nym-vpn-core/crates/nym-firewall/src/linux.rs
@@ -596,10 +596,9 @@ impl<'a> PolicyBatch<'a> {
                     .flat_map(|server| get_allow_dns_endpoints_when_connecting(*server))
                     .collect::<Vec<_>>();
 
-                // todo: we should do fwmark, at some point
                 peer_endpoints
                     .iter()
-                    .for_each(|endpoint| self.add_allow_endpoint_rules(endpoint));
+                    .for_each(|endpoint| self.add_allow_tunnel_endpoint_rules(endpoint, fwmark));
                 allowed_endpoints
                     .iter()
                     .chain(dns_endpoints.iter())


### PR DESCRIPTION
Now that https://github.com/nymtech/nym/pull/5654 is merged, we can rely on the fd callback for fwmark

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2633)
<!-- Reviewable:end -->
