### PR TITLE
Make MonitorHandle clonable

### DIFF
--- a/nym-vpn-core/crates/nym-offline-monitor/Cargo.toml
+++ b/nym-vpn-core/crates/nym-offline-monitor/Cargo.toml
@@ -12,7 +12,7 @@ license.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 futures.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["macros", "sync", "time", "rt"] }
 debounced.workspace = true
 tokio-stream.workspace = true
 tokio-util.workspace = true

--- a/nym-vpn-core/crates/nym-offline-monitor/src/lib.rs
+++ b/nym-vpn-core/crates/nym-offline-monitor/src/lib.rs
@@ -2,7 +2,7 @@
 // Copyright 2025 Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::sync::LazyLock;
+use std::sync::{Arc, LazyLock};
 
 use nym_common::ErrorExt;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
@@ -36,10 +36,11 @@ static FORCE_DISABLE_OFFLINE_MONITOR: LazyLock<bool> = LazyLock::new(|| {
         .unwrap_or(false)
 });
 
+#[derive(Clone)]
 pub struct MonitorHandle {
-    inner: Option<imp::MonitorHandle>,
+    inner: Arc<Option<imp::MonitorHandle>>,
     rx: watch::Receiver<Connectivity>,
-    _shutdown_drop_guard: DropGuard,
+    _shutdown_drop_guard: Arc<DropGuard>,
 }
 
 impl MonitorHandle {
@@ -49,9 +50,9 @@ impl MonitorHandle {
         shutdown_drop_guard: DropGuard,
     ) -> Self {
         Self {
-            inner,
+            inner: Arc::new(inner),
             rx,
-            _shutdown_drop_guard: shutdown_drop_guard,
+            _shutdown_drop_guard: Arc::new(shutdown_drop_guard),
         }
     }
 


### PR DESCRIPTION
I think it makes sense to make the `MonitorHandle` clonable so that we could use multiple subscribers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2634)
<!-- Reviewable:end -->
