### PR TITLE
refactor(tauri): add some optimizations

### DIFF
--- a/nym-vpn-app/src-tauri/src/db.rs
+++ b/nym-vpn-app/src-tauri/src/db.rs
@@ -186,14 +186,6 @@ impl Db {
                 DbError::Deserialize(e)
             });
 
-        // flush db in the background
-        let db = self.db.clone();
-        tokio::spawn(async move {
-            let _ = db.flush_async().await.inspect_err(|e| {
-                error!("failed to flush: {e}");
-            });
-            debug!("flushed db");
-        });
         debug!("set key [{key}]");
         self.discard_deserialize(key, res)
     }
@@ -219,15 +211,6 @@ impl Db {
                 error!("failed to deserialize value for key [{key}]: {e}");
                 DbError::Deserialize(e)
             });
-
-        // flush db in the background
-        let db = self.db.clone();
-        tokio::spawn(async move {
-            let _ = db.flush_async().await.inspect_err(|e| {
-                error!("failed to flush: {e}");
-            });
-            debug!("flushed db");
-        });
 
         debug!("del key [{key}]");
         self.discard_deserialize(key, res)

--- a/nym-vpn-app/src/contexts/main/provider.tsx
+++ b/nym-vpn-app/src/contexts/main/provider.tsx
@@ -1,14 +1,13 @@
 import { invoke } from '@tauri-apps/api/core';
 import React, { useEffect, useReducer } from 'react';
 import { sleep } from '../../util';
-import { Cli, NetworkEnv, SystemMessage } from '../../types';
+import { Cli, SystemMessage } from '../../types';
 import { initFirstBatch, initSecondBatch } from '../../state/init';
 import { useTauriEvents } from '../../state/useTauriEvents';
 import { S_STATE } from '../../static';
-import { CCache } from '../../cache';
-import { kvGet, kvSet } from '../../kvStore';
 import { useInAppNotify } from '../in-app-notification';
-import { daemonStatusUpdate } from '../../state/helper';
+import { daemonStatusUpdate, networkEnvChanged } from '../../state/helper';
+import { CCache } from '../../cache';
 import { MainDispatchContext, MainStateContext } from './context';
 import { initialState, reducer } from './reducer';
 
@@ -20,7 +19,6 @@ type Props = {
 
 function MainStateProvider({ children }: Props) {
   const [state, dispatch] = useReducer(reducer, initialState);
-  const { networkEnv } = state;
 
   const { push } = useInAppNotify();
   useTauriEvents(dispatch, push);
@@ -34,6 +32,12 @@ function MainStateProvider({ children }: Props) {
     }
     initialized = true;
     daemonStatusUpdate(S_STATE.vpnd, dispatch, push);
+    networkEnvChanged(S_STATE.vpnd).then(async (changed) => {
+      if (changed) {
+        console.info('network env changed, clearing cache');
+        await CCache.clear();
+      }
+    });
 
     // this first batch is needed to ensure the app is fully
     // initialized and ready, once done splash screen is removed
@@ -48,15 +52,14 @@ function MainStateProvider({ children }: Props) {
       }
       // wait for the splash screen to be visible for a short time
       // as init phase is very fast
-      // duration → 700ms
-      await sleep(700);
+      await sleep(300);
       const splash = document.getElementById('splash');
       if (splash) {
         // starts the fade out animation
         splash.style.opacity = '0';
-        // fade out animation duration is set to 150ms, so we wait 300ms
+        // fade out animation duration is set to 150ms, so we wait 200ms
         // to ensure it's done before removing the splash screen
-        await sleep(300);
+        await sleep(200);
         splash.remove();
         console.log('splash animation done');
       }
@@ -69,22 +72,6 @@ function MainStateProvider({ children }: Props) {
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  // whenever the network environment changes (e.i. daemon has been reconfigured),
-  // clear cache
-  useEffect(() => {
-    const handleNetEnvUpdate = async () => {
-      const env = await kvGet<NetworkEnv>('last-network-env');
-      if (env === networkEnv) {
-        return;
-      }
-      console.info(`network env changed [${networkEnv}], clearing cache`);
-      await kvSet('last-network-env', networkEnv);
-      await CCache.clear();
-    };
-
-    handleNetEnvUpdate();
-  }, [networkEnv]);
 
   useEffect(() => {
     if (S_STATE.systemMessageInit || state.daemonStatus === 'down') {

--- a/nym-vpn-app/src/contexts/main/reducer.ts
+++ b/nym-vpn-app/src/contexts/main/reducer.ts
@@ -23,7 +23,6 @@ import {
   UiTheme,
   VpnMode,
 } from '../../types';
-import { S_STATE } from '../../static';
 
 export type StateAction =
   | { type: 'init-done' }
@@ -71,7 +70,7 @@ export const initialState: AppState = {
   daemonStatus: 'down',
   networkEnv: 'mainnet',
   version: null,
-  vpnMode: S_STATE.vpnModeAtStart,
+  vpnMode: 'wg',
   uiTheme: 'light',
   themeMode: DefaultThemeMode,
   progressMessages: [],

--- a/nym-vpn-app/src/main.tsx
+++ b/nym-vpn-app/src/main.tsx
@@ -90,6 +90,8 @@ async function setSplashTheme(window: WebviewWindow) {
   S_STATE.vpnd =
     (await invoke<VpndStatus | undefined>('daemon_status')) || 'down';
   S_STATE.vpnModeAtStart = (await kvGet<VpnMode>('vpn-mode')) || DefaultVpnMode;
+  S_STATE.welcomeScreenSeen =
+    (await kvGet<boolean>('welcome-screen-seen')) || false;
 
   // check for unrecoverable errors
   const error = await invoke<TStartupError | undefined>('startup_error');

--- a/nym-vpn-app/src/screens/Welcome.tsx
+++ b/nym-vpn-app/src/screens/Welcome.tsx
@@ -7,6 +7,7 @@ import { kvSet } from '../kvStore';
 import { routes } from '../router';
 import { StateDispatch } from '../types';
 import { Button, Link, PageAnim, Switch } from '../ui';
+import { S_STATE } from '../static';
 import SettingsGroup from './settings/SettingsGroup';
 
 function Welcome() {
@@ -17,6 +18,7 @@ function Welcome() {
 
   const handleContinue = () => {
     kvSet('welcome-screen-seen', true).then(() => {
+      S_STATE.welcomeScreenSeen = true;
       navigate(routes.root);
     });
   };

--- a/nym-vpn-app/src/screens/home/Home.tsx
+++ b/nym-vpn-app/src/screens/home/Home.tsx
@@ -7,7 +7,6 @@ import { motion } from 'motion/react';
 import { useInAppNotify, useMainDispatch, useMainState } from '../../contexts';
 import { BackendError, StateDispatch } from '../../types';
 import { routes } from '../../router';
-import { kvGet } from '../../kvStore';
 import { S_STATE } from '../../static';
 import { Button } from '../../ui';
 import { capFirst } from '../../util';
@@ -84,13 +83,9 @@ function Home() {
   }, [networkCompat]);
 
   useEffect(() => {
-    const showWelcomeScreen = async () => {
-      const seen = await kvGet<boolean>('welcome-screen-seen');
-      if (!seen) {
-        navigate(routes.welcome);
-      }
-    };
-    showWelcomeScreen();
+    if (!S_STATE.welcomeScreenSeen) {
+      navigate(routes.welcome);
+    }
   }, [navigate]);
 
   useEffect(() => {

--- a/nym-vpn-app/src/state/helper.ts
+++ b/nym-vpn-app/src/state/helper.ts
@@ -1,12 +1,15 @@
 import i18n from 'i18next';
 import {
+  DaemonInfo,
   DaemonStatus,
+  NetworkEnv,
   StateDispatch,
   VpndStatus,
   isVpndNonCompat,
   isVpndOk,
 } from '../types';
 import { Notification } from '../contexts';
+import { kvGet, kvSet } from '../kvStore';
 
 export type TauriReq<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -45,12 +48,11 @@ export function daemonStatusUpdate(
     type: 'set-daemon-status',
     status: vpndStatusToState(status),
   });
-  let info;
-  if (isVpndOk(status) && status.ok) {
-    info = status.ok;
+  const info = getVpndInfo(status);
+  if (info) {
+    dispatch({ type: 'set-daemon-info', info });
   }
   if (isVpndNonCompat(status)) {
-    info = status.nonCompat.current;
     push({
       id: 'daemon-no-compat',
       message: i18n.t('daemon-no-compat', {
@@ -76,9 +78,30 @@ export function daemonStatusUpdate(
       throttle: 10,
     });
   }
-  if (info) {
-    dispatch({ type: 'set-daemon-info', info });
+}
+
+export async function networkEnvChanged(status: VpndStatus) {
+  if (status === 'down') {
+    return false;
   }
+  const prevEnv = await kvGet<NetworkEnv>('last-network-env');
+  const newEnv = getVpndInfo(status)?.network;
+  const hasChanged = prevEnv !== newEnv;
+  if (hasChanged) {
+    console.info(`network env changed [${newEnv}]`);
+    await kvSet('last-network-env', newEnv);
+  }
+  return hasChanged;
+}
+
+export function getVpndInfo(status: VpndStatus): DaemonInfo | null {
+  if (isVpndOk(status) && status.ok) {
+    return status.ok;
+  }
+  if (isVpndNonCompat(status)) {
+    return status.nonCompat.current;
+  }
+  return null;
 }
 
 function vpndStatusToState(status: VpndStatus): DaemonStatus {

--- a/nym-vpn-app/src/state/useTauriEvents.ts
+++ b/nym-vpn-app/src/state/useTauriEvents.ts
@@ -22,7 +22,7 @@ import {
 } from '../constants';
 import { Notification } from '../contexts';
 import { CCache } from '../cache';
-import { daemonStatusUpdate } from './helper';
+import { daemonStatusUpdate, networkEnvChanged } from './helper';
 import { tunnelUpdate } from './tunnelUpdate';
 
 export function useTauriEvents(
@@ -37,8 +37,14 @@ export function useTauriEvents(
           `received event [${event}], status: ${status === 'down' ? status : JSON.stringify(status)}`,
         );
         daemonStatusUpdate(status, dispatch, push);
-        await CCache.del('cache-account-id');
-        await CCache.del('cache-device-id');
+        const changed = await networkEnvChanged(status);
+        if (changed) {
+          console.info('network env changed, clearing cache');
+          await CCache.clear();
+        } else {
+          await CCache.del('cache-account-id');
+          await CCache.del('cache-device-id');
+        }
 
         // refresh account status
         if (isVpndOk(status) || isVpndNonCompat(status)) {

--- a/nym-vpn-app/src/static.ts
+++ b/nym-vpn-app/src/static.ts
@@ -9,6 +9,7 @@ export type SState = {
   vpnModeAtStart: VpnMode;
   systemMessageInit: boolean;
   devMode: boolean;
+  welcomeScreenSeen: boolean;
 };
 
 export const S_STATE: SState = {
@@ -17,4 +18,5 @@ export const S_STATE: SState = {
   vpnModeAtStart: 'wg',
   systemMessageInit: false,
   devMode: false,
+  welcomeScreenSeen: false,
 };


### PR DESCRIPTION
### Global optimization:
Stop flushing the db state like crazy, anyway sled "automatically fsyncs every 500ms by default"

> Flushing can take quite a lot of time, and you should measure the performance impact of using it on realistic sustained workloads running on realistic hardware.

refs
https://github.com/spacejam/sled#expectations-gotchas-advice
https://docs.rs/sled/latest/sled/struct.Tree.html#method.flush_async

### App UI optimizations:
- when the daemon is reconfigured and the network env has been switched, handle the cache cleanup logic correctly
- fix the initial UI app state when the daemon network is not `mainnet`

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2646)
<!-- Reviewable:end -->
