### PR TITLE
Add arm64 support for libwg docker

### DIFF
--- a/.github/workflows/build-and-push-wg-docker.yml
+++ b/.github/workflows/build-and-push-wg-docker.yml
@@ -19,8 +19,9 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: nymtech/android-wg-patched:latest
           file: ${{ github.workspace }}/wireguard/libwg/Dockerfile_AndroidPatchedGoruntime

--- a/wireguard/build-wireguard-go.sh
+++ b/wireguard/build-wireguard-go.sh
@@ -171,9 +171,19 @@ function build_unix {
 
 function build_android {
     echo "Building for android"
-    local docker_image_hash="fe6c1ded2e1f8a7e6ff0da2800c98b9d564d4723cc63ae46b1a8a3af33f78d1f"
 
     if $IS_DOCKER_BUILD; then
+        # See https://hub.docker.com/r/nymtech/android-wg-patched/tags
+        local docker_amd64_image_hash="965b2386e7387d0679498416fb39441c8ced350f1f7744df519495f4abd72405"
+        local docker_arm64_image_hash="e697125820a8143803a549f30d3fe935ee9f5955876345def8dc5277dd7e2606"
+        
+        # Pick the host system architecture for better performance
+        local arch="$(uname -m)";
+        case  "$arch" in
+            arm64*) local docker_image_hash=$docker_arm64_image_hash ;;
+                 *) local docker_image_hash=$docker_amd64_image_hash ;;
+        esac
+
         docker run --rm \
             -v "$(pwd)/../":/workspace \
             --entrypoint "/workspace/wireguard/$LIB_DIR/build-android.sh" \


### PR DESCRIPTION
Add linux/arm64 image for libwg docker image and pick it based on current system CPU

New images have already been published to https://hub.docker.com/r/nymtech/android-wg-patched/tags via https://github.com/nymtech/nym-vpn-client/actions/runs/14407970048

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2661)
<!-- Reviewable:end -->
