### PR TITLE
Log unexpected vpn-api error responses using debug instead of display

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
@@ -270,7 +270,7 @@ where
             .map_err(|err| {
                 VpnApiErrorResponse::try_from(err)
                     .map(ForgetAccountError::UpdateDeviceErrorResponse)
-                    .unwrap_or_else(|err| ForgetAccountError::UnexpectedResponse(err.to_string()))
+                    .unwrap_or_else(ForgetAccountError::unexpected_response)
                     .into()
             })
     }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/vpn_api_client.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/vpn_api_client.rs
@@ -38,7 +38,7 @@ impl AccountControllerVpnApiClient {
         let response = self.inner.get_account(account).await.map_err(|e| {
             VpnApiErrorResponse::try_from(e)
                 .map(StoreAccountError::GetAccountEndpointFailure)
-                .unwrap_or_else(|e| StoreAccountError::UnexpectedResponse(e.to_string()))
+                .unwrap_or_else(StoreAccountError::unexpected_response)
         });
 
         // TODO: handle these cases

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/account/forget_account.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/account/forget_account.rs
@@ -1,6 +1,8 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use std::fmt::Debug;
+
 use super::VpnApiErrorResponse;
 
 #[derive(Debug, thiserror::Error, Clone, PartialEq, Eq)]
@@ -36,5 +38,9 @@ pub enum ForgetAccountError {
 impl ForgetAccountError {
     pub fn internal(err: impl ToString) -> Self {
         ForgetAccountError::Internal(err.to_string())
+    }
+
+    pub fn unexpected_response(err: impl Debug) -> Self {
+        ForgetAccountError::UnexpectedResponse(format!("{err:?}"))
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/account/register_device.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/account/register_device.rs
@@ -1,6 +1,8 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use std::fmt::Debug;
+
 use super::VpnApiErrorResponse;
 
 #[derive(Debug, thiserror::Error, Clone, PartialEq, Eq)]
@@ -25,8 +27,8 @@ pub enum RegisterDeviceError {
 }
 
 impl RegisterDeviceError {
-    pub fn unexpected_response(message: impl ToString) -> Self {
-        RegisterDeviceError::UnexpectedResponse(message.to_string())
+    pub fn unexpected_response(message: impl Debug) -> Self {
+        RegisterDeviceError::UnexpectedResponse(format!("{message:?}"))
     }
 
     pub fn internal(message: impl ToString) -> Self {

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/account/request_zknym.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/account/request_zknym.rs
@@ -1,6 +1,8 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use std::fmt::Debug;
+
 use super::VpnApiErrorResponse;
 
 #[derive(Clone, Debug, thiserror::Error, PartialEq, Eq)]
@@ -113,8 +115,8 @@ impl RequestZkNymError {
         RequestZkNymError::Internal(message.to_string())
     }
 
-    pub fn unexpected_response(message: impl ToString) -> Self {
-        RequestZkNymError::UnexpectedErrorResponse(message.to_string())
+    pub fn unexpected_response(message: impl Debug) -> Self {
+        RequestZkNymError::UnexpectedErrorResponse(format!("{message:?}"))
     }
 
     pub fn vpn_api_error(&self) -> Option<VpnApiErrorResponse> {

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/account/store_account.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/account/store_account.rs
@@ -1,6 +1,8 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use std::fmt::Debug;
+
 use super::VpnApiErrorResponse;
 
 #[derive(Debug, thiserror::Error, Clone, PartialEq, Eq)]
@@ -28,6 +30,10 @@ impl StoreAccountError {
 
     pub fn storage(err: impl ToString) -> Self {
         StoreAccountError::Storage(err.to_string())
+    }
+
+    pub fn unexpected_response(err: impl Debug) -> Self {
+        StoreAccountError::UnexpectedResponse(format!("{err:?}"))
     }
 
     pub fn message(&self) -> String {

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/account/sync_account.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/account/sync_account.rs
@@ -1,6 +1,8 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use std::fmt::Debug;
+
 use super::VpnApiErrorResponse;
 
 #[derive(Debug, thiserror::Error, PartialEq, Eq, Clone)]
@@ -22,8 +24,8 @@ pub enum SyncAccountError {
 }
 
 impl SyncAccountError {
-    pub fn unexpected_response(err: impl ToString) -> Self {
-        SyncAccountError::UnexpectedResponse(err.to_string())
+    pub fn unexpected_response(err: impl Debug) -> Self {
+        SyncAccountError::UnexpectedResponse(format!("{err:?}"))
     }
 
     pub fn internal(err: impl ToString) -> Self {

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/account/sync_device.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/account/sync_device.rs
@@ -1,6 +1,8 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use std::fmt::Debug;
+
 use super::VpnApiErrorResponse;
 
 #[derive(Debug, thiserror::Error, PartialEq, Eq, Clone)]
@@ -25,8 +27,8 @@ pub enum SyncDeviceError {
 }
 
 impl SyncDeviceError {
-    pub fn unexpected_response(err: impl ToString) -> Self {
-        SyncDeviceError::UnexpectedResponse(err.to_string())
+    pub fn unexpected_response(err: impl Debug) -> Self {
+        SyncDeviceError::UnexpectedResponse(format!("{err:?}"))
     }
 
     pub fn internal(err: impl ToString) -> Self {


### PR DESCRIPTION
Sometimes we get unexpected error responses from the vpn-api that are
puzzling. Print the Debug impl instead of the Display impl.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2663)
<!-- Reviewable:end -->
