### PR TITLE
 Add remote time synchronization check and error handling

### DIFF
--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/util/extensions/UiExtensions.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/util/extensions/UiExtensions.kt
@@ -81,6 +81,7 @@ fun ErrorStateReason.toUserMessage(context: Context): String {
 		ErrorStateReason.MaxDevicesReached -> context.getString(R.string.max_devices_error)
 		ErrorStateReason.Firewall, ErrorStateReason.Routing -> context.getString(R.string.unexpected_error) + " ${error.javaClass.simpleName}"
 		ErrorStateReason.SubscriptionExpired -> context.getString(R.string.subscription_expired_error)
+		ErrorStateReason.DeviceTimeOutOfSync -> context.getString(R.string.device_time_out_of_sync)
 	}
 }
 

--- a/nym-vpn-android/app/src/main/res/values/strings.xml
+++ b/nym-vpn-android/app/src/main/res/values/strings.xml
@@ -259,4 +259,5 @@
 	<string name="get_help">Get help</string>
 	<string name="telegram_url">https://nym.com/go/telegram</string>
 	<string name="join_telegram">Join us on Telegram</string>
+	<string name="device_time_out_of_sync">Device time ouf of sync</string>
 </resources>

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/command_sender.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/command_sender.rs
@@ -4,7 +4,10 @@
 use std::net::SocketAddr;
 
 use nym_offline_monitor::ConnectivityHandle;
-use nym_vpn_api_client::response::{NymVpnAccountSummaryResponse, NymVpnDevice, NymVpnUsage};
+use nym_vpn_api_client::{
+    response::{NymVpnAccountSummaryResponse, NymVpnDevice, NymVpnUsage},
+    types::VpnApiTimeSynced,
+};
 use nym_vpn_lib_types::{
     AccountCommandError, ForgetAccountError, RegisterDeviceError, RequestZkNymError,
     StoreAccountError, SyncAccountError, SyncDeviceError,
@@ -208,6 +211,14 @@ impl AccountCommandSender {
         let (tx, rx) = ReturnSender::new();
         self.command_tx
             .send(AccountCommand::RegisterOfflineMonitor(tx, offline_monitor))
+            .map_err(AccountCommandError::internal)?;
+        rx.await.map_err(AccountCommandError::internal)?
+    }
+
+    pub async fn check_device_time_sync(&self) -> Result<VpnApiTimeSynced, AccountCommandError> {
+        let (tx, rx) = ReturnSender::new();
+        self.command_tx
+            .send(AccountCommand::CheckDeviceTimeSync(tx))
             .map_err(AccountCommandError::internal)?;
         rx.await.map_err(AccountCommandError::internal)?
     }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/dispatch.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/dispatch.rs
@@ -10,7 +10,10 @@ use nym_vpn_store::mnemonic::Mnemonic;
 
 use std::net::SocketAddr;
 
-use nym_vpn_api_client::response::{NymVpnAccountSummaryResponse, NymVpnDevice, NymVpnUsage};
+use nym_vpn_api_client::{
+    response::{NymVpnAccountSummaryResponse, NymVpnDevice, NymVpnUsage},
+    types::VpnApiTimeSynced,
+};
 use tokio::sync::oneshot;
 
 use crate::{
@@ -40,6 +43,7 @@ pub enum AccountCommand {
         Option<Vec<SocketAddr>>,
     ),
     RegisterOfflineMonitor(ReturnSender<(), AccountCommandError>, ConnectivityHandle),
+    CheckDeviceTimeSync(ReturnSender<VpnApiTimeSynced, AccountCommandError>),
 }
 
 impl AccountCommand {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
@@ -6,7 +6,7 @@ use std::{net::SocketAddr, sync::Arc, time::Duration};
 use nym_offline_monitor::{Connectivity, ConnectivityHandle};
 use nym_vpn_api_client::{
     response::{NymVpnDevice, NymVpnUsage},
-    types::{DeviceStatus, VpnApiAccount},
+    types::{DeviceStatus, VpnApiAccount, VpnApiTimeSynced},
 };
 use nym_vpn_lib_types::{
     AccountCommandError, ForgetAccountError, StoreAccountError, VpnApiErrorResponse,
@@ -771,6 +771,23 @@ where
         Ok(())
     }
 
+    async fn handle_check_device_time_sync(&self) -> Result<VpnApiTimeSynced, AccountCommandError> {
+        if self.offline_watch.is_offline() {
+            tracing::error!("Unable to check remote time as we are offline");
+            return Err(AccountCommandError::Offline);
+        }
+
+        self.vpn_api_client
+            .get_remote_time()
+            .await
+            .map_err(|err| {
+                VpnApiErrorResponse::try_from(err)
+                    .map(AccountCommandError::from)
+                    .unwrap_or_else(AccountCommandError::unexpected_response)
+            })
+            .map(|vpn_api_time| vpn_api_time.is_synced())
+    }
+
     async fn handle_command(&mut self, command: AccountCommand) {
         tracing::info!("← {}", command);
         match command {
@@ -840,6 +857,9 @@ where
             }
             AccountCommand::RegisterOfflineMonitor(result_tx, offline_monitor) => {
                 result_tx.send(self.handle_register_offline_monitor(offline_monitor).await);
+            }
+            AccountCommand::CheckDeviceTimeSync(result_tx) => {
+                result_tx.send(self.handle_check_device_time_sync().await);
             }
         };
     }

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
@@ -25,7 +25,10 @@ use crate::{
         NymWellknownDiscoveryItem, StatusOk,
     },
     routes,
-    types::{Device, DeviceStatus, GatewayMinPerformance, GatewayType, VpnApiAccount, VpnApiTime},
+    types::{
+        Device, DeviceStatus, GatewayMinPerformance, GatewayType, VpnApiAccount, VpnApiTime,
+        VpnApiTimeSynced,
+    },
 };
 
 pub(crate) const DEVICE_AUTHORIZATION_HEADER: &str = "x-device-authorization";
@@ -94,28 +97,39 @@ impl VpnApiClient {
         self.inner.current_url()
     }
 
-    fn use_remote_time(remote_time: VpnApiTime) -> bool {
-        if remote_time.is_almost_same() {
-            tracing::debug!("{remote_time}");
-            false
-        } else if remote_time.is_acceptable_synced() {
-            tracing::info!("{remote_time}");
-            false
-        } else {
-            tracing::warn!(
-                "The time skew between the local and remote time is too large, we'll use remote instead for JWT ({remote_time})."
-            );
-            true
-        }
-    }
-
-    async fn sync_with_remote_time(&self) -> Result<Option<VpnApiTime>> {
+    pub async fn get_remote_time(&self) -> Result<VpnApiTime> {
         let time_before = OffsetDateTime::now_utc();
         let remote_timestamp = self.get_health().await?.timestamp_utc;
         let time_after = OffsetDateTime::now_utc();
 
-        let remote_time =
-            VpnApiTime::from_remote_timestamp(time_before, remote_timestamp, time_after);
+        Ok(VpnApiTime::from_remote_timestamp(
+            time_before,
+            remote_timestamp,
+            time_after,
+        ))
+    }
+
+    fn use_remote_time(remote_time: VpnApiTime) -> bool {
+        match remote_time.is_synced() {
+            VpnApiTimeSynced::AlmostSame => {
+                tracing::debug!("{remote_time}");
+                false
+            }
+            VpnApiTimeSynced::AcceptableSynced => {
+                tracing::info!("{remote_time}");
+                false
+            }
+            VpnApiTimeSynced::NotSynced => {
+                tracing::warn!(
+                    "The time skew between the local and remote time is too large, we'll use remote instead for JWT ({remote_time})."
+                );
+                true
+            }
+        }
+    }
+
+    async fn sync_with_remote_time(&self) -> Result<Option<VpnApiTime>> {
+        let remote_time = self.get_remote_time().await?;
 
         if Self::use_remote_time(remote_time) {
             Ok(Some(remote_time))

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/types/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/types/account.rs
@@ -110,6 +110,16 @@ impl VpnApiTime {
         self.local_time_ahead_skew().abs().whole_seconds() < MAX_ACCEPTABLE_SKEW_SECONDS
     }
 
+    pub fn is_synced(&self) -> VpnApiTimeSynced {
+        if self.is_almost_same() {
+            VpnApiTimeSynced::AlmostSame
+        } else if self.is_acceptable_synced() {
+            VpnApiTimeSynced::AcceptableSynced
+        } else {
+            VpnApiTimeSynced::NotSynced
+        }
+    }
+
     pub fn estimate_remote_now(&self) -> OffsetDateTime {
         tracing::debug!(
             "Estimating remote now using (local time ahead) skew: {}",
@@ -133,6 +143,26 @@ impl fmt::Display for VpnApiTime {
             self.estimated_remote_time,
             self.local_time_ahead_skew(),
         )
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VpnApiTimeSynced {
+    AlmostSame,
+    AcceptableSynced,
+    NotSynced,
+}
+
+impl VpnApiTimeSynced {
+    pub fn is_synced(&self) -> bool {
+        matches!(
+            self,
+            VpnApiTimeSynced::AlmostSame | VpnApiTimeSynced::AcceptableSynced
+        )
+    }
+
+    pub fn is_not_synced(&self) -> bool {
+        !self.is_synced()
     }
 }
 

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/types/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/types/mod.rs
@@ -8,7 +8,7 @@ mod gateway;
 #[cfg(test)]
 mod test_fixtures;
 
-pub use account::{VpnApiAccount, VpnApiTime};
+pub use account::{VpnApiAccount, VpnApiTime, VpnApiTimeSynced};
 pub use device::{Device, DeviceStatus};
 pub use gateway::{GatewayMinPerformance, GatewayType, ScoreThresholds};
 

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/account/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/account/mod.rs
@@ -1,6 +1,8 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use std::fmt::Debug;
+
 pub mod forget_account;
 pub mod register_device;
 pub mod request_zknym;
@@ -20,6 +22,9 @@ pub enum AccountCommandError {
 
     #[error("vpn api error: {0}")]
     VpnApi(#[from] VpnApiErrorResponse),
+
+    #[error("unexpected vpn api response: {0}")]
+    UnexpectedVpnApiResponse(String),
 
     #[error("no account stored")]
     NoAccountStored,
@@ -65,6 +70,10 @@ impl AccountCommandError {
 
     pub fn storage(message: impl ToString) -> Self {
         AccountCommandError::Storage(message.to_string())
+    }
+
+    pub fn unexpected_response(message: impl Debug) -> Self {
+        AccountCommandError::UnexpectedVpnApiResponse(format!("{message:?}"))
     }
 }
 

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
@@ -201,6 +201,10 @@ pub enum ErrorStateReason {
         failed: Vec<RequestZkNymErrorReason>,
     },
 
+    /// The device time is not synced with the server time.
+    /// If the time is not synced, the device will not be able to connect to the entry gateways.
+    DeviceTimeNotSynced,
+
     /// Program errors that must not happen.
     Internal(String),
 }
@@ -217,6 +221,7 @@ pub enum ClientErrorReason {
     SubscriptionExpired,
     Dns(Option<String>),
     Api(Option<String>),
+    DeviceTimeNotSynced,
     Internal(Option<String>),
 }
 
@@ -251,6 +256,7 @@ impl From<ErrorStateReason> for ClientErrorReason {
             ErrorStateReason::ResolveGatewayAddrs => Self::Dns(Some(value.to_string())),
             ErrorStateReason::StartLocalDnsResolver => Self::Dns(Some(value.to_string())),
             ErrorStateReason::Dns => Self::Dns(Some(value.to_string())),
+            ErrorStateReason::DeviceTimeNotSynced => Self::DeviceTimeNotSynced,
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
@@ -203,7 +203,7 @@ pub enum ErrorStateReason {
 
     /// The device time is not synced with the server time.
     /// If the time is not synced, the device will not be able to connect to the entry gateways.
-    DeviceTimeNotSynced,
+    DeviceTimeOutOfSync,
 
     /// Program errors that must not happen.
     Internal(String),
@@ -221,7 +221,7 @@ pub enum ClientErrorReason {
     SubscriptionExpired,
     Dns(Option<String>),
     Api(Option<String>),
-    DeviceTimeNotSynced,
+    DeviceTimeOutOfSync,
     Internal(Option<String>),
 }
 
@@ -256,7 +256,7 @@ impl From<ErrorStateReason> for ClientErrorReason {
             ErrorStateReason::ResolveGatewayAddrs => Self::Dns(Some(value.to_string())),
             ErrorStateReason::StartLocalDnsResolver => Self::Dns(Some(value.to_string())),
             ErrorStateReason::Dns => Self::Dns(Some(value.to_string())),
-            ErrorStateReason::DeviceTimeNotSynced => Self::DeviceTimeNotSynced,
+            ErrorStateReason::DeviceTimeOutOfSync => Self::DeviceTimeOutOfSync,
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/error.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/error.rs
@@ -32,6 +32,9 @@ pub enum VpnError {
         details: super::uniffi_lib_types::VpnApiErrorResponse,
     },
 
+    #[error("unexpected response from nym-vpn-api: {details}")]
+    UnexpectedVpnApiResponse { details: String },
+
     #[error("timeout connecting to nym-vpn-api")]
     VpnApiTimeout,
 
@@ -100,6 +103,7 @@ impl From<AccountCommandError> for VpnError {
             AccountCommandError::Internal(err) => Self::InternalError { details: err },
             AccountCommandError::Storage(err) => Self::Storage { details: err },
             AccountCommandError::VpnApi(e) => Self::VpnApi { details: e.into() },
+            AccountCommandError::UnexpectedVpnApiResponse(e) => Self::InternalError { details: e },
             AccountCommandError::NoAccountStored => Self::NoAccountStored,
             AccountCommandError::NoDeviceStored => Self::NoDeviceIdentity,
             AccountCommandError::Offline => Self::NetworkConnectionError {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/uniffi_lib_types.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/uniffi_lib_types.rs
@@ -232,7 +232,7 @@ pub enum ErrorStateReason {
     SubscriptionExpired,
     Dns(Option<String>),
     Api(Option<String>),
-    DeviceTimeNotSynced,
+    DeviceTimeOutOfSync,
     Internal(Option<String>),
 }
 
@@ -498,7 +498,7 @@ impl From<ClientErrorReason> for ErrorStateReason {
             ClientErrorReason::SubscriptionExpired => Self::SubscriptionExpired,
             ClientErrorReason::Dns(message) => Self::Dns(message),
             ClientErrorReason::Api(message) => Self::Api(message),
-            ClientErrorReason::DeviceTimeNotSynced => Self::DeviceTimeNotSynced,
+            ClientErrorReason::DeviceTimeOutOfSync => Self::DeviceTimeOutOfSync,
             ClientErrorReason::Internal(message) => Self::Internal(message),
         }
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/uniffi_lib_types.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/uniffi_lib_types.rs
@@ -232,24 +232,28 @@ pub enum ErrorStateReason {
     SubscriptionExpired,
     Dns(Option<String>),
     Api(Option<String>),
+    DeviceTimeNotSynced,
     Internal(Option<String>),
 }
 
 #[derive(thiserror::Error, uniffi::Error, Debug, Clone, PartialEq, Eq)]
 pub enum StoreAccountError {
+    #[error("invalid mnemonic: {0}")]
+    InvalidMnemonic(String),
     #[error("storage: {0}")]
     Storage(String),
     #[error("vpn api endpoint failure: {0}")]
     GetAccountEndpointFailure(VpnApiErrorResponse),
     #[error("unexpected response: {0}")]
     UnexpectedResponse(String),
+    #[error("internal error: {0}")]
+    Internal(String),
 }
 
 impl From<CoreStoreAccountError> for StoreAccountError {
     fn from(value: CoreStoreAccountError) -> Self {
         match value {
-            // Map to storage error for compatibility, and to avoid churn on Android in particular
-            CoreStoreAccountError::InvalidMnemonic(message) => Self::Storage(message),
+            CoreStoreAccountError::InvalidMnemonic(message) => Self::InvalidMnemonic(message),
             CoreStoreAccountError::Storage(err) => Self::Storage(err),
             CoreStoreAccountError::GetAccountEndpointFailure(failure) => {
                 Self::GetAccountEndpointFailure(failure.into())
@@ -257,8 +261,7 @@ impl From<CoreStoreAccountError> for StoreAccountError {
             CoreStoreAccountError::UnexpectedResponse(response) => {
                 Self::UnexpectedResponse(response)
             }
-            // Map to storage error for compatibility, and to avoid churn on Android in particular
-            CoreStoreAccountError::Internal(err) => Self::Storage(err),
+            CoreStoreAccountError::Internal(err) => Self::Internal(err),
         }
     }
 }
@@ -426,6 +429,8 @@ pub enum ForgetAccountError {
     RemoveAccountFiles(String),
     #[error("failed to init device keys: {0}")]
     InitDeviceKeys(String),
+    #[error("internal error: {0}")]
+    Internal(String),
 }
 
 impl From<CoreForgetAccountError> for ForgetAccountError {
@@ -445,9 +450,7 @@ impl From<CoreForgetAccountError> for ForgetAccountError {
             }
             CoreForgetAccountError::RemoveAccountFiles(err) => Self::RemoveAccountFiles(err),
             CoreForgetAccountError::InitDeviceKeys(err) => Self::InitDeviceKeys(err),
-            // Map internal errors to RemoveAccount for compatibility, and to avoid churn on
-            // Android in particular
-            CoreForgetAccountError::Internal(err) => Self::RemoveAccount(err),
+            CoreForgetAccountError::Internal(err) => Self::Internal(err),
         }
     }
 }
@@ -495,6 +498,7 @@ impl From<ClientErrorReason> for ErrorStateReason {
             ClientErrorReason::SubscriptionExpired => Self::SubscriptionExpired,
             ClientErrorReason::Dns(message) => Self::Dns(message),
             ClientErrorReason::Api(message) => Self::Api(message),
+            ClientErrorReason::DeviceTimeNotSynced => Self::DeviceTimeNotSynced,
             ClientErrorReason::Internal(message) => Self::Internal(message),
         }
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/account.rs
@@ -55,7 +55,8 @@ pub async fn wait_for_account_sync(
     cancel_token
         .run_until_cancelled(account_controller_tx.ensure_update_account())
         .await
-        .ok_or(Error::Cancelled)??
+        .ok_or(Error::Cancelled)?
+        .map_err(Error::SyncAccount)
         .map(|_| ())
 }
 
@@ -66,7 +67,8 @@ pub async fn wait_for_device_sync(
     cancel_token
         .run_until_cancelled(account_controller_tx.ensure_update_device())
         .await
-        .ok_or(Error::Cancelled)??
+        .ok_or(Error::Cancelled)?
+        .map_err(Error::SyncDevice)
         .map(|_| ())
 }
 
@@ -77,7 +79,8 @@ pub async fn wait_for_device_register(
     cancel_token
         .run_until_cancelled(account_controller_tx.ensure_register_device())
         .await
-        .ok_or(Error::Cancelled)??
+        .ok_or(Error::Cancelled)?
+        .map_err(Error::RegisterDevice)
 }
 
 // Waiting for credentials to be ready can take a while if it's from scratch, in the order of 30
@@ -89,5 +92,6 @@ pub async fn wait_for_credentials_ready(
     cancel_token
         .run_until_cancelled(account_controller_tx.ensure_available_zk_nyms())
         .await
-        .ok_or(Error::Cancelled)??
+        .ok_or(Error::Cancelled)?
+        .map_err(Error::RequestZkNym)
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/account.rs
@@ -38,8 +38,7 @@ pub async fn check_device_time_sync(
     let device_time = cancel_token
         .run_until_cancelled(account_controller_tx.check_device_time_sync())
         .await
-        .ok_or(Error::Cancelled)?
-        .map_err(Error::Command)?;
+        .ok_or(Error::Cancelled)??;
 
     if device_time.is_not_synced() {
         tracing::error!("Device time is not synced with the vpn-api. Please sync your device time and try again.");
@@ -56,8 +55,7 @@ pub async fn wait_for_account_sync(
     cancel_token
         .run_until_cancelled(account_controller_tx.ensure_update_account())
         .await
-        .ok_or(Error::Cancelled)?
-        .map_err(Error::SyncAccount)
+        .ok_or(Error::Cancelled)??
         .map(|_| ())
 }
 
@@ -68,8 +66,7 @@ pub async fn wait_for_device_sync(
     cancel_token
         .run_until_cancelled(account_controller_tx.ensure_update_device())
         .await
-        .ok_or(Error::Cancelled)?
-        .map_err(Error::SyncDevice)
+        .ok_or(Error::Cancelled)??
         .map(|_| ())
 }
 
@@ -80,8 +77,7 @@ pub async fn wait_for_device_register(
     cancel_token
         .run_until_cancelled(account_controller_tx.ensure_register_device())
         .await
-        .ok_or(Error::Cancelled)?
-        .map_err(Error::RegisterDevice)
+        .ok_or(Error::Cancelled)??
 }
 
 // Waiting for credentials to be ready can take a while if it's from scratch, in the order of 30
@@ -93,6 +89,5 @@ pub async fn wait_for_credentials_ready(
     cancel_token
         .run_until_cancelled(account_controller_tx.ensure_available_zk_nyms())
         .await
-        .ok_or(Error::Cancelled)?
-        .map_err(Error::RequestZkNym)
+        .ok_or(Error::Cancelled)??
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/account.rs
@@ -13,6 +13,12 @@ pub enum Error {
     Cancelled,
 
     #[error(transparent)]
+    Command(#[from] nym_vpn_lib_types::AccountCommandError),
+
+    #[error("device time not synced")]
+    DeviceTimeNotSynced,
+
+    #[error(transparent)]
     SyncAccount(#[from] SyncAccountError),
 
     #[error(transparent)]
@@ -23,6 +29,24 @@ pub enum Error {
 
     #[error(transparent)]
     RequestZkNym(#[from] RequestZkNymError),
+}
+
+pub async fn check_device_time_sync(
+    account_controller_tx: AccountCommandSender,
+    cancel_token: CancellationToken,
+) -> Result<(), Error> {
+    let device_time = cancel_token
+        .run_until_cancelled(account_controller_tx.check_device_time_sync())
+        .await
+        .ok_or(Error::Cancelled)?
+        .map_err(Error::Command)?;
+
+    if device_time.is_not_synced() {
+        tracing::error!("Device time is not synced with the vpn-api. Please sync your device time and try again.");
+        return Err(Error::DeviceTimeNotSynced);
+    }
+
+    Ok(())
 }
 
 pub async fn wait_for_account_sync(

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/account.rs
@@ -16,7 +16,7 @@ pub enum Error {
     Command(#[from] nym_vpn_lib_types::AccountCommandError),
 
     #[error("device time not synced")]
-    DeviceTimeNotSynced,
+    DeviceTimeOutOfSync,
 
     #[error(transparent)]
     SyncAccount(#[from] SyncAccountError),
@@ -42,7 +42,7 @@ pub async fn check_device_time_sync(
 
     if device_time.is_not_synced() {
         tracing::error!("Device time is not synced with the vpn-api. Please sync your device time and try again.");
-        return Err(Error::DeviceTimeNotSynced);
+        return Err(Error::DeviceTimeOutOfSync);
     }
 
     Ok(())

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -613,6 +613,9 @@ pub enum Error {
 
     #[error(transparent)]
     Account(#[from] account::Error),
+
+    #[error("device time not synced")]
+    DeviceTimeNotSynced,
 }
 
 impl Error {
@@ -644,6 +647,7 @@ impl Error {
             #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
             Self::GetRouteHandle(e) => ErrorStateReason::Internal(e.to_string()),
             Self::Account(err) => err.error_state_reason()?,
+            Self::DeviceTimeNotSynced => ErrorStateReason::DeviceTimeNotSynced,
         })
     }
 }
@@ -698,6 +702,8 @@ impl account::Error {
             Self::SyncDevice(e) => Some(e.into()),
             Self::RegisterDevice(e) => Some(e.into()),
             Self::RequestZkNym(e) => Some(e.into()),
+            Self::Command(e) => Some(ErrorStateReason::Internal(e.to_string())),
+            Self::DeviceTimeNotSynced => Some(ErrorStateReason::DeviceTimeNotSynced),
             Self::Cancelled => None,
         }
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -615,7 +615,7 @@ pub enum Error {
     Account(#[from] account::Error),
 
     #[error("device time not synced")]
-    DeviceTimeNotSynced,
+    DeviceTimeOutOfSync,
 }
 
 impl Error {
@@ -647,7 +647,7 @@ impl Error {
             #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
             Self::GetRouteHandle(e) => ErrorStateReason::Internal(e.to_string()),
             Self::Account(err) => err.error_state_reason()?,
-            Self::DeviceTimeNotSynced => ErrorStateReason::DeviceTimeNotSynced,
+            Self::DeviceTimeOutOfSync => ErrorStateReason::DeviceTimeOutOfSync,
         })
     }
 }
@@ -703,7 +703,7 @@ impl account::Error {
             Self::RegisterDevice(e) => Some(e.into()),
             Self::RequestZkNym(e) => Some(e.into()),
             Self::Command(e) => Some(ErrorStateReason::Internal(e.to_string())),
-            Self::DeviceTimeNotSynced => Some(ErrorStateReason::DeviceTimeNotSynced),
+            Self::DeviceTimeOutOfSync => Some(ErrorStateReason::DeviceTimeOutOfSync),
             Self::Cancelled => None,
         }
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -205,14 +205,14 @@ pub struct TunnelMonitor {
     tun_provider: Arc<dyn OSTunProvider>,
     #[cfg(target_os = "android")]
     tun_provider: Arc<dyn AndroidTunProvider>,
-    account_controller_tx: AccountCommandSender,
+    account_commands: AccountCommandSender,
     cancel_token: CancellationToken,
 }
 
 impl TunnelMonitor {
     pub fn start(
         tunnel_parameters: TunnelParameters,
-        account_controller_tx: AccountCommandSender,
+        account_commands: AccountCommandSender,
         monitor_event_sender: mpsc::UnboundedSender<TunnelMonitorEvent>,
         mixnet_event_sender: mpsc::UnboundedSender<MixnetEvent>,
         #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
@@ -229,7 +229,7 @@ impl TunnelMonitor {
             route_handler,
             #[cfg(any(target_os = "ios", target_os = "android"))]
             tun_provider,
-            account_controller_tx,
+            account_commands,
             cancel_token: cancel_token.clone(),
         };
         let join_handle = tokio::spawn(tunnel_monitor.run());
@@ -515,10 +515,14 @@ impl TunnelMonitor {
     }
 
     async fn setup_account(&mut self) -> Result<()> {
+        // Check that the device time is synced as a precondition to continuing
+        account::check_device_time_sync(self.account_commands.clone(), self.cancel_token.clone())
+            .await?;
+
         // Check if we have ticketbooks already stored, then we can sidestep the account and device
         // sync
         let is_already_tickets_stored = self
-            .account_controller_tx
+            .account_commands
             .get_available_tickets()
             .await
             .map_err(|err| {
@@ -530,27 +534,24 @@ impl TunnelMonitor {
             // If we have tickets stored, trigger sync and register in the background while we
             // proceed anyway.
             self.send_event(TunnelMonitorEvent::SyncingAccount);
-            self.account_controller_tx.background_sync_account_state();
-            self.account_controller_tx.background_sync_device_state();
+            self.account_commands.background_sync_account_state();
+            self.account_commands.background_sync_device_state();
         } else {
             // If we don't have ticket stored, go through the steps one by one, syncing and
             // registering and getting credentials.
             self.send_event(TunnelMonitorEvent::SyncingAccount);
             account::wait_for_account_sync(
-                self.account_controller_tx.clone(),
+                self.account_commands.clone(),
                 self.cancel_token.clone(),
             )
             .await?;
 
-            account::wait_for_device_sync(
-                self.account_controller_tx.clone(),
-                self.cancel_token.clone(),
-            )
-            .await?;
+            account::wait_for_device_sync(self.account_commands.clone(), self.cancel_token.clone())
+                .await?;
 
             self.send_event(TunnelMonitorEvent::RegisteringDevice);
             account::wait_for_device_register(
-                self.account_controller_tx.clone(),
+                self.account_commands.clone(),
                 self.cancel_token.clone(),
             )
             .await?;
@@ -563,7 +564,7 @@ impl TunnelMonitor {
         {
             self.send_event(TunnelMonitorEvent::RequestingZkNyms);
             account::wait_for_credentials_ready(
-                self.account_controller_tx.clone(),
+                self.account_commands.clone(),
                 self.cancel_token.clone(),
             )
             .await?;

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/from_proto/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/from_proto/tunnel_state.rs
@@ -58,7 +58,7 @@ impl From<ProtoError> for ClientErrorReason {
             ErrorStateReason::SubscriptionExpired => ClientErrorReason::SubscriptionExpired,
             ErrorStateReason::Dns => ClientErrorReason::Dns(value.detail),
             ErrorStateReason::Api => ClientErrorReason::Api(value.detail),
-            ErrorStateReason::DeviceTimeSync => ClientErrorReason::DeviceTimeNotSynced,
+            ErrorStateReason::DeviceTimeOutOfSync => ClientErrorReason::DeviceTimeOutOfSync,
             ErrorStateReason::Internal => ClientErrorReason::Internal(value.detail),
         }
     }

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/from_proto/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/from_proto/tunnel_state.rs
@@ -58,6 +58,7 @@ impl From<ProtoError> for ClientErrorReason {
             ErrorStateReason::SubscriptionExpired => ClientErrorReason::SubscriptionExpired,
             ErrorStateReason::Dns => ClientErrorReason::Dns(value.detail),
             ErrorStateReason::Api => ClientErrorReason::Api(value.detail),
+            ErrorStateReason::DeviceTimeSync => ClientErrorReason::DeviceTimeNotSynced,
             ErrorStateReason::Internal => ClientErrorReason::Internal(value.detail),
         }
     }

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/into_proto/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/into_proto/tunnel_state.rs
@@ -83,8 +83,8 @@ impl From<ClientErrorReason> for ProtoError {
                 reason: ErrorStateReason::Api.into(),
                 detail,
             },
-            ClientErrorReason::DeviceTimeNotSynced => ProtoError {
-                reason: ErrorStateReason::DeviceTimeSync.into(),
+            ClientErrorReason::DeviceTimeOutOfSync => ProtoError {
+                reason: ErrorStateReason::DeviceTimeOutOfSync.into(),
                 detail: None,
             },
             ClientErrorReason::Internal(detail) => ProtoError {

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/into_proto/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/into_proto/tunnel_state.rs
@@ -83,6 +83,10 @@ impl From<ClientErrorReason> for ProtoError {
                 reason: ErrorStateReason::Api.into(),
                 detail,
             },
+            ClientErrorReason::DeviceTimeNotSynced => ProtoError {
+                reason: ErrorStateReason::DeviceTimeSync.into(),
+                detail: None,
+            },
             ClientErrorReason::Internal(detail) => ProtoError {
                 reason: ErrorStateReason::Internal.into(),
                 detail,

--- a/proto/nym/vpn.proto
+++ b/proto/nym/vpn.proto
@@ -387,6 +387,7 @@ message TunnelState {
     SUBSCRIPTION_EXPIRED = 7;
     DNS = 8;
     API = 9;
+    DEVICE_TIME_SYNC = 11;
     INTERNAL = 10;
   }
 

--- a/proto/nym/vpn.proto
+++ b/proto/nym/vpn.proto
@@ -387,7 +387,7 @@ message TunnelState {
     SUBSCRIPTION_EXPIRED = 7;
     DNS = 8;
     API = 9;
-    DEVICE_TIME_SYNC = 11;
+    DEVICE_TIME_OUT_OF_SYNC = 11;
     INTERNAL = 10;
   }
 


### PR DESCRIPTION
During the connecting state do an explicit time sync check against the vpn-api and go into error state if the device clock is not synced. 
While we can currently adapt to time sync mismatch when talking to the vpn-api, we can't when talking to the entry gateway. So to avoid ending up in a state that appears "stuck" to the end user, go to connection failed

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2672)
<!-- Reviewable:end -->
