### PR TITLE
Check for offline state in background tasks

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/command_handler.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/command_handler.rs
@@ -22,6 +22,7 @@ use crate::{
         },
         AccountCommand, AccountCommandResult, Command, RunningCommands,
     },
+    connectivity::OfflineWatch,
     shared_state::DeviceState,
     storage::VpnCredentialStorage,
     SharedAccountState,
@@ -49,6 +50,7 @@ impl AccountCommandHandler {
         account_state: SharedAccountState,
         vpn_api_client: nym_vpn_api_client::VpnApiClient,
         credential_storage: Arc<tokio::sync::Mutex<VpnCredentialStorage>>,
+        offline_watch: OfflineWatch,
     ) -> Self {
         let waiting_sync_account_command_handler =
             WaitingSyncAccountCommandHandler::new(account_state.clone(), vpn_api_client.clone());
@@ -58,6 +60,7 @@ impl AccountCommandHandler {
             credential_storage,
             account_state.clone(),
             vpn_api_client.clone(),
+            offline_watch,
         );
 
         Self {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/dispatch.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/dispatch.rs
@@ -62,7 +62,9 @@ impl AccountCommand {
             AccountCommand::RequestZkNym(Some(tx)) => {
                 tx.send(Err(RequestZkNymError::NoAccountStored));
             }
-            _ => {}
+            _ => {
+                tracing::error!("Command does not support no account: {self}");
+            }
         }
     }
 
@@ -78,7 +80,9 @@ impl AccountCommand {
             AccountCommand::RequestZkNym(Some(tx)) => {
                 tx.send(Err(RequestZkNymError::NoDeviceStored));
             }
-            _ => {}
+            _ => {
+                tracing::error!("Command does not support no device: {self}");
+            }
         }
     }
 
@@ -97,7 +101,9 @@ impl AccountCommand {
             AccountCommand::RequestZkNym(Some(tx)) => {
                 tx.send(Err(RequestZkNymError::Offline));
             }
-            _ => {}
+            _ => {
+                tracing::error!("Command does not support offline mode: {self}");
+            }
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/tasks/request_zknym/cached_data.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/tasks/request_zknym/cached_data.rs
@@ -7,6 +7,8 @@ use nym_credential_proxy_requests::api::v1::ticketbook::models::PartialVerificat
 use nym_vpn_api_client::VpnApiClient;
 use nym_vpn_lib_types::{RequestZkNymError, VpnApiErrorResponse};
 
+use crate::connectivity::OfflineWatch;
+
 // Generic struct to store cached data during the request process, both between concurrent requests
 // for different types, and between requests for the same type.
 #[derive(Clone)]
@@ -17,13 +19,16 @@ pub struct CachedData {
 
     // nym-vpn-api client used to fetch new data
     vpn_api_client: VpnApiClient,
+
+    offline_watch: OfflineWatch,
 }
 
 impl CachedData {
-    pub fn new(vpn_api_client: VpnApiClient) -> Self {
+    pub fn new(vpn_api_client: VpnApiClient, offline_watch: OfflineWatch) -> Self {
         CachedData {
             partial_verification_keys: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             vpn_api_client,
+            offline_watch,
         }
     }
 
@@ -43,6 +48,9 @@ impl CachedData {
             Ok(issuers.clone())
         } else {
             tracing::info!("Fetching partial verification keys for epoch: {epoch_id}");
+            if self.offline_watch.is_offline() {
+                return Err(RequestZkNymError::Offline);
+            }
             let issuers = self
                 .vpn_api_client
                 .get_directory_zk_nyms_ticketbook_partial_verification_keys()

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/tasks/request_zknym/handler.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/tasks/request_zknym/handler.rs
@@ -18,7 +18,7 @@ use nym_vpn_lib_types::{RequestZkNymError, RequestZkNymSuccess, VpnApiErrorRespo
 use tokio::task::JoinSet;
 
 use crate::{
-    commands::AccountCommandResult, shared_state::RequestZkNymResult,
+    commands::AccountCommandResult, connectivity::OfflineWatch, shared_state::RequestZkNymResult,
     storage::VpnCredentialStorage, SharedAccountState,
 };
 
@@ -36,6 +36,7 @@ pub(crate) struct WaitingRequestZkNymCommandHandler {
     credential_storage: Arc<tokio::sync::Mutex<VpnCredentialStorage>>,
     account_state: SharedAccountState,
     vpn_api_client: VpnApiClient,
+    offline_watch: OfflineWatch,
     zk_nym_fails_in_a_row: Arc<AtomicU32>,
 
     // Cache some of the data used to import zk-nyms between requests, to speed things up. Consider
@@ -48,12 +49,14 @@ impl WaitingRequestZkNymCommandHandler {
         credential_storage: Arc<tokio::sync::Mutex<VpnCredentialStorage>>,
         account_state: SharedAccountState,
         vpn_api_client: nym_vpn_api_client::VpnApiClient,
+        offline_watch: OfflineWatch,
     ) -> Self {
-        let cached_data = CachedData::new(vpn_api_client.clone());
+        let cached_data = CachedData::new(vpn_api_client.clone(), offline_watch.clone());
         WaitingRequestZkNymCommandHandler {
             credential_storage,
             account_state,
             vpn_api_client,
+            offline_watch,
             zk_nym_fails_in_a_row: Default::default(),
             cached_data,
         }
@@ -73,6 +76,7 @@ impl WaitingRequestZkNymCommandHandler {
             credential_storage: self.credential_storage.clone(),
             account_state: self.account_state.clone(),
             vpn_api_client: self.vpn_api_client.clone(),
+            offline_watch: self.offline_watch.clone(),
             zk_nym_fails_in_a_row: self.zk_nym_fails_in_a_row.clone(),
             cached_data: self.cached_data.clone(),
         }
@@ -100,6 +104,7 @@ pub(crate) struct RequestZkNymCommandHandler {
     credential_storage: Arc<tokio::sync::Mutex<VpnCredentialStorage>>,
     account_state: SharedAccountState,
     vpn_api_client: VpnApiClient,
+    offline_watch: OfflineWatch,
 
     zk_nym_fails_in_a_row: Arc<AtomicU32>,
     cached_data: CachedData,
@@ -200,6 +205,7 @@ impl RequestZkNymCommandHandler {
                 self.device.clone(),
                 self.vpn_api_client.clone(),
                 self.credential_storage.clone(),
+                self.offline_watch.clone(),
                 self.cached_data.clone(),
             );
             join_set.spawn(async move { task.request_zk_nym_ticketbook(ticket_type).await });
@@ -250,6 +256,9 @@ impl RequestZkNymCommandHandler {
     }
 
     async fn get_zk_nyms_available_for_download(&self) -> Result<Vec<ZkNymId>, RequestZkNymError> {
+        if self.offline_watch.is_offline() {
+            return Err(RequestZkNymError::Offline);
+        }
         self.vpn_api_client
             .get_zk_nyms_available_for_download(&self.account, &self.device)
             .await
@@ -279,6 +288,7 @@ impl RequestZkNymCommandHandler {
                 self.device.clone(),
                 self.vpn_api_client.clone(),
                 self.credential_storage.clone(),
+                self.offline_watch.clone(),
                 self.cached_data.clone(),
             );
             join_set

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/tasks/request_zknym/request.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/tasks/request_zknym/request.rs
@@ -23,7 +23,10 @@ use nym_vpn_api_client::{
 use nym_vpn_lib_types::{RequestZkNymError, RequestZkNymSuccess, VpnApiErrorResponse};
 use time::Date;
 
-use crate::storage::{PendingCredentialRequest, VpnCredentialStorage};
+use crate::{
+    connectivity::OfflineWatch,
+    storage::{PendingCredentialRequest, VpnCredentialStorage},
+};
 
 use super::{cached_data::CachedData, ZkNymId};
 
@@ -35,6 +38,7 @@ pub(super) struct RequestZkNymTask {
     device: Device,
     vpn_api_client: VpnApiClient,
     credential_storage: Arc<tokio::sync::Mutex<VpnCredentialStorage>>,
+    offline_watch: OfflineWatch,
     cached_data: CachedData,
 }
 
@@ -44,6 +48,7 @@ impl RequestZkNymTask {
         device: Device,
         vpn_api_client: VpnApiClient,
         credential_storage: Arc<tokio::sync::Mutex<VpnCredentialStorage>>,
+        offline_watch: OfflineWatch,
         cached_data: CachedData,
     ) -> Self {
         RequestZkNymTask {
@@ -51,6 +56,7 @@ impl RequestZkNymTask {
             device,
             vpn_api_client,
             credential_storage,
+            offline_watch,
             cached_data,
         }
     }
@@ -147,6 +153,9 @@ impl RequestZkNymTask {
         request: &ZkNymRequestData,
     ) -> Result<NymVpnZkNymPost, RequestZkNymError> {
         tracing::debug!("Requesting zk-nym ticketbook");
+        if self.offline_watch.is_offline() {
+            return Err(RequestZkNymError::Offline);
+        }
         self.vpn_api_client
             .request_zk_nym(
                 &self.account,
@@ -207,6 +216,10 @@ impl RequestZkNymTask {
         let start_time = Instant::now();
         loop {
             tracing::debug!("Polling zk-nym status");
+            if self.offline_watch.is_offline() {
+                return Err(RequestZkNymError::Offline);
+            }
+
             match self
                 .vpn_api_client
                 .get_zk_nym_by_id(&self.account, &self.device, id)
@@ -573,6 +586,9 @@ impl RequestZkNymTask {
 
     async fn confirm_zk_nym_downloaded(&self, id: &str) -> Result<StatusOk, RequestZkNymError> {
         tracing::info!("Confirming zk-nym downloaded");
+        if self.offline_watch.is_offline() {
+            return Err(RequestZkNymError::Offline);
+        }
         self.vpn_api_client
             .confirm_zk_nym_download_by_id(&self.account, &self.device, id)
             .await

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/config.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/config.rs
@@ -1,0 +1,34 @@
+// Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use std::path::PathBuf;
+
+use nym_sdk::UserAgent;
+use nym_vpn_network_config::Network;
+
+pub struct AccountControllerConfig {
+    // The data directory where we store the account and device keys.
+    pub data_dir: PathBuf,
+
+    // User agent used by api client.
+    pub user_agent: UserAgent,
+
+    // Credentials mode is a feature flag that determines if we should automatically request
+    // zk-nyms.
+    pub credentials_mode: Option<bool>,
+
+    // The network environment that the controller is running in.
+    pub network_env: Network,
+}
+
+impl AccountControllerConfig {
+    // Determine if the credentials mode is enabled. This is determined by the credentials_mode
+    // field in the config, if it is set. Else the network environment feature flag is used.
+    pub fn background_zk_nym_refresh(&self) -> bool {
+        self.credentials_mode.unwrap_or_else(|| {
+            self.network_env
+                .get_feature_flag_credential_mode()
+                .unwrap_or(false)
+        })
+    }
+}

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/connectivity.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/connectivity.rs
@@ -5,6 +5,7 @@ use nym_offline_monitor::{Connectivity, ConnectivityHandle};
 
 use crate::AccountCommandSender;
 
+#[derive(Clone)]
 pub(super) struct OfflineWatch {
     // The handle to the offline monitor, used for receiving connectivity changes.
     handle: Option<ConnectivityHandle>,

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
@@ -1,9 +1,8 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{net::SocketAddr, path::PathBuf, sync::Arc, time::Duration};
+use std::{net::SocketAddr, sync::Arc, time::Duration};
 
-use nym_http_api_client::UserAgent;
 use nym_offline_monitor::{Connectivity, ConnectivityHandle};
 use nym_vpn_api_client::{
     response::{NymVpnDevice, NymVpnUsage},
@@ -12,7 +11,6 @@ use nym_vpn_api_client::{
 use nym_vpn_lib_types::{
     AccountCommandError, ForgetAccountError, StoreAccountError, VpnApiErrorResponse,
 };
-use nym_vpn_network_config::Network;
 use nym_vpn_store::{mnemonic::Mnemonic, VpnStorage};
 use tokio::{
     sync::mpsc::{UnboundedReceiver, UnboundedSender},
@@ -27,41 +25,8 @@ use crate::{
     shared_state::{MnemonicState, ReadyToRegisterDevice, ReadyToRequestZkNym, SharedAccountState},
     storage::{AccountStorage, SharedVpnCredentialStorage, VpnCredentialStorage},
     vpn_api_client::AccountControllerVpnApiClient,
-    AccountCommandSender, AvailableTicketbooks,
+    AccountCommandSender, AccountControllerConfig, AvailableTicketbooks,
 };
-
-// The interval at which we automatically request zk-nyms
-const ZK_NYM_AUTOMATIC_REQUEST_INTERVAL: Duration = Duration::from_secs(60);
-
-// The interval at which we update the account state
-const ACCOUNT_UPDATE_INTERVAL: Duration = Duration::from_secs(5 * 60);
-
-pub struct AccountControllerConfig {
-    // The data directory where we store the account and device keys.
-    pub data_dir: PathBuf,
-
-    // User agent used by api client.
-    pub user_agent: UserAgent,
-
-    // Credentials mode is a feature flag that determines if we should automatically request
-    // zk-nyms.
-    pub credentials_mode: Option<bool>,
-
-    // The network environment that the controller is running in.
-    pub network_env: Network,
-}
-
-impl AccountControllerConfig {
-    // Determine if the credentials mode is enabled. This is determined by the credentials_mode
-    // field in the config, if it is set. Else the network environment feature flag is used.
-    fn background_zk_nym_refresh(&self) -> bool {
-        self.credentials_mode.unwrap_or_else(|| {
-            self.network_env
-                .get_feature_flag_credential_mode()
-                .unwrap_or(false)
-        })
-    }
-}
 
 pub struct AccountController<S>
 where
@@ -102,6 +67,12 @@ impl<S> AccountController<S>
 where
     S: VpnStorage,
 {
+    // The interval at which we automatically request zk-nyms
+    const ZK_NYM_AUTOMATIC_REQUEST_INTERVAL: Duration = Duration::from_secs(60);
+
+    // The interval at which we update the account state
+    const ACCOUNT_UPDATE_INTERVAL: Duration = Duration::from_secs(5 * 60);
+
     pub async fn new(
         config: AccountControllerConfig,
         storage: Arc<tokio::sync::Mutex<S>>,
@@ -955,11 +926,12 @@ where
         // Timer to periodically sync the remote account state.
         // Call tick() once to start the timer immediately. We don't want the first sync to happen
         // immediately, so we wait for the first tick to happen.
-        let mut sync_account_state_timer = tokio::time::interval(ACCOUNT_UPDATE_INTERVAL);
+        let mut sync_account_state_timer = tokio::time::interval(Self::ACCOUNT_UPDATE_INTERVAL);
         sync_account_state_timer.tick().await;
 
         // Timer to periodically check if we need to request more zk-nyms
-        let mut update_zk_nym_timer = tokio::time::interval(ZK_NYM_AUTOMATIC_REQUEST_INTERVAL);
+        let mut update_zk_nym_timer =
+            tokio::time::interval(Self::ZK_NYM_AUTOMATIC_REQUEST_INTERVAL);
 
         loop {
             tokio::select! {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
@@ -97,18 +97,19 @@ where
         // The channels used to communicate with the controller
         let command_channel = tokio::sync::mpsc::unbounded_channel();
 
-        // Keep track of the commands that are currently running
-        let command_handler = AccountCommandHandler::new(
-            account_state.clone(),
-            vpn_api_client.inner().clone(),
-            credential_storage.clone(),
-        );
-
         // The offline watch is used to keep track of the current connectivity state, since we
         // don't want to do certain operations when we are offline
         let offline_watch = OfflineWatch::new(
             AccountCommandSender::new(command_channel.0.clone(), account_state.clone()),
             initial_connectivity.unwrap_or(Connectivity::new_presume_offline()),
+        );
+
+        // Keep track of the commands that are currently running
+        let command_handler = AccountCommandHandler::new(
+            account_state.clone(),
+            vpn_api_client.inner().clone(),
+            credential_storage.clone(),
+            offline_watch.clone(),
         );
 
         Ok(AccountController {
@@ -124,19 +125,25 @@ where
         })
     }
 
+    /// Get the current state of the account. This is a shared object that can be queried without
+    /// having to ask the controller.
     pub fn get_shared_state(&self) -> SharedAccountState {
         self.account_state.clone()
     }
 
+    /// Get the command channel used to send commands to the controller.
     pub fn get_command_sender(&self) -> AccountCommandSender {
         AccountCommandSender::new(self.command_channel.0.clone(), self.account_state.clone())
     }
 
+    // Check if the controller is allowed to request zk-nyms in the background.
     async fn is_background_zk_nym_refresh_active(&self) -> bool {
         self.config.background_zk_nym_refresh()
             && !self.command_handler.max_zknym_request_fails_reached().await
     }
 
+    // Check if all ticket types are above the soft threshold. This is used to determine if we
+    // should request more zk-nyms.
     async fn is_all_ticket_types_above_soft_threshold(&self) -> Result<bool, AccountCommandError> {
         self.credential_storage
             .lock()

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/lib.rs
@@ -10,6 +10,7 @@ pub mod shared_state;
 
 mod command_sender;
 mod commands;
+mod config;
 mod connectivity;
 mod controller;
 mod error;
@@ -18,7 +19,8 @@ mod ticketbooks;
 mod vpn_api_client;
 
 pub use command_sender::AccountCommandSender;
-pub use controller::{AccountController, AccountControllerConfig};
+pub use config::AccountControllerConfig;
+pub use controller::AccountController;
 pub use error::Error;
 pub use shared_state::{AccountStateSummary, SharedAccountState};
 pub use storage::remove_files_for_account;


### PR DESCRIPTION
In background tasks launched by the account controller, check offline state when trying to reach to the vpn-api

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2681)
<!-- Reviewable:end -->
