### PR TITLE
Add makefile for windows

### DIFF
--- a/build-windows-modules.ps1
+++ b/build-windows-modules.ps1
@@ -10,19 +10,16 @@ param (
     [string]$Platform,
 
     # Whether to copy compiled binaries to build\winfw
-    # In debug builds this also makes sure to copy winfw.dll to nym-vpn-core\target\debug
     [bool]$CopyToBuildDir = $False
 )
 
 Write-Output "Compiling winfw in $BuildConfiguration for $Platform"
 
-MSBuild.exe /m .\nym-vpn-windows\winfw\winfw.sln /p:Configuration=$BuildConfiguration /p:Platform=$Platform
+MSBuild.exe /m "$PSScriptRoot\nym-vpn-windows\winfw\winfw.sln" /p:Configuration=$BuildConfiguration /p:Platform=$Platform
 
 if ($CopyToBuildDir) {
     $BuildDir = "$PSScriptRoot\nym-vpn-windows\winfw\bin\$Platform-$BuildConfiguration"
     $OutputDir = "$PSScriptRoot\build\winfw\$Platform-$BuildConfiguration"
-    $RustTargetDir = "$PSScriptRoot\nym-vpn-core\target"
-    $RustBuildDir = "$RustTargetDir\$($BuildConfiguration.ToLower())"
     $BaseLibPath = "$BuildDir\winfw"
 
     # Copy winfw.{lib,dll} to build/libwf
@@ -30,8 +27,4 @@ if ($CopyToBuildDir) {
     New-Item -ItemType Directory -Force -Path $OutputDir -Verbose
     Copy-Item -Path "$BaseLibPath.lib" -Destination $OutputDir -Verbose
     Copy-Item -Path "$BaseLibPath.dll" -Destination $OutputDir -Verbose
-
-    # Copy winfw.dll to target/<profile>
-    New-Item -ItemType Directory -Force -Path $RustBuildDir -Verbose
-    Copy-Item -Path "$BaseLibPath.dll" -Destination $RustBuildDir -Verbose
 }

--- a/nym-vpn-core/README.md
+++ b/nym-vpn-core/README.md
@@ -10,50 +10,44 @@ sudo apt install libdbus-1-dev libmnl-dev libnftnl-dev protobuf-compiler
 
 ### Windows
 
-If you don't have Visual Studio 2022 installed, here is a one liner to install all that is needed.
+- Install Visual Studio 2022 Community
 
-```pwsh
-winget install --id Microsoft.VisualStudio.2022.Community --override "--wait --add Microsoft.VisualStudio.Workload.VCTools;includeRecommended --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.VC.Llvm.Clang"
-```
+  ```pwsh
+  winget install --id Microsoft.VisualStudio.2022.Community --override "--wait --add Microsoft.VisualStudio.Workload.VCTools;includeRecommended --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.VC.Llvm.Clang"
+  ```
 
-if you already have it installed, open Visual Studio Installer and modify the Visual Studio 2022 installation by adding the following components:
+  if you already have it installed, open Visual Studio Installer and modify the Visual Studio 2022 installation by adding the following components:
 
-- Add workload: Desktop development with C++
-- Add individual components: 
-  - C++ Clang tools for Windows
-  - MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools
+  - Add workload: Desktop development with C++
+  - Add individual components: 
+    - C++ Clang tools for Windows
+    - MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools
 
-Add clang to path:
+- Install GNU make:
 
-- ARM64 host:
-```
-C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\Llvm\ARM64\bin
-```
-- x64 host:
-```
-C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\Llvm\x64\bin
-```
+  ```
+  winget install -e --id=GnuWin32.Make
+  ```
 
 ## Build
 
-1. Build the wireguard library
+- Build all dependencies: `winfw`, `libwg` and download `wintun`
   
   ```sh
-  # from the root of the repository
-  make build-wireguard
+  make -f Windows.mk RELEASE=1
   ```
 
-2. Build VPN libraries and executables
+- Build VPN libraries and executables
 
   ```sh
   cd nym-vpn-core/
 
   # build only the the vpn daemon
-  cargo build -p nym-vpnd
+  cargo build -p nym-vpnd --release
 
   # build all 
   cargo build --release
-  ```C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\Llvm\ARM64\bin
+  ```
 
 ## Build for Windows from MacOS
 

--- a/nym-vpn-core/Windows.mk
+++ b/nym-vpn-core/Windows.mk
@@ -1,0 +1,104 @@
+SHELL := C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe
+
+WIUNTUN_URL := https://www.wintun.net/builds/wintun-0.14.1.zip
+WINTUN_BIN_DIR := $(TMP)/wintun/bin
+WINTUN_DLL_NAME := wintun.dll
+WINTUN_FINGERPRINT := DF98E075A012ED8C86FBCF14854B8F9555CB3D45
+
+MSYS2_SHELL := C:/msys64/msys2_shell.cmd
+
+GO_PATH := $(ProgramW6432)/Go/bin
+MSVS_DIR := $(ProgramW6432)/Microsoft Visual Studio/2022/Community
+MSVC_PATH := $(MSVS_DIR)/VC/Tools/MSVC
+MSBUILD_PATH := $(MSVS_DIR)/MSBuild/Current/Bin
+
+# Make on Windows is a 32-bit application
+# Use PROCESSOR_ARCHITEW6432 to get the native CPU architecture
+ifdef PROCESSOR_ARCHITEW6432
+	CPU_ARCH := $(PROCESSOR_ARCHITEW6432)
+else
+	CPU_ARCH := $(PROCESSOR_ARCHITECTURE)
+endif
+
+CPU_ARCH_LOWER := $(shell "$(CPU_ARCH)".ToLower())
+
+ifeq ($(CPU_ARCH_LOWER),amd64)
+	RUST_TARGET := x86_64
+	WINFW_PLATFORM := x64
+else ifeq ($(CPU_ARCH_LOWER),arm64)
+	RUST_TARGET := aarch64
+	WINFW_PLATFORM := ARM64
+else
+	$(error Unsupported CPU architecture: $(CPU_ARCH_LOWER))
+endif
+
+ifeq ($(RELEASE),1)
+	WINFW_PROFILE := Release
+	TARGET_DIR := $(CURDIR)/target/release
+else
+	WINFW_PROFILE := Debug
+	TARGET_DIR := $(CURDIR)/target/debug
+endif
+
+LIBWG_BUILD_DIR := $(CURDIR)/../build/lib/$(RUST_TARGET)-pc-windows-msvc
+LIBWG_DLL := libwg.dll
+
+WINFW_BUILD_DIR := $(CURDIR)/../build/winfw/$(CPU_ARCH)-$(WINFW_PROFILE)
+WINFW_DLL := winfw.dll
+
+# Ensure that msys2 inherits PATH from environment
+export MSYS2_PATH_TYPE = inherit
+
+.PHONY: wintun libwg winfw create_target_dir
+
+default: wintun libwg winfw
+
+# Build libwg and copy it to build/lib
+libwg: create_target_dir
+	$(call setup_env_path) ; #\
+	if ("$(CPU_ARCH_LOWER)" -eq "arm64") { #\
+		$$wg_arm64_flag = "--arm64" ; #\
+		$$msystem = "clangarm64" ; #\
+	} else { #\
+		$$wg_arm64_flag = "" ; #\
+		$$msystem = "mingw64" ; #\
+	} #\
+	$(MSYS2_SHELL) -defterm -no-start -$$msystem -where "$(CURDIR)/../wireguard" -shell bash -c "./build-wireguard-go.sh $$wg_arm64_flag"
+	Copy-Item "$(LIBWG_BUILD_DIR)/$(LIBWG_DLL)" -Destination "$(TARGET_DIR)/$(LIBWG_DLL)" -Force -Verbose
+
+winfw: create_target_dir
+	$(call setup_env_path) ; #\
+	& "$(CURDIR)/../build-windows-modules.ps1" -BuildConfiguration $(WINFW_PROFILE) -Platform $(WINFW_PLATFORM) -CopyToBuildDir 1
+	Copy-Item "$(WINFW_BUILD_DIR)/$(WINFW_DLL)" -Destination "$(TARGET_DIR)/$(WINFW_DLL)" -Force -Verbose
+
+wintun: create_target_dir
+# Download and extract wintun
+	Invoke-WebRequest "$(WIUNTUN_URL)" -OutFile "$(TMP)/wintun.zip"; #\
+	Expand-Archive -Path $(TMP)/wintun.zip -DestinationPath "$(TMP)" -Force; #\
+
+# Check digital signature of wintun dll
+	$$sig = Get-AuthenticodeSignature -FilePath "$(WINTUN_BIN_DIR)/$(CPU_ARCH_LOWER)/$(WINTUN_DLL_NAME)"; #\
+	$$fingerprint = $$sig.SignerCertificate.Thumbprint.ToUpper(); #\
+	#\
+	if ($$fingerprint -ne "$(WINTUN_FINGERPRINT)") { #\
+		Write-Output "Fingerprint mismatch, expected $(WINTUN_FINGERPRINT), got $$fingerprint"; #\
+		exit 1; #\
+	} else { #\
+		Write-Output "Fingerprint matches!"; #\
+	}
+	
+# Copy wintun dll to target directory
+	Copy-Item -Path "$(WINTUN_BIN_DIR)/$(CPU_ARCH_LOWER)/$(WINTUN_DLL_NAME)" -Destination "$(TARGET_DIR)/$(WINTUN_DLL_NAME)" -Force -Verbose
+
+create_target_dir:
+	if (-not (Test-Path "$(TARGET_DIR)")) { #\
+		New-Item -ItemType Directory -Path "$(TARGET_DIR)" ; #\
+	}
+
+# Add Go, MSBuild and MSVC to PATH
+define setup_env_path
+	$$msvc_path = Get-ChildItem -Path "$(MSVC_PATH)" -Directory | Select-Object -ExpandProperty FullName ; #\\
+	$$env:Path += ";$(GO_PATH)" ; #\\
+	$$env:Path += ";$(MSBUILD_PATH)" ; #\\
+	$$env:Path += ";$$msvc_path\bin\Host$(CPU_ARCH_LOWER)\$(CPU_ARCH_LOWER)" ;
+endef

--- a/wireguard/README.md
+++ b/wireguard/README.md
@@ -49,8 +49,8 @@ It is forked from (https://github.com/mullvad/mullvadvpn-app) which maintains co
   TARGET_ARCH="arm64"
 
   export PATH="$PATH:/c/Program Files/Go/bin"
-  export PATH="$PATH:/c/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools/MSBuild/Current/Bin"
-  export PATH="$PATH:/c/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools/VC/Tools/MSVC/14.41.34120/bin/Host$HOST_ARCH/$TARGET_ARCH"
+  export PATH="$PATH:/c/Program Files/Microsoft Visual Studio/2022/Community/MSBuild/Current/Bin"
+  export PATH="$PATH:/c/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.41.34808/bin/Host$HOST_ARCH/$TARGET_ARCH"
   ```
 - Execute the build script: 
   - Build for x64: `./build-wireguard-go.sh`


### PR DESCRIPTION
It's cumbersome to build all Windows dependencies so I put together a Makefile for that:

- Compiles windows firewall (`winfw.dll`)
- Compiles wireguard-go wrapper library (`libwg.dll`)
- Downloads wintun, verifies the fingerprint, picks the right`wintun.dll` based on CPU architecture and puts it into `target\debug` or `target\release`

Each step copies the library (DLL) into `target\debug` or `target\release` when running make with `RELEASE=1`. For example:

```pwsh
make -f Windows.mk RELEASE=1
```

I don't mind going pure powershell but I have stumbled upon some obstacles. For example modifying the `PATH` from ps1 script would persist in the calling terminal too. I am not a powershell pro so maybe I was doing something wrong. Make on the other side spawns new shell on each line.

It's a bit funky how makefile looks given that I need to escape newlines. However it was quick and easy to put together despite the ugliness :)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2684)
<!-- Reviewable:end -->
