### PR TITLE
Fix cargo install

### DIFF
--- a/.github/workflows/build-nym-vpn-android.yml
+++ b/.github/workflows/build-nym-vpn-android.yml
@@ -116,9 +116,15 @@ jobs:
           toolchain: 1.85 # If this changes, we need a PR to Fdroid to update pipeline for reproducibility
           targets: aarch64-linux-android
 
-      - name: Install cargo deps
-        run: |
-          cargo install cargo-ndk cargo-license --locked
+      - name: Install cargo-ndk
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-ndk
+
+      - name: Install cargo-license
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-license
 
       - name: Install deps
         run: |

--- a/.github/workflows/build-nym-vpn-app-linux.yml
+++ b/.github/workflows/build-nym-vpn-app-linux.yml
@@ -59,7 +59,9 @@ jobs:
           components: rustfmt, clippy
 
       - name: Install cargo-license
-        run: cargo install --locked cargo-license
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-license
 
       - name: Install Node
         uses: actions/setup-node@v4

--- a/.github/workflows/build-nym-vpn-app-windows.yml
+++ b/.github/workflows/build-nym-vpn-app-windows.yml
@@ -104,7 +104,9 @@ jobs:
           components: rustfmt, clippy
 
       - name: Install cargo-license
-        run: cargo install --locked cargo-license
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-license
 
       - name: Install Node
         uses: actions/setup-node@v4

--- a/.github/workflows/build-nym-vpn-core-android.yml
+++ b/.github/workflows/build-nym-vpn-core-android.yml
@@ -57,9 +57,15 @@ jobs:
           echo "ANDROID_NDK_HOME=${{ steps.setup-ndk.outputs.ndk-path }}" >> $GITHUB_ENV
           echo "NDK_TOOLCHAIN_DIR=${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_ENV
 
-      - name: Install cargo deps
-        run: |
-          cargo install --locked cargo-ndk cargo-license
+      - name: Install cargo-ndk
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-ndk
+
+      - name: Install cargo-license
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-license
 
       - name: Get workspace version
         id: workspace-version
@@ -68,7 +74,9 @@ jobs:
           subcommand: workspace.package.version --entry nym-vpn-core
 
       - name: Install cargo-edit
-        run: cargo install --locked cargo-edit
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-edit
 
       - name: Append timestamp if it's a dev version
         run: ./scripts/append-timestamp-to-version.sh nym-vpn-core/Cargo.toml ${{ steps.workspace-version.outputs.metadata }}

--- a/.github/workflows/build-nym-vpn-core-deb.yml
+++ b/.github/workflows/build-nym-vpn-core-deb.yml
@@ -36,9 +36,10 @@ jobs:
           toolchain: stable
           components: rustfmt, clippy
 
-      - name: Setup cargo deb
-        run: |
-          cargo install --locked cargo-deb
+      - name: Install cargo-deb
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-deb
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
@@ -53,7 +54,9 @@ jobs:
           subcommand: workspace.package.version --entry nym-vpn-core
 
       - name: Install cargo-edit
-        run: cargo install --locked cargo-edit
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-edit
 
       - name: Append timestamp if it's a dev version
         run: ./scripts/append-timestamp-to-version.sh nym-vpn-core/Cargo.toml ${{ steps.workspace-version.outputs.metadata }}

--- a/.github/workflows/build-nym-vpn-core-ios.yml
+++ b/.github/workflows/build-nym-vpn-core-ios.yml
@@ -38,9 +38,10 @@ jobs:
           components: rustfmt, clippy
           targets: x86_64-apple-darwin aarch64-apple-ios x86_64-apple-ios aarch64-apple-ios-sim
 
-      - name: Setup cargo swift
-        run: |
-          cargo install cargo-swift
+      - name: Install cargo-swift
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-swift
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
@@ -54,7 +55,9 @@ jobs:
           subcommand: workspace.package.version --entry nym-vpn-core
 
       - name: Install cargo-edit
-        run: cargo install --locked cargo-edit
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-edit
 
       - name: Append timestamp if it's a dev version
         run: ./scripts/append-timestamp-to-version.sh nym-vpn-core/Cargo.toml ${{ steps.workspace-version.outputs.metadata }}

--- a/.github/workflows/build-nym-vpn-core-linux.yml
+++ b/.github/workflows/build-nym-vpn-core-linux.yml
@@ -53,7 +53,9 @@ jobs:
           subcommand: workspace.package.version --entry nym-vpn-core
 
       - name: Install cargo-edit
-        run: cargo install --locked cargo-edit
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-edit
 
       - name: Append timestamp if it's a dev version
         run: ./scripts/append-timestamp-to-version.sh nym-vpn-core/Cargo.toml ${{ steps.workspace-version.outputs.metadata }}

--- a/.github/workflows/build-nym-vpn-core-mac.yml
+++ b/.github/workflows/build-nym-vpn-core-mac.yml
@@ -52,8 +52,9 @@ jobs:
           brew install ./grpc-swift.rb
 
       - name: Install cargo-get
-        run: |
-          cargo install --locked cargo-get || true
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-get
 
       - name: Update nym-vpn-apple to use latest core
         run: |
@@ -76,7 +77,9 @@ jobs:
           subcommand: workspace.package.version --entry nym-vpn-core
 
       - name: Install cargo-edit
-        run: cargo install --locked cargo-edit || true
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-edit
 
       - name: Append timestamp if it's a dev version
         run: ./scripts/append-timestamp-to-version.sh nym-vpn-core/Cargo.toml ${{ steps.workspace-version.outputs.metadata }}

--- a/.github/workflows/build-nym-vpn-core-windows.yml
+++ b/.github/workflows/build-nym-vpn-core-windows.yml
@@ -58,8 +58,9 @@ jobs:
           subcommand: workspace.package.version --entry nym-vpn-core
 
       - name: Install cargo-edit
-        shell: bash
-        run: cargo install --locked cargo-edit || true
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-edit
 
       - name: Append timestamp if it's a dev version
         shell: bash

--- a/.github/workflows/ci-nym-vpn-core-android.yml
+++ b/.github/workflows/ci-nym-vpn-core-android.yml
@@ -30,8 +30,10 @@ jobs:
           components: rustfmt, clippy
           targets: aarch64-linux-android
 
-      - name: Install cargo ndk
-        run: cargo install cargo-ndk
+      - name: Install cargo-ndk
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-ndk
 
       - name: Setup NDK
         uses: nttld/setup-ndk@v1

--- a/.github/workflows/generate-build-info-core.yml
+++ b/.github/workflows/generate-build-info-core.yml
@@ -40,7 +40,9 @@ jobs:
           subcommand: workspace.package.version --entry nym-vpn-core
 
       - name: Install cargo-edit
-        run: cargo install --locked cargo-edit
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-edit
 
       - name: Append timestamp if it's a dev version
         run: ./scripts/append-timestamp-to-version.sh nym-vpn-core/Cargo.toml ${{ steps.workspace-version.outputs.metadata }}

--- a/.github/workflows/publish-nym-vpn-android.yml
+++ b/.github/workflows/publish-nym-vpn-android.yml
@@ -313,9 +313,15 @@ jobs:
         with:
           go-version: '1.23.6'  # If this changes, we need a PR to Fdroid to update pipeline for reproducibility
 
-      - name: Install cargo deps
-        run: |
-          cargo install --locked cargo-ndk cargo-license
+      - name: Install cargo-ndk
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-ndk
+      
+      - name: Install cargo-license
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-license
 
       # Here we need to decode keystore.jks from base64 string and place it
       # in the folder specified in the release signing configuration

--- a/.github/workflows/publish-nym-vpn-core.yml
+++ b/.github/workflows/publish-nym-vpn-core.yml
@@ -82,7 +82,9 @@ jobs:
           subcommand: workspace.package.version --entry nym-vpn-core
 
       - name: Install cargo-edit
-        run: cargo install --locked cargo-edit
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-edit
 
       - name: Append timestamp if it's a pre-release version
         run: ./scripts/append-timestamp-to-version.sh nym-vpn-core/Cargo.toml ${{ steps.workspace-version-pre.outputs.metadata }}


### PR DESCRIPTION
Our workflows [fail from time to time](https://github.com/nymtech/nym-vpn-client/actions/runs/14624080640/job/41031239605) because some of binaries have already been installed during the previous run.

Our current duct-tape approach is to ignore errors from `cargo install` by using `|| true` which may ignore legit errors. Let's use a proper github action that can tell if dependency is already installed and skip installation if not needed, but then also error when legit errors happen.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2702)
<!-- Reviewable:end -->
