### PR TITLE
Eliminate unwrap() in command interface

### DIFF
--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/error.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/error.rs
@@ -1,8 +1,19 @@
+// Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use std::path::PathBuf;
+
 #[derive(Debug, thiserror::Error)]
 pub enum CommandInterfaceError {
-    #[error("failed to parse DNS IP address: {ip}")]
-    FailedToParseDnsIp {
+    #[error("Failed to parse DNS IP address: {ip}")]
+    ParseDnsIp {
         ip: String,
         source: std::net::AddrParseError,
+    },
+
+    #[error("Failed to create incoming stream at {}", socket_path.display())]
+    CreateIncoming {
+        socket_path: PathBuf,
+        source: std::io::Error,
     },
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
@@ -30,8 +30,10 @@ use super::{
     error::CommandInterfaceError,
     helpers::{parse_entry_point, parse_exit_point, threshold_into_percent},
 };
-use crate::logging::LogPath;
-use crate::service::{ConnectOptions, VpnServiceCommand};
+use crate::{
+    logging::LogPath,
+    service::{ConnectOptions, VpnServiceCommand},
+};
 
 pub(super) struct CommandInterface {
     // Send commands to the VPN service
@@ -783,7 +785,7 @@ impl TryFrom<ConnectRequest> for ConnectOptions {
             .map(|dns| {
                 dns.ip
                     .parse()
-                    .map_err(|err| CommandInterfaceError::FailedToParseDnsIp {
+                    .map_err(|err| CommandInterfaceError::ParseDnsIp {
                         ip: dns.ip.clone(),
                         source: err,
                     })

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/start.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/start.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{path::PathBuf, time::Duration};
+use std::time::Duration;
 
 use nym_vpn_lib_types::TunnelEvent;
 use nym_vpn_network_config::Network;
@@ -9,14 +9,16 @@ use nym_vpn_proto::nym_vpnd_server::NymVpndServer;
 use tokio::{
     sync::{
         broadcast,
-        mpsc::{self, UnboundedReceiver, UnboundedSender},
+        mpsc::{self, UnboundedReceiver},
     },
     task::JoinHandle,
 };
 use tokio_util::sync::CancellationToken;
 use tonic::transport::Server;
 
-use super::{config::default_socket_path, listener::CommandInterface};
+use super::{
+    config::default_socket_path, error::CommandInterfaceError, listener::CommandInterface,
+};
 use crate::service::VpnServiceCommand;
 
 // If the shutdown signal is received, we give the listeners a little extra time to finish
@@ -30,50 +32,42 @@ fn grpc_span(req: &http::Request<()>) -> tracing::Span {
     span
 }
 
-async fn run_socket_listener(
-    vpn_command_tx: UnboundedSender<VpnServiceCommand>,
+pub async fn start_command_interface(
     tunnel_event_rx: broadcast::Receiver<TunnelEvent>,
-    socket_path: PathBuf,
-    shutdown_token: CancellationToken,
     network_env: Network,
-) -> Result<(), tonic::transport::Error> {
-    let command_interface = CommandInterface::new(vpn_command_tx, tunnel_event_rx, network_env);
+    shutdown_token: CancellationToken,
+) -> Result<(JoinHandle<()>, UnboundedReceiver<VpnServiceCommand>), CommandInterfaceError> {
+    tracing::debug!("Starting command interface");
+
+    let socket_path = default_socket_path();
+    let (vpn_command_tx, vpn_command_rx) = mpsc::unbounded_channel();
 
     // Remove previous socket file in case if the daemon crashed in the prior run and could not clean up the socket file.
     #[cfg(unix)]
     remove_previous_socket_file(&socket_path).await;
     tracing::info!("Starting socket listener on: {}", socket_path.display());
 
-    // Wrap the unix socket into a stream that can be used by tonic
-    let incoming = nym_ipc::server::create_incoming(socket_path).unwrap();
+    // Wrap the unix socket or named pipe into a stream that can be used by tonic
+    let incoming = nym_ipc::server::create_incoming(socket_path.clone()).map_err(|source| {
+        CommandInterfaceError::CreateIncoming {
+            socket_path,
+            source,
+        }
+    })?;
 
-    Server::builder()
-        .trace_fn(grpc_span)
-        .add_service(NymVpndServer::new(command_interface))
-        .serve_with_incoming_shutdown(incoming, shutdown_token.cancelled_owned())
-        .await
-}
-
-pub fn start_command_interface(
-    tunnel_event_rx: broadcast::Receiver<TunnelEvent>,
-    network_env: Network,
-    shutdown_token: CancellationToken,
-) -> (JoinHandle<()>, UnboundedReceiver<VpnServiceCommand>) {
-    tracing::debug!("Starting command interface");
-
-    let (vpn_command_tx, vpn_command_rx) = mpsc::unbounded_channel();
-
-    let handle = tokio::spawn(async move {
-        let child_token = shutdown_token.child_token();
+    let server_handle = tokio::spawn(async move {
+        let incoming_shutdown_token = shutdown_token.child_token();
         let socket_listener_handle = tokio::spawn(async move {
-            match run_socket_listener(
-                vpn_command_tx.clone(),
-                tunnel_event_rx.resubscribe(),
-                default_socket_path(),
-                child_token,
-                network_env.clone(),
-            )
-            .await
+            let command_interface =
+                CommandInterface::new(vpn_command_tx, tunnel_event_rx, network_env);
+
+            let server = Server::builder()
+                .trace_fn(grpc_span)
+                .add_service(NymVpndServer::new(command_interface));
+
+            match server
+                .serve_with_incoming_shutdown(incoming, incoming_shutdown_token.cancelled_owned())
+                .await
             {
                 Ok(()) => {
                     tracing::info!("Socket listener has finished");
@@ -94,7 +88,7 @@ pub fn start_command_interface(
         tracing::info!("Command interface exiting");
     });
 
-    (handle, vpn_command_rx)
+    Ok((server_handle, vpn_command_rx))
 }
 
 #[cfg(unix)]

--- a/nym-vpn-core/crates/nym-vpnd/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/main.rs
@@ -146,7 +146,8 @@ async fn run_inner_async(
         tunnel_event_rx,
         network_env.clone(),
         shutdown_token.child_token(),
-    );
+    )
+    .await?;
 
     // The user agent can be overridden by the user, but if it's not, we'll construct it
     // based on the current system information and it will be for "nym-vpnd". A number of the rpc

--- a/nym-vpn-core/crates/nym-vpnd/src/service/windows_service/mod.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/windows_service/mod.rs
@@ -222,7 +222,8 @@ async fn run_service_inner() -> anyhow::Result<()> {
         tunnel_event_rx,
         network_env.clone(),
         shutdown_token.child_token(),
-    );
+    )
+    .await?;
 
     let user_agent = crate::util::construct_user_agent();
 


### PR DESCRIPTION
- Eliminate `unwrap()` in the command interface initialization
- Return error from command interface if UDS or named pipe cannot be open

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2715)
<!-- Reviewable:end -->
