### PR TITLE
Use tokio::fs to prevent blocking async runtime

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -5081,6 +5081,7 @@ name = "nym-vpn-account-controller"
 version = "1.9.0-beta"
 dependencies = [
  "bincode",
+ "futures",
  "nym-compact-ecash",
  "nym-credential-proxy-requests",
  "nym-credential-storage",
@@ -5102,6 +5103,7 @@ dependencies = [
  "thiserror 2.0.12",
  "time",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "tracing",
  "uuid",

--- a/nym-vpn-core/crates/nym-vpn-account-controller/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 bincode.workspace = true
+futures.workspace = true
 nym-compact-ecash.workspace = true
 nym-credential-proxy-requests.workspace = true
 nym-credential-storage.workspace = true
@@ -29,12 +30,17 @@ nym-vpn-store = { workspace = true }
 nym-wg-gateway-client = { workspace = true }
 serde.workspace = true
 si-scale.workspace = true
-sqlx = { workspace = true, features = ["runtime-tokio-rustls", "sqlite", "time"] }
+sqlx = { workspace = true, features = [
+    "runtime-tokio-rustls",
+    "sqlite",
+    "time",
+] }
 strum = { workspace = true, features = ["derive"] }
 thiserror.workspace = true
 time.workspace = true
 tokio-util.workspace = true
-tokio.workspace = true
+tokio-stream.workspace = true
+tokio = { workspace = true, features = ["fs"] }
 tracing.workspace = true
 uuid.workspace = true
 zeroize.workspace = true

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
@@ -336,6 +336,7 @@ where
         // owner. Ideally we should strive for this to be removed.
         // If this fails, we still need to continue with the remaining steps
         let remove_files_result = crate::storage::remove_files_for_account(&self.config.data_dir)
+            .await
             .inspect_err(|err| {
                 tracing::error!("Failed to remove files for account: {err:?}");
             });

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/cleanup.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/cleanup.rs
@@ -2,9 +2,12 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use std::{
-    fs, io,
+    io,
     path::{Path, PathBuf},
 };
+
+use futures::StreamExt;
+use tokio_stream::wrappers::ReadDirStream;
 
 use nym_sdk::mixnet::StoragePaths;
 use nym_vpn_store::keys::persistence::{
@@ -24,7 +27,7 @@ use crate::Error;
 // TODO: implement functionality where the owning code of these files delete them instead. To
 // protect us against the names drifting out of sync.
 
-pub fn remove_files_for_account(data_dir: &Path) -> Result<(), Error> {
+pub async fn remove_files_for_account(data_dir: &Path) -> Result<(), Error> {
     // Files specific to the VPN client
     let device_key = [
         DEFAULT_PRIVATE_DEVICE_KEY_FILENAME,
@@ -65,7 +68,7 @@ pub fn remove_files_for_account(data_dir: &Path) -> Result<(), Error> {
 
     for file_path in files_to_remove {
         tracing::info!("Removing file: {}", file_path.display());
-        match fs::remove_file(&file_path) {
+        match tokio::fs::remove_file(&file_path).await {
             Ok(_) => tracing::info!("Removed file: {}", file_path.display()),
             Err(err) if err.kind() == io::ErrorKind::NotFound => {
                 tracing::debug!("File not found, skipping: {}", file_path.display());
@@ -78,14 +81,16 @@ pub fn remove_files_for_account(data_dir: &Path) -> Result<(), Error> {
     // filename as the original file, but appended with `_1234567890.corrupted`. Make sure to
     // delete all of these as well.
 
-    let corrupted_files = get_list_of_corrupted_files(data_dir).inspect_err(|err| {
-        tracing::error!("Failed to get list of corrupted files: {err}");
-    });
+    let corrupted_files = get_list_of_corrupted_files(data_dir)
+        .await
+        .inspect_err(|err| {
+            tracing::error!("Failed to get list of corrupted files: {err}");
+        });
 
     if let Ok(corrupted_files) = corrupted_files {
         for file in corrupted_files {
             tracing::info!("Removing corrupted file: {}", file.display());
-            match fs::remove_file(&file) {
+            match tokio::fs::remove_file(&file).await {
                 Ok(_) => tracing::info!("Removed corrupted file: {}", file.display()),
                 Err(err) if err.kind() == io::ErrorKind::NotFound => {
                     tracing::debug!("Corrupted file not found, skipping: {}", file.display());
@@ -98,43 +103,48 @@ pub fn remove_files_for_account(data_dir: &Path) -> Result<(), Error> {
     }
 
     // Warn if there are any files left in the data directory
-    let remaining_files = fs::read_dir(data_dir)
-        .map_err(Error::internal)?
-        .filter_map(|file| file.ok())
-        .map(|file| file.path());
-    for file in remaining_files {
-        tracing::info!("File left in data directory: {}", file.display());
+    let mut dir_stream = ReadDirStream::new(
+        tokio::fs::read_dir(data_dir)
+            .await
+            .map_err(Error::internal)?,
+    );
+
+    while let Some(entry_result) = dir_stream.next().await {
+        if let Ok(entry) = entry_result {
+            tracing::info!("File left in data directory: {}", entry.path().display());
+        }
     }
 
     Ok(())
 }
 
-fn get_list_of_corrupted_files(data_dir: &Path) -> Result<Vec<PathBuf>, Error> {
+async fn get_list_of_corrupted_files(data_dir: &Path) -> Result<Vec<PathBuf>, Error> {
     let base_name = StoragePaths::new_from_dir(data_dir)
         .map_err(Error::StoragePaths)?
         .reply_surb_database_path;
 
-    if let Some(starts_with) = base_name.file_name().and_then(|bn| bn.to_str()) {
-        // Delete files of the form `base_name._[0-9]*.corrupted`
-        let corrupted_files = fs::read_dir(data_dir)
-            .map_err(Error::internal)?
-            .filter_map(|file| file.ok())
-            .filter(|file| {
-                file.file_name()
-                    .to_str()
-                    .map(|name| name.starts_with(starts_with))
-                    .unwrap_or(false)
-            })
-            .filter(|file| {
-                file.file_name()
-                    .to_str()
-                    .map(|name| name.ends_with(".corrupted"))
-                    .unwrap_or(false)
-            })
-            .map(|file| file.path())
-            .collect();
-        Ok(corrupted_files)
-    } else {
-        Ok(vec![])
+    let Some(starts_with) = base_name.file_name().and_then(|bn| bn.to_str()) else {
+        return Ok(vec![]);
+    };
+
+    let mut dir_stream = ReadDirStream::new(
+        tokio::fs::read_dir(data_dir)
+            .await
+            .map_err(Error::internal)?,
+    );
+
+    // Delete files of the form `base_name._[0-9]*.corrupted`
+    let mut corrupted_files = vec![];
+    while let Some(entry_result) = dir_stream.next().await {
+        if let Ok(entry) = entry_result {
+            if entry
+                .file_name()
+                .to_str()
+                .is_some_and(|s| s.starts_with(starts_with) || s.ends_with(".corrupted"))
+            {
+                corrupted_files.push(entry.path());
+            }
+        }
     }
+    Ok(corrupted_files)
 }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/credentials/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/credentials/mod.rs
@@ -83,7 +83,7 @@ impl VpnCredentialStorage {
         tracing::debug!("Removing credential storage file");
         for path in storage_paths.credential_database_paths() {
             tracing::debug!("Attempting to remove file: {}", path.display());
-            match std::fs::remove_file(&path) {
+            match tokio::fs::remove_file(&path).await {
                 Ok(_) => tracing::info!("Removed file: {}", path.display()),
                 Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
                     tracing::debug!("File not found, skipping: {}", path.display())

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/credentials/pending_credential_requests/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/credentials/pending_credential_requests/mod.rs
@@ -80,7 +80,8 @@ impl PendingCredentialRequestsStorage {
 
         // Then we remove the database file
         tracing::debug!("Removing pending credential requests storage file");
-        std::fs::remove_file(&self.database_path)
+        tokio::fs::remove_file(&self.database_path)
+            .await
             .map_err(PendingCredentialRequestsStorageError::RemoveStorage)?;
         tracing::info!("Removed file: {}", self.database_path.display());
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/account.rs
@@ -318,7 +318,7 @@ pub(crate) mod raw {
         let storage_paths = StoragePaths::new_from_dir(&path).map_err(VpnError::internal)?;
         for path in storage_paths.credential_database_paths() {
             tracing::info!("Removing file: {}", path.display());
-            match std::fs::remove_file(&path) {
+            match tokio::fs::remove_file(&path).await {
                 Ok(_) => tracing::trace!("Removed file: {}", path.display()),
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                     tracing::trace!("File not found, skipping: {}", path.display())
@@ -402,11 +402,11 @@ pub(crate) mod raw {
         remove_credential_storage_raw(&path_buf).await?;
 
         // Then remove the rest of the files, that we own indirectly
-        nym_vpn_account_controller::remove_files_for_account(&path_buf).map_err(|err| {
-            VpnError::Storage {
+        nym_vpn_account_controller::remove_files_for_account(&path_buf)
+            .await
+            .map_err(|err| VpnError::Storage {
                 details: err.to_string(),
-            }
-        })?;
+            })?;
 
         Ok(())
     }

--- a/nym-vpn-core/crates/nym-vpn-store/src/keys/persistence/on_disk.rs
+++ b/nym-vpn-core/crates/nym-vpn-store/src/keys/persistence/on_disk.rs
@@ -110,13 +110,16 @@ impl OnDiskKeys {
         })
     }
 
-    fn remove_keypair_files(&self, paths: &KeyPairPath) -> Result<(), std::io::Error> {
-        std::fs::remove_file(&paths.private_key_path)?;
-        std::fs::remove_file(&paths.public_key_path)
+    async fn remove_keypair_files(&self, paths: &KeyPairPath) -> std::io::Result<()> {
+        for f in [&paths.private_key_path, &paths.public_key_path] {
+            tokio::fs::remove_file(f).await?;
+        }
+        Ok(())
     }
 
-    fn remove_keypair(&self, paths: KeyPairPath) -> Result<(), OnDiskKeysError> {
+    async fn remove_keypair(&self, paths: KeyPairPath) -> Result<(), OnDiskKeysError> {
         self.remove_keypair_files(&paths)
+            .await
             .map_err(|error| OnDiskKeysError::UnableToRemoveKeys { paths, error })
     }
 
@@ -150,9 +153,9 @@ impl OnDiskKeys {
         self.store_keys(&device_keys)
     }
 
-    fn remove_keys(&self) -> Result<(), OnDiskKeysError> {
+    async fn remove_keys(&self) -> Result<(), OnDiskKeysError> {
         let device_paths = self.paths.device_key_pair_path();
-        self.remove_keypair(device_paths)
+        self.remove_keypair(device_paths).await
     }
 }
 
@@ -181,6 +184,6 @@ impl KeyStore for OnDiskKeys {
                 tracing::warn!("Failed to reset keys before removal.");
             })
             .ok();
-        self.remove_keys()
+        self.remove_keys().await
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-store/src/mnemonic/on_disk.rs
+++ b/nym-vpn-core/crates/nym-vpn-store/src/mnemonic/on_disk.rs
@@ -4,7 +4,7 @@
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::{
-    fs::{self, File},
+    fs::{File, OpenOptions, Permissions},
     path::PathBuf,
 };
 
@@ -81,7 +81,7 @@ impl MnemonicStorage for OnDiskMnemonicStorage {
         tracing::trace!("Creating parent directories for: {}", self.path.display());
         if let Some(parent) = self.path.parent() {
             tracing::trace!("Creating parent directory: {}", parent.display());
-            fs::create_dir_all(parent).map_err(|err| {
+            tokio::fs::create_dir_all(parent).await.map_err(|err| {
                 OnDiskMnemonicStorageError::FileCreateError {
                     path: parent.to_path_buf(),
                     source: err,
@@ -92,13 +92,13 @@ impl MnemonicStorage for OnDiskMnemonicStorage {
             {
                 // Set directory permissions to 700 (rwx------)
                 tracing::trace!("Set directory permissions to 700 (rwx------)");
-                let permissions = fs::Permissions::from_mode(0o700);
-                fs::set_permissions(parent, permissions).map_err(|source| {
-                    OnDiskMnemonicStorageError::FileCreateError {
+                let permissions = Permissions::from_mode(0o700);
+                tokio::fs::set_permissions(parent, permissions)
+                    .await
+                    .map_err(|source| OnDiskMnemonicStorageError::FileCreateError {
                         path: parent.to_path_buf(),
                         source,
-                    }
-                })?;
+                    })?;
             }
 
             // TODO: same for windows
@@ -106,7 +106,7 @@ impl MnemonicStorage for OnDiskMnemonicStorage {
 
         // Another layer of defense, only create the file if it doesn't already exist
         tracing::debug!("Only creating the file if it doesn't already exist");
-        let file = std::fs::OpenOptions::new()
+        let file = OpenOptions::new()
             .create_new(true)
             .write(true)
             .open(&self.path)
@@ -121,13 +121,13 @@ impl MnemonicStorage for OnDiskMnemonicStorage {
         #[cfg(unix)]
         {
             // Set directory permissions to 600 (rw------)
-            let permissions = fs::Permissions::from_mode(0o600);
-            fs::set_permissions(self.path.clone(), permissions).map_err(|source| {
-                OnDiskMnemonicStorageError::FileCreateError {
+            let permissions = Permissions::from_mode(0o600);
+            tokio::fs::set_permissions(self.path.clone(), permissions)
+                .await
+                .map_err(|source| OnDiskMnemonicStorageError::FileCreateError {
                     path: self.path.clone(),
                     source,
-                }
-            })?;
+                })?;
         }
 
         // TODO: same for windows
@@ -141,8 +141,9 @@ impl MnemonicStorage for OnDiskMnemonicStorage {
         // Make sure that the file has permissions set to 600 (rw------)
         #[cfg(unix)]
         {
-            let permissions = fs::Permissions::from_mode(0o600);
-            fs::set_permissions(&self.path, permissions)
+            let permissions = Permissions::from_mode(0o600);
+            tokio::fs::set_permissions(&self.path, permissions)
+                .await
                 .map_err(OnDiskMnemonicStorageError::FileOpenError)?;
         }
 
@@ -156,7 +157,9 @@ impl MnemonicStorage for OnDiskMnemonicStorage {
         if !self.path.exists() {
             return Ok(());
         }
-        std::fs::remove_file(&self.path).map_err(OnDiskMnemonicStorageError::RemoveError)
+        tokio::fs::remove_file(&self.path)
+            .await
+            .map_err(OnDiskMnemonicStorageError::RemoveError)
     }
 }
 

--- a/nym-vpn-core/crates/nym-vpn-store/src/mnemonic/on_disk.rs
+++ b/nym-vpn-core/crates/nym-vpn-store/src/mnemonic/on_disk.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
+use std::{fs::Permissions, os::unix::fs::PermissionsExt};
 use std::{
-    fs::{File, OpenOptions, Permissions},
+    fs::{File, OpenOptions},
     path::PathBuf,
 };
 


### PR DESCRIPTION
This PR switches a part of codebase using `std::fs`in async functions to `tokio::fs`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2728)
<!-- Reviewable:end -->
