### PR TITLE
Use async-trait instead of suppressing async_fn_in_trait warning

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -4311,6 +4311,7 @@ dependencies = [
 name = "nym-harbour-master-client"
 version = "1.9.0-beta"
 dependencies = [
+ "async-trait",
  "chrono",
  "nym-http-api-client",
  "serde",
@@ -5269,6 +5270,7 @@ dependencies = [
 name = "nym-vpn-store"
 version = "1.9.0-beta"
 dependencies = [
+ "async-trait",
  "bip39",
  "nym-crypto",
  "nym-pemstore",

--- a/nym-vpn-core/crates/nym-harbour-master-client/Cargo.toml
+++ b/nym-vpn-core/crates/nym-harbour-master-client/Cargo.toml
@@ -9,6 +9,7 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+async-trait.workspace = true
 chrono.workspace = true
 nym-http-api-client.workspace = true
 serde = { workspace = true, features = ["derive"] }

--- a/nym-vpn-core/crates/nym-harbour-master-client/src/client.rs
+++ b/nym-vpn-core/crates/nym-harbour-master-client/src/client.rs
@@ -16,7 +16,7 @@ const PAGINATION_KEY: &str = "size";
 const PAGINATION_SIZE: &str = "500";
 const PAGINATION: (&str, &str) = (PAGINATION_KEY, PAGINATION_SIZE);
 
-#[allow(async_fn_in_trait)]
+#[async_trait::async_trait]
 pub trait HarbourMasterApiClientExt: ApiClient {
     async fn get_gateways_page(
         &self,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/storage/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/storage/mod.rs
@@ -38,6 +38,7 @@ impl VpnClientOnDiskStorage {
 
 impl nym_vpn_store::VpnStorage for VpnClientOnDiskStorage {}
 
+#[async_trait::async_trait]
 impl KeyStore for VpnClientOnDiskStorage {
     type StorageError = OnDiskKeysError;
 
@@ -62,6 +63,7 @@ impl KeyStore for VpnClientOnDiskStorage {
     }
 }
 
+#[async_trait::async_trait]
 impl MnemonicStorage for VpnClientOnDiskStorage {
     type StorageError = OnDiskMnemonicStorageError;
 

--- a/nym-vpn-core/crates/nym-vpn-store/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-store/Cargo.toml
@@ -12,6 +12,7 @@ license.workspace = true
 workspace = true
 
 [dependencies]
+async-trait.workspace = true
 bip39.workspace = true
 nym-crypto = { workspace = true, features = ["rand", "asymmetric"] }
 nym-pemstore.workspace = true

--- a/nym-vpn-core/crates/nym-vpn-store/src/keys/key_store.rs
+++ b/nym-vpn-core/crates/nym-vpn-store/src/keys/key_store.rs
@@ -5,21 +5,13 @@ use std::error::Error;
 
 use super::DeviceKeys;
 
+#[async_trait::async_trait]
 pub trait KeyStore {
     type StorageError: Error + Send + Sync + 'static;
 
-    #[allow(async_fn_in_trait)]
     async fn load_keys(&self) -> Result<DeviceKeys, Self::StorageError>;
-
-    #[allow(async_fn_in_trait)]
     async fn store_keys(&self, keys: &DeviceKeys) -> Result<(), Self::StorageError>;
-
-    #[allow(async_fn_in_trait)]
     async fn init_keys(&self, seed: Option<[u8; 32]>) -> Result<(), Self::StorageError>;
-
-    #[allow(async_fn_in_trait)]
     async fn reset_keys(&self, seed: Option<[u8; 32]>) -> Result<(), Self::StorageError>;
-
-    #[allow(async_fn_in_trait)]
     async fn remove_keys(&self) -> Result<(), Self::StorageError>;
 }

--- a/nym-vpn-core/crates/nym-vpn-store/src/keys/persistence/ephemeral.rs
+++ b/nym-vpn-core/crates/nym-vpn-store/src/keys/persistence/ephemeral.rs
@@ -17,6 +17,7 @@ pub enum EphemeralKeysError {
     UnableToLoadKeys,
 }
 
+#[async_trait::async_trait]
 impl KeyStore for InMemEphemeralKeys {
     type StorageError = EphemeralKeysError;
 

--- a/nym-vpn-core/crates/nym-vpn-store/src/keys/persistence/on_disk.rs
+++ b/nym-vpn-core/crates/nym-vpn-store/src/keys/persistence/on_disk.rs
@@ -156,6 +156,7 @@ impl OnDiskKeys {
     }
 }
 
+#[async_trait::async_trait]
 impl KeyStore for OnDiskKeys {
     type StorageError = OnDiskKeysError;
 

--- a/nym-vpn-core/crates/nym-vpn-store/src/mnemonic/ephemeral.rs
+++ b/nym-vpn-core/crates/nym-vpn-store/src/mnemonic/ephemeral.rs
@@ -36,6 +36,7 @@ impl MnemonicStorageError for InMemoryMnemonicStorageError {
     }
 }
 
+#[async_trait::async_trait]
 impl MnemonicStorage for InMemoryMnemonicStorage {
     type StorageError = InMemoryMnemonicStorageError;
 

--- a/nym-vpn-core/crates/nym-vpn-store/src/mnemonic/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-store/src/mnemonic/mod.rs
@@ -15,19 +15,13 @@ pub trait MnemonicStorageError: Error + Send + Sync + 'static {
     fn is_mnemonic_stored(&self) -> bool;
 }
 
+#[async_trait::async_trait]
 pub trait MnemonicStorage {
     type StorageError: MnemonicStorageError;
 
-    #[allow(async_fn_in_trait)]
     async fn load_mnemonic(&self) -> Result<Mnemonic, Self::StorageError>;
-
-    #[allow(async_fn_in_trait)]
     async fn store_mnemonic(&self, mnemonic: Mnemonic) -> Result<(), Self::StorageError>;
-
-    #[allow(async_fn_in_trait)]
     async fn remove_mnemonic(&self) -> Result<(), Self::StorageError>;
-
-    #[allow(async_fn_in_trait)]
     async fn is_mnemonic_stored(&self) -> Result<bool, Self::StorageError> {
         self.load_mnemonic().await.map(|_| true).or(Ok(false))
     }

--- a/nym-vpn-core/crates/nym-vpn-store/src/mnemonic/on_disk.rs
+++ b/nym-vpn-core/crates/nym-vpn-store/src/mnemonic/on_disk.rs
@@ -53,6 +53,7 @@ impl OnDiskMnemonicStorage {
     }
 }
 
+#[async_trait::async_trait]
 impl MnemonicStorage for OnDiskMnemonicStorage {
     type StorageError = OnDiskMnemonicStorageError;
 


### PR DESCRIPTION
`async-trait` desugars `async fn` into `fn() -> Box<Future>` which has been a go to solution when using `async fn` in traits in the past many years. Perhaps let's stick to it for simplicity

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2729)
<!-- Reviewable:end -->
