### PR TITLE
Update objc2 to the latest

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -705,8 +705,9 @@ dependencies = [
 
 [[package]]
 name = "block2"
-version = "0.6.0"
-source = "git+https://github.com/madsmtm/objc2?rev=91a74f332f3db66378f457ad954f26c2d72277ca#91a74f332f3db66378f457ad954f26c2d72277ca"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "340d2f0bdb2a43c1d3cd40513185b2bd7def0aa1052f956455114bc98f82dcf2"
 dependencies = [
  "objc2",
 ]
@@ -1659,8 +1660,9 @@ dependencies = [
 
 [[package]]
 name = "dispatch2"
-version = "0.2.0"
-source = "git+https://github.com/madsmtm/objc2?rev=91a74f332f3db66378f457ad954f26c2d72277ca#91a74f332f3db66378f457ad954f26c2d72277ca"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
  "bitflags 2.9.0",
  "block2",
@@ -5436,16 +5438,18 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.6.0"
-source = "git+https://github.com/madsmtm/objc2?rev=91a74f332f3db66378f457ad954f26c2d72277ca#91a74f332f3db66378f457ad954f26c2d72277ca"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88c6597e14493ab2e44ce58f2fdecf095a51f12ca57bec060a11c57332520551"
 dependencies = [
  "objc2-encode",
 ]
 
 [[package]]
 name = "objc2-core-foundation"
-version = "0.3.0"
-source = "git+https://github.com/madsmtm/objc2?rev=91a74f332f3db66378f457ad954f26c2d72277ca#91a74f332f3db66378f457ad954f26c2d72277ca"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
 dependencies = [
  "bitflags 2.9.0",
  "dispatch2",
@@ -5455,12 +5459,14 @@ dependencies = [
 [[package]]
 name = "objc2-encode"
 version = "4.1.0"
-source = "git+https://github.com/madsmtm/objc2?rev=91a74f332f3db66378f457ad954f26c2d72277ca#91a74f332f3db66378f457ad954f26c2d72277ca"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "objc2-foundation"
-version = "0.3.0"
-source = "git+https://github.com/madsmtm/objc2?rev=91a74f332f3db66378f457ad954f26c2d72277ca#91a74f332f3db66378f457ad954f26c2d72277ca"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900831247d2fe1a09a683278e5384cfb8c80c79fe6b166f9d14bfdde0ea1b03c"
 dependencies = [
  "bitflags 2.9.0",
  "block2",

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -90,14 +90,15 @@ unreachable = "deny"
 [workspace.dependencies]
 android_logger = "0.14.1"
 anyhow = "1.0.97"
-async-trait = "0.1.87"
 async-stream = "0.3.6"
+async-trait = "0.1.87"
 backon = "1.4"
 base64 = "0.22"
 base64-url = "3.0.0"
 bincode = "1.3.3"
 bip39 = "2.1"
 bitflags = "2"
+block2 = "0.6.1"
 bs58 = "0.5.1"
 bytes = "1.10"
 chrono = "0.4.40"
@@ -105,6 +106,7 @@ clap = "4.5"
 dbus = "0.9"
 debounced = "0.2"
 dirs = "5.0.1"
+dispatch2 = "0.3.0"
 duct = "0.13"
 eventlog = "0.3.0"
 futures = "0.3.31"
@@ -116,7 +118,6 @@ http = "1.3.1"
 hyper-util = "0.1.11"
 inotify = "0.11"
 ipnetwork = "0.20"
-rs-release = "0.1.7"
 itertools = "0.13.0"
 lazy_static = "1.5.0"
 libc = "0.2"
@@ -129,6 +130,8 @@ netlink-packet-route = "0.19.0"
 netlink-sys = "0.8.7"
 nftnl = "0.7.0"
 nix = "0.29"
+objc2 = "0.6.1"
+objc2-foundation = "0.3.1"
 once_cell = "1.21"
 pfctl = "0.6"
 pnet_packet = "0.35.0"
@@ -138,6 +141,7 @@ rand = "0.8.5"
 rand_chacha = "0.3.1"
 reqwest = { version = "0.12", default-features = false }
 resolv-conf = "0.7"
+rs-release = "0.1.7"
 rtnetlink = "0.14.1"
 rust2go = "0.3.16"
 semver = "1.0"
@@ -180,13 +184,6 @@ winreg = "0.55"
 wmi = "0.14"
 x25519-dalek = "2.0"
 zeroize = "1.6.0"
-
-# Switch these to the latest version once objc2 v0.6.1 released
-# https://github.com/madsmtm/objc2/milestone/7
-block2 = { git = "https://github.com/madsmtm/objc2", rev = "91a74f332f3db66378f457ad954f26c2d72277ca" }
-dispatch2 = { git = "https://github.com/madsmtm/objc2", rev = "91a74f332f3db66378f457ad954f26c2d72277ca" }
-objc2 = { git = "https://github.com/madsmtm/objc2", rev = "91a74f332f3db66378f457ad954f26c2d72277ca" }
-objc2-foundation = { git = "https://github.com/madsmtm/objc2", rev = "91a74f332f3db66378f457ad954f26c2d72277ca" }
 
 nym-apple-network = { path = "crates/nym-apple-network" }
 nym-authenticator-client = { path = "crates/nym-authenticator-client" }

--- a/nym-vpn-core/crates/nym-apple-network/src/path_monitor.rs
+++ b/nym-vpn-core/crates/nym-apple-network/src/path_monitor.rs
@@ -95,13 +95,13 @@ impl Drop for PathMonitor {
 #[cfg(test)]
 mod tests {
     use crate::{Endpoint, PathMonitor};
-    use dispatch2::{DispatchQueue, QueueAttribute};
+    use dispatch2::{DispatchQueue, DispatchQueueAttr};
 
     use std::sync::mpsc;
 
     #[test]
     fn test_create_path_monitor() {
-        let queue = DispatchQueue::new("net.nymtech.test", QueueAttribute::Serial);
+        let queue = DispatchQueue::new("net.nymtech.test", DispatchQueueAttr::SERIAL);
         let (tx, rx) = mpsc::channel();
 
         let mut path_monitor = PathMonitor::new();

--- a/nym-vpn-core/crates/nym-offline-monitor/src/apple/path_monitor.rs
+++ b/nym-vpn-core/crates/nym-offline-monitor/src/apple/path_monitor.rs
@@ -3,7 +3,7 @@
 
 use std::{sync::Arc, time::Duration};
 
-use dispatch2::{DispatchQueue, QueueAttribute};
+use dispatch2::{DispatchQueue, DispatchQueueAttr};
 use tokio::sync::{mpsc, watch, Mutex};
 use tokio_stream::{wrappers::UnboundedReceiverStream, StreamExt};
 use tokio_util::sync::CancellationToken;
@@ -102,7 +102,7 @@ pub async fn spawn_monitor(
 }
 
 fn start_path_monitor(path_tx: mpsc::UnboundedSender<Path>) -> PathMonitor {
-    let queue = DispatchQueue::new("net.nymtech.vpn.offline-monitor", QueueAttribute::Serial);
+    let queue = DispatchQueue::new("net.nymtech.vpn.offline-monitor", DispatchQueueAttr::SERIAL);
 
     let mut path_monitor = PathMonitor::new();
     path_monitor.prohibit_interface_type(InterfaceType::Other);

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/mobile.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/mobile.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use std::{error::Error as StdError, net::IpAddr};
 
 #[cfg(target_os = "ios")]
-use dispatch2::{DispatchQueue, QueueAttribute};
+use dispatch2::{DispatchQueue, DispatchQueueAttr};
 
 use nym_authenticator_client::AuthClientMixnetListenerHandle;
 #[cfg(target_os = "ios")]
@@ -158,8 +158,10 @@ impl ConnectedTunnel {
                     DEFAULT_PATH_DEBOUNCE,
                 );
 
-                let queue =
-                    DispatchQueue::new("net.nymtech.vpn.wg-path-monitor", QueueAttribute::Serial);
+                let queue = DispatchQueue::new(
+                    "net.nymtech.vpn.wg-path-monitor",
+                    DispatchQueueAttr::SERIAL,
+                );
                 let mut path_monitor = PathMonitor::new();
                 path_monitor.set_dispatch_queue(&queue);
                 path_monitor.set_update_handler(move |network_path| {


### PR DESCRIPTION
Since objc2 v6.0.1 has been released, we should use the official release instead of commit hash.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2738)
<!-- Reviewable:end -->
