### PR TITLE
Remove mix hops for registration in two hop mode

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/connect.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/connect.rs
@@ -93,8 +93,7 @@ pub(crate) async fn setup_mixnet_client(
     if two_hop_mode {
         // for mobile platforms, in two hop mode, we do less frequent cover traffic, to preserve
         // battery
-        #[cfg(any(target_os = "android", target_os = "ios"))]
-        {
+        if cfg!(any(target_os = "android", target_os = "ios")) {
             debug_config.cover_traffic.loop_cover_traffic_average_delay =
                 MOBILE_LOOP_COVER_STREAM_AVERAGE_DELAY;
         }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/connect.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/connect.rs
@@ -93,7 +93,8 @@ pub(crate) async fn setup_mixnet_client(
     if two_hop_mode {
         // for mobile platforms, in two hop mode, we do less frequent cover traffic, to preserve
         // battery
-        if cfg!(unix) || cfg!(target_os = "ios") {
+        #[cfg(any(target_os = "android", target_os = "ios"))]
+        {
             debug_config.cover_traffic.loop_cover_traffic_average_delay =
                 MOBILE_LOOP_COVER_STREAM_AVERAGE_DELAY;
         }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/connect.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/connect.rs
@@ -90,11 +90,16 @@ pub(crate) async fn setup_mixnet_client(
     #[cfg(unix)] connection_fd_callback: Arc<dyn Fn(RawFd) + Send + Sync>,
 ) -> Result<SharedMixnetClient, MixnetError> {
     let mut debug_config = nym_client_core::config::DebugConfig::default();
-    // for mobile platforms, in two hop mode, we do less frequent cover traffic,
-    // to preserve battery
-    if two_hop_mode && (cfg!(unix) || cfg!(target_os = "ios")) {
-        debug_config.cover_traffic.loop_cover_traffic_average_delay =
-            MOBILE_LOOP_COVER_STREAM_AVERAGE_DELAY;
+    if two_hop_mode {
+        // for mobile platforms, in two hop mode, we do less frequent cover traffic, to preserve
+        // battery
+        if cfg!(unix) || cfg!(target_os = "ios") {
+            debug_config.cover_traffic.loop_cover_traffic_average_delay =
+                MOBILE_LOOP_COVER_STREAM_AVERAGE_DELAY;
+        }
+
+        // If operating in two hop mode, we disable mix hops for the mixnet connection.
+        debug_config.traffic.disable_mix_hops = true;
     }
     apply_mixnet_client_config(&mixnet_client_config, &mut debug_config);
 


### PR DESCRIPTION
This PR enables a mixnet feature disabling mix hops for the mixnet client used in two hop mode

This significantly speeds up the connection process as it removes multiple layers of encryption and multiple network round trips. This does not change any of the security or privacy properties of the registration properties.

In the core this is only configurable for a mixnet client once, not per-message. So everything that the vpn client uses this mixnet client for will be sent without using mix-hops -- for example the top-up messages and anonymous statistics that are sent currently.

Associated core PR: https://github.com/nymtech/nym/pull/5696

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2740)
<!-- Reviewable:end -->
