### PR TITLE
Refactor nym-vpn-network-config

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-network-config/src/discovery.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/discovery.rs
@@ -146,18 +146,14 @@ impl Discovery {
 
     pub async fn fetch_nym_network_details(&self) -> anyhow::Result<NymNetwork> {
         tracing::debug!("Fetching nym network details");
-        // Spawn the root task
-        let network_details =
-            NymApiClient::builder::<Url, anyhow::Error>(self.nym_api_url.clone())?
-                .build::<anyhow::Error>()?
-                .get_network_details()
-                .await?;
+        let client = NymApiClient::new(self.nym_api_url.clone(), None);
+        let network_details = client.get_network_details().await?;
+
         anyhow::ensure!(
             network_details.network.network_name == self.network_name,
             "Network name mismatch between requested and fetched network details"
         );
 
-        // resolve_nym_network_details(&mut network_details.network);
         Ok(NymNetwork {
             network: network_details.network,
         })
@@ -217,21 +213,22 @@ fn empty_user_agent() -> UserAgent {
 }
 
 pub(crate) async fn fetch_nym_network_details(
-    nym_api_url: &Url,
+    nym_api_url: Url,
 ) -> anyhow::Result<NymNetworkDetailsResponse> {
     tracing::debug!("Fetching nym network details");
-    NymApiClient::builder::<Url, anyhow::Error>(nym_api_url.clone())?
-        .build::<anyhow::Error>()?
+    let client = NymApiClient::new(nym_api_url, None);
+
+    client
         .get_network_details()
         .await
         .with_context(|| "Discovery endpoint returned error response".to_owned())
 }
 
 pub(crate) async fn fetch_nym_vpn_network_details(
-    nym_vpn_api_url: &Url,
+    nym_vpn_api_url: Url,
 ) -> anyhow::Result<NymWellknownDiscoveryItem> {
     tracing::debug!("Fetching nym vpn network details");
-    VpnApiClient::new(nym_vpn_api_url.clone(), empty_user_agent())?
+    VpnApiClient::new(nym_vpn_api_url, empty_user_agent())?
         .get_wellknown_current_env()
         .await
         .with_context(|| "Discovery endpoint returned error response".to_owned())

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/discovery.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/discovery.rs
@@ -69,10 +69,10 @@ impl Discovery {
         let discovery = client.get_wellknown_discovery(network_name).await?;
 
         tracing::debug!("Discovery response: {:#?}", discovery);
-
-        if discovery.network_name != network_name {
-            anyhow::bail!("Network name mismatch between requested and fetched discovery")
-        }
+        anyhow::ensure!(
+            discovery.network_name == network_name,
+            "Network name mismatch between requested and fetched discovery"
+        );
 
         tracing::debug!("Fetched nym network discovery: {:#?}", discovery);
         discovery.try_into()
@@ -152,10 +152,11 @@ impl Discovery {
                 .build::<anyhow::Error>()?
                 .get_network_details()
                 .await?;
+        anyhow::ensure!(
+            network_details.network.network_name == self.network_name,
+            "Network name mismatch between requested and fetched network details"
+        );
 
-        if network_details.network.network_name != self.network_name {
-            anyhow::bail!("Network name mismatch between requested and fetched network details")
-        }
         // resolve_nym_network_details(&mut network_details.network);
         Ok(NymNetwork {
             network: network_details.network,

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/lib.rs
@@ -95,11 +95,11 @@ impl Network {
             .first()
             .and_then(|v| v.api_url())
             .ok_or(anyhow::anyhow!("No endpoints found"))?;
-        let network_name = discovery::fetch_nym_network_details(&nym_api_url)
+        let network_name = discovery::fetch_nym_network_details(nym_api_url)
             .map(|resp| resp.map(|d| d.network.network_name));
 
         let nym_vpn_api_url = self.nym_vpn_network.nym_vpn_api_url.clone();
-        let vpn_network_name = discovery::fetch_nym_vpn_network_details(&nym_vpn_api_url)
+        let vpn_network_name = discovery::fetch_nym_vpn_network_details(nym_vpn_api_url)
             .map(|resp| resp.map(|d| d.network_name));
 
         let (network_name, vpn_network_name) = join!(network_name, vpn_network_name);


### PR DESCRIPTION
- Use `anyhow::ensure!` to avoid negated condition
- Pass `Url` by value to streamline ownership model in methods that would typically accept references only to clone them to owned value
- Simplify code. `NymApiClient::builder` is not really doign anything and the api client can be initialized directly via `new()`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2771)
<!-- Reviewable:end -->
