### PR TITLE
firewall: remove allowed endpoints from connected policy

### DIFF
--- a/nym-vpn-core/crates/nym-firewall/src/lib.rs
+++ b/nym-vpn-core/crates/nym-firewall/src/lib.rs
@@ -144,8 +144,6 @@ pub enum FirewallPolicy {
         /// Servers that are allowed to respond to DNS requests.
         #[cfg(not(target_os = "android"))]
         dns_config: ResolvedDnsConfig,
-        /// Hosts that should be reachable outside of tunnel when connected.
-        allowed_endpoints: Vec<AllowedEndpoint>,
         /// Interface to redirect (VPN tunnel) traffic to
         #[cfg(target_os = "macos")]
         redirect_interface: Option<String>,
@@ -285,7 +283,6 @@ impl fmt::Display for FirewallPolicy {
                 allow_lan,
                 #[cfg(not(target_os = "android"))]
                 dns_config,
-                allowed_endpoints,
                 ..
             } => {
                 #[cfg(not(target_os = "android"))]
@@ -295,11 +292,10 @@ impl fmt::Display for FirewallPolicy {
 
                 write!(
                     f,
-                    "Connected to {} over {}, {} LAN. Allowing endpoints: {}. Allowing non-tunnel DNS: {}",
+                    "Connected to {} over {}, {} LAN. Allowing non-tunnel DNS: {}",
                     display_peer_endpoints(peer_endpoints),
                     display_tunnel_interface(tunnel),
                     if *allow_lan { "Allowing" } else { "Blocking" },
-                    display_allowed_endpoints(allowed_endpoints),
                     dns_str
                 )
             }

--- a/nym-vpn-core/crates/nym-firewall/src/linux.rs
+++ b/nym-vpn-core/crates/nym-firewall/src/linux.rs
@@ -674,15 +674,11 @@ impl<'a> PolicyBatch<'a> {
                 peer_endpoints,
                 tunnel,
                 allow_lan,
-                allowed_endpoints,
                 dns_config,
             } => {
                 peer_endpoints
                     .iter()
                     .for_each(|endpoint| self.add_allow_tunnel_endpoint_rules(endpoint, fwmark));
-                allowed_endpoints
-                    .iter()
-                    .for_each(|endpoint| self.add_allow_endpoint_rules(endpoint));
 
                 for server in dns_config.tunnel_config() {
                     self.add_allow_tunnel_dns_rule(

--- a/nym-vpn-core/crates/nym-firewall/src/macos.rs
+++ b/nym-vpn-core/crates/nym-firewall/src/macos.rs
@@ -356,19 +356,19 @@ impl Firewall {
     fn get_nat_rules(&mut self, policy: &FirewallPolicy) -> Result<Vec<pfctl::NatRule>> {
         let (FirewallPolicy::Connected {
             peer_endpoints,
-            allowed_endpoints,
             tunnel,
             ..
         }
         | FirewallPolicy::Connecting {
             peer_endpoints,
-            allowed_endpoints,
             tunnel: Some(tunnel),
             ..
         }) = policy
         else {
             return Ok(vec![]);
         };
+
+        let allowed_endpoints = policy.allowed_endpoints();
 
         let mut rules = vec![];
 
@@ -532,7 +532,6 @@ impl Firewall {
                 tunnel,
                 allow_lan,
                 dns_config,
-                allowed_endpoints,
                 redirect_interface,
                 dns_redirect_port: _,
             } => {
@@ -556,10 +555,6 @@ impl Firewall {
 
                 for peer_endpoint in peer_endpoints {
                     rules.push(self.get_allow_relay_rule(peer_endpoint)?);
-                }
-
-                for allowed_endpoint in allowed_endpoints {
-                    rules.push(self.get_allowed_endpoint_rule(allowed_endpoint)?);
                 }
 
                 // Important to block DNS *before* we allow the tunnel and allow LAN. So DNS

--- a/nym-vpn-core/crates/nym-firewall/src/windows/mod.rs
+++ b/nym-vpn-core/crates/nym-firewall/src/windows/mod.rs
@@ -12,12 +12,12 @@ use std::{ffi::CStr, net::IpAddr, ptr, sync::LazyLock};
 
 use nym_common::ErrorExt;
 use widestring::WideCString;
-use windows::Win32::Globalization::{MultiByteToWideChar, CP_ACP, MULTI_BYTE_TO_WIDE_CHAR_FLAGS};
+use windows::Win32::Globalization::{CP_ACP, MULTI_BYTE_TO_WIDE_CHAR_FLAGS, MultiByteToWideChar};
 
 use self::winfw::*;
 use super::{
-    net::{AllowedEndpoint, AllowedTunnelTraffic},
     FirewallArguments, FirewallPolicy, InitialFirewallState,
+    net::{AllowedEndpoint, AllowedTunnelTraffic},
 };
 use crate::FirewallPolicyError;
 
@@ -558,7 +558,7 @@ fn with_wmi_if_enabled(f: impl FnOnce(&wmi::WMIConnection)) {
 
 #[allow(non_snake_case)]
 mod winfw {
-    use super::{widestring_ip, AllowedEndpoint, AllowedTunnelTraffic, Error, WideCString};
+    use super::{AllowedEndpoint, AllowedTunnelTraffic, Error, WideCString, widestring_ip};
     use crate::net::TransportProtocol;
     use std::{
         ffi::{c_char, c_void},

--- a/nym-vpn-core/crates/nym-firewall/src/windows/mod.rs
+++ b/nym-vpn-core/crates/nym-firewall/src/windows/mod.rs
@@ -12,12 +12,12 @@ use std::{ffi::CStr, net::IpAddr, ptr, sync::LazyLock};
 
 use nym_common::ErrorExt;
 use widestring::WideCString;
-use windows::Win32::Globalization::{CP_ACP, MULTI_BYTE_TO_WIDE_CHAR_FLAGS, MultiByteToWideChar};
+use windows::Win32::Globalization::{MultiByteToWideChar, CP_ACP, MULTI_BYTE_TO_WIDE_CHAR_FLAGS};
 
 use self::winfw::*;
 use super::{
-    FirewallArguments, FirewallPolicy, InitialFirewallState,
     net::{AllowedEndpoint, AllowedTunnelTraffic},
+    FirewallArguments, FirewallPolicy, InitialFirewallState,
 };
 use crate::FirewallPolicyError;
 
@@ -183,16 +183,9 @@ impl Firewall {
                 tunnel,
                 allow_lan,
                 dns_config,
-                allowed_endpoints,
             } => {
                 let cfg = &WinFwSettings::new(allow_lan);
-                self.set_connected_state(
-                    &peer_endpoints,
-                    cfg,
-                    &tunnel,
-                    &dns_config,
-                    &allowed_endpoints,
-                )
+                self.set_connected_state(&peer_endpoints, cfg, &tunnel, &dns_config)
             }
             FirewallPolicy::Blocked {
                 allow_lan,
@@ -331,7 +324,6 @@ impl Firewall {
         winfw_settings: &WinFwSettings,
         tunnel_interface: &TunnelInterface,
         dns_config: &ResolvedDnsConfig,
-        allowed_endpoints: &[AllowedEndpoint],
     ) -> Result<(), Error> {
         tracing::trace!("Applying 'connected' firewall policy");
 
@@ -379,19 +371,6 @@ impl Firewall {
             .map(|ip| ip.as_ptr())
             .collect();
 
-        let winfw_allowed_endpoint_containers = allowed_endpoints
-            .iter()
-            .cloned()
-            .map(AllowedEndpointBridge::from)
-            .collect::<Vec<_>>();
-        let winfw_allowed_endpoints = winfw_allowed_endpoint_containers
-            .iter()
-            .map(|ep| ep.as_endpoint())
-            .collect::<Vec<_>>();
-
-        // todo: verify that this is correct way to pass array of pointers.
-        let allowed_endpoint_refs = winfw_allowed_endpoints.iter().collect::<Vec<_>>();
-
         unsafe {
             WinFw_ApplyPolicyConnected(
                 winfw_settings,
@@ -409,8 +388,6 @@ impl Firewall {
                 tunnel_dns_servers_refs.len(),
                 non_tunnel_dns_servers_refs.as_ptr(),
                 non_tunnel_dns_servers_refs.len(),
-                allowed_endpoint_refs.as_ptr() as _,
-                allowed_endpoint_refs.len(),
             )
             .into_result()
             .map_err(Error::ApplyingConnectedPolicy)
@@ -581,7 +558,7 @@ fn with_wmi_if_enabled(f: impl FnOnce(&wmi::WMIConnection)) {
 
 #[allow(non_snake_case)]
 mod winfw {
-    use super::{AllowedEndpoint, AllowedTunnelTraffic, Error, WideCString, widestring_ip};
+    use super::{widestring_ip, AllowedEndpoint, AllowedTunnelTraffic, Error, WideCString};
     use crate::net::TransportProtocol;
     use std::{
         ffi::{c_char, c_void},
@@ -871,8 +848,6 @@ mod winfw {
             numTunnelDnsServers: usize,
             nonTunnelDnsServers: *const *const libc::wchar_t,
             numNonTunnelDnsServers: usize,
-            allowedEndpoints: *const *const WinFwAllowedEndpoint<'_>,
-            numAllowedEndpoints: usize,
         ) -> WinFwPolicyStatus;
 
         #[link_name = "WinFw_ApplyPolicyBlocked"]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
@@ -13,7 +13,6 @@ use nym_dns::DnsConfig;
 use nym_firewall::LOCAL_DNS_RESOLVER;
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 use nym_firewall::{AllowedClients, AllowedEndpoint, Endpoint, FirewallPolicy, TransportProtocol};
-use nym_gateway_directory::ResolvedConfig;
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 use nym_vpn_lib_types::TunnelConnectionData;
 
@@ -39,8 +38,6 @@ pub struct ConnectedState {
     selected_gateways: SelectedGateways,
     #[cfg_attr(any(target_os = "android", target_os = "ios"), allow(unused))]
     tunnel_interface: TunnelInterface,
-    #[cfg_attr(any(target_os = "android", target_os = "ios"), allow(unused))]
-    resolved_gateway_config: ResolvedConfig,
 }
 
 impl ConnectedState {
@@ -48,7 +45,6 @@ impl ConnectedState {
         tunnel_interface: TunnelInterface,
         connection_data: ConnectionData,
         selected_gateways: SelectedGateways,
-        resolved_gateway_config: ResolvedConfig,
         tunnel_monitor_handle: TunnelMonitorHandle,
         tunnel_monitor_event_receiver: TunnelMonitorEventReceiver,
         _shared_state: &mut SharedState,
@@ -58,7 +54,6 @@ impl ConnectedState {
             tunnel_monitor_event_receiver,
             selected_gateways,
             tunnel_interface,
-            resolved_gateway_config,
         };
 
         #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
@@ -144,27 +139,11 @@ impl ConnectedState {
             53,
         );
 
-        let allowed_endpoints = self
-            .resolved_gateway_config
-            .all_socket_addrs()
-            .into_iter()
-            .map(|addr| {
-                AllowedEndpoint::new(
-                    Endpoint::from_socket_address(addr, TransportProtocol::Tcp),
-                    #[cfg(any(target_os = "linux", target_os = "macos"))]
-                    AllowedClients::Root,
-                    #[cfg(target_os = "windows")]
-                    AllowedClients::current_exe(),
-                )
-            })
-            .collect();
-
         let policy = FirewallPolicy::Connected {
             peer_endpoints,
             tunnel: nym_firewall::TunnelInterface::from(self.tunnel_interface.clone()),
             // todo: fetch this from config
             allow_lan: true,
-            allowed_endpoints,
             dns_config,
             // todo: split tunneling
             #[cfg(target_os = "macos")]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -526,7 +526,6 @@ impl TunnelStateHandler for ConnectingState {
                         tunnel_interface,
                         *connection_data,
                         self.selected_gateways.expect("selected gateways must be set"),
-                        self.resolved_gateway_config.expect("resolved gateway config must be set!"),
                         self.tunnel_monitor_handle.expect("monitor handle must be set!"),
                         self.tunnel_monitor_event_receiver,
                         shared_state,

--- a/nym-vpn-windows/winfw/src/winfw/fwcontext.cpp
+++ b/nym-vpn-windows/winfw/src/winfw/fwcontext.cpp
@@ -403,7 +403,6 @@ bool FwContext::applyPolicyConnected
 	const std::vector<WinFwAllowedEndpoint>& relays,
 	const std::optional<std::wstring>&  entryTunnelIfaceAlias ,
 	const std::optional<std::wstring>& exitTunnelIfaceAlias,
-	const std::optional<std::vector<WinFwAllowedEndpoint>>& allowedEndpoints,
 	const std::vector<wfp::IpAddress>& tunnelDnsServers,
 	const std::vector<wfp::IpAddress>& nonTunnelDnsServers
 )
@@ -413,11 +412,6 @@ bool FwContext::applyPolicyConnected
 	AppendNetBlockedRules(ruleset);
 	AppendSettingsRules(ruleset, settings);
 	AppendRelayRules(ruleset, relays);
-
-	if (allowedEndpoints.has_value())
-	{
-		AppendAllowedEndpointRules(ruleset, allowedEndpoints.value());
-	}
 
 	if (exitTunnelIfaceAlias.has_value())
 	{

--- a/nym-vpn-windows/winfw/src/winfw/fwcontext.h
+++ b/nym-vpn-windows/winfw/src/winfw/fwcontext.h
@@ -45,7 +45,6 @@ public:
 		const std::vector<WinFwAllowedEndpoint> &relays,
 		const std::optional<std::wstring> &entryTunnelIfaceAlias,
 		const std::optional<std::wstring> &exitTunnelIfaceAlias,
-		const std::optional<std::vector<WinFwAllowedEndpoint>>& allowedEndpoints,
 		const std::vector<wfp::IpAddress> &tunnelDnsServers,
 		const std::vector<wfp::IpAddress> &nonTunnelDnsServers
 	);

--- a/nym-vpn-windows/winfw/src/winfw/winfw.cpp
+++ b/nym-vpn-windows/winfw/src/winfw/winfw.cpp
@@ -452,9 +452,7 @@ WinFw_ApplyPolicyConnected(
 	const wchar_t* tunnelDnsServers[],
 	size_t numTunnelDnsServers,
 	const wchar_t* nonTunnelDnsServers[],
-	size_t numNonTunnelDnsServers,
-	const WinFwAllowedEndpoint* allowedEndpoints[],
-	size_t numAllowedEndpoints
+	size_t numNonTunnelDnsServers
 )
 {
 	if (nullptr == g_fwContext)
@@ -487,14 +485,10 @@ WinFw_ApplyPolicyConnected(
 		auto relayVector = MakeVector(relays, numRelays);
 		auto entryTunnelIfaceAliasOptStr = MakeOptionalStr(entryTunnelIfaceAlias);
 		auto exitTunnelIfaceAliasOptStr = MakeOptionalStr(exitTunnelIfaceAlias);
-		auto allowedEndpointOptVector = MakeOptionalVector(allowedEndpoints, numAllowedEndpoints);
 		auto nonTunnelDnsServerVector = MakeIpAddressVector(nonTunnelDnsServers, numNonTunnelDnsServers);
 		auto tunnelDnsServersVector = MakeIpAddressVector(tunnelDnsServers, numTunnelDnsServers);
 
 		LogAllowedEndpoints("Relays", relayVector);
-		if (allowedEndpointOptVector.has_value()) {
-			LogAllowedEndpoints("Allowed endpoints", allowedEndpointOptVector.value());
-		}
 		LogInterface("Entry tunnel interface", entryTunnelIfaceAliasOptStr);
 		LogInterface("Exit tunnel interface", exitTunnelIfaceAliasOptStr);
 		LogDnsServers("Non-tunnel DNS servers", nonTunnelDnsServerVector);
@@ -505,7 +499,6 @@ WinFw_ApplyPolicyConnected(
 			relayVector,
 			entryTunnelIfaceAliasOptStr,
 			exitTunnelIfaceAliasOptStr,
-			allowedEndpointOptVector,
 			tunnelDnsServersVector,
 			nonTunnelDnsServerVector
 		) ? WINFW_POLICY_STATUS_SUCCESS : WINFW_POLICY_STATUS_GENERAL_FAILURE;

--- a/nym-vpn-windows/winfw/src/winfw/winfw.h
+++ b/nym-vpn-windows/winfw/src/winfw/winfw.h
@@ -204,9 +204,7 @@ WinFw_ApplyPolicyConnected(
 	const wchar_t* tunnelDnsServers[],
 	size_t numTunnelDnsServers,
 	const wchar_t* nonTunnelDnsServers[],
-	size_t numNonTunnelDnsServers,
-	const WinFwAllowedEndpoint* allowedEndpoints[],
-	size_t numAllowedEndpoints
+	size_t numNonTunnelDnsServers
 );
 
 //


### PR DESCRIPTION
This was a bit rushed before the release with intent to avoid chicken and egg problem with bandwidth top-ups however it didn't quite work without routing and given the complexity, we should remove allowed endpoints from connected policy.

JIRA-VPN-3412

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2792)
<!-- Reviewable:end -->
