### PR TITLE
Retrieve iOS operating system version

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -4499,6 +4499,7 @@ name = "nym-platform-metadata"
 version = "1.10.0-beta"
 dependencies = [
  "nym-dbus",
+ "objc2-foundation",
  "rs-release",
  "windows 0.59.0",
 ]

--- a/nym-vpn-core/crates/nym-firewall/src/macos.rs
+++ b/nym-vpn-core/crates/nym-firewall/src/macos.rs
@@ -6,6 +6,7 @@ use std::{
     env, io,
     net::{IpAddr, Ipv4Addr, SocketAddr},
     ptr,
+    str::FromStr,
     sync::LazyLock,
 };
 
@@ -33,9 +34,9 @@ const ANCHOR_NAME: &str = "nym";
 /// the local DNS resoler to work around Apple's captive portals check. Exactly how this is done is
 /// documented elsewhere.
 pub static LOCAL_DNS_RESOLVER: LazyLock<bool> = LazyLock::new(|| {
-    use nym_platform_metadata::MacosVersion;
-    let version = MacosVersion::new().expect("Could not detect macOS version");
-    let v = |s| MacosVersion::from_raw_version(s).unwrap();
+    use nym_platform_metadata::AppleVersion;
+    let version = AppleVersion::current();
+    let v = |s| AppleVersion::from_str(s).unwrap();
 
     // Apple services tried to perform DNS lookups on the physical interface on some macOS
     // versions, so we added redirect rules to always redirect DNS to our local DNS resolver.
@@ -73,9 +74,9 @@ pub static LOCAL_DNS_RESOLVER: LazyLock<bool> = LazyLock::new(|| {
 /// on macOS versions that are unaffected by this naughty bug, but keep it were it is necessary for
 /// Apple services to function properly together with a VPN.
 pub static NAT_WORKAROUND: LazyLock<bool> = LazyLock::new(|| {
-    use nym_platform_metadata::MacosVersion;
-    let version = MacosVersion::new().expect("Could not detect macOS version");
-    let v = |s| MacosVersion::from_raw_version(s).unwrap();
+    use nym_platform_metadata::AppleVersion;
+    let version = AppleVersion::current();
+    let v = |s| AppleVersion::from_str(s).unwrap();
     let apply_workaround = v("14.6") <= version && version < v("15.1");
     if apply_workaround {
         tracing::debug!("Using NAT redirect workaround");

--- a/nym-vpn-core/crates/nym-platform-metadata/Cargo.toml
+++ b/nym-vpn-core/crates/nym-platform-metadata/Cargo.toml
@@ -12,6 +12,9 @@ license.workspace = true
 default = ["network-manager"]
 network-manager = ["nym-dbus"]
 
+[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
+objc2-foundation = { workspace = true, features = ["NSProcessInfo"] }
+
 [target.'cfg(target_os = "linux")'.dependencies]
 rs-release.workspace = true
 nym-dbus = { workspace = true, optional = true }

--- a/nym-vpn-core/crates/nym-platform-metadata/src/apple.rs
+++ b/nym-vpn-core/crates/nym-platform-metadata/src/apple.rs
@@ -2,23 +2,29 @@
 // Copyright 2025 Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-mod command;
+use std::{
+    cmp::Ordering,
+    fmt::{self, Formatter},
+    io,
+    str::FromStr,
+};
 
-use command::command_stdout_lossy;
-use std::{cmp::Ordering, fmt, fmt::Formatter, io};
+use objc2_foundation::NSProcessInfo;
+
+#[cfg(target_os = "macos")]
+static OS_NAME: &'static str = "macOS";
+
+#[cfg(target_os = "ios")]
+static OS_NAME: &'static str = "iOS";
 
 pub fn version() -> String {
-    let version = MacosVersion::new()
-        .map(|version| version.version())
-        .unwrap_or(String::from("N/A"));
-    format!("macOS {}", version)
+    let version = AppleVersion::current().version();
+    format!("{} {}", OS_NAME, version)
 }
 
 pub fn short_version() -> String {
-    let version = MacosVersion::new()
-        .map(|version| version.short_version())
-        .unwrap_or(String::from("N/A"));
-    format!("macOS {}", version)
+    let version = AppleVersion::current().short_version();
+    format!("{} {}", OS_NAME, version)
 }
 
 pub fn extra_metadata() -> impl Iterator<Item = (String, String)> {
@@ -26,14 +32,14 @@ pub fn extra_metadata() -> impl Iterator<Item = (String, String)> {
 }
 
 #[derive(Debug, Clone)]
-pub struct MacosVersion {
+pub struct AppleVersion {
     raw_version: String,
     major: u32,
     minor: u32,
     patch: Option<u32>,
 }
 
-impl PartialEq for MacosVersion {
+impl PartialEq for AppleVersion {
     fn eq(&self, other: &Self) -> bool {
         self.major_version() == other.major_version()
             && self.minor_version() == other.minor_version()
@@ -41,7 +47,7 @@ impl PartialEq for MacosVersion {
     }
 }
 
-impl PartialOrd for MacosVersion {
+impl PartialOrd for AppleVersion {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         let major = self.major_version().partial_cmp(&other.major_version())?;
         let minor = self.minor_version().partial_cmp(&other.minor_version())?;
@@ -50,28 +56,42 @@ impl PartialOrd for MacosVersion {
     }
 }
 
-impl fmt::Display for MacosVersion {
+impl fmt::Display for AppleVersion {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.write_str(&self.version())
     }
 }
 
-impl MacosVersion {
-    pub fn new() -> Result<MacosVersion, io::Error> {
-        Self::from_raw_version(&run_sw_vers()?)
-    }
+impl FromStr for AppleVersion {
+    type Err = io::Error;
 
-    pub fn from_raw_version(version_string: &str) -> Result<MacosVersion, io::Error> {
-        let (major, minor, patch) = parse_version_output(version_string).ok_or(io::Error::new(
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (major, minor, patch) = parse_version_output(s).ok_or(io::Error::new(
             io::ErrorKind::InvalidInput,
             "Failed to parse raw version string",
         ))?;
-        Ok(MacosVersion {
-            raw_version: version_string.to_owned(),
+        Ok(AppleVersion {
+            raw_version: s.to_owned(),
             major,
             minor,
             patch,
         })
+    }
+}
+
+impl AppleVersion {
+    pub fn current() -> AppleVersion {
+        let version = NSProcessInfo::processInfo().operatingSystemVersion();
+
+        Self {
+            raw_version: format!(
+                "{}.{}.{}",
+                version.majorVersion, version.minorVersion, version.patchVersion
+            ),
+            major: version.majorVersion as u32,
+            minor: version.minorVersion as u32,
+            patch: Some(version.patchVersion as u32),
+        }
     }
 
     /// Return the current version as a string (e.g. 14.2.1)
@@ -97,11 +117,6 @@ impl MacosVersion {
     }
 }
 
-/// Outputs a string in a format `$major.$minor.$patch`, e.g. `11.0.1`
-fn run_sw_vers() -> io::Result<String> {
-    command_stdout_lossy("sw_vers", &["-productVersion"])
-}
-
 fn parse_version_output(output: &str) -> Option<(u32, u32, Option<u32>)> {
     let mut parts = output.split('.');
     let major = parts.next()?.parse().ok()?;
@@ -111,10 +126,13 @@ fn parse_version_output(output: &str) -> Option<(u32, u32, Option<u32>)> {
 }
 
 #[test]
+fn test_get_current_version() {
+    AppleVersion::current().version();
+}
+
+#[test]
 fn test_version_parsing() {
-    // % sw_vers --productVersion
-    // 14.2.1
-    let version = MacosVersion::from_raw_version("14.2.1").expect("failed to parse version");
+    let version = AppleVersion::from_str("14.2.1").expect("failed to parse version");
     assert_eq!(version.major_version(), 14);
     assert_eq!(version.minor_version(), 2);
     assert_eq!(version.patch_version(), 1);
@@ -123,48 +141,27 @@ fn test_version_parsing() {
 #[test]
 fn test_version_order() {
     assert_eq!(
-        MacosVersion::from_raw_version("13.0").unwrap(),
-        MacosVersion::from_raw_version("13.0.0").unwrap()
+        AppleVersion::from_str("13.0").unwrap(),
+        AppleVersion::from_str("13.0.0").unwrap()
     );
 
     assert_eq!(
-        MacosVersion::from_raw_version("13.0")
+        AppleVersion::from_str("13.0")
             .unwrap()
-            .partial_cmp(&MacosVersion::from_raw_version("13.0.0").unwrap()),
+            .partial_cmp(&AppleVersion::from_str("13.0.0").unwrap()),
         Some(Ordering::Equal),
     );
 
     // test major version
-    assert!(
-        MacosVersion::from_raw_version("13.0").unwrap()
-            < MacosVersion::from_raw_version("14.2.1").unwrap()
-    );
-    assert!(
-        MacosVersion::from_raw_version("13.0").unwrap()
-            > MacosVersion::from_raw_version("12.1").unwrap()
-    );
+    assert!(AppleVersion::from_str("13.0").unwrap() < AppleVersion::from_str("14.2.1").unwrap());
+    assert!(AppleVersion::from_str("13.0").unwrap() > AppleVersion::from_str("12.1").unwrap());
 
     // test minor version
-    assert!(
-        MacosVersion::from_raw_version("14.3").unwrap()
-            > MacosVersion::from_raw_version("14.2").unwrap()
-    );
-    assert!(
-        MacosVersion::from_raw_version("14.2").unwrap()
-            < MacosVersion::from_raw_version("14.3").unwrap()
-    );
+    assert!(AppleVersion::from_str("14.3").unwrap() > AppleVersion::from_str("14.2").unwrap());
+    assert!(AppleVersion::from_str("14.2").unwrap() < AppleVersion::from_str("14.3").unwrap());
 
     // test patch version
-    assert!(
-        MacosVersion::from_raw_version("14.2.1").unwrap()
-            > MacosVersion::from_raw_version("14.2").unwrap()
-    );
-    assert!(
-        MacosVersion::from_raw_version("14.2.2").unwrap()
-            > MacosVersion::from_raw_version("14.2.1").unwrap()
-    );
-    assert!(
-        MacosVersion::from_raw_version("14.2.2").unwrap()
-            < MacosVersion::from_raw_version("14.2.3").unwrap()
-    );
+    assert!(AppleVersion::from_str("14.2.1").unwrap() > AppleVersion::from_str("14.2").unwrap());
+    assert!(AppleVersion::from_str("14.2.2").unwrap() > AppleVersion::from_str("14.2.1").unwrap());
+    assert!(AppleVersion::from_str("14.2.2").unwrap() < AppleVersion::from_str("14.2.3").unwrap());
 }

--- a/nym-vpn-core/crates/nym-platform-metadata/src/lib.rs
+++ b/nym-vpn-core/crates/nym-platform-metadata/src/lib.rs
@@ -6,8 +6,8 @@
 #[path = "linux.rs"]
 mod imp;
 
-#[cfg(target_os = "macos")]
-#[path = "macos.rs"]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[path = "apple.rs"]
 mod imp;
 
 #[cfg(windows)]
@@ -18,9 +18,8 @@ mod imp;
 #[path = "android.rs"]
 mod imp;
 
-#[cfg(target_os = "macos")]
-pub use self::imp::MacosVersion;
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+pub use imp::AppleVersion;
 #[cfg(windows)]
-pub use self::imp::WindowsVersion;
-#[cfg(not(target_os = "ios"))]
-pub use self::imp::{extra_metadata, short_version, version};
+pub use imp::WindowsVersion;
+pub use imp::{extra_metadata, short_version, version};

--- a/nym-vpn-core/crates/nym-platform-metadata/src/windows.rs
+++ b/nym-vpn-core/crates/nym-platform-metadata/src/windows.rs
@@ -17,7 +17,7 @@ use windows::{
 type RTL_OSVERSIONINFOEXW = OSVERSIONINFOEXW;
 
 pub fn version() -> String {
-    let (major, build) = WindowsVersion::new()
+    let (major, build) = WindowsVersion::current()
         .map(|version_info| {
             (
                 version_info.windows_version_string(),
@@ -30,7 +30,7 @@ pub fn version() -> String {
 }
 
 pub fn short_version() -> String {
-    let version_string = WindowsVersion::new()
+    let version_string = WindowsVersion::current()
         .map(|version| version.windows_version_string())
         .unwrap_or("N/A".into());
     format!("Windows {}", version_string)
@@ -45,7 +45,7 @@ pub struct WindowsVersion {
 }
 
 impl WindowsVersion {
-    pub fn new() -> Result<WindowsVersion, windows::core::Error> {
+    pub fn current() -> Result<WindowsVersion, windows::core::Error> {
         let ntdll = unsafe { GetModuleHandleW(w!("ntdll"))? };
         let function_address = unsafe { GetProcAddress(ntdll, s!("RtlGetVersion")) }
             .ok_or_else(windows::core::Error::from_win32)?;
@@ -116,6 +116,6 @@ mod test {
     use super::*;
     #[test]
     fn test_windows_version() {
-        WindowsVersion::new().unwrap();
+        WindowsVersion::current().unwrap();
     }
 }


### PR DESCRIPTION
We're looking to output OS version into logs to make it easier to identify where the corresponding logs come from.

This PR adds support for retrieving iOS operating system version, but also streamlines how version is obtained on macOS.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2794)
<!-- Reviewable:end -->
