### PR TITLE
Box RouteSocketMessage which is too large

### DIFF
--- a/nym-vpn-core/crates/nym-routing/src/unix/macos/watch.rs
+++ b/nym-vpn-core/crates/nym-routing/src/unix/macos/watch.rs
@@ -24,7 +24,7 @@ pub enum Error {
     Send(#[source] routing_socket::Error),
     /// Received unexpected response to route message
     #[error("unexpected message type")]
-    UnexpectedMessageType(RouteSocketMessage, MessageType),
+    UnexpectedMessageType(Box<RouteSocketMessage>, MessageType),
     /// Route not found
     #[error("route not found")]
     RouteNotFound,
@@ -101,7 +101,7 @@ impl RoutingTable {
             Ok(anything_else) => {
                 tracing::error!("Unexpected route message: {anything_else:?}");
                 Err(Error::UnexpectedMessageType(
-                    anything_else,
+                    Box::new(anything_else),
                     MessageType::RTM_ADD,
                 ))
             }
@@ -145,7 +145,7 @@ impl RoutingTable {
                 Err(Error::Deletion(route))
             }
             anything_else => Err(Error::UnexpectedMessageType(
-                anything_else,
+                Box::new(anything_else),
                 MessageType::RTM_DELETE,
             )),
         }
@@ -178,7 +178,7 @@ impl RoutingTable {
         match data::RouteSocketMessage::parse_message(&response).map_err(Error::InvalidMessage)? {
             data::RouteSocketMessage::GetRoute(route) => Ok(Some(route)),
             unexpected_route_message => Err(Error::UnexpectedMessageType(
-                unexpected_route_message,
+                Box::new(unexpected_route_message),
                 MessageType::RTM_GET,
             )),
         }


### PR DESCRIPTION
Clippy started complaining about large result types. This PR attempts to take a stab at some of those issues. `RouteSocketMessage` is 120 byte long so I figured that boxing it would be better than boxing the entire error, especially because hopefully `UnexpectedMessageType` should not happen often or ever.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2798)
<!-- Reviewable:end -->
