### PR TITLE
Fix rust2go for windows and update readme

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -6352,8 +6352,7 @@ dependencies = [
 [[package]]
 name = "rust2go"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b72d44674ddf3acb250c3cf3a608e928c6a0aa176f0f8fa9f83e7778ae713519"
+source = "git+https://github.com/ihciah/rust2go.git?rev=00b068a9a99cac4252af0ec113e2ce5f2289132a#00b068a9a99cac4252af0ec113e2ce5f2289132a"
 dependencies = [
  "bindgen 0.71.1",
  "rust2go-cli",
@@ -6365,8 +6364,7 @@ dependencies = [
 [[package]]
 name = "rust2go-cli"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5b73395abf8ad750730351b7bcb5b8fc637dadf3d900f55dc59953a5b15bf6"
+source = "git+https://github.com/ihciah/rust2go.git?rev=00b068a9a99cac4252af0ec113e2ce5f2289132a#00b068a9a99cac4252af0ec113e2ce5f2289132a"
 dependencies = [
  "cbindgen",
  "clap",
@@ -6377,8 +6375,7 @@ dependencies = [
 [[package]]
 name = "rust2go-common"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04274cfe9552d6893cf9cb17652de327c3b0f4f912b5372a904d9d97da9204c5"
+source = "git+https://github.com/ihciah/rust2go.git?rev=00b068a9a99cac4252af0ec113e2ce5f2289132a#00b068a9a99cac4252af0ec113e2ce5f2289132a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6388,14 +6385,12 @@ dependencies = [
 [[package]]
 name = "rust2go-convert"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c9b9dcfbeec346b228b700861dc2b43f32ab6679b6440db3eedc459ef024be"
+source = "git+https://github.com/ihciah/rust2go.git?rev=00b068a9a99cac4252af0ec113e2ce5f2289132a#00b068a9a99cac4252af0ec113e2ce5f2289132a"
 
 [[package]]
 name = "rust2go-macro"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f195b1658c4984e70f0aef27b49a1d2b98e106a1418542017dfc9d11636e7c4"
+source = "git+https://github.com/ihciah/rust2go.git?rev=00b068a9a99cac4252af0ec113e2ce5f2289132a#00b068a9a99cac4252af0ec113e2ce5f2289132a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -142,7 +142,7 @@ rand_chacha = "0.3.1"
 resolv-conf = "0.7"
 rs-release = "0.1.7"
 rtnetlink = "0.14.1"
-rust2go = "0.4.1"
+rust2go = { git = "https://github.com/ihciah/rust2go.git", rev = "00b068a9a99cac4252af0ec113e2ce5f2289132a" }
 semver = "1.0"
 serde = "1.0"
 serde_json = "1.0"

--- a/nym-vpn-core/README.md
+++ b/nym-vpn-core/README.md
@@ -29,6 +29,16 @@ sudo apt install libdbus-1-dev libmnl-dev libnftnl-dev protobuf-compiler
   winget install -e --id=GnuWin32.Make
   ```
 
+- Install Libclang for x86 or x64 via winget:
+
+  ```
+  winget install -e --id=LLVM.LLVM
+  ```
+
+  If you are on ARM64, head to https://github.com/llvm/llvm-project/releases and download the latest release with "woa64" suffix.
+
+  Update your environment with `LIBCLANG_PATH` set to `C:\Program Files\LLVM\bin`.
+
 ## Build on Windows
 
 ### Build all dependencies


### PR DESCRIPTION
- Fix `rust2go` compilation on Windows by pointing rust2go at not yet released patch
- Update `README.md` to reflect how to properly configure it to avoid compilation errors

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2839)
<!-- Reviewable:end -->
