### PR TITLE
Enter error state on mixnet storage error

### DIFF
--- a/nym-vpn-core/crates/nym-apple-network/src/endpoint.rs
+++ b/nym-vpn-core/crates/nym-apple-network/src/endpoint.rs
@@ -376,10 +376,10 @@ pub enum Error {
     CreateUnixAddr(#[source] nix::errno::Errno),
 
     #[error("failed to decode UTF-8 string")]
-    DecodeUtf8(std::str::Utf8Error),
+    DecodeUtf8(#[source] std::str::Utf8Error),
 
     #[error("failed to parse IP address")]
-    ParseIpAddress(std::net::AddrParseError),
+    ParseIpAddress(#[source] std::net::AddrParseError),
 
     #[error("{:?} contains nul byte", _0)]
     FieldContainsNulByte(FieldName),

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/account/forget_account.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/account/forget_account.rs
@@ -10,7 +10,7 @@ pub enum ForgetAccountError {
     #[error("registration is in progress")]
     RegistrationInProgress,
 
-    #[error("update device on vpn-api: {0}")]
+    #[error("update device on vpn-api")]
     UpdateDeviceErrorResponse(VpnApiError),
 
     #[error("unexpected response: {0}")]

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/account/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/account/mod.rs
@@ -22,7 +22,7 @@ pub enum AccountCommandError {
     #[error("storage error: {0}")]
     Storage(String),
 
-    #[error("vpn-api error: {0}")]
+    #[error("vpn-api error")]
     VpnApi(#[from] VpnApiError),
 
     #[error("unexpected vpn-api response: {0}")]
@@ -40,19 +40,19 @@ pub enum AccountCommandError {
     //
     // --- Error cases for specific commands ---
     //
-    #[error("failed to store account: {0}")]
+    #[error("failed to store account")]
     StoreAccount(#[from] store_account::StoreAccountError),
 
-    #[error("failed to sync account state: {0}")]
+    #[error("failed to sync account state")]
     SyncAccount(#[from] sync_account::SyncAccountError),
 
-    #[error("failed to sync device state: {0}")]
+    #[error("failed to sync device state")]
     SyncDevice(#[from] sync_device::SyncDeviceError),
 
-    #[error("failed to register device: {0}")]
+    #[error("failed to register device")]
     RegisterDevice(#[from] register_device::RegisterDeviceError),
 
-    #[error("failed to request zk nym: {0}")]
+    #[error("failed to request zk nym:")]
     RequestZkNym(#[from] request_zknym::RequestZkNymError),
 
     #[error("failed to request zk nym")]
@@ -61,7 +61,7 @@ pub enum AccountCommandError {
         failed: Vec<request_zknym::RequestZkNymError>,
     },
 
-    #[error("failed to forget account: {0}")]
+    #[error("failed to forget account")]
     ForgetAccount(#[from] forget_account::ForgetAccountError),
 }
 

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/account/register_device.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/account/register_device.rs
@@ -13,7 +13,7 @@ pub enum RegisterDeviceError {
     #[error("no device stored")]
     NoDeviceStored,
 
-    #[error("register device: {0}")]
+    #[error("register device")]
     RegisterDeviceEndpointFailure(VpnApiError),
 
     #[error("unexpected response: {0}")]

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/account/store_account.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/account/store_account.rs
@@ -13,7 +13,7 @@ pub enum StoreAccountError {
     #[error("storage: {0}")]
     Storage(String),
 
-    #[error("get account: {0}")]
+    #[error("get account")]
     GetAccountEndpointFailure(VpnApiError),
 
     #[error("unexpected response: {0}")]

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/account/sync_device.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/account/sync_device.rs
@@ -13,7 +13,7 @@ pub enum SyncDeviceError {
     #[error("no device stored")]
     NoDeviceStored,
 
-    #[error("sync device: {0}")]
+    #[error("sync device")]
     SyncDeviceEndpointFailure(#[from] VpnApiError),
 
     #[error("unexpected response: {0}")]

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
@@ -209,6 +209,9 @@ pub enum ErrorStateReason {
         failed: Vec<RequestZkNymErrorReason>,
     },
 
+    /// Failure to create mixnet storage.
+    CreateMixnetStorage,
+
     /// The device time is not synced with the server time.
     /// If the time is not synced, the device will not be able to connect to the entry gateways.
     DeviceTimeOutOfSync,
@@ -238,12 +241,14 @@ pub enum ClientErrorReason {
     Dns(Option<String>),
     Api(Option<String>),
     DeviceTimeOutOfSync,
+    CreateMixnetStorage,
     Internal(Option<String>),
 }
 
 impl From<ErrorStateReason> for ClientErrorReason {
     fn from(value: ErrorStateReason) -> Self {
         match value {
+            ErrorStateReason::CreateMixnetStorage => Self::CreateMixnetStorage,
             ErrorStateReason::SameEntryAndExitGateway => Self::SameEntryAndExitGateway,
             ErrorStateReason::InvalidEntryGatewayCountry => Self::InvalidEntryGatewayCountry,
             ErrorStateReason::InvalidExitGatewayCountry => Self::InvalidExitGatewayCountry,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/uniffi_lib_types.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/uniffi_lib_types.rs
@@ -238,6 +238,7 @@ pub enum ErrorStateReason {
     Dns(Option<String>),
     Api(Option<String>),
     DeviceTimeOutOfSync,
+    CreateMixnetStorage,
     Internal(Option<String>),
 }
 
@@ -524,6 +525,7 @@ impl From<ClientErrorReason> for ErrorStateReason {
             ClientErrorReason::Dns(message) => Self::Dns(message),
             ClientErrorReason::Api(message) => Self::Api(message),
             ClientErrorReason::DeviceTimeOutOfSync => Self::DeviceTimeOutOfSync,
+            ClientErrorReason::CreateMixnetStorage => Self::CreateMixnetStorage,
             ClientErrorReason::Internal(message) => Self::Internal(message),
         }
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -57,7 +57,7 @@ use crate::tunnel_provider::android::AndroidTunProvider;
 #[cfg(target_os = "ios")]
 use crate::tunnel_provider::ios::OSTunProvider;
 use crate::{
-    GatewayDirectoryError, MixnetClientConfig,
+    GatewayDirectoryError, MixnetClientConfig, MixnetError,
     bandwidth_controller::Error as BandwidthControllerError,
 };
 #[cfg(target_os = "android")]
@@ -699,6 +699,9 @@ impl tunnel::Error {
                 _ => None,
             },
             Self::DupFd(_) => Some(ErrorStateReason::DuplicateTunFd),
+            Self::MixnetClient(MixnetError::CreateMixnetClientWithDefaultStorage(_)) => {
+                Some(ErrorStateReason::CreateMixnetStorage)
+            }
             Self::AuthenticationNotPossible(_)
             | Self::AuthenticatorAddressNotFound
             | Self::ConnectToIpPacketRouter(_)

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
@@ -243,16 +243,16 @@ async fn shutdown_mixnet_client(mut task_manager: TaskManager, mixnet_client: Sh
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("failed to create gateway client: {}", _0)]
+    #[error("failed to create gateway client")]
     CreateGatewayClient(#[source] nym_gateway_directory::Error),
 
-    #[error("failed to select gateways: {}", _0)]
+    #[error("failed to select gateways")]
     SelectGateways(#[source] Box<GatewayDirectoryError>),
 
     #[error("start mixnet client timeout")]
     StartMixnetClientTimeout,
 
-    #[error("mixnet tunnel has failed: {}", _0)]
+    #[error("mixnet tunnel has failed")]
     MixnetClient(#[from] MixnetError),
 
     #[error("failed to lookup gateway: {}", gateway_id)]
@@ -262,7 +262,7 @@ pub enum Error {
         source: Box<nym_gateway_directory::Error>,
     },
 
-    #[error("failed to connect to ip packet router: {}", _0)]
+    #[error("failed to connect to ip packet router")]
     ConnectToIpPacketRouter(#[source] nym_ip_packet_client::Error),
 
     #[error(
@@ -273,24 +273,24 @@ pub enum Error {
     #[error("failed to find authenticator address")]
     AuthenticatorAddressNotFound,
 
-    #[error("failed to setup storage paths: {0}")]
+    #[error("failed to setup storage paths")]
     SetupStoragePaths(#[source] Box<nym_sdk::Error>),
 
-    #[error("bandwidth controller error: {0}")]
+    #[error("bandwidth controller error")]
     BandwidthController(#[from] crate::bandwidth_controller::Error),
 
     #[cfg(target_os = "ios")]
     #[error("failed to resolve using dns64")]
     ResolveDns64(#[from] wireguard::dns64::Error),
 
-    #[error("WireGuard error: {0}")]
+    #[error("WireGuard error")]
     Wireguard(#[from] nym_wg_go::Error),
 
-    #[error("failed to dup tunnel file descriptor: {0}")]
+    #[error("failed to dup tunnel file descriptor")]
     DupFd(#[source] std::io::Error),
 
     #[cfg(windows)]
-    #[error("failed to add default route listener: {0}")]
+    #[error("failed to add default route listener")]
     AddDefaultRouteListener(#[source] route_handler::Error),
 
     #[error("connection cancelled")]

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/from_proto/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/from_proto/tunnel_state.rs
@@ -58,6 +58,7 @@ impl From<ProtoError> for ClientErrorReason {
             ErrorStateReason::Dns => ClientErrorReason::Dns(value.detail),
             ErrorStateReason::Api => ClientErrorReason::Api(value.detail),
             ErrorStateReason::DeviceTimeOutOfSync => ClientErrorReason::DeviceTimeOutOfSync,
+            ErrorStateReason::CreateMixnetStorage => ClientErrorReason::CreateMixnetStorage,
             ErrorStateReason::Internal => ClientErrorReason::Internal(value.detail),
         }
     }

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/into_proto/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/into_proto/tunnel_state.rs
@@ -87,6 +87,10 @@ impl From<ClientErrorReason> for ProtoError {
                 reason: ErrorStateReason::DeviceTimeOutOfSync.into(),
                 detail: None,
             },
+            ClientErrorReason::CreateMixnetStorage => ProtoError {
+                reason: ErrorStateReason::CreateMixnetStorage.into(),
+                detail: None,
+            },
             ClientErrorReason::Internal(detail) => ProtoError {
                 reason: ErrorStateReason::Internal.into(),
                 detail,

--- a/proto/nym/vpn.proto
+++ b/proto/nym/vpn.proto
@@ -376,8 +376,9 @@ message TunnelState {
     SUBSCRIPTION_EXPIRED = 7;
     DNS = 8;
     API = 9;
-    DEVICE_TIME_OUT_OF_SYNC = 11;
     INTERNAL = 10;
+    DEVICE_TIME_OUT_OF_SYNC = 11;
+    CREATE_MIXNET_STORAGE = 12;
   }
 
   enum ActionAfterDisconnect {


### PR DESCRIPTION
Previously state machine would keep trying to reconnect on mixnet storage error. However these error don't seem to be recoverable. For instance thsi is a very common error on Windows:

```
Error: Tunnel monitor exited with error
Caused by: tunnel error: mixnet tunnel has failed
Caused by: mixnet tunnel has failed
Caused by: failed to create mixnet client with default storage
Caused by: I/O error: The process cannot access the file because it is being used by another process. (os error 32)
Caused by: The process cannot access the file because it is being used by another process. (os error 32)
```

This error is basically unrecoverable.

JIRA-VPN-3455

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2840)
<!-- Reviewable:end -->
