### PR TITLE
Gracefully close connection pool

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/credentials/pending_credential_requests/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/credentials/pending_credential_requests/mod.rs
@@ -60,7 +60,10 @@ impl PendingCredentialRequestsStorage {
             .ok();
 
         tracing::debug!("Running migrations");
-        sqlx::migrate!("./migrations").run(&connection_pool).await?;
+        if let Err(e) = sqlx::migrate!("./migrations").run(&connection_pool).await {
+            connection_pool.close().await;
+            return Err(e.into());
+        }
 
         Ok(Self {
             storage_manager: SqliteZkNymRequestsStorageManager::new(connection_pool),

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/credentials/pending_credential_requests/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/credentials/pending_credential_requests/mod.rs
@@ -29,7 +29,7 @@ pub(crate) struct PendingCredentialRequestsStorage {
 }
 
 impl PendingCredentialRequestsStorage {
-    pub(crate) async fn init<P: AsRef<Path>>(
+    pub async fn init<P: AsRef<Path>>(
         database_path: P,
     ) -> Result<Self, PendingCredentialRequestsStorageError> {
         tracing::debug!(
@@ -69,7 +69,7 @@ impl PendingCredentialRequestsStorage {
         })
     }
 
-    pub(crate) async fn reset(&mut self) -> Result<(), PendingCredentialRequestsStorageError> {
+    pub async fn reset(&mut self) -> Result<(), PendingCredentialRequestsStorageError> {
         // First we close the storage to ensure that all files are closed
         tracing::debug!("Closing pending credential requests storage");
         self.storage_manager.close().await;
@@ -95,7 +95,7 @@ impl PendingCredentialRequestsStorage {
         Ok(())
     }
 
-    pub(crate) async fn clean_up_stale_requests(
+    pub async fn clean_up_stale_requests(
         &self,
     ) -> Result<(), PendingCredentialRequestsStorageError> {
         let cutoff = OffsetDateTime::now_utc() - DEFAULT_STALE_REQUESTS_MAX_AGE;
@@ -120,7 +120,7 @@ impl PendingCredentialRequestsStorage {
             .map_err(Into::into)
     }
 
-    pub(crate) async fn get_pending_requests(
+    pub async fn get_pending_requests(
         &self,
     ) -> Result<Vec<PendingCredentialRequest>, PendingCredentialRequestsStorageError> {
         self.storage_manager
@@ -142,7 +142,7 @@ impl PendingCredentialRequestsStorage {
             .map_err(Into::into)
     }
 
-    pub(crate) async fn get_pending_request_by_id(
+    pub async fn get_pending_request_by_id(
         &self,
         id: &str,
     ) -> Result<Option<PendingCredentialRequest>, PendingCredentialRequestsStorageError> {
@@ -164,7 +164,7 @@ impl PendingCredentialRequestsStorage {
             .map_err(PendingCredentialRequestsStorageError::from)?
     }
 
-    pub(crate) async fn remove_pending_request(
+    pub async fn remove_pending_request(
         &self,
         id: &str,
     ) -> Result<(), PendingCredentialRequestsStorageError> {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/credentials/pending_credential_requests/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/credentials/pending_credential_requests/mod.rs
@@ -47,7 +47,6 @@ impl PendingCredentialRequestsStorage {
             .connect_with(opts)
             .await?;
 
-        tracing::debug!("Setting file permissions on the database file");
         set_file_permission_owner_rw(&database_path)
             .map_err(
                 |source| PendingCredentialRequestsStorageError::FilePermissions {
@@ -105,7 +104,7 @@ impl PendingCredentialRequestsStorage {
             .map_err(Into::into)
     }
 
-    pub(crate) async fn insert_pending_request(
+    pub async fn insert_pending_request(
         &self,
         pending_request: PendingCredentialRequest,
     ) -> Result<(), PendingCredentialRequestsStorageError> {
@@ -177,14 +176,22 @@ impl PendingCredentialRequestsStorage {
 
 fn set_file_permission_owner_rw<P: AsRef<Path>>(path: P) -> Result<(), std::io::Error> {
     #[cfg(unix)]
-    return set_file_permission_owner_rw_unix(path);
+    {
+        tracing::debug!("Setting file permissions on the database file");
+        set_file_permission_owner_rw_unix(path)
+    }
 
     #[cfg(windows)]
-    return set_file_permission_owner_rw_windows(path);
+    {
+        // We set permissions for the parent folder instead of the file itself
+        Ok(())
+    }
 
     #[cfg(not(any(unix, windows)))]
     {
-        tracing::warn!("Setting file permissions is not yet implemented for this platform!");
+        tracing::warn!(
+            "Setting file permissions on the database file is not yet implemented for this platform!"
+        );
         Ok(())
     }
 }
@@ -196,10 +203,4 @@ fn set_file_permission_owner_rw_unix<P: AsRef<Path>>(path: P) -> Result<(), std:
     let mut permissions = metadata.permissions();
     permissions.set_mode(0o600);
     std::fs::set_permissions(&path, permissions)
-}
-
-#[cfg(windows)]
-fn set_file_permission_owner_rw_windows<P: AsRef<Path>>(_path: P) -> Result<(), std::io::Error> {
-    tracing::info!("Setting file permissions on Windows is not yet implemented!");
-    Ok(())
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/logging.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/logging.rs
@@ -21,7 +21,7 @@ pub struct Options {
     pub enable_stdout_log: bool,
 }
 
-static INFO_CRATES: &[&str; 12] = &[
+static INFO_CRATES: &[&str; 11] = &[
     "hyper",
     "netlink_proto",
     "hickory_proto",
@@ -30,7 +30,6 @@ static INFO_CRATES: &[&str; 12] = &[
     "h2",
     "rustls",
     "nym_statistics_common",
-    "nym_client_core",
     "nym_sphinx_chunking",
     "nym_sphinx::preparer",
     "nym_task::manager",


### PR DESCRIPTION
- Gracefully close connection pool on migration error
- Use `pub` instead of `pub(crate)` for the struct that is already `pub(crate)` to keep it shorter/nicer
- Stop warning that we don't set db file permissions on Windows since we set them for the parent folder.
- Remove `nym_client_core` from `INFO` crates as we print quite a bit of useful information related to storage

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2843)
<!-- Reviewable:end -->
