### PR TITLE
Use child_token() instead of clone()

### DIFF
--- a/nym-vpn-core/crates/nym-offline-monitor/src/apple/ios.rs
+++ b/nym-vpn-core/crates/nym-offline-monitor/src/apple/ios.rs
@@ -12,5 +12,5 @@ pub async fn spawn_monitor(
     sender: watch::Sender<Connectivity>,
     shutdown_token: CancellationToken,
 ) -> Result<ConnectivityHandle, nym_common::BoxedError> {
-    Ok(path_monitor::spawn_monitor(sender, shutdown_token.clone()).await)
+    Ok(path_monitor::spawn_monitor(sender, shutdown_token).await)
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -583,8 +583,11 @@ impl TunnelMonitor {
 
     async fn setup_account(&mut self) -> Result<()> {
         // Check that the device time is synced as a precondition to continuing
-        account::check_device_time_sync(self.account_commands.clone(), self.shutdown_token.clone())
-            .await?;
+        account::check_device_time_sync(
+            self.account_commands.clone(),
+            self.shutdown_token.child_token(),
+        )
+        .await?;
 
         // Check if we have ticketbooks already stored, then we can sidestep the account and device
         // sync
@@ -609,20 +612,20 @@ impl TunnelMonitor {
             self.send_event(TunnelMonitorEvent::SyncingAccount);
             account::wait_for_account_sync(
                 self.account_commands.clone(),
-                self.shutdown_token.clone(),
+                self.shutdown_token.child_token(),
             )
             .await?;
 
             account::wait_for_device_sync(
                 self.account_commands.clone(),
-                self.shutdown_token.clone(),
+                self.shutdown_token.child_token(),
             )
             .await?;
 
             self.send_event(TunnelMonitorEvent::RegisteringDevice);
             account::wait_for_device_register(
                 self.account_commands.clone(),
-                self.shutdown_token.clone(),
+                self.shutdown_token.child_token(),
             )
             .await?;
         }
@@ -635,7 +638,7 @@ impl TunnelMonitor {
             self.send_event(TunnelMonitorEvent::RequestingZkNyms);
             account::wait_for_credentials_ready(
                 self.account_commands.clone(),
-                self.shutdown_token.clone(),
+                self.shutdown_token.child_token(),
             )
             .await?;
         }
@@ -648,7 +651,7 @@ impl TunnelMonitor {
         connected_mixnet: ConnectedMixnet,
     ) -> Result<StartTunnelResult> {
         let connected_tunnel = connected_mixnet
-            .connect_mixnet_tunnel(self.shutdown_token.clone())
+            .connect_mixnet_tunnel(self.shutdown_token.child_token())
             .await
             .map_err(Box::new)?;
         let assigned_addresses = connected_tunnel.assigned_addresses();
@@ -751,7 +754,7 @@ impl TunnelMonitor {
                 self.tunnel_parameters
                     .tunnel_settings
                     .enable_credentials_mode,
-                self.shutdown_token.clone(),
+                self.shutdown_token.child_token(),
             )
             .await
             .map_err(Box::new)?;
@@ -831,7 +834,7 @@ impl TunnelMonitor {
                 self.tunnel_parameters
                     .tunnel_settings
                     .enable_credentials_mode,
-                self.shutdown_token.clone(),
+                self.shutdown_token.child_token(),
             )
             .await
             .map_err(Box::new)?;
@@ -917,7 +920,7 @@ impl TunnelMonitor {
                 self.tunnel_parameters
                     .tunnel_settings
                     .enable_credentials_mode,
-                self.shutdown_token.clone(),
+                self.shutdown_token.child_token(),
             )
             .await
             .map_err(Box::new)?;
@@ -1027,7 +1030,7 @@ impl TunnelMonitor {
                 self.tunnel_parameters
                     .tunnel_settings
                     .enable_credentials_mode,
-                self.shutdown_token.clone(),
+                self.shutdown_token.child_token(),
             )
             .await
             .map_err(Box::new)?;
@@ -1149,7 +1152,7 @@ impl TunnelMonitor {
                 self.tunnel_parameters
                     .tunnel_settings
                     .enable_credentials_mode,
-                self.shutdown_token.clone(),
+                self.shutdown_token.child_token(),
             )
             .await
             .map_err(Box::new)?;


### PR DESCRIPTION
This PR ensures that child components cannot cancel work happening in parent or sibling components to maintain somewhat straightforward type hierarchy where the parent is responsible for its children and not the other way around. We should use inverse data flows to notify parents when something happened in child component and let parent decide how to go about it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2845)
<!-- Reviewable:end -->
