### PR TITLE
Properly set allowed ips for multi-hop tunnel

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
@@ -3,6 +3,7 @@
 
 use std::{error::Error as StdError, net::IpAddr};
 
+use ipnetwork::IpNetwork;
 use nym_authenticator_client::AuthClientMixnetListenerHandle;
 #[cfg(windows)]
 use tokio::sync::mpsc;
@@ -30,9 +31,12 @@ use crate::tunnel_state_machine::tunnel::wireguard::fd::DupFd;
 use crate::{
     tunnel_state_machine::tunnel::{
         Error, Result, Tombstone,
-        wireguard::{connector::ConnectionData, two_hop_config::TwoHopConfig},
+        wireguard::{
+            connector::ConnectionData,
+            two_hop_config::{ENTRY_MTU, EXIT_MTU, TwoHopConfig},
+        },
     },
-    wg_config::WgNodeConfig,
+    wg_config::{AllowedIps, WgNodeConfig},
 };
 
 pub struct ConnectedTunnel {
@@ -68,13 +72,11 @@ impl ConnectedTunnel {
     }
 
     pub fn entry_mtu(&self) -> u16 {
-        // 1500 - 80 (ipv6+wg header)
-        1420
+        ENTRY_MTU
     }
 
     pub fn exit_mtu(&self) -> u16 {
-        // 1420 - 80 (ipv6+wg header)
-        1340
+        EXIT_MTU
     }
 
     pub async fn run(
@@ -107,6 +109,9 @@ impl ConnectedTunnel {
         let wg_entry_config = WgNodeConfig::with_gateway_data(
             self.connection_data.entry.clone(),
             self.entry_gateway_client.keypair().private_key(),
+            AllowedIps::Specific(vec![IpNetwork::from(
+                self.connection_data.exit.endpoint.ip(),
+            )]),
             options.dns.clone(),
             self.entry_mtu(),
             #[cfg(target_os = "linux")]
@@ -116,11 +121,15 @@ impl ConnectedTunnel {
         let wg_exit_config = WgNodeConfig::with_gateway_data(
             self.connection_data.exit.clone(),
             self.exit_gateway_client.keypair().private_key(),
+            AllowedIps::All,
             options.dns,
             self.exit_mtu(),
             #[cfg(target_os = "linux")]
             None,
         );
+
+        tracing::info!("Entry config: {wg_entry_config:#?}");
+        tracing::info!("Exit config: {wg_exit_config:#?}");
 
         #[allow(unused_mut)]
         let mut entry_tunnel = wireguard_go::Tunnel::start(
@@ -223,6 +232,9 @@ impl ConnectedTunnel {
         let wg_entry_config = WgNodeConfig::with_gateway_data(
             self.connection_data.entry.clone(),
             self.entry_gateway_client.keypair().private_key(),
+            AllowedIps::Specific(vec![IpNetwork::from(
+                self.connection_data.exit.endpoint.ip(),
+            )]),
             options.dns.clone(),
             self.entry_mtu(),
             #[cfg(target_os = "linux")]
@@ -232,6 +244,7 @@ impl ConnectedTunnel {
         let wg_exit_config = WgNodeConfig::with_gateway_data(
             self.connection_data.exit.clone(),
             self.exit_gateway_client.keypair().private_key(),
+            AllowedIps::All,
             options.dns,
             self.exit_mtu(),
             #[cfg(target_os = "linux")]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/mobile.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/mobile.rs
@@ -10,6 +10,7 @@ use std::{error::Error as StdError, net::IpAddr};
 #[cfg(target_os = "ios")]
 use dispatch2::{DispatchQueue, DispatchQueueAttr};
 
+use ipnetwork::IpNetwork;
 use nym_authenticator_client::AuthClientMixnetListenerHandle;
 #[cfg(target_os = "ios")]
 use tokio::sync::mpsc;
@@ -38,7 +39,7 @@ use crate::{
             two_hop_config::{ENTRY_MTU, EXIT_MTU, TwoHopConfig},
         },
     },
-    wg_config::WgNodeConfig,
+    wg_config::{AllowedIps, WgNodeConfig},
 };
 
 /// Delay before acting on default route changes.
@@ -95,6 +96,9 @@ impl ConnectedTunnel {
         let wg_entry_config = WgNodeConfig::with_gateway_data(
             self.connection_data.entry.clone(),
             self.entry_gateway_client.keypair().private_key(),
+            AllowedIps::Specific(vec![IpNetwork::from(
+                self.connection_data.exit.endpoint.ip(),
+            )]),
             dns.clone(),
             self.entry_mtu(),
         );
@@ -102,6 +106,7 @@ impl ConnectedTunnel {
         let wg_exit_config = WgNodeConfig::with_gateway_data(
             self.connection_data.exit.clone(),
             self.exit_gateway_client.keypair().private_key(),
+            AllowedIps::All,
             dns,
             self.exit_mtu(),
         );

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/two_hop_config.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/two_hop_config.rs
@@ -96,6 +96,7 @@ impl TwoHopConfig {
                     ..entry.interface
                 },
                 peer: entry.peer,
+                allowed_ips: entry.allowed_ips,
             },
             exit: WgNodeConfig {
                 interface: WgInterface {
@@ -107,6 +108,7 @@ impl TwoHopConfig {
                     endpoint: forwarder_config.listen_endpoint,
                     ..exit.peer
                 },
+                allowed_ips: exit.allowed_ips,
             },
             forwarder: forwarder_config,
             tun: tun_config,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/wg_config.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/wg_config.rs
@@ -23,6 +23,9 @@ pub struct WgNodeConfig {
 
     /// Peer configuration
     pub peer: WgPeer,
+
+    /// IPs that are allowed to be routed over the tunnel interface.
+    pub allowed_ips: AllowedIps,
 }
 
 pub struct WgInterface {
@@ -64,6 +67,16 @@ impl fmt::Debug for WgInterface {
         d.field("amnezia", &self.azwg_config);
         d.finish()
     }
+}
+
+/// IPs that are allowed to be routed over the tunnel interface.
+#[derive(Debug, Clone)]
+pub enum AllowedIps {
+    /// All IPs are allowed.
+    All,
+
+    /// Specific IPs are allowed.
+    Specific(Vec<IpNetwork>),
 }
 
 #[derive(Debug, Clone)]
@@ -137,11 +150,18 @@ impl WgNodeConfig {
 
     fn allowed_ips(&self) -> Vec<IpNetwork> {
         let mut allowed_ips = vec![];
-        if self.interface.addresses.iter().any(|x| x.ip().is_ipv4()) {
-            allowed_ips.push("0.0.0.0/0".parse().unwrap());
-        }
-        if self.interface.addresses.iter().any(|x| x.ip().is_ipv6()) {
-            allowed_ips.push("::/0".parse().unwrap());
+        match self.allowed_ips {
+            AllowedIps::All => {
+                if self.interface.addresses.iter().any(|x| x.ip().is_ipv4()) {
+                    allowed_ips.push("0.0.0.0/0".parse().unwrap());
+                }
+                if self.interface.addresses.iter().any(|x| x.ip().is_ipv6()) {
+                    allowed_ips.push("::/0".parse().unwrap());
+                }
+            }
+            AllowedIps::Specific(ref ips) => {
+                allowed_ips.extend(ips);
+            }
         }
         allowed_ips
     }
@@ -151,6 +171,7 @@ impl WgNodeConfig {
     pub fn with_gateway_data(
         gateway_data: GatewayData,
         private_key: &nym_crypto::asymmetric::encryption::PrivateKey,
+        allowed_ips: AllowedIps,
         dns: Vec<IpAddr>,
         mtu: u16,
         #[cfg(target_os = "linux")] fwmark: Option<u32>,
@@ -174,6 +195,7 @@ impl WgNodeConfig {
                 public_key: PublicKey::from(*gateway_data.public_key.as_bytes()),
                 endpoint: gateway_data.endpoint,
             },
+            allowed_ips,
         }
     }
 


### PR DESCRIPTION
We should only allow`0.0.0.0/0` and `::/0` for exit tunnel, but entry tunnel should only allow traffic to flow towards exit endpoint and nowhere else. This PR ensures that this is properly implemented.

JIRA-VPN-3464

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2846)
<!-- Reviewable:end -->
