### PR TITLE
Stop printing nested error

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/dns_handler.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/dns_handler.rs
@@ -156,7 +156,7 @@ impl DnsHandlerHandle {
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("Dns monitor error: {_0}")]
+    #[error("Dns monitor error")]
     DnsMonitor(#[from] nym_dns::Error),
 
     #[error("Dns monitor is already down")]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -561,33 +561,33 @@ impl TunnelStateMachine {
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-    #[error("failed to create a route handler: {}", _0)]
+    #[error("failed to create a route handler")]
     CreateRouteHandler(#[source] route_handler::Error),
 
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-    #[error("failed to create a dns handler: {}", _0)]
+    #[error("failed to create a dns handler")]
     CreateDnsHandler(#[source] dns_handler::Error),
 
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-    #[error("failed to create firewall: {}", _0)]
+    #[error("failed to create firewall")]
     CreateFirewall(#[source] nym_firewall::Error),
 
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-    #[error("failed to apply firewall policy: {}", _0)]
+    #[error("failed to apply firewall policy")]
     ApplyFirewallPolicy(#[source] nym_firewall::Error),
 
-    #[error("failed to resolve gateway addresses: {}", _0)]
+    #[error("failed to resolve gateway addresses")]
     ResolveGatewayAddrs(#[source] nym_gateway_directory::Error),
 
     #[cfg(target_os = "macos")]
-    #[error("failed to start local dns resolver: {}", _0)]
+    #[error("failed to start local dns resolver")]
     StartLocalDnsResolver(#[source] resolver::Error),
 
-    #[error("failed to create tunnel device: {}", _0)]
+    #[error("failed to create tunnel device")]
     CreateTunDevice(#[source] tun::Error),
 
     #[cfg(windows)]
-    #[error("failed to setup wintun adapter: {}", _0)]
+    #[error("failed to setup wintun adapter")]
     SetupWintunAdapter(#[from] SetupWintunAdapterError),
 
     #[cfg(target_os = "ios")]
@@ -599,7 +599,7 @@ pub enum Error {
     ConfigureTunnelProvider(String),
 
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-    #[error("failed to obtain route handle: {}", _0)]
+    #[error("failed to obtain route handle")]
     GetRouteHandle(#[source] route_handler::Error),
 
     #[error("failed to get tunnel device name")]
@@ -615,14 +615,14 @@ pub enum Error {
     SetTunDeviceIpv6Addr(#[source] std::io::Error),
 
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-    #[error("failed to add routes: {}", _0)]
+    #[error("failed to add routes")]
     AddRoutes(#[source] route_handler::Error),
 
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-    #[error("failed to set dns: {}", _0)]
+    #[error("failed to set dns")]
     SetDns(#[source] dns_handler::Error),
 
-    #[error("tunnel error: {}", _0)]
+    #[error("tunnel error")]
     Tunnel(#[from] Box<tunnel::Error>),
 
     #[error(transparent)]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
@@ -243,16 +243,16 @@ async fn shutdown_mixnet_client(mut task_manager: TaskManager, mixnet_client: Sh
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("failed to create gateway client: {}", _0)]
+    #[error("failed to create gateway client")]
     CreateGatewayClient(#[source] nym_gateway_directory::Error),
 
-    #[error("failed to select gateways: {}", _0)]
+    #[error("failed to select gateways")]
     SelectGateways(#[source] Box<GatewayDirectoryError>),
 
     #[error("start mixnet client timeout")]
     StartMixnetClientTimeout,
 
-    #[error("mixnet tunnel has failed: {}", _0)]
+    #[error("mixnet tunnel has failed")]
     MixnetClient(#[from] MixnetError),
 
     #[error("failed to lookup gateway: {}", gateway_id)]
@@ -262,7 +262,7 @@ pub enum Error {
         source: Box<nym_gateway_directory::Error>,
     },
 
-    #[error("failed to connect to ip packet router: {}", _0)]
+    #[error("failed to connect to ip packet router")]
     ConnectToIpPacketRouter(#[source] nym_ip_packet_client::Error),
 
     #[error(
@@ -273,24 +273,24 @@ pub enum Error {
     #[error("failed to find authenticator address")]
     AuthenticatorAddressNotFound,
 
-    #[error("failed to setup storage paths: {0}")]
+    #[error("failed to setup storage paths")]
     SetupStoragePaths(#[source] Box<nym_sdk::Error>),
 
-    #[error("bandwidth controller error: {0}")]
+    #[error("bandwidth controller error")]
     BandwidthController(#[from] crate::bandwidth_controller::Error),
 
     #[cfg(target_os = "ios")]
     #[error("failed to resolve using dns64")]
     ResolveDns64(#[from] wireguard::dns64::Error),
 
-    #[error("WireGuard error: {0}")]
+    #[error("WireGuard error")]
     Wireguard(#[from] nym_wg_go::Error),
 
-    #[error("failed to dup tunnel file descriptor: {0}")]
+    #[error("failed to dup tunnel file descriptor")]
     DupFd(#[source] std::io::Error),
 
     #[cfg(windows)]
-    #[error("failed to add default route listener: {0}")]
+    #[error("failed to add default route listener")]
     AddDefaultRouteListener(#[source] route_handler::Error),
 
     #[error("connection cancelled")]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/wintun.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/wintun.rs
@@ -9,16 +9,16 @@ use windows::Win32::NetworkManagement::Ndis::NET_LUID_LH;
 /// Wintun adapter configuration error.
 #[derive(Debug, thiserror::Error)]
 pub enum SetupWintunAdapterError {
-    #[error("failed to set wintun adapter ipv4 address: {}", _0)]
+    #[error("failed to set wintun adapter ipv4 address")]
     SetIpv4Addr(#[source] nym_windows::net::Error),
 
-    #[error("failed to set wintun adapter ipv6 address: {}", _0)]
+    #[error("failed to set wintun adapter ipv6 address")]
     SetIpv6Addr(#[source] nym_windows::net::Error),
 
-    #[error("failed to set wintun adapter ipv4 gateway address: {}", _0)]
+    #[error("failed to set wintun adapter ipv4 gateway address")]
     SetIpv4Gateway(#[source] nym_windows::net::Error),
 
-    #[error("failed to set wintun adapter ipv6 gateway address: {}", _0)]
+    #[error("failed to set wintun adapter ipv6 gateway address")]
     SetIpv6Gateway(#[source] nym_windows::net::Error),
 }
 

--- a/nym-vpn-core/crates/nym-wg-go/src/lib.rs
+++ b/nym-vpn-core/crates/nym-wg-go/src/lib.rs
@@ -37,13 +37,13 @@ pub enum Error {
     #[error("wintun tunnel type contains nul byte")]
     WintunTunnelTypeContainsNulByte,
 
-    #[error("failed to start the tunnel (code: {})", _0)]
+    #[error("failed to start the tunnel (code: {0})")]
     StartTunnel(i32),
 
-    #[error("failed to open connection through the tunnel (code: {})", _0)]
+    #[error("failed to open connection through the tunnel (code: {0})")]
     OpenConnection(i32),
 
-    #[error("failed to set UAPI config (code: {})", _0)]
+    #[error("failed to set UAPI config (code: {0})")]
     SetUapiConfig(i64),
 
     #[error("failed to obtain tunnel socket fd")]


### PR DESCRIPTION
Since we've introduced error chain printer, there is no longer need to duplicate nested error messages. This PR cleans up error output

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2847)
<!-- Reviewable:end -->
