### PR TITLE
Fix CI

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/credentials/pending_credential_requests/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/credentials/pending_credential_requests/mod.rs
@@ -177,11 +177,11 @@ impl PendingCredentialRequestsStorage {
     }
 }
 
-fn set_file_permission_owner_rw<P: AsRef<Path>>(path: P) -> Result<(), std::io::Error> {
+fn set_file_permission_owner_rw<P: AsRef<Path>>(_path: P) -> Result<(), std::io::Error> {
     #[cfg(unix)]
     {
         tracing::debug!("Setting file permissions on the database file");
-        set_file_permission_owner_rw_unix(path)
+        set_file_permission_owner_rw_unix(_path)
     }
 
     #[cfg(windows)]


### PR DESCRIPTION
`path` variable is not used on all platforms, so let's underscore it to fix clippy complaint

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2848)
<!-- Reviewable:end -->
