### PR TITLE
macOS routing fixes

### DIFF
--- a/nym-vpn-core/crates/nym-routing/Cargo.toml
+++ b/nym-vpn-core/crates/nym-routing/Cargo.toml
@@ -17,6 +17,8 @@ tokio = { workspace = true, features = [
     "net",
     "io-util",
     "time",
+    "sync",
+    "macros",
 ] }
 
 [target.'cfg(not(target_os="android"))'.dependencies]

--- a/nym-vpn-core/crates/nym-routing/src/unix/macos/data.rs
+++ b/nym-vpn-core/crates/nym-routing/src/unix/macos/data.rs
@@ -1051,7 +1051,7 @@ impl Iterator for RouteSockAddrIterator<'_> {
             Consider adding them to the definition."
         );
 
-        return match RouteSocketAddress::new(current_flag, self.buffer) {
+        match RouteSocketAddress::new(current_flag, self.buffer) {
             Ok((next_addr, addr_len)) => {
                 self.advance_buffer(addr_len);
                 Some(Ok(next_addr))
@@ -1061,7 +1061,7 @@ impl Iterator for RouteSockAddrIterator<'_> {
                 self.buffer = &[];
                 Some(Err(err))
             }
-        };
+        }
     }
 }
 

--- a/nym-vpn-core/crates/nym-routing/src/unix/macos/data.rs
+++ b/nym-vpn-core/crates/nym-routing/src/unix/macos/data.rs
@@ -862,7 +862,7 @@ impl RouteSocketAddress {
 
                 // The "serialized" socket addresses must be padded to be aligned to 4 bytes, with
                 // the smallest size being 4 bytes.
-                let buffer_size = len + len % 4;
+                let buffer_size = len.next_multiple_of(4);
                 let mut buffer = vec![0u8; buffer_size];
                 unsafe {
                     // SAFETY: copying conents of addr into buffer is safe, as long as addr.len()

--- a/nym-vpn-core/crates/nym-routing/src/unix/macos/data.rs
+++ b/nym-vpn-core/crates/nym-routing/src/unix/macos/data.rs
@@ -653,7 +653,13 @@ impl Interface {
                 actual_size: buffer.len(),
             });
         }
-        let header: libc::if_msghdr = unsafe { std::ptr::read(buffer.as_ptr() as *const _) };
+
+        let header = buffer.as_ptr().cast::<libc::if_msghdr>();
+
+        // SAFETY:
+        // - `buffer` points to initialized memory of the correct size.
+        // - if_msghdr is a C struct, and valid for any bit pattern
+        let header: libc::if_msghdr = unsafe { header.read_unaligned() };
         // let payload = buffer[INTERFACE_MESSAGE_HEADER_SIZE..header.ifm_msglen.into()].to_vec();
         Ok(Self { header })
     }

--- a/nym-vpn-core/crates/nym-routing/src/unix/macos/data.rs
+++ b/nym-vpn-core/crates/nym-routing/src/unix/macos/data.rs
@@ -960,17 +960,15 @@ struct sockaddr_hdr {
 /// routing socket message.
 pub struct RouteSockAddrIterator<'a> {
     buffer: &'a [u8],
-    flags: AddressFlag,
-    // Cursor used to iterate through address flags
-    flag_cursor: i32,
+    /// Iterator over all the set bits in the provided [AddressFlag].
+    flags_iter: bitflags::iter::Iter<AddressFlag>,
 }
 
 impl<'a> RouteSockAddrIterator<'a> {
     fn new(buffer: &'a [u8], flags: AddressFlag) -> Self {
         Self {
             buffer,
-            flags,
-            flag_cursor: AddressFlag::RTA_DST.bits(),
+            flags_iter: flags.iter(),
         }
     }
 
@@ -1002,26 +1000,29 @@ impl Iterator for RouteSockAddrIterator<'_> {
     type Item = Result<RouteSocketAddress>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            // If address flags don't contain the current one, try the next one.
-            // Will return None if it runs out of valid flags.
-            let current_flag = AddressFlag::from_bits(self.flag_cursor)?;
-            self.flag_cursor <<= 1;
+        // Will return None if it runs out of set flags.
+        let current_flag = self.flags_iter.next()?;
 
-            if !self.flags.contains(current_flag) {
-                continue;
+        // Any undefiend flags are all returned as a clump in the final iteration.
+        let no_undefined_flags = AddressFlag::all().contains(current_flag);
+
+        debug_assert!(
+            no_undefined_flags,
+            "AddressFlag contained undefined bits! {current_flag:?}. \
+            Consider adding them to the definition."
+        );
+
+        return match RouteSocketAddress::new(current_flag, self.buffer) {
+            Ok((next_addr, addr_len)) => {
+                self.advance_buffer(addr_len);
+                Some(Ok(next_addr))
             }
-            return match RouteSocketAddress::new(current_flag, self.buffer) {
-                Ok((next_addr, addr_len)) => {
-                    self.advance_buffer(addr_len);
-                    Some(Ok(next_addr))
-                }
-                Err(err) => {
-                    self.buffer = &[];
-                    Some(Err(err))
-                }
-            };
-        }
+
+            Err(err) => {
+                self.buffer = &[];
+                Some(Err(err))
+            }
+        };
     }
 }
 

--- a/nym-vpn-core/crates/nym-routing/src/unix/macos/data.rs
+++ b/nym-vpn-core/crates/nym-routing/src/unix/macos/data.rs
@@ -10,6 +10,7 @@ use nix::{
 use std::{
     collections::BTreeMap,
     ffi::{c_int, c_uchar, c_ushort},
+    fmt,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
 };
 
@@ -796,7 +797,7 @@ bitflags::bitflags! {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub enum RouteSocketAddress {
     /// Corresponds to RTA_DST
     Destination(Option<SockaddrStorage>),
@@ -814,6 +815,44 @@ pub enum RouteSocketAddress {
     RedirectAuthor(Option<SockaddrStorage>),
     /// RTA_BRD
     Broadcast(Option<SockaddrStorage>),
+}
+
+/// Custom Debug-impl that uses the Display-impl of [SockaddrStorage] since its Debug-impl is
+
+/// basically unreadable.
+
+impl fmt::Debug for RouteSocketAddress {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (variant, sockaddr) = match self {
+            Self::Destination(sockaddr) => ("Destination", sockaddr),
+            Self::Gateway(sockaddr) => ("Gateway", sockaddr),
+            Self::Netmask(sockaddr) => ("Netmask", sockaddr),
+            Self::CloningMask(sockaddr) => ("CloningMask", sockaddr),
+            Self::IfName(sockaddr) => ("IfName", sockaddr),
+            Self::IfSockaddr(sockaddr) => ("IfSockaddr", sockaddr),
+            Self::RedirectAuthor(sockaddr) => ("RedirectAuthor", sockaddr),
+            Self::Broadcast(sockaddr) => ("Broadcast", sockaddr),
+        };
+
+        if let Some(sockaddr) = sockaddr {
+            if let Some(link_addr) = sockaddr.as_link_addr() {
+                // The default Display impl for LinkAddrs does not print ifindex
+
+                write!(f, "{variant}(")?;
+
+                f.debug_struct("LinkAddr")
+                    .field("addr", &link_addr.addr())
+                    .field("iface", &link_addr.ifindex())
+                    .finish()?;
+
+                write!(f, ")")
+            } else {
+                write!(f, "{variant}({sockaddr})")
+            }
+        } else {
+            write!(f, "{variant}(None)")
+        }
+    }
 }
 
 impl RouteSocketAddress {

--- a/nym-vpn-core/crates/nym-routing/src/unix/macos/data.rs
+++ b/nym-vpn-core/crates/nym-routing/src/unix/macos/data.rs
@@ -818,9 +818,7 @@ pub enum RouteSocketAddress {
 }
 
 /// Custom Debug-impl that uses the Display-impl of [SockaddrStorage] since its Debug-impl is
-
 /// basically unreadable.
-
 impl fmt::Debug for RouteSocketAddress {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let (variant, sockaddr) = match self {

--- a/nym-vpn-core/crates/nym-routing/src/unix/macos/interface.rs
+++ b/nym-vpn-core/crates/nym-routing/src/unix/macos/interface.rs
@@ -27,7 +27,7 @@ use system_configuration::{
     network_configuration::SCNetworkSet,
     preferences::SCPreferences,
     sys::schema_definitions::{
-        kSCDynamicStorePropNetPrimaryInterface, kSCPropInterfaceName, kSCPropNetIPv4Addresses,
+        kSCDynamicStorePropNetPrimaryService, kSCPropInterfaceName, kSCPropNetIPv4Addresses,
         kSCPropNetIPv4Router, kSCPropNetIPv6Addresses, kSCPropNetIPv6Router,
     },
 };
@@ -220,25 +220,18 @@ impl PrimaryInterfaceMonitor {
             .store
             .get(key)
             .and_then(|v| v.downcast_into::<CFDictionary>())?;
-        let name = get_dict_elem_as_string(&global_dict, unsafe {
-            kSCDynamicStorePropNetPrimaryInterface
+
+        let service_id = get_dict_elem_as_string(&global_dict, unsafe {
+            kSCDynamicStorePropNetPrimaryService
         })
         .or_else(|| {
-            tracing::debug!("Missing name for primary interface ({family})");
+            tracing::debug!("Missing service ID for primary interface ({family})");
             None
         })?;
-        let router_ip = get_service_router_ip(&global_dict, family).or_else(|| {
-            tracing::debug!("Missing router IP for primary interface ({name}, {family})");
+
+        self.get_network_service(&service_id, family).or_else(|| {
+            tracing::debug!("Invalid service ID for primary interface ({family})");
             None
-        })?;
-        let first_ip = get_service_first_ip(&global_dict, family).or_else(|| {
-            tracing::debug!("Missing IP for primary interface ({name}, {family})");
-            None
-        })?;
-        Some(NetworkServiceDetails {
-            name,
-            router_ip,
-            first_ip,
         })
     }
 
@@ -246,37 +239,43 @@ impl PrimaryInterfaceMonitor {
         SCNetworkSet::new(&self.prefs)
             .service_order()
             .iter()
-            .filter_map(|service_id| {
-                let service_id_s = service_id.to_string();
-                let service_key = if family == Family::V4 {
-                    format!("State:/Network/Service/{service_id_s}/IPv4")
-                } else {
-                    format!("State:/Network/Service/{service_id_s}/IPv6")
-                };
-                let service_dict = self
-                    .store
-                    .get(CFString::new(&service_key))
-                    .and_then(|v| v.downcast_into::<CFDictionary>())?;
-                let name = get_dict_elem_as_string(&service_dict, unsafe { kSCPropInterfaceName })
-                    .or_else(|| {
-                        tracing::debug!("Missing name for service {service_key} ({family})");
-                        None
-                    })?;
-                let router_ip = get_service_router_ip(&service_dict, family).or_else(|| {
-                    tracing::debug!("Missing router IP for {service_key} ({name}, {family})");
-                    None
-                })?;
-                let first_ip = get_service_first_ip(&service_dict, family).or_else(|| {
-                    tracing::debug!("Missing IP for \"{service_key}\" ({name}, {family})");
-                    None
-                })?;
-                Some(NetworkServiceDetails {
-                    name,
-                    router_ip,
-                    first_ip,
-                })
-            })
+            .filter_map(|service_id| self.get_network_service(&service_id.to_string(), family))
             .collect::<Vec<_>>()
+    }
+
+    /// Get details about a specific network interface.
+    ///
+    /// Will return `None` and log a message on any error.
+    fn get_network_service(
+        &self,
+        service_id: &str,
+        family: Family,
+    ) -> Option<NetworkServiceDetails> {
+        let service_key = network_service_key(service_id.to_string(), family);
+        let service_dict = self
+            .store
+            .get(CFString::new(&service_key))
+            .and_then(|v| v.downcast_into::<CFDictionary>())?;
+
+        let name = get_dict_elem_as_string(&service_dict, unsafe { kSCPropInterfaceName })
+            .or_else(|| {
+                tracing::debug!("Missing name for service {service_key} ({family})");
+                None
+            })?;
+        let router_ip = get_service_router_ip(&service_dict, family).or_else(|| {
+            tracing::debug!("Missing router IP for {service_key} ({name}, {family})");
+            None
+        })?;
+        let first_ip = get_service_first_ip(&service_dict, family).or_else(|| {
+            tracing::debug!("Missing IP for \"{service_key}\" ({name}, {family})");
+            None
+        })?;
+
+        Some(NetworkServiceDetails {
+            name,
+            router_ip,
+            first_ip,
+        })
     }
 
     pub fn debug(&self) {
@@ -291,6 +290,16 @@ impl PrimaryInterfaceMonitor {
             );
         }
     }
+}
+
+/// Construct the string key for a network service from its ID.
+fn network_service_key(service_id: String, family: Family) -> String {
+    let family = match family {
+        Family::V4 => "IPv4",
+        Family::V6 => "IPv6",
+    };
+
+    format!("State:/Network/Service/{service_id}/{family}")
 }
 
 /// Return a map from interface name to link addresses (AF_LINK)

--- a/nym-vpn-core/crates/nym-routing/src/unix/macos/mod.rs
+++ b/nym-vpn-core/crates/nym-routing/src/unix/macos/mod.rs
@@ -594,7 +594,6 @@ impl RouteManagerImpl {
     }
 
     /// Get the route which goes to `0.0.0.0/0`/`::/0`, if any.
-
     async fn get_actual_default_route(
         &mut self,
         family: interface::Family,

--- a/nym-vpn-core/crates/nym-routing/src/unix/macos/mod.rs
+++ b/nym-vpn-core/crates/nym-routing/src/unix/macos/mod.rs
@@ -334,7 +334,7 @@ impl RouteManagerImpl {
             self.add_route_with_record(message).await?;
         }
 
-        self.apply_tunnel_default_route().await?;
+        self.apply_tunnel_default_routes().await?;
 
         // Add routes that use the default interface
         if let Err(error) = self.apply_non_tunnel_routes().await {
@@ -414,23 +414,25 @@ impl RouteManagerImpl {
     async fn refresh_routes(&mut self) -> Result<()> {
         nym_common::detect_flood!();
 
+        // These may set `self.unhandled_default_route_changes`
         self.update_best_default_route(interface::Family::V4)?;
         self.update_best_default_route(interface::Family::V6)?;
 
         self.debug_offline();
 
         if !self.unhandled_default_route_changes {
+            self.ensure_default_tunnel_routes_exists().await?;
             return Ok(());
         }
 
-        // Remove any existing ifscope route that we've added
+        // Remove any existing ifscoped default route that we've added
         self.remove_applied_routes(|route| {
             route.is_ifscope() && route.is_default().unwrap_or(false)
         })
         .await;
 
         // Substitute route with a tunnel route
-        self.apply_tunnel_default_route().await?;
+        self.apply_tunnel_default_routes().await?;
 
         // Update routes using default interface
         self.apply_non_tunnel_routes().await?;
@@ -494,7 +496,7 @@ impl RouteManagerImpl {
 
     /// Replace the default routes with an ifscope route, and
     /// add a new default tunnel route.
-    async fn apply_tunnel_default_route(&mut self) -> Result<()> {
+    async fn apply_tunnel_default_routes(&mut self) -> Result<()> {
         // As long as the relay route has a way of reaching the internet, we'll want to add a tunnel
         // route for both IPv4 and IPv6.
         // NOTE: This is incorrect. We're assuming that any "default destination" is used for
@@ -530,22 +532,25 @@ impl RouteManagerImpl {
             self.replace_with_scoped_route(family).await?;
 
             // Make sure there is really no other unscoped default route
-            let mut msg = RouteMessage::new_route(family.default_network().into());
-            msg = msg.set_gateway_route(true);
-            let old_route = self.routing_table.get_route(&msg).await;
-            if let Ok(Some(old_route)) = old_route {
+            let actual_default_route = self.get_actual_default_route(family).await.unwrap_or(None);
+
+            if let Some(actual_default_route) = actual_default_route {
                 let tun_gateway_link_addr =
                     tunnel_route.gateway().and_then(|addr| addr.as_link_addr());
-                let current_link_addr = old_route.gateway().and_then(|addr| addr.as_link_addr());
-                if current_link_addr
-                    .map(|addr| Some(addr) != tun_gateway_link_addr)
-                    .unwrap_or(true)
-                {
+
+                let actual_link_addr = actual_default_route
+                    .gateway()
+                    .and_then(|addr| addr.as_link_addr());
+
+                if actual_link_addr.is_none() || actual_link_addr != tun_gateway_link_addr {
                     tracing::trace!("Removing existing unscoped default route");
-                    let _ = self.routing_table.delete_route(&msg).await;
-                } else if !old_route.is_ifscope() {
-                    // NOTE: Skipping route
-                    continue;
+
+                    let _ = self
+                        .routing_table
+                        .delete_route(&default_route_msg(family))
+                        .await;
+                } else if !actual_default_route.is_ifscope() {
+                    continue; // Skipping route
                 }
             }
 
@@ -554,6 +559,50 @@ impl RouteManagerImpl {
         }
 
         Ok(())
+    }
+
+    async fn ensure_default_tunnel_routes_exists(&mut self) -> Result<()> {
+        // TODO: ignore ipv6 if disabled?
+
+        for family in [interface::Family::V4, interface::Family::V6] {
+            if !self.default_route_is_tunnel_route(family).await? {
+                return self.apply_tunnel_default_routes().await;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Check if the `0.0.0.0/0`/`::/0`-route goes to our tunnel interface.
+    async fn default_route_is_tunnel_route(&mut self, family: interface::Family) -> Result<bool> {
+        let actual_default_route = self.get_actual_default_route(family).await?;
+
+        let Some(actual_default_route) = actual_default_route else {
+            return Ok(false);
+        };
+
+        let tunnel_route = match family {
+            interface::Family::V4 => self.v4_tunnel_default_route.as_ref(),
+            interface::Family::V6 => self.v6_tunnel_default_route.as_ref(),
+        };
+
+        let Some(tunnel_route) = tunnel_route else {
+            return Ok(false);
+        };
+
+        Ok(route_matches_interface(&actual_default_route, tunnel_route))
+    }
+
+    /// Get the route which goes to `0.0.0.0/0`/`::/0`, if any.
+
+    async fn get_actual_default_route(
+        &mut self,
+        family: interface::Family,
+    ) -> Result<Option<data::RouteMessage>> {
+        self.routing_table
+            .get_route(&default_route_msg(family))
+            .await
+            .map_err(Error::RoutingTable)
     }
 
     /// Update/add routes that use the default non-tunnel interface. If some applied destination is
@@ -725,6 +774,16 @@ impl RouteManagerImpl {
 
         false
     }
+}
+
+/// Construct a [RouteMessage] that refers to the `0.0.0.0/0` or `::/0` route with the
+/// RTF_GATEAWAY-flag set. Used to reference the default route created by macOS.
+fn default_route_msg(family: interface::Family) -> RouteMessage {
+    let mut msg = RouteMessage::new_route(family.default_network().into());
+
+    msg = msg.set_gateway_route(true);
+
+    msg
 }
 
 fn route_matches_interface(default_route: &RouteMessage, interface_route: &RouteMessage) -> bool {

--- a/nym-vpn-core/crates/nym-routing/src/unix/macos/routing_socket.rs
+++ b/nym-vpn-core/crates/nym-routing/src/unix/macos/routing_socket.rs
@@ -177,7 +177,7 @@ impl RoutingSocketInner {
             let mut guard = self.socket.readable().await?;
             match guard.try_io(|sock| sock.get_ref().read(out)) {
                 Ok(result) => return result,
-                Err(_err) => continue,
+                Err(_would_block) => continue,
             }
         }
     }


### PR DESCRIPTION
Backported the following improvements from mullvad repo:

- [Fix incorrect decoding of macOS SCDynStore value](https://github.com/mullvad/mullvadvpn-app/commit/c9cefd9bedaf3dce6790a61dd4c29ee211836432)
- [Fix bad pointer deref in talpid-routing::unix::macos::data](https://github.com/mullvad/mullvadvpn-app/commit/1e88c29ad942784b432be0a64ec1466d93675365)
- [Fix math in talpid-routing::unix::macos::data (?)](https://github.com/mullvad/mullvadvpn-app/commit/0574ffd7a0f9aedbac92832d37c99a72c829e3dd)
- [Replace loop+bitshift with iterator](https://github.com/mullvad/mullvadvpn-app/commit/2695724c73ed3f5d6336f8f27383617b408b9cad)
- [Ensure that default route still exist on route events](https://github.com/mullvad/mullvadvpn-app/commit/4657cc02c930beccd8cd654271830701a8268b41)
- [Implement Debug for RouteSocketAddress manually](https://github.com/mullvad/mullvadvpn-app/commit/aabe5cedec3385ad160779dda49594cb7bdbced8)
 
JIRA-VPN-3467

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2850)
<!-- Reviewable:end -->
