### PR TITLE
fix(tauri): data test attributes clashes

### DIFF
--- a/nym-vpn-app/src/screens/StartupError.tsx
+++ b/nym-vpn-app/src/screens/StartupError.tsx
@@ -40,7 +40,7 @@ function StartupError({
     <div
       className={clsx([theme === 'dark' && 'dark', 'h-full'])}
       data-testid="startup-error-container"
-      data-theme={theme}
+      data-test-theme={theme}
     >
       <div
         className={clsx([

--- a/nym-vpn-app/src/ui/Button.tsx
+++ b/nym-vpn-app/src/ui/Button.tsx
@@ -106,9 +106,9 @@ function Button({
       onClick={onClick}
       disabled={disabled}
       data-testid={testId}
-      data-color={color}
-      data-outline={outline ? 'true' : 'false'}
-      data-disabled={disabled ? 'true' : 'false'}
+      data-test-color={color}
+      data-test-outline={outline ? 'true' : 'false'}
+      data-test-disabled={disabled ? 'true' : 'false'}
     >
       {spinner ? (
         <Spinner />

--- a/nym-vpn-app/src/ui/ButtonIcon.tsx
+++ b/nym-vpn-app/src/ui/ButtonIcon.tsx
@@ -58,8 +58,8 @@ function ButtonIcon({
       }}
       disabled={disabled}
       data-testid={testId}
-      data-disabled={disabled ? 'true' : 'false'}
-      data-clicked={isClicked ? 'true' : 'false'}
+      data-test-disabled={disabled ? 'true' : 'false'}
+      data-test-clicked={isClicked ? 'true' : 'false'}
     >
       {isClicked ? (
         <motion.div

--- a/nym-vpn-app/src/ui/ButtonText.tsx
+++ b/nym-vpn-app/src/ui/ButtonText.tsx
@@ -52,8 +52,8 @@ function ButtonText({
       onDoubleClick={onDoubleClick}
       disabled={disabled}
       data-testid={testId}
-      data-disabled={disabled ? 'true' : 'false'}
-      data-truncate={truncate ? 'true' : 'false'}
+      data-test-disabled={disabled ? 'true' : 'false'}
+      data-test-truncate={truncate ? 'true' : 'false'}
     >
       <div
         className={clsx(truncate && 'text-nowrap truncate')}

--- a/nym-vpn-app/src/ui/DaemonDot.tsx
+++ b/nym-vpn-app/src/ui/DaemonDot.tsx
@@ -33,7 +33,7 @@ function DaemonDot({ status, ...rest }: DaemonDotProps) {
         status === 'ok' ? 'animate-pulse' : 'animate-pulse-fast',
       ])}
       data-testid={testId}
-      data-status={status}
+      data-test-status={status}
     >
       <div
         className={clsx(['relative w-2.5 h-2.5 rounded-full', bgColor()])}

--- a/nym-vpn-app/src/ui/Dialog.tsx
+++ b/nym-vpn-app/src/ui/Dialog.tsx
@@ -31,8 +31,8 @@ function Dialog({ open, onClose, children, className, ...rest }: DialogProps) {
       open={open}
       onClose={onClose}
       data-testid={testId}
-      data-open={open ? 'true' : 'false'}
-      data-theme={uiTheme}
+      data-test-open={open ? 'true' : 'false'}
+      data-test-theme={uiTheme}
     >
       <DialogBackdrop
         transition

--- a/nym-vpn-app/src/ui/FlagIcon.tsx
+++ b/nym-vpn-app/src/ui/FlagIcon.tsx
@@ -296,7 +296,7 @@ function FlagIcon({ code, alt, className, ...rest }: FlagIconProps) {
         ])}
         alt={alt}
         data-testid={testId}
-        data-country-code={code}
+        data-test-country-code={code}
       />
     </div>
   );

--- a/nym-vpn-app/src/ui/Link.tsx
+++ b/nym-vpn-app/src/ui/Link.tsx
@@ -33,7 +33,7 @@ function Link({
       ])}
       onClick={() => openUrl(url)}
       data-testid={testId}
-      data-url={url}
+      data-test-url={url}
     >
       {({ hover }) => (
         <>

--- a/nym-vpn-app/src/ui/MsIcon.tsx
+++ b/nym-vpn-app/src/ui/MsIcon.tsx
@@ -19,7 +19,7 @@ function MsIcon({ icon, className, ...rest }: MsIconProps) {
         className && className,
       ])}
       data-testid={testId}
-      data-icon={icon}
+      data-test-icon={icon}
     >
       {icon}
     </span>

--- a/nym-vpn-app/src/ui/PageAnim.tsx
+++ b/nym-vpn-app/src/ui/PageAnim.tsx
@@ -29,7 +29,7 @@ function PageAnim({
       }}
       className={clsx([className])}
       data-testid={testId}
-      data-slide-origin={slideOrigin}
+      data-test-slide-origin={slideOrigin}
     >
       {children}
     </motion.div>

--- a/nym-vpn-app/src/ui/PulseDot.tsx
+++ b/nym-vpn-app/src/ui/PulseDot.tsx
@@ -28,7 +28,7 @@ function PulseDot({ color = 'cornflower', ...rest }: PulseDotProps) {
         'h-[10px] w-[10px]',
       ])}
       data-testid={testId}
-      data-color={color}
+      data-test-color={color}
     >
       <div
         className={clsx(

--- a/nym-vpn-app/src/ui/RadioGroup.tsx
+++ b/nym-vpn-app/src/ui/RadioGroup.tsx
@@ -76,7 +76,7 @@ function RadioGroup<K extends Key>({
     <div
       className="select-none"
       data-testid={testId}
-      data-disabled={disabled ? 'true' : 'false'}
+      data-test-disabled={disabled ? 'true' : 'false'}
     >
       <HuRadioGroup
         value={selected}
@@ -124,7 +124,6 @@ function RadioGroup<K extends Key>({
                 disabled={option.disabled}
                 data-testid={optionTestId}
                 data-key={String(option.key)}
-                data-disabled={option.disabled ? 'true' : 'false'}
               >
                 {({ checked }) => {
                   return (
@@ -143,7 +142,6 @@ function RadioGroup<K extends Key>({
                           option.className && option.className,
                         ])}
                         data-testid={`${optionTestId}-content`}
-                        data-checked={checked ? 'true' : 'false'}
                       >
                         {radioIcons && checkedIcon(checked)}
                         {option.icon && (

--- a/nym-vpn-app/src/ui/SettingsMenuCard.tsx
+++ b/nym-vpn-app/src/ui/SettingsMenuCard.tsx
@@ -54,7 +54,7 @@ function SettingsMenuCard({
       tabIndex={disabled ? -1 : 0}
       style={style}
       data-testid={testId}
-      data-disabled={disabled ? 'true' : 'false'}
+      data-test-disabled={disabled ? 'true' : 'false'}
     >
       <div
         className={clsx(

--- a/nym-vpn-app/src/ui/Slider.tsx
+++ b/nym-vpn-app/src/ui/Slider.tsx
@@ -40,10 +40,10 @@ function Slider({
       )}
       disabled={disabled}
       data-testid={testId}
-      data-value={value}
-      data-min={min}
-      data-max={max}
-      data-disabled={disabled ? 'true' : 'false'}
+      data-test-value={value}
+      data-test-min={min}
+      data-test-max={max}
+      data-test-disabled={disabled ? 'true' : 'false'}
     >
       <RxSlider.Track
         className="relative h-1.5 grow rounded-full bg-bombay/60 dark:bg-iron"

--- a/nym-vpn-app/src/ui/Switch.tsx
+++ b/nym-vpn-app/src/ui/Switch.tsx
@@ -21,8 +21,8 @@ function Switch({ checked, onChange, disabled, ...rest }: SwitchProps) {
       ])}
       disabled={disabled}
       data-testid={testId}
-      data-checked={checked ? 'true' : 'false'}
-      data-disabled={disabled ? 'true' : 'false'}
+      data-test-checked={checked ? 'true' : 'false'}
+      data-test-disabled={disabled ? 'true' : 'false'}
     >
       <span
         className={clsx([

--- a/nym-vpn-app/src/ui/TextArea.tsx
+++ b/nym-vpn-app/src/ui/TextArea.tsx
@@ -76,8 +76,8 @@ function TextArea({
         rows={rows}
         spellCheck={spellCheck}
         data-testid={testId}
-        data-resize={resize}
-        data-rows={rows}
+        data-test-resize={resize}
+        data-test-rows={rows}
       />
       {label && (
         <Label

--- a/nym-vpn-app/src/ui/TextInput.tsx
+++ b/nym-vpn-app/src/ui/TextInput.tsx
@@ -64,7 +64,7 @@ function TextInput({
         spellCheck={spellCheck}
         autoFocus={autoFocus}
         data-testid={testId}
-        data-has-left-icon={leftIcon ? 'true' : 'false'}
+        data-test-has-left-icon={leftIcon ? 'true' : 'false'}
       />
       {label && (
         <Label

--- a/nym-vpn-app/src/ui/ThemeSetter.tsx
+++ b/nym-vpn-app/src/ui/ThemeSetter.tsx
@@ -13,7 +13,7 @@ export default function ThemeSetter({
     <div
       className={clsx([uiTheme === 'dark' && 'dark', 'h-full'])}
       data-testid="theme-setter"
-      data-theme={uiTheme}
+      data-test-theme={uiTheme}
     >
       {children}
     </div>

--- a/nym-vpn-app/src/ui/Toast.tsx
+++ b/nym-vpn-app/src/ui/Toast.tsx
@@ -109,9 +109,9 @@ function Toast({
               transition={{ duration: 0.1, ease: 'easeOut' }}
               layout
               data-testid={testId}
-              data-type={type}
-              data-duration={duration}
-              data-open={open ? 'true' : 'false'}
+              data-test-type={type}
+              data-test-duration={duration}
+              data-test-open={open ? 'true' : 'false'}
             >
               {title && <div data-testid={`${testId}-title`}>{title}</div>}
               <div data-testid={`${testId}-message`}>{message}</div>

--- a/nym-vpn-app/src/ui/TopBar.tsx
+++ b/nym-vpn-app/src/ui/TopBar.tsx
@@ -244,7 +244,9 @@ export default function TopBar() {
       ])}
       data-testid="top-bar"
       data-test-route={location.pathname}
-      data-test-no-background={currentNavLocation.noBackground ? 'true' : 'false'}
+      data-test-no-background={
+        currentNavLocation.noBackground ? 'true' : 'false'
+      }
     >
       {currentNavLocation.leftIcon ? (
         <motion.div

--- a/nym-vpn-app/src/ui/TopBar.tsx
+++ b/nym-vpn-app/src/ui/TopBar.tsx
@@ -243,8 +243,8 @@ export default function TopBar() {
           : 'dark:bg-charcoal bg-white',
       ])}
       data-testid="top-bar"
-      data-route={location.pathname}
-      data-no-background={currentNavLocation.noBackground ? 'true' : 'false'}
+      data-test-route={location.pathname}
+      data-test-no-background={currentNavLocation.noBackground ? 'true' : 'false'}
     >
       {currentNavLocation.leftIcon ? (
         <motion.div


### PR DESCRIPTION
Some recently added (#2695) data attribute for tests purposes conflict with the ones used and exposed by UI component libraries (Radix, Headless UI etc). This result in broken style and wrong behaviors because those test attributes override the values.
To solve this, this PR put all test attributes behind a specialized prefix `data-test-*`.

`data-testid` remains as is, which should be safe to use.

NOTE: QA tests would need to be updated accordingly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2856)
<!-- Reviewable:end -->
