### PR TITLE
refactor(tauri): put updater logic behind windows target

### DIFF
--- a/nym-vpn-app/src-tauri/src/commands/mod.rs
+++ b/nym-vpn-app/src-tauri/src/commands/mod.rs
@@ -7,5 +7,6 @@ pub mod fs;
 pub mod gateway;
 pub mod log;
 pub mod tunnel;
+#[cfg(windows)]
 pub mod updater;
 pub mod window;

--- a/nym-vpn-app/src-tauri/src/commands/updater.rs
+++ b/nym-vpn-app/src-tauri/src/commands/updater.rs
@@ -1,7 +1,7 @@
 use crate::env::UPDATER_ENABLED;
 use crate::error::BackendError;
-use crate::state::updater::PendingUpdate;
 use crate::updater;
+use crate::updater::PendingUpdate;
 
 use serde::{Deserialize, Serialize};
 use tauri::ipc::Channel;

--- a/nym-vpn-app/src-tauri/src/env.rs
+++ b/nym-vpn-app/src-tauri/src/env.rs
@@ -4,6 +4,7 @@ use std::env;
 // compile-time environment variables
 /// SemVer version requirement for daemon compatibility
 pub const VPND_COMPAT_REQ: Option<&str> = option_env!("VPND_COMPAT_REQ");
+#[cfg(windows)]
 pub const UPDATER_ENDPOINT: Option<&str> = option_env!("UPDATER_ENDPOINT");
 
 pub static DEV_MODE: Lazy<bool> = Lazy::new(|| {

--- a/nym-vpn-app/src-tauri/src/main.rs
+++ b/nym-vpn-app/src-tauri/src/main.rs
@@ -14,7 +14,9 @@ use crate::{
 };
 
 use crate::fs::path::APP_CONFIG_DIR;
-use crate::state::updater as updater_state;
+#[cfg(windows)]
+use crate::updater::PendingUpdate;
+
 use anyhow::{Result, anyhow};
 use clap::Parser;
 use commands::daemon as cmd_daemon;
@@ -23,6 +25,7 @@ use commands::dev as cmd_dev;
 use commands::fs as cmd_fs;
 use commands::gateway as cmd_gw;
 use commands::log as cmd_log;
+#[cfg(windows)]
 use commands::updater as cmd_updater;
 use commands::window as cmd_window;
 use commands::*;
@@ -47,6 +50,7 @@ mod startup_error;
 mod state;
 mod sys;
 mod tray;
+#[cfg(windows)]
 mod updater;
 mod window;
 
@@ -126,13 +130,22 @@ async fn main() -> Result<()> {
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_notification::init())
-        .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_os::init())
         .setup(move |app| {
             info!("app setup");
 
+            #[cfg(windows)]
+            {
+                app.handle()
+                    .plugin(tauri_plugin_updater::Builder::new().build())
+                    .inspect_err(|e| {
+                        error!("failed to init updater plugin: {e}");
+                    })
+                    .ok();
+                app.manage(PendingUpdate(Mutex::new(None)));
+            }
+
             app.manage(cli.clone());
-            app.manage(updater_state::PendingUpdate(Mutex::new(None)));
 
             info!("Creating k/v embedded db");
             let db = match Db::new() {
@@ -247,7 +260,9 @@ async fn main() -> Result<()> {
             cmd_daemon::network_compat,
             cmd_daemon::vpnd_log_dir,
             cmd_fs::log_dir,
+            #[cfg(windows)]
             cmd_updater::fetch_update,
+            #[cfg(windows)]
             cmd_updater::install_update,
         ])
         // keep the app running in the background on window close request

--- a/nym-vpn-app/src-tauri/src/state/mod.rs
+++ b/nym-vpn-app/src-tauri/src/state/mod.rs
@@ -1,6 +1,5 @@
 use tokio::sync::Mutex;
 
 pub mod app;
-pub mod updater;
 
 pub type SharedAppState = Mutex<app::AppState>;

--- a/nym-vpn-app/src-tauri/src/state/updater.rs
+++ b/nym-vpn-app/src-tauri/src/state/updater.rs
@@ -1,4 +1,0 @@
-use tauri_plugin_updater::Update;
-use tokio::sync::Mutex;
-
-pub struct PendingUpdate(pub Mutex<Option<Update>>);

--- a/nym-vpn-app/src-tauri/src/updater.rs
+++ b/nym-vpn-app/src-tauri/src/updater.rs
@@ -3,7 +3,10 @@ use crate::env;
 use anyhow::Result;
 use tauri::AppHandle;
 use tauri_plugin_updater::{Update, UpdaterExt};
+use tokio::sync::Mutex;
 use tracing::{debug, error, info, instrument, trace};
+
+pub struct PendingUpdate(pub Mutex<Option<Update>>);
 
 // Based on https://v2.tauri.app/plugin/updater/#checking-for-updates
 #[instrument(skip(app))]

--- a/nym-vpn-app/src-tauri/tauri.conf.json
+++ b/nym-vpn-app/src-tauri/tauri.conf.json
@@ -45,5 +45,16 @@
     "security": {
       "csp": null
     }
+  },
+  "plugins": {
+    "updater": {
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDU3RjI2N0FFRUEyRERGOEQKUldTTjN5M3FybWZ5VjhxOFRsLzQ2c1N0NW1PVVNxVEVVQkszYjZHc3RtcEFDOW1ZN2lIN1NGdk0K",
+      "windows": {
+        "installMode": "passive"
+      },
+      "endpoints": [
+        "https://raw.githubusercontent.com/nymtech/nym-vpn-client/refs/heads/develop/.pkg/tauri-updater/stable.json"
+      ]
+    }
   }
 }

--- a/nym-vpn-app/src-tauri/updater.conf.json
+++ b/nym-vpn-app/src-tauri/updater.conf.json
@@ -1,16 +1,5 @@
 {
   "bundle": {
     "createUpdaterArtifacts": true
-  },
-  "plugins": {
-    "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDU3RjI2N0FFRUEyRERGOEQKUldTTjN5M3FybWZ5VjhxOFRsLzQ2c1N0NW1PVVNxVEVVQkszYjZHc3RtcEFDOW1ZN2lIN1NGdk0K",
-      "windows": {
-        "installMode": "passive"
-      },
-      "endpoints": [
-        "https://raw.githubusercontent.com/nymtech/nym-vpn-client/refs/heads/develop/.pkg/tauri-updater/stable.json"
-      ]
-    }
   }
 }


### PR DESCRIPTION
- init updater plugin on Windows only
- move updater code behind windows target
- move back updater config to the main tauri config as without it the plugin will fail to init + it is safer
- still generate updater signature only when needed (enabled at build time)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2858)
<!-- Reviewable:end -->
