### PR TITLE
Adopt sqlite pool guard

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -3518,7 +3518,7 @@ dependencies = [
 [[package]]
 name = "nym-api-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "bs58",
  "cosmrs",
@@ -3585,7 +3585,7 @@ dependencies = [
 [[package]]
 name = "nym-authenticator-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -3606,7 +3606,7 @@ dependencies = [
 [[package]]
 name = "nym-bandwidth-controller"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "bip39",
  "log",
@@ -3628,7 +3628,7 @@ dependencies = [
 [[package]]
 name = "nym-bin-common"
 version = "0.6.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "const-str",
  "log",
@@ -3643,7 +3643,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core"
 version = "1.1.15"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3702,7 +3702,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-config-types"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "humantime-serde",
  "nym-config",
@@ -3718,7 +3718,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-gateways-storage"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "async-trait",
  "cosmrs",
@@ -3737,7 +3737,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-surb-storage"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -3755,7 +3755,7 @@ dependencies = [
 [[package]]
 name = "nym-coconut-dkg-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -3778,7 +3778,7 @@ dependencies = [
 [[package]]
 name = "nym-compact-ecash"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "bincode",
  "bls12_381",
@@ -3801,7 +3801,7 @@ dependencies = [
 [[package]]
 name = "nym-config"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "dirs",
  "handlebars",
@@ -3834,7 +3834,7 @@ dependencies = [
 [[package]]
 name = "nym-contracts-common"
 version = "0.5.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -3849,7 +3849,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-proxy-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "async-trait",
  "nym-credentials",
@@ -3868,7 +3868,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-storage"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3887,7 +3887,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-utils"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "log",
  "nym-bandwidth-controller",
@@ -3906,7 +3906,7 @@ dependencies = [
 [[package]]
 name = "nym-credentials"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "bincode",
  "bls12_381",
@@ -3929,7 +3929,7 @@ dependencies = [
 [[package]]
 name = "nym-credentials-interface"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "bls12_381",
  "nym-compact-ecash",
@@ -3946,7 +3946,7 @@ dependencies = [
 [[package]]
 name = "nym-crypto"
 version = "0.4.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "aead",
  "aes",
@@ -4009,7 +4009,7 @@ dependencies = [
 [[package]]
 name = "nym-ecash-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -4023,7 +4023,7 @@ dependencies = [
 [[package]]
 name = "nym-ecash-time"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "nym-compact-ecash",
  "time",
@@ -4032,7 +4032,7 @@ dependencies = [
 [[package]]
 name = "nym-exit-policy"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "serde",
  "serde_json",
@@ -4064,7 +4064,7 @@ dependencies = [
 [[package]]
 name = "nym-gateway-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "futures",
  "getrandom 0.2.16",
@@ -4166,7 +4166,7 @@ dependencies = [
 [[package]]
 name = "nym-gateway-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "bs58",
  "futures",
@@ -4196,7 +4196,7 @@ dependencies = [
 [[package]]
 name = "nym-group-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "cosmwasm-schema",
  "cw-controllers",
@@ -4221,7 +4221,7 @@ dependencies = [
 [[package]]
 name = "nym-http-api-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4245,7 +4245,7 @@ dependencies = [
 [[package]]
 name = "nym-http-api-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "bincode",
  "serde",
@@ -4255,7 +4255,7 @@ dependencies = [
 [[package]]
 name = "nym-id"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "nym-credential-storage",
  "nym-credentials",
@@ -4284,7 +4284,7 @@ dependencies = [
 [[package]]
 name = "nym-ip-packet-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "bincode",
  "bytes",
@@ -4325,7 +4325,7 @@ dependencies = [
 [[package]]
 name = "nym-metrics"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "dashmap",
  "lazy_static",
@@ -4336,7 +4336,7 @@ dependencies = [
 [[package]]
 name = "nym-mixnet-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "dashmap",
  "futures",
@@ -4357,7 +4357,7 @@ dependencies = [
 [[package]]
 name = "nym-mixnet-contract-common"
 version = "0.6.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -4379,7 +4379,7 @@ dependencies = [
 [[package]]
 name = "nym-multisig-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -4395,7 +4395,7 @@ dependencies = [
 [[package]]
 name = "nym-network-defaults"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "cargo_metadata 0.18.1",
  "dotenvy",
@@ -4410,7 +4410,7 @@ dependencies = [
 [[package]]
 name = "nym-node-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "async-trait",
  "celes",
@@ -4433,7 +4433,7 @@ dependencies = [
 [[package]]
 name = "nym-nonexhaustive-delayqueue"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -4463,7 +4463,7 @@ dependencies = [
 [[package]]
 name = "nym-ordered-buffer"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "log",
  "thiserror 2.0.12",
@@ -4472,7 +4472,7 @@ dependencies = [
 [[package]]
 name = "nym-outfox"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "blake3",
  "chacha20",
@@ -4490,7 +4490,7 @@ dependencies = [
 [[package]]
 name = "nym-pemstore"
 version = "0.3.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "pem",
  "tracing",
@@ -4532,7 +4532,7 @@ dependencies = [
 [[package]]
 name = "nym-sdk"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4586,7 +4586,7 @@ dependencies = [
 [[package]]
 name = "nym-serde-helpers"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -4598,7 +4598,7 @@ dependencies = [
 [[package]]
 name = "nym-service-provider-requests-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "serde",
  "thiserror 2.0.12",
@@ -4607,7 +4607,7 @@ dependencies = [
 [[package]]
 name = "nym-service-providers-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "async-trait",
  "log",
@@ -4621,7 +4621,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-client-core"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4654,7 +4654,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-proxy-helpers"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "bytes",
  "futures",
@@ -4669,7 +4669,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "bincode",
  "log",
@@ -4685,7 +4685,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "nym-crypto",
  "nym-metrics",
@@ -4711,7 +4711,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-acknowledgements"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "nym-crypto",
  "nym-pemstore",
@@ -4728,7 +4728,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-addressing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-types",
@@ -4739,7 +4739,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-anonymous-replies"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "bs58",
  "nym-crypto",
@@ -4758,7 +4758,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-chunking"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "dashmap",
  "log",
@@ -4776,7 +4776,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-cover"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-acknowledgements",
@@ -4794,7 +4794,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-forwarding"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "nym-outfox",
  "nym-sphinx-addressing",
@@ -4806,7 +4806,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-framing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "bytes",
  "nym-sphinx-acknowledgements",
@@ -4822,7 +4822,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-params"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-types",
@@ -4833,7 +4833,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-routing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "nym-sphinx-addressing",
  "nym-sphinx-types",
@@ -4843,7 +4843,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-types"
 version = "0.2.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "nym-outfox",
  "sphinx-packet",
@@ -4853,7 +4853,7 @@ dependencies = [
 [[package]]
 name = "nym-statistics-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "futures",
  "log",
@@ -4877,7 +4877,7 @@ dependencies = [
 [[package]]
 name = "nym-task"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "cfg-if",
  "futures",
@@ -4894,7 +4894,7 @@ dependencies = [
 [[package]]
 name = "nym-ticketbooks-merkle"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "nym-credentials-interface",
  "nym-serde-helpers",
@@ -4909,7 +4909,7 @@ dependencies = [
 [[package]]
 name = "nym-topology"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "async-trait",
  "nym-api-requests",
@@ -4930,7 +4930,7 @@ dependencies = [
 [[package]]
 name = "nym-validator-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4979,7 +4979,7 @@ dependencies = [
 [[package]]
 name = "nym-vesting-contract-common"
 version = "0.7.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -5333,7 +5333,7 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-types"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "base64 0.22.1",
  "log",
@@ -7178,7 +7178,7 @@ dependencies = [
 [[package]]
 name = "sqlx-pool-guard"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "proc_pidinfo",
  "sqlx",
@@ -8527,7 +8527,7 @@ dependencies = [
 [[package]]
 name = "wasm-utils"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#735535d902eacb4bbf8bbb354d76996775faf109"
 dependencies = [
  "futures",
  "getrandom 0.2.16",

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -2721,7 +2721,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.0",
+ "windows-core 0.59.0",
 ]
 
 [[package]]
@@ -3082,7 +3082,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3518,7 +3518,7 @@ dependencies = [
 [[package]]
 name = "nym-api-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "bs58",
  "cosmrs",
@@ -3585,7 +3585,7 @@ dependencies = [
 [[package]]
 name = "nym-authenticator-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -3606,7 +3606,7 @@ dependencies = [
 [[package]]
 name = "nym-bandwidth-controller"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "bip39",
  "log",
@@ -3628,7 +3628,7 @@ dependencies = [
 [[package]]
 name = "nym-bin-common"
 version = "0.6.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "const-str",
  "log",
@@ -3643,7 +3643,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core"
 version = "1.1.15"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3702,7 +3702,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-config-types"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "humantime-serde",
  "nym-config",
@@ -3718,7 +3718,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-gateways-storage"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "async-trait",
  "cosmrs",
@@ -3737,7 +3737,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-surb-storage"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -3746,6 +3746,7 @@ dependencies = [
  "nym-sphinx",
  "nym-task",
  "sqlx",
+ "sqlx-pool-guard",
  "thiserror 2.0.12",
  "time",
  "tokio",
@@ -3754,7 +3755,7 @@ dependencies = [
 [[package]]
 name = "nym-coconut-dkg-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -3777,7 +3778,7 @@ dependencies = [
 [[package]]
 name = "nym-compact-ecash"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "bincode",
  "bls12_381",
@@ -3800,7 +3801,7 @@ dependencies = [
 [[package]]
 name = "nym-config"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "dirs",
  "handlebars",
@@ -3833,7 +3834,7 @@ dependencies = [
 [[package]]
 name = "nym-contracts-common"
 version = "0.5.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -3848,7 +3849,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-proxy-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "async-trait",
  "nym-credentials",
@@ -3867,7 +3868,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-storage"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3877,6 +3878,7 @@ dependencies = [
  "nym-ecash-time",
  "serde",
  "sqlx",
+ "sqlx-pool-guard",
  "thiserror 2.0.12",
  "tokio",
  "zeroize",
@@ -3885,7 +3887,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-utils"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "log",
  "nym-bandwidth-controller",
@@ -3904,7 +3906,7 @@ dependencies = [
 [[package]]
 name = "nym-credentials"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "bincode",
  "bls12_381",
@@ -3927,7 +3929,7 @@ dependencies = [
 [[package]]
 name = "nym-credentials-interface"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "bls12_381",
  "nym-compact-ecash",
@@ -3944,7 +3946,7 @@ dependencies = [
 [[package]]
 name = "nym-crypto"
 version = "0.4.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "aead",
  "aes",
@@ -4007,7 +4009,7 @@ dependencies = [
 [[package]]
 name = "nym-ecash-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -4021,7 +4023,7 @@ dependencies = [
 [[package]]
 name = "nym-ecash-time"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "nym-compact-ecash",
  "time",
@@ -4030,7 +4032,7 @@ dependencies = [
 [[package]]
 name = "nym-exit-policy"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "serde",
  "serde_json",
@@ -4062,7 +4064,7 @@ dependencies = [
 [[package]]
 name = "nym-gateway-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "futures",
  "getrandom 0.2.16",
@@ -4164,7 +4166,7 @@ dependencies = [
 [[package]]
 name = "nym-gateway-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "bs58",
  "futures",
@@ -4194,7 +4196,7 @@ dependencies = [
 [[package]]
 name = "nym-group-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "cosmwasm-schema",
  "cw-controllers",
@@ -4219,7 +4221,7 @@ dependencies = [
 [[package]]
 name = "nym-http-api-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4243,7 +4245,7 @@ dependencies = [
 [[package]]
 name = "nym-http-api-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "bincode",
  "serde",
@@ -4253,7 +4255,7 @@ dependencies = [
 [[package]]
 name = "nym-id"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "nym-credential-storage",
  "nym-credentials",
@@ -4282,7 +4284,7 @@ dependencies = [
 [[package]]
 name = "nym-ip-packet-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "bincode",
  "bytes",
@@ -4323,7 +4325,7 @@ dependencies = [
 [[package]]
 name = "nym-metrics"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "dashmap",
  "lazy_static",
@@ -4334,7 +4336,7 @@ dependencies = [
 [[package]]
 name = "nym-mixnet-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "dashmap",
  "futures",
@@ -4355,7 +4357,7 @@ dependencies = [
 [[package]]
 name = "nym-mixnet-contract-common"
 version = "0.6.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -4377,7 +4379,7 @@ dependencies = [
 [[package]]
 name = "nym-multisig-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -4393,7 +4395,7 @@ dependencies = [
 [[package]]
 name = "nym-network-defaults"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "cargo_metadata 0.18.1",
  "dotenvy",
@@ -4408,7 +4410,7 @@ dependencies = [
 [[package]]
 name = "nym-node-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "async-trait",
  "celes",
@@ -4431,7 +4433,7 @@ dependencies = [
 [[package]]
 name = "nym-nonexhaustive-delayqueue"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -4461,7 +4463,7 @@ dependencies = [
 [[package]]
 name = "nym-ordered-buffer"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "log",
  "thiserror 2.0.12",
@@ -4470,7 +4472,7 @@ dependencies = [
 [[package]]
 name = "nym-outfox"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "blake3",
  "chacha20",
@@ -4488,7 +4490,7 @@ dependencies = [
 [[package]]
 name = "nym-pemstore"
 version = "0.3.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "pem",
  "tracing",
@@ -4530,7 +4532,7 @@ dependencies = [
 [[package]]
 name = "nym-sdk"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4584,7 +4586,7 @@ dependencies = [
 [[package]]
 name = "nym-serde-helpers"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -4596,7 +4598,7 @@ dependencies = [
 [[package]]
 name = "nym-service-provider-requests-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "serde",
  "thiserror 2.0.12",
@@ -4605,7 +4607,7 @@ dependencies = [
 [[package]]
 name = "nym-service-providers-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "async-trait",
  "log",
@@ -4619,7 +4621,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-client-core"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4652,7 +4654,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-proxy-helpers"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "bytes",
  "futures",
@@ -4667,7 +4669,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "bincode",
  "log",
@@ -4683,7 +4685,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "nym-crypto",
  "nym-metrics",
@@ -4709,7 +4711,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-acknowledgements"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "nym-crypto",
  "nym-pemstore",
@@ -4726,7 +4728,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-addressing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-types",
@@ -4737,7 +4739,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-anonymous-replies"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "bs58",
  "nym-crypto",
@@ -4756,7 +4758,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-chunking"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "dashmap",
  "log",
@@ -4774,7 +4776,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-cover"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-acknowledgements",
@@ -4792,7 +4794,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-forwarding"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "nym-outfox",
  "nym-sphinx-addressing",
@@ -4804,7 +4806,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-framing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "bytes",
  "nym-sphinx-acknowledgements",
@@ -4820,7 +4822,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-params"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-types",
@@ -4831,7 +4833,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-routing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "nym-sphinx-addressing",
  "nym-sphinx-types",
@@ -4841,7 +4843,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-types"
 version = "0.2.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "nym-outfox",
  "sphinx-packet",
@@ -4851,7 +4853,7 @@ dependencies = [
 [[package]]
 name = "nym-statistics-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "futures",
  "log",
@@ -4875,7 +4877,7 @@ dependencies = [
 [[package]]
 name = "nym-task"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "cfg-if",
  "futures",
@@ -4892,7 +4894,7 @@ dependencies = [
 [[package]]
 name = "nym-ticketbooks-merkle"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "nym-credentials-interface",
  "nym-serde-helpers",
@@ -4907,7 +4909,7 @@ dependencies = [
 [[package]]
 name = "nym-topology"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "async-trait",
  "nym-api-requests",
@@ -4928,7 +4930,7 @@ dependencies = [
 [[package]]
 name = "nym-validator-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4977,7 +4979,7 @@ dependencies = [
 [[package]]
 name = "nym-vesting-contract-common"
 version = "0.7.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -5330,7 +5332,7 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-types"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "base64 0.22.1",
  "log",
@@ -5863,6 +5865,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc_pidinfo"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af53dad2390f8df98dda1e4188322bdf2f91c86cf6001f51d10d64451edf463a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "prometheus"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5894,7 +5905,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "once_cell",
@@ -5914,7 +5925,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -7161,6 +7172,18 @@ dependencies = [
  "time",
  "tracing",
  "whoami",
+]
+
+[[package]]
+name = "sqlx-pool-guard"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+dependencies = [
+ "proc_pidinfo",
+ "sqlx",
+ "tokio",
+ "tracing",
+ "windows 0.61.1",
 ]
 
 [[package]]
@@ -8503,7 +8526,7 @@ dependencies = [
 [[package]]
 name = "wasm-utils"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.10-brie#2e634c59a7fa4a33c4c853936abfc8eb9a15f9c1"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
 dependencies = [
  "futures",
  "getrandom 0.2.16",
@@ -8692,6 +8715,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5ee8f3d025738cb02bad7868bbb5f8a6327501e870bf51f1b455b0a2454a419"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.61.0",
+ "windows-future",
+ "windows-link",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.0",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8749,6 +8794,16 @@ dependencies = [
  "windows-link",
  "windows-result 0.3.2",
  "windows-strings 0.4.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a1d6bbefcb7b60acd19828e1bc965da6fcf18a7e39490c5f8be71e54a19ba32"
+dependencies = [
+ "windows-core 0.61.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -8833,6 +8888,16 @@ name = "windows-link"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.0",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-registry"

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -3518,7 +3518,7 @@ dependencies = [
 [[package]]
 name = "nym-api-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "bs58",
  "cosmrs",
@@ -3585,7 +3585,7 @@ dependencies = [
 [[package]]
 name = "nym-authenticator-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -3606,7 +3606,7 @@ dependencies = [
 [[package]]
 name = "nym-bandwidth-controller"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "bip39",
  "log",
@@ -3628,7 +3628,7 @@ dependencies = [
 [[package]]
 name = "nym-bin-common"
 version = "0.6.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "const-str",
  "log",
@@ -3643,7 +3643,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core"
 version = "1.1.15"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3702,7 +3702,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-config-types"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "humantime-serde",
  "nym-config",
@@ -3718,7 +3718,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-gateways-storage"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "async-trait",
  "cosmrs",
@@ -3737,7 +3737,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-surb-storage"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -3755,7 +3755,7 @@ dependencies = [
 [[package]]
 name = "nym-coconut-dkg-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -3778,7 +3778,7 @@ dependencies = [
 [[package]]
 name = "nym-compact-ecash"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "bincode",
  "bls12_381",
@@ -3801,7 +3801,7 @@ dependencies = [
 [[package]]
 name = "nym-config"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "dirs",
  "handlebars",
@@ -3834,7 +3834,7 @@ dependencies = [
 [[package]]
 name = "nym-contracts-common"
 version = "0.5.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -3849,7 +3849,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-proxy-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "async-trait",
  "nym-credentials",
@@ -3868,7 +3868,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-storage"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3887,7 +3887,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-utils"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "log",
  "nym-bandwidth-controller",
@@ -3906,7 +3906,7 @@ dependencies = [
 [[package]]
 name = "nym-credentials"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "bincode",
  "bls12_381",
@@ -3929,7 +3929,7 @@ dependencies = [
 [[package]]
 name = "nym-credentials-interface"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "bls12_381",
  "nym-compact-ecash",
@@ -3946,7 +3946,7 @@ dependencies = [
 [[package]]
 name = "nym-crypto"
 version = "0.4.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "aead",
  "aes",
@@ -4009,7 +4009,7 @@ dependencies = [
 [[package]]
 name = "nym-ecash-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -4023,7 +4023,7 @@ dependencies = [
 [[package]]
 name = "nym-ecash-time"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "nym-compact-ecash",
  "time",
@@ -4032,7 +4032,7 @@ dependencies = [
 [[package]]
 name = "nym-exit-policy"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "serde",
  "serde_json",
@@ -4064,7 +4064,7 @@ dependencies = [
 [[package]]
 name = "nym-gateway-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "futures",
  "getrandom 0.2.16",
@@ -4166,7 +4166,7 @@ dependencies = [
 [[package]]
 name = "nym-gateway-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "bs58",
  "futures",
@@ -4196,7 +4196,7 @@ dependencies = [
 [[package]]
 name = "nym-group-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "cosmwasm-schema",
  "cw-controllers",
@@ -4221,7 +4221,7 @@ dependencies = [
 [[package]]
 name = "nym-http-api-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4245,7 +4245,7 @@ dependencies = [
 [[package]]
 name = "nym-http-api-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "bincode",
  "serde",
@@ -4255,7 +4255,7 @@ dependencies = [
 [[package]]
 name = "nym-id"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "nym-credential-storage",
  "nym-credentials",
@@ -4284,7 +4284,7 @@ dependencies = [
 [[package]]
 name = "nym-ip-packet-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "bincode",
  "bytes",
@@ -4325,7 +4325,7 @@ dependencies = [
 [[package]]
 name = "nym-metrics"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "dashmap",
  "lazy_static",
@@ -4336,7 +4336,7 @@ dependencies = [
 [[package]]
 name = "nym-mixnet-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "dashmap",
  "futures",
@@ -4357,7 +4357,7 @@ dependencies = [
 [[package]]
 name = "nym-mixnet-contract-common"
 version = "0.6.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -4379,7 +4379,7 @@ dependencies = [
 [[package]]
 name = "nym-multisig-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -4395,7 +4395,7 @@ dependencies = [
 [[package]]
 name = "nym-network-defaults"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "cargo_metadata 0.18.1",
  "dotenvy",
@@ -4410,7 +4410,7 @@ dependencies = [
 [[package]]
 name = "nym-node-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "async-trait",
  "celes",
@@ -4433,7 +4433,7 @@ dependencies = [
 [[package]]
 name = "nym-nonexhaustive-delayqueue"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -4463,7 +4463,7 @@ dependencies = [
 [[package]]
 name = "nym-ordered-buffer"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "log",
  "thiserror 2.0.12",
@@ -4472,7 +4472,7 @@ dependencies = [
 [[package]]
 name = "nym-outfox"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "blake3",
  "chacha20",
@@ -4490,7 +4490,7 @@ dependencies = [
 [[package]]
 name = "nym-pemstore"
 version = "0.3.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "pem",
  "tracing",
@@ -4532,7 +4532,7 @@ dependencies = [
 [[package]]
 name = "nym-sdk"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4586,7 +4586,7 @@ dependencies = [
 [[package]]
 name = "nym-serde-helpers"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -4598,7 +4598,7 @@ dependencies = [
 [[package]]
 name = "nym-service-provider-requests-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "serde",
  "thiserror 2.0.12",
@@ -4607,7 +4607,7 @@ dependencies = [
 [[package]]
 name = "nym-service-providers-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "async-trait",
  "log",
@@ -4621,7 +4621,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-client-core"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4654,7 +4654,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-proxy-helpers"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "bytes",
  "futures",
@@ -4669,7 +4669,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "bincode",
  "log",
@@ -4685,7 +4685,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "nym-crypto",
  "nym-metrics",
@@ -4711,7 +4711,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-acknowledgements"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "nym-crypto",
  "nym-pemstore",
@@ -4728,7 +4728,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-addressing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-types",
@@ -4739,7 +4739,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-anonymous-replies"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "bs58",
  "nym-crypto",
@@ -4758,7 +4758,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-chunking"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "dashmap",
  "log",
@@ -4776,7 +4776,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-cover"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-acknowledgements",
@@ -4794,7 +4794,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-forwarding"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "nym-outfox",
  "nym-sphinx-addressing",
@@ -4806,7 +4806,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-framing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "bytes",
  "nym-sphinx-acknowledgements",
@@ -4822,7 +4822,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-params"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-types",
@@ -4833,7 +4833,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-routing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "nym-sphinx-addressing",
  "nym-sphinx-types",
@@ -4843,7 +4843,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-types"
 version = "0.2.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "nym-outfox",
  "sphinx-packet",
@@ -4853,7 +4853,7 @@ dependencies = [
 [[package]]
 name = "nym-statistics-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "futures",
  "log",
@@ -4877,7 +4877,7 @@ dependencies = [
 [[package]]
 name = "nym-task"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "cfg-if",
  "futures",
@@ -4894,7 +4894,7 @@ dependencies = [
 [[package]]
 name = "nym-ticketbooks-merkle"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "nym-credentials-interface",
  "nym-serde-helpers",
@@ -4909,7 +4909,7 @@ dependencies = [
 [[package]]
 name = "nym-topology"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "async-trait",
  "nym-api-requests",
@@ -4930,7 +4930,7 @@ dependencies = [
 [[package]]
 name = "nym-validator-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4979,7 +4979,7 @@ dependencies = [
 [[package]]
 name = "nym-vesting-contract-common"
 version = "0.7.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -5333,7 +5333,7 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-types"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "base64 0.22.1",
  "log",
@@ -5906,7 +5906,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -5926,7 +5926,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -7178,7 +7178,7 @@ dependencies = [
 [[package]]
 name = "sqlx-pool-guard"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "proc_pidinfo",
  "sqlx",
@@ -8527,7 +8527,7 @@ dependencies = [
 [[package]]
 name = "wasm-utils"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#d2114d3c2e7cdccc35ab70fc0508f27e14a01821"
+source = "git+https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie#b599ededf374769b408f80db7cde28cacbf3d285"
 dependencies = [
  "futures",
  "getrandom 0.2.16",

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -5013,6 +5013,7 @@ dependencies = [
  "serde",
  "si-scale",
  "sqlx",
+ "sqlx-pool-guard",
  "strum",
  "thiserror 2.0.12",
  "time",

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -210,28 +210,29 @@ nym-wg-gateway-client = { path = "crates/nym-wg-gateway-client" }
 nym-wg-go = { path = "crates/nym-wg-go" }
 nym-windows = { path = "crates/nym-windows" }
 
-nym-authenticator-requests = { git = "https://github.com/nymtech/nym", branch = "release/2025.10-brie" }
-nym-api-requests = { git = "https://github.com/nymtech/nym", branch = "release/2025.10-brie" }
-nym-bandwidth-controller = { git = "https://github.com/nymtech/nym", branch = "release/2025.10-brie" }
-nym-bin-common = { git = "https://github.com/nymtech/nym", branch = "release/2025.10-brie" }
-nym-client-core = { git = "https://github.com/nymtech/nym", branch = "release/2025.10-brie" }
-nym-compact-ecash = { git = "https://github.com/nymtech/nym", branch = "release/2025.10-brie" }
-nym-config = { git = "https://github.com/nymtech/nym", branch = "release/2025.10-brie" }
-nym-contracts-common = { git = "https://github.com/nymtech/nym", branch = "release/2025.10-brie" }
-nym-credential-proxy-requests = { git = "https://github.com/nymtech/nym", branch = "release/2025.10-brie", default-features = false }
-nym-credential-storage = { git = "https://github.com/nymtech/nym", branch = "release/2025.10-brie" }
-nym-credentials = { git = "https://github.com/nymtech/nym", branch = "release/2025.10-brie" }
-nym-credentials-interface = { git = "https://github.com/nymtech/nym", branch = "release/2025.10-brie" }
-nym-crypto = { git = "https://github.com/nymtech/nym", branch = "release/2025.10-brie" }
-nym-ecash-time = { git = "https://github.com/nymtech/nym", branch = "release/2025.10-brie" }
-nym-http-api-client = { git = "https://github.com/nymtech/nym", branch = "release/2025.10-brie" }
-nym-ip-packet-requests = { git = "https://github.com/nymtech/nym", branch = "release/2025.10-brie" }
-nym-node-requests = { git = "https://github.com/nymtech/nym", branch = "release/2025.10-brie" }
-nym-pemstore = { git = "https://github.com/nymtech/nym", branch = "release/2025.10-brie" }
-nym-service-provider-requests-common = { git = "https://github.com/nymtech/nym", branch = "release/2025.10-brie" }
-nym-sdk = { git = "https://github.com/nymtech/nym", branch = "release/2025.10-brie" }
-nym-statistics-common = { git = "https://github.com/nymtech/nym", branch = "release/2025.10-brie" }
-nym-task = { git = "https://github.com/nymtech/nym", branch = "release/2025.10-brie" }
-nym-topology = { git = "https://github.com/nymtech/nym", branch = "release/2025.10-brie" }
-nym-validator-client = { git = "https://github.com/nymtech/nym", branch = "release/2025.10-brie" }
-nym-wireguard-types = { git = "https://github.com/nymtech/nym", branch = "release/2025.10-brie" }
+nym-authenticator-requests = { git = "https://github.com/nymtech/nym", branch = "am/backport-close-sqlite-pool-brie" }
+nym-api-requests = { git = "https://github.com/nymtech/nym", branch = "am/backport-close-sqlite-pool-brie" }
+nym-bandwidth-controller = { git = "https://github.com/nymtech/nym", branch = "am/backport-close-sqlite-pool-brie" }
+nym-bin-common = { git = "https://github.com/nymtech/nym", branch = "am/backport-close-sqlite-pool-brie" }
+nym-client-core = { git = "https://github.com/nymtech/nym", branch = "am/backport-close-sqlite-pool-brie" }
+nym-compact-ecash = { git = "https://github.com/nymtech/nym", branch = "am/backport-close-sqlite-pool-brie" }
+nym-config = { git = "https://github.com/nymtech/nym", branch = "am/backport-close-sqlite-pool-brie" }
+nym-contracts-common = { git = "https://github.com/nymtech/nym", branch = "am/backport-close-sqlite-pool-brie" }
+nym-credential-proxy-requests = { git = "https://github.com/nymtech/nym", branch = "am/backport-close-sqlite-pool-brie", default-features = false }
+nym-credential-storage = { git = "https://github.com/nymtech/nym", branch = "am/backport-close-sqlite-pool-brie" }
+nym-credentials = { git = "https://github.com/nymtech/nym", branch = "am/backport-close-sqlite-pool-brie" }
+nym-credentials-interface = { git = "https://github.com/nymtech/nym", branch = "am/backport-close-sqlite-pool-brie" }
+nym-crypto = { git = "https://github.com/nymtech/nym", branch = "am/backport-close-sqlite-pool-brie" }
+nym-ecash-time = { git = "https://github.com/nymtech/nym", branch = "am/backport-close-sqlite-pool-brie" }
+nym-http-api-client = { git = "https://github.com/nymtech/nym", branch = "am/backport-close-sqlite-pool-brie" }
+nym-ip-packet-requests = { git = "https://github.com/nymtech/nym", branch = "am/backport-close-sqlite-pool-brie" }
+nym-node-requests = { git = "https://github.com/nymtech/nym", branch = "am/backport-close-sqlite-pool-brie" }
+nym-pemstore = { git = "https://github.com/nymtech/nym", branch = "am/backport-close-sqlite-pool-brie" }
+nym-service-provider-requests-common = { git = "https://github.com/nymtech/nym", branch = "am/backport-close-sqlite-pool-brie" }
+nym-sdk = { git = "https://github.com/nymtech/nym", branch = "am/backport-close-sqlite-pool-brie" }
+nym-statistics-common = { git = "https://github.com/nymtech/nym", branch = "am/backport-close-sqlite-pool-brie" }
+nym-task = { git = "https://github.com/nymtech/nym", branch = "am/backport-close-sqlite-pool-brie" }
+nym-topology = { git = "https://github.com/nymtech/nym", branch = "am/backport-close-sqlite-pool-brie" }
+nym-validator-client = { git = "https://github.com/nymtech/nym", branch = "am/backport-close-sqlite-pool-brie" }
+nym-wireguard-types = { git = "https://github.com/nymtech/nym", branch = "am/backport-close-sqlite-pool-brie" }
+sqlx-pool-guard = { git = "https://github.com/nymtech/nym", branch = "am/backport-close-sqlite-pool-brie" }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/Cargo.toml
@@ -29,6 +29,7 @@ nym-vpn-lib-types = { workspace = true, features = ["nym-type-conversions"] }
 nym-vpn-network-config = { workspace = true }
 nym-vpn-store = { workspace = true }
 nym-wg-gateway-client = { workspace = true }
+sqlx-pool-guard.workspace = true
 serde.workspace = true
 si-scale.workspace = true
 sqlx = { workspace = true, features = [

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
@@ -927,6 +927,9 @@ where
                 },
             }
         }
+
+        // Important: ensure to close credential storage before drop to avoid issues with sqlx
+        self.credential_storage.lock().await.close().await;
     }
 
     async fn print_info(&self) {
@@ -1005,6 +1008,7 @@ where
         }
 
         self.cleanup().await;
+
         tracing::debug!("Account controller is exiting");
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/credentials/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/credentials/mod.rs
@@ -60,6 +60,11 @@ impl VpnCredentialStorage {
         })
     }
 
+    pub async fn close(&self) {
+        self.credential_storage.close().await;
+        self.pending_requests_storage.close().await;
+    }
+
     pub(crate) async fn reset(&mut self) -> Result<(), Error> {
         self.reset_credential_storage().await?;
         self.reset_pending_request_storage().await?;

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/credentials/pending_credential_requests/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/credentials/pending_credential_requests/mod.rs
@@ -13,6 +13,7 @@ use std::{
 
 use sqlite::SqliteZkNymRequestsStorageManager;
 use sqlx::ConnectOptions;
+use sqlx_pool_guard::SqlitePoolGuard;
 use time::OffsetDateTime;
 use tracing::log::LevelFilter;
 
@@ -43,9 +44,12 @@ impl PendingCredentialRequestsStorage {
             .log_statements(LevelFilter::Trace);
 
         tracing::debug!("Connecting to the database");
-        let connection_pool = sqlx::sqlite::SqlitePoolOptions::new()
-            .connect_with(opts)
-            .await?;
+        let connection_pool = SqlitePoolGuard::new(
+            database_path.as_ref().to_path_buf(),
+            sqlx::sqlite::SqlitePoolOptions::new()
+                .connect_with(opts)
+                .await?,
+        );
 
         set_file_permission_owner_rw(&database_path)
             .map_err(
@@ -60,7 +64,7 @@ impl PendingCredentialRequestsStorage {
             .ok();
 
         tracing::debug!("Running migrations");
-        if let Err(e) = sqlx::migrate!("./migrations").run(&connection_pool).await {
+        if let Err(e) = sqlx::migrate!("./migrations").run(&*connection_pool).await {
             connection_pool.close().await;
             return Err(e.into());
         }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/credentials/pending_credential_requests/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/credentials/pending_credential_requests/mod.rs
@@ -75,6 +75,10 @@ impl PendingCredentialRequestsStorage {
         })
     }
 
+    pub async fn close(&self) {
+        self.storage_manager.close().await
+    }
+
     pub async fn reset(&mut self) -> Result<(), PendingCredentialRequestsStorageError> {
         // First we close the storage to ensure that all files are closed
         tracing::debug!("Closing pending credential requests storage");

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/credentials/pending_credential_requests/sqlite.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/credentials/pending_credential_requests/sqlite.rs
@@ -5,13 +5,15 @@ use time::{Date, OffsetDateTime};
 
 use super::models::PendingCredentialRequestStored;
 
+use sqlx_pool_guard::SqlitePoolGuard;
+
 #[derive(Clone)]
 pub struct SqliteZkNymRequestsStorageManager {
-    connection_pool: sqlx::SqlitePool,
+    connection_pool: SqlitePoolGuard,
 }
 
 impl SqliteZkNymRequestsStorageManager {
-    pub fn new(connection_pool: sqlx::SqlitePool) -> Self {
+    pub fn new(connection_pool: SqlitePoolGuard) -> Self {
         Self { connection_pool }
     }
 
@@ -23,7 +25,7 @@ impl SqliteZkNymRequestsStorageManager {
         &self,
     ) -> Result<Vec<PendingCredentialRequestStored>, sqlx::Error> {
         sqlx::query_as("SELECT * FROM pending_zk_nym_requests")
-            .fetch_all(&self.connection_pool)
+            .fetch_all(&*self.connection_pool)
             .await
     }
 
@@ -32,7 +34,7 @@ impl SqliteZkNymRequestsStorageManager {
             "DELETE FROM pending_zk_nym_requests WHERE timestamp < ?",
             cutoff
         )
-        .execute(&self.connection_pool)
+        .execute(&*self.connection_pool)
         .await?
         .rows_affected();
         tracing::debug!("Removed {} stale pending requests", affected);
@@ -45,7 +47,7 @@ impl SqliteZkNymRequestsStorageManager {
     ) -> Result<Option<PendingCredentialRequestStored>, sqlx::Error> {
         sqlx::query_as("SELECT * FROM pending_zk_nym_requests WHERE id = ?")
             .bind(id)
-            .fetch_optional(&self.connection_pool)
+            .fetch_optional(&*self.connection_pool)
             .await
     }
 
@@ -61,14 +63,14 @@ impl SqliteZkNymRequestsStorageManager {
             expiration_date,
             request_info,
         )
-        .execute(&self.connection_pool)
+        .execute(&*self.connection_pool)
         .await?;
         Ok(())
     }
 
     pub async fn remove_pending_request(&self, id: &str) -> Result<(), sqlx::Error> {
         sqlx::query!("DELETE FROM pending_zk_nym_requests WHERE id = ?", id)
-            .execute(&self.connection_pool)
+            .execute(&*self.connection_pool)
             .await?;
         Ok(())
     }


### PR DESCRIPTION
In sympathy with https://github.com/nymtech/nym/pull/5796 this change also switches sqlite connections pools to the `SqlitePoolGuard` to ensure that database file is fully closed before proceeding.

JIRA-VPN-1471

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2875)
<!-- Reviewable:end -->
