### PR TITLE
macos: fetch initial best routes

### DIFF
--- a/nym-vpn-core/crates/nym-offline-monitor/src/apple/macos.rs
+++ b/nym-vpn-core/crates/nym-offline-monitor/src/apple/macos.rs
@@ -122,6 +122,16 @@ async fn spawn_route_monitor(
     };
 
     let initial_state = ConnectivityInner { ipv4, ipv6 };
+
+    tracing::info!(
+        "Initial connectivity: {}",
+        if initial_state.into_connectivity().is_online() {
+            "Connected"
+        } else {
+            "Offline"
+        }
+    );
+
     let mut real_state = initial_state;
     let state = Arc::new(Mutex::new(initial_state));
     let shared_state = state.clone();

--- a/nym-vpn-core/crates/nym-offline-monitor/src/apple/macos.rs
+++ b/nym-vpn-core/crates/nym-offline-monitor/src/apple/macos.rs
@@ -13,8 +13,12 @@
 //! to macOS's connectivity check. In the offline state, a DNS server on localhost prevents the
 //! connectivity check from being blocked.
 
-use std::sync::{Arc, LazyLock};
+use std::{
+    sync::{Arc, LazyLock},
+    time::Duration,
+};
 
+use futures::future::{Fuse, FutureExt};
 use nym_routing::{DefaultRouteEvent, RouteManagerHandle};
 use tokio::sync::{Mutex, watch};
 use tokio_util::sync::CancellationToken;
@@ -29,6 +33,8 @@ static USE_PATH_MONITOR: LazyLock<bool> = LazyLock::new(|| {
         .map(|v| v != "0")
         .unwrap_or(false)
 });
+
+const SYNTHETIC_OFFLINE_DURATION: Duration = Duration::from_secs(1);
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -78,10 +84,6 @@ impl ConnectivityInner {
     fn is_online(&self) -> bool {
         self.into_connectivity().is_online()
     }
-
-    fn is_offline(&self) -> bool {
-        self.into_connectivity().is_offline()
-    }
 }
 
 pub async fn spawn_monitor(
@@ -90,7 +92,7 @@ pub async fn spawn_monitor(
     shutdown_token: CancellationToken,
 ) -> Result<ConnectivityHandle, Error> {
     if *USE_PATH_MONITOR {
-        tracing::info!("Using path monitor");
+        tracing::info!("Using path monitor.");
         let path_monitor = super::path_monitor::spawn_monitor(notify_tx, shutdown_token).await;
 
         Ok(ConnectivityHandle::new(
@@ -130,49 +132,64 @@ async fn spawn_route_monitor(
         }
     );
 
+    let mut real_state = initial_state;
     let state = Arc::new(Mutex::new(initial_state));
     let shared_state = state.clone();
 
     // Detect changes to the default route
     tokio::spawn(async move {
+        let mut timeout = Fuse::terminated();
+
         loop {
             nym_common::detect_flood!();
 
             tokio::select! {
+                _ = &mut timeout => {
+                    // Update shared state
+                    let mut state = shared_state.lock().await;
+                    if real_state.is_online() {
+                        tracing::info!("Connectivity changed: Connected");
+                        let _ = notify_tx.send(real_state.into_connectivity());
+                    }
+
+                    *state = real_state;
+                }
                 route_event = route_listener.recv() => {
                     let Some(event) = route_event else {
                         break;
                     };
 
-                    let mut state = shared_state.lock().await;
-
-                    let previous_connectivity = *state;
-                    let mut new_connectivity = *state;
-
+                    // Update real state
                     match event {
                         DefaultRouteEvent::AddedOrChangedV4 => {
-                            new_connectivity.ipv4 = true;
+                            real_state.ipv4 = true;
                         }
                         DefaultRouteEvent::AddedOrChangedV6 => {
-                            new_connectivity.ipv6 = true;
+                            real_state.ipv6 = true;
                         }
                         DefaultRouteEvent::RemovedV4 => {
-                            new_connectivity.ipv4 = false;
+                            real_state.ipv4 = false;
                         }
                         DefaultRouteEvent::RemovedV6 => {
-                            new_connectivity.ipv6 = false;
+                            real_state.ipv6 = false;
                         }
                     }
 
-                    if previous_connectivity.is_online() && new_connectivity.is_offline() {
+                    // Synthesize offline state
+                    // Update shared state
+                    let mut state = shared_state.lock().await;
+                    let previous_connectivity = *state;
+                    state.ipv4 = false;
+                    state.ipv6 = false;
+
+                    if previous_connectivity.is_online() {
+                        let _ = notify_tx.send(state.into_connectivity());
                         tracing::info!("Connectivity changed: Offline");
-                    } else if previous_connectivity.is_offline() && new_connectivity.is_online() {
-                        tracing::info!("Connectivity changed: Connected");
                     }
 
-                    *state = new_connectivity;
-
-                    let _ = notify_tx.send(new_connectivity.into_connectivity());
+                    if real_state.is_online() {
+                        timeout = Box::pin(tokio::time::sleep(SYNTHETIC_OFFLINE_DURATION)).fuse();
+                    }
                 }
                 _ = shutdown_token.cancelled() => {
                     break

--- a/nym-vpn-core/crates/nym-offline-monitor/src/apple/macos.rs
+++ b/nym-vpn-core/crates/nym-offline-monitor/src/apple/macos.rs
@@ -13,12 +13,8 @@
 //! to macOS's connectivity check. In the offline state, a DNS server on localhost prevents the
 //! connectivity check from being blocked.
 
-use std::{
-    sync::{Arc, LazyLock},
-    time::Duration,
-};
+use std::sync::{Arc, LazyLock};
 
-use futures::future::{Fuse, FutureExt};
 use nym_routing::{DefaultRouteEvent, RouteManagerHandle};
 use tokio::sync::{Mutex, watch};
 use tokio_util::sync::CancellationToken;
@@ -33,8 +29,6 @@ static USE_PATH_MONITOR: LazyLock<bool> = LazyLock::new(|| {
         .map(|v| v != "0")
         .unwrap_or(false)
 });
-
-const SYNTHETIC_OFFLINE_DURATION: Duration = Duration::from_secs(1);
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -84,6 +78,10 @@ impl ConnectivityInner {
     fn is_online(&self) -> bool {
         self.into_connectivity().is_online()
     }
+
+    fn is_offline(&self) -> bool {
+        self.into_connectivity().is_offline()
+    }
 }
 
 pub async fn spawn_monitor(
@@ -92,7 +90,7 @@ pub async fn spawn_monitor(
     shutdown_token: CancellationToken,
 ) -> Result<ConnectivityHandle, Error> {
     if *USE_PATH_MONITOR {
-        tracing::info!("Using path monitor.");
+        tracing::info!("Using path monitor");
         let path_monitor = super::path_monitor::spawn_monitor(notify_tx, shutdown_token).await;
 
         Ok(ConnectivityHandle::new(
@@ -132,64 +130,49 @@ async fn spawn_route_monitor(
         }
     );
 
-    let mut real_state = initial_state;
     let state = Arc::new(Mutex::new(initial_state));
     let shared_state = state.clone();
 
     // Detect changes to the default route
     tokio::spawn(async move {
-        let mut timeout = Fuse::terminated();
-
         loop {
             nym_common::detect_flood!();
 
             tokio::select! {
-                _ = &mut timeout => {
-                    // Update shared state
-                    let mut state = shared_state.lock().await;
-                    if real_state.is_online() {
-                        tracing::info!("Connectivity changed: Connected");
-                        let _ = notify_tx.send(real_state.into_connectivity());
-                    }
-
-                    *state = real_state;
-                }
                 route_event = route_listener.recv() => {
                     let Some(event) = route_event else {
                         break;
                     };
 
-                    // Update real state
+                    let mut state = shared_state.lock().await;
+
+                    let previous_connectivity = *state;
+                    let mut new_connectivity = *state;
+
                     match event {
                         DefaultRouteEvent::AddedOrChangedV4 => {
-                            real_state.ipv4 = true;
+                            new_connectivity.ipv4 = true;
                         }
                         DefaultRouteEvent::AddedOrChangedV6 => {
-                            real_state.ipv6 = true;
+                            new_connectivity.ipv6 = true;
                         }
                         DefaultRouteEvent::RemovedV4 => {
-                            real_state.ipv4 = false;
+                            new_connectivity.ipv4 = false;
                         }
                         DefaultRouteEvent::RemovedV6 => {
-                            real_state.ipv6 = false;
+                            new_connectivity.ipv6 = false;
                         }
                     }
 
-                    // Synthesize offline state
-                    // Update shared state
-                    let mut state = shared_state.lock().await;
-                    let previous_connectivity = *state;
-                    state.ipv4 = false;
-                    state.ipv6 = false;
-
-                    if previous_connectivity.is_online() {
-                        let _ = notify_tx.send(state.into_connectivity());
+                    if previous_connectivity.is_online() && new_connectivity.is_offline() {
                         tracing::info!("Connectivity changed: Offline");
+                    } else if previous_connectivity.is_offline() && new_connectivity.is_online() {
+                        tracing::info!("Connectivity changed: Connected");
                     }
 
-                    if real_state.is_online() {
-                        timeout = Box::pin(tokio::time::sleep(SYNTHETIC_OFFLINE_DURATION)).fuse();
-                    }
+                    *state = new_connectivity;
+
+                    let _ = notify_tx.send(new_connectivity.into_connectivity());
                 }
                 _ = shutdown_token.cancelled() => {
                     break

--- a/nym-vpn-core/crates/nym-routing/src/unix/macos/mod.rs
+++ b/nym-vpn-core/crates/nym-routing/src/unix/macos/mod.rs
@@ -192,14 +192,11 @@ impl RouteManagerImpl {
                 new_best_route = self.best_default_route_rx_v4.recv() => {
                     let Some(new_best_route)= new_best_route else { continue };
                     self.handle_new_best_default_route(interface::Family::V4, new_best_route);
-
-
                 }
 
                 new_best_route = self.best_default_route_rx_v6.recv() => {
                     let Some(new_best_route)= new_best_route else { continue };
                     self.handle_new_best_default_route(interface::Family::V6, new_best_route);
-
                 }
 
                 command = manage_rx.recv() => {

--- a/nym-vpn-core/crates/nym-routing/src/unix/macos/mod.rs
+++ b/nym-vpn-core/crates/nym-routing/src/unix/macos/mod.rs
@@ -42,7 +42,6 @@ pub type Result<T> = std::result::Result<T, Error>;
 const BURST_BUFFER_PERIOD: Duration = Duration::from_millis(200);
 const BURST_LONGEST_BUFFER_PERIOD: Duration = Duration::from_secs(2);
 
-/// Maximum duration to wait for the initial best default routes
 const INITIAL_BEST_ROUTES_TIMEOUT: Duration = Duration::from_millis(200);
 
 /// Errors that can happen in the macOS routing integration.
@@ -152,7 +151,6 @@ impl RouteManagerImpl {
 
         let mut best_default_route = IpMap::new();
 
-        // Fetch initial best default routes (v4, v6)
         match tokio::time::timeout(INITIAL_BEST_ROUTES_TIMEOUT, async {
             tokio::join!(best_route_rx_v4.recv(), best_route_rx_v6.recv())
         })

--- a/nym-vpn-core/crates/nym-routing/src/unix/macos/mod.rs
+++ b/nym-vpn-core/crates/nym-routing/src/unix/macos/mod.rs
@@ -42,6 +42,9 @@ pub type Result<T> = std::result::Result<T, Error>;
 const BURST_BUFFER_PERIOD: Duration = Duration::from_millis(200);
 const BURST_LONGEST_BUFFER_PERIOD: Duration = Duration::from_secs(2);
 
+/// Maximum duration to wait for the initial best default routes
+const INITIAL_BEST_ROUTES_TIMEOUT: Duration = Duration::from_millis(200);
+
 /// Errors that can happen in the macOS routing integration.
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -147,7 +150,7 @@ impl RouteManagerImpl {
             },
         );
 
-        Ok(Self {
+        let mut route_manager = Self {
             routing_table,
             non_tunnel_routes: HashSet::new(),
             tunnel_default_routes: IpMap::new(),
@@ -161,7 +164,35 @@ impl RouteManagerImpl {
             check_default_routes_restored: Box::pin(futures::stream::pending()),
             unhandled_default_route_changes: false,
             interface_change_listeners: vec![],
-        })
+        };
+
+        route_manager.fetch_initial_best_default_routes().await;
+
+        Ok(route_manager)
+    }
+
+    /// Fetch initial best default routes (v4, v6) to pre-fill the default state of route manager
+    async fn fetch_initial_best_default_routes(&mut self) {
+        let Ok((best_v4_route, best_v6_route)) =
+            tokio::time::timeout(INITIAL_BEST_ROUTES_TIMEOUT, async {
+                tokio::join!(
+                    self.best_default_route_rx_v4.recv(),
+                    self.best_default_route_rx_v6.recv()
+                )
+            })
+            .await
+        else {
+            tracing::warn!("Timed out receiving initial best default routes");
+            return;
+        };
+
+        tracing::trace!("Received initial best default routes");
+        if let Some(best_v4_route) = best_v4_route {
+            self.handle_new_best_default_route(interface::Family::V4, best_v4_route);
+        }
+        if let Some(best_v6_route) = best_v6_route {
+            self.handle_new_best_default_route(interface::Family::V6, best_v6_route);
+        }
     }
 
     pub(crate) async fn run(mut self, mut manage_rx: mpsc::UnboundedReceiver<RouteManagerCommand>) {

--- a/nym-vpn-core/crates/nym-routing/src/unix/macos/mod.rs
+++ b/nym-vpn-core/crates/nym-routing/src/unix/macos/mod.rs
@@ -135,7 +135,7 @@ impl RouteManagerImpl {
         let (primary_interface_monitor, interface_change_rx) =
             interface::PrimaryInterfaceMonitor::new();
 
-        let (best_route_rx_v4, best_route_rx_v6) =
+        let (mut best_route_rx_v4, mut best_route_rx_v6) =
             DefaultRouteMonitor::start(primary_interface_monitor, interface_change_rx);
 
         let routing_table = RoutingTable::new().map_err(Error::RoutingTable)?;
@@ -150,12 +150,36 @@ impl RouteManagerImpl {
             },
         );
 
-        let mut route_manager = Self {
+        let mut best_default_route = IpMap::new();
+
+        // Fetch initial best default routes (v4, v6)
+        match tokio::time::timeout(INITIAL_BEST_ROUTES_TIMEOUT, async {
+            tokio::join!(best_route_rx_v4.recv(), best_route_rx_v6.recv())
+        })
+        .await
+        {
+            Ok((best_v4_route, best_v6_route)) => {
+                for (family, best_route) in [
+                    (interface::Family::V4, best_v4_route),
+                    (interface::Family::V6, best_v6_route),
+                ] {
+                    if let Some(best_route) = best_route {
+                        tracing::trace!("Best route ({family:?}): {best_route:?}");
+                        best_default_route.set(family, best_route);
+                    }
+                }
+            }
+            Err(_) => {
+                tracing::warn!("Timed out while waiting for initial best routes");
+            }
+        }
+
+        Ok(Self {
             routing_table,
             non_tunnel_routes: HashSet::new(),
             tunnel_default_routes: IpMap::new(),
             applied_routes: BTreeMap::new(),
-            best_default_route: IpMap::new(),
+            best_default_route,
             best_default_route_update: IpMap::new(),
             default_route_listeners: vec![],
             best_default_route_rx_v4: best_route_rx_v4,
@@ -164,35 +188,7 @@ impl RouteManagerImpl {
             check_default_routes_restored: Box::pin(futures::stream::pending()),
             unhandled_default_route_changes: false,
             interface_change_listeners: vec![],
-        };
-
-        route_manager.fetch_initial_best_default_routes().await;
-
-        Ok(route_manager)
-    }
-
-    /// Fetch initial best default routes (v4, v6) to pre-fill the default state of route manager
-    async fn fetch_initial_best_default_routes(&mut self) {
-        let Ok((best_v4_route, best_v6_route)) =
-            tokio::time::timeout(INITIAL_BEST_ROUTES_TIMEOUT, async {
-                tokio::join!(
-                    self.best_default_route_rx_v4.recv(),
-                    self.best_default_route_rx_v6.recv()
-                )
-            })
-            .await
-        else {
-            tracing::warn!("Timed out receiving initial best default routes");
-            return;
-        };
-
-        tracing::trace!("Received initial best default routes");
-        if let Some(best_v4_route) = best_v4_route {
-            self.handle_new_best_default_route(interface::Family::V4, best_v4_route);
-        }
-        if let Some(best_v6_route) = best_v6_route {
-            self.handle_new_best_default_route(interface::Family::V6, best_v6_route);
-        }
+        })
     }
 
     pub(crate) async fn run(mut self, mut manage_rx: mpsc::UnboundedReceiver<RouteManagerCommand>) {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
@@ -128,9 +128,6 @@ impl ConnectedTunnel {
             None,
         );
 
-        tracing::info!("Entry config: {wg_entry_config:#?}");
-        tracing::info!("Exit config: {wg_exit_config:#?}");
-
         #[allow(unused_mut)]
         let mut entry_tunnel = wireguard_go::Tunnel::start(
             wg_entry_config.into_wireguard_config(),


### PR DESCRIPTION
macOS route manager used to fetch initial default routes asynchronously. This caused a situation where querying the initial connectivity would yield no routes and thus make offline monitor falsely report that device is offline.

This PR fixes this by fetching current default as a part of `RouteManagerImpl::new()` using a short 200ms timeout just in case, which is plenty of time.

JIRA-VPN-3497

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2887)
<!-- Reviewable:end -->
