### PR TITLE
Fix error chain prints misattributed to nym_common

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -2721,7 +2721,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.59.0",
+ "windows-core 0.61.0",
 ]
 
 [[package]]
@@ -3771,6 +3771,7 @@ name = "nym-common"
 version = "1.11.0-beta"
 dependencies = [
  "tracing",
+ "tracing-test",
 ]
 
 [[package]]
@@ -7997,6 +7998,27 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "557b891436fe0d5e0e363427fc7f217abf9ccd510d5136549847bdcbcd011d68"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
+dependencies = [
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -169,6 +169,7 @@ tracing = "0.1"
 tracing-appender = "0.2.3"
 tracing-oslog = "0.2.0"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-test = "0.2.5"
 triggered = "0.1.3"
 tun = { version = "0.6.1", features = ["async"] }
 uniffi = { version = "0.27.3", features = ["cli"] }

--- a/nym-vpn-core/crates/nym-common/Cargo.toml
+++ b/nym-vpn-core/crates/nym-common/Cargo.toml
@@ -8,3 +8,4 @@ edition.workspace = true
 
 [dependencies]
 tracing.workspace = true
+tracing-test.workspace = true

--- a/nym-vpn-core/crates/nym-common/src/error.rs
+++ b/nym-vpn-core/crates/nym-common/src/error.rs
@@ -11,12 +11,6 @@ pub trait ErrorExt {
 
     /// Like [Self::display_chain] but with an extra message at the start of the chain.
     fn display_chain_with_msg<S: AsRef<str>>(&self, msg: S) -> String;
-
-    /// Print error chain to log using error level.
-    fn trace_chain(&self);
-
-    /// Like [Self::trace_chain] but with an extra message at the start of the chain.
-    fn trace_chain_with_msg<S: AsRef<str>>(&self, msg: S);
 }
 
 impl<E: Error> ErrorExt for E {
@@ -39,16 +33,55 @@ impl<E: Error> ErrorExt for E {
         }
         s
     }
-
-    fn trace_chain(&self) {
-        tracing::error!("{}", self.display_chain());
-    }
-
-    fn trace_chain_with_msg<S: AsRef<str>>(&self, msg: S) {
-        tracing::error!("{}", self.display_chain_with_msg(msg));
-    }
 }
 
+#[macro_export]
+macro_rules! trace_err_chain {
+    ($err:expr) => {
+        tracing::error!("{}", $crate::ErrorExt::display_chain(&$err));
+    };
+    ($err:expr, $($args:tt)*) => {
+        tracing::error!("{}", $crate::ErrorExt::display_chain_with_msg(&$err, ::std::format!($($args)*)));
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use tracing_test::traced_test;
+
+    use std::{io, path::PathBuf};
+
+    #[test]
+    #[traced_test]
+    fn test_trace_err_chain() {
+        trace_err_chain!(io::Error::other("file not found"));
+        assert!(logs_contain("Error: file not found"));
+    }
+
+    #[test]
+    #[traced_test]
+    fn test_trace_err_chain_with_msg() {
+        trace_err_chain!(io::Error::other("file not found"), "failed to open file");
+        assert!(logs_contain("Error: failed to open file"));
+        // todo: fix once it supports multiline messages
+        // https://github.com/dbrgn/tracing-test/issues/48
+        // assert!(logs_contain("Caused by: file not found"));
+    }
+
+    #[test]
+    #[traced_test]
+    fn test_trace_err_chain_with_msgfmt() {
+        trace_err_chain!(
+            io::Error::other("file not found"),
+            "failed to open file: {}",
+            PathBuf::from("test.txt").display()
+        );
+        assert!(logs_contain("Error: failed to open file: test.txt"));
+        // todo: fix once it supports multiline messages
+        // https://github.com/dbrgn/tracing-test/issues/48
+        // assert!(logs_contain("Caused by: file not found"));
+    }
+}
 #[derive(Debug)]
 pub struct BoxedError(Box<dyn Error + 'static + Send>);
 

--- a/nym-vpn-core/crates/nym-connection-monitor/src/icmp_beacon.rs
+++ b/nym-vpn-core/crates/nym-connection-monitor/src/icmp_beacon.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use bytes::Bytes;
-use nym_common::ErrorExt;
+use nym_common::trace_err_chain;
 use nym_config::defaults::mixnet_vpn::{NYM_TUN_DEVICE_ADDRESS_V4, NYM_TUN_DEVICE_ADDRESS_V6};
 use nym_ip_packet_requests::{IpPair, codec::MultiIpPacketCodec};
 use nym_sdk::{
@@ -144,16 +144,16 @@ impl IcmpConnectionBeacon {
                 _ = ping_interval.tick() => {
                     let cancellable_fut = async {
                         if let Err(err) = self.ping_v4_ipr_tun_device_over_the_mixnet().await {
-                            err.trace_chain_with_msg("Failed to send ICMP ping");
+                            trace_err_chain!(err, "Failed to send ICMP ping");
                         }
                         if let Err(err) = self.ping_v6_ipr_tun_device_over_the_mixnet().await {
-                            err.trace_chain_with_msg("Failed to send ICMPv6 ping");
+                            trace_err_chain!(err, "Failed to send ICMPv6 ping");
                         }
                         if let Err(err) = self.ping_v4_some_external_ip_over_the_mixnet().await {
-                            err.trace_chain_with_msg("Failed to send ICMP ping");
+                            trace_err_chain!(err, "Failed to send ICMP ping");
                         }
                         if let Err(err) = self.ping_v6_some_external_ip_over_the_mixnet().await {
-                            err.trace_chain_with_msg("Failed to send ICMPv6 ping");
+                            trace_err_chain!(err, "Failed to send ICMPv6 ping");
                         }
                     };
 
@@ -245,7 +245,7 @@ pub fn start_icmp_connection_beacon(
         IcmpConnectionBeacon::new(mixnet_client_sender, our_ips, ipr_address, icmp_identifier);
     tokio::spawn(async move {
         beacon.run(shutdown_listener).await.inspect_err(|err| {
-            err.trace_chain_with_msg("IcmpConnectionBeacon failed");
+            trace_err_chain!(err, "IcmpConnectionBeacon failed");
         })
     })
 }

--- a/nym-vpn-core/crates/nym-connection-monitor/src/mixnet_beacon.rs
+++ b/nym-vpn-core/crates/nym-connection-monitor/src/mixnet_beacon.rs
@@ -3,7 +3,7 @@
 
 use std::time::Duration;
 
-use nym_common::ErrorExt;
+use nym_common::trace_err_chain;
 use nym_sdk::{
     TaskClient,
     mixnet::{InputMessage, MixnetClientSender, MixnetMessageSender, Recipient},
@@ -58,7 +58,10 @@ impl MixnetConnectionBeacon {
                             let _ping_id = match ping_result {
                                 Ok(id) => id,
                                 Err(err) => {
-                                    err.trace_chain_with_msg("Failed to send mixnet self ping");
+                                    trace_err_chain!(
+                                        err,
+                                        "Failed to send mixnet self ping"
+                                    );
                                     continue;
                                 }
                             };
@@ -97,6 +100,6 @@ pub fn start_mixnet_connection_beacon(
         beacon
             .run(shutdown_listener)
             .await
-            .inspect_err(|err| err.trace_chain_with_msg("Mixnet connection beacon error"))
+            .inspect_err(|err| trace_err_chain!(err, "Mixnet connection beacon error"))
     })
 }

--- a/nym-vpn-core/crates/nym-connection-monitor/src/monitor.rs
+++ b/nym-vpn-core/crates/nym-connection-monitor/src/monitor.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use futures::{StreamExt, channel::mpsc};
-use nym_common::ErrorExt;
+use nym_common::trace_err_chain;
 use nym_sdk::TaskClient;
 use tokio::task::JoinHandle;
 
@@ -299,7 +299,7 @@ pub fn start_connection_monitor(
     let monitor = ConnectionMonitor::new(connection_event_rx);
     tokio::spawn(async move {
         monitor.run(shutdown_listener).await.inspect_err(|err| {
-            err.trace_chain_with_msg("Connection monitor error");
+            trace_err_chain!(err, "Connection monitor error");
         })
     })
 }

--- a/nym-vpn-core/crates/nym-dns/src/linux/static_resolv_conf.rs
+++ b/nym-vpn-core/crates/nym-dns/src/linux/static_resolv_conf.rs
@@ -10,7 +10,7 @@ use resolv_conf::{Config, ScopedIp};
 use tokio::sync::Mutex;
 use triggered::{Listener, Trigger, trigger};
 
-use nym_common::ErrorExt;
+use nym_common::trace_err_chain;
 
 const RESOLV_CONF_BACKUP_PATH: &str = "/etc/resolv.conf.nymbackup";
 const RESOLV_CONF_PATH: &str = "/etc/resolv.conf";
@@ -161,7 +161,7 @@ impl DnsWatcher {
                 Some(_) = events.next() => {
                     let mut locked_state = state.lock().await;
                     if let Err(error) = Self::update(locked_state.as_mut()) {
-                        error.trace_chain_with_msg(
+                        trace_err_chain!(error,
                             "Failed to update DNS state after DNS settings changed"
                         );
                     }

--- a/nym-vpn-core/crates/nym-dns/src/linux/systemd_resolved.rs
+++ b/nym-vpn-core/crates/nym-dns/src/linux/systemd_resolved.rs
@@ -4,7 +4,7 @@
 
 use std::net::IpAddr;
 
-use nym_common::ErrorExt;
+use nym_common::trace_err_chain;
 use nym_dbus::systemd_resolved::{AsyncHandle, SystemdResolved as DbusInterface};
 use nym_routing::RouteManagerHandle;
 
@@ -49,7 +49,7 @@ impl SystemdResolved {
         self.tunnel_index = tunnel_index;
 
         if let Err(error) = self.dbus_interface.disable_dot(self.tunnel_index).await {
-            error.trace_chain_with_msg("Failed to disable DoT");
+            trace_err_chain!(error, "Failed to disable DoT");
         }
 
         if let Err(error) = self
@@ -57,7 +57,7 @@ impl SystemdResolved {
             .set_domains(tunnel_index, &[(".", true)])
             .await
         {
-            error.trace_chain_with_msg("Failed to set search domains");
+            trace_err_chain!(error, "Failed to set search domains");
         }
 
         let _ = self
@@ -74,7 +74,7 @@ impl SystemdResolved {
             .set_domains(self.tunnel_index, &[])
             .await
         {
-            error.trace_chain_with_msg("Failed to set search domains");
+            trace_err_chain!(error, "Failed to set search domains");
         }
 
         let _ = self

--- a/nym-vpn-core/crates/nym-dns/src/windows/netsh.rs
+++ b/nym-vpn-core/crates/nym-dns/src/windows/netsh.rs
@@ -18,7 +18,7 @@ use tokio::{
 };
 use windows::Win32::{Foundation::MAX_PATH, System::SystemInformation::GetSystemDirectoryW};
 
-use nym_common::ErrorExt;
+use nym_common::trace_err_chain;
 use nym_windows::net::{index_from_luid, luid_from_alias};
 
 use crate::{DnsMonitorT, ResolvedDnsConfig};
@@ -124,7 +124,7 @@ impl DnsMonitorT for DnsMonitor {
             netsh_input.push_str(&create_netsh_flush_command(index, IpVersion::V6));
 
             if let Err(error) = run_netsh_with_timeout(netsh_input, NETSH_TIMEOUT).await {
-                error.trace_chain_with_msg("Failed to reset DNS");
+                trace_err_chain!(error, "Failed to reset DNS");
             }
         }
         Ok(())

--- a/nym-vpn-core/crates/nym-firewall/src/windows/mod.rs
+++ b/nym-vpn-core/crates/nym-firewall/src/windows/mod.rs
@@ -10,7 +10,7 @@ use nym_dns::ResolvedDnsConfig;
 
 use std::{ffi::CStr, net::IpAddr, ptr, sync::LazyLock};
 
-use nym_common::ErrorExt;
+use nym_common::trace_err_chain;
 use widestring::WideCString;
 use windows::Win32::Globalization::{CP_ACP, MULTI_BYTE_TO_WIDE_CHAR_FLAGS, MultiByteToWideChar};
 
@@ -545,9 +545,7 @@ fn consume_and_log_hyperv_err<T>(
     result: Result<T, hyperv::Error>,
 ) -> Option<T> {
     result
-        .inspect_err(|error| {
-            error.trace_chain_with_msg(format!("{action}. {HYPERV_LEAK_WARNING_MSG}"))
-        })
+        .inspect_err(|error| trace_err_chain!(error, "{action}. {HYPERV_LEAK_WARNING_MSG}"))
         .ok()
 }
 

--- a/nym-vpn-core/crates/nym-gateway-directory/src/helpers.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/helpers.rs
@@ -3,7 +3,7 @@
 
 use std::net::{IpAddr, SocketAddr};
 
-use nym_common::ErrorExt;
+use nym_common::trace_err_chain;
 use nym_http_api_client::HickoryDnsResolver;
 
 use crate::{Config, Error, error::Result, gateway_client::ResolvedConfig};
@@ -12,7 +12,7 @@ async fn try_resolve_hostname(hostname: &str) -> Result<Vec<IpAddr>> {
     tracing::debug!("Trying to resolve hostname: {hostname}");
     let resolver = HickoryDnsResolver::default();
     let addrs = resolver.resolve_str(hostname).await.map_err(|err| {
-        err.trace_chain_with_msg("Failed to resolve gateway hostname");
+        trace_err_chain!(err, "Failed to resolve gateway hostname");
         Error::FailedToDnsResolveGateway {
             hostname: hostname.to_string(),
             source: err,

--- a/nym-vpn-core/crates/nym-offline-monitor/src/windows.rs
+++ b/nym-vpn-core/crates/nym-offline-monitor/src/windows.rs
@@ -7,7 +7,7 @@ use std::{io, sync::Arc, time::Duration};
 use tokio::sync::{Mutex, watch};
 use tokio_util::sync::CancellationToken;
 
-use nym_common::ErrorExt;
+use nym_common::trace_err_chain;
 use nym_routing::{CallbackHandle, EventType, RouteManagerHandle, get_best_default_route};
 use nym_windows::{
     net::AddressFamily,
@@ -105,13 +105,13 @@ impl BroadcastListener {
         let v4_connectivity = get_best_default_route(AddressFamily::Ipv4)
             .map(|route| route.is_some())
             .unwrap_or_else(|error| {
-                error.trace_chain_with_msg("Failed to check initial IPv4 connectivity");
+                trace_err_chain!(error, "Failed to check initial IPv4 connectivity");
                 true
             });
         let v6_connectivity = get_best_default_route(AddressFamily::Ipv6)
             .map(|route| route.is_some())
             .unwrap_or_else(|error| {
-                error.trace_chain_with_msg("Failed to check initial IPv6 connectivity");
+                trace_err_chain!(error, "Failed to check initial IPv6 connectivity");
                 true
             });
 

--- a/nym-vpn-core/crates/nym-routing/src/unix/linux.rs
+++ b/nym-vpn-core/crates/nym-routing/src/unix/linux.rs
@@ -7,7 +7,7 @@ use crate::{
     imp::{CallbackMessage, RouteManagerCommand},
 };
 use netlink_sys::AsyncSocket;
-use nym_common::ErrorExt;
+use nym_common::trace_err_chain;
 use std::{
     collections::{BTreeMap, HashSet},
     io,
@@ -358,7 +358,7 @@ impl RouteManagerImpl {
                 },
                 Some((route_change, _socket)) = self.messages.next() => {
                     if let Err(error) = self.process_netlink_message(route_change) {
-                        error.trace_chain_with_msg("Failed to process netlink message");
+                        trace_err_chain!(error, "Failed to process netlink message");
                     }
                 }
             };
@@ -739,7 +739,7 @@ impl RouteManagerImpl {
         self.cleanup_routes().await;
 
         if let Err(error) = self.clear_routing_rules().await {
-            error.trace_chain_with_msg("Failed to remove routing rules");
+            trace_err_chain!(error, "Failed to remove routing rules");
         }
     }
 

--- a/nym-vpn-core/crates/nym-routing/src/unix/macos/mod.rs
+++ b/nym-vpn-core/crates/nym-routing/src/unix/macos/mod.rs
@@ -10,7 +10,7 @@ use futures::{
 };
 use ipnetwork::IpNetwork;
 use nix::net::if_::if_nametoindex;
-use nym_common::ErrorExt;
+use nym_common::trace_err_chain;
 use std::{
     collections::{BTreeMap, HashSet},
     net::{IpAddr, SocketAddr},
@@ -451,7 +451,7 @@ impl RouteManagerImpl {
             // ignore all other message types
             Ok(_) => {}
             Err(err) => {
-                err.trace_chain_with_msg("Failed to receive a message from the routing table");
+                trace_err_chain!(err, "Failed to receive a message from the routing table");
             }
         }
     }

--- a/nym-vpn-core/crates/nym-routing/src/windows/mod.rs
+++ b/nym-vpn-core/crates/nym-routing/src/windows/mod.rs
@@ -13,7 +13,7 @@ use futures::{
 };
 pub use get_best_default_route::{InterfaceAndGateway, get_best_default_route};
 use net::AddressFamily;
-use nym_common::ErrorExt;
+use nym_common::trace_err_chain;
 use nym_windows::net;
 pub use route_manager::{Callback, CallbackHandle, Route, RouteManagerInternal};
 use std::{collections::HashSet, io, net::IpAddr};
@@ -212,7 +212,7 @@ impl RouteManagerHandle {
                 }
                 RouteManagerCommand::ClearRoutes => {
                     if let Err(e) = internal.delete_applied_routes() {
-                        e.trace_chain_with_msg("Could not clear routes");
+                        trace_err_chain!(e, "Could not clear routes");
                     }
                 }
                 RouteManagerCommand::RegisterDefaultRouteChangeCallback(callback, tx) => {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/cleanup.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/cleanup.rs
@@ -9,7 +9,7 @@ use std::{
 use futures::StreamExt;
 use tokio_stream::wrappers::ReadDirStream;
 
-use nym_common::ErrorExt;
+use nym_common::trace_err_chain;
 use nym_sdk::mixnet::StoragePaths;
 use nym_vpn_store::keys::persistence::{
     DEFAULT_PRIVATE_DEVICE_KEY_FILENAME, DEFAULT_PUBLIC_DEVICE_KEY_FILENAME,
@@ -75,11 +75,9 @@ pub async fn remove_files_for_account(data_dir: &Path) -> Result<(), Error> {
             Err(err) if err.kind() == io::ErrorKind::NotFound => {
                 tracing::debug!("File not found, skipping: {}", file_path.display());
             }
-            Err(err) => tracing::error!(
-                "Failed to remove file {}: {}",
-                file_path.display(),
-                err.display_chain()
-            ),
+            Err(err) => {
+                trace_err_chain!(err, "Failed to remove file {}", file_path.display());
+            }
         }
     }
 
@@ -102,10 +100,7 @@ pub async fn remove_files_for_account(data_dir: &Path) -> Result<(), Error> {
                     tracing::debug!("Corrupted file not found, skipping: {}", file.display());
                 }
                 Err(err) => {
-                    err.trace_chain_with_msg(format!(
-                        "Failed to remove corrupted file {}",
-                        file.display()
-                    ));
+                    trace_err_chain!(err, "Failed to remove corrupted file {}", file.display());
                 }
             }
         }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/credentials/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/credentials/mod.rs
@@ -14,7 +14,7 @@ use std::{
     sync::Arc,
 };
 
-use nym_common::ErrorExt;
+use nym_common::trace_err_chain;
 use nym_compact_ecash::VerificationKeyAuth;
 use nym_credential_storage::persistent_storage::PersistentStorage as PersistentCredentialStorage;
 use nym_credentials::{
@@ -95,7 +95,7 @@ impl VpnCredentialStorage {
                     tracing::debug!("File not found, skipping: {}", path.display())
                 }
                 Err(err) => {
-                    err.trace_chain_with_msg(format!("Failed to remove file {}", path.display()));
+                    trace_err_chain!(err, "Failed to remove file {}", path.display());
                     return Err(Error::RemoveCredentialStorage(err));
                 }
             }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/ticketbooks.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/ticketbooks.rs
@@ -3,7 +3,7 @@
 
 use std::fmt;
 
-use nym_common::ErrorExt;
+use nym_common::trace_err_chain;
 use nym_credential_storage::models::BasicTicketbookInformation;
 use nym_credentials_interface::TicketType;
 use serde::{Deserialize, Serialize};
@@ -220,7 +220,7 @@ impl TryFrom<Vec<BasicTicketbookInformation>> for AvailableTicketbooks {
             .filter_map(|ticketbook| {
                 AvailableTicketbook::try_from(ticketbook)
                     .inspect_err(|err| {
-                        err.trace_chain_with_msg("Failed to parse ticketbook");
+                        trace_err_chain!(err, "Failed to parse ticketbook");
                     })
                     .ok()
             })

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/account.rs
@@ -3,7 +3,7 @@
 
 use std::{path::PathBuf, str::FromStr, sync::Arc, time::Duration};
 
-use nym_common::ErrorExt;
+use nym_common::trace_err_chain;
 use nym_vpn_account_controller::{
     AccountCommandSender, SharedAccountState, shared_state::DeviceState,
 };
@@ -325,7 +325,7 @@ pub(crate) mod raw {
                     tracing::trace!("File not found, skipping: {}", path.display())
                 }
                 Err(e) => {
-                    e.trace_chain_with_msg(format!("Failed to remove file: {}", path.display()));
+                    trace_err_chain!(e, "Failed to remove file: {}", path.display());
 
                     return Err(VpnError::InternalError {
                         details: e.to_string(),

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/state_machine.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/state_machine.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use nym_common::ErrorExt;
+use nym_common::trace_err_chain;
 use nym_vpn_account_controller::AccountCommandSender;
 use nym_vpn_network_config::Network;
 use tokio::{sync::mpsc, task::JoinHandle};
@@ -60,7 +60,7 @@ fn setup_statistics_recipient(
         .map(nym_gateway_directory::Recipient::try_from_base58_string)
         .transpose()
         .inspect_err(|err| {
-            err.trace_chain_with_msg("Failed to parse statistics recipient");
+            trace_err_chain!(err, "Failed to parse statistics recipient");
         })
         .unwrap_or_default()
         .map(Box::new);

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -33,7 +33,7 @@ use nym_vpn_network_config::Network;
 use tokio::{sync::mpsc, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
 
-use nym_common::ErrorExt;
+use nym_common::trace_err_chain;
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 use nym_dns::DnsConfig;
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
@@ -446,7 +446,7 @@ impl TunnelStateMachine {
             .register_offline_monitor(offline_watch)
             .await
             .inspect_err(|err| {
-                err.trace_chain_with_msg("Failed to register offline watch");
+                trace_err_chain!(err, "Failed to register offline watch");
             })
             .ok();
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/route_handler.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/route_handler.rs
@@ -5,7 +5,7 @@ use std::{collections::HashSet, fmt, net::IpAddr};
 
 use ipnetwork::IpNetwork;
 
-use nym_common::ErrorExt;
+use nym_common::trace_err_chain;
 #[cfg(not(target_os = "linux"))]
 use nym_routing::NetNode;
 #[cfg(windows)]
@@ -67,19 +67,19 @@ impl RouteHandler {
 
     pub async fn remove_routes(&mut self) {
         if let Err(e) = self.route_manager.clear_routes() {
-            e.trace_chain_with_msg("Failed to remove routes");
+            trace_err_chain!(e, "Failed to remove routes");
         }
 
         #[cfg(target_os = "linux")]
         if let Err(e) = self.route_manager.clear_routing_rules().await {
-            e.trace_chain_with_msg("Failed to remove routing rules");
+            trace_err_chain!(e, "Failed to remove routing rules");
         }
     }
 
     #[cfg(target_os = "macos")]
     pub async fn refresh_routes(&mut self) {
         if let Err(e) = self.route_manager.refresh_routes() {
-            e.trace_chain_with_msg("Failed to refresh routes");
+            trace_err_chain!(e, "Failed to refresh routes");
         }
     }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
@@ -6,7 +6,7 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 #[cfg(any(target_os = "linux", target_os = "windows"))]
-use nym_common::ErrorExt;
+use nym_common::trace_err_chain;
 #[cfg(target_os = "macos")]
 use nym_dns::DnsConfig;
 #[cfg(target_os = "macos")]
@@ -218,7 +218,7 @@ impl ConnectedState {
             .reset_before_interface_removal()
             .await
         {
-            error.trace_chain_with_msg("Failed to reset DNS");
+            trace_err_chain!(error, "Failed to reset DNS");
         }
 
         // On macOS, configure only the local DNS resolver

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -11,7 +11,7 @@ use futures::{
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
-use nym_common::ErrorExt;
+use nym_common::trace_err_chain;
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 use nym_dns::DnsConfig;
 #[cfg(target_os = "macos")]
@@ -209,7 +209,10 @@ impl ConnectingState {
             .firewall
             .apply_policy(policy)
             .inspect_err(|error| {
-                error.trace_chain_with_msg("Failed to apply firewall policy for connecting state");
+                trace_err_chain!(
+                    error,
+                    "Failed to apply firewall policy for connecting state"
+                );
             })
             .map_err(Error::ApplyFirewallPolicy)
     }
@@ -227,9 +230,7 @@ impl ConnectingState {
                 .set("lo".to_owned(), system_dns)
                 .await
                 .inspect_err(|err| {
-                    err.trace_chain_with_msg(
-                        "Failed to configure system to use filtering resolver",
-                    );
+                    trace_err_chain!(err, "Failed to configure system to use filtering resolver",);
                 });
         }
 
@@ -324,7 +325,7 @@ impl ConnectingState {
             .set_static_api_addresses(resolved_gateway_config.nym_vpn_api_socket_addrs.to_owned())
             .await
         {
-            e.trace_chain_with_msg("Failed to set static API addresses");
+            trace_err_chain!(e, "Failed to set static API addresses");
             return NextTunnelState::NewState(
                 ErrorState::enter(
                     ErrorStateReason::Internal(

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnected_state.rs
@@ -4,7 +4,7 @@
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
-use nym_common::ErrorExt;
+use nym_common::trace_err_chain;
 
 use crate::tunnel_state_machine::{
     NextTunnelState, PrivateTunnelState, SharedState, TunnelCommand, TunnelStateHandler,
@@ -30,7 +30,7 @@ impl DisconnectedState {
             .set_static_api_addresses(None)
             .await
         {
-            e.trace_chain_with_msg("Failed to unset static API addresses");
+            trace_err_chain!(e, "Failed to unset static API addresses");
         }
 
         // Drop tombstone to close tunnel devices.
@@ -42,14 +42,14 @@ impl DisconnectedState {
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     fn reset_firewall_policy(shared_state: &mut SharedState) {
         if let Err(e) = shared_state.firewall.reset_policy() {
-            e.trace_chain_with_msg("Failed to reset firewall policy");
+            trace_err_chain!(e, "Failed to reset firewall policy");
         }
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     async fn reset_dns(shared_state: &mut SharedState) {
         if let Err(error) = shared_state.dns_handler.reset().await {
-            error.trace_chain_with_msg("Failed to reset DNS");
+            trace_err_chain!(error, "Failed to reset DNS");
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
@@ -20,7 +20,7 @@ use tokio_util::sync::CancellationToken;
     target_os = "windows",
     target_os = "ios"
 ))]
-use nym_common::ErrorExt;
+use nym_common::trace_err_chain;
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 use nym_firewall::FirewallPolicy;
 
@@ -67,7 +67,7 @@ impl ErrorState {
 
         #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
         if let Err(e) = Self::set_firewall_policy(_shared_state) {
-            e.trace_chain_with_msg("Failed to apply firewall policy for blocked state");
+            trace_err_chain!(e, "Failed to apply firewall policy for blocked state");
         }
 
         (Box::new(Self), PrivateTunnelState::Error(reason))
@@ -92,14 +92,14 @@ impl ErrorState {
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     fn reset_firewall_policy(shared_state: &mut SharedState) {
         if let Err(e) = shared_state.firewall.reset_policy() {
-            e.trace_chain_with_msg("Failed to reset firewall policy");
+            trace_err_chain!(e, "Failed to reset firewall policy");
         }
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     async fn reset_dns(shared_state: &mut SharedState) {
         if let Err(error) = shared_state.dns_handler.reset().await {
-            error.trace_chain_with_msg("Unable to disable filtering resolver");
+            trace_err_chain!(error, "Unable to disable filtering resolver");
         }
     }
 
@@ -115,7 +115,7 @@ impl ErrorState {
             .set("lo".to_owned(), system_dns)
             .await
             .inspect_err(|err| {
-                err.trace_chain_with_msg("Failed to configure system to use filtering resolver");
+                trace_err_chain!(err, "Failed to configure system to use filtering resolver");
             })
             .map_err(Error::SetDns)
     }
@@ -134,7 +134,7 @@ impl ErrorState {
             .set_tunnel_network_settings(tunnel_network_settings.into_tunnel_network_settings())
             .await
         {
-            e.trace_chain_with_msg("Failed to set tunnel network settings");
+            trace_err_chain!(e, "Failed to set tunnel network settings");
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/offline_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/offline_state.rs
@@ -5,7 +5,7 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-use nym_common::ErrorExt;
+use nym_common::trace_err_chain;
 #[cfg(target_os = "macos")]
 use nym_dns::DnsConfig;
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
@@ -42,7 +42,7 @@ impl OfflineState {
 
         #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
         if let Err(e) = Self::set_firewall_policy(_shared_state) {
-            e.trace_chain_with_msg("Failed to apply firewall policy for blocked state");
+            trace_err_chain!(e, "Failed to apply firewall policy for blocked state");
         }
 
         (
@@ -73,14 +73,14 @@ impl OfflineState {
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     fn reset_firewall_policy(shared_state: &mut SharedState) {
         if let Err(e) = shared_state.firewall.reset_policy() {
-            e.trace_chain_with_msg("Failed to reset firewall policy");
+            trace_err_chain!(e, "Failed to reset firewall policy");
         }
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     async fn reset_dns(shared_state: &mut SharedState) {
         if let Err(error) = shared_state.dns_handler.reset().await {
-            error.trace_chain_with_msg("Unable to reset DNS");
+            trace_err_chain!(error, "Unable to reset DNS");
         }
     }
 
@@ -96,7 +96,7 @@ impl OfflineState {
             .set("lo".to_owned(), system_dns)
             .await
             .inspect_err(|err| {
-                err.trace_chain_with_msg("Failed to configure system to use filtering resolver");
+                trace_err_chain!(err, "Failed to configure system to use filtering resolver");
             })
             .map_err(Error::SetDns)
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -52,7 +52,7 @@ use super::{
 };
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 use super::{route_handler::RoutingConfig, tun_ipv6};
-use nym_common::ErrorExt;
+use nym_common::trace_err_chain;
 use nym_vpn_lib_types::{
     ConnectionData, ErrorStateReason, Gateway, MixnetConnectionData, MixnetEvent, NymAddress,
     RequestZkNymError, TunnelConnectionData, TunnelType, WireguardConnectionData, WireguardNode,
@@ -265,7 +265,7 @@ impl TunnelMonitor {
         let (tombstone, reason) = match self.run_inner().await {
             Ok(tombstone) => (tombstone, None),
             Err(e) => {
-                e.trace_chain_with_msg("Tunnel monitor exited with error");
+                trace_err_chain!(e, "Tunnel monitor exited with error");
                 (Tombstone::default(), e.error_state_reason())
             }
         };
@@ -529,7 +529,7 @@ impl TunnelMonitor {
             .wait()
             .await
             .inspect_err(|e| {
-                e.trace_chain_with_msg("Failed to gracefully shutdown the tunnel");
+                trace_err_chain!(e, "Failed to gracefully shutdown the tunnel");
             })
             .unwrap_or_default();
 


### PR DESCRIPTION
This PR replaces `ErrorExt::trace_chain()` with a `trace_err_chain!()` macros to prevent attributing all logged errors to nym_common. 

- The macros can be called with error alone: 
  ```rs
   trace_err_chain!(err);
   ``` 
- or with error and message:
  ```rs
  trace_err_chain!(err, "Something went wrong");
  ```
- or with error and formatted message just like `format!`:
  ```rs
  trace_err_chain!(
    err, 
    "Something went wrong when opening the file: {}", 
    PathBuf::from("test.txt").display()
  );
  ```

JIRA-VPN-3469

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2893)
<!-- Reviewable:end -->
