### PR TITLE
Fix nym-network regression

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-network-config/src/nym_network.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/nym_network.rs
@@ -83,6 +83,10 @@ impl NymNetwork {
                     );
                     Err(e)
                 }
+            })?
+            .write_to_file(config_dir)
+            .inspect_err(|err| {
+                tracing::error!("Failed to write nym network file: {err}");
             })?;
         }
 


### PR DESCRIPTION
Seems like a call to write nym-network to file was mistakenly removed in https://github.com/nymtech/nym-vpn-client/commit/a041e16d0b97095b1bee1b075d338e1e8fae4c24#diff-27f64eb10376b2afbe3eb40b8888dd83af77bbfcbeb099f6d22f211f661d927dL85

This PR re-adds it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2906)
<!-- Reviewable:end -->
