### PR TITLE
feat(tauri-nsis): remove nym-vpnd dir

### DIFF
--- a/nym-vpn-app/src-tauri/bundle/windows/installer.nsi
+++ b/nym-vpn-app/src-tauri/bundle/windows/installer.nsi
@@ -888,7 +888,12 @@ Section Uninstall
     RmDir /r "$APPDATA\${APPDIR}"
     RmDir /r "$LOCALAPPDATA\${BUNDLEID}"
     RmDir /r "$LOCALAPPDATA\${APPDIR}"
-    RmDir /r "C:\ProgramData\nym-vpnd"
+
+    ; Switch context to point to <DRIVE>:\ProgramData
+    SetShellVarContext all
+    RmDir /r "$APPDATA\nym-vpnd"
+    ; Revert to current context just in case
+    SetShellVarContext current
   ${EndIf}
 
   !ifmacrodef NSIS_HOOK_POSTUNINSTALL

--- a/nym-vpn-app/src-tauri/bundle/windows/installer.nsi
+++ b/nym-vpn-app/src-tauri/bundle/windows/installer.nsi
@@ -888,6 +888,7 @@ Section Uninstall
     RmDir /r "$APPDATA\${APPDIR}"
     RmDir /r "$LOCALAPPDATA\${BUNDLEID}"
     RmDir /r "$LOCALAPPDATA\${APPDIR}"
+    RmDir /r "C:\ProgramData\nym-vpnd"
   ${EndIf}
 
   !ifmacrodef NSIS_HOOK_POSTUNINSTALL


### PR DESCRIPTION
On Windows, uninstall, remove `C:\ProgramData\nym-vpnd` directory when user checks the option "Delete the application data"

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2907)
<!-- Reviewable:end -->
