### PR TITLE
tonic: remove shutdown timeout

### DIFF
--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/start.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/start.rs
@@ -1,8 +1,6 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::time::Duration;
-
 use nym_vpn_lib_types::TunnelEvent;
 use nym_vpn_network_config::Network;
 use nym_vpn_proto::nym_vpnd_server::NymVpndServer;
@@ -20,9 +18,6 @@ use super::{
     config::default_socket_path, error::CommandInterfaceError, listener::CommandInterface,
 };
 use crate::service::VpnServiceCommand;
-
-// If the shutdown signal is received, we give the listeners a little extra time to finish
-const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
 
 fn grpc_span(req: &http::Request<()>) -> tracing::Span {
     let service = req.uri().path().trim_start_matches('/');
@@ -78,11 +73,8 @@ pub async fn start_command_interface(
             }
         });
 
-        shutdown_token.cancelled().await;
-        match tokio::time::timeout(SHUTDOWN_TIMEOUT, socket_listener_handle).await {
-            Ok(Ok(())) => {}
-            Ok(Err(e)) => tracing::error!("Failed to join on socket listener: {}", e),
-            Err(_) => tracing::warn!("Socket listener did not finish in time"),
+        if let Err(e) = socket_listener_handle.await {
+            tracing::error!("Failed to join on socket listener: {}", e);
         }
 
         tracing::info!("Command interface exiting");


### PR DESCRIPTION
This PR removes a shutdown timeout for tonic server. We used to have some mysterious issues related to it being stuck due to open connections. However this might have been the case before tonic 0.12 and it does not seem to be the case anymore.

I verified that vpnd properly exits while listening to tunnel status:

```
% sudo RUST_LOG="info,tonic=trace" ./target/debug/nym-vpnd

2025-06-13T14:48:48.335458Z TRACE tonic::transport::server: connection accepted
2025-06-13T14:48:48.338743Z  INFO grpc_vpnd: ← ListenToTunnelState ()
2025-06-13T14:48:48.936319Z  INFO grpc_vpnd: nym_vpnd::command_interface::start: close time.busy=651µs time.idle=597ms req="ListenToTunnelState"
2025-06-13T14:48:50.584013Z  INFO nym_vpnd::shutdown_handler: Received Ctrl-C signal.
2025-06-13T14:48:50.584263Z TRACE tonic::transport::server: signal received, shutting down
2025-06-13T14:48:50.584541Z TRACE tonic::transport::server: waiting for 1 connections to close
2025-06-13T14:48:50.584858Z  INFO nym_vpnd::service::vpn_service: Received shutdown signal
2025-06-13T14:48:50.591225Z  INFO nym_vpnd::service::vpn_service: Exiting vpn service run loop
2025-06-13T14:48:50.592385Z  INFO nym_vpnd::service::vpn_service: VPN service has successfully exited
2025-06-13T14:48:50.593062Z TRACE tonic::transport::server: connection closed
2025-06-13T14:48:50.593596Z  INFO nym_vpnd::command_interface::start: Socket listener has finished
2025-06-13T14:48:50.593681Z  INFO nym_vpnd::command_interface::start: Command interface exiting
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2938)
<!-- Reviewable:end -->
