### PR TITLE
Migrate to vergen-git

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -3659,7 +3659,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "utoipa",
- "vergen",
+ "vergen 8.3.1",
 ]
 
 [[package]]
@@ -3864,7 +3864,7 @@ dependencies = [
  "schemars",
  "serde",
  "thiserror 2.0.12",
- "vergen",
+ "vergen 8.3.1",
 ]
 
 [[package]]
@@ -4182,7 +4182,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
- "vergen",
+ "vergen-gitcl",
  "x25519-dalek",
 ]
 
@@ -5140,7 +5140,7 @@ dependencies = [
  "tun",
  "uniffi",
  "url",
- "vergen",
+ "vergen-gitcl",
  "windows 0.59.0",
 ]
 
@@ -5244,7 +5244,7 @@ dependencies = [
  "tokio",
  "tonic",
  "tower",
- "vergen",
+ "vergen-gitcl",
 ]
 
 [[package]]
@@ -5291,7 +5291,7 @@ dependencies = [
  "tracing-appender",
  "tracing-oslog",
  "tracing-subscriber",
- "vergen",
+ "vergen-gitcl",
  "windows 0.59.0",
  "windows-service",
  "zeroize",
@@ -5453,12 +5453,11 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "os_info"
-version = "3.12.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0e1ac5fde8d43c34139135df8ea9ee9465394b2d8d20f032d38998f64afffc3"
+checksum = "41fc863e2ca13dc2d5c34fb22ea4a588248ac14db929616ba65c45f21744b1e9"
 dependencies = [
  "log",
- "plist",
  "serde",
  "windows-sys 0.52.0",
 ]
@@ -5757,19 +5756,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
-name = "plist"
-version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d77244ce2d584cd84f6a15f86195b8c9b2a0dfbfd817c09e0464244091a58ed"
-dependencies = [
- "base64 0.22.1",
- "indexmap 2.9.0",
- "quick-xml",
- "serde",
- "time",
-]
-
-[[package]]
 name = "pnet_base"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6016,15 +6002,6 @@ name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
-
-[[package]]
-name = "quick-xml"
-version = "0.37.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "quinn"
@@ -8583,6 +8560,47 @@ dependencies = [
  "rustc_version",
  "rustversion",
  "time",
+]
+
+[[package]]
+name = "vergen"
+version = "9.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b2bf58be11fc9414104c6d3a2e464163db5ef74b12296bda593cac37b6e4777"
+dependencies = [
+ "anyhow",
+ "cargo_metadata 0.19.2",
+ "derive_builder",
+ "regex",
+ "rustc_version",
+ "rustversion",
+ "time",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-gitcl"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9dfc1de6eb2e08a4ddf152f1b179529638bedc0ea95e6d667c014506377aefe"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
+ "time",
+ "vergen 9.0.6",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-lib"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b07e6010c0f3e59fcb164e0163834597da68d1f864e2b8ca49f74de01e9c166"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
 ]
 
 [[package]]

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -175,7 +175,7 @@ tun = { version = "0.6.1", features = ["async"] }
 uniffi = { version = "0.29.3", features = ["cli"] }
 url = "2.5"
 uuid = "1.17"
-vergen = { version = "8.3.1", default-features = false }
+vergen-gitcl = { version = "1.0.8", default-features = false }
 which = { version = "7.0", default-features = false }
 widestring = "1.0"
 windows = "0.59"

--- a/nym-vpn-core/crates/nym-gateway-probe/Cargo.toml
+++ b/nym-vpn-core/crates/nym-gateway-probe/Cargo.toml
@@ -55,12 +55,10 @@ nym-sdk.workspace = true
 nym-task.workspace = true
 
 [build-dependencies]
-vergen = { workspace = true, default-features = false, features = [
+vergen-gitcl = { workspace = true, default-features = false, features = [
     "build",
-    "git",
-    "gitcl",
-    "rustc",
     "cargo",
+    "rustc",
 ] }
 
 rust2go = { workspace = true, features = ["build"] }

--- a/nym-vpn-core/crates/nym-gateway-probe/build.rs
+++ b/nym-vpn-core/crates/nym-gateway-probe/build.rs
@@ -1,19 +1,17 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use vergen::EmitBuilder;
+use vergen_gitcl::{BuildBuilder, CargoBuilder, Emitter, GitclBuilder, RustcBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     rust2go::Builder::new()
         .with_go_src("./netstack_ping")
         .build();
 
-    EmitBuilder::builder()
-        .all_build()
-        .all_git()
-        .all_rustc()
-        .all_cargo()
-        .emit()
-        .expect("failed to extract build metadata");
-    Ok(())
+    Ok(Emitter::default()
+        .add_instructions(&BuildBuilder::all_build()?)?
+        .add_instructions(&CargoBuilder::all_cargo()?)?
+        .add_instructions(&GitclBuilder::all_git()?)?
+        .add_instructions(&RustcBuilder::all_rustc()?)?
+        .emit()?)
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
@@ -108,12 +108,10 @@ dispatch2.workspace = true
 
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }
-vergen = { workspace = true, default-features = false, features = [
+vergen-gitcl = { workspace = true, default-features = false, features = [
     "build",
-    "git",
-    "gitcl",
-    "rustc",
     "cargo",
+    "rustc",
 ] }
 
 [features]

--- a/nym-vpn-core/crates/nym-vpn-lib/build.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/build.rs
@@ -1,15 +1,13 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use vergen::EmitBuilder;
+use vergen_gitcl::{BuildBuilder, CargoBuilder, Emitter, GitclBuilder, RustcBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    EmitBuilder::builder()
-        .all_build()
-        .all_git()
-        .all_rustc()
-        .all_cargo()
-        .emit()
-        .expect("failed to extract build metadata");
-    Ok(())
+    Ok(Emitter::default()
+        .add_instructions(&BuildBuilder::all_build()?)?
+        .add_instructions(&CargoBuilder::all_cargo()?)?
+        .add_instructions(&GitclBuilder::all_git()?)?
+        .add_instructions(&RustcBuilder::all_rustc()?)?
+        .emit()?)
 }

--- a/nym-vpn-core/crates/nym-vpnc/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpnc/Cargo.toml
@@ -28,12 +28,10 @@ nym-vpnd-types = { workspace = true }
 nym-vpn-lib-types = { workspace = true }
 
 [build-dependencies]
-vergen = { workspace = true, default-features = false, features = [
+vergen-gitcl = { workspace = true, default-features = false, features = [
     "build",
-    "git",
-    "gitcl",
-    "rustc",
     "cargo",
+    "rustc",
 ] }
 
 # Debian

--- a/nym-vpn-core/crates/nym-vpnc/build.rs
+++ b/nym-vpn-core/crates/nym-vpnc/build.rs
@@ -1,15 +1,13 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use vergen::EmitBuilder;
+use vergen_gitcl::{BuildBuilder, CargoBuilder, Emitter, GitclBuilder, RustcBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    EmitBuilder::builder()
-        .all_build()
-        .all_git()
-        .all_rustc()
-        .all_cargo()
-        .emit()
-        .expect("failed to extract build metadata");
-    Ok(())
+    Ok(Emitter::default()
+        .add_instructions(&BuildBuilder::all_build()?)?
+        .add_instructions(&CargoBuilder::all_cargo()?)?
+        .add_instructions(&GitclBuilder::all_git()?)?
+        .add_instructions(&RustcBuilder::all_rustc()?)?
+        .emit()?)
 }

--- a/nym-vpn-core/crates/nym-vpnd/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpnd/Cargo.toml
@@ -80,12 +80,10 @@ features = [
 ]
 
 [build-dependencies]
-vergen = { workspace = true, default-features = false, features = [
+vergen-gitcl = { workspace = true, default-features = false, features = [
     "build",
-    "git",
-    "gitcl",
-    "rustc",
     "cargo",
+    "rustc",
 ] }
 
 # Debian

--- a/nym-vpn-core/crates/nym-vpnd/build.rs
+++ b/nym-vpn-core/crates/nym-vpnd/build.rs
@@ -1,15 +1,13 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use vergen::EmitBuilder;
+use vergen_gitcl::{BuildBuilder, CargoBuilder, Emitter, GitclBuilder, RustcBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    EmitBuilder::builder()
-        .all_build()
-        .all_git()
-        .all_rustc()
-        .all_cargo()
-        .emit()
-        .expect("failed to extract build metadata");
-    Ok(())
+    Ok(Emitter::default()
+        .add_instructions(&BuildBuilder::all_build()?)?
+        .add_instructions(&CargoBuilder::all_cargo()?)?
+        .add_instructions(&GitclBuilder::all_git()?)?
+        .add_instructions(&RustcBuilder::all_rustc()?)?
+        .emit()?)
 }


### PR DESCRIPTION
Vergen was split up onto multiple individual crates. Since we generate git versions, I figured we should stick to `vergen-gitcl` which is to my understanding vergen + git using git cli.

Migration guide: https://github.com/rustyhorde/vergen/blob/master/MIGRATING_v8_to_v9.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2939)
<!-- Reviewable:end -->
