### PR TITLE
Update cargo deny

### DIFF
--- a/.github/workflows/ci-nym-vpn-core-cargo-deny.yml
+++ b/.github/workflows/ci-nym-vpn-core-cargo-deny.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'nym-vpn-core/**/Cargo.lock'
       - 'nym-vpn-core/**/Cargo.toml'
+      - 'nym-vpn-core/deny.toml'
       - '.github/workflows/ci-nym-vpn-core-cargo-deny.yml'
 jobs:
   cargo-deny:

--- a/nym-vpn-core/deny.toml
+++ b/nym-vpn-core/deny.toml
@@ -241,7 +241,7 @@ unknown-git = "warn"
 # if not specified. If it is specified but empty, no registries are allowed.
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
-allow-git = ["https://github.com/madsmtm/objc2"]
+allow-git = []
 
 [sources.allow-org]
 # github.com organizations to allow git sources for

--- a/nym-vpn-core/deny.toml
+++ b/nym-vpn-core/deny.toml
@@ -236,7 +236,7 @@ unused = "deny"
 unknown-registry = "warn"
 # Lint level for what to happen when a crate from a git repository that is not
 # in the allow list is encountered
-unknown-git = "warn"
+unknown-git = "error"
 # List of URLs for allowed crate registries. Defaults to the crates.io index
 # if not specified. If it is specified but empty, no registries are allowed.
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/nym-vpn-core/deny.toml
+++ b/nym-vpn-core/deny.toml
@@ -233,22 +233,22 @@ unused = "deny"
 [sources]
 # Lint level for what to happen when a crate from a crate registry that is not
 # in the allow list is encountered
-unknown-registry = "warn"
+unknown-registry = "deny"
 # Lint level for what to happen when a crate from a git repository that is not
 # in the allow list is encountered
-unknown-git = "error"
+unknown-git = "deny"
 # List of URLs for allowed crate registries. Defaults to the crates.io index
 # if not specified. If it is specified but empty, no registries are allowed.
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
 allow-git = [
-    "https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie",
+    "git+https://github.com/jstuczyn/bls12_381?branch=temp/experimental-serdect-updated",
     "https://github.com/ihciah/rust2go.git?rev=00b068a9a99cac4252af0ec113e2ce5f2289132a",
 ]
 
 [sources.allow-org]
 # github.com organizations to allow git sources for
-github = []
+github = ["nymtech"]
 # gitlab.com organizations to allow git sources for
 gitlab = []
 # bitbucket.org organizations to allow git sources for

--- a/nym-vpn-core/deny.toml
+++ b/nym-vpn-core/deny.toml
@@ -241,7 +241,10 @@ unknown-git = "warn"
 # if not specified. If it is specified but empty, no registries are allowed.
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
-allow-git = []
+allow-git = [
+    "https://github.com/nymtech/nym?branch=am%2Fbackport-close-sqlite-pool-brie",
+    "https://github.com/ihciah/rust2go.git?rev=00b068a9a99cac4252af0ec113e2ce5f2289132a",
+]
 
 [sources.allow-org]
 # github.com organizations to allow git sources for


### PR DESCRIPTION
- Re-run cargo-deny on changes to `deny.toml`
- Remove no longer directly referenced objc2 repo
- Allow rust2go direct commit hash until the relevant patch for Windows is released
- Add Andrew's repo to allowed
- Allow git sources for the org (nymtech)
- Switch from warn to error on all other dependencies that are used directly from git or from different crates registries

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2943)
<!-- Reviewable:end -->
