### PR TITLE
Update rust2go to a833a4a

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -6442,7 +6442,7 @@ dependencies = [
 [[package]]
 name = "rust2go"
 version = "0.4.1"
-source = "git+https://github.com/ihciah/rust2go.git?rev=00b068a9a99cac4252af0ec113e2ce5f2289132a#00b068a9a99cac4252af0ec113e2ce5f2289132a"
+source = "git+https://github.com/ihciah/rust2go.git?rev=a833a4a103e0ea77684cbf9cc84320d049394301#a833a4a103e0ea77684cbf9cc84320d049394301"
 dependencies = [
  "bindgen 0.71.1",
  "rust2go-cli",
@@ -6454,7 +6454,7 @@ dependencies = [
 [[package]]
 name = "rust2go-cli"
 version = "0.4.1"
-source = "git+https://github.com/ihciah/rust2go.git?rev=00b068a9a99cac4252af0ec113e2ce5f2289132a#00b068a9a99cac4252af0ec113e2ce5f2289132a"
+source = "git+https://github.com/ihciah/rust2go.git?rev=a833a4a103e0ea77684cbf9cc84320d049394301#a833a4a103e0ea77684cbf9cc84320d049394301"
 dependencies = [
  "cbindgen",
  "clap",
@@ -6465,7 +6465,7 @@ dependencies = [
 [[package]]
 name = "rust2go-common"
 version = "0.4.0"
-source = "git+https://github.com/ihciah/rust2go.git?rev=00b068a9a99cac4252af0ec113e2ce5f2289132a#00b068a9a99cac4252af0ec113e2ce5f2289132a"
+source = "git+https://github.com/ihciah/rust2go.git?rev=a833a4a103e0ea77684cbf9cc84320d049394301#a833a4a103e0ea77684cbf9cc84320d049394301"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6475,12 +6475,12 @@ dependencies = [
 [[package]]
 name = "rust2go-convert"
 version = "0.1.0"
-source = "git+https://github.com/ihciah/rust2go.git?rev=00b068a9a99cac4252af0ec113e2ce5f2289132a#00b068a9a99cac4252af0ec113e2ce5f2289132a"
+source = "git+https://github.com/ihciah/rust2go.git?rev=a833a4a103e0ea77684cbf9cc84320d049394301#a833a4a103e0ea77684cbf9cc84320d049394301"
 
 [[package]]
 name = "rust2go-macro"
 version = "0.4.0"
-source = "git+https://github.com/ihciah/rust2go.git?rev=00b068a9a99cac4252af0ec113e2ce5f2289132a#00b068a9a99cac4252af0ec113e2ce5f2289132a"
+source = "git+https://github.com/ihciah/rust2go.git?rev=a833a4a103e0ea77684cbf9cc84320d049394301#a833a4a103e0ea77684cbf9cc84320d049394301"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -142,7 +142,7 @@ rand_chacha = "0.3.1"
 resolv-conf = "0.7"
 rs-release = "0.1.7"
 rtnetlink = "0.17"
-rust2go = { git = "https://github.com/ihciah/rust2go.git", rev = "00b068a9a99cac4252af0ec113e2ce5f2289132a" }
+rust2go = { git = "https://github.com/ihciah/rust2go.git", rev = "a833a4a103e0ea77684cbf9cc84320d049394301" }
 semver = "1.0"
 serde = "1.0"
 serde_json = "1.0"


### PR DESCRIPTION
There is a patch in rust2go that hasn't been released yet and it seems to be fixing some memory issues. 

@durch could you please test it and see if that helps with some of crashes that you've been seeing lately?

Commit: https://github.com/ihciah/rust2go/commit/a833a4a103e0ea77684cbf9cc84320d049394301

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2957)
<!-- Reviewable:end -->
