### PR TITLE
ci: linux: fix golang version

### DIFF
--- a/.github/workflows/build-wireguard-go-linux.yml
+++ b/.github/workflows/build-wireguard-go-linux.yml
@@ -18,6 +18,11 @@ jobs:
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y git curl gcc g++ make
 
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23.6'
+
       - name: Checkout nym-vpn-client
         uses: actions/checkout@v4
 


### PR DESCRIPTION
Fix golang to 1.23.6 in linux workflow for wireguard-go

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2959)
<!-- Reviewable:end -->
