### PR TITLE
Enforce golang version

### DIFF
--- a/.github/workflows/build-nym-vpn-android.yml
+++ b/.github/workflows/build-nym-vpn-android.yml
@@ -109,8 +109,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.6'
-
+          go-version: ${{ vars.REQUIRED_GOLANG_VERSION }}
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.85 # If this changes, we need a PR to Fdroid to update pipeline for reproducibility

--- a/.github/workflows/build-nym-vpn-android.yml
+++ b/.github/workflows/build-nym-vpn-android.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.6'  # If this changes, we need a PR to Fdroid to update pipeline for reproducibility
+          go-version: '1.23.6'
 
       - uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/build-nym-vpn-core-android.yml
+++ b/.github/workflows/build-nym-vpn-core-android.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.6'  # If this changes, we need a PR to Fdroid to update pipeline for reproducibility
+          go-version: '1.23.6'
 
       - name: Setup NDK
         uses: nttld/setup-ndk@v1

--- a/.github/workflows/build-nym-vpn-core-android.yml
+++ b/.github/workflows/build-nym-vpn-core-android.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.6'
+          go-version: ${{ vars.REQUIRED_GOLANG_VERSION }}
 
       - name: Setup NDK
         uses: nttld/setup-ndk@v1

--- a/.github/workflows/build-nym-vpn-core-mac.yml
+++ b/.github/workflows/build-nym-vpn-core-mac.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Go toochain
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.6'
+          go-version: ${{ vars.REQUIRED_GOLANG_VERSION }}
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3

--- a/.github/workflows/build-nym-vpn-core-mac.yml
+++ b/.github/workflows/build-nym-vpn-core-mac.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Go toochain
         uses: actions/setup-go@v5
         with:
-          go-version: "stable"
+          go-version: '1.23.6'
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3

--- a/.github/workflows/build-nym-vpn-core-windows.yml
+++ b/.github/workflows/build-nym-vpn-core-windows.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install Go toolchain
         uses: actions/setup-go@v5
         with:
-          go-version: "stable"
+          go-version: '1.23.6'
 
       - name: Get workspace version
         id: workspace-version

--- a/.github/workflows/build-nym-vpn-core-windows.yml
+++ b/.github/workflows/build-nym-vpn-core-windows.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install Go toolchain
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.6'
+          go-version: ${{ vars.REQUIRED_GOLANG_VERSION }}
 
       - name: Get workspace version
         id: workspace-version

--- a/.github/workflows/build-wireguard-go-deb.yml
+++ b/.github/workflows/build-wireguard-go-deb.yml
@@ -17,6 +17,11 @@ jobs:
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y git curl gcc g++ make
 
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ vars.REQUIRED_GOLANG_VERSION }}
+
       - name: Checkout nym-vpn-client
         uses: actions/checkout@v4
 

--- a/.github/workflows/build-wireguard-go-ios.yml
+++ b/.github/workflows/build-wireguard-go-ios.yml
@@ -20,8 +20,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: "stable"
-          cache-dependency-path: "**/go.sum"
+          go-version: '1.23.6'
 
       - name: Build wireguard
         run: ./wireguard/build-wireguard-go.sh --ios

--- a/.github/workflows/build-wireguard-go-ios.yml
+++ b/.github/workflows/build-wireguard-go-ios.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.6'
+          go-version: ${{ vars.REQUIRED_GOLANG_VERSION }}
 
       - name: Build wireguard
         run: ./wireguard/build-wireguard-go.sh --ios

--- a/.github/workflows/build-wireguard-go-mac.yml
+++ b/.github/workflows/build-wireguard-go-mac.yml
@@ -20,8 +20,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: "stable"
-          cache-dependency-path: "**/go.sum"
+          go-version: '1.23.6'
 
       - name: Build wireguard
         run: ./wireguard/build-wireguard-go.sh

--- a/.github/workflows/build-wireguard-go-mac.yml
+++ b/.github/workflows/build-wireguard-go-mac.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.6'
+          go-version: ${{ vars.REQUIRED_GOLANG_VERSION }}
 
       - name: Build wireguard
         run: ./wireguard/build-wireguard-go.sh

--- a/.github/workflows/build-wireguard-go-windows.yml
+++ b/.github/workflows/build-wireguard-go-windows.yml
@@ -22,8 +22,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: "stable"
-          cache-dependency-path: "**/go.sum"
+          go-version: '1.23.6'
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3

--- a/.github/workflows/build-wireguard-go-windows.yml
+++ b/.github/workflows/build-wireguard-go-windows.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.6'
+          go-version: ${{ vars.REQUIRED_GOLANG_VERSION }}
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3

--- a/.github/workflows/ci-nym-vpn-android.yml
+++ b/.github/workflows/ci-nym-vpn-android.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           sparse-checkout: |
             nym-vpn-android
+      
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/ci-nym-vpn-core-android.yml
+++ b/.github/workflows/ci-nym-vpn-core-android.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          ggo-version: '1.23.6'
+          go-version: ${{ vars.REQUIRED_GOLANG_VERSION }}
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3

--- a/.github/workflows/ci-nym-vpn-core-android.yml
+++ b/.github/workflows/ci-nym-vpn-core-android.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: "stable"
+          ggo-version: '1.23.6'
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3

--- a/.github/workflows/ci-nym-vpn-core-ios.yml
+++ b/.github/workflows/ci-nym-vpn-core-ios.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.6'
+          go-version: ${{ vars.REQUIRED_GOLANG_VERSION }}
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3

--- a/.github/workflows/ci-nym-vpn-core-ios.yml
+++ b/.github/workflows/ci-nym-vpn-core-ios.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: "stable"
+          go-version: '1.23.6'
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3

--- a/.github/workflows/ci-nym-vpn-core-linux.yml
+++ b/.github/workflows/ci-nym-vpn-core-linux.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: "stable"
+          go-version: '1.23.6'
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3

--- a/.github/workflows/ci-nym-vpn-core-linux.yml
+++ b/.github/workflows/ci-nym-vpn-core-linux.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.6'
+          go-version: ${{ vars.REQUIRED_GOLANG_VERSION }}
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3

--- a/.github/workflows/ci-nym-vpn-core-macos.yml
+++ b/.github/workflows/ci-nym-vpn-core-macos.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.6'
+          go-version: ${{ vars.REQUIRED_GOLANG_VERSION }}
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3

--- a/.github/workflows/ci-nym-vpn-core-macos.yml
+++ b/.github/workflows/ci-nym-vpn-core-macos.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: "stable"
+          go-version: '1.23.6'
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3

--- a/.github/workflows/ci-nym-vpn-core-windows.yml
+++ b/.github/workflows/ci-nym-vpn-core-windows.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.6'
+          go-version: ${{ vars.REQUIRED_GOLANG_VERSION }}
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3

--- a/.github/workflows/ci-nym-vpn-core-windows.yml
+++ b/.github/workflows/ci-nym-vpn-core-windows.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: "stable"
+          go-version: '1.23.6'
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3

--- a/.github/workflows/publish-nym-vpn-android.yml
+++ b/.github/workflows/publish-nym-vpn-android.yml
@@ -311,7 +311,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.6'
+          go-version: ${{ vars.REQUIRED_GOLANG_VERSION }}
 
       - name: Install cargo-ndk
         uses: baptiste0928/cargo-install@v3

--- a/.github/workflows/publish-nym-vpn-android.yml
+++ b/.github/workflows/publish-nym-vpn-android.yml
@@ -311,7 +311,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.6'  # If this changes, we need a PR to Fdroid to update pipeline for reproducibility
+          go-version: '1.23.6'
 
       - name: Install cargo-ndk
         uses: baptiste0928/cargo-install@v3

--- a/wireguard/build-wireguard-go.sh
+++ b/wireguard/build-wireguard-go.sh
@@ -5,6 +5,8 @@ set -eu
 
 LIB_DIR="libwg"
 
+REQUIRED_GOLANG_VERSION="1.23.6"
+
 IS_ANDROID_BUILD=false
 IS_IOS_BUILD=false
 IS_DOCKER_BUILD=false
@@ -326,7 +328,28 @@ function build_wireguard_go {
     esac
 }
 
+function check_golang_version() {
+    local go_path=$(which go)
+    if [ $? -eq 0 ]; then
+        echo "Found golang: $go_path"
+    else
+        echo "Golang is not found. Please install go$REQUIRED_GOLANG_VERSION"
+        exit 3
+    fi
+
+    # Extract go version from the output that looks as: 
+    # go version go1.24.4 darwin/arm64
+    local go_version=$(go version | cut -d' ' -f3 | cut -c 3-)
+    echo "Golang version: ${go_version}"
+    if [ "$go_version" != "$REQUIRED_GOLANG_VERSION" ]; then
+        echo "Required golang version: $REQUIRED_GOLANG_VERSION"
+        echo "Please install it and re-run this script"
+        exit 3
+    fi
+}
+
 # Ensure we are in the correct directory for the execution of this script
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $script_dir
+check_golang_version
 build_wireguard_go $@

--- a/wireguard/libwg/go.mod
+++ b/wireguard/libwg/go.mod
@@ -1,8 +1,6 @@
 module github.com/nymtech/nym-vpn-client/wireguard/libwg
 
-go 1.22.3
-
-toolchain go1.23.6
+go 1.23.6
 
 require (
 	// golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173


### PR DESCRIPTION
Enforce golang version when building wireguard-go/libwg to ensure that all workflows immediately error if they use different version of golang for any reason.

JIRA-VPN-3547

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2960)
<!-- Reviewable:end -->
