### PR TITLE
Harmonize rust toolchain configuration

### DIFF
--- a/.github/workflows/build-nym-vpn-android.yml
+++ b/.github/workflows/build-nym-vpn-android.yml
@@ -110,9 +110,11 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ vars.REQUIRED_GOLANG_VERSION }}
-      - uses: dtolnay/rust-toolchain@master
+      
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.85 # If this changes, we need a PR to Fdroid to update pipeline for reproducibility
+          toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
           targets: aarch64-linux-android
 
       - name: Install cargo-ndk

--- a/.github/workflows/build-nym-vpn-core-android.yml
+++ b/.github/workflows/build-nym-vpn-core-android.yml
@@ -33,9 +33,10 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y libdbus-1-dev libmnl-dev libnftnl-dev protobuf-compiler
 
-      - uses: dtolnay/rust-toolchain@master
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.85 # If this changes, we need a PR to Fdroid to update pipeline for reproducibility
+          toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
           targets: aarch64-linux-android 
 
       - name: Set up Go

--- a/.github/workflows/build-nym-vpn-core-deb.yml
+++ b/.github/workflows/build-nym-vpn-core-deb.yml
@@ -30,9 +30,9 @@ jobs:
           sudo apt-get update && sudo apt-get install -y libdbus-1-dev libmnl-dev libnftnl-dev protobuf-compiler
 
       - name: Install rust toolchain
-        uses: brndnmtthws/rust-action-rustup@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
           components: rustfmt, clippy
 
       - name: Install cargo-deb

--- a/.github/workflows/build-nym-vpn-core-ios.yml
+++ b/.github/workflows/build-nym-vpn-core-ios.yml
@@ -31,9 +31,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install rust toolchain
-        uses: brndnmtthws/rust-action-rustup@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
           components: rustfmt, clippy
           targets: x86_64-apple-darwin aarch64-apple-ios x86_64-apple-ios aarch64-apple-ios-sim
 

--- a/.github/workflows/build-nym-vpn-core-linux.yml
+++ b/.github/workflows/build-nym-vpn-core-linux.yml
@@ -37,9 +37,9 @@ jobs:
           sudo apt-get update && sudo apt-get install -y libdbus-1-dev libmnl-dev libnftnl-dev protobuf-compiler
 
       - name: Install rust toolchain
-        uses: brndnmtthws/rust-action-rustup@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
           components: rustfmt, clippy
 
       - name: Install Protoc

--- a/.github/workflows/build-nym-vpn-core-mac.yml
+++ b/.github/workflows/build-nym-vpn-core-mac.yml
@@ -28,10 +28,10 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Install Rust toolchain
-        uses: brndnmtthws/rust-action-rustup@v1
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
           components: rustfmt, clippy
           targets: x86_64-apple-darwin aarch64-apple-darwin
 

--- a/.github/workflows/build-nym-vpn-core-windows.yml
+++ b/.github/workflows/build-nym-vpn-core-windows.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.85
+          toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
           components: rustfmt, clippy
 
       - name: Install Go toolchain

--- a/.github/workflows/ci-nym-vpn-app-rust.yml
+++ b/.github/workflows/ci-nym-vpn-app-rust.yml
@@ -47,17 +47,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install rust toolchain
-        if: "!contains(matrix.os, 'windows')"
-        id: rust-toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
-
-      - name: Install rust toolchain (Windows)
-        if: contains(matrix.os, 'windows')
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.85
+          toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
           components: rustfmt, clippy
 
       - name: Set env

--- a/.github/workflows/ci-nym-vpn-core-android.yml
+++ b/.github/workflows/ci-nym-vpn-core-android.yml
@@ -24,9 +24,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install rust toolchain
-        uses: brndnmtthws/rust-action-rustup@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
           components: rustfmt, clippy
           targets: aarch64-linux-android
 

--- a/.github/workflows/ci-nym-vpn-core-ios.yml
+++ b/.github/workflows/ci-nym-vpn-core-ios.yml
@@ -30,9 +30,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install rust toolchain
-        uses: brndnmtthws/rust-action-rustup@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
           components: rustfmt, clippy
           targets: aarch64-apple-ios
 

--- a/.github/workflows/ci-nym-vpn-core-linux.yml
+++ b/.github/workflows/ci-nym-vpn-core-linux.yml
@@ -24,9 +24,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install rust toolchain
-        uses: brndnmtthws/rust-action-rustup@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
           components: rustfmt, clippy
 
       - name: Install Go

--- a/.github/workflows/ci-nym-vpn-core-macos.yml
+++ b/.github/workflows/ci-nym-vpn-core-macos.yml
@@ -29,9 +29,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install rust toolchain
-        uses: brndnmtthws/rust-action-rustup@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
           components: rustfmt, clippy
 
       - name: Install Go

--- a/.github/workflows/ci-nym-vpn-core-windows.yml
+++ b/.github/workflows/ci-nym-vpn-core-windows.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.85
+          toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
           components: rustfmt, clippy
 
       - name: Install target i686-pc-windows-msvc

--- a/.github/workflows/publish-nym-vpn-android.yml
+++ b/.github/workflows/publish-nym-vpn-android.yml
@@ -303,9 +303,10 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - uses: dtolnay/rust-toolchain@master
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.85 # If this changes, we need a PR to Fdroid to update pipeline for reproducibility
+          toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
           targets: aarch64-linux-android
 
       - name: Set up Go

--- a/.github/workflows/publish-nym-vpn-core.yml
+++ b/.github/workflows/publish-nym-vpn-core.yml
@@ -81,9 +81,9 @@ jobs:
           sudo apt update && sudo apt install -y gettext-base gh zip
 
       - name: Install rust toolchain
-        uses: brndnmtthws/rust-action-rustup@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
           components: rustfmt, clippy
 
       - name: Get nym-vpn-core workspace version

--- a/nym-vpn-core/crates/nym-routing/src/windows/route_manager.rs
+++ b/nym-vpn-core/crates/nym-routing/src/windows/route_manager.rs
@@ -785,12 +785,9 @@ impl Adapters {
             tracing::error!(
                 "Expecting IP_ADAPTER_ADDRESSES to have size {code_size} bytes. Found structure with size {system_size} bytes."
             );
-            return Err(Error::Adapter(io::Error::new(
-                io::ErrorKind::Other,
-                format!(
-                    "Expecting IP_ADAPTER_ADDRESSES to have size {code_size} bytes. Found structure with size {system_size} bytes."
-                ),
-            )));
+            return Err(Error::Adapter(io::Error::other(format!(
+                "Expecting IP_ADAPTER_ADDRESSES to have size {code_size} bytes. Found structure with size {system_size} bytes."
+            ))));
         }
 
         // Initialize members.

--- a/nym-vpn-core/crates/nym-windows/src/security/acl_entry_list.rs
+++ b/nym-vpn-core/crates/nym-windows/src/security/acl_entry_list.rs
@@ -40,8 +40,7 @@ impl AclEntryList<'_> {
             .map(|i| {
                 // Safety: cast to isize should be fine as number of entries is likely limited.
                 let entry_ptr = unsafe { self.entries.offset(i as isize) };
-                let explicit_access = unsafe { BorrowedExplicitAccess::from_ptr(entry_ptr) };
-                explicit_access
+                unsafe { BorrowedExplicitAccess::from_ptr(entry_ptr) }
             })
             .collect::<Vec<_>>()
     }


### PR DESCRIPTION
This PR harmonized rust toolchain configuration:

- Set rust toolchain to 1.87.0 (latest stable)
- Switch to using `dtolnay/rust-toolchain` which is proven to be trusted gh action

JIRA-VPN-3548

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2962)
<!-- Reviewable:end -->
