### PR TITLE
Print network in discovery test

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-network-config/src/discovery.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/discovery.rs
@@ -330,7 +330,12 @@ mod tests {
             Discovery::default_sandbox(),
             Discovery::default_canary(),
         ] {
-            let fetched = Discovery::fetch(&discovery.network_name).await.unwrap();
+            let fetched = Discovery::fetch(&discovery.network_name)
+                .await
+                .expect(&format!(
+                    "failed to fetch discovery for {}",
+                    discovery.network_name
+                ));
 
             // Only compare the base fields
             assert_eq!(discovery.network_name, fetched.network_name);


### PR DESCRIPTION
`test_discovery_default_same_as_fetched` has been failing a lot. Let's print which network causes problems.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2968)
<!-- Reviewable:end -->
