### PR TITLE
Run clippy first, add core build for macos

### DIFF
--- a/.github/workflows/ci-nym-vpn-core-android.yml
+++ b/.github/workflows/ci-nym-vpn-core-android.yml
@@ -67,12 +67,12 @@ jobs:
         run: |
           cargo fmt --check --all
 
-      - name: Build
-        working-directory: nym-vpn-core
-        run: |
-          cargo ndk -t aarch64-linux-android -o ./build build -p nym-vpn-lib
-
       - name: Clippy
         working-directory: nym-vpn-core
         run: |
           cargo ndk -t aarch64-linux-android clippy -p nym-vpn-lib -- -Dwarning
+
+      - name: Build
+        working-directory: nym-vpn-core
+        run: |
+          cargo ndk -t aarch64-linux-android -o ./build build -p nym-vpn-lib

--- a/.github/workflows/ci-nym-vpn-core-ios.yml
+++ b/.github/workflows/ci-nym-vpn-core-ios.yml
@@ -57,6 +57,11 @@ jobs:
         run: |
           cargo fmt --check --all
 
+      - name: Clippy
+        working-directory: nym-vpn-core
+        run: |
+          cargo clippy --target aarch64-apple-ios -p nym-vpn-lib --locked -- -Dwarnings
+
       - name: Build
         working-directory: nym-vpn-core
         run: |
@@ -76,8 +81,3 @@ jobs:
           name: updated-uniffi-ios
           path: nym-vpn-core/build/nym_vpn_lib.swift
           retention-days: 1
-
-      - name: Clippy
-        working-directory: nym-vpn-core
-        run: |
-          cargo clippy --target aarch64-apple-ios -p nym-vpn-lib --locked -- -Dwarnings

--- a/.github/workflows/ci-nym-vpn-core-linux.yml
+++ b/.github/workflows/ci-nym-vpn-core-linux.yml
@@ -57,6 +57,11 @@ jobs:
         run: |
           cargo fmt --check --all
 
+      - name: Clippy
+        working-directory: nym-vpn-core
+        run: |
+          cargo clippy --workspace --locked -- -Dwarnings
+
       - name: Build
         working-directory: nym-vpn-core
         run: |
@@ -66,9 +71,4 @@ jobs:
         working-directory: nym-vpn-core
         run: |
           cargo test --verbose --workspace --locked
-
-      - name: Clippy
-        working-directory: nym-vpn-core
-        run: |
-          cargo clippy --workspace --locked -- -Dwarnings
 

--- a/.github/workflows/ci-nym-vpn-core-macos.yml
+++ b/.github/workflows/ci-nym-vpn-core-macos.yml
@@ -54,13 +54,19 @@ jobs:
         working-directory: nym-vpn-core
         run: |
           cargo fmt --check --all
+      
+      - name: Clippy
+        working-directory: nym-vpn-core
+        run: |
+          cargo clippy --workspace --locked -- -Dwarnings
+
+      - name: Build
+        working-directory: nym-vpn-core
+        run: |
+          cargo build --verbose --workspace --locked
 
       - name: Run tests
         working-directory: nym-vpn-core
         run: |
           cargo test --verbose --workspace --locked
 
-      - name: Clippy
-        working-directory: nym-vpn-core
-        run: |
-          cargo clippy --workspace --locked -- -Dwarnings

--- a/.github/workflows/ci-nym-vpn-core-windows.yml
+++ b/.github/workflows/ci-nym-vpn-core-windows.yml
@@ -79,6 +79,11 @@ jobs:
         run: |
           cargo fmt --check --all
 
+      - name: Clippy
+        working-directory: nym-vpn-core
+        run: |
+          cargo clippy --workspace --exclude nym-gateway-probe --locked -- -Dwarnings
+
       - name: Build
         working-directory: nym-vpn-core
         run: |
@@ -88,8 +93,3 @@ jobs:
         working-directory: nym-vpn-core
         run: |
           cargo test --verbose --workspace --exclude nym-gateway-probe --locked
-
-      - name: Clippy
-        working-directory: nym-vpn-core
-        run: |
-          cargo clippy --workspace --exclude nym-gateway-probe --locked -- -Dwarnings


### PR DESCRIPTION
Some of tests fail due to API issues, and clippy task is set to run after tests. Let's fix this by moving clippy to the top before building vpn lib.

Also let's re-add the vpn lib build task to macos runner.

JIRA-VPN-3555

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2970)
<!-- Reviewable:end -->
