### PR TITLE
Run daemon in debug to collect more useful logs

### DIFF
--- a/nym-vpn-apple/Daemon/net.nymtech.vpn.helper.plist
+++ b/nym-vpn-apple/Daemon/net.nymtech.vpn.helper.plist
@@ -7,6 +7,7 @@
 	<key>ProgramArguments</key>
 	<array>
 		<string>Contents/MacOS/net.nymtech.vpn.helper</string>
+		<string>-v</string>
 		<string>--run-as-service</string>
 	</array>
 	<key>KeepAlive</key>

--- a/nym-vpn-core/crates/nym-vpnd/.pkg/aur/nym-vpnd.service
+++ b/nym-vpn-core/crates/nym-vpnd/.pkg/aur/nym-vpnd.service
@@ -6,7 +6,7 @@ Wants=network-pre.target
 After=network-pre.target NetworkManager.service systemd-resolved.service
 
 [Service]
-ExecStart=/usr/bin/nym-vpnd --run-as-service
+ExecStart=/usr/bin/nym-vpnd -v --run-as-service
 Restart=on-failure
 RestartSec=5
 

--- a/nym-vpn-core/crates/nym-vpnd/linux/unit-scripts/nym-vpnd.service
+++ b/nym-vpn-core/crates/nym-vpnd/linux/unit-scripts/nym-vpnd.service
@@ -6,7 +6,7 @@ StartLimitIntervalSec=24
 After=NetworkManager.service systemd-resolved.service
 
 [Service]
-ExecStart=/usr/bin/nym-vpnd --run-as-service
+ExecStart=/usr/bin/nym-vpnd -v --run-as-service
 Restart=always
 RestartSec=2
 

--- a/nym-vpn-core/crates/nym-vpnd/src/service/windows_service/mod.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/windows_service/mod.rs
@@ -276,7 +276,7 @@ pub(super) fn get_service_info() -> ServiceInfo {
         start_type: ServiceStartType::AutoStart,
         error_control: ServiceErrorControl::Normal,
         executable_path: env::current_exe().unwrap(),
-        launch_arguments: vec![OsString::from("--run-as-service")],
+        launch_arguments: vec![OsString::from("-v"), OsString::from("--run-as-service")],
         dependencies: vec![
             // Base Filter Engine
             ServiceDependency::Service(OsString::from("BFE")),


### PR DESCRIPTION
Let's enable debug for the daemon because info level logs are rarely all that useful. We'll need to silence some of our crates to reduce the noise but this PR is the first step.

JIRA-VPN-3560

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2972)
<!-- Reviewable:end -->
