### PR TITLE
Android.mk: add missing OS identifier

### DIFF
--- a/nym-vpn-core/Android.mk
+++ b/nym-vpn-core/Android.mk
@@ -1,4 +1,5 @@
-# Linker/compiler flags for producing reproducible output
+# cargo ndk always builds for Linux/Android
+OS := Linux
 include reproducible_builds.mk
 
 RELEASE ?= true

--- a/nym-vpn-core/reproducible_builds.mk
+++ b/nym-vpn-core/reproducible_builds.mk
@@ -7,6 +7,10 @@ RUST_COMPILER_SYS_ROOT = $(shell rustc --print sysroot)
 # Rust flags used for redacting common paths in binaries
 IDEMPOTENT_RUSTFLAGS = --remap-path-prefix $(HOME)= --remap-path-prefix $(PROJECT_ROOT)= --remap-path-prefix $(RUST_COMPILER_SYS_ROOT)=
 
+ifndef OS
+$(error Please set the "OS" variable, accepted values include the result of "uname -s")
+endif
+
 # Disable build-id on Linux
 ifeq ($(OS),Linux)
 	IDEMPOTENT_RUSTFLAGS += -C link-args=-Wl,--build-id=none


### PR DESCRIPTION
`reproducible_builds.mk` requires `OS` variable to be set to properly configure the compiler. Unfortunately `OS` was missing from `Android.mk`.

This PR fixes this by:
- Adding check and error in `reproducible_builds.mk` if `OS` is not set
- Set `OS` to "Linux" in `Android.mk` before including `reproducible_builds.mk`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2992)
<!-- Reviewable:end -->
