### PR TITLE
gh: fix deb workflow

### DIFF
--- a/.github/workflows/build-nym-vpn-core-deb.yml
+++ b/.github/workflows/build-nym-vpn-core-deb.yml
@@ -13,6 +13,8 @@ env:
 jobs:
   build-wireguard-go-linux:
     uses: ./.github/workflows/build-wireguard-go-linux.yml
+    with:
+      artifact_name: wireguard-go_deb_x86_64
 
   build-linux:
     needs: build-wireguard-go-linux
@@ -61,7 +63,7 @@ jobs:
       - name: Download wireguard-go artifacts
         uses: actions/download-artifact@v4
         with:
-          name: wireguard-go_ubuntu-22.04_x86_64
+          name: wireguard-go_deb_x86_64
           path: build/lib/x86_64-unknown-linux-gnu
 
       - name: Build nym-vpn-core debian packages

--- a/.github/workflows/build-wireguard-go-linux.yml
+++ b/.github/workflows/build-wireguard-go-linux.yml
@@ -2,6 +2,10 @@ name: build-wireguard-go-linux
 on:
   workflow_dispatch:
   workflow_call:
+    inputs:
+      artifact_name:
+        required: false
+        type: string
   pull_request:
     paths:
       - "wireguard/**"
@@ -31,10 +35,19 @@ jobs:
         run: |
           ./wireguard/build-wireguard-go.sh
 
+      - name: Set artifact name
+        id: set_artifact_name
+        run: |
+          if [ -z "${{ inputs.artifact_name }}" ]; then
+            echo "artifact_name=wireguard-go_ubuntu-22.04_x86_64" >> $GITHUB_OUTPUT
+          else
+            echo "artifact_name=${{ inputs.artifact_name }}" >> $GITHUB_OUTPUT
+          fi
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: wireguard-go_ubuntu-22.04_x86_64
+          name: ${{ steps.set_artifact_name.outputs.artifact_name }}
           path: build/lib/x86_64-unknown-linux-gnu
           if-no-files-found: error
           retention-days: 10


### PR DESCRIPTION
When both Linux and deb core build workflows build wireguard-go-linux they attempt to overwrite the same artifact which causes issues on CI. Let's make a workflow identical to the one used for linux.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/2999)
<!-- Reviewable:end -->
