### PR TITLE
workflow: do not run-fail if gen-hashes fails

### DIFF
--- a/.github/workflows/gen-hashes-json.yml
+++ b/.github/workflows/gen-hashes-json.yml
@@ -18,6 +18,7 @@ jobs:
   gen-hashes:
     name: Generate hashes.json
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - name: Generate hashes.json
         uses: nymtech/nym/.github/actions/nym-hash-releases@develop

--- a/.github/workflows/publish-nym-vpn-app.yml
+++ b/.github/workflows/publish-nym-vpn-app.yml
@@ -367,6 +367,7 @@ jobs:
   gen-hashes:
     uses: ./.github/workflows/gen-hashes-json.yml
     needs: publish
+    if: ${{ inputs.release_type == 'stable' }}
     with:
       release_tag: ${{ needs.publish.outputs.release_tag }}
     secrets: inherit


### PR DESCRIPTION
This job can potentially kill any other running jobs when it fails, even after a successful release
example https://github.com/nymtech/nym-vpn-client/actions/runs/15815129145

I think workflow run should continue when it fails, should be safe
Also, it is only needed on public releases

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3002)
<!-- Reviewable:end -->
