### PR TITLE
feat(vpnd): add toggle sentry monitoring API

### DIFF
--- a/nym-vpn-app/src-tauri/Cargo.toml
+++ b/nym-vpn-app/src-tauri/Cargo.toml
@@ -70,8 +70,8 @@ windows = { version = "0.60.0", features = [
     "Win32_Foundation",
 ] }
 
-[profile.release]
-codegen-units = 1
-opt-level = "z"
-lto = true
-strip = true
+#[profile.release]
+#codegen-units = 1
+#opt-level = "z"
+#lto = true
+#strip = true

--- a/nym-vpn-app/src-tauri/Cargo.toml
+++ b/nym-vpn-app/src-tauri/Cargo.toml
@@ -70,8 +70,8 @@ windows = { version = "0.60.0", features = [
     "Win32_Foundation",
 ] }
 
-#[profile.release]
-#codegen-units = 1
-#opt-level = "z"
-#lto = true
-#strip = true
+[profile.release]
+codegen-units = 1
+opt-level = "z"
+lto = true
+strip = true

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/connection_handler.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/connection_handler.rs
@@ -17,15 +17,14 @@ use nym_vpn_lib_types::{
 use nym_vpn_network_config::{FeatureFlags, ParsedAccountLinks, SystemMessages};
 use nym_vpnd_types::gateway;
 
+use super::protobuf::error::VpnCommandSendError;
 use crate::{
     logging::LogPath,
     service::{
-        AccountLinksError, ConnectArgs, ConnectOptions, GATEWAY_DIRECTORY_CLIENT, SetNetworkError,
-        VpnServiceCommand, VpnServiceDeleteLogFileError,
+        AccountLinksError, ConnectArgs, ConnectOptions, GATEWAY_DIRECTORY_CLIENT,
+        GlobalConfigError, SetNetworkError, VpnServiceCommand, VpnServiceDeleteLogFileError,
     },
 };
-
-use super::protobuf::error::VpnCommandSendError;
 
 #[derive(Debug, thiserror::Error)]
 pub enum ListGatewayError {
@@ -294,6 +293,19 @@ impl CommandInterfaceConnectionHandler {
 
     pub async fn handle_get_log_path(&self) -> Result<Option<LogPath>, VpnCommandSendError> {
         self.send_and_wait(VpnServiceCommand::GetLogPath, ()).await
+    }
+
+    pub async fn handle_is_sentry_enabled(&self) -> Result<bool, VpnCommandSendError> {
+        self.send_and_wait(VpnServiceCommand::IsSentryEnabled, ())
+            .await
+    }
+
+    pub async fn handle_toggle_sentry(
+        &self,
+        enable: bool,
+    ) -> Result<Result<(), GlobalConfigError>, VpnCommandSendError> {
+        self.send_and_wait(VpnServiceCommand::ToggleSentry, enable)
+            .await
     }
 
     async fn send_and_wait<R, F, O>(&self, command: F, opts: O) -> Result<R, VpnCommandSendError>

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface/listener.rs
@@ -11,13 +11,14 @@ use nym_vpn_lib_types::TunnelEvent;
 use nym_vpn_proto::{
     AccountManagement, AvailableTickets, ConfirmZkNymDownloadedRequest,
     ConfirmZkNymDownloadedResponse, ConnectRequest, ConnectResponse, DeleteLogFileResponse,
-    DisconnectResponse, ForgetAccountResponse, GetAccountIdentityResponse, GetAccountLinksRequest,
-    GetAccountStateResponse, GetAccountUsageResponse, GetDeviceIdentityResponse,
-    GetDeviceZkNymsResponse, GetDevicesResponse, GetFeatureFlagsResponse, GetLogPathResponse,
+    DisableSentryResponse, DisconnectResponse, EnableSentryResponse, ForgetAccountResponse,
+    GetAccountIdentityResponse, GetAccountLinksRequest, GetAccountStateResponse,
+    GetAccountUsageResponse, GetDeviceIdentityResponse, GetDeviceZkNymsResponse,
+    GetDevicesResponse, GetFeatureFlagsResponse, GetLogPathResponse,
     GetNetworkCompatibilityResponse, GetSystemMessagesResponse, GetZkNymByIdRequest,
     GetZkNymByIdResponse, GetZkNymsAvailableForDownloadResponse, InfoResponse,
-    IsAccountStoredResponse, ListCountriesRequest, ListCountriesResponse, ListGatewaysRequest,
-    ListGatewaysResponse, RefreshAccountStateResponse, RegisterDeviceResponse,
+    IsAccountStoredResponse, IsSentryEnabledResponse, ListCountriesRequest, ListCountriesResponse,
+    ListGatewaysRequest, ListGatewaysResponse, RefreshAccountStateResponse, RegisterDeviceResponse,
     RequestZkNymResponse, ResetDeviceIdentityRequest, ResetDeviceIdentityResponse,
     SetNetworkRequest, SetNetworkResponse, StoreAccountRequest, StoreAccountResponse, TunnelState,
     conversions::ConversionError, get_account_state_response::AccountStateSummary,
@@ -760,6 +761,52 @@ impl NymVpnd for CommandInterface {
         };
         tracing::debug!("log dir path: {}", log_path.dir.display());
         Ok(tonic::Response::new(log_path.into()))
+    }
+
+    async fn is_sentry_enabled(
+        &self,
+        _: tonic::Request<()>,
+    ) -> Result<tonic::Response<IsSentryEnabledResponse>, tonic::Status> {
+        let result = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
+            .handle_is_sentry_enabled()
+            .await?;
+        tracing::debug!("sentry monitoring enabled: {}", result);
+        let response = IsSentryEnabledResponse { enabled: result };
+        Ok(tonic::Response::new(response))
+    }
+
+    async fn enable_sentry(
+        &self,
+        _: tonic::Request<()>,
+    ) -> Result<tonic::Response<EnableSentryResponse>, tonic::Status> {
+        let result = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
+            .handle_toggle_sentry(true)
+            .await?;
+        match &result {
+            Ok(_) => tracing::info!("sentry monitoring enabled ⚠ vpnd needs to be restarted ⚠"),
+            Err(err) => tracing::error!("failed to enable sentry monitoring: {:?}", err),
+        }
+        let response = EnableSentryResponse {
+            success: result.is_ok(),
+        };
+        Ok(tonic::Response::new(response))
+    }
+
+    async fn disable_sentry(
+        &self,
+        _: tonic::Request<()>,
+    ) -> Result<tonic::Response<DisableSentryResponse>, tonic::Status> {
+        let result = CommandInterfaceConnectionHandler::new(self.vpn_command_tx.clone())
+            .handle_toggle_sentry(false)
+            .await?;
+        match &result {
+            Ok(_) => tracing::info!("sentry monitoring disabled ⚠ vpnd needs to be restarted ⚠"),
+            Err(err) => tracing::error!("failed to disable sentry monitoring: {}", err),
+        }
+        let response = DisableSentryResponse {
+            success: result.is_ok(),
+        };
+        Ok(tonic::Response::new(response))
     }
 }
 

--- a/nym-vpn-core/crates/nym-vpnd/src/config.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/config.rs
@@ -6,12 +6,14 @@ use nym_vpn_lib::nym_config::defaults::NymNetworkDetails;
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct GlobalConfigFile {
     pub network_name: String,
+    pub sentry_monitoring: Option<bool>,
 }
 
 impl Default for GlobalConfigFile {
     fn default() -> Self {
         Self {
             network_name: NymNetworkDetails::default().network_name,
+            sentry_monitoring: None,
         }
     }
 }
@@ -32,5 +34,17 @@ impl GlobalConfigFile {
 
         crate::service::write_config_file(&global_config_file_path, global_config)
             .map_err(Into::into)
+    }
+
+    pub fn sentry_enabled() -> bool {
+        let global_config_file_path =
+            crate::service::config_dir().join(crate::service::DEFAULT_GLOBAL_CONFIG_FILE);
+
+        crate::service::read_config_file::<GlobalConfigFile>(&global_config_file_path)
+            .inspect_err(|e| {
+                eprintln!("failed to read global config file: {}", e);
+            })
+            .ok()
+            .is_some_and(|cfg| matches!(cfg.sentry_monitoring, Some(true)))
     }
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/config.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/config.rs
@@ -6,14 +6,15 @@ use nym_vpn_lib::nym_config::defaults::NymNetworkDetails;
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct GlobalConfigFile {
     pub network_name: String,
-    pub sentry_monitoring: Option<bool>,
+    #[serde(default)]
+    pub sentry_monitoring: bool,
 }
 
 impl Default for GlobalConfigFile {
     fn default() -> Self {
         Self {
             network_name: NymNetworkDetails::default().network_name,
-            sentry_monitoring: None,
+            sentry_monitoring: false,
         }
     }
 }
@@ -45,6 +46,6 @@ impl GlobalConfigFile {
                 eprintln!("failed to read global config file: {}", e);
             })
             .ok()
-            .is_some_and(|cfg| matches!(cfg.sentry_monitoring, Some(true)))
+            .is_some_and(|cfg| cfg.sentry_monitoring)
     }
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/main.rs
@@ -16,6 +16,7 @@ use logging::{LogFileRemover, LoggingSetup};
 use nym_vpn_network_config::Network;
 use sentry::ClientInitGuard;
 use service::NymVpnService;
+use std::time::Duration;
 use tokio::sync::{broadcast, mpsc};
 use tokio_util::sync::CancellationToken;
 use tracing_appender::non_blocking::WorkerGuard;
@@ -214,6 +215,7 @@ fn init_sentry() -> Option<ClientInitGuard> {
                 sample_rate: 1.0,
                 traces_sample_rate: 1.0,
                 enable_logs: true,
+                shutdown_timeout: Duration::from_secs(2),
                 ..Default::default()
             },
         ));

--- a/nym-vpn-core/crates/nym-vpnd/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/main.rs
@@ -31,17 +31,18 @@ fn main() -> anyhow::Result<()> {
 fn run() -> anyhow::Result<Option<WorkerGuard>> {
     let args = CliArgs::parse();
     let _sentry_guard = init_sentry();
+    let sentry_enabled = _sentry_guard.is_some_and(|client| client.is_enabled());
 
     let options = logging::Options {
         verbosity_level: args.verbosity_level(),
         enable_file_log: args.command.run_as_service,
         enable_stdout_log: true,
-        sentry: _sentry_guard.is_some(),
+        sentry: sentry_enabled,
     };
     let logging_setup = logging::setup_logging(options);
     let global_config_file = setup_global_config(args.network.as_deref())?;
 
-    run_inner(args, global_config_file, logging_setup)
+    run_inner(args, global_config_file, logging_setup, sentry_enabled)
 }
 
 #[cfg(windows)]
@@ -115,12 +116,13 @@ fn run_inner(
     args: CliArgs,
     global_config_file: GlobalConfigFile,
     logging_setup: Option<LoggingSetup>,
+    sentry_enabled: bool,
 ) -> anyhow::Result<Option<WorkerGuard>> {
     runtime::new_runtime().block_on(async {
         let network_env =
             environment::setup_environment(&global_config_file, args.config_env_file.as_deref())
                 .await?;
-        run_inner_async(args, network_env, logging_setup).await
+        run_inner_async(args, network_env, logging_setup, sentry_enabled).await
     })
 }
 
@@ -128,6 +130,7 @@ async fn run_inner_async(
     args: CliArgs,
     network_env: Network,
     logging_setup: Option<LoggingSetup>,
+    sentry_enabled: bool,
 ) -> anyhow::Result<Option<WorkerGuard>> {
     let log_path = logging_setup
         .as_ref()
@@ -167,6 +170,7 @@ async fn run_inner_async(
         network_env,
         user_agent,
         log_path,
+        sentry_enabled,
     );
 
     let mut shutdown_join_set = shutdown_handler::install(shutdown_token);
@@ -194,8 +198,12 @@ async fn run_inner_async(
 }
 
 fn init_sentry() -> Option<ClientInitGuard> {
+    let enabled = GlobalConfigFile::sentry_enabled();
+    if !enabled {
+        return None;
+    }
     if let Some(dsn) = environment::sentry_dsn() {
-        println!("sentry monitoring enabled");
+        println!("⚠ sentry monitoring enabled ⚠");
         let guard = sentry::init((
             dsn,
             sentry::ClientOptions {
@@ -209,6 +217,7 @@ fn init_sentry() -> Option<ClientInitGuard> {
         ));
         Some(guard)
     } else {
+        println!("failed to init sentry: SENTRY_DSN is not set");
         None
     }
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/main.rs
@@ -49,6 +49,7 @@ fn run() -> anyhow::Result<Option<WorkerGuard>> {
 fn run() -> anyhow::Result<Option<WorkerGuard>> {
     let args = CliArgs::parse();
     let _sentry_guard = init_sentry();
+    let sentry_enabled = _sentry_guard.is_some_and(|client| client.is_enabled());
 
     if args.command.install {
         println!(
@@ -79,7 +80,7 @@ fn run() -> anyhow::Result<Option<WorkerGuard>> {
             verbosity_level: args.verbosity_level(),
             enable_file_log: true,
             enable_stdout_log: false,
-            sentry: _sentry_guard.is_some(),
+            sentry: sentry_enabled,
         });
         let worker_guard = service::windows_service::start(
             service::windows_service::ServiceNetworkConfig {
@@ -87,6 +88,7 @@ fn run() -> anyhow::Result<Option<WorkerGuard>> {
                 config_env_file: args.config_env_file.to_owned(),
             },
             logging_setup,
+            sentry_enabled,
         )?;
         Ok(worker_guard)
     } else {
@@ -94,12 +96,12 @@ fn run() -> anyhow::Result<Option<WorkerGuard>> {
             verbosity_level: args.verbosity_level(),
             enable_file_log: false,
             enable_stdout_log: true,
-            sentry: _sentry_guard.is_some(),
+            sentry: sentry_enabled,
         };
         let logging_setup = logging::setup_logging(options);
         let global_config_file = setup_global_config(args.network.as_deref())?;
 
-        run_inner(args, global_config_file, logging_setup)
+        run_inner(args, global_config_file, logging_setup, sentry_enabled)
     }
 }
 

--- a/nym-vpn-core/crates/nym-vpnd/src/service/error.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/error.rs
@@ -55,4 +55,12 @@ pub enum Error {
     StateMachine(#[source] TunnelStateMachineError),
 }
 
+#[derive(Clone, Debug, thiserror::Error)]
+pub enum GlobalConfigError {
+    #[error("failed to read config")]
+    ReadConfig(String),
+    #[error("failed to write config")]
+    WriteConfig(String),
+}
+
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/nym-vpn-core/crates/nym-vpnd/src/service/mod.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/mod.rs
@@ -11,7 +11,9 @@ pub use config::{
     DEFAULT_GLOBAL_CONFIG_FILE, DEFAULT_LOG_FILE, DEFAULT_OLD_LOG_FILE, config_dir,
     create_config_file, log_dir, read_config_file, write_config_file,
 };
-pub use error::{AccountLinksError, SetNetworkError, VpnServiceDeleteLogFileError};
+pub use error::{
+    AccountLinksError, GlobalConfigError, SetNetworkError, VpnServiceDeleteLogFileError,
+};
 pub use vpn_service::{
     ConnectArgs, ConnectOptions, GATEWAY_DIRECTORY_CLIENT, NymVpnService, VpnServiceCommand,
 };

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -48,6 +48,7 @@ use super::{
         VpnServiceDeleteLogFileError,
     },
 };
+use crate::service::error::GlobalConfigError;
 use crate::{config::GlobalConfigFile, logging::LogPath};
 
 // Lazy initialized static instance of CachingGatewayClient, using OnceLock
@@ -118,6 +119,8 @@ pub enum VpnServiceCommand {
         oneshot::Sender<Result<(), VpnServiceDeleteLogFileError>>,
         (),
     ),
+    IsSentryEnabled(oneshot::Sender<bool>, ()),
+    ToggleSentry(oneshot::Sender<Result<(), GlobalConfigError>>, bool),
 }
 
 #[derive(Debug)]
@@ -197,6 +200,9 @@ where
 
     // The (optional) recipient to send statistics to
     statistics_recipient: Option<Recipient>,
+
+    // Sentry client has been initialized and is enabled
+    sentry_enabled: bool,
 }
 
 impl NymVpnService<nym_vpn_lib::storage::VpnClientOnDiskStorage> {
@@ -208,9 +214,10 @@ impl NymVpnService<nym_vpn_lib::storage::VpnClientOnDiskStorage> {
         network_env: Network,
         user_agent: UserAgent,
         log_path: Option<LogPath>,
+        sentry_enabled: bool,
     ) -> JoinHandle<()> {
         tracing::trace!("Starting VPN service");
-        tokio::spawn(async {
+        tokio::spawn(async move {
             match NymVpnService::new(
                 vpn_command_rx,
                 tunnel_event_tx,
@@ -219,6 +226,7 @@ impl NymVpnService<nym_vpn_lib::storage::VpnClientOnDiskStorage> {
                 network_env,
                 user_agent,
                 log_path,
+                sentry_enabled,
             )
             .await
             {
@@ -249,6 +257,7 @@ impl NymVpnService<nym_vpn_lib::storage::VpnClientOnDiskStorage> {
         network_env: Network,
         user_agent: UserAgent,
         log_path: Option<LogPath>,
+        sentry_enabled: bool,
     ) -> Result<Self> {
         let network_name = network_env.nym_network_details().network_name.clone();
 
@@ -405,6 +414,7 @@ impl NymVpnService<nym_vpn_lib::storage::VpnClientOnDiskStorage> {
             event_receiver,
             shutdown_token,
             statistics_recipient,
+            sentry_enabled,
         })
     }
 }
@@ -570,6 +580,12 @@ where
             }
             VpnServiceCommand::DeleteLogFile(tx, ()) => {
                 let _ = tx.send(self.handle_delete_log_file().await);
+            }
+            VpnServiceCommand::IsSentryEnabled(tx, ()) => {
+                let _ = tx.send(self.handle_is_sentry_enabled().await);
+            }
+            VpnServiceCommand::ToggleSentry(tx, enable) => {
+                let _ = tx.send(self.handle_toggle_sentry(enable).await);
             }
         }
     }
@@ -934,6 +950,26 @@ where
                 ));
             }
         }
+        Ok(())
+    }
+
+    async fn handle_is_sentry_enabled(&self) -> bool {
+        GlobalConfigFile::read_from_file()
+            .inspect_err(|e| {
+                tracing::error!("Failed to read global config file: {}", e);
+            })
+            .ok()
+            .and_then(|c| c.sentry_monitoring)
+            // if something goes wrong with the config file, fallback to the real state of Sentry client
+            .unwrap_or(self.sentry_enabled)
+    }
+
+    async fn handle_toggle_sentry(&self, enable: bool) -> Result<(), GlobalConfigError> {
+        let mut config = GlobalConfigFile::read_from_file()
+            .map_err(|e| GlobalConfigError::ReadConfig(e.to_string()))?;
+        config.sentry_monitoring = Some(enable);
+        GlobalConfigFile::write_to_file(&config)
+            .map_err(|e| GlobalConfigError::WriteConfig(e.to_string()))?;
         Ok(())
     }
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -206,6 +206,7 @@ where
 }
 
 impl NymVpnService<nym_vpn_lib::storage::VpnClientOnDiskStorage> {
+    #![allow(clippy::too_many_arguments)]
     pub fn spawn(
         vpn_command_rx: mpsc::UnboundedReceiver<VpnServiceCommand>,
         tunnel_event_tx: broadcast::Sender<TunnelEvent>,

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -39,6 +39,7 @@ use nym_vpn_lib_types::{
     TunnelType, VpnServiceConnectError, VpnServiceDisconnectError, VpnServiceInfo,
 };
 use nym_vpn_network_config::{FeatureFlags, Network, ParsedAccountLinks, SystemMessages};
+use std::time::Duration;
 use zeroize::Zeroizing;
 
 use super::{
@@ -969,6 +970,12 @@ where
         let mut config = GlobalConfigFile::read_from_file()
             .map_err(|e| GlobalConfigError::ReadConfig(e.to_string()))?;
         config.sentry_monitoring = Some(enable);
+        if !enable {
+            if let Some(client) = sentry::Hub::current().client() {
+                client.close(Some(Duration::from_secs(1)));
+                tracing::debug!("sentry client closed");
+            }
+        }
         GlobalConfigFile::write_to_file(&config)
             .map_err(|e| GlobalConfigError::WriteConfig(e.to_string()))?;
         Ok(())

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -961,7 +961,7 @@ where
                 tracing::error!("Failed to read global config file: {}", e);
             })
             .ok()
-            .and_then(|c| c.sentry_monitoring)
+            .map(|c| c.sentry_monitoring)
             // if something goes wrong with the config file, fallback to the real state of Sentry client
             .unwrap_or(self.sentry_enabled)
     }
@@ -969,7 +969,7 @@ where
     async fn handle_toggle_sentry(&self, enable: bool) -> Result<(), GlobalConfigError> {
         let mut config = GlobalConfigFile::read_from_file()
             .map_err(|e| GlobalConfigError::ReadConfig(e.to_string()))?;
-        config.sentry_monitoring = Some(enable);
+        config.sentry_monitoring = enable;
         if !enable {
             if let Some(client) = sentry::Hub::current().client() {
                 client.close(Some(Duration::from_secs(1)));

--- a/nym-vpn-core/crates/nym-vpnd/src/service/windows_service/mod.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/windows_service/mod.rs
@@ -75,7 +75,7 @@ static LOGGING_SETUP: LazyLock<Mutex<Option<LoggingSetup>>> = LazyLock::new(|| M
 static LOGGING_WORKER_GUARD: LazyLock<Mutex<Option<WorkerGuard>>> =
     LazyLock::new(|| Mutex::new(None));
 
-/// Whether a sentry client has been initialized, passed from `main()` and used later to interact with logging.
+/// Whether a sentry client has been initialized, passed from `main()` and used later by the vpn service.
 static SENTRY_ENABLED: LazyLock<Mutex<bool>> = LazyLock::new(|| Mutex::new(false));
 
 fn service_main(arguments: Vec<OsString>) {

--- a/nym-vpn-core/crates/nym-vpnd/src/service/windows_service/mod.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/windows_service/mod.rs
@@ -75,6 +75,9 @@ static LOGGING_SETUP: LazyLock<Mutex<Option<LoggingSetup>>> = LazyLock::new(|| M
 static LOGGING_WORKER_GUARD: LazyLock<Mutex<Option<WorkerGuard>>> =
     LazyLock::new(|| Mutex::new(None));
 
+/// Whether a sentry client has been initialized, passed from `main()` and used later to interact with logging.
+static SENTRY_ENABLED: LazyLock<Mutex<bool>> = LazyLock::new(|| Mutex::new(false));
+
 fn service_main(arguments: Vec<OsString>) {
     if let Err(err) = run_service(arguments) {
         tracing::error!("service_main: {:?}", err);
@@ -164,6 +167,7 @@ async fn run_service_inner() -> anyhow::Result<()> {
 
     let network_config = (*SERVICE_NETWORK_CONFIG.lock().await).clone();
     let logging_setup = (*LOGGING_SETUP.lock().await).take();
+    let sentry_enabled = *SENTRY_ENABLED.lock().await;
     let log_path = logging_setup.as_ref().map(|setup| setup.log_path.clone());
     let cloned_network_config = network_config.clone();
     let network_env_result = tokio::task::spawn(async move {
@@ -237,6 +241,7 @@ async fn run_service_inner() -> anyhow::Result<()> {
         network_env,
         user_agent,
         log_path,
+        sentry_enabled,
     );
 
     tracing::info!("Service has started");
@@ -292,10 +297,12 @@ pub(super) fn get_service_info() -> ServiceInfo {
 pub fn start(
     service_network_config: ServiceNetworkConfig,
     logging_setup: Option<LoggingSetup>,
+    sentry_enabled: bool,
 ) -> Result<Option<WorkerGuard>, windows_service::Error> {
     // Important: release mutex lock before starting service dispatcher to avoid deadlock.
     *SERVICE_NETWORK_CONFIG.blocking_lock() = service_network_config;
     *LOGGING_SETUP.blocking_lock() = logging_setup;
+    *SENTRY_ENABLED.blocking_lock() = sentry_enabled;
 
     // Register generated `ffi_service_main` with the system and start the service, blocking
     // this thread until the service is stopped.

--- a/proto/nym/vpn.proto
+++ b/proto/nym/vpn.proto
@@ -488,6 +488,18 @@ message GetLogPathResponse {
   string filename = 2;
 }
 
+message IsSentryEnabledResponse {
+  bool enabled = 1;
+}
+
+message EnableSentryResponse {
+  bool success = 1;
+}
+
+message DisableSentryResponse {
+  bool success = 1;
+}
+
 service NymVpnd {
   // Get info regarding the nym-vpnd in general, like version etc.
   rpc Info (google.protobuf.Empty) returns (InfoResponse) {}
@@ -594,5 +606,14 @@ service NymVpnd {
 
   // Delete the log file
   rpc DeleteLogFile (google.protobuf.Empty) returns (DeleteLogFileResponse) {}
+
+  // Check if Sentry error monitoring is enabled
+  rpc IsSentryEnabled (google.protobuf.Empty) returns (IsSentryEnabledResponse) {}
+
+  // Enable Sentry error monitoring
+  rpc EnableSentry (google.protobuf.Empty) returns (EnableSentryResponse) {}
+
+  // Disable Sentry error monitoring
+  rpc DisableSentry (google.protobuf.Empty) returns (DisableSentryResponse) {}
 }
 


### PR DESCRIPTION
Add a new API to daemon to toggle Sentry monitoring and handle it as a persistent state (enabled/disabled).

```
  // Check if Sentry error monitoring is enabled
  rpc IsSentryEnabled (google.protobuf.Empty) returns (IsSentryEnabledResponse) {}

  // Enable Sentry error monitoring
  rpc EnableSentry (google.protobuf.Empty) returns (EnableSentryResponse) {}

  // Disable Sentry error monitoring
  rpc DisableSentry (google.protobuf.Empty) returns (DisableSentryResponse) {}
```

The state is persisted in the global config file `/etc/nym/config.toml` (Linux) with a new optional property

```
sentry_monitoring = true # false or omitted
```

NOTE: Due to Sentry design and the way it is initialized, when the user toggle it, the vpnd process (or service) need to be restarted for the change to take effect.
This would require to put a dedicated message and the apps UI to let the user know.
(same way as we do for sentry instance running in the client app side, at least for tauri client)

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3006)
<!-- Reviewable:end -->
