### PR TITLE
Change stdcall to system calling convention

### DIFF
--- a/nym-vpn-core/crates/nym-dns/src/windows/iphlpapi.rs
+++ b/nym-vpn-core/crates/nym-dns/src/windows/iphlpapi.rs
@@ -56,7 +56,7 @@ pub enum Error {
     GetFunction(#[source] windows::core::Error),
 }
 
-type SetInterfaceDnsSettingsFn = unsafe extern "stdcall" fn(
+type SetInterfaceDnsSettingsFn = unsafe extern "system" fn(
     interface: GUID,
     settings: *const DNS_INTERFACE_SETTINGS,
 ) -> WIN32_ERROR;

--- a/nym-vpn-core/crates/nym-platform-metadata/src/windows.rs
+++ b/nym-vpn-core/crates/nym-platform-metadata/src/windows.rs
@@ -50,7 +50,7 @@ impl WindowsVersion {
         let function_address = unsafe { GetProcAddress(ntdll, s!("RtlGetVersion")) }
             .ok_or_else(windows::core::Error::from_win32)?;
 
-        let rtl_get_version: extern "stdcall" fn(*mut RTL_OSVERSIONINFOEXW) =
+        let rtl_get_version: extern "system" fn(*mut RTL_OSVERSIONINFOEXW) =
             unsafe { *(&function_address as *const _ as *const _) };
 
         let mut version_info: MaybeUninit<RTL_OSVERSIONINFOEXW> = mem::MaybeUninit::zeroed();


### PR DESCRIPTION
Based on https://github.com/rust-lang/rust/issues/137018 Rust 1.88 deprecates the `stdcall` convention. `system` should be used instead which will translate to the right convention when using winapi on windows.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3019)
<!-- Reviewable:end -->
