### PR TITLE
feat(vpn_lib): add sentry

### DIFF
--- a/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/NymBackend.kt
+++ b/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/NymBackend.kt
@@ -116,7 +116,7 @@ class NymBackend private constructor(private val context: Context) : Backend, Tu
 	private fun init(environment: Tunnel.Environment, credentialMode: Boolean?) = ProcessLifecycleOwner.get().lifecycleScope.launch(ioDispatcher) {
 		runCatching {
 			startNetworkMonitorJob()
-			initLogger(null, LOG_LEVEL, null)
+			initLogger(null, LOG_LEVEL, false)
 			initEnvironment(environment)
 			configureLib(credentialMode)
 			initialized.complete(Unit)
@@ -171,7 +171,7 @@ class NymBackend private constructor(private val context: Context) : Backend, Tu
 
 	private suspend fun configureLib(credentialMode: Boolean?) {
 		withContext(ioDispatcher) {
-			nym_vpn_lib.configureLib(storagePath, credentialMode, null)
+			nym_vpn_lib.configureLib(storagePath, credentialMode, false)
 		}
 	}
 

--- a/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/NymBackend.kt
+++ b/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/NymBackend.kt
@@ -116,7 +116,7 @@ class NymBackend private constructor(private val context: Context) : Backend, Tu
 	private fun init(environment: Tunnel.Environment, credentialMode: Boolean?) = ProcessLifecycleOwner.get().lifecycleScope.launch(ioDispatcher) {
 		runCatching {
 			startNetworkMonitorJob()
-			initLogger(null, LOG_LEVEL)
+			initLogger(null, LOG_LEVEL, null)
 			initEnvironment(environment)
 			configureLib(credentialMode)
 			initialized.complete(Unit)
@@ -171,7 +171,7 @@ class NymBackend private constructor(private val context: Context) : Backend, Tu
 
 	private suspend fun configureLib(credentialMode: Boolean?) {
 		withContext(ioDispatcher) {
-			nym_vpn_lib.configureLib(storagePath, credentialMode)
+			nym_vpn_lib.configureLib(storagePath, credentialMode, null)
 		}
 	}
 

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -5117,6 +5117,7 @@ dependencies = [
  "nym-windows",
  "nym-wireguard-types",
  "rand 0.8.5",
+ "sentry",
  "serde_json",
  "sysinfo",
  "thiserror 2.0.12",

--- a/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
@@ -71,6 +71,15 @@ nym-vpn-network-config.workspace = true
 nym-vpn-store.workspace = true
 nym-wg-gateway-client.workspace = true
 nym-wg-go.workspace = true
+sentry = { workspace = true, features = [
+    "backtrace",
+    "contexts",
+    "panic",
+    "reqwest",
+    "rustls",
+    "tracing",
+    "logs",
+] }
 
 [target.'cfg(unix)'.dependencies]
 nix = { workspace = true, features = [

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 //! The Uniffi generated bindings for the Nym VPN library. The API is designed to be used by
-//! frontends to interact with the Nym VPN library. The API is designed to be platform agnostic and
+//! frontends to interact with the Nym VPN library. The API is designed to be platform-agnostic and
 //! should work on any platform that supports the Uniffi FFI bindings.
 //!
 //! Usage:
@@ -11,7 +11,7 @@
 //!
 //!    This is required to set the network environment details.
 //!
-//! 2. Initialise the library: `configureLib(..)`.
+//! 2. Initialize the library: `configureLib(..)`.
 //!
 //!    This sets up the logger and starts the account controller that runs in the background and
 //!    manages the account state.
@@ -51,6 +51,7 @@ pub mod swift;
 
 mod account;
 mod environment;
+mod sentry_monitoring;
 mod state_machine;
 mod uniffi_custom_impls;
 mod uniffi_lib_types;
@@ -61,6 +62,7 @@ use account::AccountControllerHandle;
 use lazy_static::lazy_static;
 use nym_gateway_directory::CachingGatewayClient;
 use nym_vpn_api_client::types::ScoreThresholds;
+use sentry::ClientInitGuard;
 use tokio::{runtime::Runtime, sync::Mutex};
 
 use self::error::VpnError;
@@ -85,6 +87,7 @@ lazy_static! {
     static ref NETWORK_ENVIRONMENT: Mutex<Option<nym_vpn_network_config::Network>> =
         Mutex::new(None);
     static ref GATEWAY_DIRECTORY_CLIENT: Mutex<Option<CachingGatewayClient>> = Mutex::new(None);
+    static ref SENTRY_CLIENT: Mutex<Option<ClientInitGuard>> = Mutex::new(None);
 }
 
 /// Fetches the network environment details from the network name and initializes the environment,
@@ -121,31 +124,57 @@ pub fn currentEnvironment() -> Result<NetworkEnvironment, VpnError> {
 /// Setup the library with the given data directory and optionally enable credential mode.
 #[allow(non_snake_case)]
 #[uniffi::export]
-pub fn configureLib(data_dir: String, credential_mode: Option<bool>) -> Result<(), VpnError> {
-    RUNTIME.block_on(configure_lib(data_dir, credential_mode))
+pub fn configureLib(
+    data_dir: String,
+    credential_mode: Option<bool>,
+    sentry_monitoring: Option<bool>,
+) -> Result<(), VpnError> {
+    RUNTIME.block_on(configure_lib(data_dir, credential_mode, sentry_monitoring))
 }
 
-async fn configure_lib(data_dir: String, credential_mode: Option<bool>) -> Result<(), VpnError> {
+async fn configure_lib(
+    data_dir: String,
+    credential_mode: Option<bool>,
+    sentry_monitoring: Option<bool>,
+) -> Result<(), VpnError> {
     let network = environment::current_environment_details().await?;
+    let sentry_enabled = sentry_monitoring.is_some_and(|v| v);
+    if sentry_enabled {
+        let mut guard = SENTRY_CLIENT.lock().await;
+        *guard = sentry_monitoring::init();
+    }
     account::init_account_controller(PathBuf::from(data_dir), credential_mode, network).await
 }
 
-fn init_logger(path: Option<PathBuf>, debug_level: Option<String>) {
+async fn init_logger(
+    path: Option<PathBuf>,
+    debug_level: Option<String>,
+    sentry_monitoring: Option<bool>,
+) {
     let default_log_level = env::var("RUST_LOG").unwrap_or("info".to_string());
     let log_level = debug_level.unwrap_or(default_log_level);
+    let sentry_enabled = sentry_monitoring.is_some_and(|v| v);
     tracing::info!("Setting log level: {log_level}, path?: {path:?}");
+    if sentry_enabled {
+        let mut guard = SENTRY_CLIENT.lock().await;
+        *guard = sentry_monitoring::init();
+    }
     #[cfg(target_os = "ios")]
-    swift::init_logs(log_level, path);
+    swift::init_logs(log_level, path, sentry_enabled);
     #[cfg(target_os = "android")]
     android::init_logs(log_level);
 }
 
-/// Additional extra function for when only only want to set the logger without initializing the
-/// library. Thus it's only needed when `configureLib` is not used.
+/// Additional extra function for when only want to set the logger without initializing the
+/// library. Thus, it's only needed when `configureLib` is not used.
 #[allow(non_snake_case)]
 #[uniffi::export]
-pub fn initLogger(path: Option<PathBuf>, debug_level: Option<String>) {
-    init_logger(path, debug_level);
+pub async fn initLogger(
+    path: Option<PathBuf>,
+    debug_level: Option<String>,
+    sentry_monitoring: Option<bool>,
+) {
+    init_logger(path, debug_level, sentry_monitoring).await;
 }
 
 /// Returns the system messages for the current network environment

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/mod.rs
@@ -127,7 +127,7 @@ pub fn currentEnvironment() -> Result<NetworkEnvironment, VpnError> {
 pub fn configureLib(
     data_dir: String,
     credential_mode: Option<bool>,
-    sentry_monitoring: Option<bool>,
+    sentry_monitoring: bool,
 ) -> Result<(), VpnError> {
     RUNTIME.block_on(configure_lib(data_dir, credential_mode, sentry_monitoring))
 }
@@ -135,32 +135,26 @@ pub fn configureLib(
 async fn configure_lib(
     data_dir: String,
     credential_mode: Option<bool>,
-    sentry_monitoring: Option<bool>,
+    sentry_monitoring: bool,
 ) -> Result<(), VpnError> {
     let network = environment::current_environment_details().await?;
-    let sentry_enabled = sentry_monitoring.is_some_and(|v| v);
-    if sentry_enabled {
+    if sentry_monitoring {
         let mut guard = SENTRY_CLIENT.lock().await;
         *guard = sentry_monitoring::init();
     }
     account::init_account_controller(PathBuf::from(data_dir), credential_mode, network).await
 }
 
-async fn init_logger(
-    path: Option<PathBuf>,
-    debug_level: Option<String>,
-    sentry_monitoring: Option<bool>,
-) {
+async fn init_logger(path: Option<PathBuf>, debug_level: Option<String>, sentry_monitoring: bool) {
     let default_log_level = env::var("RUST_LOG").unwrap_or("info".to_string());
     let log_level = debug_level.unwrap_or(default_log_level);
-    let sentry_enabled = sentry_monitoring.is_some_and(|v| v);
     tracing::info!("Setting log level: {log_level}, path?: {path:?}");
-    if sentry_enabled {
+    if sentry_monitoring {
         let mut guard = SENTRY_CLIENT.lock().await;
         *guard = sentry_monitoring::init();
     }
     #[cfg(target_os = "ios")]
-    swift::init_logs(log_level, path, sentry_enabled);
+    swift::init_logs(log_level, path, sentry_monitoring);
     #[cfg(target_os = "android")]
     android::init_logs(log_level);
 }
@@ -172,7 +166,7 @@ async fn init_logger(
 pub async fn initLogger(
     path: Option<PathBuf>,
     debug_level: Option<String>,
-    sentry_monitoring: Option<bool>,
+    sentry_monitoring: bool,
 ) {
     init_logger(path, debug_level, sentry_monitoring).await;
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/sentry_monitoring.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/sentry_monitoring.rs
@@ -1,3 +1,6 @@
+// Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
 use sentry::ClientInitGuard;
 use std::time::Duration;
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/sentry_monitoring.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/sentry_monitoring.rs
@@ -1,0 +1,23 @@
+use sentry::ClientInitGuard;
+use std::time::Duration;
+
+pub fn init() -> Option<ClientInitGuard> {
+    let dsn = std::env::var("VPNLIB_SENTRY_DSN")
+        .ok()
+        .or_else(|| option_env!("VPNLIB_SENTRY_DSN").map(|s| s.to_string()))?;
+
+    println!("⚠ sentry monitoring enabled ⚠");
+    let guard = sentry::init((
+        dsn,
+        sentry::ClientOptions {
+            release: sentry::release_name!(),
+            send_default_pii: false,
+            sample_rate: 1.0,
+            traces_sample_rate: 1.0,
+            enable_logs: true,
+            shutdown_timeout: Duration::from_secs(2),
+            ..Default::default()
+        },
+    ));
+    Some(guard)
+}

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/swift.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/swift.rs
@@ -4,9 +4,11 @@
 use std::{fs::OpenOptions, path::PathBuf, str::FromStr};
 
 use sentry::integrations::tracing as sentry_tracing;
+use tracing::Level;
 use tracing_oslog::OsLogger;
 use tracing_subscriber::{
-    Registry, filter::LevelFilter, fmt::Layer, layer::SubscriberExt, util::SubscriberInitExt,
+    Layer, Registry, filter::LevelFilter, fmt::Layer as fmtLayer, layer::SubscriberExt,
+    util::SubscriberInitExt,
 };
 
 pub fn init_logs(level: String, path: Option<PathBuf>, sentry: bool) {
@@ -60,7 +62,7 @@ pub fn init_logs(level: String, path: Option<PathBuf>, sentry: bool) {
             .open(path)
             .ok()
             .map(|file| {
-                Layer::default()
+                fmtLayer::default()
                     .with_writer(file)
                     .with_ansi(false)
                     .compact()

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/swift.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/swift.rs
@@ -3,12 +3,13 @@
 
 use std::{fs::OpenOptions, path::PathBuf, str::FromStr};
 
+use sentry::integrations::tracing as sentry_tracing;
 use tracing_oslog::OsLogger;
 use tracing_subscriber::{
     Registry, filter::LevelFilter, fmt::Layer, layer::SubscriberExt, util::SubscriberInitExt,
 };
 
-pub fn init_logs(level: String, path: Option<PathBuf>) {
+pub fn init_logs(level: String, path: Option<PathBuf>, sentry: bool) {
     let oslogger_layer = OsLogger::new("net.nymtech.vpn.agent", "default");
 
     let filter = tracing_subscriber::EnvFilter::builder()
@@ -37,6 +38,7 @@ pub fn init_logs(level: String, path: Option<PathBuf>) {
 
     let registry = Registry::default().with(oslogger_layer);
 
+    let mut layers = Vec::new();
     let file_layer = path.as_ref().and_then(|path| {
         // Ensure log directory exists
         if let Some(parent) = path.parent() {
@@ -65,11 +67,19 @@ pub fn init_logs(level: String, path: Option<PathBuf>) {
             })
     });
 
-    let result = if let Some(file_layer) = file_layer {
-        registry.with(file_layer).with(filter).try_init()
-    } else {
-        registry.with(filter).try_init()
+    if let Some(file_layer) = file_layer {
+        layers.push(file_layer.boxed());
     };
+    if sentry {
+        let layer = sentry_tracing::layer().event_filter(|md| match md.level() {
+            &Level::ERROR | &Level::WARN => sentry_tracing::EventFilter::Event,
+            &Level::TRACE => sentry_tracing::EventFilter::Ignore,
+            _ => sentry_tracing::EventFilter::Breadcrumb,
+        });
+        layers.push(layer.boxed());
+    }
+
+    let result = registry.with(layers).with(filter).try_init();
 
     if let Err(err) = result {
         eprintln!("Failed to initialize logger: {err}");


### PR DESCRIPTION
This PR adds a sentry instance (when enabled) at the vpn lib level (Rust).
The DSN would have to be provided via the `VPNLIB_SENTRY_DSN`  env variable (runtime or compile time)

### Uniffi API changes

`configureLib` now takes a 3rd argument, whether sentry monitoring is enabled or disabled

```
configureLib(
    data_dir: String,
    credential_mode: Option<bool>,
    sentry_monitoring: bool,
)
```

Same for `initLogger` (when `configureLib` is not called)

```
initLogger(
    path: Option<PathBuf>,
    debug_level: Option<String>,
    sentry_monitoring: bool,
)
```

If false or not given, sentry client will not be initialized.

The state (enabled or disabled) of sentry monitoring, would have to be controlled (and stored) in the app client side.

## TODO
For Android, we need to check and confirm this is useful and actually working as expected. Because, even if it is 2 different clients (Android/Kotlin and Rust) having 2 sentry instances running in parallel on the same process could potentially lead to unexpected issues.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3022)
<!-- Reviewable:end -->
