### PR TITLE
APPLE: iOS update tunnel last error polling

### DIFF
--- a/nym-vpn-apple/NymMixnetTunnel/PacketTunneProvider+Messaging.swift
+++ b/nym-vpn-apple/NymMixnetTunnel/PacketTunneProvider+Messaging.swift
@@ -26,10 +26,11 @@ extension PacketTunnelProvider {
                     afterDisconnectAction = nil
                 }
 
-                let statusResponse = TunnelStatusResponse(
+                let statusResponse = await TunnelStatusResponse(
                     status: TunnelStatus(from: tunnelState),
                     retryAttempt: retryAttempt,
-                    afterDisconnectAction: afterDisconnectAction
+                    afterDisconnectAction: afterDisconnectAction,
+                    lastError: tunnelActor.lastError
                 )
                 return try JSONEncoder().encode(statusResponse)
             } catch {

--- a/nym-vpn-apple/NymMixnetTunnel/PacketTunnelProvider.swift
+++ b/nym-vpn-apple/NymMixnetTunnel/PacketTunnelProvider.swift
@@ -57,13 +57,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             throw PacketTunnelProviderError.noCredentialDataDir
         }
 
-        do {
-            try await startNymVpn(credentialDataPath: credentialDataPath, vpnConfig: vpnConfig)
-        } catch {
-            try? stopVpn()
-            try? shutdown()
-            throw error
-        }
+        try await startNymVpn(credentialDataPath: credentialDataPath, vpnConfig: vpnConfig)
     }
 
     override func stopTunnel(with reason: NEProviderStopReason) async {

--- a/nym-vpn-apple/NymMixnetTunnel/TunnelActor.swift
+++ b/nym-vpn-apple/NymMixnetTunnel/TunnelActor.swift
@@ -18,6 +18,7 @@ actor TunnelActor {
     var canReassert = false
 
     @Published private(set) var tunnelState: TunnelState?
+    var lastError: ErrorReason?
 
     init() {
         let (eventStream, eventContinuation) = AsyncStream<TunnelEvent>.makeStream()
@@ -53,11 +54,28 @@ actor TunnelActor {
                 tunnelProvider?.reasserting = false
             }
             canReassert = true
-        case .error:
+        case let .error(errorStateReason):
             if canReassert {
                 // todo: remove once we properly handle error state
                 tunnelProvider?.cancelTunnelWithError(PacketTunnelProviderError.errorState)
             }
+            lastError = ErrorReason(with: errorStateReason)
+            tunnelState = .connected(
+                connectionData: ConnectionData(
+                    entryGateway: Gateway(id: ""),
+                    exitGateway: Gateway(id: ""),
+                    connectedAt: nil,
+                    tunnel: .mixnet(
+                        MixnetConnectionData(
+                            nymAddress: NymAddress(nymAddress: "127.0.0.1", gatewayId: "127.0.0.1"),
+                            exitIpr: NymAddress(nymAddress: "127.0.0.1", gatewayId: "127.0.0.1"),
+                            ipv4: "0.0.0.0",
+                            ipv6: "0.0.0.0"
+                        )
+                    )
+                )
+            )
+            return
         case .disconnecting(.error):
             await NotificationMessages.scheduleDisconnectNotification()
         default:
@@ -76,14 +94,14 @@ actor TunnelActor {
             case .connected, .disconnected:
                 return
             case let .error(errorStateReason):
-                throw ErrorReason(with: errorStateReason).nsError
+                lastError = ErrorReason(with: errorStateReason)
             case .disconnecting, .none, .connecting:
                 break
             case let .some(.offline(reconnect: reconnect)):
                 if reconnect {
                     break
                 } else {
-                    throw ErrorReason.offline
+                    throw ErrorReason.offline.nsError
                 }
             }
         }

--- a/nym-vpn-apple/Services/Sources/Services/ConnectionManager/ConnectionManager+iOS.swift
+++ b/nym-vpn-apple/Services/Sources/Services/ConnectionManager/ConnectionManager+iOS.swift
@@ -60,6 +60,14 @@ extension ConnectionManager {
                     self?.afterDisconnectAction = action
                 }
             }
+
+        tunnelLastErrorCancelable = tunnel.$lastError
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] newError in
+                MainActor.assumeIsolated {
+                    self?.lastError = newError
+                }
+            }
     }
 }
 
@@ -146,9 +154,9 @@ extension ConnectionManager {
         guard let activeTunnel else { return false }
 
         switch activeTunnel.status {
-        case .connected, .connecting, .reasserting, .restarting, .offlineReconnect:
+        case .connected, .connecting, .reasserting, .restarting, .offlineReconnect, .error:
             return true
-        case .disconnecting, .disconnected, .offline, .unknown, .error:
+        case .disconnecting, .disconnected, .offline, .unknown:
             return false
         }
     }

--- a/nym-vpn-apple/Services/Sources/Services/ConnectionManager/ConnectionManager.swift
+++ b/nym-vpn-apple/Services/Sources/Services/ConnectionManager/ConnectionManager.swift
@@ -29,6 +29,7 @@ public final class ConnectionManager: ObservableObject {
     var tunnelStatusUpdateCancellable: AnyCancellable?
     var tunnelRetryAttemptCancellable: AnyCancellable?
     var tunnelAfterRetryCancellable: AnyCancellable?
+    var tunnelLastErrorCancelable: AnyCancellable?
 
     // TODO: remove this once iOS tunnel supports tunnel reconnection
     public var isReconnecting = false

--- a/nym-vpn-apple/Services/Sources/Services/Tunnels/Tunnel.swift
+++ b/nym-vpn-apple/Services/Sources/Services/Tunnels/Tunnel.swift
@@ -9,6 +9,7 @@ public final class Tunnel: NSObject, ObservableObject {
     @Published public var status: TunnelStatus
     @Published public var retryAttempt: Int?
     @Published public var afterDisconnectAction: AfterDisconnectAction?
+    @Published public var lastError: Error?
 
     private var logger: Logger
     private var isPolling = false
@@ -23,9 +24,15 @@ public final class Tunnel: NSObject, ObservableObject {
         self.tunnel = tunnel
         self.status = TunnelStatus(from: tunnel.connection.status)
         self.logger = Logger(label: "Tunnel \(name)")
+        super.init()
+
+        if status == .connected {
+            startPollingTunnelStatus()
+        }
     }
 
     func connect(recursionCount: UInt = 0, lastError: Error? = nil) async throws {
+        self.lastError = nil
         startPollingTunnelStatus()
         if recursionCount >= 8 {
             logger.log(level: .error, "Connecting failed after 8 attempts. Last error: \(String(describing: lastError))")
@@ -138,7 +145,14 @@ private extension Tunnel {
         retryAttempt = decodedResponse.retryAttempt
         afterDisconnectAction = decodedResponse.afterDisconnectAction
 
-        guard isPolling, status != decodedResponse.status else { return }
-        status = decodedResponse.status
+        guard isPolling else { return }
+        if let newError = decodedResponse.lastError {
+            guard status != .error else { return }
+            status = .error
+            lastError = newError
+        } else {
+            guard status != decodedResponse.status else { return }
+            status = decodedResponse.status
+        }
     }
 }

--- a/nym-vpn-apple/Services/Sources/Services/Tunnels/TunnelsManager.swift
+++ b/nym-vpn-apple/Services/Sources/Services/Tunnels/TunnelsManager.swift
@@ -146,10 +146,6 @@ private extension TunnelsManager {
                 else {
                     return
                 }
-                logger.log(
-                    level: .debug,
-                    "Tunnel '\(tunnel.name)' connection status changed to '\(tunnel.tunnel.connection.status)'"
-                )
                 tunnel.updateStatus()
 #if os(iOS)
                 Task { [weak self] in
@@ -162,21 +158,19 @@ private extension TunnelsManager {
 
 #if os(iOS)
     func updateLastTunnelErrorIfNeeded() async {
-        guard activeTunnel?.status == .disconnecting && activeTunnel?.status != .connected else { return }
+        guard activeTunnel?.status == .disconnecting else { return }
 
-        do {
-            try await activeTunnel?.tunnel.connection.fetchLastDisconnectError()
-        } catch let error as NSError {
+        if let error = activeTunnel?.lastError as? NSError {
             switch error.domain {
             case VPNErrorReason.domain:
                 lastError = VPNErrorReason(nsError: error)
             case ErrorReason.domain:
                 lastError = ErrorReason(nsError: error)
             default:
-                lastError = GeneralNymError.somethingWentWrong
+                lastError = error
             }
-        } catch {
-            lastError = GeneralNymError.somethingWentWrong
+        } else {
+            lastError = nil
         }
     }
 #endif

--- a/nym-vpn-apple/ServicesMutual/Package.swift
+++ b/nym-vpn-apple/ServicesMutual/Package.swift
@@ -84,7 +84,9 @@ let package = Package(
         ),
         .target(
             name: "TunnelStatus",
-            dependencies: [],
+            dependencies: [
+                "ErrorReason"
+            ],
             path: "Sources/TunnelStatus"
         )
     ]

--- a/nym-vpn-apple/ServicesMutual/Sources/ErrorReason/ErrorReason.swift
+++ b/nym-vpn-apple/ServicesMutual/Sources/ErrorReason/ErrorReason.swift
@@ -4,7 +4,7 @@ import MixnetLibrary
 #endif
 import Theme
 
-public enum ErrorReason: LocalizedError {
+public enum ErrorReason: LocalizedError, Codable {
     // App
     case offline
     case noAccountStored

--- a/nym-vpn-apple/ServicesMutual/Sources/TunnelStatus/TunnelStatusResponse.swift
+++ b/nym-vpn-apple/ServicesMutual/Sources/TunnelStatus/TunnelStatusResponse.swift
@@ -1,11 +1,20 @@
+import ErrorReason
+
 public struct TunnelStatusResponse: Codable {
     public let status: TunnelStatus
     public let retryAttempt: Int?
     public let afterDisconnectAction: AfterDisconnectAction?
+    public let lastError: ErrorReason?
 
-    public init(status: TunnelStatus, retryAttempt: Int?, afterDisconnectAction: AfterDisconnectAction?) {
+    public init(
+        status: TunnelStatus,
+        retryAttempt: Int?,
+        afterDisconnectAction: AfterDisconnectAction?,
+        lastError: ErrorReason?
+    ) {
         self.status = status
         self.retryAttempt = retryAttempt
         self.afterDisconnectAction = afterDisconnectAction
+        self.lastError = lastError
     }
 }


### PR DESCRIPTION
Couldn't find a Jira ticket.

Change the way the tunnel queries the error.
On error state - we fake successful tunnel connection, to keep the firewall engaged.
User manually needs to disconnect on error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3030)
<!-- Reviewable:end -->
