### PR TITLE
fix(amneziawg-go): drop specific amneziawg-go message to avoid log spam

### DIFF
--- a/nym-vpn-core/crates/nym-wg-go/src/wireguard_go.rs
+++ b/nym-vpn-core/crates/nym-wg-go/src/wireguard_go.rs
@@ -311,6 +311,8 @@ unsafe extern "C" {
     unsafe fn wgRebindTunnelSocket(address_family: u16, interface_index: u32);
 }
 
+const TRANSPORT_PACKET_TYPE_LOG: &str = "transport packet lined up with another msg type";
+
 /// Callback used by libwg to pass wireguard-go logs.
 ///
 /// # Safety
@@ -324,6 +326,13 @@ pub unsafe extern "system" fn wg_logger_callback(
     if !msg.is_null() {
         let str = unsafe { CStr::from_ptr(msg).to_string_lossy() };
         let trimmed_str = str.trim_end();
+        // TODO this is spamming aggressively, drop those lines
+        if trimmed_str
+            .to_lowercase()
+            .contains(TRANSPORT_PACKET_TYPE_LOG)
+        {
+            return;
+        }
         tracing::debug!("{}", trimmed_str);
     }
 }


### PR DESCRIPTION
This log message from [amneziawg-go](https://github.com/search?q=repo%3Aamnezia-vpn%2Famneziawg-go+%22Transport+packet+lined+up+with+another+msg+type%22&type=code) has been reported spamming aggressively in one internal report.

(~200lines/sec produced more than 1B lines, 100MB log file for a user session less than one day long)

Temporarily silence it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3032)
<!-- Reviewable:end -->
