### PR TITLE
feat(tauri): add vpnd sentry control

### DIFF
--- a/nym-vpn-app/src-tauri/src/commands/sentry.rs
+++ b/nym-vpn-app/src-tauri/src/commands/sentry.rs
@@ -3,17 +3,24 @@ use tauri::State;
 use tracing::{debug, info, instrument};
 
 use crate::error::BackendError;
+use crate::grpc::client::GrpcClient;
 use crate::state::{SharedAppConfig, SharedAppState};
 
 #[instrument(skip_all)]
 #[tauri::command]
-pub async fn enable_sentry(app_config: State<'_, SharedAppConfig>) -> Result<(), BackendError> {
+pub async fn enable_sentry(
+    app_config: State<'_, SharedAppConfig>,
+    grpc: State<'_, GrpcClient>,
+) -> Result<(), BackendError> {
     let mut config_guard = app_config.lock().await;
     let mut config = config_guard.read()?;
     config.sentry_monitoring = true;
     config_guard.data = config;
     config_guard.write()?;
     info!("sentry monitoring enabled, app restart required");
+
+    info!("enabling vpnd sentry monitoring");
+    grpc.enable_sentry().await?;
 
     Ok(())
 }
@@ -23,6 +30,7 @@ pub async fn enable_sentry(app_config: State<'_, SharedAppConfig>) -> Result<(),
 pub async fn disable_sentry(
     app_config: State<'_, SharedAppConfig>,
     app_state: State<'_, SharedAppState>,
+    grpc: State<'_, GrpcClient>,
 ) -> Result<(), BackendError> {
     let mut config_guard = app_config.lock().await;
     let mut config = config_guard.read()?;
@@ -37,8 +45,10 @@ pub async fn disable_sentry(
         client.close(Some(Duration::from_millis(200)));
         info!("sentry client closed");
     }
-
     info!("sentry monitoring disable ⚠ app restart required ⚠");
+
+    info!("disabling vpnd sentry monitoring");
+    grpc.disable_sentry().await?;
     Ok(())
 }
 

--- a/nym-vpn-app/src-tauri/src/grpc/client.rs
+++ b/nym-vpn-app/src-tauri/src/grpc/client.rs
@@ -538,6 +538,76 @@ impl GrpcClient {
                 VpndError::internal("no network compatibility data")
             })
     }
+
+    /// Is sentry enabled at daemon level
+    #[instrument(skip_all)]
+    pub async fn sentry_enabled(&self) -> Result<bool, VpndError> {
+        let mut vpnd = self.vpnd().await?;
+
+        let request = Request::new(());
+        let response = vpnd
+            .is_sentry_enabled(request)
+            .await
+            .map_err(|e| {
+                error!("grpc: {}", e);
+                VpndError::GrpcError(e)
+            })?
+            .into_inner();
+
+        debug!("vpnd sentry enabled: {}", response.enabled);
+        if response.enabled {
+            info!("⚠ vpnd sentry monitoring is enabled ⚠");
+        }
+        Ok(response.enabled)
+    }
+
+    /// Enable sentry at daemon level
+    #[instrument(skip_all)]
+    pub async fn enable_sentry(&self) -> Result<(), VpndError> {
+        let mut vpnd = self.vpnd().await?;
+
+        let request = Request::new(());
+        let response = vpnd
+            .enable_sentry(request)
+            .await
+            .map_err(|e| {
+                error!("grpc: {}", e);
+                VpndError::GrpcError(e)
+            })?
+            .into_inner();
+
+        debug!("vpnd sentry enabled: {}", response.success);
+        if !response.success {
+            error!("failed to enable sentry");
+            return Err(VpndError::internal("failed to enable sentry"));
+        }
+        info!("restart vpnd (service) required for the change to take effect");
+        Ok(())
+    }
+
+    /// Disable sentry at daemon level
+    #[instrument(skip_all)]
+    pub async fn disable_sentry(&self) -> Result<(), VpndError> {
+        let mut vpnd = self.vpnd().await?;
+
+        let request = Request::new(());
+        let response = vpnd
+            .disable_sentry(request)
+            .await
+            .map_err(|e| {
+                error!("grpc: {}", e);
+                VpndError::GrpcError(e)
+            })?
+            .into_inner();
+
+        debug!("vpnd sentry disabled: {}", response.success);
+        if !response.success {
+            error!("failed to disable sentry");
+            return Err(VpndError::internal("failed to disable sentry"));
+        }
+        info!("restart vpnd (service) recommended");
+        Ok(())
+    }
 }
 
 async fn get_channel(socket_path: PathBuf) -> Result<Channel> {

--- a/nym-vpn-app/src-tauri/src/main.rs
+++ b/nym-vpn-app/src-tauri/src/main.rs
@@ -217,10 +217,16 @@ async fn main() -> Result<()> {
                 info!("starting vpnd spy");
                 loop {
                     if let Ok(info) = c_grpc.vpnd_info().await {
+                        // connected to the daemon
+
                         c_grpc.update_vpnd_state(info, &handle).await.ok();
                         // initialize tunnel state
                         c_grpc.tunnel_state(&handle).await.ok();
                         info!("watching vpn tunnel events");
+                        // vpnd sentry check
+                        sentry::vpnd_check(sentry_enabled, &c_grpc).await.ok();
+                        // start watching tunnel events, this is a blocking call
+                        // and will keep the task alive as long as vpnd is running
                         c_grpc.watch_tunnel_events(&handle).await.ok();
                         // if the tunnel stream cuts off, that means vpnd is down
                         AppState::vpnd_down(&handle).await;

--- a/nym-vpn-app/src-tauri/src/sentry.rs
+++ b/nym-vpn-app/src-tauri/src/sentry.rs
@@ -1,10 +1,13 @@
-use crate::env::APP_SENTRY_DSN;
-use crate::sys::OsInfo;
-
+use anyhow::Result;
 use sentry::{ClientInitGuard, User};
 use std::time::Duration;
-use tracing::{info, warn};
+use tracing::{error, info, instrument, warn};
 
+use crate::env::APP_SENTRY_DSN;
+use crate::grpc::client::GrpcClient;
+use crate::sys::OsInfo;
+
+#[instrument(skip_all)]
 pub fn init(os: &OsInfo) -> Option<ClientInitGuard> {
     let Some(dsn) = APP_SENTRY_DSN.as_ref() else {
         warn!("failed to init sentry: APP_SENTRY_DSN is not set");
@@ -36,4 +39,29 @@ pub fn init(os: &OsInfo) -> Option<ClientInitGuard> {
         }));
     });
     Some(guard)
+}
+
+// Check the state of sentry monitoring at daemon level and
+// sync it with the app state if needed (as shown to the user in UI)
+#[instrument(skip(grpc))]
+pub async fn vpnd_check(sentry_enabled: bool, grpc: &GrpcClient) -> Result<()> {
+    let vpnd_enabled = grpc.sentry_enabled().await.inspect_err(|e| {
+        error!("failed to check sentry state: {:?}", e);
+    })?;
+    if vpnd_enabled == sentry_enabled {
+        // all good
+        return Ok(());
+    }
+    warn!(
+        "sentry state mismatch: app sentry enabled: {}, vpnd sentry enabled: {}",
+        sentry_enabled, vpnd_enabled
+    );
+    if sentry_enabled {
+        info!("enabling vpnd sentry monitoring");
+        grpc.enable_sentry().await?;
+    } else {
+        info!("disabling vpnd sentry monitoring");
+        grpc.disable_sentry().await?;
+    }
+    Ok(())
 }

--- a/nym-vpn-app/src/i18n/en/settings.json
+++ b/nym-vpn-app/src/i18n/en/settings.json
@@ -10,7 +10,7 @@
   "notifications": {
     "title": "Desktop notifications"
   },
-  "monitoring-alert": "You must restart the app for the change to take effect.",
+  "monitoring-alert": "You should restart the app and daemon service for the change to take effect.",
   "support": {
     "title": "Support & feedback",
     "faq": "Check the FAQ",

--- a/nym-vpn-app/src/i18n/fr/settings.json
+++ b/nym-vpn-app/src/i18n/fr/settings.json
@@ -10,7 +10,7 @@
   "notifications": {
     "title": "Notifications sur le bureau"
   },
-  "monitoring-alert": "Redémarrez l'application pour que le changement s'applique.",
+  "monitoring-alert": "Redémarrez l'application et le service du daemon pour que le changement s'applique.",
   "support": {
     "title": "Support et commentaire",
     "faq": "Consulter la FAQ",


### PR DESCRIPTION
Add control over vpnd sentry from the app side. Reuse the same toggle action in the UI to enable/disable both app and daemon sentry instances. Still **OFF by default**.
Added a check at early stage of the grpc connection with daemon, to check and keep in sync sentry state across app and vpnd sides.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3038)
<!-- Reviewable:end -->
