### PR TITLE
Set route mtu in multihop

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- sqlx-pool-guard public interface issue (https://github.com/nymtech/nym-vpn-client/pull/2925)
+- Wait for sqlite database to close before exiting the daemon to prevent database corruption (https://github.com/nymtech/nym-vpn-client/pull/2925)
 - Unblock mixnet client because of a deadlock (https://github.com/nymtech/nym-vpn-client/pull/3039)
 - Apply patch to h2 crate so hickory-dns DoH connections consider server go-away close as valid preventing spurious warn logging (https://github.com/nymtech/nym-vpn-client/pull/3053)
 - Fix tunnel connectivity issues by applying route MTU for multihop tunnel (https://github.com/nymtech/nym-vpn-client/pull/3051)

--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Wait for sqlite database to close before exiting the daemon to prevent database corruption (https://github.com/nymtech/nym-vpn-client/pull/2925)
+- Fix bug that prevented the database(s) from closing gracefully before being disposed (https://github.com/nymtech/nym-vpn-client/pull/2925)
 - Unblock mixnet client because of a deadlock (https://github.com/nymtech/nym-vpn-client/pull/3039)
 - Apply patch to h2 crate so hickory-dns DoH connections consider server go-away close as valid preventing spurious warn logging (https://github.com/nymtech/nym-vpn-client/pull/3053)
 - Fix tunnel connectivity issues by applying route MTU for multihop tunnel (https://github.com/nymtech/nym-vpn-client/pull/3051)

--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - sqlx-pool-guard public interface issue (https://github.com/nymtech/nym-vpn-client/pull/2925)
 - Unblock mixnet client because of a deadlock (https://github.com/nymtech/nym-vpn-client/pull/3039)
 - Apply patch to h2 crate so hickory-dns DoH connections consider server go-away close as valid preventing spurious warn logging (https://github.com/nymtech/nym-vpn-client/pull/3053)
+- Fix tunnel connectivity issues by applying route MTU for multihop tunnel (https://github.com/nymtech/nym-vpn-client/pull/3051)
 
 
 ## [1.11.0] - 2025-06-18

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -334,8 +334,6 @@ pub struct TunnelMetadata {
     ips: Vec<IpAddr>,
     ipv4_gateway: Option<Ipv4Addr>,
     ipv6_gateway: Option<Ipv6Addr>,
-    #[allow(unused)]
-    mtu: u16,
 }
 
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -334,6 +334,7 @@ pub struct TunnelMetadata {
     ips: Vec<IpAddr>,
     ipv4_gateway: Option<Ipv4Addr>,
     ipv6_gateway: Option<Ipv6Addr>,
+    #[allow(unused)]
     mtu: u16,
 }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -334,6 +334,7 @@ pub struct TunnelMetadata {
     ips: Vec<IpAddr>,
     ipv4_gateway: Option<Ipv4Addr>,
     ipv6_gateway: Option<Ipv6Addr>,
+    mtu: u16,
 }
 
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -11,7 +11,7 @@ mod resolver;
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 mod route_handler;
 mod states;
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 mod tun_ipv6;
 #[cfg(any(target_os = "ios", target_os = "android"))]
 mod tun_name;

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/route_handler.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/route_handler.rs
@@ -117,16 +117,7 @@ impl RouteHandler {
                     IpNetwork::from(entry_gateway_address),
                     NetNode::DefaultNode,
                 ));
-
-                routes.insert(RequiredRoute::new(
-                    "0.0.0.0/0".parse().unwrap(),
-                    Node::device(tun_name.to_owned()),
-                ));
-
-                routes.insert(RequiredRoute::new(
-                    "::0/0".parse().unwrap(),
-                    Node::device(tun_name.to_owned()),
-                ));
+                routes.extend(Self::get_wildcard_routes(tun_name));
             }
             RoutingConfig::Wireguard {
                 entry_tun_name,
@@ -140,21 +131,8 @@ impl RouteHandler {
                     IpNetwork::from(entry_gateway_address),
                     NetNode::DefaultNode,
                 ));
-
-                routes.insert(RequiredRoute::new(
-                    IpNetwork::from(exit_gateway_address),
-                    Node::device(entry_tun_name.to_owned()),
-                ));
-
-                routes.insert(RequiredRoute::new(
-                    "0.0.0.0/0".parse().unwrap(),
-                    Node::device(exit_tun_name.to_owned()),
-                ));
-
-                routes.insert(RequiredRoute::new(
-                    "::0/0".parse().unwrap(),
-                    Node::device(exit_tun_name.to_owned()),
-                ));
+                routes.insert(Self::get_exit_route(exit_gateway_address, entry_tun_name));
+                routes.extend(Self::get_wildcard_routes(exit_tun_name));
             }
             RoutingConfig::WireguardNetstack {
                 exit_tun_name,
@@ -166,28 +144,46 @@ impl RouteHandler {
                     IpNetwork::from(entry_gateway_address),
                     NetNode::DefaultNode,
                 ));
-
-                routes.insert(RequiredRoute::new(
-                    "0.0.0.0/0".parse().unwrap(),
-                    Node::device(exit_tun_name.to_owned()),
-                ));
-
-                routes.insert(RequiredRoute::new(
-                    "::0/0".parse().unwrap(),
-                    Node::device(exit_tun_name.to_owned()),
-                ));
+                routes.extend(Self::get_wildcard_routes(exit_tun_name));
             }
         }
 
+        routes
+    }
+
+    fn get_exit_route(ip_addr: IpAddr, iface: String) -> RequiredRoute {
+        let route = RequiredRoute::new(IpNetwork::from(ip_addr), Node::device(iface));
+
         #[cfg(target_os = "linux")]
         {
-            routes = routes
-                .into_iter()
-                .map(|r| r.use_main_table(false))
-                .collect();
+            route.use_main_table(false)
         }
 
-        routes
+        #[cfg(not(target_os = "linux"))]
+        {
+            route
+        }
+    }
+
+    fn get_wildcard_routes(iface: String) -> Vec<RequiredRoute> {
+        let ipv4_route =
+            RequiredRoute::new("0.0.0.0/0".parse().unwrap(), Node::device(iface.to_owned()));
+        let ipv6_route = RequiredRoute::new("::0/0".parse().unwrap(), Node::device(iface));
+
+        let routes = vec![ipv4_route, ipv6_route];
+
+        #[cfg(target_os = "linux")]
+        {
+            routes
+                .into_iter()
+                .map(|r| r.use_main_table(false))
+                .collect()
+        }
+
+        #[cfg(not(target_os = "linux"))]
+        {
+            routes
+        }
     }
 }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/route_handler.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/route_handler.rs
@@ -186,7 +186,7 @@ impl RouteHandler {
         route
     }
 
-    fn get_default_routes(iface: String, mtu: u16) -> Vec<RequiredRoute> {
+    fn get_default_routes(iface: String, _mtu: u16) -> Vec<RequiredRoute> {
         let ipv4_route =
             RequiredRoute::new("0.0.0.0/0".parse().unwrap(), Node::device(iface.to_owned()));
         let ipv6_route = RequiredRoute::new("::0/0".parse().unwrap(), Node::device(iface));
@@ -204,7 +204,7 @@ impl RouteHandler {
 
         #[cfg(any(target_os = "linux", target_os = "macos"))]
         {
-            routes = routes.into_iter().map(|r| r.mtu(mtu)).collect();
+            routes = routes.into_iter().map(|r| r.mtu(_mtu)).collect();
         }
 
         routes

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/route_handler.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/route_handler.rs
@@ -169,7 +169,7 @@ impl RouteHandler {
         routes
     }
 
-    fn get_multihop_exit_route(ip_addr: IpAddr, iface: String, mtu: u16) -> RequiredRoute {
+    fn get_multihop_exit_route(ip_addr: IpAddr, iface: String, _mtu: u16) -> RequiredRoute {
         #[allow(unused_mut)]
         let mut route = RequiredRoute::new(IpNetwork::from(ip_addr), Node::device(iface));
 
@@ -180,7 +180,7 @@ impl RouteHandler {
 
         #[cfg(any(target_os = "linux", target_os = "macos"))]
         {
-            route = route.mtu(mtu);
+            route = route.mtu(_mtu);
         }
 
         route

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/route_handler.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/route_handler.rs
@@ -20,18 +20,22 @@ pub const TUNNEL_FWMARK: u32 = 0x14d;
 pub enum RoutingConfig {
     Mixnet {
         tun_name: String,
+        tun_mtu: u16,
         #[cfg(not(target_os = "linux"))]
         entry_gateway_address: IpAddr,
     },
     Wireguard {
         entry_tun_name: String,
         exit_tun_name: String,
+        entry_tun_mtu: u16,
+        exit_tun_mtu: u16,
         #[cfg(not(target_os = "linux"))]
         entry_gateway_address: IpAddr,
         exit_gateway_address: IpAddr,
     },
     WireguardNetstack {
         exit_tun_name: String,
+        exit_tun_mtu: u16,
         #[cfg(not(target_os = "linux"))]
         entry_gateway_address: IpAddr,
     },
@@ -83,15 +87,20 @@ impl RouteHandler {
         }
     }
 
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    pub async fn get_mtu_for_route(&mut self, ip_addr: IpAddr) -> Result<u16> {
+        Ok(self.route_manager.get_mtu_for_route(ip_addr).await?)
+    }
+
     #[cfg(windows)]
     pub async fn add_default_route_listener(
         &mut self,
         event_handler: Callback,
     ) -> Result<CallbackHandle> {
-        self.route_manager
+        Ok(self
+            .route_manager
             .add_default_route_change_callback(event_handler)
-            .await
-            .map_err(Error::from)
+            .await?)
     }
 
     pub async fn stop(self) {
@@ -109,6 +118,7 @@ impl RouteHandler {
         match routing_config {
             RoutingConfig::Mixnet {
                 tun_name,
+                tun_mtu,
                 #[cfg(not(target_os = "linux"))]
                 entry_gateway_address,
             } => {
@@ -117,11 +127,13 @@ impl RouteHandler {
                     IpNetwork::from(entry_gateway_address),
                     NetNode::DefaultNode,
                 ));
-                routes.extend(Self::get_wildcard_routes(tun_name));
+                routes.extend(Self::get_default_routes(tun_name, tun_mtu));
             }
             RoutingConfig::Wireguard {
                 entry_tun_name,
                 exit_tun_name,
+                entry_tun_mtu,
+                exit_tun_mtu,
                 #[cfg(not(target_os = "linux"))]
                 entry_gateway_address,
                 exit_gateway_address,
@@ -131,11 +143,17 @@ impl RouteHandler {
                     IpNetwork::from(entry_gateway_address),
                     NetNode::DefaultNode,
                 ));
-                routes.insert(Self::get_exit_route(exit_gateway_address, entry_tun_name));
-                routes.extend(Self::get_wildcard_routes(exit_tun_name));
+
+                routes.insert(Self::get_multihop_exit_route(
+                    exit_gateway_address,
+                    entry_tun_name,
+                    entry_tun_mtu,
+                ));
+                routes.extend(Self::get_default_routes(exit_tun_name, exit_tun_mtu));
             }
             RoutingConfig::WireguardNetstack {
                 exit_tun_name,
+                exit_tun_mtu,
                 #[cfg(not(target_os = "linux"))]
                 entry_gateway_address,
             } => {
@@ -144,46 +162,52 @@ impl RouteHandler {
                     IpNetwork::from(entry_gateway_address),
                     NetNode::DefaultNode,
                 ));
-                routes.extend(Self::get_wildcard_routes(exit_tun_name));
+                routes.extend(Self::get_default_routes(exit_tun_name, exit_tun_mtu));
             }
         }
 
         routes
     }
 
-    fn get_exit_route(ip_addr: IpAddr, iface: String) -> RequiredRoute {
-        let route = RequiredRoute::new(IpNetwork::from(ip_addr), Node::device(iface));
+    fn get_multihop_exit_route(ip_addr: IpAddr, iface: String, mtu: u16) -> RequiredRoute {
+        #[allow(unused_mut)]
+        let mut route = RequiredRoute::new(IpNetwork::from(ip_addr), Node::device(iface));
 
         #[cfg(target_os = "linux")]
         {
-            route.use_main_table(false)
+            route = route.use_main_table(false);
         }
 
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         {
-            route
+            route = route.mtu(mtu);
         }
+
+        route
     }
 
-    fn get_wildcard_routes(iface: String) -> Vec<RequiredRoute> {
+    fn get_default_routes(iface: String, mtu: u16) -> Vec<RequiredRoute> {
         let ipv4_route =
             RequiredRoute::new("0.0.0.0/0".parse().unwrap(), Node::device(iface.to_owned()));
         let ipv6_route = RequiredRoute::new("::0/0".parse().unwrap(), Node::device(iface));
 
-        let routes = vec![ipv4_route, ipv6_route];
+        #[allow(unused_mut)]
+        let mut routes = vec![ipv4_route, ipv6_route];
 
         #[cfg(target_os = "linux")]
         {
-            routes
+            routes = routes
                 .into_iter()
                 .map(|r| r.use_main_table(false))
-                .collect()
+                .collect();
         }
 
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         {
-            routes
+            routes = routes.into_iter().map(|r| r.mtu(mtu)).collect();
         }
+
+        routes
     }
 }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tun_ipv6.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tun_ipv6.rs
@@ -1,28 +1,27 @@
 // Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{io, net::Ipv6Addr};
+use std::{io, net::Ipv6Addr, process::Command};
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
-use std::process::Command;
-
-pub fn set_ipv6_addr(_device_name: &str, _ipv6_addr: Ipv6Addr) -> io::Result<()> {
-    #[cfg(target_os = "linux")]
+#[cfg(target_os = "linux")]
+pub fn set_ipv6_addr(device_name: &str, ipv6_addr: Ipv6Addr) -> io::Result<()> {
     Command::new("ip")
         .args([
             "-6",
             "addr",
             "add",
-            &_ipv6_addr.to_string(),
+            &ipv6_addr.to_string(),
             "dev",
-            _device_name,
+            device_name,
         ])
         .output()?;
+    Ok(())
+}
 
-    #[cfg(target_os = "macos")]
+#[cfg(target_os = "macos")]
+pub fn set_ipv6_addr(device_name: &str, ipv6_addr: Ipv6Addr) -> io::Result<()> {
     Command::new("ifconfig")
-        .args([_device_name, "inet6", "add", &_ipv6_addr.to_string()])
+        .args([device_name, "inet6", "add", &ipv6_addr.to_string()])
         .output()?;
-
     Ok(())
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -651,12 +651,34 @@ impl TunnelMonitor {
             .map_err(Box::new)?;
         let assigned_addresses = connected_tunnel.assigned_addresses();
 
-        let mtu: u16 = self
+        let mtu = if let Some(mtu) = self
             .tunnel_parameters
             .tunnel_settings
             .mixnet_tunnel_options
             .mtu
-            .unwrap_or(DEFAULT_TUN_MTU);
+        {
+            mtu
+        } else {
+            #[cfg(any(target_os = "linux", target_os = "windows"))]
+            {
+                use nym_common::ErrorExt;
+                self.route_handler
+                    .get_mtu_for_route(assigned_addresses.entry_mixnet_gateway_ip)
+                    .await
+                    .inspect_err(|e| {
+                        tracing::warn!(
+                            "{}",
+                            e.display_chain_with_msg("Failed to detect mtu for route")
+                        );
+                    })
+                    .unwrap_or(DEFAULT_TUN_MTU)
+            }
+
+            #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+            {
+                DEFAULT_TUN_MTU
+            }
+        };
 
         #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
         let tun_device = Self::create_mixnet_device(assigned_addresses.interface_addresses, mtu)?;
@@ -703,6 +725,7 @@ impl TunnelMonitor {
         {
             let routing_config = RoutingConfig::Mixnet {
                 tun_name: tun_name.clone(),
+                tun_mtu: mtu,
                 #[cfg(not(target_os = "linux"))]
                 entry_gateway_address: assigned_addresses.entry_mixnet_gateway_ip,
             };
@@ -721,6 +744,7 @@ impl TunnelMonitor {
 
         let tunnel_metadata = TunnelMetadata {
             interface: tun_name,
+            mtu,
             ips: vec![
                 IpAddr::V4(assigned_addresses.interface_addresses.ipv4),
                 IpAddr::V6(assigned_addresses.interface_addresses.ipv6),
@@ -757,19 +781,21 @@ impl TunnelMonitor {
             .map_err(Box::new)?;
         let conn_data = connected_tunnel.connection_data();
 
+        let exit_tun_mtu = connected_tunnel.exit_mtu();
         let exit_tun = Self::create_wireguard_device(
             IpPair {
                 ipv4: conn_data.exit.private_ipv4,
                 ipv6: conn_data.exit.private_ipv6,
             },
             Some(conn_data.entry.private_ipv4),
-            connected_tunnel.exit_mtu(),
+            exit_tun_mtu,
         )?;
         let exit_tun_name = exit_tun.get_ref().name().map_err(Error::GetTunDeviceName)?;
         tracing::info!("Created exit tun device: {}", exit_tun_name);
 
         let routing_config = RoutingConfig::WireguardNetstack {
             exit_tun_name: exit_tun_name.clone(),
+            exit_tun_mtu,
             #[cfg(not(target_os = "linux"))]
             entry_gateway_address: conn_data.entry.endpoint.ip(),
         };
@@ -798,6 +824,7 @@ impl TunnelMonitor {
 
         let tunnel_metadata = TunnelMetadata {
             interface: exit_tun_name,
+            mtu: exit_tun_mtu,
             ips: vec![
                 IpAddr::V4(conn_data.exit.private_ipv4),
                 IpAddr::V6(conn_data.exit.private_ipv6),
@@ -834,6 +861,7 @@ impl TunnelMonitor {
             .map_err(Box::new)?;
         let conn_data = connected_tunnel.connection_data();
         let entry_gateway_address = conn_data.entry.endpoint.ip();
+        let exit_mtu = connected_tunnel.exit_mtu();
 
         let exit_adapter_config = WintunAdapterConfig {
             interface_ipv4: conn_data.exit.private_ipv4,
@@ -843,6 +871,7 @@ impl TunnelMonitor {
         };
         let mut tunnel_metadata = TunnelMetadata {
             interface: "".to_owned(),
+            mtu: exit_mtu,
             ips: vec![
                 IpAddr::V4(conn_data.exit.private_ipv4),
                 IpAddr::V6(conn_data.exit.private_ipv6),
@@ -888,6 +917,7 @@ impl TunnelMonitor {
 
         let routing_config = RoutingConfig::WireguardNetstack {
             exit_tun_name: wintun_exit_interface.name.clone(),
+            exit_tun_mtu: exit_mtu,
             entry_gateway_address,
         };
         // todo: make sure to shutdown tunnel_handle on failure!
@@ -917,13 +947,14 @@ impl TunnelMonitor {
             .map_err(Box::new)?;
         let conn_data = connected_tunnel.connection_data();
 
+        let entry_mtu = connected_tunnel.entry_mtu();
         let entry_tun = Self::create_wireguard_device(
             IpPair {
                 ipv4: conn_data.entry.private_ipv4,
                 ipv6: conn_data.entry.private_ipv6,
             },
             None,
-            connected_tunnel.entry_mtu(),
+            entry_mtu,
         )?;
         let entry_tun_name = entry_tun
             .get_ref()
@@ -933,6 +964,7 @@ impl TunnelMonitor {
 
         let entry_tunnel_metadata = TunnelMetadata {
             interface: entry_tun_name,
+            mtu: entry_mtu,
             ips: vec![
                 IpAddr::V4(conn_data.entry.private_ipv4),
                 IpAddr::V6(conn_data.entry.private_ipv6),
@@ -941,6 +973,7 @@ impl TunnelMonitor {
             ipv6_gateway: None,
         };
 
+        let exit_mtu = connected_tunnel.exit_mtu();
         let exit_tun = Self::create_wireguard_device(
             IpPair {
                 ipv4: conn_data.exit.private_ipv4,
@@ -948,13 +981,14 @@ impl TunnelMonitor {
             },
             // todo: this needs to be able to set both destinations?
             Some(conn_data.entry.private_ipv4),
-            connected_tunnel.exit_mtu(),
+            exit_mtu,
         )?;
         let exit_tun_name = exit_tun.get_ref().name().map_err(Error::GetTunDeviceName)?;
         tracing::info!("Created exit tun device: {}", exit_tun_name);
 
         let exit_tunnel_metadata = TunnelMetadata {
             interface: exit_tun_name.clone(),
+            mtu: exit_mtu,
             ips: vec![
                 IpAddr::V4(conn_data.exit.private_ipv4),
                 IpAddr::V6(conn_data.exit.private_ipv6),
@@ -966,6 +1000,8 @@ impl TunnelMonitor {
         let routing_config = RoutingConfig::Wireguard {
             entry_tun_name: entry_tunnel_metadata.interface.clone(),
             exit_tun_name: exit_tunnel_metadata.interface.clone(),
+            entry_tun_mtu: entry_mtu,
+            exit_tun_mtu: exit_mtu,
             #[cfg(not(target_os = "linux"))]
             entry_gateway_address: conn_data.entry.endpoint.ip(),
             exit_gateway_address: conn_data.exit.endpoint.ip(),
@@ -1023,6 +1059,8 @@ impl TunnelMonitor {
             .await
             .map_err(Box::new)?;
         let conn_data = connected_tunnel.connection_data();
+        let entry_tun_mtu = connected_tunnel.entry_mtu();
+        let exit_tun_mtu = connected_tunnel.exit_mtu();
 
         let entry_gateway_address = conn_data.entry.endpoint.ip();
         let exit_gateway_address = conn_data.exit.endpoint.ip();
@@ -1035,6 +1073,7 @@ impl TunnelMonitor {
         };
         let mut entry_tunnel_metadata = TunnelMetadata {
             interface: "".to_owned(),
+            mtu: entry_tun_mtu,
             ips: vec![
                 IpAddr::V4(conn_data.entry.private_ipv4),
                 IpAddr::V6(conn_data.entry.private_ipv6),
@@ -1051,6 +1090,7 @@ impl TunnelMonitor {
         };
         let mut exit_tunnel_metadata = TunnelMetadata {
             interface: "".to_owned(),
+            mtu: exit_tun_mtu,
             ips: vec![
                 IpAddr::V4(conn_data.exit.private_ipv4),
                 IpAddr::V6(conn_data.exit.private_ipv6),
@@ -1116,6 +1156,8 @@ impl TunnelMonitor {
         let routing_config = RoutingConfig::Wireguard {
             entry_tun_name: wintun_entry_interface.name.clone(),
             exit_tun_name: wintun_exit_interface.name.clone(),
+            entry_tun_mtu,
+            exit_tun_mtu,
             entry_gateway_address,
             exit_gateway_address,
         };
@@ -1142,6 +1184,7 @@ impl TunnelMonitor {
             .await
             .map_err(Box::new)?;
 
+        let mtu = connected_tunnel.exit_mtu();
         let conn_data = connected_tunnel.connection_data();
 
         let packet_tunnel_settings = tunnel_provider::tunnel_settings::TunnelSettings {
@@ -1156,7 +1199,7 @@ impl TunnelMonitor {
                 IpNetwork::V6(Ipv6Network::from(conn_data.exit.private_ipv6)),
             ],
             remote_addresses: vec![conn_data.entry.endpoint.ip()],
-            mtu: connected_tunnel.exit_mtu(),
+            mtu,
         };
 
         let tun_device = self.create_tun_device(packet_tunnel_settings).await?;
@@ -1164,6 +1207,7 @@ impl TunnelMonitor {
         let interface = tun_name::get_tun_name(&tun_fd).map_err(Error::GetTunDeviceName)?;
         let tunnel_metadata = TunnelMetadata {
             interface,
+            mtu,
             ips: vec![
                 IpAddr::V4(conn_data.exit.private_ipv4),
                 IpAddr::V6(conn_data.exit.private_ipv6),

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -914,6 +914,11 @@ impl TunnelMonitor {
         tracing::info!("Created wintun device: {}", wintun_exit_interface.name);
 
         wintun::setup_wintun_adapter(wintun_exit_interface.windows_luid(), exit_adapter_config)?;
+        wintun::initialize_interfaces(
+            wintun_exit_interface.windows_luid(),
+            Some(exit_mtu),
+            Some(exit_mtu),
+        )?;
 
         let routing_config = RoutingConfig::WireguardNetstack {
             exit_tun_name: wintun_exit_interface.name.clone(),
@@ -1144,6 +1149,17 @@ impl TunnelMonitor {
         wintun::setup_wintun_adapter(wintun_entry_interface.windows_luid(), entry_adapter_config)?;
         wintun::setup_wintun_adapter(wintun_exit_interface.windows_luid(), exit_adapter_config)?;
 
+        wintun::initialize_interfaces(
+            wintun_entry_interface.windows_luid(),
+            Some(entry_tun_mtu),
+            Some(entry_tun_mtu),
+        )?;
+        wintun::initialize_interfaces(
+            wintun_exit_interface.windows_luid(),
+            Some(exit_tun_mtu),
+            Some(exit_tun_mtu),
+        )?;
+
         // Update interface names in tunnel metadata
         entry_tunnel_metadata.interface = wintun_entry_interface.name.clone();
         exit_tunnel_metadata.interface = wintun_exit_interface.name.clone();
@@ -1284,6 +1300,8 @@ impl TunnelMonitor {
 
         tun_ipv6::set_ipv6_addr(&tun_name, interface_addresses.ipv6)
             .map_err(Error::SetTunDeviceIpv6Addr)?;
+        #[cfg(windows)]
+        wintun::initialize_interfaces_with_alias(&tun_name, Some(mtu), Some(mtu))?;
 
         Ok(tun_device)
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -744,7 +744,6 @@ impl TunnelMonitor {
 
         let tunnel_metadata = TunnelMetadata {
             interface: tun_name,
-            mtu,
             ips: vec![
                 IpAddr::V4(assigned_addresses.interface_addresses.ipv4),
                 IpAddr::V6(assigned_addresses.interface_addresses.ipv6),
@@ -824,7 +823,6 @@ impl TunnelMonitor {
 
         let tunnel_metadata = TunnelMetadata {
             interface: exit_tun_name,
-            mtu: exit_tun_mtu,
             ips: vec![
                 IpAddr::V4(conn_data.exit.private_ipv4),
                 IpAddr::V6(conn_data.exit.private_ipv6),
@@ -871,7 +869,6 @@ impl TunnelMonitor {
         };
         let mut tunnel_metadata = TunnelMetadata {
             interface: "".to_owned(),
-            mtu: exit_mtu,
             ips: vec![
                 IpAddr::V4(conn_data.exit.private_ipv4),
                 IpAddr::V6(conn_data.exit.private_ipv6),
@@ -969,7 +966,6 @@ impl TunnelMonitor {
 
         let entry_tunnel_metadata = TunnelMetadata {
             interface: entry_tun_name,
-            mtu: entry_mtu,
             ips: vec![
                 IpAddr::V4(conn_data.entry.private_ipv4),
                 IpAddr::V6(conn_data.entry.private_ipv6),
@@ -993,7 +989,6 @@ impl TunnelMonitor {
 
         let exit_tunnel_metadata = TunnelMetadata {
             interface: exit_tun_name.clone(),
-            mtu: exit_mtu,
             ips: vec![
                 IpAddr::V4(conn_data.exit.private_ipv4),
                 IpAddr::V6(conn_data.exit.private_ipv6),
@@ -1078,7 +1073,6 @@ impl TunnelMonitor {
         };
         let mut entry_tunnel_metadata = TunnelMetadata {
             interface: "".to_owned(),
-            mtu: entry_tun_mtu,
             ips: vec![
                 IpAddr::V4(conn_data.entry.private_ipv4),
                 IpAddr::V6(conn_data.entry.private_ipv6),
@@ -1095,7 +1089,6 @@ impl TunnelMonitor {
         };
         let mut exit_tunnel_metadata = TunnelMetadata {
             interface: "".to_owned(),
-            mtu: exit_tun_mtu,
             ips: vec![
                 IpAddr::V4(conn_data.exit.private_ipv4),
                 IpAddr::V6(conn_data.exit.private_ipv6),
@@ -1223,7 +1216,6 @@ impl TunnelMonitor {
         let interface = tun_name::get_tun_name(&tun_fd).map_err(Error::GetTunDeviceName)?;
         let tunnel_metadata = TunnelMetadata {
             interface,
-            mtu,
             ips: vec![
                 IpAddr::V4(conn_data.exit.private_ipv4),
                 IpAddr::V6(conn_data.exit.private_ipv6),

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -41,7 +41,9 @@ use tun::Device;
 use nym_ip_packet_requests::IpPair;
 
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-use super::route_handler::RouteHandler;
+use super::route_handler::{RouteHandler, RoutingConfig};
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+use super::tun_ipv6;
 #[cfg(any(target_os = "ios", target_os = "android"))]
 use super::tun_name;
 use super::{
@@ -50,8 +52,6 @@ use super::{
         self, AnyTunnelHandle, ConnectedMixnet, MixnetConnectOptions, SelectedGateways, Tombstone,
     },
 };
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-use super::{route_handler::RoutingConfig, tun_ipv6};
 use nym_common::trace_err_chain;
 use nym_vpn_lib_types::{
     ConnectionData, ErrorStateReason, Gateway, MixnetConnectionData, MixnetEvent, NymAddress,
@@ -1298,10 +1298,16 @@ impl TunnelMonitor {
             .name()
             .map_err(Error::GetTunDeviceName)?;
 
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         tun_ipv6::set_ipv6_addr(&tun_name, interface_addresses.ipv6)
             .map_err(Error::SetTunDeviceIpv6Addr)?;
+
         #[cfg(windows)]
-        wintun::initialize_interfaces_with_alias(&tun_name, Some(mtu), Some(mtu))?;
+        {
+            let interface_luid = wintun::get_interface_luid_for_alias(&tun_name)?;
+            wintun::add_ipv6_address(interface_luid, interface_addresses.ipv6)?;
+            wintun::initialize_interfaces(interface_luid, Some(mtu), Some(mtu))?;
+        }
 
         Ok(tun_device)
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/wintun.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/wintun.rs
@@ -72,6 +72,15 @@ pub fn setup_wintun_adapter(
     Ok(())
 }
 
+/// Set IPv6 address only on network interface
+pub fn add_ipv6_address(
+    luid: NET_LUID_LH,
+    interface_ipv6: Ipv6Addr,
+) -> Result<(), SetupWintunAdapterError> {
+    wnet::add_ip_address_for_interface(luid, IpAddr::V6(interface_ipv6))
+        .map_err(SetupWintunAdapterError::SetIpv6Addr)
+}
+
 /// Sets MTU, metric, and disables unnecessary features for the IP interfaces
 /// on the specified network interface (identified by `luid`).
 pub fn initialize_interfaces(
@@ -114,17 +123,10 @@ pub fn initialize_interfaces(
     Ok(())
 }
 
-/// Does all the same as `initialize_interfaces` using interface alias.
-pub fn initialize_interfaces_with_alias(
+/// Returns interface LUID for alias upon success, otherwise error.
+pub fn get_interface_luid_for_alias(
     interface_alias: &str,
-    ipv4_mtu: Option<u16>,
-    ipv6_mtu: Option<u16>,
-) -> Result<(), SetupWintunAdapterError> {
-    let luid = wnet::luid_from_alias(interface_alias)
-        .map_err(SetupWintunAdapterError::GetInterfaceLuidFromAlias)?;
-    tracing::debug!(
-        "Converted interface alias {interface_alias} to luid: {}",
-        unsafe { luid.Value }
-    );
-    initialize_interfaces(luid, ipv4_mtu, ipv6_mtu)
+) -> Result<NET_LUID_LH, SetupWintunAdapterError> {
+    wnet::luid_from_alias(interface_alias)
+        .map_err(SetupWintunAdapterError::GetInterfaceLuidFromAlias)
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/wintun.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/wintun.rs
@@ -1,10 +1,13 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use nym_windows::net as wnet;
+use nym_windows::net::{self as wnet, AddressFamily};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
-use windows::Win32::NetworkManagement::Ndis::NET_LUID_LH;
+use windows::Win32::{
+    Foundation::ERROR_NOT_FOUND, NetworkManagement::Ndis::NET_LUID_LH,
+    Networking::WinSock::RouterDiscoveryDisabled,
+};
 
 /// Wintun adapter configuration error.
 #[derive(Debug, thiserror::Error)]
@@ -20,6 +23,15 @@ pub enum SetupWintunAdapterError {
 
     #[error("failed to set wintun adapter ipv6 gateway address")]
     SetIpv6Gateway(#[source] nym_windows::net::Error),
+
+    #[error("failed to set interface mtu")]
+    SetMtu(#[source] windows::core::Error),
+
+    #[error("failed to set ip interface entry")]
+    SetIpInterfaceEntry(#[source] windows::core::Error),
+
+    #[error("failed to obtain interface luid from alias")]
+    GetInterfaceLuidFromAlias(#[source] std::io::Error),
 }
 
 /// Struct holding wintun adapter IP configuration.
@@ -58,4 +70,61 @@ pub fn setup_wintun_adapter(
     }
 
     Ok(())
+}
+
+/// Sets MTU, metric, and disables unnecessary features for the IP interfaces
+/// on the specified network interface (identified by `luid`).
+pub fn initialize_interfaces(
+    luid: NET_LUID_LH,
+    ipv4_mtu: Option<u16>,
+    ipv6_mtu: Option<u16>,
+) -> Result<(), SetupWintunAdapterError> {
+    for (family, mtu) in &[
+        (AddressFamily::Ipv4, ipv4_mtu),
+        (AddressFamily::Ipv6, ipv6_mtu),
+    ] {
+        let mut row = match wnet::get_ip_interface_entry(*family, &luid) {
+            Ok(row) => row,
+            Err(error) if error.code() == ERROR_NOT_FOUND.into() => {
+                tracing::warn!("Interface not found for {family}");
+                continue;
+            }
+            Err(error) => return Err(SetupWintunAdapterError::SetMtu(error)),
+        };
+
+        if let Some(mtu) = mtu {
+            row.NlMtu = u32::from(*mtu);
+        }
+
+        // Disable DAD, DHCP, and router discovery
+        row.SitePrefixLength = 0;
+        row.RouterDiscoveryBehavior = RouterDiscoveryDisabled;
+        row.DadTransmits = 0;
+        row.ManagedAddressConfigurationSupported = false;
+        row.OtherStatefulConfigurationSupported = false;
+
+        // Ensure lowest interface metric
+        row.Metric = 1;
+        row.UseAutomaticMetric = false;
+
+        wnet::set_ip_interface_entry(&mut row)
+            .map_err(SetupWintunAdapterError::SetIpInterfaceEntry)?;
+    }
+
+    Ok(())
+}
+
+/// Does all the same as `initialize_interfaces` using interface alias.
+pub fn initialize_interfaces_with_alias(
+    interface_alias: &str,
+    ipv4_mtu: Option<u16>,
+    ipv6_mtu: Option<u16>,
+) -> Result<(), SetupWintunAdapterError> {
+    let luid = wnet::luid_from_alias(interface_alias)
+        .map_err(SetupWintunAdapterError::GetInterfaceLuidFromAlias)?;
+    tracing::debug!(
+        "Converted interface alias {interface_alias} to luid: {}",
+        unsafe { luid.Value }
+    );
+    initialize_interfaces(luid, ipv4_mtu, ipv6_mtu)
 }


### PR DESCRIPTION
- macOS, Linux: set route MTU for multi-hop tunnel. Although I am not fully certain, the assumption is that if MTU is not set for the route, the system is free to run PMTUD to determine it, which could probably cause fragmentation issues if it turns out to be lower than tunnel interface MTU.
- Linux: ensure that only default routes `0.0.0.0/0`, `::0/0` and multi-hop exit route bypass the main table.
- Windows: set interface IP configuration specifying: the lowest interface metric (1), disable DAD, router discovery, dhcp, MTU which I assume is basically an equivalent of route MTU on other platforms.
- Set IPv6 address for mixnet tunnel interface.
- Linux, Windows: consult routing table for the MTU suitable for mixnet tunnel instead of hardcoding `1500`. Fallback to `1500` in case of error.
- Libwg: remove a workaround for Go runtime crash, which has been fixed since Go 1.23.6 (Moved to https://github.com/nymtech/nym-vpn-client/pull/3057)

JIRA-VPN-3575

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3051)
<!-- Reviewable:end -->
