### PR TITLE
Add import sorting

### DIFF
--- a/nym-vpn-core/README.md
+++ b/nym-vpn-core/README.md
@@ -1,5 +1,25 @@
 # Nym VPN Core
 
+## Code formatting
+
+We use some of nightly features of rustfmt to format the codebase. Please install the nightly rust with rustfmt:
+
+```sh
+rustup toolchain install nightly -c rustfmt
+```
+
+Format the code using the following command:
+
+```sh
+cargo +nightly fmt
+```
+
+If you use VSCode and automatic formatting, configure rust-analyzer to use nightly rustfmt:
+
+```json
+"rust-analyzer.rustfmt.extraArgs": ["+nightly"],
+```
+
 ## Prerequisites
 
 ### Linux 

--- a/nym-vpn-core/crates/nym-statistics/src/api_client.rs
+++ b/nym-vpn-core/crates/nym-statistics/src/api_client.rs
@@ -3,8 +3,7 @@
 
 use serde::Serialize;
 
-use crate::config::StatisticsControllerConfig;
-use crate::error::Error;
+use crate::{config::StatisticsControllerConfig, error::Error};
 
 #[derive(Clone, Debug)]
 pub(crate) struct StatisticsControllerApiClient {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/topology_provider.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/topology_provider.rs
@@ -12,8 +12,7 @@ use tokio::sync::{
 use tokio_util::sync::CancellationToken;
 use url::Url;
 
-use nym_client_core::NymTopology;
-use nym_client_core::client::topology_control::nym_api_provider::Config;
+use nym_client_core::{NymTopology, client::topology_control::nym_api_provider::Config};
 use nym_sdk::{NymApiTopologyProvider, TopologyProvider, UserAgent};
 
 enum FetcherCommand {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/storage/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/storage/mod.rs
@@ -4,9 +4,7 @@
 use std::path::Path;
 
 use nym_vpn_store::{
-    keys::device::{
-        DeviceKeyStore, DeviceKeys, {DeviceKeysPaths, OnDiskKeysError},
-    },
+    keys::device::{DeviceKeyStore, DeviceKeys, DeviceKeysPaths, OnDiskKeysError},
     mnemonic::{Mnemonic, MnemonicStorage, on_disk::OnDiskMnemonicStorageError},
 };
 

--- a/nym-vpn-core/rustfmt.toml
+++ b/nym-vpn-core/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Crate"


### PR DESCRIPTION
## Description

Enable import sorting using crate [granularity](https://rust-lang.github.io/rustfmt/?version=v1.8.0&search=group#imports_granularity)

This feature has been around for years and makes imports quite compact. It does require nightly compiler AFAIK but that shouldn't be a problem.

For those using VSCode to format, the following needs to be added to rust-analyzer configuration:

```
"rust-analyzer.rustfmt.extraArgs": ["+nightly"],
```

## Checklist:

- [ ] Changelog

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3075)
<!-- Reviewable:end -->
