### PR TITLE
Add setting to toggle IPv6 support

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Probe sends zk-nyms (https://github.com/nymtech/nym-vpn-client/pull/3011)
 - Two keypairs per gateway (first part) (https://github.com/nymtech/nym-vpn-client/pull/3035)
 - Don't wait on topology fetch from network on state machine start (https://github.com/nymtech/nym-vpn-client/pull/3072)
+- Add setting to toggle IPv6 support.
 
 ### Changed
 

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -5158,6 +5158,7 @@ dependencies = [
  "url",
  "vergen-gitcl",
  "windows 0.59.0",
+ "winreg 0.55.0",
 ]
 
 [[package]]

--- a/nym-vpn-core/crates/nym-routing/src/unix/mod.rs
+++ b/nym-vpn-core/crates/nym-routing/src/unix/mod.rs
@@ -263,10 +263,13 @@ impl RouteManagerHandle {
 
     /// Ensure that packets are routed using the correct tables.
     #[cfg(target_os = "linux")]
-    pub async fn create_routing_rules(&self) -> Result<(), Error> {
+    pub async fn create_routing_rules(&self, enable_ipv6: bool) -> Result<(), Error> {
         let (response_tx, response_rx) = oneshot::channel();
         self.tx
-            .send(RouteManagerCommand::CreateRoutingRules(true, response_tx))
+            .send(RouteManagerCommand::CreateRoutingRules(
+                enable_ipv6,
+                response_tx,
+            ))
             .map_err(|_| Error::RouteManagerDown)?;
         response_rx
             .await

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/connection_data.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/connection_data.rs
@@ -107,7 +107,7 @@ pub struct MixnetConnectionData {
     pub entry_ip: IpAddr,
     pub exit_ip: IpAddr,
     pub ipv4: Ipv4Addr,
-    pub ipv6: Ipv6Addr,
+    pub ipv6: Option<Ipv6Addr>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -121,7 +121,7 @@ pub struct WireguardNode {
     pub endpoint: SocketAddr,
     pub public_key: String,
     pub private_ipv4: Ipv4Addr,
-    pub private_ipv6: Ipv6Addr,
+    pub private_ipv6: Option<Ipv6Addr>,
 }
 
 #[cfg(feature = "nym-type-conversions")]
@@ -131,7 +131,7 @@ impl From<nym_wg_gateway_client::GatewayData> for WireguardNode {
             endpoint: value.endpoint,
             public_key: value.public_key.to_base64(),
             private_ipv4: value.private_ipv4,
-            private_ipv6: value.private_ipv6,
+            private_ipv6: Some(value.private_ipv6),
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
@@ -216,6 +216,9 @@ pub enum ErrorStateReason {
     /// If the time is not synced, the device will not be able to connect to the entry gateways.
     DeviceTimeOutOfSync,
 
+    /// IPv6 is disabled in the system.
+    Ipv6Unavailable,
+
     /// Program errors that must not happen.
     Internal(String),
 }
@@ -242,6 +245,7 @@ pub enum ClientErrorReason {
     Api(Option<String>),
     DeviceTimeOutOfSync,
     CreateMixnetStorage,
+    Ipv6Unavailable,
     Internal(Option<String>),
 }
 
@@ -278,6 +282,7 @@ impl From<ErrorStateReason> for ClientErrorReason {
             ErrorStateReason::StartLocalDnsResolver => Self::Dns(Some(value.to_string())),
             ErrorStateReason::SetDns => Self::Dns(Some(value.to_string())),
             ErrorStateReason::DeviceTimeOutOfSync => Self::DeviceTimeOutOfSync,
+            ErrorStateReason::Ipv6Unavailable => Self::Ipv6Unavailable,
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
@@ -94,6 +94,7 @@ nix = { workspace = true, features = [
 
 [target.'cfg(windows)'.dependencies]
 windows = { workspace = true, features = ["Win32_NetworkManagement_Ndis"] }
+winreg.workspace = true
 nym-windows.workspace = true
 nym-routing.workspace = true
 nym-dns.workspace = true

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/state_machine.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/state_machine.rs
@@ -80,6 +80,7 @@ pub(super) async fn start_state_machine(
     let user_agent = nym_sdk::UserAgent::from(config.user_agent.clone());
 
     let tunnel_settings = TunnelSettings {
+        enable_ipv6: true,
         tunnel_type,
         mixnet_tunnel_options: MixnetTunnelOptions::default(),
         wireguard_tunnel_options: WireguardTunnelOptions::default(),

--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/uniffi_lib_types.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/uniffi_lib_types.rs
@@ -240,6 +240,7 @@ pub enum ErrorStateReason {
     Api(Option<String>),
     DeviceTimeOutOfSync,
     CreateMixnetStorage,
+    Ipv6Unavailable,
     Internal(Option<String>),
 }
 
@@ -591,6 +592,7 @@ impl From<ClientErrorReason> for ErrorStateReason {
             ClientErrorReason::Api(message) => Self::Api(message),
             ClientErrorReason::DeviceTimeOutOfSync => Self::DeviceTimeOutOfSync,
             ClientErrorReason::CreateMixnetStorage => Self::CreateMixnetStorage,
+            ClientErrorReason::Ipv6Unavailable => Self::Ipv6Unavailable,
             ClientErrorReason::Internal(message) => Self::Internal(message),
         }
     }
@@ -686,7 +688,7 @@ pub struct MixnetConnectionData {
     pub nym_address: NymAddress,
     pub exit_ipr: NymAddress,
     pub ipv4: Ipv4Addr,
-    pub ipv6: Ipv6Addr,
+    pub ipv6: Option<Ipv6Addr>,
 }
 
 #[derive(uniffi::Record)]
@@ -700,7 +702,7 @@ pub struct WireguardNode {
     pub endpoint: SocketAddr,
     pub public_key: String,
     pub private_ipv4: Ipv4Addr,
-    pub private_ipv6: Ipv6Addr,
+    pub private_ipv6: Option<Ipv6Addr>,
 }
 
 impl From<CoreWireguardNode> for WireguardNode {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/ipv6_availability.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/ipv6_availability.rs
@@ -1,0 +1,41 @@
+// Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+#[cfg(windows)]
+pub async fn is_ipv6_enabled_in_os() -> bool {
+    use winreg::{RegKey, enums::HKEY_LOCAL_MACHINE};
+
+    const IPV6_DISABLED_ON_TUNNELS_MASK: u32 = 0x01;
+
+    // Check registry if IPv6 is disabled on tunnel interfaces, as documented in
+    // https://support.microsoft.com/en-us/help/929852/guidance-for-configuring-ipv6-in-windows-for-advanced-users
+    RegKey::predef(HKEY_LOCAL_MACHINE)
+        .open_subkey(r"SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters")
+        .and_then(|ipv6_config| ipv6_config.get_value("DisabledComponents"))
+        .map(|ipv6_disabled_bits: u32| (ipv6_disabled_bits & IPV6_DISABLED_ON_TUNNELS_MASK) == 0)
+        .unwrap_or(true)
+}
+
+#[cfg(not(windows))]
+pub async fn is_ipv6_enabled_in_os() -> bool {
+    #[cfg(target_os = "linux")]
+    {
+        // - Use `/proc/sys/net/ipv6/conf/default` instead of `/proc/sys/net/ipv6/conf/default/all`,
+        //   because when configuring the kernel with `ipv6.disable_ipv6=1`, `all` would be `0`, however `default` would be `1`.
+        //   In such configuration manipulating routing table is not possible anyway due to permission error.
+        //   See: https://wiki.archlinux.org/title/IPv6 (paragraph 10.1)
+        //
+        // - If kernel is configured with `ipv6.disable=1` then `/proc/sys/net/ipv6/*` does not even exist.
+        //
+        // - When setting `net.ipv6.conf.all.disable_ipv6=1` at runtime, `net.ipv6.conf.default`
+        //   is automatically updated to `1` too.
+        tokio::fs::read_to_string("/proc/sys/net/ipv6/conf/default/disable_ipv6")
+            .await
+            .map(|disable_ipv6| disable_ipv6.trim() == "0")
+            .unwrap_or(false)
+    }
+    #[cfg(any(target_os = "macos", target_os = "android", target_os = "ios"))]
+    {
+        true
+    }
+}

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -6,6 +6,7 @@ mod account;
 mod android_connectivity_adapter;
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 mod dns_handler;
+mod ipv6_availability;
 #[cfg(target_os = "macos")]
 mod resolver;
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
@@ -27,6 +28,8 @@ use std::{
     path::PathBuf,
 };
 
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+use nym_dns::ResolvedDnsConfig;
 use nym_offline_monitor::ConnectivityHandle;
 use nym_statistics::{StatisticsSender, events::StatisticsEvent};
 use nym_vpn_account_controller::AccountCommandSender;
@@ -91,6 +94,9 @@ enum NextTunnelState {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct TunnelSettings {
+    /// Whether to enable support for IPv6.
+    pub enable_ipv6: bool,
+
     /// Type of tunnel.
     pub tunnel_type: TunnelType,
 
@@ -118,6 +124,27 @@ pub struct TunnelSettings {
 
     /// The user agent used for HTTP requests.
     pub user_agent: Option<UserAgent>,
+}
+
+impl TunnelSettings {
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+    /// Returns resolved DNS config resolved against default DNS IPs.
+    pub fn resolved_dns_config(&self) -> ResolvedDnsConfig {
+        self.dns.to_dns_config().resolve(
+            &self.default_dns_ips(),
+            #[cfg(target_os = "macos")]
+            53,
+        )
+    }
+
+    /// Returns DNS IPs filtering out IPv6 addresses when IPv6 is disabled.
+    pub fn default_dns_ips(&self) -> Vec<IpAddr> {
+        crate::DEFAULT_DNS_SERVERS
+            .iter()
+            .filter(|ip| ip.is_ipv4() || (ip.is_ipv6() && self.enable_ipv6))
+            .copied()
+            .collect()
+    }
 }
 
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
@@ -203,6 +230,7 @@ impl DnsOptions {
 impl Default for TunnelSettings {
     fn default() -> Self {
         Self {
+            enable_ipv6: true,
             tunnel_type: TunnelType::Wireguard,
             mixnet_tunnel_options: MixnetTunnelOptions::default(),
             mixnet_client_config: None,
@@ -634,6 +662,9 @@ pub enum Error {
 
     #[error("device time not synced")]
     DeviceTimeOutOfSync,
+
+    #[error("ipv6 is disabled in the system")]
+    Ipv6Unavailable,
 }
 
 impl Error {
@@ -666,6 +697,7 @@ impl Error {
             Self::GetRouteHandle(e) => ErrorStateReason::Internal(e.to_string()),
             Self::Account(err) => err.error_state_reason()?,
             Self::DeviceTimeOutOfSync => ErrorStateReason::DeviceTimeOutOfSync,
+            Self::Ipv6Unavailable => ErrorStateReason::Ipv6Unavailable,
         })
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/route_handler.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/route_handler.rs
@@ -58,11 +58,15 @@ impl RouteHandler {
         Ok(Self { route_manager })
     }
 
-    pub async fn add_routes(&mut self, routing_config: RoutingConfig) -> Result<()> {
-        let routes = Self::get_routes(routing_config);
+    pub async fn add_routes(
+        &mut self,
+        routing_config: RoutingConfig,
+        enable_ipv6: bool,
+    ) -> Result<()> {
+        let routes = Self::get_routes(routing_config, enable_ipv6);
 
         #[cfg(target_os = "linux")]
-        self.route_manager.create_routing_rules().await?;
+        self.route_manager.create_routing_rules(enable_ipv6).await?;
 
         self.route_manager.add_routes(routes).await?;
 
@@ -112,7 +116,7 @@ impl RouteHandler {
         self.route_manager.clone()
     }
 
-    fn get_routes(routing_config: RoutingConfig) -> HashSet<RequiredRoute> {
+    fn get_routes(routing_config: RoutingConfig, enable_ipv6: bool) -> HashSet<RequiredRoute> {
         let mut routes = HashSet::new();
 
         match routing_config {
@@ -127,7 +131,7 @@ impl RouteHandler {
                     IpNetwork::from(entry_gateway_address),
                     NetNode::DefaultNode,
                 ));
-                routes.extend(Self::get_default_routes(tun_name, tun_mtu));
+                routes.extend(Self::get_default_routes(tun_name, tun_mtu, enable_ipv6));
             }
             RoutingConfig::Wireguard {
                 entry_tun_name,
@@ -149,7 +153,11 @@ impl RouteHandler {
                     entry_tun_name,
                     entry_tun_mtu,
                 ));
-                routes.extend(Self::get_default_routes(exit_tun_name, exit_tun_mtu));
+                routes.extend(Self::get_default_routes(
+                    exit_tun_name,
+                    exit_tun_mtu,
+                    enable_ipv6,
+                ));
             }
             RoutingConfig::WireguardNetstack {
                 exit_tun_name,
@@ -162,7 +170,11 @@ impl RouteHandler {
                     IpNetwork::from(entry_gateway_address),
                     NetNode::DefaultNode,
                 ));
-                routes.extend(Self::get_default_routes(exit_tun_name, exit_tun_mtu));
+                routes.extend(Self::get_default_routes(
+                    exit_tun_name,
+                    exit_tun_mtu,
+                    enable_ipv6,
+                ));
             }
         }
 
@@ -186,13 +198,20 @@ impl RouteHandler {
         route
     }
 
-    fn get_default_routes(iface: String, _mtu: u16) -> Vec<RequiredRoute> {
-        let ipv4_route =
-            RequiredRoute::new("0.0.0.0/0".parse().unwrap(), Node::device(iface.to_owned()));
-        let ipv6_route = RequiredRoute::new("::0/0".parse().unwrap(), Node::device(iface));
+    fn get_default_routes(iface: String, _mtu: u16, enable_ipv6: bool) -> Vec<RequiredRoute> {
+        let mut routes = Vec::new();
 
-        #[allow(unused_mut)]
-        let mut routes = vec![ipv4_route, ipv6_route];
+        routes.push(RequiredRoute::new(
+            "0.0.0.0/0".parse().unwrap(),
+            Node::device(iface.to_owned()),
+        ));
+
+        if enable_ipv6 {
+            routes.push(RequiredRoute::new(
+                "::0/0".parse().unwrap(),
+                Node::device(iface),
+            ));
+        }
 
         #[cfg(target_os = "linux")]
         {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
@@ -136,12 +136,7 @@ impl ConnectedState {
             peer_endpoints.push(allowed_endpoint);
         }
 
-        let dns_config = shared_state.tunnel_settings.dns.to_dns_config().resolve(
-            &crate::DEFAULT_DNS_SERVERS,
-            #[cfg(target_os = "macos")]
-            53,
-        );
-
+        let dns_config = shared_state.tunnel_settings.resolved_dns_config();
         let policy = FirewallPolicy::Connected {
             peer_endpoints,
             tunnel: nym_firewall::TunnelInterface::from(self.tunnel_interface.clone()),
@@ -163,12 +158,7 @@ impl ConnectedState {
 
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     async fn set_dns(&self, shared_state: &mut SharedState) -> Result<()> {
-        let dns_config = shared_state.tunnel_settings.dns.to_dns_config().resolve(
-            &crate::DEFAULT_DNS_SERVERS,
-            #[cfg(target_os = "macos")]
-            53,
-        );
-
+        let dns_config = shared_state.tunnel_settings.resolved_dns_config();
         let tunnel_metadata = self.tunnel_interface.exit_tunnel_metadata();
 
         #[cfg(any(target_os = "linux", target_os = "windows"))]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -144,6 +144,9 @@ impl ConnectingState {
                 entry_gateway
                     .ips
                     .iter()
+                    .filter(|ip| {
+                        ip.is_ipv4() || (ip.is_ipv6() && shared_state.tunnel_settings.enable_ipv6)
+                    })
                     .map(|ip| {
                         AllowedEndpoint::new(
                             Endpoint::new(*ip, ws_port, TransportProtocol::Tcp),
@@ -168,15 +171,18 @@ impl ConnectingState {
             peer_endpoints.push(allowed_endpoint);
         }
         // Set non-tunnel DNS to allow api client to use those DNS servers.
-        let dns_config = DnsConfig::from_addresses(&[], &crate::DEFAULT_DNS_SERVERS).resolve(
-            // pass empty because we already override the config with non-tunnel addresses.
-            &[],
-            #[cfg(target_os = "macos")]
-            53,
-        );
+        let dns_config =
+            DnsConfig::from_addresses(&[], &shared_state.tunnel_settings.default_dns_ips())
+                .resolve(
+                    // pass empty because we already override the config with non-tunnel addresses.
+                    &[],
+                    #[cfg(target_os = "macos")]
+                    53,
+                );
 
         let allowed_endpoints = resolved_gateway_addresses
             .iter()
+            .filter(|ip| ip.is_ipv4() || (ip.is_ipv6() && shared_state.tunnel_settings.enable_ipv6))
             .map(|addr| {
                 AllowedEndpoint::new(
                     Endpoint::from_socket_address(*addr, TransportProtocol::Tcp),

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -145,7 +145,7 @@ impl ConnectingState {
                     .ips
                     .iter()
                     .filter(|ip| {
-                        ip.is_ipv4() || (ip.is_ipv6() && shared_state.tunnel_settings.enable_ipv6)
+                        ip.is_ipv4() || (shared_state.tunnel_settings.enable_ipv6 && ip.is_ipv6())
                     })
                     .map(|ip| {
                         AllowedEndpoint::new(
@@ -182,7 +182,7 @@ impl ConnectingState {
 
         let allowed_endpoints = resolved_gateway_addresses
             .iter()
-            .filter(|ip| ip.is_ipv4() || (ip.is_ipv6() && shared_state.tunnel_settings.enable_ipv6))
+            .filter(|ip| ip.is_ipv4() || (shared_state.tunnel_settings.enable_ipv6 && ip.is_ipv6()))
             .map(|addr| {
                 AllowedEndpoint::new(
                     Endpoint::from_socket_address(*addr, TransportProtocol::Tcp),

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mixnet/connected_tunnel.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mixnet/connected_tunnel.rs
@@ -77,6 +77,7 @@ impl ConnectedTunnel {
         connection_monitor.start(
             mixnet_client_sender,
             self.assigned_addresses.mixnet_client_address,
+            // todo: not fully possible to disable IPv6 because IpPair is passed.
             self.assigned_addresses.interface_addresses,
             self.assigned_addresses.exit_mix_addresses.into(),
             &self.task_manager,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -301,9 +301,7 @@ impl TunnelMonitor {
                 .ok_or(Error::Tunnel(Box::new(tunnel::Error::Cancelled)))?;
         }
 
-        if self.tunnel_parameters.tunnel_settings.enable_ipv6
-            && !ipv6_availability::is_ipv6_enabled_in_os().await
-        {
+        if self.enable_ipv6() && !ipv6_availability::is_ipv6_enabled_in_os().await {
             return Err(Error::Ipv6Unavailable);
         }
 
@@ -692,9 +690,7 @@ impl TunnelMonitor {
         #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
         let tun_device = Self::create_mixnet_device(
             assigned_addresses.interface_addresses.ipv4,
-            self.tunnel_parameters
-                .tunnel_settings
-                .enable_ipv6
+            self.enable_ipv6()
                 .then_some(assigned_addresses.interface_addresses.ipv6),
             mtu,
         )?;
@@ -705,7 +701,7 @@ impl TunnelMonitor {
                 assigned_addresses.interface_addresses.ipv4,
             ))];
 
-            if self.tunnel_parameters.tunnel_settings.enable_ipv6 {
+            if self.enable_ipv6() {
                 interface_addresses.push(IpNetwork::V6(Ipv6Network::from(
                     assigned_addresses.interface_addresses.ipv6,
                 )));
@@ -748,11 +744,7 @@ impl TunnelMonitor {
                 entry_gateway_address: assigned_addresses.entry_mixnet_gateway_ip,
             };
 
-            self.set_routes(
-                routing_config,
-                self.tunnel_parameters.tunnel_settings.enable_ipv6,
-            )
-            .await?;
+            self.set_routes(routing_config, self.enable_ipv6()).await?;
         }
 
         let tunnel_conn_data = TunnelConnectionData::Mixnet(MixnetConnectionData {
@@ -769,7 +761,7 @@ impl TunnelMonitor {
         });
 
         let mut ips = vec![IpAddr::V4(assigned_addresses.interface_addresses.ipv4)];
-        if self.tunnel_parameters.tunnel_settings.enable_ipv6 {
+        if self.enable_ipv6() {
             ips.push(IpAddr::V6(assigned_addresses.interface_addresses.ipv6));
         }
         let tunnel_metadata = TunnelMetadata {
@@ -810,10 +802,7 @@ impl TunnelMonitor {
         let exit_tun_mtu = connected_tunnel.exit_mtu();
         let exit_tun = Self::create_wireguard_device(
             conn_data.exit.private_ipv4,
-            self.tunnel_parameters
-                .tunnel_settings
-                .enable_ipv6
-                .then_some(conn_data.exit.private_ipv6),
+            self.enable_ipv6().then_some(conn_data.exit.private_ipv6),
             Some(conn_data.entry.private_ipv4),
             exit_tun_mtu,
         )?;
@@ -827,11 +816,7 @@ impl TunnelMonitor {
             entry_gateway_address: conn_data.entry.endpoint.ip(),
         };
 
-        self.set_routes(
-            routing_config,
-            self.tunnel_parameters.tunnel_settings.enable_ipv6,
-        )
-        .await?;
+        self.set_routes(routing_config, self.enable_ipv6()).await?;
 
         let tunnel_conn_data = TunnelConnectionData::Wireguard(WireguardConnectionData {
             entry: WireguardNode::from(conn_data.entry.clone()),
@@ -940,10 +925,7 @@ impl TunnelMonitor {
         wintun::initialize_interfaces(
             wintun_exit_interface.windows_luid(),
             Some(exit_mtu),
-            self.tunnel_parameters
-                .tunnel_settings
-                .enable_ipv6
-                .then_some(exit_mtu),
+            self.enable_ipv6().then_some(exit_mtu),
         )?;
 
         let routing_config = RoutingConfig::WireguardNetstack {
@@ -952,13 +934,7 @@ impl TunnelMonitor {
             entry_gateway_address,
         };
 
-        if let Err(err) = self
-            .set_routes(
-                routing_config,
-                self.tunnel_parameters.tunnel_settings.enable_ipv6,
-            )
-            .await
-        {
+        if let Err(err) = self.set_routes(routing_config, self.enable_ipv6()).await {
             tunnel_handle.cancel();
             _ = tunnel_handle.wait().await;
             return Err(err);
@@ -991,10 +967,7 @@ impl TunnelMonitor {
         let entry_mtu = connected_tunnel.entry_mtu();
         let entry_tun = Self::create_wireguard_device(
             conn_data.entry.private_ipv4,
-            self.tunnel_parameters
-                .tunnel_settings
-                .enable_ipv6
-                .then_some(conn_data.entry.private_ipv6),
+            self.enable_ipv6().then_some(conn_data.entry.private_ipv6),
             None,
             entry_mtu,
         )?;
@@ -1005,7 +978,7 @@ impl TunnelMonitor {
         tracing::info!("Created entry tun device: {}", entry_tun_name);
 
         let mut ips = vec![IpAddr::V4(conn_data.entry.private_ipv4)];
-        if self.tunnel_parameters.tunnel_settings.enable_ipv6 {
+        if self.enable_ipv6() {
             ips.push(IpAddr::V6(conn_data.entry.private_ipv6));
         }
         let entry_tunnel_metadata = TunnelMetadata {
@@ -1018,10 +991,7 @@ impl TunnelMonitor {
         let exit_mtu = connected_tunnel.exit_mtu();
         let exit_tun = Self::create_wireguard_device(
             conn_data.exit.private_ipv4,
-            self.tunnel_parameters
-                .tunnel_settings
-                .enable_ipv6
-                .then_some(conn_data.exit.private_ipv6),
+            self.enable_ipv6().then_some(conn_data.exit.private_ipv6),
             // todo: this needs to be able to set both destinations?
             Some(conn_data.entry.private_ipv4),
             exit_mtu,
@@ -1030,7 +1000,7 @@ impl TunnelMonitor {
         tracing::info!("Created exit tun device: {}", exit_tun_name);
 
         let mut ips = vec![IpAddr::V4(conn_data.exit.private_ipv4)];
-        if self.tunnel_parameters.tunnel_settings.enable_ipv6 {
+        if self.enable_ipv6() {
             ips.push(IpAddr::V6(conn_data.exit.private_ipv6));
         }
 
@@ -1054,11 +1024,7 @@ impl TunnelMonitor {
             entry_gateway_address: conn_data.entry.endpoint.ip(),
             exit_gateway_address: conn_data.exit.endpoint.ip(),
         };
-        self.set_routes(
-            routing_config,
-            self.tunnel_parameters.tunnel_settings.enable_ipv6,
-        )
-        .await?;
+        self.set_routes(routing_config, self.enable_ipv6()).await?;
 
         let tunnel_conn_data = TunnelConnectionData::Wireguard(WireguardConnectionData {
             entry: WireguardNode::from(conn_data.entry.clone()),
@@ -1110,17 +1076,13 @@ impl TunnelMonitor {
 
         let entry_adapter_config = WintunAdapterConfig {
             interface_ipv4: conn_data.entry.private_ipv4,
-            interface_ipv6: self
-                .tunnel_parameters
-                .tunnel_settings
-                .enable_ipv6
-                .then_some(conn_data.entry.private_ipv6),
+            interface_ipv6: self.enable_ipv6().then_some(conn_data.entry.private_ipv6),
             gateway_ipv4: None,
             gateway_ipv6: None,
         };
 
         let mut ips = vec![IpAddr::V4(conn_data.entry.private_ipv4)];
-        if self.tunnel_parameters.tunnel_settings.enable_ipv6 {
+        if self.enable_ipv6() {
             ips.push(IpAddr::V6(conn_data.entry.private_ipv6))
         }
         let mut entry_tunnel_metadata = TunnelMetadata {
@@ -1132,31 +1094,19 @@ impl TunnelMonitor {
 
         let exit_adapter_config = WintunAdapterConfig {
             interface_ipv4: conn_data.exit.private_ipv4,
-            interface_ipv6: self
-                .tunnel_parameters
-                .tunnel_settings
-                .enable_ipv6
-                .then_some(conn_data.exit.private_ipv6),
+            interface_ipv6: self.enable_ipv6().then_some(conn_data.exit.private_ipv6),
             gateway_ipv4: Some(conn_data.entry.private_ipv4),
-            gateway_ipv6: self
-                .tunnel_parameters
-                .tunnel_settings
-                .enable_ipv6
-                .then_some(conn_data.entry.private_ipv6),
+            gateway_ipv6: self.enable_ipv6().then_some(conn_data.entry.private_ipv6),
         };
         let mut ips = vec![IpAddr::V4(conn_data.exit.private_ipv4)];
-        if self.tunnel_parameters.tunnel_settings.enable_ipv6 {
+        if self.enable_ipv6() {
             ips.push(IpAddr::V6(conn_data.entry.private_ipv6));
         }
         let mut exit_tunnel_metadata = TunnelMetadata {
             interface: "".to_owned(),
             ips,
             ipv4_gateway: Some(conn_data.entry.private_ipv4),
-            ipv6_gateway: self
-                .tunnel_parameters
-                .tunnel_settings
-                .enable_ipv6
-                .then_some(conn_data.entry.private_ipv6),
+            ipv6_gateway: self.enable_ipv6().then_some(conn_data.entry.private_ipv6),
         };
 
         let tunnel_conn_data = TunnelConnectionData::Wireguard(WireguardConnectionData {
@@ -1202,18 +1152,12 @@ impl TunnelMonitor {
         wintun::initialize_interfaces(
             wintun_entry_interface.windows_luid(),
             Some(entry_tun_mtu),
-            self.tunnel_parameters
-                .tunnel_settings
-                .enable_ipv6
-                .then_some(entry_tun_mtu),
+            self.enable_ipv6().then_some(entry_tun_mtu),
         )?;
         wintun::initialize_interfaces(
             wintun_exit_interface.windows_luid(),
             Some(exit_tun_mtu),
-            self.tunnel_parameters
-                .tunnel_settings
-                .enable_ipv6
-                .then_some(exit_tun_mtu),
+            self.enable_ipv6().then_some(exit_tun_mtu),
         )?;
 
         // Update interface names in tunnel metadata
@@ -1234,13 +1178,7 @@ impl TunnelMonitor {
             exit_gateway_address,
         };
 
-        if let Err(err) = self
-            .set_routes(
-                routing_config,
-                self.tunnel_parameters.tunnel_settings.enable_ipv6,
-            )
-            .await
-        {
+        if let Err(err) = self.set_routes(routing_config, self.enable_ipv6()).await {
             tunnel_handle.cancel();
             tunnel_handle.wait().await.ok();
             return Err(err);
@@ -1272,7 +1210,7 @@ impl TunnelMonitor {
         let mut interface_addresses = vec![IpNetwork::V4(Ipv4Network::from(
             conn_data.exit.private_ipv4,
         ))];
-        if self.tunnel_parameters.tunnel_settings.enable_ipv6 {
+        if self.enable_ipv6() {
             interface_addresses.push(IpNetwork::V6(Ipv6Network::from(
                 conn_data.exit.private_ipv6,
             )));
@@ -1293,7 +1231,7 @@ impl TunnelMonitor {
         let tun_fd = unsafe { BorrowedFd::borrow_raw(tun_device.get_ref().as_raw_fd()) };
         let interface = tun_name::get_tun_name(&tun_fd).map_err(Error::GetTunDeviceName)?;
         let mut ips = vec![IpAddr::V4(conn_data.exit.private_ipv4)];
-        if self.tunnel_parameters.tunnel_settings.enable_ipv6 {
+        if self.enable_ipv6() {
             ips.push(IpAddr::V6(conn_data.exit.private_ipv6));
         }
         let tunnel_metadata = TunnelMetadata {
@@ -1468,6 +1406,10 @@ impl TunnelMonitor {
         let _ = owned_tun_fd.into_raw_fd();
 
         Ok(device)
+    }
+
+    fn enable_ipv6(&self) -> bool {
+        self.tunnel_parameters.tunnel_settings.enable_ipv6
     }
 }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -6,8 +6,8 @@ use futures::{FutureExt, future::Fuse};
 use nix::sys::socket::{SetSockOpt, sockopt::Mark};
 use nym_sdk::UserAgent;
 use nym_vpn_network_config::start_background_file_refresh;
-#[cfg(any(target_os = "linux", target_os = "macos"))]
-use std::net::Ipv4Addr;
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+use std::net::{Ipv4Addr, Ipv6Addr};
 #[cfg(any(target_os = "linux", target_os = "ios", target_os = "android"))]
 use std::os::fd::BorrowedFd;
 #[cfg(any(target_os = "android", target_os = "ios"))]
@@ -37,9 +37,6 @@ use tokio_util::sync::CancellationToken;
 use tun::AsyncDevice;
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 use tun::Device;
-
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-use nym_ip_packet_requests::IpPair;
 
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 use super::route_handler::{RouteHandler, RoutingConfig};
@@ -73,7 +70,7 @@ use crate::tunnel_provider::ios::OSTunProvider;
 use crate::tunnel_state_machine::route_handler::TUNNEL_FWMARK;
 use crate::{
     VpnTopologyProvider,
-    tunnel_state_machine::{WireguardMultihopMode, account},
+    tunnel_state_machine::{WireguardMultihopMode, account, ipv6_availability},
 };
 
 /// Default MTU for mixnet tun device.
@@ -302,6 +299,12 @@ impl TunnelMonitor {
                 .run_until_cancelled(tokio::time::sleep(delay))
                 .await
                 .ok_or(Error::Tunnel(Box::new(tunnel::Error::Cancelled)))?;
+        }
+
+        if self.tunnel_parameters.tunnel_settings.enable_ipv6
+            && !ipv6_availability::is_ipv6_enabled_in_os().await
+        {
+            return Err(Error::Ipv6Unavailable);
         }
 
         self.send_event(TunnelMonitorEvent::InitializingClient);
@@ -687,25 +690,34 @@ impl TunnelMonitor {
         };
 
         #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-        let tun_device = Self::create_mixnet_device(assigned_addresses.interface_addresses, mtu)?;
+        let tun_device = Self::create_mixnet_device(
+            assigned_addresses.interface_addresses.ipv4,
+            self.tunnel_parameters
+                .tunnel_settings
+                .enable_ipv6
+                .then_some(assigned_addresses.interface_addresses.ipv6),
+            mtu,
+        )?;
 
         #[cfg(any(target_os = "ios", target_os = "android"))]
         let tun_device = {
+            let mut interface_addresses = vec![IpNetwork::V4(Ipv4Network::from(
+                assigned_addresses.interface_addresses.ipv4,
+            ))];
+
+            if self.tunnel_parameters.tunnel_settings.enable_ipv6 {
+                interface_addresses.push(IpNetwork::V6(Ipv6Network::from(
+                    assigned_addresses.interface_addresses.ipv6,
+                )));
+            }
             let packet_tunnel_settings = tunnel_provider::tunnel_settings::TunnelSettings {
                 dns_servers: self
                     .tunnel_parameters
                     .tunnel_settings
                     .dns
-                    .ip_addresses(&crate::DEFAULT_DNS_SERVERS)
+                    .ip_addresses(&self.tunnel_parameters.tunnel_settings.default_dns_ips())
                     .to_vec(),
-                interface_addresses: vec![
-                    IpNetwork::V4(Ipv4Network::from(
-                        assigned_addresses.interface_addresses.ipv4,
-                    )),
-                    IpNetwork::V6(Ipv6Network::from(
-                        assigned_addresses.interface_addresses.ipv6,
-                    )),
-                ],
+                interface_addresses,
                 remote_addresses: vec![assigned_addresses.entry_mixnet_gateway_ip],
                 mtu,
             };
@@ -736,7 +748,11 @@ impl TunnelMonitor {
                 entry_gateway_address: assigned_addresses.entry_mixnet_gateway_ip,
             };
 
-            self.set_routes(routing_config).await?;
+            self.set_routes(
+                routing_config,
+                self.tunnel_parameters.tunnel_settings.enable_ipv6,
+            )
+            .await?;
         }
 
         let tunnel_conn_data = TunnelConnectionData::Mixnet(MixnetConnectionData {
@@ -745,15 +761,20 @@ impl TunnelMonitor {
             entry_ip: assigned_addresses.entry_mixnet_gateway_ip,
             exit_ip: assigned_addresses.exit_mixnet_gateway_ip,
             ipv4: assigned_addresses.interface_addresses.ipv4,
-            ipv6: assigned_addresses.interface_addresses.ipv6,
+            ipv6: self
+                .tunnel_parameters
+                .tunnel_settings
+                .enable_ipv6
+                .then_some(assigned_addresses.interface_addresses.ipv6),
         });
 
+        let mut ips = vec![IpAddr::V4(assigned_addresses.interface_addresses.ipv4)];
+        if self.tunnel_parameters.tunnel_settings.enable_ipv6 {
+            ips.push(IpAddr::V6(assigned_addresses.interface_addresses.ipv6));
+        }
         let tunnel_metadata = TunnelMetadata {
             interface: tun_name,
-            ips: vec![
-                IpAddr::V4(assigned_addresses.interface_addresses.ipv4),
-                IpAddr::V6(assigned_addresses.interface_addresses.ipv6),
-            ],
+            ips,
             ipv4_gateway: None,
             ipv6_gateway: None,
         };
@@ -788,10 +809,11 @@ impl TunnelMonitor {
 
         let exit_tun_mtu = connected_tunnel.exit_mtu();
         let exit_tun = Self::create_wireguard_device(
-            IpPair {
-                ipv4: conn_data.exit.private_ipv4,
-                ipv6: conn_data.exit.private_ipv6,
-            },
+            conn_data.exit.private_ipv4,
+            self.tunnel_parameters
+                .tunnel_settings
+                .enable_ipv6
+                .then_some(conn_data.exit.private_ipv6),
             Some(conn_data.entry.private_ipv4),
             exit_tun_mtu,
         )?;
@@ -805,23 +827,18 @@ impl TunnelMonitor {
             entry_gateway_address: conn_data.entry.endpoint.ip(),
         };
 
-        self.set_routes(routing_config).await?;
+        self.set_routes(
+            routing_config,
+            self.tunnel_parameters.tunnel_settings.enable_ipv6,
+        )
+        .await?;
 
         let tunnel_conn_data = TunnelConnectionData::Wireguard(WireguardConnectionData {
             entry: WireguardNode::from(conn_data.entry.clone()),
             exit: WireguardNode::from(conn_data.exit.clone()),
         });
 
-        let dns_config = self
-            .tunnel_parameters
-            .tunnel_settings
-            .dns
-            .to_dns_config()
-            .resolve(
-                &crate::DEFAULT_DNS_SERVERS,
-                #[cfg(target_os = "macos")]
-                53,
-            );
+        let dns_config = self.tunnel_parameters.tunnel_settings.resolved_dns_config();
         let tunnel_options = TunnelOptions::Netstack(NetstackTunnelOptions {
             exit_tun,
             dns: dns_config.tunnel_config().to_vec(),
@@ -869,9 +886,17 @@ impl TunnelMonitor {
 
         let exit_adapter_config = WintunAdapterConfig {
             interface_ipv4: conn_data.exit.private_ipv4,
-            interface_ipv6: conn_data.exit.private_ipv6,
+            interface_ipv6: self
+                .tunnel_parameters
+                .tunnel_settings
+                .enable_ipv6
+                .then_some(conn_data.exit.private_ipv6),
             gateway_ipv4: Some(conn_data.entry.private_ipv4),
-            gateway_ipv6: Some(conn_data.entry.private_ipv6),
+            gateway_ipv6: self
+                .tunnel_parameters
+                .tunnel_settings
+                .enable_ipv6
+                .then_some(conn_data.entry.private_ipv6),
         };
         let mut tunnel_metadata = TunnelMetadata {
             interface: "".to_owned(),
@@ -888,12 +913,7 @@ impl TunnelMonitor {
             exit: WireguardNode::from(conn_data.exit.clone()),
         });
 
-        let dns_config = self
-            .tunnel_parameters
-            .tunnel_settings
-            .dns
-            .to_dns_config()
-            .resolve(&crate::DEFAULT_DNS_SERVERS);
+        let dns_config = self.tunnel_parameters.tunnel_settings.resolved_dns_config();
         let tunnel_options = TunnelOptions::Netstack(NetstackTunnelOptions {
             exit_tun_name: WG_EXIT_WINTUN_NAME.to_owned(),
             exit_tun_guid: WG_EXIT_WINTUN_GUID.to_owned(),
@@ -901,7 +921,7 @@ impl TunnelMonitor {
             dns: dns_config.tunnel_config().to_vec(),
         });
 
-        let tunnel_handle = connected_tunnel
+        let mut tunnel_handle = connected_tunnel
             .run(
                 #[cfg(windows)]
                 self.route_handler.clone(),
@@ -920,7 +940,10 @@ impl TunnelMonitor {
         wintun::initialize_interfaces(
             wintun_exit_interface.windows_luid(),
             Some(exit_mtu),
-            Some(exit_mtu),
+            self.tunnel_parameters
+                .tunnel_settings
+                .enable_ipv6
+                .then_some(exit_mtu),
         )?;
 
         let routing_config = RoutingConfig::WireguardNetstack {
@@ -928,8 +951,18 @@ impl TunnelMonitor {
             exit_tun_mtu: exit_mtu,
             entry_gateway_address,
         };
-        // todo: make sure to shutdown tunnel_handle on failure!
-        self.set_routes(routing_config).await?;
+
+        if let Err(err) = self
+            .set_routes(
+                routing_config,
+                self.tunnel_parameters.tunnel_settings.enable_ipv6,
+            )
+            .await
+        {
+            tunnel_handle.cancel();
+            _ = tunnel_handle.wait().await;
+            return Err(err);
+        }
 
         // Update interface name in tunnel metadata
         tunnel_metadata.interface = wintun_exit_interface.name.clone();
@@ -957,10 +990,11 @@ impl TunnelMonitor {
 
         let entry_mtu = connected_tunnel.entry_mtu();
         let entry_tun = Self::create_wireguard_device(
-            IpPair {
-                ipv4: conn_data.entry.private_ipv4,
-                ipv6: conn_data.entry.private_ipv6,
-            },
+            conn_data.entry.private_ipv4,
+            self.tunnel_parameters
+                .tunnel_settings
+                .enable_ipv6
+                .then_some(conn_data.entry.private_ipv6),
             None,
             entry_mtu,
         )?;
@@ -970,22 +1004,24 @@ impl TunnelMonitor {
             .map_err(Error::GetTunDeviceName)?;
         tracing::info!("Created entry tun device: {}", entry_tun_name);
 
+        let mut ips = vec![IpAddr::V4(conn_data.entry.private_ipv4)];
+        if self.tunnel_parameters.tunnel_settings.enable_ipv6 {
+            ips.push(IpAddr::V6(conn_data.entry.private_ipv6));
+        }
         let entry_tunnel_metadata = TunnelMetadata {
             interface: entry_tun_name,
-            ips: vec![
-                IpAddr::V4(conn_data.entry.private_ipv4),
-                IpAddr::V6(conn_data.entry.private_ipv6),
-            ],
+            ips,
             ipv4_gateway: None,
             ipv6_gateway: None,
         };
 
         let exit_mtu = connected_tunnel.exit_mtu();
         let exit_tun = Self::create_wireguard_device(
-            IpPair {
-                ipv4: conn_data.exit.private_ipv4,
-                ipv6: conn_data.exit.private_ipv6,
-            },
+            conn_data.exit.private_ipv4,
+            self.tunnel_parameters
+                .tunnel_settings
+                .enable_ipv6
+                .then_some(conn_data.exit.private_ipv6),
             // todo: this needs to be able to set both destinations?
             Some(conn_data.entry.private_ipv4),
             exit_mtu,
@@ -993,14 +1029,20 @@ impl TunnelMonitor {
         let exit_tun_name = exit_tun.get_ref().name().map_err(Error::GetTunDeviceName)?;
         tracing::info!("Created exit tun device: {}", exit_tun_name);
 
+        let mut ips = vec![IpAddr::V4(conn_data.exit.private_ipv4)];
+        if self.tunnel_parameters.tunnel_settings.enable_ipv6 {
+            ips.push(IpAddr::V6(conn_data.exit.private_ipv6));
+        }
+
         let exit_tunnel_metadata = TunnelMetadata {
             interface: exit_tun_name.clone(),
-            ips: vec![
-                IpAddr::V4(conn_data.exit.private_ipv4),
-                IpAddr::V6(conn_data.exit.private_ipv6),
-            ],
+            ips,
             ipv4_gateway: Some(conn_data.entry.private_ipv4),
-            ipv6_gateway: Some(conn_data.entry.private_ipv6),
+            ipv6_gateway: self
+                .tunnel_parameters
+                .tunnel_settings
+                .enable_ipv6
+                .then_some(conn_data.entry.private_ipv6),
         };
 
         let routing_config = RoutingConfig::Wireguard {
@@ -1012,23 +1054,18 @@ impl TunnelMonitor {
             entry_gateway_address: conn_data.entry.endpoint.ip(),
             exit_gateway_address: conn_data.exit.endpoint.ip(),
         };
-        self.set_routes(routing_config).await?;
+        self.set_routes(
+            routing_config,
+            self.tunnel_parameters.tunnel_settings.enable_ipv6,
+        )
+        .await?;
 
         let tunnel_conn_data = TunnelConnectionData::Wireguard(WireguardConnectionData {
             entry: WireguardNode::from(conn_data.entry.clone()),
             exit: WireguardNode::from(conn_data.exit.clone()),
         });
 
-        let dns_config = self
-            .tunnel_parameters
-            .tunnel_settings
-            .dns
-            .to_dns_config()
-            .resolve(
-                &crate::DEFAULT_DNS_SERVERS,
-                #[cfg(target_os = "macos")]
-                53,
-            );
+        let dns_config = self.tunnel_parameters.tunnel_settings.resolved_dns_config();
         let tunnel_options = TunnelOptions::TunTun(TunTunTunnelOptions {
             entry_tun,
             exit_tun,
@@ -1073,34 +1110,53 @@ impl TunnelMonitor {
 
         let entry_adapter_config = WintunAdapterConfig {
             interface_ipv4: conn_data.entry.private_ipv4,
-            interface_ipv6: conn_data.entry.private_ipv6,
+            interface_ipv6: self
+                .tunnel_parameters
+                .tunnel_settings
+                .enable_ipv6
+                .then_some(conn_data.entry.private_ipv6),
             gateway_ipv4: None,
             gateway_ipv6: None,
         };
+
+        let mut ips = vec![IpAddr::V4(conn_data.entry.private_ipv4)];
+        if self.tunnel_parameters.tunnel_settings.enable_ipv6 {
+            ips.push(IpAddr::V6(conn_data.entry.private_ipv6))
+        }
         let mut entry_tunnel_metadata = TunnelMetadata {
             interface: "".to_owned(),
-            ips: vec![
-                IpAddr::V4(conn_data.entry.private_ipv4),
-                IpAddr::V6(conn_data.entry.private_ipv6),
-            ],
+            ips,
             ipv4_gateway: None,
             ipv6_gateway: None,
         };
 
         let exit_adapter_config = WintunAdapterConfig {
             interface_ipv4: conn_data.exit.private_ipv4,
-            interface_ipv6: conn_data.exit.private_ipv6,
+            interface_ipv6: self
+                .tunnel_parameters
+                .tunnel_settings
+                .enable_ipv6
+                .then_some(conn_data.exit.private_ipv6),
             gateway_ipv4: Some(conn_data.entry.private_ipv4),
-            gateway_ipv6: Some(conn_data.entry.private_ipv6),
+            gateway_ipv6: self
+                .tunnel_parameters
+                .tunnel_settings
+                .enable_ipv6
+                .then_some(conn_data.entry.private_ipv6),
         };
+        let mut ips = vec![IpAddr::V4(conn_data.exit.private_ipv4)];
+        if self.tunnel_parameters.tunnel_settings.enable_ipv6 {
+            ips.push(IpAddr::V6(conn_data.entry.private_ipv6));
+        }
         let mut exit_tunnel_metadata = TunnelMetadata {
             interface: "".to_owned(),
-            ips: vec![
-                IpAddr::V4(conn_data.exit.private_ipv4),
-                IpAddr::V6(conn_data.exit.private_ipv6),
-            ],
+            ips,
             ipv4_gateway: Some(conn_data.entry.private_ipv4),
-            ipv6_gateway: Some(conn_data.entry.private_ipv6),
+            ipv6_gateway: self
+                .tunnel_parameters
+                .tunnel_settings
+                .enable_ipv6
+                .then_some(conn_data.entry.private_ipv6),
         };
 
         let tunnel_conn_data = TunnelConnectionData::Wireguard(WireguardConnectionData {
@@ -1108,12 +1164,7 @@ impl TunnelMonitor {
             exit: WireguardNode::from(conn_data.exit.clone()),
         });
 
-        let dns_config = self
-            .tunnel_parameters
-            .tunnel_settings
-            .dns
-            .to_dns_config()
-            .resolve(&crate::DEFAULT_DNS_SERVERS);
+        let dns_config = self.tunnel_parameters.tunnel_settings.resolved_dns_config();
         let tunnel_options = TunnelOptions::TunTun(TunTunTunnelOptions {
             entry_tun_name: WG_ENTRY_WINTUN_NAME.to_owned(),
             entry_tun_guid: WG_ENTRY_WINTUN_GUID.to_owned(),
@@ -1123,7 +1174,7 @@ impl TunnelMonitor {
             dns: dns_config.tunnel_config().to_vec(),
         });
 
-        let tunnel_handle = connected_tunnel
+        let mut tunnel_handle = connected_tunnel
             .run(
                 #[cfg(windows)]
                 self.route_handler.clone(),
@@ -1151,12 +1202,18 @@ impl TunnelMonitor {
         wintun::initialize_interfaces(
             wintun_entry_interface.windows_luid(),
             Some(entry_tun_mtu),
-            Some(entry_tun_mtu),
+            self.tunnel_parameters
+                .tunnel_settings
+                .enable_ipv6
+                .then_some(entry_tun_mtu),
         )?;
         wintun::initialize_interfaces(
             wintun_exit_interface.windows_luid(),
             Some(exit_tun_mtu),
-            Some(exit_tun_mtu),
+            self.tunnel_parameters
+                .tunnel_settings
+                .enable_ipv6
+                .then_some(exit_tun_mtu),
         )?;
 
         // Update interface names in tunnel metadata
@@ -1176,8 +1233,18 @@ impl TunnelMonitor {
             entry_gateway_address,
             exit_gateway_address,
         };
-        // todo: make sure to shutdown tunnel_handle on failure!
-        self.set_routes(routing_config).await?;
+
+        if let Err(err) = self
+            .set_routes(
+                routing_config,
+                self.tunnel_parameters.tunnel_settings.enable_ipv6,
+            )
+            .await
+        {
+            tunnel_handle.cancel();
+            tunnel_handle.wait().await.ok();
+            return Err(err);
+        }
 
         Ok(StartTunnelResult {
             tunnel_interface,
@@ -1202,17 +1269,22 @@ impl TunnelMonitor {
         let mtu = connected_tunnel.exit_mtu();
         let conn_data = connected_tunnel.connection_data();
 
+        let mut interface_addresses = vec![IpNetwork::V4(Ipv4Network::from(
+            conn_data.exit.private_ipv4,
+        ))];
+        if self.tunnel_parameters.tunnel_settings.enable_ipv6 {
+            interface_addresses.push(IpNetwork::V6(Ipv6Network::from(
+                conn_data.exit.private_ipv6,
+            )));
+        }
         let packet_tunnel_settings = tunnel_provider::tunnel_settings::TunnelSettings {
             dns_servers: self
                 .tunnel_parameters
                 .tunnel_settings
                 .dns
-                .ip_addresses(&crate::DEFAULT_DNS_SERVERS)
+                .ip_addresses(&self.tunnel_parameters.tunnel_settings.default_dns_ips())
                 .to_vec(),
-            interface_addresses: vec![
-                IpNetwork::V4(Ipv4Network::from(conn_data.exit.private_ipv4)),
-                IpNetwork::V6(Ipv6Network::from(conn_data.exit.private_ipv6)),
-            ],
+            interface_addresses,
             remote_addresses: vec![conn_data.entry.endpoint.ip()],
             mtu,
         };
@@ -1220,12 +1292,13 @@ impl TunnelMonitor {
         let tun_device = self.create_tun_device(packet_tunnel_settings).await?;
         let tun_fd = unsafe { BorrowedFd::borrow_raw(tun_device.get_ref().as_raw_fd()) };
         let interface = tun_name::get_tun_name(&tun_fd).map_err(Error::GetTunDeviceName)?;
+        let mut ips = vec![IpAddr::V4(conn_data.exit.private_ipv4)];
+        if self.tunnel_parameters.tunnel_settings.enable_ipv6 {
+            ips.push(IpAddr::V6(conn_data.exit.private_ipv6));
+        }
         let tunnel_metadata = TunnelMetadata {
             interface,
-            ips: vec![
-                IpAddr::V4(conn_data.exit.private_ipv4),
-                IpAddr::V6(conn_data.exit.private_ipv6),
-            ],
+            ips,
             ipv4_gateway: None,
             ipv6_gateway: None,
         };
@@ -1241,7 +1314,7 @@ impl TunnelMonitor {
             .tunnel_parameters
             .tunnel_settings
             .dns
-            .ip_addresses(&crate::DEFAULT_DNS_SERVERS)
+            .ip_addresses(&self.tunnel_parameters.tunnel_settings.default_dns_ips())
             .to_vec();
 
         let tunnel_handle = connected_tunnel
@@ -1262,9 +1335,9 @@ impl TunnelMonitor {
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-    async fn set_routes(&mut self, routing_config: RoutingConfig) -> Result<()> {
+    async fn set_routes(&mut self, routing_config: RoutingConfig, enable_ipv6: bool) -> Result<()> {
         self.route_handler
-            .add_routes(routing_config)
+            .add_routes(routing_config, enable_ipv6)
             .await
             .map_err(Error::AddRoutes)?;
 
@@ -1272,17 +1345,18 @@ impl TunnelMonitor {
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-    fn create_mixnet_device(interface_addresses: IpPair, mtu: u16) -> Result<AsyncDevice> {
+    fn create_mixnet_device(
+        interface_ipv4: Ipv4Addr,
+        interface_ipv6: Option<Ipv6Addr>,
+        mtu: u16,
+    ) -> Result<AsyncDevice> {
         let mut tun_config = tun::Configuration::default();
 
         // rust-tun uses the same name for tunnel type.
         #[cfg(windows)]
         tun_config.name(MIXNET_WINTUN_NAME);
 
-        tun_config
-            .address(interface_addresses.ipv4)
-            .mtu(i32::from(mtu))
-            .up();
+        tun_config.address(interface_ipv4).mtu(i32::from(mtu)).up();
 
         #[cfg(target_os = "linux")]
         tun_config.platform(|platform_config| {
@@ -1297,14 +1371,24 @@ impl TunnelMonitor {
             .map_err(Error::GetTunDeviceName)?;
 
         #[cfg(any(target_os = "linux", target_os = "macos"))]
-        tun_ipv6::set_ipv6_addr(&tun_name, interface_addresses.ipv6)
-            .map_err(Error::SetTunDeviceIpv6Addr)?;
+        if let Some(interface_ipv6) = interface_ipv6 {
+            tun_ipv6::set_ipv6_addr(&tun_name, interface_ipv6)
+                .map_err(Error::SetTunDeviceIpv6Addr)?;
+        }
 
         #[cfg(windows)]
         {
             let interface_luid = wintun::get_interface_luid_for_alias(&tun_name)?;
-            wintun::add_ipv6_address(interface_luid, interface_addresses.ipv6)?;
-            wintun::initialize_interfaces(interface_luid, Some(mtu), Some(mtu))?;
+
+            if let Some(interface_ipv6) = interface_ipv6 {
+                wintun::add_ipv6_address(interface_luid, interface_ipv6)?;
+            }
+
+            wintun::initialize_interfaces(
+                interface_luid,
+                Some(mtu),
+                interface_ipv6.is_some().then_some(mtu),
+            )?;
         }
 
         Ok(tun_device)
@@ -1312,14 +1396,15 @@ impl TunnelMonitor {
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     fn create_wireguard_device(
-        interface_addresses: IpPair,
+        interface_ipv4: Ipv4Addr,
+        interface_ipv6: Option<Ipv6Addr>,
         destination: Option<Ipv4Addr>,
         mtu: u16,
     ) -> Result<AsyncDevice> {
         let mut tun_config = tun::Configuration::default();
 
         tun_config
-            .address(interface_addresses.ipv4)
+            .address(interface_ipv4)
             .netmask(Ipv4Addr::BROADCAST)
             .mtu(i32::from(mtu))
             .up();
@@ -1340,8 +1425,10 @@ impl TunnelMonitor {
             .name()
             .map_err(Error::GetTunDeviceName)?;
 
-        tun_ipv6::set_ipv6_addr(&tun_name, interface_addresses.ipv6)
-            .map_err(Error::SetTunDeviceIpv6Addr)?;
+        if let Some(interface_ipv6) = interface_ipv6 {
+            tun_ipv6::set_ipv6_addr(&tun_name, interface_ipv6)
+                .map_err(Error::SetTunDeviceIpv6Addr)?;
+        }
 
         Ok(tun_device)
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/wintun.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/wintun.rs
@@ -40,7 +40,7 @@ pub struct WintunAdapterConfig {
     pub interface_ipv4: Ipv4Addr,
 
     /// Interface IPv6 address.
-    pub interface_ipv6: Ipv6Addr,
+    pub interface_ipv6: Option<Ipv6Addr>,
 
     /// Default IPv4 gateway.
     pub gateway_ipv4: Option<Ipv4Addr>,
@@ -56,8 +56,11 @@ pub fn setup_wintun_adapter(
 ) -> Result<(), SetupWintunAdapterError> {
     wnet::add_ip_address_for_interface(luid, IpAddr::V4(adapter_config.interface_ipv4))
         .map_err(SetupWintunAdapterError::SetIpv4Addr)?;
-    wnet::add_ip_address_for_interface(luid, IpAddr::V6(adapter_config.interface_ipv6))
-        .map_err(SetupWintunAdapterError::SetIpv6Addr)?;
+
+    if let Some(interface_ipv6) = adapter_config.interface_ipv6 {
+        wnet::add_ip_address_for_interface(luid, IpAddr::V6(interface_ipv6))
+            .map_err(SetupWintunAdapterError::SetIpv6Addr)?;
+    }
 
     if let Some(gateway_ipv4) = adapter_config.gateway_ipv4 {
         wnet::add_default_ipv4_gateway_for_interface(luid, gateway_ipv4)

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -44,7 +44,7 @@ message MixConnectedStateDetails {
   Address nym_address = 1;
   Address exit_ipr = 2;
   string ipv4 = 3;
-  string ipv6 = 4;
+  optional string ipv6 = 4;
 }
 
 message WgConnectedStateDetails {
@@ -188,6 +188,7 @@ message ConnectRequest {
   EntryNode entry = 1;
   ExitNode exit = 2;
   Dns dns = 3;
+  bool disable_ipv6 = 14;
   bool enable_two_hop = 5;
   bool netstack = 13;
   bool disable_poisson_rate = 6;
@@ -283,7 +284,7 @@ message MixnetConnectionData {
   Address nym_address = 1;
   Address exit_ipr = 2;
   string ipv4 = 3;
-  string ipv6 = 4;
+  optional string ipv6 = 4;
   string entry_ip = 5;
   string exit_ip = 6;
 }
@@ -297,7 +298,7 @@ message WireguardNode {
   string endpoint = 1;
   string public_key = 2;
   string private_ipv4 = 3;
-  string private_ipv6 = 4;
+  optional string private_ipv6 = 4;
 }
 
 message TunnelConnectionData {
@@ -329,6 +330,7 @@ message TunnelState {
     INTERNAL = 10;
     DEVICE_TIME_OUT_OF_SYNC = 11;
     CREATE_MIXNET_STORAGE = 12;
+    IPV6_UNAVAILABLE = 13;
   }
 
   enum ActionAfterDisconnect {

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/tunnel_state.rs
@@ -6,7 +6,6 @@ use std::{
     str::FromStr,
 };
 
-use nym_http_api_client::Client;
 use nym_vpn_lib_types::{
     ActionAfterDisconnect, ClientErrorReason, ConnectionData, Gateway, MixnetConnectionData,
     NymAddress, TunnelConnectionData, TunnelState, WireguardConnectionData, WireguardNode,

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/tunnel_state.rs
@@ -6,6 +6,7 @@ use std::{
     str::FromStr,
 };
 
+use nym_http_api_client::Client;
 use nym_vpn_lib_types::{
     ActionAfterDisconnect, ClientErrorReason, ConnectionData, Gateway, MixnetConnectionData,
     NymAddress, TunnelConnectionData, TunnelState, WireguardConnectionData, WireguardNode,
@@ -54,6 +55,9 @@ impl From<proto::tunnel_state::Error> for ClientErrorReason {
             }
             proto::tunnel_state::ErrorStateReason::CreateMixnetStorage => {
                 ClientErrorReason::CreateMixnetStorage
+            }
+            proto::tunnel_state::ErrorStateReason::Ipv6Unavailable => {
+                ClientErrorReason::Ipv6Unavailable
             }
             proto::tunnel_state::ErrorStateReason::Internal => {
                 ClientErrorReason::Internal(value.detail)
@@ -111,6 +115,10 @@ impl From<ClientErrorReason> for proto::tunnel_state::Error {
             },
             ClientErrorReason::CreateMixnetStorage => proto::tunnel_state::Error {
                 reason: proto::tunnel_state::ErrorStateReason::CreateMixnetStorage.into(),
+                detail: None,
+            },
+            ClientErrorReason::Ipv6Unavailable => proto::tunnel_state::Error {
+                reason: proto::tunnel_state::ErrorStateReason::Ipv6Unavailable.into(),
                 detail: None,
             },
             ClientErrorReason::Internal(detail) => proto::tunnel_state::Error {
@@ -280,8 +288,14 @@ impl TryFrom<proto::MixnetConnectionData> for MixnetConnectionData {
                 .map_err(|e| ConversionError::ParseAddr("MixnetConnectionData.exit_ip", e))?,
             ipv4: Ipv4Addr::from_str(&value.ipv4)
                 .map_err(|e| ConversionError::ParseAddr("MixnetConnectionData.ipv4", e))?,
-            ipv6: Ipv6Addr::from_str(&value.ipv6)
-                .map_err(|e| ConversionError::ParseAddr("MixnetConnectionData.ipv6", e))?,
+            ipv6: value
+                .ipv6
+                .as_deref()
+                .map(|ipv6| {
+                    Ipv6Addr::from_str(ipv6)
+                        .map_err(|e| ConversionError::ParseAddr("MixnetConnectionData.ipv6", e))
+                })
+                .transpose()?,
         })
     }
 }
@@ -300,7 +314,7 @@ impl From<MixnetConnectionData> for proto::MixnetConnectionData {
             entry_ip: value.entry_ip.to_string(),
             exit_ip: value.exit_ip.to_string(),
             ipv4: value.ipv4.to_string(),
-            ipv6: value.ipv6.to_string(),
+            ipv6: value.ipv6.map(|ipv6| ipv6.to_string()),
         }
     }
 }
@@ -343,8 +357,14 @@ impl TryFrom<proto::WireguardNode> for WireguardNode {
             public_key: value.public_key,
             private_ipv4: Ipv4Addr::from_str(&value.private_ipv4)
                 .map_err(|e| ConversionError::ParseAddr("WireguardNode.private_ipv4", e))?,
-            private_ipv6: Ipv6Addr::from_str(&value.private_ipv6)
-                .map_err(|e| ConversionError::ParseAddr("WireguardNode.private_ipv6", e))?,
+            private_ipv6: value
+                .private_ipv6
+                .as_deref()
+                .map(|private_ipv6| {
+                    Ipv6Addr::from_str(private_ipv6)
+                        .map_err(|e| ConversionError::ParseAddr("WireguardNode.private_ipv6", e))
+                })
+                .transpose()?,
         })
     }
 }
@@ -355,7 +375,10 @@ impl From<WireguardNode> for proto::WireguardNode {
             public_key: value.public_key,
             endpoint: value.endpoint.to_string(),
             private_ipv4: value.private_ipv4.to_string(),
-            private_ipv6: value.private_ipv6.to_string(),
+            private_ipv6: value
+                .private_ipv6
+                .as_ref()
+                .map(|private_ipv6| private_ipv6.to_string()),
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/vpnd.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/vpnd.rs
@@ -376,6 +376,7 @@ impl TryFrom<ConnectArgs> for proto::ConnectRequest {
                 .options
                 .dns
                 .map(|ip| proto::Dns { ip: ip.to_string() }),
+            disable_ipv6: value.options.disable_ipv6,
             enable_two_hop: value.options.enable_two_hop,
             netstack: value.options.netstack,
             disable_poisson_rate: value.options.disable_poisson_rate,
@@ -403,6 +404,7 @@ impl TryFrom<proto::ConnectRequest> for ConnectOptions {
 
         Ok(Self {
             dns,
+            disable_ipv6: value.disable_ipv6,
             enable_two_hop: value.enable_two_hop,
             netstack: value.netstack,
             disable_poisson_rate: value.disable_poisson_rate,

--- a/nym-vpn-core/crates/nym-vpnc/src/cli.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/cli.rs
@@ -152,6 +152,10 @@ pub struct ConnectArgs {
     #[arg(long)]
     pub dns: Option<IpAddr>,
 
+    /// Disable IPv6 support
+    #[arg(long)]
+    pub disable_ipv6: bool,
+
     /// Enable two-hop wireguard traffic. This means that traffic jumps directly from entry gateway to
     /// exit gateway using Wireguard protocol.
     #[arg(long)]

--- a/nym-vpn-core/crates/nym-vpnc/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/main.rs
@@ -115,6 +115,7 @@ async fn connect(
         exit: connect_args.exit_point()?,
         options: ConnectOptions {
             dns: connect_args.dns,
+            disable_ipv6: connect_args.disable_ipv6,
             enable_two_hop: connect_args.enable_two_hop,
             netstack: connect_args.netstack,
             disable_poisson_rate: connect_args.disable_poisson_rate,

--- a/nym-vpn-core/crates/nym-vpnd-types/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpnd-types/src/lib.rs
@@ -23,6 +23,7 @@ pub struct ConnectArgs {
 #[derive(Default, Debug, Clone)]
 pub struct ConnectOptions {
     pub dns: Option<IpAddr>,
+    pub disable_ipv6: bool,
     pub enable_two_hop: bool,
     pub netstack: bool,
     pub disable_poisson_rate: bool,

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -708,6 +708,7 @@ where
             .unwrap_or(DnsOptions::default());
 
         let tunnel_settings = TunnelSettings {
+            enable_ipv6: !options.disable_ipv6,
             tunnel_type,
             mixnet_tunnel_options: MixnetTunnelOptions {
                 mtu: None,

--- a/nym-vpn-core/crates/nym-windows/src/security/acl_entry_list.rs
+++ b/nym-vpn-core/crates/nym-windows/src/security/acl_entry_list.rs
@@ -35,7 +35,7 @@ impl AclEntryList<'_> {
     }
 
     /// Return a view into explicit access structs.
-    pub fn as_vec(&self) -> Vec<BorrowedExplicitAccess> {
+    pub fn as_vec(&self) -> Vec<BorrowedExplicitAccess<'_>> {
         (0..self.num_entries)
             .map(|i| {
                 // Safety: cast to isize should be fine as number of entries is likely limited.

--- a/nym-vpn-core/crates/nym-windows/src/security/borrowed_acl.rs
+++ b/nym-vpn-core/crates/nym-windows/src/security/borrowed_acl.rs
@@ -33,7 +33,7 @@ impl BorrowedAcl<'_> {
     }
 
     /// Get ACL entries.
-    pub fn get_entries(&self) -> Result<AclEntryList> {
+    pub fn get_entries(&self) -> Result<AclEntryList<'_>> {
         let mut num_entries = 0;
         let mut entries: *mut EXPLICIT_ACCESS_W = std::ptr::null_mut();
 


### PR DESCRIPTION
## Description

- Add a setting to enable IPv6 (on by default)
- Add `--disable-ipv6` flag to nym-vpnc
- Enter error state if IPv6 is requested but not available

How to test on Linux (Ubuntu):

1. Disable IPv6 at runtime:

```sh
sudo sysctl -w net.ipv6.conf.all.disable_ipv6=1
```

2. Or edit `/etc/default/grub` using various kernel options passed via `GRUB_CMDLINE_LINUX_DEFAULT` (tested on Ubuntu):
  - `ipv6.disable=1` – fully disabled IPv6 stack, `/proc/sys/net/ipv6/conf/default/disable_ipv6` does not exit
  - `ipv6.disable_ipv6=1` – `/proc/sys/net/ipv6/conf/default/disable_ipv6`  exists but returns `1`
  - `sudo update-grub` each time then `reboot`

Then connect the tunnel:

```sh
nym-vpnc connect --enable-two-hop
```

This should make tunnel state machine enter error state:

```
ERROR nym_vpn_lib::tunnel_state_machine::tunnel_monitor: Error: Tunnel monitor exited with error
Caused by: ipv6 is disabled in the system
```

Re-run with `--disable-ipv6` to connect without IPv6:

```sh
./target/debug/nym-vpnc connect --enable-two-hop --disable-ipv6
```

## Checklist:

- [x] Changelog

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3078)
<!-- Reviewable:end -->
