### PR TITLE
feat(vpnd): add network statistics toggle

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add setting to toggle IPv6 support.
-
+- vpnd: Add support to toggle network statistics collection.
 
 ## [1.12.0] - 2025-07-18
 

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -838,9 +838,18 @@ service NymVpnService {
   // Check if Sentry error monitoring is enabled
   rpc IsSentryEnabled (google.protobuf.Empty) returns (google.protobuf.BoolValue) {}
 
-  // Enable Sentry error monitoring
+  // Enable Sentry error monitoring (requires daemon restart)
   rpc EnableSentry (google.protobuf.Empty) returns (google.protobuf.Empty) {}
 
-  // Disable Sentry error monitoring
+  // Disable Sentry error monitoring (requires daemon restart)
   rpc DisableSentry (google.protobuf.Empty) returns (google.protobuf.Empty) {}
+
+  // Check if collect network statistics is enabled
+  rpc IsCollectNetworkStatsEnabled (google.protobuf.Empty) returns (google.protobuf.BoolValue) {}
+
+  // Enable collect network statistics (requires daemon restart)
+  rpc EnableCollectNetworkStats (google.protobuf.Empty) returns (google.protobuf.Empty) {}
+
+  // Disable collect network statistics (requires daemon restart)
+  rpc DisableCollectNetworkStats (google.protobuf.Empty) returns (google.protobuf.Empty) {}
 }

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -844,12 +844,12 @@ service NymVpnService {
   // Disable Sentry error monitoring (requires daemon restart)
   rpc DisableSentry (google.protobuf.Empty) returns (google.protobuf.Empty) {}
 
-  // Check if collect network statistics is enabled
+  // Check if network statistics collection is enabled
   rpc IsCollectNetworkStatsEnabled (google.protobuf.Empty) returns (google.protobuf.BoolValue) {}
 
-  // Enable collect network statistics (requires daemon restart)
+  // Enable network statistics collection (requires daemon restart)
   rpc EnableCollectNetworkStats (google.protobuf.Empty) returns (google.protobuf.Empty) {}
 
-  // Disable collect network statistics (requires daemon restart)
+  // Disable network statistics collection (requires daemon restart)
   rpc DisableCollectNetworkStats (google.protobuf.Empty) returns (google.protobuf.Empty) {}
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface.rs
@@ -560,6 +560,42 @@ impl NymVpnService for CommandInterface {
             })?;
         Ok(tonic::Response::new(()))
     }
+
+    async fn is_collect_network_stats_enabled(
+        &self,
+        _: tonic::Request<()>,
+    ) -> std::result::Result<tonic::Response<bool>, tonic::Status> {
+        let result = self
+            .send_and_wait(VpnServiceCommand::IsCollectNetStatsEnabled, ())
+            .await?;
+        Ok(tonic::Response::new(result))
+    }
+
+    async fn enable_collect_network_stats(
+        &self,
+        _: tonic::Request<()>,
+    ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
+        self.send_and_wait(VpnServiceCommand::ToggleCollectNetStats, true)
+            .await?
+            .map_err(|err| {
+                tracing::error!("Failed to enable collect network stats: {err}");
+                tonic::Status::internal("failed to enable collect network stats")
+            })?;
+        Ok(tonic::Response::new(()))
+    }
+
+    async fn disable_collect_network_stats(
+        &self,
+        _: tonic::Request<()>,
+    ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
+        self.send_and_wait(VpnServiceCommand::ToggleCollectNetStats, false)
+            .await?
+            .map_err(|err| {
+                tracing::error!("Failed to disable collect network stats: {err}");
+                tonic::Status::internal("failed to disable collect network stats")
+            })?;
+        Ok(tonic::Response::new(()))
+    }
 }
 
 pub async fn start_command_interface(

--- a/nym-vpn-core/crates/nym-vpnd/src/config.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/config.rs
@@ -8,6 +8,8 @@ pub struct GlobalConfigFile {
     pub network_name: String,
     #[serde(default)]
     pub sentry_monitoring: bool,
+    #[serde(default)]
+    pub collect_network_statistics: bool,
 }
 
 impl Default for GlobalConfigFile {
@@ -15,6 +17,7 @@ impl Default for GlobalConfigFile {
         Self {
             network_name: NymNetworkDetails::default().network_name,
             sentry_monitoring: false,
+            collect_network_statistics: false,
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/main.rs
@@ -141,7 +141,14 @@ fn run_inner(
         let network_env =
             environment::setup_environment(&global_config_file, args.config_env_file.as_deref())
                 .await?;
-        run_inner_async(args, network_env, logging_setup, sentry_enabled).await
+        run_inner_async(
+            args,
+            network_env,
+            logging_setup,
+            sentry_enabled,
+            global_config_file.collect_network_statistics,
+        )
+        .await
     })
 }
 
@@ -150,6 +157,7 @@ async fn run_inner_async(
     network_env: Network,
     logging_setup: Option<LoggingSetup>,
     sentry_enabled: bool,
+    netstats_enabled: bool,
 ) -> anyhow::Result<Option<WorkerGuard>> {
     let log_path = logging_setup
         .as_ref()
@@ -188,6 +196,7 @@ async fn run_inner_async(
         args.stats_id_seed,
         log_path,
         sentry_enabled,
+        netstats_enabled,
     );
 
     let mut shutdown_join_set = shutdown_handler::install(shutdown_token);

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -124,6 +124,8 @@ pub enum VpnServiceCommand {
     DeleteLogFile(oneshot::Sender<()>, ()),
     IsSentryEnabled(oneshot::Sender<bool>, ()),
     ToggleSentry(oneshot::Sender<Result<(), GlobalConfigError>>, bool),
+    IsCollectNetStatsEnabled(oneshot::Sender<bool>, ()),
+    ToggleCollectNetStats(oneshot::Sender<Result<(), GlobalConfigError>>, bool),
 }
 
 pub struct NymVpnService<S>
@@ -189,6 +191,9 @@ where
     // Sentry client has been initialized and is enabled
     sentry_enabled: bool,
 
+    // Whether network statistics reporting is enabled
+    network_statistics_enabled: bool,
+
     // The statistics channel sender
     statistics_event_sender: StatisticsSender,
 }
@@ -205,6 +210,7 @@ impl NymVpnService<nym_vpn_lib::storage::VpnClientOnDiskStorage> {
         stats_id_seed: Option<String>,
         log_path: Option<LogPath>,
         sentry_enabled: bool,
+        netstats_enabled: bool,
     ) -> JoinHandle<()> {
         tracing::trace!("Starting VPN service");
         tokio::spawn(async move {
@@ -218,6 +224,7 @@ impl NymVpnService<nym_vpn_lib::storage::VpnClientOnDiskStorage> {
                 stats_id_seed,
                 log_path,
                 sentry_enabled,
+                netstats_enabled,
             )
             .await
             {
@@ -251,6 +258,7 @@ impl NymVpnService<nym_vpn_lib::storage::VpnClientOnDiskStorage> {
         stats_id_seed: Option<String>,
         log_path: Option<LogPath>,
         sentry_enabled: bool,
+        netstats_enabled: bool,
     ) -> Result<Self> {
         let network_name = network_env.nym_network_details().network_name.clone();
 
@@ -312,7 +320,8 @@ impl NymVpnService<nym_vpn_lib::storage::VpnClientOnDiskStorage> {
         // Statistics collection setup
         let statistics_controller_config =
             StatisticsControllerConfig::new(statistics_api, user_agent.clone())
-                .with_stats_id_seed(stats_id_seed);
+                .with_stats_id_seed(stats_id_seed)
+                .with_enabled(netstats_enabled);
 
         // Statistics collection can technically fail, but if it's the case, we just disable it as it is not operation critical.
         let statistics_controller = StatisticsController::new(
@@ -419,6 +428,7 @@ impl NymVpnService<nym_vpn_lib::storage::VpnClientOnDiskStorage> {
             shutdown_token,
             gateway_directory_client,
             sentry_enabled,
+            network_statistics_enabled: netstats_enabled,
             statistics_event_sender,
         })
     }
@@ -602,6 +612,12 @@ where
             }
             VpnServiceCommand::ToggleSentry(tx, enable) => {
                 let _ = tx.send(self.handle_toggle_sentry(enable).await);
+            }
+            VpnServiceCommand::IsCollectNetStatsEnabled(tx, ()) => {
+                let _ = tx.send(self.handle_is_collect_network_stats_enabled().await);
+            }
+            VpnServiceCommand::ToggleCollectNetStats(tx, enable) => {
+                let _ = tx.send(self.handle_toggle_collect_network_stats(enable).await);
             }
         }
     }
@@ -1029,6 +1045,28 @@ where
         }
         GlobalConfigFile::write_to_file(&config)
             .map_err(|e| GlobalConfigError::WriteConfig(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn handle_is_collect_network_stats_enabled(&self) -> bool {
+        self.network_statistics_enabled
+    }
+
+    async fn handle_toggle_collect_network_stats(
+        &mut self,
+        enable: bool,
+    ) -> Result<(), GlobalConfigError> {
+        let mut config = GlobalConfigFile::read_from_file()
+            .map_err(|e| GlobalConfigError::ReadConfig(e.to_string()))?;
+        config.collect_network_statistics = enable;
+        if enable {
+            tracing::info!("Collect network statistics enabled, daemon needs to be restarted");
+        } else {
+            tracing::info!("Collect network statistics disabled, daemon needs to be restarted");
+        }
+        GlobalConfigFile::write_to_file(&config)
+            .map_err(|e| GlobalConfigError::WriteConfig(e.to_string()))?;
+        self.network_statistics_enabled = enable;
         Ok(())
     }
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/service/windows_service/mod.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/windows_service/mod.rs
@@ -170,9 +170,10 @@ async fn run_service_inner() -> anyhow::Result<()> {
     let sentry_enabled = *SENTRY_ENABLED.lock().await;
     let log_path = logging_setup.as_ref().map(|setup| setup.log_path.clone());
     let cloned_network_config = network_config.clone();
+    let global_config_file = crate::setup_global_config(cloned_network_config.network.as_deref())?;
+    let netstats_enabled = global_config_file.collect_network_statistics;
+
     let network_env_result = tokio::task::spawn(async move {
-        let global_config_file =
-            crate::setup_global_config(cloned_network_config.network.as_deref())?;
         crate::environment::setup_environment(
             &global_config_file,
             cloned_network_config.config_env_file.as_deref(),
@@ -240,6 +241,7 @@ async fn run_service_inner() -> anyhow::Result<()> {
         None,
         log_path,
         sentry_enabled,
+        netstats_enabled,
     );
 
     tracing::info!("Service has started");


### PR DESCRIPTION
Add toggle support for network statistics collection.

GRPC API changes (non-breaking):

```
  // Check if network statistics collection is enabled
  rpc IsCollectNetworkStatsEnabled (google.protobuf.Empty) returns (google.protobuf.BoolValue) {}

  // Enable network statistics collection (requires daemon restart)
  rpc EnableCollectNetworkStats (google.protobuf.Empty) returns (google.protobuf.Empty) {}

  // Disable network statistics collection (requires daemon restart)
  rpc DisableCollectNetworkStats (google.protobuf.Empty) returns (google.protobuf.Empty) {}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3105)
<!-- Reviewable:end -->
