### PR TITLE
refactor(tauri): do not spam logs at warn level about vpnd down

### DIFF
--- a/nym-vpn-app/src-tauri/src/grpc/client.rs
+++ b/nym-vpn-app/src-tauri/src/grpc/client.rs
@@ -1,13 +1,13 @@
-use std::{
-    env::consts::{ARCH, OS},
-    path::PathBuf,
-};
-
 use anyhow::{Result, anyhow};
 use nym_vpn_proto::proto::{
     ConnectRequest, Dns, GetAccountLinksRequest, ListGatewaysRequest, Location,
     StoreAccountRequest, UserAgent, nym_vpn_service_client::NymVpnServiceClient,
     tunnel_event::Event,
+};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::{
+    env::consts::{ARCH, OS},
+    path::PathBuf,
 };
 use tauri::{AppHandle, Manager, PackageInfo};
 use tokio::sync::mpsc;
@@ -44,6 +44,10 @@ const DEFAULT_SOCKET_PATH: &str = "/var/run/nym-vpn.sock";
 #[cfg(windows)]
 const DEFAULT_SOCKET_PATH: &str = r"\\.\pipe\nym-vpn";
 const DUMMY_HTTP_ENDPOINT: &str = "http://[::1]:53181";
+
+// simple flag to save that "failed to connect to daemon"
+// warning has been logged once when vpnd is down
+pub static VPND_DOWN_LOGGED: AtomicBool = AtomicBool::new(false);
 
 #[derive(Debug, Clone)]
 pub struct GrpcClient {
@@ -94,9 +98,16 @@ impl GrpcClient {
     #[instrument(skip_all)]
     pub async fn vpnd(&self) -> Result<NymVpnServiceClient<Channel>, VpndError> {
         let channel = get_channel(self.socket.clone()).await.map_err(|e| {
-            warn!("failed to connect to the daemon: {}", e);
+            let logged = VPND_DOWN_LOGGED.load(Ordering::Relaxed);
+            if !logged {
+                warn!("failed to connect to the daemon: {}", e);
+                VPND_DOWN_LOGGED.store(true, Ordering::Relaxed);
+            } else {
+                debug!("failed to connect to the daemon: {}", e);
+            }
             VpndError::FailedToConnectIpc(e)
         })?;
+        VPND_DOWN_LOGGED.store(false, Ordering::Relaxed);
         Ok(NymVpnServiceClient::new(channel))
     }
 
@@ -189,7 +200,8 @@ impl GrpcClient {
                         tx.send(update).await.unwrap();
                     }
                     Ok(None) => {
-                        warn!("listen tunnel state stream closed by the server");
+                        warn!("vpnd DOWN: tunnel state stream closed");
+                        VPND_DOWN_LOGGED.store(true, Ordering::Relaxed);
                         return;
                     }
                     Err(e) => {

--- a/nym-vpn-app/src-tauri/src/grpc/client.rs
+++ b/nym-vpn-app/src-tauri/src/grpc/client.rs
@@ -47,7 +47,7 @@ const DUMMY_HTTP_ENDPOINT: &str = "http://[::1]:53181";
 
 // simple flag to save that "failed to connect to daemon"
 // warning has been logged once when vpnd is down
-pub static VPND_DOWN_LOGGED: AtomicBool = AtomicBool::new(false);
+static VPND_DOWN_LOGGED: AtomicBool = AtomicBool::new(false);
 
 #[derive(Debug, Clone)]
 pub struct GrpcClient {

--- a/nym-vpn-app/src-tauri/src/main.rs
+++ b/nym-vpn-app/src-tauri/src/main.rs
@@ -4,7 +4,10 @@
 use std::time::Duration;
 
 use crate::cli::{Commands, db_command};
+use crate::fs::path::APP_CONFIG_DIR;
 use crate::startup_error::{ErrorKey, StartupError};
+#[cfg(windows)]
+use crate::updater::PendingUpdate;
 use crate::window::AppWindow;
 use crate::{
     cli::Cli,
@@ -12,10 +15,6 @@ use crate::{
     fs::{app::AppFs, config::AppConfig},
     grpc::client::GrpcClient,
 };
-
-use crate::fs::path::APP_CONFIG_DIR;
-#[cfg(windows)]
-use crate::updater::PendingUpdate;
 
 use anyhow::{Result, anyhow};
 use clap::Parser;
@@ -48,7 +47,6 @@ mod events;
 mod fs;
 mod grpc;
 mod log;
-mod misc;
 mod sentry;
 mod startup_error;
 mod state;
@@ -56,6 +54,7 @@ mod sys;
 mod tray;
 #[cfg(windows)]
 mod updater;
+mod vpnd;
 mod window;
 
 pub const APP_NAME: &str = "NymVPN";
@@ -224,8 +223,8 @@ async fn main() -> Result<()> {
                         // initialize tunnel state
                         c_grpc.tunnel_state(&handle).await.ok();
                         info!("watching vpn tunnel events");
-                        sentry::vpnd_check(sentry_enabled, &c_grpc).await.ok();
-                        misc::netstats_check(&db, &c_grpc).await.ok();
+                        vpnd::sentry_check(sentry_enabled, &c_grpc).await.ok();
+                        vpnd::netstats_check(&db, &c_grpc).await.ok();
                         // start watching tunnel events, this is a blocking call
                         // and will keep the task alive as long as vpnd is running
                         c_grpc.watch_tunnel_events(&handle).await.ok();

--- a/nym-vpn-app/src-tauri/src/sentry.rs
+++ b/nym-vpn-app/src-tauri/src/sentry.rs
@@ -1,10 +1,8 @@
-use anyhow::Result;
 use sentry::{ClientInitGuard, User};
 use std::time::Duration;
-use tracing::{error, info, instrument, warn};
+use tracing::{info, instrument, warn};
 
 use crate::env::APP_SENTRY_DSN;
-use crate::grpc::client::GrpcClient;
 use crate::sys::OsInfo;
 
 #[instrument(skip_all)]
@@ -39,29 +37,4 @@ pub fn init(os: &OsInfo) -> Option<ClientInitGuard> {
         }));
     });
     Some(guard)
-}
-
-// Check the state of sentry monitoring at daemon level and
-// sync it with the app state if needed (as shown to the user in UI)
-#[instrument(skip(grpc))]
-pub async fn vpnd_check(sentry_enabled: bool, grpc: &GrpcClient) -> Result<()> {
-    let vpnd_enabled = grpc.sentry_enabled().await.inspect_err(|e| {
-        error!("failed to check sentry state: {:?}", e);
-    })?;
-    if vpnd_enabled == sentry_enabled {
-        // all good
-        return Ok(());
-    }
-    warn!(
-        "sentry state mismatch: app sentry enabled: {}, vpnd sentry enabled: {}",
-        sentry_enabled, vpnd_enabled
-    );
-    if sentry_enabled {
-        info!("enabling vpnd sentry monitoring");
-        grpc.enable_sentry().await?;
-    } else {
-        info!("disabling vpnd sentry monitoring");
-        grpc.disable_sentry().await?;
-    }
-    Ok(())
 }

--- a/nym-vpn-app/src-tauri/src/state/app.rs
+++ b/nym-vpn-app/src-tauri/src/state/app.rs
@@ -163,7 +163,7 @@ impl AppState {
         let app_state = app.state::<SharedAppState>();
         let mut state = app_state.lock().await;
         if state.vpnd_status != VpndStatus::Down {
-            warn!("vpnd DOWN");
+            info!("vpnd DOWN");
             state.vpnd_status = VpndStatus::Down;
             app.emit_vpnd_status(state.vpnd_status.clone());
         }

--- a/nym-vpn-app/src-tauri/src/vpnd.rs
+++ b/nym-vpn-app/src-tauri/src/vpnd.rs
@@ -1,4 +1,4 @@
-use tracing::{error, info, instrument};
+use tracing::{error, info, instrument, warn};
 
 use crate::db::{Db, Key};
 use crate::grpc::client::GrpcClient;
@@ -28,6 +28,31 @@ pub async fn netstats_check(db: &Db, grpc: &GrpcClient) -> anyhow::Result<()> {
     } else {
         info!("disabled vpnd network statistics collection");
         grpc.disable_netstats().await?;
+    }
+    Ok(())
+}
+
+// Check the state of sentry monitoring in daemon side
+// if needed sync it with the saved setting from the app db
+#[instrument(skip(grpc))]
+pub async fn sentry_check(sentry_enabled: bool, grpc: &GrpcClient) -> anyhow::Result<()> {
+    let vpnd_enabled = grpc.sentry_enabled().await.inspect_err(|e| {
+        error!("failed to check sentry state: {:?}", e);
+    })?;
+    if vpnd_enabled == sentry_enabled {
+        // all good
+        return Ok(());
+    }
+    warn!(
+        "sentry state mismatch: app sentry enabled: {}, vpnd sentry enabled: {}",
+        sentry_enabled, vpnd_enabled
+    );
+    if sentry_enabled {
+        info!("enabling vpnd sentry monitoring");
+        grpc.enable_sentry().await?;
+    } else {
+        info!("disabling vpnd sentry monitoring");
+        grpc.disable_sentry().await?;
     }
     Ok(())
 }


### PR DESCRIPTION
- avoid logging at `WARN` level  in a loop about daemon gRPC connection failure
- prevent logs spam and generating noisy Sentry events
- when vpnd is down, ie. the client fails to connect to vpnd, only emit one log at `WARN` level
- some refactor

Implementation detail worth mentioning:
I'm using a global static `AtomicBool` to store when it is logged instead of a regular struct property to avoid refactoring basically all the gPRC client methods as `&mut self`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3117)
<!-- Reviewable:end -->
