### PR TITLE
ci(tauri): add link to changelog in release notes

### DIFF
--- a/.github/workflows/publish-nym-vpn-app.yml
+++ b/.github/workflows/publish-nym-vpn-app.yml
@@ -192,11 +192,7 @@ jobs:
           ${{ env.BUILD_INFO }}
           ```
 
-          SHA256 checksums
-
-          ```
-          ${{ env.SHA256SUMS }}
-          ```
+          [CHANGELOG](https://github.com/nymtech/nym-vpn-client/blob/develop/nym-vpn-app/CHANGELOG.md)
           '
             echo EOF
           } >> "$GITHUB_ENV"

--- a/nym-vpn-app/CHANGELOG.md
+++ b/nym-vpn-app/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add Sentry error monitoring at daemon level, controlled by
-  the exising toggle in app settings (OFF by default)
+  the existing toggle in app settings (OFF by default)
 
 ### Changed
 


### PR DESCRIPTION
- add link to changelog in release notes
- remove sha256sums from the release notes because it is redundant as it is provided by GH in the assets list
- fix typo

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3129)
<!-- Reviewable:end -->
