### PR TITLE
Fix stackoverflow on Windows

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add setting to toggle IPv6 support.
 - vpnd: Add support to toggle network statistics collection.
 
+### Fixed
+
+- Box too large futures to fix stackoverflow on Windows (https://github.com/nymtech/nym-vpn-client/pull/3139)
+
 ## [1.12.0] - 2025-07-18
 
 ### Added

--- a/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/connect.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/connect.rs
@@ -94,11 +94,23 @@ pub async fn setup_mixnet_client(
             .map_err(|err| MixnetError::CreateMixnetClientWithDefaultStorage(Box::new(err)))?;
 
         let builder = MixnetClientBuilder::new_with_storage(storage);
-        build_and_connect_mixnet_client(builder, setup_options, debug_config, task_client).await?
+        Box::pin(build_and_connect_mixnet_client(
+            builder,
+            setup_options,
+            debug_config,
+            task_client,
+        ))
+        .await?
     } else {
         tracing::debug!("Using ephemeral key storage");
         let builder = MixnetClientBuilder::new_ephemeral();
-        build_and_connect_mixnet_client(builder, setup_options, debug_config, task_client).await?
+        Box::pin(build_and_connect_mixnet_client(
+            builder,
+            setup_options,
+            debug_config,
+            task_client,
+        ))
+        .await?
     };
 
     Ok(Arc::new(Mutex::new(Some(mixnet_client))))

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connector.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connector.rs
@@ -53,7 +53,7 @@ impl Connector {
         data_path: Option<PathBuf>,
         cancel_token: CancellationToken,
     ) -> Result<ConnectedTunnel, ConnectorError> {
-        let result = Self::connect_inner(
+        let result = Box::pin(Self::connect_inner(
             &self.task_manager,
             network,
             self.mixnet_client.clone(),
@@ -61,7 +61,7 @@ impl Connector {
             selected_gateways,
             data_path,
             cancel_token,
-        )
+        ))
         .await;
 
         match result {
@@ -131,68 +131,70 @@ impl Connector {
         );
 
         let shutdown = task_manager.subscribe_named("bandwidth_controller");
-        let (connection_data, bandwidth_controller_handle) =
-            if let Some(data_path) = data_path.as_ref() {
-                let paths = StoragePaths::new_from_dir(data_path)
-                    .map_err(|err| Error::SetupStoragePaths(Box::new(err)))?;
-                let storage = paths
-                    .persistent_credential_storage()
-                    .await
-                    .map_err(|err| Error::SetupStoragePaths(Box::new(err)))?;
-                let bw = BandwidthController::new(
-                    storage,
-                    network,
-                    wg_entry_gateway_client.light_client(),
-                    wg_exit_gateway_client.light_client(),
-                    shutdown,
-                )?;
-                let entry_fut = bw.get_initial_bandwidth(
+        let (connection_data, bandwidth_controller_handle) = if let Some(data_path) =
+            data_path.as_ref()
+        {
+            let paths = StoragePaths::new_from_dir(data_path)
+                .map_err(|err| Error::SetupStoragePaths(Box::new(err)))?;
+            let storage = paths
+                .persistent_credential_storage()
+                .await
+                .map_err(|err| Error::SetupStoragePaths(Box::new(err)))?;
+            let bw = BandwidthController::new(
+                storage,
+                network,
+                wg_entry_gateway_client.light_client(),
+                wg_exit_gateway_client.light_client(),
+                shutdown,
+            )?;
+            let entry_fut = bw.get_initial_bandwidth(
+                TicketType::V1WireguardEntry,
+                gateway_directory_client.clone(),
+                &mut wg_entry_gateway_client,
+            );
+            let exit_fut = bw.get_initial_bandwidth(
+                TicketType::V1WireguardExit,
+                gateway_directory_client.clone(),
+                &mut wg_exit_gateway_client,
+            );
+
+            let (entry, exit) = Box::pin(
+                cancel_token.run_until_cancelled(async { tokio::try_join!(entry_fut, exit_fut) }),
+            )
+            .await
+            .ok_or(tunnel::Error::Cancelled)??;
+
+            let bandwidth_controller_handle = tokio::spawn(bw.run());
+
+            (ConnectionData { entry, exit }, bandwidth_controller_handle)
+        } else {
+            let storage = EphemeralCredentialStorage::default();
+            let bw = BandwidthController::new(
+                storage,
+                network,
+                wg_entry_gateway_client.light_client(),
+                wg_exit_gateway_client.light_client(),
+                shutdown,
+            )?;
+            let entry = bw
+                .get_initial_bandwidth(
                     TicketType::V1WireguardEntry,
                     gateway_directory_client.clone(),
                     &mut wg_entry_gateway_client,
-                );
-                let exit_fut = bw.get_initial_bandwidth(
+                )
+                .await?;
+            let exit = bw
+                .get_initial_bandwidth(
                     TicketType::V1WireguardExit,
-                    gateway_directory_client.clone(),
+                    gateway_directory_client,
                     &mut wg_exit_gateway_client,
-                );
+                )
+                .await?;
 
-                let (entry, exit) = cancel_token
-                    .run_until_cancelled(async { tokio::try_join!(entry_fut, exit_fut) })
-                    .await
-                    .ok_or(tunnel::Error::Cancelled)??;
+            let bandwidth_controller_handle = tokio::spawn(bw.run());
 
-                let bandwidth_controller_handle = tokio::spawn(bw.run());
-
-                (ConnectionData { entry, exit }, bandwidth_controller_handle)
-            } else {
-                let storage = EphemeralCredentialStorage::default();
-                let bw = BandwidthController::new(
-                    storage,
-                    network,
-                    wg_entry_gateway_client.light_client(),
-                    wg_exit_gateway_client.light_client(),
-                    shutdown,
-                )?;
-                let entry = bw
-                    .get_initial_bandwidth(
-                        TicketType::V1WireguardEntry,
-                        gateway_directory_client.clone(),
-                        &mut wg_entry_gateway_client,
-                    )
-                    .await?;
-                let exit = bw
-                    .get_initial_bandwidth(
-                        TicketType::V1WireguardExit,
-                        gateway_directory_client,
-                        &mut wg_exit_gateway_client,
-                    )
-                    .await?;
-
-                let bandwidth_controller_handle = tokio::spawn(bw.run());
-
-                (ConnectionData { entry, exit }, bandwidth_controller_handle)
-            };
+            (ConnectionData { entry, exit }, bandwidth_controller_handle)
+        };
 
         if let Some(exit_country_code) = selected_gateways.exit.two_letter_iso_country_code() {
             auth_client.send_stats_event(

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -266,7 +266,7 @@ impl TunnelMonitor {
     }
 
     async fn run(mut self) -> Tombstone {
-        let (tombstone, reason) = match self.run_inner().await {
+        let (tombstone, reason) = match Box::pin(self.run_inner()).await {
             Ok(tombstone) => (tombstone, None),
             Err(e) => {
                 trace_err_chain!(e, "Tunnel monitor exited with error");
@@ -426,14 +426,14 @@ impl TunnelMonitor {
                 }
             }
         };
-        let mut connected_mixnet = tunnel::connect_mixnet(
+        let mut connected_mixnet = Box::pin(tunnel::connect_mixnet(
             connect_options,
             &self.tunnel_parameters.nym_config.network_env,
             self.gateway_directory_client.clone(),
             self.shutdown_token.child_token(),
             #[cfg(unix)]
             Arc::new(connection_fd_callback),
-        )
+        ))
         .await
         .map_err(Box::new)?;
 


### PR DESCRIPTION
## Description

Box too large futures to fix stackoverflow on Windows. Clippy can be used to identify the large futures:

```
cargo clippy -- -W clippy::large_futures -W clippy::large_stack_frames -A clippy::collapsible_if -A clippy::manual_is_multiple_of -A unused
```

JIRA-VPN-3757


## Checklist:

- [x] Changelog

JIRA-VPN-3757

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3139)
<!-- Reviewable:end -->
