### PR TITLE
Enable clippy large futures

### DIFF
--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -82,11 +82,10 @@ license = "GPL-3.0-only"
 unwrap_used = "deny"
 expect_used = "deny"
 todo = "deny"
-dbg_macro = "deny"
 exit = "deny"
 panic = "deny"
 unimplemented = "deny"
-unreachable = "deny"
+large_futures = "warn"
 
 [workspace.dependencies]
 android_logger = "0.14.1"

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -79,12 +79,6 @@ edition = "2024"
 license = "GPL-3.0-only"
 
 [workspace.lints.clippy]
-unwrap_used = "deny"
-expect_used = "deny"
-todo = "deny"
-exit = "deny"
-panic = "deny"
-unimplemented = "deny"
 large_futures = "warn"
 
 [workspace.dependencies]

--- a/nym-vpn-core/crates/nym-apple-network/Cargo.toml
+++ b/nym-vpn-core/crates/nym-apple-network/Cargo.toml
@@ -8,6 +8,9 @@ documentation.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 dispatch2.workspace = true
 objc2-foundation = { workspace = true, features = ["NSString"] }

--- a/nym-vpn-core/crates/nym-apple-network/src/endpoint.rs
+++ b/nym-vpn-core/crates/nym-apple-network/src/endpoint.rs
@@ -236,7 +236,7 @@ impl AddressEndpoint {
 
         Self {
             inner: unsafe { Retained::retain(nw_endpoint_ref.as_ptr()) }
-                .expect("failed ot retain address endpoint"),
+                .expect("failed to retain address endpoint"),
         }
     }
 
@@ -278,7 +278,7 @@ impl UrlEndpoint {
 
         Self {
             inner: unsafe { Retained::retain(nw_endpoint_ref.as_ptr()) }
-                .expect("failed ot retain url endpoint"),
+                .expect("failed to retain url endpoint"),
         }
     }
 
@@ -324,7 +324,7 @@ impl BonjourServiceEndpoint {
 
         Self {
             inner: unsafe { Retained::retain(nw_endpoint_ref.as_ptr()) }
-                .expect("failed ot retain bonjour service endpoint"),
+                .expect("failed to retain bonjour service endpoint"),
         }
     }
 

--- a/nym-vpn-core/crates/nym-authenticator-client/Cargo.toml
+++ b/nym-vpn-core/crates/nym-authenticator-client/Cargo.toml
@@ -8,6 +8,9 @@ documentation.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 bincode.workspace = true
 futures.workspace = true

--- a/nym-vpn-core/crates/nym-common/Cargo.toml
+++ b/nym-vpn-core/crates/nym-common/Cargo.toml
@@ -6,6 +6,9 @@ repository.workspace = true
 license.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 tracing.workspace = true
 tracing-test.workspace = true

--- a/nym-vpn-core/crates/nym-connection-monitor/Cargo.toml
+++ b/nym-vpn-core/crates/nym-connection-monitor/Cargo.toml
@@ -8,6 +8,9 @@ documentation.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 bincode.workspace = true
 bytes.workspace = true

--- a/nym-vpn-core/crates/nym-dbus/Cargo.toml
+++ b/nym-vpn-core/crates/nym-dbus/Cargo.toml
@@ -6,6 +6,9 @@ license.workspace = true
 edition.workspace = true
 version.workspace = true
 
+[lints]
+workspace = true
+
 [target.'cfg(target_os = "linux")'.dependencies]
 dbus.workspace = true
 libc.workspace = true

--- a/nym-vpn-core/crates/nym-dns/Cargo.toml
+++ b/nym-vpn-core/crates/nym-dns/Cargo.toml
@@ -11,6 +11,9 @@ license.workspace = true
 [lib]
 crate-type = ["cdylib", "lib", "staticlib"]
 
+[lints]
+workspace = true
+
 [dependencies]
 nix = { workspace = true, features = ["net"] }
 thiserror.workspace = true

--- a/nym-vpn-core/crates/nym-firewall/Cargo.toml
+++ b/nym-vpn-core/crates/nym-firewall/Cargo.toml
@@ -8,6 +8,9 @@ documentation.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 ipnetwork.workspace = true
 libc.workspace = true

--- a/nym-vpn-core/crates/nym-gateway-directory/Cargo.toml
+++ b/nym-vpn-core/crates/nym-gateway-directory/Cargo.toml
@@ -8,6 +8,9 @@ documentation.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 futures.workspace = true
 itertools.workspace = true

--- a/nym-vpn-core/crates/nym-gateway-probe/Cargo.toml
+++ b/nym-vpn-core/crates/nym-gateway-probe/Cargo.toml
@@ -7,7 +7,9 @@ homepage.workspace = true
 documentation.workspace = true
 edition.workspace = true
 license.workspace = true
-build = "build.rs"
+
+[lints]
+workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
+++ b/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
@@ -252,7 +252,7 @@ impl Probe {
             bw_client.acquire().await?;
         }
 
-        let mixnet_client = Box::pin(disconnected_mixnet_client.connect_to_mixnet().await);
+        let mixnet_client = Box::pin(disconnected_mixnet_client.connect_to_mixnet()).await;
 
         let mixnet_client = match mixnet_client {
             Ok(mixnet_client) => mixnet_client,

--- a/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
+++ b/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
@@ -252,7 +252,7 @@ impl Probe {
             bw_client.acquire().await?;
         }
 
-        let mixnet_client = disconnected_mixnet_client.connect_to_mixnet().await;
+        let mixnet_client = Box::pin(disconnected_mixnet_client.connect_to_mixnet().await);
 
         let mixnet_client = match mixnet_client {
             Ok(mixnet_client) => mixnet_client,

--- a/nym-vpn-core/crates/nym-gateway-probe/src/run.rs
+++ b/nym-vpn-core/crates/nym-gateway-probe/src/run.rs
@@ -130,13 +130,12 @@ pub(crate) async fn run() -> anyhow::Result<ProbeResult> {
     if let Some(awg_args) = args.amnezia_args {
         trial.with_amnezia(&awg_args);
     }
-    trial
-        .probe(
-            gateway_config,
-            args.ignore_egress_epoch_role,
-            args.only_wireguard,
-        )
-        .await
+    Box::pin(trial.probe(
+        gateway_config,
+        args.ignore_egress_epoch_role,
+        args.only_wireguard,
+    ))
+    .await
 }
 
 async fn fetch_random_gateway_with_ipr(

--- a/nym-vpn-core/crates/nym-harbour-master-client/Cargo.toml
+++ b/nym-vpn-core/crates/nym-harbour-master-client/Cargo.toml
@@ -8,6 +8,9 @@ documentation.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 async-trait.workspace = true
 chrono.workspace = true

--- a/nym-vpn-core/crates/nym-ip-packet-client/Cargo.toml
+++ b/nym-vpn-core/crates/nym-ip-packet-client/Cargo.toml
@@ -8,6 +8,9 @@ documentation.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 bytes.workspace = true
 futures.workspace = true

--- a/nym-vpn-core/crates/nym-macos/Cargo.toml
+++ b/nym-vpn-core/crates/nym-macos/Cargo.toml
@@ -7,6 +7,9 @@ repository.workspace = true
 license.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [target.'cfg(target_os="macos")'.dependencies]
 libc.workspace = true
 tracing.workspace = true

--- a/nym-vpn-core/crates/nym-offline-monitor/Cargo.toml
+++ b/nym-vpn-core/crates/nym-offline-monitor/Cargo.toml
@@ -8,6 +8,9 @@ documentation.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 thiserror.workspace = true
 tracing.workspace = true

--- a/nym-vpn-core/crates/nym-platform-metadata/Cargo.toml
+++ b/nym-vpn-core/crates/nym-platform-metadata/Cargo.toml
@@ -8,6 +8,9 @@ documentation.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 default = ["network-manager"]
 network-manager = ["nym-dbus"]

--- a/nym-vpn-core/crates/nym-routing/Cargo.toml
+++ b/nym-vpn-core/crates/nym-routing/Cargo.toml
@@ -6,6 +6,9 @@ repository.workspace = true
 license.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 thiserror.workspace = true
 futures.workspace = true

--- a/nym-vpn-core/crates/nym-statistics-api-client/Cargo.toml
+++ b/nym-vpn-core/crates/nym-statistics-api-client/Cargo.toml
@@ -8,6 +8,9 @@ documentation.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 nym-http-api-client.workspace = true
 serde = { workspace = true, features = ["derive"] }

--- a/nym-vpn-core/crates/nym-vpn-api-client/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-api-client/Cargo.toml
@@ -8,6 +8,9 @@ documentation.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 backon.workspace = true
 base64-url.workspace = true

--- a/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
@@ -11,6 +11,9 @@ license.workspace = true
 [lib]
 crate-type = ["cdylib", "lib", "staticlib"]
 
+[lints]
+workspace = true
+
 [dependencies]
 async-trait.workspace = true
 bincode.workspace = true

--- a/nym-vpn-core/crates/nym-vpn-network-config/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-network-config/Cargo.toml
@@ -8,6 +8,9 @@ documentation.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 thiserror.workspace = true
 futures-util.workspace = true

--- a/nym-vpn-core/crates/nym-vpn-proto/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-proto/Cargo.toml
@@ -8,6 +8,9 @@ documentation.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 prost-types.workspace = true
 prost.workspace = true

--- a/nym-vpn-core/crates/nym-vpnc/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpnc/Cargo.toml
@@ -9,6 +9,9 @@ documentation.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive", "wrap_help"] }

--- a/nym-vpn-core/crates/nym-vpnd/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpnd/Cargo.toml
@@ -9,6 +9,9 @@ documentation.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 bip39.workspace = true

--- a/nym-vpn-core/crates/nym-wg-gateway-client/Cargo.toml
+++ b/nym-vpn-core/crates/nym-wg-gateway-client/Cargo.toml
@@ -8,6 +8,9 @@ documentation.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 nym-authenticator-requests.workspace = true
 nym-bandwidth-controller.workspace = true

--- a/nym-vpn-core/crates/nym-wg-go/Cargo.toml
+++ b/nym-vpn-core/crates/nym-wg-go/Cargo.toml
@@ -8,6 +8,9 @@ documentation.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 default = []
 amnezia = []

--- a/nym-vpn-core/crates/nym-windows/Cargo.toml
+++ b/nym-vpn-core/crates/nym-windows/Cargo.toml
@@ -6,6 +6,9 @@ license.workspace = true
 edition.workspace = true
 version.workspace = true
 
+[lints]
+workspace = true
+
 [target.'cfg(windows)'.dependencies]
 bitflags.workspace = true
 thiserror.workspace = true

--- a/nym-vpn-core/crates/uniffi-bindgen/Cargo.toml
+++ b/nym-vpn-core/crates/uniffi-bindgen/Cargo.toml
@@ -8,5 +8,8 @@ documentation.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 uniffi = { workspace = true, features = ["cli"] }


### PR DESCRIPTION
## Description

- This PR enables `clippy::large_futures` warning
- Remove lints for unwrap, expect, todo, dbg_macro, exit, panic, unimplemented, unreachable - I think that some of those should not be prohibited and others are quite restrictive to enable them right away and require more consideration 
- Inherit lints across workspace
- Minor typo fixes

## Checklist:

- [x] Changelog

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3151)
<!-- Reviewable:end -->
