### PR TITLE
Move task manager ownership to TunnelMonitor

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improve shutdown sequence by exiting internal components in the reverse order of their creation. Drain tunnel events and deliver them to listeners before exiting the daemon. (https://github.com/nymtech/nym-vpn-client/pull/3185)
 - Fix potential infinite loop when sending a disconnect message over mixnet. Limit disconnect timeout to 5 seconds and add 500ms delay between retries. (https://github.com/nymtech/nym-vpn-client/pull/3160)
+- Prevent gateways refresh from blocking daemon shutdown during initialization. (https://github.com/nymtech/nym-vpn-client/pull/3160)
 
 
 ## [1.13.1] - 2025-07-30

--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Improve shutdown sequence by exiting internal components in the reverse order of their creation. Drain tunnel events and deliver them to listeners before exiting the daemon. (https://github.com/nymtech/nym-vpn-client/pull/3185)
+- Fix potential infinite loop when sending a disconnect message over mixnet. Limit disconnect timeout to 5 seconds and add 500ms delay between retries. (https://github.com/nymtech/nym-vpn-client/pull/3160)
+
 
 ## [1.13.1] - 2025-07-30
 

--- a/nym-vpn-core/crates/nym-authenticator-client/src/mixnet_listener.rs
+++ b/nym-vpn-core/crates/nym-authenticator-client/src/mixnet_listener.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
 use futures::StreamExt;
 use nym_sdk::mixnet::{MixnetClient, ReconstructedMessage};

--- a/nym-vpn-core/crates/nym-authenticator-client/src/mixnet_listener.rs
+++ b/nym-vpn-core/crates/nym-authenticator-client/src/mixnet_listener.rs
@@ -29,31 +29,26 @@ pub struct AuthClientMixnetListener {
     message_broadcast: MixnetMessageBroadcastSender,
 
     // Listen to cancel from the outside world
-    external_cancel_token: CancellationToken,
+    shutdown_token: CancellationToken,
 }
 
 impl AuthClientMixnetListener {
-    pub fn new(mixnet_client: SharedMixnetClient) -> Self {
+    pub fn new(mixnet_client: SharedMixnetClient, shutdown_token: CancellationToken) -> Self {
         let (message_broadcast, _) = broadcast::channel(100);
         Self {
             mixnet_client,
             message_broadcast,
-            external_cancel_token: CancellationToken::new(),
+            shutdown_token,
         }
-    }
-
-    pub fn with_external_cancel_token(mut self, external_cancel_token: CancellationToken) -> Self {
-        self.external_cancel_token = external_cancel_token;
-        self
     }
 
     pub fn subscribe(&self) -> MixnetMessageBroadcastReceiver {
         self.message_broadcast.subscribe()
     }
 
-    async fn run(self, cancel_token: CancellationToken) {
+    async fn run(self) {
         let mut mixnet_client = self.mixnet_client.lock().await.take().unwrap();
-        cancel_token
+        self.shutdown_token
             .run_until_cancelled(async {
                 while let Some(event) = mixnet_client.next().await {
                     if let Err(err) = self.message_broadcast.send(Arc::new(event)) {
@@ -69,16 +64,11 @@ impl AuthClientMixnetListener {
     pub fn start(self) -> AuthClientMixnetListenerHandle {
         let mixnet_client = self.mixnet_client.clone();
         let message_broadcast = self.message_broadcast.clone();
-        let external_cancel_token = self.external_cancel_token.clone();
-        let internal_cancel_token = self.external_cancel_token.child_token();
-
-        let handle = tokio::spawn(self.run(internal_cancel_token.clone()));
+        let handle = tokio::spawn(self.run());
 
         AuthClientMixnetListenerHandle {
             mixnet_client,
             message_broadcast,
-            external_cancel_token,
-            internal_cancel_token,
             handle,
         }
     }
@@ -87,8 +77,6 @@ impl AuthClientMixnetListener {
 pub struct AuthClientMixnetListenerHandle {
     mixnet_client: SharedMixnetClient,
     message_broadcast: MixnetMessageBroadcastSender,
-    external_cancel_token: CancellationToken,
-    internal_cancel_token: CancellationToken,
     handle: JoinHandle<()>,
 }
 
@@ -116,28 +104,9 @@ impl AuthClientMixnetListenerHandle {
         self.message_broadcast.subscribe()
     }
 
-    pub async fn disconnect(mut self) -> AuthClientMixnetListener {
-        self.internal_cancel_token.cancel();
-        self = self.wait().await;
-        AuthClientMixnetListener {
-            mixnet_client: self.mixnet_client,
-            message_broadcast: self.message_broadcast,
-            external_cancel_token: self.external_cancel_token,
+    pub async fn wait(self) {
+        if let Err(err) = self.handle.await {
+            tracing::error!("Error waiting for auth clients mixnet listener to stop: {err}");
         }
-    }
-
-    pub async fn wait(mut self) -> Self {
-        tokio::select! {
-            join_result = &mut self.handle => {
-                if let Err(err) = join_result {
-                    tracing::error!("Error waiting for auth clients mixnet listener to stop: {err}");
-                }
-            }
-            _ = tokio::time::sleep(Duration::from_secs(5)) => {
-                tracing::error!("Timeout waiting for auth clients mixnet listener to stop. Forcing stop");
-                self.handle.abort();
-            }
-        }
-        self
     }
 }

--- a/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
+++ b/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
@@ -305,8 +305,11 @@ impl Probe {
         let wg_outcome = if let (Some(authenticator), Some(ip_address)) =
             (node_info.authenticator_address, node_info.ip_address)
         {
+            let cancel_token = CancellationToken::new();
             // Start the mixnet listener that the auth clients use to receive messages.
-            let mixnet_listener_task = AuthClientMixnetListener::new(shared_client.clone()).start();
+            let mixnet_listener_task =
+                AuthClientMixnetListener::new(shared_client.clone(), cancel_token.child_token())
+                    .start();
             let auth_client = mixnet_listener_task
                 .new_auth_client()
                 .await
@@ -343,7 +346,8 @@ impl Probe {
             .await
             .unwrap_or_default();
 
-            let _ = mixnet_listener_task.disconnect().await;
+            cancel_token.cancel();
+            mixnet_listener_task.wait().await;
 
             outcome
         } else {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
@@ -367,6 +367,7 @@ impl<St: Storage> BandwidthController<St> {
             tokio::select! {
                 _ = self.shutdown_token.cancelled() => {
                     tracing::trace!("BandwidthController: Received shutdown");
+                    break;
                 }
                 _ = self.task_client.recv() => {
                     tracing::trace!("BandwidthController: Received shutdown");

--- a/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
@@ -3,8 +3,8 @@
 
 use std::time::Duration;
 
-use nym_vpn_network_config::Network;
 use tokio_stream::{StreamExt, wrappers::IntervalStream};
+use tokio_util::sync::CancellationToken;
 
 use nym_common::ErrorExt;
 use nym_credentials_interface::TicketType;
@@ -17,6 +17,7 @@ use nym_validator_client::{
     QueryHttpRpcNyxdClient,
     nyxd::{Config as NyxdClientConfig, NyxdClient},
 };
+use nym_vpn_network_config::Network;
 use nym_wg_gateway_client::{
     ErrorMessage, GatewayData, TICKETS_TO_SPEND, WgGatewayClient, WgGatewayLightClient,
 };
@@ -167,7 +168,8 @@ pub(crate) struct BandwidthController<St> {
     exit_depletion_rate: DepletionRate,
     entry_previous_empty_query: bool,
     exit_previous_empty_query: bool,
-    shutdown: TaskClient,
+    task_client: TaskClient,
+    shutdown_token: CancellationToken,
 }
 
 impl<St: Storage> BandwidthController<St> {
@@ -176,7 +178,8 @@ impl<St: Storage> BandwidthController<St> {
         network: &Network,
         wg_entry_gateway_client: WgGatewayLightClient,
         wg_exit_gateway_client: WgGatewayLightClient,
-        shutdown: TaskClient,
+        task_client: TaskClient,
+        shutdown_token: CancellationToken,
     ) -> Result<Self> {
         let client = get_nyxd_client(network)?;
         let inner = nym_bandwidth_controller::BandwidthController::new(storage, client);
@@ -192,7 +195,8 @@ impl<St: Storage> BandwidthController<St> {
             exit_depletion_rate: Default::default(),
             entry_previous_empty_query: false,
             exit_previous_empty_query: false,
-            shutdown,
+            task_client,
+            shutdown_token,
         })
     }
 
@@ -276,7 +280,10 @@ impl<St: Storage> BandwidthController<St> {
         };
 
         tokio::select! {
-            _ = self.shutdown.recv() => {
+            _ = self.shutdown_token.cancelled() => {
+                tracing::trace!("BandwidthController: Received shutdown");
+            }
+            _ = self.task_client.recv() => {
                 tracing::trace!("BandwidthController: Received shutdown");
             }
             ret = wg_gateway_client.query_bandwidth() => {
@@ -308,7 +315,7 @@ impl<St: Storage> BandwidthController<St> {
                                 {
                                     tracing::warn!("Error topping up with more bandwidth {:?}", e);
                                     // TODO: try to return this error in the JoinHandle instead
-                                    self.shutdown
+                                    self.task_client
                                         .send_we_stopped(Box::new(ErrorMessage::OutOfBandwidth {
                                             gateway_id: Box::new(
                                                 wg_gateway_client.auth_recipient().gateway(),
@@ -323,7 +330,7 @@ impl<St: Storage> BandwidthController<St> {
                     }
                     Ok(None) => {
                         if (entry && self.entry_previous_empty_query) || (!entry && self.exit_previous_empty_query) {
-                            self.shutdown
+                            self.task_client
                             .send_we_stopped(Box::new(ErrorMessage::DisconnectedByGateway {
                                 gateway_id: Box::new(
                                     wg_gateway_client.auth_recipient().gateway(),
@@ -356,9 +363,12 @@ impl<St: Storage> BandwidthController<St> {
     {
         // Skip the first, immediate tick
         self.timeout_check_interval.next().await;
-        while !self.shutdown.is_shutdown() {
+        while !self.task_client.is_shutdown() {
             tokio::select! {
-                _ = self.shutdown.recv() => {
+                _ = self.shutdown_token.cancelled() => {
+                    tracing::trace!("BandwidthController: Received shutdown");
+                }
+                _ = self.task_client.recv() => {
                     tracing::trace!("BandwidthController: Received shutdown");
                 }
                 _ = self.timeout_check_interval.next() => {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/connect.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/connect.rs
@@ -15,9 +15,8 @@ use nym_sdk::{
 };
 use nym_vpn_network_config::Network;
 use nym_vpn_store::mnemonic::MnemonicStorage as _;
-use tokio::sync::Mutex;
 
-use super::{MixnetError, SharedMixnetClient, topology_provider::VpnTopologyProvider};
+use super::{MixnetError, topology_provider::VpnTopologyProvider};
 use crate::{MixnetClientConfig, storage::VpnClientOnDiskStorage};
 
 const VPN_AVERAGE_PACKET_DELAY: Duration = Duration::from_millis(15);

--- a/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/connect.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/connect.rs
@@ -41,7 +41,7 @@ pub async fn setup_mixnet_client(
     mixnet_client_config: MixnetClientConfig,
     setup_options: SetupMixnetClientOptions,
     mut task_client: nym_task::TaskClient,
-) -> Result<SharedMixnetClient, MixnetError> {
+) -> Result<MixnetClient, MixnetError> {
     let mut debug_config = nym_client_core::config::DebugConfig::default();
     debug_config.traffic.average_packet_delay = VPN_AVERAGE_PACKET_DELAY;
     if setup_options.two_hop_mode {
@@ -110,7 +110,7 @@ pub async fn setup_mixnet_client(
         .await?
     };
 
-    Ok(Arc::new(Mutex::new(Some(mixnet_client))))
+    Ok(mixnet_client)
 }
 
 async fn build_and_connect_mixnet_client<S>(

--- a/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/connect.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/connect.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #[cfg(unix)]
-use std::os::fd::RawFd;
-use std::{path::PathBuf, result::Result, sync::Arc, time::Duration};
+use std::{os::fd::RawFd, sync::Arc};
+use std::{path::PathBuf, result::Result, time::Duration};
 
 use nym_client_core::config::RememberMe;
 use nym_sdk::{

--- a/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/mixnet_listener.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/mixnet_listener.rs
@@ -81,7 +81,7 @@ impl MixnetListener {
 
         while !self.task_client.is_shutdown() {
             tokio::select! {
-                _ = self.task_client.recv_with_delay() => {
+                _ = self.task_client.recv() => {
                     tracing::debug!("Mixnet listener: Received shutdown");
                     break;
                 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/processor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/processor.rs
@@ -186,6 +186,10 @@ impl MixnetProcessor {
 
             tokio::select! {
                 biased;
+                _ = &mut ipr_disconnect_timeout => {
+                    tracing::warn!("Timed out waiting for ipr disconnect");
+                    break;
+                }
                 // When we get the cancel token, send a disconnect message to the IPR. We keep
                 // running until the mixnet listener receives the disconnect response, so we can
                 // make sure we've fully disconnected before we return.
@@ -209,10 +213,6 @@ impl MixnetProcessor {
                         continue;
                     }
                     has_sent_ipr_disconnect = true;
-                }
-                _ = &mut ipr_disconnect_timeout => {
-                    tracing::warn!("Timed out waiting for ipr disconnect");
-                    break;
                 }
                 // When the mixnet listener receives the disconnect response, it will notify us
                 // that it's done. This means we can now stop

--- a/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/processor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/processor.rs
@@ -25,6 +25,9 @@ use super::{MixnetError, SharedMixnetClient, backpressure::MixnetBackpressureMon
 /// How much time to wait for ipr disconnect before proceeding to shutdown.
 const IPR_DISCONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Interval between attempts to send ipr disconnect
+const IPR_DISCONNECT_RETRY_DELAY: Duration = Duration::from_millis(500);
+
 #[derive(Debug)]
 pub struct MixnetProcessorConfig {
     pub ip_packet_router_address: IpPacketRouterAddress,
@@ -205,11 +208,13 @@ impl MixnetProcessor {
                         Ok(input_message) => input_message,
                         Err(err) => {
                             tracing::error!("Failed to create disconnect message: {err}");
+                            tokio::time::sleep(IPR_DISCONNECT_RETRY_DELAY).await;
                             continue;
                         }
                     };
                     if let Err(err) = mixnet_sender.send(input_message).await {
                         tracing::error!("Failed to send disconnect message: {err}");
+                        tokio::time::sleep(IPR_DISCONNECT_RETRY_DELAY).await;
                         continue;
                     }
                     has_sent_ipr_disconnect = true;

--- a/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/processor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/processor.rs
@@ -81,9 +81,6 @@ struct MixnetProcessor {
 
     // Listen for when we should disconnect from the IPR and being shutting down
     cancel_token: CancellationToken,
-
-    // Once we've disconnected from the IPR, we need to notify the connection monitor
-    notify_disconnected: oneshot::Sender<()>,
 }
 
 impl MixnetProcessor {
@@ -94,7 +91,6 @@ impl MixnetProcessor {
         ip_packet_router_address: IpPacketRouterAddress,
         our_ips: IpPair,
         cancel_token: CancellationToken,
-        notify_disconnected: oneshot::Sender<()>,
     ) -> Self {
         MixnetProcessor {
             device,
@@ -104,7 +100,6 @@ impl MixnetProcessor {
             our_ips,
             icmp_beacon_identifier: connection_monitor.icmp_beacon_identifier(),
             cancel_token,
-            notify_disconnected,
         }
     }
 
@@ -279,20 +274,6 @@ impl MixnetProcessor {
         tracing::info!("Waiting for mixnet listener to finish");
         let tun_device_sink = mixnet_listener_handle.await.unwrap();
 
-        // Notify the tunnel monitor that we are disconnected from the IPR, and don't need the
-        // mixnet connection anymore. The tunnel monitor will in turn call on the TaskManager to
-        // signal shutdown for the mixnet client.
-        if self.notify_disconnected.send(()).is_err() {
-            tracing::error!("Failed to notify that the IPR is disconnected");
-        } else {
-            // After we've notified that we are disconnected, wait until the TaskManager has signelled
-            // shutdown before we return.
-            // Possibly we don't need this, but it seems like the correct thing to do. The footgun here
-            // is that we don't want to drop the mixnet client before the task manager has signalled
-            // shutdown.
-            task_client_mix_processor.recv_timeout().await;
-        }
-
         tracing::debug!("MixnetProcessor: Exiting");
         Ok(tun_device_sink
             .reunite(tun_device_stream)
@@ -373,7 +354,6 @@ pub async fn start_processor(
     task_manager: &TaskManager,
     connection_monitor: &ConnectionMonitorTask,
     cancel_token: CancellationToken,
-    notify_disconnected: oneshot::Sender<()>,
 ) -> JoinHandle<Result<AsyncDevice, MixnetError>> {
     tracing::info!("Creating mixnet processor");
     let processor = MixnetProcessor::new(
@@ -383,7 +363,6 @@ pub async fn start_processor(
         config.ip_packet_router_address,
         config.our_ips,
         cancel_token,
-        notify_disconnected,
     );
 
     let task_client_mix_processor = task_manager.subscribe_named("mixnet_processor");

--- a/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/processor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/processor.rs
@@ -198,12 +198,14 @@ impl MixnetProcessor {
                 // make sure we've fully disconnected before we return.
                 _ = self.cancel_token.cancelled(), if !has_sent_ipr_disconnect => {
                     // Start disconnect timeout upon receiving cancellation in the very first time.
-                    if !is_disconnect_timeout_active {
+                    if is_disconnect_timeout_active {
+                        tracing::debug!("Re-sending disconnect message");
+                    } else {
                         is_disconnect_timeout_active = true;
                         ipr_disconnect_timeout.set(tokio::time::sleep(IPR_DISCONNECT_TIMEOUT).fuse());
+                        tracing::debug!("Cancel token triggered, sending disconnect message");
                     }
 
-                    tracing::debug!("MixnetProcessor: cancel token triggered, sending disconnect message");
                     let input_message = match message_creator.create_disconnect_message() {
                         Ok(input_message) => input_message,
                         Err(err) => {
@@ -217,23 +219,25 @@ impl MixnetProcessor {
                         tokio::time::sleep(IPR_DISCONNECT_RETRY_DELAY).await;
                         continue;
                     }
+
+                    tracing::info!("Sent disconnect message");
                     has_sent_ipr_disconnect = true;
                 }
                 // When the mixnet listener receives the disconnect response, it will notify us
                 // that it's done. This means we can now stop
                 _ = &mut mixnet_listener_done => {
-                    tracing::debug!("MixnetProcessor: mixnet listener has finished");
+                    tracing::debug!("Mixnet listener has finished");
                     break;
                 }
                 // Handle task manager shutdown
                 _ = task_client_mix_processor.recv() => {
-                    tracing::debug!("MixnetProcessor: Received shutdown");
+                    tracing::debug!("Received shutdown");
                     break;
                 }
                 // The backpressure monitor will notify us when the backpressure is lifted, so we
                 // can restart the select with updated preconditions
                 _ = notify_backpressure_lifted.notified(), if is_backpressure => {
-                    tracing::trace!("MixnetProcessor: backpressure lifted");
+                    tracing::trace!("Backpressure lifted");
                     continue;
                 }
                 // Read from the tun device and send the IP packet to the mixnet
@@ -248,7 +252,7 @@ impl MixnetProcessor {
                                 }
                             }
                             _ = task_client_mix_processor.recv() => {
-                                tracing::debug!("MixnetProcessor: Received shutdown while sending.");
+                                tracing::debug!("Received shutdown while sending.");
                                 break;
                             }
                         }
@@ -258,14 +262,14 @@ impl MixnetProcessor {
                         break;
                     }
                     None => {
-                        tracing::error!("Mixnet processor: tun device stream ended");
+                        tracing::error!("Tun device stream ended");
                         break;
                     }
                 },
                 // To make sure we don't wait too long before filling up the buffer, which destroys
                 // latency, cap the time waiting for the buffer to fill
                 _ = payload_topup_interval.tick() => {
-                    tracing::trace!("MixnetProcessor: Buffer timeout");
+                    tracing::trace!("Buffer timeout");
 
                     // If we already have pending packets that we are waiting to send to the
                     // mixnet, there is no point in flushing the current buffer. Instead keep
@@ -283,7 +287,7 @@ impl MixnetProcessor {
                             }
                         }
                         _ = task_client_mix_processor.recv() => {
-                            tracing::debug!("MixnetProcessor: Received shutdown while flushing");
+                            tracing::debug!("Received shutdown while flushing");
                             break;
                         }
                     }
@@ -297,7 +301,7 @@ impl MixnetProcessor {
         tracing::info!("Waiting for mixnet listener to finish");
         let tun_device_sink = mixnet_listener_handle.await.unwrap();
 
-        tracing::debug!("MixnetProcessor: Exiting");
+        tracing::debug!("Exiting");
         Ok(tun_device_sink
             .reunite(tun_device_stream)
             .expect("reunite should work because of same device split")

--- a/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/processor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/processor.rs
@@ -1,10 +1,10 @@
 // Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::result::Result;
+use std::{result::Result, time::Duration};
 
 use bytes::{Bytes, BytesMut};
-use futures::{StreamExt, channel::mpsc};
+use futures::{FutureExt, StreamExt, channel::mpsc, future::Fuse, pin_mut};
 use nym_connection_monitor::{ConnectionMonitorTask, ConnectionStatusEvent};
 use nym_gateway_directory::IpPacketRouterAddress;
 use nym_ip_packet_requests::{
@@ -21,6 +21,9 @@ use tokio_util::{codec::Encoder, sync::CancellationToken};
 use tun::{AsyncDevice, Device};
 
 use super::{MixnetError, SharedMixnetClient, backpressure::MixnetBackpressureMonitor};
+
+/// How much time to wait for ipr disconnect before proceeding to shutdown.
+const IPR_DISCONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Debug)]
 pub struct MixnetProcessorConfig {
@@ -153,6 +156,13 @@ impl MixnetProcessor {
         // times
         let mut has_sent_ipr_disconnect = false;
 
+        // Keeps track of whether ipr disconnect timeout has been activated.
+        let mut is_disconnect_timeout_active = false;
+
+        // Ipr disconnect timeout future set upon cancellation
+        let ipr_disconnect_timeout = Fuse::terminated();
+        pin_mut!(ipr_disconnect_timeout);
+
         let mut payload_topup_interval =
             tokio::time::interval(nym_ip_packet_requests::codec::BUFFER_TIMEOUT);
 
@@ -180,6 +190,12 @@ impl MixnetProcessor {
                 // running until the mixnet listener receives the disconnect response, so we can
                 // make sure we've fully disconnected before we return.
                 _ = self.cancel_token.cancelled(), if !has_sent_ipr_disconnect => {
+                    // Start disconnect timeout upon receiving cancellation in the very first time.
+                    if !is_disconnect_timeout_active {
+                        is_disconnect_timeout_active = true;
+                        ipr_disconnect_timeout.set(tokio::time::sleep(IPR_DISCONNECT_TIMEOUT).fuse());
+                    }
+
                     tracing::debug!("MixnetProcessor: cancel token triggered, sending disconnect message");
                     let input_message = match message_creator.create_disconnect_message() {
                         Ok(input_message) => input_message,
@@ -194,16 +210,18 @@ impl MixnetProcessor {
                     }
                     has_sent_ipr_disconnect = true;
                 }
+                _ = &mut ipr_disconnect_timeout => {
+                    tracing::warn!("Timed out waiting for ipr disconnect");
+                    break;
+                }
                 // When the mixnet listener receives the disconnect response, it will notify us
                 // that it's done. This means we can now stop
                 _ = &mut mixnet_listener_done => {
                     tracing::debug!("MixnetProcessor: mixnet listener has finished");
                     break;
                 }
-                // In the tunnel monitor, if it times out waiting to hear that we have
-                // disconnected, it will call on the TaskManager to signal shutdown anyway. This is
-                // captured here.
-                _ = task_client_mix_processor.recv_with_delay() => {
+                // Handle task manager shutdown
+                _ = task_client_mix_processor.recv() => {
                     tracing::debug!("MixnetProcessor: Received shutdown");
                     break;
                 }
@@ -224,7 +242,7 @@ impl MixnetProcessor {
                                     tracing::error!("Failed to send IP packet to the mixnet");
                                 }
                             }
-                            _ = task_client_mix_processor.recv_with_delay() => {
+                            _ = task_client_mix_processor.recv() => {
                                 tracing::debug!("MixnetProcessor: Received shutdown while sending.");
                                 break;
                             }
@@ -259,7 +277,7 @@ impl MixnetProcessor {
                                 tracing::error!("Failed to flush the multi IP packet sink");
                             }
                         }
-                        _ = task_client_mix_processor.recv_with_delay() => {
+                        _ = task_client_mix_processor.recv() => {
                             tracing::debug!("MixnetProcessor: Received shutdown while flushing");
                             break;
                         }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/resolver.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/resolver.rs
@@ -418,7 +418,7 @@ impl ResolverImpl {
 
     /// This function is called when a DNS query is sent to the local resolver
     async fn lookup<R: ResponseHandler>(&self, message: &Request, mut response_handler: R) {
-        tracing::debug!(
+        tracing::trace!(
             "Lookup for: {}, client: {}/{}",
             message
                 .queries()

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/any_tunnel_handle.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/any_tunnel_handle.rs
@@ -38,15 +38,6 @@ impl AnyTunnelHandle {
         }
     }
 
-    pub async fn recv_error(
-        &mut self,
-    ) -> Option<Box<dyn std::error::Error + 'static + Send + Sync>> {
-        match self {
-            Self::Mixnet(handle) => handle.recv_error().await,
-            Self::Wireguard(handle) => handle.recv_error().await,
-        }
-    }
-
     pub async fn wait(self) -> Result<Tombstone> {
         match self {
             Self::Mixnet(handle) => match handle.wait().await {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/any_tunnel_handle.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/any_tunnel_handle.rs
@@ -26,11 +26,11 @@ impl From<WireguardTunnelHandle> for AnyTunnelHandle {
 }
 
 impl AnyTunnelHandle {
-    pub async fn cancel(&mut self) {
+    pub fn cancel(&mut self) {
         tracing::trace!("Cancelling tunnel handle");
         match self {
             Self::Mixnet(handle) => {
-                handle.cancel().await;
+                handle.cancel();
             }
             Self::Wireguard(handle) => {
                 handle.cancel();

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mixnet/connected_tunnel.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mixnet/connected_tunnel.rs
@@ -21,7 +21,6 @@ use crate::{
 
 /// Type representing a connected mixnet tunnel.
 pub struct ConnectedTunnel {
-    task_manager: TaskManager,
     mixnet_client: SharedMixnetClient,
     assigned_addresses: AssignedAddresses,
     cancel_token: CancellationToken,
@@ -29,13 +28,11 @@ pub struct ConnectedTunnel {
 
 impl ConnectedTunnel {
     pub fn new(
-        task_manager: TaskManager,
         mixnet_client: SharedMixnetClient,
         assigned_addresses: AssignedAddresses,
         cancel_token: CancellationToken,
     ) -> Self {
         Self {
-            task_manager,
             mixnet_client,
             assigned_addresses,
             cancel_token,
@@ -46,7 +43,11 @@ impl ConnectedTunnel {
         &self.assigned_addresses
     }
 
-    pub async fn run(self, tun_device: AsyncDevice) -> Result<TunnelHandle> {
+    pub async fn run(
+        self,
+        task_manager: &TaskManager,
+        tun_device: AsyncDevice,
+    ) -> Result<TunnelHandle> {
         let connection_monitor = ConnectionMonitorTask::setup();
 
         let processor_config = MixnetProcessorConfig::new(
@@ -60,7 +61,7 @@ impl ConnectedTunnel {
             processor_config,
             tun_device,
             self.mixnet_client.clone(),
-            &self.task_manager,
+            task_manager,
             &connection_monitor,
             self.cancel_token.clone(),
             ipr_disconnect_tx,
@@ -80,11 +81,10 @@ impl ConnectedTunnel {
             // todo: not fully possible to disable IPv6 because IpPair is passed.
             self.assigned_addresses.interface_addresses,
             self.assigned_addresses.exit_mix_addresses.into(),
-            &self.task_manager,
+            task_manager,
         );
 
         Ok(TunnelHandle {
-            task_manager: self.task_manager,
             processor_handle,
             processor_disconnected: Some(ipr_disconnect_rx),
         })
@@ -95,7 +95,6 @@ pub type ProcessorHandle = JoinHandle<Result<AsyncDevice, MixnetError>>;
 
 /// Type providing a back channel for tunnel errors and a way to wait for tunnel to finish execution.
 pub struct TunnelHandle {
-    task_manager: TaskManager,
     processor_handle: ProcessorHandle,
     processor_disconnected: Option<oneshot::Receiver<()>>,
 }
@@ -104,10 +103,6 @@ impl TunnelHandle {
     /// Cancel tunnel execution.
     pub async fn cancel(&mut self) {
         self.wait_for_processor_disconnect().await;
-
-        if let Err(e) = self.task_manager.signal_shutdown() {
-            tracing::error!("Failed to signal task manager shutdown: {}", e);
-        }
     }
 
     async fn wait_for_processor_disconnect(&mut self) {
@@ -129,20 +124,8 @@ impl TunnelHandle {
         }
     }
 
-    /// Wait for the next error.
-    ///
-    /// This method is cancel safe.
-    /// Returns `None` if the underlying channel has been closed.
-    pub async fn recv_error(&mut self) -> Option<Box<dyn StdError + 'static + Send + Sync>> {
-        self.task_manager.wait_for_error().await
-    }
-
     /// Wait until the tunnel finished execution.
     pub async fn wait(mut self) -> Result<Result<Tombstone, MixnetError>, JoinError> {
-        // First we need to wait for all the mixnet tasks to finish
-        tracing::trace!("Waiting for task manager shutdown");
-        self.task_manager.wait_for_graceful_shutdown().await;
-
         tracing::trace!("Waiting for mixnet processor handle");
         self.processor_handle
             .await

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mixnet/connected_tunnel.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mixnet/connected_tunnel.rs
@@ -1,13 +1,8 @@
 // Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::time::Duration;
-
 use nym_task::TaskManager;
-use tokio::{
-    sync::oneshot,
-    task::{JoinError, JoinHandle},
-};
+use tokio::task::{JoinError, JoinHandle};
 use tokio_util::sync::CancellationToken;
 use tun::AsyncDevice;
 
@@ -103,7 +98,7 @@ impl TunnelHandle {
     }
 
     /// Wait until the tunnel finished execution.
-    pub async fn wait(mut self) -> Result<Result<Tombstone, MixnetError>, JoinError> {
+    pub async fn wait(self) -> Result<Result<Tombstone, MixnetError>, JoinError> {
         tracing::trace!("Waiting for mixnet processor handle");
         self.processor_handle
             .await

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mixnet/connected_tunnel.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mixnet/connected_tunnel.rs
@@ -55,8 +55,6 @@ impl ConnectedTunnel {
             self.assigned_addresses.interface_addresses,
         );
 
-        let (ipr_disconnect_tx, ipr_disconnect_rx) = oneshot::channel();
-
         let processor_handle = crate::mixnet::start_processor(
             processor_config,
             tun_device,
@@ -64,7 +62,6 @@ impl ConnectedTunnel {
             task_manager,
             &connection_monitor,
             self.cancel_token.clone(),
-            ipr_disconnect_tx,
         )
         .await;
 
@@ -86,7 +83,7 @@ impl ConnectedTunnel {
 
         Ok(TunnelHandle {
             processor_handle,
-            processor_disconnected: Some(ipr_disconnect_rx),
+            cancel_token: self.cancel_token,
         })
     }
 }
@@ -96,36 +93,17 @@ pub type ProcessorHandle = JoinHandle<Result<AsyncDevice, MixnetError>>;
 /// Type providing a back channel for tunnel errors and a way to wait for tunnel to finish execution.
 pub struct TunnelHandle {
     processor_handle: ProcessorHandle,
-    processor_disconnected: Option<oneshot::Receiver<()>>,
+    cancel_token: CancellationToken,
 }
 
 impl TunnelHandle {
     /// Cancel tunnel execution.
-    pub async fn cancel(&mut self) {
-        self.wait_for_processor_disconnect().await;
-    }
-
-    async fn wait_for_processor_disconnect(&mut self) {
-        tracing::info!("Waiting for the mixnet processor to disconnect");
-        if let Some(processor_disconnected) = self.processor_disconnected.take() {
-            tokio::time::timeout(Duration::from_secs(10), processor_disconnected)
-                .await
-                .unwrap_or_else(|_| {
-                    tracing::error!(
-                        "Timed out waiting for processor to disconnect. Forcing shutdown."
-                    );
-                    Ok(())
-                })
-                .unwrap_or_else(|e| {
-                    tracing::error!("Failed to wait for processor to disconnect: {e}");
-                });
-        } else {
-            tracing::error!("Processor has already disconnected");
-        }
+    pub fn cancel(&self) {
+        self.cancel_token.cancel();
     }
 
     /// Wait until the tunnel finished execution.
-    pub async fn wait(self) -> Result<Result<Tombstone, MixnetError>, JoinError> {
+    pub async fn wait(mut self) -> Result<Result<Tombstone, MixnetError>, JoinError> {
         tracing::trace!("Waiting for mixnet processor handle");
         self.processor_handle
             .await

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mixnet/connected_tunnel.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mixnet/connected_tunnel.rs
@@ -1,7 +1,7 @@
 // Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{error::Error as StdError, time::Duration};
+use std::time::Duration;
 
 use nym_task::TaskManager;
 use tokio::{
@@ -125,7 +125,7 @@ impl TunnelHandle {
     }
 
     /// Wait until the tunnel finished execution.
-    pub async fn wait(mut self) -> Result<Result<Tombstone, MixnetError>, JoinError> {
+    pub async fn wait(self) -> Result<Result<Tombstone, MixnetError>, JoinError> {
         tracing::trace!("Waiting for mixnet processor handle");
         self.processor_handle
             .await

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mixnet/connector.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mixnet/connector.rs
@@ -7,7 +7,6 @@ use nym_gateway_directory::{CachingGatewayClient, IpPacketRouterAddress, Recipie
 use nym_ip_packet_client::IprClientConnect;
 use nym_ip_packet_requests::IpPair;
 use nym_sdk::mixnet::ConnectionStatsEvent;
-use nym_task::TaskManager;
 use tokio_util::sync::CancellationToken;
 
 use crate::{
@@ -29,19 +28,16 @@ pub struct AssignedAddresses {
 
 /// Type responsible for connecting the mixnet tunnel.
 pub struct Connector {
-    task_manager: TaskManager,
     mixnet_client: SharedMixnetClient,
     gateway_directory_client: CachingGatewayClient,
 }
 
 impl Connector {
     pub fn new(
-        task_manager: TaskManager,
         mixnet_client: SharedMixnetClient,
         gateway_directory_client: CachingGatewayClient,
     ) -> Self {
         Self {
-            task_manager,
             mixnet_client,
             gateway_directory_client,
         }
@@ -52,30 +48,28 @@ impl Connector {
         selected_gateways: SelectedGateways,
         cancel_token: CancellationToken,
     ) -> Result<ConnectedTunnel, ConnectorError> {
-        let result = Self::connect_inner(
+        let assigned_addresses = Self::connect_inner(
             selected_gateways,
             self.mixnet_client.clone(),
             self.gateway_directory_client.clone(),
             cancel_token.clone(),
         )
-        .await;
-
-        match result {
-            Ok(assigned_addresses) => Ok(ConnectedTunnel::new(
-                self.task_manager,
-                self.mixnet_client,
-                assigned_addresses,
-                cancel_token,
-            )),
-            Err(e) => Err(ConnectorError::new(
+        .await
+        .map_err(|e| {
+            ConnectorError::new(
                 e,
                 AnyConnector::Mixnet(Self::new(
-                    self.task_manager,
-                    self.mixnet_client,
+                    self.mixnet_client.clone(),
                     self.gateway_directory_client,
                 )),
-            )),
-        }
+            )
+        })?;
+
+        Ok(ConnectedTunnel::new(
+            self.mixnet_client,
+            assigned_addresses,
+            cancel_token,
+        ))
     }
 
     async fn connect_inner(
@@ -138,11 +132,5 @@ impl Connector {
             exit_mix_addresses,
             interface_addresses,
         })
-    }
-
-    /// Gracefully shutdown task manager and mixnet client, and consume the struct.
-    pub async fn dispose(self) {
-        tracing::debug!("Shutting down mixnet client");
-        tunnel::shutdown_mixnet_client(self.task_manager, self.mixnet_client).await;
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mixnet/connector.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mixnet/connector.rs
@@ -12,7 +12,7 @@ use tokio_util::sync::CancellationToken;
 use crate::{
     mixnet::SharedMixnetClient,
     tunnel_state_machine::tunnel::{
-        self, AnyConnector, ConnectorError, Error, Result, gateway_selector::SelectedGateways,
+        self, Error, Result, gateway_selector::SelectedGateways,
         mixnet::connected_tunnel::ConnectedTunnel,
     },
 };
@@ -47,23 +47,14 @@ impl Connector {
         self,
         selected_gateways: SelectedGateways,
         cancel_token: CancellationToken,
-    ) -> Result<ConnectedTunnel, ConnectorError> {
+    ) -> Result<ConnectedTunnel> {
         let assigned_addresses = Self::connect_inner(
             selected_gateways,
             self.mixnet_client.clone(),
             self.gateway_directory_client.clone(),
             cancel_token.clone(),
         )
-        .await
-        .map_err(|e| {
-            ConnectorError::new(
-                e,
-                AnyConnector::Mixnet(Self::new(
-                    self.mixnet_client.clone(),
-                    self.gateway_directory_client,
-                )),
-            )
-        })?;
+        .await?;
 
         Ok(ConnectedTunnel::new(
             self.mixnet_client,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
@@ -17,7 +17,10 @@ use nym_gateway_directory::{CachingGatewayClient, EntryPoint, ExitPoint};
 use nym_sdk::UserAgent;
 use nym_task::{TaskManager, TaskStatus};
 use nym_vpn_network_config::Network;
-use tokio::{sync::mpsc, task::JoinHandle};
+use tokio::{
+    sync::{Mutex, mpsc},
+    task::JoinHandle,
+};
 use tokio_util::sync::CancellationToken;
 
 #[cfg(windows)]
@@ -130,7 +133,6 @@ pub async fn select_gateways(
 
 pub async fn connect_mixnet(
     task_manager: &TaskManager,
-    shared_mixnet_client: SharedMixnetClient,
     options: MixnetConnectOptions,
     network_env: &Network,
     gateway_directory_client: CachingGatewayClient,
@@ -179,13 +181,11 @@ pub async fn connect_mixnet(
                 .and_then(|x| x.map_err(Error::MixnetClient))
         })?;
 
-    *shared_mixnet_client.lock().await = Some(mixnet_client);
-
     Ok(ConnectedMixnet {
         selected_gateways: options.selected_gateways,
         data_path: options.data_path,
         gateway_directory_client,
-        mixnet_client: shared_mixnet_client,
+        mixnet_client: Arc::new(Mutex::new(Some(mixnet_client))),
     })
 }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
@@ -8,9 +8,9 @@ mod status_listener;
 mod tombstone;
 pub mod wireguard;
 
-use std::{error::Error as StdError, fmt, path::PathBuf, time::Duration};
 #[cfg(unix)]
 use std::{os::fd::RawFd, sync::Arc};
+use std::{path::PathBuf, time::Duration};
 
 pub use gateway_selector::SelectedGateways;
 use nym_gateway_directory::{CachingGatewayClient, EntryPoint, ExitPoint};
@@ -71,7 +71,6 @@ impl ConnectedMixnet {
         connector
             .connect(self.selected_gateways, cancel_token)
             .await
-            .map_err(|connector_error| connector_error.error)
     }
 
     /// Creates a tunnel over WireGuard.
@@ -93,7 +92,6 @@ impl ConnectedMixnet {
                 cancel_token,
             )
             .await
-            .map_err(|connector_error| connector_error.error)
     }
 }
 
@@ -261,39 +259,4 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 pub enum AnyConnector {
     Mixnet(mixnet::connector::Connector),
     Wireguard(wireguard::connector::Connector),
-}
-
-/// Error returned when connector is unable to connect the tunnel.
-pub struct ConnectorError {
-    /// The error returned during the attempt to connect the tunnel.
-    pub error: Error,
-
-    /// The source connector.
-    pub connector: AnyConnector,
-}
-
-impl ConnectorError {
-    fn new(error: Error, connector: AnyConnector) -> Self {
-        Self { error, connector }
-    }
-}
-
-impl StdError for ConnectorError {
-    fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        Some(&self.error)
-    }
-}
-
-impl fmt::Debug for ConnectorError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ConnectorError")
-            .field("error", &self.error)
-            .finish_non_exhaustive()
-    }
-}
-
-impl fmt::Display for ConnectorError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.error.fmt(f)
-    }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
@@ -9,8 +9,8 @@ mod tombstone;
 pub mod wireguard;
 
 #[cfg(unix)]
-use std::{os::fd::RawFd, sync::Arc};
-use std::{path::PathBuf, time::Duration};
+use std::os::fd::RawFd;
+use std::{path::PathBuf, sync::Arc, time::Duration};
 
 pub use gateway_selector::SelectedGateways;
 use nym_gateway_directory::{CachingGatewayClient, EntryPoint, ExitPoint};

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
@@ -32,10 +32,8 @@ use status_listener::StatusListener;
 pub use tombstone::Tombstone;
 
 pub(crate) const MIXNET_CLIENT_STARTUP_TIMEOUT: Duration = Duration::from_secs(30);
-pub(crate) const TASK_MANAGER_SHUTDOWN_TIMER_SECS: u64 = 10;
 
 pub struct ConnectedMixnet {
-    task_manager: TaskManager,
     gateway_directory_client: CachingGatewayClient,
     selected_gateways: SelectedGateways,
     data_path: Option<PathBuf>,
@@ -49,12 +47,13 @@ impl ConnectedMixnet {
 
     pub async fn start_event_listener(
         &mut self,
+        task_manager: &mut TaskManager,
         event_sender: mpsc::UnboundedSender<MixnetEvent>,
         cancel_token: CancellationToken,
     ) -> JoinHandle<()> {
         let (status_tx, status_rx) = futures::channel::mpsc::channel(10);
 
-        self.task_manager
+        task_manager
             .start_status_listener(status_tx, TaskStatus::Ready)
             .await;
 
@@ -66,57 +65,35 @@ impl ConnectedMixnet {
         self,
         cancel_token: CancellationToken,
     ) -> Result<mixnet::connected_tunnel::ConnectedTunnel> {
-        let connector = mixnet::connector::Connector::new(
-            self.task_manager,
-            self.mixnet_client,
-            self.gateway_directory_client,
-        );
+        let connector =
+            mixnet::connector::Connector::new(self.mixnet_client, self.gateway_directory_client);
 
-        match connector
+        connector
             .connect(self.selected_gateways, cancel_token)
             .await
-        {
-            Ok(connected_tunnel) => Ok(connected_tunnel),
-            Err(connector_error) => {
-                connector_error.connector.dispose().await;
-                Err(connector_error.error)
-            }
-        }
+            .map_err(|connector_error| connector_error.error)
     }
 
     /// Creates a tunnel over WireGuard.
     pub async fn connect_wireguard_tunnel(
         self,
+        task_manager: &TaskManager,
         network: &Network,
         cancel_token: CancellationToken,
     ) -> Result<wireguard::connected_tunnel::ConnectedTunnel> {
-        let connector = wireguard::connector::Connector::new(
-            self.task_manager,
-            self.mixnet_client,
-            self.gateway_directory_client,
-        );
+        let connector =
+            wireguard::connector::Connector::new(self.mixnet_client, self.gateway_directory_client);
 
-        match connector
+        connector
             .connect(
+                task_manager,
                 network,
                 self.selected_gateways,
                 self.data_path,
                 cancel_token,
             )
             .await
-        {
-            Ok(connected_tunnel) => Ok(connected_tunnel),
-            Err(connector_error) => {
-                connector_error.connector.dispose().await;
-                Err(connector_error.error)
-            }
-        }
-    }
-
-    /// Gracefully shutdown the mixnet client and consume the struct.
-    pub async fn dispose(self) {
-        tracing::debug!("Shutting down connected mixnet");
-        shutdown_mixnet_client(self.task_manager, self.mixnet_client).await;
+            .map_err(|connector_error| connector_error.error)
     }
 }
 
@@ -154,13 +131,14 @@ pub async fn select_gateways(
 }
 
 pub async fn connect_mixnet(
+    task_manager: &TaskManager,
+    shared_mixnet_client: SharedMixnetClient,
     options: MixnetConnectOptions,
     network_env: &Network,
     gateway_directory_client: CachingGatewayClient,
     cancel_token: CancellationToken,
     #[cfg(unix)] connection_fd_callback: Arc<dyn Fn(RawFd) + Send + Sync>,
 ) -> Result<ConnectedMixnet> {
-    let task_manager = TaskManager::new(TASK_MANAGER_SHUTDOWN_TIMER_SECS);
     let task_client = task_manager.subscribe_named("mixnet_client_main");
     let mut mixnet_client_config = options.mixnet_client_config.clone().unwrap_or_default();
 
@@ -194,49 +172,23 @@ pub async fn connect_mixnet(
         ),
     );
 
-    let res = cancel_token
+    let mixnet_client = cancel_token
         .run_until_cancelled(connect_fut)
         .await
         .ok_or(Error::Cancelled)
         .and_then(|res| {
             res.map_err(|_| Error::StartMixnetClientTimeout)
                 .and_then(|x| x.map_err(Error::MixnetClient))
-        });
+        })?;
 
-    match res {
-        Ok(mixnet_client) => Ok(ConnectedMixnet {
-            task_manager,
-            selected_gateways: options.selected_gateways,
-            data_path: options.data_path,
-            gateway_directory_client,
-            mixnet_client,
-        }),
-        Err(e) => {
-            shutdown_task_manager(task_manager).await;
-            Err(e)
-        }
-    }
-}
+    *shared_mixnet_client.lock().await = Some(mixnet_client);
 
-async fn shutdown_task_manager(mut task_manager: TaskManager) {
-    if task_manager.signal_shutdown().is_err() {
-        tracing::error!("Failed to signal task manager shutdown");
-    }
-
-    tracing::debug!("Waiting for task manager to shutdown");
-    task_manager.wait_for_graceful_shutdown().await;
-}
-
-async fn shutdown_mixnet_client(mut task_manager: TaskManager, mixnet_client: SharedMixnetClient) {
-    if let Err(e) = task_manager.signal_shutdown() {
-        tracing::error!("Failed to signal task manager shutdown: {}", e);
-    }
-
-    tracing::debug!("Disposing mixnet client");
-    mixnet_client.lock().await.take();
-
-    tracing::debug!("Waiting for task manager to shutdown");
-    task_manager.wait_for_graceful_shutdown().await;
+    Ok(ConnectedMixnet {
+        selected_gateways: options.selected_gateways,
+        data_path: options.data_path,
+        gateway_directory_client,
+        mixnet_client: shared_mixnet_client,
+    })
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -309,15 +261,6 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 pub enum AnyConnector {
     Mixnet(mixnet::connector::Connector),
     Wireguard(wireguard::connector::Connector),
-}
-
-impl AnyConnector {
-    pub async fn dispose(self) {
-        match self {
-            Self::Mixnet(connector) => connector.dispose().await,
-            Self::Wireguard(connector) => connector.dispose().await,
-        }
-    }
 }
 
 /// Error returned when connector is unable to connect the tunnel.

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
@@ -1,7 +1,7 @@
 // Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{error::Error as StdError, net::IpAddr};
+use std::net::IpAddr;
 
 use ipnetwork::IpNetwork;
 use nym_authenticator_client::AuthClientMixnetListenerHandle;

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
@@ -40,7 +40,6 @@ use crate::{
 };
 
 pub struct ConnectedTunnel {
-    task_manager: TaskManager,
     entry_gateway_client: WgGatewayClient,
     exit_gateway_client: WgGatewayClient,
     connection_data: ConnectionData,
@@ -50,7 +49,6 @@ pub struct ConnectedTunnel {
 
 impl ConnectedTunnel {
     pub fn new(
-        task_manager: TaskManager,
         entry_gateway_client: WgGatewayClient,
         exit_gateway_client: WgGatewayClient,
         connection_data: ConnectionData,
@@ -58,7 +56,6 @@ impl ConnectedTunnel {
         auth_client_mixnet_listener_handle: AuthClientMixnetListenerHandle,
     ) -> Self {
         Self {
-            task_manager,
             entry_gateway_client,
             exit_gateway_client,
             connection_data,
@@ -209,7 +206,6 @@ impl ConnectedTunnel {
         });
 
         Ok(TunnelHandle {
-            task_manager: self.task_manager,
             shutdown_token,
             event_handler_task,
             bandwidth_controller_handle: self.bandwidth_controller_handle,
@@ -326,7 +322,6 @@ impl ConnectedTunnel {
         });
 
         Ok(TunnelHandle {
-            task_manager: self.task_manager,
             shutdown_token,
             event_handler_task,
             bandwidth_controller_handle: self.bandwidth_controller_handle,
@@ -450,7 +445,6 @@ pub struct NetstackTunnelOptions {
 }
 
 pub struct TunnelHandle {
-    task_manager: TaskManager,
     shutdown_token: CancellationToken,
     event_handler_task: JoinHandle<Tombstone>,
     bandwidth_controller_handle: JoinHandle<()>,
@@ -465,18 +459,6 @@ impl TunnelHandle {
     /// Close entry and exit WireGuard tunnels and signal mixnet facilities shutdown.
     pub fn cancel(&mut self) {
         self.shutdown_token.cancel();
-
-        if let Err(e) = self.task_manager.signal_shutdown() {
-            tracing::error!("Failed to signal task manager shutdown: {}", e);
-        }
-    }
-
-    /// Wait for the next mixnet error.
-    ///
-    /// This method is cancel safe.
-    /// Returns `None` if the underlying channel has been closed.
-    pub async fn recv_error(&mut self) -> Option<Box<dyn StdError + 'static + Send + Sync>> {
-        self.task_manager.wait_for_error().await
     }
 
     /// Wait until the tunnel finished execution.

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
@@ -14,7 +14,6 @@ use tun::AsyncDevice;
 
 #[cfg(windows)]
 use nym_routing::{Callback, CallbackHandle, EventType};
-use nym_task::TaskManager;
 use nym_wg_gateway_client::WgGatewayClient;
 #[cfg(windows)]
 use nym_wg_go::wireguard_go::WintunInterface;

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
@@ -468,10 +468,7 @@ impl TunnelHandle {
             tracing::error!("Failed to join on bandwidth controller: {}", e);
         }
 
-        // No need to call cancel on auth_clients_mixnet_listener_handle as its external
-        // cancel_token should already be cancelled by the time we reach this point.
-        // We just need to wait for the task to finish.
-        self.auth_client_mixnet_listener_handle.wait().await;
+        let _ = self.auth_client_mixnet_listener_handle.disconnect().await;
 
         self.event_handler_task.await
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/desktop.rs
@@ -468,7 +468,7 @@ impl TunnelHandle {
             tracing::error!("Failed to join on bandwidth controller: {}", e);
         }
 
-        let _ = self.auth_client_mixnet_listener_handle.disconnect().await;
+        let _ = self.auth_client_mixnet_listener_handle.wait().await;
 
         self.event_handler_task.await
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/mobile.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel/mobile.rs
@@ -1,11 +1,11 @@
 // Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use std::net::IpAddr;
 #[cfg(target_os = "android")]
 use std::sync::Arc;
 #[cfg(target_os = "ios")]
 use std::time::Duration;
-use std::{error::Error as StdError, net::IpAddr};
 
 #[cfg(target_os = "ios")]
 use dispatch2::{DispatchQueue, DispatchQueueAttr};
@@ -22,7 +22,6 @@ use tun::AsyncDevice;
 
 #[cfg(target_os = "ios")]
 use nym_apple_network::PathMonitor;
-use nym_task::TaskManager;
 use nym_wg_gateway_client::WgGatewayClient;
 use nym_wg_go::{netstack, wireguard_go};
 
@@ -47,7 +46,6 @@ use crate::{
 const DEFAULT_PATH_DEBOUNCE: Duration = Duration::from_millis(250);
 
 pub struct ConnectedTunnel {
-    task_manager: TaskManager,
     entry_gateway_client: WgGatewayClient,
     exit_gateway_client: WgGatewayClient,
     connection_data: ConnectionData,
@@ -57,7 +55,6 @@ pub struct ConnectedTunnel {
 
 impl ConnectedTunnel {
     pub fn new(
-        task_manager: TaskManager,
         entry_gateway_client: WgGatewayClient,
         exit_gateway_client: WgGatewayClient,
         connection_data: ConnectionData,
@@ -65,7 +62,6 @@ impl ConnectedTunnel {
         auth_client_mixnet_listener_handle: AuthClientMixnetListenerHandle,
     ) -> Self {
         Self {
-            task_manager,
             entry_gateway_client,
             exit_gateway_client,
             connection_data,
@@ -229,7 +225,6 @@ impl ConnectedTunnel {
         });
 
         Ok(TunnelHandle {
-            task_manager: self.task_manager,
             shutdown_token,
             event_loop_handle,
             bandwidth_controller_handle: self.bandwidth_controller_handle,
@@ -239,7 +234,6 @@ impl ConnectedTunnel {
 }
 
 pub struct TunnelHandle {
-    task_manager: TaskManager,
     shutdown_token: CancellationToken,
     event_loop_handle: JoinHandle<Tombstone>,
     bandwidth_controller_handle: JoinHandle<()>,
@@ -250,18 +244,6 @@ impl TunnelHandle {
     /// Close entry and exit WireGuard tunnels and signal mixnet facilities shutdown.
     pub fn cancel(&mut self) {
         self.shutdown_token.cancel();
-
-        if let Err(e) = self.task_manager.signal_shutdown() {
-            tracing::error!("Failed to signal task manager shutdown: {}", e);
-        }
-    }
-
-    /// Wait for the next mixnet error.
-    ///
-    /// This method is cancel safe.
-    /// Returns `None` if the underlying channel has been closed.
-    pub async fn recv_error(&mut self) -> Option<Box<dyn StdError + 'static + Send + Sync>> {
-        self.task_manager.wait_for_error().await
     }
 
     /// Wait until the tunnel finished execution.

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connector.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connector.rs
@@ -94,9 +94,9 @@ impl Connector {
 
         // Start the auth client mixnet listener, which will listen for incoming messages from the
         // mixnet and rebroadcast them to the auth clients.
-        let mixnet_listener = AuthClientMixnetListener::new(mixnet_client.clone())
-            .with_external_cancel_token(cancel_token.clone())
-            .start();
+        let mixnet_listener =
+            AuthClientMixnetListener::new(mixnet_client.clone(), cancel_token.child_token())
+                .start();
 
         let auth_client = mixnet_listener
             .new_auth_client()
@@ -132,6 +132,7 @@ impl Connector {
                 wg_entry_gateway_client.light_client(),
                 wg_exit_gateway_client.light_client(),
                 shutdown,
+                cancel_token.clone(),
             )?;
             let entry_fut = bw.get_initial_bandwidth(
                 TicketType::V1WireguardEntry,
@@ -161,6 +162,7 @@ impl Connector {
                 wg_entry_gateway_client.light_client(),
                 wg_exit_gateway_client.light_client(),
                 shutdown,
+                cancel_token.clone(),
             )?;
             let entry = bw
                 .get_initial_bandwidth(

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connector.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connector.rs
@@ -29,32 +29,31 @@ pub struct ConnectionData {
 }
 
 pub struct Connector {
-    task_manager: TaskManager,
     mixnet_client: SharedMixnetClient,
     gateway_directory_client: CachingGatewayClient,
 }
 
 impl Connector {
     pub fn new(
-        task_manager: TaskManager,
         mixnet_client: SharedMixnetClient,
         gateway_directory_client: CachingGatewayClient,
     ) -> Self {
         Self {
-            task_manager,
             mixnet_client,
             gateway_directory_client,
         }
     }
+
     pub async fn connect(
         self,
+        task_manager: &TaskManager,
         network: &Network,
         selected_gateways: SelectedGateways,
         data_path: Option<PathBuf>,
         cancel_token: CancellationToken,
     ) -> Result<ConnectedTunnel, ConnectorError> {
-        let result = Box::pin(Self::connect_inner(
-            &self.task_manager,
+        let connect_result = Box::pin(Self::connect_inner(
+            task_manager,
             network,
             self.mixnet_client.clone(),
             self.gateway_directory_client.clone(),
@@ -62,26 +61,24 @@ impl Connector {
             data_path,
             cancel_token,
         ))
-        .await;
-
-        match result {
-            Ok(connect_result) => Ok(ConnectedTunnel::new(
-                self.task_manager,
-                connect_result.entry_gateway_client,
-                connect_result.exit_gateway_client,
-                connect_result.connection_data,
-                connect_result.bandwidth_controller_handle,
-                connect_result.auth_client_mixnet_listener_handle,
-            )),
-            Err(e) => Err(ConnectorError::new(
+        .await
+        .map_err(|e| {
+            ConnectorError::new(
                 e,
                 AnyConnector::Wireguard(Self::new(
-                    self.task_manager,
                     self.mixnet_client,
                     self.gateway_directory_client,
                 )),
-            )),
-        }
+            )
+        })?;
+
+        Ok(ConnectedTunnel::new(
+            connect_result.entry_gateway_client,
+            connect_result.exit_gateway_client,
+            connect_result.connection_data,
+            connect_result.bandwidth_controller_handle,
+            connect_result.auth_client_mixnet_listener_handle,
+        ))
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -222,12 +219,6 @@ impl Connector {
             entry_authenticator_address,
             exit_authenticator_address,
         ))
-    }
-
-    /// Gracefully shutdown task manager and mixnet client, and consume the struct.
-    pub async fn dispose(self) {
-        tracing::debug!("Shutting down mixnet client");
-        tunnel::shutdown_mixnet_client(self.task_manager, self.mixnet_client).await;
     }
 }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connector.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connector.rs
@@ -18,9 +18,7 @@ use super::connected_tunnel::ConnectedTunnel;
 use crate::{
     bandwidth_controller::BandwidthController,
     mixnet::SharedMixnetClient,
-    tunnel_state_machine::tunnel::{
-        self, AnyConnector, ConnectorError, Error, Result, gateway_selector::SelectedGateways,
-    },
+    tunnel_state_machine::tunnel::{self, Error, Result, gateway_selector::SelectedGateways},
 };
 
 pub struct ConnectionData {
@@ -51,7 +49,7 @@ impl Connector {
         selected_gateways: SelectedGateways,
         data_path: Option<PathBuf>,
         cancel_token: CancellationToken,
-    ) -> Result<ConnectedTunnel, ConnectorError> {
+    ) -> Result<ConnectedTunnel> {
         let connect_result = Box::pin(Self::connect_inner(
             task_manager,
             network,
@@ -61,16 +59,7 @@ impl Connector {
             data_path,
             cancel_token,
         ))
-        .await
-        .map_err(|e| {
-            ConnectorError::new(
-                e,
-                AnyConnector::Wireguard(Self::new(
-                    self.mixnet_client,
-                    self.gateway_directory_client,
-                )),
-            )
-        })?;
+        .await?;
 
         Ok(ConnectedTunnel::new(
             connect_result.entry_gateway_client,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -71,7 +71,6 @@ use crate::tunnel_provider::ios::OSTunProvider;
 use crate::tunnel_state_machine::route_handler::TUNNEL_FWMARK;
 use crate::{
     VpnTopologyProvider,
-    mixnet::SharedMixnetClient,
     tunnel_state_machine::{WireguardMultihopMode, account, ipv6_availability},
 };
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -812,7 +812,7 @@ impl TunnelMonitor {
 
         let tunnel_handle = AnyTunnelHandle::from(
             connected_tunnel
-                .run(tunnel_options)
+                .run(task_manager, tunnel_options)
                 .await
                 .map_err(Box::new)?,
         );
@@ -1013,7 +1013,7 @@ impl TunnelMonitor {
 
         let tunnel_handle = AnyTunnelHandle::from(
             connected_tunnel
-                .run(tunnel_options)
+                .run(task_manager, tunnel_options)
                 .await
                 .map_err(Box::new)?,
         );

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -589,11 +589,6 @@ impl TunnelMonitor {
             }
         }
 
-        // Signal task manager to shutdown to stop detached tasks
-        if task_manager.signal_shutdown().is_err() {
-            tracing::error!("Failed to signal task manager shutdown");
-        }
-
         // Trigger cancellation since many other tasks depend on shutdown token
         self.shutdown_token.cancel();
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -536,7 +536,7 @@ impl TunnelMonitor {
         self.recv_error(task_manager, fused_background_error).await;
 
         tracing::info!("Wait for tunnel to exit");
-        tunnel_handle.cancel().await;
+        tunnel_handle.cancel();
 
         let tun_devices = tunnel_handle
             .wait()

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -24,8 +24,6 @@ use std::{
 };
 #[cfg(unix)]
 use std::{os::fd::RawFd, sync::Arc};
-#[cfg(any(target_os = "linux", target_os = "macos"))]
-use tokio_util::task;
 
 #[cfg(windows)]
 use super::wintun::{self, WintunAdapterConfig};
@@ -812,7 +810,7 @@ impl TunnelMonitor {
 
         let tunnel_handle = AnyTunnelHandle::from(
             connected_tunnel
-                .run(task_manager, tunnel_options)
+                .run(tunnel_options)
                 .await
                 .map_err(Box::new)?,
         );
@@ -1013,7 +1011,7 @@ impl TunnelMonitor {
 
         let tunnel_handle = AnyTunnelHandle::from(
             connected_tunnel
-                .run(task_manager, tunnel_options)
+                .run(tunnel_options)
                 .await
                 .map_err(Box::new)?,
         );

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -263,21 +263,13 @@ impl TunnelMonitor {
 
     async fn run(mut self) -> Tombstone {
         let mut task_manager = TaskManager::new(TASK_MANAGER_SHUTDOWN_TIMEOUT_SECS);
-        let shared_mixnet_client = SharedMixnetClient::default();
-
-        let (tombstone, reason) =
-            match Box::pin(self.run_inner(&mut task_manager, shared_mixnet_client.clone())).await {
-                Ok(tombstone) => (tombstone, None),
-                Err(e) => {
-                    trace_err_chain!(e, "Tunnel monitor exited with error");
-                    (Tombstone::default(), e.error_state_reason())
-                }
-            };
-
-        if let Some(mixnet_client) = shared_mixnet_client.lock().await.take() {
-            tracing::debug!("Drop mixnet client");
-            mixnet_client.disconnect().await;
-        }
+        let (tombstone, reason) = match Box::pin(self.run_inner(&mut task_manager)).await {
+            Ok(tombstone) => (tombstone, None),
+            Err(e) => {
+                trace_err_chain!(e, "Tunnel monitor exited with error");
+                (Tombstone::default(), e.error_state_reason())
+            }
+        };
 
         tracing::debug!("Waiting for task manager to shutdown");
         if task_manager.signal_shutdown().is_err() {
@@ -298,11 +290,7 @@ impl TunnelMonitor {
         tombstone
     }
 
-    async fn run_inner(
-        &mut self,
-        task_manager: &mut TaskManager,
-        shared_mixnet_client: SharedMixnetClient,
-    ) -> Result<Tombstone> {
+    async fn run_inner(&mut self, task_manager: &mut TaskManager) -> Result<Tombstone> {
         if self.tunnel_parameters.retry_attempt > 0 {
             let delay = wait_delay(self.tunnel_parameters.retry_attempt);
             tracing::debug!("Waiting for {}s before connecting.", delay.as_secs());
@@ -447,7 +435,6 @@ impl TunnelMonitor {
         };
         let mut connected_mixnet = Box::pin(tunnel::connect_mixnet(
             task_manager,
-            shared_mixnet_client,
             connect_options,
             &self.tunnel_parameters.nym_config.network_env,
             self.gateway_directory_client.clone(),

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -270,12 +270,13 @@ impl TunnelMonitor {
             }
         };
 
-        tracing::debug!("Waiting for task manager to shutdown");
+        // Repeat task manager shutdown in case of early return from run_inner()
         if task_manager.signal_shutdown().is_err() {
             tracing::error!("Failed to signal task manager shutdown");
         }
+
+        tracing::debug!("Waiting for task manager shutdown");
         task_manager.wait_for_graceful_shutdown().await;
-        tracing::debug!("Task manager shutdown complete");
 
         let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
         self.send_event(TunnelMonitorEvent::Down {
@@ -586,6 +587,11 @@ impl TunnelMonitor {
                     tracing::debug!("Background task finished");
                 }
             }
+        }
+
+        // Signal task manager to shutdown to stop detached tasks
+        if task_manager.signal_shutdown().is_err() {
+            tracing::error!("Failed to signal task manager shutdown");
         }
 
         // Trigger cancellation since many other tasks depend on shutdown token

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -825,10 +825,12 @@ impl TunnelMonitor {
     #[cfg(windows)]
     async fn start_wireguard_netstack_tunnel(
         &mut self,
+        task_manager: &TaskManager,
         connected_mixnet: ConnectedMixnet,
     ) -> Result<StartTunnelResult> {
         let connected_tunnel = connected_mixnet
             .connect_wireguard_tunnel(
+                task_manager,
                 &self.tunnel_parameters.nym_config.network_env,
                 self.shutdown_token.child_token(),
             )

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -5,6 +5,7 @@ use futures::{FutureExt, future::Fuse};
 #[cfg(target_os = "linux")]
 use nix::sys::socket::{SetSockOpt, sockopt::Mark};
 use nym_sdk::UserAgent;
+use nym_task::TaskManager;
 use nym_vpn_account_controller::AccountStateReceiver;
 use nym_vpn_network_config::start_background_file_refresh;
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
@@ -23,6 +24,8 @@ use std::{
 };
 #[cfg(unix)]
 use std::{os::fd::RawFd, sync::Arc};
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+use tokio_util::task;
 
 #[cfg(windows)]
 use super::wintun::{self, WintunAdapterConfig};
@@ -70,6 +73,7 @@ use crate::tunnel_provider::ios::OSTunProvider;
 use crate::tunnel_state_machine::route_handler::TUNNEL_FWMARK;
 use crate::{
     VpnTopologyProvider,
+    mixnet::SharedMixnetClient,
     tunnel_state_machine::{WireguardMultihopMode, account, ipv6_availability},
 };
 
@@ -121,6 +125,9 @@ const MAX_WAIT_DELAY: Duration = Duration::from_secs(15);
 
 /// Timeout when waiting for reply from the event handler.
 const REPLY_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Task manager shutdown timeout in seconds.
+const TASK_MANAGER_SHUTDOWN_TIMEOUT_SECS: u64 = 10;
 
 #[derive(Debug)]
 pub enum TunnelMonitorEvent {
@@ -257,13 +264,29 @@ impl TunnelMonitor {
     }
 
     async fn run(mut self) -> Tombstone {
-        let (tombstone, reason) = match Box::pin(self.run_inner()).await {
-            Ok(tombstone) => (tombstone, None),
-            Err(e) => {
-                trace_err_chain!(e, "Tunnel monitor exited with error");
-                (Tombstone::default(), e.error_state_reason())
-            }
-        };
+        let mut task_manager = TaskManager::new(TASK_MANAGER_SHUTDOWN_TIMEOUT_SECS);
+        let shared_mixnet_client = SharedMixnetClient::default();
+
+        let (tombstone, reason) =
+            match Box::pin(self.run_inner(&mut task_manager, shared_mixnet_client.clone())).await {
+                Ok(tombstone) => (tombstone, None),
+                Err(e) => {
+                    trace_err_chain!(e, "Tunnel monitor exited with error");
+                    (Tombstone::default(), e.error_state_reason())
+                }
+            };
+
+        if let Some(mixnet_client) = shared_mixnet_client.lock().await.take() {
+            tracing::debug!("Drop mixnet client");
+            mixnet_client.disconnect().await;
+        }
+
+        tracing::debug!("Waiting for task manager to shutdown");
+        if task_manager.signal_shutdown().is_err() {
+            tracing::error!("Failed to signal task manager shutdown");
+        }
+        task_manager.wait_for_graceful_shutdown().await;
+        tracing::debug!("Task manager shutdown complete");
 
         let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
         self.send_event(TunnelMonitorEvent::Down {
@@ -277,7 +300,11 @@ impl TunnelMonitor {
         tombstone
     }
 
-    async fn run_inner(&mut self) -> Result<Tombstone> {
+    async fn run_inner(
+        &mut self,
+        task_manager: &mut TaskManager,
+        shared_mixnet_client: SharedMixnetClient,
+    ) -> Result<Tombstone> {
         if self.tunnel_parameters.retry_attempt > 0 {
             let delay = wait_delay(self.tunnel_parameters.retry_attempt);
             tracing::debug!("Waiting for {}s before connecting.", delay.as_secs());
@@ -421,6 +448,8 @@ impl TunnelMonitor {
             }
         };
         let mut connected_mixnet = Box::pin(tunnel::connect_mixnet(
+            task_manager,
+            shared_mixnet_client,
             connect_options,
             &self.tunnel_parameters.nym_config.network_env,
             self.gateway_directory_client.clone(),
@@ -433,6 +462,7 @@ impl TunnelMonitor {
 
         let status_listener_handle = connected_mixnet
             .start_event_listener(
+                task_manager,
                 self.mixnet_event_sender.clone(),
                 self.shutdown_token.child_token(),
             )
@@ -444,7 +474,10 @@ impl TunnelMonitor {
             tunnel_conn_data,
             mut tunnel_handle,
         } = match self.tunnel_parameters.tunnel_settings.tunnel_type {
-            TunnelType::Mixnet => self.start_mixnet_tunnel(connected_mixnet).await?,
+            TunnelType::Mixnet => {
+                self.start_mixnet_tunnel(task_manager, connected_mixnet)
+                    .await?
+            }
             TunnelType::Wireguard => {
                 match self
                     .tunnel_parameters
@@ -454,10 +487,11 @@ impl TunnelMonitor {
                 {
                     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
                     WireguardMultihopMode::TunTun => {
-                        self.start_wireguard_tunnel(connected_mixnet).await?
+                        self.start_wireguard_tunnel(task_manager, connected_mixnet)
+                            .await?
                     }
                     WireguardMultihopMode::Netstack => {
-                        self.start_wireguard_netstack_tunnel(connected_mixnet)
+                        self.start_wireguard_netstack_tunnel(task_manager, connected_mixnet)
                             .await?
                     }
                 }
@@ -515,8 +549,7 @@ impl TunnelMonitor {
             connection_data: Box::new(connection_data),
         });
 
-        self.recv_error(&mut tunnel_handle, fused_background_error)
-            .await;
+        self.recv_error(task_manager, fused_background_error).await;
 
         tracing::info!("Wait for tunnel to exit");
         tunnel_handle.cancel().await;
@@ -547,12 +580,12 @@ impl TunnelMonitor {
 
     async fn recv_error(
         &self,
-        tunnel_handle: &mut AnyTunnelHandle,
+        task_manager: &mut TaskManager,
         background_error_rx: Fuse<impl Future<Output = Option<()>>>,
     ) {
         tokio::select! {
             _ = self.shutdown_token.cancelled() => {}
-            task_error = tunnel_handle.recv_error() => {
+            task_error = task_manager.wait_for_error() => {
                 match task_error {
                     Some(task_error) => {
                         tracing::error!("Task manager quit with error: {}", task_error);
@@ -585,6 +618,7 @@ impl TunnelMonitor {
 
     async fn start_mixnet_tunnel(
         &mut self,
+        task_manager: &TaskManager,
         connected_mixnet: ConnectedMixnet,
     ) -> Result<StartTunnelResult> {
         let connected_tunnel = connected_mixnet
@@ -708,7 +742,7 @@ impl TunnelMonitor {
 
         let tunnel_handle = AnyTunnelHandle::from(
             connected_tunnel
-                .run(tun_device)
+                .run(task_manager, tun_device)
                 .await
                 .map_err(|e| Error::Tunnel(Box::new(e)))?,
         );
@@ -723,10 +757,12 @@ impl TunnelMonitor {
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     async fn start_wireguard_netstack_tunnel(
         &mut self,
+        task_manager: &TaskManager,
         connected_mixnet: ConnectedMixnet,
     ) -> Result<StartTunnelResult> {
         let connected_tunnel = connected_mixnet
             .connect_wireguard_tunnel(
+                task_manager,
                 &self.tunnel_parameters.nym_config.network_env,
                 self.shutdown_token.child_token(),
             )
@@ -888,10 +924,12 @@ impl TunnelMonitor {
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     async fn start_wireguard_tunnel(
         &mut self,
+        task_manager: &TaskManager,
         connected_mixnet: ConnectedMixnet,
     ) -> Result<StartTunnelResult> {
         let connected_tunnel = connected_mixnet
             .connect_wireguard_tunnel(
+                task_manager,
                 &self.tunnel_parameters.nym_config.network_env,
                 self.shutdown_token.child_token(),
             )
@@ -993,10 +1031,12 @@ impl TunnelMonitor {
     #[cfg(windows)]
     async fn start_wireguard_tunnel(
         &mut self,
+        task_manager: &TaskManager,
         connected_mixnet: ConnectedMixnet,
     ) -> Result<StartTunnelResult> {
         let connected_tunnel = connected_mixnet
             .connect_wireguard_tunnel(
+                task_manager,
                 &self.tunnel_parameters.nym_config.network_env,
                 self.shutdown_token.child_token(),
             )
@@ -1129,10 +1169,12 @@ impl TunnelMonitor {
     #[cfg(any(target_os = "ios", target_os = "android"))]
     async fn start_wireguard_netstack_tunnel(
         &self,
+        task_manager: &TaskManager,
         connected_mixnet: ConnectedMixnet,
     ) -> Result<StartTunnelResult> {
         let connected_tunnel = connected_mixnet
             .connect_wireguard_tunnel(
+                task_manager,
                 &self.tunnel_parameters.nym_config.network_env,
                 self.shutdown_token.child_token(),
             )

--- a/nym-vpn-core/crates/nym-vpnd/src/logging.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/logging.rs
@@ -21,7 +21,7 @@ use nym_vpnd_types::log_path::LogPath;
 
 use crate::service;
 
-static INFO_CRATES: &[&str; 12] = &[
+static INFO_CRATES: &[&str; 13] = &[
     "hyper",
     "netlink_proto",
     "hickory_proto",
@@ -34,6 +34,7 @@ static INFO_CRATES: &[&str; 12] = &[
     "nym_sphinx::preparer",
     "nym_task::manager",
     "nym_client_core::client::real_messages_control",
+    "nym_client_core::client::received_buffer",
 ];
 
 static WARN_CRATES: &[&str; 1] = &["hickory_server"];

--- a/nym-vpn-core/crates/nym-vpnd/src/service/error.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/error.rs
@@ -53,6 +53,9 @@ pub enum Error {
 
     #[error("mixnet setup error")]
     MixnetSetup(#[from] MixnetError),
+
+    #[error("cancelled during initialization")]
+    CancelledInitialization,
 }
 
 #[derive(Clone, Debug, thiserror::Error)]

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -395,7 +395,8 @@ impl NymVpnService {
         // todo: we must not block service initialization
         shutdown_token
             .run_until_cancelled(gateway_directory_client.refresh_all())
-            .await;
+            .await
+            .ok_or(Error::CancelledInitialization)?;
 
         let validator_client = nym_validator_client::NymApiClient::new_with_user_agent(
             api_url,


### PR DESCRIPTION
## Description

This PR mostly focuses on ensuring that mixnet client and task manager are properly cleaned up as they are not drop friendly.

- Move `TaskManager` to `TunnelMonitor::run()` which is guaranteed to drop `TaskManager` last

Changes not visible to user, so no changelog entry.

## Checklist:

- [x] Changelog

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3160)
<!-- Reviewable:end -->
