### PR TITLE
Map wg log level to tracing levels

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add setting to toggle IPv6 support.
 - vpnd: Add support to toggle network statistics collection.
 
+### Changed
+
+- Reduce noisiness of WireGuard logs (https://github.com/nymtech/nym-vpn-client/pull/3169)
+
 ## [1.12.0] - 2025-07-18
 
 ### Added
@@ -26,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use nym cheddar fork (https://github.com/nymtech/nym-vpn-client/pull/3048)
 
 ### Removed
+
 - Remove a shutdown timeout for tonic server (https://github.com/nymtech/nym-vpn-client/pull/2938)
 - Remove shared mixnet client (https://github.com/nymtech/nym-vpn-client/pull/2967)
 - Remove wireguard credential mode flag (https://github.com/nymtech/nym-vpn-client/pull/3021)

--- a/nym-vpn-core/crates/nym-wg-go/src/wireguard_go.rs
+++ b/nym-vpn-core/crates/nym-wg-go/src/wireguard_go.rs
@@ -317,13 +317,35 @@ unsafe extern "C" {
 /// Do not call this method directly.
 #[doc(hidden)]
 pub unsafe extern "system" fn wg_logger_callback(
-    _log_level: u32,
+    log_level: u32,
     msg: *const c_char,
     _ctx: *mut c_void,
 ) {
-    if !msg.is_null() {
+    if let Some(wg_log_level) = WgLogLevel::from_u32(log_level)
+        && !msg.is_null()
+    {
         let str = unsafe { CStr::from_ptr(msg).to_string_lossy() };
         let trimmed_str = str.trim_end();
-        tracing::debug!("{}", trimmed_str);
+
+        match wg_log_level {
+            WgLogLevel::Error => tracing::error!("{trimmed_str}"),
+            WgLogLevel::Verbose => tracing::trace!("{trimmed_str}"),
+        }
+    }
+}
+
+#[repr(u32)]
+enum WgLogLevel {
+    Error = 1,
+    Verbose = 2,
+}
+
+impl WgLogLevel {
+    fn from_u32(value: u32) -> Option<Self> {
+        match value {
+            x if x == WgLogLevel::Error as u32 => Some(WgLogLevel::Error),
+            x if x == WgLogLevel::Verbose as u32 => Some(WgLogLevel::Verbose),
+            _ => None,
+        }
     }
 }


### PR DESCRIPTION
## Description

- Parse wireguard log levels as described in https://github.com/amnezia-vpn/amneziawg-go/blob/1abd24b5b9ca89609d26af1f43743d8a9dc940da/device/logger.go#L24-L28
- Map verbose to trace in tracing framework due to noisy logs
- Map error to error in tracing framework

## Checklist:

- [x] Changelog

JIRA-VPN-3771

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3169)
<!-- Reviewable:end -->
