### PR TITLE
APPLE(macOS): fix screen opened on renewal error

### DIFF
--- a/nym-vpn-apple/Home/Sources/Home/HomeViewModel.swift
+++ b/nym-vpn-apple/Home/Sources/Home/HomeViewModel.swift
@@ -181,8 +181,12 @@ public extension HomeViewModel {
     }
 
     @MainActor func navigateToPlanPurchase() {
+#if os(iOS)
         path.append(HomeLink.settings)
         path.append(SettingLink.createAccountSuccess)
+#elseif os(macOS)
+        try? externalLinkManager.openExternalURL(urlString: configurationManager.accountLinks?.account)
+#endif
     }
 
 #if os(macOS)

--- a/nym-vpn-apple/ServicesMacOS/Sources/GRPCManager/GRPCManager+Countries.swift
+++ b/nym-vpn-apple/ServicesMacOS/Sources/GRPCManager/GRPCManager+Countries.swift
@@ -2,8 +2,6 @@ import CountriesManagerTypes
 
 extension GRPCManager {
     public func countryCodes(for type: NodeType) async throws -> [String] {
-
-
         var request = NymVpnService_ListCountriesRequest()
         request.kind = type.convertToGatewayType()
         request.userAgent = userAgent


### PR DESCRIPTION
## Description

Open account link on macOS instead of plan purchase screen.

## Checklist:

- [ ] Changelog

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3173)
<!-- Reviewable:end -->
