### PR TITLE
Improve daemon shutdown

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgrade nym to emmental (https://github.com/nymtech/nym-vpn-client/pull/3155)
 
+### Fixed
+
+- Improve shutdown sequence by exiting internal components in the reverse order of their creation. Drain tunnel events and deliver them to listeners before exiting the daemon. (https://github.com/nymtech/nym-vpn-client/pull/3185)
+
 ## [1.13.1] - 2025-07-30
 
 ### Changed

--- a/nym-vpn-core/crates/nym-vpnc/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/main.rs
@@ -197,6 +197,9 @@ async fn wait_until_disconnected(mut rpc_client: RpcClient) -> Result<()> {
 }
 
 async fn status(mut rpc_client: RpcClient, listen: bool) -> Result<()> {
+    let new_state = rpc_client.get_tunnel_state().await?;
+    println!("{new_state}");
+
     if listen {
         let mut stream = rpc_client.listen_to_tunnel_state().await?;
 
@@ -204,9 +207,6 @@ async fn status(mut rpc_client: RpcClient, listen: bool) -> Result<()> {
             let new_state = new_state?;
             println!("{new_state}");
         }
-    } else {
-        let new_state = rpc_client.get_tunnel_state().await?;
-        println!("{new_state}");
     }
 
     Ok(())

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface.rs
@@ -170,8 +170,11 @@ impl NymVpnService for CommandInterface {
         let rx = self
             .send_and_wait(VpnServiceCommand::SubscribeToTunnelState, ())
             .await?;
-        let stream = tokio_stream::wrappers::WatchStream::new(rx)
-            .map(|new_state| Ok(proto::TunnelState::from(new_state)));
+        let stream = tokio_stream::wrappers::BroadcastStream::new(rx).map(|new_state| {
+            new_state
+                .map(proto::TunnelState::from)
+                .map_err(|_| tonic::Status::internal("Failed to receive tunnel state"))
+        });
         Ok(tonic::Response::new(
             Box::pin(stream) as Self::ListenToTunnelStateStream
         ))

--- a/nym-vpn-core/crates/nym-vpnd/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/main.rs
@@ -176,13 +176,21 @@ async fn run_standalone(
 struct VpnServiceHandle {
     vpn_service_handle: JoinHandle<()>,
     command_handle: JoinHandle<()>,
+    command_shutdown_token: CancellationToken,
 }
 
 impl VpnServiceHandle {
-    pub fn new(vpn_service_handle: JoinHandle<()>, command_handle: JoinHandle<()>) -> Self {
+    /// Initialize with vpn service handle and command handle.
+    /// `command_shutdown_token` must propagate cancellation to `command_handle`.
+    pub fn new(
+        vpn_service_handle: JoinHandle<()>,
+        command_handle: JoinHandle<()>,
+        command_shutdown_token: CancellationToken,
+    ) -> Self {
         Self {
             vpn_service_handle,
             command_handle,
+            command_shutdown_token,
         }
     }
 
@@ -190,6 +198,8 @@ impl VpnServiceHandle {
         if let Err(e) = self.vpn_service_handle.await {
             tracing::error!("Failed to join on vpn service: {}", e);
         }
+
+        self.command_shutdown_token.cancel();
 
         if let Err(e) = self.command_handle.await {
             tracing::error!("Failed to join on command interface: {}", e);
@@ -202,11 +212,13 @@ async fn setup_vpn_service(
     log_file_remover_handle: Option<LogFileRemoverHandle>,
     shutdown_token: CancellationToken,
 ) -> anyhow::Result<VpnServiceHandle> {
+    let command_shutdown_token = CancellationToken::new();
     let (tunnel_event_tx, tunnel_event_rx) = broadcast::channel(10);
-
-    let (command_handle, vpn_command_rx) =
-        command_interface::start_command_interface(tunnel_event_rx, shutdown_token.child_token())
-            .await?;
+    let (command_handle, vpn_command_rx) = command_interface::start_command_interface(
+        tunnel_event_rx,
+        command_shutdown_token.child_token(),
+    )
+    .await?;
 
     let vpn_service_handle = NymVpnService::spawn(
         vpn_command_rx,
@@ -216,7 +228,11 @@ async fn setup_vpn_service(
         shutdown_token.child_token(),
     );
 
-    Ok(VpnServiceHandle::new(vpn_service_handle, command_handle))
+    Ok(VpnServiceHandle::new(
+        vpn_service_handle,
+        command_handle,
+        command_shutdown_token,
+    ))
 }
 
 fn setup_global_config(network: Option<String>) -> anyhow::Result<GlobalConfigFile> {

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -4,13 +4,14 @@
 use std::{path::PathBuf, sync::Arc, time::Instant};
 
 use bip39::Mnemonic;
+use futures::{FutureExt, pin_mut};
 use nym_statistics::{
     StatisticsController, StatisticsControllerConfig,
     events::{StatisticsEvent, StatisticsSender},
 };
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 use tokio::{
-    sync::{broadcast, mpsc, oneshot, watch},
+    sync::{broadcast, mpsc, oneshot},
     task::JoinHandle,
 };
 use tokio_util::sync::CancellationToken;
@@ -79,7 +80,7 @@ pub enum VpnServiceCommand {
     Connect(oneshot::Sender<()>, ConnectArgs),
     Disconnect(oneshot::Sender<()>, ()),
     GetTunnelState(oneshot::Sender<TunnelState>, ()),
-    SubscribeToTunnelState(oneshot::Sender<watch::Receiver<TunnelState>>, ()),
+    SubscribeToTunnelState(oneshot::Sender<broadcast::Receiver<TunnelState>>, ()),
     StoreAccount(
         oneshot::Sender<Result<(), StoreAccountError>>,
         StoreAccountRequest,
@@ -128,6 +129,15 @@ pub enum VpnServiceCommand {
     ToggleCollectNetStats(oneshot::Sender<Result<(), GlobalConfigError>>, bool),
 }
 
+pub struct NymVpnServiceParameters {
+    pub log_path: Option<LogPath>,
+    pub network_env: Box<Network>,
+    pub sentry_enabled: bool,
+    pub netstats_enabled: bool,
+    pub stats_id_seed: Option<String>,
+    pub user_agent: UserAgent,
+}
+
 pub struct NymVpnService<S>
 where
     S: nym_vpn_store::VpnStorage,
@@ -166,11 +176,14 @@ where
     // Storage backend
     storage: Arc<tokio::sync::Mutex<S>>,
 
-    // Last known tunnel state wrapped in a `watch::Sender` that can be used to track tunnel state individually
-    tunnel_state: watch::Sender<TunnelState>,
+    // Channel used for propagating tunnel state to consumers
+    tunnel_state_sender: broadcast::Sender<TunnelState>,
+
+    // Last known tunnel state
+    tunnel_state: TunnelState,
 
     // Tunnel state machine handle
-    state_machine_handle: JoinHandle<()>,
+    state_machine_handle: Option<JoinHandle<()>>,
 
     // Account controller handle
     account_controller_handle: JoinHandle<()>,
@@ -182,8 +195,14 @@ where
     // Event channel for receiving events from state machine
     event_receiver: mpsc::UnboundedReceiver<TunnelEvent>,
 
-    // Service shutdown token.
+    // VPN service shutdown token.
     shutdown_token: CancellationToken,
+
+    // Shutdown token used by state machine
+    state_machine_shutdown_token: CancellationToken,
+
+    // Shutdown token used for account and statistics controllers and other services that are safe to exit altogether.
+    services_shutdown_token: CancellationToken,
 
     // Gateway directory client
     gateway_directory_client: CachingGatewayClient,
@@ -196,15 +215,6 @@ where
 
     // The statistics channel sender
     statistics_event_sender: StatisticsSender,
-}
-
-pub struct NymVpnServiceParameters {
-    pub log_path: Option<LogPath>,
-    pub network_env: Box<Network>,
-    pub sentry_enabled: bool,
-    pub netstats_enabled: bool,
-    pub stats_id_seed: Option<String>,
-    pub user_agent: UserAgent,
 }
 
 impl NymVpnService<nym_vpn_lib::storage::VpnClientOnDiskStorage> {
@@ -270,6 +280,9 @@ impl NymVpnService<nym_vpn_lib::storage::VpnClientOnDiskStorage> {
         // Make sure the data dir exists
         super::config::create_data_dir(&data_dir, &network_name).map_err(Error::ConfigSetup)?;
 
+        let state_machine_shutdown_token = CancellationToken::new();
+        let services_shutdown_token = CancellationToken::new();
+
         let statistics_api = parameters
             .network_env
             .system_configuration
@@ -299,7 +312,7 @@ impl NymVpnService<nym_vpn_lib::storage::VpnClientOnDiskStorage> {
             account_controller_config,
             Arc::clone(&storage),
             Some(connectivity_handle.clone()),
-            shutdown_token.child_token(),
+            services_shutdown_token.child_token(),
         )
         .await
         .map_err(|err| {
@@ -324,7 +337,7 @@ impl NymVpnService<nym_vpn_lib::storage::VpnClientOnDiskStorage> {
         let statistics_controller = StatisticsController::new(
             statistics_controller_config,
             network_data_dir.clone(),
-            shutdown_token.child_token(),
+            services_shutdown_token.child_token(),
         )
         .await;
 
@@ -387,7 +400,7 @@ impl NymVpnService<nym_vpn_lib::storage::VpnClientOnDiskStorage> {
             parameters.network_env.api_url(),
             validator_client,
             false,
-            shutdown_token.child_token(),
+            services_shutdown_token.child_token(),
         );
         topology_provider.fetch().await;
 
@@ -403,7 +416,7 @@ impl NymVpnService<nym_vpn_lib::storage::VpnClientOnDiskStorage> {
             connectivity_handle,
             #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
             route_handler,
-            shutdown_token.child_token(),
+            state_machine_shutdown_token.child_token(),
         )
         .await
         .map_err(Error::StateMachine)?;
@@ -420,13 +433,16 @@ impl NymVpnService<nym_vpn_lib::storage::VpnClientOnDiskStorage> {
             data_dir: network_data_dir,
             log_path: parameters.log_path,
             storage,
-            tunnel_state: watch::Sender::new(TunnelState::Disconnected),
-            state_machine_handle,
+            tunnel_state: TunnelState::Disconnected,
+            tunnel_state_sender: broadcast::Sender::new(10),
+            state_machine_handle: Some(state_machine_handle),
             account_controller_handle,
             statistics_controller_handle,
             command_sender,
             event_receiver,
             shutdown_token,
+            services_shutdown_token,
+            state_machine_shutdown_token,
             gateway_directory_client,
             sentry_enabled: parameters.sentry_enabled,
             network_statistics_enabled: parameters.netstats_enabled,
@@ -446,28 +462,44 @@ where
                     self.handle_service_command_timed(command).await;
                 }
                 Some(event) = self.event_receiver.recv() => {
-                    if let Err(e) = self.tunnel_event_tx.send(event.clone()) {
-                        tracing::error!("Failed to send tunnel event: {}", e);
-                    }
-
-                    match event {
-                        TunnelEvent::NewState(new_state) => {
-                            // Replace value even when there are no receivers.
-                            let _ = self.tunnel_state.send_replace(new_state.clone());
-                        }
-                        TunnelEvent::MixnetState(_) => {}
-                    }
+                    self.handle_tunnel_event(event);
                 }
                 _ = self.shutdown_token.cancelled() => {
                     tracing::info!("Received shutdown signal");
                     break;
                 }
-                else => {
-                    tracing::warn!("Event loop is interrupted");
-                    break;
+            }
+        }
+
+        // Cancel state machine first and wait for it to complete
+        self.state_machine_shutdown_token.cancel();
+
+        if let Some(state_machine_handle) = self.state_machine_handle.take() {
+            // Drain tunnel events channel and wait for the tunnel state machine to quit
+            let fused_state_machine_handle = state_machine_handle.fuse();
+            pin_mut!(fused_state_machine_handle);
+
+            loop {
+                tokio::select! {
+                    result = &mut fused_state_machine_handle => {
+                        if let Err(e) = result {
+                            tracing::error!("Failed to join on state machine handle: {}", e);
+                        }
+                        // The loop will continue until `event_receiver` is fully drained
+                        self.event_receiver.close();
+                    }
+                    event = self.event_receiver.recv() => {
+                        match event {
+                            Some(event) => self.handle_tunnel_event(event),
+                            None => break,
+                        }
+                    }
                 }
             }
         }
+
+        // Cancel all other services and wait for them to complete
+        self.services_shutdown_token.cancel();
 
         if let Err(e) = self.account_controller_handle.await {
             tracing::error!("Failed to join on account controller handle: {}", e);
@@ -477,13 +509,23 @@ where
             tracing::error!("Failed to join on statistics controller handle: {}", e);
         }
 
-        if let Err(e) = self.state_machine_handle.await {
-            tracing::error!("Failed to join on state machine handle: {}", e);
-        }
-
         tracing::info!("Exiting vpn service run loop");
 
         Ok(())
+    }
+
+    fn handle_tunnel_event(&mut self, event: TunnelEvent) {
+        if self.tunnel_event_tx.send(event.clone()).is_err() {
+            tracing::error!("Failed to send tunnel event");
+        }
+
+        match event {
+            TunnelEvent::NewState(new_state) => {
+                self.tunnel_state = new_state.clone();
+                let _ = self.tunnel_state_sender.send(new_state);
+            }
+            TunnelEvent::MixnetState(_) => {}
+        }
     }
 
     // Wrap handle_service_command in timing code to log long-running commands
@@ -766,11 +808,11 @@ where
     }
 
     fn handle_get_tunnel_state(&self) -> TunnelState {
-        self.tunnel_state.borrow().to_owned()
+        self.tunnel_state.clone()
     }
 
-    fn handle_subscribe_to_tunnel_state(&self) -> watch::Receiver<TunnelState> {
-        self.tunnel_state.subscribe()
+    fn handle_subscribe_to_tunnel_state(&self) -> broadcast::Receiver<TunnelState> {
+        self.tunnel_state_sender.subscribe()
     }
 
     async fn handle_info(&self) -> VpnServiceInfo {
@@ -892,7 +934,7 @@ where
     }
 
     async fn handle_forget_account(&mut self) -> Result<(), ForgetAccountError> {
-        if *self.tunnel_state.borrow() != TunnelState::Disconnected {
+        if self.tunnel_state != TunnelState::Disconnected {
             return Err(ForgetAccountError::internal(
                 "Unable to forget account while connected",
             ));
@@ -950,7 +992,7 @@ where
         &mut self,
         seed: Option<[u8; 32]>,
     ) -> Result<(), AccountCommandError> {
-        if *self.tunnel_state.borrow() != TunnelState::Disconnected {
+        if self.tunnel_state != TunnelState::Disconnected {
             return Err(AccountCommandError::internal(
                 "Unable to reset device identity while connected",
             ));


### PR DESCRIPTION
## Description

Currently we use a single cancellation token across the entire daemon. This could  be harmful and cause errors as channels between internal components are being severed in no particular order.

In order to address that, multiple cancellation tokens are being introduced:

- Main shutdown token passed to `NymVpnService` remains the same. It begins the shutdown.
- Tunnel state machine shutdown token
- Services shutdown token that covers account and statistics controllers
- Command interface shutdown token

Shutdown sequence looks as such:

- Tunnel state machine exits. The remainder of buffered tunnel events is drained and delivered over grpc
- Account and statistics controllers exit
- Command interface (grpc) exits gracefully

## Checklist:

- [x] Changelog

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3185)
<!-- Reviewable:end -->
