### PR TITLE
cli: fix obtaining initial tunnel state

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-proto/src/rpc_client.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/rpc_client.rs
@@ -120,7 +120,7 @@ impl RpcClient {
 
     pub async fn listen_to_tunnel_state(
         &mut self,
-    ) -> Result<impl Stream<Item = Result<TunnelState>>> {
+    ) -> Result<impl Stream<Item = Result<TunnelState>> + 'static> {
         let listener = self
             .0
             .listen_to_tunnel_state(())
@@ -135,7 +135,9 @@ impl RpcClient {
         }))
     }
 
-    pub async fn listen_to_events(&mut self) -> Result<impl Stream<Item = Result<TunnelEvent>>> {
+    pub async fn listen_to_events(
+        &mut self,
+    ) -> Result<impl Stream<Item = Result<TunnelEvent>> + 'static> {
         let listener = self
             .0
             .listen_to_events(())

--- a/nym-vpn-core/crates/nym-vpnc/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/main.rs
@@ -197,16 +197,22 @@ async fn wait_until_disconnected(mut rpc_client: RpcClient) -> Result<()> {
 }
 
 async fn status(mut rpc_client: RpcClient, listen: bool) -> Result<()> {
-    let new_state = rpc_client.get_tunnel_state().await?;
-    println!("{new_state}");
-
     if listen {
         let mut stream = rpc_client.listen_to_tunnel_state().await?;
+
+        let initial_state = tokio::select! {
+            initial_state = rpc_client.get_tunnel_state() => initial_state,
+            Some(initial_state) = stream.next() => initial_state
+        }?;
+        println!("{initial_state}");
 
         while let Some(new_state) = stream.next().await {
             let new_state = new_state?;
             println!("{new_state}");
         }
+    } else {
+        let new_state = rpc_client.get_tunnel_state().await?;
+        println!("{new_state}");
     }
 
     Ok(())


### PR DESCRIPTION
## Description

Race `get_tunnel_state()` and tunnel state event stream to obtain initial state.

## Checklist:

- [x] Changelog

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3188)
<!-- Reviewable:end -->
