### PR TITLE
feat(tauri): when vpnd is down switch tunnel state in UI to unknown

### DIFF
--- a/nym-vpn-app/CHANGELOG.md
+++ b/nym-vpn-app/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Improve UI emphasis when connection to the daemon is down
+
 ## [1.13.0] - 2025-07-30
 
 ### Added

--- a/nym-vpn-app/src-tauri/src/main.rs
+++ b/nym-vpn-app/src-tauri/src/main.rs
@@ -222,9 +222,9 @@ async fn main() -> Result<()> {
                         c_grpc.update_vpnd_state(info, &handle).await.ok();
                         // initialize tunnel state
                         c_grpc.tunnel_state(&handle).await.ok();
-                        info!("watching vpn tunnel events");
                         vpnd::sentry_check(sentry_enabled, &c_grpc).await.ok();
                         vpnd::netstats_check(&db, &c_grpc).await.ok();
+                        info!("watching vpn tunnel events");
                         // start watching tunnel events, this is a blocking call
                         // and will keep the task alive as long as vpnd is running
                         c_grpc.watch_tunnel_events(&handle).await.ok();

--- a/nym-vpn-app/src/contexts/main/reducer.ts
+++ b/nym-vpn-app/src/contexts/main/reducer.ts
@@ -102,9 +102,26 @@ export function reducer(state: AppState, action: StateAction): AppState {
         initialized: true,
       };
     case 'set-daemon-status':
+      if (action.status === 'down') {
+        return {
+          ...state,
+          daemonStatus: action.status,
+          state: 'unknown',
+          tunnel: null,
+          progressMessages: [],
+          tunnelConnectedAt: null,
+          tunnelError: null,
+          retryAttempt: 0,
+          error: {
+            key: 'not-connected-to-daemon',
+            message: 'Not connected to the daemon',
+          },
+        };
+      }
       return {
         ...state,
         daemonStatus: action.status,
+        error: null,
       };
     case 'set-daemon-info':
       return {

--- a/nym-vpn-app/src/contexts/main/reducer.ts
+++ b/nym-vpn-app/src/contexts/main/reducer.ts
@@ -69,7 +69,7 @@ export type StateAction =
 
 export const initialState: AppState = {
   initialized: false,
-  state: 'Disconnected',
+  state: 'disconnected',
   tunnel: null,
   tunnelError: null,
   daemonStatus: 'down',
@@ -159,9 +159,9 @@ export function reducer(state: AppState, action: StateAction): AppState {
         tunnelError: action.error,
       };
     case 'connect':
-      return { ...state, state: 'Connecting' };
+      return { ...state, state: 'connecting' };
     case 'disconnect':
-      return { ...state, state: 'Disconnecting' };
+      return { ...state, state: 'disconnecting' };
     case 'set-version':
       return {
         ...state,
@@ -170,7 +170,7 @@ export function reducer(state: AppState, action: StateAction): AppState {
     case 'set-tunnel-connected':
       return {
         ...state,
-        state: 'Connected',
+        state: 'connected',
         tunnel: action.tunnel,
         progressMessages: [],
         tunnelConnectedAt: action.tunnel.connectedAt
@@ -183,7 +183,7 @@ export function reducer(state: AppState, action: StateAction): AppState {
     case 'set-tunnel-disconnected':
       return {
         ...state,
-        state: 'Disconnected',
+        state: 'disconnected',
         tunnel: null,
         progressMessages: [],
         tunnelConnectedAt: null,
@@ -193,7 +193,7 @@ export function reducer(state: AppState, action: StateAction): AppState {
     case 'set-tunnel-connecting':
       return {
         ...state,
-        state: 'Connecting',
+        state: 'connecting',
         tunnel: action.payload.tunnel,
         retryAttempt: action.payload.retryAttempt || 0,
         tunnelError: null,
@@ -201,21 +201,21 @@ export function reducer(state: AppState, action: StateAction): AppState {
     case 'set-tunnel-disconnecting':
       return {
         ...state,
-        state: 'Disconnecting',
+        state: 'disconnecting',
         tunnel: null,
         tunnelError: null,
       };
     case 'set-tunnel-offline':
       return {
         ...state,
-        state: action.reconnect ? 'OfflineAutoReconnect' : 'Offline',
+        state: action.reconnect ? 'offline-auto-reconnect' : 'offline',
         tunnel: null,
         tunnelError: null,
       };
     case 'set-tunnel-inerror':
       return {
         ...state,
-        state: 'Error',
+        state: 'error',
         tunnelError: action.error,
       };
     case 'set-account':

--- a/nym-vpn-app/src/screens/home/ConnectionBadge.tsx
+++ b/nym-vpn-app/src/screens/home/ConnectionBadge.tsx
@@ -9,34 +9,34 @@ function ConnectionBadge({ state }: { state: TunnelState }) {
 
   const getBadgeStyle = (state: TunnelState) => {
     switch (state) {
-      case 'Connected':
+      case 'connected':
         return ['text-malachite-moss dark:text-malachite bg-malachite/10!'];
-      case 'Disconnected':
+      case 'disconnected':
         return ['text-iron dark:text-bombay'];
-      case 'Connecting':
-      case 'Disconnecting':
+      case 'connecting':
+      case 'disconnecting':
         return ['text-baltic-sea dark:text-white'];
-      case 'Error':
-      case 'Offline':
-      case 'OfflineAutoReconnect':
+      case 'error':
+      case 'offline':
+      case 'offline-auto-reconnect':
         return ['text-baltic-sea bg-aphrodisiac!'];
     }
   };
 
   const getStatusText = (state: TunnelState) => {
     switch (state) {
-      case 'Connected':
+      case 'connected':
         return t('status.connected');
-      case 'Disconnected':
+      case 'disconnected':
         return t('status.disconnected');
-      case 'Connecting':
+      case 'connecting':
         return t('status.connecting');
-      case 'Disconnecting':
+      case 'disconnecting':
         return t('status.disconnecting');
-      case 'Error':
+      case 'error':
         return t('status.error');
-      case 'Offline':
-      case 'OfflineAutoReconnect':
+      case 'offline':
+      case 'offline-auto-reconnect':
         return t('status.offline');
     }
   };
@@ -56,7 +56,7 @@ function ConnectionBadge({ state }: { state: TunnelState }) {
       data-status={state}
     >
       <span data-testid="connection-status-text">{getStatusText(state)}</span>
-      {(state === 'Connecting' || state === 'Disconnecting') && (
+      {(state === 'connecting' || state === 'disconnecting') && (
         <PulseDot color="cornflower" data-testid="connection-pulse-dot" />
       )}
     </motion.div>

--- a/nym-vpn-app/src/screens/home/ConnectionBadge.tsx
+++ b/nym-vpn-app/src/screens/home/ConnectionBadge.tsx
@@ -19,6 +19,7 @@ function ConnectionBadge({ state }: { state: TunnelState }) {
       case 'error':
       case 'offline':
       case 'offline-auto-reconnect':
+      case 'unknown':
         return ['text-baltic-sea bg-aphrodisiac!'];
     }
   };
@@ -28,6 +29,7 @@ function ConnectionBadge({ state }: { state: TunnelState }) {
       case 'connected':
         return t('status.connected');
       case 'disconnected':
+      case 'unknown':
         return t('status.disconnected');
       case 'connecting':
         return t('status.connecting');

--- a/nym-vpn-app/src/screens/home/Home.tsx
+++ b/nym-vpn-app/src/screens/home/Home.tsx
@@ -4,7 +4,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { useNavigate } from 'react-router';
 import clsx from 'clsx';
 import { motion } from 'motion/react';
-import { useInAppNotify, useMainDispatch, useMainState } from '../../contexts';
+import { useMainDispatch, useMainState } from '../../contexts';
 import { BackendError, StateDispatch } from '../../types';
 import { routes } from '../../router';
 import { S_STATE } from '../../static';
@@ -25,7 +25,6 @@ function Home() {
     useMainState();
   const dispatch = useMainDispatch() as StateDispatch;
   const navigate = useNavigate();
-  const { push } = useInAppNotify();
   const { t } = useTranslation('home');
   const loading = state === 'disconnecting';
   const hopSelectDisabled = daemonStatus === 'down' || state !== 'disconnected';
@@ -89,21 +88,6 @@ function Home() {
     }
   }, [navigate]);
 
-  useEffect(() => {
-    if (daemonStatus === 'down') {
-      push({
-        id: 'daemon-not-connected',
-        message: t('daemon-not-connected', {
-          ns: 'notifications',
-        }),
-        close: true,
-        duration: 2000,
-        type: 'error',
-        throttle: 5,
-      });
-    }
-  }, [push, t, daemonStatus]);
-
   const getButtonText = useCallback(() => {
     const stop = capFirst(t('stop', { ns: 'glossary' }));
     const cancel = capFirst(t('cancel', { ns: 'glossary' }));
@@ -111,6 +95,7 @@ function Home() {
       case 'connected':
         return t('disconnect');
       case 'disconnected':
+      case 'unknown':
         return t('connect');
       case 'connecting':
         return stop;
@@ -136,6 +121,8 @@ function Home() {
       case 'disconnecting':
       case 'error':
         return 'red';
+      case 'unknown':
+        return 'gray';
     }
   };
 

--- a/nym-vpn-app/src/screens/home/Home.tsx
+++ b/nym-vpn-app/src/screens/home/Home.tsx
@@ -27,25 +27,25 @@ function Home() {
   const navigate = useNavigate();
   const { push } = useInAppNotify();
   const { t } = useTranslation('home');
-  const loading = state === 'Disconnecting';
-  const hopSelectDisabled = daemonStatus === 'down' || state !== 'Disconnected';
+  const loading = state === 'disconnecting';
+  const hopSelectDisabled = daemonStatus === 'down' || state !== 'disconnected';
 
   const [isDialogUpdateOpen, setIsDialogUpdateOpen] = useState(false);
 
   const handleClick = () => {
-    if (state === 'Disconnected' && !account) {
+    if (state === 'disconnected' && !account) {
       navigate(routes.login);
       return;
     }
     dispatch({ type: 'disconnect' });
     if (
-      state === 'Connected' ||
-      state === 'Connecting' ||
-      state === 'OfflineAutoReconnect' ||
-      state === 'Error'
+      state === 'connected' ||
+      state === 'connecting' ||
+      state === 'offline-auto-reconnect' ||
+      state === 'error'
     ) {
       console.info('disconnect');
-      if (state === 'Connecting') {
+      if (state === 'connecting') {
         dispatch({ type: 'new-progress-message', message: 'Canceling' });
       }
       invoke('disconnect')
@@ -55,7 +55,7 @@ function Home() {
         .catch((e: unknown) => {
           dispatch({ type: 'set-error', error: e as BackendError });
         });
-    } else if (state === 'Disconnected') {
+    } else if (state === 'disconnected') {
       console.info('connect');
       dispatch({ type: 'reset-error' });
       dispatch({ type: 'connect' });
@@ -108,33 +108,33 @@ function Home() {
     const stop = capFirst(t('stop', { ns: 'glossary' }));
     const cancel = capFirst(t('cancel', { ns: 'glossary' }));
     switch (state) {
-      case 'Connected':
+      case 'connected':
         return t('disconnect');
-      case 'Disconnected':
+      case 'disconnected':
         return t('connect');
-      case 'Connecting':
+      case 'connecting':
         return stop;
-      case 'Disconnecting':
+      case 'disconnecting':
         return null;
-      case 'Offline':
+      case 'offline':
         return t('connect');
-      case 'OfflineAutoReconnect':
+      case 'offline-auto-reconnect':
         return stop;
-      case 'Error':
+      case 'error':
         return cancel;
     }
   }, [state, t]);
 
   const getButtonColor = () => {
     switch (state) {
-      case 'Disconnected':
-      case 'Offline':
+      case 'disconnected':
+      case 'offline':
         return 'malachite';
-      case 'Connected':
-      case 'Connecting':
-      case 'OfflineAutoReconnect':
-      case 'Disconnecting':
-      case 'Error':
+      case 'connected':
+      case 'connecting':
+      case 'offline-auto-reconnect':
+      case 'disconnecting':
+      case 'error':
         return 'red';
     }
   };
@@ -198,7 +198,7 @@ function Home() {
           <Button
             onClick={handleClick}
             color={getButtonColor()}
-            disabled={loading || daemonStatus === 'down' || state === 'Offline'}
+            disabled={loading || daemonStatus === 'down' || state === 'offline'}
             spinner={loading}
             className={clsx(['h-14', loading && 'data-disabled:opacity-80'])}
             data-testid="home-connection-button"

--- a/nym-vpn-app/src/screens/home/NetworkModeSelect.tsx
+++ b/nym-vpn-app/src/screens/home/NetworkModeSelect.tsx
@@ -23,7 +23,7 @@ function NetworkModeSelect() {
   const { t } = useTranslation('home');
 
   const handleNetworkModeChange = async (value: VpnMode) => {
-    if (state === 'Disconnected' && value !== vpnMode) {
+    if (state === 'disconnected' && value !== vpnMode) {
       setLoading(true);
       try {
         await invoke<void>('set_vpn_mode', { mode: value });
@@ -42,7 +42,7 @@ function NetworkModeSelect() {
   };
 
   const handleDisabledState = () => {
-    if (state !== 'Disconnected') {
+    if (state !== 'disconnected') {
       toast();
     }
   };
@@ -61,7 +61,7 @@ function NetworkModeSelect() {
         key: 'wg',
         label: t('fast-mode.title'),
         desc: t('fast-mode.desc'),
-        disabled: state !== 'Disconnected' || loading,
+        disabled: state !== 'disconnected' || loading,
         icon: (checked) => (
           <span
             className={iconStyle(checked)}
@@ -76,7 +76,7 @@ function NetworkModeSelect() {
         key: 'mixnet',
         label: t('privacy-mode.title'),
         desc: t('privacy-mode.desc'),
-        disabled: state !== 'Disconnected' || loading,
+        disabled: state !== 'disconnected' || loading,
         icon: (checked) => (
           <span
             className={iconStyle(checked)}

--- a/nym-vpn-app/src/screens/home/TunnelState.tsx
+++ b/nym-vpn-app/src/screens/home/TunnelState.tsx
@@ -12,12 +12,12 @@ function TunnelState() {
   const state = useMainState();
   const [showBadge, setShowBadge] = useState(true);
   const loading =
-    state.state === 'Connecting' || state.state === 'Disconnecting';
+    state.state === 'connecting' || state.state === 'disconnecting';
   const isError = state.tunnelError || state.error;
   const isOffline =
-    state.state === 'Offline' || state.state === 'OfflineAutoReconnect';
+    state.state === 'offline' || state.state === 'offline-auto-reconnect';
   const showRetryAttempt =
-    state.state === 'Connecting' && !state.error && state.retryAttempt > 0;
+    state.state === 'connecting' && !state.error && state.retryAttempt > 0;
   const showProgressMsg =
     loading &&
     state.progressMessages.length > 0 &&
@@ -100,13 +100,13 @@ function TunnelState() {
           !isError &&
           InfoMessage(
             t(
-              state.state === 'Offline'
+              state.state === 'offline'
                 ? 'offline-message'
                 : 'offline-reconnect-message',
               { ns: 'home' },
             ),
           )}
-        {state.state === 'Connected' && <ConnectionTimer />}
+        {state.state === 'connected' && <ConnectionTimer />}
         {isError && (
           <motion.div
             initial={{ opacity: 0, scale: 0.9, translateX: -8 }}

--- a/nym-vpn-app/src/screens/home/util.ts
+++ b/nym-vpn-app/src/screens/home/util.ts
@@ -11,20 +11,20 @@ export function useActionToast(action: 'node-select' | 'mode-select') {
     (throttle = 2) => {
       let text = null;
       switch (state) {
-        case 'Connected':
+        case 'connected':
           text = t('snackbar-disabled-message.connected');
           break;
-        case 'Connecting':
+        case 'connecting':
           text = t('snackbar-disabled-message.connecting');
           break;
-        case 'Disconnecting':
+        case 'disconnecting':
           text = t('snackbar-disabled-message.disconnecting');
           break;
-        case 'Offline':
-        case 'OfflineAutoReconnect':
+        case 'offline':
+        case 'offline-auto-reconnect':
           text = t('snackbar-disabled-message.offline');
           break;
-        case 'Error':
+        case 'error':
           text = t('snackbar-disabled-message.error');
           break;
       }

--- a/nym-vpn-app/src/screens/login/Login.tsx
+++ b/nym-vpn-app/src/screens/login/Login.tsx
@@ -42,7 +42,7 @@ function Login() {
       return;
     }
     // kinda overkill but who knows?
-    if (state !== 'Disconnected') {
+    if (state !== 'disconnected') {
       console.warn(`cannot login while tunnel state is ${state}`);
       return;
     }
@@ -126,7 +126,7 @@ function Login() {
         <div className="w-full flex flex-col justify-center items-center gap-6 mb-2">
           <Button
             onClick={handleClick}
-            disabled={daemonStatus === 'down' || state !== 'Disconnected'}
+            disabled={daemonStatus === 'down' || state !== 'disconnected'}
             className={clsx(
               'h-14',
               daemonStatus === 'down' &&

--- a/nym-vpn-app/src/screens/settings/Logout.tsx
+++ b/nym-vpn-app/src/screens/settings/Logout.tsx
@@ -22,7 +22,7 @@ function Logout() {
   const logoutCopy = capFirst(t('logout', { ns: 'glossary' }));
 
   const logout = async () => {
-    if (state !== 'Disconnected') {
+    if (state !== 'disconnected') {
       console.warn(`cannot logout while tunnel state is ${state}`);
       push({
         message: t('logout.from-state', { ns: 'notifications', state }),
@@ -71,7 +71,7 @@ function Logout() {
       <SettingsMenuCard
         title={logoutCopy}
         onClick={() => setIsOpen(true)}
-        disabled={daemonStatus === 'down' || state !== 'Disconnected'}
+        disabled={daemonStatus === 'down' || state !== 'disconnected'}
         data-testid="logout-button"
       />
       <Dialog

--- a/nym-vpn-app/src/state/helper.ts
+++ b/nym-vpn-app/src/state/helper.ts
@@ -72,7 +72,6 @@ export function daemonStatusUpdate(
       close: true,
       duration: 6000,
       type: 'error',
-      throttle: 10,
     });
   }
 }

--- a/nym-vpn-app/src/state/useExit.ts
+++ b/nym-vpn-app/src/state/useExit.ts
@@ -12,10 +12,10 @@ export function useExit() {
   const exit = async () => {
     console.info('app exit');
     if (
-      state.state === 'Connected' ||
-      state.state === 'Error' ||
-      state.state === 'Connecting' ||
-      state.state === 'OfflineAutoReconnect'
+      state.state === 'connected' ||
+      state.state === 'error' ||
+      state.state === 'connecting' ||
+      state.state === 'offline-auto-reconnect'
     ) {
       // TODO add a timeout to prevent the app from hanging
       // in bad disconnect scenarios

--- a/nym-vpn-app/src/types/app-state.ts
+++ b/nym-vpn-app/src/types/app-state.ts
@@ -12,13 +12,13 @@ import {
 import { Tunnel, TunnelError } from './tunnel';
 
 export type TunnelState =
-  | 'Connected'
-  | 'Disconnected'
-  | 'Connecting'
-  | 'Disconnecting'
-  | 'Error'
-  | 'Offline'
-  | 'OfflineAutoReconnect';
+  | 'connected'
+  | 'disconnected'
+  | 'connecting'
+  | 'disconnecting'
+  | 'error'
+  | 'offline'
+  | 'offline-auto-reconnect';
 
 export type VpnMode = 'wg' | 'mixnet';
 

--- a/nym-vpn-app/src/types/app-state.ts
+++ b/nym-vpn-app/src/types/app-state.ts
@@ -18,7 +18,9 @@ export type TunnelState =
   | 'disconnecting'
   | 'error'
   | 'offline'
-  | 'offline-auto-reconnect';
+  | 'offline-auto-reconnect'
+  // when not connected to the daemon, the state is unknown
+  | 'unknown';
 
 export type VpnMode = 'wg' | 'mixnet';
 


### PR DESCRIPTION
- UI: add a new virtual tunnel state “unknown”, used whenever daemon connection is down
- minor UI changes when daemon is down, show a static error in the UI "Not connected to the daemon" 
- refactor: rename tunnel state union type using kebab-case

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3189)
<!-- Reviewable:end -->
