### PR TITLE
Avoid `canonicalize()` failures breaking build scripts.

### DIFF
--- a/nym-vpn-core/crates/nym-firewall/build.rs
+++ b/nym-vpn-core/crates/nym-firewall/build.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{env, path::PathBuf};
+use std::{env, fs, path::PathBuf};
 
 fn main() {
     let target_os = env::var("CARGO_CFG_TARGET_OS").expect("target os is not set");
@@ -13,8 +13,14 @@ fn main() {
     let arch = env::var("CARGO_CFG_TARGET_ARCH").expect("target arch is not set");
     let profile = env::var("PROFILE").expect("profile is not set");
 
-    let build_dir = PathBuf::from(manifest_path)
-        .join("../../../build/winfw")
+    let build_dir = PathBuf::from(manifest_path).join("../../../build/winfw");
+
+    // .canonicalize will fail if the build directory does not exist
+    if !build_dir.exists() {
+        fs::create_dir(&build_dir).expect("failed to create build dir");
+    }
+
+    let build_dir = build_dir
         .canonicalize()
         .expect("failed to canonicalize build dir path");
     let cpp_arch = match arch.as_str() {

--- a/nym-vpn-core/crates/nym-firewall/build.rs
+++ b/nym-vpn-core/crates/nym-firewall/build.rs
@@ -15,7 +15,7 @@ fn main() {
 
     let build_dir = PathBuf::from(manifest_path).join("../../../build/winfw");
 
-    // .canonicalize will fail if the build directory does not exist
+    // canonicalize() will fail if the build directory does not exist
     if !build_dir.exists() {
         fs::create_dir(&build_dir).expect("failed to create build dir");
     }
@@ -23,6 +23,7 @@ fn main() {
     let build_dir = build_dir
         .canonicalize()
         .expect("failed to canonicalize build dir path");
+
     let cpp_arch = match arch.as_str() {
         "x86_64" => "x64",
         "aarch64" => "ARM64",

--- a/nym-vpn-core/crates/nym-firewall/build.rs
+++ b/nym-vpn-core/crates/nym-firewall/build.rs
@@ -17,7 +17,7 @@ fn main() {
 
     // canonicalize() will fail if the build directory does not exist
     if !build_dir.exists() {
-        fs::create_dir(&build_dir).expect("failed to create build dir");
+        fs::create_dir_all(&build_dir).expect("failed to create build dir");
     }
 
     let build_dir = build_dir

--- a/nym-vpn-core/crates/nym-wg-go/build.rs
+++ b/nym-vpn-core/crates/nym-wg-go/build.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{env, path::PathBuf, fs};
+use std::{env, fs, path::PathBuf};
 
 fn main() {
     let manifest_path = env::var_os("CARGO_MANIFEST_DIR").expect("manifest dir is not set");
@@ -12,8 +12,7 @@ fn main() {
 
     // canonicalize() will fail if the build directory does not exist
     if !build_dir.exists() {
-        fs::create_dir(&build_dir)
-            .expect("failed to create build dir");
+        fs::create_dir_all(&build_dir).expect("failed to create build dir");
     }
 
     let mut build_dir = build_dir

--- a/nym-vpn-core/crates/nym-wg-go/build.rs
+++ b/nym-vpn-core/crates/nym-wg-go/build.rs
@@ -10,7 +10,7 @@ fn main() {
 
     let build_dir = PathBuf::from(manifest_path).join("../../../build/lib");
 
-    // .canonicalize will fail if the build directory does not exist
+    // canonicalize() will fail if the build directory does not exist
     if !build_dir.exists() {
         fs::create_dir(&build_dir)
             .expect("failed to create build dir");

--- a/nym-vpn-core/crates/nym-wg-go/build.rs
+++ b/nym-vpn-core/crates/nym-wg-go/build.rs
@@ -1,15 +1,22 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{env, path::PathBuf};
+use std::{env, path::PathBuf, fs};
 
 fn main() {
     let manifest_path = env::var_os("CARGO_MANIFEST_DIR").expect("manifest dir is not set");
     let target = env::var("TARGET").expect("target is not set");
     let target_os = env::var("CARGO_CFG_TARGET_OS").expect("target os is not set");
 
-    let mut build_dir = PathBuf::from(manifest_path)
-        .join("../../../build/lib")
+    let build_dir = PathBuf::from(manifest_path).join("../../../build/lib");
+
+    // .canonicalize will fail if the build directory does not exist
+    if !build_dir.exists() {
+        fs::create_dir(&build_dir)
+            .expect("failed to create build dir");
+    }
+
+    let mut build_dir = build_dir
         .canonicalize()
         .expect("failed to canonicalize build dir path");
 


### PR DESCRIPTION
## Description

When loading the project in CLion I noticed that `nym-firewall` was failing to configure because the `build/lib` directory didn't exist.

## Checklist:

- [ ] Changelog

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3190)
<!-- Reviewable:end -->
