### PR TITLE
ci: migrate to arc-ubuntu-22.04

### DIFF
--- a/.github/workflows/build-nym-vpn-android.yml
+++ b/.github/workflows/build-nym-vpn-android.yml
@@ -63,13 +63,13 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: arc-ubuntu-24.04
     env:
       SIGNING_KEY_ALIAS: ${{ secrets.ANDROID_SIGNING_KEY_ALIAS }}
       SIGNING_KEY_PASSWORD: ${{ secrets.ANDROID_SIGNING_KEY_PASSWORD }}
       SIGNING_STORE_PASSWORD: ${{ secrets.ANDROID_SIGNING_STORE_PASSWORD }}
       SENTRY_DSN: ${{ secrets.ANDROID_SENTRY_DSN }}
-      KEY_STORE_FILE: 'android_keystore.jks'
+      KEY_STORE_FILE: "android_keystore.jks"
       KEY_STORE_LOCATION: ${{ github.workspace }}/nym-vpn-android/app/keystore/
     defaults:
       run:
@@ -83,8 +83,8 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: '17'
+          distribution: "temurin"
+          java-version: "17"
           cache: gradle
 
       - name: Setup Android SDK
@@ -113,7 +113,7 @@ jobs:
           cache-dependency-path: |
             wireguard/libwg/go.sum
             nym-vpn-core/crates/nym-gateway-probe/netstack_ping/go.sum
-      
+
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/build-nym-vpn-android.yml
+++ b/.github/workflows/build-nym-vpn-android.yml
@@ -63,7 +63,7 @@ env:
 
 jobs:
   build:
-    runs-on: arc-ubuntu-24.04
+    runs-on: arc-ubuntu-22.04
     env:
       SIGNING_KEY_ALIAS: ${{ secrets.ANDROID_SIGNING_KEY_ALIAS }}
       SIGNING_KEY_PASSWORD: ${{ secrets.ANDROID_SIGNING_KEY_PASSWORD }}

--- a/.github/workflows/build-nym-vpn-app-linux.yml
+++ b/.github/workflows/build-nym-vpn-app-linux.yml
@@ -36,7 +36,7 @@ env:
 
 jobs:
   build-linux:
-    runs-on: arc-ubuntu-24.04
+    runs-on: arc-ubuntu-22.04
     outputs:
       UPLOAD_DIR_LINUX: ${{ env.UPLOAD_DIR_LINUX }}
       PKG_VERSION: ${{ steps.package-version.outputs.metadata }}

--- a/.github/workflows/build-nym-vpn-app-linux.yml
+++ b/.github/workflows/build-nym-vpn-app-linux.yml
@@ -36,7 +36,7 @@ env:
 
 jobs:
   build-linux:
-    runs-on: ubuntu-22.04
+    runs-on: arc-ubuntu-24.04
     outputs:
       UPLOAD_DIR_LINUX: ${{ env.UPLOAD_DIR_LINUX }}
       PKG_VERSION: ${{ steps.package-version.outputs.metadata }}

--- a/.github/workflows/build-nym-vpn-core-android.yml
+++ b/.github/workflows/build-nym-vpn-core-android.yml
@@ -19,7 +19,7 @@ jobs:
 
   build-android:
     needs: build-wireguard-go-android
-    runs-on: arc-ubuntu-24.04
+    runs-on: arc-ubuntu-22.04
     outputs:
       UPLOAD_DIR_ANDROID: ${{ env.UPLOAD_DIR_ANDROID }}
       RUST_VERSION: ${{ steps.rust-version.outputs.rustc }}

--- a/.github/workflows/build-nym-vpn-core-android.yml
+++ b/.github/workflows/build-nym-vpn-core-android.yml
@@ -19,7 +19,7 @@ jobs:
 
   build-android:
     needs: build-wireguard-go-android
-    runs-on: ubuntu-22.04
+    runs-on: arc-ubuntu-24.04
     outputs:
       UPLOAD_DIR_ANDROID: ${{ env.UPLOAD_DIR_ANDROID }}
       RUST_VERSION: ${{ steps.rust-version.outputs.rustc }}

--- a/.github/workflows/build-nym-vpn-core-deb.yml
+++ b/.github/workflows/build-nym-vpn-core-deb.yml
@@ -18,7 +18,7 @@ jobs:
 
   build-linux:
     needs: build-wireguard-go-linux
-    runs-on: ubuntu-22.04
+    runs-on: arc-ubuntu-24.04
     outputs:
       UPLOAD_DIR_DEB: ${{ env.UPLOAD_DIR_DEB }}
     steps:

--- a/.github/workflows/build-nym-vpn-core-deb.yml
+++ b/.github/workflows/build-nym-vpn-core-deb.yml
@@ -18,7 +18,7 @@ jobs:
 
   build-linux:
     needs: build-wireguard-go-linux
-    runs-on: arc-ubuntu-24.04
+    runs-on: arc-ubuntu-22.04
     outputs:
       UPLOAD_DIR_DEB: ${{ env.UPLOAD_DIR_DEB }}
     steps:

--- a/.github/workflows/build-nym-vpn-core-linux.yml
+++ b/.github/workflows/build-nym-vpn-core-linux.yml
@@ -22,7 +22,7 @@ jobs:
 
   build-linux:
     needs: build-wireguard-go-linux
-    runs-on: ubuntu-22.04
+    runs-on: arc-ubuntu-24.04
     outputs:
       UPLOAD_DIR_LINUX: ${{ env.UPLOAD_DIR_LINUX }}
       RUST_VERSION: ${{ steps.rust-version.outputs.rustc }}
@@ -69,7 +69,7 @@ jobs:
       - name: Download wireguard-go artifacts
         uses: actions/download-artifact@v4
         with:
-          name: wireguard-go_ubuntu-22.04_x86_64
+          name: wireguard-go_ubuntu-24.04_x86_64
           path: build/lib/x86_64-unknown-linux-gnu
 
       - name: Build nym-vpn-core

--- a/.github/workflows/build-nym-vpn-core-linux.yml
+++ b/.github/workflows/build-nym-vpn-core-linux.yml
@@ -22,7 +22,7 @@ jobs:
 
   build-linux:
     needs: build-wireguard-go-linux
-    runs-on: arc-ubuntu-24.04
+    runs-on: arc-ubuntu-22.04
     outputs:
       UPLOAD_DIR_LINUX: ${{ env.UPLOAD_DIR_LINUX }}
       RUST_VERSION: ${{ steps.rust-version.outputs.rustc }}

--- a/.github/workflows/build-wireguard-go-android.yml
+++ b/.github/workflows/build-wireguard-go-android.yml
@@ -12,12 +12,12 @@ env:
 
 jobs:
   build:
-    runs-on: 'ubuntu-22.04'
+    runs-on: arc-ubuntu-24.04
 
     steps:
       - name: Checkout nym-vpn-client
         uses: actions/checkout@v4
-     
+
       - name: Install Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/build-wireguard-go-android.yml
+++ b/.github/workflows/build-wireguard-go-android.yml
@@ -18,6 +18,9 @@ jobs:
       - name: Checkout nym-vpn-client
         uses: actions/checkout@v4
 
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y rsync
+
       - name: Install Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/build-wireguard-go-android.yml
+++ b/.github/workflows/build-wireguard-go-android.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   build:
-    runs-on: arc-ubuntu-24.04
+    runs-on: arc-ubuntu-22.04
 
     steps:
       - name: Checkout nym-vpn-client

--- a/.github/workflows/build-wireguard-go-linux.yml
+++ b/.github/workflows/build-wireguard-go-linux.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build:
-    runs-on: arc-ubuntu-24.04
+    runs-on: arc-ubuntu-22.04
 
     steps:
       - name: Install system dependencies

--- a/.github/workflows/build-wireguard-go-linux.yml
+++ b/.github/workflows/build-wireguard-go-linux.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: arc-ubuntu-24.04
 
     steps:
       - name: Install system dependencies
@@ -39,7 +39,7 @@ jobs:
         id: set_artifact_name
         run: |
           if [ -z "${{ inputs.artifact_name }}" ]; then
-            echo "artifact_name=wireguard-go_ubuntu-22.04_x86_64" >> $GITHUB_OUTPUT
+            echo "artifact_name=wireguard-go_ubuntu-24.04_x86_64" >> $GITHUB_OUTPUT
           else
             echo "artifact_name=${{ inputs.artifact_name }}" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/ci-nym-vpn-android.yml
+++ b/.github/workflows/ci-nym-vpn-android.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-22.04
+    runs-on: arc-ubuntu-24.04
     defaults:
       run:
         working-directory: nym-vpn-android
@@ -22,12 +22,12 @@ jobs:
         with:
           sparse-checkout: |
             nym-vpn-android
-      
+
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: '17'
+          distribution: "temurin"
+          java-version: "17"
           cache: gradle
 
       - name: Install deps
@@ -45,5 +45,5 @@ jobs:
   build-nym-vpn-android:
     uses: ./.github/workflows/build-nym-vpn-android.yml
     with:
-      build_type: 'debug'
-      build_format: 'apk'
+      build_type: "debug"
+      build_format: "apk"

--- a/.github/workflows/ci-nym-vpn-android.yml
+++ b/.github/workflows/ci-nym-vpn-android.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   check:
-    runs-on: arc-ubuntu-24.04
+    runs-on: arc-ubuntu-22.04
     defaults:
       run:
         working-directory: nym-vpn-android

--- a/.github/workflows/ci-nym-vpn-app-js.yml
+++ b/.github/workflows/ci-nym-vpn-app-js.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [arc-ubuntu-24.04, custom-windows-11]
+        os: [arc-ubuntu-22.04, custom-windows-11]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/ci-nym-vpn-app-js.yml
+++ b/.github/workflows/ci-nym-vpn-app-js.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, custom-windows-11]
+        os: [arc-ubuntu-24.04, custom-windows-11]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/ci-nym-vpn-app-rust.yml
+++ b/.github/workflows/ci-nym-vpn-app-rust.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, custom-macos-15, custom-windows-11]
+        os: [arc-ubuntu-24.04, custom-macos-15, custom-windows-11]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -60,6 +60,9 @@ jobs:
             triplet=x86_64-unknown-linux-gnu
           elif ${{ contains(matrix.os, 'ubuntu-22.04') }}; then
             platform_arch=ubuntu-22.04_x86_64
+            triplet=x86_64-unknown-linux-gnu
+          elif ${{ contains(matrix.os, 'arc-ubuntu-24.04') }}; then
+            platform_arch=ubuntu-24.04_x86_64
             triplet=x86_64-unknown-linux-gnu
           elif ${{ matrix.os == 'macos-12' || matrix.os == 'macos-13' }}; then
             platform_arch=macos_x86_64

--- a/.github/workflows/ci-nym-vpn-app-rust.yml
+++ b/.github/workflows/ci-nym-vpn-app-rust.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [arc-ubuntu-24.04, custom-macos-15, custom-windows-11]
+        os: [arc-ubuntu-22.04, custom-macos-15, custom-windows-11]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/ci-nym-vpn-app-rust.yml
+++ b/.github/workflows/ci-nym-vpn-app-rust.yml
@@ -58,10 +58,10 @@ jobs:
           if ${{ contains(matrix.os, 'ubuntu-20.04') }}; then
             platform_arch=ubuntu-20.04_x86_64
             triplet=x86_64-unknown-linux-gnu
-          elif ${{ contains(matrix.os, 'ubuntu-22.04') }}; then
+          elif ${{ contains(matrix.os, 'ubuntu-22.04') || contains(matrix.os, 'arc-ubuntu-22.04') }}; then
             platform_arch=ubuntu-22.04_x86_64
             triplet=x86_64-unknown-linux-gnu
-          elif ${{ contains(matrix.os, 'arc-ubuntu-24.04') }}; then
+          elif ${{ contains(matrix.os, 'ubuntu-24.04') || contains(matrix.os, 'arc-ubuntu-24.04') }}; then
             platform_arch=ubuntu-24.04_x86_64
             triplet=x86_64-unknown-linux-gnu
           elif ${{ matrix.os == 'macos-12' || matrix.os == 'macos-13' }}; then

--- a/.github/workflows/ci-nym-vpn-core-android.yml
+++ b/.github/workflows/ci-nym-vpn-core-android.yml
@@ -17,7 +17,7 @@ jobs:
     uses: ./.github/workflows/build-wireguard-go-android.yml
 
   build:
-    runs-on: arc-ubuntu-24.04
+    runs-on: arc-ubuntu-22.04
     needs: build-wireguard-go-android
 
     steps:

--- a/.github/workflows/ci-nym-vpn-core-android.yml
+++ b/.github/workflows/ci-nym-vpn-core-android.yml
@@ -17,7 +17,7 @@ jobs:
     uses: ./.github/workflows/build-wireguard-go-android.yml
 
   build:
-    runs-on: ubuntu-22.04
+    runs-on: arc-ubuntu-24.04
     needs: build-wireguard-go-android
 
     steps:

--- a/.github/workflows/ci-nym-vpn-core-cargo-deny.yml
+++ b/.github/workflows/ci-nym-vpn-core-cargo-deny.yml
@@ -3,13 +3,13 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
-      - 'nym-vpn-core/**/Cargo.lock'
-      - 'nym-vpn-core/**/Cargo.toml'
-      - 'nym-vpn-core/deny.toml'
-      - '.github/workflows/ci-nym-vpn-core-cargo-deny.yml'
+      - "nym-vpn-core/**/Cargo.lock"
+      - "nym-vpn-core/**/Cargo.toml"
+      - "nym-vpn-core/deny.toml"
+      - ".github/workflows/ci-nym-vpn-core-cargo-deny.yml"
 jobs:
   cargo-deny:
-    runs-on: ubuntu-22.04
+    runs-on: arc-ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci-nym-vpn-core-cargo-deny.yml
+++ b/.github/workflows/ci-nym-vpn-core-cargo-deny.yml
@@ -9,7 +9,7 @@ on:
       - ".github/workflows/ci-nym-vpn-core-cargo-deny.yml"
 jobs:
   cargo-deny:
-    runs-on: arc-ubuntu-24.04
+    runs-on: arc-ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci-nym-vpn-core-cargo-deny.yml
+++ b/.github/workflows/ci-nym-vpn-core-cargo-deny.yml
@@ -12,9 +12,16 @@ jobs:
     runs-on: arc-ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: EmbarkStudios/cargo-deny-action@v2
+
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
-          manifest-path: ./nym-vpn-core/Cargo.toml
-          command: check licenses bans sources
-          arguments: --all-features
+          toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
+
+      - name: Install cargo-deny
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-deny
+
+      - name: Run cargo-deny
+        run: cargo deny --manifest-path ./nym-vpn-core/Cargo.toml --locked --all-features check licenses bans sources

--- a/.github/workflows/ci-nym-vpn-core-linux.yml
+++ b/.github/workflows/ci-nym-vpn-core-linux.yml
@@ -17,7 +17,7 @@ jobs:
     uses: ./.github/workflows/build-wireguard-go-linux.yml
 
   build:
-    runs-on: ubuntu-22.04
+    runs-on: arc-ubuntu-24.04
     needs: build-wireguard-go-linux
 
     steps:
@@ -49,7 +49,7 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          name: wireguard-go_ubuntu-22.04_x86_64
+          name: wireguard-go_ubuntu-24.04_x86_64
           path: build/lib/x86_64-unknown-linux-gnu
 
       - name: rustfmt check
@@ -71,4 +71,3 @@ jobs:
         working-directory: nym-vpn-core
         run: |
           cargo test --verbose --workspace --locked
-

--- a/.github/workflows/ci-nym-vpn-core-linux.yml
+++ b/.github/workflows/ci-nym-vpn-core-linux.yml
@@ -17,7 +17,7 @@ jobs:
     uses: ./.github/workflows/build-wireguard-go-linux.yml
 
   build:
-    runs-on: arc-ubuntu-24.04
+    runs-on: arc-ubuntu-22.04
     needs: build-wireguard-go-linux
 
     steps:

--- a/.github/workflows/generate-build-info-core.yml
+++ b/.github/workflows/generate-build-info-core.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   generate-build-info-core:
-    runs-on: arc-ubuntu-24.04
+    runs-on: arc-ubuntu-22.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/generate-build-info-core.yml
+++ b/.github/workflows/generate-build-info-core.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   generate-build-info-core:
-    runs-on: ubuntu-22.04
+    runs-on: arc-ubuntu-24.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -27,8 +27,7 @@ jobs:
 
       - name: Get current date
         id: date
-        run:
-          echo "date=$(date)" >> $GITHUB_OUTPUT
+        run: echo "date=$(date)" >> $GITHUB_OUTPUT
 
       - name: Install rust toolchain
         uses: brndnmtthws/rust-action-rustup@v1

--- a/.github/workflows/generate-build-info-nym-vpn-app.yml
+++ b/.github/workflows/generate-build-info-nym-vpn-app.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   generate-build-info-nym-vpn-app:
-    runs-on: ubuntu-22.04
+    runs-on: arc-ubuntu-24.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -27,8 +27,7 @@ jobs:
 
       - name: Get current date
         id: date
-        run:
-          echo "date=$(date)" >> $GITHUB_OUTPUT
+        run: echo "date=$(date)" >> $GITHUB_OUTPUT
 
       - name: Generate build-info
         run: |

--- a/.github/workflows/generate-build-info-nym-vpn-app.yml
+++ b/.github/workflows/generate-build-info-nym-vpn-app.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   generate-build-info-nym-vpn-app:
-    runs-on: arc-ubuntu-24.04
+    runs-on: arc-ubuntu-22.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/publish-nym-vpn-android.yml
+++ b/.github/workflows/publish-nym-vpn-android.yml
@@ -45,10 +45,10 @@ on:
 
   push:
     tags:
-      - 'nym-vpn-android-v*.*.*'
+      - "nym-vpn-android-v*.*.*"
 env:
   UPLOAD_DIR_ANDROID: android_artifacts
-  RELEASE_NOTES: ''
+  RELEASE_NOTES: ""
 
 jobs:
   build-nym-vpn-android-apk:
@@ -71,7 +71,7 @@ jobs:
     if: ${{ inputs.release_type != 'none' }}
     needs:
       - build-nym-vpn-android-apk
-    runs-on: ubuntu-22.04
+    runs-on: arc-ubuntu-24.04
     defaults:
       run:
         working-directory: nym-vpn-android
@@ -136,7 +136,6 @@ jobs:
           file_path=$(find ${{ github.workspace }}/temp -type f -iname "*.apk" | tail -n1)
           echo "checksum=$(apksigner verify -print-certs $file_path | grep -Po "(?<=SHA-256 digest:) .*" | tr -d "[:blank:]")" >> $GITHUB_OUTPUT
 
-
       - name: Create release with fastlane changelog notes
         id: create_release
         uses: softprops/action-gh-release@v2
@@ -166,7 +165,7 @@ jobs:
             ```sh
             ${{ steps.checksum.outputs.checksum }}
             ```
-            
+
             To verify fingerprint:
             ```sh
             apksigner verify --print-certs [path to APK file] | grep SHA-256
@@ -178,9 +177,8 @@ jobs:
           prerelease: ${{ inputs.release_type != 'release' }}
           append_body: true
 
-
   publish-nym-fdroid:
-    runs-on: ubuntu-22.04
+    runs-on: arc-ubuntu-24.04
     needs:
       - publish-github
     if: inputs.release_type == 'release'
@@ -193,7 +191,7 @@ jobs:
           event-type: fdroid-update
 
   publish-accrescent:
-    runs-on: ubuntu-22.04
+    runs-on: arc-ubuntu-24.04
     env:
       SIGNING_KEY_ALIAS: ${{ secrets.ANDROID_SIGNING_KEY_ALIAS }}
       SIGNING_KEY_PASSWORD: ${{ secrets.ANDROID_SIGNING_KEY_PASSWORD }}
@@ -202,12 +200,11 @@ jobs:
     needs:
       - build-nym-vpn-android-aab
     steps:
-
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
-          distribution: 'temurin'
+          java-version: "17"
+          distribution: "temurin"
 
       - name: Make download dir
         run: mkdir ${{ github.workspace }}/temp
@@ -226,7 +223,7 @@ jobs:
         id: decode_keystore
         uses: timheuer/base64-to-file@v1.2
         with:
-          fileName: 'android_keystore.jks'
+          fileName: "android_keystore.jks"
           encodedString: ${{ secrets.ANDROID_KEYSTORE }}
 
       - name: Download bundletool
@@ -249,12 +246,11 @@ jobs:
           name: app-apks
           path: app-fdroid-release.apks
           if-no-files-found: error
-      
 
   publish-play:
     if: ${{ inputs.track != 'none' && inputs.track != '' }}
     # issue here: https://github.com/ruby/setup-ruby?tab=readme-ov-file#using-self-hosted-runners
-    runs-on: ubuntu-22.04
+    runs-on: arc-ubuntu-24.04
     defaults:
       run:
         working-directory: nym-vpn-android
@@ -263,13 +259,13 @@ jobs:
       SIGNING_KEY_PASSWORD: ${{ secrets.ANDROID_SIGNING_KEY_PASSWORD }}
       SIGNING_STORE_PASSWORD: ${{ secrets.ANDROID_SIGNING_STORE_PASSWORD }}
       SENTRY_DSN: ${{ secrets.ANDROID_SENTRY_DSN }}
-      KEY_STORE_FILE: 'android_keystore.jks'
+      KEY_STORE_FILE: "android_keystore.jks"
       KEY_STORE_LOCATION: ${{ github.workspace }}/nym-vpn-android/app/keystore/
     steps:
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2' # Not needed with a .ruby-version file
+          ruby-version: "3.2" # Not needed with a .ruby-version file
           bundler-cache: true
 
       - uses: actions/checkout@v4
@@ -277,8 +273,8 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: '17'
+          distribution: "temurin"
+          java-version: "17"
           cache: gradle
 
       - name: Install deps
@@ -314,7 +310,7 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-ndk
-      
+
       - name: Install cargo-license
         uses: baptiste0928/cargo-install@v3
         with:
@@ -352,5 +348,3 @@ jobs:
           bundle exec fastlane ${{ inputs.track }} skip_bundle:${{github.event.inputs.publish-bundle == 'true'}} skip_metadata:${{github.event.inputs.publish-metadata == 'true'}}
         env:
           ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
-          
-          

--- a/.github/workflows/publish-nym-vpn-android.yml
+++ b/.github/workflows/publish-nym-vpn-android.yml
@@ -71,7 +71,7 @@ jobs:
     if: ${{ inputs.release_type != 'none' }}
     needs:
       - build-nym-vpn-android-apk
-    runs-on: arc-ubuntu-24.04
+    runs-on: arc-ubuntu-22.04
     defaults:
       run:
         working-directory: nym-vpn-android
@@ -178,7 +178,7 @@ jobs:
           append_body: true
 
   publish-nym-fdroid:
-    runs-on: arc-ubuntu-24.04
+    runs-on: arc-ubuntu-22.04
     needs:
       - publish-github
     if: inputs.release_type == 'release'
@@ -191,7 +191,7 @@ jobs:
           event-type: fdroid-update
 
   publish-accrescent:
-    runs-on: arc-ubuntu-24.04
+    runs-on: arc-ubuntu-22.04
     env:
       SIGNING_KEY_ALIAS: ${{ secrets.ANDROID_SIGNING_KEY_ALIAS }}
       SIGNING_KEY_PASSWORD: ${{ secrets.ANDROID_SIGNING_KEY_PASSWORD }}
@@ -250,7 +250,7 @@ jobs:
   publish-play:
     if: ${{ inputs.track != 'none' && inputs.track != '' }}
     # issue here: https://github.com/ruby/setup-ruby?tab=readme-ov-file#using-self-hosted-runners
-    runs-on: arc-ubuntu-24.04
+    runs-on: arc-ubuntu-22.04
     defaults:
       run:
         working-directory: nym-vpn-android

--- a/.github/workflows/publish-nym-vpn-app.yml
+++ b/.github/workflows/publish-nym-vpn-app.yml
@@ -70,7 +70,7 @@ jobs:
       - build-linux
       - build-windows
       - generate-build-info-nym-vpn-app
-    runs-on: arc-ubuntu-24.04
+    runs-on: arc-ubuntu-22.04
     outputs:
       release_tag: ${{ steps.set_tag.outputs.tag }}
       release_id: ${{ steps.create_release.outputs.id }}

--- a/.github/workflows/publish-nym-vpn-app.yml
+++ b/.github/workflows/publish-nym-vpn-app.yml
@@ -10,7 +10,7 @@ on:
         default: nym-vpn-app-v1.2.3
       release_type:
         type: choice
-        description: "Release type, \"stable\" for public releases (signed Windows only), \"nightly\" for nightly build, \"dev\" for any other releases"
+        description: 'Release type, "stable" for public releases (signed Windows only), "nightly" for nightly build, "dev" for any other releases'
         options:
           - dev
           - nightly
@@ -18,7 +18,7 @@ on:
         default: dev
         required: true
       pre_release:
-        description: "Label as \"Pre-release\""
+        description: 'Label as "Pre-release"'
         required: false
         type: boolean
         default: false
@@ -70,7 +70,7 @@ jobs:
       - build-linux
       - build-windows
       - generate-build-info-nym-vpn-app
-    runs-on: ubuntu-22.04
+    runs-on: arc-ubuntu-24.04
     outputs:
       release_tag: ${{ steps.set_tag.outputs.tag }}
       release_id: ${{ steps.create_release.outputs.id }}
@@ -167,19 +167,19 @@ jobs:
       - name: Set release notes header (stable)
         if: ${{ env.RELEASE_TYPE == 'stable' }}
         env:
-          EMOJI: ':ship:'
+          EMOJI: ":ship:"
         run: echo "RELEASE_NOTES_HEADER='$EMOJI Linux and Windows desktop app'" >> $GITHUB_ENV
 
       - name: Set release notes header (dev)
         if: ${{ env.RELEASE_TYPE == 'dev' }}
         env:
-          EMOJI: ':hammer_and_wrench:'
+          EMOJI: ":hammer_and_wrench:"
         run: echo "RELEASE_NOTES_HEADER='$EMOJI Linux and Windows desktop app, **dev** build'" >> $GITHUB_ENV
 
       - name: Set release notes header (nightly)
         if: ${{ env.RELEASE_TYPE == 'nightly' }}
         env:
-          EMOJI: ':night_with_stars:'
+          EMOJI: ":night_with_stars:"
         run: echo "RELEASE_NOTES_HEADER='$EMOJI Linux and Windows desktop app, **nightly** build'" >> $GITHUB_ENV
 
       - name: Release notes
@@ -220,7 +220,7 @@ jobs:
     with:
       channel: ${{ inputs.release_type == 'stable' && 'stable' || 'dev' }}
       version: ${{ needs.publish.outputs.version }}
-      platform: 'windows-x86_64'
+      platform: "windows-x86_64"
       url: https://github.com/nymtech/nym-vpn-client/releases/download/${{ needs.publish.outputs.release_tag }}/${{ needs.publish.outputs.win_updater_exe }}
       signature: ${{ needs.publish.outputs.win_updater_sig }}
 
@@ -258,7 +258,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          ref: 'develop'
+          ref: "develop"
 
       - name: Install deps
         run: |
@@ -294,8 +294,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          GIT_BRANCH: 'tauri_postrel_${{ needs.publish.outputs.version }}'
-          COMMIT_MSG: 'tauri: bump linux installer and update flatpak metainfo v${{ needs.publish.outputs.version }}'
+          GIT_BRANCH: "tauri_postrel_${{ needs.publish.outputs.version }}"
+          COMMIT_MSG: "tauri: bump linux installer and update flatpak metainfo v${{ needs.publish.outputs.version }}"
           PR_TITLE: "tauri: post release update v${{ needs.publish.outputs.version }}"
           PR_BODY: |
             - bump Linux installer script

--- a/.github/workflows/publish-nym-vpn-app.yml
+++ b/.github/workflows/publish-nym-vpn-app.yml
@@ -94,8 +94,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
           components: rustfmt, clippy
 
       - name: Get package version

--- a/.github/workflows/publish-nym-vpn-core.yml
+++ b/.github/workflows/publish-nym-vpn-core.yml
@@ -64,7 +64,7 @@ jobs:
       - build-nym-vpn-core-ios
       - build-nym-vpn-core-windows
       - generate-build-info-core
-    runs-on: ubuntu-22.04
+    runs-on: arc-ubuntu-24.04
     permissions:
       contents: write
     outputs:

--- a/.github/workflows/publish-nym-vpn-core.yml
+++ b/.github/workflows/publish-nym-vpn-core.yml
@@ -64,7 +64,7 @@ jobs:
       - build-nym-vpn-core-ios
       - build-nym-vpn-core-windows
       - generate-build-info-core
-    runs-on: arc-ubuntu-24.04
+    runs-on: arc-ubuntu-22.04
     permissions:
       contents: write
     outputs:


### PR DESCRIPTION
## Description

- As per suggestion from Lawrence, this PR migrates us from Github CI to self-hosted ARC instances.
- Minor auto-formatting performed by Zed
- Use the same rust version to build tauri apps as we use for the rest. It's all stable.
-  Switch to running cargo-deny directly instead of GitHub action that seems to require Docker
- Add missing `rsync` in some workflows

Note that `arc-ubuntu-24.04` don't seem to work, that's why we switch to `arc-ubuntu-22.04`

## Checklist:

- [x] Changelog

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3193)
<!-- Reviewable:end -->
