### PR TITLE
Avoid blocking service initialization

### DIFF
--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -390,7 +390,11 @@ impl NymVpnService<nym_vpn_lib::storage::VpnClientOnDiskStorage> {
             GatewayClient::new(gateway_config, parameters.user_agent.clone()).unwrap();
         let gateway_directory_client =
             CachingGatewayClient::new(gateway_directory_client, Some(connectivity_handle.clone()));
-        gateway_directory_client.refresh_all().await;
+
+        // todo: we must not block service initialization
+        shutdown_token
+            .run_until_cancelled(gateway_directory_client.refresh_all())
+            .await;
 
         let validator_client = nym_validator_client::NymApiClient::new_with_user_agent(
             api_url,


### PR DESCRIPTION
## Description

Currently if the daemon starts with a blocked network, the gateway refresh may hang the daemon preventing sigterm/ctrl+c from exiting the daemon.

The larger overhaul of this will be done separately. Obviously the gateway refresh must be moved into background


## Checklist:

- [x] Changelog

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3194)
<!-- Reviewable:end -->
