### PR TITLE
dependabot: disable src-tauri

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,16 +40,16 @@ updates:
           - "*"
         update-types:
           - "patch"
-  - package-ecosystem: cargo
-    directory: /nym-vpn-app/src-tauri
-    schedule:
-      interval: weekly
-    groups:
-      patch-updates:
-        patterns:
-          - "*"
-        update-types:
-          - "patch"
+  # - package-ecosystem: cargo
+  #   directory: /nym-vpn-app/src-tauri
+  #   schedule:
+  #     interval: weekly
+  #   groups:
+  #     patch-updates:
+  #       patterns:
+  #         - "*"
+  #       update-types:
+  #         - "patch"
   - package-ecosystem: npm
     directory: /nym-vpn-app
     schedule:


### PR DESCRIPTION


## Description

Disable src-tauri due to issues with dependabot updating different Cargo.lock files in the repo. Reported in https://github.com/dependabot/dependabot-core/issues/12766

## Checklist:

- [x] Changelog

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3208)
<!-- Reviewable:end -->
