### PR TITLE
Serialize IpPair to bytes

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/platform/uniffi_custom_impls.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/platform/uniffi_custom_impls.rs
@@ -106,16 +106,23 @@ uniffi::custom_type!(BoxedRecepient, String, {
 
 uniffi::custom_type!(
     IpPair,
-    String, {
+    Vec<u8>, {
         remote,
         try_lift: |val| {
-            Ok(
-                serde_json::from_str(&val).map_err(|e| VpnError::InternalError {
-                    details: e.to_string(),
-                })?,
-            )
+            let bytes: [u8; 20] = val.try_into().expect("Invalid length for IpPair byte representation");
+            let ipv4_bytes: [u8; 4] = bytes[0..4].try_into().unwrap();
+            let ipv6_bytes: [u8; 16] = bytes[4..20].try_into().unwrap();
+
+            Ok(IpPair {
+                ipv4: Ipv4Addr::from(ipv4_bytes),
+                ipv6: Ipv6Addr::from(ipv6_bytes)
+            })
         },
-        lower: |val| serde_json::to_string(&val).expect("Failed to serialize ip pair")
+        lower: |val| {
+            val.ipv4.octets().into_iter()
+                .chain(val.ipv6.octets().into_iter())
+                .collect()
+        }
     }
 );
 


### PR DESCRIPTION
## Description

Serialize `IpPair` as byte array instead of JSON.

## Checklist:

- [x] Changelog

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3211)
<!-- Reviewable:end -->
