### PR TITLE
Change tabs to spaces in Windows.mk.

### DIFF
--- a/nym-vpn-core/Windows.mk
+++ b/nym-vpn-core/Windows.mk
@@ -43,16 +43,18 @@ else
     CPU_ARCH ?= $(PROCESSOR_ARCHITECTURE)
 endif
 
-ifeq ($(CPU_ARCH),AMD64)
+CPU_ARCH_LOWER := $(shell "$(CPU_ARCH)".ToLower())
+
+ifeq ($(CPU_ARCH_LOWER),amd64)
     RUST_TARGET := x86_64
     WINFW_PLATFORM := x64
     MSVC_PLATFORM := x64
-else ifeq ($(CPU_ARCH),ARM64)
+else ifeq ($(CPU_ARCH_LOWER),arm64)
     RUST_TARGET := aarch64
     WINFW_PLATFORM := ARM64
     MSVC_PLATFORM := arm64
 else
-    $(error Unsupported CPU architecture: $(CPU_ARCH))
+    $(error Unsupported CPU architecture: $(CPU_ARCH_LOWER))
 endif
 
 ifeq ($(RELEASE),1)
@@ -81,7 +83,7 @@ default: wintun libwg winfw
 # Build libwg and copy it to build/lib
 libwg: create_target_dir
 	$(call setup_env_path) ; #\
-	if ("$(CPU_ARCH)" -eq "ARM64") { #\
+	if ("$(CPU_ARCH_LOWER)" -eq "arm64") { #\
 		$$wg_arm64_flag = "--arm64" ; #\
 		$$msystem = "clangarm64" ; #\
 	} else { #\
@@ -110,7 +112,7 @@ wintun: create_target_dir
 	Expand-Archive -Path $(TMP)/wintun.zip -DestinationPath "$(TMP)" -Force
 
 # Check digital signature of wintun dll
-	$$sig = Get-AuthenticodeSignature -FilePath "$(WINTUN_BIN_DIR)/$(CPU_ARCH)/$(WINTUN_DLL_NAME)"; #\
+	$$sig = Get-AuthenticodeSignature -FilePath "$(WINTUN_BIN_DIR)/$(CPU_ARCH_LOWER)/$(WINTUN_DLL_NAME)"; #\
 	$$fingerprint = $$sig.SignerCertificate.Thumbprint.ToUpper(); #\
 	#\
 	if ($$fingerprint -ne "$(WINTUN_FINGERPRINT)") { #\
@@ -121,7 +123,7 @@ wintun: create_target_dir
 	}
 	
 # Copy wintun dll to target directory
-	Copy-Item -Path "$(WINTUN_BIN_DIR)/$(CPU_ARCH)/$(WINTUN_DLL_NAME)" -Destination "$(TARGET_DIR)/$(WINTUN_DLL_NAME)" -Force -Verbose
+	Copy-Item -Path "$(WINTUN_BIN_DIR)/$(CPU_ARCH_LOWER)/$(WINTUN_DLL_NAME)" -Destination "$(TARGET_DIR)/$(WINTUN_DLL_NAME)" -Force -Verbose
 
 create_target_dir:
 	if (-not (Test-Path "$(TARGET_DIR)")) { #\

--- a/nym-vpn-core/Windows.mk
+++ b/nym-vpn-core/Windows.mk
@@ -43,18 +43,18 @@ else
     CPU_ARCH ?= $(PROCESSOR_ARCHITECTURE)
 endif
 
-CPU_ARCH_LOWER := $(shell "$(CPU_ARCH)".ToLower())
-
-ifeq ($(CPU_ARCH_LOWER),amd64)
+ifeq ($(CPU_ARCH),AMD64)
     RUST_TARGET := x86_64
     WINFW_PLATFORM := x64
     MSVC_PLATFORM := x64
-else ifeq ($(CPU_ARCH_LOWER),arm64)
+    CPU_ARCH_LOWER := amd64
+else ifeq ($(CPU_ARCH),ARM64)
     RUST_TARGET := aarch64
     WINFW_PLATFORM := ARM64
     MSVC_PLATFORM := arm64
+    CPU_ARCH_LOWER := arm64
 else
-    $(error Unsupported CPU architecture: $(CPU_ARCH_LOWER))
+    $(error Unsupported CPU architecture: $(CPU_ARCH))
 endif
 
 ifeq ($(RELEASE),1)

--- a/nym-vpn-core/Windows.mk
+++ b/nym-vpn-core/Windows.mk
@@ -13,9 +13,9 @@
 
 # Powershell on CI does not support the `Expand-Archive` cmdlet. Prefer pwsh instead.
 ifdef PWSH
-	SHELL := $(ProgramW6432)/PowerShell/7/pwsh.exe
+    SHELL := $(ProgramW6432)/PowerShell/7/pwsh.exe
 else
-	SHELL := $(windir)/System32/WindowsPowerShell/v1.0/powershell.exe
+    SHELL := $(windir)/System32/WindowsPowerShell/v1.0/powershell.exe
 endif
 
 WIUNTUN_URL := https://www.wintun.net/builds/wintun-0.14.1.zip
@@ -38,31 +38,31 @@ BUILDTOOLS_MSBUILD_PATH := $(BUILDTOOLS_DIR)/MSBuild/Current/Bin
 # Make on Windows is a 32-bit application
 # Use PROCESSOR_ARCHITEW6432 to get the native CPU architecture
 ifdef PROCESSOR_ARCHITEW6432
-	CPU_ARCH ?= $(PROCESSOR_ARCHITEW6432)
+    CPU_ARCH ?= $(PROCESSOR_ARCHITEW6432)
 else
-	CPU_ARCH ?= $(PROCESSOR_ARCHITECTURE)
+    CPU_ARCH ?= $(PROCESSOR_ARCHITECTURE)
 endif
 
 CPU_ARCH_LOWER := $(shell "$(CPU_ARCH)".ToLower())
 
 ifeq ($(CPU_ARCH_LOWER),amd64)
-	RUST_TARGET := x86_64
-	WINFW_PLATFORM := x64
-	MSVC_PLATFORM := x64
+    RUST_TARGET := x86_64
+    WINFW_PLATFORM := x64
+    MSVC_PLATFORM := x64
 else ifeq ($(CPU_ARCH_LOWER),arm64)
-	RUST_TARGET := aarch64
-	WINFW_PLATFORM := ARM64
-	MSVC_PLATFORM := arm64
+    RUST_TARGET := aarch64
+    WINFW_PLATFORM := ARM64
+    MSVC_PLATFORM := arm64
 else
-	$(error Unsupported CPU architecture: $(CPU_ARCH_LOWER))
+    $(error Unsupported CPU architecture: $(CPU_ARCH_LOWER))
 endif
 
 ifeq ($(RELEASE),1)
-	WINFW_PROFILE := Release
-	TARGET_DIR ?= $(CURDIR)/target/release
+    WINFW_PROFILE := Release
+    TARGET_DIR ?= $(CURDIR)/target/release
 else
-	WINFW_PROFILE := Debug
-	TARGET_DIR ?= $(CURDIR)/target/debug
+    WINFW_PROFILE := Debug
+    TARGET_DIR ?= $(CURDIR)/target/debug
 endif
 
 LIBWG_BUILD_DIR := $(CURDIR)/../build/lib/$(RUST_TARGET)-pc-windows-msvc

--- a/nym-vpn-core/Windows.mk
+++ b/nym-vpn-core/Windows.mk
@@ -43,18 +43,16 @@ else
     CPU_ARCH ?= $(PROCESSOR_ARCHITECTURE)
 endif
 
-CPU_ARCH_LOWER := $(shell "$(CPU_ARCH)".ToLower())
-
-ifeq ($(CPU_ARCH_LOWER),amd64)
+ifeq ($(CPU_ARCH),AMD64)
     RUST_TARGET := x86_64
     WINFW_PLATFORM := x64
     MSVC_PLATFORM := x64
-else ifeq ($(CPU_ARCH_LOWER),arm64)
+else ifeq ($(CPU_ARCH),ARM64)
     RUST_TARGET := aarch64
     WINFW_PLATFORM := ARM64
     MSVC_PLATFORM := arm64
 else
-    $(error Unsupported CPU architecture: $(CPU_ARCH_LOWER))
+    $(error Unsupported CPU architecture: $(CPU_ARCH))
 endif
 
 ifeq ($(RELEASE),1)
@@ -83,7 +81,7 @@ default: wintun libwg winfw
 # Build libwg and copy it to build/lib
 libwg: create_target_dir
 	$(call setup_env_path) ; #\
-	if ("$(CPU_ARCH_LOWER)" -eq "arm64") { #\
+	if ("$(CPU_ARCH)" -eq "ARM64") { #\
 		$$wg_arm64_flag = "--arm64" ; #\
 		$$msystem = "clangarm64" ; #\
 	} else { #\
@@ -112,7 +110,7 @@ wintun: create_target_dir
 	Expand-Archive -Path $(TMP)/wintun.zip -DestinationPath "$(TMP)" -Force
 
 # Check digital signature of wintun dll
-	$$sig = Get-AuthenticodeSignature -FilePath "$(WINTUN_BIN_DIR)/$(CPU_ARCH_LOWER)/$(WINTUN_DLL_NAME)"; #\
+	$$sig = Get-AuthenticodeSignature -FilePath "$(WINTUN_BIN_DIR)/$(CPU_ARCH)/$(WINTUN_DLL_NAME)"; #\
 	$$fingerprint = $$sig.SignerCertificate.Thumbprint.ToUpper(); #\
 	#\
 	if ($$fingerprint -ne "$(WINTUN_FINGERPRINT)") { #\
@@ -123,7 +121,7 @@ wintun: create_target_dir
 	}
 	
 # Copy wintun dll to target directory
-	Copy-Item -Path "$(WINTUN_BIN_DIR)/$(CPU_ARCH_LOWER)/$(WINTUN_DLL_NAME)" -Destination "$(TARGET_DIR)/$(WINTUN_DLL_NAME)" -Force -Verbose
+	Copy-Item -Path "$(WINTUN_BIN_DIR)/$(CPU_ARCH)/$(WINTUN_DLL_NAME)" -Destination "$(TARGET_DIR)/$(WINTUN_DLL_NAME)" -Force -Verbose
 
 create_target_dir:
 	if (-not (Test-Path "$(TARGET_DIR)")) { #\


### PR DESCRIPTION
## Description
Indented lines inside `ifeq` need to be spaces instead of tabs in order to avoid the error:

```
*** commands commence before first target.  Stop.
```

Also stop using `$(CPU_ARCH_LOWER)` as if the user has a PowerShell `Profile.ps1` then it will break.

## Checklist:

- [ ] Changelog

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3221)
<!-- Reviewable:end -->
