### PR TITLE
feat: added timeout for resolving hostnames

### DIFF
--- a/nym-vpn-core/crates/nym-gateway-directory/src/error.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/error.rs
@@ -30,6 +30,9 @@ pub enum Error {
     #[error("resolved hostname {0} but no IP address found")]
     ResolvedHostnameButNoIp(String),
 
+    #[error("timed out while attempting to resolve hostname: {hostname}")]
+    HostnameResolutionTimeout { hostname: String },
+
     #[error("failed to lookup described gateways")]
     FailedToLookupDescribedGateways(#[source] nym_validator_client::ValidatorClientError),
 

--- a/nym-vpn-core/crates/nym-gateway-directory/src/helpers.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/helpers.rs
@@ -2,22 +2,39 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use std::net::{IpAddr, SocketAddr};
+use std::time::Duration;
 
 use nym_common::trace_err_chain;
 use nym_http_api_client::HickoryDnsResolver;
 
 use crate::{Config, Error, error::Result, gateway_client::ResolvedConfig};
 
+// be generous with the resolution timeout
+const HOSTNAME_RESOLUTION_TIMEOUT: Duration = Duration::from_secs(10);
+
 async fn try_resolve_hostname(hostname: &str) -> Result<Vec<IpAddr>> {
     tracing::debug!("Trying to resolve hostname: {hostname}");
     let resolver = HickoryDnsResolver::default();
-    let addrs = resolver.resolve_str(hostname).await.map_err(|err| {
-        trace_err_chain!(err, "Failed to resolve gateway hostname");
-        Error::FailedToDnsResolveGateway {
-            hostname: hostname.to_string(),
-            source: err,
-        }
-    })?;
+
+    let addrs =
+        match tokio::time::timeout(HOSTNAME_RESOLUTION_TIMEOUT, resolver.resolve_str(hostname))
+            .await
+        {
+            Ok(Ok(addrs)) => addrs,
+            Ok(Err(err)) => {
+                trace_err_chain!(err, "Failed to resolve hostname");
+                return Err(Error::FailedToDnsResolveGateway {
+                    hostname: hostname.to_string(),
+                    source: err,
+                });
+            }
+            Err(_timeout) => {
+                return Err(Error::HostnameResolutionTimeout {
+                    hostname: hostname.to_string(),
+                });
+            }
+        };
+
     tracing::debug!("Resolved to: {addrs:?}");
 
     let ips = addrs.iter().collect::<Vec<_>>();


### PR DESCRIPTION
## Description

I've noticed that during reconnection client might get stuck in dns resolution for quite some time (in my instance it was attempting to lookup `rpc.nymtech.net`) thus blocking any progress. this PR introduces generous timeout of 10s to make sure we don't get stuck for too long.

JIRA-VPN-3382

## Checklist:

- [ ] Changelog

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3231)
<!-- Reviewable:end -->
