### PR TITLE
Account Controller : Better response for account and device id

### DIFF
--- a/nym-vpn-app/src-tauri/src/commands/account.rs
+++ b/nym-vpn-app/src-tauri/src/commands/account.rs
@@ -111,7 +111,7 @@ pub async fn get_account_id(grpc: State<'_, GrpcClient>) -> Result<Option<String
 
 #[instrument(skip_all)]
 #[tauri::command]
-pub async fn get_device_id(grpc: State<'_, GrpcClient>) -> Result<String, BackendError> {
+pub async fn get_device_id(grpc: State<'_, GrpcClient>) -> Result<Option<String>, BackendError> {
     grpc.device_id()
         .await
         .map_err(|e| {
@@ -119,6 +119,10 @@ pub async fn get_device_id(grpc: State<'_, GrpcClient>) -> Result<String, Backen
             e.into()
         })
         .inspect(|id| {
-            info!("device id: {id}");
+            if let Some(id) = id {
+                info!("device id: {id}");
+            } else {
+                info!("no device id");
+            }
         })
 }

--- a/nym-vpn-app/src-tauri/src/grpc/client.rs
+++ b/nym-vpn-app/src-tauri/src/grpc/client.rs
@@ -396,7 +396,7 @@ impl GrpcClient {
 
     /// Get the device identity
     #[instrument(skip_all)]
-    pub async fn device_id(&self) -> Result<String, VpndError> {
+    pub async fn device_id(&self) -> Result<Option<String>, VpndError> {
         let mut vpnd = self.vpnd().await?;
 
         let response = vpnd

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/command_sender.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/command_sender.rs
@@ -110,7 +110,7 @@ impl AccountCommandSender {
         rx.await.map_err(AccountCommandError::internal)?
     }
 
-    pub async fn get_device_identity(&self) -> Result<String, AccountCommandError> {
+    pub async fn get_device_identity(&self) -> Result<Option<String>, AccountCommandError> {
         let (tx, rx) = ReturnSender::new();
         self.command_tx
             .send(AccountCommand::Common(CommonCommand::GetDeviceIdentity(tx)))

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/common_handler.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/common_handler.rs
@@ -88,13 +88,11 @@ async fn handle_get_usage<C: ConnectivityMonitor>(
 
 pub(crate) fn handle_get_device_identity<C: ConnectivityMonitor>(
     shared_state: &SharedAccountState<C>,
-) -> Result<String, AccountCommandError> {
+) -> Result<Option<String>, AccountCommandError> {
     let device = shared_state
         .device
         .as_ref()
-        .ok_or(AccountCommandError::NoDeviceStored)?
-        .identity_key()
-        .to_string();
+        .map(|device| device.identity_key().to_string());
 
     tracing::debug!("Device identity: {device:?}");
     Ok(device)

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/dispatch.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/dispatch.rs
@@ -52,7 +52,7 @@ pub enum CommonCommand {
     GetAccountIdentity(ReturnSender<Option<String>, AccountCommandError>),
 
     /// Returns Some(id) if the current device has an identity (is registered), None otherwise
-    GetDeviceIdentity(ReturnSender<String, AccountCommandError>),
+    GetDeviceIdentity(ReturnSender<Option<String>, AccountCommandError>),
 
     /// Returns the state of the account
     GetUsage(ReturnSender<Vec<NymVpnUsage>, AccountCommandError>),

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/logged_out_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/logged_out_state.rs
@@ -75,11 +75,12 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for LoggedOutState
                     AccountCommand::Common(common_command) => {
                         match common_command {
                             CommonCommand::SetStaticApiAddresses(return_sender, socket_addrs) => return_sender.send(common_handler::handle_set_static_api_addresses(shared_state,socket_addrs)),
+
                             CommonCommand::GetAccountIdentity(return_sender) => return_sender.send(Ok(None)),
+                            CommonCommand::GetStoredMnemonic(return_sender) => return_sender.send(Ok(None)),
+                            CommonCommand::GetDeviceIdentity(return_sender) => return_sender.send(Ok(None)),
 
                             CommonCommand::GetUsage(return_sender) => return_no_account(return_sender),
-                            CommonCommand::GetStoredMnemonic(return_sender) => return_no_account(return_sender),
-                            CommonCommand::GetDeviceIdentity(return_sender) => return_no_account(return_sender),
                             CommonCommand::GetDevices(return_sender) => return_no_account(return_sender),
                             CommonCommand::GetActiveDevices(return_sender) => return_no_account(return_sender),
                             CommonCommand::GetAvailableTickets(return_sender) => return_no_account(return_sender),

--- a/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/commands.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/commands.rs
@@ -32,11 +32,11 @@ async fn logged_out_state_command() -> anyhow::Result<()> {
     assert_eq!(test_bench.command_sender.get_account_id().await, Ok(None));
     assert_eq!(
         test_bench.command_sender.get_stored_mnemonic().await,
-        Err(AccountCommandError::NoAccountStored)
+        Ok(None)
     );
     assert_eq!(
         test_bench.command_sender.get_device_identity().await,
-        Err(AccountCommandError::NoAccountStored)
+        Ok(None)
     );
 
     assert_eq!(
@@ -162,7 +162,7 @@ async fn offline_state_command() -> anyhow::Result<()> {
     );
     assert_eq!(
         test_bench.command_sender.get_device_identity().await,
-        Err(AccountCommandError::NoDeviceStored)
+        Ok(None)
     );
 
     // Offline, but storing an account

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/account.rs
@@ -250,7 +250,7 @@ pub(super) async fn get_stored_mnemonic() -> Result<String, VpnError> {
         .to_string())
 }
 
-pub(super) async fn get_device_id() -> Result<String, VpnError> {
+pub(super) async fn get_device_id() -> Result<Option<String>, VpnError> {
     get_command_sender()
         .await?
         .get_device_identity()

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/account.rs
@@ -250,12 +250,12 @@ pub(super) async fn get_stored_mnemonic() -> Result<String, VpnError> {
         .to_string())
 }
 
-pub(super) async fn get_device_id() -> Result<Option<String>, VpnError> {
+pub(super) async fn get_device_id() -> Result<String, VpnError> {
     get_command_sender()
         .await?
         .get_device_identity()
-        .await
-        .map_err(VpnError::from)
+        .await?
+        .ok_or(VpnError::NoAccountStored)
 }
 
 // Raw API that directly accesses storage without going through the account controller.

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/lib.rs
@@ -333,7 +333,7 @@ pub fn forgetAccountRaw(path: String) -> Result<(), VpnError> {
 /// Get the device identity
 #[allow(non_snake_case)]
 #[uniffi::export]
-pub fn getDeviceIdentity() -> Result<Option<String>, VpnError> {
+pub fn getDeviceIdentity() -> Result<String, VpnError> {
     RUNTIME.block_on(account::get_device_id())
 }
 

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/lib.rs
@@ -333,7 +333,7 @@ pub fn forgetAccountRaw(path: String) -> Result<(), VpnError> {
 /// Get the device identity
 #[allow(non_snake_case)]
 #[uniffi::export]
-pub fn getDeviceIdentity() -> Result<String, VpnError> {
+pub fn getDeviceIdentity() -> Result<Option<String>, VpnError> {
     RUNTIME.block_on(account::get_device_id())
 }
 

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -554,7 +554,7 @@ message ResetDeviceIdentityRequest {
 }
 
 message GetDeviceIdentityResponse {
-  string device_identity = 1;
+  optional string device_identity = 1;
 }
 
 message GetDevicesResponse {

--- a/nym-vpn-core/crates/nym-vpn-proto/src/rpc_client.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/rpc_client.rs
@@ -294,7 +294,7 @@ impl RpcClient {
         Ok(())
     }
 
-    pub async fn get_device_identity(&mut self) -> Result<String> {
+    pub async fn get_device_identity(&mut self) -> Result<Option<String>> {
         let response = self
             .0
             .get_device_identity(())

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -104,7 +104,10 @@ pub enum VpnServiceCommand {
         oneshot::Sender<Result<(), AccountCommandError>>,
         Option<Seed>,
     ),
-    GetDeviceIdentity(oneshot::Sender<Result<String, AccountCommandError>>, ()),
+    GetDeviceIdentity(
+        oneshot::Sender<Result<Option<String>, AccountCommandError>>,
+        (),
+    ),
     GetDevices(
         oneshot::Sender<Result<Vec<NymVpnDevice>, AccountCommandError>>,
         (),
@@ -1005,7 +1008,7 @@ impl NymVpnService {
         Ok(())
     }
 
-    async fn handle_get_device_identity(&self) -> Result<String, AccountCommandError> {
+    async fn handle_get_device_identity(&self) -> Result<Option<String>, AccountCommandError> {
         self.account_command_tx.get_device_identity().await
     }
 


### PR DESCRIPTION
## Description

This PR unifies the response of the `get_account_id`, `get_stored_mnemonic` and `get_device_id` commands after weird behaviours were spotted during the tests.

### Current behavior : 

|                            | `get_account_id` | `get_stored_mnemonic` | `get_device_id` |
|----------------|-------------------|--------------------------|------------------|
|LoggedOutState| `Ok(None)`          |  `Err(NoAccountStored)`| `Err(NoAccountStored)`|
|OfflineState, logged out | `Ok(None)`          |  `Ok(None)`| `Err(NoDeviceStored)`|
|OfflineState, logged in| `Ok(Some(...))`          |  `Ok(Some(...))`| `Ok(Some(...))`|

### Target behavior : 

|                            | `get_account_id` | `get_stored_mnemonic` | `get_device_id` |
|----------------|-------------------|--------------------------|------------------|
|LoggedOutState| `Ok(None)`          |  `Ok(None)`| `Ok(None)`|
|OfflineState, logged out | `Ok(None)`          |  `Ok(None)`| `Ok(None)`|
|OfflineState, logged in| `Ok(Some(...))`          |  `Ok(Some(...))`| `Ok(Some(...))`|



The reasoning behind this is that  it isn't exceptional that no account is present, so we shouldn't return an error. 
It also improve the CLI response avoiding the ugly grpc error when in truth, everything went well, there just wasn't anything to return 


### Note
This is a separate PR wrt to #3253 as this one does introduce slight behavior changes. I'll retarget it once that first one gets merged

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3262)
<!-- Reviewable:end -->
