### PR TITLE
ci: update cargo-deny license

### DIFF
--- a/nym-vpn-core/deny.toml
+++ b/nym-vpn-core/deny.toml
@@ -95,7 +95,7 @@ allow = [
     "BSD-3-Clause",
     "CC0-1.0",
     "CDLA-Permissive-2.0",
-    "GPL-3.0",
+    "GPL-3.0-only",
     "ISC",
     "MIT",
     "MPL-2.0",


### PR DESCRIPTION
## Ticket

JIRA-VPN-XXXX

## Description

`cargo-deny` v0.18.4 is pedantic about licenses. We need to switch from deprecated GPL-3.0 to GPL-3.0-only to keep it happy.


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3264)
<!-- Reviewable:end -->
