### PR TITLE
Enable network stats collection by default

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Upgrade nym to emmental (https://github.com/nymtech/nym-vpn-client/pull/3155)
+- Enable anonymous network statistics collection by default in the daemon, only for new installations (https://github.com/nymtech/nym-vpn-client/pull/3265)
 
 ### Fixed
 

--- a/nym-vpn-core/crates/nym-vpnd/src/config.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/config.rs
@@ -8,7 +8,7 @@ pub struct GlobalConfigFile {
     pub network_name: String,
     #[serde(default)]
     pub sentry_monitoring: bool,
-    #[serde(default)]
+    #[serde(default = "default_true")]
     pub collect_network_statistics: bool,
 }
 
@@ -17,7 +17,7 @@ impl Default for GlobalConfigFile {
         Self {
             network_name: NymNetworkDetails::default().network_name,
             sentry_monitoring: false,
-            collect_network_statistics: false,
+            collect_network_statistics: true,
         }
     }
 }
@@ -51,4 +51,8 @@ impl GlobalConfigFile {
             .ok()
             .is_some_and(|cfg| cfg.sentry_monitoring)
     }
+}
+
+fn default_true() -> bool {
+    true
 }


### PR DESCRIPTION
## Ticket

JIRA-VPN-3817

## Description

This PR enables anonymous network stats collection by default for new installations.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)
