### PR TITLE
Mark failure to resolve API hostnames recoverable

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgrade nym to emmental (https://github.com/nymtech/nym-vpn-client/pull/3155)
 - Enable anonymous network statistics collection by default in the daemon, only for new installations (https://github.com/nymtech/nym-vpn-client/pull/3265)
+- Reconnect on failure to resolve gateway addresses instead of entering error state (https://github.com/nymtech/nym-vpn-client/pull/3268)
 
 ### Fixed
 

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
@@ -157,9 +157,6 @@ pub enum ErrorStateReason {
     /// Failure to configure packet tunnel provider.
     TunnelProvider,
 
-    /// Failure to resolve API addresses.
-    ResolveGatewayAddrs,
-
     /// Failure to start local dns resolver.
     StartLocalDnsResolver,
 
@@ -239,7 +236,6 @@ impl From<ErrorStateReason> for ClientErrorReason {
             | ErrorStateReason::DuplicateTunFd => Self::Internal(Some(value.to_string())),
             ErrorStateReason::Internal(message) => Self::Internal(Some(message)),
             ErrorStateReason::Routing => Self::Routing,
-            ErrorStateReason::ResolveGatewayAddrs => Self::Dns(Some(value.to_string())),
             ErrorStateReason::StartLocalDnsResolver => Self::Dns(Some(value.to_string())),
             ErrorStateReason::SetDns => Self::Dns(Some(value.to_string())),
             ErrorStateReason::Ipv6Unavailable => Self::Ipv6Unavailable,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -597,8 +597,8 @@ pub enum Error {
     #[error("failed to apply firewall policy")]
     ApplyFirewallPolicy(#[source] nym_firewall::Error),
 
-    #[error("failed to resolve gateway addresses")]
-    ResolveGatewayAddrs(#[source] nym_gateway_directory::Error),
+    #[error("failed to resolve API hostnames")]
+    ResolveApiHostnames(#[source] nym_gateway_directory::Error),
 
     #[cfg(target_os = "macos")]
     #[error("failed to start local dns resolver")]
@@ -669,7 +669,7 @@ impl Error {
             Self::GetTunDeviceName(_) => ErrorStateReason::TunDevice,
             #[cfg(any(target_os = "ios", target_os = "android"))]
             Self::GetTunDeviceName(_) => ErrorStateReason::TunDevice,
-            Self::ResolveGatewayAddrs(_) => ErrorStateReason::ResolveGatewayAddrs,
+            Self::ResolveApiHostnames(_) => None?,
             #[cfg(target_os = "macos")]
             Self::StartLocalDnsResolver(_) => ErrorStateReason::StartLocalDnsResolver,
             #[cfg(windows)]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -3,6 +3,7 @@
 
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 use std::net::SocketAddr;
+use std::time::Duration;
 
 use futures::{
     FutureExt,
@@ -36,11 +37,21 @@ use crate::tunnel_state_machine::{
     },
 };
 
+/// Initial delay between retry attempts.
+const INITIAL_WAIT_DELAY: Duration = Duration::from_secs(2);
+
+/// Wait delay multiplier used for each subsequent retry attempt.
+const DELAY_MULTIPLIER: u32 = 2;
+
+/// Max wait delay between retry attempts.
+const MAX_WAIT_DELAY: Duration = Duration::from_secs(15);
+
 /// Default websocket port used as a fallback
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 const DEFAULT_WS_PORT: u16 = 80;
 
 type ResolveConfigFuture = BoxFuture<'static, Result<ResolvedConfig>>;
+type ReconnectDelayFuture = BoxFuture<'static, ()>;
 
 pub struct ConnectingState {
     retry_attempt: u32,
@@ -50,6 +61,7 @@ pub struct ConnectingState {
     selected_gateways: Option<SelectedGateways>,
     resolved_gateway_config: Option<ResolvedConfig>,
     resolve_config_fut: Fuse<ResolveConfigFuture>,
+    reconnect_delay_fut: Fuse<ReconnectDelayFuture>,
 }
 
 impl ConnectingState {
@@ -98,14 +110,14 @@ impl ConnectingState {
             }
         }
 
-        let gateway_config = shared_state.nym_config.gateway_config.clone();
-        let resolve_config_fut = async move {
-            nym_gateway_directory::resolve_config(&gateway_config)
-                .await
-                .map_err(Error::ResolveGatewayAddrs)
-        }
-        .boxed()
-        .fuse();
+        let resolve_config_fut = Fuse::terminated();
+        let reconnect_delay_fut = if retry_attempt > 0 {
+            let wait_delay = wait_delay(retry_attempt);
+            tracing::info!("Waiting {}s before reconnect", wait_delay.as_secs());
+            tokio::time::sleep(wait_delay).boxed().fuse()
+        } else {
+            std::future::ready(()).boxed().fuse()
+        };
 
         let (monitor_event_sender, monitor_event_receiver) = mpsc::unbounded_channel();
 
@@ -118,9 +130,10 @@ impl ConnectingState {
                 selected_gateways,
                 resolved_gateway_config: None,
                 resolve_config_fut,
+                reconnect_delay_fut,
             }),
             PrivateTunnelState::Connecting {
-                retry_attempt: 0,
+                retry_attempt,
                 connection_data: None,
             },
         )
@@ -282,13 +295,13 @@ impl ConnectingState {
                 resolved_gateway_config
             }
             Err(e) => {
+                let next_attempt = self.retry_attempt.saturating_add(1);
+                tracing::info!(
+                    "Failed to resolve gateway config: {e}. Reconnecting, attempt {next_attempt}."
+                );
                 return NextTunnelState::NewState(
-                    ErrorState::enter(
-                        e.error_state_reason()
-                            .expect("failed to map to error reason"),
-                        shared_state,
-                    )
-                    .await,
+                    ConnectingState::enter(next_attempt, self.selected_gateways, shared_state)
+                        .await,
                 );
             }
         };
@@ -363,7 +376,6 @@ impl ConnectingState {
             resolved_gateway_config: resolved_gateway_config.clone(),
             tunnel_settings: shared_state.tunnel_settings.clone(),
             selected_gateways: self.selected_gateways.clone(),
-            retry_attempt: self.retry_attempt,
         };
         let tunnel_monitor_handle = TunnelMonitor::start(
             tunnel_parameters,
@@ -457,114 +469,124 @@ impl TunnelStateHandler for ConnectingState {
         shared_state: &'async_trait mut SharedState,
     ) -> NextTunnelState {
         tokio::select! {
+            _ = &mut self.reconnect_delay_fut => {
+                let gateway_config = shared_state.nym_config.gateway_config.clone();
+
+                self.resolve_config_fut = async move {
+                    nym_gateway_directory::resolve_config(&gateway_config)
+                        .await
+                        .map_err(Error::ResolveApiHostnames)
+                }
+                .boxed()
+                .fuse();
+
+                NextTunnelState::SameState(self)
+            },
             resolved_gateway_config = &mut self.resolve_config_fut => {
                 self.handle_resolved_gateway_config(resolved_gateway_config, shared_state).await
             }
             Some(monitor_event) = self.tunnel_monitor_event_receiver.recv() => {
-            match monitor_event {
-                TunnelMonitorEvent::ReconnectCooldown { .. } => {
-                    NextTunnelState::SameState(self)
-                }
-                TunnelMonitorEvent::InitializingClient => {
-                    NextTunnelState::SameState(self)
-                }
-                TunnelMonitorEvent::SelectingGateways => {
-                    NextTunnelState::SameState(self)
-                }
-                TunnelMonitorEvent::SelectedGateways {
-                    gateways, reply_tx
-                } => {
-                   let next_state = match self.handle_selected_gateways(gateways, shared_state).await {
-                        Ok(()) => {
-                            NextTunnelState::SameState(self)
-                        }
-                        Err(e) => {
-                            if let Some(tunnel_monitor_handle) = self.tunnel_monitor_handle {
-                                NextTunnelState::NewState(DisconnectingState::enter(
-                                    // todo: fix that expect()
-                                    PrivateActionAfterDisconnect::Error(e.error_state_reason().expect("failed to obtain error state reason")),
-                                    tunnel_monitor_handle,
-                                    shared_state
-                                ))
-                            } else {
-                                NextTunnelState::NewState(ErrorState::enter(
-                                    // todo: fix that expect()
-                                    e.error_state_reason().expect("failed to obtain error state reason"),
-                                    shared_state
-                                ).await)
+                match monitor_event {
+                    TunnelMonitorEvent::InitializingClient => {
+                        NextTunnelState::SameState(self)
+                    }
+                    TunnelMonitorEvent::SelectingGateways => {
+                        NextTunnelState::SameState(self)
+                    }
+                    TunnelMonitorEvent::SelectedGateways {
+                        gateways, reply_tx
+                    } => {
+                    let next_state = match self.handle_selected_gateways(gateways, shared_state).await {
+                            Ok(()) => {
+                                NextTunnelState::SameState(self)
                             }
-                        }
-                    };
-                    _ = reply_tx.send(());
-                    next_state
-                }
-                TunnelMonitorEvent::InterfaceUp {
-                    tunnel_interface, connection_data, reply_tx
-                }  => {
-                    let next_state = match self.handle_interface_up(tunnel_interface, shared_state).await {
-                        Ok(()) => {
-                            let state = PrivateTunnelState::Connecting { retry_attempt: self.retry_attempt, connection_data: Some(*connection_data) };
-                            NextTunnelState::NewState((self, state))
-                        },
-                        Err(e) => {
-                            if let Some(tunnel_monitor_handle) = self.tunnel_monitor_handle {
-                                NextTunnelState::NewState(DisconnectingState::enter(
-                                    // todo: fix that expect()
-                                    PrivateActionAfterDisconnect::Error(e.error_state_reason().expect("failed to obtain error state reason")),
-                                    tunnel_monitor_handle,
-                                    shared_state
-                                ))
-                            } else {
-                                NextTunnelState::NewState(ErrorState::enter(
-                                    // todo: fix that expect()
-                                    e.error_state_reason().expect("failed to obtain error state reason"),
-                                    shared_state
-                                ).await)
+                            Err(e) => {
+                                if let Some(tunnel_monitor_handle) = self.tunnel_monitor_handle {
+                                    NextTunnelState::NewState(DisconnectingState::enter(
+                                        // todo: fix that expect()
+                                        PrivateActionAfterDisconnect::Error(e.error_state_reason().expect("failed to obtain error state reason")),
+                                        tunnel_monitor_handle,
+                                        shared_state
+                                    ))
+                                } else {
+                                    NextTunnelState::NewState(ErrorState::enter(
+                                        // todo: fix that expect()
+                                        e.error_state_reason().expect("failed to obtain error state reason"),
+                                        shared_state
+                                    ).await)
+                                }
                             }
-                        }
-                    };
-                    _ = reply_tx.send(());
-                    next_state
-                }
-                TunnelMonitorEvent::Up { tunnel_interface, connection_data } => {
-                    NextTunnelState::NewState(ConnectedState::enter(
-                        tunnel_interface,
-                        *connection_data,
-                        self.selected_gateways.expect("selected gateways must be set"),
-                        self.tunnel_monitor_handle.expect("monitor handle must be set!"),
-                        self.tunnel_monitor_event_receiver,
-                        shared_state,
-                    ).await)
-                }
-                TunnelMonitorEvent::Down { error_state_reason, reply_tx } => {
-                    // Signal that the message was received first.
-                    _ = reply_tx.send(());
-
-                    if let Some(error_state_reason) = error_state_reason {
-                        NextTunnelState::NewState(DisconnectingState::enter(
-                            PrivateActionAfterDisconnect::Error(error_state_reason),
+                        };
+                        _ = reply_tx.send(());
+                        next_state
+                    }
+                    TunnelMonitorEvent::InterfaceUp {
+                        tunnel_interface, connection_data, reply_tx
+                    }  => {
+                        let next_state = match self.handle_interface_up(tunnel_interface, shared_state).await {
+                            Ok(()) => {
+                                let state = PrivateTunnelState::Connecting { retry_attempt: self.retry_attempt, connection_data: Some(*connection_data) };
+                                NextTunnelState::NewState((self, state))
+                            },
+                            Err(e) => {
+                                if let Some(tunnel_monitor_handle) = self.tunnel_monitor_handle {
+                                    NextTunnelState::NewState(DisconnectingState::enter(
+                                        // todo: fix that expect()
+                                        PrivateActionAfterDisconnect::Error(e.error_state_reason().expect("failed to obtain error state reason")),
+                                        tunnel_monitor_handle,
+                                        shared_state
+                                    ))
+                                } else {
+                                    NextTunnelState::NewState(ErrorState::enter(
+                                        // todo: fix that expect()
+                                        e.error_state_reason().expect("failed to obtain error state reason"),
+                                        shared_state
+                                    ).await)
+                                }
+                            }
+                        };
+                        _ = reply_tx.send(());
+                        next_state
+                    }
+                    TunnelMonitorEvent::Up { tunnel_interface, connection_data } => {
+                        NextTunnelState::NewState(ConnectedState::enter(
+                            tunnel_interface,
+                            *connection_data,
+                            self.selected_gateways.expect("selected gateways must be set"),
                             self.tunnel_monitor_handle.expect("monitor handle must be set!"),
-                            shared_state
-                        ))
-                    } else {
-                        if let Some(tunnel_monitor_handle) = self.tunnel_monitor_handle {
-                            let tombstone = tunnel_monitor_handle.wait().await;
-                            Self::handle_tunnel_close(tombstone, shared_state).await;
-                        }
-
-                        let next_attempt = self.retry_attempt.saturating_add(1);
-                        tracing::info!(
-                            "Tunnel closed. Reconnecting, attempt {}.",
-                            next_attempt
-                        );
-                        NextTunnelState::NewState(ConnectingState::enter(
-                            next_attempt,
-                            self.selected_gateways,
-                            shared_state
+                            self.tunnel_monitor_event_receiver,
+                            shared_state,
                         ).await)
                     }
+                    TunnelMonitorEvent::Down { error_state_reason, reply_tx } => {
+                        // Signal that the message was received first.
+                        _ = reply_tx.send(());
+
+                        if let Some(error_state_reason) = error_state_reason {
+                            NextTunnelState::NewState(DisconnectingState::enter(
+                                PrivateActionAfterDisconnect::Error(error_state_reason),
+                                self.tunnel_monitor_handle.expect("monitor handle must be set!"),
+                                shared_state
+                            ))
+                        } else {
+                            if let Some(tunnel_monitor_handle) = self.tunnel_monitor_handle {
+                                let tombstone = tunnel_monitor_handle.wait().await;
+                                Self::handle_tunnel_close(tombstone, shared_state).await;
+                            }
+
+                            let next_attempt = self.retry_attempt.saturating_add(1);
+                            tracing::info!(
+                                "Tunnel closed. Reconnecting, attempt {}.",
+                                next_attempt
+                            );
+                            NextTunnelState::NewState(ConnectingState::enter(
+                                next_attempt,
+                                self.selected_gateways,
+                                shared_state
+                            ).await)
+                        }
+                    }
                 }
-            }
            }
             Some(command) = command_rx.recv() => {
                 match command {
@@ -626,4 +648,10 @@ impl TunnelStateHandler for ConnectingState {
             }
         }
     }
+}
+
+fn wait_delay(retry_attempt: u32) -> Duration {
+    let multiplier = retry_attempt.saturating_mul(DELAY_MULTIPLIER);
+    let delay = INITIAL_WAIT_DELAY.saturating_mul(multiplier);
+    std::cmp::min(delay, MAX_WAIT_DELAY)
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -16,12 +16,7 @@ use std::os::fd::BorrowedFd;
 use std::os::fd::{AsRawFd, IntoRawFd};
 #[cfg(target_os = "android")]
 use std::os::fd::{FromRawFd, OwnedFd};
-use std::{
-    cmp,
-    net::IpAddr,
-    path::PathBuf,
-    time::{Duration, Instant},
-};
+use std::{net::IpAddr, path::PathBuf, time::Duration};
 #[cfg(unix)]
 use std::{os::fd::RawFd, sync::Arc};
 
@@ -109,15 +104,6 @@ const WG_EXIT_WINTUN_GUID: &str = "{AFE43773-E1F8-4EBB-8536-176AB86AFE9C}";
 pub type TunnelMonitorEventSender = mpsc::UnboundedSender<TunnelMonitorEvent>;
 pub type TunnelMonitorEventReceiver = mpsc::UnboundedReceiver<TunnelMonitorEvent>;
 
-/// Initial delay between retry attempts.
-const INITIAL_WAIT_DELAY: Duration = Duration::from_secs(2);
-
-/// Wait delay multiplier used for each subsequent retry attempt.
-const DELAY_MULTIPLIER: u32 = 2;
-
-/// Max wait delay between retry attempts.
-const MAX_WAIT_DELAY: Duration = Duration::from_secs(15);
-
 /// Timeout when waiting for reply from the event handler.
 const REPLY_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -126,16 +112,6 @@ const TASK_MANAGER_SHUTDOWN_TIMEOUT_SECS: u64 = 10;
 
 #[derive(Debug)]
 pub enum TunnelMonitorEvent {
-    /// Awaiting a cooldown period before reconnecting
-    #[allow(dead_code)]
-    ReconnectCooldown {
-        /// Cooldown begin time
-        begin_time: Instant,
-
-        /// Cooldown duration
-        duration: Duration,
-    },
-
     /// Initializing mixnet client
     InitializingClient,
 
@@ -204,7 +180,6 @@ pub struct TunnelParameters {
     pub resolved_gateway_config: ResolvedConfig,
     pub tunnel_settings: TunnelSettings,
     pub selected_gateways: Option<SelectedGateways>,
-    pub retry_attempt: u32,
 }
 
 pub struct TunnelMonitor {
@@ -289,20 +264,6 @@ impl TunnelMonitor {
     }
 
     async fn run_inner(&mut self, task_manager: &mut TaskManager) -> Result<Tombstone> {
-        if self.tunnel_parameters.retry_attempt > 0 {
-            let delay = wait_delay(self.tunnel_parameters.retry_attempt);
-            tracing::debug!("Waiting for {}s before connecting.", delay.as_secs());
-            self.send_event(TunnelMonitorEvent::ReconnectCooldown {
-                begin_time: Instant::now(),
-                duration: delay,
-            });
-
-            self.shutdown_token
-                .run_until_cancelled(tokio::time::sleep(delay))
-                .await
-                .ok_or(Error::Tunnel(Box::new(tunnel::Error::Cancelled)))?;
-        }
-
         if self.enable_ipv6() && !ipv6_availability::is_ipv6_enabled_in_os().await {
             return Err(Error::Ipv6Unavailable);
         }
@@ -1373,12 +1334,6 @@ impl TunnelMonitor {
     fn enable_ipv6(&self) -> bool {
         self.tunnel_parameters.tunnel_settings.enable_ipv6
     }
-}
-
-fn wait_delay(retry_attempt: u32) -> Duration {
-    let multiplier = retry_attempt.saturating_mul(DELAY_MULTIPLIER);
-    let delay = INITIAL_WAIT_DELAY.saturating_mul(multiplier);
-    cmp::min(delay, MAX_WAIT_DELAY)
 }
 
 pub struct StartTunnelResult {


### PR DESCRIPTION
## Ticket

JIRA-VPN-3777

## Description

- Mark failure to resolve API hostnames recoverable making state machine enter a reconnect loop instead of error state
- Move reconnect delay from tunnel monitor to connecting state
- Rename `ResolveGatewayAddrs` to `ResolveApiHostnames`


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3268)
<!-- Reviewable:end -->
