### PR TITLE
fix(tauri): webview window quirks

### DIFF
--- a/nym-vpn-app/src-tauri/src/cli.rs
+++ b/nym-vpn-app/src-tauri/src/cli.rs
@@ -49,7 +49,7 @@ pub enum LogLevel {
     Error,
 }
 
-#[derive(Parser, Serialize, Deserialize, Debug, Clone)]
+#[derive(Parser, Serialize, Deserialize, Debug, Clone, Default)]
 #[command(author, version, about, long_about = None)]
 pub struct Cli {
     /// Print build information

--- a/nym-vpn-app/src-tauri/src/main.rs
+++ b/nym-vpn-app/src-tauri/src/main.rs
@@ -183,7 +183,7 @@ async fn main() -> Result<()> {
             app_window.set_bg_color(&db).ok();
             #[cfg(target_os = "linux")]
             app_window.set_max_size(os.display_server.clone()).ok();
-            #[cfg(windows)]
+            #[cfg(not(target_os = "linux"))]
             app_window.set_max_size().ok();
 
             let fs_config = {

--- a/nym-vpn-app/src-tauri/src/main.rs
+++ b/nym-vpn-app/src-tauri/src/main.rs
@@ -181,6 +181,9 @@ async fn main() -> Result<()> {
 
             let app_window = AppWindow::create_main_window(app.handle(), &cli)?;
             app_window.set_bg_color(&db).ok();
+            #[cfg(target_os = "linux")]
+            app_window.set_max_size(os.display_server.clone()).ok();
+            #[cfg(windows)]
             app_window.set_max_size().ok();
 
             let fs_config = {

--- a/nym-vpn-app/src-tauri/src/sys.rs
+++ b/nym-vpn-app/src-tauri/src/sys.rs
@@ -54,6 +54,7 @@ pub struct OsInfo {
     pub version: String,
     pub kernel: Option<String>,
     pub arch: String,
+    #[cfg(any(target_os = "linux", target_os = "openbsd"))]
     pub display_server: DisplayServer,
     #[cfg(any(target_os = "linux", target_os = "openbsd"))]
     pub gpu: GpuType,
@@ -68,6 +69,7 @@ impl OsInfo {
             version: system.os_version,
             kernel: Some(system.kernel_version),
             arch: system.arch,
+            #[cfg(any(target_os = "linux", target_os = "openbsd"))]
             display_server: get_display_server(),
             #[cfg(any(target_os = "linux", target_os = "openbsd"))]
             gpu: gpu_info(),
@@ -133,6 +135,7 @@ impl std::fmt::Display for OsInfo {
     }
 }
 
+#[cfg(any(target_os = "linux", target_os = "openbsd"))]
 impl Default for GpuType {
     fn default() -> Self {
         GpuType::Unknown(None)

--- a/nym-vpn-app/src-tauri/src/sys.rs
+++ b/nym-vpn-app/src-tauri/src/sys.rs
@@ -7,7 +7,7 @@ use tracing::{error, info, warn};
 use ts_rs::TS;
 
 #[cfg(any(target_os = "linux", target_os = "openbsd"))]
-#[derive(Debug, Clone, Default, Serialize, TS, strum::AsRefStr)]
+#[derive(Debug, Clone, Serialize, TS, strum::AsRefStr)]
 #[serde(rename_all = "kebab-case")]
 #[ts(export)]
 pub enum GpuType {
@@ -16,12 +16,11 @@ pub enum GpuType {
     #[strum(serialize = "AMD")]
     Amd,
     Intel,
-    #[default]
-    Unknown,
+    Unknown(Option<String>),
 }
 
 #[cfg(any(target_os = "linux", target_os = "openbsd"))]
-#[derive(Debug, Clone, Default, Serialize, TS, strum::AsRefStr)]
+#[derive(Debug, Clone, Default, Serialize, TS, strum::AsRefStr, Eq, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 #[ts(export)]
 pub enum DisplayServer {
@@ -55,7 +54,6 @@ pub struct OsInfo {
     pub version: String,
     pub kernel: Option<String>,
     pub arch: String,
-    #[cfg(any(target_os = "linux", target_os = "openbsd"))]
     pub display_server: DisplayServer,
     #[cfg(any(target_os = "linux", target_os = "openbsd"))]
     pub gpu: GpuType,
@@ -70,7 +68,6 @@ impl OsInfo {
             version: system.os_version,
             kernel: Some(system.kernel_version),
             arch: system.arch,
-            #[cfg(any(target_os = "linux", target_os = "openbsd"))]
             display_server: get_display_server(),
             #[cfg(any(target_os = "linux", target_os = "openbsd"))]
             gpu: gpu_info(),
@@ -98,11 +95,11 @@ fn gpu_info() -> GpuType {
     let Ok(output) = Command::new("lspci").arg("-nn").output().inspect_err(|e| {
         error!("failed to run lspci: {}", e);
     }) else {
-        return GpuType::Unknown;
+        return GpuType::Unknown(None);
     };
     if !output.status.success() {
         error!("lspci failed: {}", String::from_utf8_lossy(&output.stderr));
-        return GpuType::Unknown;
+        return GpuType::Unknown(None);
     }
     let output = String::from_utf8_lossy(&output.stdout);
     let Some(info) = output
@@ -110,7 +107,7 @@ fn gpu_info() -> GpuType {
         .find(|line| line.to_lowercase().contains("vga compatible controller"))
     else {
         warn!("no VGA device found in lspci output");
-        return GpuType::Unknown;
+        return GpuType::Unknown(None);
     };
     debug!("GPU info: {}", info);
     if info.to_lowercase().contains("nvidia") {
@@ -120,8 +117,8 @@ fn gpu_info() -> GpuType {
     } else if info.to_lowercase().contains("intel") {
         return GpuType::Intel;
     }
-    warn!("unknown GPU type: {}", info);
-    GpuType::Unknown
+    info!("unknown GPU type: {}", info);
+    GpuType::Unknown(Some(info.to_string()))
 }
 
 impl std::fmt::Display for OsInfo {
@@ -133,5 +130,11 @@ impl std::fmt::Display for OsInfo {
             self.kernel.as_deref().unwrap_or("unknown"),
             self.arch
         )
+    }
+}
+
+impl Default for GpuType {
+    fn default() -> Self {
+        GpuType::Unknown(None)
     }
 }

--- a/nym-vpn-app/src-tauri/src/tray.rs
+++ b/nym-vpn-app/src-tauri/src/tray.rs
@@ -98,9 +98,9 @@ pub fn setup(app: &AppHandle) -> Result<()> {
     Ok(())
 }
 
+#[instrument(skip(app))]
 fn show_window(app: &AppHandle, toggle: bool) -> Result<()> {
-    let window = AppWindow::get_or_create(app, MAIN_WINDOW_LABEL)
-        .inspect_err(|e| error!("failed to get main window {e}"))?;
+    let window = AppWindow::get_or_create(app, MAIN_WINDOW_LABEL)?;
     if !window.is_visible() {
         trace!("showing main window");
         window

--- a/nym-vpn-app/src-tauri/src/window.rs
+++ b/nym-vpn-app/src-tauri/src/window.rs
@@ -16,7 +16,7 @@ use tauri::{
     AppHandle, LogicalPosition, LogicalSize, Manager, PhysicalPosition, PhysicalSize, Theme,
     WebviewUrl, WebviewWindow, WebviewWindowBuilder,
 };
-use tracing::{debug, error, info, instrument, trace, warn};
+use tracing::{debug, error, instrument, trace, warn};
 use ts_rs::TS;
 
 const MAIN_WEBVIEW_URL: &str = "index.html";
@@ -164,18 +164,18 @@ impl AppWindow {
             error!("failed to get current monitor: {e}");
         })?
         else {
-            if cfg!(target_os = "linux") {
+            #[cfg(target_os = "linux")]
+            {
                 // On Wayland it is expected failing to detected monitor info
                 // especially when the window is not yet visible
                 if display_server == DisplayServer::Wayland {
-                    info!("failed to get current monitor details");
+                    tracing::info!("failed to get current monitor details");
                 } else {
                     warn!("failed to get current monitor details");
                 }
-            } else {
-                warn!("failed to get current monitor details");
             }
-
+            #[cfg(not(target_os = "linux"))]
+            warn!("failed to get current monitor details");
             return Ok(());
         };
         // in case of monitor > 1440p, increase the max allowed window size

--- a/nym-vpn-app/src-tauri/src/window.rs
+++ b/nym-vpn-app/src-tauri/src/window.rs
@@ -103,28 +103,24 @@ impl AppWindow {
         Ok(())
     }
 
-    #[instrument(skip(app))]
-    pub fn get(app: &AppHandle, label: &str) -> Result<Self> {
-        Ok(AppWindow(app.get_webview_window(label).ok_or_else(
-            || {
-                error!("failed to get window {}", label);
-                anyhow!("failed to get window {}", label)
-            },
-        )?))
-    }
-
-    /// try to get the window, if not found recreate it from its config
+    /// try to get the window, if not found create it from its config
     #[instrument(skip(app))]
     pub fn get_or_create(app: &AppHandle, label: &str) -> Result<Self> {
-        let cli = app.state::<Cli>();
+        let cli = app
+            .try_state::<Cli>()
+            .map(|s| s.inner().clone())
+            .unwrap_or_default();
         let window = app
             .get_webview_window(label)
             .map(AppWindow)
             .or_else(|| {
-                debug!("main window not found, re-creating it");
+                debug!("main window not found, creating it");
                 AppWindow::create_main_window(app, &cli).ok()
             })
-            .ok_or_else(|| anyhow!("failed to get window {}", label))?;
+            .ok_or_else(|| {
+                error!("failed to get window {label}");
+                anyhow!("failed to get window {}", label)
+            })?;
         Ok(window)
     }
 
@@ -268,10 +264,8 @@ impl From<&PhysicalPosition<i32>> for WindowPosition {
 
 #[instrument(skip_all)]
 pub fn focus_main_window(app: &AppHandle) {
-    if let Ok(win) = AppWindow::get(app, MAIN_WINDOW_LABEL) {
+    if let Ok(win) = AppWindow::get_or_create(app, MAIN_WINDOW_LABEL) {
         win.wake_up();
-    } else {
-        error!("failed to get window {}", MAIN_WINDOW_LABEL);
     }
 }
 

--- a/nym-vpn-app/src-tauri/src/window.rs
+++ b/nym-vpn-app/src-tauri/src/window.rs
@@ -3,6 +3,7 @@ use crate::db::{Db, Key};
 use crate::env::{DEV_MODE, UPDATER_ENABLED};
 use crate::startup_error::StartupError;
 use crate::state::app::VpnMode;
+#[cfg(target_os = "linux")]
 use crate::sys::DisplayServer;
 use crate::{
     APP_NAME, DEFAULT_NETSTATS_ENABLED, DEFAULT_SENTRY_ENABLED, ENV_APP_NOSPLASH,
@@ -163,10 +164,14 @@ impl AppWindow {
             error!("failed to get current monitor: {e}");
         })?
         else {
-            // On Wayland it is expected failing to detected monitor info
-            // especially when the window is not yet visible
-            if display_server == DisplayServer::Wayland {
-                info!("failed to get current monitor details");
+            if cfg!(target_os = "linux") {
+                // On Wayland it is expected failing to detected monitor info
+                // especially when the window is not yet visible
+                if display_server == DisplayServer::Wayland {
+                    info!("failed to get current monitor details");
+                } else {
+                    warn!("failed to get current monitor details");
+                }
             } else {
                 warn!("failed to get current monitor details");
             }

--- a/nym-vpn-app/src-tauri/src/window.rs
+++ b/nym-vpn-app/src-tauri/src/window.rs
@@ -3,6 +3,7 @@ use crate::db::{Db, Key};
 use crate::env::{DEV_MODE, UPDATER_ENABLED};
 use crate::startup_error::StartupError;
 use crate::state::app::VpnMode;
+use crate::sys::DisplayServer;
 use crate::{
     APP_NAME, DEFAULT_NETSTATS_ENABLED, DEFAULT_SENTRY_ENABLED, ENV_APP_NOSPLASH,
     MAIN_WINDOW_LABEL, env,
@@ -14,7 +15,7 @@ use tauri::{
     AppHandle, LogicalPosition, LogicalSize, Manager, PhysicalPosition, PhysicalSize, Theme,
     WebviewUrl, WebviewWindow, WebviewWindowBuilder,
 };
-use tracing::{debug, error, instrument, trace, warn};
+use tracing::{debug, error, info, instrument, trace, warn};
 use ts_rs::TS;
 
 const MAIN_WEBVIEW_URL: &str = "index.html";
@@ -154,12 +155,22 @@ impl AppWindow {
     }
 
     #[instrument(skip_all)]
-    pub fn set_max_size(&self) -> Result<()> {
+    pub fn set_max_size(
+        &self,
+        #[cfg(target_os = "linux")] display_server: DisplayServer,
+    ) -> Result<()> {
         let Some(monitor) = self.0.current_monitor().inspect_err(|e| {
             error!("failed to get current monitor: {e}");
         })?
         else {
-            warn!("failed to get current monitor details");
+            // On Wayland it is expected failing to detected monitor info
+            // especially when the window is not yet visible
+            if display_server == DisplayServer::Wayland {
+                info!("failed to get current monitor details");
+            } else {
+                warn!("failed to get current monitor details");
+            }
+
             return Ok(());
         };
         // in case of monitor > 1440p, increase the max allowed window size


### PR DESCRIPTION
- create a fresh webview window when there is logic trying to get it but for some reason there is no app window yet
this should fix some situations where the client tries to get the app window, and it just fails without any fallback
- reduce some logs noise when tauri fails to get current monitor info on Wayland, as it seems to be “expected” for this particular display server

JIRA-VPN-3805

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3271)
<!-- Reviewable:end -->
