### PR TITLE
[bugfix] VPN-3825 account controller and firewall

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/command_sender.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/command_sender.rs
@@ -157,18 +157,18 @@ impl AccountCommandSender {
         rx.await.map_err(AccountCommandError::internal)?
     }
 
-    pub async fn set_firewall_up(&self) -> Result<(), AccountCommandError> {
+    pub async fn set_vpn_api_firewall_up(&self) -> Result<(), AccountCommandError> {
         let (tx, rx) = ReturnSender::new();
         self.command_tx
-            .send(AccountCommand::FirewallUp(tx))
+            .send(AccountCommand::VpnApiFirewallUp(tx))
             .map_err(AccountCommandError::internal)?;
         rx.await.map_err(AccountCommandError::internal)?
     }
 
-    pub async fn set_firewall_down(&self) -> Result<(), AccountCommandError> {
+    pub async fn set_vpn_api_firewall_down(&self) -> Result<(), AccountCommandError> {
         let (tx, rx) = ReturnSender::new();
         self.command_tx
-            .send(AccountCommand::FirewallDown(tx))
+            .send(AccountCommand::VpnApiFirewallDown(tx))
             .map_err(AccountCommandError::internal)?;
         rx.await.map_err(AccountCommandError::internal)?
     }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/command_sender.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/command_sender.rs
@@ -156,4 +156,20 @@ impl AccountCommandSender {
             .map_err(AccountCommandError::internal)?;
         rx.await.map_err(AccountCommandError::internal)?
     }
+
+    pub async fn set_firewall_up(&self) -> Result<(), AccountCommandError> {
+        let (tx, rx) = ReturnSender::new();
+        self.command_tx
+            .send(AccountCommand::FirewallUp(tx))
+            .map_err(AccountCommandError::internal)?;
+        rx.await.map_err(AccountCommandError::internal)?
+    }
+
+    pub async fn set_firewall_down(&self) -> Result<(), AccountCommandError> {
+        let (tx, rx) = ReturnSender::new();
+        self.command_tx
+            .send(AccountCommand::FirewallDown(tx))
+            .map_err(AccountCommandError::internal)?;
+        rx.await.map_err(AccountCommandError::internal)?
+    }
 }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/dispatch.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/dispatch.rs
@@ -38,6 +38,12 @@ pub enum AccountCommand {
     /// Forces the AC to sync with the VPN API
     RefreshAccountState(ReturnSender<(), AccountCommandError>),
 
+    /// Tells the AC it's firewalled off the VPN API, so it should stop/pause network communication
+    FirewallUp(ReturnSender<(), AccountCommandError>),
+
+    /// Tells the AC free to go ahead
+    FirewallDown(ReturnSender<(), AccountCommandError>),
+
     /// Read-only commands
     Common(CommonCommand),
 }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/dispatch.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/dispatch.rs
@@ -39,10 +39,10 @@ pub enum AccountCommand {
     RefreshAccountState(ReturnSender<(), AccountCommandError>),
 
     /// Tells the AC it's firewalled off the VPN API, so it should stop/pause network communication
-    FirewallUp(ReturnSender<(), AccountCommandError>),
+    VpnApiFirewallUp(ReturnSender<(), AccountCommandError>),
 
     /// Tells the AC free to go ahead
-    FirewallDown(ReturnSender<(), AccountCommandError>),
+    VpnApiFirewallDown(ReturnSender<(), AccountCommandError>),
 
     /// Read-only commands
     Common(CommonCommand),

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/shared_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/shared_state.rs
@@ -34,6 +34,9 @@ pub(crate) struct SharedAccountState<C: ConnectivityMonitor> {
     /// Registered device
     pub(crate) device: Option<Device>,
 
+    /// Firewall status
+    pub(crate) firewall_active: bool,
+
     /// Channel to send storage operation to the AccountController
     pub(crate) storage_op_sender: mpsc::UnboundedSender<AccountStorageOp>,
 }
@@ -55,6 +58,7 @@ impl<C: ConnectivityMonitor> SharedAccountState<C> {
             vpn_api_client,
             vpn_api_account,
             device,
+            firewall_active: false,
             storage_op_sender,
         }
     }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/error_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/error_state.rs
@@ -103,11 +103,11 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ErrorState {
                         }
                     },
 
-                    AccountCommand::FirewallDown(return_sender) =>  {
+                    AccountCommand::VpnApiFirewallDown(return_sender) =>  {
                         shared_state.firewall_active = false;
                         return_sender.send(Ok(()));
                     },
-                    AccountCommand::FirewallUp(return_sender) => {
+                    AccountCommand::VpnApiFirewallUp(return_sender) => {
                         shared_state.firewall_active = true;
                         return_sender.send(Ok(()));
                     },

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/error_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/error_state.rs
@@ -30,6 +30,7 @@ use crate::{
 /// - LoggedOutState : We successfully handled a forget_account command
 pub struct ErrorState {
     refresh_timer: Pin<Box<Sleep>>,
+    reason: AccountControllerErrorStateReason,
 }
 
 impl ErrorState {
@@ -42,7 +43,10 @@ impl ErrorState {
         let refresh_timer = Box::pin(tokio::time::sleep(ACCOUNT_UPDATE_INTERVAL));
         tracing::error!("Account Controller entering error state : {reason:#?}");
         (
-            Box::new(Self { refresh_timer }),
+            Box::new(Self {
+                refresh_timer,
+                reason: reason.clone(),
+            }),
             PrivateAccountControllerState::Error(reason),
         )
     }
@@ -58,7 +62,12 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ErrorState {
     ) -> NextAccountControllerState<C> {
         tokio::select! {
         _ = &mut self.refresh_timer => {
-                NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0))
+                if shared_state.firewall_active {
+                    tracing::debug!("VPN API is firewalled, timed account syncing skipped");
+                    return NextAccountControllerState::NewState(ErrorState::enter(self.reason));
+                } else {
+                    return NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0));
+                }
             },
             Some(command) = command_rx.recv() => {
                 match command {
@@ -87,7 +96,20 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ErrorState {
                     },
                     AccountCommand::RefreshAccountState(return_sender) => {
                         return_sender.send(Ok(()));
-                        return NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0));
+                        if shared_state.firewall_active {
+                            return NextAccountControllerState::SameState(self);
+                        } else {
+                            return NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0));
+                        }
+                    },
+
+                    AccountCommand::FirewallDown(return_sender) =>  {
+                        shared_state.firewall_active = false;
+                        return_sender.send(Ok(()));
+                    },
+                    AccountCommand::FirewallUp(return_sender) => {
+                        shared_state.firewall_active = true;
+                        return_sender.send(Ok(()));
                     },
 
                     AccountCommand::Common(common_command) => {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/logged_out_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/logged_out_state.rs
@@ -72,11 +72,11 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for LoggedOutState
                     AccountCommand::RegisterAccount(return_sender, _, _) => return_no_account(return_sender),
                     AccountCommand::RefreshAccountState(return_sender) => return_no_account(return_sender),
 
-                    AccountCommand::FirewallDown(return_sender) =>  {
+                    AccountCommand::VpnApiFirewallDown(return_sender) =>  {
                         shared_state.firewall_active = false;
                         return_sender.send(Ok(()));
                     },
-                    AccountCommand::FirewallUp(return_sender) => {
+                    AccountCommand::VpnApiFirewallUp(return_sender) => {
                         shared_state.firewall_active = true;
                         return_sender.send(Ok(()));
                     },

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/logged_out_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/logged_out_state.rs
@@ -72,6 +72,15 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for LoggedOutState
                     AccountCommand::RegisterAccount(return_sender, _, _) => return_no_account(return_sender),
                     AccountCommand::RefreshAccountState(return_sender) => return_no_account(return_sender),
 
+                    AccountCommand::FirewallDown(return_sender) =>  {
+                        shared_state.firewall_active = false;
+                        return_sender.send(Ok(()));
+                    },
+                    AccountCommand::FirewallUp(return_sender) => {
+                        shared_state.firewall_active = true;
+                        return_sender.send(Ok(()));
+                    },
+
                     AccountCommand::Common(common_command) => {
                         match common_command {
                             CommonCommand::SetStaticApiAddresses(return_sender, socket_addrs) => return_sender.send(common_handler::handle_set_static_api_addresses(shared_state,socket_addrs)),

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/offline_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/offline_state.rs
@@ -66,11 +66,11 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for OfflineState {
 
                     AccountCommand::RefreshAccountState(return_sender) => return_no_connectivity(return_sender),
 
-                    AccountCommand::FirewallDown(return_sender) =>  {
+                    AccountCommand::VpnApiFirewallDown(return_sender) =>  {
                         shared_state.firewall_active = false;
                         return_sender.send(Ok(()));
                     },
-                    AccountCommand::FirewallUp(return_sender) => {
+                    AccountCommand::VpnApiFirewallUp(return_sender) => {
                         shared_state.firewall_active = true;
                         return_sender.send(Ok(()));
                     },

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/offline_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/offline_state.rs
@@ -66,6 +66,15 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for OfflineState {
 
                     AccountCommand::RefreshAccountState(return_sender) => return_no_connectivity(return_sender),
 
+                    AccountCommand::FirewallDown(return_sender) =>  {
+                        shared_state.firewall_active = false;
+                        return_sender.send(Ok(()));
+                    },
+                    AccountCommand::FirewallUp(return_sender) => {
+                        shared_state.firewall_active = true;
+                        return_sender.send(Ok(()));
+                    },
+
 
                     AccountCommand::Common(common_command) => {
                         match common_command {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/ready_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/ready_state.rs
@@ -96,11 +96,11 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ReadyState {
                         }
                     },
 
-                    AccountCommand::FirewallDown(return_sender) =>  {
+                    AccountCommand::VpnApiFirewallDown(return_sender) =>  {
                         shared_state.firewall_active = false;
                         return_sender.send(Ok(()));
                     },
-                    AccountCommand::FirewallUp(return_sender) => {
+                    AccountCommand::VpnApiFirewallUp(return_sender) => {
                         shared_state.firewall_active = true;
                         return_sender.send(Ok(()));
                     },

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/ready_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/ready_state.rs
@@ -56,7 +56,12 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ReadyState {
     ) -> NextAccountControllerState<C> {
         tokio::select! {
             _ = &mut self.refresh_timer => {
-                NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0))
+                if shared_state.firewall_active {
+                    tracing::debug!("VPN API is firewalled, timed account syncing skipped");
+                    return NextAccountControllerState::NewState(ReadyState::enter());
+                } else {
+                    return NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0));
+                }
             },
             Some(command) = command_rx.recv() => {
                 match command {
@@ -84,7 +89,20 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ReadyState {
                     },
                     AccountCommand::RefreshAccountState(return_sender) => {
                         return_sender.send(Ok(()));
-                        return NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0));
+                        if shared_state.firewall_active {
+                            return NextAccountControllerState::SameState(self);
+                        } else {
+                            return NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0));
+                        }
+                    },
+
+                    AccountCommand::FirewallDown(return_sender) =>  {
+                        shared_state.firewall_active = false;
+                        return_sender.send(Ok(()));
+                    },
+                    AccountCommand::FirewallUp(return_sender) => {
+                        shared_state.firewall_active = true;
+                        return_sender.send(Ok(()));
                     },
 
                     AccountCommand::Common(common_command) => common_handler::handle_common_command(common_command, shared_state).await,

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
@@ -256,13 +256,13 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingState {
                         return NextAccountControllerState::NewState(SyncingState::enter(shared_state,0));
                     },
 
-                    AccountCommand::FirewallDown(return_sender) =>  {
+                    AccountCommand::VpnApiFirewallDown(return_sender) =>  {
                         shared_state.firewall_active = false;
                         return_sender.send(Ok(()));
                         return NextAccountControllerState::NewState(SyncingState::enter(shared_state, self.attempts));
                     },
 
-                    AccountCommand::FirewallUp(return_sender) => {
+                    AccountCommand::VpnApiFirewallUp(return_sender) => {
                         shared_state.firewall_active = true;
                         self.syncing_state_handle.abort();
                         return_sender.send(Ok(()));

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
@@ -242,15 +242,32 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingState {
                         }
                     },
                     AccountCommand::RefreshAccountState(return_sender) => {
-                        self.syncing_state_handle.abort();
                         return_sender.send(Ok(()));
-                        return NextAccountControllerState::NewState(SyncingState::enter(shared_state,0));
+                        if shared_state.firewall_active {
+                            return NextAccountControllerState::SameState(self);
+                        } else {
+                            self.syncing_state_handle.abort();
+                            return NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0));
+                        }
                     },
                     AccountCommand::ResetDeviceIdentity(return_sender, seed) => {
                         return_sender.send(handler::handle_reset_device_identity(shared_state, seed).await);
                         self.syncing_state_handle.abort();
                         return NextAccountControllerState::NewState(SyncingState::enter(shared_state,0));
                     },
+
+                    AccountCommand::FirewallDown(return_sender) =>  {
+                        shared_state.firewall_active = false;
+                        return_sender.send(Ok(()));
+                        return NextAccountControllerState::NewState(SyncingState::enter(shared_state, self.attempts));
+                    },
+
+                    AccountCommand::FirewallUp(return_sender) => {
+                        shared_state.firewall_active = true;
+                        self.syncing_state_handle.abort();
+                        return_sender.send(Ok(()));
+                    },
+
                     AccountCommand::Common(common_command) => {
                         common_handler::handle_common_command(common_command, shared_state).await
                     },

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/requesting_zknym_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/requesting_zknym_state.rs
@@ -242,9 +242,25 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for RequestingZkNy
                         return NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0));
                     },
                     AccountCommand::RefreshAccountState(return_sender) => {
+                        return_sender.send(Ok(()));
+                        if shared_state.firewall_active {
+                            return NextAccountControllerState::SameState(self);
+                        } else {
+                            self.zk_nym_fetching_handle.abort();
+                            return NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0));
+                        }
+                    },
+
+                    AccountCommand::FirewallDown(return_sender) =>  {
+                        shared_state.firewall_active = false;
+                        return_sender.send(Ok(()));
+                        return NextAccountControllerState::NewState(RequestingZkNymsState::enter(shared_state, self.attempts, self.fair_usage_left));
+                    },
+
+                    AccountCommand::FirewallUp(return_sender) => {
+                        shared_state.firewall_active = true;
                         self.zk_nym_fetching_handle.abort();
                         return_sender.send(Ok(()));
-                        return NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0));
                     },
                     AccountCommand::Common(common_command) => {
                         common_handler::handle_common_command(common_command, shared_state).await

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/requesting_zknym_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/requesting_zknym_state.rs
@@ -251,13 +251,13 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for RequestingZkNy
                         }
                     },
 
-                    AccountCommand::FirewallDown(return_sender) =>  {
+                    AccountCommand::VpnApiFirewallDown(return_sender) =>  {
                         shared_state.firewall_active = false;
                         return_sender.send(Ok(()));
                         return NextAccountControllerState::NewState(RequestingZkNymsState::enter(shared_state, self.attempts, self.fair_usage_left));
                     },
 
-                    AccountCommand::FirewallUp(return_sender) => {
+                    AccountCommand::VpnApiFirewallUp(return_sender) => {
                         shared_state.firewall_active = true;
                         self.zk_nym_fetching_handle.abort();
                         return_sender.send(Ok(()));

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -111,7 +111,10 @@ impl ConnectingState {
         }
 
         // If that fails, it's not really important
-        let _ = shared_state.account_command_tx.set_firewall_up().await;
+        let _ = shared_state
+            .account_command_tx
+            .set_vpn_api_firewall_up()
+            .await;
 
         let resolve_config_fut = Fuse::terminated();
         let reconnect_delay_fut = if retry_attempt > 0 {
@@ -334,8 +337,6 @@ impl ConnectingState {
             }
         }
 
-        let _ = shared_state.account_command_tx.set_firewall_down().await;
-
         if resolved_gateway_config.nym_vpn_api_socket_addrs.is_none()
             || resolved_gateway_config
                 .nym_vpn_api_socket_addrs
@@ -361,6 +362,11 @@ impl ConnectingState {
                 .await,
             );
         }
+
+        let _ = shared_state
+            .account_command_tx
+            .set_vpn_api_firewall_down()
+            .await;
 
         let Some(tunnel_monitor_event_sender) = self.tunnel_monitor_event_sender.take() else {
             return NextTunnelState::NewState(

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -110,6 +110,9 @@ impl ConnectingState {
             }
         }
 
+        // If that fails, it's not really important
+        let _ = shared_state.account_command_tx.set_firewall_up().await;
+
         let resolve_config_fut = Fuse::terminated();
         let reconnect_delay_fut = if retry_attempt > 0 {
             let wait_delay = wait_delay(retry_attempt);
@@ -330,6 +333,8 @@ impl ConnectingState {
                 );
             }
         }
+
+        let _ = shared_state.account_command_tx.set_firewall_down().await;
 
         if resolved_gateway_config.nym_vpn_api_socket_addrs.is_none()
             || resolved_gateway_config

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnected_state.rs
@@ -25,7 +25,10 @@ impl DisconnectedState {
         #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
         Self::reset_firewall_policy(shared_state);
 
-        let _ = shared_state.account_command_tx.set_vpn_api_firewall_down().await;
+        let _ = shared_state
+            .account_command_tx
+            .set_vpn_api_firewall_down()
+            .await;
 
         if let Err(e) = shared_state
             .account_command_tx

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnected_state.rs
@@ -25,6 +25,8 @@ impl DisconnectedState {
         #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
         Self::reset_firewall_policy(shared_state);
 
+        let _ = shared_state.account_command_tx.set_firewall_down().await;
+
         if let Err(e) = shared_state
             .account_command_tx
             .set_static_api_addresses(None)

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnected_state.rs
@@ -25,7 +25,7 @@ impl DisconnectedState {
         #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
         Self::reset_firewall_policy(shared_state);
 
-        let _ = shared_state.account_command_tx.set_firewall_down().await;
+        let _ = shared_state.account_command_tx.set_vpn_api_firewall_down().await;
 
         if let Err(e) = shared_state
             .account_command_tx

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
@@ -71,7 +71,7 @@ impl ErrorState {
         if let Err(e) = Self::set_firewall_policy(_shared_state) {
             trace_err_chain!(e, "Failed to apply firewall policy for blocked state");
         }
-
+        let _ = _shared_state.account_command_tx.set_firewall_up().await;
         (Box::new(Self), PrivateTunnelState::Error(reason))
     }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
@@ -71,7 +71,10 @@ impl ErrorState {
         if let Err(e) = Self::set_firewall_policy(_shared_state) {
             trace_err_chain!(e, "Failed to apply firewall policy for blocked state");
         }
-        let _ = _shared_state.account_command_tx.set_vpn_api_firewall_up().await;
+        let _ = _shared_state
+            .account_command_tx
+            .set_vpn_api_firewall_up()
+            .await;
         (Box::new(Self), PrivateTunnelState::Error(reason))
     }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
@@ -71,7 +71,7 @@ impl ErrorState {
         if let Err(e) = Self::set_firewall_policy(_shared_state) {
             trace_err_chain!(e, "Failed to apply firewall policy for blocked state");
         }
-        let _ = _shared_state.account_command_tx.set_firewall_up().await;
+        let _ = _shared_state.account_command_tx.set_vpn_api_firewall_up().await;
         (Box::new(Self), PrivateTunnelState::Error(reason))
     }
 


### PR DESCRIPTION
## Ticket

JIRA-VPN-3825

## Description

Add `FirewallUp` and `FirewallDown` commands to AC to tell it to pause/resume network operation

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3274)
<!-- Reviewable:end -->
