### PR TITLE
Set toolchain and LTO

### DIFF
--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -80,6 +80,10 @@ homepage = "https://nymtech.net"
 documentation = "https://nymtech.net"
 edition = "2024"
 license = "GPL-3.0-only"
+rust-version = "1.88"
+
+[profile.release]
+lto = true
 
 [workspace.lints.clippy]
 large_futures = "warn"


### PR DESCRIPTION
## Description

- Set toolchain version in `Cargo.toml` which should warn if Rust compiler installed on the machine is not compatible. For instance the new syntax for if-let chains will not compile on older compilers (before 1.88)
- Enable `lto` for release profile which should better optimize the binary in release mode at the price of longer linker times


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3283)
<!-- Reviewable:end -->
