### PR TITLE
Add more uniffi rpc methods

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-rpc-uniffi/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-rpc-uniffi/src/lib.rs
@@ -11,7 +11,7 @@ use futures::StreamExt;
 use nym_vpn_proto::rpc_client::{Error as DaemonRpcError, RpcClient as DaemonRpcClient};
 use tokio_util::sync::CancellationToken;
 
-use nym_vpn_lib_types_uniffi::{TunnelEvent, TunnelState};
+use nym_vpn_lib_types_uniffi::{AccountControllerState, TunnelEvent, TunnelState};
 
 #[derive(Debug, uniffi::Object)]
 pub struct RpcError {
@@ -69,6 +69,18 @@ pub trait TunnelEventObserver: Send + Sync {
     fn on_close(&self);
 }
 
+#[uniffi::export(with_foreign)]
+pub trait TunnelStateObserver: Send + Sync {
+    fn on_tunnel_state_change(&self, new_state: TunnelState);
+    fn on_close(&self);
+}
+
+#[uniffi::export(with_foreign)]
+pub trait AccountEventObserver: Send + Sync {
+    fn on_account_state_change(&self, new_state: AccountControllerState);
+    fn on_close(&self);
+}
+
 #[derive(Clone, uniffi::Object)]
 struct RpcClient {
     inner: DaemonRpcClient,
@@ -107,29 +119,140 @@ impl RpcClient {
 
         tokio::spawn(async move {
             loop {
-                tokio::select! {
-                    _ = child_token.cancelled() => {
-                        break;
-                    },
-                    event = event_stream.next() => {
-                        match event {
-                            Some(Ok(evt)) => {
-                                let tunnel_event = TunnelEvent::from(evt);
-                                observer.on_tunnel_event(tunnel_event);
-                            }
-                            Some(Err(err)) => {
-                                tracing::error!("Error receiving event: {err}");
-                                break;
-                            }
-                            None => break
-                        }
+                match child_token
+                    .run_until_cancelled(event_stream.next())
+                    .await
+                    .flatten()
+                {
+                    Some(Ok(evt)) => {
+                        observer.on_tunnel_event(TunnelEvent::from(evt));
                     }
+                    Some(Err(err)) => {
+                        tracing::error!("Error receiving next event: {err}");
+                        break;
+                    }
+                    None => break,
                 }
             }
-
             observer.on_close();
         });
 
         Ok(StreamObserver::new(cancel_token))
+    }
+
+    pub async fn listen_to_tunnel_state(
+        &self,
+        observer: Arc<dyn TunnelStateObserver>,
+    ) -> Result<StreamObserver> {
+        let cancel_token = CancellationToken::new();
+        let child_token = cancel_token.child_token();
+        let mut event_stream = self.inner.clone().listen_to_tunnel_state().await?;
+
+        tokio::spawn(async move {
+            loop {
+                match child_token
+                    .run_until_cancelled(event_stream.next())
+                    .await
+                    .flatten()
+                {
+                    Some(Ok(evt)) => {
+                        observer.on_tunnel_state_change(TunnelState::from(evt));
+                    }
+                    Some(Err(err)) => {
+                        tracing::error!("Error receiving next tunnel state: {err}");
+                        break;
+                    }
+                    None => break,
+                }
+            }
+            observer.on_close();
+        });
+
+        Ok(StreamObserver::new(cancel_token))
+    }
+
+    pub async fn is_account_stored(&self) -> Result<bool> {
+        Ok(self.inner.clone().is_account_stored().await?)
+    }
+
+    pub async fn get_account_identity(&self) -> Result<Option<String>> {
+        Ok(self.inner.clone().get_account_identity().await?)
+    }
+
+    pub async fn get_account_state(&self) -> Result<AccountControllerState> {
+        Ok(self
+            .inner
+            .clone()
+            .get_account_state()
+            .await
+            .map(AccountControllerState::from)?)
+    }
+
+    pub async fn listen_to_account_controller_state(
+        &self,
+        observer: Arc<dyn AccountEventObserver>,
+    ) -> Result<StreamObserver> {
+        let cancel_token = CancellationToken::new();
+        let child_token = cancel_token.child_token();
+        let mut event_stream = self
+            .inner
+            .clone()
+            .listen_to_account_controller_state()
+            .await?;
+
+        tokio::spawn(async move {
+            loop {
+                match child_token
+                    .run_until_cancelled(event_stream.next())
+                    .await
+                    .flatten()
+                {
+                    Some(Ok(evt)) => {
+                        observer.on_account_state_change(AccountControllerState::from(evt));
+                    }
+                    Some(Err(err)) => {
+                        tracing::error!("Error receiving next account state: {err}");
+                        break;
+                    }
+                    None => break,
+                }
+            }
+            observer.on_close();
+        });
+
+        Ok(StreamObserver::new(cancel_token))
+    }
+
+    pub async fn refresh_account_state(&self) -> Result<()> {
+        self.inner.clone().refresh_account_state().await?;
+        Ok(())
+    }
+
+    pub async fn reset_device_identity(&self, seed: Option<Vec<u8>>) -> Result<()> {
+        self.inner.clone().reset_device_identity(seed).await?;
+        Ok(())
+    }
+
+    pub async fn get_device_identity(&self) -> Result<Option<String>> {
+        Ok(self.inner.clone().get_device_identity().await?)
+    }
+
+    pub async fn delete_log_file(&self) -> Result<()> {
+        self.inner.clone().delete_log_file().await?;
+        Ok(())
+    }
+
+    pub async fn is_sentry_enabled(&self) -> Result<bool> {
+        Ok(self.inner.clone().is_sentry_enabled().await?)
+    }
+
+    pub async fn enable_sentry(&self) -> Result<()> {
+        self.inner.clone().enable_sentry().await?;
+        Ok(())
+    }
+
+    pub async fn disable_sentry(&self) -> Result<()> {
+        self.inner.clone().disable_sentry().await?;
+        Ok(())
     }
 }


### PR DESCRIPTION
## Description

This PR adds some more RPC methods to the RpcClient, but not all of them yet as I need to wrap `nym-vpnd-types` for uniffi before being able to expose calls touching the daemon.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3291)
<!-- Reviewable:end -->
