### PR TITLE
Generate version header

### DIFF
--- a/.github/workflows/build-nym-vpn-core-windows.yml
+++ b/.github/workflows/build-nym-vpn-core-windows.yml
@@ -63,6 +63,11 @@ jobs:
         with:
           crate: cargo-edit
 
+      - name: Install cargo-get
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-get
+
       - name: Append timestamp if it's a dev version
         shell: bash
         run: ./scripts/append-timestamp-to-version.sh nym-vpn-core/Cargo.toml ${{ steps.workspace-version.outputs.metadata }}

--- a/.github/workflows/build-winfw-windows.yml
+++ b/.github/workflows/build-winfw-windows.yml
@@ -26,6 +26,11 @@ jobs:
         with:
           submodules: true
 
+      - name: Install cargo-get
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-get
+
       - name: Setup MSBuild.exe
         uses: microsoft/setup-msbuild@v2
 

--- a/.github/workflows/build-wireguard-go-windows.yml
+++ b/.github/workflows/build-wireguard-go-windows.yml
@@ -38,6 +38,11 @@ jobs:
           winget list GnuWin32.Make || winget install --disable-interactivity --id GnuWin32.Make
           echo "${env:ProgramFiles(x86)}\GnuWin32\bin" | Out-File -FilePath "$env:GITHUB_PATH" -Append
 
+      - name: Install cargo-get
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-get
+
       - name: Build wireguard
         env:
           MSYS2_LOCATION: ${{ steps.msys2.outputs.msys2-location }}

--- a/.github/workflows/ci-nym-vpn-core-windows.yml
+++ b/.github/workflows/ci-nym-vpn-core-windows.yml
@@ -61,6 +61,11 @@ jobs:
           winget list GnuWin32.Make || winget install --disable-interactivity --id GnuWin32.Make
           echo "${env:ProgramFiles(x86)}\GnuWin32\bin" | Out-File -FilePath "$env:GITHUB_PATH" -Append
 
+      - name: Install cargo-get
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-get
+
       - name: Download artifacts
         uses: actions/download-artifact@v5
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -15,11 +15,6 @@ bin
 **/.DS_Store
 /.cargo
 /nym-vpn-core/.cargo
-nym-vpn-core/nym-vpn-lib/generated/headers/module.modulemap
-nym-vpn-core/nym-vpn-lib/uniffi/nym_vpn_libFFI.modulemap
-nym-vpn-core/nym-vpn-lib/uniffi/nym_vpn_libFFI.h
-nym-vpn-core/crates/nym-vpn-lib/NymVpnLib
-nym-vpn-core/crates/nym-vpn-lib/generated
 nym-vpn-apple/MixnetLibrary/Sources/MixnetLibrary/RustFramework.xcframework
 
 # Wireguard-go artifacts
@@ -28,9 +23,14 @@ wireguard/libwg/exports.def
 wireguard/libwg/libwg.exp
 wireguard/libwg/libwg.h
 
+# Auto-generated version headers
+wireguard/libwg/version.h
+nym-vpn-windows/winfw/src/winfw/version.h
+
 # uniffi binaries
-nym-vpn-core/crates/*/generated
+nym-vpn-core/crates/nym-vpn-rpc-uniffi/generated
 nym-vpn-core/crates/nym-vpn-rpc-uniffi/NymVPNRpc
+nym-vpn-core/crates/nym-vpn-lib-uniffi/generated
 nym-vpn-core/crates/nym-vpn-lib-uniffi/NymVPNLib
 
 # Visual Studio

--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add timeout to DNS resolution fixing indefinite connecting state. (https://github.com/nymtech/nym-vpn-client/pull/3231)
 - [macOS] Fix issues with DNS not being properly reset on disconnect on macOS 15. (https://github.com/nymtech/nym-vpn-client/pull/3232)
 - [macOS] Bind DNS resolver to random loopback IP on port 53 to fix compatibility issues with other software, notably `dig` and `nslookup`. (https://github.com/nymtech/nym-vpn-client/pull/3232)
+- [Windows] Embed core version into `winfw.dll` and `libwg.dll` (https://github.com/nymtech/nym-vpn-client/pull/3292)
 
 
 ## [1.13.1] - 2025-07-30

--- a/nym-vpn-core/README.md
+++ b/nym-vpn-core/README.md
@@ -130,6 +130,11 @@ After installing Rust, install the following Rust targets and dependencies to en
         pacman -S mingw-w64-x86_64-clang
         pacman -S mingw-w64-clang-aarch64-clang
         ```
+1. Install `cargo-get`:
+
+    ```sh
+    cargo install cargo-get
+    ```
 
 ## Code formatting
 

--- a/nym-vpn-core/Windows.mk
+++ b/nym-vpn-core/Windows.mk
@@ -1,5 +1,5 @@
 # Makefile used for building Windows dependencies used by nym-vpnd
-# 
+#
 # Supported variables:
 #
 # Primary variables:
@@ -65,6 +65,9 @@ else
     TARGET_DIR ?= $(CURDIR)/target/debug
 endif
 
+LIBWG_VERSION_HEADER_PATH = $(CURDIR)/../wireguard/libwg/version.h
+WINFW_VERSION_HEADER_PATH = $(CURDIR)/../nym-vpn-windows/winfw/src/winfw/version.h
+
 LIBWG_BUILD_DIR := $(CURDIR)/../build/lib/$(RUST_TARGET)-pc-windows-msvc
 LIBWG_DLL := libwg.dll
 
@@ -76,12 +79,12 @@ WINFW_LIB := winfw.lib
 # Ensure that msys2 inherits PATH from environment
 export MSYS2_PATH_TYPE = inherit
 
-.PHONY: wintun libwg winfw create_target_dir
+.PHONY: wintun libwg winfw create_target_dir create_version_header
 
 default: wintun libwg winfw
 
 # Build libwg and copy it to build/lib
-libwg: create_target_dir
+libwg: create_target_dir create_version_header
 	$(call setup_env_path) ; #\
 	if ("$(CPU_ARCH_LOWER)" -eq "arm64") { #\
 		$$wg_arm64_flag = "--arm64" ; #\
@@ -93,11 +96,11 @@ libwg: create_target_dir
 	$(MSYS2_SHELL) -defterm -no-start -$$msystem -where "$(CURDIR)/../wireguard" -shell bash -c "./build-wireguard-go.sh $$wg_arm64_flag"
 	Copy-Item "$(LIBWG_BUILD_DIR)/$(LIBWG_DLL)" -Destination "$(TARGET_DIR)/$(LIBWG_DLL)" -Force -Verbose
 
-winfw: create_target_dir
+winfw: create_target_dir create_version_header
 # Setup environment and build winfw
 	$(call setup_env_path) ; #\
 	MSBuild.exe /m "$(CURDIR)/../nym-vpn-windows/winfw/winfw.sln" /p:Configuration=$(WINFW_PROFILE) /p:Platform=$(WINFW_PLATFORM)
-	
+
 # Copy winfw dll and lib to distribution directory where nym-vpn-core looks for import lib
 	New-Item -ItemType Directory -Force -Path "$(WINFW_DIST_DIR)" -Verbose
 	Copy-Item "$(WINFW_BUILD_DIR)/$(WINFW_DLL)" -Destination "$(WINFW_DIST_DIR)/$(WINFW_DLL)" -Force -Verbose
@@ -121,7 +124,7 @@ wintun: create_target_dir
 	} else { #\
 		Write-Output "Fingerprint matches!"; #\
 	}
-	
+
 # Copy wintun dll to target directory
 	Copy-Item -Path "$(WINTUN_BIN_DIR)/$(CPU_ARCH_LOWER)/$(WINTUN_DLL_NAME)" -Destination "$(TARGET_DIR)/$(WINTUN_DLL_NAME)" -Force -Verbose
 
@@ -129,6 +132,25 @@ create_target_dir:
 	if (-not (Test-Path "$(TARGET_DIR)")) { #\
 		New-Item -ItemType Directory -Path "$(TARGET_DIR)" ; #\
 	}
+
+# Create version header used by version resources of libwg and winfw DLLs
+create_version_header:
+	$$MajorVersion = $$(cargo get workspace.package.version --major) ; #\
+	$$MinorVersion = $$(cargo get workspace.package.version --minor) ; #\
+	$$PatchVersion = $$(cargo get workspace.package.version --patch) ; #\
+	$$ProductVersion = $$(cargo get workspace.package.version --major --minor --patch --delimiter ".") ; #\
+	#\
+	$$VersionHeader = @() ; #\
+	$$VersionHeader += "#ifndef VERSION_H" ; #\
+	$$VersionHeader += "#define VERSION_H" ; #\
+	$$VersionHeader += "#define MAJOR_VERSION $$MajorVersion" ; #\
+	$$VersionHeader += "#define MINOR_VERSION $$MinorVersion" ; #\
+	$$VersionHeader += "#define PATCH_VERSION $$PatchVersion" ; #\
+	$$VersionHeader += "#define PRODUCT_VERSION `"$$ProductVersion`"" ; #\
+	$$VersionHeader += "#endif" ; #\
+	#\
+	$$VersionHeader | Out-String | Out-File -Encoding utf8 -FilePath "$(LIBWG_VERSION_HEADER_PATH)" ; #\
+	$$VersionHeader | Out-String | Out-File -Encoding utf8 -FilePath "$(WINFW_VERSION_HEADER_PATH)"
 
 # Add Go, MSBuild and MSVC to PATH
 # Both Visual Studio and build tools come with the same set of tools

--- a/nym-vpn-windows/winfw/src/winfw/version.h
+++ b/nym-vpn-windows/winfw/src/winfw/version.h
@@ -1,9 +1,8 @@
-#ifndef VERSION_H
+﻿#ifndef VERSION_H
 #define VERSION_H
-
-#define MAJOR_VERSION 2025
-#define MINOR_VERSION 4
+#define MAJOR_VERSION 1
+#define MINOR_VERSION 14
 #define PATCH_VERSION 0
-#define PRODUCT_VERSION "1.0"
+#define PRODUCT_VERSION "1.14.0"
+#endif
 
-#endif // VERSION_H

--- a/wireguard/libwg/version.h
+++ b/wireguard/libwg/version.h
@@ -1,9 +1,8 @@
-#ifndef VERSION_H
+﻿#ifndef VERSION_H
 #define VERSION_H
-
-#define MAJOR_VERSION 2025
-#define MINOR_VERSION 4
+#define MAJOR_VERSION 1
+#define MINOR_VERSION 14
 #define PATCH_VERSION 0
-#define PRODUCT_VERSION "1.0"
+#define PRODUCT_VERSION "1.14.0"
+#endif
 
-#endif // VERSION_H


### PR DESCRIPTION
## Ticket

JIRA-VPN-3029

## Description

Automatically produce `version.h` header for libwg and winfw which is embedded into DLL version info. The version is generated based on version in `Cargo.toml` and requires `cargo-get` to extract version information from toml.

Since both `version.h` files have been added to gitignore, git should remain clean after build eliminating the need to commit modifications to header files.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3292)
<!-- Reviewable:end -->
