### PR TITLE
android: separate offline monitoring from tunnel provider

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/lib.rs
@@ -87,7 +87,7 @@ use offline_monitor::OfflineMonitorHandle;
 use state_machine::StateMachineHandle;
 use stats::StatisticsControllerHandle;
 #[cfg(target_os = "android")]
-use tunnel_provider::android::AndroidTunProvider;
+use tunnel_provider::android::{AndroidConnectivityMonitor, AndroidTunProvider};
 #[cfg(target_os = "ios")]
 use tunnel_provider::ios::OSTunProvider;
 
@@ -160,7 +160,7 @@ async fn configure_lib(config: NymVpnLibConfig) -> Result<(), VpnError> {
     }
     offline_monitor::init_offline_monitor(
         #[cfg(target_os = "android")]
-        config.tun_provider,
+        config.connectivity_monitor,
     )
     .await?;
     stats::init_statistics_controller(
@@ -585,5 +585,5 @@ pub struct NymVpnLibConfig {
     pub sentry_monitoring: bool,
     pub statistics_enabled: bool,
     #[cfg(target_os = "android")]
-    pub tun_provider: Arc<dyn AndroidTunProvider>,
+    pub connectivity_monitor: Arc<dyn AndroidConnectivityMonitor>,
 }

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/offline_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/offline_monitor.rs
@@ -8,21 +8,22 @@ use crate::{OFFLINE_MONITOR_HANDLE, error::VpnError};
 
 #[cfg(target_os = "android")]
 use crate::tunnel_provider::android::{
-    AndroidTunProvider, ConnectivityObserverInvalidation, ConnectivityReceiver, ConnectivitySender,
+    AndroidConnectivityMonitor, ConnectivityObserverInvalidation, ConnectivityReceiver,
+    ConnectivitySender,
 };
 use nym_offline_monitor::ConnectivityHandle;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use nym_vpn_lib::tunnel_state_machine::{self, RouteHandler};
 
 pub async fn init_offline_monitor(
-    #[cfg(target_os = "android")] tun_provider: Arc<dyn AndroidTunProvider>,
+    #[cfg(target_os = "android")] connectivity_monitor: Arc<dyn AndroidConnectivityMonitor>,
 ) -> Result<(), VpnError> {
     let mut guard = OFFLINE_MONITOR_HANDLE.lock().await;
 
     if guard.is_none() {
         let offline_monitor_handle = start_offline_monitor(
             #[cfg(target_os = "android")]
-            tun_provider,
+            connectivity_monitor,
         )
         .await?;
         *guard = Some(offline_monitor_handle);
@@ -34,8 +35,8 @@ pub async fn init_offline_monitor(
     }
 }
 
-pub async fn start_offline_monitor(
-    #[cfg(target_os = "android")] tun_provider: Arc<dyn AndroidTunProvider>,
+async fn start_offline_monitor(
+    #[cfg(target_os = "android")] connectivity_monitor: Arc<dyn AndroidConnectivityMonitor>,
 ) -> Result<OfflineMonitorHandle, VpnError> {
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     let route_handler = tunnel_state_machine::RouteHandler::new()
@@ -43,7 +44,7 @@ pub async fn start_offline_monitor(
         .map_err(tunnel_state_machine::Error::CreateRouteHandler)?;
 
     #[cfg(target_os = "android")]
-    let connectivity_receiver = register_connectivity_observer(tun_provider);
+    let connectivity_receiver = register_connectivity_observer(connectivity_monitor);
 
     let connectivity_handle = nym_offline_monitor::spawn_monitor(
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
@@ -64,18 +65,18 @@ pub async fn start_offline_monitor(
 
 #[cfg(target_os = "android")]
 fn register_connectivity_observer(
-    tun_provider: Arc<dyn AndroidTunProvider>,
+    connectivity_monitor: Arc<dyn AndroidConnectivityMonitor>,
 ) -> ConnectivityReceiver {
     let (connectivity_tx, connectivity_rx) = tokio::sync::mpsc::unbounded_channel();
     let connectivity_sender = Arc::new(ConnectivitySender::new(connectivity_tx));
     let connectivity_observer_invalidation = ConnectivityObserverInvalidation::new(
-        Arc::downgrade(&tun_provider),
+        connectivity_monitor.clone(),
         Arc::downgrade(&connectivity_sender),
     );
     let connectivity_receiver =
         ConnectivityReceiver::new(connectivity_rx, connectivity_observer_invalidation);
 
-    tun_provider.add_connectivity_observer(connectivity_sender);
+    connectivity_monitor.add_connectivity_observer(connectivity_sender);
     connectivity_receiver
 }
 

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/tunnel_provider/android.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/tunnel_provider/android.rs
@@ -16,6 +16,7 @@ use crate::VpnError;
 /// Unique sender id used to distinguish between multiple instances of `ConnectivitySender` when used on Android side.
 static CONNECTIVITY_SENDER_ID: AtomicU64 = AtomicU64::new(0);
 
+/// Abstract network connectivity observer.
 #[uniffi::export(with_foreign)]
 pub trait ConnectivityObserver: Send + Sync + std::fmt::Debug {
     /// Returns a unique identifier for this observer.
@@ -25,14 +26,19 @@ pub trait ConnectivityObserver: Send + Sync + std::fmt::Debug {
     fn on_network_change(&self, is_online: bool);
 }
 
+/// Abstract Android tunnel provider.
 #[uniffi::export(with_foreign)]
 pub trait AndroidTunProvider: Send + Sync + Debug {
-    /// Bypasses the VPN for a given socket.
+    /// Bypass VPN for a given socket.
     fn bypass(&self, socket: i32);
 
-    /// Configures the VPN tunnel with the given settings returning a file descriptor to tunnel device that can be used to read and write packets.
+    /// Configure VPN tunnel with the given settings returning a file descriptor to tunnel device that can be used to read and write packets.
     fn configure_tunnel(&self, config: TunnelNetworkSettings) -> Result<RawFd, VpnError>;
+}
 
+/// Abstract network connectivity monitor.
+#[uniffi::export(with_foreign)]
+pub trait AndroidConnectivityMonitor: Send + Sync + Debug {
     /// Add network connectivity observer.
     fn add_connectivity_observer(&self, observer: Arc<dyn ConnectivityObserver>);
 
@@ -120,17 +126,17 @@ impl nym_offline_monitor::NativeConnectivityAdapter for ConnectivityReceiver {
 /// Invalidation token cancelling `ConnectivitySender` observation on drop
 #[derive(Debug)]
 pub struct ConnectivityObserverInvalidation {
-    tun_provider: Weak<dyn AndroidTunProvider>,
+    connectivity_monitor: Arc<dyn AndroidConnectivityMonitor>,
     sender: Weak<ConnectivitySender>,
 }
 
 impl ConnectivityObserverInvalidation {
     pub fn new(
-        tun_provider: Weak<dyn AndroidTunProvider>,
+        connectivity_monitor: Arc<dyn AndroidConnectivityMonitor>,
         sender: Weak<ConnectivitySender>,
     ) -> Self {
         Self {
-            tun_provider,
+            connectivity_monitor,
             sender,
         }
     }
@@ -138,10 +144,9 @@ impl ConnectivityObserverInvalidation {
 
 impl Drop for ConnectivityObserverInvalidation {
     fn drop(&mut self) {
-        if let Some(tun_provider) = self.tun_provider.upgrade()
-            && let Some(sender) = self.sender.upgrade()
-        {
-            tun_provider.remove_connectivity_observer(sender);
+        if let Some(sender) = self.sender.upgrade() {
+            self.connectivity_monitor
+                .remove_connectivity_observer(sender);
         }
     }
 }


### PR DESCRIPTION
## Ticket

JIRA-VPN-3804

## Description

This PR separates connectivity monitoring from `AndroidTunProvider` and into separate object `AndroidConnectivityMonitor`.

`NymVpnLibConfig` now accepts `AndroidConnectivityMonitor` instead of `AndroidTunProvider`.

This is a breaking change and Android app needs to be adjusted.


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3301)
<!-- Reviewable:end -->
