### PR TITLE
fix(tauri): use 10/12 screen height instead of full screen

### DIFF
--- a/nym-vpn-app/index.html
+++ b/nym-vpn-app/index.html
@@ -11,7 +11,7 @@
   <!-- overflow-hidden is needed during splash animation to avoid scrollbar to shows up
    when root font size is restored from user saved preferences -->
   <body class="h-screen overflow-hidden">
-    <div id="root" class="h-full font-sans"></div>
+    <div id="root" class="h-10/12 font-sans"></div>
     <script type="module" src="/src/dev.ts"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>


### PR DESCRIPTION
# Proposed resizing of the app to not fill the screen.

## Description
Proposed resizing of the app to take up less screen space by setting the screen height to h-10/12 instead of h-full.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3314)
<!-- Reviewable:end -->
