### PR TITLE
grpc: pass error state as is

### DIFF
--- a/nym-vpn-app/src-tauri/Cargo.lock
+++ b/nym-vpn-app/src-tauri/Cargo.lock
@@ -1133,16 +1133,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1262,13 +1252,13 @@ dependencies = [
 
 [[package]]
 name = "dbus"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bb21987b9fb1613058ba3843121dd18b163b254d8a6e797e144cbac14d96d1b"
+checksum = "6e8d0767bcb66eb101d5ab87b9f38542691185af14fa8a7026c2490e62b45cfc"
 dependencies = [
  "libc",
  "libdbus-sys",
- "winapi",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2496,7 +2486,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -3391,7 +3381,7 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tracing",
- "windows 0.61.3",
+ "windows",
 ]
 
 [[package]]
@@ -3403,8 +3393,7 @@ dependencies = [
  "rs-release",
  "sha2",
  "sysinfo",
- "tracing",
- "windows 0.61.3",
+ "windows",
 ]
 
 [[package]]
@@ -3452,7 +3441,7 @@ dependencies = [
  "tracing-subscriber",
  "ts-rs",
  "url",
- "windows 0.61.3",
+ "windows",
 ]
 
 [[package]]
@@ -3474,7 +3463,7 @@ dependencies = [
  "thiserror 2.0.16",
  "tokio",
  "tracing",
- "windows 0.61.3",
+ "windows",
 ]
 
 [[package]]
@@ -3615,6 +3604,16 @@ dependencies = [
  "block2 0.6.1",
  "libc",
  "objc2 0.6.1",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c1c64d6120e51cd86033f67176b1cb66780c2efe34dec55176f77befd93c0a"
+dependencies = [
+ "libc",
  "objc2-core-foundation",
 ]
 
@@ -4605,26 +4604,6 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
-
-[[package]]
-name = "rayon"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
 
 [[package]]
 name = "redox_syscall"
@@ -5622,16 +5601,16 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.33.1"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
+checksum = "07cec4dc2d2e357ca1e610cfb07de2fa7a10fc3e9fe89f72545f3d244ea87753"
 dependencies = [
- "core-foundation-sys",
  "libc",
  "memchr",
  "ntapi",
- "rayon",
- "windows 0.57.0",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
 ]
 
 [[package]]
@@ -5681,8 +5660,8 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows 0.61.3",
- "windows-core 0.61.2",
+ "windows",
+ "windows-core",
  "windows-version",
  "x11-dl",
 ]
@@ -5765,7 +5744,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows 0.61.3",
+ "windows",
 ]
 
 [[package]]
@@ -5954,7 +5933,7 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.16",
  "url",
- "windows 0.61.3",
+ "windows",
  "zbus",
 ]
 
@@ -6070,7 +6049,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows 0.61.3",
+ "windows",
 ]
 
 [[package]]
@@ -6096,7 +6075,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows 0.61.3",
+ "windows",
  "wry",
 ]
 
@@ -6157,7 +6136,7 @@ checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
 dependencies = [
  "quick-xml 0.37.5",
  "thiserror 2.0.16",
- "windows 0.61.3",
+ "windows",
  "windows-version",
 ]
 
@@ -7252,10 +7231,10 @@ checksum = "d4ba622a989277ef3886dd5afb3e280e3dd6d974b766118950a08f8f678ad6a4"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows 0.61.3",
- "windows-core 0.61.2",
- "windows-implement 0.60.0",
- "windows-interface 0.59.1",
+ "windows",
+ "windows-core",
+ "windows-implement",
+ "windows-interface",
 ]
 
 [[package]]
@@ -7276,8 +7255,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36695906a1b53a3bf5c4289621efedac12b73eeb0b89e7e1a89b517302d5d75c"
 dependencies = [
  "thiserror 2.0.16",
- "windows 0.61.3",
- "windows-core 0.61.2",
+ "windows",
+ "windows-core",
 ]
 
 [[package]]
@@ -7334,22 +7313,12 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
-dependencies = [
- "windows-core 0.57.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-future",
  "windows-link",
  "windows-numerics",
@@ -7361,19 +7330,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core 0.61.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
-dependencies = [
- "windows-implement 0.57.0",
- "windows-interface 0.57.0",
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
+ "windows-core",
 ]
 
 [[package]]
@@ -7382,10 +7339,10 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement 0.60.0",
- "windows-interface 0.59.1",
+ "windows-implement",
+ "windows-interface",
  "windows-link",
- "windows-result 0.3.4",
+ "windows-result",
  "windows-strings 0.4.2",
 ]
 
@@ -7395,20 +7352,9 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link",
  "windows-threading",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
 ]
 
 [[package]]
@@ -7416,17 +7362,6 @@ name = "windows-implement"
 version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7456,7 +7391,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link",
 ]
 
@@ -7466,18 +7401,9 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
- "windows-result 0.3.4",
+ "windows-result",
  "windows-strings 0.3.1",
  "windows-targets 0.53.2",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -7928,8 +7854,8 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows 0.61.3",
- "windows-core 0.61.2",
+ "windows",
+ "windows-core",
  "windows-version",
  "x11-dl",
 ]

--- a/nym-vpn-core/crates/nym-statistics/src/events.rs
+++ b/nym-vpn-core/crates/nym-statistics/src/events.rs
@@ -80,7 +80,7 @@ impl StatisticsEvent {
             TunnelState::Connecting { .. } => None, // We don't want an event from that as it can fire multiple times when connecting.
             TunnelState::Connected { .. } => Some(Self::new_connected()),
             TunnelState::Disconnecting { .. } => Some(Self::new_disconnecting()),
-            TunnelState::Error(client_error_reason) => Some(Self::new_error(client_error_reason)),
+            TunnelState::Error(reason) => Some(Self::new_error(reason)),
             TunnelState::Offline { .. } => None,
         }
     }

--- a/nym-vpn-core/crates/nym-vpn-lib-types-uniffi/src/tunnel_state_machine.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types-uniffi/src/tunnel_state_machine.rs
@@ -5,8 +5,6 @@ use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 
 use time::OffsetDateTime;
 
-use super::AccountControllerErrorStateReason;
-
 #[derive(uniffi::Enum)]
 pub enum TunnelEvent {
     NewState(TunnelState),
@@ -260,8 +258,20 @@ pub enum ErrorStateReason {
     /// increase request, causing credential waste
     BadBandwidthIncrease,
 
-    /// Account error
-    AccountControl(AccountControllerErrorStateReason),
+    /// Bandwidth Exceeded
+    BandwidthExceeded,
+
+    /// Account status is not "Active"
+    AccountStatusNotActive { status: String },
+
+    /// Inactive Subscription
+    InactiveSubscription,
+
+    /// Max device numbers reached
+    MaxDevicesReached,
+
+    /// Device time is off by too much, Zk-nyms use will fail
+    DeviceTimeDesynced,
 
     /// Device is logged out
     DeviceLoggedOut,
@@ -391,9 +401,13 @@ impl From<nym_vpn_lib_types::ErrorStateReason> for ErrorStateReason {
                 Self::InvalidExitGatewayCountry
             }
             nym_vpn_lib_types::ErrorStateReason::BadBandwidthIncrease => Self::BadBandwidthIncrease,
-            nym_vpn_lib_types::ErrorStateReason::AccountControl(reason) => {
-                Self::AccountControl(AccountControllerErrorStateReason::from(reason))
+            nym_vpn_lib_types::ErrorStateReason::BandwidthExceeded => Self::BandwidthExceeded,
+            nym_vpn_lib_types::ErrorStateReason::AccountStatusNotActive { status } => {
+                Self::AccountStatusNotActive { status }
             }
+            nym_vpn_lib_types::ErrorStateReason::InactiveSubscription => Self::InactiveSubscription,
+            nym_vpn_lib_types::ErrorStateReason::MaxDevicesReached => Self::MaxDevicesReached,
+            nym_vpn_lib_types::ErrorStateReason::DeviceTimeDesynced => Self::DeviceTimeDesynced,
             nym_vpn_lib_types::ErrorStateReason::DeviceLoggedOut => Self::DeviceLoggedOut,
             nym_vpn_lib_types::ErrorStateReason::Internal(msg) => Self::Internal(msg),
         }

--- a/nym-vpn-core/crates/nym-vpn-lib-types-uniffi/src/tunnel_state_machine.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types-uniffi/src/tunnel_state_machine.rs
@@ -5,6 +5,8 @@ use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 
 use time::OffsetDateTime;
 
+use super::AccountControllerErrorStateReason;
+
 #[derive(uniffi::Enum)]
 pub enum TunnelEvent {
     NewState(TunnelState),
@@ -258,20 +260,8 @@ pub enum ErrorStateReason {
     /// increase request, causing credential waste
     BadBandwidthIncrease,
 
-    /// Bandwidth Exceeded
-    BandwidthExceeded,
-
-    /// Account status is not "Active"
-    AccountStatusNotActive { status: String },
-
-    /// Inactive Subscription
-    InactiveSubscription,
-
-    /// Max device numbers reached
-    MaxDevicesReached,
-
-    /// Device time is off by too much, Zk-nyms use will fail
-    DeviceTimeDesynced,
+    /// Account error
+    AccountControl(AccountControllerErrorStateReason),
 
     /// Device is logged out
     DeviceLoggedOut,
@@ -401,13 +391,9 @@ impl From<nym_vpn_lib_types::ErrorStateReason> for ErrorStateReason {
                 Self::InvalidExitGatewayCountry
             }
             nym_vpn_lib_types::ErrorStateReason::BadBandwidthIncrease => Self::BadBandwidthIncrease,
-            nym_vpn_lib_types::ErrorStateReason::BandwidthExceeded => Self::BandwidthExceeded,
-            nym_vpn_lib_types::ErrorStateReason::AccountStatusNotActive { status } => {
-                Self::AccountStatusNotActive { status }
+            nym_vpn_lib_types::ErrorStateReason::AccountControl(reason) => {
+                Self::AccountControl(AccountControllerErrorStateReason::from(reason))
             }
-            nym_vpn_lib_types::ErrorStateReason::InactiveSubscription => Self::InactiveSubscription,
-            nym_vpn_lib_types::ErrorStateReason::MaxDevicesReached => Self::MaxDevicesReached,
-            nym_vpn_lib_types::ErrorStateReason::DeviceTimeDesynced => Self::DeviceTimeDesynced,
             nym_vpn_lib_types::ErrorStateReason::DeviceLoggedOut => Self::DeviceLoggedOut,
             nym_vpn_lib_types::ErrorStateReason::Internal(msg) => Self::Internal(msg),
         }

--- a/nym-vpn-core/crates/nym-vpn-lib-types-uniffi/src/tunnel_state_machine.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types-uniffi/src/tunnel_state_machine.rs
@@ -257,12 +257,6 @@ pub enum ErrorStateReason {
     /// increase request, causing credential waste
     BadBandwidthIncrease,
 
-    /// Failure to duplicate tunnel file descriptor.
-    DuplicateTunFd,
-
-    /// Failure to create mixnet storage.
-    CreateMixnetStorage,
-
     /// IPv6 is disabled in the system.
     Ipv6Unavailable,
 
@@ -398,8 +392,6 @@ impl From<nym_vpn_lib_types::ErrorStateReason> for ErrorStateReason {
                 Self::InvalidExitGatewayCountry
             }
             nym_vpn_lib_types::ErrorStateReason::BadBandwidthIncrease => Self::BadBandwidthIncrease,
-            nym_vpn_lib_types::ErrorStateReason::DuplicateTunFd => Self::DuplicateTunFd,
-            nym_vpn_lib_types::ErrorStateReason::CreateMixnetStorage => Self::CreateMixnetStorage,
             nym_vpn_lib_types::ErrorStateReason::Ipv6Unavailable => Self::Ipv6Unavailable,
             nym_vpn_lib_types::ErrorStateReason::Internal(msg) => Self::Internal(msg),
             nym_vpn_lib_types::ErrorStateReason::AccountControllerError(reason) => {

--- a/nym-vpn-core/crates/nym-vpn-lib-types-uniffi/src/tunnel_state_machine.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types-uniffi/src/tunnel_state_machine.rs
@@ -244,9 +244,6 @@ pub enum ErrorStateReason {
     /// Failure to configure packet tunnel provider.
     TunnelProvider,
 
-    /// Failure to start local dns resolver.
-    StartLocalDnsResolver,
-
     /// Same entry and exit gateway are unsupported.
     SameEntryAndExitGateway,
 

--- a/nym-vpn-core/crates/nym-vpn-lib-types-uniffi/src/tunnel_state_machine.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types-uniffi/src/tunnel_state_machine.rs
@@ -271,7 +271,7 @@ pub enum ErrorStateReason {
     MaxDevicesReached,
 
     /// Device time is off by too much, Zk-nyms use will fail
-    DeviceTimeDesynced,
+    DeviceTimeOutOfSync,
 
     /// Device is logged out
     DeviceLoggedOut,
@@ -382,10 +382,10 @@ impl From<nym_vpn_lib_types::ErrorStateReason> for ErrorStateReason {
     fn from(value: nym_vpn_lib_types::ErrorStateReason) -> Self {
         match value {
             nym_vpn_lib_types::ErrorStateReason::SetFirewallPolicy => Self::SetFirewallPolicy,
-            nym_vpn_lib_types::ErrorStateReason::Routing => Self::SetRouting,
+            nym_vpn_lib_types::ErrorStateReason::SetRouting => Self::SetRouting,
             nym_vpn_lib_types::ErrorStateReason::SetDns => Self::SetDns,
-            nym_vpn_lib_types::ErrorStateReason::ConfigureTunnelDevice => Self::TunDevice,
-            nym_vpn_lib_types::ErrorStateReason::ConfigureTunnelProvider => Self::TunnelProvider,
+            nym_vpn_lib_types::ErrorStateReason::TunDevice => Self::TunDevice,
+            nym_vpn_lib_types::ErrorStateReason::TunnelProvider => Self::TunnelProvider,
             nym_vpn_lib_types::ErrorStateReason::Ipv6Unavailable => Self::Ipv6Unavailable,
             nym_vpn_lib_types::ErrorStateReason::SameEntryAndExitGateway => {
                 Self::SameEntryAndExitGateway
@@ -401,7 +401,7 @@ impl From<nym_vpn_lib_types::ErrorStateReason> for ErrorStateReason {
             nym_vpn_lib_types::ErrorStateReason::InactiveAccount => Self::InactiveAccount,
             nym_vpn_lib_types::ErrorStateReason::InactiveSubscription => Self::InactiveSubscription,
             nym_vpn_lib_types::ErrorStateReason::MaxDevicesReached => Self::MaxDevicesReached,
-            nym_vpn_lib_types::ErrorStateReason::DeviceTimeOutOfSync => Self::DeviceTimeDesynced,
+            nym_vpn_lib_types::ErrorStateReason::DeviceTimeOutOfSync => Self::DeviceTimeOutOfSync,
             nym_vpn_lib_types::ErrorStateReason::DeviceLoggedOut => Self::DeviceLoggedOut,
             nym_vpn_lib_types::ErrorStateReason::Internal(msg) => Self::Internal(msg),
         }

--- a/nym-vpn-core/crates/nym-vpn-lib-types-uniffi/src/tunnel_state_machine.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types-uniffi/src/tunnel_state_machine.rs
@@ -231,16 +231,16 @@ pub enum ErrorStateReason {
     SetFirewallPolicy,
 
     /// Failure to configure routing.
-    Routing,
+    SetRouting,
 
     /// Failure to configure dns.
     SetDns,
 
     /// Failure to configure tunnel device.
-    ConfigureTunnelDevice,
+    TunDevice,
 
-    /// Failure to set packet tunnel provider network settings.
-    SetTunnelProviderSettings,
+    /// Failure to configure tunnel provider.
+    TunnelProvider,
 
     /// IPv6 is disabled in the system.
     Ipv6Unavailable,
@@ -382,14 +382,10 @@ impl From<nym_vpn_lib_types::ErrorStateReason> for ErrorStateReason {
     fn from(value: nym_vpn_lib_types::ErrorStateReason) -> Self {
         match value {
             nym_vpn_lib_types::ErrorStateReason::SetFirewallPolicy => Self::SetFirewallPolicy,
-            nym_vpn_lib_types::ErrorStateReason::Routing => Self::Routing,
+            nym_vpn_lib_types::ErrorStateReason::Routing => Self::SetRouting,
             nym_vpn_lib_types::ErrorStateReason::SetDns => Self::SetDns,
-            nym_vpn_lib_types::ErrorStateReason::ConfigureTunnelDevice => {
-                Self::ConfigureTunnelDevice
-            }
-            nym_vpn_lib_types::ErrorStateReason::SetTunnelProviderSettings => {
-                Self::SetTunnelProviderSettings
-            }
+            nym_vpn_lib_types::ErrorStateReason::ConfigureTunnelDevice => Self::TunDevice,
+            nym_vpn_lib_types::ErrorStateReason::ConfigureTunnelProvider => Self::TunnelProvider,
             nym_vpn_lib_types::ErrorStateReason::Ipv6Unavailable => Self::Ipv6Unavailable,
             nym_vpn_lib_types::ErrorStateReason::SameEntryAndExitGateway => {
                 Self::SameEntryAndExitGateway

--- a/nym-vpn-core/crates/nym-vpn-lib-types-uniffi/src/tunnel_state_machine.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types-uniffi/src/tunnel_state_machine.rs
@@ -237,7 +237,7 @@ pub enum ErrorStateReason {
     SetDns,
 
     /// Failure to configure tunnel device.
-    TunDevice,
+    ConfigureTunnelDevice,
 
     /// Failure to set packet tunnel provider network settings.
     SetTunnelProviderSettings,
@@ -384,7 +384,9 @@ impl From<nym_vpn_lib_types::ErrorStateReason> for ErrorStateReason {
             nym_vpn_lib_types::ErrorStateReason::SetFirewallPolicy => Self::SetFirewallPolicy,
             nym_vpn_lib_types::ErrorStateReason::Routing => Self::Routing,
             nym_vpn_lib_types::ErrorStateReason::SetDns => Self::SetDns,
-            nym_vpn_lib_types::ErrorStateReason::TunDevice => Self::TunDevice,
+            nym_vpn_lib_types::ErrorStateReason::ConfigureTunnelDevice => {
+                Self::ConfigureTunnelDevice
+            }
             nym_vpn_lib_types::ErrorStateReason::SetTunnelProviderSettings => {
                 Self::SetTunnelProviderSettings
             }

--- a/nym-vpn-core/crates/nym-vpn-lib-types-uniffi/src/tunnel_state_machine.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types-uniffi/src/tunnel_state_machine.rs
@@ -239,8 +239,8 @@ pub enum ErrorStateReason {
     /// Failure to configure tunnel device.
     TunDevice,
 
-    /// Failure to configure packet tunnel provider.
-    TunnelProvider,
+    /// Failure to set packet tunnel provider network settings.
+    SetTunnelProviderSettings,
 
     /// IPv6 is disabled in the system.
     Ipv6Unavailable,
@@ -385,7 +385,9 @@ impl From<nym_vpn_lib_types::ErrorStateReason> for ErrorStateReason {
             nym_vpn_lib_types::ErrorStateReason::Routing => Self::Routing,
             nym_vpn_lib_types::ErrorStateReason::SetDns => Self::SetDns,
             nym_vpn_lib_types::ErrorStateReason::TunDevice => Self::TunDevice,
-            nym_vpn_lib_types::ErrorStateReason::TunnelProvider => Self::TunnelProvider,
+            nym_vpn_lib_types::ErrorStateReason::SetTunnelProviderSettings => {
+                Self::SetTunnelProviderSettings
+            }
             nym_vpn_lib_types::ErrorStateReason::Ipv6Unavailable => Self::Ipv6Unavailable,
             nym_vpn_lib_types::ErrorStateReason::SameEntryAndExitGateway => {
                 Self::SameEntryAndExitGateway

--- a/nym-vpn-core/crates/nym-vpn-lib-types-uniffi/src/tunnel_state_machine.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types-uniffi/src/tunnel_state_machine.rs
@@ -5,8 +5,6 @@ use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 
 use time::OffsetDateTime;
 
-use super::account_controller::AccountControllerErrorStateReason;
-
 #[derive(uniffi::Enum)]
 pub enum TunnelEvent {
     NewState(TunnelState),
@@ -270,7 +268,7 @@ pub enum ErrorStateReason {
     InactiveSubscription,
 
     /// Max device numbers reached
-    MaxDeviceReached,
+    MaxDevicesReached,
 
     /// Device time is off by too much, Zk-nyms use will fail
     DeviceTimeDesynced,
@@ -383,7 +381,7 @@ impl From<nym_vpn_api_client::response::NymErrorResponse> for VpnApiErrorRespons
 impl From<nym_vpn_lib_types::ErrorStateReason> for ErrorStateReason {
     fn from(value: nym_vpn_lib_types::ErrorStateReason) -> Self {
         match value {
-            nym_vpn_lib_types::ErrorStateReason::Firewall => Self::Firewall,
+            nym_vpn_lib_types::ErrorStateReason::SetFirewallPolicy => Self::Firewall,
             nym_vpn_lib_types::ErrorStateReason::Routing => Self::Routing,
             nym_vpn_lib_types::ErrorStateReason::SetDns => Self::SetDns,
             nym_vpn_lib_types::ErrorStateReason::TunDevice => Self::TunDevice,
@@ -400,6 +398,12 @@ impl From<nym_vpn_lib_types::ErrorStateReason> for ErrorStateReason {
             }
             nym_vpn_lib_types::ErrorStateReason::BadBandwidthIncrease => Self::BadBandwidthIncrease,
             nym_vpn_lib_types::ErrorStateReason::BandwidthExceeded => Self::BandwidthExceeded,
+            nym_vpn_lib_types::ErrorStateReason::AccountStatusNotActive { status } => {
+                Self::AccountStatusNotActive { status }
+            }
+            nym_vpn_lib_types::ErrorStateReason::InactiveSubscription => Self::InactiveSubscription,
+            nym_vpn_lib_types::ErrorStateReason::MaxDevicesReached => Self::MaxDevicesReached,
+            nym_vpn_lib_types::ErrorStateReason::DeviceTimeDesynced => Self::DeviceTimeDesynced,
             nym_vpn_lib_types::ErrorStateReason::DeviceLoggedOut => Self::DeviceLoggedOut,
             nym_vpn_lib_types::ErrorStateReason::Internal(msg) => Self::Internal(msg),
         }

--- a/nym-vpn-core/crates/nym-vpn-lib-types-uniffi/src/tunnel_state_machine.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types-uniffi/src/tunnel_state_machine.rs
@@ -244,6 +244,9 @@ pub enum ErrorStateReason {
     /// Failure to configure packet tunnel provider.
     TunnelProvider,
 
+    /// IPv6 is disabled in the system.
+    Ipv6Unavailable,
+
     /// Same entry and exit gateway are unsupported.
     SameEntryAndExitGateway,
 
@@ -257,20 +260,26 @@ pub enum ErrorStateReason {
     /// increase request, causing credential waste
     BadBandwidthIncrease,
 
-    /// IPv6 is disabled in the system.
-    Ipv6Unavailable,
+    /// Bandwidth Exceeded
+    BandwidthExceeded,
+
+    /// Account status is not "Active"
+    AccountStatusNotActive { status: String },
+
+    /// Inactive Subscription
+    InactiveSubscription,
+
+    /// Max device numbers reached
+    MaxDeviceReached,
+
+    /// Device time is off by too much, Zk-nyms use will fail
+    DeviceTimeDesynced,
+
+    /// Device is logged out
+    DeviceLoggedOut,
 
     /// Program errors that must not happen.
     Internal(String),
-
-    /// Account controller is in error state.
-    AccountControllerError(AccountControllerErrorStateReason),
-
-    /// Account controller is offline
-    AccountControllerOffline,
-
-    /// Account controller is logged out
-    AccountControllerLoggedOut,
 }
 
 #[derive(uniffi::Record, Clone, Debug, PartialEq, Eq)]
@@ -379,9 +388,7 @@ impl From<nym_vpn_lib_types::ErrorStateReason> for ErrorStateReason {
             nym_vpn_lib_types::ErrorStateReason::SetDns => Self::SetDns,
             nym_vpn_lib_types::ErrorStateReason::TunDevice => Self::TunDevice,
             nym_vpn_lib_types::ErrorStateReason::TunnelProvider => Self::TunnelProvider,
-            nym_vpn_lib_types::ErrorStateReason::StartLocalDnsResolver => {
-                Self::StartLocalDnsResolver
-            }
+            nym_vpn_lib_types::ErrorStateReason::Ipv6Unavailable => Self::Ipv6Unavailable,
             nym_vpn_lib_types::ErrorStateReason::SameEntryAndExitGateway => {
                 Self::SameEntryAndExitGateway
             }
@@ -392,17 +399,9 @@ impl From<nym_vpn_lib_types::ErrorStateReason> for ErrorStateReason {
                 Self::InvalidExitGatewayCountry
             }
             nym_vpn_lib_types::ErrorStateReason::BadBandwidthIncrease => Self::BadBandwidthIncrease,
-            nym_vpn_lib_types::ErrorStateReason::Ipv6Unavailable => Self::Ipv6Unavailable,
+            nym_vpn_lib_types::ErrorStateReason::BandwidthExceeded => Self::BandwidthExceeded,
+            nym_vpn_lib_types::ErrorStateReason::DeviceLoggedOut => Self::DeviceLoggedOut,
             nym_vpn_lib_types::ErrorStateReason::Internal(msg) => Self::Internal(msg),
-            nym_vpn_lib_types::ErrorStateReason::AccountControllerError(reason) => {
-                Self::AccountControllerError(AccountControllerErrorStateReason::from(reason))
-            }
-            nym_vpn_lib_types::ErrorStateReason::AccountControllerOffline => {
-                Self::AccountControllerOffline
-            }
-            nym_vpn_lib_types::ErrorStateReason::AccountControllerLoggedOut => {
-                Self::AccountControllerLoggedOut
-            }
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib-types-uniffi/src/tunnel_state_machine.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types-uniffi/src/tunnel_state_machine.rs
@@ -5,6 +5,8 @@ use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 
 use time::OffsetDateTime;
 
+use super::account_controller::AccountControllerErrorStateReason;
+
 #[derive(uniffi::Enum)]
 pub enum TunnelEvent {
     NewState(TunnelState),
@@ -227,21 +229,57 @@ impl From<nym_vpn_lib_types::ActionAfterDisconnect> for ActionAfterDisconnect {
 
 #[derive(uniffi::Enum)]
 pub enum ErrorStateReason {
+    /// Issues related to firewall configuration.
     Firewall,
+
+    /// Failure to configure routing.
     Routing,
+
+    /// Failure to configure dns.
+    SetDns,
+
+    /// Failure to configure tunnel device.
+    TunDevice,
+
+    /// Failure to configure packet tunnel provider.
+    TunnelProvider,
+
+    /// Failure to start local dns resolver.
+    StartLocalDnsResolver,
+
+    /// Same entry and exit gateway are unsupported.
     SameEntryAndExitGateway,
+
+    /// Invalid country set for entry gateway
     InvalidEntryGatewayCountry,
+
+    /// Invalid country set for exit gateway
     InvalidExitGatewayCountry,
-    MaxDevicesReached,
-    BandwidthExceeded,
-    InactiveSubscription,
-    Dns(Option<String>),
-    Api(Option<String>),
-    DeviceTimeOutOfSync,
+
+    /// Gateway is not responding or responding badly to a bandwidth
+    /// increase request, causing credential waste
+    BadBandwidthIncrease,
+
+    /// Failure to duplicate tunnel file descriptor.
+    DuplicateTunFd,
+
+    /// Failure to create mixnet storage.
     CreateMixnetStorage,
+
+    /// IPv6 is disabled in the system.
     Ipv6Unavailable,
-    Internal(Option<String>),
-    AccountControl(Option<String>),
+
+    /// Program errors that must not happen.
+    Internal(String),
+
+    /// Account controller is in error state.
+    AccountControllerError(AccountControllerErrorStateReason),
+
+    /// Account controller is offline
+    AccountControllerOffline,
+
+    /// Account controller is logged out
+    AccountControllerLoggedOut,
 }
 
 #[derive(uniffi::Record, Clone, Debug, PartialEq, Eq)]
@@ -342,33 +380,39 @@ impl From<nym_vpn_api_client::response::NymErrorResponse> for VpnApiErrorRespons
     }
 }
 
-impl From<nym_vpn_lib_types::ClientErrorReason> for ErrorStateReason {
-    fn from(value: nym_vpn_lib_types::ClientErrorReason) -> Self {
+impl From<nym_vpn_lib_types::ErrorStateReason> for ErrorStateReason {
+    fn from(value: nym_vpn_lib_types::ErrorStateReason) -> Self {
         match value {
-            nym_vpn_lib_types::ClientErrorReason::Firewall => Self::Firewall,
-            nym_vpn_lib_types::ClientErrorReason::Routing => Self::Routing,
-            nym_vpn_lib_types::ClientErrorReason::SameEntryAndExitGateway => {
+            nym_vpn_lib_types::ErrorStateReason::Firewall => Self::Firewall,
+            nym_vpn_lib_types::ErrorStateReason::Routing => Self::Routing,
+            nym_vpn_lib_types::ErrorStateReason::SetDns => Self::SetDns,
+            nym_vpn_lib_types::ErrorStateReason::TunDevice => Self::TunDevice,
+            nym_vpn_lib_types::ErrorStateReason::TunnelProvider => Self::TunnelProvider,
+            nym_vpn_lib_types::ErrorStateReason::StartLocalDnsResolver => {
+                Self::StartLocalDnsResolver
+            }
+            nym_vpn_lib_types::ErrorStateReason::SameEntryAndExitGateway => {
                 Self::SameEntryAndExitGateway
             }
-            nym_vpn_lib_types::ClientErrorReason::InvalidEntryGatewayCountry => {
+            nym_vpn_lib_types::ErrorStateReason::InvalidEntryGatewayCountry => {
                 Self::InvalidEntryGatewayCountry
             }
-            nym_vpn_lib_types::ClientErrorReason::InvalidExitGatewayCountry => {
+            nym_vpn_lib_types::ErrorStateReason::InvalidExitGatewayCountry => {
                 Self::InvalidExitGatewayCountry
             }
-            nym_vpn_lib_types::ClientErrorReason::MaxDevicesReached => Self::MaxDevicesReached,
-            nym_vpn_lib_types::ClientErrorReason::BandwidthExceeded => Self::BandwidthExceeded,
-            nym_vpn_lib_types::ClientErrorReason::InactiveSubscription => {
-                Self::InactiveSubscription
+            nym_vpn_lib_types::ErrorStateReason::BadBandwidthIncrease => Self::BadBandwidthIncrease,
+            nym_vpn_lib_types::ErrorStateReason::DuplicateTunFd => Self::DuplicateTunFd,
+            nym_vpn_lib_types::ErrorStateReason::CreateMixnetStorage => Self::CreateMixnetStorage,
+            nym_vpn_lib_types::ErrorStateReason::Ipv6Unavailable => Self::Ipv6Unavailable,
+            nym_vpn_lib_types::ErrorStateReason::Internal(msg) => Self::Internal(msg),
+            nym_vpn_lib_types::ErrorStateReason::AccountControllerError(reason) => {
+                Self::AccountControllerError(AccountControllerErrorStateReason::from(reason))
             }
-            nym_vpn_lib_types::ClientErrorReason::Dns(message) => Self::Dns(message),
-            nym_vpn_lib_types::ClientErrorReason::Api(message) => Self::Api(message),
-            nym_vpn_lib_types::ClientErrorReason::DeviceTimeOutOfSync => Self::DeviceTimeOutOfSync,
-            nym_vpn_lib_types::ClientErrorReason::CreateMixnetStorage => Self::CreateMixnetStorage,
-            nym_vpn_lib_types::ClientErrorReason::Ipv6Unavailable => Self::Ipv6Unavailable,
-            nym_vpn_lib_types::ClientErrorReason::Internal(message) => Self::Internal(message),
-            nym_vpn_lib_types::ClientErrorReason::AccountControl(message) => {
-                Self::AccountControl(message)
+            nym_vpn_lib_types::ErrorStateReason::AccountControllerOffline => {
+                Self::AccountControllerOffline
+            }
+            nym_vpn_lib_types::ErrorStateReason::AccountControllerLoggedOut => {
+                Self::AccountControllerLoggedOut
             }
         }
     }

--- a/nym-vpn-core/crates/nym-vpn-lib-types-uniffi/src/tunnel_state_machine.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types-uniffi/src/tunnel_state_machine.rs
@@ -262,7 +262,7 @@ pub enum ErrorStateReason {
     BandwidthExceeded,
 
     /// Account status is not "Active"
-    AccountStatusNotActive { status: String },
+    InactiveAccount,
 
     /// Inactive Subscription
     InactiveSubscription,
@@ -402,12 +402,10 @@ impl From<nym_vpn_lib_types::ErrorStateReason> for ErrorStateReason {
             }
             nym_vpn_lib_types::ErrorStateReason::BadBandwidthIncrease => Self::BadBandwidthIncrease,
             nym_vpn_lib_types::ErrorStateReason::BandwidthExceeded => Self::BandwidthExceeded,
-            nym_vpn_lib_types::ErrorStateReason::AccountStatusNotActive { status } => {
-                Self::AccountStatusNotActive { status }
-            }
+            nym_vpn_lib_types::ErrorStateReason::InactiveAccount => Self::InactiveAccount,
             nym_vpn_lib_types::ErrorStateReason::InactiveSubscription => Self::InactiveSubscription,
             nym_vpn_lib_types::ErrorStateReason::MaxDevicesReached => Self::MaxDevicesReached,
-            nym_vpn_lib_types::ErrorStateReason::DeviceTimeDesynced => Self::DeviceTimeDesynced,
+            nym_vpn_lib_types::ErrorStateReason::DeviceTimeOutOfSync => Self::DeviceTimeDesynced,
             nym_vpn_lib_types::ErrorStateReason::DeviceLoggedOut => Self::DeviceLoggedOut,
             nym_vpn_lib_types::ErrorStateReason::Internal(msg) => Self::Internal(msg),
         }

--- a/nym-vpn-core/crates/nym-vpn-lib-types-uniffi/src/tunnel_state_machine.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types-uniffi/src/tunnel_state_machine.rs
@@ -227,8 +227,8 @@ impl From<nym_vpn_lib_types::ActionAfterDisconnect> for ActionAfterDisconnect {
 
 #[derive(uniffi::Enum)]
 pub enum ErrorStateReason {
-    /// Issues related to firewall configuration.
-    Firewall,
+    /// Failure to set firewall policy.
+    SetFirewallPolicy,
 
     /// Failure to configure routing.
     Routing,
@@ -381,7 +381,7 @@ impl From<nym_vpn_api_client::response::NymErrorResponse> for VpnApiErrorRespons
 impl From<nym_vpn_lib_types::ErrorStateReason> for ErrorStateReason {
     fn from(value: nym_vpn_lib_types::ErrorStateReason) -> Self {
         match value {
-            nym_vpn_lib_types::ErrorStateReason::SetFirewallPolicy => Self::Firewall,
+            nym_vpn_lib_types::ErrorStateReason::SetFirewallPolicy => Self::SetFirewallPolicy,
             nym_vpn_lib_types::ErrorStateReason::Routing => Self::Routing,
             nym_vpn_lib_types::ErrorStateReason::SetDns => Self::SetDns,
             nym_vpn_lib_types::ErrorStateReason::TunDevice => Self::TunDevice,

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
@@ -26,6 +26,4 @@ pub use tunnel_event::{
     BandwidthEvent, ConnectionEvent, ConnectionStatisticsEvent, MixnetEvent, SphinxPacketRates,
     TunnelEvent,
 };
-pub use tunnel_state::{
-    ActionAfterDisconnect, ClientErrorReason, ErrorStateReason, TunnelState, TunnelType,
-};
+pub use tunnel_state::{ActionAfterDisconnect, ErrorStateReason, TunnelState, TunnelType};

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
@@ -167,12 +167,6 @@ pub enum ErrorStateReason {
     /// increase request, causing credential waste
     BadBandwidthIncrease,
 
-    /// Failure to duplicate tunnel file descriptor.
-    DuplicateTunFd,
-
-    /// Failure to create mixnet storage.
-    CreateMixnetStorage,
-
     /// IPv6 is disabled in the system.
     Ipv6Unavailable,
 

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
@@ -147,8 +147,8 @@ pub enum ErrorStateReason {
     /// Failure to configure tunnel device.
     TunDevice,
 
-    /// Failure to configure packet tunnel provider.
-    TunnelProvider,
+    /// Failure to configure packet tunnel provider (iOS and Android only)
+    SetTunnelProviderSettings,
 
     /// IPv6 is disabled in the system.
     Ipv6Unavailable,

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
@@ -1,10 +1,6 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::fmt;
-
-use crate::AccountControllerErrorStateReason;
-
 use super::connection_data::{ConnectionData, TunnelConnectionData};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -43,8 +39,8 @@ pub enum TunnelState {
     },
 }
 
-impl fmt::Display for TunnelState {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl std::fmt::Display for TunnelState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Disconnected => f.write_str("Disconnected"),
             Self::Connecting {
@@ -154,6 +150,9 @@ pub enum ErrorStateReason {
     /// Failure to configure packet tunnel provider.
     TunnelProvider,
 
+    /// IPv6 is disabled in the system.
+    Ipv6Unavailable,
+
     /// Same entry and exit gateway are unsupported.
     SameEntryAndExitGateway,
 
@@ -167,17 +166,23 @@ pub enum ErrorStateReason {
     /// increase request, causing credential waste
     BadBandwidthIncrease,
 
-    /// IPv6 is disabled in the system.
-    Ipv6Unavailable,
+    /// Bandwidth Exceeded
+    BandwidthExceeded,
 
-    /// Account controller is in error state.
-    AccountControllerError(AccountControllerErrorStateReason),
+    /// Account status is not "Active"
+    AccountStatusNotActive { status: String },
 
-    /// Account controller is offline
-    AccountControllerOffline,
+    /// Inactive Subscription
+    InactiveSubscription,
 
-    /// Account controller is logged out
-    AccountControllerLoggedOut,
+    /// Max device numbers reached
+    MaxDevicesReached,
+
+    /// Device time is off by too much, Zk-nyms use will fail
+    DeviceTimeDesynced,
+
+    /// Device is logged out
+    DeviceLoggedOut,
 
     /// Program errors that must not happen.
     Internal(String),

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
@@ -139,16 +139,16 @@ pub enum ErrorStateReason {
     SetFirewallPolicy,
 
     /// Failure to configure routing.
-    Routing,
+    SetRouting,
 
     /// Failure to configure dns.
     SetDns,
 
     /// Failure to configure tunnel device.
-    ConfigureTunnelDevice,
+    TunDevice,
 
     /// Failure to configure packet tunnel provider (iOS and Android only)
-    SetTunnelProviderSettings,
+    TunnelProvider,
 
     /// IPv6 is disabled in the system.
     Ipv6Unavailable,

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
@@ -136,7 +136,7 @@ pub enum ActionAfterDisconnect {
 #[derive(Debug, Clone, Eq, PartialEq, strum_macros::Display)]
 pub enum ErrorStateReason {
     /// Issues related to firewall configuration.
-    Firewall,
+    SetFirewallPolicy,
 
     /// Failure to configure routing.
     Routing,

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
@@ -1,7 +1,10 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use super::connection_data::{ConnectionData, TunnelConnectionData};
+use super::{
+    AccountControllerErrorStateReason,
+    connection_data::{ConnectionData, TunnelConnectionData},
+};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum TunnelType {
@@ -166,20 +169,8 @@ pub enum ErrorStateReason {
     /// increase request, causing credential waste
     BadBandwidthIncrease,
 
-    /// Bandwidth Exceeded
-    BandwidthExceeded,
-
-    /// Account status is not "Active"
-    AccountStatusNotActive { status: String },
-
-    /// Inactive Subscription
-    InactiveSubscription,
-
-    /// Max device numbers reached
-    MaxDevicesReached,
-
-    /// Device time is off by too much, Zk-nyms use will fail
-    DeviceTimeDesynced,
+    /// Account error
+    AccountControl(AccountControllerErrorStateReason),
 
     /// Device is logged out
     DeviceLoggedOut,

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
@@ -145,7 +145,7 @@ pub enum ErrorStateReason {
     SetDns,
 
     /// Failure to configure tunnel device.
-    TunDevice,
+    ConfigureTunnelDevice,
 
     /// Failure to configure packet tunnel provider (iOS and Android only)
     SetTunnelProviderSettings,

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
@@ -135,7 +135,7 @@ pub enum ActionAfterDisconnect {
 
 #[derive(Debug, Clone, Eq, PartialEq, strum_macros::Display)]
 pub enum ErrorStateReason {
-    /// Issues related to firewall configuration.
+    /// Failure to set firewall policy.
     SetFirewallPolicy,
 
     /// Failure to configure routing.

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
@@ -1,10 +1,7 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use super::{
-    AccountControllerErrorStateReason,
-    connection_data::{ConnectionData, TunnelConnectionData},
-};
+use super::connection_data::{ConnectionData, TunnelConnectionData};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum TunnelType {
@@ -169,8 +166,20 @@ pub enum ErrorStateReason {
     /// increase request, causing credential waste
     BadBandwidthIncrease,
 
-    /// Account error
-    AccountControl(AccountControllerErrorStateReason),
+    /// Bandwidth Exceeded
+    BandwidthExceeded,
+
+    /// Account status is not "Active"
+    AccountStatusNotActive { status: String },
+
+    /// Inactive Subscription
+    InactiveSubscription,
+
+    /// Max device numbers reached
+    MaxDevicesReached,
+
+    /// Device time is off by too much, Zk-nyms use will fail
+    DeviceTimeDesynced,
 
     /// Device is logged out
     DeviceLoggedOut,

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
@@ -170,7 +170,7 @@ pub enum ErrorStateReason {
     BandwidthExceeded,
 
     /// Account status is not "Active"
-    AccountStatusNotActive { status: String },
+    InactiveAccount,
 
     /// Inactive Subscription
     InactiveSubscription,
@@ -179,7 +179,7 @@ pub enum ErrorStateReason {
     MaxDevicesReached,
 
     /// Device time is off by too much, Zk-nyms use will fail
-    DeviceTimeDesynced,
+    DeviceTimeOutOfSync,
 
     /// Device is logged out
     DeviceLoggedOut,

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
@@ -154,9 +154,6 @@ pub enum ErrorStateReason {
     /// Failure to configure packet tunnel provider.
     TunnelProvider,
 
-    /// Failure to start local dns resolver.
-    StartLocalDnsResolver,
-
     /// Same entry and exit gateway are unsupported.
     SameEntryAndExitGateway,
 

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
@@ -3,10 +3,7 @@
 
 use std::fmt;
 
-use crate::{
-    AccountControllerErrorStateReason, RequestZkNymErrorReason, VpnApiErrorResponse,
-    account::VpnApiError,
-};
+use crate::AccountControllerErrorStateReason;
 
 use super::connection_data::{ConnectionData, TunnelConnectionData};
 
@@ -37,7 +34,7 @@ pub enum TunnelState {
     },
 
     /// Tunnel is disconnected due to failure.
-    Error(ClientErrorReason),
+    Error(ErrorStateReason),
 
     /// Tunnel is disconnected, network connectivity is unavailable.
     Offline {
@@ -182,9 +179,6 @@ pub enum ErrorStateReason {
     /// IPv6 is disabled in the system.
     Ipv6Unavailable,
 
-    /// Program errors that must not happen.
-    Internal(String),
-
     /// Account controller is in error state.
     AccountControllerError(AccountControllerErrorStateReason),
 
@@ -193,6 +187,9 @@ pub enum ErrorStateReason {
 
     /// Account controller is logged out
     AccountControllerLoggedOut,
+
+    /// Program errors that must not happen.
+    Internal(String),
 }
 
 impl ErrorStateReason {
@@ -200,96 +197,5 @@ impl ErrorStateReason {
     #[cfg(target_os = "macos")]
     pub fn prevents_filtering_resolver(&self) -> bool {
         matches!(self, ErrorStateReason::SetDns)
-    }
-}
-
-#[derive(Debug, Clone, Eq, PartialEq, strum_macros::Display)]
-pub enum ClientErrorReason {
-    Firewall,
-    Routing,
-    SameEntryAndExitGateway,
-    InvalidEntryGatewayCountry,
-    InvalidExitGatewayCountry,
-    MaxDevicesReached,
-    BandwidthExceeded,
-    InactiveSubscription,
-    Dns(Option<String>),
-    Api(Option<String>),
-    DeviceTimeOutOfSync,
-    CreateMixnetStorage,
-    Ipv6Unavailable,
-    Internal(Option<String>),
-    AccountControl(Option<String>),
-}
-
-impl From<ErrorStateReason> for ClientErrorReason {
-    fn from(value: ErrorStateReason) -> Self {
-        match value {
-            ErrorStateReason::CreateMixnetStorage => Self::CreateMixnetStorage,
-            ErrorStateReason::SameEntryAndExitGateway => Self::SameEntryAndExitGateway,
-            ErrorStateReason::InvalidEntryGatewayCountry => Self::InvalidEntryGatewayCountry,
-            ErrorStateReason::InvalidExitGatewayCountry => Self::InvalidExitGatewayCountry,
-            ErrorStateReason::BadBandwidthIncrease => Self::Api(Some(value.to_string())),
-            ErrorStateReason::Firewall => Self::Firewall,
-            ErrorStateReason::TunDevice
-            | ErrorStateReason::TunnelProvider
-            | ErrorStateReason::DuplicateTunFd => Self::Internal(Some(value.to_string())),
-            ErrorStateReason::Internal(message) => Self::Internal(Some(message)),
-            ErrorStateReason::Routing => Self::Routing,
-            ErrorStateReason::StartLocalDnsResolver => Self::Dns(Some(value.to_string())),
-            ErrorStateReason::SetDns => Self::Dns(Some(value.to_string())),
-            ErrorStateReason::Ipv6Unavailable => Self::Ipv6Unavailable,
-            ErrorStateReason::AccountControllerError(
-                AccountControllerErrorStateReason::BandwidthExceeded { .. },
-            ) => Self::BandwidthExceeded,
-            ErrorStateReason::AccountControllerError(
-                AccountControllerErrorStateReason::MaxDeviceReached,
-            ) => Self::MaxDevicesReached,
-            ErrorStateReason::AccountControllerError(
-                AccountControllerErrorStateReason::InactiveSubscription,
-            ) => Self::InactiveSubscription,
-            ErrorStateReason::AccountControllerError(
-                AccountControllerErrorStateReason::DeviceTimeDesynced,
-            ) => Self::DeviceTimeOutOfSync,
-            ErrorStateReason::AccountControllerError(reason) => {
-                Self::AccountControl(Some(reason.to_string()))
-            }
-            ErrorStateReason::AccountControllerOffline => {
-                Self::AccountControl(Some("offline".into()))
-            }
-            ErrorStateReason::AccountControllerLoggedOut => {
-                Self::AccountControl(Some("logged out".into()))
-            }
-        }
-    }
-}
-
-impl From<RequestZkNymErrorReason> for ClientErrorReason {
-    fn from(error: RequestZkNymErrorReason) -> Self {
-        match error {
-            RequestZkNymErrorReason::VpnApi(e) => e.into(),
-            RequestZkNymErrorReason::UnexpectedVpnApiResponse(message) => Self::Api(Some(message)),
-            reason => Self::Internal(Some(reason.to_string())),
-        }
-    }
-}
-
-impl From<VpnApiError> for ClientErrorReason {
-    fn from(error: VpnApiError) -> Self {
-        match error {
-            VpnApiError::Response(e) => e.into(),
-            VpnApiError::StatusCode { .. } => Self::Api(Some(error.to_string())),
-            VpnApiError::Timeout(..) => Self::Api(Some(error.to_string())),
-        }
-    }
-}
-
-impl From<VpnApiErrorResponse> for ClientErrorReason {
-    fn from(error: VpnApiErrorResponse) -> Self {
-        let message = match error.message_id {
-            None => error.message,
-            Some(id) => format!("{}, ID [{}]", error.message, id),
-        };
-        Self::Api(Some(message))
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -44,8 +44,8 @@ use nym_gateway_directory::{
 };
 use nym_sdk::UserAgent;
 use nym_vpn_lib_types::{
-    ActionAfterDisconnect, ConnectionData, ErrorStateReason, MixnetEvent, TunnelEvent, TunnelState,
-    TunnelType,
+    AccountControllerErrorStateReason, ActionAfterDisconnect, ConnectionData, ErrorStateReason,
+    MixnetEvent, TunnelEvent, TunnelState, TunnelType,
 };
 use nym_wg_gateway_client::Error as WgGatewayClientError;
 
@@ -765,12 +765,41 @@ impl account::Error {
             Self::Command(e) => Some(ErrorStateReason::Internal(e.to_string())),
             Self::Cancelled => None,
             Self::ControllerState(e) => match e {
-                AcError::Offline => Some(ErrorStateReason::AccountControllerOffline),
-                AcError::NoAccountStored => Some(ErrorStateReason::AccountControllerLoggedOut),
+                AcError::Offline => None,
+                AcError::NoAccountStored => Some(ErrorStateReason::DeviceLoggedOut),
                 AcError::Internal(e) => Some(ErrorStateReason::Internal(e.to_string())),
-                AcError::ErrorState(reason) => {
-                    Some(ErrorStateReason::AccountControllerError(reason))
+                AcError::ErrorState(
+                    AccountControllerErrorStateReason::AccountStatusNotActive { status },
+                ) => Some(ErrorStateReason::AccountStatusNotActive { status }),
+                AcError::ErrorState(AccountControllerErrorStateReason::BandwidthExceeded {
+                    ..
+                }) => Some(ErrorStateReason::BandwidthExceeded),
+                AcError::ErrorState(AccountControllerErrorStateReason::InactiveSubscription) => {
+                    Some(ErrorStateReason::InactiveSubscription)
                 }
+                AcError::ErrorState(AccountControllerErrorStateReason::MaxDeviceReached) => {
+                    Some(ErrorStateReason::MaxDevicesReached)
+                }
+                AcError::ErrorState(AccountControllerErrorStateReason::DeviceTimeDesynced) => {
+                    Some(ErrorStateReason::DeviceTimeDesynced)
+                }
+                AcError::ErrorState(AccountControllerErrorStateReason::Internal {
+                    context,
+                    details,
+                }) => Some(ErrorStateReason::Internal(format!("{context} {details}"))),
+                AcError::ErrorState(AccountControllerErrorStateReason::Storage { context }) => {
+                    Some(ErrorStateReason::Internal(format!(
+                        "Failed to initialize account storage: {}",
+                        context
+                    )))
+                }
+                AcError::ErrorState(AccountControllerErrorStateReason::ApiFailure {
+                    context,
+                    details,
+                }) => Some(ErrorStateReason::Internal(format!(
+                    "Account API failure: {} {}",
+                    context, details
+                ))),
             },
         }
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -788,7 +788,9 @@ impl account::Error {
                 AcError::ErrorState(AccountControllerErrorStateReason::Internal {
                     context,
                     details,
-                }) => Some(ErrorStateReason::Internal(format!("{context} {details}"))),
+                }) => Some(ErrorStateReason::Internal(format!(
+                    "Internal account controller error: {context} {details}"
+                ))),
                 AcError::ErrorState(AccountControllerErrorStateReason::Storage { context }) => {
                     Some(ErrorStateReason::Internal(format!(
                         "Failed to initialize account storage: {}",

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -691,7 +691,7 @@ impl Error {
             Self::SetupWintunAdapter(_) => ErrorStateReason::TunDevice,
             Self::Tunnel(e) => e.error_state_reason()?,
             #[cfg(any(target_os = "ios", target_os = "android"))]
-            Self::ConfigureTunnelProvider(_) => ErrorStateReason::TunnelProvider,
+            Self::ConfigureTunnelProvider(_) => ErrorStateReason::SetTunnelProviderSettings,
             #[cfg(target_os = "ios")]
             Self::LocateTunDevice(_) => ErrorStateReason::TunDevice,
             #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -795,16 +795,14 @@ impl account::Error {
                 ))),
                 AcError::ErrorState(AccountControllerErrorStateReason::Storage { context }) => {
                     Some(ErrorStateReason::Internal(format!(
-                        "Failed to initialize account storage: {}",
-                        context
+                        "Failed to initialize account storage: {context}",
                     )))
                 }
                 AcError::ErrorState(AccountControllerErrorStateReason::ApiFailure {
                     context,
                     details,
                 }) => Some(ErrorStateReason::Internal(format!(
-                    "Account API failure: {} {}",
-                    context, details
+                    "Account API failure: {context} {details}"
                 ))),
             },
         }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -607,8 +607,8 @@ pub enum Error {
     CreateFirewall(#[source] nym_firewall::Error),
 
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-    #[error("failed to apply firewall policy")]
-    ApplyFirewallPolicy(#[source] nym_firewall::Error),
+    #[error("failed to set firewall policy")]
+    SetFirewallPolicy(#[source] nym_firewall::Error),
 
     #[error("failed to resolve API hostnames")]
     ResolveApiHostnames(#[source] nym_gateway_directory::Error),
@@ -674,7 +674,9 @@ impl Error {
             #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
             Self::CreateDnsHandler(_) | Self::SetDns(_) => ErrorStateReason::SetDns,
             #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-            Self::CreateFirewall(_) | Self::ApplyFirewallPolicy(_) => ErrorStateReason::Firewall,
+            Self::CreateFirewall(_) => None?,
+            #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+            Self::SetFirewallPolicy(_) => ErrorStateReason::SetFirewallPolicy,
             Self::CreateTunDevice(_) => ErrorStateReason::TunDevice,
             #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
             Self::SetTunDeviceIpv6Addr(_) => ErrorStateReason::TunDevice,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -44,8 +44,8 @@ use nym_gateway_directory::{
 };
 use nym_sdk::UserAgent;
 use nym_vpn_lib_types::{
-    AccountControllerErrorStateReason, ActionAfterDisconnect, ConnectionData, ErrorStateReason,
-    MixnetEvent, TunnelEvent, TunnelState, TunnelType,
+    ActionAfterDisconnect, ConnectionData, ErrorStateReason, MixnetEvent, TunnelEvent, TunnelState,
+    TunnelType,
 };
 use nym_wg_gateway_client::Error as WgGatewayClientError;
 
@@ -677,23 +677,23 @@ impl Error {
             Self::CreateFirewall(_) => None?,
             #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
             Self::SetFirewallPolicy(_) => ErrorStateReason::SetFirewallPolicy,
-            Self::CreateTunDevice(_) => ErrorStateReason::TunDevice,
+            Self::CreateTunDevice(_) => ErrorStateReason::ConfigureTunnelDevice,
             #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-            Self::SetTunDeviceIpv6Addr(_) => ErrorStateReason::TunDevice,
+            Self::SetTunDeviceIpv6Addr(_) => ErrorStateReason::ConfigureTunnelDevice,
             #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-            Self::GetTunDeviceName(_) => ErrorStateReason::TunDevice,
+            Self::GetTunDeviceName(_) => ErrorStateReason::ConfigureTunnelDevice,
             #[cfg(any(target_os = "ios", target_os = "android"))]
-            Self::GetTunDeviceName(_) => ErrorStateReason::TunDevice,
+            Self::GetTunDeviceName(_) => ErrorStateReason::ConfigureTunnelDevice,
             Self::ResolveApiHostnames(_) => None?,
             #[cfg(target_os = "macos")]
             Self::StartLocalDnsResolver(_) => None?,
             #[cfg(windows)]
-            Self::SetupWintunAdapter(_) => ErrorStateReason::TunDevice,
+            Self::SetupWintunAdapter(_) => ErrorStateReason::ConfigureTunnelDevice,
             Self::Tunnel(e) => e.error_state_reason()?,
             #[cfg(any(target_os = "ios", target_os = "android"))]
             Self::ConfigureTunnelProvider(_) => ErrorStateReason::SetTunnelProviderSettings,
             #[cfg(target_os = "ios")]
-            Self::LocateTunDevice(_) => ErrorStateReason::TunDevice,
+            Self::LocateTunDevice(_) => ErrorStateReason::ConfigureTunnelDevice,
             #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
             Self::GetRouteHandle(e) => ErrorStateReason::Internal(e.to_string()),
             Self::Account(err) => err.error_state_reason()?,
@@ -770,40 +770,7 @@ impl account::Error {
                 AcError::Offline => None,
                 AcError::NoAccountStored => Some(ErrorStateReason::DeviceLoggedOut),
                 AcError::Internal(e) => Some(ErrorStateReason::Internal(e.to_string())),
-                AcError::ErrorState(
-                    AccountControllerErrorStateReason::AccountStatusNotActive { status },
-                ) => Some(ErrorStateReason::AccountStatusNotActive { status }),
-                AcError::ErrorState(AccountControllerErrorStateReason::BandwidthExceeded {
-                    ..
-                }) => Some(ErrorStateReason::BandwidthExceeded),
-                AcError::ErrorState(AccountControllerErrorStateReason::InactiveSubscription) => {
-                    Some(ErrorStateReason::InactiveSubscription)
-                }
-                AcError::ErrorState(AccountControllerErrorStateReason::MaxDeviceReached) => {
-                    Some(ErrorStateReason::MaxDevicesReached)
-                }
-                AcError::ErrorState(AccountControllerErrorStateReason::DeviceTimeDesynced) => {
-                    Some(ErrorStateReason::DeviceTimeDesynced)
-                }
-                AcError::ErrorState(AccountControllerErrorStateReason::Internal {
-                    context,
-                    details,
-                }) => Some(ErrorStateReason::Internal(format!(
-                    "Internal account controller error: {context} {details}"
-                ))),
-                AcError::ErrorState(AccountControllerErrorStateReason::Storage { context }) => {
-                    Some(ErrorStateReason::Internal(format!(
-                        "Failed to initialize account storage: {}",
-                        context
-                    )))
-                }
-                AcError::ErrorState(AccountControllerErrorStateReason::ApiFailure {
-                    context,
-                    details,
-                }) => Some(ErrorStateReason::Internal(format!(
-                    "Account API failure: {} {}",
-                    context, details
-                ))),
+                AcError::ErrorState(reason) => Some(ErrorStateReason::AccountControl(reason)),
             },
         }
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -670,11 +670,13 @@ impl Error {
     fn error_state_reason(self) -> Option<ErrorStateReason> {
         Some(match self {
             #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-            Self::CreateRouteHandler(_) | Self::AddRoutes(_) => ErrorStateReason::SetRouting,
+            Self::CreateRouteHandler(_) | Self::CreateDnsHandler(_) | Self::CreateFirewall(_) => {
+                None?
+            }
             #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-            Self::CreateDnsHandler(_) | Self::SetDns(_) => ErrorStateReason::SetDns,
+            Self::AddRoutes(_) => ErrorStateReason::SetRouting,
             #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-            Self::CreateFirewall(_) => None?,
+            Self::SetDns(_) => ErrorStateReason::SetDns,
             #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
             Self::SetFirewallPolicy(_) => ErrorStateReason::SetFirewallPolicy,
             Self::CreateTunDevice(_) => ErrorStateReason::TunDevice,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -44,8 +44,8 @@ use nym_gateway_directory::{
 };
 use nym_sdk::UserAgent;
 use nym_vpn_lib_types::{
-    ActionAfterDisconnect, ConnectionData, ErrorStateReason, MixnetEvent, TunnelEvent, TunnelState,
-    TunnelType,
+    AccountControllerErrorStateReason, ActionAfterDisconnect, ConnectionData, ErrorStateReason,
+    MixnetEvent, TunnelEvent, TunnelState, TunnelType,
 };
 use nym_wg_gateway_client::Error as WgGatewayClientError;
 
@@ -677,23 +677,23 @@ impl Error {
             Self::CreateFirewall(_) => None?,
             #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
             Self::SetFirewallPolicy(_) => ErrorStateReason::SetFirewallPolicy,
-            Self::CreateTunDevice(_) => ErrorStateReason::ConfigureTunnelDevice,
+            Self::CreateTunDevice(_) => ErrorStateReason::TunDevice,
             #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-            Self::SetTunDeviceIpv6Addr(_) => ErrorStateReason::ConfigureTunnelDevice,
+            Self::SetTunDeviceIpv6Addr(_) => ErrorStateReason::TunDevice,
             #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-            Self::GetTunDeviceName(_) => ErrorStateReason::ConfigureTunnelDevice,
+            Self::GetTunDeviceName(_) => ErrorStateReason::TunDevice,
             #[cfg(any(target_os = "ios", target_os = "android"))]
-            Self::GetTunDeviceName(_) => ErrorStateReason::ConfigureTunnelDevice,
+            Self::GetTunDeviceName(_) => ErrorStateReason::TunDevice,
             Self::ResolveApiHostnames(_) => None?,
             #[cfg(target_os = "macos")]
             Self::StartLocalDnsResolver(_) => None?,
             #[cfg(windows)]
-            Self::SetupWintunAdapter(_) => ErrorStateReason::ConfigureTunnelDevice,
+            Self::SetupWintunAdapter(_) => ErrorStateReason::TunDevice,
             Self::Tunnel(e) => e.error_state_reason()?,
             #[cfg(any(target_os = "ios", target_os = "android"))]
             Self::ConfigureTunnelProvider(_) => ErrorStateReason::SetTunnelProviderSettings,
             #[cfg(target_os = "ios")]
-            Self::LocateTunDevice(_) => ErrorStateReason::ConfigureTunnelDevice,
+            Self::LocateTunDevice(_) => ErrorStateReason::TunDevice,
             #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
             Self::GetRouteHandle(e) => ErrorStateReason::Internal(e.to_string()),
             Self::Account(err) => err.error_state_reason()?,
@@ -770,7 +770,40 @@ impl account::Error {
                 AcError::Offline => None,
                 AcError::NoAccountStored => Some(ErrorStateReason::DeviceLoggedOut),
                 AcError::Internal(e) => Some(ErrorStateReason::Internal(e.to_string())),
-                AcError::ErrorState(reason) => Some(ErrorStateReason::AccountControl(reason)),
+                AcError::ErrorState(
+                    AccountControllerErrorStateReason::AccountStatusNotActive { status },
+                ) => Some(ErrorStateReason::AccountStatusNotActive { status }),
+                AcError::ErrorState(AccountControllerErrorStateReason::BandwidthExceeded {
+                    ..
+                }) => Some(ErrorStateReason::BandwidthExceeded),
+                AcError::ErrorState(AccountControllerErrorStateReason::InactiveSubscription) => {
+                    Some(ErrorStateReason::InactiveSubscription)
+                }
+                AcError::ErrorState(AccountControllerErrorStateReason::MaxDeviceReached) => {
+                    Some(ErrorStateReason::MaxDevicesReached)
+                }
+                AcError::ErrorState(AccountControllerErrorStateReason::DeviceTimeDesynced) => {
+                    Some(ErrorStateReason::DeviceTimeDesynced)
+                }
+                AcError::ErrorState(AccountControllerErrorStateReason::Internal {
+                    context,
+                    details,
+                }) => Some(ErrorStateReason::Internal(format!(
+                    "Internal account controller error: {context} {details}"
+                ))),
+                AcError::ErrorState(AccountControllerErrorStateReason::Storage { context }) => {
+                    Some(ErrorStateReason::Internal(format!(
+                        "Failed to initialize account storage: {}",
+                        context
+                    )))
+                }
+                AcError::ErrorState(AccountControllerErrorStateReason::ApiFailure {
+                    context,
+                    details,
+                }) => Some(ErrorStateReason::Internal(format!(
+                    "Account API failure: {} {}",
+                    context, details
+                ))),
             },
         }
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -693,7 +693,7 @@ impl Error {
             Self::SetupWintunAdapter(_) => ErrorStateReason::TunDevice,
             Self::Tunnel(e) => e.error_state_reason()?,
             #[cfg(any(target_os = "ios", target_os = "android"))]
-            Self::TunnelProvider(_) => ErrorStateReason::TunnelProvider,
+            Self::ConfigureTunnelProvider(_) => ErrorStateReason::TunnelProvider,
             #[cfg(target_os = "ios")]
             Self::LocateTunDevice(_) => ErrorStateReason::TunDevice,
             #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -677,23 +677,23 @@ impl Error {
             Self::CreateFirewall(_) => None?,
             #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
             Self::SetFirewallPolicy(_) => ErrorStateReason::SetFirewallPolicy,
-            Self::CreateTunDevice(_) => ErrorStateReason::TunDevice,
+            Self::CreateTunDevice(_) => ErrorStateReason::ConfigureTunnelDevice,
             #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-            Self::SetTunDeviceIpv6Addr(_) => ErrorStateReason::TunDevice,
+            Self::SetTunDeviceIpv6Addr(_) => ErrorStateReason::ConfigureTunnelDevice,
             #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-            Self::GetTunDeviceName(_) => ErrorStateReason::TunDevice,
+            Self::GetTunDeviceName(_) => ErrorStateReason::ConfigureTunnelDevice,
             #[cfg(any(target_os = "ios", target_os = "android"))]
-            Self::GetTunDeviceName(_) => ErrorStateReason::TunDevice,
+            Self::GetTunDeviceName(_) => ErrorStateReason::ConfigureTunnelDevice,
             Self::ResolveApiHostnames(_) => None?,
             #[cfg(target_os = "macos")]
             Self::StartLocalDnsResolver(_) => None?,
             #[cfg(windows)]
-            Self::SetupWintunAdapter(_) => ErrorStateReason::TunDevice,
+            Self::SetupWintunAdapter(_) => ErrorStateReason::ConfigureTunnelDevice,
             Self::Tunnel(e) => e.error_state_reason()?,
             #[cfg(any(target_os = "ios", target_os = "android"))]
             Self::ConfigureTunnelProvider(_) => ErrorStateReason::SetTunnelProviderSettings,
             #[cfg(target_os = "ios")]
-            Self::LocateTunDevice(_) => ErrorStateReason::TunDevice,
+            Self::LocateTunDevice(_) => ErrorStateReason::ConfigureTunnelDevice,
             #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
             Self::GetRouteHandle(e) => ErrorStateReason::Internal(e.to_string()),
             Self::Account(err) => err.error_state_reason()?,
@@ -771,8 +771,8 @@ impl account::Error {
                 AcError::NoAccountStored => Some(ErrorStateReason::DeviceLoggedOut),
                 AcError::Internal(e) => Some(ErrorStateReason::Internal(e.to_string())),
                 AcError::ErrorState(
-                    AccountControllerErrorStateReason::AccountStatusNotActive { status },
-                ) => Some(ErrorStateReason::AccountStatusNotActive { status }),
+                    AccountControllerErrorStateReason::AccountStatusNotActive { .. },
+                ) => Some(ErrorStateReason::InactiveAccount),
                 AcError::ErrorState(AccountControllerErrorStateReason::BandwidthExceeded {
                     ..
                 }) => Some(ErrorStateReason::BandwidthExceeded),
@@ -783,7 +783,7 @@ impl account::Error {
                     Some(ErrorStateReason::MaxDevicesReached)
                 }
                 AcError::ErrorState(AccountControllerErrorStateReason::DeviceTimeDesynced) => {
-                    Some(ErrorStateReason::DeviceTimeDesynced)
+                    Some(ErrorStateReason::DeviceTimeOutOfSync)
                 }
                 AcError::ErrorState(AccountControllerErrorStateReason::Internal {
                     context,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -684,7 +684,7 @@ impl Error {
             Self::GetTunDeviceName(_) => ErrorStateReason::TunDevice,
             Self::ResolveApiHostnames(_) => None?,
             #[cfg(target_os = "macos")]
-            Self::StartLocalDnsResolver(_) => ErrorStateReason::StartLocalDnsResolver,
+            Self::StartLocalDnsResolver(_) => None?,
             #[cfg(windows)]
             Self::SetupWintunAdapter(_) => ErrorStateReason::TunDevice,
             Self::Tunnel(e) => e.error_state_reason()?,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -44,8 +44,8 @@ use nym_gateway_directory::{
 };
 use nym_sdk::UserAgent;
 use nym_vpn_lib_types::{
-    ActionAfterDisconnect, ClientErrorReason, ConnectionData, ErrorStateReason, MixnetEvent,
-    TunnelEvent, TunnelState, TunnelType,
+    ActionAfterDisconnect, ConnectionData, ErrorStateReason, MixnetEvent, TunnelEvent, TunnelState,
+    TunnelType,
 };
 use nym_wg_gateway_client::Error as WgGatewayClientError;
 
@@ -268,7 +268,7 @@ impl From<PrivateTunnelState> for TunnelState {
             PrivateTunnelState::Disconnecting { after_disconnect } => Self::Disconnecting {
                 after_disconnect: ActionAfterDisconnect::from(after_disconnect),
             },
-            PrivateTunnelState::Error(reason) => Self::Error(ClientErrorReason::from(reason)),
+            PrivateTunnelState::Error(reason) => Self::Error(reason),
             PrivateTunnelState::Offline { reconnect } => Self::Offline { reconnect },
         }
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -670,30 +670,30 @@ impl Error {
     fn error_state_reason(self) -> Option<ErrorStateReason> {
         Some(match self {
             #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-            Self::CreateRouteHandler(_) | Self::AddRoutes(_) => ErrorStateReason::Routing,
+            Self::CreateRouteHandler(_) | Self::AddRoutes(_) => ErrorStateReason::SetRouting,
             #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
             Self::CreateDnsHandler(_) | Self::SetDns(_) => ErrorStateReason::SetDns,
             #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
             Self::CreateFirewall(_) => None?,
             #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
             Self::SetFirewallPolicy(_) => ErrorStateReason::SetFirewallPolicy,
-            Self::CreateTunDevice(_) => ErrorStateReason::ConfigureTunnelDevice,
+            Self::CreateTunDevice(_) => ErrorStateReason::TunDevice,
             #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-            Self::SetTunDeviceIpv6Addr(_) => ErrorStateReason::ConfigureTunnelDevice,
+            Self::SetTunDeviceIpv6Addr(_) => ErrorStateReason::TunDevice,
             #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-            Self::GetTunDeviceName(_) => ErrorStateReason::ConfigureTunnelDevice,
+            Self::GetTunDeviceName(_) => ErrorStateReason::TunDevice,
             #[cfg(any(target_os = "ios", target_os = "android"))]
-            Self::GetTunDeviceName(_) => ErrorStateReason::ConfigureTunnelDevice,
+            Self::GetTunDeviceName(_) => ErrorStateReason::TunDevice,
             Self::ResolveApiHostnames(_) => None?,
             #[cfg(target_os = "macos")]
             Self::StartLocalDnsResolver(_) => None?,
             #[cfg(windows)]
-            Self::SetupWintunAdapter(_) => ErrorStateReason::ConfigureTunnelDevice,
+            Self::SetupWintunAdapter(_) => ErrorStateReason::TunDevice,
             Self::Tunnel(e) => e.error_state_reason()?,
             #[cfg(any(target_os = "ios", target_os = "android"))]
-            Self::ConfigureTunnelProvider(_) => ErrorStateReason::SetTunnelProviderSettings,
+            Self::TunnelProvider(_) => ErrorStateReason::TunnelProvider,
             #[cfg(target_os = "ios")]
-            Self::LocateTunDevice(_) => ErrorStateReason::ConfigureTunnelDevice,
+            Self::LocateTunDevice(_) => ErrorStateReason::TunDevice,
             #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
             Self::GetRouteHandle(e) => ErrorStateReason::Internal(e.to_string()),
             Self::Account(err) => err.error_state_reason()?,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -732,10 +732,12 @@ impl tunnel::Error {
                 }
                 _ => None,
             },
-            Self::DupFd(_) => Some(ErrorStateReason::DuplicateTunFd),
-            Self::MixnetClient(MixnetError::CreateMixnetClientWithDefaultStorage(_)) => {
-                Some(ErrorStateReason::CreateMixnetStorage)
-            }
+            Self::DupFd(_) => Some(ErrorStateReason::Internal(
+                "Failed to dup tunnel fd".to_owned(),
+            )),
+            Self::MixnetClient(MixnetError::CreateMixnetClientWithDefaultStorage(_)) => Some(
+                ErrorStateReason::Internal("Failed to create mixnet storage".to_owned()),
+            ),
             Self::AuthenticationNotPossible(_)
             | Self::AuthenticatorAddressNotFound
             | Self::ConnectToIpPacketRouter(_)

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/resolver.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/resolver.rs
@@ -747,10 +747,7 @@ impl LookupObject for ForwardLookup {
 
 #[cfg(test)]
 mod test {
-    use std::{
-        net::{SocketAddrV4, UdpSocket},
-        time::Duration,
-    };
+    use std::{net::UdpSocket, time::Duration};
 
     use hickory_server::resolver::{
         TokioResolver,
@@ -758,7 +755,7 @@ mod test {
         name_server::TokioConnectionProvider,
     };
     use nix::sys::socket::{
-        self, AddressFamily, SockFlag, SockProtocol, SockType, SockaddrIn, SockaddrStorage, sockopt,
+        self, AddressFamily, SockFlag, SockProtocol, SockType, SockaddrStorage, sockopt,
     };
     use tokio_util::sync::CancellationToken;
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
@@ -59,20 +59,16 @@ impl ConnectedState {
             .set_firewall_policy(shared_state, &connection_data)
             .await
         {
+            trace_err_chain!(e, "Failed to apply firewall policy");
             return DisconnectingState::enter(
-                PrivateActionAfterDisconnect::Error(
-                    e.error_state_reason()
-                        .expect("failed to obtain error state reason"),
-                ),
+                PrivateActionAfterDisconnect::Error(ErrorStateReason::SetFirewallPolicy),
                 connected_state.tunnel_monitor_handle,
                 shared_state,
             );
         } else if let Err(e) = connected_state.set_dns(shared_state).await {
+            trace_err_chain!(e, "Failed to set dns");
             return DisconnectingState::enter(
-                PrivateActionAfterDisconnect::Error(
-                    e.error_state_reason()
-                        .expect("failed to obtain error state reason"),
-                ),
+                PrivateActionAfterDisconnect::Error(ErrorStateReason::SetDns),
                 connected_state.tunnel_monitor_handle,
                 shared_state,
             );
@@ -149,7 +145,7 @@ impl ConnectedState {
         shared_state
             .firewall
             .apply_policy(policy)
-            .map_err(Error::CreateFirewall)
+            .map_err(Error::SetFirewallPolicy)
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -72,12 +72,8 @@ impl ConnectingState {
     ) -> (Box<dyn TunnelStateHandler>, PrivateTunnelState) {
         #[cfg(target_os = "macos")]
         if let Err(e) = Self::set_local_dns_resolver(shared_state).await {
-            return ErrorState::enter(
-                e.error_state_reason()
-                    .expect("failed to map to error state reason"), // todo: fix me
-                shared_state,
-            )
-            .await;
+            trace_err_chain!(e, "Failed to configure system to use filtering resolver",);
+            return ErrorState::enter(ErrorStateReason::SetDns, shared_state).await;
         }
 
         if shared_state
@@ -101,12 +97,8 @@ impl ConnectingState {
             if let Err(e) =
                 Self::set_firewall_policy(shared_state, None, entry_gateway, None, &[]).await
             {
-                return ErrorState::enter(
-                    e.error_state_reason()
-                        .expect("failed to map to error state reason"),
-                    shared_state,
-                )
-                .await;
+                trace_err_chain!(e, "failed to set firewall policy");
+                return ErrorState::enter(ErrorStateReason::SetFirewallPolicy, shared_state).await;
             }
         }
 
@@ -237,7 +229,7 @@ impl ConnectingState {
                     "Failed to apply firewall policy for connecting state"
                 );
             })
-            .map_err(Error::ApplyFirewallPolicy)
+            .map_err(Error::SetFirewallPolicy)
     }
 
     #[cfg(target_os = "macos")]
@@ -248,19 +240,14 @@ impl ConnectingState {
                 &[shared_state.filtering_resolver.listen_addr().ip()],
                 shared_state.filtering_resolver.listen_addr().port(),
             );
-            if let Err(error) = shared_state
+            shared_state
                 .dns_handler
                 .set("lo".to_owned(), system_dns)
                 .await
-            {
-                trace_err_chain!(
-                    error,
-                    "Failed to configure system to use filtering resolver",
-                );
-            }
+                .map_err(Error::SetDns)
+        } else {
+            Ok(())
         }
-
-        Ok(())
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
@@ -335,13 +322,9 @@ impl ConnectingState {
             )
             .await
             {
+                trace_err_chain!(e, "failed to set firewall policy");
                 return NextTunnelState::NewState(
-                    ErrorState::enter(
-                        e.error_state_reason()
-                            .expect("failed to map to error state reason"),
-                        shared_state,
-                    )
-                    .await,
+                    ErrorState::enter(ErrorStateReason::SetFirewallPolicy, shared_state).await,
                 );
             }
         }
@@ -524,17 +507,12 @@ impl TunnelStateHandler for ConnectingState {
                             Err(e) => {
                                 if let Some(tunnel_monitor_handle) = self.tunnel_monitor_handle {
                                     NextTunnelState::NewState(DisconnectingState::enter(
-                                        // todo: fix that expect()
-                                        PrivateActionAfterDisconnect::Error(e.error_state_reason().expect("failed to obtain error state reason")),
+                                        PrivateActionAfterDisconnect::Error(ErrorStateReason::SetFirewallPolicy),
                                         tunnel_monitor_handle,
                                         shared_state
                                     ))
                                 } else {
-                                    NextTunnelState::NewState(ErrorState::enter(
-                                        // todo: fix that expect()
-                                        e.error_state_reason().expect("failed to obtain error state reason"),
-                                        shared_state
-                                    ).await)
+                                    NextTunnelState::NewState(ErrorState::enter(ErrorStateReason::SetFirewallPolicy, shared_state).await)
                                 }
                             }
                         };
@@ -552,17 +530,12 @@ impl TunnelStateHandler for ConnectingState {
                             Err(e) => {
                                 if let Some(tunnel_monitor_handle) = self.tunnel_monitor_handle {
                                     NextTunnelState::NewState(DisconnectingState::enter(
-                                        // todo: fix that expect()
-                                        PrivateActionAfterDisconnect::Error(e.error_state_reason().expect("failed to obtain error state reason")),
+                                        PrivateActionAfterDisconnect::Error(ErrorStateReason::SetFirewallPolicy),
                                         tunnel_monitor_handle,
                                         shared_state
                                     ))
                                 } else {
-                                    NextTunnelState::NewState(ErrorState::enter(
-                                        // todo: fix that expect()
-                                        e.error_state_reason().expect("failed to obtain error state reason"),
-                                        shared_state
-                                    ).await)
+                                    NextTunnelState::NewState(ErrorState::enter(ErrorStateReason::SetFirewallPolicy, shared_state).await)
                                 }
                             }
                         };

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -505,6 +505,7 @@ impl TunnelStateHandler for ConnectingState {
                                 NextTunnelState::SameState(self)
                             }
                             Err(e) => {
+                                trace_err_chain!(e, "Failed to set firewall policy");
                                 if let Some(tunnel_monitor_handle) = self.tunnel_monitor_handle {
                                     NextTunnelState::NewState(DisconnectingState::enter(
                                         PrivateActionAfterDisconnect::Error(ErrorStateReason::SetFirewallPolicy),
@@ -528,6 +529,7 @@ impl TunnelStateHandler for ConnectingState {
                                 NextTunnelState::NewState((self, state))
                             },
                             Err(e) => {
+                                trace_err_chain!(e, "Failed to set firewall policy");
                                 if let Some(tunnel_monitor_handle) = self.tunnel_monitor_handle {
                                     NextTunnelState::NewState(DisconnectingState::enter(
                                         PrivateActionAfterDisconnect::Error(ErrorStateReason::SetFirewallPolicy),

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
@@ -89,7 +89,7 @@ impl ErrorState {
         shared_state
             .firewall
             .apply_policy(policy)
-            .map_err(Error::ApplyFirewallPolicy)
+            .map_err(Error::SetFirewallPolicy)
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
@@ -52,26 +52,26 @@ pub struct ErrorState;
 impl ErrorState {
     pub async fn enter(
         reason: ErrorStateReason,
-        _shared_state: &mut SharedState,
+        shared_state: &mut SharedState,
     ) -> (Box<dyn TunnelStateHandler>, PrivateTunnelState) {
         #[cfg(target_os = "macos")]
         if !reason.prevents_filtering_resolver() {
             // Set system DNS to our local DNS resolver
-            if Self::set_local_dns_resolver(_shared_state).await.is_err() {
-                return Box::pin(Self::enter(ErrorStateReason::SetDns, _shared_state)).await;
+            if Self::set_local_dns_resolver(shared_state).await.is_err() {
+                return Box::pin(Self::enter(ErrorStateReason::SetDns, shared_state)).await;
             }
         }
 
         #[cfg(target_os = "ios")]
         {
-            Self::set_blocking_network_settings(_shared_state.tun_provider.clone()).await;
+            Self::set_blocking_network_settings(shared_state.tun_provider.clone()).await;
         }
 
         #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-        if let Err(e) = Self::set_firewall_policy(_shared_state) {
+        if let Err(e) = Self::set_firewall_policy(shared_state) {
             trace_err_chain!(e, "Failed to apply firewall policy for blocked state");
         }
-        let _ = _shared_state
+        let _ = shared_state
             .account_command_tx
             .set_vpn_api_firewall_up()
             .await;

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/offline_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/offline_state.rs
@@ -67,7 +67,7 @@ impl OfflineState {
         shared_state
             .firewall
             .apply_policy(policy)
-            .map_err(Error::ApplyFirewallPolicy)
+            .map_err(Error::SetFirewallPolicy)
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -365,7 +365,7 @@ message TunnelState {
       message SetFirewallPolicy {}
       message Routing {}
       message SetDns {}
-      message TunDevice {}
+      message ConfigureTunnelDevice {}
       message SetTunnelProviderSettings {}
       message Ipv6Unavailable {}
       message SameEntryAndExitGateway {}
@@ -388,7 +388,7 @@ message TunnelState {
           SetFirewallPolicy set_firewall_policy = 1;
           Routing routing = 2;
           SetDns set_dns = 3;
-          TunDevice tun_device = 4;
+          ConfigureTunnelDevice configure_tunnel_device = 4;
           SetTunnelProviderSettings set_tunnel_provider_settings = 5;
           Ipv6Unavailable ipv6_unavailable = 6;
           SameEntryAndExitGateway same_entry_and_exit_gateway = 7;

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -324,23 +324,85 @@ message TunnelConnectionData {
   }
 }
 
+
+
 message TunnelState {
-  enum ErrorStateReason {
-    FIREWALL = 0;
-    ROUTING = 1;
-    SAME_ENTRY_AND_EXIT_GATEWAY = 2;
-    INVALID_ENTRY_GATEWAY_COUNTRY = 3;
-    INVALID_EXIT_GATEWAY_COUNTRY = 4;
-    MAX_DEVICES_REACHED = 5;
-    BANDWIDTH_EXCEEDED = 6;
-    INACTIVE_SUBSCRIPTION = 7;
-    DNS = 8;
-    API = 9;
-    INTERNAL = 10;
-    DEVICE_TIME_OUT_OF_SYNC = 11;
-    CREATE_MIXNET_STORAGE = 12;
-    IPV6_UNAVAILABLE = 13;
-    ACCOUNT_CONTROL = 14;
+  message AccountControllerErrorStateReason {
+      message Storage {
+          string context = 1;
+      }
+      message ApiFailure {
+          string context = 1;
+          string details = 2;
+      }
+      message Internal {
+          string context = 1;
+          string details = 2;
+      }
+      message BandwidthExceeded {
+          string context = 1;
+      }
+      message AccountStatusNotActive {
+          string status = 1;
+      }
+      message InactiveSubscription {}
+      message MaxDeviceReached {}
+      message DeviceTimeDesynced {}
+
+      oneof reason {
+          Storage storage = 1;
+          ApiFailure api_failure = 2;
+          Internal internal = 3;
+          BandwidthExceeded bandwidth_exceeded = 4;
+          AccountStatusNotActive account_status_not_active = 5;
+          InactiveSubscription inactive_subscription = 6;
+          MaxDeviceReached max_device_reached = 7;
+          DeviceTimeDesynced device_time_desynced = 8;
+      }
+  }
+
+  message ErrorStateReason {
+      message Firewall {}
+      message Routing {}
+      message SetDns {}
+      message TunDevice {}
+      message TunnelProvider {}
+      message StartLocalDnsResolver {}
+      message SameEntryAndExitGateway {}
+      message InvalidEntryGatewayCountry {}
+      message InvalidExitGatewayCountry {}
+      message BadBandwidthIncrease {}
+      message DuplicateTunFd {}
+      message CreateMixnetStorage {}
+      message Ipv6Unavailable {}
+      message AccountControllerError {
+          AccountControllerErrorStateReason reason = 1;
+      }
+      message AccountControllerOffline {}
+      message AccountControllerLoggedOut {}
+      message Internal {
+          string message = 1;
+      }
+
+      oneof reason {
+          Firewall firewall = 1;
+          Routing routing = 2;
+          SetDns set_dns = 3;
+          TunDevice tun_device = 4;
+          TunnelProvider tunnel_provider = 5;
+          StartLocalDnsResolver start_local_dns_resolver = 6;
+          SameEntryAndExitGateway same_entry_and_exit_gateway = 7;
+          InvalidEntryGatewayCountry invalid_entry_gateway_country = 8;
+          InvalidExitGatewayCountry invalid_exit_gateway_country = 9;
+          BadBandwidthIncrease bad_bandwidth_increase = 10;
+          DuplicateTunFd duplicate_tun_fd = 11;
+          CreateMixnetStorage create_mixnet_storage = 12;
+          Ipv6Unavailable ipv6_unavailable = 13;
+          AccountControllerError account_controller_error = 14;
+          AccountControllerOffline account_controller_offline = 15;
+          AccountControllerLoggedOut account_controller_logged_out = 16;
+          Internal internal = 17;
+      }
   }
 
   enum ActionAfterDisconnect {
@@ -363,8 +425,6 @@ message TunnelState {
   }
   message Error {
     ErrorStateReason reason = 1;
-    // for errors with details like Dns, Api, Internal
-    optional string detail = 2;
   }
   message Offline {
     bool reconnect = 1;
@@ -455,7 +515,7 @@ message AccountCommandError {
     string internal = 1;
     string storage_error = 2;
     VpnApiError vpn_api = 3;
-    string unexpected_response = 4; 
+    string unexpected_response = 4;
     bool no_account_stored = 5;
     bool no_device_stored = 6;
     bool existing_account = 7;

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -329,10 +329,10 @@ message TunnelConnectionData {
 message TunnelState {
   enum ErrorStateReason {
     SET_FIREWALL_POLICY = 0;
-    ROUTING = 1;
+    SET_ROUTING = 1;
     SET_DNS = 2;
-    CONFIGURE_TUNNEL_DEVICE = 3;
-    SET_TUNNEL_PROVIDER_SETTINGS = 4;
+    TUN_DEVICE = 3;
+    TUNNEL_PROVIDER = 4;
     IPV6_UNAVAILABLE = 5;
     SAME_ENTRY_AND_EXIT_GATEWAY = 6;
     INVALID_ENTRY_GATEWAY_COUNTRY = 7;

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -362,7 +362,7 @@ message TunnelState {
   }
 
   message ErrorStateReason {
-      message Firewall {}
+      message SetFirewallPolicy {}
       message Routing {}
       message SetDns {}
       message TunDevice {}
@@ -385,7 +385,7 @@ message TunnelState {
       }
 
       oneof reason {
-          Firewall firewall = 1;
+          SetFirewallPolicy set_firewall_policy = 1;
           Routing routing = 2;
           SetDns set_dns = 3;
           TunDevice tun_device = 4;

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -371,8 +371,6 @@ message TunnelState {
       message InvalidEntryGatewayCountry {}
       message InvalidExitGatewayCountry {}
       message BadBandwidthIncrease {}
-      message DuplicateTunFd {}
-      message CreateMixnetStorage {}
       message Ipv6Unavailable {}
       message AccountControllerError {
           AccountControllerErrorStateReason reason = 1;
@@ -393,13 +391,11 @@ message TunnelState {
           InvalidEntryGatewayCountry invalid_entry_gateway_country = 7;
           InvalidExitGatewayCountry invalid_exit_gateway_country = 8;
           BadBandwidthIncrease bad_bandwidth_increase = 9;
-          DuplicateTunFd duplicate_tun_fd = 10;
-          CreateMixnetStorage create_mixnet_storage = 11;
-          Ipv6Unavailable ipv6_unavailable = 12;
-          AccountControllerError account_controller_error = 13;
-          AccountControllerOffline account_controller_offline = 14;
-          AccountControllerLoggedOut account_controller_logged_out = 15;
-          Internal internal = 16;
+          Ipv6Unavailable ipv6_unavailable = 10;
+          AccountControllerError account_controller_error = 11;
+          AccountControllerOffline account_controller_offline = 12;
+          AccountControllerLoggedOut account_controller_logged_out = 13;
+          Internal internal = 14;
       }
   }
 

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -367,7 +367,6 @@ message TunnelState {
       message SetDns {}
       message TunDevice {}
       message TunnelProvider {}
-      message StartLocalDnsResolver {}
       message SameEntryAndExitGateway {}
       message InvalidEntryGatewayCountry {}
       message InvalidExitGatewayCountry {}
@@ -390,18 +389,17 @@ message TunnelState {
           SetDns set_dns = 3;
           TunDevice tun_device = 4;
           TunnelProvider tunnel_provider = 5;
-          StartLocalDnsResolver start_local_dns_resolver = 6;
-          SameEntryAndExitGateway same_entry_and_exit_gateway = 7;
-          InvalidEntryGatewayCountry invalid_entry_gateway_country = 8;
-          InvalidExitGatewayCountry invalid_exit_gateway_country = 9;
-          BadBandwidthIncrease bad_bandwidth_increase = 10;
-          DuplicateTunFd duplicate_tun_fd = 11;
-          CreateMixnetStorage create_mixnet_storage = 12;
-          Ipv6Unavailable ipv6_unavailable = 13;
-          AccountControllerError account_controller_error = 14;
-          AccountControllerOffline account_controller_offline = 15;
-          AccountControllerLoggedOut account_controller_logged_out = 16;
-          Internal internal = 17;
+          SameEntryAndExitGateway same_entry_and_exit_gateway = 6;
+          InvalidEntryGatewayCountry invalid_entry_gateway_country = 7;
+          InvalidExitGatewayCountry invalid_exit_gateway_country = 8;
+          BadBandwidthIncrease bad_bandwidth_increase = 9;
+          DuplicateTunFd duplicate_tun_fd = 10;
+          CreateMixnetStorage create_mixnet_storage = 11;
+          Ipv6Unavailable ipv6_unavailable = 12;
+          AccountControllerError account_controller_error = 13;
+          AccountControllerOffline account_controller_offline = 14;
+          AccountControllerLoggedOut account_controller_logged_out = 15;
+          Internal internal = 16;
       }
   }
 

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -372,6 +372,13 @@ message TunnelState {
       message InvalidEntryGatewayCountry {}
       message InvalidExitGatewayCountry {}
       message BadBandwidthIncrease {}
+      message BandwidthExceeded {}
+      message AccountStatusNotActive {
+          string status = 1;
+      }
+      message InactiveSubscription {}
+      message MaxDevicesReached {}
+      message DeviceTimeDesynced {}
       message DeviceLoggedOut {}
       message Internal {
           string message = 1;
@@ -388,9 +395,13 @@ message TunnelState {
           InvalidEntryGatewayCountry invalid_entry_gateway_country = 8;
           InvalidExitGatewayCountry invalid_exit_gateway_country = 9;
           BadBandwidthIncrease bad_bandwidth_increase = 10;
-          AccountControllerErrorStateReason account_control = 11;
-          DeviceLoggedOut device_logged_out = 12;
-          Internal internal = 13;
+          BandwidthExceeded bandwidth_exceeded = 11;
+          AccountStatusNotActive account_state_not_active = 12;
+          InactiveSubscription inactive_subscription = 13;
+          MaxDevicesReached max_devices_reached = 14;
+          DeviceTimeDesynced device_time_desynced = 15;
+          DeviceLoggedOut device_logged_out = 16;
+          Internal internal = 17;
       }
   }
 

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -327,82 +327,24 @@ message TunnelConnectionData {
 
 
 message TunnelState {
-  message AccountControllerErrorStateReason {
-      message Storage {
-          string context = 1;
-      }
-      message ApiFailure {
-          string context = 1;
-          string details = 2;
-      }
-      message Internal {
-          string context = 1;
-          string details = 2;
-      }
-      message BandwidthExceeded {
-          string context = 1;
-      }
-      message AccountStatusNotActive {
-          string status = 1;
-      }
-      message InactiveSubscription {}
-      message MaxDeviceReached {}
-      message DeviceTimeDesynced {}
-
-      oneof reason {
-          Storage storage = 1;
-          ApiFailure api_failure = 2;
-          Internal internal = 3;
-          BandwidthExceeded bandwidth_exceeded = 4;
-          AccountStatusNotActive account_status_not_active = 5;
-          InactiveSubscription inactive_subscription = 6;
-          MaxDeviceReached max_device_reached = 7;
-          DeviceTimeDesynced device_time_desynced = 8;
-      }
-  }
-
-  message ErrorStateReason {
-      message SetFirewallPolicy {}
-      message Routing {}
-      message SetDns {}
-      message ConfigureTunnelDevice {}
-      message SetTunnelProviderSettings {}
-      message Ipv6Unavailable {}
-      message SameEntryAndExitGateway {}
-      message InvalidEntryGatewayCountry {}
-      message InvalidExitGatewayCountry {}
-      message BadBandwidthIncrease {}
-      message BandwidthExceeded {}
-      message AccountStatusNotActive {
-          string status = 1;
-      }
-      message InactiveSubscription {}
-      message MaxDevicesReached {}
-      message DeviceTimeDesynced {}
-      message DeviceLoggedOut {}
-      message Internal {
-          string message = 1;
-      }
-
-      oneof reason {
-          SetFirewallPolicy set_firewall_policy = 1;
-          Routing routing = 2;
-          SetDns set_dns = 3;
-          ConfigureTunnelDevice configure_tunnel_device = 4;
-          SetTunnelProviderSettings set_tunnel_provider_settings = 5;
-          Ipv6Unavailable ipv6_unavailable = 6;
-          SameEntryAndExitGateway same_entry_and_exit_gateway = 7;
-          InvalidEntryGatewayCountry invalid_entry_gateway_country = 8;
-          InvalidExitGatewayCountry invalid_exit_gateway_country = 9;
-          BadBandwidthIncrease bad_bandwidth_increase = 10;
-          BandwidthExceeded bandwidth_exceeded = 11;
-          AccountStatusNotActive account_state_not_active = 12;
-          InactiveSubscription inactive_subscription = 13;
-          MaxDevicesReached max_devices_reached = 14;
-          DeviceTimeDesynced device_time_desynced = 15;
-          DeviceLoggedOut device_logged_out = 16;
-          Internal internal = 17;
-      }
+  enum ErrorStateReason {
+    SET_FIREWALL_POLICY = 0;
+    ROUTING = 1;
+    SET_DNS = 2;
+    CONFIGURE_TUNNEL_DEVICE = 3;
+    SET_TUNNEL_PROVIDER_SETTINGS = 4;
+    IPV6_UNAVAILABLE = 5;
+    SAME_ENTRY_AND_EXIT_GATEWAY = 6;
+    INVALID_ENTRY_GATEWAY_COUNTRY = 7;
+    INVALID_EXIT_GATEWAY_COUNTRY = 8;
+    BAD_BANDWIDTH_INCREASE = 9;
+    BANDWIDTH_EXCEEDED = 10;
+    INACTIVE_SUBSCRIPTION = 11;
+    INACTIVE_ACCOUNT = 12;
+    MAX_DEVICES_REACHED = 13;
+    DEVICE_TIME_OUT_OF_SYNC = 14;
+    DEVICE_LOGGED_OUT = 15;
+    INTERNAL = 16;
   }
 
   enum ActionAfterDisconnect {
@@ -425,6 +367,7 @@ message TunnelState {
   }
   message Error {
     ErrorStateReason reason = 1;
+    optional string message = 2;
   }
   message Offline {
     bool reconnect = 1;

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -372,13 +372,6 @@ message TunnelState {
       message InvalidEntryGatewayCountry {}
       message InvalidExitGatewayCountry {}
       message BadBandwidthIncrease {}
-      message BandwidthExceeded {}
-      message AccountStatusNotActive {
-          string status = 1;
-      }
-      message InactiveSubscription {}
-      message MaxDevicesReached {}
-      message DeviceTimeDesynced {}
       message DeviceLoggedOut {}
       message Internal {
           string message = 1;
@@ -395,13 +388,9 @@ message TunnelState {
           InvalidEntryGatewayCountry invalid_entry_gateway_country = 8;
           InvalidExitGatewayCountry invalid_exit_gateway_country = 9;
           BadBandwidthIncrease bad_bandwidth_increase = 10;
-          BandwidthExceeded bandwidth_exceeded = 11;
-          AccountStatusNotActive account_state_not_active = 12;
-          InactiveSubscription inactive_subscription = 13;
-          MaxDevicesReached max_devices_reached = 14;
-          DeviceTimeDesynced device_time_desynced = 15;
-          DeviceLoggedOut device_logged_out = 16;
-          Internal internal = 17;
+          AccountControllerErrorStateReason account_control = 11;
+          DeviceLoggedOut device_logged_out = 12;
+          Internal internal = 13;
       }
   }
 

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -367,16 +367,19 @@ message TunnelState {
       message SetDns {}
       message TunDevice {}
       message TunnelProvider {}
+      message Ipv6Unavailable {}
       message SameEntryAndExitGateway {}
       message InvalidEntryGatewayCountry {}
       message InvalidExitGatewayCountry {}
       message BadBandwidthIncrease {}
-      message Ipv6Unavailable {}
-      message AccountControllerError {
-          AccountControllerErrorStateReason reason = 1;
+      message BandwidthExceeded {}
+      message AccountStatusNotActive {
+          string status = 1;
       }
-      message AccountControllerOffline {}
-      message AccountControllerLoggedOut {}
+      message InactiveSubscription {}
+      message MaxDevicesReached {}
+      message DeviceTimeDesynced {}
+      message DeviceLoggedOut {}
       message Internal {
           string message = 1;
       }
@@ -387,15 +390,18 @@ message TunnelState {
           SetDns set_dns = 3;
           TunDevice tun_device = 4;
           TunnelProvider tunnel_provider = 5;
-          SameEntryAndExitGateway same_entry_and_exit_gateway = 6;
-          InvalidEntryGatewayCountry invalid_entry_gateway_country = 7;
-          InvalidExitGatewayCountry invalid_exit_gateway_country = 8;
-          BadBandwidthIncrease bad_bandwidth_increase = 9;
-          Ipv6Unavailable ipv6_unavailable = 10;
-          AccountControllerError account_controller_error = 11;
-          AccountControllerOffline account_controller_offline = 12;
-          AccountControllerLoggedOut account_controller_logged_out = 13;
-          Internal internal = 14;
+          Ipv6Unavailable ipv6_unavailable = 6;
+          SameEntryAndExitGateway same_entry_and_exit_gateway = 7;
+          InvalidEntryGatewayCountry invalid_entry_gateway_country = 8;
+          InvalidExitGatewayCountry invalid_exit_gateway_country = 9;
+          BadBandwidthIncrease bad_bandwidth_increase = 10;
+          BandwidthExceeded bandwidth_exceeded = 11;
+          AccountStatusNotActive account_state_not_active = 12;
+          InactiveSubscription inactive_subscription = 13;
+          MaxDevicesReached max_devices_reached = 14;
+          DeviceTimeDesynced device_time_desynced = 15;
+          DeviceLoggedOut device_logged_out = 16;
+          Internal internal = 17;
       }
   }
 

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -366,7 +366,7 @@ message TunnelState {
       message Routing {}
       message SetDns {}
       message TunDevice {}
-      message TunnelProvider {}
+      message SetTunnelProviderSettings {}
       message Ipv6Unavailable {}
       message SameEntryAndExitGateway {}
       message InvalidEntryGatewayCountry {}
@@ -389,7 +389,7 @@ message TunnelState {
           Routing routing = 2;
           SetDns set_dns = 3;
           TunDevice tun_device = 4;
-          TunnelProvider tunnel_provider = 5;
+          SetTunnelProviderSettings set_tunnel_provider_settings = 5;
           Ipv6Unavailable ipv6_unavailable = 6;
           SameEntryAndExitGateway same_entry_and_exit_gateway = 7;
           InvalidEntryGatewayCountry invalid_entry_gateway_country = 8;

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/tunnel_state.rs
@@ -53,10 +53,6 @@ impl TryFrom<proto::tunnel_state::ErrorStateReason> for ErrorStateReason {
             Reason::BadBandwidthIncrease(error_state_reason::BadBandwidthIncrease {}) => {
                 Self::BadBandwidthIncrease
             }
-            Reason::DuplicateTunFd(error_state_reason::DuplicateTunFd {}) => Self::DuplicateTunFd,
-            Reason::CreateMixnetStorage(error_state_reason::CreateMixnetStorage {}) => {
-                Self::CreateMixnetStorage
-            }
             Reason::Ipv6Unavailable(error_state_reason::Ipv6Unavailable {}) => {
                 Self::Ipv6Unavailable
             }
@@ -123,12 +119,6 @@ impl From<ErrorStateReason> for proto::tunnel_state::ErrorStateReason {
             }
             ErrorStateReason::BadBandwidthIncrease => {
                 Reason::BadBandwidthIncrease(error_state_reason::BadBandwidthIncrease {})
-            }
-            ErrorStateReason::DuplicateTunFd => {
-                Reason::DuplicateTunFd(error_state_reason::DuplicateTunFd {})
-            }
-            ErrorStateReason::CreateMixnetStorage => {
-                Reason::CreateMixnetStorage(error_state_reason::CreateMixnetStorage {})
             }
             ErrorStateReason::Ipv6Unavailable => {
                 Reason::Ipv6Unavailable(error_state_reason::Ipv6Unavailable {})

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/tunnel_state.rs
@@ -41,6 +41,9 @@ impl TryFrom<proto::tunnel_state::ErrorStateReason> for ErrorStateReason {
             Reason::SetDns(error_state_reason::SetDns {}) => Self::SetDns,
             Reason::TunDevice(error_state_reason::TunDevice {}) => Self::TunDevice,
             Reason::TunnelProvider(error_state_reason::TunnelProvider {}) => Self::TunnelProvider,
+            Reason::Ipv6Unavailable(error_state_reason::Ipv6Unavailable {}) => {
+                Self::Ipv6Unavailable
+            }
             Reason::SameEntryAndExitGateway(error_state_reason::SameEntryAndExitGateway {}) => {
                 Self::SameEntryAndExitGateway
             }
@@ -53,46 +56,26 @@ impl TryFrom<proto::tunnel_state::ErrorStateReason> for ErrorStateReason {
             Reason::BadBandwidthIncrease(error_state_reason::BadBandwidthIncrease {}) => {
                 Self::BadBandwidthIncrease
             }
-            Reason::Ipv6Unavailable(error_state_reason::Ipv6Unavailable {}) => {
-                Self::Ipv6Unavailable
+            Reason::BandwidthExceeded(error_state_reason::BandwidthExceeded {}) => {
+                Self::BandwidthExceeded
             }
-            Reason::AccountControllerError(ac_error) => {
-                Self::AccountControllerError(AccountControllerErrorStateReason::try_from(ac_error)?)
+            Reason::AccountStateNotActive(error_state_reason::AccountStatusNotActive {
+                status,
+            }) => Self::AccountStatusNotActive { status },
+            Reason::InactiveSubscription(error_state_reason::InactiveSubscription {}) => {
+                Self::InactiveSubscription
             }
-            Reason::AccountControllerOffline(error_state_reason::AccountControllerOffline {}) => {
-                Self::AccountControllerOffline
+            Reason::DeviceLoggedOut(error_state_reason::DeviceLoggedOut {}) => {
+                Self::DeviceLoggedOut
             }
-            Reason::AccountControllerLoggedOut(
-                error_state_reason::AccountControllerLoggedOut {},
-            ) => Self::AccountControllerLoggedOut,
+            Reason::MaxDevicesReached(error_state_reason::MaxDevicesReached {}) => {
+                Self::MaxDevicesReached
+            }
+            Reason::DeviceTimeDesynced(error_state_reason::DeviceTimeDesynced {}) => {
+                Self::DeviceTimeDesynced
+            }
             Reason::Internal(error_state_reason::Internal { message }) => Self::Internal(message),
         })
-    }
-}
-
-impl TryFrom<proto::tunnel_state::error_state_reason::AccountControllerError>
-    for AccountControllerErrorStateReason
-{
-    type Error = ConversionError;
-
-    fn try_from(
-        value: proto::tunnel_state::error_state_reason::AccountControllerError,
-    ) -> Result<Self, ConversionError> {
-        let reason = value
-            .reason
-            .ok_or(ConversionError::NoValueSet("AccountControllerError.reason"))?;
-
-        AccountControllerErrorStateReason::try_from(reason)
-    }
-}
-
-impl From<AccountControllerErrorStateReason>
-    for proto::tunnel_state::error_state_reason::AccountControllerError
-{
-    fn from(value: AccountControllerErrorStateReason) -> Self {
-        Self {
-            reason: Some(proto::tunnel_state::AccountControllerErrorStateReason::from(value)),
-        }
     }
 }
 
@@ -108,6 +91,9 @@ impl From<ErrorStateReason> for proto::tunnel_state::ErrorStateReason {
             ErrorStateReason::TunnelProvider => {
                 Reason::TunnelProvider(error_state_reason::TunnelProvider {})
             }
+            ErrorStateReason::Ipv6Unavailable => {
+                Reason::Ipv6Unavailable(error_state_reason::Ipv6Unavailable {})
+            }
             ErrorStateReason::SameEntryAndExitGateway => {
                 Reason::SameEntryAndExitGateway(error_state_reason::SameEntryAndExitGateway {})
             }
@@ -120,18 +106,24 @@ impl From<ErrorStateReason> for proto::tunnel_state::ErrorStateReason {
             ErrorStateReason::BadBandwidthIncrease => {
                 Reason::BadBandwidthIncrease(error_state_reason::BadBandwidthIncrease {})
             }
-            ErrorStateReason::Ipv6Unavailable => {
-                Reason::Ipv6Unavailable(error_state_reason::Ipv6Unavailable {})
+            ErrorStateReason::BandwidthExceeded => {
+                Reason::BandwidthExceeded(error_state_reason::BandwidthExceeded {})
             }
-            ErrorStateReason::AccountControllerError(reason) => Reason::AccountControllerError(
-                error_state_reason::AccountControllerError::from(reason),
-            ),
-            ErrorStateReason::AccountControllerOffline => {
-                Reason::AccountControllerOffline(error_state_reason::AccountControllerOffline {})
+            ErrorStateReason::AccountStatusNotActive { status } => {
+                Reason::AccountStateNotActive(error_state_reason::AccountStatusNotActive { status })
             }
-            ErrorStateReason::AccountControllerLoggedOut => Reason::AccountControllerLoggedOut(
-                error_state_reason::AccountControllerLoggedOut {},
-            ),
+            ErrorStateReason::InactiveSubscription => {
+                Reason::InactiveSubscription(error_state_reason::InactiveSubscription {})
+            }
+            ErrorStateReason::MaxDevicesReached => {
+                Reason::MaxDevicesReached(error_state_reason::MaxDevicesReached {})
+            }
+            ErrorStateReason::DeviceTimeDesynced => {
+                Reason::DeviceTimeDesynced(error_state_reason::DeviceTimeDesynced {})
+            }
+            ErrorStateReason::DeviceLoggedOut => {
+                Reason::DeviceLoggedOut(error_state_reason::DeviceLoggedOut {})
+            }
             ErrorStateReason::Internal(message) => {
                 Reason::Internal(error_state_reason::Internal { message })
             }

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/tunnel_state.rs
@@ -62,23 +62,11 @@ impl TryFrom<proto::tunnel_state::ErrorStateReason> for ErrorStateReason {
             Reason::BadBandwidthIncrease(error_state_reason::BadBandwidthIncrease {}) => {
                 Self::BadBandwidthIncrease
             }
-            Reason::BandwidthExceeded(error_state_reason::BandwidthExceeded {}) => {
-                Self::BandwidthExceeded
-            }
-            Reason::AccountStateNotActive(error_state_reason::AccountStatusNotActive {
-                status,
-            }) => Self::AccountStatusNotActive { status },
-            Reason::InactiveSubscription(error_state_reason::InactiveSubscription {}) => {
-                Self::InactiveSubscription
+            Reason::AccountControl(reason) => {
+                Self::AccountControl(AccountControllerErrorStateReason::try_from(reason)?)
             }
             Reason::DeviceLoggedOut(error_state_reason::DeviceLoggedOut {}) => {
                 Self::DeviceLoggedOut
-            }
-            Reason::MaxDevicesReached(error_state_reason::MaxDevicesReached {}) => {
-                Self::MaxDevicesReached
-            }
-            Reason::DeviceTimeDesynced(error_state_reason::DeviceTimeDesynced {}) => {
-                Self::DeviceTimeDesynced
             }
             Reason::Internal(error_state_reason::Internal { message }) => Self::Internal(message),
         })
@@ -116,21 +104,9 @@ impl From<ErrorStateReason> for proto::tunnel_state::ErrorStateReason {
             ErrorStateReason::BadBandwidthIncrease => {
                 Reason::BadBandwidthIncrease(error_state_reason::BadBandwidthIncrease {})
             }
-            ErrorStateReason::BandwidthExceeded => {
-                Reason::BandwidthExceeded(error_state_reason::BandwidthExceeded {})
-            }
-            ErrorStateReason::AccountStatusNotActive { status } => {
-                Reason::AccountStateNotActive(error_state_reason::AccountStatusNotActive { status })
-            }
-            ErrorStateReason::InactiveSubscription => {
-                Reason::InactiveSubscription(error_state_reason::InactiveSubscription {})
-            }
-            ErrorStateReason::MaxDevicesReached => {
-                Reason::MaxDevicesReached(error_state_reason::MaxDevicesReached {})
-            }
-            ErrorStateReason::DeviceTimeDesynced => {
-                Reason::DeviceTimeDesynced(error_state_reason::DeviceTimeDesynced {})
-            }
+            ErrorStateReason::AccountControl(reason) => Reason::AccountControl(
+                proto::tunnel_state::AccountControllerErrorStateReason::from(reason),
+            ),
             ErrorStateReason::DeviceLoggedOut => {
                 Reason::DeviceLoggedOut(error_state_reason::DeviceLoggedOut {})
             }

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/tunnel_state.rs
@@ -7,9 +7,8 @@ use std::{
 };
 
 use nym_vpn_lib_types::{
-    AccountControllerErrorStateReason, ActionAfterDisconnect, ConnectionData, ErrorStateReason,
-    Gateway, MixnetConnectionData, NymAddress, TunnelConnectionData, TunnelState,
-    WireguardConnectionData, WireguardNode,
+    ActionAfterDisconnect, ConnectionData, ErrorStateReason, Gateway, MixnetConnectionData,
+    NymAddress, TunnelConnectionData, TunnelState, WireguardConnectionData, WireguardNode,
 };
 
 use crate::{conversions::ConversionError, proto};
@@ -25,206 +24,109 @@ impl From<proto::tunnel_state::ActionAfterDisconnect> for ActionAfterDisconnect 
     }
 }
 
-impl TryFrom<proto::tunnel_state::ErrorStateReason> for ErrorStateReason {
+impl TryFrom<proto::tunnel_state::Error> for ErrorStateReason {
     type Error = ConversionError;
 
-    fn try_from(value: proto::tunnel_state::ErrorStateReason) -> Result<Self, ConversionError> {
-        use proto::tunnel_state::error_state_reason::{self, Reason};
-
-        let reason = value
-            .reason
-            .ok_or(ConversionError::NoValueSet("ErrorStateReason.reason"))?;
+    fn try_from(value: proto::tunnel_state::Error) -> Result<Self, ConversionError> {
+        use proto::tunnel_state::ErrorStateReason as Reason;
+        let reason = proto::tunnel_state::ErrorStateReason::try_from(value.reason)
+            .map_err(|_| ConversionError::NoValueSet("tunnel_state::Error::reason"))?;
 
         Ok(match reason {
-            Reason::SetFirewallPolicy(error_state_reason::SetFirewallPolicy {}) => {
-                Self::SetFirewallPolicy
-            }
-            Reason::Routing(error_state_reason::Routing {}) => Self::Routing,
-            Reason::SetDns(error_state_reason::SetDns {}) => Self::SetDns,
-            Reason::ConfigureTunnelDevice(error_state_reason::ConfigureTunnelDevice {}) => {
-                Self::ConfigureTunnelDevice
-            }
-            Reason::SetTunnelProviderSettings(error_state_reason::SetTunnelProviderSettings {}) => {
-                Self::SetTunnelProviderSettings
-            }
-            Reason::Ipv6Unavailable(error_state_reason::Ipv6Unavailable {}) => {
-                Self::Ipv6Unavailable
-            }
-            Reason::SameEntryAndExitGateway(error_state_reason::SameEntryAndExitGateway {}) => {
-                Self::SameEntryAndExitGateway
-            }
-            Reason::InvalidEntryGatewayCountry(
-                error_state_reason::InvalidEntryGatewayCountry {},
-            ) => Self::InvalidEntryGatewayCountry,
-            Reason::InvalidExitGatewayCountry(error_state_reason::InvalidExitGatewayCountry {}) => {
-                Self::InvalidExitGatewayCountry
-            }
-            Reason::BadBandwidthIncrease(error_state_reason::BadBandwidthIncrease {}) => {
-                Self::BadBandwidthIncrease
-            }
-            Reason::BandwidthExceeded(error_state_reason::BandwidthExceeded {}) => {
-                Self::BandwidthExceeded
-            }
-            Reason::AccountStateNotActive(error_state_reason::AccountStatusNotActive {
-                status,
-            }) => Self::AccountStatusNotActive { status },
-            Reason::InactiveSubscription(error_state_reason::InactiveSubscription {}) => {
-                Self::InactiveSubscription
-            }
-            Reason::DeviceLoggedOut(error_state_reason::DeviceLoggedOut {}) => {
-                Self::DeviceLoggedOut
-            }
-            Reason::MaxDevicesReached(error_state_reason::MaxDevicesReached {}) => {
-                Self::MaxDevicesReached
-            }
-            Reason::DeviceTimeDesynced(error_state_reason::DeviceTimeDesynced {}) => {
-                Self::DeviceTimeDesynced
-            }
-            Reason::Internal(error_state_reason::Internal { message }) => Self::Internal(message),
+            Reason::SetFirewallPolicy => Self::SetFirewallPolicy,
+            Reason::Routing => Self::Routing,
+            Reason::SetDns => Self::SetDns,
+            Reason::ConfigureTunnelDevice => Self::ConfigureTunnelDevice,
+            Reason::SetTunnelProviderSettings => Self::SetTunnelProviderSettings,
+            Reason::Ipv6Unavailable => Self::Ipv6Unavailable,
+            Reason::SameEntryAndExitGateway => Self::SameEntryAndExitGateway,
+            Reason::InvalidEntryGatewayCountry => Self::InvalidEntryGatewayCountry,
+            Reason::InvalidExitGatewayCountry => Self::InvalidExitGatewayCountry,
+            Reason::BadBandwidthIncrease => Self::BadBandwidthIncrease,
+            Reason::BandwidthExceeded => Self::BandwidthExceeded,
+            Reason::InactiveAccount => Self::InactiveAccount,
+            Reason::InactiveSubscription => Self::InactiveSubscription,
+            Reason::MaxDevicesReached => Self::MaxDevicesReached,
+            Reason::DeviceTimeOutOfSync => Self::DeviceTimeOutOfSync,
+            Reason::DeviceLoggedOut => Self::DeviceLoggedOut,
+            Reason::Internal => Self::Internal(value.message.unwrap_or_default()),
         })
     }
 }
 
-impl From<ErrorStateReason> for proto::tunnel_state::ErrorStateReason {
+impl From<ErrorStateReason> for proto::tunnel_state::Error {
     fn from(value: ErrorStateReason) -> Self {
-        use proto::tunnel_state::error_state_reason::{self, Reason};
+        use proto::tunnel_state::ErrorStateReason as Reason;
 
-        let reason = match value {
-            ErrorStateReason::SetFirewallPolicy => {
-                Reason::SetFirewallPolicy(error_state_reason::SetFirewallPolicy {})
-            }
-            ErrorStateReason::Routing => Reason::Routing(error_state_reason::Routing {}),
-            ErrorStateReason::SetDns => Reason::SetDns(error_state_reason::SetDns {}),
-            ErrorStateReason::ConfigureTunnelDevice => {
-                Reason::ConfigureTunnelDevice(error_state_reason::ConfigureTunnelDevice {})
-            }
-            ErrorStateReason::SetTunnelProviderSettings => {
-                Reason::SetTunnelProviderSettings(error_state_reason::SetTunnelProviderSettings {})
-            }
-            ErrorStateReason::Ipv6Unavailable => {
-                Reason::Ipv6Unavailable(error_state_reason::Ipv6Unavailable {})
-            }
-            ErrorStateReason::SameEntryAndExitGateway => {
-                Reason::SameEntryAndExitGateway(error_state_reason::SameEntryAndExitGateway {})
-            }
-            ErrorStateReason::InvalidEntryGatewayCountry => Reason::InvalidEntryGatewayCountry(
-                error_state_reason::InvalidEntryGatewayCountry {},
-            ),
-            ErrorStateReason::InvalidExitGatewayCountry => {
-                Reason::InvalidExitGatewayCountry(error_state_reason::InvalidExitGatewayCountry {})
-            }
-            ErrorStateReason::BadBandwidthIncrease => {
-                Reason::BadBandwidthIncrease(error_state_reason::BadBandwidthIncrease {})
-            }
-            ErrorStateReason::BandwidthExceeded => {
-                Reason::BandwidthExceeded(error_state_reason::BandwidthExceeded {})
-            }
-            ErrorStateReason::AccountStatusNotActive { status } => {
-                Reason::AccountStateNotActive(error_state_reason::AccountStatusNotActive { status })
-            }
-            ErrorStateReason::InactiveSubscription => {
-                Reason::InactiveSubscription(error_state_reason::InactiveSubscription {})
-            }
-            ErrorStateReason::MaxDevicesReached => {
-                Reason::MaxDevicesReached(error_state_reason::MaxDevicesReached {})
-            }
-            ErrorStateReason::DeviceTimeDesynced => {
-                Reason::DeviceTimeDesynced(error_state_reason::DeviceTimeDesynced {})
-            }
-            ErrorStateReason::DeviceLoggedOut => {
-                Reason::DeviceLoggedOut(error_state_reason::DeviceLoggedOut {})
-            }
-            ErrorStateReason::Internal(message) => {
-                Reason::Internal(error_state_reason::Internal { message })
-            }
-        };
-
-        Self {
-            reason: Some(reason),
-        }
-    }
-}
-
-impl TryFrom<proto::tunnel_state::AccountControllerErrorStateReason>
-    for AccountControllerErrorStateReason
-{
-    type Error = ConversionError;
-
-    fn try_from(
-        value: proto::tunnel_state::AccountControllerErrorStateReason,
-    ) -> Result<Self, ConversionError> {
-        use proto::tunnel_state::account_controller_error_state_reason::{
-            self as error_state_reason, Reason,
-        };
-
-        let reason = value.reason.ok_or(ConversionError::NoValueSet(
-            "AccountControllerErrorStateReason.reason",
-        ))?;
-
-        Ok(match reason {
-            Reason::Storage(error_state_reason::Storage { context }) => Self::Storage { context },
-            Reason::ApiFailure(error_state_reason::ApiFailure { context, details }) => {
-                Self::ApiFailure { context, details }
-            }
-            Reason::Internal(error_state_reason::Internal { context, details }) => {
-                Self::Internal { context, details }
-            }
-            Reason::BandwidthExceeded(error_state_reason::BandwidthExceeded { context }) => {
-                Self::BandwidthExceeded { context }
-            }
-            Reason::AccountStatusNotActive(error_state_reason::AccountStatusNotActive {
-                status,
-            }) => Self::AccountStatusNotActive { status },
-            Reason::InactiveSubscription(error_state_reason::InactiveSubscription {}) => {
-                Self::InactiveSubscription
-            }
-            Reason::MaxDeviceReached(error_state_reason::MaxDeviceReached {}) => {
-                Self::MaxDeviceReached
-            }
-            Reason::DeviceTimeDesynced(error_state_reason::DeviceTimeDesynced {}) => {
-                Self::DeviceTimeDesynced
-            }
-        })
-    }
-}
-
-impl From<AccountControllerErrorStateReason>
-    for proto::tunnel_state::AccountControllerErrorStateReason
-{
-    fn from(value: AccountControllerErrorStateReason) -> Self {
-        use proto::tunnel_state::account_controller_error_state_reason::{
-            self as error_state_reason, Reason,
-        };
-        let reason = match value {
-            AccountControllerErrorStateReason::Storage { context } => {
-                Reason::Storage(error_state_reason::Storage { context })
-            }
-            AccountControllerErrorStateReason::ApiFailure { context, details } => {
-                Reason::ApiFailure(error_state_reason::ApiFailure { context, details })
-            }
-            AccountControllerErrorStateReason::Internal { context, details } => {
-                Reason::Internal(error_state_reason::Internal { context, details })
-            }
-            AccountControllerErrorStateReason::BandwidthExceeded { context } => {
-                Reason::BandwidthExceeded(error_state_reason::BandwidthExceeded { context })
-            }
-            AccountControllerErrorStateReason::AccountStatusNotActive { status } => {
-                Reason::AccountStatusNotActive(error_state_reason::AccountStatusNotActive {
-                    status,
-                })
-            }
-            AccountControllerErrorStateReason::InactiveSubscription => {
-                Reason::InactiveSubscription(error_state_reason::InactiveSubscription {})
-            }
-            AccountControllerErrorStateReason::MaxDeviceReached => {
-                Reason::MaxDeviceReached(error_state_reason::MaxDeviceReached {})
-            }
-            AccountControllerErrorStateReason::DeviceTimeDesynced => {
-                Reason::DeviceTimeDesynced(error_state_reason::DeviceTimeDesynced {})
-            }
-        };
-        Self {
-            reason: Some(reason),
+        match value {
+            ErrorStateReason::SetFirewallPolicy => Self {
+                reason: Reason::SetFirewallPolicy.into(),
+                message: None,
+            },
+            ErrorStateReason::Routing => Self {
+                reason: Reason::Routing.into(),
+                message: None,
+            },
+            ErrorStateReason::SetDns => Self {
+                reason: Reason::SetDns.into(),
+                message: None,
+            },
+            ErrorStateReason::ConfigureTunnelDevice => Self {
+                reason: Reason::ConfigureTunnelDevice.into(),
+                message: None,
+            },
+            ErrorStateReason::SetTunnelProviderSettings => Self {
+                reason: Reason::SetTunnelProviderSettings.into(),
+                message: None,
+            },
+            ErrorStateReason::Ipv6Unavailable => Self {
+                reason: Reason::Ipv6Unavailable.into(),
+                message: None,
+            },
+            ErrorStateReason::SameEntryAndExitGateway => Self {
+                reason: Reason::SameEntryAndExitGateway.into(),
+                message: None,
+            },
+            ErrorStateReason::InvalidEntryGatewayCountry => Self {
+                reason: Reason::InvalidEntryGatewayCountry.into(),
+                message: None,
+            },
+            ErrorStateReason::InvalidExitGatewayCountry => Self {
+                reason: Reason::InvalidExitGatewayCountry.into(),
+                message: None,
+            },
+            ErrorStateReason::BadBandwidthIncrease => Self {
+                reason: Reason::BadBandwidthIncrease.into(),
+                message: None,
+            },
+            ErrorStateReason::BandwidthExceeded => Self {
+                reason: Reason::BandwidthExceeded.into(),
+                message: None,
+            },
+            ErrorStateReason::InactiveAccount => Self {
+                reason: Reason::InactiveAccount.into(),
+                message: None,
+            },
+            ErrorStateReason::InactiveSubscription => Self {
+                reason: Reason::InactiveSubscription.into(),
+                message: None,
+            },
+            ErrorStateReason::MaxDevicesReached => Self {
+                reason: Reason::MaxDevicesReached.into(),
+                message: None,
+            },
+            ErrorStateReason::DeviceTimeOutOfSync => Self {
+                reason: Reason::DeviceTimeOutOfSync.into(),
+                message: None,
+            },
+            ErrorStateReason::DeviceLoggedOut => Self {
+                reason: Reason::DeviceLoggedOut.into(),
+                message: None,
+            },
+            ErrorStateReason::Internal(message) => Self {
+                reason: Reason::Internal.into(),
+                message: Some(message),
+            },
         }
     }
 }
@@ -272,13 +174,7 @@ impl TryFrom<proto::TunnelState> for TunnelState {
 
                 Self::Connected { connection_data }
             }
-            proto::tunnel_state::State::Error(proto::tunnel_state::Error { reason }) => {
-                Self::Error(
-                    reason
-                        .ok_or(ConversionError::NoValueSet("TunnelState.reason"))
-                        .and_then(ErrorStateReason::try_from)?,
-                )
-            }
+            proto::tunnel_state::State::Error(err) => Self::Error(ErrorStateReason::try_from(err)?),
             proto::tunnel_state::State::Offline(proto::tunnel_state::Offline { reconnect }) => {
                 Self::Offline { reconnect }
             }
@@ -539,9 +435,7 @@ impl From<TunnelState> for proto::TunnelState {
                 proto::tunnel_state::State::Offline(proto::tunnel_state::Offline { reconnect })
             }
             TunnelState::Error(reason) => {
-                proto::tunnel_state::State::Error(proto::tunnel_state::Error {
-                    reason: Some(proto::tunnel_state::ErrorStateReason::from(reason)),
-                })
+                proto::tunnel_state::State::Error(proto::tunnel_state::Error::from(reason))
             }
         };
 

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/tunnel_state.rs
@@ -42,7 +42,9 @@ impl TryFrom<proto::tunnel_state::ErrorStateReason> for ErrorStateReason {
             Reason::Routing(error_state_reason::Routing {}) => Self::Routing,
             Reason::SetDns(error_state_reason::SetDns {}) => Self::SetDns,
             Reason::TunDevice(error_state_reason::TunDevice {}) => Self::TunDevice,
-            Reason::TunnelProvider(error_state_reason::TunnelProvider {}) => Self::TunnelProvider,
+            Reason::SetTunnelProviderSettings(error_state_reason::SetTunnelProviderSettings {}) => {
+                Self::SetTunnelProviderSettings
+            }
             Reason::Ipv6Unavailable(error_state_reason::Ipv6Unavailable {}) => {
                 Self::Ipv6Unavailable
             }
@@ -92,8 +94,8 @@ impl From<ErrorStateReason> for proto::tunnel_state::ErrorStateReason {
             ErrorStateReason::Routing => Reason::Routing(error_state_reason::Routing {}),
             ErrorStateReason::SetDns => Reason::SetDns(error_state_reason::SetDns {}),
             ErrorStateReason::TunDevice => Reason::TunDevice(error_state_reason::TunDevice {}),
-            ErrorStateReason::TunnelProvider => {
-                Reason::TunnelProvider(error_state_reason::TunnelProvider {})
+            ErrorStateReason::SetTunnelProviderSettings => {
+                Reason::SetTunnelProviderSettings(error_state_reason::SetTunnelProviderSettings {})
             }
             ErrorStateReason::Ipv6Unavailable => {
                 Reason::Ipv6Unavailable(error_state_reason::Ipv6Unavailable {})

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/tunnel_state.rs
@@ -36,7 +36,9 @@ impl TryFrom<proto::tunnel_state::ErrorStateReason> for ErrorStateReason {
             .ok_or(ConversionError::NoValueSet("ErrorStateReason.reason"))?;
 
         Ok(match reason {
-            Reason::Firewall(error_state_reason::Firewall {}) => Self::Firewall,
+            Reason::SetFirewallPolicy(error_state_reason::SetFirewallPolicy {}) => {
+                Self::SetFirewallPolicy
+            }
             Reason::Routing(error_state_reason::Routing {}) => Self::Routing,
             Reason::SetDns(error_state_reason::SetDns {}) => Self::SetDns,
             Reason::TunDevice(error_state_reason::TunDevice {}) => Self::TunDevice,
@@ -84,7 +86,9 @@ impl From<ErrorStateReason> for proto::tunnel_state::ErrorStateReason {
         use proto::tunnel_state::error_state_reason::{self, Reason};
 
         let reason = match value {
-            ErrorStateReason::Firewall => Reason::Firewall(error_state_reason::Firewall {}),
+            ErrorStateReason::SetFirewallPolicy => {
+                Reason::SetFirewallPolicy(error_state_reason::SetFirewallPolicy {})
+            }
             ErrorStateReason::Routing => Reason::Routing(error_state_reason::Routing {}),
             ErrorStateReason::SetDns => Reason::SetDns(error_state_reason::SetDns {}),
             ErrorStateReason::TunDevice => Reason::TunDevice(error_state_reason::TunDevice {}),

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/tunnel_state.rs
@@ -62,11 +62,23 @@ impl TryFrom<proto::tunnel_state::ErrorStateReason> for ErrorStateReason {
             Reason::BadBandwidthIncrease(error_state_reason::BadBandwidthIncrease {}) => {
                 Self::BadBandwidthIncrease
             }
-            Reason::AccountControl(reason) => {
-                Self::AccountControl(AccountControllerErrorStateReason::try_from(reason)?)
+            Reason::BandwidthExceeded(error_state_reason::BandwidthExceeded {}) => {
+                Self::BandwidthExceeded
+            }
+            Reason::AccountStateNotActive(error_state_reason::AccountStatusNotActive {
+                status,
+            }) => Self::AccountStatusNotActive { status },
+            Reason::InactiveSubscription(error_state_reason::InactiveSubscription {}) => {
+                Self::InactiveSubscription
             }
             Reason::DeviceLoggedOut(error_state_reason::DeviceLoggedOut {}) => {
                 Self::DeviceLoggedOut
+            }
+            Reason::MaxDevicesReached(error_state_reason::MaxDevicesReached {}) => {
+                Self::MaxDevicesReached
+            }
+            Reason::DeviceTimeDesynced(error_state_reason::DeviceTimeDesynced {}) => {
+                Self::DeviceTimeDesynced
             }
             Reason::Internal(error_state_reason::Internal { message }) => Self::Internal(message),
         })
@@ -104,9 +116,21 @@ impl From<ErrorStateReason> for proto::tunnel_state::ErrorStateReason {
             ErrorStateReason::BadBandwidthIncrease => {
                 Reason::BadBandwidthIncrease(error_state_reason::BadBandwidthIncrease {})
             }
-            ErrorStateReason::AccountControl(reason) => Reason::AccountControl(
-                proto::tunnel_state::AccountControllerErrorStateReason::from(reason),
-            ),
+            ErrorStateReason::BandwidthExceeded => {
+                Reason::BandwidthExceeded(error_state_reason::BandwidthExceeded {})
+            }
+            ErrorStateReason::AccountStatusNotActive { status } => {
+                Reason::AccountStateNotActive(error_state_reason::AccountStatusNotActive { status })
+            }
+            ErrorStateReason::InactiveSubscription => {
+                Reason::InactiveSubscription(error_state_reason::InactiveSubscription {})
+            }
+            ErrorStateReason::MaxDevicesReached => {
+                Reason::MaxDevicesReached(error_state_reason::MaxDevicesReached {})
+            }
+            ErrorStateReason::DeviceTimeDesynced => {
+                Reason::DeviceTimeDesynced(error_state_reason::DeviceTimeDesynced {})
+            }
             ErrorStateReason::DeviceLoggedOut => {
                 Reason::DeviceLoggedOut(error_state_reason::DeviceLoggedOut {})
             }

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/tunnel_state.rs
@@ -41,7 +41,9 @@ impl TryFrom<proto::tunnel_state::ErrorStateReason> for ErrorStateReason {
             }
             Reason::Routing(error_state_reason::Routing {}) => Self::Routing,
             Reason::SetDns(error_state_reason::SetDns {}) => Self::SetDns,
-            Reason::TunDevice(error_state_reason::TunDevice {}) => Self::TunDevice,
+            Reason::ConfigureTunnelDevice(error_state_reason::ConfigureTunnelDevice {}) => {
+                Self::ConfigureTunnelDevice
+            }
             Reason::SetTunnelProviderSettings(error_state_reason::SetTunnelProviderSettings {}) => {
                 Self::SetTunnelProviderSettings
             }
@@ -93,7 +95,9 @@ impl From<ErrorStateReason> for proto::tunnel_state::ErrorStateReason {
             }
             ErrorStateReason::Routing => Reason::Routing(error_state_reason::Routing {}),
             ErrorStateReason::SetDns => Reason::SetDns(error_state_reason::SetDns {}),
-            ErrorStateReason::TunDevice => Reason::TunDevice(error_state_reason::TunDevice {}),
+            ErrorStateReason::ConfigureTunnelDevice => {
+                Reason::ConfigureTunnelDevice(error_state_reason::ConfigureTunnelDevice {})
+            }
             ErrorStateReason::SetTunnelProviderSettings => {
                 Reason::SetTunnelProviderSettings(error_state_reason::SetTunnelProviderSettings {})
             }

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/tunnel_state.rs
@@ -34,10 +34,10 @@ impl TryFrom<proto::tunnel_state::Error> for ErrorStateReason {
 
         Ok(match reason {
             Reason::SetFirewallPolicy => Self::SetFirewallPolicy,
-            Reason::Routing => Self::Routing,
+            Reason::SetRouting => Self::SetRouting,
             Reason::SetDns => Self::SetDns,
-            Reason::ConfigureTunnelDevice => Self::ConfigureTunnelDevice,
-            Reason::SetTunnelProviderSettings => Self::SetTunnelProviderSettings,
+            Reason::TunDevice => Self::TunDevice,
+            Reason::TunnelProvider => Self::TunnelProvider,
             Reason::Ipv6Unavailable => Self::Ipv6Unavailable,
             Reason::SameEntryAndExitGateway => Self::SameEntryAndExitGateway,
             Reason::InvalidEntryGatewayCountry => Self::InvalidEntryGatewayCountry,
@@ -63,20 +63,20 @@ impl From<ErrorStateReason> for proto::tunnel_state::Error {
                 reason: Reason::SetFirewallPolicy.into(),
                 message: None,
             },
-            ErrorStateReason::Routing => Self {
-                reason: Reason::Routing.into(),
+            ErrorStateReason::SetRouting => Self {
+                reason: Reason::SetRouting.into(),
                 message: None,
             },
             ErrorStateReason::SetDns => Self {
                 reason: Reason::SetDns.into(),
                 message: None,
             },
-            ErrorStateReason::ConfigureTunnelDevice => Self {
-                reason: Reason::ConfigureTunnelDevice.into(),
+            ErrorStateReason::TunDevice => Self {
+                reason: Reason::TunDevice.into(),
                 message: None,
             },
-            ErrorStateReason::SetTunnelProviderSettings => Self {
-                reason: Reason::SetTunnelProviderSettings.into(),
+            ErrorStateReason::TunnelProvider => Self {
+                reason: Reason::TunnelProvider.into(),
                 message: None,
             },
             ErrorStateReason::Ipv6Unavailable => Self {

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/tunnel_state.rs
@@ -41,9 +41,6 @@ impl TryFrom<proto::tunnel_state::ErrorStateReason> for ErrorStateReason {
             Reason::SetDns(error_state_reason::SetDns {}) => Self::SetDns,
             Reason::TunDevice(error_state_reason::TunDevice {}) => Self::TunDevice,
             Reason::TunnelProvider(error_state_reason::TunnelProvider {}) => Self::TunnelProvider,
-            Reason::StartLocalDnsResolver(error_state_reason::StartLocalDnsResolver {}) => {
-                Self::StartLocalDnsResolver
-            }
             Reason::SameEntryAndExitGateway(error_state_reason::SameEntryAndExitGateway {}) => {
                 Self::SameEntryAndExitGateway
             }
@@ -114,9 +111,6 @@ impl From<ErrorStateReason> for proto::tunnel_state::ErrorStateReason {
             ErrorStateReason::TunDevice => Reason::TunDevice(error_state_reason::TunDevice {}),
             ErrorStateReason::TunnelProvider => {
                 Reason::TunnelProvider(error_state_reason::TunnelProvider {})
-            }
-            ErrorStateReason::StartLocalDnsResolver => {
-                Reason::StartLocalDnsResolver(error_state_reason::StartLocalDnsResolver {})
             }
             ErrorStateReason::SameEntryAndExitGateway => {
                 Reason::SameEntryAndExitGateway(error_state_reason::SameEntryAndExitGateway {})

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/tunnel_state.rs
@@ -7,8 +7,9 @@ use std::{
 };
 
 use nym_vpn_lib_types::{
-    ActionAfterDisconnect, ClientErrorReason, ConnectionData, Gateway, MixnetConnectionData,
-    NymAddress, TunnelConnectionData, TunnelState, WireguardConnectionData, WireguardNode,
+    AccountControllerErrorStateReason, ActionAfterDisconnect, ConnectionData, ErrorStateReason,
+    Gateway, MixnetConnectionData, NymAddress, TunnelConnectionData, TunnelState,
+    WireguardConnectionData, WireguardNode,
 };
 
 use crate::{conversions::ConversionError, proto};
@@ -24,113 +25,220 @@ impl From<proto::tunnel_state::ActionAfterDisconnect> for ActionAfterDisconnect 
     }
 }
 
-impl From<proto::tunnel_state::Error> for ClientErrorReason {
-    fn from(value: proto::tunnel_state::Error) -> Self {
-        match value.reason() {
-            proto::tunnel_state::ErrorStateReason::Firewall => ClientErrorReason::Firewall,
-            proto::tunnel_state::ErrorStateReason::Routing => ClientErrorReason::Routing,
-            proto::tunnel_state::ErrorStateReason::SameEntryAndExitGateway => {
-                ClientErrorReason::SameEntryAndExitGateway
+impl TryFrom<proto::tunnel_state::ErrorStateReason> for ErrorStateReason {
+    type Error = ConversionError;
+
+    fn try_from(value: proto::tunnel_state::ErrorStateReason) -> Result<Self, ConversionError> {
+        use proto::tunnel_state::error_state_reason::{self, Reason};
+
+        let reason = value
+            .reason
+            .ok_or(ConversionError::NoValueSet("ErrorStateReason.reason"))?;
+
+        Ok(match reason {
+            Reason::Firewall(error_state_reason::Firewall {}) => Self::Firewall,
+            Reason::Routing(error_state_reason::Routing {}) => Self::Routing,
+            Reason::SetDns(error_state_reason::SetDns {}) => Self::SetDns,
+            Reason::TunDevice(error_state_reason::TunDevice {}) => Self::TunDevice,
+            Reason::TunnelProvider(error_state_reason::TunnelProvider {}) => Self::TunnelProvider,
+            Reason::StartLocalDnsResolver(error_state_reason::StartLocalDnsResolver {}) => {
+                Self::StartLocalDnsResolver
             }
-            proto::tunnel_state::ErrorStateReason::InvalidEntryGatewayCountry => {
-                ClientErrorReason::InvalidEntryGatewayCountry
+            Reason::SameEntryAndExitGateway(error_state_reason::SameEntryAndExitGateway {}) => {
+                Self::SameEntryAndExitGateway
             }
-            proto::tunnel_state::ErrorStateReason::InvalidExitGatewayCountry => {
-                ClientErrorReason::InvalidExitGatewayCountry
+            Reason::InvalidEntryGatewayCountry(
+                error_state_reason::InvalidEntryGatewayCountry {},
+            ) => Self::InvalidEntryGatewayCountry,
+            Reason::InvalidExitGatewayCountry(error_state_reason::InvalidExitGatewayCountry {}) => {
+                Self::InvalidExitGatewayCountry
             }
-            proto::tunnel_state::ErrorStateReason::MaxDevicesReached => {
-                ClientErrorReason::MaxDevicesReached
+            Reason::BadBandwidthIncrease(error_state_reason::BadBandwidthIncrease {}) => {
+                Self::BadBandwidthIncrease
             }
-            proto::tunnel_state::ErrorStateReason::BandwidthExceeded => {
-                ClientErrorReason::BandwidthExceeded
+            Reason::DuplicateTunFd(error_state_reason::DuplicateTunFd {}) => Self::DuplicateTunFd,
+            Reason::CreateMixnetStorage(error_state_reason::CreateMixnetStorage {}) => {
+                Self::CreateMixnetStorage
             }
-            proto::tunnel_state::ErrorStateReason::InactiveSubscription => {
-                ClientErrorReason::InactiveSubscription
+            Reason::Ipv6Unavailable(error_state_reason::Ipv6Unavailable {}) => {
+                Self::Ipv6Unavailable
             }
-            proto::tunnel_state::ErrorStateReason::Dns => ClientErrorReason::Dns(value.detail),
-            proto::tunnel_state::ErrorStateReason::Api => ClientErrorReason::Api(value.detail),
-            proto::tunnel_state::ErrorStateReason::CreateMixnetStorage => {
-                ClientErrorReason::CreateMixnetStorage
+            Reason::AccountControllerError(ac_error) => {
+                Self::AccountControllerError(AccountControllerErrorStateReason::try_from(ac_error)?)
             }
-            proto::tunnel_state::ErrorStateReason::DeviceTimeOutOfSync => {
-                ClientErrorReason::DeviceTimeOutOfSync
+            Reason::AccountControllerOffline(error_state_reason::AccountControllerOffline {}) => {
+                Self::AccountControllerOffline
             }
-            proto::tunnel_state::ErrorStateReason::Ipv6Unavailable => {
-                ClientErrorReason::Ipv6Unavailable
-            }
-            proto::tunnel_state::ErrorStateReason::Internal => {
-                ClientErrorReason::Internal(value.detail)
-            }
-            proto::tunnel_state::ErrorStateReason::AccountControl => {
-                ClientErrorReason::AccountControl(value.detail)
-            }
+            Reason::AccountControllerLoggedOut(
+                error_state_reason::AccountControllerLoggedOut {},
+            ) => Self::AccountControllerLoggedOut,
+            Reason::Internal(error_state_reason::Internal { message }) => Self::Internal(message),
+        })
+    }
+}
+
+impl TryFrom<proto::tunnel_state::error_state_reason::AccountControllerError>
+    for AccountControllerErrorStateReason
+{
+    type Error = ConversionError;
+
+    fn try_from(
+        value: proto::tunnel_state::error_state_reason::AccountControllerError,
+    ) -> Result<Self, ConversionError> {
+        let reason = value
+            .reason
+            .ok_or(ConversionError::NoValueSet("AccountControllerError.reason"))?;
+
+        AccountControllerErrorStateReason::try_from(reason)
+    }
+}
+
+impl From<AccountControllerErrorStateReason>
+    for proto::tunnel_state::error_state_reason::AccountControllerError
+{
+    fn from(value: AccountControllerErrorStateReason) -> Self {
+        Self {
+            reason: Some(proto::tunnel_state::AccountControllerErrorStateReason::from(value)),
         }
     }
 }
 
-impl From<ClientErrorReason> for proto::tunnel_state::Error {
-    fn from(value: ClientErrorReason) -> Self {
-        match value {
-            ClientErrorReason::Firewall => proto::tunnel_state::Error {
-                reason: proto::tunnel_state::ErrorStateReason::Firewall.into(),
-                detail: None,
-            },
-            ClientErrorReason::Routing => proto::tunnel_state::Error {
-                reason: proto::tunnel_state::ErrorStateReason::Routing.into(),
-                detail: None,
-            },
-            ClientErrorReason::SameEntryAndExitGateway => proto::tunnel_state::Error {
-                reason: proto::tunnel_state::ErrorStateReason::SameEntryAndExitGateway.into(),
-                detail: None,
-            },
-            ClientErrorReason::InvalidEntryGatewayCountry => proto::tunnel_state::Error {
-                reason: proto::tunnel_state::ErrorStateReason::InvalidEntryGatewayCountry.into(),
-                detail: None,
-            },
-            ClientErrorReason::InvalidExitGatewayCountry => proto::tunnel_state::Error {
-                reason: proto::tunnel_state::ErrorStateReason::InvalidExitGatewayCountry.into(),
-                detail: None,
-            },
-            ClientErrorReason::MaxDevicesReached => proto::tunnel_state::Error {
-                reason: proto::tunnel_state::ErrorStateReason::MaxDevicesReached.into(),
-                detail: None,
-            },
-            ClientErrorReason::BandwidthExceeded => proto::tunnel_state::Error {
-                reason: proto::tunnel_state::ErrorStateReason::BandwidthExceeded.into(),
-                detail: None,
-            },
-            ClientErrorReason::InactiveSubscription => proto::tunnel_state::Error {
-                reason: proto::tunnel_state::ErrorStateReason::InactiveSubscription.into(),
-                detail: None,
-            },
-            ClientErrorReason::Dns(detail) => proto::tunnel_state::Error {
-                reason: proto::tunnel_state::ErrorStateReason::Dns.into(),
-                detail,
-            },
-            ClientErrorReason::Api(detail) => proto::tunnel_state::Error {
-                reason: proto::tunnel_state::ErrorStateReason::Api.into(),
-                detail,
-            },
-            ClientErrorReason::CreateMixnetStorage => proto::tunnel_state::Error {
-                reason: proto::tunnel_state::ErrorStateReason::CreateMixnetStorage.into(),
-                detail: None,
-            },
-            ClientErrorReason::Ipv6Unavailable => proto::tunnel_state::Error {
-                reason: proto::tunnel_state::ErrorStateReason::Ipv6Unavailable.into(),
-                detail: None,
-            },
-            ClientErrorReason::DeviceTimeOutOfSync => proto::tunnel_state::Error {
-                reason: proto::tunnel_state::ErrorStateReason::DeviceTimeOutOfSync.into(),
-                detail: None,
-            },
-            ClientErrorReason::Internal(detail) => proto::tunnel_state::Error {
-                reason: proto::tunnel_state::ErrorStateReason::Internal.into(),
-                detail,
-            },
-            ClientErrorReason::AccountControl(detail) => proto::tunnel_state::Error {
-                reason: proto::tunnel_state::ErrorStateReason::AccountControl.into(),
-                detail,
-            },
+impl From<ErrorStateReason> for proto::tunnel_state::ErrorStateReason {
+    fn from(value: ErrorStateReason) -> Self {
+        use proto::tunnel_state::error_state_reason::{self, Reason};
+
+        let reason = match value {
+            ErrorStateReason::Firewall => Reason::Firewall(error_state_reason::Firewall {}),
+            ErrorStateReason::Routing => Reason::Routing(error_state_reason::Routing {}),
+            ErrorStateReason::SetDns => Reason::SetDns(error_state_reason::SetDns {}),
+            ErrorStateReason::TunDevice => Reason::TunDevice(error_state_reason::TunDevice {}),
+            ErrorStateReason::TunnelProvider => {
+                Reason::TunnelProvider(error_state_reason::TunnelProvider {})
+            }
+            ErrorStateReason::StartLocalDnsResolver => {
+                Reason::StartLocalDnsResolver(error_state_reason::StartLocalDnsResolver {})
+            }
+            ErrorStateReason::SameEntryAndExitGateway => {
+                Reason::SameEntryAndExitGateway(error_state_reason::SameEntryAndExitGateway {})
+            }
+            ErrorStateReason::InvalidEntryGatewayCountry => Reason::InvalidEntryGatewayCountry(
+                error_state_reason::InvalidEntryGatewayCountry {},
+            ),
+            ErrorStateReason::InvalidExitGatewayCountry => {
+                Reason::InvalidExitGatewayCountry(error_state_reason::InvalidExitGatewayCountry {})
+            }
+            ErrorStateReason::BadBandwidthIncrease => {
+                Reason::BadBandwidthIncrease(error_state_reason::BadBandwidthIncrease {})
+            }
+            ErrorStateReason::DuplicateTunFd => {
+                Reason::DuplicateTunFd(error_state_reason::DuplicateTunFd {})
+            }
+            ErrorStateReason::CreateMixnetStorage => {
+                Reason::CreateMixnetStorage(error_state_reason::CreateMixnetStorage {})
+            }
+            ErrorStateReason::Ipv6Unavailable => {
+                Reason::Ipv6Unavailable(error_state_reason::Ipv6Unavailable {})
+            }
+            ErrorStateReason::AccountControllerError(reason) => Reason::AccountControllerError(
+                error_state_reason::AccountControllerError::from(reason),
+            ),
+            ErrorStateReason::AccountControllerOffline => {
+                Reason::AccountControllerOffline(error_state_reason::AccountControllerOffline {})
+            }
+            ErrorStateReason::AccountControllerLoggedOut => Reason::AccountControllerLoggedOut(
+                error_state_reason::AccountControllerLoggedOut {},
+            ),
+            ErrorStateReason::Internal(message) => {
+                Reason::Internal(error_state_reason::Internal { message })
+            }
+        };
+
+        Self {
+            reason: Some(reason),
+        }
+    }
+}
+
+impl TryFrom<proto::tunnel_state::AccountControllerErrorStateReason>
+    for AccountControllerErrorStateReason
+{
+    type Error = ConversionError;
+
+    fn try_from(
+        value: proto::tunnel_state::AccountControllerErrorStateReason,
+    ) -> Result<Self, ConversionError> {
+        use proto::tunnel_state::account_controller_error_state_reason::{
+            self as error_state_reason, Reason,
+        };
+
+        let reason = value.reason.ok_or(ConversionError::NoValueSet(
+            "AccountControllerErrorStateReason.reason",
+        ))?;
+
+        Ok(match reason {
+            Reason::Storage(error_state_reason::Storage { context }) => Self::Storage { context },
+            Reason::ApiFailure(error_state_reason::ApiFailure { context, details }) => {
+                Self::ApiFailure { context, details }
+            }
+            Reason::Internal(error_state_reason::Internal { context, details }) => {
+                Self::Internal { context, details }
+            }
+            Reason::BandwidthExceeded(error_state_reason::BandwidthExceeded { context }) => {
+                Self::BandwidthExceeded { context }
+            }
+            Reason::AccountStatusNotActive(error_state_reason::AccountStatusNotActive {
+                status,
+            }) => Self::AccountStatusNotActive { status },
+            Reason::InactiveSubscription(error_state_reason::InactiveSubscription {}) => {
+                Self::InactiveSubscription
+            }
+            Reason::MaxDeviceReached(error_state_reason::MaxDeviceReached {}) => {
+                Self::MaxDeviceReached
+            }
+            Reason::DeviceTimeDesynced(error_state_reason::DeviceTimeDesynced {}) => {
+                Self::DeviceTimeDesynced
+            }
+        })
+    }
+}
+
+impl From<AccountControllerErrorStateReason>
+    for proto::tunnel_state::AccountControllerErrorStateReason
+{
+    fn from(value: AccountControllerErrorStateReason) -> Self {
+        use proto::tunnel_state::account_controller_error_state_reason::{
+            self as error_state_reason, Reason,
+        };
+        let reason = match value {
+            AccountControllerErrorStateReason::Storage { context } => {
+                Reason::Storage(error_state_reason::Storage { context })
+            }
+            AccountControllerErrorStateReason::ApiFailure { context, details } => {
+                Reason::ApiFailure(error_state_reason::ApiFailure { context, details })
+            }
+            AccountControllerErrorStateReason::Internal { context, details } => {
+                Reason::Internal(error_state_reason::Internal { context, details })
+            }
+            AccountControllerErrorStateReason::BandwidthExceeded { context } => {
+                Reason::BandwidthExceeded(error_state_reason::BandwidthExceeded { context })
+            }
+            AccountControllerErrorStateReason::AccountStatusNotActive { status } => {
+                Reason::AccountStatusNotActive(error_state_reason::AccountStatusNotActive {
+                    status,
+                })
+            }
+            AccountControllerErrorStateReason::InactiveSubscription => {
+                Reason::InactiveSubscription(error_state_reason::InactiveSubscription {})
+            }
+            AccountControllerErrorStateReason::MaxDeviceReached => {
+                Reason::MaxDeviceReached(error_state_reason::MaxDeviceReached {})
+            }
+            AccountControllerErrorStateReason::DeviceTimeDesynced => {
+                Reason::DeviceTimeDesynced(error_state_reason::DeviceTimeDesynced {})
+            }
+        };
+        Self {
+            reason: Some(reason),
         }
     }
 }
@@ -178,8 +286,12 @@ impl TryFrom<proto::TunnelState> for TunnelState {
 
                 Self::Connected { connection_data }
             }
-            proto::tunnel_state::State::Error(error_state_reason) => {
-                Self::Error(error_state_reason.into())
+            proto::tunnel_state::State::Error(proto::tunnel_state::Error { reason }) => {
+                Self::Error(
+                    reason
+                        .ok_or(ConversionError::NoValueSet("TunnelState.reason"))
+                        .and_then(ErrorStateReason::try_from)?,
+                )
             }
             proto::tunnel_state::State::Offline(proto::tunnel_state::Offline { reconnect }) => {
                 Self::Offline { reconnect }
@@ -441,7 +553,9 @@ impl From<TunnelState> for proto::TunnelState {
                 proto::tunnel_state::State::Offline(proto::tunnel_state::Offline { reconnect })
             }
             TunnelState::Error(reason) => {
-                proto::tunnel_state::State::Error(proto::tunnel_state::Error::from(reason))
+                proto::tunnel_state::State::Error(proto::tunnel_state::Error {
+                    reason: Some(proto::tunnel_state::ErrorStateReason::from(reason)),
+                })
             }
         };
 


### PR DESCRIPTION
## Ticket

JIRA-VPN-3854

## Description

`ClientErrorState` used to creating very broad categories of errors. One example is DNS errors, whether a failure to set DNS on computer or DNS failure when resolving hostname, all were put under DNS category.

- This PR replaces `ClientErrorState` with `ErrorStateReason`
- Move some error variants into internal error


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3331)
<!-- Reviewable:end -->
