### PR TITLE
bugfix: retry bandwidth acquisition on sequence number mismatch

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -2266,6 +2266,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getset"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.103",
+]
+
+[[package]]
 name = "ghash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3626,20 +3638,56 @@ dependencies = [
  "ecdsa",
  "hex",
  "humantime-serde",
- "nym-coconut-dkg-common",
- "nym-compact-ecash",
- "nym-config",
- "nym-contracts-common",
- "nym-credentials-interface",
- "nym-crypto",
+ "nym-coconut-dkg-common 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-compact-ecash 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "nym-ecash-signer-check-types",
- "nym-ecash-time",
- "nym-mixnet-contract-common",
- "nym-network-defaults",
- "nym-node-requests",
- "nym-noise-keys",
- "nym-serde-helpers",
- "nym-ticketbooks-merkle",
+ "nym-ecash-time 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-node-requests 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-noise-keys 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-serde-helpers 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-ticketbooks-merkle 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "schemars",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tendermint",
+ "tendermint-rpc",
+ "thiserror 2.0.16",
+ "time",
+ "tracing",
+ "utoipa",
+]
+
+[[package]]
+name = "nym-api-requests"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "bs58",
+ "cosmrs",
+ "cosmwasm-std",
+ "ecdsa",
+ "getset",
+ "hex",
+ "humantime-serde",
+ "nym-compact-ecash 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-ecash-time 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-node-requests 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-noise-keys 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-serde-helpers 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-ticketbooks-merkle 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "schemars",
  "serde",
  "serde_json",
@@ -3671,11 +3719,11 @@ dependencies = [
  "bincode",
  "futures",
  "nym-authenticator-requests",
- "nym-credentials-interface",
- "nym-crypto",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "nym-sdk",
  "nym-service-provider-requests-common",
- "nym-wireguard-types",
+ "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "semver",
  "thiserror 2.0.16",
  "tokio",
@@ -3691,12 +3739,12 @@ dependencies = [
  "base64 0.22.1",
  "bincode",
  "hmac",
- "nym-credentials-interface",
- "nym-crypto",
- "nym-network-defaults",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "nym-service-provider-requests-common",
- "nym-sphinx",
- "nym-wireguard-types",
+ "nym-sphinx 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "rand 0.8.5",
  "serde",
  "sha2 0.10.9",
@@ -3711,15 +3759,37 @@ source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#
 dependencies = [
  "bip39",
  "log",
- "nym-credential-storage",
- "nym-credentials",
- "nym-credentials-interface",
- "nym-crypto",
- "nym-ecash-contract-common",
- "nym-ecash-time",
- "nym-network-defaults",
- "nym-task",
- "nym-validator-client",
+ "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-ecash-contract-common 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-ecash-time 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-task 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "rand 0.8.5",
+ "thiserror 2.0.16",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "nym-bandwidth-controller"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "bip39",
+ "log",
+ "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-ecash-contract-common 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-ecash-time 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-task 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "rand 0.8.5",
  "thiserror 2.0.16",
  "url",
@@ -3742,6 +3812,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nym-bin-common"
+version = "0.6.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "const-str",
+ "log",
+ "schemars",
+ "serde",
+ "utoipa",
+ "vergen 8.3.1",
+]
+
+[[package]]
 name = "nym-client-core"
 version = "1.1.15"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
@@ -3756,28 +3839,28 @@ dependencies = [
  "humantime",
  "hyper 1.6.0",
  "hyper-util",
- "nym-bandwidth-controller",
- "nym-client-core-config-types",
- "nym-client-core-gateways-storage",
- "nym-client-core-surb-storage",
- "nym-credential-storage",
- "nym-credentials-interface",
- "nym-crypto",
- "nym-ecash-time",
- "nym-gateway-client",
- "nym-gateway-requests",
- "nym-http-api-client",
- "nym-id",
- "nym-mixnet-client",
- "nym-mixnet-contract-common",
- "nym-network-defaults",
- "nym-nonexhaustive-delayqueue",
- "nym-pemstore",
- "nym-sphinx",
- "nym-statistics-common",
- "nym-task",
- "nym-topology",
- "nym-validator-client",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-client-core-config-types 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-client-core-gateways-storage 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-client-core-surb-storage 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-ecash-time 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-gateway-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-gateway-requests 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-id 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-mixnet-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-nonexhaustive-delayqueue 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-statistics-common 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-task 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-topology 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "serde",
@@ -3794,7 +3877,63 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-utils",
+ "wasm-utils 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "wasmtimer",
+ "zeroize",
+]
+
+[[package]]
+name = "nym-client-core"
+version = "1.1.15"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bs58",
+ "futures",
+ "gloo-timers",
+ "http-body-util",
+ "humantime",
+ "hyper 1.6.0",
+ "hyper-util",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-client-core-config-types 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-client-core-gateways-storage 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-client-core-surb-storage 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-ecash-time 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-gateway-client 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-gateway-requests 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-id 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-mixnet-client 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-nonexhaustive-delayqueue 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-statistics-common 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-task 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-topology 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "si-scale",
+ "thiserror 2.0.16",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tokio-tungstenite",
+ "tracing",
+ "tungstenite",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-utils 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "wasmtimer",
  "zeroize",
 ]
@@ -3805,11 +3944,27 @@ version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
  "humantime-serde",
- "nym-config",
- "nym-pemstore",
- "nym-sphinx-addressing",
- "nym-sphinx-params",
- "nym-statistics-common",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-params 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-statistics-common 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "serde",
+ "thiserror 2.0.16",
+ "url",
+]
+
+[[package]]
+name = "nym-client-core-config-types"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "humantime-serde",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-params 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-statistics-common 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "serde",
  "thiserror 2.0.16",
  "url",
@@ -3822,8 +3977,27 @@ source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#
 dependencies = [
  "async-trait",
  "cosmrs",
- "nym-crypto",
- "nym-gateway-requests",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-gateway-requests 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "serde",
+ "sqlx",
+ "thiserror 2.0.16",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "nym-client-core-gateways-storage"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "async-trait",
+ "cosmrs",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-gateway-requests 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "serde",
  "sqlx",
  "thiserror 2.0.16",
@@ -3841,11 +4015,28 @@ source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#
 dependencies = [
  "async-trait",
  "dashmap",
- "nym-crypto",
- "nym-sphinx",
- "nym-task",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-task 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "sqlx",
- "sqlx-pool-guard",
+ "sqlx-pool-guard 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "thiserror 2.0.16",
+ "time",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "nym-client-core-surb-storage"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "async-trait",
+ "dashmap",
+ "nym-sphinx 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-task 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "sqlx",
+ "sqlx-pool-guard 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "thiserror 2.0.16",
  "time",
  "tokio",
@@ -3862,8 +4053,22 @@ dependencies = [
  "cw-utils",
  "cw2",
  "cw4",
- "nym-contracts-common",
- "nym-multisig-contract-common",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+]
+
+[[package]]
+name = "nym-coconut-dkg-common"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-utils",
+ "cw2",
+ "cw4",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
 ]
 
 [[package]]
@@ -3887,8 +4092,31 @@ dependencies = [
  "ff",
  "group",
  "itertools 0.14.0",
- "nym-network-defaults",
- "nym-pemstore",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "rand 0.8.5",
+ "serde",
+ "sha2 0.10.9",
+ "subtle 2.6.1",
+ "thiserror 2.0.16",
+ "zeroize",
+]
+
+[[package]]
+name = "nym-compact-ecash"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "bincode",
+ "bls12_381",
+ "bs58",
+ "cfg-if",
+ "digest 0.10.7",
+ "ff",
+ "group",
+ "itertools 0.14.0",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "rand 0.8.5",
  "serde",
  "sha2 0.10.9",
@@ -3905,7 +4133,22 @@ dependencies = [
  "dirs",
  "handlebars",
  "log",
- "nym-network-defaults",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "serde",
+ "thiserror 2.0.16",
+ "toml 0.8.23",
+ "url",
+]
+
+[[package]]
+name = "nym-config"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "dirs",
+ "handlebars",
+ "log",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "serde",
  "thiserror 2.0.16",
  "toml 0.8.23",
@@ -3920,10 +4163,10 @@ dependencies = [
  "bytes",
  "futures",
  "nym-common",
- "nym-config",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "nym-ip-packet-requests",
  "nym-sdk",
- "nym-task",
+ "nym-task 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "pnet_packet",
  "thiserror 2.0.16",
  "tokio",
@@ -3946,15 +4189,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "nym-contracts-common"
+version = "0.5.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "bs58",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus",
+ "schemars",
+ "serde",
+ "thiserror 2.0.16",
+ "vergen 8.3.1",
+]
+
+[[package]]
 name = "nym-credential-proxy-requests"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
  "async-trait",
- "nym-credentials",
- "nym-credentials-interface",
- "nym-http-api-client",
- "nym-serde-helpers",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-serde-helpers 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "reqwest 0.12.20",
  "schemars",
  "serde",
@@ -3972,12 +4230,31 @@ dependencies = [
  "async-trait",
  "bincode",
  "log",
- "nym-compact-ecash",
- "nym-credentials",
- "nym-ecash-time",
+ "nym-compact-ecash 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-ecash-time 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "serde",
  "sqlx",
- "sqlx-pool-guard",
+ "sqlx-pool-guard 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "thiserror 2.0.16",
+ "tokio",
+ "zeroize",
+]
+
+[[package]]
+name = "nym-credential-storage"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "async-trait",
+ "bincode",
+ "log",
+ "nym-compact-ecash 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-ecash-time 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "serde",
+ "sqlx",
+ "sqlx-pool-guard 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "thiserror 2.0.16",
  "tokio",
  "zeroize",
@@ -3989,14 +4266,33 @@ version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
  "log",
- "nym-bandwidth-controller",
- "nym-client-core",
- "nym-config",
- "nym-credential-storage",
- "nym-credentials",
- "nym-credentials-interface",
- "nym-ecash-time",
- "nym-validator-client",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-client-core 1.1.15 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-ecash-time 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "thiserror 2.0.16",
+ "time",
+ "tokio",
+]
+
+[[package]]
+name = "nym-credential-utils"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "log",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-client-core 1.1.15 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-ecash-time 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "thiserror 2.0.16",
  "time",
  "tokio",
@@ -4011,15 +4307,38 @@ dependencies = [
  "bls12_381",
  "cosmrs",
  "log",
- "nym-api-requests",
- "nym-credentials-interface",
- "nym-crypto",
- "nym-ecash-contract-common",
- "nym-ecash-time",
- "nym-http-api-client",
- "nym-network-defaults",
- "nym-serde-helpers",
- "nym-validator-client",
+ "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-ecash-contract-common 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-ecash-time 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-serde-helpers 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "serde",
+ "thiserror 2.0.16",
+ "time",
+ "zeroize",
+]
+
+[[package]]
+name = "nym-credentials"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "bincode",
+ "bls12_381",
+ "cosmrs",
+ "log",
+ "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-ecash-contract-common 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-ecash-time 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-serde-helpers 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "serde",
  "thiserror 2.0.16",
  "time",
@@ -4032,9 +4351,26 @@ version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
  "bls12_381",
- "nym-compact-ecash",
- "nym-ecash-time",
- "nym-network-defaults",
+ "nym-compact-ecash 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-ecash-time 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "rand 0.8.5",
+ "serde",
+ "strum",
+ "thiserror 2.0.16",
+ "time",
+ "utoipa",
+]
+
+[[package]]
+name = "nym-credentials-interface"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "bls12_381",
+ "nym-compact-ecash 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-ecash-time 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "rand 0.8.5",
  "serde",
  "strum",
@@ -4060,8 +4396,37 @@ dependencies = [
  "generic-array 0.14.7",
  "hkdf",
  "hmac",
- "nym-pemstore",
- "nym-sphinx-types",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "rand 0.8.5",
+ "serde",
+ "serde_bytes",
+ "sha2 0.10.9",
+ "subtle-encoding",
+ "thiserror 2.0.16",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
+name = "nym-crypto"
+version = "0.4.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "aead",
+ "aes",
+ "aes-gcm-siv",
+ "blake3",
+ "bs58",
+ "cipher",
+ "ctr",
+ "digest 0.10.7",
+ "ed25519-dalek",
+ "generic-array 0.14.7",
+ "hkdf",
+ "hmac",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "rand 0.8.5",
  "serde",
  "serde_bytes",
@@ -4117,7 +4482,21 @@ dependencies = [
  "cosmwasm-std",
  "cw-controllers",
  "cw-utils",
- "nym-multisig-contract-common",
+ "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "thiserror 2.0.16",
+]
+
+[[package]]
+name = "nym-ecash-contract-common"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "bs58",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-controllers",
+ "cw-utils",
+ "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "thiserror 2.0.16",
 ]
 
@@ -4126,8 +4505,8 @@ name = "nym-ecash-signer-check-types"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
- "nym-coconut-dkg-common",
- "nym-crypto",
+ "nym-coconut-dkg-common 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "semver",
  "serde",
  "thiserror 2.0.16",
@@ -4142,7 +4521,16 @@ name = "nym-ecash-time"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
- "nym-compact-ecash",
+ "nym-compact-ecash 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "time",
+]
+
+[[package]]
+name = "nym-ecash-time"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "nym-compact-ecash 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "time",
 ]
 
@@ -4150,6 +4538,18 @@ dependencies = [
 name = "nym-exit-policy"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 2.0.16",
+ "tracing",
+ "utoipa",
+]
+
+[[package]]
+name = "nym-exit-policy"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
 dependencies = [
  "serde",
  "serde_json",
@@ -4187,19 +4587,19 @@ dependencies = [
  "futures",
  "getrandom 0.2.16",
  "gloo-utils",
- "nym-bandwidth-controller",
- "nym-credential-storage",
- "nym-credentials",
- "nym-credentials-interface",
- "nym-crypto",
- "nym-gateway-requests",
- "nym-http-api-client",
- "nym-network-defaults",
- "nym-pemstore",
- "nym-sphinx",
- "nym-statistics-common",
- "nym-task",
- "nym-validator-client",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-gateway-requests 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-statistics-common 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-task 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "rand 0.8.5",
  "serde",
  "si-scale",
@@ -4213,7 +4613,46 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-utils",
+ "wasm-utils 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "wasmtimer",
+ "zeroize",
+]
+
+[[package]]
+name = "nym-gateway-client"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "futures",
+ "getrandom 0.2.16",
+ "gloo-utils",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-gateway-requests 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-statistics-common 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-task 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "rand 0.8.5",
+ "serde",
+ "si-scale",
+ "thiserror 2.0.16",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tokio-tungstenite",
+ "tracing",
+ "tungstenite",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-utils 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "wasmtimer",
  "zeroize",
 ]
@@ -4224,14 +4663,14 @@ version = "1.15.0-beta"
 dependencies = [
  "futures",
  "itertools 0.13.0",
- "nym-client-core",
+ "nym-client-core 1.1.15 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "nym-common",
- "nym-http-api-client",
- "nym-network-defaults",
+ "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "nym-offline-monitor",
  "nym-sdk",
- "nym-topology",
- "nym-validator-client",
+ "nym-topology 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "nym-vpn-api-client",
  "rand 0.8.5",
  "serde",
@@ -4255,20 +4694,21 @@ dependencies = [
  "hex",
  "nym-authenticator-client",
  "nym-authenticator-requests",
- "nym-bandwidth-controller",
- "nym-bin-common",
- "nym-client-core",
- "nym-config",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-client-core 1.1.15 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "nym-connection-monitor",
- "nym-credentials-interface",
- "nym-crypto",
+ "nym-credential-utils 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "nym-gateway-directory",
  "nym-ip-packet-client",
  "nym-ip-packet-requests",
  "nym-sdk",
- "nym-task",
- "nym-validator-client",
- "nym-wireguard-types",
+ "nym-task 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "pnet_packet",
  "rand 0.8.5",
  "rust2go",
@@ -4291,14 +4731,44 @@ dependencies = [
  "bs58",
  "futures",
  "generic-array 0.14.7",
- "nym-credentials",
- "nym-credentials-interface",
- "nym-crypto",
- "nym-pemstore",
- "nym-serde-helpers",
- "nym-sphinx",
- "nym-statistics-common",
- "nym-task",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-serde-helpers 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-statistics-common 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-task 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "strum",
+ "subtle 2.6.1",
+ "thiserror 2.0.16",
+ "time",
+ "tokio",
+ "tracing",
+ "tungstenite",
+ "wasmtimer",
+ "zeroize",
+]
+
+[[package]]
+name = "nym-gateway-requests"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "bs58",
+ "futures",
+ "generic-array 0.14.7",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-serde-helpers 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-statistics-common 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-task 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -4326,12 +4796,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "nym-group-contract-common"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "cosmwasm-schema",
+ "cw-controllers",
+ "cw4",
+ "schemars",
+ "serde",
+]
+
+[[package]]
 name = "nym-harbour-master-client"
 version = "1.15.0-beta"
 dependencies = [
  "async-trait",
  "chrono",
- "nym-http-api-client",
+ "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "serde",
  "serde_json",
  "thiserror 2.0.16",
@@ -4351,9 +4833,34 @@ dependencies = [
  "http 1.3.1",
  "itertools 0.14.0",
  "mime",
- "nym-bin-common",
- "nym-http-api-common",
- "nym-network-defaults",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-http-api-common 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "once_cell",
+ "reqwest 0.12.20",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.16",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "nym-http-api-client"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "async-trait",
+ "bincode",
+ "bytes",
+ "encoding_rs",
+ "hickory-resolver",
+ "http 1.3.1",
+ "itertools 0.14.0",
+ "mime",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-http-api-common 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "once_cell",
  "reqwest 0.12.20",
  "serde",
@@ -4376,12 +4883,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "nym-http-api-common"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "bincode",
+ "serde",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
 name = "nym-id"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
- "nym-credential-storage",
- "nym-credentials",
+ "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "thiserror 2.0.16",
+ "time",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "nym-id"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "thiserror 2.0.16",
  "time",
  "tracing",
@@ -4410,10 +4941,10 @@ source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#
 dependencies = [
  "bincode",
  "bytes",
- "nym-bin-common",
- "nym-crypto",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "nym-service-provider-requests-common",
- "nym-sphinx",
+ "nym-sphinx 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "rand 0.8.5",
  "serde",
  "thiserror 2.0.16",
@@ -4457,14 +4988,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "nym-metrics"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "dashmap",
+ "lazy_static",
+ "prometheus",
+ "tracing",
+]
+
+[[package]]
 name = "nym-mixnet-client"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
  "dashmap",
  "futures",
- "nym-noise",
- "nym-sphinx",
+ "nym-noise 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "nym-mixnet-client"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "dashmap",
+ "futures",
+ "nym-noise 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -4481,7 +5037,28 @@ dependencies = [
  "cw-controllers",
  "cw-storage-plus",
  "humantime-serde",
- "nym-contracts-common",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "schemars",
+ "semver",
+ "serde",
+ "serde_repr",
+ "thiserror 2.0.16",
+ "time",
+ "utoipa",
+]
+
+[[package]]
+name = "nym-mixnet-contract-common"
+version = "0.6.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "bs58",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-controllers",
+ "cw-storage-plus",
+ "humantime-serde",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "schemars",
  "semver",
  "serde",
@@ -4495,6 +5072,22 @@ dependencies = [
 name = "nym-multisig-contract-common"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus",
+ "cw-utils",
+ "cw3",
+ "cw4",
+ "schemars",
+ "serde",
+ "thiserror 2.0.16",
+]
+
+[[package]]
+name = "nym-multisig-contract-common"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -4523,6 +5116,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "nym-network-defaults"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "cargo_metadata 0.19.2",
+ "dotenvy",
+ "log",
+ "regex",
+ "schemars",
+ "serde",
+ "url",
+ "utoipa",
+]
+
+[[package]]
 name = "nym-node-requests"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
@@ -4531,12 +5139,34 @@ dependencies = [
  "celes",
  "humantime",
  "humantime-serde",
- "nym-bin-common",
- "nym-crypto",
- "nym-exit-policy",
- "nym-http-api-client",
- "nym-noise-keys",
- "nym-wireguard-types",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-exit-policy 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-noise-keys 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "schemars",
+ "serde",
+ "serde_json",
+ "strum",
+ "thiserror 2.0.16",
+ "time",
+ "utoipa",
+]
+
+[[package]]
+name = "nym-node-requests"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "celes",
+ "humantime",
+ "humantime-serde",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-exit-policy 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-noise-keys 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "schemars",
  "serde",
  "serde_json",
@@ -4554,8 +5184,28 @@ dependencies = [
  "arc-swap",
  "bytes",
  "futures",
- "nym-crypto",
- "nym-noise-keys",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-noise-keys 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "pin-project",
+ "sha2 0.10.9",
+ "snow",
+ "strum",
+ "thiserror 2.0.16",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "nym-noise"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "futures",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-noise-keys 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "pin-project",
  "sha2 0.10.9",
  "snow",
@@ -4571,7 +5221,18 @@ name = "nym-noise-keys"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
- "nym-crypto",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "schemars",
+ "serde",
+ "utoipa",
+]
+
+[[package]]
+name = "nym-noise-keys"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "schemars",
  "serde",
  "utoipa",
@@ -4581,6 +5242,17 @@ dependencies = [
 name = "nym-nonexhaustive-delayqueue"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
+dependencies = [
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "wasmtimer",
+]
+
+[[package]]
+name = "nym-nonexhaustive-delayqueue"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -4635,9 +5307,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "nym-outfox"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "blake3",
+ "chacha20",
+ "chacha20poly1305",
+ "getrandom 0.2.16",
+ "log",
+ "rand 0.8.5",
+ "rayon",
+ "sphinx-packet",
+ "thiserror 2.0.16",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
 name = "nym-pemstore"
 version = "0.3.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
+dependencies = [
+ "pem",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "nym-pemstore"
+version = "0.3.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
 dependencies = [
  "pem",
  "tracing",
@@ -4652,7 +5352,21 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-controllers",
- "nym-contracts-common",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "schemars",
+ "serde",
+ "thiserror 2.0.16",
+]
+
+[[package]]
+name = "nym-performance-contract-common"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-controllers",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "schemars",
  "serde",
  "thiserror 2.0.16",
@@ -4711,27 +5425,27 @@ dependencies = [
  "http 1.3.1",
  "httpcodec",
  "log",
- "nym-bandwidth-controller",
- "nym-bin-common",
- "nym-client-core",
- "nym-credential-storage",
- "nym-credential-utils",
- "nym-credentials",
- "nym-credentials-interface",
- "nym-crypto",
- "nym-gateway-requests",
- "nym-http-api-client",
- "nym-network-defaults",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-client-core 1.1.15 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-credential-utils 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-gateway-requests 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "nym-ordered-buffer",
  "nym-service-providers-common",
  "nym-socks5-client-core",
  "nym-socks5-requests",
- "nym-sphinx",
- "nym-sphinx-addressing",
- "nym-statistics-common",
- "nym-task",
- "nym-topology",
- "nym-validator-client",
+ "nym-sphinx 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-statistics-common 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-task 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-topology 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "rand 0.8.5",
  "serde",
  "tap",
@@ -4761,6 +5475,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nym-serde-helpers"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "base64 0.22.1",
+ "bs58",
+ "hex",
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "nym-service-provider-requests-common"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
@@ -4776,8 +5502,8 @@ source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#
 dependencies = [
  "async-trait",
  "log",
- "nym-bin-common",
- "nym-sphinx-anonymous-replies",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-anonymous-replies 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "serde",
  "serde_json",
  "thiserror 2.0.16",
@@ -4792,19 +5518,19 @@ dependencies = [
  "dirs",
  "futures",
  "log",
- "nym-bandwidth-controller",
- "nym-client-core",
- "nym-config",
- "nym-contracts-common",
- "nym-credential-storage",
- "nym-mixnet-contract-common",
- "nym-network-defaults",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-client-core 1.1.15 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "nym-service-providers-common",
  "nym-socks5-proxy-helpers",
  "nym-socks5-requests",
- "nym-sphinx",
- "nym-task",
- "nym-validator-client",
+ "nym-sphinx 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-task 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "pin-project",
  "rand 0.8.5",
  "reqwest 0.12.20",
@@ -4826,7 +5552,7 @@ dependencies = [
  "log",
  "nym-ordered-buffer",
  "nym-socks5-requests",
- "nym-task",
+ "nym-task 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "tokio",
  "tokio-util",
 ]
@@ -4838,9 +5564,9 @@ source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#
 dependencies = [
  "bincode",
  "log",
- "nym-exit-policy",
+ "nym-exit-policy 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "nym-service-providers-common",
- "nym-sphinx-addressing",
+ "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "serde",
  "serde_json",
  "tap",
@@ -4852,19 +5578,45 @@ name = "nym-sphinx"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
- "nym-crypto",
- "nym-metrics",
- "nym-sphinx-acknowledgements",
- "nym-sphinx-addressing",
- "nym-sphinx-anonymous-replies",
- "nym-sphinx-chunking",
- "nym-sphinx-cover",
- "nym-sphinx-forwarding",
- "nym-sphinx-framing",
- "nym-sphinx-params",
- "nym-sphinx-routing",
- "nym-sphinx-types",
- "nym-topology",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-metrics 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-acknowledgements 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-anonymous-replies 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-chunking 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-cover 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-forwarding 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-framing 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-params 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-routing 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-topology 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_distr",
+ "thiserror 2.0.16",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "nym-sphinx"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-metrics 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-acknowledgements 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-anonymous-replies 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-chunking 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-cover 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-forwarding 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-framing 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-params 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-routing 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-topology 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_distr",
@@ -4878,13 +5630,30 @@ name = "nym-sphinx-acknowledgements"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
- "nym-crypto",
- "nym-pemstore",
- "nym-sphinx-addressing",
- "nym-sphinx-params",
- "nym-sphinx-routing",
- "nym-sphinx-types",
- "nym-topology",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-params 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-routing 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-topology 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "rand 0.8.5",
+ "thiserror 2.0.16",
+ "zeroize",
+]
+
+[[package]]
+name = "nym-sphinx-acknowledgements"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-params 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-routing 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-topology 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "rand 0.8.5",
  "thiserror 2.0.16",
  "zeroize",
@@ -4895,8 +5664,19 @@ name = "nym-sphinx-addressing"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
- "nym-crypto",
- "nym-sphinx-types",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "serde",
+ "thiserror 2.0.16",
+]
+
+[[package]]
+name = "nym-sphinx-addressing"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "serde",
  "thiserror 2.0.16",
 ]
@@ -4907,12 +5687,30 @@ version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
  "bs58",
- "nym-crypto",
- "nym-sphinx-addressing",
- "nym-sphinx-params",
- "nym-sphinx-routing",
- "nym-sphinx-types",
- "nym-topology",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-params 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-routing 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-topology 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "rand 0.8.5",
+ "thiserror 2.0.16",
+ "tracing",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "nym-sphinx-anonymous-replies"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "bs58",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-params 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-routing 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-topology 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "rand 0.8.5",
  "thiserror 2.0.16",
  "tracing",
@@ -4926,11 +5724,29 @@ source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#
 dependencies = [
  "dashmap",
  "log",
- "nym-crypto",
- "nym-metrics",
- "nym-sphinx-addressing",
- "nym-sphinx-params",
- "nym-sphinx-types",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-metrics 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-params 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "rand 0.8.5",
+ "serde",
+ "thiserror 2.0.16",
+ "utoipa",
+]
+
+[[package]]
+name = "nym-sphinx-chunking"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "dashmap",
+ "log",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-metrics 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-params 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "rand 0.8.5",
  "serde",
  "thiserror 2.0.16",
@@ -4942,15 +5758,33 @@ name = "nym-sphinx-cover"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
- "nym-crypto",
- "nym-sphinx-acknowledgements",
- "nym-sphinx-addressing",
- "nym-sphinx-chunking",
- "nym-sphinx-forwarding",
- "nym-sphinx-params",
- "nym-sphinx-routing",
- "nym-sphinx-types",
- "nym-topology",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-acknowledgements 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-chunking 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-forwarding 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-params 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-routing 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-topology 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "rand 0.8.5",
+ "thiserror 2.0.16",
+]
+
+[[package]]
+name = "nym-sphinx-cover"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-acknowledgements 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-chunking 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-forwarding 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-params 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-routing 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-topology 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "rand 0.8.5",
  "thiserror 2.0.16",
 ]
@@ -4960,10 +5794,22 @@ name = "nym-sphinx-forwarding"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
- "nym-sphinx-addressing",
- "nym-sphinx-anonymous-replies",
- "nym-sphinx-params",
- "nym-sphinx-types",
+ "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-anonymous-replies 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-params 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "thiserror 2.0.16",
+]
+
+[[package]]
+name = "nym-sphinx-forwarding"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-anonymous-replies 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-params 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "thiserror 2.0.16",
 ]
 
@@ -4973,11 +5819,27 @@ version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
  "bytes",
- "nym-sphinx-acknowledgements",
- "nym-sphinx-addressing",
- "nym-sphinx-forwarding",
- "nym-sphinx-params",
- "nym-sphinx-types",
+ "nym-sphinx-acknowledgements 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-forwarding 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-params 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "thiserror 2.0.16",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "nym-sphinx-framing"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "bytes",
+ "nym-sphinx-acknowledgements 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-forwarding 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-params 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "thiserror 2.0.16",
  "tokio-util",
  "tracing",
@@ -4988,8 +5850,19 @@ name = "nym-sphinx-params"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
- "nym-crypto",
- "nym-sphinx-types",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "serde",
+ "thiserror 2.0.16",
+]
+
+[[package]]
+name = "nym-sphinx-params"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "serde",
  "thiserror 2.0.16",
 ]
@@ -4999,8 +5872,18 @@ name = "nym-sphinx-routing"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
- "nym-sphinx-addressing",
- "nym-sphinx-types",
+ "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "thiserror 2.0.16",
+]
+
+[[package]]
+name = "nym-sphinx-routing"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "thiserror 2.0.16",
 ]
 
@@ -5009,7 +5892,17 @@ name = "nym-sphinx-types"
 version = "0.2.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
- "nym-outfox",
+ "nym-outfox 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "sphinx-packet",
+ "thiserror 2.0.16",
+]
+
+[[package]]
+name = "nym-sphinx-types"
+version = "0.2.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "nym-outfox 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "sphinx-packet",
  "thiserror 2.0.16",
 ]
@@ -5019,15 +5912,15 @@ name = "nym-statistics"
 version = "1.15.0-beta"
 dependencies = [
  "futures",
- "nym-bin-common",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "nym-sdk",
  "nym-statistics-api-client",
- "nym-statistics-common",
+ "nym-statistics-common 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "nym-vpn-lib-types",
  "rand 0.8.5",
  "serde",
  "sqlx",
- "sqlx-pool-guard",
+ "sqlx-pool-guard 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "sysinfo 0.37.0",
  "thiserror 2.0.16",
  "tokio",
@@ -5040,7 +5933,7 @@ dependencies = [
 name = "nym-statistics-api-client"
 version = "1.15.0-beta"
 dependencies = [
- "nym-http-api-client",
+ "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "serde",
  "thiserror 2.0.16",
  "url",
@@ -5053,11 +5946,35 @@ source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#
 dependencies = [
  "futures",
  "log",
- "nym-credentials-interface",
- "nym-crypto",
- "nym-metrics",
- "nym-sphinx",
- "nym-task",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-metrics 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-task 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "si-scale",
+ "strum",
+ "sysinfo 0.33.1",
+ "thiserror 2.0.16",
+ "time",
+ "tokio",
+ "wasmtimer",
+]
+
+[[package]]
+name = "nym-statistics-common"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "futures",
+ "log",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-metrics 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-task 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -5088,12 +6005,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "nym-task"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "cfg-if",
+ "futures",
+ "log",
+ "thiserror 2.0.16",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasmtimer",
+]
+
+[[package]]
 name = "nym-ticketbooks-merkle"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
- "nym-credentials-interface",
- "nym-serde-helpers",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-serde-helpers 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "rs_merkle",
+ "schemars",
+ "serde",
+ "sha2 0.10.9",
+ "time",
+ "utoipa",
+]
+
+[[package]]
+name = "nym-ticketbooks-merkle"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-serde-helpers 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "rs_merkle",
  "schemars",
  "serde",
@@ -5108,11 +6057,31 @@ version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
  "async-trait",
- "nym-api-requests",
- "nym-crypto",
- "nym-mixnet-contract-common",
- "nym-sphinx-addressing",
- "nym-sphinx-types",
+ "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "rand 0.8.5",
+ "reqwest 0.12.20",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.16",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "nym-topology"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "async-trait",
+ "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "rand 0.8.5",
  "reqwest 0.12.20",
  "serde",
@@ -5143,20 +6112,70 @@ dependencies = [
  "flate2",
  "futures",
  "itertools 0.14.0",
- "nym-api-requests",
- "nym-coconut-dkg-common",
- "nym-compact-ecash",
- "nym-config",
- "nym-contracts-common",
- "nym-ecash-contract-common",
- "nym-group-contract-common",
- "nym-http-api-client",
- "nym-mixnet-contract-common",
- "nym-multisig-contract-common",
- "nym-network-defaults",
- "nym-performance-contract-common",
- "nym-serde-helpers",
- "nym-vesting-contract-common",
+ "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-coconut-dkg-common 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-compact-ecash 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-ecash-contract-common 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-group-contract-common 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-performance-contract-common 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-serde-helpers 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-vesting-contract-common 0.7.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "prost",
+ "reqwest 0.12.20",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tendermint-rpc",
+ "thiserror 2.0.16",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "wasmtimer",
+ "zeroize",
+]
+
+[[package]]
+name = "nym-validator-client"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bip32",
+ "bip39",
+ "colored",
+ "cosmrs",
+ "cosmwasm-std",
+ "cw-controllers",
+ "cw-utils",
+ "cw2",
+ "cw3",
+ "cw4",
+ "eyre",
+ "flate2",
+ "futures",
+ "itertools 0.14.0",
+ "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-coconut-dkg-common 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-compact-ecash 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-ecash-contract-common 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-group-contract-common 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-performance-contract-common 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-serde-helpers 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-vesting-contract-common 0.7.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "prost",
  "reqwest 0.12.20",
  "serde",
@@ -5179,8 +6198,21 @@ source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "nym-contracts-common",
- "nym-mixnet-contract-common",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "serde",
+ "thiserror 2.0.16",
+]
+
+[[package]]
+name = "nym-vesting-contract-common"
+version = "0.7.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "serde",
  "thiserror 2.0.16",
 ]
@@ -5194,13 +6226,13 @@ dependencies = [
  "bincode",
  "futures",
  "nym-common",
- "nym-compact-ecash",
+ "nym-compact-ecash 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "nym-credential-proxy-requests",
- "nym-credential-storage",
- "nym-credentials",
- "nym-credentials-interface",
- "nym-ecash-time",
- "nym-http-api-client",
+ "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-ecash-time 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "nym-offline-monitor",
  "nym-sdk",
  "nym-vpn-api-client",
@@ -5212,7 +6244,7 @@ dependencies = [
  "serde",
  "si-scale",
  "sqlx",
- "sqlx-pool-guard",
+ "sqlx-pool-guard 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "strum",
  "tempfile",
  "thiserror 2.0.16",
@@ -5235,14 +6267,14 @@ dependencies = [
  "bs58",
  "chrono",
  "itertools 0.13.0",
- "nym-compact-ecash",
- "nym-config",
- "nym-contracts-common",
+ "nym-compact-ecash 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "nym-credential-proxy-requests",
- "nym-crypto",
- "nym-http-api-client",
- "nym-network-defaults",
- "nym-validator-client",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -5274,18 +6306,18 @@ dependencies = [
  "nix 0.30.1",
  "nym-apple-network",
  "nym-authenticator-client",
- "nym-bandwidth-controller",
- "nym-bin-common",
- "nym-client-core",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-client-core 1.1.15 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "nym-common",
- "nym-config",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "nym-connection-monitor",
- "nym-credentials-interface",
- "nym-crypto",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "nym-dns",
  "nym-firewall",
  "nym-gateway-directory",
- "nym-http-api-client",
+ "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "nym-ip-packet-client",
  "nym-ip-packet-requests",
  "nym-macos",
@@ -5293,9 +6325,9 @@ dependencies = [
  "nym-routing",
  "nym-sdk",
  "nym-statistics",
- "nym-statistics-common",
- "nym-task",
- "nym-validator-client",
+ "nym-statistics-common 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-task 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "nym-vpn-account-controller",
  "nym-vpn-lib-types",
  "nym-vpn-network-config",
@@ -5303,7 +6335,7 @@ dependencies = [
  "nym-wg-gateway-client",
  "nym-wg-go",
  "nym-windows",
- "nym-wireguard-types",
+ "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "rand 0.8.5",
  "serial_test",
  "thiserror 2.0.16",
@@ -5325,10 +6357,10 @@ dependencies = [
 name = "nym-vpn-lib-types"
 version = "1.15.0-beta"
 dependencies = [
- "nym-bandwidth-controller",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "nym-connection-monitor",
  "nym-gateway-directory",
- "nym-statistics-common",
+ "nym-statistics-common 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "nym-vpn-api-client",
  "nym-wg-gateway-client",
  "si-scale",
@@ -5342,7 +6374,7 @@ name = "nym-vpn-lib-types-uniffi"
 version = "1.15.0-beta"
 dependencies = [
  "ipnetwork",
- "nym-config",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "nym-gateway-directory",
  "nym-ip-packet-requests",
  "nym-sdk",
@@ -5365,10 +6397,10 @@ dependencies = [
  "itertools 0.13.0",
  "lazy_static",
  "log",
- "nym-bin-common",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "nym-common",
  "nym-gateway-directory",
- "nym-http-api-client",
+ "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "nym-offline-monitor",
  "nym-platform-metadata",
  "nym-sdk",
@@ -5401,12 +6433,12 @@ version = "1.15.0-beta"
 dependencies = [
  "futures-util",
  "itertools 0.13.0",
- "nym-api-requests",
+ "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "nym-common",
- "nym-http-api-client",
- "nym-network-defaults",
+ "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "nym-sdk",
- "nym-validator-client",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "nym-vpn-api-client",
  "serde",
  "serde_json",
@@ -5423,9 +6455,9 @@ dependencies = [
 name = "nym-vpn-proto"
 version = "1.15.0-beta"
 dependencies = [
- "nym-config",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "nym-gateway-directory",
- "nym-http-api-client",
+ "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "nym-ipc",
  "nym-sdk",
  "nym-vpn-api-client",
@@ -5462,8 +6494,8 @@ version = "1.15.0-beta"
 dependencies = [
  "async-trait",
  "bip39",
- "nym-crypto",
- "nym-pemstore",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "serde",
@@ -5483,9 +6515,9 @@ dependencies = [
  "anyhow",
  "celes",
  "clap",
- "nym-bin-common",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "nym-gateway-directory",
- "nym-http-api-client",
+ "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "nym-vpn-lib-types",
  "nym-vpn-proto",
  "nym-vpnd-types",
@@ -5505,13 +6537,13 @@ dependencies = [
  "eventlog",
  "futures",
  "log-panics",
- "nym-bin-common",
- "nym-http-api-client",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "nym-ipc",
  "nym-offline-monitor",
  "nym-platform-metadata",
  "nym-statistics",
- "nym-task",
+ "nym-task 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "nym-vpn-account-controller",
  "nym-vpn-api-client",
  "nym-vpn-lib",
@@ -5546,7 +6578,7 @@ version = "1.15.0-beta"
 dependencies = [
  "nym-gateway-directory",
  "nym-sdk",
- "nym-validator-client",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "nym-vpn-lib-types",
  "nym-vpn-network-config",
  "serde",
@@ -5560,14 +6592,14 @@ version = "1.15.0-beta"
 dependencies = [
  "nym-authenticator-client",
  "nym-authenticator-requests",
- "nym-bandwidth-controller",
- "nym-credentials-interface",
- "nym-crypto",
+ "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "nym-gateway-directory",
- "nym-node-requests",
- "nym-pemstore",
+ "nym-node-requests 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "nym-sdk",
- "nym-validator-client",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
  "nym-wg-go",
  "rand 0.8.5",
  "thiserror 2.0.16",
@@ -5610,8 +6642,22 @@ source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#
 dependencies = [
  "base64 0.22.1",
  "log",
- "nym-config",
- "nym-network-defaults",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "serde",
+ "thiserror 2.0.16",
+ "x25519-dalek",
+]
+
+[[package]]
+name = "nym-wireguard-types"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
  "serde",
  "thiserror 2.0.16",
  "x25519-dalek",
@@ -6161,6 +7207,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -7693,6 +8761,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlx-pool-guard"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
+dependencies = [
+ "proc_pidinfo",
+ "sqlx",
+ "tokio",
+ "tracing",
+ "windows 0.61.3",
+]
+
+[[package]]
 name = "sqlx-postgres"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9176,6 +10256,22 @@ dependencies = [
 name = "wasm-utils"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
+dependencies = [
+ "futures",
+ "getrandom 0.2.16",
+ "gloo-net",
+ "gloo-utils",
+ "js-sys",
+ "tungstenite",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-utils"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
 dependencies = [
  "futures",
  "getrandom 0.2.16",

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -2266,18 +2266,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getset"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
-dependencies = [
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.103",
-]
-
-[[package]]
 name = "ghash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3638,56 +3626,20 @@ dependencies = [
  "ecdsa",
  "hex",
  "humantime-serde",
- "nym-coconut-dkg-common 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-compact-ecash 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-coconut-dkg-common",
+ "nym-compact-ecash",
+ "nym-config",
+ "nym-contracts-common",
+ "nym-credentials-interface",
+ "nym-crypto",
  "nym-ecash-signer-check-types",
- "nym-ecash-time 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-node-requests 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-noise-keys 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-serde-helpers 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-ticketbooks-merkle 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "schemars",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "tendermint",
- "tendermint-rpc",
- "thiserror 2.0.16",
- "time",
- "tracing",
- "utoipa",
-]
-
-[[package]]
-name = "nym-api-requests"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "bs58",
- "cosmrs",
- "cosmwasm-std",
- "ecdsa",
- "getset",
- "hex",
- "humantime-serde",
- "nym-compact-ecash 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-ecash-time 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-node-requests 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-noise-keys 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-serde-helpers 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-ticketbooks-merkle 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-ecash-time",
+ "nym-mixnet-contract-common",
+ "nym-network-defaults",
+ "nym-node-requests",
+ "nym-noise-keys",
+ "nym-serde-helpers",
+ "nym-ticketbooks-merkle",
  "schemars",
  "serde",
  "serde_json",
@@ -3719,11 +3671,11 @@ dependencies = [
  "bincode",
  "futures",
  "nym-authenticator-requests",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-credentials-interface",
+ "nym-crypto",
  "nym-sdk",
  "nym-service-provider-requests-common",
- "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-wireguard-types",
  "semver",
  "thiserror 2.0.16",
  "tokio",
@@ -3739,12 +3691,12 @@ dependencies = [
  "base64 0.22.1",
  "bincode",
  "hmac",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-credentials-interface",
+ "nym-crypto",
+ "nym-network-defaults",
  "nym-service-provider-requests-common",
- "nym-sphinx 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx",
+ "nym-wireguard-types",
  "rand 0.8.5",
  "serde",
  "sha2 0.10.9",
@@ -3759,37 +3711,15 @@ source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#
 dependencies = [
  "bip39",
  "log",
- "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-ecash-contract-common 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-ecash-time 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-task 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "rand 0.8.5",
- "thiserror 2.0.16",
- "url",
- "zeroize",
-]
-
-[[package]]
-name = "nym-bandwidth-controller"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "bip39",
- "log",
- "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-ecash-contract-common 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-ecash-time 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-task 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-credential-storage",
+ "nym-credentials",
+ "nym-credentials-interface",
+ "nym-crypto",
+ "nym-ecash-contract-common",
+ "nym-ecash-time",
+ "nym-network-defaults",
+ "nym-task",
+ "nym-validator-client",
  "rand 0.8.5",
  "thiserror 2.0.16",
  "url",
@@ -3812,19 +3742,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nym-bin-common"
-version = "0.6.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "const-str",
- "log",
- "schemars",
- "serde",
- "utoipa",
- "vergen 8.3.1",
-]
-
-[[package]]
 name = "nym-client-core"
 version = "1.1.15"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
@@ -3839,28 +3756,28 @@ dependencies = [
  "humantime",
  "hyper 1.6.0",
  "hyper-util",
- "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-client-core-config-types 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-client-core-gateways-storage 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-client-core-surb-storage 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-ecash-time 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-gateway-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-gateway-requests 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-id 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-mixnet-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-nonexhaustive-delayqueue 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-statistics-common 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-task 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-topology 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-bandwidth-controller",
+ "nym-client-core-config-types",
+ "nym-client-core-gateways-storage",
+ "nym-client-core-surb-storage",
+ "nym-credential-storage",
+ "nym-credentials-interface",
+ "nym-crypto",
+ "nym-ecash-time",
+ "nym-gateway-client",
+ "nym-gateway-requests",
+ "nym-http-api-client",
+ "nym-id",
+ "nym-mixnet-client",
+ "nym-mixnet-contract-common",
+ "nym-network-defaults",
+ "nym-nonexhaustive-delayqueue",
+ "nym-pemstore",
+ "nym-sphinx",
+ "nym-statistics-common",
+ "nym-task",
+ "nym-topology",
+ "nym-validator-client",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "serde",
@@ -3877,63 +3794,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-utils 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "wasmtimer",
- "zeroize",
-]
-
-[[package]]
-name = "nym-client-core"
-version = "1.1.15"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "async-trait",
- "base64 0.22.1",
- "bs58",
- "futures",
- "gloo-timers",
- "http-body-util",
- "humantime",
- "hyper 1.6.0",
- "hyper-util",
- "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-client-core-config-types 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-client-core-gateways-storage 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-client-core-surb-storage 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-ecash-time 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-gateway-client 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-gateway-requests 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-id 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-mixnet-client 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-nonexhaustive-delayqueue 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-statistics-common 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-task 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-topology 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "si-scale",
- "thiserror 2.0.16",
- "time",
- "tokio",
- "tokio-stream",
- "tokio-tungstenite",
- "tracing",
- "tungstenite",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-utils 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "wasm-utils",
  "wasmtimer",
  "zeroize",
 ]
@@ -3944,27 +3805,11 @@ version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
  "humantime-serde",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-params 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-statistics-common 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "serde",
- "thiserror 2.0.16",
- "url",
-]
-
-[[package]]
-name = "nym-client-core-config-types"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "humantime-serde",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-params 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-statistics-common 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-config",
+ "nym-pemstore",
+ "nym-sphinx-addressing",
+ "nym-sphinx-params",
+ "nym-statistics-common",
  "serde",
  "thiserror 2.0.16",
  "url",
@@ -3977,27 +3822,8 @@ source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#
 dependencies = [
  "async-trait",
  "cosmrs",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-gateway-requests 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "serde",
- "sqlx",
- "thiserror 2.0.16",
- "time",
- "tokio",
- "tracing",
- "url",
- "zeroize",
-]
-
-[[package]]
-name = "nym-client-core-gateways-storage"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "async-trait",
- "cosmrs",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-gateway-requests 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-crypto",
+ "nym-gateway-requests",
  "serde",
  "sqlx",
  "thiserror 2.0.16",
@@ -4015,28 +3841,11 @@ source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#
 dependencies = [
  "async-trait",
  "dashmap",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-task 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-crypto",
+ "nym-sphinx",
+ "nym-task",
  "sqlx",
- "sqlx-pool-guard 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "thiserror 2.0.16",
- "time",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "nym-client-core-surb-storage"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "async-trait",
- "dashmap",
- "nym-sphinx 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-task 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "sqlx",
- "sqlx-pool-guard 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "sqlx-pool-guard",
  "thiserror 2.0.16",
  "time",
  "tokio",
@@ -4053,22 +3862,8 @@ dependencies = [
  "cw-utils",
  "cw2",
  "cw4",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
-]
-
-[[package]]
-name = "nym-coconut-dkg-common"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-utils",
- "cw2",
- "cw4",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-contracts-common",
+ "nym-multisig-contract-common",
 ]
 
 [[package]]
@@ -4092,31 +3887,8 @@ dependencies = [
  "ff",
  "group",
  "itertools 0.14.0",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "rand 0.8.5",
- "serde",
- "sha2 0.10.9",
- "subtle 2.6.1",
- "thiserror 2.0.16",
- "zeroize",
-]
-
-[[package]]
-name = "nym-compact-ecash"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "bincode",
- "bls12_381",
- "bs58",
- "cfg-if",
- "digest 0.10.7",
- "ff",
- "group",
- "itertools 0.14.0",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-network-defaults",
+ "nym-pemstore",
  "rand 0.8.5",
  "serde",
  "sha2 0.10.9",
@@ -4133,22 +3905,7 @@ dependencies = [
  "dirs",
  "handlebars",
  "log",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "serde",
- "thiserror 2.0.16",
- "toml 0.8.23",
- "url",
-]
-
-[[package]]
-name = "nym-config"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "dirs",
- "handlebars",
- "log",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-network-defaults",
  "serde",
  "thiserror 2.0.16",
  "toml 0.8.23",
@@ -4163,10 +3920,10 @@ dependencies = [
  "bytes",
  "futures",
  "nym-common",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-config",
  "nym-ip-packet-requests",
  "nym-sdk",
- "nym-task 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-task",
  "pnet_packet",
  "thiserror 2.0.16",
  "tokio",
@@ -4189,30 +3946,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "nym-contracts-common"
-version = "0.5.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "bs58",
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-storage-plus",
- "schemars",
- "serde",
- "thiserror 2.0.16",
- "vergen 8.3.1",
-]
-
-[[package]]
 name = "nym-credential-proxy-requests"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
  "async-trait",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-serde-helpers 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-credentials",
+ "nym-credentials-interface",
+ "nym-http-api-client",
+ "nym-serde-helpers",
  "reqwest 0.12.20",
  "schemars",
  "serde",
@@ -4230,31 +3972,12 @@ dependencies = [
  "async-trait",
  "bincode",
  "log",
- "nym-compact-ecash 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-ecash-time 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-compact-ecash",
+ "nym-credentials",
+ "nym-ecash-time",
  "serde",
  "sqlx",
- "sqlx-pool-guard 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "thiserror 2.0.16",
- "tokio",
- "zeroize",
-]
-
-[[package]]
-name = "nym-credential-storage"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "async-trait",
- "bincode",
- "log",
- "nym-compact-ecash 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-ecash-time 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "serde",
- "sqlx",
- "sqlx-pool-guard 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "sqlx-pool-guard",
  "thiserror 2.0.16",
  "tokio",
  "zeroize",
@@ -4266,33 +3989,14 @@ version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
  "log",
- "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-client-core 1.1.15 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-ecash-time 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "thiserror 2.0.16",
- "time",
- "tokio",
-]
-
-[[package]]
-name = "nym-credential-utils"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "log",
- "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-client-core 1.1.15 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-ecash-time 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-bandwidth-controller",
+ "nym-client-core",
+ "nym-config",
+ "nym-credential-storage",
+ "nym-credentials",
+ "nym-credentials-interface",
+ "nym-ecash-time",
+ "nym-validator-client",
  "thiserror 2.0.16",
  "time",
  "tokio",
@@ -4307,38 +4011,15 @@ dependencies = [
  "bls12_381",
  "cosmrs",
  "log",
- "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-ecash-contract-common 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-ecash-time 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-serde-helpers 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "serde",
- "thiserror 2.0.16",
- "time",
- "zeroize",
-]
-
-[[package]]
-name = "nym-credentials"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "bincode",
- "bls12_381",
- "cosmrs",
- "log",
- "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-ecash-contract-common 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-ecash-time 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-serde-helpers 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-api-requests",
+ "nym-credentials-interface",
+ "nym-crypto",
+ "nym-ecash-contract-common",
+ "nym-ecash-time",
+ "nym-http-api-client",
+ "nym-network-defaults",
+ "nym-serde-helpers",
+ "nym-validator-client",
  "serde",
  "thiserror 2.0.16",
  "time",
@@ -4351,26 +4032,9 @@ version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
  "bls12_381",
- "nym-compact-ecash 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-ecash-time 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "rand 0.8.5",
- "serde",
- "strum",
- "thiserror 2.0.16",
- "time",
- "utoipa",
-]
-
-[[package]]
-name = "nym-credentials-interface"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "bls12_381",
- "nym-compact-ecash 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-ecash-time 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-compact-ecash",
+ "nym-ecash-time",
+ "nym-network-defaults",
  "rand 0.8.5",
  "serde",
  "strum",
@@ -4396,37 +4060,8 @@ dependencies = [
  "generic-array 0.14.7",
  "hkdf",
  "hmac",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "rand 0.8.5",
- "serde",
- "serde_bytes",
- "sha2 0.10.9",
- "subtle-encoding",
- "thiserror 2.0.16",
- "x25519-dalek",
- "zeroize",
-]
-
-[[package]]
-name = "nym-crypto"
-version = "0.4.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "aead",
- "aes",
- "aes-gcm-siv",
- "blake3",
- "bs58",
- "cipher",
- "ctr",
- "digest 0.10.7",
- "ed25519-dalek",
- "generic-array 0.14.7",
- "hkdf",
- "hmac",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-pemstore",
+ "nym-sphinx-types",
  "rand 0.8.5",
  "serde",
  "serde_bytes",
@@ -4482,21 +4117,7 @@ dependencies = [
  "cosmwasm-std",
  "cw-controllers",
  "cw-utils",
- "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "thiserror 2.0.16",
-]
-
-[[package]]
-name = "nym-ecash-contract-common"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "bs58",
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-controllers",
- "cw-utils",
- "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-multisig-contract-common",
  "thiserror 2.0.16",
 ]
 
@@ -4505,8 +4126,8 @@ name = "nym-ecash-signer-check-types"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
- "nym-coconut-dkg-common 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-coconut-dkg-common",
+ "nym-crypto",
  "semver",
  "serde",
  "thiserror 2.0.16",
@@ -4521,16 +4142,7 @@ name = "nym-ecash-time"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
- "nym-compact-ecash 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "time",
-]
-
-[[package]]
-name = "nym-ecash-time"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "nym-compact-ecash 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-compact-ecash",
  "time",
 ]
 
@@ -4538,18 +4150,6 @@ dependencies = [
 name = "nym-exit-policy"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
-dependencies = [
- "serde",
- "serde_json",
- "thiserror 2.0.16",
- "tracing",
- "utoipa",
-]
-
-[[package]]
-name = "nym-exit-policy"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
 dependencies = [
  "serde",
  "serde_json",
@@ -4587,19 +4187,19 @@ dependencies = [
  "futures",
  "getrandom 0.2.16",
  "gloo-utils",
- "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-gateway-requests 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-statistics-common 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-task 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-bandwidth-controller",
+ "nym-credential-storage",
+ "nym-credentials",
+ "nym-credentials-interface",
+ "nym-crypto",
+ "nym-gateway-requests",
+ "nym-http-api-client",
+ "nym-network-defaults",
+ "nym-pemstore",
+ "nym-sphinx",
+ "nym-statistics-common",
+ "nym-task",
+ "nym-validator-client",
  "rand 0.8.5",
  "serde",
  "si-scale",
@@ -4613,46 +4213,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-utils 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "wasmtimer",
- "zeroize",
-]
-
-[[package]]
-name = "nym-gateway-client"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "futures",
- "getrandom 0.2.16",
- "gloo-utils",
- "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-gateway-requests 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-statistics-common 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-task 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "rand 0.8.5",
- "serde",
- "si-scale",
- "thiserror 2.0.16",
- "time",
- "tokio",
- "tokio-stream",
- "tokio-tungstenite",
- "tracing",
- "tungstenite",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-utils 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "wasm-utils",
  "wasmtimer",
  "zeroize",
 ]
@@ -4663,14 +4224,14 @@ version = "1.15.0-beta"
 dependencies = [
  "futures",
  "itertools 0.13.0",
- "nym-client-core 1.1.15 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-client-core",
  "nym-common",
- "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-http-api-client",
+ "nym-network-defaults",
  "nym-offline-monitor",
  "nym-sdk",
- "nym-topology 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-topology",
+ "nym-validator-client",
  "nym-vpn-api-client",
  "rand 0.8.5",
  "serde",
@@ -4694,21 +4255,21 @@ dependencies = [
  "hex",
  "nym-authenticator-client",
  "nym-authenticator-requests",
- "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-client-core 1.1.15 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-bandwidth-controller",
+ "nym-bin-common",
+ "nym-client-core",
+ "nym-config",
  "nym-connection-monitor",
- "nym-credential-utils 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-credential-utils",
+ "nym-credentials-interface",
+ "nym-crypto",
  "nym-gateway-directory",
  "nym-ip-packet-client",
  "nym-ip-packet-requests",
  "nym-sdk",
- "nym-task 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-task",
+ "nym-validator-client",
+ "nym-wireguard-types",
  "pnet_packet",
  "rand 0.8.5",
  "rust2go",
@@ -4731,44 +4292,14 @@ dependencies = [
  "bs58",
  "futures",
  "generic-array 0.14.7",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-serde-helpers 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-statistics-common 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-task 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "strum",
- "subtle 2.6.1",
- "thiserror 2.0.16",
- "time",
- "tokio",
- "tracing",
- "tungstenite",
- "wasmtimer",
- "zeroize",
-]
-
-[[package]]
-name = "nym-gateway-requests"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "bs58",
- "futures",
- "generic-array 0.14.7",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-serde-helpers 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-statistics-common 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-task 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-credentials",
+ "nym-credentials-interface",
+ "nym-crypto",
+ "nym-pemstore",
+ "nym-serde-helpers",
+ "nym-sphinx",
+ "nym-statistics-common",
+ "nym-task",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -4787,18 +4318,6 @@ dependencies = [
 name = "nym-group-contract-common"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
-dependencies = [
- "cosmwasm-schema",
- "cw-controllers",
- "cw4",
- "schemars",
- "serde",
-]
-
-[[package]]
-name = "nym-group-contract-common"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
 dependencies = [
  "cosmwasm-schema",
  "cw-controllers",
@@ -4813,7 +4332,7 @@ version = "1.15.0-beta"
 dependencies = [
  "async-trait",
  "chrono",
- "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-http-api-client",
  "serde",
  "serde_json",
  "thiserror 2.0.16",
@@ -4833,34 +4352,9 @@ dependencies = [
  "http 1.3.1",
  "itertools 0.14.0",
  "mime",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-http-api-common 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "once_cell",
- "reqwest 0.12.20",
- "serde",
- "serde_json",
- "thiserror 2.0.16",
- "tracing",
- "url",
- "wasmtimer",
-]
-
-[[package]]
-name = "nym-http-api-client"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "async-trait",
- "bincode",
- "bytes",
- "encoding_rs",
- "hickory-resolver",
- "http 1.3.1",
- "itertools 0.14.0",
- "mime",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-http-api-common 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-bin-common",
+ "nym-http-api-common",
+ "nym-network-defaults",
  "once_cell",
  "reqwest 0.12.20",
  "serde",
@@ -4883,36 +4377,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "nym-http-api-common"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "bincode",
- "serde",
- "serde_json",
- "tracing",
-]
-
-[[package]]
 name = "nym-id"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
- "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "thiserror 2.0.16",
- "time",
- "tracing",
- "zeroize",
-]
-
-[[package]]
-name = "nym-id"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-credential-storage",
+ "nym-credentials",
  "thiserror 2.0.16",
  "time",
  "tracing",
@@ -4941,10 +4411,10 @@ source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#
 dependencies = [
  "bincode",
  "bytes",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-bin-common",
+ "nym-crypto",
  "nym-service-provider-requests-common",
- "nym-sphinx 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx",
  "rand 0.8.5",
  "serde",
  "thiserror 2.0.16",
@@ -4988,39 +4458,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "nym-metrics"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "dashmap",
- "lazy_static",
- "prometheus",
- "tracing",
-]
-
-[[package]]
 name = "nym-mixnet-client"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
  "dashmap",
  "futures",
- "nym-noise 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "nym-mixnet-client"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "dashmap",
- "futures",
- "nym-noise 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-noise",
+ "nym-sphinx",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -5037,28 +4482,7 @@ dependencies = [
  "cw-controllers",
  "cw-storage-plus",
  "humantime-serde",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "schemars",
- "semver",
- "serde",
- "serde_repr",
- "thiserror 2.0.16",
- "time",
- "utoipa",
-]
-
-[[package]]
-name = "nym-mixnet-contract-common"
-version = "0.6.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "bs58",
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-controllers",
- "cw-storage-plus",
- "humantime-serde",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-contracts-common",
  "schemars",
  "semver",
  "serde",
@@ -5085,40 +4509,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "nym-multisig-contract-common"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-storage-plus",
- "cw-utils",
- "cw3",
- "cw4",
- "schemars",
- "serde",
- "thiserror 2.0.16",
-]
-
-[[package]]
 name = "nym-network-defaults"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
-dependencies = [
- "cargo_metadata 0.19.2",
- "dotenvy",
- "log",
- "regex",
- "schemars",
- "serde",
- "url",
- "utoipa",
-]
-
-[[package]]
-name = "nym-network-defaults"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
 dependencies = [
  "cargo_metadata 0.19.2",
  "dotenvy",
@@ -5139,34 +4532,12 @@ dependencies = [
  "celes",
  "humantime",
  "humantime-serde",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-exit-policy 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-noise-keys 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "schemars",
- "serde",
- "serde_json",
- "strum",
- "thiserror 2.0.16",
- "time",
- "utoipa",
-]
-
-[[package]]
-name = "nym-node-requests"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "celes",
- "humantime",
- "humantime-serde",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-exit-policy 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-noise-keys 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-bin-common",
+ "nym-crypto",
+ "nym-exit-policy",
+ "nym-http-api-client",
+ "nym-noise-keys",
+ "nym-wireguard-types",
  "schemars",
  "serde",
  "serde_json",
@@ -5184,28 +4555,8 @@ dependencies = [
  "arc-swap",
  "bytes",
  "futures",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-noise-keys 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "pin-project",
- "sha2 0.10.9",
- "snow",
- "strum",
- "thiserror 2.0.16",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "nym-noise"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "arc-swap",
- "bytes",
- "futures",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-noise-keys 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-crypto",
+ "nym-noise-keys",
  "pin-project",
  "sha2 0.10.9",
  "snow",
@@ -5221,18 +4572,7 @@ name = "nym-noise-keys"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "schemars",
- "serde",
- "utoipa",
-]
-
-[[package]]
-name = "nym-noise-keys"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-crypto",
  "schemars",
  "serde",
  "utoipa",
@@ -5242,17 +4582,6 @@ dependencies = [
 name = "nym-nonexhaustive-delayqueue"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
-dependencies = [
- "tokio",
- "tokio-stream",
- "tokio-util",
- "wasmtimer",
-]
-
-[[package]]
-name = "nym-nonexhaustive-delayqueue"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -5307,37 +4636,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "nym-outfox"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "blake3",
- "chacha20",
- "chacha20poly1305",
- "getrandom 0.2.16",
- "log",
- "rand 0.8.5",
- "rayon",
- "sphinx-packet",
- "thiserror 2.0.16",
- "x25519-dalek",
- "zeroize",
-]
-
-[[package]]
 name = "nym-pemstore"
 version = "0.3.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
-dependencies = [
- "pem",
- "tracing",
- "zeroize",
-]
-
-[[package]]
-name = "nym-pemstore"
-version = "0.3.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
 dependencies = [
  "pem",
  "tracing",
@@ -5352,21 +4653,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-controllers",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "schemars",
- "serde",
- "thiserror 2.0.16",
-]
-
-[[package]]
-name = "nym-performance-contract-common"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-controllers",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-contracts-common",
  "schemars",
  "serde",
  "thiserror 2.0.16",
@@ -5425,27 +4712,27 @@ dependencies = [
  "http 1.3.1",
  "httpcodec",
  "log",
- "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-client-core 1.1.15 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-credential-utils 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-gateway-requests 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-bandwidth-controller",
+ "nym-bin-common",
+ "nym-client-core",
+ "nym-credential-storage",
+ "nym-credential-utils",
+ "nym-credentials",
+ "nym-credentials-interface",
+ "nym-crypto",
+ "nym-gateway-requests",
+ "nym-http-api-client",
+ "nym-network-defaults",
  "nym-ordered-buffer",
  "nym-service-providers-common",
  "nym-socks5-client-core",
  "nym-socks5-requests",
- "nym-sphinx 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-statistics-common 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-task 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-topology 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx",
+ "nym-sphinx-addressing",
+ "nym-statistics-common",
+ "nym-task",
+ "nym-topology",
+ "nym-validator-client",
  "rand 0.8.5",
  "serde",
  "tap",
@@ -5475,18 +4762,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nym-serde-helpers"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "base64 0.22.1",
- "bs58",
- "hex",
- "serde",
- "time",
-]
-
-[[package]]
 name = "nym-service-provider-requests-common"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
@@ -5502,8 +4777,8 @@ source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#
 dependencies = [
  "async-trait",
  "log",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-anonymous-replies 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-bin-common",
+ "nym-sphinx-anonymous-replies",
  "serde",
  "serde_json",
  "thiserror 2.0.16",
@@ -5518,19 +4793,19 @@ dependencies = [
  "dirs",
  "futures",
  "log",
- "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-client-core 1.1.15 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-bandwidth-controller",
+ "nym-client-core",
+ "nym-config",
+ "nym-contracts-common",
+ "nym-credential-storage",
+ "nym-mixnet-contract-common",
+ "nym-network-defaults",
  "nym-service-providers-common",
  "nym-socks5-proxy-helpers",
  "nym-socks5-requests",
- "nym-sphinx 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-task 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx",
+ "nym-task",
+ "nym-validator-client",
  "pin-project",
  "rand 0.8.5",
  "reqwest 0.12.20",
@@ -5552,7 +4827,7 @@ dependencies = [
  "log",
  "nym-ordered-buffer",
  "nym-socks5-requests",
- "nym-task 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-task",
  "tokio",
  "tokio-util",
 ]
@@ -5564,9 +4839,9 @@ source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#
 dependencies = [
  "bincode",
  "log",
- "nym-exit-policy 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-exit-policy",
  "nym-service-providers-common",
- "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-sphinx-addressing",
  "serde",
  "serde_json",
  "tap",
@@ -5578,45 +4853,19 @@ name = "nym-sphinx"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-metrics 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-acknowledgements 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-anonymous-replies 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-chunking 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-cover 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-forwarding 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-framing 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-params 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-routing 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-topology 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "rand_distr",
- "thiserror 2.0.16",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "nym-sphinx"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-metrics 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-acknowledgements 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-anonymous-replies 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-chunking 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-cover 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-forwarding 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-framing 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-params 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-routing 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-topology 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-crypto",
+ "nym-metrics",
+ "nym-sphinx-acknowledgements",
+ "nym-sphinx-addressing",
+ "nym-sphinx-anonymous-replies",
+ "nym-sphinx-chunking",
+ "nym-sphinx-cover",
+ "nym-sphinx-forwarding",
+ "nym-sphinx-framing",
+ "nym-sphinx-params",
+ "nym-sphinx-routing",
+ "nym-sphinx-types",
+ "nym-topology",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_distr",
@@ -5630,30 +4879,13 @@ name = "nym-sphinx-acknowledgements"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-params 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-routing 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-topology 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "rand 0.8.5",
- "thiserror 2.0.16",
- "zeroize",
-]
-
-[[package]]
-name = "nym-sphinx-acknowledgements"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-params 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-routing 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-topology 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-crypto",
+ "nym-pemstore",
+ "nym-sphinx-addressing",
+ "nym-sphinx-params",
+ "nym-sphinx-routing",
+ "nym-sphinx-types",
+ "nym-topology",
  "rand 0.8.5",
  "thiserror 2.0.16",
  "zeroize",
@@ -5664,19 +4896,8 @@ name = "nym-sphinx-addressing"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "serde",
- "thiserror 2.0.16",
-]
-
-[[package]]
-name = "nym-sphinx-addressing"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-crypto",
+ "nym-sphinx-types",
  "serde",
  "thiserror 2.0.16",
 ]
@@ -5687,30 +4908,12 @@ version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
  "bs58",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-params 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-routing 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-topology 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "rand 0.8.5",
- "thiserror 2.0.16",
- "tracing",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "nym-sphinx-anonymous-replies"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "bs58",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-params 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-routing 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-topology 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-crypto",
+ "nym-sphinx-addressing",
+ "nym-sphinx-params",
+ "nym-sphinx-routing",
+ "nym-sphinx-types",
+ "nym-topology",
  "rand 0.8.5",
  "thiserror 2.0.16",
  "tracing",
@@ -5724,29 +4927,11 @@ source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#
 dependencies = [
  "dashmap",
  "log",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-metrics 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-params 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "rand 0.8.5",
- "serde",
- "thiserror 2.0.16",
- "utoipa",
-]
-
-[[package]]
-name = "nym-sphinx-chunking"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "dashmap",
- "log",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-metrics 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-params 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-crypto",
+ "nym-metrics",
+ "nym-sphinx-addressing",
+ "nym-sphinx-params",
+ "nym-sphinx-types",
  "rand 0.8.5",
  "serde",
  "thiserror 2.0.16",
@@ -5758,33 +4943,15 @@ name = "nym-sphinx-cover"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-acknowledgements 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-chunking 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-forwarding 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-params 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-routing 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-topology 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "rand 0.8.5",
- "thiserror 2.0.16",
-]
-
-[[package]]
-name = "nym-sphinx-cover"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-acknowledgements 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-chunking 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-forwarding 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-params 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-routing 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-topology 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-crypto",
+ "nym-sphinx-acknowledgements",
+ "nym-sphinx-addressing",
+ "nym-sphinx-chunking",
+ "nym-sphinx-forwarding",
+ "nym-sphinx-params",
+ "nym-sphinx-routing",
+ "nym-sphinx-types",
+ "nym-topology",
  "rand 0.8.5",
  "thiserror 2.0.16",
 ]
@@ -5794,22 +4961,10 @@ name = "nym-sphinx-forwarding"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
- "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-anonymous-replies 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-params 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "thiserror 2.0.16",
-]
-
-[[package]]
-name = "nym-sphinx-forwarding"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-anonymous-replies 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-params 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-addressing",
+ "nym-sphinx-anonymous-replies",
+ "nym-sphinx-params",
+ "nym-sphinx-types",
  "thiserror 2.0.16",
 ]
 
@@ -5819,27 +4974,11 @@ version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
  "bytes",
- "nym-sphinx-acknowledgements 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-forwarding 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-params 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "thiserror 2.0.16",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "nym-sphinx-framing"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "bytes",
- "nym-sphinx-acknowledgements 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-forwarding 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-params 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-acknowledgements",
+ "nym-sphinx-addressing",
+ "nym-sphinx-forwarding",
+ "nym-sphinx-params",
+ "nym-sphinx-types",
  "thiserror 2.0.16",
  "tokio-util",
  "tracing",
@@ -5850,19 +4989,8 @@ name = "nym-sphinx-params"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "serde",
- "thiserror 2.0.16",
-]
-
-[[package]]
-name = "nym-sphinx-params"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-crypto",
+ "nym-sphinx-types",
  "serde",
  "thiserror 2.0.16",
 ]
@@ -5872,18 +5000,8 @@ name = "nym-sphinx-routing"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
- "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "thiserror 2.0.16",
-]
-
-[[package]]
-name = "nym-sphinx-routing"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-sphinx-addressing",
+ "nym-sphinx-types",
  "thiserror 2.0.16",
 ]
 
@@ -5892,17 +5010,7 @@ name = "nym-sphinx-types"
 version = "0.2.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
- "nym-outfox 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "sphinx-packet",
- "thiserror 2.0.16",
-]
-
-[[package]]
-name = "nym-sphinx-types"
-version = "0.2.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "nym-outfox 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-outfox",
  "sphinx-packet",
  "thiserror 2.0.16",
 ]
@@ -5912,15 +5020,15 @@ name = "nym-statistics"
 version = "1.15.0-beta"
 dependencies = [
  "futures",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-bin-common",
  "nym-sdk",
  "nym-statistics-api-client",
- "nym-statistics-common 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-statistics-common",
  "nym-vpn-lib-types",
  "rand 0.8.5",
  "serde",
  "sqlx",
- "sqlx-pool-guard 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "sqlx-pool-guard",
  "sysinfo 0.37.0",
  "thiserror 2.0.16",
  "tokio",
@@ -5933,7 +5041,7 @@ dependencies = [
 name = "nym-statistics-api-client"
 version = "1.15.0-beta"
 dependencies = [
- "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-http-api-client",
  "serde",
  "thiserror 2.0.16",
  "url",
@@ -5946,35 +5054,11 @@ source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#
 dependencies = [
  "futures",
  "log",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-metrics 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-task 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "si-scale",
- "strum",
- "sysinfo 0.33.1",
- "thiserror 2.0.16",
- "time",
- "tokio",
- "wasmtimer",
-]
-
-[[package]]
-name = "nym-statistics-common"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "futures",
- "log",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-metrics 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-task 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-credentials-interface",
+ "nym-crypto",
+ "nym-metrics",
+ "nym-sphinx",
+ "nym-task",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -6005,44 +5089,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "nym-task"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "cfg-if",
- "futures",
- "log",
- "thiserror 2.0.16",
- "tokio",
- "tokio-util",
- "tracing",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasmtimer",
-]
-
-[[package]]
 name = "nym-ticketbooks-merkle"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-serde-helpers 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "rs_merkle",
- "schemars",
- "serde",
- "sha2 0.10.9",
- "time",
- "utoipa",
-]
-
-[[package]]
-name = "nym-ticketbooks-merkle"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-serde-helpers 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-credentials-interface",
+ "nym-serde-helpers",
  "rs_merkle",
  "schemars",
  "serde",
@@ -6057,31 +5109,11 @@ version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
 dependencies = [
  "async-trait",
- "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "rand 0.8.5",
- "reqwest 0.12.20",
- "serde",
- "serde_json",
- "thiserror 2.0.16",
- "time",
- "tracing",
-]
-
-[[package]]
-name = "nym-topology"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "async-trait",
- "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-addressing 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-api-requests",
+ "nym-crypto",
+ "nym-mixnet-contract-common",
+ "nym-sphinx-addressing",
+ "nym-sphinx-types",
  "rand 0.8.5",
  "reqwest 0.12.20",
  "serde",
@@ -6112,70 +5144,20 @@ dependencies = [
  "flate2",
  "futures",
  "itertools 0.14.0",
- "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-coconut-dkg-common 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-compact-ecash 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-ecash-contract-common 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-group-contract-common 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-performance-contract-common 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-serde-helpers 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-vesting-contract-common 0.7.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "prost",
- "reqwest 0.12.20",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "tendermint-rpc",
- "thiserror 2.0.16",
- "time",
- "tokio",
- "tracing",
- "url",
- "wasmtimer",
- "zeroize",
-]
-
-[[package]]
-name = "nym-validator-client"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "async-trait",
- "base64 0.22.1",
- "bip32",
- "bip39",
- "colored",
- "cosmrs",
- "cosmwasm-std",
- "cw-controllers",
- "cw-utils",
- "cw2",
- "cw3",
- "cw4",
- "eyre",
- "flate2",
- "futures",
- "itertools 0.14.0",
- "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-coconut-dkg-common 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-compact-ecash 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-ecash-contract-common 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-group-contract-common 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-performance-contract-common 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-serde-helpers 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-vesting-contract-common 0.7.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-api-requests",
+ "nym-coconut-dkg-common",
+ "nym-compact-ecash",
+ "nym-config",
+ "nym-contracts-common",
+ "nym-ecash-contract-common",
+ "nym-group-contract-common",
+ "nym-http-api-client",
+ "nym-mixnet-contract-common",
+ "nym-multisig-contract-common",
+ "nym-network-defaults",
+ "nym-performance-contract-common",
+ "nym-serde-helpers",
+ "nym-vesting-contract-common",
  "prost",
  "reqwest 0.12.20",
  "serde",
@@ -6198,21 +5180,8 @@ source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "serde",
- "thiserror 2.0.16",
-]
-
-[[package]]
-name = "nym-vesting-contract-common"
-version = "0.7.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-contracts-common",
+ "nym-mixnet-contract-common",
  "serde",
  "thiserror 2.0.16",
 ]
@@ -6226,13 +5195,13 @@ dependencies = [
  "bincode",
  "futures",
  "nym-common",
- "nym-compact-ecash 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-compact-ecash",
  "nym-credential-proxy-requests",
- "nym-credential-storage 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-credentials 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-ecash-time 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-credential-storage",
+ "nym-credentials",
+ "nym-credentials-interface",
+ "nym-ecash-time",
+ "nym-http-api-client",
  "nym-offline-monitor",
  "nym-sdk",
  "nym-vpn-api-client",
@@ -6244,7 +5213,7 @@ dependencies = [
  "serde",
  "si-scale",
  "sqlx",
- "sqlx-pool-guard 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "sqlx-pool-guard",
  "strum",
  "tempfile",
  "thiserror 2.0.16",
@@ -6267,14 +5236,14 @@ dependencies = [
  "bs58",
  "chrono",
  "itertools 0.13.0",
- "nym-compact-ecash 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-compact-ecash",
+ "nym-config",
+ "nym-contracts-common",
  "nym-credential-proxy-requests",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-crypto",
+ "nym-http-api-client",
+ "nym-network-defaults",
+ "nym-validator-client",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -6306,18 +5275,18 @@ dependencies = [
  "nix 0.30.1",
  "nym-apple-network",
  "nym-authenticator-client",
- "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-client-core 1.1.15 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-bandwidth-controller",
+ "nym-bin-common",
+ "nym-client-core",
  "nym-common",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-config",
  "nym-connection-monitor",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-credentials-interface",
+ "nym-crypto",
  "nym-dns",
  "nym-firewall",
  "nym-gateway-directory",
- "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-http-api-client",
  "nym-ip-packet-client",
  "nym-ip-packet-requests",
  "nym-macos",
@@ -6325,9 +5294,9 @@ dependencies = [
  "nym-routing",
  "nym-sdk",
  "nym-statistics",
- "nym-statistics-common 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-task 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-statistics-common",
+ "nym-task",
+ "nym-validator-client",
  "nym-vpn-account-controller",
  "nym-vpn-lib-types",
  "nym-vpn-network-config",
@@ -6335,7 +5304,7 @@ dependencies = [
  "nym-wg-gateway-client",
  "nym-wg-go",
  "nym-windows",
- "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-wireguard-types",
  "rand 0.8.5",
  "serial_test",
  "thiserror 2.0.16",
@@ -6357,10 +5326,10 @@ dependencies = [
 name = "nym-vpn-lib-types"
 version = "1.15.0-beta"
 dependencies = [
- "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-bandwidth-controller",
  "nym-connection-monitor",
  "nym-gateway-directory",
- "nym-statistics-common 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-statistics-common",
  "nym-vpn-api-client",
  "nym-wg-gateway-client",
  "si-scale",
@@ -6374,7 +5343,7 @@ name = "nym-vpn-lib-types-uniffi"
 version = "1.15.0-beta"
 dependencies = [
  "ipnetwork",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-config",
  "nym-gateway-directory",
  "nym-ip-packet-requests",
  "nym-sdk",
@@ -6397,10 +5366,10 @@ dependencies = [
  "itertools 0.13.0",
  "lazy_static",
  "log",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-bin-common",
  "nym-common",
  "nym-gateway-directory",
- "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-http-api-client",
  "nym-offline-monitor",
  "nym-platform-metadata",
  "nym-sdk",
@@ -6433,12 +5402,12 @@ version = "1.15.0-beta"
 dependencies = [
  "futures-util",
  "itertools 0.13.0",
- "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-api-requests",
  "nym-common",
- "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-http-api-client",
+ "nym-network-defaults",
  "nym-sdk",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-validator-client",
  "nym-vpn-api-client",
  "serde",
  "serde_json",
@@ -6455,9 +5424,9 @@ dependencies = [
 name = "nym-vpn-proto"
 version = "1.15.0-beta"
 dependencies = [
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-config",
  "nym-gateway-directory",
- "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-http-api-client",
  "nym-ipc",
  "nym-sdk",
  "nym-vpn-api-client",
@@ -6494,8 +5463,8 @@ version = "1.15.0-beta"
 dependencies = [
  "async-trait",
  "bip39",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-crypto",
+ "nym-pemstore",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "serde",
@@ -6515,9 +5484,9 @@ dependencies = [
  "anyhow",
  "celes",
  "clap",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-bin-common",
  "nym-gateway-directory",
- "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-http-api-client",
  "nym-vpn-lib-types",
  "nym-vpn-proto",
  "nym-vpnd-types",
@@ -6537,13 +5506,13 @@ dependencies = [
  "eventlog",
  "futures",
  "log-panics",
- "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-bin-common",
+ "nym-http-api-client",
  "nym-ipc",
  "nym-offline-monitor",
  "nym-platform-metadata",
  "nym-statistics",
- "nym-task 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-task",
  "nym-vpn-account-controller",
  "nym-vpn-api-client",
  "nym-vpn-lib",
@@ -6578,7 +5547,7 @@ version = "1.15.0-beta"
 dependencies = [
  "nym-gateway-directory",
  "nym-sdk",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-validator-client",
  "nym-vpn-lib-types",
  "nym-vpn-network-config",
  "serde",
@@ -6592,14 +5561,14 @@ version = "1.15.0-beta"
 dependencies = [
  "nym-authenticator-client",
  "nym-authenticator-requests",
- "nym-bandwidth-controller 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-bandwidth-controller",
+ "nym-credentials-interface",
+ "nym-crypto",
  "nym-gateway-directory",
- "nym-node-requests 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-node-requests",
+ "nym-pemstore",
  "nym-sdk",
- "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
+ "nym-validator-client",
  "nym-wg-go",
  "rand 0.8.5",
  "thiserror 2.0.16",
@@ -6642,22 +5611,8 @@ source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#
 dependencies = [
  "base64 0.22.1",
  "log",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=domain-fronting-integration)",
- "serde",
- "thiserror 2.0.16",
- "x25519-dalek",
-]
-
-[[package]]
-name = "nym-wireguard-types"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "base64 0.22.1",
- "log",
- "nym-config 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
- "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched)",
+ "nym-config",
+ "nym-network-defaults",
  "serde",
  "thiserror 2.0.16",
  "x25519-dalek",
@@ -7207,28 +6162,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
-]
-
-[[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn 2.0.103",
 ]
 
 [[package]]
@@ -8761,18 +7694,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sqlx-pool-guard"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
-dependencies = [
- "proc_pidinfo",
- "sqlx",
- "tokio",
- "tracing",
- "windows 0.61.3",
-]
-
-[[package]]
 name = "sqlx-postgres"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10256,22 +9177,6 @@ dependencies = [
 name = "wasm-utils"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=domain-fronting-integration#036088671e1ba9c1f48fd19b265a10a11a11b7be"
-dependencies = [
- "futures",
- "getrandom 0.2.16",
- "gloo-net",
- "gloo-utils",
- "js-sys",
- "tungstenite",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "wasm-utils"
-version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2025.13.1-emmental-patched#7677c024940eb6ca86cb76149e16cac10b0a30a4"
 dependencies = [
  "futures",
  "getrandom 0.2.16",

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -247,4 +247,4 @@ nym-topology = { git = "https://github.com/nymtech/nym", branch = "domain-fronti
 nym-validator-client = { git = "https://github.com/nymtech/nym", branch = "domain-fronting-integration" }
 nym-wireguard-types = { git = "https://github.com/nymtech/nym", branch = "domain-fronting-integration" }
 sqlx-pool-guard = { git = "https://github.com/nymtech/nym", branch = "domain-fronting-integration" }
-nym-credential-utils = { git = "https://github.com/nymtech/nym", branch = "release/2025.13.1-emmental-patched" }
+nym-credential-utils = { git = "https://github.com/nymtech/nym", branch = "domain-fronting-integration" }

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -45,33 +45,34 @@ default-members = [
 ]
 
 # For local development
-# [patch."https://github.com/nymtech/nym"]
-# nym-authenticator-requests = { path = "../../nym/common/authenticator-requests" }
-# nym-api-requests = { path = "../../nym/nym-api/nym-api-requests" }
-# nym-bandwidth-controller = { path = "../../nym/common/bandwidth-controller" }
-# nym-bin-common = { path = "../../nym/common/bin-common" }
-# nym-client-core = { path = "../../nym/common/client-core" }
-# nym-compact-ecash = { path = "../../nym/common/nym_offline_compact_ecash" }
-# nym-config = { path = "../../nym/common/config" }
-# nym-contracts-common = { path = "../../nym/common/cosmwasm-smart-contracts/contracts-common" }
-# nym-credential-proxy-requests = { path = "../../nym/nym-credential-proxy/nym-credential-proxy-requests", default-features = false }
-# nym-credential-storage = { path = "../../nym/common/credential-storage" }
-# nym-credentials = { path = "../../nym/common/credentials" }
-# nym-credentials-interface = { path = "../../nym/common/credentials-interface" }
-# nym-crypto = { path = "../../nym/common/crypto" }
-# nym-ecash-time = { path = "../../nym/common/ecash-time" }
-# nym-http-api-client = { path = "../../nym/common/http-api-client" }
-# nym-ip-packet-requests = { path = "../../nym/common/ip-packet-requests" }
-# nym-network-defaults = { path = "../../nym/common/network-defaults" }
-# nym-node-requests = { path = "../../nym/nym-node/nym-node-requests" }
-# nym-pemstore = { path = "../../nym/common/pemstore" }
-# nym-service-provider-requests-common = { path = "../../nym/common/service-provider-requests-common" }
-# nym-sdk = { path = "../../nym/sdk/rust/nym-sdk" }
-# nym-statistics-common = { path = "../../nym/common/statistics" }
-# nym-task = { path = "../../nym/common/task" }
-# nym-topology = { path = "../../nym/common/topology" }
-# nym-validator-client = { path = "../../nym/common/client-libs/validator-client" }
-# nym-wireguard-types = { path = "../../nym/common/wireguard-types" }
+#[patch."https://github.com/nymtech/nym"]
+#nym-authenticator-requests = { path = "../../nym/common/authenticator-requests" }
+#nym-api-requests = { path = "../../nym/nym-api/nym-api-requests" }
+#nym-bandwidth-controller = { path = "../../nym/common/bandwidth-controller" }
+#nym-bin-common = { path = "../../nym/common/bin-common" }
+#nym-client-core = { path = "../../nym/common/client-core" }
+#nym-compact-ecash = { path = "../../nym/common/nym_offline_compact_ecash" }
+#nym-config = { path = "../../nym/common/config" }
+#nym-contracts-common = { path = "../../nym/common/cosmwasm-smart-contracts/contracts-common" }
+#nym-credential-proxy-requests = { path = "../../nym/nym-credential-proxy/nym-credential-proxy-requests", default-features = false }
+#nym-credential-storage = { path = "../../nym/common/credential-storage" }
+#nym-credentials = { path = "../../nym/common/credentials" }
+#nym-credentials-interface = { path = "../../nym/common/credentials-interface" }
+#nym-crypto = { path = "../../nym/common/crypto" }
+#nym-ecash-time = { path = "../../nym/common/ecash-time" }
+#nym-http-api-client = { path = "../../nym/common/http-api-client" }
+#nym-ip-packet-requests = { path = "../../nym/common/ip-packet-requests" }
+#nym-network-defaults = { path = "../../nym/common/network-defaults" }
+#nym-node-requests = { path = "../../nym/nym-node/nym-node-requests" }
+#nym-pemstore = { path = "../../nym/common/pemstore" }
+#nym-service-provider-requests-common = { path = "../../nym/common/service-provider-requests-common" }
+#nym-sdk = { path = "../../nym/sdk/rust/nym-sdk" }
+#nym-statistics-common = { path = "../../nym/common/statistics" }
+#nym-task = { path = "../../nym/common/task" }
+#nym-topology = { path = "../../nym/common/topology" }
+#nym-validator-client = { path = "../../nym/common/client-libs/validator-client" }
+#nym-wireguard-types = { path = "../../nym/common/wireguard-types" }
+#nym-credential-utils = { path = "../../nym/common/credential-utils" }
 
 [workspace.package]
 version = "1.15.0-beta"
@@ -246,3 +247,4 @@ nym-topology = { git = "https://github.com/nymtech/nym", branch = "domain-fronti
 nym-validator-client = { git = "https://github.com/nymtech/nym", branch = "domain-fronting-integration" }
 nym-wireguard-types = { git = "https://github.com/nymtech/nym", branch = "domain-fronting-integration" }
 sqlx-pool-guard = { git = "https://github.com/nymtech/nym", branch = "domain-fronting-integration" }
+nym-credential-utils = { git = "https://github.com/nymtech/nym", branch = "release/2025.13.1-emmental-patched" }

--- a/nym-vpn-core/crates/nym-gateway-probe/Cargo.toml
+++ b/nym-vpn-core/crates/nym-gateway-probe/Cargo.toml
@@ -56,6 +56,7 @@ nym-ip-packet-requests.workspace = true
 nym-sdk.workspace = true
 nym-task.workspace = true
 nym-validator-client.workspace = true
+nym-credential-utils.workspace = true
 
 [build-dependencies]
 vergen-gitcl = { workspace = true, default-features = false, features = [

--- a/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
+++ b/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
@@ -202,7 +202,7 @@ impl Probe {
         ticketbook_type: TicketType,
     ) -> anyhow::Result<()> {
         // TODO: make it configurable
-        const MAX_RETRIES: usize = 10;
+        const MAX_RETRIES: usize = 50;
         for i in 0..MAX_RETRIES {
             debug!("attempt {i} for attempting to acquire {ticketbook_type} bandwidth");
             let bw_client = disconnected_mixnet_client
@@ -248,7 +248,9 @@ impl Probe {
                 }
             }
 
-            // no need for backoff as we're limited by block time anyway
+            // add a bit of backoff as if the rpc node is slightly out of sync,
+            // we might use our retry budget for abci queries to the simulate endpoint
+            tokio::time::sleep(Duration::from_secs(1)).await;
         }
 
         bail!("failed to acquire bandwidth after {MAX_RETRIES} attempts")

--- a/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
+++ b/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
@@ -860,11 +860,3 @@ fn unpack_data_response(reconstructed_message: &ReconstructedMessage) -> Option<
         }
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[tokio::test]
-    async fn foo() {}
-}

--- a/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
+++ b/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
@@ -17,6 +17,7 @@ use nym_authenticator_client::{
     AuthClientMixnetListener, AuthenticatorResponse, AuthenticatorVersion, ClientMessage,
 };
 use nym_authenticator_requests::{v2, v3, v4, v5};
+use nym_bandwidth_controller::error::BandwidthControllerError;
 use nym_client_core::config::ForgetMe;
 use nym_config::defaults::{
     NymNetworkDetails,
@@ -38,9 +39,10 @@ use nym_ip_packet_requests::{
     },
 };
 use nym_sdk::mixnet::{
-    Ephemeral, MixnetClient, MixnetClientBuilder, MixnetClientStorage, NodeIdentity,
-    ReconstructedMessage,
+    DisconnectedMixnetClient, Ephemeral, MixnetClient, MixnetClientBuilder, MixnetClientStorage,
+    NodeIdentity, ReconstructedMessage,
 };
+use nym_validator_client::nyxd::error::NyxdError;
 use nym_wireguard_types::PeerPublicKey;
 use tokio::sync::Mutex;
 use tokio_util::{codec::Decoder, sync::CancellationToken};
@@ -194,17 +196,73 @@ impl Probe {
         self
     }
 
+    async fn acquire_bandwidth(
+        &self,
+        disconnected_mixnet_client: &DisconnectedMixnetClient<Ephemeral>,
+        ticketbook_type: TicketType,
+    ) -> anyhow::Result<()> {
+        // TODO: make it configurable
+        const MAX_RETRIES: usize = 10;
+        for i in 0..MAX_RETRIES {
+            debug!("attempt {i} for attempting to acquire {ticketbook_type} bandwidth");
+            let bw_client = disconnected_mixnet_client
+                .create_bandwidth_client(self.credentials_args.mnemonic.clone(), ticketbook_type)
+                .await?;
+            match bw_client.acquire().await {
+                Ok(_) => return Ok(()),
+                Err(nym_sdk::Error::CredentialIssuanceError { source }) => match source {
+                    nym_credential_utils::errors::Error::BandwidthControllerError(
+                        BandwidthControllerError::Nyxd(nyxd_error),
+                    ) => match nyxd_error {
+                        // happens when sequence issue occurs during tx delivery
+                        NyxdError::BroadcastTxErrorDeliverTx { hash, raw_log, .. } => {
+                            // unfortunately at this point we have to do string matching as the log
+                            // is returned from the go nyxd binary
+                            if raw_log.contains("account sequence mismatch") {
+                                error!(
+                                    "another process is using the same mnemonic. we failed to broadcast transaction {hash} due to mismatched sequence number"
+                                )
+                            }
+                        }
+                        // happens when sequence issue occurs during tx simulate
+                        NyxdError::AbciError { log, .. } => {
+                            // unfortunately at this point we have to do string matching as the log
+                            // is returned from the go nyxd binary
+                            if log.contains("account sequence mismatch") {
+                                error!(
+                                    "another process is using the same mnemonic. we failed to simulate transaction due to mismatched sequence number"
+                                )
+                            }
+                        }
+                        other => {
+                            return Err(other)
+                                .context("another nyxd failure during bandwidth acquisition");
+                        }
+                    },
+                    other => {
+                        return Err(other.into());
+                    }
+                },
+                Err(other) => {
+                    return Err(other.into());
+                }
+            }
+
+            // no need for backoff as we're limited by block time anyway
+        }
+
+        bail!("failed to acquire bandwidth after {MAX_RETRIES} attempts")
+    }
+
     pub async fn probe(
         self,
         gateway_config: GatewayDirectoryConfig,
         ignore_egress_epoch_role: bool,
         only_wireguard: bool,
     ) -> anyhow::Result<ProbeResult> {
-        let entry_point = self.entrypoint;
-
         // Setup the entry gateways
         let gateways = lookup_gateways(gateway_config.clone()).await?;
-        let entry_gateway = entry_point.lookup_gateway(&gateways).await?;
+        let entry_gateway = self.entrypoint.lookup_gateway(&gateways).await?;
         let tested_entry = self.tested_node.is_same_as_entry();
 
         let node_info: TestedNodeDetails = match self.tested_node {
@@ -246,10 +304,8 @@ impl Probe {
             TicketType::V1WireguardEntry,
             TicketType::V1WireguardExit,
         ] {
-            let bw_client = disconnected_mixnet_client
-                .create_bandwidth_client(self.credentials_args.mnemonic.clone(), ticketbook_type)
+            self.acquire_bandwidth(&disconnected_mixnet_client, ticketbook_type)
                 .await?;
-            bw_client.acquire().await?;
         }
 
         let mixnet_client = Box::pin(disconnected_mixnet_client.connect_to_mixnet()).await;
@@ -803,4 +859,12 @@ fn unpack_data_response(reconstructed_message: &ReconstructedMessage) -> Option<
             None
         }
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn foo() {}
 }

--- a/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
+++ b/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
@@ -204,12 +204,22 @@ impl Probe {
         // TODO: make it configurable
         const MAX_RETRIES: usize = 50;
         for i in 0..MAX_RETRIES {
-            debug!("attempt {i} for attempting to acquire {ticketbook_type} bandwidth");
+            let attempt = i + 1; // since humans usually don't count from 0 in this instance
+            debug!(
+                "attempt {attempt}/{MAX_RETRIES} for attempting to acquire {ticketbook_type} bandwidth"
+            );
             let bw_client = disconnected_mixnet_client
                 .create_bandwidth_client(self.credentials_args.mnemonic.clone(), ticketbook_type)
                 .await?;
             match bw_client.acquire().await {
-                Ok(_) => return Ok(()),
+                Ok(_) => {
+                    if i > 0 {
+                        info!(
+                            "managed to acquire {ticketbook_type} bandwidth after {attempt} attempts",
+                        );
+                    }
+                    return Ok(());
+                }
                 Err(nym_sdk::Error::CredentialIssuanceError { source }) => match source {
                     nym_credential_utils::errors::Error::BandwidthControllerError(
                         BandwidthControllerError::Nyxd(nyxd_error),


### PR DESCRIPTION
## Ticket

[NET-589](https://nymtech.atlassian.net/browse/NET-589)

## Description

if gateway probe bandwidth acquisition fails due to mismatched sequence number, the request is retried up to maximum of 50 tries.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)


[NET-589]: https://nymtech.atlassian.net/browse/NET-589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3336)
<!-- Reviewable:end -->
