### PR TITLE
[AccountController ] Change AC tests to be multi-threaded

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-account-controller/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/Cargo.toml
@@ -41,7 +41,7 @@ thiserror.workspace = true
 time.workspace = true
 tokio-util.workspace = true
 tokio-stream.workspace = true
-tokio = { workspace = true, features = ["fs", "rt-multi-thread", "macros"] }
+tokio = { workspace = true, features = ["fs"] }
 tracing.workspace = true
 zeroize.workspace = true
 
@@ -56,3 +56,4 @@ nym-compact-ecash.workspace = true
 nym-http-api-client.workspace = true
 tempfile.workspace = true
 wiremock.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/Cargo.toml
@@ -41,7 +41,7 @@ thiserror.workspace = true
 time.workspace = true
 tokio-util.workspace = true
 tokio-stream.workspace = true
-tokio = { workspace = true, features = ["fs"] }
+tokio = { workspace = true, features = ["fs", "rt-multi-thread", "macros"] }
 tracing.workspace = true
 zeroize.workspace = true
 

--- a/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/commands.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/commands.rs
@@ -8,7 +8,7 @@ use nym_vpn_lib_types::{
     AccountCommandError, AccountControllerErrorStateReason, AccountControllerState,
 };
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn logged_out_state_command() -> anyhow::Result<()> {
     // Get the test_bench without credential for easier testing
     let mut test_bench = TestBench::new_no_credentials().await?;
@@ -94,7 +94,7 @@ async fn logged_out_state_command() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn offline_state_command() -> anyhow::Result<()> {
     // Get the test_bench without credential for easier testing
     let mut test_bench = TestBench::new_no_credentials().await?;
@@ -218,7 +218,7 @@ async fn offline_state_command() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn ready_state_command() -> anyhow::Result<()> {
     // Get the test_bench without credential for easier testing
     let mut test_bench = TestBench::new_no_credentials().await?;
@@ -327,7 +327,7 @@ async fn ready_state_command() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn error_state_command() -> anyhow::Result<()> {
     // Get the test_bench without credential for easier testing
     let mut test_bench = TestBench::new_no_credentials().await?;

--- a/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/common/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/common/mod.rs
@@ -227,7 +227,7 @@ impl TestBench {
 
         let wait_for_state_fut = state_watcher.wait_for(|state| *state == expected_state);
 
-        let _ = tokio::time::timeout(Duration::from_secs(5), wait_for_state_fut).await;
+        let _ = tokio::time::timeout(Duration::from_secs(10), wait_for_state_fut).await;
 
         // For the nice output in tests
         assert_eq!(self.state_receiver.get_state(), expected_state);

--- a/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/paths.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/paths.rs
@@ -16,7 +16,7 @@ use nym_vpn_lib_types::{AccountControllerErrorStateReason, AccountControllerStat
 ///
 /// 4. Use TestBench::assert_state to test the AC state. This takes care of yielding back to the tokio and wait a certain time for the state we're looking for
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn offline_test() -> anyhow::Result<()> {
     // Get the test_bench
     let mut test_bench = TestBench::new_no_credentials().await?;
@@ -67,7 +67,7 @@ async fn offline_test() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn api_error_reponse_test() -> anyhow::Result<()> {
     // Get the test_bench
     let mut test_bench = TestBench::new().await?;
@@ -93,7 +93,7 @@ async fn api_error_reponse_test() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn unregistered_account_test() -> anyhow::Result<()> {
     // Get the test_bench
     let mut test_bench = TestBench::new().await?;
@@ -117,7 +117,7 @@ async fn unregistered_account_test() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn desynced_device_test() -> anyhow::Result<()> {
     // Get the test_bench
     let mut test_bench = TestBench::new().await?;
@@ -139,7 +139,7 @@ async fn desynced_device_test() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn inactive_account_test() -> anyhow::Result<()> {
     // Get the test_bench
     let mut test_bench = TestBench::new().await?;
@@ -163,7 +163,7 @@ async fn inactive_account_test() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn account_with_inactive_sub_test() -> anyhow::Result<()> {
     // Get the test_bench
     let mut test_bench = TestBench::new().await?;
@@ -185,7 +185,7 @@ async fn account_with_inactive_sub_test() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn account_with_max_device_test() -> anyhow::Result<()> {
     // Get the test_bench
     let mut test_bench = TestBench::new().await?;
@@ -207,7 +207,7 @@ async fn account_with_max_device_test() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn account_with_no_fair_usage_test() -> anyhow::Result<()> {
     // Get the test_bench
     let mut test_bench = TestBench::new().await?;
@@ -231,7 +231,7 @@ async fn account_with_no_fair_usage_test() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn zk_nym_issuance_test() -> anyhow::Result<()> {
     // Get the test_bench
     let mut test_bench = TestBench::new().await?;
@@ -260,7 +260,7 @@ async fn zk_nym_issuance_test() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn e2e_new_device_test() -> anyhow::Result<()> {
     // Get the test_bench
     let mut test_bench = TestBench::new().await?;


### PR DESCRIPTION

## Description

Some AccountController tests seem to fail sometimes. 
This PR aims to fix that by making the tests multi threaded allowing the AccountController to be moor free in a separate thread

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3338)
<!-- Reviewable:end -->
