### PR TITLE
Fix daemon init failure due to domain fronting

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
@@ -82,12 +82,25 @@ impl VpnApiClient {
             })?;
 
         // Build client with domain fronting support from network details
-        let inner = nym_http_api_client::ClientBuilder::from_network(network)
-            .map_err(|e| {
-                let err: HttpClientError<UnexpectedError> =
-                    HttpClientError::GenericRequestFailure(e.to_string());
-                VpnApiClientError::CreateVpnApiClient(err)
-            })?
+        let nym_vpn_api_urls = vpn_urls
+            .iter()
+            .map(|v| {
+                v.url.parse().map_err(|e| {
+                    let err: HttpClientError<UnexpectedError> =
+                        HttpClientError::GenericRequestFailure(format!("Invalid VPN API URL: {e}"));
+                    VpnApiClientError::CreateVpnApiClient(err)
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        // TODO: from_network is buggy! it uses nym_api_urls instead of nym_vpn_api_urls!
+        // nym_http_api_client::ClientBuilder::from_network(network)
+        let inner = nym_http_api_client::ClientBuilder::new_with_urls(nym_vpn_api_urls)
+            // .map_err(|e| {
+            //     let err: HttpClientError<UnexpectedError> =
+            //         HttpClientError::GenericRequestFailure(e.to_string());
+            //     VpnApiClientError::CreateVpnApiClient(err)
+            // })?
             .with_user_agent(user_agent.clone())
             .with_timeout(NYM_VPN_API_TIMEOUT)
             .build::<UnexpectedError>()
@@ -131,12 +144,26 @@ impl VpnApiClient {
             )))
         })?;
 
-        let mut builder = nym_http_api_client::ClientBuilder::from_network(network)
-            .map_err(|e| {
-                VpnApiClientError::CreateVpnApiClient(HttpClientError::GenericRequestFailure(
-                    format!("Failed to create HTTP client from network: {e}"),
-                ))
-            })?
+        // Build client with domain fronting support from network details
+        let nym_vpn_api_urls = vpn_urls
+            .iter()
+            .map(|v| {
+                v.url.parse().map_err(|e| {
+                    let err: HttpClientError<UnexpectedError> =
+                        HttpClientError::GenericRequestFailure(format!("Invalid VPN API URL: {e}"));
+                    VpnApiClientError::CreateVpnApiClient(err)
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        // TODO: from_network is buggy! it uses nym_api_urls instead of nym_vpn_api_urls!
+        // nym_http_api_client::ClientBuilder::from_network(network)
+        let mut builder = nym_http_api_client::ClientBuilder::new_with_urls(nym_vpn_api_urls)
+            // .map_err(|e| {
+            //     VpnApiClientError::CreateVpnApiClient(HttpClientError::GenericRequestFailure(
+            //         format!("Failed to create HTTP client from network: {e}"),
+            //     ))
+            // })?
             .with_user_agent(user_agent.clone())
             .with_timeout(NYM_VPN_API_TIMEOUT);
 

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/error.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/error.rs
@@ -17,7 +17,7 @@ pub const FAIR_USAGE_DEPLETED_CODE_ID: &str = "e0b78604-bb9b-4524-add1-f50fe2614
 
 #[derive(Debug, thiserror::Error)]
 pub enum VpnApiClientError {
-    #[error("failed tp create vpn api client")]
+    #[error("failed to create vpn api client")]
     CreateVpnApiClient(#[source] HttpClientError<UnexpectedError>),
 
     #[error("failed to get account")]

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/error.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/error.rs
@@ -126,7 +126,7 @@ pub enum VpnApiClientError {
     PostAccount(#[source] HttpClientError<UnexpectedError>),
 }
 
-pub type Result<T> = std::result::Result<T, VpnApiClientError>;
+pub type Result<T, E = VpnApiClientError> = std::result::Result<T, E>;
 
 impl TryFrom<VpnApiClientError> for NymErrorResponse {
     type Error = VpnApiClientError;

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
@@ -585,12 +585,20 @@ where
     }
 }
 
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct ApiUrl {
+    pub url: String,
+    pub fronts: Option<Vec<String>>,
+}
+
 // The response type we fetch from the discovery endpoint
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct NymWellknownDiscoveryItemResponse {
     pub network_name: String,
     pub nym_api_url: String,
+    pub nym_api_urls: Vec<ApiUrl>,
     pub nym_vpn_api_url: String,
+    pub nym_vpn_api_urls: Vec<ApiUrl>,
     pub account_management: Option<AccountManagementResponse>,
     pub feature_flags: Option<serde_json::Value>,
     pub system_messages: Option<Vec<SystemMessageResponse>>,

--- a/nym-vpn-core/crates/nym-vpn-lib-types-uniffi/src/network_config.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types-uniffi/src/network_config.rs
@@ -197,7 +197,7 @@ impl From<nym_vpn_network_config::SystemMessage> for SystemMessage {
         SystemMessage {
             name: value.name,
             message: value.message,
-            properties: value.properties.into_inner(),
+            properties: value.properties.map(|v| v.into_inner()).unwrap_or_default(),
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-network-config/default/canary_discovery.json
+++ b/nym-vpn-core/crates/nym-vpn-network-config/default/canary_discovery.json
@@ -1,18 +1,58 @@
 {
-    "network_name": "canary",
-    "nym_api_url": "https://canary-api.performance.nymte.ch/api/",
-    "nym_vpn_api_url": "https://nym-vpn-api-git-deploy-canary-nyx-network-staging.vercel.app/api/",
-    "account_management": {
-        "url": "https://nymcom-git-deploy-canary-nyx-network-staging.vercel.app/",
-        "paths": {
-            "account": "{locale}/account/{account_id}",
-            "sign_up": "{locale}/account/create",
-            "sign_in": "{locale}/account/login"
-        }
+  "network_name": "canary",
+  "nym_api_url": "https://canary-api.performance.nymte.ch/api/",
+  "nym_api_urls": [
+    {
+      "url": "https://canary-api.performance.nymte.ch/api/"
     },
-    "feature_flags": {
-        "zkNyms": {
-            "credentialMode": "false"
-        }
+    {
+      "url": "https://nym-frontdoor.vercel.app/canary/api/",
+      "fronts": [
+        "vercel.app",
+        "vercel.com"
+      ]
     }
+  ],
+  "nym_vpn_api_url": "https://nym-vpn-api-git-deploy-canary-nyx-network-staging.vercel.app/api/",
+  "nym_vpn_api_urls": [
+    {
+      "url": "https://nym-vpn-api-git-deploy-canary-nyx-network-staging.vercel.app/api/",
+      "fronts": [
+        "vercel.app",
+        "vercel.com"
+      ]
+    }
+  ],
+  "account_management": {
+    "url": "https://nymcom-git-deploy-canary-nyx-network-staging.vercel.app/",
+    "paths": {
+      "sign_up": "{locale}/account/create",
+      "sign_in": "{locale}/account/login",
+      "account": "{locale}/account/{account_id}"
+    }
+  },
+  "system_configuration": {
+    "mix_thresholds": {
+      "high": 75,
+      "medium": 50,
+      "low": 25
+    },
+    "wg_thresholds": {
+      "high": 75,
+      "medium": 50,
+      "low": 25
+    }
+  },
+  "network_compatibility": {
+    "core": "1.9.0",
+    "macos": "2.4.0",
+    "ios": "2.7.1",
+    "tauri": "1.9.0",
+    "android": "1.5.0"
+  },
+  "feature_flags": {
+    "zkNyms": {
+      "credentialMode": "true"
+    }
+  }
 }

--- a/nym-vpn-core/crates/nym-vpn-network-config/default/mainnet_discovery.json
+++ b/nym-vpn-core/crates/nym-vpn-network-config/default/mainnet_discovery.json
@@ -1,18 +1,71 @@
 {
-    "network_name": "mainnet",
-    "nym_api_url": "https://validator.nymtech.net/api/",
-    "nym_vpn_api_url": "https://nymvpn.com/api/",
-    "account_management": {
-        "url": "https://nym.com/",
-        "paths": {
-            "account": "{locale}/account/{account_id}",
-            "sign_up": "{locale}/account/create",
-            "sign_in": "{locale}/account/login"
-        }
+  "network_name": "mainnet",
+  "nym_api_url": "https://validator.nymtech.net/api/",
+  "nym_api_urls": [
+    {
+      "url": "https://validator.nymtech.net/api/"
     },
-    "feature_flags": {
-        "zkNyms": {
-            "credentialMode": "true"
-        }
+    {
+      "url": "https://nym-frontdoor.vercel.app/api/",
+      "fronts": ["vercel.app", "vercel.com"]
+    },
+    {
+      "url": "https://nym-frontdoor.global.ssl.fastly.net/api/",
+      "fronts": ["yelp.global.ssl.fastly.net"]
     }
+  ],
+  "nym_vpn_api_url": "https://nymvpn.com/api/",
+  "nym_vpn_api_urls": [
+    {
+      "url": "https://nymvpn.com/api/",
+      "fronts": ["vercel.app", "vercel.com"]
+    },
+    {
+      "url": "https://nymvpn-frontdoor.global.ssl.fastly.net/api",
+      "fronts": ["yelp.global.ssl.fastly.net"]
+    }
+  ],
+  "account_management": {
+    "url": "https://nym.com/",
+    "paths": {
+      "sign_up": "{locale}/account/create",
+      "sign_in": "{locale}/account/login",
+      "account": "{locale}/account/{account_id}"
+    }
+  },
+  "system_configuration": {
+    "mix_thresholds": {
+      "high": 75,
+      "medium": 50,
+      "low": 25
+    },
+    "wg_thresholds": {
+      "high": 75,
+      "medium": 50,
+      "low": 25
+    },
+    "iOSinAppPurchasesPlanIds": {
+      "1": "1_month_may_2025",
+      "2": "1_year_may_2025"
+    },
+    "min_supported_app_versions": {
+      "android": "1.5.0",
+      "core": "1.9.0",
+      "ios": "2.7.1",
+      "macos": "2.4.0",
+      "tauri": "1.9.0"
+    }
+  },
+  "network_compatibility": {
+    "core": "1.9.0",
+    "macos": "2.4.0",
+    "ios": "2.7.1",
+    "tauri": "1.9.0",
+    "android": "1.5.0"
+  },
+  "feature_flags": {
+    "zkNyms": {
+      "credentialMode": "true"
+    }
+  }
 }

--- a/nym-vpn-core/crates/nym-vpn-network-config/default/sandbox_discovery.json
+++ b/nym-vpn-core/crates/nym-vpn-network-config/default/sandbox_discovery.json
@@ -1,18 +1,82 @@
 {
-    "network_name": "sandbox",
-    "nym_api_url": "https://sandbox-nym-api1.nymtech.net/api/",
-    "nym_vpn_api_url": "https://nym-vpn-api-git-deploy-sandbox-nyx-network-staging.vercel.app/api/",
-    "account_management": {
-        "url": "https://nymcom-git-deploy-sandbox-nyx-network-staging.vercel.app/",
-        "paths": {
-            "account": "{locale}/account/{account_id}",
-            "sign_up": "{locale}/account/create",
-            "sign_in": "{locale}/account/login"
-        }
+  "network_name": "sandbox",
+  "nym_api_url": "https://sandbox-nym-api1.nymtech.net/api/",
+  "nym_api_urls": [
+    {
+      "url": "https://sandbox-nym-api1.nymtech.net/api/"
     },
-    "feature_flags": {
-        "zkNyms": {
-            "credentialMode": "false"
-        }
+    {
+      "url": "https://nym-frontdoor.vercel.app/sandbox/api/",
+      "fronts": [
+        "vercel.app",
+        "vercel.com"
+      ]
     }
+  ],
+  "nym_vpn_api_url": "https://nym-vpn-api-git-deploy-sandbox-nyx-network-staging.vercel.app/api/",
+  "nym_vpn_api_urls": [
+    {
+      "url": "https://nym-vpn-api-git-deploy-sandbox-nyx-network-staging.vercel.app/api/",
+      "fronts": [
+        "vercel.app",
+        "vercel.com"
+      ]
+    }
+  ],
+  "account_management": {
+    "url": "https://nymcom-git-deploy-sandbox-nyx-network-staging.vercel.app/",
+    "paths": {
+      "sign_up": "{locale}/account/create",
+      "sign_in": "{locale}/account/login",
+      "account": "{locale}/account/{account_id}"
+    }
+  },
+  "system_messages": [
+    {
+      "name": "test_message",
+      "displayFrom": "2024-11-05T12:00:00.000Z",
+      "displayUntil": "",
+      "message": "This is a test message for sandbox",
+      "properties": null
+    }
+  ],
+  "system_configuration": {
+    "mix_thresholds": {
+      "high": 75,
+      "medium": 50,
+      "low": 25
+    },
+    "wg_thresholds": {
+      "high": 75,
+      "medium": 50,
+      "low": 25
+    },
+    "iOSinAppPurchasesPlanIds": {
+      "1": "1_month_may_2025",
+      "2": "1_year_may_2025"
+    },
+    "min_supported_app_versions": {
+      "android": "1.5.0",
+      "core": "1.9.0",
+      "ios": "2.2.0",
+      "macos": "2.4.0",
+      "tauri": "1.9.0"
+    },
+    "statistics_api": "https://nym-statistics-api-staging.nymte.ch"
+  },
+  "network_compatibility": {
+    "core": "1.9.0",
+    "macos": "2.4.0",
+    "ios": "2.7.1",
+    "tauri": "1.9.0",
+    "android": "1.5.0"
+  },
+  "feature_flags": {
+    "website": {
+      "showAccounts": "true"
+    },
+    "zkNyms": {
+      "credentialMode": "true"
+    }
+  }
 }

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/discovery.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/discovery.rs
@@ -465,10 +465,10 @@ mod tests {
                 ),
                 display_until: None,
                 message: "This is a test message, no need to panic!".to_owned(),
-                properties: Properties::from(HashMap::from([(
+                properties: Some(Properties::from(HashMap::from([(
                     "modal".to_owned(),
                     "true".to_owned(),
-                )])),
+                )]))),
             }]),
             system_configuration: None,
         };

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/discovery.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/discovery.rs
@@ -19,7 +19,7 @@ use nym_api_requests::NymNetworkDetailsResponse;
 use nym_validator_client::nym_api::NymApiClientExt;
 
 use crate::{
-    AccountManagement, Error, FeatureFlags, Result, SystemMessages,
+    AccountManagement, ApiUrl, Error, FeatureFlags, Result, SystemMessages,
     system_configuration::SystemConfiguration,
 };
 
@@ -41,7 +41,9 @@ pub struct Discovery {
     // Base network setup
     pub(super) network_name: String,
     pub(super) nym_api_url: Url,
+    pub(super) nym_api_urls: Vec<ApiUrl>,
     pub(super) nym_vpn_api_url: Url,
+    pub(super) nym_vpn_api_urls: Vec<ApiUrl>,
 
     // Additional context
     pub(super) account_management: Option<AccountManagement>,
@@ -252,17 +254,37 @@ impl TryFrom<NymWellknownDiscoveryItemResponse> for Discovery {
                 source,
             }
         })?;
+
+        let nym_api_urls = discovery
+            .nym_api_urls
+            .into_iter()
+            .map(|api_url| ApiUrl {
+                url: api_url.url,
+                fronts: api_url.fronts,
+            })
+            .collect::<Vec<_>>();
+
         let nym_vpn_api_url = discovery.nym_vpn_api_url.parse().map_err(|source| {
             DiscoveryFromNymWellknownDiscoveryError::ParseNymVpnApiUrl {
                 value: discovery.nym_vpn_api_url,
                 source,
             }
         })?;
+        let nym_vpn_api_urls = discovery
+            .nym_vpn_api_urls
+            .into_iter()
+            .map(|api_url| ApiUrl {
+                url: api_url.url,
+                fronts: api_url.fronts,
+            })
+            .collect::<Vec<_>>();
 
         Ok(Self {
             network_name: discovery.network_name,
             nym_api_url,
+            nym_api_urls,
             nym_vpn_api_url,
+            nym_vpn_api_urls,
             account_management,
             feature_flags,
             system_configuration,
@@ -349,7 +371,19 @@ mod tests {
         let json = r#"{
             "network_name": "qa",
             "nym_api_url": "https://foo.ch/api/",
+            "nym_api_urls": [
+                {
+                    "url": "https://foo.ch/api/",
+                    "fronts": ["foobar.ch", "qux.baz"]
+                }
+            ],
             "nym_vpn_api_url": "https://bar.ch/api/",
+            "nym_vpn_api_urls": [
+                {
+                    "url": "https://bar.ch/api/",
+                    "fronts": ["quxbar.ch", "qux.baz"]
+                }
+            ],
             "account_management": {
                 "url": "https://foobar.ch/",
                 "paths": {
@@ -391,7 +425,15 @@ mod tests {
         let expected_network = Discovery {
             network_name: "qa".to_owned(),
             nym_api_url: "https://foo.ch/api/".parse().unwrap(),
+            nym_api_urls: vec![ApiUrl {
+                url: "https://foo.ch/api/".parse().unwrap(),
+                fronts: Some(vec!["foobar.ch".to_owned(), "qux.baz".to_owned()]),
+            }],
             nym_vpn_api_url: "https://bar.ch/api/".parse().unwrap(),
+            nym_vpn_api_urls: vec![ApiUrl {
+                url: "https://bar.ch/api/".parse().unwrap(),
+                fronts: Some(vec!["quxbar.ch".to_owned(), "qux.baz".to_owned()]),
+            }],
             account_management: Some(AccountManagement {
                 url: "https://foobar.ch/".parse().unwrap(),
                 paths: AccountManagementPaths {

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/lib.rs
@@ -210,7 +210,50 @@ pub async fn discover_env(config_path: &Path, network_name: &str) -> Result<Netw
     }
 
     // Using discovery, fetch and setup nym network details
-    let nym_network = NymNetwork::ensure_exists(config_path, &discovery).await?;
+    let mut nym_network = NymNetwork::ensure_exists(config_path, &discovery).await?;
+
+    // Patch up the network details with domain fronting data
+    // TODO: remove once network details contain domain fronting data
+    if nym_network
+        .network
+        .nym_api_urls
+        .as_ref()
+        .is_none_or(|nym_api_urls| nym_api_urls.is_empty())
+    {
+        nym_network.network.nym_api_urls = Some(
+            discovery
+                .nym_api_urls
+                .iter()
+                .cloned()
+                .map(|api_url| nym_network_defaults::ApiUrl {
+                    url: api_url.url,
+                    front_hosts: api_url.fronts,
+                })
+                .collect(),
+        );
+    }
+
+    // Patch up the network details with domain fronting
+    // TODO: remove once network details contain domain fronting data
+    if nym_network
+        .network
+        .nym_vpn_api_urls
+        .as_ref()
+        .is_none_or(|nym_vpn_api_urls| nym_vpn_api_urls.is_empty())
+    {
+        nym_network.network.nym_vpn_api_urls = Some(
+            discovery
+                .nym_vpn_api_urls
+                .iter()
+                .cloned()
+                .map(|api_url| nym_network_defaults::ApiUrl {
+                    url: api_url.url,
+                    front_hosts: api_url.fronts,
+                })
+                .collect(),
+        );
+    }
+
     let endpoint = nym_network
         .network
         .endpoints

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/lib.rs
@@ -192,7 +192,7 @@ pub async fn discover_env(config_path: &Path, network_name: &str) -> Result<Netw
 
     // Lookup network discovery to bootstrap
     let discovery = Discovery::ensure_exists(config_path, network_name).await?;
-    tracing::info!("Discovery: {:#?}", discovery);
+    tracing::trace!("Discovery: {:#?}", discovery);
 
     tracing::trace!(
         "System messages: {}",

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/lib.rs
@@ -48,6 +48,8 @@ const NETWORKS_SUBDIR: &str = "networks";
 // Refresh the discovery and network details files periodically
 const MAX_FILE_AGE: Duration = Duration::from_secs(60 * 60 * 24);
 
+pub type ApiUrl = nym_vpn_api_client::response::ApiUrl;
+
 #[derive(Clone, Debug)]
 pub struct Network {
     pub nym_network: NymNetwork,
@@ -190,7 +192,7 @@ pub async fn discover_env(config_path: &Path, network_name: &str) -> Result<Netw
 
     // Lookup network discovery to bootstrap
     let discovery = Discovery::ensure_exists(config_path, network_name).await?;
-    tracing::trace!("Discovery: {:#?}", discovery);
+    tracing::info!("Discovery: {:#?}", discovery);
 
     tracing::trace!(
         "System messages: {}",

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/nym_vpn_network.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/nym_vpn_network.rs
@@ -7,27 +7,39 @@ use nym_network_defaults::{NymNetworkDetails, var_names};
 use url::Url;
 
 use crate::{
-    AccountManagement, ParsedAccountLinks, Result, SystemMessages,
+    AccountManagement, ApiUrl, ParsedAccountLinks, Result, SystemMessages,
     account_management::AccountLinksConversionError, discovery::Discovery,
 };
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct NymVpnNetwork {
     pub nym_vpn_api_url: Url,
+    pub nym_vpn_api_urls: Vec<ApiUrl>,
     pub account_management: Option<AccountManagement>,
     pub system_messages: SystemMessages,
 }
 
 impl NymVpnNetwork {
     pub fn new(network_details: NymNetworkDetails) -> Self {
-        // These expects are safe because we are using the hardcoded mainnet defaults
+        tracing::info!("NymNetworkDetails!!!! {:#?}", network_details);
+
+        // TODO: refactor out this junk
         #[allow(clippy::expect_used)]
         Self {
             nym_vpn_api_url: network_details
                 .nym_vpn_api_url
-                .expect("mainnet default for nym_vpn_api_url is missing")
+                .expect("nym_vpn_api_url is missing")
                 .parse()
-                .expect("mainnet default for nym_vpn_api_url is invalid"),
+                .expect("nym_vpn_api_url is invalid"),
+            nym_vpn_api_urls: network_details
+                .nym_vpn_api_urls
+                .unwrap_or_default()
+                .into_iter()
+                .map(|api_url| ApiUrl {
+                    url: api_url.url,
+                    fronts: api_url.front_hosts,
+                })
+                .collect(),
             account_management: None,
             system_messages: SystemMessages::default(),
         }
@@ -65,6 +77,7 @@ impl From<Discovery> for NymVpnNetwork {
     fn from(discovery: Discovery) -> Self {
         Self {
             nym_vpn_api_url: discovery.nym_vpn_api_url,
+            nym_vpn_api_urls: discovery.nym_vpn_api_urls,
             account_management: discovery.account_management,
             system_messages: discovery.system_messages,
         }
@@ -75,6 +88,9 @@ impl From<Discovery> for NymVpnNetwork {
 pub enum NymVpnNetworkFromDetailsError {
     #[error("Nym vpn api url is missing in the network details")]
     NymVpnApiUrlMissing,
+
+    #[error("Nym vpn api urls are missing in the network details")]
+    NymVpnApiUrlsMissing,
 
     #[error("Failed to parse Nym VPN API URL")]
     ParseNymVpnApiUrlError(#[source] url::ParseError),
@@ -90,9 +106,21 @@ impl TryFrom<&NymNetworkDetails> for NymVpnNetwork {
             .ok_or(NymVpnNetworkFromDetailsError::NymVpnApiUrlMissing)?
             .parse()
             .map_err(NymVpnNetworkFromDetailsError::ParseNymVpnApiUrlError)?;
-
+        let nym_vpn_api_urls = network_details
+            .nym_vpn_api_urls
+            .clone()
+            .ok_or(NymVpnNetworkFromDetailsError::NymVpnApiUrlsMissing)?
+            .iter()
+            .map(|api_url| {
+                Ok(ApiUrl {
+                    url: api_url.url.clone(),
+                    fronts: api_url.front_hosts.clone(),
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
         Ok(Self {
             nym_vpn_api_url,
+            nym_vpn_api_urls,
             account_management: None,
             system_messages: SystemMessages::default(),
         })

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/nym_vpn_network.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/nym_vpn_network.rs
@@ -21,8 +21,6 @@ pub struct NymVpnNetwork {
 
 impl NymVpnNetwork {
     pub fn new(network_details: NymNetworkDetails) -> Self {
-        tracing::info!("NymNetworkDetails!!!! {:#?}", network_details);
-
         // TODO: refactor out this junk
         #[allow(clippy::expect_used)]
         Self {

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/system_messages.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/system_messages.rs
@@ -11,9 +11,28 @@ use url::Url;
 
 use crate::system_configuration::{ScoreThresholds, SystemConfiguration};
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
 pub struct SystemMessages {
     pub messages: Vec<SystemMessage>,
+}
+
+impl<'de> Deserialize<'de> for SystemMessages {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let messages = Vec::<SystemMessage>::deserialize(deserializer)?;
+        Ok(SystemMessages { messages })
+    }
+}
+
+impl Serialize for SystemMessages {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.messages.serialize(serializer)
+    }
 }
 
 impl SystemMessages {
@@ -64,7 +83,7 @@ pub struct SystemMessage {
     pub display_from: Option<OffsetDateTime>,
     pub display_until: Option<OffsetDateTime>,
     pub message: String,
-    pub properties: Properties,
+    pub properties: Option<Properties>,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -97,7 +116,9 @@ impl fmt::Display for SystemMessage {
         write!(
             f,
             "{{ name: \"{}\", message: \"{}\", properties: {} }}",
-            self.name, self.message, self.properties
+            self.name,
+            self.message,
+            self.properties.as_ref().unwrap_or(&Properties::default())
         )
     }
 }
@@ -148,7 +169,7 @@ impl From<SystemMessageResponse> for SystemMessage {
 
         let properties = Properties::deserialize(response.properties)
             .inspect_err(|e| tracing::warn!("Failed to parse properties: {}", e))
-            .unwrap_or(Properties::default());
+            .ok();
 
         Self {
             name: response.name,
@@ -213,10 +234,10 @@ mod tests {
                 ),
                 display_until: None,
                 message: "This is a test message, no need to panic!".to_string(),
-                properties: Properties(HashMap::from_iter(vec![(
+                properties: Some(Properties(HashMap::from_iter(vec![(
                     "modal".to_string(),
                     "true".to_string()
-                )])),
+                )]))),
             }
         );
     }
@@ -229,10 +250,10 @@ mod tests {
             display_from: Some(OffsetDateTime::now_utc() - time::Duration::days(1)),
             display_until: None,
             message: "This is a test message, no need to panic!".to_string(),
-            properties: Properties(HashMap::from_iter(vec![(
+            properties: Some(Properties(HashMap::from_iter(vec![(
                 "modal".to_string(),
                 "true".to_string(),
-            )])),
+            )]))),
         };
         assert!(message.is_current());
     }
@@ -245,10 +266,10 @@ mod tests {
             display_from: Some(OffsetDateTime::now_utc() + time::Duration::days(1)),
             display_until: None,
             message: "This is a test message, no need to panic!".to_string(),
-            properties: Properties(HashMap::from_iter(vec![(
+            properties: Some(Properties(HashMap::from_iter(vec![(
                 "modal".to_string(),
                 "true".to_string(),
-            )])),
+            )]))),
         };
         assert!(!message.is_current());
     }
@@ -262,10 +283,10 @@ mod tests {
             // Today
             display_until: Some(OffsetDateTime::now_utc()),
             message: "This is a test message, no need to panic!".to_string(),
-            properties: Properties(HashMap::from_iter(vec![(
+            properties: Some(Properties(HashMap::from_iter(vec![(
                 "modal".to_string(),
                 "true".to_string(),
-            )])),
+            )]))),
         };
         assert!(!message.is_current());
     }

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -134,6 +134,7 @@ message NymNetworkDetails {
 
 message NymVpnNetworkDetails {
   Url nym_vpn_api_url = 1;
+  repeated ApiUrl nym_vpn_api_urls = 2;
 }
 
 message AccountManagement {
@@ -455,7 +456,7 @@ message AccountCommandError {
     string internal = 1;
     string storage_error = 2;
     VpnApiError vpn_api = 3;
-    string unexpected_response = 4; 
+    string unexpected_response = 4;
     bool no_account_stored = 5;
     bool no_device_stored = 6;
     bool existing_account = 7;

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/network_config.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/network_config.rs
@@ -269,10 +269,33 @@ impl From<nym_vpn_network_config::NymNetwork> for proto::NymNetworkDetails {
     }
 }
 
+impl From<nym_vpn_network_config::ApiUrl> for proto::ApiUrl {
+    fn from(value: nym_vpn_network_config::ApiUrl) -> Self {
+        Self {
+            url: value.url.to_string(),
+            front_hosts: value.fronts.unwrap_or_default(),
+        }
+    }
+}
+
+impl From<proto::ApiUrl> for nym_vpn_network_config::ApiUrl {
+    fn from(value: proto::ApiUrl) -> Self {
+        Self {
+            url: value.url,
+            fronts: Some(value.front_hosts),
+        }
+    }
+}
+
 impl From<nym_vpn_network_config::NymVpnNetwork> for proto::NymVpnNetworkDetails {
     fn from(nym_vpn_network: nym_vpn_network_config::NymVpnNetwork) -> Self {
         proto::NymVpnNetworkDetails {
             nym_vpn_api_url: Some(proto::Url::from(nym_vpn_network.nym_vpn_api_url)),
+            nym_vpn_api_urls: nym_vpn_network
+                .nym_vpn_api_urls
+                .into_iter()
+                .map(proto::ApiUrl::from)
+                .collect(),
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/network_config.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/network_config.rs
@@ -305,7 +305,10 @@ impl From<nym_vpn_network_config::SystemMessage> for proto::SystemMessage {
         Self {
             name: system_message.name,
             message: system_message.message,
-            properties: system_message.properties.into_inner(),
+            properties: system_message
+                .properties
+                .map(|v| v.into_inner())
+                .unwrap_or_default(),
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/vpnd.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/vpnd.rs
@@ -10,7 +10,7 @@ use nym_config::defaults::NymNetworkDetails;
 use nym_gateway_directory::GatewayType;
 use nym_sdk::UserAgent;
 use nym_vpn_network_config::{
-    NymNetwork, NymVpnNetwork, SystemMessage, SystemMessages, system_messages::Properties,
+    ApiUrl, NymNetwork, NymVpnNetwork, SystemMessage, SystemMessages, system_messages::Properties,
 };
 use nym_vpnd_types::{
     AccountCommandResponse, ConnectArgs, ConnectOptions, ListCountriesOptions, ListGatewaysOptions,
@@ -249,8 +249,14 @@ impl TryFrom<proto::InfoResponse> for nym_vpnd_types::service::VpnServiceInfo {
                             ConversionError::Generic(format!("failed to parse Url: {e}"))
                         })
                     })?;
+                let nym_vpn_api_urls = s
+                    .nym_vpn_api_urls
+                    .into_iter()
+                    .map(ApiUrl::from)
+                    .collect::<Vec<_>>();
                 Ok(NymVpnNetwork {
                     nym_vpn_api_url,
+                    nym_vpn_api_urls,
                     account_management: Default::default(),
                     system_messages: Default::default(),
                 })

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/vpnd.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/vpnd.rs
@@ -340,7 +340,7 @@ impl From<proto::SystemMessage> for SystemMessage {
             display_until: None,
             name: value.name,
             message: value.message,
-            properties: Properties::from(value.properties),
+            properties: Some(Properties::from(value.properties)),
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -300,6 +300,11 @@ impl NymVpnService {
             network_env: *parameters.network_env.clone(),
         };
 
+        tracing::info!(
+            "nym_network_details(): {:#?}",
+            parameters.network_env.nym_network_details()
+        );
+
         let nym_vpn_api_client = nym_vpn_api_client::VpnApiClient::from_network(
             parameters.network_env.nym_network_details(),
             parameters.user_agent.clone(),

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -300,11 +300,6 @@ impl NymVpnService {
             network_env: *parameters.network_env.clone(),
         };
 
-        tracing::info!(
-            "nym_network_details(): {:#?}",
-            parameters.network_env.nym_network_details()
-        );
-
         let nym_vpn_api_client = nym_vpn_api_client::VpnApiClient::from_network(
             parameters.network_env.nym_network_details(),
             parameters.user_agent.clone(),


### PR DESCRIPTION
## Ticket

JIRA-VPN-3872

## Description

The daemon cannot start due to missing `nym_vpn_api_urls` and `nym_api_urls` used by domain fronting. This PR fixes this however due to network details missing domain fronting info, this PR is not entirely fixing the problem.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3343)
<!-- Reviewable:end -->
