### PR TITLE
bugfix: ensure Gateway is using correct key rotation id when converting from node description

### DIFF
--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
@@ -4,6 +4,7 @@
 use itertools::Itertools;
 use nym_sdk::mixnet::NodeIdentity;
 use nym_topology::{NodeId, RoutingNode};
+use nym_validator_client::models::{KeyRotationId, NymNodeDescription};
 use nym_vpn_api_client::types::{NaiveFloat, Percent, ScoreThresholds};
 use rand::seq::IteratorRandom;
 use std::{fmt, net::IpAddr};
@@ -106,6 +107,79 @@ impl Gateway {
         if let (Some(wg_thresholds), Some(score)) = (wg_thresholds, self.wg_score.as_mut()) {
             score.update_to_new_thresholds(wg_thresholds);
         }
+    }
+
+    pub fn try_from_node_description(
+        node_description: NymNodeDescription,
+        current_key_rotation: KeyRotationId,
+    ) -> Result<Self> {
+        let identity = node_description.description.host_information.keys.ed25519;
+        let location = node_description
+            .description
+            .auxiliary_details
+            .location
+            .map(|l| Location {
+                two_letter_iso_country_code: l.alpha2.to_string(),
+                ..Default::default()
+            });
+        let ipr_address = node_description
+            .description
+            .ip_packet_router
+            .as_ref()
+            .and_then(|ipr| {
+                IpPacketRouterAddress::try_from_base58_string(&ipr.address)
+                    .inspect_err(|err| error!("Failed to parse IPR address: {err}"))
+                    .ok()
+            });
+        let authenticator_address = node_description
+            .description
+            .authenticator
+            .as_ref()
+            .and_then(|a| {
+                AuthAddress::try_from_base58_string(&a.address)
+                    .inspect_err(|err| error!("Failed to parse authenticator address: {err}"))
+                    .ok()
+            });
+        let version = Some(node_description.version().to_string());
+        let role = if node_description.description.declared_role.entry {
+            nym_validator_client::nym_nodes::NodeRole::EntryGateway
+        } else if node_description.description.declared_role.exit_ipr
+            || node_description.description.declared_role.exit_nr
+        {
+            nym_validator_client::nym_nodes::NodeRole::ExitGateway
+        } else {
+            nym_validator_client::nym_nodes::NodeRole::Inactive
+        };
+
+        let gateway = RoutingNode::try_from(&node_description.to_skimmed_node(
+            current_key_rotation,
+            role,
+            Default::default(),
+        ))
+        .map_err(|_| Error::MalformedGateway)?;
+
+        let host = gateway.ws_entry_address(false);
+        let entry_info = &gateway.entry;
+        let clients_ws_port = entry_info.as_ref().map(|g| g.clients_ws_port);
+        let clients_wss_port = entry_info.as_ref().and_then(|g| g.clients_wss_port);
+        let ips = node_description.description.host_information.ip_address;
+        Ok(Gateway {
+            identity,
+            moniker: String::new(),
+            location,
+            ipr_address,
+            authenticator_address,
+            last_probe: None,
+            ips,
+            host,
+            clients_ws_port,
+            clients_wss_port,
+            mixnet_performance: None,
+            wg_performance: None,
+            wg_score: None,
+            mixnet_score: None,
+            version,
+        })
     }
 }
 
@@ -281,79 +355,6 @@ impl TryFrom<nym_vpn_api_client::response::NymDirectoryGateway> for Gateway {
             wg_performance,
             wg_score: wg_performance.map(Score::from),
             version: gateway.build_information.map(|info| info.build_version),
-        })
-    }
-}
-
-impl TryFrom<nym_validator_client::models::NymNodeDescription> for Gateway {
-    type Error = Error;
-
-    fn try_from(
-        node_description: nym_validator_client::models::NymNodeDescription,
-    ) -> Result<Self> {
-        let identity = node_description.description.host_information.keys.ed25519;
-        let location = node_description
-            .description
-            .auxiliary_details
-            .location
-            .map(|l| Location {
-                two_letter_iso_country_code: l.alpha2.to_string(),
-                ..Default::default()
-            });
-        let ipr_address = node_description
-            .description
-            .ip_packet_router
-            .as_ref()
-            .and_then(|ipr| {
-                IpPacketRouterAddress::try_from_base58_string(&ipr.address)
-                    .inspect_err(|err| error!("Failed to parse IPR address: {err}"))
-                    .ok()
-            });
-        let authenticator_address = node_description
-            .description
-            .authenticator
-            .as_ref()
-            .and_then(|a| {
-                AuthAddress::try_from_base58_string(&a.address)
-                    .inspect_err(|err| error!("Failed to parse authenticator address: {err}"))
-                    .ok()
-            });
-        let version = Some(node_description.version().to_string());
-        let role = if node_description.description.declared_role.entry {
-            nym_validator_client::nym_nodes::NodeRole::EntryGateway
-        } else if node_description.description.declared_role.exit_ipr
-            || node_description.description.declared_role.exit_nr
-        {
-            nym_validator_client::nym_nodes::NodeRole::ExitGateway
-        } else {
-            nym_validator_client::nym_nodes::NodeRole::Inactive
-        };
-
-        let gateway =
-            RoutingNode::try_from(&node_description.to_skimmed_node(0, role, Default::default()))
-                .map_err(|_| Error::MalformedGateway)?;
-
-        let host = gateway.ws_entry_address(false);
-        let entry_info = &gateway.entry;
-        let clients_ws_port = entry_info.as_ref().map(|g| g.clients_ws_port);
-        let clients_wss_port = entry_info.as_ref().and_then(|g| g.clients_wss_port);
-        let ips = node_description.description.host_information.ip_address;
-        Ok(Gateway {
-            identity,
-            moniker: String::new(),
-            location,
-            ipr_address,
-            authenticator_address,
-            last_probe: None,
-            ips,
-            host,
-            clients_ws_port,
-            clients_wss_port,
-            mixnet_performance: None,
-            wg_performance: None,
-            wg_score: None,
-            mixnet_score: None,
-            version,
         })
     }
 }

--- a/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
@@ -289,35 +289,39 @@ impl GatewayClient {
     }
 
     pub async fn lookup_all_gateways_from_nym_api(&self) -> Result<GatewayList> {
+        let skimmed_gateways = self.lookup_skimmed_gateways().await?;
+        let key_rotation_id = skimmed_gateways.metadata.rotation_id;
+
         let mut gateways = self
             .lookup_described_nodes()
             .await?
             .into_iter()
             .filter(|node| node.description.declared_role.entry)
             .filter_map(|gw| {
-                Gateway::try_from(gw)
+                Gateway::try_from_node_description(gw, key_rotation_id)
                     .inspect_err(|err| error!("Failed to parse gateway: {err}"))
                     .ok()
             })
             .collect::<Vec<_>>();
-        let skimmed_gateways = self.lookup_skimmed_gateways().await?;
         append_performance(&mut gateways, skimmed_gateways.nodes);
         filter_on_mixnet_min_performance(&mut gateways, &self.min_gateway_performance);
         Ok(GatewayList::new(gateways))
     }
 
     pub async fn lookup_all_nymnodes(&self) -> Result<NymNodeList> {
+        let skimmed_nodes = self.lookup_skimmed_nodes().await?;
+        let key_rotation_id = skimmed_nodes.metadata.rotation_id;
+
         let mut nodes = self
             .lookup_described_nodes()
             .await?
             .into_iter()
             .filter_map(|gw| {
-                NymNode::try_from(gw)
+                NymNode::try_from_node_description(gw, key_rotation_id)
                     .inspect_err(|err| error!("Failed to parse node: {err}"))
                     .ok()
             })
             .collect::<Vec<_>>();
-        let skimmed_nodes = self.lookup_skimmed_nodes().await?;
         append_performance(&mut nodes, skimmed_nodes.nodes);
         filter_on_mixnet_min_performance(&mut nodes, &self.min_gateway_performance);
         Ok(GatewayList::new(nodes))

--- a/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
+++ b/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
@@ -274,6 +274,7 @@ impl Probe {
     ) -> anyhow::Result<ProbeResult> {
         // Setup the entry gateways
         let gateways = lookup_gateways(gateway_config.clone()).await?;
+
         let entry_gateway = self.entrypoint.lookup_gateway(&gateways).await?;
         let tested_entry = self.tested_node.is_same_as_entry();
 


### PR DESCRIPTION
## Description

Information about key rotation id was being dropped when converting from `NymNodeDescription` into `Gateway` and as the result, we were only making best-effort guess for the correct x25519 key. since it was just a guess, it was not guaranteed to be correct. this PR propagates information about key rotation, which we already had on hand.

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3346)
<!-- Reviewable:end -->
