### PR TITLE
Provide progress when establishing connection

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Provide metadata to keep track of progress when establishing connection (https://github.com/nymtech/nym-vpn-client/pull/3351)
+
 ### Fixed
 
 - [Windows] Embed core version into `winfw.dll` and `libwg.dll` (https://github.com/nymtech/nym-vpn-client/pull/3292)

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -5442,6 +5442,7 @@ dependencies = [
  "futures",
  "log-panics",
  "nym-bin-common",
+ "nym-common",
  "nym-http-api-client",
  "nym-ipc",
  "nym-offline-monitor",

--- a/nym-vpn-core/crates/nym-vpn-lib-types-uniffi/src/tunnel_state_machine.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types-uniffi/src/tunnel_state_machine.rs
@@ -25,11 +25,27 @@ impl From<nym_vpn_lib_types::TunnelEvent> for TunnelEvent {
 }
 
 #[derive(uniffi::Enum)]
+pub enum TunnelType {
+    Mixnet,
+    Wireguard,
+}
+
+impl From<nym_vpn_lib_types::TunnelType> for TunnelType {
+    fn from(value: nym_vpn_lib_types::TunnelType) -> Self {
+        match value {
+            nym_vpn_lib_types::TunnelType::Mixnet => Self::Mixnet,
+            nym_vpn_lib_types::TunnelType::Wireguard => Self::Wireguard,
+        }
+    }
+}
+
+#[derive(uniffi::Enum)]
 pub enum TunnelState {
     Disconnected,
     Connecting {
         retry_attempt: u32,
         state: EstablishConnectionState,
+        tunnel_type: TunnelType,
         connection_data: Option<EstablishConnectionData>,
     },
     Connected {
@@ -55,13 +71,16 @@ impl From<nym_vpn_lib_types::TunnelState> for TunnelState {
             nym_vpn_lib_types::TunnelState::Connecting {
                 retry_attempt,
                 state,
+                tunnel_type,
                 connection_data,
             } => {
                 let connection_data = connection_data.map(EstablishConnectionData::from);
                 let state = EstablishConnectionState::from(state);
+                let tunnel_type = TunnelType::from(tunnel_type);
                 TunnelState::Connecting {
                     retry_attempt,
                     state,
+                    tunnel_type,
                     connection_data,
                 }
             }

--- a/nym-vpn-core/crates/nym-vpn-lib-types-uniffi/src/tunnel_state_machine.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types-uniffi/src/tunnel_state_machine.rs
@@ -29,7 +29,8 @@ pub enum TunnelState {
     Disconnected,
     Connecting {
         retry_attempt: u32,
-        connection_data: Option<EstablishingConnectionData>,
+        state: EstablishConnectionState,
+        connection_data: Option<EstablishConnectionData>,
     },
     Connected {
         connection_data: ConnectionData,
@@ -53,11 +54,14 @@ impl From<nym_vpn_lib_types::TunnelState> for TunnelState {
             }
             nym_vpn_lib_types::TunnelState::Connecting {
                 retry_attempt,
+                state,
                 connection_data,
             } => {
-                let connection_data = connection_data.map(EstablishingConnectionData::from);
+                let connection_data = connection_data.map(EstablishConnectionData::from);
+                let state = EstablishConnectionState::from(state);
                 TunnelState::Connecting {
                     retry_attempt,
+                    state,
                     connection_data,
                 }
             }
@@ -457,15 +461,50 @@ impl From<nym_vpn_lib_types::ConnectionData> for ConnectionData {
     }
 }
 
+#[derive(uniffi::Enum)]
+pub enum EstablishConnectionState {
+    ResolvingApiAddresses,
+    AwaitingAccountReadiness,
+    RefreshingGateways,
+    SelectingGateways,
+    ConnectingMixnetClient,
+    ConnectingTunnel,
+}
+
+impl From<nym_vpn_lib_types::EstablishConnectionState> for EstablishConnectionState {
+    fn from(value: nym_vpn_lib_types::EstablishConnectionState) -> Self {
+        match value {
+            nym_vpn_lib_types::EstablishConnectionState::ResolvingApiAddresses => {
+                EstablishConnectionState::ResolvingApiAddresses
+            }
+            nym_vpn_lib_types::EstablishConnectionState::AwaitingAccountReadiness => {
+                EstablishConnectionState::AwaitingAccountReadiness
+            }
+            nym_vpn_lib_types::EstablishConnectionState::RefreshingGateways => {
+                EstablishConnectionState::RefreshingGateways
+            }
+            nym_vpn_lib_types::EstablishConnectionState::SelectingGateways => {
+                EstablishConnectionState::SelectingGateways
+            }
+            nym_vpn_lib_types::EstablishConnectionState::ConnectingMixnetClient => {
+                EstablishConnectionState::ConnectingMixnetClient
+            }
+            nym_vpn_lib_types::EstablishConnectionState::ConnectingTunnel => {
+                EstablishConnectionState::ConnectingTunnel
+            }
+        }
+    }
+}
+
 #[derive(uniffi::Record)]
-pub struct EstablishingConnectionData {
+pub struct EstablishConnectionData {
     pub entry_gateway: Gateway,
     pub exit_gateway: Gateway,
     pub tunnel: Option<TunnelConnectionData>,
 }
 
-impl From<nym_vpn_lib_types::EstablishingConnectionData> for EstablishingConnectionData {
-    fn from(value: nym_vpn_lib_types::EstablishingConnectionData) -> Self {
+impl From<nym_vpn_lib_types::EstablishConnectionData> for EstablishConnectionData {
+    fn from(value: nym_vpn_lib_types::EstablishConnectionData) -> Self {
         Self {
             entry_gateway: Gateway::from(value.entry_gateway),
             exit_gateway: Gateway::from(value.exit_gateway),

--- a/nym-vpn-core/crates/nym-vpn-lib-types-uniffi/src/tunnel_state_machine.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types-uniffi/src/tunnel_state_machine.rs
@@ -29,7 +29,7 @@ pub enum TunnelState {
     Disconnected,
     Connecting {
         retry_attempt: u32,
-        connection_data: Option<ConnectionData>,
+        connection_data: Option<EstablishingConnectionData>,
     },
     Connected {
         connection_data: ConnectionData,
@@ -54,10 +54,13 @@ impl From<nym_vpn_lib_types::TunnelState> for TunnelState {
             nym_vpn_lib_types::TunnelState::Connecting {
                 retry_attempt,
                 connection_data,
-            } => TunnelState::Connecting {
-                retry_attempt,
-                connection_data: connection_data.map(ConnectionData::from),
-            },
+            } => {
+                let connection_data = connection_data.map(EstablishingConnectionData::from);
+                TunnelState::Connecting {
+                    retry_attempt,
+                    connection_data,
+                }
+            }
             nym_vpn_lib_types::TunnelState::Disconnecting { after_disconnect } => {
                 TunnelState::Disconnecting {
                     after_disconnect: ActionAfterDisconnect::from(after_disconnect),
@@ -448,8 +451,25 @@ impl From<nym_vpn_lib_types::ConnectionData> for ConnectionData {
         Self {
             entry_gateway: Gateway::from(value.entry_gateway),
             exit_gateway: Gateway::from(value.exit_gateway),
-            connected_at: value.connected_at,
+            connected_at: Some(value.connected_at),
             tunnel: TunnelConnectionData::from(value.tunnel),
+        }
+    }
+}
+
+#[derive(uniffi::Record)]
+pub struct EstablishingConnectionData {
+    pub entry_gateway: Gateway,
+    pub exit_gateway: Gateway,
+    pub tunnel: Option<TunnelConnectionData>,
+}
+
+impl From<nym_vpn_lib_types::EstablishingConnectionData> for EstablishingConnectionData {
+    fn from(value: nym_vpn_lib_types::EstablishingConnectionData) -> Self {
+        Self {
+            entry_gateway: Gateway::from(value.entry_gateway),
+            exit_gateway: Gateway::from(value.exit_gateway),
+            tunnel: value.tunnel.map(TunnelConnectionData::from),
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/connection_data.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/connection_data.rs
@@ -27,7 +27,20 @@ impl From<nym_gateway_directory::Gateway> for Gateway {
     }
 }
 
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EstablishingConnectionData {
+    /// Mixnet entry gateway.
+    pub entry_gateway: Gateway,
+
+    /// Mixnet exit gateway.
+    pub exit_gateway: Gateway,
+
+    /// Tunnel connection data.
+    /// Becomes available once tunnel connection is initiated.
+    pub tunnel: Option<TunnelConnectionData>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ConnectionData {
     /// Mixnet entry gateway.
     pub entry_gateway: Gateway,
@@ -35,23 +48,11 @@ pub struct ConnectionData {
     /// Mixnet exit gateway.
     pub exit_gateway: Gateway,
 
-    /// When the tunnel was last established.
-    /// Set once the tunnel is connected.
-    pub connected_at: Option<OffsetDateTime>,
+    /// When the tunnel connection was last established.
+    pub connected_at: OffsetDateTime,
 
     /// Tunnel connection data.
     pub tunnel: TunnelConnectionData,
-}
-
-impl fmt::Debug for ConnectionData {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ConnectionData")
-            .field("entry_gateway", &self.entry_gateway)
-            .field("exit_gateway", &self.exit_gateway)
-            .field("connected_at", &self.connected_at)
-            .field("tunnel", &self.tunnel)
-            .finish()
-    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/connection_data.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/connection_data.rs
@@ -8,6 +8,8 @@ use std::{
 
 use time::OffsetDateTime;
 
+use crate::TunnelType;
+
 // Represents the identity of a gateway
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Gateway {
@@ -65,12 +67,12 @@ pub enum EstablishConnectionState {
 impl fmt::Display for EstablishConnectionState {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
-            EstablishConnectionState::ResolvingApiAddresses => "Resolving API addresses",
-            EstablishConnectionState::AwaitingAccountReadiness => "Awaiting account readiness",
-            EstablishConnectionState::RefreshingGateways => "Refreshing gateways",
-            EstablishConnectionState::SelectingGateways => "Selecting gateways",
-            EstablishConnectionState::ConnectingMixnetClient => "Connecting mixnet client",
-            EstablishConnectionState::ConnectingTunnel => "Connecting tunnel",
+            EstablishConnectionState::ResolvingApiAddresses => "resolving api addresses",
+            EstablishConnectionState::AwaitingAccountReadiness => "awaiting account readiness",
+            EstablishConnectionState::RefreshingGateways => "refreshing gateways",
+            EstablishConnectionState::SelectingGateways => "selecting gateways",
+            EstablishConnectionState::ConnectingMixnetClient => "connecting mixnet client",
+            EstablishConnectionState::ConnectingTunnel => "connecting tunnel",
         })
     }
 }
@@ -94,6 +96,15 @@ pub struct ConnectionData {
 pub enum TunnelConnectionData {
     Mixnet(MixnetConnectionData),
     Wireguard(WireguardConnectionData),
+}
+
+impl TunnelConnectionData {
+    pub fn tunnel_type(&self) -> TunnelType {
+        match self {
+            TunnelConnectionData::Mixnet(_) => TunnelType::Mixnet,
+            TunnelConnectionData::Wireguard(_) => TunnelType::Wireguard,
+        }
+    }
 }
 
 // Represents a nym-address of the form id.enc@gateway

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/connection_data.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/connection_data.rs
@@ -28,7 +28,7 @@ impl From<nym_gateway_directory::Gateway> for Gateway {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct EstablishingConnectionData {
+pub struct EstablishConnectionData {
     /// Mixnet entry gateway.
     pub entry_gateway: Gateway,
 
@@ -38,6 +38,41 @@ pub struct EstablishingConnectionData {
     /// Tunnel connection data.
     /// Becomes available once tunnel connection is initiated.
     pub tunnel: Option<TunnelConnectionData>,
+}
+
+/// Describes the current state when establishing connection.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum EstablishConnectionState {
+    /// Resolving API IP addresses
+    ResolvingApiAddresses,
+
+    /// Awaiting for account to be ready for establishing connection
+    AwaitingAccountReadiness,
+
+    /// Refreshing gateways
+    RefreshingGateways,
+
+    /// Selecting gateways
+    SelectingGateways,
+
+    /// Connecting mixnet client
+    ConnectingMixnetClient,
+
+    /// Establishing tunnel connection
+    ConnectingTunnel,
+}
+
+impl fmt::Display for EstablishConnectionState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            EstablishConnectionState::ResolvingApiAddresses => "Resolving API addresses",
+            EstablishConnectionState::AwaitingAccountReadiness => "Awaiting account readiness",
+            EstablishConnectionState::RefreshingGateways => "Refreshing gateways",
+            EstablishConnectionState::SelectingGateways => "Selecting gateways",
+            EstablishConnectionState::ConnectingMixnetClient => "Connecting mixnet client",
+            EstablishConnectionState::ConnectingTunnel => "Connecting tunnel",
+        })
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
@@ -19,8 +19,8 @@ pub use account::{
     ticketbooks::AvailableTickets,
 };
 pub use connection_data::{
-    ConnectionData, Gateway, MixnetConnectionData, NymAddress, TunnelConnectionData,
-    WireguardConnectionData, WireguardNode,
+    ConnectionData, EstablishingConnectionData, Gateway, MixnetConnectionData, NymAddress,
+    TunnelConnectionData, WireguardConnectionData, WireguardNode,
 };
 pub use tunnel_event::{
     BandwidthEvent, ConnectionEvent, ConnectionStatisticsEvent, MixnetEvent, SphinxPacketRates,

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
@@ -19,8 +19,8 @@ pub use account::{
     ticketbooks::AvailableTickets,
 };
 pub use connection_data::{
-    ConnectionData, EstablishingConnectionData, Gateway, MixnetConnectionData, NymAddress,
-    TunnelConnectionData, WireguardConnectionData, WireguardNode,
+    ConnectionData, EstablishConnectionData, EstablishConnectionState, Gateway,
+    MixnetConnectionData, NymAddress, TunnelConnectionData, WireguardConnectionData, WireguardNode,
 };
 pub use tunnel_event::{
     BandwidthEvent, ConnectionEvent, ConnectionStatisticsEvent, MixnetEvent, SphinxPacketRates,

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use super::connection_data::{ConnectionData, TunnelConnectionData};
+use super::connection_data::{ConnectionData, EstablishingConnectionData, TunnelConnectionData};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum TunnelType {
@@ -18,7 +18,7 @@ pub enum TunnelState {
     /// Tunnel connection is being established.
     Connecting {
         retry_attempt: u32,
-        connection_data: Option<ConnectionData>,
+        connection_data: Option<EstablishingConnectionData>,
     },
 
     /// Tunnel is connected.
@@ -48,7 +48,7 @@ impl std::fmt::Display for TunnelState {
                 connection_data,
             } => match connection_data {
                 Some(connection_data) => match connection_data.tunnel {
-                    TunnelConnectionData::Mixnet(ref data) => {
+                    Some(TunnelConnectionData::Mixnet(ref data)) => {
                         write!(
                             f,
                             "Connecting mixnet tunnel to {} → {} (entry: {} → exit: {}), attempt {}",
@@ -59,12 +59,21 @@ impl std::fmt::Display for TunnelState {
                             retry_attempt
                         )
                     }
-                    TunnelConnectionData::Wireguard(ref data) => {
+                    Some(TunnelConnectionData::Wireguard(ref data)) => {
                         write!(
                             f,
                             "Connecting wireguard tunnel to {} → {} (entry: {} → exit: {}), attempt {}",
                             data.entry.endpoint,
                             data.exit.endpoint,
+                            connection_data.entry_gateway.id,
+                            connection_data.exit_gateway.id,
+                            retry_attempt
+                        )
+                    }
+                    None => {
+                        write!(
+                            f,
+                            "Connecting (entry: {} → exit: {}), attempt {}",
                             connection_data.entry_gateway.id,
                             connection_data.exit_gateway.id,
                             retry_attempt

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
@@ -1,7 +1,9 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use super::connection_data::{ConnectionData, EstablishingConnectionData, TunnelConnectionData};
+use super::connection_data::{
+    ConnectionData, EstablishConnectionData, EstablishConnectionState, TunnelConnectionData,
+};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum TunnelType {
@@ -18,7 +20,8 @@ pub enum TunnelState {
     /// Tunnel connection is being established.
     Connecting {
         retry_attempt: u32,
-        connection_data: Option<EstablishingConnectionData>,
+        state: EstablishConnectionState,
+        connection_data: Option<EstablishConnectionData>,
     },
 
     /// Tunnel is connected.
@@ -45,38 +48,42 @@ impl std::fmt::Display for TunnelState {
             Self::Disconnected => f.write_str("Disconnected"),
             Self::Connecting {
                 retry_attempt,
+                state,
                 connection_data,
             } => match connection_data {
                 Some(connection_data) => match connection_data.tunnel {
                     Some(TunnelConnectionData::Mixnet(ref data)) => {
                         write!(
                             f,
-                            "Connecting mixnet tunnel to {} → {} (entry: {} → exit: {}), attempt {}",
+                            "Connecting mixnet tunnel to {} → {} (entry: {} → exit: {}), attempt {}, {}",
                             data.entry_ip,
                             data.exit_ip,
                             data.nym_address.gateway_id(),
                             data.exit_ipr.gateway_id(),
-                            retry_attempt
+                            retry_attempt,
+                            state
                         )
                     }
                     Some(TunnelConnectionData::Wireguard(ref data)) => {
                         write!(
                             f,
-                            "Connecting wireguard tunnel to {} → {} (entry: {} → exit: {}), attempt {}",
+                            "Connecting wireguard tunnel to {} → {} (entry: {} → exit: {}), attempt {}, {}",
                             data.entry.endpoint,
                             data.exit.endpoint,
                             connection_data.entry_gateway.id,
                             connection_data.exit_gateway.id,
-                            retry_attempt
+                            retry_attempt,
+                            state
                         )
                     }
                     None => {
                         write!(
                             f,
-                            "Connecting (entry: {} → exit: {}), attempt {}",
+                            "Connecting (entry: {} → exit: {}), attempt {}, {}",
                             connection_data.entry_gateway.id,
                             connection_data.exit_gateway.id,
-                            retry_attempt
+                            retry_attempt,
+                            state
                         )
                     }
                 },

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
@@ -11,6 +11,15 @@ pub enum TunnelType {
     Wireguard,
 }
 
+impl TunnelType {
+    pub fn short_name(&self) -> &'static str {
+        match self {
+            Self::Mixnet => "mix",
+            Self::Wireguard => "wg",
+        }
+    }
+}
+
 /// Public enum describing the tunnel state
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum TunnelState {
@@ -21,6 +30,7 @@ pub enum TunnelState {
     Connecting {
         retry_attempt: u32,
         state: EstablishConnectionState,
+        tunnel_type: TunnelType,
         connection_data: Option<EstablishConnectionData>,
     },
 
@@ -49,64 +59,76 @@ impl std::fmt::Display for TunnelState {
             Self::Connecting {
                 retry_attempt,
                 state,
+                tunnel_type,
                 connection_data,
             } => match connection_data {
                 Some(connection_data) => match connection_data.tunnel {
                     Some(TunnelConnectionData::Mixnet(ref data)) => {
                         write!(
                             f,
-                            "Connecting mixnet tunnel to {} → {} (entry: {} → exit: {}), attempt {}, {}",
+                            "Connecting {} to {} [{}] → {} [{}], {}, #{}",
+                            tunnel_type.short_name(),
                             data.entry_ip,
-                            data.exit_ip,
                             data.nym_address.gateway_id(),
+                            data.exit_ip,
                             data.exit_ipr.gateway_id(),
+                            state,
                             retry_attempt,
-                            state
                         )
                     }
                     Some(TunnelConnectionData::Wireguard(ref data)) => {
                         write!(
                             f,
-                            "Connecting wireguard tunnel to {} → {} (entry: {} → exit: {}), attempt {}, {}",
+                            "Connecting {} to {} [{}] → {} [{}], {}, #{}",
+                            tunnel_type.short_name(),
                             data.entry.endpoint,
-                            data.exit.endpoint,
                             connection_data.entry_gateway.id,
+                            data.exit.endpoint,
                             connection_data.exit_gateway.id,
+                            state,
                             retry_attempt,
-                            state
                         )
                     }
                     None => {
                         write!(
                             f,
-                            "Connecting (entry: {} → exit: {}), attempt {}, {}",
+                            "Connecting {} [{}] → [{}], {}, #{}",
+                            tunnel_type.short_name(),
                             connection_data.entry_gateway.id,
                             connection_data.exit_gateway.id,
+                            state,
                             retry_attempt,
-                            state
                         )
                     }
                 },
-                None => write!(f, "Connecting, attempt {retry_attempt}"),
+                None => write!(
+                    f,
+                    "Connecting {}, {}, #{}",
+                    tunnel_type.short_name(),
+                    state,
+                    retry_attempt
+                ),
             },
             Self::Connected { connection_data } => match connection_data.tunnel {
                 TunnelConnectionData::Mixnet(ref data) => {
                     write!(
                         f,
-                        "Connected mixnet tunnel to {} → {} (entry: {} → exit: {})",
+                        "Connected {} to {} [{}] → {} [{}]",
+                        connection_data.tunnel.tunnel_type().short_name(),
                         data.entry_ip,
-                        data.exit_ip,
                         data.nym_address.gateway_id(),
+                        data.exit_ip,
                         data.exit_ipr.gateway_id(),
                     )
                 }
                 TunnelConnectionData::Wireguard(ref data) => {
                     write!(
                         f,
-                        "Connected wireguard tunnel {} → {} (entry: {} → exit: {})",
+                        "Connected {} to {} [{}] → {} [{}]",
+                        connection_data.tunnel.tunnel_type().short_name(),
                         data.entry.endpoint,
-                        data.exit.endpoint,
                         connection_data.entry_gateway.id,
+                        data.exit.endpoint,
                         connection_data.exit_gateway.id,
                     )
                 }

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
@@ -66,7 +66,7 @@ impl std::fmt::Display for TunnelState {
                     Some(TunnelConnectionData::Mixnet(ref data)) => {
                         write!(
                             f,
-                            "Connecting {} to {} [{}] → {} [{}], {}, #{}",
+                            "Connecting {} to {} [{}] → {} [{}], {}, try #{}",
                             tunnel_type.short_name(),
                             data.entry_ip,
                             data.nym_address.gateway_id(),
@@ -79,7 +79,7 @@ impl std::fmt::Display for TunnelState {
                     Some(TunnelConnectionData::Wireguard(ref data)) => {
                         write!(
                             f,
-                            "Connecting {} to {} [{}] → {} [{}], {}, #{}",
+                            "Connecting {} to {} [{}] → {} [{}], {}, try #{}",
                             tunnel_type.short_name(),
                             data.entry.endpoint,
                             connection_data.entry_gateway.id,
@@ -92,7 +92,7 @@ impl std::fmt::Display for TunnelState {
                     None => {
                         write!(
                             f,
-                            "Connecting {} [{}] → [{}], {}, #{}",
+                            "Connecting {} [{}] → [{}], {}, try #{}",
                             tunnel_type.short_name(),
                             connection_data.entry_gateway.id,
                             connection_data.exit_gateway.id,
@@ -103,7 +103,7 @@ impl std::fmt::Display for TunnelState {
                 },
                 None => write!(
                     f,
-                    "Connecting {}, {}, #{}",
+                    "Connecting {}, {}, try #{}",
                     tunnel_type.short_name(),
                     state,
                     retry_attempt

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -45,7 +45,7 @@ use nym_gateway_directory::{
 use nym_sdk::UserAgent;
 use nym_vpn_lib_types::{
     AccountControllerErrorStateReason, ActionAfterDisconnect, ConnectionData, ErrorStateReason,
-    MixnetEvent, TunnelEvent, TunnelState, TunnelType,
+    EstablishingConnectionData, MixnetEvent, TunnelEvent, TunnelState, TunnelType,
 };
 use nym_wg_gateway_client::Error as WgGatewayClientError;
 
@@ -281,7 +281,7 @@ enum PrivateTunnelState {
     Connecting {
         /// Connection attempt.
         retry_attempt: u32,
-        connection_data: Option<ConnectionData>,
+        connection_data: Option<EstablishingConnectionData>,
     },
     Connected {
         connection_data: ConnectionData,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -262,10 +262,12 @@ impl From<PrivateTunnelState> for TunnelState {
             PrivateTunnelState::Connecting {
                 retry_attempt,
                 state,
+                tunnel_type,
                 connection_data,
             } => Self::Connecting {
                 retry_attempt,
                 state,
+                tunnel_type,
                 connection_data,
             },
             PrivateTunnelState::Disconnecting { after_disconnect } => Self::Disconnecting {
@@ -285,6 +287,7 @@ enum PrivateTunnelState {
         /// Connection attempt.
         retry_attempt: u32,
         state: EstablishConnectionState,
+        tunnel_type: TunnelType,
         connection_data: Option<EstablishConnectionData>,
     },
     Connected {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -45,7 +45,8 @@ use nym_gateway_directory::{
 use nym_sdk::UserAgent;
 use nym_vpn_lib_types::{
     AccountControllerErrorStateReason, ActionAfterDisconnect, ConnectionData, ErrorStateReason,
-    EstablishingConnectionData, MixnetEvent, TunnelEvent, TunnelState, TunnelType,
+    EstablishConnectionData, EstablishConnectionState, MixnetEvent, TunnelEvent, TunnelState,
+    TunnelType,
 };
 use nym_wg_gateway_client::Error as WgGatewayClientError;
 
@@ -260,9 +261,11 @@ impl From<PrivateTunnelState> for TunnelState {
             }
             PrivateTunnelState::Connecting {
                 retry_attempt,
+                state,
                 connection_data,
             } => Self::Connecting {
                 retry_attempt,
+                state,
                 connection_data,
             },
             PrivateTunnelState::Disconnecting { after_disconnect } => Self::Disconnecting {
@@ -281,7 +284,8 @@ enum PrivateTunnelState {
     Connecting {
         /// Connection attempt.
         retry_attempt: u32,
-        connection_data: Option<EstablishingConnectionData>,
+        state: EstablishConnectionState,
+        connection_data: Option<EstablishConnectionData>,
     },
     Connected {
         connection_data: ConnectionData,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -20,9 +20,8 @@ use nym_firewall::{
     AllowedClients, AllowedEndpoint, AllowedTunnelTraffic, Endpoint, FirewallPolicy,
     TransportProtocol,
 };
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-use nym_gateway_directory::Gateway;
 use nym_gateway_directory::ResolvedConfig;
+use nym_vpn_lib_types::{EstablishingConnectionData, Gateway};
 
 #[cfg(target_os = "macos")]
 use crate::tunnel_state_machine::resolver::LOCAL_DNS_RESOLVER;
@@ -119,6 +118,15 @@ impl ConnectingState {
 
         let (monitor_event_sender, monitor_event_receiver) = mpsc::unbounded_channel();
 
+        let initial_connection_data =
+            selected_gateways
+                .as_ref()
+                .map(|gateways| EstablishingConnectionData {
+                    entry_gateway: Gateway::from(*gateways.entry.clone()),
+                    exit_gateway: Gateway::from(*gateways.exit.clone()),
+                    tunnel: None,
+                });
+
         (
             Box::new(Self {
                 tunnel_monitor_handle: None,
@@ -132,7 +140,7 @@ impl ConnectingState {
             }),
             PrivateTunnelState::Connecting {
                 retry_attempt,
-                connection_data: None,
+                connection_data: initial_connection_data,
             },
         )
     }
@@ -141,7 +149,7 @@ impl ConnectingState {
     async fn set_firewall_policy(
         shared_state: &mut SharedState,
         tunnel: Option<TunnelInterface>,
-        entry_gateway: Option<&Gateway>,
+        entry_gateway: Option<&nym_gateway_directory::Gateway>,
         wg_entry_endpoint: Option<SocketAddr>,
         resolved_gateway_addresses: &[SocketAddr],
     ) -> Result<()> {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -21,7 +21,7 @@ use nym_firewall::{
     TransportProtocol,
 };
 use nym_gateway_directory::ResolvedConfig;
-use nym_vpn_lib_types::{EstablishingConnectionData, Gateway};
+use nym_vpn_lib_types::{EstablishConnectionData, EstablishConnectionState, Gateway};
 
 #[cfg(target_os = "macos")]
 use crate::tunnel_state_machine::resolver::LOCAL_DNS_RESOLVER;
@@ -58,6 +58,7 @@ pub struct ConnectingState {
     tunnel_monitor_event_sender: Option<TunnelMonitorEventSender>,
     tunnel_monitor_event_receiver: TunnelMonitorEventReceiver,
     selected_gateways: Option<SelectedGateways>,
+    connection_data: Option<EstablishConnectionData>,
     resolved_gateway_config: Option<ResolvedConfig>,
     resolve_config_fut: Fuse<ResolveConfigFuture>,
     reconnect_delay_fut: Fuse<ReconnectDelayFuture>,
@@ -121,28 +122,28 @@ impl ConnectingState {
         let initial_connection_data =
             selected_gateways
                 .as_ref()
-                .map(|gateways| EstablishingConnectionData {
+                .map(|gateways| EstablishConnectionData {
                     entry_gateway: Gateway::from(*gateways.entry.clone()),
                     exit_gateway: Gateway::from(*gateways.exit.clone()),
                     tunnel: None,
                 });
 
-        (
-            Box::new(Self {
-                tunnel_monitor_handle: None,
-                tunnel_monitor_event_sender: Some(monitor_event_sender),
-                tunnel_monitor_event_receiver: monitor_event_receiver,
-                retry_attempt,
-                selected_gateways,
-                resolved_gateway_config: None,
-                resolve_config_fut,
-                reconnect_delay_fut,
-            }),
-            PrivateTunnelState::Connecting {
-                retry_attempt,
-                connection_data: initial_connection_data,
-            },
-        )
+        let connecting_state = Self {
+            tunnel_monitor_handle: None,
+            tunnel_monitor_event_sender: Some(monitor_event_sender),
+            tunnel_monitor_event_receiver: monitor_event_receiver,
+            retry_attempt,
+            selected_gateways,
+            connection_data: initial_connection_data.clone(),
+            resolved_gateway_config: None,
+            resolve_config_fut,
+            reconnect_delay_fut,
+        };
+
+        let tunnel_state = connecting_state
+            .make_connecting_tunnel_state(EstablishConnectionState::ResolvingApiAddresses);
+
+        (Box::new(connecting_state), tunnel_state)
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
@@ -411,8 +412,11 @@ impl ConnectingState {
     async fn handle_interface_up(
         &mut self,
         _tunnel_interface: TunnelInterface,
+        connection_data: Box<EstablishConnectionData>,
         _shared_state: &mut SharedState,
     ) -> Result<()> {
+        self.connection_data = Some(*connection_data);
+
         #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
         {
             let resolved_addrs =
@@ -470,6 +474,14 @@ impl ConnectingState {
         #[cfg(any(target_os = "ios", target_os = "android"))]
         Ok(())
     }
+
+    fn make_connecting_tunnel_state(&self, state: EstablishConnectionState) -> PrivateTunnelState {
+        PrivateTunnelState::Connecting {
+            retry_attempt: self.retry_attempt,
+            state,
+            connection_data: self.connection_data.clone(),
+        }
+    }
 }
 
 #[async_trait::async_trait]
@@ -499,11 +511,25 @@ impl TunnelStateHandler for ConnectingState {
             }
             Some(monitor_event) = self.tunnel_monitor_event_receiver.recv() => {
                 match monitor_event {
-                    TunnelMonitorEvent::InitializingClient => {
-                        NextTunnelState::SameState(self)
+                    TunnelMonitorEvent::AwaitingAccountReadiness => {
+                        let new_state = self.make_connecting_tunnel_state(EstablishConnectionState::AwaitingAccountReadiness);
+                        NextTunnelState::NewState((self, new_state))
+                    }
+                    TunnelMonitorEvent::RefreshingGateways => {
+                        let new_state = self.make_connecting_tunnel_state(EstablishConnectionState::RefreshingGateways);
+                        NextTunnelState::NewState((self, new_state))
+                    }
+                    TunnelMonitorEvent::ConnectingMixnetClient => {
+                        let new_state = self.make_connecting_tunnel_state(EstablishConnectionState::ConnectingMixnetClient);
+                        NextTunnelState::NewState((self, new_state))
+                    }
+                    TunnelMonitorEvent::ConnectingTunnel => {
+                        let new_state = self.make_connecting_tunnel_state(EstablishConnectionState::ConnectingTunnel);
+                        NextTunnelState::NewState((self, new_state))
                     }
                     TunnelMonitorEvent::SelectingGateways => {
-                        NextTunnelState::SameState(self)
+                        let new_state = self.make_connecting_tunnel_state(EstablishConnectionState::SelectingGateways);
+                        NextTunnelState::NewState((self, new_state))
                     }
                     TunnelMonitorEvent::SelectedGateways {
                         gateways, reply_tx
@@ -531,9 +557,9 @@ impl TunnelStateHandler for ConnectingState {
                     TunnelMonitorEvent::InterfaceUp {
                         tunnel_interface, connection_data, reply_tx
                     }  => {
-                        let next_state = match self.handle_interface_up(tunnel_interface, shared_state).await {
+                        let next_state = match self.handle_interface_up(tunnel_interface, connection_data, shared_state).await {
                             Ok(()) => {
-                                let state = PrivateTunnelState::Connecting { retry_attempt: self.retry_attempt, connection_data: Some(*connection_data) };
+                                let state = self.make_connecting_tunnel_state(EstablishConnectionState::ConnectingTunnel);
                                 NextTunnelState::NewState((self, state))
                             },
                             Err(e) => {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -140,8 +140,10 @@ impl ConnectingState {
             reconnect_delay_fut,
         };
 
-        let tunnel_state = connecting_state
-            .make_connecting_tunnel_state(EstablishConnectionState::ResolvingApiAddresses);
+        let tunnel_state = connecting_state.make_connecting_tunnel_state(
+            shared_state,
+            EstablishConnectionState::ResolvingApiAddresses,
+        );
 
         (Box::new(connecting_state), tunnel_state)
     }
@@ -475,10 +477,15 @@ impl ConnectingState {
         Ok(())
     }
 
-    fn make_connecting_tunnel_state(&self, state: EstablishConnectionState) -> PrivateTunnelState {
+    fn make_connecting_tunnel_state(
+        &self,
+        shared_state: &SharedState,
+        state: EstablishConnectionState,
+    ) -> PrivateTunnelState {
         PrivateTunnelState::Connecting {
             retry_attempt: self.retry_attempt,
             state,
+            tunnel_type: shared_state.tunnel_settings.tunnel_type,
             connection_data: self.connection_data.clone(),
         }
     }
@@ -512,23 +519,19 @@ impl TunnelStateHandler for ConnectingState {
             Some(monitor_event) = self.tunnel_monitor_event_receiver.recv() => {
                 match monitor_event {
                     TunnelMonitorEvent::AwaitingAccountReadiness => {
-                        let new_state = self.make_connecting_tunnel_state(EstablishConnectionState::AwaitingAccountReadiness);
+                        let new_state = self.make_connecting_tunnel_state(shared_state, EstablishConnectionState::AwaitingAccountReadiness);
                         NextTunnelState::NewState((self, new_state))
                     }
                     TunnelMonitorEvent::RefreshingGateways => {
-                        let new_state = self.make_connecting_tunnel_state(EstablishConnectionState::RefreshingGateways);
+                        let new_state = self.make_connecting_tunnel_state(shared_state, EstablishConnectionState::RefreshingGateways);
                         NextTunnelState::NewState((self, new_state))
                     }
                     TunnelMonitorEvent::ConnectingMixnetClient => {
-                        let new_state = self.make_connecting_tunnel_state(EstablishConnectionState::ConnectingMixnetClient);
-                        NextTunnelState::NewState((self, new_state))
-                    }
-                    TunnelMonitorEvent::ConnectingTunnel => {
-                        let new_state = self.make_connecting_tunnel_state(EstablishConnectionState::ConnectingTunnel);
+                        let new_state = self.make_connecting_tunnel_state(shared_state, EstablishConnectionState::ConnectingMixnetClient);
                         NextTunnelState::NewState((self, new_state))
                     }
                     TunnelMonitorEvent::SelectingGateways => {
-                        let new_state = self.make_connecting_tunnel_state(EstablishConnectionState::SelectingGateways);
+                        let new_state = self.make_connecting_tunnel_state(shared_state, EstablishConnectionState::SelectingGateways);
                         NextTunnelState::NewState((self, new_state))
                     }
                     TunnelMonitorEvent::SelectedGateways {
@@ -559,7 +562,7 @@ impl TunnelStateHandler for ConnectingState {
                     }  => {
                         let next_state = match self.handle_interface_up(tunnel_interface, connection_data, shared_state).await {
                             Ok(()) => {
-                                let state = self.make_connecting_tunnel_state(EstablishConnectionState::ConnectingTunnel);
+                                let state = self.make_connecting_tunnel_state(shared_state, EstablishConnectionState::ConnectingTunnel);
                                 NextTunnelState::NewState((self, state))
                             },
                             Err(e) => {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -48,8 +48,9 @@ use super::{
 };
 use nym_common::trace_err_chain;
 use nym_vpn_lib_types::{
-    ConnectionData, ErrorStateReason, Gateway, MixnetConnectionData, MixnetEvent, NymAddress,
-    TunnelConnectionData, TunnelType, WireguardConnectionData, WireguardNode,
+    ConnectionData, ErrorStateReason, EstablishingConnectionData, Gateway, MixnetConnectionData,
+    MixnetEvent, NymAddress, TunnelConnectionData, TunnelType, WireguardConnectionData,
+    WireguardNode,
 };
 
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
@@ -130,7 +131,7 @@ pub enum TunnelMonitorEvent {
         /// Tunnel interface
         tunnel_interface: TunnelInterface,
         /// Connection data
-        connection_data: Box<ConnectionData>,
+        connection_data: Box<EstablishingConnectionData>,
         /// Back channel to acknowledge that the event has been processed
         reply_tx: tokio::sync::oneshot::Sender<()>,
     },
@@ -442,17 +443,16 @@ impl TunnelMonitor {
             }
         };
 
-        let connection_data = ConnectionData {
-            entry_gateway: Gateway::from(*selected_gateways.entry),
-            exit_gateway: Gateway::from(*selected_gateways.exit),
-            connected_at: None,
-            tunnel: tunnel_conn_data,
+        let establishing_connection_data = EstablishingConnectionData {
+            entry_gateway: Gateway::from(*selected_gateways.entry.clone()),
+            exit_gateway: Gateway::from(*selected_gateways.exit.clone()),
+            tunnel: Some(tunnel_conn_data.clone()),
         };
 
         let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
         self.send_event(TunnelMonitorEvent::InterfaceUp {
             tunnel_interface: tunnel_interface.clone(),
-            connection_data: Box::new(connection_data.clone()),
+            connection_data: Box::new(establishing_connection_data),
             reply_tx,
         });
 
@@ -485,8 +485,10 @@ impl TunnelMonitor {
             .unwrap_or(Fuse::terminated());
 
         let connection_data = ConnectionData {
-            connected_at: Some(OffsetDateTime::now_utc()),
-            ..connection_data
+            entry_gateway: Gateway::from(*selected_gateways.entry),
+            exit_gateway: Gateway::from(*selected_gateways.exit),
+            connected_at: OffsetDateTime::now_utc(),
+            tunnel: tunnel_conn_data,
         };
         self.send_event(TunnelMonitorEvent::Up {
             tunnel_interface,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -132,9 +132,6 @@ pub enum TunnelMonitorEvent {
     /// Connecting mixnet client
     ConnectingMixnetClient,
 
-    /// Connecting tunnel
-    ConnectingTunnel,
-
     /// Tunnel interface is up.
     InterfaceUp {
         /// Tunnel interface
@@ -417,8 +414,6 @@ impl TunnelMonitor {
         ))
         .await
         .map_err(Box::new)?;
-
-        self.send_event(TunnelMonitorEvent::ConnectingTunnel);
 
         let status_listener_handle = connected_mixnet
             .start_event_listener(

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -48,7 +48,7 @@ use super::{
 };
 use nym_common::trace_err_chain;
 use nym_vpn_lib_types::{
-    ConnectionData, ErrorStateReason, EstablishingConnectionData, Gateway, MixnetConnectionData,
+    ConnectionData, ErrorStateReason, EstablishConnectionData, Gateway, MixnetConnectionData,
     MixnetEvent, NymAddress, TunnelConnectionData, TunnelType, WireguardConnectionData,
     WireguardNode,
 };
@@ -113,8 +113,11 @@ const TASK_MANAGER_SHUTDOWN_TIMEOUT_SECS: u64 = 10;
 
 #[derive(Debug)]
 pub enum TunnelMonitorEvent {
-    /// Initializing mixnet client
-    InitializingClient,
+    /// Checking account
+    AwaitingAccountReadiness,
+
+    /// Refreshing gateways
+    RefreshingGateways,
 
     /// Selecting gateways
     SelectingGateways,
@@ -126,12 +129,18 @@ pub enum TunnelMonitorEvent {
         reply_tx: tokio::sync::oneshot::Sender<()>,
     },
 
+    /// Connecting mixnet client
+    ConnectingMixnetClient,
+
+    /// Connecting tunnel
+    ConnectingTunnel,
+
     /// Tunnel interface is up.
     InterfaceUp {
         /// Tunnel interface
         tunnel_interface: TunnelInterface,
         /// Connection data
-        connection_data: Box<EstablishingConnectionData>,
+        connection_data: Box<EstablishConnectionData>,
         /// Back channel to acknowledge that the event has been processed
         reply_tx: tokio::sync::oneshot::Sender<()>,
     },
@@ -269,14 +278,14 @@ impl TunnelMonitor {
             return Err(Error::Ipv6Unavailable);
         }
 
-        self.send_event(TunnelMonitorEvent::InitializingClient);
+        self.send_event(TunnelMonitorEvent::AwaitingAccountReadiness);
 
         self.account_controller_state
             .wait_for_account_ready_to_connect()
             .await
             .map_err(|e| Error::Account(account::Error::ControllerState(e)))?;
 
-        self.send_event(TunnelMonitorEvent::SelectingGateways);
+        self.send_event(TunnelMonitorEvent::RefreshingGateways);
 
         let gateway_performance_options = self
             .tunnel_parameters
@@ -330,6 +339,8 @@ impl TunnelMonitor {
             if let Some(selected_gateways) = self.tunnel_parameters.selected_gateways.clone() {
                 selected_gateways
             } else {
+                self.send_event(TunnelMonitorEvent::SelectingGateways);
+
                 let new_gateways = tunnel::select_gateways(
                     self.gateway_directory_client.clone(),
                     self.tunnel_parameters.tunnel_settings.tunnel_type,
@@ -353,6 +364,8 @@ impl TunnelMonitor {
 
                 new_gateways
             };
+
+        self.send_event(TunnelMonitorEvent::ConnectingMixnetClient);
 
         let connect_options = MixnetConnectOptions {
             data_path: self.tunnel_parameters.nym_config.data_path.clone(),
@@ -405,6 +418,8 @@ impl TunnelMonitor {
         .await
         .map_err(Box::new)?;
 
+        self.send_event(TunnelMonitorEvent::ConnectingTunnel);
+
         let status_listener_handle = connected_mixnet
             .start_event_listener(
                 task_manager,
@@ -443,7 +458,7 @@ impl TunnelMonitor {
             }
         };
 
-        let establishing_connection_data = EstablishingConnectionData {
+        let establishing_connection_data = EstablishConnectionData {
             entry_gateway: Gateway::from(*selected_gateways.entry.clone()),
             exit_gateway: Gateway::from(*selected_gateways.exit.clone()),
             tunnel: Some(tunnel_conn_data.clone()),

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -283,17 +283,26 @@ message GetAccountLinksRequest {
   string locale = 1;
 }
 
-message EstablishingConnectionData {
+enum EstablishConnectionState {
+    RESOLVING_API_ADDRESSES = 0;
+    AWAITING_ACCOUNT_READINESS = 1;
+    REFRESHING_GATEWAYS = 2;
+    SELECTING_GATEWAYS = 3;
+    CONNECTING_MIXNET_CLIENT = 4;
+    CONNECTING_TUNNEL = 5;
+}
+
+message EstablishConnectionData {
   Gateway entry_gateway = 1;
   Gateway exit_gateway = 2;
-  optional TunnelConnectionData tunnel = 4;
+  optional TunnelConnectionData tunnel = 3;
 }
 
 message ConnectionData {
   Gateway entry_gateway = 1;
   Gateway exit_gateway = 2;
   google.protobuf.Timestamp connected_at = 3;
-  optional TunnelConnectionData tunnel = 4;
+  TunnelConnectionData tunnel = 4;
 }
 
 message MixnetConnectionData {
@@ -362,7 +371,8 @@ message TunnelState {
   message Disconnected {}
   message Connecting {
     uint32 retry_attempt = 1;
-    optional EstablishingConnectionData connection_data = 2;
+    EstablishConnectionState state = 2;
+    optional EstablishConnectionData connection_data = 3;
   }
   message Connected {
     ConnectionData connection_data = 1;

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -283,6 +283,11 @@ message GetAccountLinksRequest {
   string locale = 1;
 }
 
+enum TunnelType {
+  MIXNET = 0;
+  WIREGUARD = 1;
+}
+
 enum EstablishConnectionState {
     RESOLVING_API_ADDRESSES = 0;
     AWAITING_ACCOUNT_READINESS = 1;
@@ -372,7 +377,8 @@ message TunnelState {
   message Connecting {
     uint32 retry_attempt = 1;
     EstablishConnectionState state = 2;
-    optional EstablishConnectionData connection_data = 3;
+    TunnelType tunnel_type = 3;
+    optional EstablishConnectionData connection_data = 4;
   }
   message Connected {
     ConnectionData connection_data = 1;

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -283,11 +283,17 @@ message GetAccountLinksRequest {
   string locale = 1;
 }
 
+message EstablishingConnectionData {
+  Gateway entry_gateway = 1;
+  Gateway exit_gateway = 2;
+  optional TunnelConnectionData tunnel = 4;
+}
+
 message ConnectionData {
   Gateway entry_gateway = 1;
   Gateway exit_gateway = 2;
   google.protobuf.Timestamp connected_at = 3;
-  TunnelConnectionData tunnel = 4;
+  optional TunnelConnectionData tunnel = 4;
 }
 
 message MixnetConnectionData {
@@ -356,7 +362,7 @@ message TunnelState {
   message Disconnected {}
   message Connecting {
     uint32 retry_attempt = 1;
-    optional ConnectionData connection_data = 2;
+    optional EstablishingConnectionData connection_data = 2;
   }
   message Connected {
     ConnectionData connection_data = 1;

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/tunnel_state.rs
@@ -7,9 +7,9 @@ use std::{
 };
 
 use nym_vpn_lib_types::{
-    ActionAfterDisconnect, ConnectionData, ErrorStateReason, EstablishingConnectionData, Gateway,
-    MixnetConnectionData, NymAddress, TunnelConnectionData, TunnelState, WireguardConnectionData,
-    WireguardNode,
+    ActionAfterDisconnect, ConnectionData, ErrorStateReason, EstablishConnectionData,
+    EstablishConnectionState, Gateway, MixnetConnectionData, NymAddress, TunnelConnectionData,
+    TunnelState, WireguardConnectionData, WireguardNode,
 };
 
 use crate::{conversions::ConversionError, proto};
@@ -157,14 +157,19 @@ impl TryFrom<proto::TunnelState> for TunnelState {
             }
             proto::tunnel_state::State::Connecting(proto::tunnel_state::Connecting {
                 retry_attempt,
+                state,
                 connection_data,
             }) => {
                 let connection_data = connection_data
-                    .map(EstablishingConnectionData::try_from)
+                    .map(EstablishConnectionData::try_from)
                     .transpose()?;
+                let state = proto::EstablishConnectionState::try_from(state)
+                    .map_err(|e| ConversionError::Decode("EstablishConnectionState", e))
+                    .map(EstablishConnectionState::from)?;
 
                 Self::Connecting {
                     retry_attempt,
+                    state,
                     connection_data,
                 }
             }
@@ -185,10 +190,38 @@ impl TryFrom<proto::TunnelState> for TunnelState {
     }
 }
 
-impl TryFrom<proto::EstablishingConnectionData> for EstablishingConnectionData {
+impl From<proto::EstablishConnectionState> for EstablishConnectionState {
+    fn from(value: proto::EstablishConnectionState) -> Self {
+        match value {
+            proto::EstablishConnectionState::AwaitingAccountReadiness => {
+                Self::AwaitingAccountReadiness
+            }
+            proto::EstablishConnectionState::ResolvingApiAddresses => Self::ResolvingApiAddresses,
+            proto::EstablishConnectionState::RefreshingGateways => Self::RefreshingGateways,
+            proto::EstablishConnectionState::SelectingGateways => Self::SelectingGateways,
+            proto::EstablishConnectionState::ConnectingMixnetClient => Self::ConnectingMixnetClient,
+            proto::EstablishConnectionState::ConnectingTunnel => Self::ConnectingTunnel,
+        }
+    }
+}
+
+impl From<EstablishConnectionState> for proto::EstablishConnectionState {
+    fn from(value: EstablishConnectionState) -> Self {
+        match value {
+            EstablishConnectionState::AwaitingAccountReadiness => Self::AwaitingAccountReadiness,
+            EstablishConnectionState::ResolvingApiAddresses => Self::ResolvingApiAddresses,
+            EstablishConnectionState::RefreshingGateways => Self::RefreshingGateways,
+            EstablishConnectionState::SelectingGateways => Self::SelectingGateways,
+            EstablishConnectionState::ConnectingMixnetClient => Self::ConnectingMixnetClient,
+            EstablishConnectionState::ConnectingTunnel => Self::ConnectingTunnel,
+        }
+    }
+}
+
+impl TryFrom<proto::EstablishConnectionData> for EstablishConnectionData {
     type Error = ConversionError;
 
-    fn try_from(value: proto::EstablishingConnectionData) -> Result<Self, Self::Error> {
+    fn try_from(value: proto::EstablishConnectionData) -> Result<Self, Self::Error> {
         let entry_gateway =
             value
                 .entry_gateway
@@ -249,9 +282,9 @@ impl TryFrom<proto::ConnectionData> for ConnectionData {
     }
 }
 
-impl From<EstablishingConnectionData> for proto::EstablishingConnectionData {
-    fn from(value: EstablishingConnectionData) -> Self {
-        proto::EstablishingConnectionData {
+impl From<EstablishConnectionData> for proto::EstablishConnectionData {
+    fn from(value: EstablishConnectionData) -> Self {
+        proto::EstablishConnectionData {
             entry_gateway: Some(proto::Gateway::from(value.entry_gateway)),
             exit_gateway: Some(proto::Gateway::from(value.exit_gateway)),
             tunnel: value.tunnel.map(proto::TunnelConnectionData::from),
@@ -460,10 +493,12 @@ impl From<TunnelState> for proto::TunnelState {
             }
             TunnelState::Connecting {
                 retry_attempt,
+                state,
                 connection_data,
             } => proto::tunnel_state::State::Connecting(proto::tunnel_state::Connecting {
                 retry_attempt,
-                connection_data: connection_data.map(proto::EstablishingConnectionData::from),
+                state: proto::EstablishConnectionState::from(state) as i32,
+                connection_data: connection_data.map(proto::EstablishConnectionData::from),
             }),
             TunnelState::Connected { connection_data } => {
                 proto::tunnel_state::State::Connected(proto::tunnel_state::Connected {

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/tunnel_state.rs
@@ -7,8 +7,9 @@ use std::{
 };
 
 use nym_vpn_lib_types::{
-    ActionAfterDisconnect, ConnectionData, ErrorStateReason, Gateway, MixnetConnectionData,
-    NymAddress, TunnelConnectionData, TunnelState, WireguardConnectionData, WireguardNode,
+    ActionAfterDisconnect, ConnectionData, ErrorStateReason, EstablishingConnectionData, Gateway,
+    MixnetConnectionData, NymAddress, TunnelConnectionData, TunnelState, WireguardConnectionData,
+    WireguardNode,
 };
 
 use crate::{conversions::ConversionError, proto};
@@ -158,7 +159,9 @@ impl TryFrom<proto::TunnelState> for TunnelState {
                 retry_attempt,
                 connection_data,
             }) => {
-                let connection_data = connection_data.map(ConnectionData::try_from).transpose()?;
+                let connection_data = connection_data
+                    .map(EstablishingConnectionData::try_from)
+                    .transpose()?;
 
                 Self::Connecting {
                     retry_attempt,
@@ -182,17 +185,50 @@ impl TryFrom<proto::TunnelState> for TunnelState {
     }
 }
 
+impl TryFrom<proto::EstablishingConnectionData> for EstablishingConnectionData {
+    type Error = ConversionError;
+
+    fn try_from(value: proto::EstablishingConnectionData) -> Result<Self, Self::Error> {
+        let entry_gateway =
+            value
+                .entry_gateway
+                .map(Gateway::from)
+                .ok_or(ConversionError::NoValueSet(
+                    "EstablishingConnectionData.entry_gateway",
+                ))?;
+
+        let exit_gateway =
+            value
+                .exit_gateway
+                .map(Gateway::from)
+                .ok_or(ConversionError::NoValueSet(
+                    "EstablishingConnectionData.exit_gateway",
+                ))?;
+
+        let tunnel = value
+            .tunnel
+            .map(TunnelConnectionData::try_from)
+            .transpose()?;
+
+        Ok(Self {
+            entry_gateway,
+            exit_gateway,
+            tunnel,
+        })
+    }
+}
+
 impl TryFrom<proto::ConnectionData> for ConnectionData {
     type Error = ConversionError;
 
     fn try_from(value: proto::ConnectionData) -> Result<Self, Self::Error> {
         let connected_at = value
             .connected_at
-            .map(|timestamp| {
-                crate::conversions::prost::prost_timestamp_into_offset_datetime(timestamp)
-            })
-            .transpose()
-            .map_err(|e| ConversionError::ConvertTime("ConnectionData.connected_at", e))?;
+            .ok_or(ConversionError::NoValueSet("ConnectionData.connected_at"))?;
+
+        let connected_at =
+            crate::conversions::prost::prost_timestamp_into_offset_datetime(connected_at)
+                .map_err(|e| ConversionError::ConvertTime("ConnectionData.connected_at", e))?;
 
         let tunnel_connection_data = value
             .tunnel
@@ -213,14 +249,24 @@ impl TryFrom<proto::ConnectionData> for ConnectionData {
     }
 }
 
+impl From<EstablishingConnectionData> for proto::EstablishingConnectionData {
+    fn from(value: EstablishingConnectionData) -> Self {
+        proto::EstablishingConnectionData {
+            entry_gateway: Some(proto::Gateway::from(value.entry_gateway)),
+            exit_gateway: Some(proto::Gateway::from(value.exit_gateway)),
+            tunnel: value.tunnel.map(proto::TunnelConnectionData::from),
+        }
+    }
+}
+
 impl From<ConnectionData> for proto::ConnectionData {
     fn from(value: ConnectionData) -> proto::ConnectionData {
         proto::ConnectionData {
             entry_gateway: Some(proto::Gateway::from(value.entry_gateway)),
             exit_gateway: Some(proto::Gateway::from(value.exit_gateway)),
-            connected_at: value
-                .connected_at
-                .map(crate::conversions::prost::offset_datetime_into_proto_timestamp),
+            connected_at: Some(
+                crate::conversions::prost::offset_datetime_into_proto_timestamp(value.connected_at),
+            ),
             tunnel: Some(proto::TunnelConnectionData::from(value.tunnel)),
         }
     }
@@ -417,7 +463,7 @@ impl From<TunnelState> for proto::TunnelState {
                 connection_data,
             } => proto::tunnel_state::State::Connecting(proto::tunnel_state::Connecting {
                 retry_attempt,
-                connection_data: connection_data.map(proto::ConnectionData::from),
+                connection_data: connection_data.map(proto::EstablishingConnectionData::from),
             }),
             TunnelState::Connected { connection_data } => {
                 proto::tunnel_state::State::Connected(proto::tunnel_state::Connected {

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/tunnel_state.rs
@@ -9,7 +9,7 @@ use std::{
 use nym_vpn_lib_types::{
     ActionAfterDisconnect, ConnectionData, ErrorStateReason, EstablishConnectionData,
     EstablishConnectionState, Gateway, MixnetConnectionData, NymAddress, TunnelConnectionData,
-    TunnelState, WireguardConnectionData, WireguardNode,
+    TunnelState, TunnelType, WireguardConnectionData, WireguardNode,
 };
 
 use crate::{conversions::ConversionError, proto};
@@ -158,6 +158,7 @@ impl TryFrom<proto::TunnelState> for TunnelState {
             proto::tunnel_state::State::Connecting(proto::tunnel_state::Connecting {
                 retry_attempt,
                 state,
+                tunnel_type,
                 connection_data,
             }) => {
                 let connection_data = connection_data
@@ -166,10 +167,14 @@ impl TryFrom<proto::TunnelState> for TunnelState {
                 let state = proto::EstablishConnectionState::try_from(state)
                     .map_err(|e| ConversionError::Decode("EstablishConnectionState", e))
                     .map(EstablishConnectionState::from)?;
+                let tunnel_type = proto::TunnelType::try_from(tunnel_type)
+                    .map_err(|e| ConversionError::Decode("TunnelType", e))
+                    .map(TunnelType::from)?;
 
                 Self::Connecting {
                     retry_attempt,
                     state,
+                    tunnel_type,
                     connection_data,
                 }
             }
@@ -187,6 +192,24 @@ impl TryFrom<proto::TunnelState> for TunnelState {
                 Self::Offline { reconnect }
             }
         })
+    }
+}
+
+impl From<proto::TunnelType> for TunnelType {
+    fn from(value: proto::TunnelType) -> Self {
+        match value {
+            proto::TunnelType::Mixnet => Self::Mixnet,
+            proto::TunnelType::Wireguard => Self::Wireguard,
+        }
+    }
+}
+
+impl From<TunnelType> for proto::TunnelType {
+    fn from(value: TunnelType) -> Self {
+        match value {
+            TunnelType::Mixnet => Self::Mixnet,
+            TunnelType::Wireguard => Self::Wireguard,
+        }
     }
 }
 
@@ -494,10 +517,12 @@ impl From<TunnelState> for proto::TunnelState {
             TunnelState::Connecting {
                 retry_attempt,
                 state,
+                tunnel_type,
                 connection_data,
             } => proto::tunnel_state::State::Connecting(proto::tunnel_state::Connecting {
                 retry_attempt,
                 state: proto::EstablishConnectionState::from(state) as i32,
+                tunnel_type: proto::TunnelType::from(tunnel_type) as i32,
                 connection_data: connection_data.map(proto::EstablishConnectionData::from),
             }),
             TunnelState::Connected { connection_data } => {

--- a/nym-vpn-core/crates/nym-vpnd/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpnd/Cargo.toml
@@ -48,6 +48,7 @@ sentry = { workspace = true, features = [
 # sha2.workspace = true
 
 # Local crates
+nym-common.workspace = true
 nym-ipc.workspace = true
 nym-offline-monitor.workspace = true
 nym-statistics = { workspace = true }

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -16,6 +16,7 @@ use tokio::{
 };
 use tokio_util::sync::CancellationToken;
 
+use nym_common::trace_err_chain;
 use nym_vpn_account_controller::{
     AccountCommandSender, AccountController, AccountControllerConfig, AccountStateReceiver,
     AvailableTicketbooks,
@@ -244,7 +245,7 @@ impl NymVpnService {
                     }
                 }
                 Err(err) => {
-                    tracing::error!("Failed to initialize VPN service: {err:?}");
+                    trace_err_chain!(err, "Failed to initialize VPN service");
                 }
             }
         })
@@ -305,7 +306,7 @@ impl NymVpnService {
             parameters.user_agent.clone(),
         )
         .map_err(|err| {
-            tracing::error!("Failed to create NymVPN API client");
+            trace_err_chain!(err, "Failed to create NymVPN API client");
             AccountControllerError::Initialization {
                 reason: err.to_string(),
             }


### PR DESCRIPTION
## Ticket

TBD

## Description

- Provide metadata to keep track of progress when establishing connection by translating tunnel monitor events into tunnel state
- Update CLI output to reflect that and also be more compact
- Gateways reused between reconnects are shared immediately via tunnel state upon entering reconnect

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3351)
<!-- Reviewable:end -->
