### PR TITLE
fix test checking default envs against served envs

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-network-config/default/envs.json
+++ b/nym-vpn-core/crates/nym-vpn-network-config/default/envs.json
@@ -2,5 +2,5 @@
   "mainnet",
   "sandbox",
   "canary",
-  "qa"
+  "evil-env"
 ]


### PR DESCRIPTION


## Description

Update the default available environment names to match those served by the vpn api.
Fixes a test in the `nym-vpn-network-config` package.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3388)
<!-- Reviewable:end -->
