### PR TITLE
Fix block on waiting for mixnet listener to quit

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix edgecase where mixnet processor could be blocked from exiting by mixnet listener causing the client to be stuck in disconnecting state (https://github.com/nymtech/nym-vpn-client/pull/3394)
+
 ## [1.15.0] - TBD
 
 ### Added

--- a/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/error.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/error.rs
@@ -39,6 +39,9 @@ pub enum MixnetError {
     #[error("failed to send input message")]
     SendInputMessage(#[source] Box<nym_sdk::Error>),
 
-    #[error("Mixnet client is already disposed")]
+    #[error("mixnet client is already disposed")]
     ClientAlreadyDisposed,
+
+    #[error("failed to join on mixnet listener")]
+    JoinMixnetListener(#[source] tokio::task::JoinError),
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/mixnet_listener.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/mixnet_listener.rs
@@ -7,8 +7,8 @@ use nym_connection_monitor::{ConnectionStatusEvent, IcmpBeaconReply, Icmpv6Beaco
 use nym_ip_packet_client::{IprListener, MixnetMessageOutcome};
 use nym_ip_packet_requests::IpPair;
 use nym_task::TaskClient;
-use tokio::{sync::oneshot, task::JoinHandle};
-use tokio_util::codec::Framed;
+use tokio::task::JoinHandle;
+use tokio_util::{codec::Framed, sync::CancellationToken};
 use tun::{AsyncDevice, TunPacket, TunPacketCodec};
 
 use super::SharedMixnetClient;
@@ -36,19 +36,23 @@ pub(super) struct MixnetListener {
 
     // Connection event sender
     connection_event_tx: mpsc::UnboundedSender<ConnectionStatusEvent>,
+
+    // Cancellation token
+    shutdown_token: CancellationToken,
 }
 
 impl MixnetListener {
-    pub(super) async fn new(
+    pub(super) fn spawn(
         mixnet_client: SharedMixnetClient,
         task_client: TaskClient,
         tun_device_sink: SplitSink<Framed<AsyncDevice, TunPacketCodec>, TunPacket>,
         icmp_beacon_identifier: u16,
         our_ips: IpPair,
         connection_event_tx: mpsc::UnboundedSender<ConnectionStatusEvent>,
-    ) -> Self {
+        shutdown_token: CancellationToken,
+    ) -> JoinHandle<SplitSink<Framed<AsyncDevice, TunPacketCodec>, TunPacket>> {
         let ipr_listener = IprListener::new();
-        Self {
+        let mixnet_listener = Self {
             mixnet_client,
             ipr_listener,
             task_client,
@@ -56,7 +60,9 @@ impl MixnetListener {
             icmp_beacon_identifier,
             our_ips,
             connection_event_tx,
-        }
+            shutdown_token,
+        };
+        tokio::spawn(mixnet_listener.run())
     }
 
     fn send_connection_event(&self, event: ConnectionStatusEvent) {
@@ -82,6 +88,10 @@ impl MixnetListener {
         while !self.task_client.is_shutdown() {
             tokio::select! {
                 _ = self.task_client.recv() => {
+                    tracing::debug!("Mixnet listener: Received shutdown");
+                    break;
+                }
+                _ = self.shutdown_token.cancelled() => {
                     tracing::debug!("Mixnet listener: Received shutdown");
                     break;
                 }
@@ -127,17 +137,6 @@ impl MixnetListener {
 
         tracing::debug!("Mixnet listener: Exiting");
         self.tun_device_sink
-    }
-
-    pub(super) fn start(
-        self,
-        is_done: oneshot::Sender<()>,
-    ) -> JoinHandle<SplitSink<Framed<AsyncDevice, TunPacketCodec>, TunPacket>> {
-        tokio::spawn(async move {
-            let tun_device_sink = self.run().await;
-            let _ = is_done.send(());
-            tun_device_sink
-        })
     }
 }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/processor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/processor.rs
@@ -16,7 +16,7 @@ use nym_sdk::mixnet::{
     InputMessage, MixnetClientSender, MixnetMessageSender, MixnetMessageSinkTranslator, Recipient,
 };
 use nym_task::{TaskClient, TaskManager, connections::TransmissionLane};
-use tokio::{sync::oneshot, task::JoinHandle};
+use tokio::task::JoinHandle;
 use tokio_util::{codec::Encoder, sync::CancellationToken};
 use tun::{AsyncDevice, Device};
 
@@ -138,22 +138,18 @@ impl MixnetProcessor {
 
         let message_creator = MessageCreator::new(self.ip_packet_router_address.into());
 
-        // Listen for when the mixnet listener is done
-        let (mixnet_listener_done_tx, mixnet_listener_done) = oneshot::channel();
-        tokio::pin!(mixnet_listener_done);
-
         // Starting the mixnet listener.
         tracing::debug!("Starting mixnet listener");
-        let mixnet_listener = super::mixnet_listener::MixnetListener::new(
+        let mixnet_listener_shutdown_token = CancellationToken::new();
+        let mut mixnet_listener_handle = super::mixnet_listener::MixnetListener::spawn(
             self.mixnet_client.clone(),
             task_client_mix_listener,
             tun_device_sink,
             self.icmp_beacon_identifier,
             self.our_ips,
             self.connection_event_tx.clone(),
-        )
-        .await;
-        let mixnet_listener_handle = mixnet_listener.start(mixnet_listener_done_tx);
+            mixnet_listener_shutdown_token.child_token(),
+        );
 
         // Keep track of whether we've sent the disconnect message, so we don't send it multiple
         // times
@@ -225,7 +221,7 @@ impl MixnetProcessor {
                 }
                 // When the mixnet listener receives the disconnect response, it will notify us
                 // that it's done. This means we can now stop
-                _ = &mut mixnet_listener_done => {
+                _ = &mut mixnet_listener_handle => {
                     tracing::debug!("Mixnet listener has finished");
                     break;
                 }
@@ -252,7 +248,11 @@ impl MixnetProcessor {
                                 }
                             }
                             _ = task_client_mix_processor.recv() => {
-                                tracing::debug!("Received shutdown while sending.");
+                                tracing::debug!("Received shutdown while sending");
+                                break;
+                            }
+                            _ = self.cancel_token.cancelled() => {
+                                tracing::debug!("Received cancellation while sending");
                                 break;
                             }
                         }
@@ -290,6 +290,10 @@ impl MixnetProcessor {
                             tracing::debug!("Received shutdown while flushing");
                             break;
                         }
+                        _ = self.cancel_token.cancelled() => {
+                            tracing::debug!("Received shutdown while flushing");
+                            break;
+                        }
                     }
                 }
             }
@@ -299,7 +303,10 @@ impl MixnetProcessor {
         backpressure_monitor.stop().await;
 
         tracing::info!("Waiting for mixnet listener to finish");
-        let tun_device_sink = mixnet_listener_handle.await.unwrap();
+        mixnet_listener_shutdown_token.cancel();
+        let tun_device_sink = mixnet_listener_handle
+            .await
+            .map_err(MixnetError::JoinMixnetListener)?;
 
         tracing::debug!("Exiting");
         Ok(tun_device_sink


### PR DESCRIPTION

## Ticket

JIRA-VPN-3861

## Description

- It seems that calling cancellation of shutdown token does not always propagate towards mixnet listener causing it to block the processor exit. This PR adds a separate cancellation token for mixnet listener and cancels it before waiting for `JoinHandle`
- Remove the unnecessary oneshot channel and poll `JoinHandle` to determine when mixnet listener finished execution.
- Compliment `task_client_mix_processor.recv()` with `self.cancel_token.cancelled()` in some code paths where cancellation may come from different sources.


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3394)
<!-- Reviewable:end -->
