### PR TITLE
bugfix: propagate non-sequence chain errors

### DIFF
--- a/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
+++ b/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
@@ -222,23 +222,47 @@ impl Probe {
                         BandwidthControllerError::Nyxd(nyxd_error),
                     ) => match nyxd_error {
                         // happens when sequence issue occurs during tx delivery
-                        NyxdError::BroadcastTxErrorDeliverTx { hash, raw_log, .. } => {
+                        NyxdError::BroadcastTxErrorDeliverTx {
+                            hash,
+                            height,
+                            code,
+                            raw_log,
+                        } => {
                             // unfortunately at this point we have to do string matching as the log
                             // is returned from the go nyxd binary
                             if raw_log.contains("account sequence mismatch") {
                                 error!(
                                     "another process is using the same mnemonic. we failed to broadcast transaction {hash} due to mismatched sequence number"
                                 )
+                            } else {
+                                return Err(NyxdError::BroadcastTxErrorDeliverTx {
+                                    hash,
+                                    height,
+                                    code,
+                                    raw_log,
+                                }
+                                .into());
                             }
                         }
                         // happens when sequence issue occurs during tx simulate
-                        NyxdError::AbciError { log, .. } => {
+                        NyxdError::AbciError {
+                            code,
+                            log,
+                            pretty_log,
+                        } => {
                             // unfortunately at this point we have to do string matching as the log
                             // is returned from the go nyxd binary
                             if log.contains("account sequence mismatch") {
                                 error!(
                                     "another process is using the same mnemonic. we failed to simulate transaction due to mismatched sequence number"
                                 )
+                            } else {
+                                return Err(NyxdError::AbciError {
+                                    code,
+                                    log,
+                                    pretty_log,
+                                }
+                                .into());
                             }
                         }
                         other => {


### PR DESCRIPTION
As we found yesterday the hard way, some chain errors were being swallowed when attempting to run the probe causing us a lot of confusion. So for example if transactions were failing due to misconfiguration (*cough* like invalid bech32 prefix), we'd never be shown this information. This PR fixes that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3410)
<!-- Reviewable:end -->
