### PR TITLE
fix(vpnd-sentry): don't set extra metadata tag if no extra data available

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix edgecase where mixnet processor could be blocked from exiting by mixnet listener causing the client to be stuck in disconnecting state (https://github.com/nymtech/nym-vpn-client/pull/3394)
+- Fix Sentry extra metadata tag when there is no OS extra info
+  (https://github.com/nymtech/nym-vpn-client/pull/3411)
 
 ## [1.15.0] - TBD
 

--- a/nym-vpn-core/crates/nym-vpnd/src/sentry.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/sentry.rs
@@ -54,7 +54,9 @@ pub fn init_sentry() -> Option<ClientInitGuard> {
     ));
     sentry::configure_scope(|scope| {
         scope.set_tag("os_version", &os_info.os_version);
-        scope.set_tag("extra_metadata", os_info.extra.join(", "));
+        if !os_info.extra.is_empty() {
+            scope.set_tag("extra_metadata", os_info.extra.join(", "));
+        }
         scope.set_user(Some(sentry::User {
             id: Some(os_info.hash_identifier()), // anonymized user identifier
             ip_address: None,


### PR DESCRIPTION
Fix sentry "Processing error"s on event when there is no extra metadata

<img width="1463" height="58" alt="image" src="https://github.com/user-attachments/assets/2c5997a8-ef5f-4431-aa8e-38db4b61a39b" />
<img width="239" height="54" alt="image" src="https://github.com/user-attachments/assets/adca9bf5-ae70-4a96-bdca-f01482c6d9e7" />


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3411)
<!-- Reviewable:end -->
