### PR TITLE
Fix type name clash

### DIFF
--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/manager/backend/model/ConnectionInfo.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/manager/backend/model/ConnectionInfo.kt
@@ -2,13 +2,13 @@ package net.nymtech.nymvpn.manager.backend.model
 
 import nym_vpn_lib_types.ConnectionData
 import nym_vpn_lib_types.EstablishConnectionData
-import nym_vpn_lib_types.Gateway
+import nym_vpn_lib_types.GatewayId
 import nym_vpn_lib_types.OffsetDateTime
 import nym_vpn_lib_types.TunnelConnectionData
 
 data class ConnectionInfo(
-	var entryGateway: Gateway,
-	var exitGateway: Gateway,
+	var entryGateway: GatewayId,
+	var exitGateway: GatewayId,
 	var connectedAt: OffsetDateTime?,
 	var tunnel: TunnelConnectionData?,
 )

--- a/nym-vpn-app/src-tauri/src/grpc/node.rs
+++ b/nym-vpn-app/src-tauri/src/grpc/node.rs
@@ -1,5 +1,5 @@
 use nym_vpn_proto::proto::{
-    EntryNode, ExitNode, Gateway as ProtoGateway, Location, entry_node::EntryNodeEnum,
+    EntryNode, ExitNode, GatewayId as ProtoGateway, Location, entry_node::EntryNodeEnum,
     exit_node::ExitNodeEnum,
 };
 use serde::{Deserialize, Serialize};

--- a/nym-vpn-apple/NymMixnetTunnel/TunnelActor.swift
+++ b/nym-vpn-apple/NymMixnetTunnel/TunnelActor.swift
@@ -62,8 +62,8 @@ actor TunnelActor {
             lastError = ErrorReason(with: errorStateReason)
             tunnelState = .connected(
                 connectionData: ConnectionData(
-                    entryGateway: Gateway(id: ""),
-                    exitGateway: Gateway(id: ""),
+                    entryGateway: GatewayId(id: ""),
+                    exitGateway: GatewayId(id: ""),
                     connectedAt: nil,
                     tunnel: .mixnet(
                         MixnetConnectionData(

--- a/nym-vpn-core/crates/nym-vpn-lib-types-uniffi/src/tunnel_state_machine.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types-uniffi/src/tunnel_state_machine.rs
@@ -435,13 +435,13 @@ impl From<nym_vpn_lib_types::ErrorStateReason> for ErrorStateReason {
 }
 
 #[derive(uniffi::Record)]
-pub struct Gateway {
+pub struct GatewayId {
     /// Gateway id in base58.
     pub id: String,
 }
 
-impl From<nym_vpn_lib_types::Gateway> for Gateway {
-    fn from(value: nym_vpn_lib_types::Gateway) -> Self {
+impl From<nym_vpn_lib_types::GatewayId> for GatewayId {
+    fn from(value: nym_vpn_lib_types::GatewayId) -> Self {
         Self { id: value.id }
     }
 }
@@ -463,8 +463,8 @@ impl From<nym_vpn_lib_types::NymAddress> for NymAddress {
 
 #[derive(uniffi::Record)]
 pub struct ConnectionData {
-    pub entry_gateway: Gateway,
-    pub exit_gateway: Gateway,
+    pub entry_gateway: GatewayId,
+    pub exit_gateway: GatewayId,
     pub connected_at: Option<OffsetDateTime>,
     pub tunnel: TunnelConnectionData,
 }
@@ -472,8 +472,8 @@ pub struct ConnectionData {
 impl From<nym_vpn_lib_types::ConnectionData> for ConnectionData {
     fn from(value: nym_vpn_lib_types::ConnectionData) -> Self {
         Self {
-            entry_gateway: Gateway::from(value.entry_gateway),
-            exit_gateway: Gateway::from(value.exit_gateway),
+            entry_gateway: GatewayId::from(value.entry_gateway),
+            exit_gateway: GatewayId::from(value.exit_gateway),
             connected_at: Some(value.connected_at),
             tunnel: TunnelConnectionData::from(value.tunnel),
         }
@@ -517,16 +517,16 @@ impl From<nym_vpn_lib_types::EstablishConnectionState> for EstablishConnectionSt
 
 #[derive(uniffi::Record)]
 pub struct EstablishConnectionData {
-    pub entry_gateway: Gateway,
-    pub exit_gateway: Gateway,
+    pub entry_gateway: GatewayId,
+    pub exit_gateway: GatewayId,
     pub tunnel: Option<TunnelConnectionData>,
 }
 
 impl From<nym_vpn_lib_types::EstablishConnectionData> for EstablishConnectionData {
     fn from(value: nym_vpn_lib_types::EstablishConnectionData) -> Self {
         Self {
-            entry_gateway: Gateway::from(value.entry_gateway),
-            exit_gateway: Gateway::from(value.exit_gateway),
+            entry_gateway: GatewayId::from(value.entry_gateway),
+            exit_gateway: GatewayId::from(value.exit_gateway),
             tunnel: value.tunnel.map(TunnelConnectionData::from),
         }
     }

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/connection_data.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/connection_data.rs
@@ -12,18 +12,18 @@ use crate::TunnelType;
 
 // Represents the identity of a gateway
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub struct Gateway {
+pub struct GatewayId {
     pub id: String,
 }
 
-impl Gateway {
+impl GatewayId {
     pub fn new(id: String) -> Self {
         Self { id }
     }
 }
 
 #[cfg(feature = "nym-type-conversions")]
-impl From<nym_gateway_directory::Gateway> for Gateway {
+impl From<nym_gateway_directory::Gateway> for GatewayId {
     fn from(value: nym_gateway_directory::Gateway) -> Self {
         Self::new(value.identity().to_base58_string())
     }
@@ -32,10 +32,10 @@ impl From<nym_gateway_directory::Gateway> for Gateway {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EstablishConnectionData {
     /// Mixnet entry gateway.
-    pub entry_gateway: Gateway,
+    pub entry_gateway: GatewayId,
 
     /// Mixnet exit gateway.
-    pub exit_gateway: Gateway,
+    pub exit_gateway: GatewayId,
 
     /// Tunnel connection data.
     /// Becomes available once tunnel connection is initiated.
@@ -80,10 +80,10 @@ impl fmt::Display for EstablishConnectionState {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ConnectionData {
     /// Mixnet entry gateway.
-    pub entry_gateway: Gateway,
+    pub entry_gateway: GatewayId,
 
     /// Mixnet exit gateway.
-    pub exit_gateway: Gateway,
+    pub exit_gateway: GatewayId,
 
     /// When the tunnel connection was last established.
     pub connected_at: OffsetDateTime,

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
@@ -19,7 +19,7 @@ pub use account::{
     ticketbooks::AvailableTickets,
 };
 pub use connection_data::{
-    ConnectionData, EstablishConnectionData, EstablishConnectionState, Gateway,
+    ConnectionData, EstablishConnectionData, EstablishConnectionState, GatewayId,
     MixnetConnectionData, NymAddress, TunnelConnectionData, WireguardConnectionData, WireguardNode,
 };
 pub use tunnel_event::{

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -21,7 +21,7 @@ use nym_firewall::{
     TransportProtocol,
 };
 use nym_gateway_directory::ResolvedConfig;
-use nym_vpn_lib_types::{EstablishConnectionData, EstablishConnectionState, Gateway};
+use nym_vpn_lib_types::{EstablishConnectionData, EstablishConnectionState, GatewayId};
 
 #[cfg(target_os = "macos")]
 use crate::tunnel_state_machine::resolver::LOCAL_DNS_RESOLVER;
@@ -123,8 +123,8 @@ impl ConnectingState {
             selected_gateways
                 .as_ref()
                 .map(|gateways| EstablishConnectionData {
-                    entry_gateway: Gateway::from(*gateways.entry.clone()),
-                    exit_gateway: Gateway::from(*gateways.exit.clone()),
+                    entry_gateway: GatewayId::from(*gateways.entry.clone()),
+                    exit_gateway: GatewayId::from(*gateways.exit.clone()),
                     tunnel: None,
                 });
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -53,7 +53,7 @@ use super::{
 };
 use nym_common::trace_err_chain;
 use nym_vpn_lib_types::{
-    ConnectionData, ErrorStateReason, EstablishConnectionData, Gateway, MixnetConnectionData,
+    ConnectionData, ErrorStateReason, EstablishConnectionData, GatewayId, MixnetConnectionData,
     MixnetEvent, NymAddress, TunnelConnectionData, TunnelType, WireguardConnectionData,
     WireguardNode,
 };
@@ -479,8 +479,8 @@ impl TunnelMonitor {
         };
 
         let establishing_connection_data = EstablishConnectionData {
-            entry_gateway: Gateway::from(*selected_gateways.entry.clone()),
-            exit_gateway: Gateway::from(*selected_gateways.exit.clone()),
+            entry_gateway: GatewayId::from(*selected_gateways.entry.clone()),
+            exit_gateway: GatewayId::from(*selected_gateways.exit.clone()),
             tunnel: Some(tunnel_conn_data.clone()),
         };
 
@@ -520,8 +520,8 @@ impl TunnelMonitor {
             .unwrap_or(Fuse::terminated());
 
         let connection_data = ConnectionData {
-            entry_gateway: Gateway::from(*selected_gateways.entry),
-            exit_gateway: Gateway::from(*selected_gateways.exit),
+            entry_gateway: GatewayId::from(*selected_gateways.entry),
+            exit_gateway: GatewayId::from(*selected_gateways.exit),
             connected_at: OffsetDateTime::now_utc(),
             tunnel: tunnel_conn_data,
         };

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -7,7 +7,7 @@ import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
 
 // Represents the identity of a gateway
-message Gateway {
+message GatewayId {
   string id = 1;
 }
 
@@ -25,7 +25,7 @@ message Location {
 
 message EntryNode {
   oneof entry_node_enum {
-    Gateway gateway = 1;
+    GatewayId gateway = 1;
     Location location = 2;
     google.protobuf.Empty random = 4;
   }
@@ -34,7 +34,7 @@ message EntryNode {
 message ExitNode {
   oneof exit_node_enum {
     Address address = 1;
-    Gateway gateway = 2;
+    GatewayId gateway = 2;
     Location location = 3;
     google.protobuf.Empty random = 4;
   }
@@ -240,7 +240,7 @@ message Probe {
 }
 
 message GatewayResponse {
-  Gateway id = 1;
+  GatewayId id = 1;
   Location location = 2;
   Probe last_probe = 3;
   optional Score wg_score = 4;
@@ -298,14 +298,14 @@ enum EstablishConnectionState {
 }
 
 message EstablishConnectionData {
-  Gateway entry_gateway = 1;
-  Gateway exit_gateway = 2;
+  GatewayId entry_gateway = 1;
+  GatewayId exit_gateway = 2;
   optional TunnelConnectionData tunnel = 3;
 }
 
 message ConnectionData {
-  Gateway entry_gateway = 1;
-  Gateway exit_gateway = 2;
+  GatewayId entry_gateway = 1;
+  GatewayId exit_gateway = 2;
   google.protobuf.Timestamp connected_at = 3;
   TunnelConnectionData tunnel = 4;
 }

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/mod.rs
@@ -74,9 +74,11 @@ impl From<url::Url> for proto::Url {
 impl From<&nym_sdk::mixnet::NodeIdentity> for proto::EntryNode {
     fn from(identity: &nym_sdk::mixnet::NodeIdentity) -> Self {
         Self {
-            entry_node_enum: Some(proto::entry_node::EntryNodeEnum::Gateway(proto::Gateway {
-                id: identity.to_base58_string(),
-            })),
+            entry_node_enum: Some(proto::entry_node::EntryNodeEnum::Gateway(
+                proto::GatewayId {
+                    id: identity.to_base58_string(),
+                },
+            )),
         }
     }
 }
@@ -84,7 +86,7 @@ impl From<&nym_sdk::mixnet::NodeIdentity> for proto::EntryNode {
 impl From<&nym_sdk::mixnet::NodeIdentity> for proto::ExitNode {
     fn from(identity: &nym_sdk::mixnet::NodeIdentity) -> Self {
         Self {
-            exit_node_enum: Some(proto::exit_node::ExitNodeEnum::Gateway(proto::Gateway {
+            exit_node_enum: Some(proto::exit_node::ExitNodeEnum::Gateway(proto::GatewayId {
                 id: identity.to_base58_string(),
             })),
         }

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/tunnel_state.rs
@@ -8,7 +8,7 @@ use std::{
 
 use nym_vpn_lib_types::{
     ActionAfterDisconnect, ConnectionData, ErrorStateReason, EstablishConnectionData,
-    EstablishConnectionState, Gateway, MixnetConnectionData, NymAddress, TunnelConnectionData,
+    EstablishConnectionState, GatewayId, MixnetConnectionData, NymAddress, TunnelConnectionData,
     TunnelState, TunnelType, WireguardConnectionData, WireguardNode,
 };
 
@@ -248,7 +248,7 @@ impl TryFrom<proto::EstablishConnectionData> for EstablishConnectionData {
         let entry_gateway =
             value
                 .entry_gateway
-                .map(Gateway::from)
+                .map(GatewayId::from)
                 .ok_or(ConversionError::NoValueSet(
                     "EstablishingConnectionData.entry_gateway",
                 ))?;
@@ -256,7 +256,7 @@ impl TryFrom<proto::EstablishConnectionData> for EstablishConnectionData {
         let exit_gateway =
             value
                 .exit_gateway
-                .map(Gateway::from)
+                .map(GatewayId::from)
                 .ok_or(ConversionError::NoValueSet(
                     "EstablishingConnectionData.exit_gateway",
                 ))?;
@@ -294,11 +294,11 @@ impl TryFrom<proto::ConnectionData> for ConnectionData {
             connected_at,
             entry_gateway: value
                 .entry_gateway
-                .map(Gateway::from)
+                .map(GatewayId::from)
                 .ok_or(ConversionError::NoValueSet("ConnectionData.entry_gateway"))?,
             exit_gateway: value
                 .exit_gateway
-                .map(Gateway::from)
+                .map(GatewayId::from)
                 .ok_or(ConversionError::NoValueSet("ConnectionData.exit_gateway"))?,
             tunnel: TunnelConnectionData::try_from(tunnel_connection_data)?,
         })
@@ -308,8 +308,8 @@ impl TryFrom<proto::ConnectionData> for ConnectionData {
 impl From<EstablishConnectionData> for proto::EstablishConnectionData {
     fn from(value: EstablishConnectionData) -> Self {
         proto::EstablishConnectionData {
-            entry_gateway: Some(proto::Gateway::from(value.entry_gateway)),
-            exit_gateway: Some(proto::Gateway::from(value.exit_gateway)),
+            entry_gateway: Some(proto::GatewayId::from(value.entry_gateway)),
+            exit_gateway: Some(proto::GatewayId::from(value.exit_gateway)),
             tunnel: value.tunnel.map(proto::TunnelConnectionData::from),
         }
     }
@@ -318,8 +318,8 @@ impl From<EstablishConnectionData> for proto::EstablishConnectionData {
 impl From<ConnectionData> for proto::ConnectionData {
     fn from(value: ConnectionData) -> proto::ConnectionData {
         proto::ConnectionData {
-            entry_gateway: Some(proto::Gateway::from(value.entry_gateway)),
-            exit_gateway: Some(proto::Gateway::from(value.exit_gateway)),
+            entry_gateway: Some(proto::GatewayId::from(value.entry_gateway)),
+            exit_gateway: Some(proto::GatewayId::from(value.exit_gateway)),
             connected_at: Some(
                 crate::conversions::prost::offset_datetime_into_proto_timestamp(value.connected_at),
             ),
@@ -485,8 +485,8 @@ impl From<WireguardNode> for proto::WireguardNode {
     }
 }
 
-impl From<proto::Gateway> for Gateway {
-    fn from(value: proto::Gateway) -> Self {
+impl From<proto::GatewayId> for GatewayId {
+    fn from(value: proto::GatewayId) -> Self {
         Self::new(value.id)
     }
 }
@@ -551,8 +551,8 @@ impl From<TunnelState> for proto::TunnelState {
     }
 }
 
-impl From<Gateway> for proto::Gateway {
-    fn from(value: Gateway) -> Self {
+impl From<GatewayId> for proto::GatewayId {
+    fn from(value: GatewayId) -> Self {
         Self { id: value.id }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/vpnd.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/vpnd.rs
@@ -187,7 +187,7 @@ impl TryFrom<proto::GatewayResponse> for nym_vpnd_types::gateway::Gateway {
 
 impl From<nym_vpnd_types::gateway::Gateway> for proto::GatewayResponse {
     fn from(gateway: nym_vpnd_types::gateway::Gateway) -> Self {
-        let id = Some(proto::Gateway {
+        let id = Some(proto::GatewayId {
             id: gateway.identity_key.to_string(),
         });
         let location = gateway.location.map(proto::Location::from);
@@ -457,9 +457,11 @@ impl TryFrom<nym_gateway_directory::EntryPoint> for proto::EntryNode {
     fn try_from(value: nym_gateway_directory::EntryPoint) -> Result<Self, Self::Error> {
         match value {
             nym_gateway_directory::EntryPoint::Gateway { identity } => Ok(proto::EntryNode {
-                entry_node_enum: Some(proto::entry_node::EntryNodeEnum::Gateway(proto::Gateway {
-                    id: identity.to_base58_string(),
-                })),
+                entry_node_enum: Some(proto::entry_node::EntryNodeEnum::Gateway(
+                    proto::GatewayId {
+                        id: identity.to_base58_string(),
+                    },
+                )),
             }),
             nym_gateway_directory::EntryPoint::Location { location } => Ok(proto::EntryNode {
                 entry_node_enum: Some(proto::entry_node::EntryNodeEnum::Location(
@@ -526,7 +528,7 @@ impl TryFrom<nym_gateway_directory::ExitPoint> for proto::ExitNode {
                 })
             }
             nym_gateway_directory::ExitPoint::Gateway { identity } => {
-                proto::exit_node::ExitNodeEnum::Gateway(proto::Gateway {
+                proto::exit_node::ExitNodeEnum::Gateway(proto::GatewayId {
                     id: identity.to_base58_string(),
                 })
             }

--- a/nym-vpn-core/crates/nym-vpn-rpc-uniffi/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-rpc-uniffi/src/lib.rs
@@ -16,7 +16,7 @@ use nym_vpn_lib_types_uniffi::{
     NetworkCompatibility, SystemMessage, TunnelEvent, TunnelState,
 };
 use nym_vpnd_types_uniffi::{
-    gateway::{Country, Gateway},
+    gateway::{Gateway, GatewayCountry},
     log_path::LogPath,
     nym_vpn_api::{NymVpnDevice, NymVpnUsage},
     service::VpnServiceInfo,
@@ -169,7 +169,7 @@ impl RpcClient {
         Ok(gateways)
     }
 
-    pub async fn list_countries(&self, gw_type: GatewayType) -> Result<Vec<Country>> {
+    pub async fn list_countries(&self, gw_type: GatewayType) -> Result<Vec<GatewayCountry>> {
         let options = nym_vpnd_types::ListCountriesOptions {
             gw_type: nym_gateway_directory::GatewayType::from(gw_type),
             user_agent: None,
@@ -180,7 +180,7 @@ impl RpcClient {
             .list_countries(options)
             .await?
             .into_iter()
-            .map(Country::from)
+            .map(GatewayCountry::from)
             .collect();
         Ok(countries)
     }

--- a/nym-vpn-core/crates/nym-vpnd-types-uniffi/src/gateway.rs
+++ b/nym-vpn-core/crates/nym-vpnd-types-uniffi/src/gateway.rs
@@ -5,13 +5,13 @@
 pub struct Gateway {
     pub identity_key: String,
     pub moniker: String,
-    pub location: Option<Location>,
-    pub mixnet_score: Option<Score>,
-    pub wg_score: Option<Score>,
+    pub location: Option<GatewayLocation>,
+    pub mixnet_score: Option<GatewayScore>,
+    pub wg_score: Option<GatewayScore>,
 }
 
 #[derive(uniffi::Enum)]
-pub enum Score {
+pub enum GatewayScore {
     High,
     Medium,
     Low,
@@ -19,20 +19,20 @@ pub enum Score {
 }
 
 #[derive(uniffi::Record)]
-pub struct Location {
+pub struct GatewayLocation {
     pub two_letter_iso_country_code: String,
     pub latitude: Option<f64>,
     pub longitude: Option<f64>,
 }
 
 #[derive(uniffi::Record)]
-pub struct Country {
+pub struct GatewayCountry {
     pub iso_code: String,
 }
 
-impl From<nym_vpnd_types::gateway::Location> for Location {
+impl From<nym_vpnd_types::gateway::Location> for GatewayLocation {
     fn from(location: nym_vpnd_types::gateway::Location) -> Self {
-        Location {
+        GatewayLocation {
             two_letter_iso_country_code: location.two_letter_iso_country_code,
             latitude: location.latitude,
             longitude: location.longitude,
@@ -40,13 +40,13 @@ impl From<nym_vpnd_types::gateway::Location> for Location {
     }
 }
 
-impl From<nym_vpnd_types::gateway::Score> for Score {
+impl From<nym_vpnd_types::gateway::Score> for GatewayScore {
     fn from(score: nym_vpnd_types::gateway::Score) -> Self {
         match score {
-            nym_vpnd_types::gateway::Score::High => Score::High,
-            nym_vpnd_types::gateway::Score::Medium => Score::Medium,
-            nym_vpnd_types::gateway::Score::Low => Score::Low,
-            nym_vpnd_types::gateway::Score::None => Score::None,
+            nym_vpnd_types::gateway::Score::High => GatewayScore::High,
+            nym_vpnd_types::gateway::Score::Medium => GatewayScore::Medium,
+            nym_vpnd_types::gateway::Score::Low => GatewayScore::Low,
+            nym_vpnd_types::gateway::Score::None => GatewayScore::None,
         }
     }
 }
@@ -56,16 +56,16 @@ impl From<nym_vpnd_types::gateway::Gateway> for Gateway {
         Gateway {
             identity_key: gateway.identity_key,
             moniker: gateway.moniker,
-            location: gateway.location.map(Location::from),
-            mixnet_score: gateway.mixnet_score.map(Score::from),
-            wg_score: gateway.wg_score.map(Score::from),
+            location: gateway.location.map(GatewayLocation::from),
+            mixnet_score: gateway.mixnet_score.map(GatewayScore::from),
+            wg_score: gateway.wg_score.map(GatewayScore::from),
         }
     }
 }
 
-impl From<nym_vpnd_types::gateway::Country> for Country {
+impl From<nym_vpnd_types::gateway::Country> for GatewayCountry {
     fn from(country: nym_vpnd_types::gateway::Country) -> Self {
-        Country {
+        GatewayCountry {
             iso_code: country.iso_code,
         }
     }

--- a/nym-vpn-core/iOS.mk
+++ b/nym-vpn-core/iOS.mk
@@ -36,7 +36,7 @@ build: $(LIBWG_BUILD_DIR)/libwg.a
 
 swift-package: $(LIBWG_BUILD_DIR)/libwg.a
 	cd $(LIB_CRATE_DIR); \
-	$(ALL_IDEMPOTENT_FLAGS) cargo swift package --accept-all --platforms ios --name NymVPNLib --xcframework-name NymVPNLibUniffi --release ; \
+	$(ALL_IDEMPOTENT_FLAGS) cargo swift package --accept-all --platforms ios --name NymVPNLib --xcframework-name NymVPNLibUniffi $(RELEASE_FLAG) ; \
 	sed -i '' -e '/.macOS(.v10_15)/d' "NymVPNLib/Package.swift"
 
 libwg: $(LIBWG_BUILD_DIR)/libwg.a

--- a/nym-vpn-core/iOS.mk
+++ b/nym-vpn-core/iOS.mk
@@ -36,7 +36,8 @@ build: $(LIBWG_BUILD_DIR)/libwg.a
 
 swift-package: $(LIBWG_BUILD_DIR)/libwg.a
 	cd $(LIB_CRATE_DIR); \
-	$(ALL_IDEMPOTENT_FLAGS) cargo swift package --accept-all --platforms ios --name NymVPNLib --xcframework-name NymVPNLibUniffi --release
+	$(ALL_IDEMPOTENT_FLAGS) cargo swift package --accept-all --platforms ios --name NymVPNLib --xcframework-name NymVPNLibUniffi --release ; \
+	sed -i '' -e '/.macOS(.v10_15)/d' "NymVPNLib/Package.swift"
 
 libwg: $(LIBWG_BUILD_DIR)/libwg.a
 

--- a/nym-vpn-core/macOS.mk
+++ b/nym-vpn-core/macOS.mk
@@ -20,7 +20,8 @@ all: rpc-swift-package
 
 rpc-swift-package:
 	cd $(RPC_CRATE_DIR); \
-	$(ALL_IDEMPOTENT_FLAGS) cargo swift package --accept-all --platforms macos --name NymVPNRpc --xcframework-name NymVPNRpcUniffi $(RELEASE_FLAG)
+	$(ALL_IDEMPOTENT_FLAGS) cargo swift package --accept-all --platforms macos --name NymVPNRpc --xcframework-name NymVPNRpcUniffi $(RELEASE_FLAG) ; \
+	sed -i '' -e '/.iOS(.v13),/d' "NymVPNRpc/Package.swift"
 
 clean:
 	cargo clean --target x86_64-apple-darwin


### PR DESCRIPTION
## Ticket

JIRA-VPN-3962

## Description

- Rename `Gateway` to `GatewayId`
- uniffi: prefix gateway types to avoid type name clash
- makefile: strip unsupported OSes from generated Package.swift

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3430)
<!-- Reviewable:end -->
