### PR TITLE
feat(tauri): add quic and domain-fronting settings

### DIFF
--- a/nym-vpn-app/CHANGELOG.md
+++ b/nym-vpn-app/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Show the picked gateway name the tunnel is connected to, when
   connecting/connected and the selected node is a country
+- Add QUIC mode and Domain-fronting (aka stealth API) settings options
 
 ### Fixed
 

--- a/nym-vpn-app/src-tauri/src/db.rs
+++ b/nym-vpn-app/src-tauri/src/db.rs
@@ -24,7 +24,7 @@ pub type JsonValue = Value;
 #[derive(Deserialize, Serialize, AsRefStr, EnumIter, Debug, Clone, Copy, TS)]
 #[strum(serialize_all = "kebab-case")]
 #[serde(rename_all = "kebab-case")]
-#[ts(export)]
+#[ts(export, export_to = "DbKey.ts", rename = "DbKey")]
 pub enum Key {
     UiTheme,
     UiRootFontSize,
@@ -35,14 +35,16 @@ pub enum Key {
     WelcomeScreenSeen,
     DesktopNotifications,
     LastNetworkEnv,
+    DisableIpv6,
+    NetworkStatsEnabled,
+    QuicEnabled,
+    DomainFrontingEnabled,
     // some data cache (no semantic difference)
     CacheMxEntryGateways,
     CacheMxExitGateways,
     CacheWgGateways,
     CacheAccountId,
     CacheDeviceId,
-    DisableIpv6,
-    NetworkStatsEnabled,
 }
 
 impl Display for Key {

--- a/nym-vpn-app/src-tauri/src/grpc/feature_flags.rs
+++ b/nym-vpn-app/src-tauri/src/grpc/feature_flags.rs
@@ -39,13 +39,12 @@ impl From<&GetFeatureFlagsResponse> for FeatureFlags {
 
 fn get_bool_value(map: &HashMap<String, FeatureFlagGroup>, key: &str, subkey: &str) -> bool {
     map.get(key)
-        .map(|group| {
-            group.map.get(subkey).map(|v| match v.as_str() {
-                "true" | "TRUE" => true,
-                _ => false,
-            })
+        .and_then(|group| {
+            group
+                .map
+                .get(subkey)
+                .map(|v| matches!(v.to_lowercase().as_str(), "true"))
         })
-        .flatten()
         .unwrap_or(false)
 }
 

--- a/nym-vpn-app/src-tauri/src/grpc/feature_flags.rs
+++ b/nym-vpn-app/src-tauri/src/grpc/feature_flags.rs
@@ -1,34 +1,56 @@
+use nym_vpn_proto::proto::{FeatureFlagGroup, GetFeatureFlagsResponse};
 use serde::Serialize;
 use std::collections::HashMap;
 use ts_rs::TS;
 
+const KEY_VERSIONS: &str = "versions";
+const KEY_QUIC: &str = "quic";
+const KEY_DOMAIN_FRONTING: &str = "domain_fronting";
+const KEY_ZKNYMS: &str = "zkNyms";
+const KEY_GW_UPDATE: &str = "gatewayMetadataUpdate";
+
 #[derive(Clone, Serialize, TS)]
 #[ts(export)]
+#[serde(rename_all = "camelCase")]
 pub struct FeatureFlags {
+    pub quic: bool,
+    pub domain_fronting: bool,
+    pub zknym_credential: bool,
+    pub gateway_update_version: Option<String>,
     pub flags: HashMap<String, String>,
-    pub groups: HashMap<String, FeatureFlagGroup>,
 }
 
-#[derive(Clone, Serialize, TS)]
-#[ts(export)]
-pub struct FeatureFlagGroup(HashMap<String, String>);
-
-impl From<&nym_vpn_proto::proto::GetFeatureFlagsResponse> for FeatureFlags {
-    fn from(feature_flags: &nym_vpn_proto::proto::GetFeatureFlagsResponse) -> Self {
+impl From<&GetFeatureFlagsResponse> for FeatureFlags {
+    fn from(feature_flags: &GetFeatureFlagsResponse) -> Self {
         let mut flags = HashMap::new();
         for (key, value) in &feature_flags.flags {
             flags.insert(key.clone(), value.clone());
         }
 
-        let mut groups = HashMap::new();
-        for (group_key, group) in &feature_flags.groups {
-            let mut group_flags = HashMap::new();
-            for (key, value) in &group.map {
-                group_flags.insert(key.clone(), value.clone());
-            }
-            groups.insert(group_key.clone(), FeatureFlagGroup(group_flags));
+        FeatureFlags {
+            quic: get_bool_value(&feature_flags.groups, KEY_QUIC, "enabled"),
+            domain_fronting: get_bool_value(&feature_flags.groups, KEY_DOMAIN_FRONTING, "enabled"),
+            zknym_credential: get_bool_value(&feature_flags.groups, KEY_ZKNYMS, "credentialMode"),
+            gateway_update_version: get_version_value(&feature_flags.groups, KEY_GW_UPDATE),
+            flags,
         }
-
-        FeatureFlags { flags, groups }
     }
+}
+
+fn get_bool_value(map: &HashMap<String, FeatureFlagGroup>, key: &str, subkey: &str) -> bool {
+    map.get(key)
+        .map(|group| {
+            group.map.get(subkey).map(|v| match v.as_str() {
+                "true" | "TRUE" => true,
+                _ => false,
+            })
+        })
+        .flatten()
+        .unwrap_or(false)
+}
+
+fn get_version_value(map: &HashMap<String, FeatureFlagGroup>, key: &str) -> Option<String> {
+    map.get(KEY_VERSIONS)
+        .and_then(|group| group.map.get(key))
+        .cloned()
 }

--- a/nym-vpn-app/src-tauri/src/main.rs
+++ b/nym-vpn-app/src-tauri/src/main.rs
@@ -66,6 +66,8 @@ const ENV_APP_NOSPLASH: &str = "APP_NOSPLASH";
 const VPND_RETRY_INTERVAL: Duration = Duration::from_secs(2);
 const DEFAULT_SENTRY_ENABLED: bool = false;
 const DEFAULT_NETSTATS_ENABLED: bool = true;
+const DEFAULT_QUIC: bool = false;
+const DEFAULT_DOMAIN_FRONTING: bool = false;
 
 // build time pkg data
 build_info::build_info!(fn build_info);

--- a/nym-vpn-app/src-tauri/src/startup_error.rs
+++ b/nym-vpn-app/src-tauri/src/startup_error.rs
@@ -23,8 +23,9 @@ pub enum ErrorKey {
 }
 
 #[derive(Debug, Serialize, Deserialize, TS, Clone)]
-#[ts(export)]
+#[ts(export, export_to = "JsEnv.ts")]
 pub struct StartupError {
+    #[ts(inline)]
     pub key: ErrorKey,
     pub detail: Option<String>,
 }

--- a/nym-vpn-app/src-tauri/src/window.rs
+++ b/nym-vpn-app/src-tauri/src/window.rs
@@ -7,8 +7,8 @@ use crate::state::app::VpnMode;
 use crate::sys::DisplayServer;
 use crate::sys::OsInfo;
 use crate::{
-    APP_NAME, DEFAULT_NETSTATS_ENABLED, DEFAULT_SENTRY_ENABLED, ENV_APP_NOSPLASH,
-    MAIN_WINDOW_LABEL, env,
+    APP_NAME, DEFAULT_DOMAIN_FRONTING, DEFAULT_NETSTATS_ENABLED, DEFAULT_QUIC,
+    DEFAULT_SENTRY_ENABLED, ENV_APP_NOSPLASH, MAIN_WINDOW_LABEL, env,
 };
 use anyhow::{Result, anyhow};
 use serde::{Deserialize, Serialize};
@@ -49,14 +49,17 @@ enum UiMode {
 
 #[derive(Serialize, Deserialize, Debug, Default, TS)]
 #[serde(rename_all = "camelCase")]
-#[ts(export)]
+#[ts(export, export_to = "JsEnv.ts", rename = "JsEnv")]
 pub struct WindowInitEnv {
     pub dev_mode: bool,
     pub updater_enabled: bool,
     pub no_splash: bool,
+    #[ts(inline)]
     pub default_vpn_mode: VpnMode,
-    pub default_sentry_enabled: bool,
-    pub default_netstats_enabled: bool,
+    pub default_sentry: bool,
+    pub default_netstats: bool,
+    pub default_quic: bool,
+    pub default_domain_fronting: bool,
     pub startup_error: Option<StartupError>,
 }
 
@@ -333,8 +336,10 @@ impl WindowInitEnv {
             updater_enabled: *UPDATER_ENABLED,
             no_splash,
             default_vpn_mode: Default::default(),
-            default_sentry_enabled: DEFAULT_SENTRY_ENABLED,
-            default_netstats_enabled: DEFAULT_NETSTATS_ENABLED,
+            default_sentry: DEFAULT_SENTRY_ENABLED,
+            default_netstats: DEFAULT_NETSTATS_ENABLED,
+            default_quic: DEFAULT_QUIC,
+            default_domain_fronting: DEFAULT_DOMAIN_FRONTING,
             startup_error,
         }
     }

--- a/nym-vpn-app/src/@types/global.d.ts
+++ b/nym-vpn-app/src/@types/global.d.ts
@@ -8,10 +8,12 @@ type JsEnv = {
   devMode: boolean;
   updaterEnabled: boolean;
   noSplash: boolean;
-  defaultVpnMode: 'wg' | 'mixnet';
-  defaultSentryEnabled: boolean;
-  defaultNetstatsEnabled: boolean;
-  startupError?: StartupError | null;
+  defaultVpnMode: 'mixnet' | 'wg';
+  defaultSentry: boolean;
+  defaultNetstats: boolean;
+  defaultQuic: boolean;
+  defaultDomainFronting: boolean;
+  startupError: StartupError | null;
 };
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions

--- a/nym-vpn-app/src/constants.ts
+++ b/nym-vpn-app/src/constants.ts
@@ -39,3 +39,6 @@ export const GatewaysCacheDuration = 300; // 5min
 export const NymVpnPricingUrl = 'https://nym.com/pricing';
 export const SentryPrivacyPolicyUrl = 'https://sentry.io/privacy/';
 export const AnonNetworkStatsUrl = 'https://nym.com/anonymous-stats';
+// TODO
+export const QuicUrl = '';
+export const DomainFrontingUrl = '';

--- a/nym-vpn-app/src/contexts/main/reducer.ts
+++ b/nym-vpn-app/src/contexts/main/reducer.ts
@@ -70,7 +70,9 @@ export type StateAction =
   | { type: 'set-account-syncing'; syncing: boolean }
   | { type: 'set-welcome-checked'; checked: boolean }
   | { type: 'set-account-error'; error: AppError | null }
-  | { type: 'set-backend-flags'; flags: FeatureFlags | null };
+  | { type: 'set-backend-flags'; flags: FeatureFlags | null }
+  | { type: 'set-quic'; enabled: boolean }
+  | { type: 'set-domain-fronting'; enabled: boolean };
 
 export const initialState: AppState = {
   initialized: false,
@@ -100,6 +102,8 @@ export const initialState: AppState = {
   ipv6Support: true,
   networkStats: false,
   welcomeChecked: false,
+  quic: false,
+  domainFronting: false,
 };
 
 export function reducer(state: AppState, action: StateAction): AppState {
@@ -333,6 +337,16 @@ export function reducer(state: AppState, action: StateAction): AppState {
       return {
         ...state,
         backendFlags: action.flags,
+      };
+    case 'set-quic':
+      return {
+        ...state,
+        quic: action.enabled,
+      };
+    case 'set-domain-fronting':
+      return {
+        ...state,
+        domainFronting: action.enabled,
       };
 
     case 'reset':

--- a/nym-vpn-app/src/contexts/main/reducer.ts
+++ b/nym-vpn-app/src/contexts/main/reducer.ts
@@ -14,6 +14,7 @@ import {
   Country,
   DaemonInfo,
   DaemonStatus,
+  FeatureFlags,
   Gateway,
   NetworkCompat,
   NodeHop,
@@ -68,7 +69,8 @@ export type StateAction =
   | { type: 'set-account-state'; state: AccountState }
   | { type: 'set-account-syncing'; syncing: boolean }
   | { type: 'set-welcome-checked'; checked: boolean }
-  | { type: 'set-account-error'; error: AppError | null };
+  | { type: 'set-account-error'; error: AppError | null }
+  | { type: 'set-backend-flags'; flags: FeatureFlags | null };
 
 export const initialState: AppState = {
   initialized: false,
@@ -326,6 +328,11 @@ export function reducer(state: AppState, action: StateAction): AppState {
       return {
         ...state,
         welcomeChecked: action.checked,
+      };
+    case 'set-backend-flags':
+      return {
+        ...state,
+        backendFlags: action.flags,
       };
 
     case 'reset':

--- a/nym-vpn-app/src/dev.ts
+++ b/nym-vpn-app/src/dev.ts
@@ -1,11 +1,14 @@
 if (import.meta.env.MODE === 'dev-browser') {
   window._APP = {
-    defaultNetstatsEnabled: true,
-    defaultSentryEnabled: false,
     defaultVpnMode: 'wg',
     devMode: true,
+    defaultNetstats: true,
+    defaultSentry: false,
+    defaultDomainFronting: false,
+    defaultQuic: false,
     updaterEnabled: true,
     noSplash: true,
+    startupError: null,
   };
   // @ts-expect-error mocking os plugin
   window.__TAURI_OS_PLUGIN_INTERNALS__ = {

--- a/nym-vpn-app/src/i18n/en/settings.json
+++ b/nym-vpn-app/src/i18n/en/settings.json
@@ -35,6 +35,22 @@
     "app": "App logs",
     "daemon": "Daemon logs"
   },
+  "anti-censorship": {
+    "title": "Anti-censorship",
+    "intro": "Enable these features if you're experiencing connection issues or NymVPN blocking in your location.",
+    "quic": {
+      "label": "Enhanced connection (QUIC)",
+      "warning": "Changes will apply after reconnect",
+      "content": "Improves the Fast mode reliability in restrictive networks by wrapping WireGuard traffic in QUIC (HTTP/3) to appear as regular web browsing.\n\nNote: Limits entry server options to QUIC-compatible gateways only.",
+      "link": "How QUIC improves connections"
+    },
+    "stealth-api": {
+      "label": "Stealth API connect",
+      "warning": "Changes will apply after reconnect",
+      "content": "Disguises API requests behind popular, allowed domains to bypass VPN blocking.",
+      "link": "How the Stealth API connect mode works"
+    }
+  },
   "faq": "FAQ",
   "display-theme": "Display mode",
   "logout-confirmation": {

--- a/nym-vpn-app/src/i18n/en/settings.json
+++ b/nym-vpn-app/src/i18n/en/settings.json
@@ -85,8 +85,7 @@
     "network-stats": {
       "label": "Anonymous network stats",
       "sublabel": "Changes will apply after daemon restart.",
-      "desc1": "Help us build a faster network by sharing anonymous performance data from your region. We use this to optimize speeds, reduce disconnections, and steer server coverage where it's needed most.",
-      "desc2": "Only network performance data is shared - never your browsing activity or personal data.",
+      "desc": "Help us build a faster network by sharing anonymous performance data from your region. We use this to optimize speeds, reduce disconnections, and steer server coverage where it's needed most.\n\nOnly network performance data is shared - never your browsing activity or personal data.",
       "link": "Learn exactly what's shared"
     }
   },

--- a/nym-vpn-app/src/i18n/fr/settings.json
+++ b/nym-vpn-app/src/i18n/fr/settings.json
@@ -69,8 +69,7 @@
     "network-stats": {
       "label": "Statistiques réseau anonymes",
       "sublabel": "Les changements s'appliqueront au redémarrage du démon.",
-      "desc1": "Aidez-nous à construire un réseau plus rapide en partageant des données de performances anonymisées dans votre région. Nous les utilisons afin de réduire le taux de déconnexion et orienter nos déploiements de serveurs où cela se révèle nécessaire.",
-      "desc2": "Seules les données de performance du réseau sont partagées — jamais de données personnelles ou liées à vos activités en ligne.",
+      "desc": "Aidez-nous à construire un réseau plus rapide en partageant des données de performances anonymisées dans votre région. Nous les utilisons afin de réduire le taux de déconnexion et orienter nos déploiements de serveurs où cela se révèle nécessaire.\n\nSeules les données de performance du réseau sont partagées — jamais de données personnelles ou liées à vos activités en ligne.",
       "link": "Apprenez en détail ce qui est partagé"
     }
   },

--- a/nym-vpn-app/src/main.tsx
+++ b/nym-vpn-app/src/main.tsx
@@ -8,7 +8,7 @@ import duration from 'dayjs/plugin/duration';
 import App from './App';
 import { mockTauriIPC } from './dev/setup';
 import { kvGet } from './kvStore';
-import { VpnMode, VpndStatus } from './types';
+import { InitState, VpnMode, VpndStatus } from './types';
 import { StartupError } from './screens';
 import { init } from './log';
 import { getTheme } from './util';
@@ -77,7 +77,7 @@ dayjs.extend(duration);
   }
 
   // pre-get and prepare some early stage state
-  const initState = {
+  const initState: InitState = {
     vpnd: (await invoke<VpndStatus | undefined>('daemon_status')) || 'down',
     vpnMode: (await kvGet<VpnMode>('vpn-mode')) || defaultVpnMode,
     uiTheme: await getTheme(),

--- a/nym-vpn-app/src/router.tsx
+++ b/nym-vpn-app/src/router.tsx
@@ -2,6 +2,7 @@ import { lazy } from 'react';
 import { createBrowserRouter } from 'react-router';
 import {
   AccountRouteIndex,
+  AntiCensorship,
   Appearance,
   AppearanceRouteIndex,
   DataAndPrivacy,
@@ -37,6 +38,7 @@ export const routes = {
   display: '/settings/appearance/display',
   lang: '/settings/appearance/lang',
   logs: '/settings/logs',
+  antiCensorship: '/settings/anti-censorship',
   dataPrivacy: '/settings/data-privacy',
   support: '/settings/support',
   legal: '/settings/legal',
@@ -124,6 +126,11 @@ const router = createBrowserRouter([
           {
             path: routes.logs,
             element: <Logs />,
+            errorElement: <Error />,
+          },
+          {
+            path: routes.antiCensorship,
+            element: <AntiCensorship />,
             errorElement: <Error />,
           },
           {

--- a/nym-vpn-app/src/screens/Welcome.tsx
+++ b/nym-vpn-app/src/screens/Welcome.tsx
@@ -10,8 +10,8 @@ import { StateDispatch } from '../types';
 import { Button, Link, PageAnim, Switch } from '../ui';
 import SettingsGroup from './settings/SettingsGroup';
 
-const defaultSentry = window._APP.defaultSentryEnabled;
-const defaultNetstats = window._APP.defaultNetstatsEnabled;
+const defaultSentry = window._APP.defaultSentry;
+const defaultNetstats = window._APP.defaultNetstats;
 
 function Welcome() {
   const [monitoring, setMonitoring] = useState<boolean>(defaultSentry);

--- a/nym-vpn-app/src/screens/settings/Settings.tsx
+++ b/nym-vpn-app/src/screens/settings/Settings.tsx
@@ -99,6 +99,12 @@ function Settings() {
             ),
             disabled: true,
           },
+          {
+            title: t('anti-censorship.title', { ns: 'settings' }),
+            leadingIcon: 'dns',
+            onClick: () => navigate(routes.antiCensorship),
+            trailing: <MsIcon icon="arrow_right" className="dark:text-white" />,
+          },
         ]}
       />
       <SettingsGroup

--- a/nym-vpn-app/src/screens/settings/Settings.tsx
+++ b/nym-vpn-app/src/screens/settings/Settings.tsx
@@ -13,7 +13,7 @@ import SettingsGroup from './SettingsGroup';
 import Logout from './Logout';
 
 function Settings() {
-  const { desktopNotifications, ipv6Support } = useMainState();
+  const { desktopNotifications, ipv6Support, backendFlags } = useMainState();
 
   const navigate = useNavigate();
   const dispatch = useMainDispatch() as StateDispatch;
@@ -21,6 +21,7 @@ function Settings() {
   const { exit } = useExit();
   const { enabled: autostartEnabled, toggle: toggleAutostart } = useAutostart();
   const toggleDNotifications = useDesktopNotifications();
+  const showAntiCensorship = backendFlags?.quic || backendFlags?.domainFronting;
 
   const handleAutostartChanged = async () => {
     await toggleAutostart();
@@ -99,7 +100,7 @@ function Settings() {
             ),
             disabled: true,
           },
-          {
+          showAntiCensorship && {
             title: t('anti-censorship.title', { ns: 'settings' }),
             leadingIcon: 'dns',
             onClick: () => navigate(routes.antiCensorship),

--- a/nym-vpn-app/src/screens/settings/SettingsGroup.tsx
+++ b/nym-vpn-app/src/screens/settings/SettingsGroup.tsx
@@ -12,17 +12,26 @@ type Setting = {
   className?: string;
   'data-testid'?: string;
 };
+function isSettingItem(item: Setting | undefined | boolean): item is Setting {
+  return (
+    item !== undefined &&
+    item !== false &&
+    (item as Setting).title !== undefined
+  );
+}
 
 type Props = {
-  settings: Setting[];
+  settings: (Setting | undefined | boolean)[];
   className?: string;
   'data-testid'?: string;
 };
 
 function SettingsGroup({ settings, className, ...rest }: Props) {
+  const items = settings.filter((v) => isSettingItem(v));
+
   return (
     <RadioGroup className={clsx([className])} {...rest}>
-      {settings.map((setting, index) => {
+      {items.map((setting, index) => {
         const testId = setting['data-testid'];
 
         return (
@@ -36,13 +45,13 @@ function SettingsGroup({ settings, className, ...rest }: Props) {
               'hover:bg-white/60 dark:hover:bg-charcoal/85',
               'transition duration-75',
               index === 0 && 'rounded-t-lg',
-              index === settings.length - 1 &&
-                settings.length === 2 &&
+              index === items.length - 1 &&
+                items.length === 2 &&
                 'border-t border-faded-lavender dark:border-ash',
               index !== 0 &&
-                index !== settings.length - 1 &&
+                index !== items.length - 1 &&
                 'border-y border-faded-lavender dark:border-ash',
-              index === settings.length - 1 && 'rounded-b-lg',
+              index === items.length - 1 && 'rounded-b-lg',
               setting.desc ? 'py-2' : 'py-4',
               setting.disabled &&
                 'opacity-50 pointer-events-none cursor-default!',

--- a/nym-vpn-app/src/screens/settings/anti-censorship/AntiCensorship.tsx
+++ b/nym-vpn-app/src/screens/settings/anti-censorship/AntiCensorship.tsx
@@ -88,7 +88,6 @@ function AntiCensorship() {
             <Link
               className="w-fit text-sm"
               text={t('anti-censorship.stealth-api.link')}
-              // TODO add url
               url={DomainFrontingUrl}
               color="primary"
               icon

--- a/nym-vpn-app/src/screens/settings/anti-censorship/AntiCensorship.tsx
+++ b/nym-vpn-app/src/screens/settings/anti-censorship/AntiCensorship.tsx
@@ -3,9 +3,10 @@ import { CardSwitch, Link, PageAnim, SettingsMenuCardBig } from '../../../ui';
 import { useMainDispatch, useMainState } from '../../../contexts';
 import { StateDispatch } from '../../../types';
 import { kvSet } from '../../../kvStore';
+import { DomainFrontingUrl, QuicUrl } from '../../../constants';
 
 function AntiCensorship() {
-  const { quic, domainFronting } = useMainState();
+  const { quic, domainFronting, backendFlags } = useMainState();
 
   const dispatch = useMainDispatch() as StateDispatch;
 
@@ -29,61 +30,72 @@ function AntiCensorship() {
     } catch {}
   };
 
+  if (!backendFlags?.quic && !backendFlags?.domainFronting) {
+    return (
+      <PageAnim className="xs:max-w-lg h-full flex flex-col mt-2 gap-6 select-none">
+        This feature is not available
+      </PageAnim>
+    );
+  }
+
   return (
     <PageAnim className="xs:max-w-lg h-full flex flex-col mt-2 gap-6 select-none">
       <div className="text-iron dark:text-bombay">
         {t('anti-censorship.intro')}
       </div>
-      <SettingsMenuCardBig
-        header={
-          <CardSwitch
-            header={t('anti-censorship.quic.label')}
-            subheader={t('anti-censorship.quic.warning')}
-            subheaderColor="king-nacho"
-            checked={quic}
-            onClick={onQuicChange}
-          />
-        }
-      >
-        <div className="flex flex-col gap-2">
-          <p className="text-sm text-iron dark:text-bombay">
-            {t('anti-censorship.quic.content')}
-          </p>
-          <Link
-            className="w-fit text-sm text-iron dark:text-bombay"
-            text={t('anti-censorship.quic.link')}
-            // TODO add url
-            url=""
-            color="primary"
-            icon
-          />
-        </div>
-      </SettingsMenuCardBig>
-      <SettingsMenuCardBig
-        header={
-          <CardSwitch
-            header={t('anti-censorship.stealth-api.label')}
-            subheader={t('anti-censorship.stealth-api.warning')}
-            subheaderColor="king-nacho"
-            checked={domainFronting}
-            onClick={onDomainFrontingChange}
-          />
-        }
-      >
-        <div className="flex flex-col gap-2">
-          <p className="text-sm text-iron dark:text-bombay">
-            {t('anti-censorship.stealth-api.content')}
-          </p>
-          <Link
-            className="w-fit text-sm text-iron dark:text-bombay"
-            text={t('anti-censorship.stealth-api.link')}
-            // TODO add url
-            url=""
-            color="primary"
-            icon
-          />
-        </div>
-      </SettingsMenuCardBig>
+      {backendFlags?.quic && (
+        <SettingsMenuCardBig
+          header={
+            <CardSwitch
+              header={t('anti-censorship.quic.label')}
+              subheader={t('anti-censorship.quic.warning')}
+              subheaderColor="king-nacho"
+              checked={quic}
+              onClick={onQuicChange}
+            />
+          }
+        >
+          <div className="flex flex-col gap-2">
+            <p className="text-sm text-iron dark:text-bombay whitespace-pre-line">
+              {t('anti-censorship.quic.content')}
+            </p>
+            <Link
+              className="w-fit text-sm"
+              text={t('anti-censorship.quic.link')}
+              url={QuicUrl}
+              color="primary"
+              icon
+            />
+          </div>
+        </SettingsMenuCardBig>
+      )}
+      {backendFlags?.domainFronting && (
+        <SettingsMenuCardBig
+          header={
+            <CardSwitch
+              header={t('anti-censorship.stealth-api.label')}
+              subheader={t('anti-censorship.stealth-api.warning')}
+              subheaderColor="king-nacho"
+              checked={domainFronting}
+              onClick={onDomainFrontingChange}
+            />
+          }
+        >
+          <div className="flex flex-col gap-2">
+            <p className="text-sm text-iron dark:text-bombay whitespace-pre-line">
+              {t('anti-censorship.stealth-api.content')}
+            </p>
+            <Link
+              className="w-fit text-sm"
+              text={t('anti-censorship.stealth-api.link')}
+              // TODO add url
+              url={DomainFrontingUrl}
+              color="primary"
+              icon
+            />
+          </div>
+        </SettingsMenuCardBig>
+      )}
     </PageAnim>
   );
 }

--- a/nym-vpn-app/src/screens/settings/anti-censorship/AntiCensorship.tsx
+++ b/nym-vpn-app/src/screens/settings/anti-censorship/AntiCensorship.tsx
@@ -1,0 +1,91 @@
+import { useTranslation } from 'react-i18next';
+import { CardSwitch, Link, PageAnim, SettingsMenuCardBig } from '../../../ui';
+import { useMainDispatch, useMainState } from '../../../contexts';
+import { StateDispatch } from '../../../types';
+import { kvSet } from '../../../kvStore';
+
+function AntiCensorship() {
+  const { quic, domainFronting } = useMainState();
+
+  const dispatch = useMainDispatch() as StateDispatch;
+
+  const { t } = useTranslation('settings');
+
+  const onQuicChange = async () => {
+    const isChecked = !quic;
+    await kvSet('quic-enabled', isChecked);
+    dispatch({ type: 'set-quic', enabled: isChecked });
+    try {
+      // TODO invoke command
+    } catch {}
+  };
+
+  const onDomainFrontingChange = async () => {
+    const isChecked = !domainFronting;
+    await kvSet('domain-fronting-enabled', isChecked);
+    dispatch({ type: 'set-domain-fronting', enabled: isChecked });
+    try {
+      // TODO invoke command
+    } catch {}
+  };
+
+  return (
+    <PageAnim className="xs:max-w-lg h-full flex flex-col mt-2 gap-6 select-none">
+      <div className="text-iron dark:text-bombay">
+        {t('anti-censorship.intro')}
+      </div>
+      <SettingsMenuCardBig
+        header={
+          <CardSwitch
+            header={t('anti-censorship.quic.label')}
+            subheader={t('anti-censorship.quic.warning')}
+            subheaderColor="king-nacho"
+            checked={quic}
+            onClick={onQuicChange}
+          />
+        }
+      >
+        <div className="flex flex-col gap-2">
+          <p className="text-sm text-iron dark:text-bombay">
+            {t('anti-censorship.quic.content')}
+          </p>
+          <Link
+            className="w-fit text-sm text-iron dark:text-bombay"
+            text={t('anti-censorship.quic.link')}
+            // TODO add url
+            url=""
+            color="primary"
+            icon
+          />
+        </div>
+      </SettingsMenuCardBig>
+      <SettingsMenuCardBig
+        header={
+          <CardSwitch
+            header={t('anti-censorship.stealth-api.label')}
+            subheader={t('anti-censorship.stealth-api.warning')}
+            subheaderColor="king-nacho"
+            checked={domainFronting}
+            onClick={onDomainFrontingChange}
+          />
+        }
+      >
+        <div className="flex flex-col gap-2">
+          <p className="text-sm text-iron dark:text-bombay">
+            {t('anti-censorship.stealth-api.content')}
+          </p>
+          <Link
+            className="w-fit text-sm text-iron dark:text-bombay"
+            text={t('anti-censorship.stealth-api.link')}
+            // TODO add url
+            url=""
+            color="primary"
+            icon
+          />
+        </div>
+      </SettingsMenuCardBig>
+    </PageAnim>
+  );
+}
+
+export default AntiCensorship;

--- a/nym-vpn-app/src/screens/settings/anti-censorship/index.ts
+++ b/nym-vpn-app/src/screens/settings/anti-censorship/index.ts
@@ -1,0 +1,1 @@
+export { default as AntiCensorship } from './AntiCensorship';

--- a/nym-vpn-app/src/screens/settings/data-privacy/DataAndPrivacy.tsx
+++ b/nym-vpn-app/src/screens/settings/data-privacy/DataAndPrivacy.tsx
@@ -53,17 +53,15 @@ function DataAndPrivacy() {
         }
       >
         <div className="flex flex-col gap-2">
-          <p className="text-sm text-iron dark:text-bombay">
-            {t('privacy.network-stats.desc1')}
-          </p>
-          <p className="text-sm text-iron dark:text-bombay">
-            {t('privacy.network-stats.desc2')}
+          <p className="text-sm text-iron dark:text-bombay whitespace-pre-line">
+            {t('privacy.network-stats.desc')}
           </p>
           <Link
-            className="w-fit text-sm text-iron dark:text-bombay"
+            className="w-fit text-sm"
             text={t('privacy.network-stats.link')}
             url={AnonNetworkStatsUrl}
-            color="iron"
+            color="primary"
+            icon
           />
         </div>
       </SettingsMenuCardBig>
@@ -79,14 +77,15 @@ function DataAndPrivacy() {
         }
       >
         <div className="flex flex-col gap-2">
-          <p className="text-sm text-iron dark:text-bombay">
+          <p className="text-sm text-iron dark:text-bombay whitespace-pre-line">
             {t('privacy.error-monitoring.desc')}
           </p>
           <Link
-            className="w-fit text-sm text-iron dark:text-bombay"
+            className="w-fit text-sm"
             text={t('privacy.error-monitoring.link')}
             url={SentryPrivacyPolicyUrl}
-            color="iron"
+            color="primary"
+            icon
           />
         </div>
       </SettingsMenuCardBig>

--- a/nym-vpn-app/src/screens/settings/index.ts
+++ b/nym-vpn-app/src/screens/settings/index.ts
@@ -6,3 +6,4 @@ export * from './legal';
 export * from './support';
 export * from './dev';
 export * from './data-privacy';
+export * from './anti-censorship';

--- a/nym-vpn-app/src/state/init.ts
+++ b/nym-vpn-app/src/state/init.ts
@@ -14,6 +14,7 @@ import {
   AccountLinks,
   CodeDependency,
   Country,
+  FeatureFlags,
   Gateway,
   InitState,
   NetworkCompat,
@@ -113,6 +114,19 @@ export async function initFirstBatch(
         type: 'set-account',
         stored: stored || false,
       });
+    },
+  };
+
+  const getFeatureFlagsRq: TauriReq<() => Promise<FeatureFlags | undefined>> = {
+    name: 'getFeatureFlagsRq',
+    request: () => invoke<FeatureFlags>('feature_flags'),
+    onFulfilled: (flags) => {
+      if (flags) {
+        dispatch({
+          type: 'set-backend-flags',
+          flags,
+        });
+      }
     },
   };
 
@@ -237,6 +251,7 @@ export async function initFirstBatch(
       initStateRq,
       getStoredAccountRq,
       getAccountStateRq,
+      getFeatureFlagsRq,
       ...requests,
     ];
   }

--- a/nym-vpn-app/src/state/init.ts
+++ b/nym-vpn-app/src/state/init.ts
@@ -27,6 +27,9 @@ import {
 import { updateAccountState, updateTunnel } from './update';
 import { TauriReq, fireRequests } from './helper';
 
+const defaultQuic = window._APP.defaultQuic;
+const defaultDomFront = window._APP.defaultDomainFronting;
+
 // initialize connection state
 const getInitialTunnelState = async () => {
   return await invoke<TunnelStateIpc>('get_tunnel_state');
@@ -222,6 +225,25 @@ export async function initFirstBatch(
     },
   };
 
+  const getQuicRq: TauriReq<() => Promise<boolean | undefined>> = {
+    name: 'getQuicRq',
+    request: () => kvGet<boolean>('quic-enabled'),
+    onFulfilled: (enabled) => {
+      dispatch({ type: 'set-quic', enabled: enabled || defaultQuic });
+    },
+  };
+
+  const getDomainFrontingRq: TauriReq<() => Promise<boolean | undefined>> = {
+    name: 'getDomainFrontingRq',
+    request: () => kvGet<boolean>('domain-fronting-enabled'),
+    onFulfilled: (enabled) => {
+      dispatch({
+        type: 'set-domain-fronting',
+        enabled: enabled || defaultDomFront,
+      });
+    },
+  };
+
   const getNetworkStatsRq: TauriReq<() => Promise<boolean | undefined>> = {
     name: 'getNetworkStats',
     request: () => kvGet<boolean>('network-stats-enabled'),
@@ -244,6 +266,8 @@ export async function initFirstBatch(
     getDesktopNotificationsRq,
     getIpv6SupportRq,
     getNetworkStatsRq,
+    getQuicRq,
+    getDomainFrontingRq,
   ];
 
   if (initState.vpnd !== 'down') {

--- a/nym-vpn-app/src/state/useTauriEvents.ts
+++ b/nym-vpn-app/src/state/useTauriEvents.ts
@@ -5,6 +5,7 @@ import i18n from 'i18next';
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow';
 import {
   AccountLinks,
+  FeatureFlags,
   MixnetEventPayload,
   StateDispatch,
   TAccountState,
@@ -46,7 +47,7 @@ export function useTauriEvents(
           await CCache.del('cache-device-id');
         }
 
-        // refresh account status
+        // when (re)connected to daemon, refresh some state
         if (isVpndOk(status) || isVpndNonCompat(status)) {
           try {
             const stored = await invoke<boolean | undefined>(
@@ -59,6 +60,13 @@ export function useTauriEvents(
               locale: i18n.language,
             });
             dispatch({ type: 'set-account-links', links });
+          } catch {}
+          try {
+            const flags = await invoke<FeatureFlags>('feature_flags');
+            dispatch({
+              type: 'set-backend-flags',
+              flags,
+            });
           } catch {}
         }
       },

--- a/nym-vpn-app/src/types/app-state.ts
+++ b/nym-vpn-app/src/types/app-state.ts
@@ -90,6 +90,8 @@ export type AppState = {
   networkStats: boolean;
   // whether the user has completed once the welcome screen
   welcomeChecked: boolean;
+  quic: boolean;
+  domainFronting: boolean;
 };
 
 export type ProgressMsg = 'canceling';

--- a/nym-vpn-app/src/types/app-state.ts
+++ b/nym-vpn-app/src/types/app-state.ts
@@ -6,6 +6,7 @@ import {
   AccountLinks,
   AccountState,
   ErrorKey,
+  FeatureFlags,
   Gateway,
   NetworkCompat,
   NetworkEnv,
@@ -57,6 +58,8 @@ export type AppState = {
   accountSyncing: boolean;
   daemonStatus: DaemonStatus;
   daemonVersion?: string;
+  // feature flags from backend and APIs (via daemon)
+  backendFlags?: FeatureFlags | null;
   networkEnv: NetworkEnv;
   version: string | null;
   error?: AppError | null;

--- a/nym-vpn-app/src/types/tauri.ts
+++ b/nym-vpn-app/src/types/tauri.ts
@@ -22,13 +22,15 @@ export type DbKey =
   | 'welcome-screen-seen'
   | 'desktop-notifications'
   | 'last-network-env'
+  | 'disable-ipv6'
+  | 'network-stats-enabled'
+  | 'quic-enabled'
+  | 'domain-fronting-enabled'
   | 'cache-mx-entry-gateways'
   | 'cache-mx-exit-gateways'
   | 'cache-wg-gateways'
   | 'cache-account-id'
-  | 'cache-device-id'
-  | 'disable-ipv6'
-  | 'network-stats-enabled';
+  | 'cache-device-id';
 
 /*
  * Enum of the possible specialized errors emitted by the daemon or from the

--- a/nym-vpn-app/src/types/tauri.ts
+++ b/nym-vpn-app/src/types/tauri.ts
@@ -161,3 +161,11 @@ export function isAccountError(
 ): state is AccountStateError {
   return (state as AccountStateError).error !== undefined;
 }
+
+export type FeatureFlags = {
+  quic: boolean;
+  domainFronting: boolean;
+  zknymCredential: boolean;
+  gatewayUpdateVersion: string | null;
+  flags: Record<string, string>;
+};

--- a/nym-vpn-app/src/ui/Link.tsx
+++ b/nym-vpn-app/src/ui/Link.tsx
@@ -7,7 +7,7 @@ type LinkProps = {
   text: string;
   url: string;
   icon?: boolean | string;
-  color?: 'malachite' | 'iron';
+  color?: 'primary' | 'malachite' | 'iron';
   className?: string;
   textClassName?: string;
   'data-testid'?: string;
@@ -33,6 +33,7 @@ function Link({
         'inline-flex flex-row items-center gap-1',
         color === 'malachite' && 'text-malachite-moss dark:text-malachite',
         color === 'iron' && 'text-iron dark:text-bombay',
+        color === 'primary' && 'text-baltic-sea dark:text-white',
         className && className,
       ])}
       onClick={() => openUrl(url)}

--- a/nym-vpn-app/src/ui/TopBar.tsx
+++ b/nym-vpn-app/src/ui/TopBar.tsx
@@ -121,6 +121,13 @@ export default function TopBar() {
           navigate(-1);
         },
       },
+      '/settings/anti-censorship': {
+        title: t('anti-censorship.title', { ns: 'settings' }),
+        leftIcon: 'arrow_back',
+        handleLeftNav: () => {
+          navigate(-1);
+        },
+      },
       '/settings/feedback': {
         title: t('feedback'),
         leftIcon: 'arrow_back',


### PR DESCRIPTION
- add new settings option, feature-flags guarded, to enable/disable QUIC and domain-fronting
- get the feature-flags from grpc

NOTE: not yet fully integrated, since vpnd currently does not support nor exposes the required API

JIRA-VPN-3402 
JIRA-VPN-3930

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3442)
<!-- Reviewable:end -->
