### PR TITLE
cli: clean up set-entry and set-exit

### DIFF
--- a/nym-vpn-core/crates/nym-vpnc/src/cli.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/cli.rs
@@ -31,24 +31,24 @@ pub enum Command {
     /// Connect to the Nym network (deprecated)
     Connect(Box<ConnectArgs>),
 
-    /// Connect the tunnel if it had been disconnected.
+    /// Connect the tunnel if it had been disconnected
     ConnectV2 {
         /// Blocks until the connection is established or failed
         #[arg(short, long)]
         wait: bool,
     },
 
-    /// Reconnect the tunnel if it had been connected.
+    /// Reconnect the tunnel if it had been connected
     Reconnect,
 
-    /// Disconnect from the Nym network.
+    /// Disconnect the tunnel
     Disconnect {
         /// Blocks until disconnected.
         #[arg(short, long, default_value = "false", action = ArgAction::SetTrue)]
         wait: bool,
     },
 
-    /// Get the current status of the connection.
+    /// Get the current connection status
     Status {
         /// Monitor tunnel state continuously until ctrl+c.
         #[arg(long, default_value = "false", action = ArgAction::SetTrue)]
@@ -73,21 +73,21 @@ pub enum Command {
         exit: CliExit,
     },
 
-    /// Set IPv6 support state
+    /// Enable or disable IPv6 in the tunnel
     SetIpv6 {
         /// Set IPv6 support state (on|off)
         #[arg(value_parser = BooleanOption::value_parser(), value_name = "on|off")]
         enabled: BooleanOption,
     },
 
-    /// Set two-hop mode
+    /// Enable or disable two-hop mode
     SetTwoHop {
         /// Set two-hop mode (on|off)
         #[arg(value_parser = BooleanOption::value_parser(), value_name = "on|off")]
         enabled: BooleanOption,
     },
 
-    /// Set netstack based implementation for two-hop wireguard.
+    /// Enable or disable netstack based implementation for WireGuard
     SetNetstack {
         /// Set netstack implementation (on|off)
         #[arg(value_parser = BooleanOption::value_parser(), value_name = "on|off")]

--- a/nym-vpn-core/crates/nym-vpnc/src/cli.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/cli.rs
@@ -12,8 +12,7 @@ use nym_gateway_directory::{EntryPoint, ExitPoint, NodeIdentity, Recipient};
 use nym_http_api_client::UserAgent;
 
 #[derive(Parser)]
-#[clap(author = "Nymtech", version, about)]
-pub struct CliArgs {
+#[clap(version, about)]
 pub struct LegacyCliArgs {
     /// Override the default user agent string.
     #[arg(long, value_parser = parse_user_agent)]

--- a/nym-vpn-core/crates/nym-vpnc/src/cli.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/cli.rs
@@ -14,6 +14,7 @@ use nym_http_api_client::UserAgent;
 #[derive(Parser)]
 #[clap(author = "Nymtech", version, about)]
 pub struct CliArgs {
+pub struct LegacyCliArgs {
     /// Override the default user agent string.
     #[arg(long, value_parser = parse_user_agent)]
     pub user_agent: Option<UserAgent>,

--- a/nym-vpn-core/crates/nym-vpnc/src/cli.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/cli.rs
@@ -177,10 +177,10 @@ pub enum Internal {
 #[derive(Args)]
 pub struct ConnectArgs {
     #[command(flatten)]
-    pub entry: CliEntry,
+    pub entry: LegacyCliEntry,
 
     #[command(flatten)]
-    pub exit: CliExit,
+    pub exit: LegacyCliExit,
 
     /// Set the IP address of the DNS server to use.
     #[arg(long)]
@@ -227,8 +227,118 @@ impl ConnectArgs {
 }
 
 #[derive(Args)]
-#[group(multiple = false)]
+#[group(multiple = false, required = true)]
 pub struct CliEntry {
+    /// Mixnet public ID of the entry gateway.
+    #[arg(long)]
+    pub id: Option<String>,
+
+    /// Auto-select entry gateway by country ISO.
+    #[arg(long)]
+    pub country: Option<celes::Country>,
+
+    /// Auto-select entry gateway randomly.
+    #[arg(long)]
+    pub random: bool,
+}
+
+impl CliEntry {
+    pub fn entry_point(&self) -> Result<EntryPoint> {
+        if let Some(ref entry_gateway_id) = self.id {
+            Ok(EntryPoint::Gateway {
+                identity: NodeIdentity::from_base58_string(entry_gateway_id)
+                    .map_err(|_| anyhow!("Failed to parse gateway id"))?,
+            })
+        } else if let Some(ref entry_gateway_country) = self.country {
+            Ok(EntryPoint::Location {
+                location: entry_gateway_country.alpha2.to_string(),
+            })
+        } else if self.random {
+            Ok(EntryPoint::Random)
+        } else {
+            unreachable!()
+        }
+    }
+}
+
+#[derive(Args)]
+#[group(multiple = false, required = true)]
+pub struct CliExit {
+    /// Mixnet recipient address of the IPR connecting to, if specified directly. This is only
+    /// useful when connecting to standalone IPRs.
+    #[clap(long, hide = true)]
+    pub ipr_address: Option<String>,
+
+    /// Mixnet public ID of the exit gateway.
+    #[clap(long)]
+    pub id: Option<String>,
+
+    /// Auto-select exit gateway by country ISO.
+    #[clap(long)]
+    pub country: Option<celes::Country>,
+
+    /// Auto-select exit gateway randomly.
+    #[clap(long)]
+    pub random: bool,
+}
+
+impl CliExit {
+    pub fn exit_point(&self) -> Result<ExitPoint> {
+        if let Some(ref exit_router_address) = self.ipr_address {
+            Ok(ExitPoint::Address {
+                address: Box::new(
+                    Recipient::try_from_base58_string(exit_router_address)
+                        .map_err(|_| anyhow!("Failed to parse exit node address"))?,
+                ),
+            })
+        } else if let Some(ref exit_router_id) = self.id {
+            Ok(ExitPoint::Gateway {
+                identity: NodeIdentity::from_base58_string(exit_router_id.clone())
+                    .map_err(|_| anyhow!("Failed to parse gateway id"))?,
+            })
+        } else if let Some(ref exit_gateway_country) = self.country {
+            Ok(ExitPoint::Location {
+                location: exit_gateway_country.alpha2.to_string(),
+            })
+        } else if self.random {
+            Ok(ExitPoint::Random)
+        } else {
+            unreachable!()
+        }
+    }
+}
+
+impl TryFrom<CliExit> for ExitPoint {
+    type Error = anyhow::Error;
+
+    fn try_from(value: CliExit) -> std::result::Result<Self, Self::Error> {
+        if let Some(ref exit_router_address) = value.ipr_address {
+            Ok(ExitPoint::Address {
+                address: Box::new(
+                    Recipient::try_from_base58_string(exit_router_address)
+                        .map_err(|_| anyhow!("Failed to parse exit node address"))?,
+                ),
+            })
+        } else if let Some(ref exit_router_id) = value.id {
+            Ok(ExitPoint::Gateway {
+                identity: NodeIdentity::from_base58_string(exit_router_id.clone())
+                    .map_err(|_| anyhow!("Failed to parse gateway id"))?,
+            })
+        } else if let Some(ref exit_gateway_country) = value.country {
+            Ok(ExitPoint::Location {
+                location: exit_gateway_country.alpha2.to_string(),
+            })
+        } else if value.random {
+            Ok(ExitPoint::Random)
+        } else {
+            Err(anyhow!("Invalid Exit Point value"))
+        }
+    }
+}
+
+#[derive(Args)]
+#[group(multiple = false)]
+pub struct LegacyCliEntry {
     /// Mixnet public ID of the entry gateway.
     #[arg(long, alias = "entry-gateway-id")]
     pub entry_id: Option<String>,
@@ -242,7 +352,7 @@ pub struct CliEntry {
     pub entry_random: bool,
 }
 
-impl CliEntry {
+impl LegacyCliEntry {
     pub fn entry_point(&self) -> Result<Option<EntryPoint>> {
         if let Some(ref entry_gateway_id) = self.entry_id {
             Ok(Some(EntryPoint::Gateway {
@@ -263,7 +373,7 @@ impl CliEntry {
 
 #[derive(Args)]
 #[group(multiple = false)]
-pub struct CliExit {
+pub struct LegacyCliExit {
     /// Mixnet recipient address of the IPR connecting to, if specified directly. This is only
     /// useful when connecting to standalone IPRs.
     #[clap(long, hide = true, alias = "exit-router-address")]
@@ -282,7 +392,7 @@ pub struct CliExit {
     pub exit_random: bool,
 }
 
-impl CliExit {
+impl LegacyCliExit {
     pub fn exit_point(&self) -> Result<Option<ExitPoint>> {
         if let Some(ref exit_router_address) = self.exit_ipr_address {
             Ok(Some(ExitPoint::Address {
@@ -308,10 +418,10 @@ impl CliExit {
     }
 }
 
-impl TryFrom<CliExit> for ExitPoint {
+impl TryFrom<LegacyCliExit> for ExitPoint {
     type Error = anyhow::Error;
 
-    fn try_from(value: CliExit) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: LegacyCliExit) -> std::result::Result<Self, Self::Error> {
         if let Some(ref exit_router_address) = value.exit_ipr_address {
             Ok(ExitPoint::Address {
                 address: Box::new(

--- a/nym-vpn-core/crates/nym-vpnc/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/main.rs
@@ -108,6 +108,10 @@ async fn connect(
     connect_args: cli::ConnectArgs,
     user_agent: UserAgent,
 ) -> Result<()> {
+    println!(
+        "This call is deprecated and going to be removed soon. Please switch to using connect_v2"
+    );
+
     let options = ConnectArgs {
         entry: connect_args.entry_point()?,
         exit: connect_args.exit_point()?,

--- a/nym-vpn-core/crates/nym-vpnc/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/main.rs
@@ -21,7 +21,7 @@ use crate::cli::{CliEntry, CliExit, Command};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let args = cli::CliArgs::parse();
+    let args = cli::LegacyCliArgs::parse();
     let mut rpc_client = RpcClient::new()
         .await
         .context("Failed to create RPC client")?;

--- a/nym-vpn-core/crates/nym-vpnc/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/main.rs
@@ -3,7 +3,7 @@
 
 mod cli;
 
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{Context, Result, bail};
 use clap::Parser;
 use cli::Internal;
 use nym_gateway_directory::GatewayType;
@@ -242,25 +242,13 @@ async fn get_config(mut rpc_client: RpcClient) -> Result<()> {
 }
 
 async fn set_entry_point(mut rpc_client: RpcClient, entry: CliEntry) -> Result<()> {
-    if let Some(entry_point) = entry.entry_point()? {
-        rpc_client.set_entry_point(entry_point).await?;
-        Ok(())
-    } else {
-        Err(anyhow!(
-            "You must specify at least one of --entry-id, --entry-country, or --entry-random"
-        ))
-    }
+    rpc_client.set_entry_point(entry.entry_point()?).await?;
+    Ok(())
 }
 
 async fn set_exit_point(mut rpc_client: RpcClient, exit: CliExit) -> Result<()> {
-    if let Some(exit_point) = exit.exit_point()? {
-        rpc_client.set_exit_point(exit_point).await?;
-        Ok(())
-    } else {
-        Err(anyhow!(
-            "You must specify at least one of --exit-id, --exit-country, --exit-ipr-address, or --exit-random"
-        ))
-    }
+    rpc_client.set_exit_point(exit.exit_point()?).await?;
+    Ok(())
 }
 
 async fn set_disable_ipv6(mut rpc_client: RpcClient, disable_ipv6: bool) -> Result<()> {


### PR DESCRIPTION


## Description

- Prefix old `CliEntry` and `CliExit`  with `Legacy` to keep it working the same way it used for legacy `ConnectArgs`
- Update new `CliEntry` and `CliExit` with `required = true` to enable automatic validation by clap. I.e running `nym-vpnc set-entry` or `nym-vpnc set-exit` without parameters should automatically output help.
- Rename `CliArgs` to `LegacyCliArgs`
- Remove `clap(author)` since clap does not output author by default anymore

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3461)
<!-- Reviewable:end -->
