### PR TITLE
VPN-4030: Switch more functions to `async`.

### DIFF
--- a/nym-vpn-core/crates/nym-vpnd/src/config.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/config.rs
@@ -220,28 +220,29 @@ fn default_true() -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{fs, path::PathBuf};
+    use std::path::PathBuf;
     use tempfile::tempdir;
+    use tokio::fs;
 
     // Config directory will be deleted on drop
-    fn setup() -> (tempfile::TempDir, PathBuf, PathBuf) {
+    async fn setup() -> (tempfile::TempDir, PathBuf, PathBuf) {
         let temp_dir = tempdir().unwrap();
         let config_path = temp_dir.path();
 
         println!("Using config dir: {config_path:?}");
 
         let toml_path = config_path.join(crate::service::DEFAULT_GLOBAL_CONFIG_FILE_TOML);
-        let _ = fs::remove_file(&toml_path);
+        let _ = fs::remove_file(&toml_path).await;
 
         let json_path = config_path.join(crate::service::DEFAULT_GLOBAL_CONFIG_FILE_JSON);
-        let _ = fs::remove_file(&json_path);
+        let _ = fs::remove_file(&json_path).await;
 
         (temp_dir, toml_path, json_path)
     }
 
     #[tokio::test]
     async fn test_global_config_migrate() {
-        let (temp_dir, toml_path, json_path) = setup();
+        let (temp_dir, toml_path, json_path) = setup().await;
 
         let toml_content = r#"
 network_name = "tulips"
@@ -257,7 +258,7 @@ collect_network_statistics = true
 }"#;
 
         // Write the TOML config file
-        fs::write(&toml_path, toml_content).unwrap();
+        fs::write(&toml_path, toml_content).await.unwrap();
 
         // Read the TOML config and migrate it to JSON
         let config = GlobalConfig::read_from_config_dir(temp_dir.path())
@@ -280,7 +281,7 @@ collect_network_statistics = true
         assert!(config.collect_network_statistics);
 
         // Check the JSON is the right version and all snake-case
-        let read_json_content = fs::read_to_string(&json_path).unwrap();
+        let read_json_content = fs::read_to_string(&json_path).await.unwrap();
         assert_eq!(json_content, read_json_content);
     }
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/config.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/config.rs
@@ -24,12 +24,12 @@ impl Default for GlobalConfig {
 }
 
 impl GlobalConfig {
-    pub fn read_from_default_config_dir() -> anyhow::Result<Self> {
+    pub async fn read_from_default_config_dir() -> anyhow::Result<Self> {
         let config_dir = crate::service::config_dir();
-        Self::read_from_config_dir(&config_dir)
+        Self::read_from_config_dir(&config_dir).await
     }
 
-    pub fn read_from_config_dir(config_dir: &Path) -> anyhow::Result<Self> {
+    pub async fn read_from_config_dir(config_dir: &Path) -> anyhow::Result<Self> {
         let json_config_path = config_dir.join(crate::service::DEFAULT_GLOBAL_CONFIG_FILE_JSON);
         let json_config_exists = json_config_path.exists();
         let toml_config_path = config_dir.join(crate::service::DEFAULT_GLOBAL_CONFIG_FILE_TOML);
@@ -38,6 +38,7 @@ impl GlobalConfig {
         let config = if json_config_exists {
             let ext_config =
                 crate::service::read_json_config_file::<GlobalConfigExt>(&json_config_path)
+                    .await
                     .context(anyhow!(
                         "Failed to read global config file {}",
                         json_config_path.display()
@@ -49,6 +50,7 @@ impl GlobalConfig {
         } else if toml_config_exists {
             let legacy_config =
                 crate::service::read_toml_config_file::<LegacyGlobalConfig>(&toml_config_path)
+                    .await
                     .context(anyhow!(
                         "Failed to read global config file {}",
                         toml_config_path.display()
@@ -71,32 +73,36 @@ impl GlobalConfig {
 
         // Always write back config file back using the latest JSON version
         // TODO: Avoid doing this as it's double-writing the config file.
-        config.write_to_config_dir(config_dir)?;
+        config.write_to_config_dir(config_dir).await?;
 
         Ok(config)
     }
 
-    pub fn write_to_default_config_dir(&self) -> anyhow::Result<()> {
+    pub async fn write_to_default_config_dir(&self) -> anyhow::Result<()> {
         let config_dir = crate::service::config_dir();
-        self.write_to_config_dir(&config_dir)
+        self.write_to_config_dir(&config_dir).await
     }
 
-    pub fn write_to_config_dir(&self, config_dir: &Path) -> anyhow::Result<()> {
+    pub async fn write_to_config_dir(&self, config_dir: &Path) -> anyhow::Result<()> {
         let json_config_path = config_dir.join(crate::service::DEFAULT_GLOBAL_CONFIG_FILE_JSON);
 
         let ext_config = GlobalConfigExt::try_from(self).context(anyhow!(
             "Failed to convert global config to external representation for writing"
         ))?;
 
-        crate::service::write_json_config_file(&json_config_path, &ext_config).context(anyhow!(
-            "Failed to write global config file {}",
-            json_config_path.display()
-        ))
+        crate::service::write_json_config_file(&json_config_path, &ext_config)
+            .await
+            .context(anyhow!(
+                "Failed to write global config file {}",
+                json_config_path.display()
+            ))
     }
 
     // Calling this means the global configuration file is read twice 😒
-    pub fn sentry_enabled() -> bool {
-        let config = Self::read_from_default_config_dir().unwrap_or_default();
+    pub async fn sentry_enabled() -> bool {
+        let config = Self::read_from_default_config_dir()
+            .await
+            .unwrap_or_default();
         config.sentry_monitoring
     }
 }
@@ -233,8 +239,8 @@ mod tests {
         (temp_dir, toml_path, json_path)
     }
 
-    #[test]
-    fn test_global_config_migrate() {
+    #[tokio::test]
+    async fn test_global_config_migrate() {
         let (temp_dir, toml_path, json_path) = setup();
 
         let toml_content = r#"
@@ -254,7 +260,9 @@ collect_network_statistics = true
         fs::write(&toml_path, toml_content).unwrap();
 
         // Read the TOML config and migrate it to JSON
-        let config = GlobalConfig::read_from_config_dir(temp_dir.path()).unwrap();
+        let config = GlobalConfig::read_from_config_dir(temp_dir.path())
+            .await
+            .unwrap();
         assert_eq!(config.network_name, "tulips");
         assert!(!config.sentry_monitoring);
         assert!(config.collect_network_statistics);
@@ -264,7 +272,9 @@ collect_network_statistics = true
         assert!(json_path.exists());
 
         // Read the JSON config
-        let config = GlobalConfig::read_from_config_dir(temp_dir.path()).unwrap();
+        let config = GlobalConfig::read_from_config_dir(temp_dir.path())
+            .await
+            .unwrap();
         assert_eq!(config.network_name, "tulips");
         assert!(!config.sentry_monitoring);
         assert!(config.collect_network_statistics);

--- a/nym-vpn-core/crates/nym-vpnd/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/main.rs
@@ -63,7 +63,7 @@ async fn run_vpn_service(args: CliArgs) -> anyhow::Result<()> {
     // It would be better to call `init_sentry()` much later, as it forces a double-read
     // of the global configuration file, however there is a chicken-and-egg problem WRT
     // logging setup and reading the config file.
-    let _sentry_guard = sentry::init_sentry();
+    let _sentry_guard = sentry::init_sentry().await;
     let sentry_enabled = _sentry_guard.is_some();
 
     let shutdown_token = CancellationToken::new();
@@ -142,7 +142,7 @@ async fn run_standalone(
     log_file_remover_handle: Option<LogFileRemoverHandle>,
     shutdown_token: CancellationToken,
 ) -> anyhow::Result<()> {
-    let global_config_file = setup_global_config(parameters.network)?;
+    let global_config_file = setup_global_config(parameters.network).await?;
 
     // Migrate global configuration here, where we will have more information about the environment.
 
@@ -236,11 +236,11 @@ async fn setup_vpn_service(
     ))
 }
 
-fn setup_global_config(network: Option<String>) -> anyhow::Result<GlobalConfig> {
-    let mut global_config_file = GlobalConfig::read_from_default_config_dir()?;
+async fn setup_global_config(network: Option<String>) -> anyhow::Result<GlobalConfig> {
+    let mut global_config_file = GlobalConfig::read_from_default_config_dir().await?;
     if let Some(network) = network {
         global_config_file.network_name = network;
-        global_config_file.write_to_default_config_dir()?;
+        global_config_file.write_to_default_config_dir().await?;
     }
     Ok(global_config_file)
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/sentry.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/sentry.rs
@@ -15,8 +15,8 @@ static EXCLUDED_ERRORS: [&str; 6] = [
     "connection timed out",
 ];
 
-pub fn init_sentry() -> Option<ClientInitGuard> {
-    if !GlobalConfig::sentry_enabled() {
+pub async fn init_sentry() -> Option<ClientInitGuard> {
+    if !GlobalConfig::sentry_enabled().await {
         return None;
     }
 

--- a/nym-vpn-core/crates/nym-vpnd/src/service/config.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/config.rs
@@ -973,9 +973,6 @@ pub async fn read_json_config_file<C>(file_path: &Path) -> Result<C, ConfigSetup
 where
     C: DeserializeOwned,
 {
-    // This is a step backwards, not using streaming in order to use async I/O, however
-    // the alternative is to use a blocking call inside a tokio::task::spawn_blocking,
-    // which seems even worse.
     let bytes = tokio::fs::read(file_path)
         .await
         .map_err(|error| ConfigSetupError::ReadConfig {
@@ -993,7 +990,13 @@ pub async fn write_json_config_file<C>(file_path: &Path, config: &C) -> Result<(
 where
     C: Serialize,
 {
-    // Create path
+    let json_bytes =
+        serde_json::to_vec_pretty(&config).map_err(|error| ConfigSetupError::SerializeJson {
+            file: file_path.to_path_buf(),
+            error: Box::new(error),
+        })?;
+
+    // Ensure parent directory exists
     let config_dir = file_path
         .parent()
         .ok_or_else(|| ConfigSetupError::GetParentDirectory {
@@ -1014,15 +1017,8 @@ where
             error,
         })?;
 
-    let writer = io::BufWriter::new(file);
+    let mut writer = io::BufWriter::new(file);
 
-    let json_bytes =
-        serde_json::to_vec_pretty(&config).map_err(|error| ConfigSetupError::SerializeJson {
-            file: file_path.to_path_buf(),
-            error: Box::new(error),
-        })?;
-
-    let mut writer = writer;
     writer
         .write_all(&json_bytes)
         .await
@@ -1031,14 +1027,12 @@ where
             error,
         })?;
     writer
-        .flush()
+        .flush() // This is important!
         .await
         .map_err(|error| ConfigSetupError::WriteFile {
             file: file_path.to_path_buf(),
             error,
-        })?;
-
-    Ok(())
+        })
 }
 
 pub async fn create_data_dir(data_dir: &Path, network_name: &str) -> Result<(), ConfigSetupError> {

--- a/nym-vpn-core/crates/nym-vpnd/src/service/config.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/config.rs
@@ -14,12 +14,16 @@ use nym_vpn_lib::{
 use nym_vpn_lib_types::{TunnelEvent, TunnelType, service::VpnServiceConfig};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use std::{
-    fmt, fs,
+    fmt,
     net::IpAddr,
     path::{Path, PathBuf},
     str::FromStr,
 };
-use tokio::sync::broadcast;
+use tokio::{
+    fs,
+    io::{self, AsyncWriteExt},
+    sync::broadcast,
+};
 
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
@@ -90,13 +94,13 @@ pub struct VpnServiceConfigManager {
 
 #[allow(dead_code)]
 impl VpnServiceConfigManager {
-    pub fn new(
+    pub async fn new(
         network_config_dir: &Path,
         tunnel_event_tx: Option<broadcast::Sender<TunnelEvent>>,
     ) -> Result<Self> {
         let toml_config_path = network_config_dir.join(DEFAULT_CONFIG_FILE_TOML);
         let json_config_path = network_config_dir.join(DEFAULT_CONFIG_FILE_JSON);
-        let (config, version) = Self::read_from_file(&toml_config_path, &json_config_path)?;
+        let (config, version) = Self::read_from_file(&toml_config_path, &json_config_path).await?;
 
         let config_manager = Self {
             json_config_path,
@@ -106,7 +110,7 @@ impl VpnServiceConfigManager {
 
         // If we didn't read the latest version then write the config straight back to file
         if version != LATEST_CONFIG_VERSION {
-            config_manager.write_to_file();
+            config_manager.write_to_file().await;
         }
 
         // If the deprecated TOML file exists then remove it
@@ -115,7 +119,7 @@ impl VpnServiceConfigManager {
                 "Removing deprecated config file {}",
                 toml_config_path.display()
             );
-            if let Err(e) = fs::remove_file(&toml_config_path) {
+            if let Err(e) = fs::remove_file(&toml_config_path).await {
                 trace_err_chain!(e, "Failed to remove deprecated config file");
             }
         }
@@ -127,103 +131,108 @@ impl VpnServiceConfigManager {
         &self.config
     }
 
-    pub fn set_config(&mut self, config: VpnServiceConfig) {
+    pub async fn set_config(&mut self, config: VpnServiceConfig) {
         if self.config != config {
             self.config = config;
-            self.save_config_and_send_event();
+            self.save_config_and_send_event().await;
         }
     }
 
-    pub fn set_entry_point(&mut self, entry_point: EntryPoint) {
+    pub async fn set_entry_point(&mut self, entry_point: EntryPoint) {
         if self.config.entry_point != entry_point {
             self.config.entry_point = entry_point;
-            self.save_config_and_send_event();
+            self.save_config_and_send_event().await;
         }
     }
 
-    pub fn set_exit_point(&mut self, exit_point: ExitPoint) {
+    pub async fn set_exit_point(&mut self, exit_point: ExitPoint) {
         if self.config.exit_point != exit_point {
             self.config.exit_point = exit_point;
-            self.save_config_and_send_event();
+            self.save_config_and_send_event().await;
         }
     }
 
-    pub fn set_dns(&mut self, dns: Option<IpAddr>) {
+    pub async fn set_dns(&mut self, dns: Option<IpAddr>) {
         if self.config.dns != dns {
             self.config.dns = dns;
-            self.save_config_and_send_event();
+            self.save_config_and_send_event().await;
         }
     }
 
-    pub fn set_disable_ipv6(&mut self, disable_ipv6: bool) {
+    pub async fn set_disable_ipv6(&mut self, disable_ipv6: bool) {
         if self.config.disable_ipv6 != disable_ipv6 {
             self.config.disable_ipv6 = disable_ipv6;
-            self.save_config_and_send_event();
+            self.save_config_and_send_event().await;
         }
     }
 
-    pub fn set_enable_two_hop(&mut self, enable_two_hop: bool) {
+    pub async fn set_enable_two_hop(&mut self, enable_two_hop: bool) {
         if self.config.enable_two_hop != enable_two_hop {
             self.config.enable_two_hop = enable_two_hop;
-            self.save_config_and_send_event();
+            self.save_config_and_send_event().await;
         }
     }
 
-    pub fn set_netstack(&mut self, netstack: bool) {
+    pub async fn set_netstack(&mut self, netstack: bool) {
         if self.config.netstack != netstack {
             self.config.netstack = netstack;
-            self.save_config_and_send_event();
+            self.save_config_and_send_event().await;
         }
     }
 
-    pub fn set_allow_lan(&mut self, allow_lan: bool) {
-        self.config.allow_lan = allow_lan;
-        let _ = self.write_to_file();
+    pub async fn set_allow_lan(&mut self, allow_lan: bool) {
+        if self.config.allow_lan != allow_lan {
+            self.config.allow_lan = allow_lan;
+            self.save_config_and_send_event().await;
+        }
     }
 
-    pub fn set_disable_poisson_rate(&mut self, disable_poisson_rate: bool) {
+    pub async fn set_disable_poisson_rate(&mut self, disable_poisson_rate: bool) {
         if self.config.disable_poisson_rate != disable_poisson_rate {
             self.config.disable_poisson_rate = disable_poisson_rate;
-            self.save_config_and_send_event();
+            self.save_config_and_send_event().await;
         }
     }
 
-    pub fn set_disable_background_cover_traffic(&mut self, disable: bool) {
+    pub async fn set_disable_background_cover_traffic(&mut self, disable: bool) {
         if self.config.disable_background_cover_traffic != disable {
             self.config.disable_background_cover_traffic = disable;
-            self.save_config_and_send_event();
+            self.save_config_and_send_event().await;
         }
     }
 
-    pub fn set_min_mixnode_performance(&mut self, min_mixnode_performance: Option<u8>) {
+    pub async fn set_min_mixnode_performance(&mut self, min_mixnode_performance: Option<u8>) {
         if self.config.min_mixnode_performance != min_mixnode_performance {
             self.config.min_mixnode_performance = min_mixnode_performance.map(|u| u.min(100));
-            self.save_config_and_send_event();
+            self.save_config_and_send_event().await;
         }
     }
 
-    pub fn set_min_gateway_mixnet_performance(
+    pub async fn set_min_gateway_mixnet_performance(
         &mut self,
         min_gateway_mixnet_performance: Option<u8>,
     ) {
         if self.config.min_gateway_mixnet_performance != min_gateway_mixnet_performance {
             self.config.min_gateway_mixnet_performance =
                 min_gateway_mixnet_performance.map(|u| u.min(100));
-            self.save_config_and_send_event();
+            self.save_config_and_send_event().await;
         }
     }
 
-    pub fn set_min_gateway_vpn_performance(&mut self, min_gateway_vpn_performance: Option<u8>) {
+    pub async fn set_min_gateway_vpn_performance(
+        &mut self,
+        min_gateway_vpn_performance: Option<u8>,
+    ) {
         if self.config.min_gateway_vpn_performance != min_gateway_vpn_performance {
             self.config.min_gateway_vpn_performance =
                 min_gateway_vpn_performance.map(|u| u.min(100));
-            self.save_config_and_send_event();
+            self.save_config_and_send_event().await;
         }
     }
 
-    fn save_config_and_send_event(&self) {
+    async fn save_config_and_send_event(&self) {
         // This function already logs
-        let _ = self.write_to_file();
+        let _ = self.write_to_file().await;
 
         // Notify all clients that the config has changed
         if let Some(tx) = self.tunnel_event_tx.as_ref() {
@@ -239,12 +248,13 @@ impl VpnServiceConfigManager {
     }
 
     /// Returns the configuration as well as the version read from file.
-    fn read_from_file(
+    async fn read_from_file(
         toml_config_path: &Path,
         json_config_path: &Path,
     ) -> Result<(VpnServiceConfig, u8)> {
         let (config, version) = if json_config_path.exists() {
             let ext_config = read_json_config_file::<VpnServiceConfigExt>(json_config_path)
+                .await
                 .map_err(Error::ConfigSetup)?;
             let version = ext_config.version();
 
@@ -258,6 +268,7 @@ impl VpnServiceConfigManager {
             (config, version)
         } else if toml_config_path.exists() {
             let legacy_config = read_toml_config_file::<LegacyVpnServiceConfig>(toml_config_path)
+                .await
                 .map_err(Error::ConfigSetup)?;
 
             tracing::info!("Read service config from {}", toml_config_path.display());
@@ -274,7 +285,7 @@ impl VpnServiceConfigManager {
         Ok((config, version))
     }
 
-    fn write_to_file(&self) -> bool {
+    async fn write_to_file(&self) -> bool {
         let ext_config =
             match VpnServiceConfigExt::try_from(&self.config).map_err(Error::ConfigSetup) {
                 Ok(ext_config) => ext_config,
@@ -286,6 +297,7 @@ impl VpnServiceConfigManager {
         let version = ext_config.version();
 
         match write_json_config_file(&self.json_config_path, &ext_config)
+            .await
             .map_err(Error::ConfigSetup)
         {
             Ok(_) => {
@@ -837,7 +849,7 @@ pub enum ConfigSetupError {
     ReadConfig {
         file: PathBuf,
         #[source]
-        error: std::io::Error,
+        error: io::Error,
     },
 
     #[error("failed to get parent directory of {file}")]
@@ -847,21 +859,18 @@ pub enum ConfigSetupError {
     CreateDirectory {
         dir: PathBuf,
         #[source]
-        error: std::io::Error,
+        error: io::Error,
     },
 
     #[error("failed to write file {file}")]
-    WriteFile {
-        file: PathBuf,
-        error: std::io::Error,
-    },
+    WriteFile { file: PathBuf, error: io::Error },
 
     #[cfg(unix)]
     #[error("failed to set permissions for directory {dir}")]
     SetPermissions {
         dir: PathBuf,
         #[source]
-        error: std::io::Error,
+        error: io::Error,
     },
 
     #[cfg(windows)]
@@ -943,37 +952,44 @@ pub fn config_dir() -> PathBuf {
         .unwrap_or_else(|_| default_config_dir())
 }
 
-pub fn read_toml_config_file<C>(file_path: &Path) -> Result<C, ConfigSetupError>
+pub async fn read_toml_config_file<C>(file_path: &Path) -> Result<C, ConfigSetupError>
 where
     C: DeserializeOwned,
 {
     let file_content =
-        fs::read_to_string(file_path).map_err(|error| ConfigSetupError::ReadConfig {
-            file: file_path.to_path_buf(),
-            error,
-        })?;
+        fs::read_to_string(file_path)
+            .await
+            .map_err(|error| ConfigSetupError::ReadConfig {
+                file: file_path.to_path_buf(),
+                error,
+            })?;
     toml::from_str(&file_content).map_err(|error| ConfigSetupError::ParseToml {
         file: file_path.to_path_buf(),
         error: Box::new(error),
     })
 }
 
-pub fn read_json_config_file<C>(file_path: &Path) -> Result<C, ConfigSetupError>
+pub async fn read_json_config_file<C>(file_path: &Path) -> Result<C, ConfigSetupError>
 where
     C: DeserializeOwned,
 {
-    let file = fs::File::open(file_path).map_err(|error| ConfigSetupError::ReadConfig {
-        file: file_path.to_path_buf(),
-        error,
-    })?;
-    let reader = std::io::BufReader::new(file);
-    serde_json::from_reader(reader).map_err(|error| ConfigSetupError::ParseJson {
+    // This is a step backwards, not using streaming in order to use async I/O, however
+    // the alternative is to use a blocking call inside a tokio::task::spawn_blocking,
+    // which seems even worse.
+    let bytes = tokio::fs::read(file_path)
+        .await
+        .map_err(|error| ConfigSetupError::ReadConfig {
+            file: file_path.to_path_buf(),
+            error,
+        })?;
+
+    serde_json::from_slice(&bytes).map_err(|error| ConfigSetupError::ParseJson {
         file: file_path.to_path_buf(),
         error: Box::new(error),
     })
 }
 
-pub fn write_json_config_file<C>(file_path: &Path, config: &C) -> Result<(), ConfigSetupError>
+pub async fn write_json_config_file<C>(file_path: &Path, config: &C) -> Result<(), ConfigSetupError>
 where
     C: Serialize,
 {
@@ -983,33 +999,57 @@ where
         .ok_or_else(|| ConfigSetupError::GetParentDirectory {
             file: file_path.to_path_buf(),
         })?;
-    fs::create_dir_all(config_dir).map_err(|error| ConfigSetupError::CreateDirectory {
-        dir: config_dir.to_path_buf(),
-        error,
-    })?;
 
-    let file = fs::File::create(file_path).map_err(|error| ConfigSetupError::WriteFile {
-        file: file_path.to_path_buf(),
-        error,
-    })?;
-    let writer = std::io::BufWriter::new(file);
-    serde_json::to_writer_pretty(writer, &config).map_err(|error| {
-        ConfigSetupError::SerializeJson {
+    fs::create_dir_all(config_dir)
+        .await
+        .map_err(|error| ConfigSetupError::CreateDirectory {
+            dir: config_dir.to_path_buf(),
+            error,
+        })?;
+
+    let file = fs::File::create(file_path)
+        .await
+        .map_err(|error| ConfigSetupError::WriteFile {
+            file: file_path.to_path_buf(),
+            error,
+        })?;
+
+    let writer = io::BufWriter::new(file);
+
+    let json_bytes =
+        serde_json::to_vec_pretty(&config).map_err(|error| ConfigSetupError::SerializeJson {
             file: file_path.to_path_buf(),
             error: Box::new(error),
-        }
-    })?;
+        })?;
+
+    let mut writer = writer;
+    writer
+        .write_all(&json_bytes)
+        .await
+        .map_err(|error| ConfigSetupError::WriteFile {
+            file: file_path.to_path_buf(),
+            error,
+        })?;
+    writer
+        .flush()
+        .await
+        .map_err(|error| ConfigSetupError::WriteFile {
+            file: file_path.to_path_buf(),
+            error,
+        })?;
 
     Ok(())
 }
 
-pub fn create_data_dir(data_dir: &Path, network_name: &str) -> Result<(), ConfigSetupError> {
+pub async fn create_data_dir(data_dir: &Path, network_name: &str) -> Result<(), ConfigSetupError> {
     let network_data_dir = data_dir.join(network_name);
 
-    fs::create_dir_all(&network_data_dir).map_err(|error| ConfigSetupError::CreateDirectory {
-        dir: network_data_dir.clone(),
-        error,
-    })?;
+    fs::create_dir_all(&network_data_dir)
+        .await
+        .map_err(|error| ConfigSetupError::CreateDirectory {
+            dir: network_data_dir.clone(),
+            error,
+        })?;
 
     tracing::debug!(
         "Making sure data dir exists at {}",
@@ -1076,14 +1116,12 @@ fn set_data_dir_permissions(data_dir: &Path) -> nym_windows::security::Result<()
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use pretty_assertions::assert_eq;
-    use std::fs;
     use tempfile::tempdir;
 
-    use super::*;
-
     // Test migrating from TOML to the latest JSON version
-    fn run_migrate_toml_test(
+    async fn run_migrate_toml_test(
         toml_content: &str,
         json_latest_content: &str,
         entry_point: gateway_directory::EntryPoint,
@@ -1095,16 +1133,18 @@ mod tests {
         println!("Using config dir: {config_path:?}");
 
         let network_config_path = config_path.join("tulips");
-        let _ = fs::create_dir_all(&network_config_path);
+        let _ = fs::create_dir_all(&network_config_path).await;
         let toml_path = network_config_path.join(DEFAULT_CONFIG_FILE_TOML);
         let json_path = network_config_path.join(DEFAULT_CONFIG_FILE_JSON);
 
         // Write the TOML config file
-        fs::write(&toml_path, toml_content).unwrap();
+        fs::write(&toml_path, toml_content).await.unwrap();
 
         // Read the TOML config and migrate it to latest JSON version.  The latest version of the
         // JSON will be written straight back to disk.
-        let config_manager = VpnServiceConfigManager::new(&network_config_path, None).unwrap();
+        let config_manager = VpnServiceConfigManager::new(&network_config_path, None)
+            .await
+            .unwrap();
         let config = config_manager.config();
         assert_eq!(config.entry_point, entry_point);
         assert_eq!(config.exit_point, exit_point);
@@ -1114,42 +1154,46 @@ mod tests {
         assert!(json_path.exists());
 
         // Read the JSON config
-        let config_manager = VpnServiceConfigManager::new(&network_config_path, None).unwrap();
+        let config_manager = VpnServiceConfigManager::new(&network_config_path, None)
+            .await
+            .unwrap();
         let config = config_manager.config();
         assert_eq!(config.entry_point, entry_point);
         assert_eq!(config.exit_point, exit_point);
 
         // Check the JSON is the right version and all snake-case
-        let read_json_content = fs::read_to_string(&json_path).unwrap();
+        let read_json_content = fs::read_to_string(&json_path).await.unwrap();
         assert_eq!(json_latest_content, read_json_content);
     }
 
     // Test migrating from JSON v1 to the latest JSON version
-    fn run_migrate_json_v1_test(json_v1_content: &str, json_latest_content: &str) {
+    async fn run_migrate_json_v1_test(json_v1_content: &str, json_latest_content: &str) {
         let temp_dir = tempdir().unwrap();
         let config_path = temp_dir.path();
 
         println!("Using config dir: {config_path:?}");
 
         let network_config_path = config_path.join("tulips");
-        let _ = fs::create_dir_all(&network_config_path);
+        let _ = fs::create_dir_all(&network_config_path).await;
         let json_path = network_config_path.join(DEFAULT_CONFIG_FILE_JSON);
 
         // Write the JSON v1 config file
-        fs::write(&json_path, json_v1_content).unwrap();
+        fs::write(&json_path, json_v1_content).await.unwrap();
 
         // Read the JSON v1 config and migrate it to latest JSON.  The latest version of the
         // JSON will be written straight back to disk.
-        let _config_manager = VpnServiceConfigManager::new(&network_config_path, None).unwrap();
+        let _config_manager = VpnServiceConfigManager::new(&network_config_path, None)
+            .await
+            .unwrap();
 
         // Check the JSON is the right version and all snake-case (ignore whitespace/order)
-        let read_json_content = fs::read_to_string(&json_path).unwrap();
+        let read_json_content = fs::read_to_string(&json_path).await.unwrap();
         let expected: serde_json::Value = serde_json::from_str(json_latest_content).unwrap();
         let actual: serde_json::Value = serde_json::from_str(&read_json_content).unwrap();
         assert_eq!(expected, actual);
     }
 
-    fn run_serialize_test(config: VpnServiceConfig) {
+    async fn run_serialize_test(config: VpnServiceConfig) {
         let temp_dir = tempdir().unwrap();
         let config_path = temp_dir.path();
 
@@ -1158,19 +1202,23 @@ mod tests {
         let network_config_path = config_path.join("tulips");
 
         // Write the config to disk
-        let mut config_manager = VpnServiceConfigManager::new(&network_config_path, None).unwrap();
-        config_manager.set_config(config.clone());
-        assert!(config_manager.write_to_file());
+        let mut config_manager = VpnServiceConfigManager::new(&network_config_path, None)
+            .await
+            .unwrap();
+        config_manager.set_config(config.clone()).await;
+        assert!(config_manager.write_to_file().await);
         drop(config_manager);
 
         // Read it back and compare it
-        let config_manager = VpnServiceConfigManager::new(&network_config_path, None).unwrap();
+        let config_manager = VpnServiceConfigManager::new(&network_config_path, None)
+            .await
+            .unwrap();
         let read_config = config_manager.config();
         assert_eq!(&config, read_config);
     }
 
-    #[test]
-    fn test_service_config_migrate_toml_location() {
+    #[tokio::test]
+    async fn test_service_config_migrate_toml_location() {
         let toml_content = r#"
 [entry_point.Location]
 location = "FR"
@@ -1211,11 +1259,11 @@ location = "BE"
             two_letter_iso_country_code: "BE".to_string(),
         };
 
-        run_migrate_toml_test(toml_content, json_content, entry_point, exit_point);
+        run_migrate_toml_test(toml_content, json_content, entry_point, exit_point).await;
     }
 
-    #[test]
-    fn test_service_config_migrate_gateway() {
+    #[tokio::test]
+    async fn test_service_config_migrate_gateway() {
         let toml_content = r#"
 [entry_point.Gateway]
 identity = [ 92, 25, 33, 77, 4, 117, 82, 117, 246, 239, 233, 11, 129, 183, 86, 194, 140, 95, 21, 196, 121, 130, 232, 195, 71, 173, 66, 124, 5, 14, 114, 107, ]
@@ -1262,12 +1310,12 @@ identity = [ 99, 23, 98, 234, 66, 161, 195, 63, 155, 161, 250, 207, 17, 158, 136
             .unwrap(),
         };
 
-        run_migrate_toml_test(toml_content, json_content, entry_point, exit_point);
+        run_migrate_toml_test(toml_content, json_content, entry_point, exit_point).await;
     }
 
-    #[test]
+    #[tokio::test]
     #[ignore] // Temporarily disabled due to issues with ExitPoint::Address (de)serialisation.
-    fn test_service_config_migrate_toml_address() {
+    async fn test_service_config_migrate_toml_address() {
         let toml_content = r#"
 [entry_point.Gateway]
 identity = [92, 25, 33, 77, 4, 117, 82, 117, 246, 239, 233, 11, 129, 183, 86, 194, 140, 95, 21, 196, 121, 130, 232, 195, 71, 173, 66, 124, 5, 14, 114, 107]
@@ -1312,11 +1360,11 @@ address = [5, 56, 84, 195, 94, 238, 210, 124, 65, 143, 209, 144, 22, 255, 91, 18
             )
         };
 
-        run_migrate_toml_test(toml_content, json_content, entry_point, exit_point);
+        run_migrate_toml_test(toml_content, json_content, entry_point, exit_point).await;
     }
 
-    #[test]
-    fn test_service_config_migrate_toml_random() {
+    #[tokio::test]
+    async fn test_service_config_migrate_toml_random() {
         let toml_content = r#"
 entry_point = "Random"
 exit_point = "Random"
@@ -1342,11 +1390,11 @@ exit_point = "Random"
 
         let exit_point = gateway_directory::ExitPoint::Random;
 
-        run_migrate_toml_test(toml_content, json_content, entry_point, exit_point);
+        run_migrate_toml_test(toml_content, json_content, entry_point, exit_point).await;
     }
 
-    #[test]
-    fn test_service_config_migrate_from_v1() {
+    #[tokio::test]
+    async fn test_service_config_migrate_from_v1() {
         let json_v1_content = r#"{
   "version": "v1",
   "entry_point": {
@@ -1385,17 +1433,17 @@ exit_point = "Random"
   "min_gateway_vpn_performance": null
 }"#;
 
-        run_migrate_json_v1_test(json_v1_content, json_latest_content);
+        run_migrate_json_v1_test(json_v1_content, json_latest_content).await;
     }
 
-    #[test]
-    fn test_service_config_serialize_defaults() {
+    #[tokio::test]
+    async fn test_service_config_serialize_defaults() {
         let config = VpnServiceConfig::default();
-        run_serialize_test(config);
+        run_serialize_test(config).await;
     }
 
-    #[test]
-    fn test_service_config_serialize_full() {
+    #[tokio::test]
+    async fn test_service_config_serialize_full() {
         let config = VpnServiceConfig {
             entry_point: gateway_directory::EntryPoint::Country {
                 two_letter_iso_country_code: "US".to_string(),
@@ -1417,6 +1465,6 @@ exit_point = "Random"
             min_gateway_mixnet_performance: Some(64u8),
             min_gateway_vpn_performance: Some(1u8),
         };
-        run_serialize_test(config);
+        run_serialize_test(config).await;
     }
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/service/config.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/config.rs
@@ -1061,12 +1061,12 @@ pub async fn create_data_dir(data_dir: &Path, network_name: &str) -> Result<(), 
         {
             // Set directory permissions to 700 (rwx------)
             let permissions = std::fs::Permissions::from_mode(0o700);
-            fs::set_permissions(dir_path, permissions).map_err(|error| {
-                ConfigSetupError::SetPermissions {
+            fs::set_permissions(dir_path, permissions)
+                .await
+                .map_err(|error| ConfigSetupError::SetPermissions {
                     dir: dir_path.to_path_buf(),
                     error,
-                }
-            })?;
+                })?;
         }
 
         #[cfg(windows)]

--- a/nym-vpn-core/crates/nym-vpnd/src/service/config.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/config.rs
@@ -1060,7 +1060,7 @@ pub async fn create_data_dir(data_dir: &Path, network_name: &str) -> Result<(), 
         #[cfg(unix)]
         {
             // Set directory permissions to 700 (rwx------)
-            let permissions = fs::Permissions::from_mode(0o700);
+            let permissions = std::fs::Permissions::from_mode(0o700);
             fs::set_permissions(dir_path, permissions).map_err(|error| {
                 ConfigSetupError::SetPermissions {
                     dir: dir_path.to_path_buf(),

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -282,7 +282,9 @@ impl NymVpnService {
         let storage = nym_vpn_lib::storage::VpnClientOnDiskStorage::new(network_data_dir.clone());
 
         // Make sure the data dir exists
-        super::config::create_data_dir(&data_dir, &network_name).map_err(Error::ConfigSetup)?;
+        super::config::create_data_dir(&data_dir, &network_name)
+            .await
+            .map_err(Error::ConfigSetup)?;
 
         let state_machine_shutdown_token = CancellationToken::new();
         let services_shutdown_token = CancellationToken::new();
@@ -364,7 +366,7 @@ impl NymVpnService {
         .await;
 
         let config_manager =
-            VpnServiceConfigManager::new(&config_dir, Some(tunnel_event_tx.clone()))?;
+            VpnServiceConfigManager::new(&config_dir, Some(tunnel_event_tx.clone())).await?;
 
         let statistics_event_sender = statistics_controller.get_statistics_sender();
         let statistics_controller_handle = tokio::task::spawn(statistics_controller.run());
@@ -551,7 +553,7 @@ impl NymVpnService {
         Ok(())
     }
 
-    fn set_target_state(&mut self, new_state: TargetState) -> bool {
+    async fn set_target_state(&mut self, new_state: TargetState) -> bool {
         if self.target_state != new_state || self.tunnel_state.is_error_state() {
             tracing::debug!("Set target state {} => {}", self.target_state, new_state);
             self.target_state = new_state;
@@ -571,7 +573,7 @@ impl NymVpnService {
         }
     }
 
-    fn reconnect_tunnel(&self) -> bool {
+    async fn reconnect_tunnel(&self) -> bool {
         match self.target_state {
             TargetState::Secured => {
                 let _ = self.command_sender.send(TunnelCommand::Connect);
@@ -628,72 +630,72 @@ impl NymVpnService {
     async fn handle_service_command(&mut self, command: VpnServiceCommand) {
         match command {
             VpnServiceCommand::Info(tx, ()) => {
-                let result = self.handle_info();
+                let result = self.handle_info().await;
                 let _ = tx.send(result);
             }
             VpnServiceCommand::GetConfig(tx, ()) => {
-                let result = self.handle_get_config();
+                let result = self.handle_get_config().await;
                 let _ = tx.send(result);
             }
             VpnServiceCommand::SetEntryPoint(tx, entry_point) => {
-                self.handle_set_entry_point(entry_point);
+                self.handle_set_entry_point(entry_point).await;
                 let _ = tx.send(());
             }
             VpnServiceCommand::SetExitPoint(tx, exit_point) => {
-                self.handle_set_exit_point(exit_point);
+                self.handle_set_exit_point(exit_point).await;
                 let _ = tx.send(());
             }
             VpnServiceCommand::SetDisableIPv6(tx, disable_ipv6) => {
-                self.handle_set_disable_ipv6(disable_ipv6);
+                self.handle_set_disable_ipv6(disable_ipv6).await;
                 let _ = tx.send(());
             }
             VpnServiceCommand::SetEnableTwoHop(tx, enable_two_hop) => {
-                self.handle_set_enable_two_hop(enable_two_hop);
+                self.handle_set_enable_two_hop(enable_two_hop).await;
                 let _ = tx.send(());
             }
             VpnServiceCommand::SetNetstack(tx, netstack) => {
-                self.handle_set_netstack(netstack);
+                self.handle_set_netstack(netstack).await;
                 let _ = tx.send(());
             }
             VpnServiceCommand::SetAllowLan(tx, allow_lan) => {
-                self.handle_set_allow_lan(allow_lan, tx);
+                self.handle_set_allow_lan(allow_lan, tx).await;
             }
             VpnServiceCommand::SetNetwork(tx, network) => {
-                let result = self.handle_set_network(network);
+                let result = self.handle_set_network(network).await;
                 let _ = tx.send(result);
             }
             VpnServiceCommand::GetSystemMessages(tx, ()) => {
-                let result = self.handle_get_system_messages();
+                let result = self.handle_get_system_messages().await;
                 let _ = tx.send(result);
             }
             VpnServiceCommand::GetNetworkCompatibility(tx, ()) => {
-                let result = self.handle_get_network_compatibility();
+                let result = self.handle_get_network_compatibility().await;
                 let _ = tx.send(result);
             }
             VpnServiceCommand::GetFeatureFlags(tx, ()) => {
-                let result = self.handle_get_feature_flags();
+                let result = self.handle_get_feature_flags().await;
                 let _ = tx.send(result);
             }
             VpnServiceCommand::ListGateways(tx, options) => {
-                self.handle_list_gateways(options, tx);
+                self.handle_list_gateways(options, tx).await;
             }
             VpnServiceCommand::ListCountries(tx, options) => {
-                self.handle_list_countries(options, tx)
+                self.handle_list_countries(options, tx).await;
             }
             VpnServiceCommand::Connect(tx, connect_args) => {
                 self.handle_connect(connect_args).await.ok();
                 let _ = tx.send(());
             }
             VpnServiceCommand::SetTargetState(tx, target_state) => {
-                let accepted = self.set_target_state(target_state);
+                let accepted = self.set_target_state(target_state).await;
                 let _ = tx.send(accepted);
             }
             VpnServiceCommand::Reconnect(tx, ()) => {
-                let accepted = self.reconnect_tunnel();
+                let accepted = self.reconnect_tunnel().await;
                 let _ = tx.send(accepted);
             }
             VpnServiceCommand::GetTunnelState(tx, ()) => {
-                let result = self.handle_get_tunnel_state();
+                let result = self.handle_get_tunnel_state().await;
                 let _ = tx.send(result);
             }
             VpnServiceCommand::StoreAccount(tx, account) => {
@@ -712,7 +714,7 @@ impl NymVpnService {
                 let _ = tx.send(self.handle_get_account_links(locale).await);
             }
             VpnServiceCommand::GetAccountState(tx, ()) => {
-                let _ = tx.send(self.handle_get_account_state());
+                let _ = tx.send(self.handle_get_account_state().await);
             }
             VpnServiceCommand::RefreshAccountState(tx, ()) => {
                 self.handle_refresh_account_state().await;
@@ -744,21 +746,24 @@ impl NymVpnService {
                 let _ = tx.send(());
             }
             VpnServiceCommand::IsSentryEnabled(tx, ()) => {
-                let _ = tx.send(self.handle_is_sentry_enabled());
+                let enabled = self.handle_is_sentry_enabled().await;
+                let _ = tx.send(enabled);
             }
             VpnServiceCommand::ToggleSentry(tx, enable) => {
-                let _ = tx.send(self.handle_toggle_sentry(enable));
+                let result = self.handle_toggle_sentry(enable).await;
+                let _ = tx.send(result);
             }
             VpnServiceCommand::IsCollectNetStatsEnabled(tx, ()) => {
-                let _ = tx.send(self.handle_is_collect_network_stats_enabled());
+                let _ = tx.send(self.handle_is_collect_network_stats_enabled().await);
             }
             VpnServiceCommand::ToggleCollectNetStats(tx, enable) => {
-                let _ = tx.send(self.handle_toggle_collect_network_stats(enable));
+                let result = self.handle_toggle_collect_network_stats(enable).await;
+                let _ = tx.send(result);
             }
         }
     }
 
-    fn handle_info(&self) -> VpnServiceInfo {
+    async fn handle_info(&self) -> VpnServiceInfo {
         let bin_info = nym_bin_common::bin_info_local_vergen!();
 
         VpnServiceInfo {
@@ -772,48 +777,49 @@ impl NymVpnService {
         }
     }
 
-    fn handle_get_config(&self) -> VpnServiceConfig {
+    async fn handle_get_config(&self) -> VpnServiceConfig {
         self.config_manager.config().clone()
     }
 
-    fn handle_set_entry_point(&mut self, entry_point: EntryPoint) {
-        self.config_manager.set_entry_point(entry_point);
+    async fn handle_set_entry_point(&mut self, entry_point: EntryPoint) {
+        self.config_manager.set_entry_point(entry_point).await;
         self.update_tunnel_settings_with_throttle();
     }
 
-    fn handle_set_exit_point(&mut self, exit_point: ExitPoint) {
-        self.config_manager.set_exit_point(exit_point);
+    async fn handle_set_exit_point(&mut self, exit_point: ExitPoint) {
+        self.config_manager.set_exit_point(exit_point).await;
         self.update_tunnel_settings_with_throttle();
     }
 
-    fn handle_set_disable_ipv6(&mut self, disable_ipv6: bool) {
-        self.config_manager.set_disable_ipv6(disable_ipv6);
+    async fn handle_set_disable_ipv6(&mut self, disable_ipv6: bool) {
+        self.config_manager.set_disable_ipv6(disable_ipv6).await;
         self.update_tunnel_settings_with_throttle();
     }
 
-    fn handle_set_enable_two_hop(&mut self, enable_two_hop: bool) {
-        self.config_manager.set_enable_two_hop(enable_two_hop);
+    async fn handle_set_enable_two_hop(&mut self, enable_two_hop: bool) {
+        self.config_manager.set_enable_two_hop(enable_two_hop).await;
         self.update_tunnel_settings_with_throttle();
     }
 
-    fn handle_set_netstack(&mut self, netstack: bool) {
-        self.config_manager.set_netstack(netstack);
+    async fn handle_set_netstack(&mut self, netstack: bool) {
+        self.config_manager.set_netstack(netstack).await;
         self.update_tunnel_settings_with_throttle();
     }
 
-    fn handle_set_allow_lan(&mut self, allow_lan: bool, complete_tx: oneshot::Sender<()>) {
-        self.config_manager.set_allow_lan(allow_lan);
+    async fn handle_set_allow_lan(&mut self, allow_lan: bool, complete_tx: oneshot::Sender<()>) {
+        self.config_manager.set_allow_lan(allow_lan).await;
         _ = self
             .command_sender
             .send(TunnelCommand::SetAllowLan(allow_lan, complete_tx));
     }
 
-    fn handle_set_network(&self, network: String) -> Result<(), SetNetworkError> {
-        let mut global_config = GlobalConfig::read_from_default_config_dir().map_err(|source| {
-            SetNetworkError::ReadConfig {
-                source: source.into(),
-            }
-        })?;
+    async fn handle_set_network(&self, network: String) -> Result<(), SetNetworkError> {
+        let mut global_config =
+            GlobalConfig::read_from_default_config_dir()
+                .await
+                .map_err(|source| SetNetworkError::ReadConfig {
+                    source: source.into(),
+                })?;
 
         let network_selected = NetworkEnvironments::try_from(network.as_str())
             .map_err(|_err| SetNetworkError::NetworkNotFound(network.to_owned()))?;
@@ -821,6 +827,7 @@ impl NymVpnService {
 
         global_config
             .write_to_default_config_dir()
+            .await
             .map_err(|source| SetNetworkError::WriteConfig {
                 source: source.into(),
             })?;
@@ -832,22 +839,22 @@ impl NymVpnService {
         Ok(())
     }
 
-    fn handle_get_system_messages(&self) -> SystemMessages {
+    async fn handle_get_system_messages(&self) -> SystemMessages {
         self.network_env.nym_vpn_network.system_messages.clone()
     }
 
-    fn handle_get_network_compatibility(&self) -> Option<NetworkCompatibility> {
+    async fn handle_get_network_compatibility(&self) -> Option<NetworkCompatibility> {
         self.network_env
             .system_configuration
             .as_ref()
             .and_then(|sc| sc.min_supported_app_versions.clone())
     }
 
-    fn handle_get_feature_flags(&self) -> Option<FeatureFlags> {
+    async fn handle_get_feature_flags(&self) -> Option<FeatureFlags> {
         self.network_env.feature_flags.clone()
     }
 
-    fn handle_list_gateways(
+    async fn handle_list_gateways(
         &self,
         options: ListGatewaysOptions,
         completion_tx: oneshot::Sender<Result<Vec<Gateway>, ListGatewaysError>>,
@@ -874,7 +881,7 @@ impl NymVpnService {
         });
     }
 
-    fn handle_list_countries(
+    async fn handle_list_countries(
         &self,
         options: ListCountriesOptions,
         completion_tx: oneshot::Sender<Result<Vec<Country>, ListGatewaysError>>,
@@ -910,8 +917,7 @@ impl NymVpnService {
 
         let entry_point = entry.unwrap_or(self.config_manager.config().entry_point.clone());
         let exit_point = exit.unwrap_or(self.config_manager.config().exit_point.clone());
-
-        self.config_manager.set_config(VpnServiceConfig {
+        let config = VpnServiceConfig {
             entry_point,
             exit_point,
             disable_ipv6: options.disable_ipv6,
@@ -924,7 +930,9 @@ impl NymVpnService {
             min_gateway_vpn_performance: None,
             disable_poisson_rate: options.disable_poisson_rate,
             disable_background_cover_traffic: options.disable_background_cover_traffic,
-        });
+        };
+
+        self.config_manager.set_config(config).await;
 
         self.statistics_event_sender
             .report(StatisticsEvent::new_connecting(
@@ -937,13 +945,13 @@ impl NymVpnService {
         if self.target_state == TargetState::Secured {
             let _ = self.command_sender.send(TunnelCommand::Connect);
         } else {
-            let _ = self.set_target_state(TargetState::Secured);
+            let _ = self.set_target_state(TargetState::Secured).await;
         }
 
         Ok(())
     }
 
-    fn handle_get_tunnel_state(&self) -> TunnelState {
+    async fn handle_get_tunnel_state(&self) -> TunnelState {
         self.tunnel_state.clone()
     }
 
@@ -1008,7 +1016,7 @@ impl NymVpnService {
             })
     }
 
-    fn handle_get_account_state(&self) -> AccountControllerState {
+    async fn handle_get_account_state(&self) -> AccountControllerState {
         self.account_state_rx.get_state()
     }
 
@@ -1065,8 +1073,9 @@ impl NymVpnService {
         }
     }
 
-    fn handle_is_sentry_enabled(&self) -> bool {
+    async fn handle_is_sentry_enabled(&self) -> bool {
         GlobalConfig::read_from_default_config_dir()
+            .await
             .inspect_err(|e| {
                 tracing::error!("Failed to read global config file: {}", e);
             })
@@ -1076,8 +1085,9 @@ impl NymVpnService {
             .unwrap_or(self.sentry_enabled)
     }
 
-    fn handle_toggle_sentry(&self, enable: bool) -> Result<(), GlobalConfigError> {
+    async fn handle_toggle_sentry(&self, enable: bool) -> Result<(), GlobalConfigError> {
         let mut config = GlobalConfig::read_from_default_config_dir()
+            .await
             .map_err(|e| GlobalConfigError::ReadConfig(e.to_string()))?;
         config.sentry_monitoring = enable;
         if enable {
@@ -1090,19 +1100,21 @@ impl NymVpnService {
             tracing::info!("Sentry monitoring disabled, daemon needs to be restarted");
         }
         GlobalConfig::write_to_default_config_dir(&config)
+            .await
             .map_err(|e| GlobalConfigError::WriteConfig(e.to_string()))?;
         Ok(())
     }
 
-    fn handle_is_collect_network_stats_enabled(&self) -> bool {
+    async fn handle_is_collect_network_stats_enabled(&self) -> bool {
         self.network_statistics_enabled
     }
 
-    fn handle_toggle_collect_network_stats(
+    async fn handle_toggle_collect_network_stats(
         &mut self,
         enable: bool,
     ) -> Result<(), GlobalConfigError> {
         let mut config = GlobalConfig::read_from_default_config_dir()
+            .await
             .map_err(|e| GlobalConfigError::ReadConfig(e.to_string()))?;
         config.collect_network_statistics = enable;
         if enable {
@@ -1111,6 +1123,7 @@ impl NymVpnService {
             tracing::info!("Collect network statistics disabled, daemon needs to be restarted");
         }
         GlobalConfig::write_to_default_config_dir(&config)
+            .await
             .map_err(|e| GlobalConfigError::WriteConfig(e.to_string()))?;
         self.network_statistics_enabled = enable;
         Ok(())

--- a/nym-vpn-core/crates/nym-vpnd/src/windows_service/mod.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/windows_service/mod.rs
@@ -116,7 +116,7 @@ async fn run_service() -> anyhow::Result<()> {
     tracing::info!("Service is starting...");
     persistent_status.set_pending_start(Duration::from_secs(20))?;
 
-    let global_config_file = crate::setup_global_config(run_params.network.clone())?;
+    let global_config_file = crate::setup_global_config(run_params.network.clone()).await?;
     let network_env = match crate::environment::setup_environment(
         &global_config_file,
         run_params.config_env_file.as_deref(),


### PR DESCRIPTION
## Ticket

JIRA-VPN-4030

## Description

Use `tokio:fs` to read and write config files, which has meant many many functions are now `async`.

There are some `handle_xxx()` functions in `vpn_service.rs` which don't need to be `async`, however so many are now, it feels right that all are.

One backward step of using async I/O is that streaming cannot be used without spawning a thread, so we are back to reading/writing the file content from a byte array.

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3507)
<!-- Reviewable:end -->
