### PR TITLE
Write account controller unit test logs to `stdout`.

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/common/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/common/mod.rs
@@ -31,11 +31,9 @@ static TEST_TRACING: OnceLock<()> = OnceLock::new();
 
 pub fn init_tracing() {
     TEST_TRACING.get_or_init(|| {
-        // Build env filter: if user provided RUST_LOG we honour it, otherwise fall back.
         let env_filter = if std::env::var("RUST_LOG").is_ok() {
             EnvFilter::from_default_env()
         } else {
-            // Show INFO for our crates by default; DEBUG can be enabled with RUST_LOG.
             EnvFilter::new("info,nym_vpn_account_controller=info,nym_vpn_api_client=info")
         };
 
@@ -43,7 +41,8 @@ pub fn init_tracing() {
             .with_target(false)
             .compact()
             .with_thread_ids(true)
-            .with_thread_names(true);
+            .with_thread_names(true)
+            .with_writer(std::io::stdout);
 
         tracing_subscriber::registry()
             .with(env_filter)


### PR DESCRIPTION
Write the account controller unit tests to `stdout` instead of `stderr`, so they don't appear in the CI logs unless there is an error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3509)
<!-- Reviewable:end -->
