### PR TITLE
VPN-4010: Use default config on read error.

### DIFF
--- a/nym-vpn-core/crates/nym-vpnd/src/config.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/config.rs
@@ -6,7 +6,7 @@ use nym_vpn_lib::nym_config::defaults::NymNetworkDetails;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct GlobalConfig {
     pub network_name: String,
     pub sentry_monitoring: bool,
@@ -30,6 +30,22 @@ impl GlobalConfig {
     }
 
     pub async fn read_from_config_dir(config_dir: &Path) -> anyhow::Result<Self> {
+        let config = match Self::read_config(config_dir).await {
+            Ok(config) => config,
+            Err(err) => {
+                tracing::error!("Failed to read global config file; using default : {err}");
+                GlobalConfig::default()
+            }
+        };
+
+        // Always write back config file back using the latest JSON version
+        // TODO: Avoid doing this as it's double-writing the config file.
+        config.write_to_config_dir(config_dir).await?;
+
+        Ok(config)
+    }
+
+    async fn read_config(config_dir: &Path) -> anyhow::Result<Self> {
         let json_config_path = config_dir.join(crate::service::DEFAULT_GLOBAL_CONFIG_FILE_JSON);
         let json_config_exists = json_config_path.exists();
         let toml_config_path = config_dir.join(crate::service::DEFAULT_GLOBAL_CONFIG_FILE_TOML);
@@ -70,10 +86,6 @@ impl GlobalConfig {
             );
             let _ = std::fs::remove_file(&toml_config_path);
         }
-
-        // Always write back config file back using the latest JSON version
-        // TODO: Avoid doing this as it's double-writing the config file.
-        config.write_to_config_dir(config_dir).await?;
 
         Ok(config)
     }
@@ -283,5 +295,37 @@ collect_network_statistics = true
         // Check the JSON is the right version and all snake-case
         let read_json_content = fs::read_to_string(&json_path).await.unwrap();
         assert_eq!(json_content, read_json_content);
+    }
+
+    #[tokio::test]
+    async fn test_global_config_fallback_default() {
+        let (temp_dir, toml_path, json_path) = setup().await;
+
+        let broken_toml_content = r#"
+netwoXrk_name = "tulips"
+sentry_monitoring = false
+collect_network_statistics = true
+"#;
+
+        let broken_json_content = r#"{
+  "version": "v1",
+  "network_name": "tulips",
+  "sentry_mXonitoring": false,
+  "collect_network_statistics": true
+}"#;
+
+        // Write the (broken) TOML config file
+        fs::write(&toml_path, broken_toml_content).await.unwrap();
+        let config = GlobalConfig::read_from_config_dir(temp_dir.path())
+            .await
+            .unwrap();
+        assert_eq!(config, GlobalConfig::default());
+
+        // Write the (broken) JSON config file
+        fs::write(&json_path, broken_json_content).await.unwrap();
+        let config = GlobalConfig::read_from_config_dir(temp_dir.path())
+            .await
+            .unwrap();
+        assert_eq!(config, GlobalConfig::default());
     }
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/service/config.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/config.rs
@@ -100,7 +100,18 @@ impl VpnServiceConfigManager {
     ) -> Result<Self> {
         let toml_config_path = network_config_dir.join(DEFAULT_CONFIG_FILE_TOML);
         let json_config_path = network_config_dir.join(DEFAULT_CONFIG_FILE_JSON);
-        let (config, version) = Self::read_from_file(&toml_config_path, &json_config_path).await?;
+        let (config, version) =
+            match Self::read_from_file(&toml_config_path, &json_config_path).await {
+                Ok((config, version)) => (config, version),
+                Err(e) => {
+                    trace_err_chain!(
+                        e,
+                        "Failed to read service config file {}; using default",
+                        json_config_path.display()
+                    );
+                    (VpnServiceConfig::default(), 0)
+                }
+            };
 
         let config_manager = Self {
             json_config_path,
@@ -1160,8 +1171,8 @@ mod tests {
         assert_eq!(json_latest_content, read_json_content);
     }
 
-    // Test migrating from JSON v1 to the latest JSON version
-    async fn run_migrate_json_v1_test(json_v1_content: &str, json_latest_content: &str) {
+    // Test migrating from an old JSON version to the latest JSON version
+    async fn run_migrate_json_test(json_old_content: &str, json_latest_content: &str) {
         let temp_dir = tempdir().unwrap();
         let config_path = temp_dir.path();
 
@@ -1171,10 +1182,10 @@ mod tests {
         let _ = fs::create_dir_all(&network_config_path).await;
         let json_path = network_config_path.join(DEFAULT_CONFIG_FILE_JSON);
 
-        // Write the JSON v1 config file
-        fs::write(&json_path, json_v1_content).await.unwrap();
+        // Write the old JSON config file
+        fs::write(&json_path, json_old_content).await.unwrap();
 
-        // Read the JSON v1 config and migrate it to latest JSON.  The latest version of the
+        // Read the old JSON config and migrate it to latest JSON.  The latest version of the
         // JSON will be written straight back to disk.
         let _config_manager = VpnServiceConfigManager::new(&network_config_path, None)
             .await
@@ -1187,6 +1198,7 @@ mod tests {
         assert_eq!(expected, actual);
     }
 
+    // Test serializing and deserializing the config produces the same result
     async fn run_serialize_test(config: VpnServiceConfig) {
         let temp_dir = tempdir().unwrap();
         let config_path = temp_dir.path();
@@ -1209,6 +1221,28 @@ mod tests {
             .unwrap();
         let read_config = config_manager.config();
         assert_eq!(&config, read_config);
+    }
+
+    // Test reading a broken config falls back to a default config
+    async fn run_fallback_test(broken_json_content: &str) {
+        let temp_dir = tempdir().unwrap();
+        let config_path = temp_dir.path();
+
+        println!("Using config dir: {config_path:?}");
+
+        let network_config_path = config_path.join("tulips");
+        let _ = fs::create_dir_all(&network_config_path).await;
+        let json_path = network_config_path.join(DEFAULT_CONFIG_FILE_JSON);
+
+        // Write the broken JSON config file
+        fs::write(&json_path, broken_json_content).await.unwrap();
+
+        // Ensure reading the broken config falls back to default config
+        let config_manager = VpnServiceConfigManager::new(&network_config_path, None)
+            .await
+            .unwrap();
+
+        assert_eq!(config_manager.config(), &VpnServiceConfig::default());
     }
 
     #[tokio::test]
@@ -1427,7 +1461,53 @@ exit_point = "Random"
   "min_gateway_vpn_performance": null
 }"#;
 
-        run_migrate_json_v1_test(json_v1_content, json_latest_content).await;
+        run_migrate_json_test(json_v1_content, json_latest_content).await;
+    }
+
+    #[tokio::test]
+    async fn test_service_config_fallback_default_v1() {
+        let broken_json_content = r#"{
+  "version": "v1",
+  "entrXy_point": {
+    "gateway": {
+      "identity": "7CWjY3QFoA9dgE535u9bQiXCfzgMZvSpJu842GA1Wn42"
+    }
+  },
+  "exit_point": {
+    "address": {
+      "address": "MNrmKzuKjNdbEhfPUzVNfjw63oBQNSayqoQKGL4JjAV.6fDcSN6faGpvA3pd3riCwjpzXc7RQfWmGMa82UVoEwKE@d5adfJNtcdZW2XwK85JAAU8nXAs9JCPYn2RNvDLZn4e"
+    }
+  }
+}"#;
+        run_fallback_test(broken_json_content).await;
+    }
+
+    #[tokio::test]
+    async fn test_service_config_fallback_default_v2() {
+        let broken_json_content = r#"{
+  "version": "v2",
+  "entry_point": {
+    "gateway": {
+      "identity": "7CWjY3QFoA9dgE535u9bQiXCfzgMZvSpJu842GA1Wn42"
+    }
+  },
+  "exit_point": {
+    "address": {
+      "address": "MNrmKzuKjNdbEhfPUzVNfjw63oBQNSayqoQKGL4JjAV.6fDcSN6faGpvA3pd3riCwjpzXc7RQfWmGMa82UVoEwKE@d5adfJNtcdZW2XwK85JAAU8nXAs9JCPYn2RNvDLZn4e"
+    }
+  },
+  "dns": null,
+  "disable_ipv6": false,
+  "enable_two_hop": false,
+  "netstack": false,
+  "disable_poisson_rate": false,
+  "disable_background_cover_traffic": false,
+  "min_mixnode_performance": null,
+  "min_gateway_mixnet_performance": null,
+  "min_gateway_vpn_performance": null
+}"#;
+
+        run_fallback_test(broken_json_content).await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
If either the global or service config file is malformed, then we keep calm and carry on.  After a bit of moaning.

## Ticket

JIRA-VPN-4010

## Description

Don't fail to start-up if the configuration on disk is invalid.

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3512)
<!-- Reviewable:end -->
