### PR TITLE
fix: store last known tunnel state

### DIFF
--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -601,6 +601,9 @@ impl NymVpnService {
     }
 
     fn handle_tunnel_event(&mut self, event: TunnelEvent) {
+        if let TunnelEvent::NewState(ref state) = event {
+            self.tunnel_state = state.clone();
+        }
         if self.tunnel_event_tx.send(event).is_err() {
             tracing::error!("Failed to send tunnel event");
         }


### PR DESCRIPTION
## Description

Seems like [I removed the call storing the last known tunnel state](https://github.com/nymtech/nym-vpn-client/commit/17c2bc1bcd16a737a8abaf98477dcd6f8cd464b6#diff-93b99b4f915ea60535254437960efba7606cc1506cde3f2836ebf5cf4fe3f98aL607) in the vpn service. This PR restores this. Sorry for that.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3515)
<!-- Reviewable:end -->
