### PR TITLE
Nym-gateway-directory is no longer optional

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib-types/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/Cargo.toml
@@ -15,7 +15,6 @@ workspace = true
 nym-type-conversions = [
     "dep:nym-bandwidth-controller",
     "dep:nym-connection-monitor",
-    "dep:nym-gateway-directory",
     "dep:nym-statistics-common",
     "dep:nym-vpn-api-client",
     "dep:nym-wg-gateway-client",
@@ -28,7 +27,7 @@ time.workspace = true
 
 nym-bandwidth-controller = { workspace = true, optional = true }
 nym-connection-monitor = { workspace = true, optional = true }
-nym-gateway-directory = { workspace = true, optional = true }
+nym-gateway-directory = { workspace = true }
 nym-statistics-common = { workspace = true, optional = true }
 nym-vpn-api-client = { workspace = true, optional = true }
 nym-wg-gateway-client = { workspace = true, optional = true }


### PR DESCRIPTION
## Description

Since `VpnServiceConfig` references `EntryPoint` and `ExitPoint` from `nym-gateway-directory`, we have to remove it from optional dependencies. Because of how Rust merges all features in the workspace, this works fine when compiling the entire workspace. However Rust fails to compile when compiling individual crates such as `nym-vpn-cli`


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3531)
<!-- Reviewable:end -->
