### PR TITLE
Rename RichLocation to Location

### DIFF
--- a/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/NymBackend.kt
+++ b/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/NymBackend.kt
@@ -315,6 +315,7 @@ class NymBackend private constructor(private val context: Context) : Backend, Tu
 						tunnel.entryPoint,
 						tunnel.exitPoint,
 						tunnel.mode.isTwoHop(),
+						false,
 						vpnService.await(),
 						storagePath,
 						storagePath,

--- a/nym-vpn-app/src-tauri/src/grpc/client.rs
+++ b/nym-vpn-app/src-tauri/src/grpc/client.rs
@@ -15,7 +15,7 @@ use super::{
 use anyhow::{Result, anyhow};
 use nym_vpn_proto::proto::{
     AccountControllerState, ConnectRequest, Dns, GetAccountLinksRequest, ListGatewaysRequest,
-    RichLocation, StoreAccountRequest, TunnelEvent, TunnelState as PTunnelState, UserAgent,
+    Location, StoreAccountRequest, TunnelEvent, TunnelState as PTunnelState, UserAgent,
     nym_vpn_service_client::NymVpnServiceClient, tunnel_event::Event,
 };
 use once_cell::sync::Lazy;
@@ -677,10 +677,10 @@ async fn connect(socket_path: PathBuf) -> Result<Channel> {
         .await?)
 }
 
-impl TryFrom<&RichLocation> for Country {
+impl TryFrom<&Location> for Country {
     type Error = anyhow::Error;
 
-    fn try_from(location: &RichLocation) -> Result<Country, Self::Error> {
+    fn try_from(location: &Location) -> Result<Country, Self::Error> {
         Country::try_new_from_code(&location.two_letter_iso_country_code).ok_or_else(|| {
             let msg = format!(
                 "invalid country code {}",

--- a/nym-vpn-app/src-tauri/src/grpc/gateway.rs
+++ b/nym-vpn-app/src-tauri/src/grpc/gateway.rs
@@ -169,8 +169,8 @@ impl From<GatewayType> for p::GatewayType {
     }
 }
 
-impl From<p::RichLocation> for Location {
-    fn from(proto: p::RichLocation) -> Self {
+impl From<p::Location> for Location {
+    fn from(proto: p::Location) -> Self {
         Location {
             latitude: proto.latitude,
             longitude: proto.longitude,

--- a/nym-vpn-core/crates/nym-vpn-lib-types-uniffi/src/gateway.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types-uniffi/src/gateway.rs
@@ -201,7 +201,7 @@ impl From<nym_vpn_lib_types::Performance> for Performance {
 pub struct Gateway {
     pub id: String,
     pub moniker: String,
-    pub location: Option<RichLocation>,
+    pub location: Option<Location>,
     pub mixnet_score: Option<Score>,
     pub wg_performance: Option<Performance>,
     pub exit_ipv4s: Vec<Ipv4Addr>,
@@ -214,7 +214,7 @@ impl From<nym_gateway_directory::Gateway> for Gateway {
         let (exit_ipv4s, exit_ipv6s) = value.split_ips();
         Gateway {
             moniker: value.moniker,
-            location: value.location.map(RichLocation::from),
+            location: value.location.map(Location::from),
             id: value.identity.to_base58_string(),
             mixnet_score: value.mixnet_score.map(Score::from),
             wg_performance: value.wg_performance.map(Performance::from),
@@ -229,7 +229,7 @@ impl From<nym_vpn_lib_types::Gateway> for Gateway {
     fn from(value: nym_vpn_lib_types::Gateway) -> Self {
         Gateway {
             moniker: value.moniker,
-            location: value.location.map(RichLocation::from),
+            location: value.location.map(Location::from),
             id: value.identity_key,
             mixnet_score: value.mixnet_score.map(Score::from),
             wg_performance: value.wg_performance.map(Performance::from),
@@ -292,7 +292,7 @@ impl From<nym_vpn_lib_types::Asn> for Asn {
 }
 
 #[derive(Debug, PartialEq, uniffi::Record, Clone)]
-pub struct RichLocation {
+pub struct Location {
     pub two_letter_iso_country_code: String,
     pub latitude: f64,
     pub longitude: f64,
@@ -301,41 +301,28 @@ pub struct RichLocation {
     pub asn: Option<Asn>,
 }
 
-impl From<nym_gateway_directory::Location> for RichLocation {
+impl From<nym_gateway_directory::Location> for Location {
     fn from(value: nym_gateway_directory::Location) -> Self {
-        RichLocation {
-            two_letter_iso_country_code: value.two_letter_iso_country_code,
-            latitude: value.latitude,
-            longitude: value.longitude,
-            city: value.city,
-            region: value.region,
-            asn: value.asn.map(Into::into),
-        }
-    }
-}
-
-impl From<nym_vpn_lib_types::Location> for RichLocation {
-    fn from(value: nym_vpn_lib_types::Location) -> Self {
-        RichLocation {
-            two_letter_iso_country_code: value.two_letter_iso_country_code,
-            latitude: value.latitude,
-            longitude: value.longitude,
-            city: value.city,
-            region: value.region,
-            asn: value.asn.map(Into::into),
-        }
-    }
-}
-
-#[derive(Debug, PartialEq, uniffi::Record, Clone)]
-pub struct Location {
-    pub two_letter_iso_country_code: String,
-}
-
-impl From<nym_gateway_directory::Country> for Location {
-    fn from(value: nym_gateway_directory::Country) -> Self {
         Location {
-            two_letter_iso_country_code: value.iso_code().to_string(),
+            two_letter_iso_country_code: value.two_letter_iso_country_code,
+            latitude: value.latitude,
+            longitude: value.longitude,
+            city: value.city,
+            region: value.region,
+            asn: value.asn.map(Into::into),
+        }
+    }
+}
+
+impl From<nym_vpn_lib_types::Location> for Location {
+    fn from(value: nym_vpn_lib_types::Location) -> Self {
+        Location {
+            two_letter_iso_country_code: value.two_letter_iso_country_code,
+            latitude: value.latitude,
+            longitude: value.longitude,
+            city: value.city,
+            region: value.region,
+            asn: value.asn.map(Into::into),
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -36,7 +36,7 @@ message Region {
   string region = 1;
 }
 
-message RichLocation {
+message Location {
   string two_letter_iso_country_code = 1;
   double latitude = 2;
   double longitude = 3;
@@ -285,7 +285,7 @@ message Probe {
 
 message GatewayResponse {
   GatewayId id = 1;
-  RichLocation location = 2;
+  Location location = 2;
   Probe last_probe = 3;
   optional uint32 mixnet_performance = 10;
   optional Performance wg_performance = 4;

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/vpnd.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/vpnd.rs
@@ -23,10 +23,10 @@ use nym_vpn_network_config::{
 
 use crate::{conversions::ConversionError, proto};
 
-impl TryFrom<proto::RichLocation> for nym_vpn_lib_types::Location {
+impl TryFrom<proto::Location> for nym_vpn_lib_types::Location {
     type Error = ConversionError;
 
-    fn try_from(location: proto::RichLocation) -> Result<Self, Self::Error> {
+    fn try_from(location: proto::Location) -> Result<Self, Self::Error> {
         Ok(Self {
             two_letter_iso_country_code: location.two_letter_iso_country_code,
             latitude: location.latitude,
@@ -252,7 +252,7 @@ impl From<nym_vpn_lib_types::Gateway> for proto::GatewayResponse {
         let id = Some(proto::GatewayId {
             id: gateway.identity_key.to_string(),
         });
-        let location = gateway.location.map(proto::RichLocation::from);
+        let location = gateway.location.map(proto::Location::from);
         let last_probe = gateway.last_probe.map(proto::Probe::from);
         let moniker = gateway.moniker;
         let exit_ipv4s = gateway.exit_ipv4s.iter().map(|ip| ip.to_string()).collect();
@@ -602,9 +602,9 @@ impl TryFrom<proto::Asn> for nym_vpn_lib_types::Asn {
     }
 }
 
-impl From<nym_vpn_lib_types::Location> for proto::RichLocation {
+impl From<nym_vpn_lib_types::Location> for proto::Location {
     fn from(location: nym_vpn_lib_types::Location) -> Self {
-        proto::RichLocation {
+        Self {
             two_letter_iso_country_code: location.two_letter_iso_country_code,
             latitude: location.latitude,
             longitude: location.longitude,


### PR DESCRIPTION
## Description

`Location` became unused in uniffi. `RichLocation` was added instead and mapped to `Location` from lib types. This PR aligns both types and removes the old unused `Location`

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3577)
<!-- Reviewable:end -->
