### PR TITLE
make vpn-api-client optional again in vpn-lib-types

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib-types/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/Cargo.toml
@@ -17,6 +17,7 @@ nym-type-conversions = [
     "dep:nym-connection-monitor",
     "dep:nym-statistics-common",
     "dep:nym-registration-common",
+    "dep:nym-vpn-api-client",
 ]
 
 [dependencies]
@@ -33,6 +34,6 @@ nym-sdk.workspace = true
 nym-validator-client.workspace = true
 nym-statistics-common = { workspace = true, optional = true }
 nym-vpn-network-config.workspace = true
-nym-vpn-api-client.workspace = true
+nym-vpn-api-client = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 strum_macros.workspace = true

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/bridges.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/bridges.rs
@@ -1,4 +1,0 @@
-// Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
-// SPDX-License-Identifier: GPL-3.0-only
-
-pub use nym_vpn_api_client::response::{BridgeInformation, BridgeParameters, QuicClientOptions};

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
@@ -4,7 +4,6 @@
 //! Types shared between nym-vpn-lib and other crates in the workspace.
 
 mod account;
-mod bridges;
 mod connection_data;
 mod gateway;
 mod log_path;
@@ -23,7 +22,6 @@ pub use account::{
     request_zknym::{RequestZkNymError, RequestZkNymErrorReason, RequestZkNymSuccess},
     ticketbooks::AvailableTickets,
 };
-pub use bridges::{BridgeInformation, BridgeParameters, QuicClientOptions};
 pub use connection_data::{
     ConnectionData, EstablishConnectionData, EstablishConnectionState, GatewayId,
     MixnetConnectionData, NymAddress, TunnelConnectionData, WireguardConnectionData, WireguardNode,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/transports/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/transports/mod.rs
@@ -17,7 +17,7 @@ use tracing::*;
 
 mod certs;
 use certs::*;
-pub use nym_vpn_lib_types::{BridgeInformation, BridgeParameters, QuicClientOptions};
+pub use nym_vpn_api_client::response::{BridgeInformation, BridgeParameters, QuicClientOptions};
 
 const LENGTH_DELIMITER_BYTELEN: usize = 2;
 const INITIAL_CONNECTION_TIMEOUT: Duration = Duration::from_secs(10);


### PR DESCRIPTION
Everything is in the title

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3584)
<!-- Reviewable:end -->
