### PR TITLE
CI: offload some of the work from custom-macos-15 to GH builds

### DIFF
--- a/.github/workflows/build-nym-vpn-core-ios.yml
+++ b/.github/workflows/build-nym-vpn-core-ios.yml
@@ -21,6 +21,7 @@ jobs:
   build-ios:
     needs: build-wireguard-go-ios
     runs-on: custom-macos-15
+    timeout-minutes: 30
     outputs:
       UPLOAD_DIR_IOS: ${{ env.UPLOAD_DIR_IOS }}
       RUST_VERSION: ${{ steps.rust-version.outputs.rustc }}

--- a/.github/workflows/build-nym-vpn-core-mac.yml
+++ b/.github/workflows/build-nym-vpn-core-mac.yml
@@ -19,7 +19,8 @@ jobs:
 
   build-mac:
     needs: build-wireguard-go-mac
-    runs-on: custom-macos-15
+    runs-on: macos-15
+    timeout-minutes: 45
     outputs:
       UPLOAD_DIR_MAC: ${{ env.UPLOAD_DIR_MAC }}
     steps:

--- a/.github/workflows/build-wireguard-go-ios.yml
+++ b/.github/workflows/build-wireguard-go-ios.yml
@@ -13,16 +13,27 @@ env:
 jobs:
   build:
     runs-on: custom-macos-15
+    timeout-minutes: 5
 
     steps:
       - name: Checkout nym-vpn-client
         uses: actions/checkout@v4
-      
+
       - name: Install Go
         uses: actions/setup-go@v5
         with:
           go-version: ${{ vars.REQUIRED_GOLANG_VERSION }}
           cache: false
+
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
       - name: Build wireguard
         run: ./wireguard/build-wireguard-go.sh --ios

--- a/.github/workflows/build-wireguard-go-mac.yml
+++ b/.github/workflows/build-wireguard-go-mac.yml
@@ -1,4 +1,5 @@
 name: build-wireguard-go-mac
+
 on:
   workflow_dispatch:
   workflow_call:
@@ -13,15 +14,27 @@ env:
 jobs:
   build:
     runs-on: custom-macos-15
+    timeout-minutes: 5
+
     steps:
       - name: Checkout nym-vpn-client
         uses: actions/checkout@v4
-      
+
       - name: Install Go
         uses: actions/setup-go@v5
         with:
           go-version: ${{ vars.REQUIRED_GOLANG_VERSION }}
           cache: false
+
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
       - name: Build wireguard
         run: ./wireguard/build-wireguard-go.sh

--- a/.github/workflows/ci-nym-vpn-app-rust.yml
+++ b/.github/workflows/ci-nym-vpn-app-rust.yml
@@ -17,8 +17,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [arc-linux-latest, custom-macos-15, custom-windows-11]
+        os: [arc-linux-latest, custom-macos-15, macos-15, custom-windows-11]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
 
     steps:
       - name: "Cleanup working directory"

--- a/.github/workflows/ci-nym-vpn-core-ios.yml
+++ b/.github/workflows/ci-nym-vpn-core-ios.yml
@@ -18,11 +18,20 @@ jobs:
     uses: ./.github/workflows/build-wireguard-go-ios.yml
 
   build:
-    runs-on: custom-macos-15
+    runs-on: ${{ matrix.runner }}
     needs: build-wireguard-go-ios
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - custom-macos-15
+          - macos-15
 
     steps:
-      - name: "Cleanup working directory"
+      - name: Cleanup working directory
+        if: matrix.runner == 'custom-macos-15'
         shell: bash
         run: |
           ls -la ./
@@ -45,6 +54,27 @@ jobs:
         with:
           version: "21.12" # 3.21.12: the version on ubuntu 24.04. Don't change this!
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
+
+      - name: Cache Cargo build
+        uses: actions/cache@v4
+        with:
+          path: nym-vpn-core/target/
+          key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('nym-vpn-core/**/*.rs') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}-
+            ${{ runner.os }}-cargo-build-
 
       - name: Download artifacts
         uses: actions/download-artifact@v5

--- a/.github/workflows/ci-nym-vpn-core-macos.yml
+++ b/.github/workflows/ci-nym-vpn-core-macos.yml
@@ -1,7 +1,6 @@
 name: ci-nym-vpn-core-macos
 
 on:
-  # push:
   pull_request:
     paths:
       - "nym-vpn-core/**"
@@ -17,11 +16,20 @@ jobs:
     uses: ./.github/workflows/build-wireguard-go-mac.yml
 
   build:
-    runs-on: custom-macos-15
+    runs-on: ${{ matrix.runner }}
     needs: build-wireguard-go-mac
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - custom-macos-15
+          - macos-15
 
     steps:
-      - name: "Cleanup working directory"
+      - name: Cleanup working directory
+        if: matrix.runner == 'custom-macos-15'
         shell: bash
         run: |
           ls -la ./
@@ -37,7 +45,7 @@ jobs:
         with:
           toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
           components: rustfmt, clippy
-      
+
       - name: Install Go
         uses: actions/setup-go@v5
         with:
@@ -50,6 +58,27 @@ jobs:
           version: "21.12" # 3.21.12: the version on ubuntu 24.04. Don't change this!
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Cache Cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
+
+      - name: Cache Cargo build
+        uses: actions/cache@v4
+        with:
+          path: nym-vpn-core/target/
+          key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('nym-vpn-core/**/*.rs') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}-
+            ${{ runner.os }}-cargo-build-
+
       - name: Download artifacts
         uses: actions/download-artifact@v5
         with:
@@ -60,7 +89,7 @@ jobs:
         working-directory: nym-vpn-core
         run: |
           cargo fmt --check --all
-      
+
       - name: Clippy
         working-directory: nym-vpn-core
         run: |
@@ -75,4 +104,3 @@ jobs:
         working-directory: nym-vpn-core
         run: |
           cargo test --verbose --workspace --locked
-


### PR DESCRIPTION
custom-macos-15 runner ram has wobbles, use the matrix to balance out  CI jobs on both custom-macos-15 and macos-15 runners. added caching and timeouts to increase performance.

## Ticket

JIRA-VPN-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3590)
<!-- Reviewable:end -->
