### PR TITLE
Quic Transport related fixes

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -366,15 +366,13 @@ impl ConnectingState {
     ) -> Result<()> {
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         let set_policy_result = {
-            let mut bridge_endpoints = Vec::new();
             if shared_state.tunnel_settings.bridges_enabled()
                 && let Some(params) = &gateways.entry.bridge_params
             {
-                bridge_endpoints = params.get_addrs();
+                self.firewall_policy_params.bridge_endpoints = params.get_addrs()
             }
 
             self.firewall_policy_params.ws_entry_endpoints = gateways.entry.endpoints();
-            self.firewall_policy_params.bridge_endpoints = bridge_endpoints;
             Self::set_firewall_policy(shared_state, &self.firewall_policy_params)
         };
         self.selected_gateways = Some(*gateways);

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -362,12 +362,20 @@ impl ConnectingState {
     async fn handle_selected_gateways(
         &mut self,
         gateways: Box<SelectedGateways>,
-        _shared_state: &mut SharedState,
+        shared_state: &mut SharedState,
     ) -> Result<()> {
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         let set_policy_result = {
+            let mut bridge_endpoints = Vec::new();
+            if shared_state.tunnel_settings.bridges_enabled()
+                && let Some(params) = &gateways.entry.bridge_params
+            {
+                bridge_endpoints = params.get_addrs();
+            }
+
             self.firewall_policy_params.ws_entry_endpoints = gateways.entry.endpoints();
-            Self::set_firewall_policy(_shared_state, &self.firewall_policy_params)
+            self.firewall_policy_params.bridge_endpoints = bridge_endpoints;
+            Self::set_firewall_policy(shared_state, &self.firewall_policy_params)
         };
         self.selected_gateways = Some(*gateways);
 
@@ -673,7 +681,7 @@ impl ConnectingPolicyParameters {
             .filter(|addr| addr.is_ipv4() || (self.enable_ipv6 && addr.is_ipv6()))
             .for_each(|addr| {
                 let allow_bridge_endpoint = AllowedEndpoint::new(
-                    Endpoint::from_socket_address(*addr, TransportProtocol::Tcp),
+                    Endpoint::from_socket_address(*addr, TransportProtocol::Udp),
                     #[cfg(any(target_os = "linux", target_os = "macos"))]
                     AllowedClients::Root,
                     #[cfg(target_os = "windows")]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -362,18 +362,18 @@ impl ConnectingState {
     async fn handle_selected_gateways(
         &mut self,
         gateways: Box<SelectedGateways>,
-        shared_state: &mut SharedState,
+        _shared_state: &mut SharedState,
     ) -> Result<()> {
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         let set_policy_result = {
-            if shared_state.tunnel_settings.bridges_enabled()
+            if _shared_state.tunnel_settings.bridges_enabled()
                 && let Some(params) = &gateways.entry.bridge_params
             {
                 self.firewall_policy_params.bridge_endpoints = params.get_addrs()
             }
 
             self.firewall_policy_params.ws_entry_endpoints = gateways.entry.endpoints();
-            Self::set_firewall_policy(shared_state, &self.firewall_policy_params)
+            Self::set_firewall_policy(_shared_state, &self.firewall_policy_params)
         };
         self.selected_gateways = Some(*gateways);
 

--- a/nym-vpn-core/crates/nym-vpnd/src/service/config.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/config.rs
@@ -344,7 +344,7 @@ impl VpnServiceConfigManager {
     }
 
     pub fn generate_tunnel_settings(&self) -> TunnelSettings {
-        tracing::debug!("Using config: {:?}", self.config);
+        tracing::info!("Using config: {:?}", self.config);
 
         let gateway_options = GatewayPerformanceOptions {
             mixnet_min_performance: self.config.min_gateway_mixnet_performance,


### PR DESCRIPTION
## Description

Fix a bg relating to firewall exceptions when using quic transport bridge.

Tested as working in canary :heavy_check_mark: 


## Checklist:

- [x] bridge related firewall exceptions added in `handle_selected_gateway`
- [x] fix firewall rule bug that was setting quic exceptions to TCP instead of UDP.
- [x] full config to be logged at `info` level instead of `debug`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3596)
<!-- Reviewable:end -->
