### PR TITLE
feat(tauri-nsis): improve nsis installer experience when vpnd fails

### DIFF
--- a/nym-vpn-app/CHANGELOG.md
+++ b/nym-vpn-app/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - When navigating from the _Server details_ screen back to the node list,
   restore previous expanded nodes and scroll to the last focused node
+- [Windows] Improve Windows installer when vpnd service fails 
+  to install, uninstall or start
 
 ### Fixed
 

--- a/nym-vpn-app/CHANGELOG.md
+++ b/nym-vpn-app/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - When navigating from the _Server details_ screen back to the node list,
   restore previous expanded nodes and scroll to the last focused node
-- [Windows] Improve Windows installer when vpnd service fails 
+- [Windows] Improve Windows installer when vpnd service fails
   to install, uninstall or start
 
 ### Fixed

--- a/nym-vpn-app/README.md
+++ b/nym-vpn-app/README.md
@@ -173,7 +173,9 @@ To generate bindings, first
 [annotate](https://github.com/Aleph-Alpha/ts-rs/blob/main/example/src/lib.rs)
 Rust types, then run
 
-```
+```shell
+npm run tsgen
+# or
 cd src-tauri
 cargo test
 ```

--- a/nym-vpn-app/package.json
+++ b/nym-vpn-app/package.json
@@ -23,8 +23,8 @@
     "fmt": "prettier --write --ignore-unknown \"**/*\"",
     "fmt:check": "prettier --check --ignore-unknown \"**/*\"",
     "tscheck": "tsc --noEmit",
+    "tsgen": "cd src-tauri && cargo test && prettier --write ../src/types/tauri.ts",
     "tauri": "tauri",
-    "gen:ts": "cd src-tauri && cargo test && prettier --write ../src/types/tauri.ts",
     "gen:licenses": "run-p --aggregate-output gen:licenses:rust gen:licenses:js",
     "gen:licenses:js": "npx --yes license-checker-rseidelsohn@4.3.0 --production --json > public/licenses-js.json",
     "gen:licenses:rust": "cargo license -j --avoid-dev-deps --avoid-build-deps --manifest-path src-tauri/Cargo.toml > public/licenses-rust.json"

--- a/nym-vpn-app/src-tauri/bundle/windows/installer.nsi
+++ b/nym-vpn-app/src-tauri/bundle/windows/installer.nsi
@@ -186,12 +186,19 @@ FunctionEnd
 !macro VPND_UNINSTALL un
   Function ${un}VpndUninstall
     Call ${un}GetVpndVersionFull
-    ${If} $VpndVersionMajor == 1
-    ${AndIf} $VpndVersionMinor < 14
-      DetailPrint "vpnd version is pre 1.14, using --uninstall flag"
-      ExecWait '"$INSTDIR\nym-vpnd.exe" --uninstall'
-    ${Else}
-      ExecWait '"$INSTDIR\nym-vpnd.exe" uninstall-service'
+    vpnd-uninstall:
+      ${If} $VpndVersionMajor == 1
+      ${AndIf} $VpndVersionMinor < 14
+        DetailPrint "vpnd version is pre 1.14, using --uninstall flag"
+        ExecWait '"$INSTDIR\nym-vpnd.exe" --uninstall' $9
+      ${Else}
+        ExecWait '"$INSTDIR\nym-vpnd.exe" uninstall-service' $9
+      ${EndIf}
+    ${If} $9 <> 0
+      ; if vpnd fails to uninstall all we can do is to notify the user
+      ; !DO NOT ABORT HERE! this will lock the user from uninstalling the app!
+      DetailPrint "'nym-vpnd.exe uninstall-service' failed: $9"
+      MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION "Failed to uninstall NymVPN service [$9]" /SD IDABORT IDRETRY vpnd-uninstall
     ${EndIf}
   FunctionEnd
 !macroend
@@ -694,6 +701,26 @@ Section Install
   File "..\..\..\..\wintun.dll"
   File "..\..\..\..\winfw.dll"
 
+  ; Install NymVPN service, abort early if something goes wrong
+  vpnd-install:
+    ExecWait '"$INSTDIR\nym-vpnd.exe" install-service' $3
+  ${If} $3 <> 0
+    DetailPrint "'nym-vpnd.exe install-service' failed: $3"
+    MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION "An error occurred while installing NymVPN service [$3]" /SD IDABORT IDRETRY vpnd-install
+      Call Cleanup
+      Abort
+  ${EndIf}
+
+  ; Start NymVPN service, notify user if something goes wrong
+  vpnd-start:
+    ExecWait '"$INSTDIR\nym-vpnd.exe" start-service' $3
+  ${If} $3 <> 0
+    ; if vpnd fails to start we notify the user and continue as this
+    ; can been solved later on
+    DetailPrint "'nym-vpnd.exe start-service' failed: $3"
+    MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION "Failed to start NymVPN service [$3]" /SD IDABORT IDRETRY vpnd-start
+  ${EndIf}
+
   ; Copy resources
   {{#each resources_dirs}}
     CreateDirectory "$INSTDIR\\{{this}}"
@@ -765,10 +792,6 @@ Section Install
     WriteRegStr SHCTX "${UNINSTKEY}" "HelpLink" "${HOMEPAGE}"
   !endif
 
-  ; Install NymVPN service
-  ExecWait '"$INSTDIR\nym-vpnd.exe" install-service'
-  ExecWait '"$INSTDIR\nym-vpnd.exe" start-service'
-
   ; Create start menu shortcut
   !insertmacro MUI_STARTMENU_WRITE_BEGIN Application
     Call CreateOrUpdateStartMenuShortcut
@@ -802,6 +825,15 @@ Function .onInstSuccess
       nsis_tauri_utils::RunAsUser "$INSTDIR\${MAINBINARYNAME}.exe" "$R0"
     ${EndIf}
   ${EndIf}
+FunctionEnd
+
+Function Cleanup
+  ; cleanup
+  Delete "$INSTDIR\${MAINBINARYNAME}.exe"
+  Delete "$INSTDIR\nym-vpnd.exe"
+  Delete "$INSTDIR\libwg.dll"
+  Delete "$INSTDIR\wintun.dll"
+  Delete "$INSTDIR\winfw.dll"
 FunctionEnd
 
 Function un.onInit

--- a/nym-vpn-app/src-tauri/bundle/windows/installer.nsi
+++ b/nym-vpn-app/src-tauri/bundle/windows/installer.nsi
@@ -196,7 +196,8 @@ FunctionEnd
       ${EndIf}
     ${If} $9 <> 0
       ; if vpnd fails to uninstall all we can do is to notify the user
-      ; !DO NOT ABORT HERE! this will lock the user from uninstalling the app!
+      ; !DO NOT ABORT HERE! this will lock forever the user with a broken uninstaller!
+      ; preventing user to install/uninstall/update
       DetailPrint "'nym-vpnd.exe uninstall-service' failed: $9"
       MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION "Failed to uninstall NymVPN service [$9]" /SD IDABORT IDRETRY vpnd-uninstall
     ${EndIf}
@@ -828,7 +829,6 @@ Function .onInstSuccess
 FunctionEnd
 
 Function Cleanup
-  ; cleanup
   Delete "$INSTDIR\${MAINBINARYNAME}.exe"
   Delete "$INSTDIR\nym-vpnd.exe"
   Delete "$INSTDIR\libwg.dll"


### PR DESCRIPTION
- on install abort the install early if vpnd install fails
- on install notify the user when vpnd failed to start, but continue the installation because the issue could be fixed later on and because at this point vpnd is already installed so not a good idea to abort here
- on uninstall/update notify the user when vpnd fails to uninstall
- for each cases a message box will open with the corresponding error message including the exit status code of the vpnd command
- for each cases user can click "Retry" to retry vpnd install/uninstall/start
- for each cases user can click "Cancel" to abort or skip

**IMPORTANT** why not aborting the uninstall/update process when `vpnd.exe uninstall-service` fails?

Because if you do that you lock forever the user with an installed app and a broken uninstaller. The only way to recover is to manually nuke lot of keys in the Windows registry in order to "release" the app install, then allowing to reinstall and cleanup (I experienced it myself, was fun xD)

JIRA-VPN-3886 JIRA-VPN-3887

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3597)
<!-- Reviewable:end -->
