### PR TITLE
chore(tauri): bump dev version, update doc and fix typo

### DIFF
--- a/nym-vpn-app/docs/type-bindings.md
+++ b/nym-vpn-app/docs/type-bindings.md
@@ -1,0 +1,40 @@
+## Type bindings
+
+[ts-rs](https://github.com/Aleph-Alpha/ts-rs) is used to generate
+TypeScript type definitions from Rust types
+
+The UI web app (Js) is consuming typed data from tauri (Rust).
+In order to enforce end-to-end typing across boundary, TypeScript
+types are generated from Rust (eg. `struct`s and `enum`s).
+
+To generate ts types run
+
+```shell
+npm run tsgen
+# or
+cd src-tauri && cargo test
+```
+
+This will generate all the types in `src/types/tauri.ts`. This
+file is git tracked. Be sure to commit new changes.
+
+### During dev iterations
+
+See how to [annotate](https://github.com/Aleph-Alpha/ts-rs/blob/main/example/src/lib.rs)
+Rust types.
+
+When introducing changes in Rust side impacting shared types,
+you must re-generate them, then handle any breaking.
+
+For example, run the following commands to check for any ts errors
+
+```shell
+npm run tsgen
+npm run tscheck
+```
+
+### CI
+
+In CI a check is made to ensure that ts code is not broken,
+including the generated types.
+If CI is red on this check -> UI is broken!

--- a/nym-vpn-app/src-tauri/Cargo.lock
+++ b/nym-vpn-app/src-tauri/Cargo.lock
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-app"
-version = "1.17.0-dev"
+version = "1.18.0-dev"
 dependencies = [
  "anyhow",
  "build-info",

--- a/nym-vpn-app/src-tauri/Cargo.toml
+++ b/nym-vpn-app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nym-vpn-app"
-version = "1.17.0-dev"
+version = "1.18.0-dev"
 description = "NymVPN desktop client"
 authors = [
     "Nym Technologies SA",

--- a/nym-vpn-app/src-tauri/tauri.conf.json
+++ b/nym-vpn-app/src-tauri/tauri.conf.json
@@ -28,7 +28,7 @@
     ],
     "linux": {
       "deb": {
-        "depends": ["nym-vpnd (>= 1.17.0~beta)"],
+        "depends": ["nym-vpnd (>= 1.18.0~beta)"],
         "desktopTemplate": "./bundle/deb/main.desktop"
       }
     }

--- a/nym-vpn-app/src/i18n/en/settings.json
+++ b/nym-vpn-app/src/i18n/en/settings.json
@@ -37,7 +37,7 @@
   },
   "anti-censorship": {
     "title": "Anti-censorship",
-    "intro": "Enable these features if you're experiencing connection issues or NymVPN blocking in your location.",
+    "intro": "Enable these features if you're experiencing connection issues or NymVPN is blocked in your location.",
     "quic": {
       "label": "Enhanced connection (QUIC)",
       "warning": "Changes will apply after reconnect",

--- a/nym-vpn-app/src/screens/settings/Settings.tsx
+++ b/nym-vpn-app/src/screens/settings/Settings.tsx
@@ -102,7 +102,7 @@ function Settings() {
           },
           showAntiCensorship && {
             title: t('anti-censorship.title', { ns: 'settings' }),
-            leadingIcon: 'dns',
+            leadingIcon: 'campaign',
             onClick: () => navigate(routes.antiCensorship),
             trailing: <MsIcon icon="arrow_right" className="dark:text-white" />,
           },

--- a/nym-vpn-app/vpnd_compat.toml
+++ b/nym-vpn-app/vpnd_compat.toml
@@ -1,2 +1,2 @@
 # semver requirement of supported daemon version(s)
-version = ">=1.17.0-beta"
+version = ">=1.18.0-beta"


### PR DESCRIPTION
Note: vpnd deb requirement has been bumped to `>= 1.18.0-beta` as in develop vpnd is still at `1.17.0-beta` but should be bumped soon

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3618)
<!-- Reviewable:end -->
