### PR TITLE
Feature/vpn 4161 propagate net discovery

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
@@ -272,6 +272,10 @@ impl TunnelStateHandler for ConnectedState {
                         _ = reply_tx.send(());
                         self.handle_tunnel_down(error_state_reason, shared_state).await
                     }
+                    TunnelMonitorEvent::NewNetworkEnv { network } => {
+                        shared_state.nym_config.network_env = *network;
+                        NextTunnelState::SameState(self)
+                    }
                     _ => {
                         NextTunnelState::SameState(self)
                     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -523,6 +523,10 @@ impl TunnelStateHandler for ConnectingState {
                             self.reconnect(shared_state).await
                         }
                     }
+                    TunnelMonitorEvent::NewNetworkEnv { network } => {
+                        shared_state.nym_config.network_env = *network;
+                        NextTunnelState::SameState(self)
+                    }
                 }
            }
             Some(command) = command_rx.recv() => {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use futures::{FutureExt, future::Fuse};
+use futures::{FutureExt, future::Fuse, pin_mut};
 
 use nym_registration_client::{
     MixnetRegistrationResult, RegistrationClientBuilder, RegistrationClientBuilderConfig,
@@ -609,26 +609,29 @@ impl TunnelMonitor {
             }
         }
 
+        let mixnet_monitoring_token = tunnel_handle
+            .mixnet_client_token()
+            .map(|token| token.cancelled_owned().fuse())
+            .unwrap_or(Fuse::terminated());
+
+        let fused_discovery_refresher_rx = discovery_refresher_rx
+            .as_mut()
+            .map(|r| r.recv().fuse())
+            .unwrap_or(Fuse::terminated());
+
+        pin_mut!(mixnet_monitoring_token);
+        pin_mut!(fused_discovery_refresher_rx);
+
         loop {
-            let mixnet_monitoring_token = tunnel_handle
-                .mixnet_client_token()
-                .map(|token| token.cancelled_owned().fuse())
-                .unwrap_or(Fuse::terminated());
-
-            let fused_discovery_refresher_rx = discovery_refresher_rx
-                .as_mut()
-                .map(|r| r.recv().fuse())
-                .unwrap_or(Fuse::terminated());
-
             tokio::select! {
-                _  = mixnet_monitoring_token => {
+                _  = &mut mixnet_monitoring_token => {
                     tracing::error!("MixnetClient exited unexpectedly");
                     break;
                 }
                 _ = self.shutdown_token.cancelled() => {
                     break;
                 }
-                ret = fused_discovery_refresher_rx => {
+                ret = &mut fused_discovery_refresher_rx => {
                     match ret {
                         Some(Ok(network)) => {
                             tracing::info!("Refreshed discovery file");

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -1,6 +1,8 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use futures::{FutureExt, future::Fuse};
+
 use nym_registration_client::{
     MixnetRegistrationResult, RegistrationClientBuilder, RegistrationClientBuilderConfig,
     RegistrationNymNode, RegistrationResult, WireguardRegistrationResult,
@@ -608,6 +610,11 @@ impl TunnelMonitor {
         }
 
         loop {
+            let fused_discovery_refresher_rx = discovery_refresher_rx
+                .as_mut()
+                .map(|r| r.recv().fuse())
+                .unwrap_or(Fuse::terminated());
+
             tokio::select! {
                 _  = async {
                     match tunnel_handle.mixnet_client_token() {
@@ -621,12 +628,7 @@ impl TunnelMonitor {
                 _ = self.shutdown_token.cancelled() => {
                     break;
                 }
-                ret = async {
-                    match &mut discovery_refresher_rx {
-                        Some(rx) => rx.recv().await,
-                        None => std::future::pending().await,
-                    }
-                } => {
+                ret = fused_discovery_refresher_rx => {
                     match ret {
                         Some(Ok(network)) => {
                             tracing::info!("Refreshed discovery file");

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -1,8 +1,6 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use futures::{FutureExt, future::Fuse};
-
 use nym_registration_client::{
     MixnetRegistrationResult, RegistrationClientBuilder, RegistrationClientBuilderConfig,
     RegistrationNymNode, RegistrationResult, WireguardRegistrationResult,
@@ -603,14 +601,14 @@ impl TunnelMonitor {
             }
         }
 
-        let mixnet_monitoring_token = tunnel_handle
-            .mixnet_client_token()
-            .map(|token| token.cancelled_owned().fuse())
-            .unwrap_or(Fuse::terminated());
-
         loop {
             tokio::select! {
-                _  = mixnet_monitoring_token => {
+                _  = async {
+                    match tunnel_handle.mixnet_client_token() {
+                        Some(token) => token.cancelled().await,
+                        None => std::future::pending().await,
+                    }
+                } => {
                     tracing::error!("MixnetClient exited unexpectedly");
                     break;
                 }
@@ -624,11 +622,11 @@ impl TunnelMonitor {
                     }
                 } => {
                     match ret {
-                        Some(Ok(discovery)) => {
+                        Some(Ok(_discovery)) => {
                             tracing::info!("Refreshed discovery file");
-                            if let Err(err) = self.custom_topology_provider.update_discovery(discovery).await {
-                                trace_err_chain!(err, "Failed to update discovery in custom topology provider");
-                            }
+                            //if let Err(err) = self.custom_topology_provider.update_discovery(discovery).await {
+                            //    trace_err_chain!(err, "Failed to update discovery in custom topology provider");
+                            //}
                         }
                         Some(Err(err)) => {
                             trace_err_chain!(err, "Failed to refresh discovery file");
@@ -665,33 +663,6 @@ impl TunnelMonitor {
         tracing::info!("Tunnel monitor finished");
 
         Ok(tun_devices)
-    }
-
-    async fn recv_error(
-        &self,
-        mixnet_cancel_token: Option<CancellationToken>,
-        background_file_rx: Fuse<impl Future<Output = Option<()>>>,
-    ) {
-        // Watch on the mixnet client of nothing if it doesn't exist
-        let mixnet_monitoring_token = mixnet_cancel_token
-            .map(|token| token.cancelled_owned().fuse())
-            .unwrap_or(Fuse::terminated());
-        tokio::select! {
-            _  = mixnet_monitoring_token => {
-                tracing::error!("MixnetClient exited unexpectedly");
-            }
-            _ = self.shutdown_token.cancelled() => {}
-            ret = background_file_rx => {
-                if ret.is_some() {
-                    tracing::error!("Background task errored out");
-                } else {
-                    tracing::debug!("Background task finished");
-                }
-            }
-        }
-
-        // Trigger cancellation since many other tasks depend on shutdown token
-        self.shutdown_token.cancel();
     }
 
     fn send_event(&mut self, event: TunnelMonitorEvent) {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -21,7 +21,6 @@ use std::os::fd::{AsRawFd, IntoRawFd};
 use std::os::fd::{FromRawFd, OwnedFd};
 use std::{
     net::{IpAddr, SocketAddr},
-    path::PathBuf,
     time::Duration,
 };
 #[cfg(unix)]
@@ -552,24 +551,20 @@ impl TunnelMonitor {
 
         // todo: do initial ping
 
-        let (discovery_refresher_handle, mut discovery_refresher_rx) = self
-            .tunnel_parameters
-            .nym_config
-            .config_path
-            .as_ref()
-            .and_then(|config_path: &PathBuf| config_path.parent())
-            .map(|config_dir| {
-                let (discovery_refresher_tx, discovery_refresher_rx) =
-                    tokio::sync::mpsc::channel(1);
-                let discovery_refresher_handle = start_background_file_refresh(
-                    config_dir.to_path_buf(),
-                    self.tunnel_parameters.nym_config.network_env.clone(),
-                    discovery_refresher_tx,
-                    self.shutdown_token.child_token(),
-                );
-                (discovery_refresher_handle, discovery_refresher_rx)
-            })
-            .unzip();
+        let (discovery_refresher_tx, mut discovery_refresher_rx) = tokio::sync::mpsc::channel(1);
+        let discovery_refresher_handle = if let Some(config_path) =
+            self.tunnel_parameters.nym_config.config_path.as_ref()
+            && let Some(config_dir) = config_path.parent()
+        {
+            Some(start_background_file_refresh(
+                config_dir.to_path_buf(),
+                self.tunnel_parameters.nym_config.network_env.clone(),
+                discovery_refresher_tx.clone(),
+                self.shutdown_token.child_token(),
+            ))
+        } else {
+            None
+        };
 
         let connection_data = ConnectionData {
             entry_gateway: GatewayId::from(selected_gateways.entry_gateway().clone()),
@@ -613,14 +608,7 @@ impl TunnelMonitor {
             .mixnet_client_token()
             .map(|token| token.cancelled_owned().fuse())
             .unwrap_or(Fuse::terminated());
-
-        let fused_discovery_refresher_rx = discovery_refresher_rx
-            .as_mut()
-            .map(|r| r.recv().fuse())
-            .unwrap_or(Fuse::terminated());
-
         pin_mut!(mixnet_monitoring_token);
-        pin_mut!(fused_discovery_refresher_rx);
 
         loop {
             tokio::select! {
@@ -631,7 +619,7 @@ impl TunnelMonitor {
                 _ = self.shutdown_token.cancelled() => {
                     break;
                 }
-                ret = &mut fused_discovery_refresher_rx => {
+                ret = discovery_refresher_rx.recv() => {
                     match ret {
                         Some(Ok(network)) => {
                             tracing::info!("Refreshed discovery file");

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -8,7 +8,7 @@ use nym_registration_client::{
 use nym_registration_common::NymNode;
 use nym_sdk::UserAgent;
 use nym_vpn_account_controller::AccountStateReceiver;
-use nym_vpn_network_config::start_background_file_refresh;
+use nym_vpn_network_config::{Network, start_background_file_refresh};
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use std::net::{Ipv4Addr, Ipv6Addr};
 #[cfg(any(target_os = "linux", target_os = "ios", target_os = "android"))]
@@ -168,6 +168,12 @@ pub enum TunnelMonitorEvent {
         error_state_reason: Option<ErrorStateReason>,
         /// Back channel to acknowledge that the event has been processed
         reply_tx: tokio::sync::oneshot::Sender<()>,
+    },
+
+    /// A new network environment was discovered
+    NewNetworkEnv {
+        /// The new network environment
+        network: Box<Network>,
     },
 }
 
@@ -622,11 +628,9 @@ impl TunnelMonitor {
                     }
                 } => {
                     match ret {
-                        Some(Ok(_discovery)) => {
+                        Some(Ok(network)) => {
                             tracing::info!("Refreshed discovery file");
-                            //if let Err(err) = self.custom_topology_provider.update_discovery(discovery).await {
-                            //    trace_err_chain!(err, "Failed to update discovery in custom topology provider");
-                            //}
+                            self.send_event(TunnelMonitorEvent::NewNetworkEnv { network: Box::new(network) });
                         }
                         Some(Err(err)) => {
                             trace_err_chain!(err, "Failed to refresh discovery file");

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -610,18 +610,18 @@ impl TunnelMonitor {
         }
 
         loop {
+            let mixnet_monitoring_token = tunnel_handle
+                .mixnet_client_token()
+                .map(|token| token.cancelled_owned().fuse())
+                .unwrap_or(Fuse::terminated());
+
             let fused_discovery_refresher_rx = discovery_refresher_rx
                 .as_mut()
                 .map(|r| r.recv().fuse())
                 .unwrap_or(Fuse::terminated());
 
             tokio::select! {
-                _  = async {
-                    match tunnel_handle.mixnet_client_token() {
-                        Some(token) => token.cancelled().await,
-                        None => std::future::pending().await,
-                    }
-                } => {
+                _  = mixnet_monitoring_token => {
                     tracing::error!("MixnetClient exited unexpectedly");
                     break;
                 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -546,27 +546,24 @@ impl TunnelMonitor {
 
         // todo: do initial ping
 
-        let (discovery_refresher_handle, mut background_error_rx) = self
+        let (discovery_refresher_handle, mut discovery_refresher_rx) = self
             .tunnel_parameters
             .nym_config
             .config_path
             .as_ref()
             .and_then(|config_path: &PathBuf| config_path.parent())
             .map(|config_dir| {
-                let (background_error_tx, background_error_rx) = tokio::sync::mpsc::channel(1);
+                let (discovery_refresher_tx, discovery_refresher_rx) =
+                    tokio::sync::mpsc::channel(1);
                 let discovery_refresher_handle = start_background_file_refresh(
                     config_dir.to_path_buf(),
                     self.tunnel_parameters.nym_config.network_env.clone(),
-                    background_error_tx,
+                    discovery_refresher_tx,
                     self.shutdown_token.child_token(),
                 );
-                (discovery_refresher_handle, background_error_rx)
+                (discovery_refresher_handle, discovery_refresher_rx)
             })
             .unzip();
-        let fused_background_error = background_error_rx
-            .as_mut()
-            .map(|r| r.recv().fuse())
-            .unwrap_or(Fuse::terminated());
 
         let connection_data = ConnectionData {
             entry_gateway: GatewayId::from(selected_gateways.entry_gateway().clone()),
@@ -606,10 +603,49 @@ impl TunnelMonitor {
             }
         }
 
-        self.recv_error(tunnel_handle.mixnet_client_token(), fused_background_error)
-            .await;
+        let mixnet_monitoring_token = tunnel_handle
+            .mixnet_client_token()
+            .map(|token| token.cancelled_owned().fuse())
+            .unwrap_or(Fuse::terminated());
 
-        tracing::info!("Wait for tunnel to exit");
+        loop {
+            tokio::select! {
+                _  = mixnet_monitoring_token => {
+                    tracing::error!("MixnetClient exited unexpectedly");
+                    break;
+                }
+                _ = self.shutdown_token.cancelled() => {
+                    break;
+                }
+                ret = async {
+                    match &mut discovery_refresher_rx {
+                        Some(rx) => rx.recv().await,
+                        None => std::future::pending().await,
+                    }
+                } => {
+                    match ret {
+                        Some(Ok(discovery)) => {
+                            tracing::info!("Refreshed discovery file");
+                            if let Err(err) = self.custom_topology_provider.update_discovery(discovery).await {
+                                trace_err_chain!(err, "Failed to update discovery in custom topology provider");
+                            }
+                        }
+                        Some(Err(err)) => {
+                            trace_err_chain!(err, "Failed to refresh discovery file");
+                        }
+                        None => {
+                            // channel closed
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Trigger cancellation since many other tasks depend on shutdown token
+        self.shutdown_token.cancel();
+
+        tracing::info!("Waiting for tunnel to exit");
         tunnel_handle.cancel();
 
         let tun_devices = tunnel_handle
@@ -634,7 +670,7 @@ impl TunnelMonitor {
     async fn recv_error(
         &self,
         mixnet_cancel_token: Option<CancellationToken>,
-        background_error_rx: Fuse<impl Future<Output = Option<()>>>,
+        background_file_rx: Fuse<impl Future<Output = Option<()>>>,
     ) {
         // Watch on the mixnet client of nothing if it doesn't exist
         let mixnet_monitoring_token = mixnet_cancel_token
@@ -645,7 +681,7 @@ impl TunnelMonitor {
                 tracing::error!("MixnetClient exited unexpectedly");
             }
             _ = self.shutdown_token.cancelled() => {}
-            ret = background_error_rx => {
+            ret = background_file_rx => {
                 if ret.is_some() {
                     tracing::error!("Background task errored out");
                 } else {

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/lib.rs
@@ -47,7 +47,7 @@ use std::{
 const NETWORKS_SUBDIR: &str = "networks";
 
 // Refresh the discovery and network details files periodically
-const MAX_FILE_AGE: Duration = Duration::from_secs(60 * 60 * 24);
+const MAX_FILE_AGE: Duration = Duration::from_secs(60 * 60);
 
 pub type ApiUrl = nym_vpn_api_client::response::ApiUrl;
 

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/lib.rs
@@ -202,6 +202,10 @@ pub async fn discover_env(config_path: &Path, network_name: &str) -> Result<Netw
         discovery.system_messages.clone().into_current_messages()
     );
 
+    network_from_discovery(config_path, discovery).await
+}
+
+pub async fn network_from_discovery(config_path: &Path, discovery: Discovery) -> Result<Network> {
     let feature_flags = discovery.feature_flags.clone();
     if let Some(ref feature_flags) = feature_flags {
         tracing::debug!("Feature flags: {}", feature_flags);
@@ -378,7 +382,10 @@ pub enum Error {
     InconsistentNetwork,
 
     #[error("failed to refresh discovery file")]
-    FailedToRefreshDiscoveryFile,
+    RefreshDiscoveryFile,
+
+    #[error("failed to parse refreshed discovery file")]
+    ParseDiscoveryFile,
 }
 
 impl Error {

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/lib.rs
@@ -35,6 +35,7 @@ use crate::{
     discovery::DiscoveryFromNymWellknownDiscoveryError,
     nym_vpn_network::{NymVpnNetworkAccountLinksConversionError, NymVpnNetworkFromDetailsError},
 };
+
 use nym_http_api_client::HttpClientError;
 use std::{
     fmt::Debug,
@@ -372,6 +373,12 @@ pub enum Error {
 
     #[error("HTTP Client Error: {0}")]
     HttpClient(#[from] Box<HttpClientError>),
+
+    #[error("inconsistent network detected")]
+    InconsistentNetwork,
+
+    #[error("failed to refresh discovery file")]
+    FailedToRefreshDiscoveryFile,
 }
 
 impl Error {

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/refresh.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/refresh.rs
@@ -7,39 +7,35 @@ use nym_common::trace_err_chain;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
-use crate::{Error, Network, NymNetwork, Result, discovery::Discovery, envs::RegisteredNetworks};
+use crate::{
+    Error, Network, NymNetwork, Result, discovery::Discovery, envs::RegisteredNetworks,
+    network_from_discovery,
+};
 
 const CHECK_INTERVAL: Duration = Duration::from_secs(60 * 60);
 
 struct FileRefresher {
     config_path: PathBuf,
-    network: Network,
-    discovery_refresher_tx: tokio::sync::mpsc::Sender<Result<Discovery>>,
+    discovery_refresher_tx: tokio::sync::mpsc::Sender<Result<Network>>,
     cancel_token: CancellationToken,
 }
 
 impl FileRefresher {
     fn new(
         config_path: PathBuf,
-        network: Network,
-        discovery_refresher_tx: tokio::sync::mpsc::Sender<Result<Discovery>>,
+        discovery_refresher_tx: tokio::sync::mpsc::Sender<Result<Network>>,
         cancel_token: CancellationToken,
     ) -> Self {
         Self {
             config_path,
-            network,
             discovery_refresher_tx,
             cancel_token,
         }
     }
 
-    async fn refresh_discovery_file(&self) -> Result<Option<Discovery>> {
-        if Discovery::path_is_stale(
-            self.config_path.as_path(),
-            &self.network.nym_network.network.network_name,
-        )? {
-            let discovery =
-                Discovery::fetch(&self.network.nym_network.network.network_name).await?;
+    async fn refresh_discovery_file(&self, network_name: &str) -> Result<Option<Discovery>> {
+        if Discovery::path_is_stale(self.config_path.as_path(), network_name)? {
+            let discovery = Discovery::fetch(network_name).await?;
             discovery.write_to_file(self.config_path.as_path())?;
             Ok(Some(discovery))
         } else {
@@ -47,11 +43,12 @@ impl FileRefresher {
         }
     }
 
-    async fn refresh_nym_network_file(&self, discovery: &Discovery) -> Result<()> {
-        if NymNetwork::path_is_stale(
-            self.config_path.as_path(),
-            &self.network.nym_network.network.network_name,
-        )? {
+    async fn refresh_nym_network_file(
+        &self,
+        network_name: &str,
+        discovery: &Discovery,
+    ) -> Result<()> {
+        if NymNetwork::path_is_stale(self.config_path.as_path(), network_name)? {
             discovery.update_nym_network_file(&self.config_path).await?;
         }
 
@@ -62,7 +59,7 @@ impl FileRefresher {
         RegisteredNetworks::try_update_file(&self.config_path).await
     }
 
-    async fn run(self) {
+    async fn run(self, mut network: Network) {
         let mut interval = tokio::time::interval(CHECK_INTERVAL);
         let mut checked_consistency = false;
 
@@ -73,7 +70,7 @@ impl FileRefresher {
                 loop {
                     interval.tick().await;
                     if !checked_consistency {
-                        match self.network.check_consistency().await {
+                        match network.check_consistency().await {
                             // This is probably because of network unavailability, so consistency can't be checked yet
                             Err(e) => tracing::warn!("Could not check consistency: {e:?}"),
                             Ok(false) => {
@@ -93,19 +90,44 @@ impl FileRefresher {
                         trace_err_chain!(err, "Failed to refresh envs file");
                     }
 
-                    match self.refresh_discovery_file().await {
+                    match self
+                        .refresh_discovery_file(&network.nym_network.network.network_name)
+                        .await
+                    {
                         Err(err) => {
                             trace_err_chain!(err, "Failed to refresh discovery file");
                             self.discovery_refresher_tx
-                                .send(Err(Error::FailedToRefreshDiscoveryFile))
+                                .send(Err(Error::RefreshDiscoveryFile))
                                 .await
                                 .ok();
                         }
                         Ok(Some(discovery)) => {
-                            if let Err(err) = self.refresh_nym_network_file(&discovery).await {
+                            if let Err(err) = self
+                                .refresh_nym_network_file(
+                                    &network.nym_network.network.network_name,
+                                    &discovery,
+                                )
+                                .await
+                            {
                                 trace_err_chain!(err, "Failed to refresh nym network file");
                             }
-                            self.discovery_refresher_tx.send(Ok(discovery)).await.ok();
+
+                            match network_from_discovery(&self.config_path, discovery).await {
+                                Err(err) => {
+                                    trace_err_chain!(
+                                        err,
+                                        "Failed to parse refreshed discovery file"
+                                    );
+                                    self.discovery_refresher_tx
+                                        .send(Err(Error::ParseDiscoveryFile))
+                                        .await
+                                        .ok();
+                                }
+                                Ok(new_network) => {
+                                    network = new_network.clone();
+                                    self.discovery_refresher_tx.send(Ok(new_network)).await.ok();
+                                }
+                            }
                         }
                         _ => {}
                     }
@@ -119,9 +141,9 @@ impl FileRefresher {
 pub fn start_background_file_refresh(
     config_path: PathBuf,
     network: Network,
-    discovery_refresher_tx: tokio::sync::mpsc::Sender<Result<Discovery>>,
+    discovery_refresher_tx: tokio::sync::mpsc::Sender<Result<Network>>,
     cancel_token: CancellationToken,
 ) -> JoinHandle<()> {
-    let refresher = FileRefresher::new(config_path, network, discovery_refresher_tx, cancel_token);
-    tokio::spawn(refresher.run())
+    let refresher = FileRefresher::new(config_path, discovery_refresher_tx, cancel_token);
+    tokio::spawn(refresher.run(network))
 }

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/refresh.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/refresh.rs
@@ -7,14 +7,14 @@ use nym_common::trace_err_chain;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
-use crate::{Network, NymNetwork, Result, discovery::Discovery, envs::RegisteredNetworks};
+use crate::{Error, Network, NymNetwork, Result, discovery::Discovery, envs::RegisteredNetworks};
 
 const CHECK_INTERVAL: Duration = Duration::from_secs(60 * 60);
 
 struct FileRefresher {
     config_path: PathBuf,
     network: Network,
-    background_error_tx: tokio::sync::mpsc::Sender<()>,
+    discovery_refresher_tx: tokio::sync::mpsc::Sender<Result<Discovery>>,
     cancel_token: CancellationToken,
 }
 
@@ -22,13 +22,13 @@ impl FileRefresher {
     fn new(
         config_path: PathBuf,
         network: Network,
-        background_error_tx: tokio::sync::mpsc::Sender<()>,
+        discovery_refresher_tx: tokio::sync::mpsc::Sender<Result<Discovery>>,
         cancel_token: CancellationToken,
     ) -> Self {
         Self {
             config_path,
             network,
-            background_error_tx,
+            discovery_refresher_tx,
             cancel_token,
         }
     }
@@ -47,7 +47,7 @@ impl FileRefresher {
         }
     }
 
-    async fn refresh_nym_network_file(&self, discovery: Discovery) -> Result<()> {
+    async fn refresh_nym_network_file(&self, discovery: &Discovery) -> Result<()> {
         if NymNetwork::path_is_stale(
             self.config_path.as_path(),
             &self.network.nym_network.network.network_name,
@@ -78,8 +78,10 @@ impl FileRefresher {
                             Err(e) => tracing::warn!("Could not check consistency: {e:?}"),
                             Ok(false) => {
                                 tracing::error!("Inconsistent network");
-                                self.background_error_tx.send(()).await.ok();
-                                return;
+                                self.discovery_refresher_tx
+                                    .send(Err(Error::InconsistentNetwork))
+                                    .await
+                                    .ok();
                             }
                             Ok(true) => {
                                 checked_consistency = true;
@@ -94,11 +96,16 @@ impl FileRefresher {
                     match self.refresh_discovery_file().await {
                         Err(err) => {
                             trace_err_chain!(err, "Failed to refresh discovery file");
+                            self.discovery_refresher_tx
+                                .send(Err(Error::FailedToRefreshDiscoveryFile))
+                                .await
+                                .ok();
                         }
                         Ok(Some(discovery)) => {
-                            if let Err(err) = self.refresh_nym_network_file(discovery).await {
+                            if let Err(err) = self.refresh_nym_network_file(&discovery).await {
                                 trace_err_chain!(err, "Failed to refresh nym network file");
                             }
+                            self.discovery_refresher_tx.send(Ok(discovery)).await.ok();
                         }
                         _ => {}
                     }
@@ -112,9 +119,9 @@ impl FileRefresher {
 pub fn start_background_file_refresh(
     config_path: PathBuf,
     network: Network,
-    background_error_tx: tokio::sync::mpsc::Sender<()>,
+    discovery_refresher_tx: tokio::sync::mpsc::Sender<Result<Discovery>>,
     cancel_token: CancellationToken,
 ) -> JoinHandle<()> {
-    let refresher = FileRefresher::new(config_path, network, background_error_tx, cancel_token);
+    let refresher = FileRefresher::new(config_path, network, discovery_refresher_tx, cancel_token);
     tokio::spawn(refresher.run())
 }


### PR DESCRIPTION
## Ticket

JIRA-VPN-4161

## Description

When the network file refresher runs it now sends the new network environment into the tunnel state machine.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3619)
<!-- Reviewable:end -->
