### PR TITLE
Gateway probe: add subcommand to run in local mode and add more file download details

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -4380,6 +4380,7 @@ dependencies = [
  "nym-client-core",
  "nym-config",
  "nym-connection-monitor",
+ "nym-credential-utils",
  "nym-credentials",
  "nym-credentials-interface",
  "nym-crypto",

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -241,6 +241,7 @@ nym-config = { git = "https://github.com/nymtech/nym", branch = "develop" }
 nym-contracts-common = { git = "https://github.com/nymtech/nym", branch = "develop" }
 nym-credential-proxy-requests = { git = "https://github.com/nymtech/nym", branch = "develop", default-features = false }
 nym-credential-storage = { git = "https://github.com/nymtech/nym", branch = "develop" }
+nym-credential-utils = { git = "https://github.com/nymtech/nym", branch = "develop" }
 nym-credentials = { git = "https://github.com/nymtech/nym", branch = "develop" }
 nym-credentials-interface = { git = "https://github.com/nymtech/nym", branch = "develop" }
 nym-crypto = { git = "https://github.com/nymtech/nym", branch = "develop" }
@@ -263,4 +264,3 @@ nym-wireguard-private-metadata-client = { git = "https://github.com/nymtech/nym"
 nym-wireguard-private-metadata-shared = { git = "https://github.com/nymtech/nym", branch = "develop" }
 nym-wireguard-types = { git = "https://github.com/nymtech/nym", branch = "develop" }
 sqlx-pool-guard = { git = "https://github.com/nymtech/nym", branch = "develop" }
-nym-credential-utils = { git = "https://github.com/nymtech/nym", branch = "develop" }

--- a/nym-vpn-core/crates/nym-gateway-probe/Cargo.toml
+++ b/nym-vpn-core/crates/nym-gateway-probe/Cargo.toml
@@ -48,6 +48,7 @@ nym-crypto.workspace = true
 nym-config.workspace = true
 nym-connection-monitor = { workspace = true }
 nym-credentials-interface.workspace = true
+nym-credential-utils.workspace = true
 nym-gateway-directory = { workspace = true }
 nym-ip-packet-client = { workspace = true }
 nym-authenticator-client = { workspace = true }

--- a/nym-vpn-core/crates/nym-gateway-probe/netstack_ping/lib.go
+++ b/nym-vpn-core/crates/nym-gateway-probe/netstack_ping/lib.go
@@ -63,15 +63,17 @@ type NetstackRequestGo struct {
 }
 
 type NetstackResponse struct {
-	CanHandshake        bool   `json:"can_handshake"`
-	SentIps             uint16 `json:"sent_ips"`
-	ReceivedIps         uint16 `json:"received_ips"`
-	SentHosts           uint16 `json:"sent_hosts"`
-	ReceivedHosts       uint16 `json:"received_hosts"`
-	CanResolveDns       bool   `json:"can_resolve_dns"`
-	DownloadedFile      string `json:"downloaded_file"`
-	DownloadDurationSec uint64 `json:"download_duration_sec"`
-	DownloadError       string `json:"download_error"`
+	CanHandshake                 bool   `json:"can_handshake"`
+	SentIps                      uint16 `json:"sent_ips"`
+	ReceivedIps                  uint16 `json:"received_ips"`
+	SentHosts                    uint16 `json:"sent_hosts"`
+	ReceivedHosts                uint16 `json:"received_hosts"`
+	CanResolveDns                bool   `json:"can_resolve_dns"`
+	DownloadedFile               string `json:"downloaded_file"`
+	DownloadedFileSizeBytes      uint64 `json:"downloaded_file_size_bytes"`
+	DownloadDurationSec          uint64 `json:"download_duration_sec"`
+	DownloadDurationMilliseconds uint64 `json:"download_duration_milliseconds"`
+	DownloadError                string `json:"download_error"`
 }
 
 type SuccessResult = struct {
@@ -163,7 +165,7 @@ func ping(req NetstackRequestGo) (NetstackResponse, error) {
 		ipc.WriteString("\nallowed_ip=::/0\n")
 	}
 
-	response := NetstackResponse{false, 0, 0, 0, 0, false, "", 0, ""}
+	response := NetstackResponse{false, 0, 0, 0, 0, false, "", 0, 0, 0, ""}
 
 	dev.IpcSet(ipc.String())
 
@@ -257,11 +259,14 @@ func ping(req NetstackRequestGo) (NetstackResponse, error) {
 	}
 
 	response.DownloadDurationSec = uint64(downloadDuration.Seconds())
+	response.DownloadDurationMilliseconds = uint64(downloadDuration.Milliseconds())
 	response.DownloadedFile = usedURL
 	if err != nil {
 		response.DownloadError = err.Error()
+		response.DownloadedFileSizeBytes = 0
 	} else {
 		response.DownloadError = ""
+		response.DownloadedFileSizeBytes = uint64(len(fileContent))
 	}
 
 	return response, nil

--- a/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
+++ b/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use crate::{netstack::NetstackResult, types::Entry};
+use anyhow::Context;
 use anyhow::{anyhow, bail};
 use base64::{Engine as _, engine::general_purpose};
 use bytes::BytesMut;
@@ -18,6 +19,8 @@ use nym_authenticator_requests::{
     AuthenticatorVersion, client_message::ClientMessage, response::AuthenticatorResponse, v2, v3,
     v4, v5,
 };
+use nym_bandwidth_controller::error::BandwidthControllerError;
+use nym_client_core::client::base_client::storage::OnDiskPersistent;
 use nym_client_core::config::ForgetMe;
 use nym_config::defaults::{
     NymNetworkDetails,
@@ -39,14 +42,17 @@ use nym_ip_packet_requests::{
         ControlResponse, DataResponse, InfoLevel, IpPacketResponse, IpPacketResponseData,
     },
 };
-use nym_sdk::{
-    bandwidth::BandwidthImporter,
-    mixnet::{
-        Ephemeral, EphemeralCredentialStorage, MixnetClient, MixnetClientBuilder,
-        MixnetClientStorage, NodeIdentity, ReconstructedMessage,
-    },
+use nym_sdk::bandwidth::BandwidthImporter;
+use nym_sdk::mixnet::{
+    CredentialStorage, DisconnectedMixnetClient, Ephemeral, EphemeralCredentialStorage,
+    MixnetClient, MixnetClientBuilder, MixnetClientStorage, NodeIdentity, ReconstructedMessage,
+    StoragePaths,
 };
+use nym_validator_client::nyxd::error::NyxdError;
 use nym_wireguard_types::PeerPublicKey;
+use rand::rngs::OsRng;
+use std::path::PathBuf;
+
 use tokio_util::{codec::Decoder, sync::CancellationToken};
 use tracing::*;
 use types::WgProbeResults;
@@ -68,7 +74,7 @@ use crate::monorepo_ns_client_types::AttachedTicketMaterials;
 pub use error::{Error, Result};
 pub use types::{IpPingReplies, ProbeOutcome, ProbeResult};
 
-#[derive(Args)]
+#[derive(Args, Clone)]
 pub struct NetstackArgs {
     #[arg(long, default_value_t = 180)]
     netstack_download_timeout_sec: u64,
@@ -104,16 +110,21 @@ pub struct NetstackArgs {
 #[derive(Args)]
 pub struct CredentialArgs {
     #[arg(long)]
-    ticket_materials: String,
+    ticket_materials: Option<String>,
 
-    #[arg(long)]
+    #[arg(long, default_value_t = 1)]
     ticket_materials_revision: u8,
 }
 
 impl CredentialArgs {
-    fn decode_attached_ticket_materials(&self) -> Result<AttachedTicketMaterials> {
+    fn decode_attached_ticket_materials(&self) -> anyhow::Result<AttachedTicketMaterials> {
+        let ticket_materials = self
+            .ticket_materials
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("ticket_materials is required"))?;
+
         Ok(AttachedTicketMaterials::from_serialised_string(
-            &self.ticket_materials,
+            ticket_materials,
             self.ticket_materials_revision,
         )?)
     }
@@ -265,11 +276,215 @@ impl Probe {
         let mut rng = rand::thread_rng();
         let tickets_materials = self.credentials_args.decode_attached_ticket_materials()?;
 
+        let tested_entry = self.tested_node.is_same_as_entry();
+        let (mixnet_entry_gateway_id, node_info) =
+            self.lookup_gateway(gateway_config.clone()).await?;
+
+        let storage = Ephemeral::default();
+
+        // Connect to the mixnet via the entry gateway
+        let disconnected_mixnet_client = MixnetClientBuilder::new_with_storage(storage.clone())
+            .request_gateway(mixnet_entry_gateway_id.to_string())
+            .network_details(NymNetworkDetails::new_from_env())
+            .debug_config(mixnet_debug_config(
+                gateway_config.min_gateway_performance,
+                ignore_egress_epoch_role,
+            ))
+            .with_forget_me(ForgetMe::new_all())
+            .credentials_mode(true)
+            .build()?;
+
+        // in normal operation expects the ticket material to be provided as an argument
+        let bandwidth_import = disconnected_mixnet_client.begin_bandwidth_import();
+        import_bandwidth(bandwidth_import, tickets_materials).await?;
+
+        let mixnet_client = Box::pin(disconnected_mixnet_client.connect_to_mixnet()).await;
+
+        self.do_probe_test(
+            gateway_config,
+            mixnet_client,
+            storage,
+            mixnet_entry_gateway_id,
+            node_info,
+            tested_entry,
+            only_wireguard,
+        )
+        .await
+    }
+
+    pub async fn probe_run_locally(
+        self,
+        config_dir: &PathBuf,
+        mnemonic: &str,
+        gateway_config: GatewayDirectoryConfig,
+        ignore_egress_epoch_role: bool,
+        only_wireguard: bool,
+    ) -> anyhow::Result<ProbeResult> {
+        let tested_entry = self.tested_node.is_same_as_entry();
+        let (mixnet_entry_gateway_id, node_info) =
+            self.lookup_gateway(gateway_config.clone()).await?;
+
+        if config_dir.is_file() {
+            bail!("provided configuration directory is a file");
+        }
+
+        if !config_dir.exists() {
+            std::fs::create_dir_all(config_dir)?;
+        }
+
+        let storage_paths = StoragePaths::new_from_dir(config_dir)?;
+        let storage = storage_paths
+            .initialise_default_persistent_storage()
+            .await?;
+
+        // Connect to the mixnet via the entry gateway, without forget-me flag so that gateway remembers client
+        // and keeps its bandwidth between probe runs
+        let disconnected_mixnet_client = MixnetClientBuilder::new_with_storage(storage.clone())
+            .request_gateway(mixnet_entry_gateway_id.to_string())
+            .network_details(NymNetworkDetails::new_from_env())
+            .debug_config(mixnet_debug_config(
+                gateway_config.min_gateway_performance,
+                ignore_egress_epoch_role,
+            ))
+            .credentials_mode(true)
+            .build()?;
+
+        let key_store = storage.key_store();
+        let mut rng = OsRng;
+
+        // WORKAROUND SINCE IT HASN'T MADE IT TO THE MONOREPO:
+        if key_store.load_keys().await.is_err() {
+            tracing::log::debug!("Generating new client keys");
+            nym_client_core::init::generate_new_client_keys(&mut rng, key_store).await?;
+        }
+
+        for ticketbook_type in [
+            TicketType::V1MixnetEntry,
+            TicketType::V1WireguardEntry,
+            TicketType::V1WireguardExit,
+        ] {
+            self.acquire_bandwidth(mnemonic, &disconnected_mixnet_client, ticketbook_type)
+                .await?;
+        }
+
+        let mixnet_client = Box::pin(disconnected_mixnet_client.connect_to_mixnet()).await;
+
+        self.do_probe_test(
+            gateway_config,
+            mixnet_client,
+            storage,
+            mixnet_entry_gateway_id,
+            node_info,
+            tested_entry,
+            only_wireguard,
+        )
+        .await
+    }
+
+    async fn acquire_bandwidth(
+        &self,
+        mnemonic: &str,
+        disconnected_mixnet_client: &DisconnectedMixnetClient<OnDiskPersistent>,
+        ticketbook_type: TicketType,
+    ) -> anyhow::Result<()> {
+        // TODO: make it configurable
+        const MAX_RETRIES: usize = 50;
+        for i in 0..MAX_RETRIES {
+            let attempt = i + 1; // since humans usually don't count from 0 in this instance
+            info!(
+                "attempt {attempt}/{MAX_RETRIES} for attempting to acquire {ticketbook_type} bandwidth"
+            );
+            let bw_client = disconnected_mixnet_client
+                .create_bandwidth_client(mnemonic.to_string(), ticketbook_type)
+                .await?;
+            info!("Calling bandwidth controller acquire() for {ticketbook_type}");
+            match bw_client.acquire().await {
+                Ok(_) => {
+                    if i > 0 {
+                        info!(
+                            "managed to acquire {ticketbook_type} bandwidth after {attempt} attempts",
+                        );
+                    }
+                    return Ok(());
+                }
+                Err(nym_sdk::Error::CredentialIssuanceError { source }) => match source {
+                    nym_credential_utils::errors::Error::BandwidthControllerError(
+                        BandwidthControllerError::Nyxd(nyxd_error),
+                    ) => match nyxd_error {
+                        // happens when sequence issue occurs during tx delivery
+                        NyxdError::BroadcastTxErrorDeliverTx {
+                            hash,
+                            height,
+                            code,
+                            raw_log,
+                        } => {
+                            // unfortunately at this point we have to do string matching as the log
+                            // is returned from the go nyxd binary
+                            if raw_log.contains("account sequence mismatch") {
+                                error!(
+                                    "another process is using the same mnemonic. we failed to broadcast transaction {hash} due to mismatched sequence number"
+                                )
+                            } else {
+                                return Err(NyxdError::BroadcastTxErrorDeliverTx {
+                                    hash,
+                                    height,
+                                    code,
+                                    raw_log,
+                                }
+                                .into());
+                            }
+                        }
+                        // happens when sequence issue occurs during tx simulate
+                        NyxdError::AbciError {
+                            code,
+                            log,
+                            pretty_log,
+                        } => {
+                            // unfortunately at this point we have to do string matching as the log
+                            // is returned from the go nyxd binary
+                            if log.contains("account sequence mismatch") {
+                                error!(
+                                    "another process is using the same mnemonic. we failed to simulate transaction due to mismatched sequence number"
+                                )
+                            } else {
+                                return Err(NyxdError::AbciError {
+                                    code,
+                                    log,
+                                    pretty_log,
+                                }
+                                .into());
+                            }
+                        }
+                        other => {
+                            return Err(other)
+                                .context("another nyxd failure during bandwidth acquisition");
+                        }
+                    },
+                    other => {
+                        return Err(other.into());
+                    }
+                },
+                Err(other) => {
+                    return Err(other.into());
+                }
+            }
+
+            // add a bit of backoff as if the rpc node is slightly out of sync,
+            // we might use our retry budget for abci queries to the simulate endpoint
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+
+        bail!("failed to acquire bandwidth after {MAX_RETRIES} attempts")
+    }
+
+    pub async fn lookup_gateway(
+        &self,
+        gateway_config: GatewayDirectoryConfig,
+    ) -> anyhow::Result<(NodeIdentity, TestedNodeDetails)> {
         // Setup the entry gateways
         let gateways = lookup_gateways(gateway_config.clone()).await?;
 
         let entry_gateway = self.entrypoint.lookup_gateway(&gateways, None)?;
-        let tested_entry = self.tested_node.is_same_as_entry();
 
         let node_info: TestedNodeDetails = match self.tested_node {
             TestedNode::Custom { identity } => {
@@ -291,25 +506,24 @@ impl Probe {
             node_info.authenticator_version
         );
 
-        let storage = Ephemeral::default();
+        Ok((mixnet_entry_gateway_id, node_info))
+    }
 
-        // Connect to the mixnet via the entry gateway
-        let disconnected_mixnet_client = MixnetClientBuilder::new_with_storage(storage.clone())
-            .request_gateway(mixnet_entry_gateway_id.to_string())
-            .network_details(NymNetworkDetails::new_from_env())
-            .debug_config(mixnet_debug_config(
-                gateway_config.min_gateway_performance,
-                ignore_egress_epoch_role,
-            ))
-            .with_forget_me(ForgetMe::new_all())
-            .credentials_mode(true)
-            .build()?;
-
-        let bandwidth_import = disconnected_mixnet_client.begin_bandwidth_import();
-        import_bandwidth(bandwidth_import, tickets_materials).await?;
-
-        let mixnet_client = Box::pin(disconnected_mixnet_client.connect_to_mixnet()).await;
-
+    #[allow(clippy::too_many_arguments)]
+    pub async fn do_probe_test<T>(
+        &self,
+        gateway_config: GatewayDirectoryConfig,
+        mixnet_client: nym_sdk::Result<MixnetClient>,
+        storage: T,
+        mixnet_entry_gateway_id: NodeIdentity,
+        node_info: TestedNodeDetails,
+        tested_entry: bool,
+        only_wireguard: bool,
+    ) -> anyhow::Result<ProbeResult>
+    where
+        T: MixnetClientStorage + Clone + 'static,
+        <T::CredentialStore as CredentialStorage>::StorageError: Send + Sync,
+    {
         let mixnet_client = match mixnet_client {
             Ok(mixnet_client) => mixnet_client,
             Err(err) => {
@@ -377,7 +591,7 @@ impl Probe {
                 ip_address,
             );
             let config = nym_validator_client::nyxd::Config::try_from_nym_network_details(
-                &nym_config::defaults::NymNetworkDetails::new_from_env(),
+                &NymNetworkDetails::new_from_env(),
             )?;
             let client = nym_validator_client::nyxd::NyxdClient::connect(
                 config,
@@ -400,8 +614,8 @@ impl Probe {
                 auth_client,
                 ip_address,
                 node_info.authenticator_version,
-                self.amnezia_args,
-                self.netstack_args,
+                self.amnezia_args.clone(),
+                self.netstack_args.clone(),
                 credential,
             )
             .await
@@ -585,6 +799,10 @@ async fn wg_probe(
                     netstack_response_v4.received_ips as f32 / netstack_response_v4.sent_ips as f32;
 
                 wg_outcome.download_duration_sec_v4 = netstack_response_v4.download_duration_sec;
+                wg_outcome.download_duration_milliseconds_v4 =
+                    netstack_response_v4.download_duration_milliseconds;
+                wg_outcome.downloaded_file_size_bytes_v4 =
+                    netstack_response_v4.downloaded_file_size_bytes;
                 wg_outcome.downloaded_file_v4 = netstack_response_v4.downloaded_file;
                 wg_outcome.download_error_v4 = netstack_response_v4.download_error;
             }
@@ -613,6 +831,10 @@ async fn wg_probe(
                     netstack_response_v6.received_ips as f32 / netstack_response_v6.sent_ips as f32;
 
                 wg_outcome.download_duration_sec_v6 = netstack_response_v6.download_duration_sec;
+                wg_outcome.download_duration_milliseconds_v6 =
+                    netstack_response_v6.download_duration_milliseconds;
+                wg_outcome.downloaded_file_size_bytes_v6 =
+                    netstack_response_v6.downloaded_file_size_bytes;
                 wg_outcome.downloaded_file_v6 = netstack_response_v6.downloaded_file;
                 wg_outcome.download_error_v6 = netstack_response_v6.download_error;
             }

--- a/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
+++ b/nym-vpn-core/crates/nym-gateway-probe/src/lib.rs
@@ -44,7 +44,7 @@ use nym_ip_packet_requests::{
 };
 use nym_sdk::bandwidth::BandwidthImporter;
 use nym_sdk::mixnet::{
-    CredentialStorage, DisconnectedMixnetClient, Ephemeral, EphemeralCredentialStorage,
+    CredentialStorage, DisconnectedMixnetClient, Ephemeral, EphemeralCredentialStorage, KeyStore,
     MixnetClient, MixnetClientBuilder, MixnetClientStorage, NodeIdentity, ReconstructedMessage,
     StoragePaths,
 };
@@ -273,7 +273,6 @@ impl Probe {
         ignore_egress_epoch_role: bool,
         only_wireguard: bool,
     ) -> anyhow::Result<ProbeResult> {
-        let mut rng = rand::thread_rng();
         let tickets_materials = self.credentials_args.decode_attached_ticket_materials()?;
 
         let tested_entry = self.tested_node.is_same_as_entry();
@@ -524,6 +523,7 @@ impl Probe {
         T: MixnetClientStorage + Clone + 'static,
         <T::CredentialStore as CredentialStorage>::StorageError: Send + Sync,
     {
+        let mut rng = rand::thread_rng();
         let mixnet_client = match mixnet_client {
             Ok(mixnet_client) => mixnet_client,
             Err(err) => {

--- a/nym-vpn-core/crates/nym-gateway-probe/src/netstack.rs
+++ b/nym-vpn-core/crates/nym-gateway-probe/src/netstack.rs
@@ -163,6 +163,8 @@ pub struct NetstackResponse {
     pub can_resolve_dns: bool,
     pub downloaded_file: String,
     pub download_duration_sec: u64,
+    pub downloaded_file_size_bytes: u64,
+    pub download_duration_milliseconds: u64,
     pub download_error: String,
 }
 

--- a/nym-vpn-core/crates/nym-gateway-probe/src/run.rs
+++ b/nym-vpn-core/crates/nym-gateway-probe/src/run.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use anyhow::anyhow;
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use nym_bin_common::bin_info;
 use nym_config::defaults::setup_env;
 use nym_gateway_directory::{EntryPoint, GatewayMinPerformance};
@@ -26,36 +26,39 @@ fn validate_node_identity(s: &str) -> Result<NodeIdentity, String> {
 #[derive(Parser)]
 #[clap(author = "Nymtech", version, long_version = pretty_build_info_static(), about)]
 struct CliArgs {
+    #[command(subcommand)]
+    command: Option<Commands>,
+
     /// Path pointing to an env file describing the network.
-    #[arg(short, long)]
+    #[arg(short, long, global = true)]
     config_env_file: Option<PathBuf>,
 
     /// The specific gateway specified by ID.
-    #[arg(long, short = 'g', alias = "gateway")]
+    #[arg(long, short = 'g', alias = "gateway", global = true)]
     entry_gateway: Option<String>,
 
     /// Identity of the node to test
-    #[arg(long, short, value_parser = validate_node_identity)]
+    #[arg(long, short, value_parser = validate_node_identity, global = true)]
     node: Option<NodeIdentity>,
 
-    #[arg(long)]
+    #[arg(long, global = true)]
     min_gateway_mixnet_performance: Option<u8>,
 
-    #[arg(long)]
+    #[arg(long, global = true)]
     min_gateway_vpn_performance: Option<u8>,
 
-    #[arg(long)]
+    #[arg(long, global = true)]
     only_wireguard: bool,
 
     /// Disable logging during probe
     #[arg(long, short)]
     ignore_egress_epoch_role: bool,
 
-    #[arg(long)]
+    #[arg(long, global = true)]
     no_log: bool,
 
     /// Arguments to be appended to the wireguard config enabling amnezia-wg configuration
-    #[arg(long, short)]
+    #[arg(long, short, global = true)]
     amnezia_args: Option<String>,
 
     /// Arguments to manage netstack downloads
@@ -65,6 +68,19 @@ struct CliArgs {
     /// Arguments to manage credentials
     #[command(flatten)]
     credential_args: CredentialArgs,
+}
+
+#[derive(Subcommand, Debug)]
+enum Commands {
+    /// Run the probe locally
+    RunLocal {
+        /// Provide a mnemonic to get credentials
+        #[arg(long)]
+        mnemonic: String,
+
+        #[arg(long, default_value = "/tmp/nym-gateway-probe/config/")]
+        config_dir: PathBuf,
+    },
 }
 
 fn setup_logging() {
@@ -113,8 +129,8 @@ pub(crate) async fn run() -> anyhow::Result<ProbeResult> {
         wg_score_thresholds: None,
     };
 
-    let entry = if let Some(gateway) = args.entry_gateway {
-        EntryPoint::from_base58_string(&gateway)?
+    let entry = if let Some(gateway) = &args.entry_gateway {
+        EntryPoint::from_base58_string(gateway)?
     } else {
         fetch_random_gateway_with_ipr(gateway_config.clone()).await?
     };
@@ -130,12 +146,30 @@ pub(crate) async fn run() -> anyhow::Result<ProbeResult> {
     if let Some(awg_args) = args.amnezia_args {
         trial.with_amnezia(&awg_args);
     }
-    Box::pin(trial.probe(
-        gateway_config,
-        args.ignore_egress_epoch_role,
-        args.only_wireguard,
-    ))
-    .await
+
+    match &args.command {
+        Some(Commands::RunLocal {
+            mnemonic,
+            config_dir,
+        }) => {
+            Box::pin(trial.probe_run_locally(
+                config_dir,
+                mnemonic,
+                gateway_config,
+                args.ignore_egress_epoch_role,
+                args.only_wireguard,
+            ))
+            .await
+        }
+        None => {
+            Box::pin(trial.probe(
+                gateway_config,
+                args.ignore_egress_epoch_role,
+                args.only_wireguard,
+            ))
+            .await
+        }
+    }
 }
 
 async fn fetch_random_gateway_with_ipr(

--- a/nym-vpn-core/crates/nym-gateway-probe/src/types.rs
+++ b/nym-vpn-core/crates/nym-gateway-probe/src/types.rs
@@ -31,10 +31,14 @@ pub struct WgProbeResults {
     pub ping_ips_performance_v6: f32,
 
     pub download_duration_sec_v4: u64,
+    pub download_duration_milliseconds_v4: u64,
+    pub downloaded_file_size_bytes_v4: u64,
     pub downloaded_file_v4: String,
     pub download_error_v4: String,
 
     pub download_duration_sec_v6: u64,
+    pub downloaded_file_size_bytes_v6: u64,
+    pub download_duration_milliseconds_v6: u64,
     pub downloaded_file_v6: String,
     pub download_error_v6: String,
 }


### PR DESCRIPTION
This PR adds two changes:

1. more detailed information in the probe output for file downloads:
- size of file downloaded in bytes
- milliseconds taken to download file

2. Adds a sub-command to run the gateway probe in local mode by providing a mnemonic

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3626)
<!-- Reviewable:end -->
