### PR TITLE
Bug/bandwidth check disconnects client

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
@@ -258,6 +258,7 @@ pub(crate) struct BandwidthController {
     entry_previous_error_query: bool,
     exit_previous_error_query: bool,
     shutdown_token: CancellationToken,
+    successful_checks: u64,
 }
 
 impl BandwidthController {
@@ -280,6 +281,7 @@ impl BandwidthController {
             entry_previous_error_query: false,
             exit_previous_error_query: false,
             shutdown_token,
+            successful_checks: 0,
         }
     }
 
@@ -401,6 +403,8 @@ impl BandwidthController {
             ret = wg_metadata_client.query_bandwidth() => {
                 match ret {
                     Ok(remaining_bandwidth) => {
+                        self.successful_checks += 1;
+
                         if entry {
                             self.entry_previous_error_query = false;
                         } else {
@@ -436,8 +440,10 @@ impl BandwidthController {
                         tracing::warn!("{e}");
                         if (entry && self.entry_previous_error_query) || (!entry && self.exit_previous_error_query) {
                             tracing::error!("gateway {} is erroring out", wg_metadata_client.gateway_id());
-                            // For now let's keep the old behavior of stopping
-                            self.shutdown_token.cancel();
+                            // For now let's keep the old behavior of stopping, but only if we've had a successful check before
+                            if self.successful_checks != 0 {
+                                self.shutdown_token.cancel();
+                            }
                         } else {
                             if entry {
                                 self.entry_previous_error_query = true;


### PR DESCRIPTION
If the bandwidth availability check fails and we haven't received any for the current session then don't closedown the tunnel as it's probably because the operator hasn't opened port 51830.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3638)
<!-- Reviewable:end -->
