### PR TITLE
Tunnel state handling on quic connection related failures.

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/transports/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/transports/mod.rs
@@ -207,8 +207,12 @@ pub async fn process_udp<R, W>(
         token.clone(),
     ));
 
-    // Wait for both tasks to complete
-    let _ = tasks.join_all().await;
+    // Wait for both tasks to complete, if either one exits it _should_ cancel the other as well.
+    for res in tasks.join_all().await {
+        if let Err(e) = res {
+            tracing::error!("bridge udp forwarder error: {e}");
+        }
+    }
 }
 
 // Assumes that the socket has already had `connect` called.

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/transports/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/transports/mod.rs
@@ -213,6 +213,7 @@ pub async fn process_udp<R, W>(
             tracing::error!("bridge udp forwarder error: {e}");
         }
     }
+    info!("transport udp forwarder shutdown");
 }
 
 // Assumes that the socket has already had `connect` called.
@@ -328,16 +329,7 @@ pub struct ClientOptions {
 impl TryFrom<&QuicClientOptions> for ClientOptions {
     type Error = TransportError;
     fn try_from(value: &QuicClientOptions) -> Result<Self, Self::Error> {
-        let mut pubkey_bytes = [0u8; 32];
-        BASE64_STANDARD
-            .decode_slice(&value.id_pubkey, &mut pubkey_bytes)
-            .map_err(|e| {
-                TransportError::config_err(format!(
-                    "failed to decode Quic bridge public key as base64: {e}"
-                ))
-            })?;
-        let id_pubkey = VerifyingKey::from_bytes(&pubkey_bytes)
-            .map_err(|e| TransportError::config_err(format!("bad Quic bridge public key: {e}")))?;
+        let id_pubkey = Self::parse_base64_pubkey(&value.id_pubkey)?;
 
         Ok(Self {
             addresses: value.addresses.clone(),
@@ -348,6 +340,19 @@ impl TryFrom<&QuicClientOptions> for ClientOptions {
 }
 
 impl ClientOptions {
+    fn parse_base64_pubkey(key: impl AsRef<str>) -> Result<VerifyingKey, TransportError> {
+        let mut pubkey_bytes = [0u8; 32];
+        BASE64_STANDARD
+            .decode_slice(key.as_ref(), &mut pubkey_bytes)
+            .map_err(|e| {
+                TransportError::config_err(format!(
+                    "failed to decode Quic bridge public key as base64: {e}"
+                ))
+            })?;
+        VerifyingKey::from_bytes(&pubkey_bytes)
+            .map_err(|e| TransportError::config_err(format!("bad Quic bridge public key: {e}")))
+    }
+
     fn get_ipv4(&self) -> Option<SocketAddr> {
         self.addresses.iter().find(|s| s.is_ipv4()).cloned()
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/transports/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/transports/mod.rs
@@ -36,6 +36,9 @@ pub enum TransportError {
     #[error("insufficient or broken transport params: {0}")]
     Config(String),
 
+    #[error("transport connection was cancelled")]
+    Cancelled,
+
     #[error("transport error: {0}")]
     Other(String),
 }
@@ -61,16 +64,26 @@ pub struct BridgeConn {
 }
 
 impl BridgeConn {
-    pub async fn try_connect(params: BridgeParameters) -> Result<Self, TransportError> {
+    pub async fn try_connect(
+        params: BridgeParameters,
+        token: CancellationToken,
+    ) -> Result<Self, TransportError> {
         let start = Instant::now();
 
         match params {
             BridgeParameters::QuicPlain(ref opts) => {
                 let opts = ClientOptions::try_from(opts)?;
-                let conn = transport_conn(&opts).await?;
+
+                let conn = token
+                    .run_until_cancelled(transport_conn(&opts))
+                    .await
+                    .ok_or(TransportError::Cancelled)??;
                 let endpoint = conn.remote_address();
                 // .context("failed to connect to transport conn")?;
-                let (writer, reader) = conn.open_bi().await?;
+                let (writer, reader) = token
+                    .run_until_cancelled(conn.open_bi())
+                    .await
+                    .ok_or(TransportError::Cancelled)??;
                 // .context("failed to connect to transport stream")?;
                 info!("quic transport connected in {:?}", start.elapsed());
                 Ok(Self {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
@@ -619,60 +619,22 @@ impl TunnelHandle {
 
     /// Wait until the tunnel finished execution.
     ///
-    /// If one of the required subsystems encounters an error and closes early, signal for the
-    /// tunnel to shutdown using the cancellation token.
-    ///
-    /// Returns a tombstone containing the no longer used tunnel devices and wireguard tunnels (on
-    /// Windows).
+    /// Returns a tombstone containing the no longer used tunnel devices and wireguard tunnels (on Windows).
     pub async fn wait(self) -> Result<Tombstone, JoinError> {
-        // Wrap handles with auto-cancel behavior
-        let shutdown_token = self.shutdown_token.clone();
-        let bandwidth_handle = async move {
-            let res = self.bandwidth_controller_handle.await;
-            if !shutdown_token.is_cancelled() {
-                shutdown_token.cancel();
-            }
-            res
-        };
-        let shutdown_token = self.shutdown_token.clone();
-        let transport_handle = async move {
-            if let Some(handle) = self.transport_fwd_handle {
-                let res = handle.await;
-                if !shutdown_token.is_cancelled() {
-                    shutdown_token.cancel();
-                }
-                res
-            } else {
-                Ok(())
-            }
-        };
-
-        // spawn all required tasks by their join handles
-        let mut required_tasks = tokio::task::JoinSet::new();
-        // Bandwidth controller - auto-cancels token on exit
-        required_tasks.spawn(bandwidth_handle);
-        // Transport forwarder - auto-cancels token on exit if task it exists.
-        required_tasks.spawn(transport_handle);
-
-        // Await the event handler task and use its result as tombstone
-        let tombstone = self.event_handler_task.await;
-        if !self.shutdown_token.is_cancelled() {
-            self.shutdown_token.cancel();
+        if let Err(e) = self.bandwidth_controller_handle.await {
+            tracing::error!("Failed to join on bandwidth controller: {}", e);
         }
-
-        // Make sure all tasks finish before we move on
-        for result in required_tasks.join_all().await {
-            if let Err(e) = &result {
-                tracing::error!("failed to join or encountered subsystem error : {e}",);
-            }
-        }
-
-        // Clean up auth client handle
         if let Some(auth_client_handle) = self.auth_client_mixnet_listener_handle {
             auth_client_handle.stop().await;
         }
 
-        tombstone
+        if let Some(handle) = self.transport_fwd_handle
+            && let Err(e) = handle.await
+        {
+            tracing::error!("Failed to join on transport forwarder: {}", e);
+        }
+
+        self.event_handler_task.await
     }
 
     /// Returns entry wintun interface descriptor when available.

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
@@ -619,22 +619,60 @@ impl TunnelHandle {
 
     /// Wait until the tunnel finished execution.
     ///
-    /// Returns a tombstone containing the no longer used tunnel devices and wireguard tunnels (on Windows).
+    /// If one of the required subsystems encounters an error and closes early, signal for the
+    /// tunnel to shutdown using the cancellation token.
+    ///
+    /// Returns a tombstone containing the no longer used tunnel devices and wireguard tunnels (on
+    /// Windows).
     pub async fn wait(self) -> Result<Tombstone, JoinError> {
-        if let Err(e) = self.bandwidth_controller_handle.await {
-            tracing::error!("Failed to join on bandwidth controller: {}", e);
+        // Wrap handles with auto-cancel behavior
+        let shutdown_token = self.shutdown_token.clone();
+        let bandwidth_handle = async move {
+            let res = self.bandwidth_controller_handle.await;
+            if !shutdown_token.is_cancelled() {
+                shutdown_token.cancel();
+            }
+            res
+        };
+        let shutdown_token = self.shutdown_token.clone();
+        let transport_handle = async move {
+            if let Some(handle) = self.transport_fwd_handle {
+                let res = handle.await;
+                if !shutdown_token.is_cancelled() {
+                    shutdown_token.cancel();
+                }
+                res
+            } else {
+                Ok(())
+            }
+        };
+
+        // spawn all required tasks by their join handles
+        let mut required_tasks = tokio::task::JoinSet::new();
+        // Bandwidth controller - auto-cancels token on exit
+        required_tasks.spawn(bandwidth_handle);
+        // Transport forwarder - auto-cancels token on exit if task it exists.
+        required_tasks.spawn(transport_handle);
+
+        // Await the event handler task and use its result as tombstone
+        let tombstone = self.event_handler_task.await;
+        if !self.shutdown_token.is_cancelled() {
+            self.shutdown_token.cancel();
         }
+
+        // Make sure all tasks finish before we move on
+        for result in required_tasks.join_all().await {
+            if let Err(e) = &result {
+                tracing::error!("failed to join or encountered subsystem error : {e}",);
+            }
+        }
+
+        // Clean up auth client handle
         if let Some(auth_client_handle) = self.auth_client_mixnet_listener_handle {
             auth_client_handle.stop().await;
         }
 
-        if let Some(handle) = self.transport_fwd_handle
-            && let Err(e) = handle.await
-        {
-            tracing::error!("Failed to join on transport forwarder: {}", e);
-        }
-
-        self.event_handler_task.await
+        tombstone
     }
 
     /// Returns entry wintun interface descriptor when available.

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -885,11 +885,19 @@ impl TunnelMonitor {
             // and the bind address of that UDP listener is provided to the entry wireguard tunnel
             // as the endpoint address.
             tracing::info!("Establishing DVPN QUIC transport tunnel");
-            let udp_fwd_cancel = self.shutdown_token.child_token();
-            let bridge_conn = transports::BridgeConn::try_connect(entry_bridge_params).await?;
+
+            let bridge_conn = transports::BridgeConn::try_connect(
+                entry_bridge_params,
+                self.shutdown_token.child_token(),
+            )
+            .await?;
             connection_data.entry_bridge_addr = Some(bridge_conn.endpoint);
-            let (local_fwd_listen_addr, fwd_handle) =
-                transports::UdpForwarder::launch(bridge_conn, None, udp_fwd_cancel.clone()).await?;
+            let (local_fwd_listen_addr, fwd_handle) = transports::UdpForwarder::launch(
+                bridge_conn,
+                None,
+                self.shutdown_token.child_token(),
+            )
+            .await?;
             transport_fwd_handle = Some(fwd_handle);
             tracing::info!(
                 "quic transport connected, udp forwarder open on {local_fwd_listen_addr:?}"

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -888,16 +888,15 @@ impl TunnelMonitor {
 
             let bridge_conn = transports::BridgeConn::try_connect(
                 entry_bridge_params,
-                self.shutdown_token.child_token(),
+                self.shutdown_token.clone(),
             )
-            .await?;
+            .await
+            .inspect_err(|_| self.shutdown_token.cancel())?;
             connection_data.entry_bridge_addr = Some(bridge_conn.endpoint);
-            let (local_fwd_listen_addr, fwd_handle) = transports::UdpForwarder::launch(
-                bridge_conn,
-                None,
-                self.shutdown_token.child_token(),
-            )
-            .await?;
+            let (local_fwd_listen_addr, fwd_handle) =
+                transports::UdpForwarder::launch(bridge_conn, None, self.shutdown_token.clone())
+                    .await
+                    .inspect_err(|_| self.shutdown_token.cancel())?;
             transport_fwd_handle = Some(fwd_handle);
             tracing::info!(
                 "quic transport connected, udp forwarder open on {local_fwd_listen_addr:?}"

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/account.rs
@@ -64,7 +64,7 @@ impl TryFrom<proto::VpnApiError> for VpnApiError {
             proto::vpn_api_error::ErrorDetail::Timeout(msg) => Self::Timeout(msg),
             proto::vpn_api_error::ErrorDetail::StatusCode(e) => Self::StatusCode {
                 code: e.code.try_into().map_err(|e| {
-                    ConversionError::Generic(format!("failed to convert status code: {}", e))
+                    ConversionError::Generic(format!("failed to convert status code: {e}"))
                 })?,
                 message: e.message,
             },


### PR DESCRIPTION
## Ticket

Net-596 / NET-512 / NET-343

## Description

1.  While connecting using the Quic transport, there was an issue (specifics don’t really matter, the gateway was incompatible with quic). While it was waiting in attempting to connect to a gateway I knew wouldn’t work I hit ctrl-c (or sent disconnect) to stop the connect attempt. The cancel blocked on the quic connection failng, i.e. timing out. This should definitely not block this way. The quic connection should be aborted when the connect attempt is cancelled. 

2.  If an error occurs in the UdpForwarder it will stop and cancel it’s (local) CancellationToken. However, there is no mechanism at the moment by which that error is propagated back to the tunnel state to inform it that the tunnel has entered an error state and should shut down and potentially attempt to reconnect. 

## Checklist:

- [x] condition quic connection establishment on statemachine cancellation 
- [x] tunnel subsystem exit handling and propagation -- i.e. if UDP forwarder closes early, close tunnel.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3655)
<!-- Reviewable:end -->
