### PR TITLE
Fix android 2025.16 release

### DIFF
--- a/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/NymBackend.kt
+++ b/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/NymBackend.kt
@@ -316,6 +316,7 @@ class NymBackend private constructor(private val context: Context) : Backend, Tu
 						tunnel.exitPoint,
 						tunnel.mode.isTwoHop(),
 						false,
+						false,
 						vpnService.await(),
 						storagePath,
 						storagePath,


### PR DESCRIPTION

## Description

Adds missing `false` for residential exit parameter.

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3658)
<!-- Reviewable:end -->
