### PR TITLE
Adapt android app to the new uniffi interface, cleanup android.mk

### DIFF
--- a/.github/workflows/ci-nym-vpn-android.yml
+++ b/.github/workflows/ci-nym-vpn-android.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "nym-vpn-core/crates/**"
       - "nym-vpn-core/Cargo.toml"
+      - "nym-vpn-core/Android.mk"
       - "nym-vpn-android/**"
       - ".github/workflows/ci-nym-vpn-android.yml"
       - ".github/workflows/build-nym-vpn-android.yml"

--- a/.github/workflows/ci-nym-vpn-core-android.yml
+++ b/.github/workflows/ci-nym-vpn-core-android.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "nym-vpn-core/crates/**"
       - "nym-vpn-core/Cargo.toml"
+      - "nym-vpn-core/Android.mk"
       - ".github/workflows/ci-nym-vpn-core-android.yml"
   workflow_dispatch:
 

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/manager/backend/BackendManager.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/manager/backend/BackendManager.kt
@@ -5,7 +5,7 @@ import net.nymtech.nymvpn.manager.backend.model.TunnelManagerState
 import net.nymtech.vpn.backend.Backend
 import net.nymtech.vpn.backend.Tunnel
 import net.nymtech.vpn.model.NymGateway
-import nym_vpn_lib_types.AccountLinks
+import nym_vpn_lib_types.ParsedAccountLinks
 import nym_vpn_lib_types.GatewayType
 import nym_vpn_lib_types.SystemMessage
 
@@ -16,7 +16,7 @@ interface BackendManager {
 	suspend fun storeMnemonic(mnemonic: String)
 	suspend fun isMnemonicStored(): Boolean
 	suspend fun removeMnemonic()
-	suspend fun getAccountLinks(): AccountLinks?
+	suspend fun getAccountLinks(): ParsedAccountLinks?
 	suspend fun getSystemMessages(): List<SystemMessage>
 	suspend fun getGateways(gatewayType: GatewayType): List<NymGateway>
 	suspend fun refreshAccountLinks()

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/manager/backend/NymBackendManager.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/manager/backend/NymBackendManager.kt
@@ -38,7 +38,7 @@ import net.nymtech.vpn.model.BackendEvent
 import net.nymtech.vpn.model.NymGateway
 import net.nymtech.vpn.model.SettingsConfig
 import net.nymtech.vpn.util.exceptions.BackendException
-import nym_vpn_lib_types.AccountLinks
+import nym_vpn_lib_types.ParsedAccountLinks
 import nym_vpn_lib_types.BandwidthEvent
 import nym_vpn_lib_types.ConnectionData
 import nym_vpn_lib_types.ConnectionEvent
@@ -199,7 +199,7 @@ class NymBackendManager @Inject constructor(
 		return backend.await().getAccountIdentity()
 	}
 
-	override suspend fun getAccountLinks(): AccountLinks? {
+	override suspend fun getAccountLinks(): ParsedAccountLinks? {
 		return try {
 			backend.await().getAccountLinks()
 		} catch (_: Exception) {

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/manager/backend/model/TunnelManagerState.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/manager/backend/model/TunnelManagerState.kt
@@ -1,7 +1,7 @@
 package net.nymtech.nymvpn.manager.backend.model
 
 import net.nymtech.vpn.backend.Tunnel
-import nym_vpn_lib_types.AccountLinks
+import nym_vpn_lib_types.ParsedAccountLinks
 import nym_vpn_lib_types.EstablishConnectionState
 
 data class TunnelManagerState(
@@ -13,7 +13,7 @@ data class TunnelManagerState(
 	val isMnemonicStored: Boolean = false,
 	val deviceId: String? = null,
 	val accountId: String? = null,
-	val accountLinks: AccountLinks? = null,
+	val accountLinks: ParsedAccountLinks? = null,
 	val isInitialized: Boolean = false,
 	val isNetworkCompatible: Boolean = true,
 )

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/login/components/MaxDevicesModal.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/login/components/MaxDevicesModal.kt
@@ -17,10 +17,10 @@ import net.nymtech.nymvpn.R
 import net.nymtech.nymvpn.ui.common.Modal
 import net.nymtech.nymvpn.ui.theme.CustomTypography
 import net.nymtech.nymvpn.util.extensions.openWebUrl
-import nym_vpn_lib_types.AccountLinks
+import nym_vpn_lib_types.ParsedAccountLinks
 
 @Composable
-fun MaxDevicesModal(show: Boolean, accountLinks: AccountLinks?, onDismiss: () -> Unit) {
+fun MaxDevicesModal(show: Boolean, accountLinks: ParsedAccountLinks?, onDismiss: () -> Unit) {
 	val context = LocalContext.current
 
 	Modal(
@@ -37,8 +37,8 @@ fun MaxDevicesModal(show: Boolean, accountLinks: AccountLinks?, onDismiss: () ->
 		},
 		text = {
 			CredentialModalBody {
-				accountLinks?.signIn?.let {
-					context.openWebUrl(it)
+				accountLinks?.let {
+					context.openWebUrl(it.signIn)
 					onDismiss()
 				}
 			}

--- a/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/Backend.kt
+++ b/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/Backend.kt
@@ -1,15 +1,15 @@
 package net.nymtech.vpn.backend
 
 import net.nymtech.vpn.model.NymGateway
-import nym_vpn_lib_types.AccountLinks
+import nym_vpn_lib_types.ParsedAccountLinks
 import nym_vpn_lib_types.GatewayType
-import nym_vpn_lib_types.NetworkEnvironment
+import nym_vpn_lib_types.Network
 import nym_vpn_lib_types.SystemMessage
 import nym_vpn_lib_types.UserAgent
 
 interface Backend {
 
-	suspend fun getAccountLinks(): AccountLinks
+	suspend fun getAccountLinks(): ParsedAccountLinks
 
 	suspend fun getSystemMessages(): List<SystemMessage>
 
@@ -27,7 +27,7 @@ interface Backend {
 
 	suspend fun removeMnemonic()
 
-	suspend fun getCurrentEnvironment(): NetworkEnvironment
+	suspend fun getCurrentEnvironment(): Network
 
 	suspend fun start(tunnel: Tunnel, userAgent: UserAgent)
 

--- a/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/NymBackend.kt
+++ b/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/NymBackend.kt
@@ -27,7 +27,7 @@ import net.nymtech.vpn.util.extensions.asTunnelState
 import net.nymtech.vpn.util.extensions.startServiceByClass
 import net.nymtech.vpn.util.notifications.VpnNotificationManager
 import nym_vpn_lib.AndroidConnectivityMonitor
-import nym_vpn_lib_types.AccountLinks
+import nym_vpn_lib_types.ParsedAccountLinks
 import nym_vpn_lib.ConnectivityObserver
 import nym_vpn_lib_types.GatewayType
 import nym_vpn_lib.NymVpnLibConfig
@@ -46,7 +46,7 @@ import nym_vpn_lib.isAccountMnemonicStored
 import nym_vpn_lib.login
 import nym_vpn_lib.startVpn
 import nym_vpn_lib.stopVpn
-import nym_vpn_lib_types.NetworkEnvironment
+import nym_vpn_lib_types.Network
 import org.semver4j.Semver
 import timber.log.Timber
 import java.util.Locale
@@ -194,7 +194,7 @@ class NymBackend private constructor(private val context: Context) : Backend, Tu
 	}
 
 	@Throws(VpnException::class)
-	override suspend fun getAccountLinks(): AccountLinks {
+	override suspend fun getAccountLinks(): ParsedAccountLinks {
 		return withContext(ioDispatcher) {
 			initialized.await()
 			nym_vpn_lib.getAccountLinks(getCurrentLocaleLanguageCode())
@@ -266,7 +266,7 @@ class NymBackend private constructor(private val context: Context) : Backend, Tu
 		}
 	}
 
-	override suspend fun getCurrentEnvironment(): NetworkEnvironment {
+	override suspend fun getCurrentEnvironment(): Network {
 		return nym_vpn_lib.currentEnvironment()
 	}
 

--- a/nym-vpn-android/core/src/main/java/net/nymtech/vpn/model/NymGateway.kt
+++ b/nym-vpn-android/core/src/main/java/net/nymtech/vpn/model/NymGateway.kt
@@ -31,7 +31,7 @@ data class NymGateway(
 	companion object {
 		fun from(gateway: Gateway): NymGateway {
 			return NymGateway(
-				identity = gateway.id,
+				identity = gateway.identityKey,
 				name = gateway.moniker,
 				twoLetterCountryISO = gateway.location?.twoLetterIsoCountryCode?.lowercase(),
 				mixnetScore = gateway.mixnetScore,

--- a/nym-vpn-core/Android.mk
+++ b/nym-vpn-core/Android.mk
@@ -41,9 +41,7 @@ all: $(ARM64_V8_BUILD_DIR)/libwg.so build uniffi $(LICENSES_FILE)
 build: $(ARM64_V8_BUILD_DIR)/libwg.so
 	$(ALL_IDEMPOTENT_FLAGS) cargo ndk -t arm64-v8a -o $(JNI_LIBS_DIR) build --package nym-vpn-lib-uniffi $(RELEASE_FLAG)
 	cd $(ARM64_V8_BUILD_DIR) ; \
-	mv libnym_vpn_lib_uniffi.so libnym_vpn_lib.so ; \
-	mv libnym_vpn_lib_types.so libnym_vpn_lib_types.so
-
+	mv libnym_vpn_lib_uniffi.so libnym_vpn_lib.so
 
 uniffi: build
 	cargo run --bin uniffi-bindgen generate \

--- a/nym-vpn-core/Android.mk
+++ b/nym-vpn-core/Android.mk
@@ -39,16 +39,15 @@ LIBWG_SOURCES := $(wildcard $(WIREGUARD_DIR)/libwg/*.go) $(wildcard $(WIREGUARD_
 all: $(ARM64_V8_BUILD_DIR)/libwg.so build uniffi $(LICENSES_FILE)
 
 build: $(ARM64_V8_BUILD_DIR)/libwg.so
-	$(ALL_IDEMPOTENT_FLAGS) cargo ndk -t arm64-v8a -o $(JNI_LIBS_DIR) build --package nym-vpn-lib-uniffi --package nym-vpn-lib-types $(RELEASE_FLAG)
+	$(ALL_IDEMPOTENT_FLAGS) cargo ndk -t arm64-v8a -o $(JNI_LIBS_DIR) build --package nym-vpn-lib-uniffi $(RELEASE_FLAG)
 	cd $(ARM64_V8_BUILD_DIR) ; \
-	mv libnym_vpn_lib_uniffi.so libnym_vpn_lib.so
+	mv libnym_vpn_lib_uniffi.so libnym_vpn_lib.so ; \
+	mv libnym_vpn_lib_types.so libnym_vpn_lib_types.so
+
 
 uniffi: build
 	cargo run --bin uniffi-bindgen generate \
 		--library $(DYNAMIC_LIB_PATH) \
-		--language kotlin --out-dir $(UNIFFI_OUT_DIR) -n
-	cargo run --bin uniffi-bindgen generate \
-		--library $(ARM64_V8_BUILD_DIR)/libnym_vpn_lib_types.so \
 		--language kotlin --out-dir $(UNIFFI_OUT_DIR) -n
 
 $(ARM64_V8_BUILD_DIR)/libwg.so: $(LIBWG_SOURCES)

--- a/nym-vpn-core/Android.mk
+++ b/nym-vpn-core/Android.mk
@@ -34,11 +34,11 @@ LICENSES_FILE := $(ANDROID_DIR)/core/src/main/assets/licenses_rust.json
 # todo: consider migrating libwg builds to makefile to avoid rebuilds but for now this should make this makefile aware of changes to go sources
 LIBWG_SOURCES := $(wildcard $(WIREGUARD_DIR)/libwg/*.go) $(wildcard $(WIREGUARD_DIR)/libwg/*/*.go)
 
-.PHONY: build uniffi libwg clean
+.PHONY: build uniffi libwg clean clean-build-artifacts
 
 all: $(ARM64_V8_BUILD_DIR)/libwg.so build uniffi $(LICENSES_FILE)
 
-build: $(ARM64_V8_BUILD_DIR)/libwg.so
+build: clean-build-artifacts $(ARM64_V8_BUILD_DIR)/libwg.so
 	$(ALL_IDEMPOTENT_FLAGS) cargo ndk -t arm64-v8a -o $(JNI_LIBS_DIR) build --package nym-vpn-lib-uniffi $(RELEASE_FLAG)
 	cd $(ARM64_V8_BUILD_DIR) ; \
 	mv libnym_vpn_lib_uniffi.so libnym_vpn_lib.so
@@ -54,7 +54,15 @@ $(ARM64_V8_BUILD_DIR)/libwg.so: $(LIBWG_SOURCES)
 libwg: $(ARM64_V8_BUILD_DIR)/libwg.so
 
 clean:
+	rm -rf $(ARM64_V8_BUILD_DIR) || true
 	rm -rf $(JNI_LIBS_DIR) || true
+
+# Clean build artifacts created by `cargo ndk` except libwg.so
+# This is needed because rustc outputs additional dynamic libraries along our artifacts, for ex: librustls_platform_verifier-e39f954511af018a.so
+# Where the hash part of the library name is generated and may change over time
+clean-build-artifacts:
+	cd $(ARM64_V8_BUILD_DIR) ; \
+	find . ! -name 'libwg.so' -type f -exec rm -f {} +
 
 $(LICENSES_FILE): $(CURDIR)/Cargo.lock
 	cargo license -j --avoid-dev-deps --current-dir $(CURDIR)/crates/nym-vpn-lib --filter-platform aarch64-linux-android --avoid-build-deps > $(LICENSES_FILE)

--- a/nym-vpn-core/Android.mk
+++ b/nym-vpn-core/Android.mk
@@ -61,8 +61,10 @@ clean:
 # This is needed because rustc outputs additional dynamic libraries along our artifacts, for ex: librustls_platform_verifier-e39f954511af018a.so
 # Where the hash part of the library name is generated and may change over time
 clean-build-artifacts:
-	cd $(ARM64_V8_BUILD_DIR) ; \
-	find . ! -name 'libwg.so' -type f -exec rm -f {} +
+	if [ -d $(ARM64_V8_BUILD_DIR) ]; then \
+	    cd $(ARM64_V8_BUILD_DIR) ; \
+		find . ! -name 'libwg.so' -type f -exec rm -f {} + ; \
+	fi
 
 $(LICENSES_FILE): $(CURDIR)/Cargo.lock
 	cargo license -j --avoid-dev-deps --current-dir $(CURDIR)/crates/nym-vpn-lib --filter-platform aarch64-linux-android --avoid-build-deps > $(LICENSES_FILE)

--- a/nym-vpn-core/Android.mk
+++ b/nym-vpn-core/Android.mk
@@ -34,11 +34,11 @@ LICENSES_FILE := $(ANDROID_DIR)/core/src/main/assets/licenses_rust.json
 # todo: consider migrating libwg builds to makefile to avoid rebuilds but for now this should make this makefile aware of changes to go sources
 LIBWG_SOURCES := $(wildcard $(WIREGUARD_DIR)/libwg/*.go) $(wildcard $(WIREGUARD_DIR)/libwg/*/*.go)
 
-.PHONY: build uniffi libwg clean clean-build-artifacts
+.PHONY: build uniffi libwg clean
 
 all: $(ARM64_V8_BUILD_DIR)/libwg.so build uniffi $(LICENSES_FILE)
 
-build: clean-build-artifacts $(ARM64_V8_BUILD_DIR)/libwg.so
+build: $(ARM64_V8_BUILD_DIR)/libwg.so
 	$(ALL_IDEMPOTENT_FLAGS) cargo ndk -t arm64-v8a -o $(JNI_LIBS_DIR) build --package nym-vpn-lib-uniffi $(RELEASE_FLAG)
 	cd $(ARM64_V8_BUILD_DIR) ; \
 	mv libnym_vpn_lib_uniffi.so libnym_vpn_lib.so
@@ -56,15 +56,6 @@ libwg: $(ARM64_V8_BUILD_DIR)/libwg.so
 clean:
 	rm -rf $(ARM64_V8_BUILD_DIR) || true
 	rm -rf $(JNI_LIBS_DIR) || true
-
-# Clean build artifacts created by `cargo ndk` except libwg.so
-# This is needed because rustc outputs additional dynamic libraries along our artifacts, for ex: librustls_platform_verifier-e39f954511af018a.so
-# Where the hash part of the library name is generated and may change over time
-clean-build-artifacts:
-	if [ -d $(ARM64_V8_BUILD_DIR) ]; then \
-	    cd $(ARM64_V8_BUILD_DIR) ; \
-		find . ! -name 'libwg.so' -type f -exec rm -f {} + ; \
-	fi
 
 $(LICENSES_FILE): $(CURDIR)/Cargo.lock
 	cargo license -j --avoid-dev-deps --current-dir $(CURDIR)/crates/nym-vpn-lib --filter-platform aarch64-linux-android --avoid-build-deps > $(LICENSES_FILE)

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -8513,15 +8513,6 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
@@ -9004,9 +8995,9 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "uniffi"
-version = "0.29.4"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6d968cb62160c11f2573e6be724ef8b1b18a277aededd17033f8a912d73e2b4"
+checksum = "c866f627c3f04c3df068b68bb2d725492caaa539dd313e2a9d26bb85b1a32f4e"
 dependencies = [
  "anyhow",
  "camino",
@@ -9028,9 +9019,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.29.4"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6b39ef1acbe1467d5d210f274fae344cb6f8766339330cb4c9688752899bf6b"
+checksum = "7c8ca600167641ebe7c8ba9254af40492dda3397c528cc3b2f511bd23e8541a5"
 dependencies = [
  "anyhow",
  "askama",
@@ -9045,7 +9036,7 @@ dependencies = [
  "serde",
  "tempfile",
  "textwrap",
- "toml 0.5.11",
+ "toml 0.9.7",
  "uniffi_internal_macros",
  "uniffi_meta",
  "uniffi_pipeline",
@@ -9054,9 +9045,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_build"
-version = "0.29.4"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6683e6b665423cddeacd89a3f97312cf400b2fb245a26f197adaf65c45d505b2"
+checksum = "3e55c05228f4858bb258f651d21d743fcc1fe5a2ec20d3c0f9daefddb105ee4d"
 dependencies = [
  "anyhow",
  "camino",
@@ -9065,9 +9056,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_core"
-version = "0.29.4"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d990b553d6b9a7ee9c3ae71134674739913d52350b56152b0e613595bb5a6f"
+checksum = "7e7a5a038ebffe8f4cf91416b154ef3c2468b18e828b7009e01b1b99938089f9"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -9078,9 +9069,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_internal_macros"
-version = "0.29.4"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f4f224becf14885c10e6e400b95cc4d1985738140cb194ccc2044563f8a56b"
+checksum = "e3c2a6f93e7b73726e2015696ece25ca0ac5a5f1cf8d6a7ab5214dd0a01d2edf"
 dependencies = [
  "anyhow",
  "indexmap 2.11.4",
@@ -9091,9 +9082,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.29.4"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b481d385af334871d70904e6a5f129be7cd38c18fcf8dd8fd1f646b426a56d58"
+checksum = "64c6309fc36c7992afc03bc0c5b059c656bccbef3f2a4bc362980017f8936141"
 dependencies = [
  "camino",
  "fs-err",
@@ -9102,15 +9093,15 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.106",
- "toml 0.5.11",
+ "toml 0.9.7",
  "uniffi_meta",
 ]
 
 [[package]]
 name = "uniffi_meta"
-version = "0.29.4"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f817868a3b171bb7bf259e882138d104deafde65684689b4694c846d322491"
+checksum = "0a138823392dba19b0aa494872689f97d0ee157de5852e2bec157ce6de9cdc22"
 dependencies = [
  "anyhow",
  "siphasher 0.3.11",
@@ -9120,9 +9111,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_pipeline"
-version = "0.29.4"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b147e133ad7824e32426b90bc41fda584363563f2ba747f590eca1fd6fd14e6"
+checksum = "8c27c4b515d25f8e53cc918e238c39a79c3144a40eaf2e51c4a7958973422c29"
 dependencies = [
  "anyhow",
  "heck",
@@ -9133,9 +9124,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_udl"
-version = "0.29.4"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caed654fb73da5abbc7a7e9c741532284532ba4762d6fe5071372df22a41730a"
+checksum = "d0adacdd848aeed7af4f5af7d2f621d5e82531325d405e29463482becfdeafca"
 dependencies = [
  "anyhow",
  "textwrap",

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -188,7 +188,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-test = "0.2.5"
 triggered = "0.1.3"
 tun = { version = "0.6.1", features = ["async"] }
-uniffi = { version = "0.29.4", features = ["cli"] }
+uniffi = { version = "0.30", features = ["cli"] }
 url = "2.5"
 vergen-gitcl = { version = "1.0.8", default-features = false }
 webpki-roots = "0.26"

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/account/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/account/mod.rs
@@ -93,8 +93,8 @@ pub enum VpnApiError {
     #[error("timeout: {0}")]
     Timeout(String),
 
-    #[error("status code: {code}, error: {message}")]
-    StatusCode { code: u16, message: String },
+    #[error("status code: {code}, error: {msg}")]
+    StatusCode { code: u16, msg: String },
 
     #[error(transparent)]
     Response(#[from] VpnApiErrorResponse),
@@ -150,7 +150,7 @@ impl TryFrom<nym_vpn_api_client::error::VpnApiClientError> for VpnApiError {
         {
             Some(code) => Ok(Self::StatusCode {
                 code: code.into(),
-                message: err.to_string(),
+                msg: err.to_string(),
             }),
             None => Err(err),
         }

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/account.rs
@@ -66,7 +66,7 @@ impl TryFrom<proto::VpnApiError> for VpnApiError {
                 code: e.code.try_into().map_err(|e| {
                     ConversionError::Generic(format!("failed to convert status code: {e}"))
                 })?,
-                message: e.message,
+                msg: e.message,
             },
             proto::vpn_api_error::ErrorDetail::Response(vpn_api_error_response) => {
                 Self::Response(vpn_api_error_response.into())
@@ -208,7 +208,7 @@ impl From<VpnApiError> for proto::VpnApiError {
     fn from(value: VpnApiError) -> Self {
         let error_detail = match value {
             VpnApiError::Timeout(msg) => proto::vpn_api_error::ErrorDetail::Timeout(msg),
-            VpnApiError::StatusCode { code, message } => {
+            VpnApiError::StatusCode { code, msg: message } => {
                 proto::vpn_api_error::ErrorDetail::StatusCode(proto::vpn_api_error::StatusError {
                     code: u32::from(code),
                     message,


### PR DESCRIPTION
## Description


- Adapt android app to new `nym-vpn-lib-types`
- With addition of QUIC, rustc outputs one more library in the build dir: `librustls_platform_verifier-e39f954511af018a.so`. Hence I have added a makefile step to clear out all build artifcats just in case that that the hash changes for `librustls_platform_verifier`
- No need to run `uniffi-bindgen` manually, since it runs automatically for `nym-vpn-lib-types` because it's a dependency of `nym-vpn-lib-uniffi`.
- No need to pass `--package nym-vpn-lib-types ` to `cargo ndk` because it's a dependency of `nym-vpn-lib-uniffi` and will be built implicitly.

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3659)
<!-- Reviewable:end -->
