### PR TITLE
api client: remove feat clap

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -5337,7 +5337,6 @@ dependencies = [
  "bip39",
  "bs58",
  "chrono",
- "clap",
  "itertools 0.13.0",
  "nym-compact-ecash",
  "nym-config",

--- a/nym-vpn-core/crates/nym-vpn-api-client/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-api-client/Cargo.toml
@@ -16,7 +16,6 @@ backon.workspace = true
 base64-url.workspace = true
 bip39 = { workspace = true, features = ["zeroize"] }
 bs58.workspace = true
-clap = { workspace = true, features = ["derive"], optional = true }
 chrono = { workspace = true, features = ["serde"] }
 itertools.workspace = true
 nym-compact-ecash.workspace = true
@@ -47,6 +46,8 @@ tokio = { workspace = true, features = ["full"] }
 bip39 = { workspace = true, features = ["zeroize"] }
 
 [features]
-cli = ["clap"]
 default = ["network-defaults"]
-network-defaults = ["dep:nym-network-defaults", "nym-http-api-client/network-defaults"]
+network-defaults = [
+    "dep:nym-network-defaults",
+    "nym-http-api-client/network-defaults",
+]

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/types/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/types/account.rs
@@ -29,7 +29,6 @@ pub enum Error {
 /// Defines the mode of operation of the associated account.
 #[derive(Debug, Copy, Clone, strum_macros::Display)]
 #[strum(serialize_all = "snake_case")]
-#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 pub enum VpnAccountMode {
     /// Account works in the API mode, i.e. the subscription is managed
     /// by the VPN API which provides required ticketbooks
@@ -38,7 +37,6 @@ pub enum VpnAccountMode {
     /// Account works in the decentralised mode, i.e. there is no associated subscription
     /// and the account uses its own funds for obtaining required ticketbooks
     // add an alias for our US friends
-    #[cfg_attr(feature = "cli", value(alias("decentralized")))]
     Decentralised,
 }
 


### PR DESCRIPTION

## Description

This feature is no longer used as nym-vpn-cli reimplements the same type on its own. 

Currently all types used by consumers must be placed in `nym-vpn-lib-types` due to multiple reasons related to generation of uniffi/typescript bindings, issues related to including a large sub-tree of dependencies coming from all dependent crates.

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3664)
<!-- Reviewable:end -->
