### PR TITLE
Update windows to 0.62.2

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -622,7 +622,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1062,7 +1062,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2885,7 +2885,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.1",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -3242,7 +3242,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4162,7 +4162,7 @@ dependencies = [
  "tracing",
  "triggered",
  "which",
- "windows 0.61.3",
+ "windows 0.62.2",
  "winreg 0.55.0",
 ]
 
@@ -4234,7 +4234,7 @@ dependencies = [
  "thiserror 2.0.17",
  "tracing",
  "widestring",
- "windows 0.61.3",
+ "windows 0.62.2",
  "wmi",
 ]
 
@@ -4500,7 +4500,7 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tracing",
- "windows 0.61.3",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -4734,7 +4734,7 @@ dependencies = [
  "rs-release",
  "sha2 0.10.9",
  "sysinfo",
- "windows 0.61.3",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -4789,7 +4789,7 @@ dependencies = [
  "tokio",
  "tracing",
  "widestring",
- "windows 0.61.3",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -5431,7 +5431,7 @@ dependencies = [
  "url",
  "vergen-gitcl",
  "webpki-roots 0.26.11",
- "windows 0.61.3",
+ "windows 0.62.2",
  "winreg 0.55.0",
  "x509-parser",
 ]
@@ -5641,7 +5641,7 @@ dependencies = [
  "tracing-oslog",
  "tracing-subscriber",
  "vergen-gitcl",
- "windows 0.61.3",
+ "windows 0.62.2",
  "windows-service",
 ]
 
@@ -5656,7 +5656,7 @@ dependencies = [
  "rand 0.8.5",
  "thiserror 2.0.17",
  "tracing",
- "windows 0.61.3",
+ "windows 0.62.2",
  "x25519-dalek",
  "zeroize",
 ]
@@ -5686,7 +5686,7 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "tracing",
- "windows 0.61.3",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -9666,14 +9666,14 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.62.1"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49e6c4a1f363c8210c6f77ba24f645c61c6fb941eccf013da691f7e09515b8ac"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-collections 0.3.1",
- "windows-core 0.62.1",
- "windows-future 0.3.1",
- "windows-numerics 0.3.0",
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -9687,11 +9687,11 @@ dependencies = [
 
 [[package]]
 name = "windows-collections"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "123e712f464a8a60ce1a13f4c446d2d43ab06464cb5842ff68f5c71b6fb7852e"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.62.1",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -9722,8 +9722,8 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement 0.60.1",
- "windows-interface 0.59.2",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
@@ -9731,15 +9731,15 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.62.1"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6844ee5416b285084d3d3fffd743b925a6c9385455f64f6d4fa3031c4c2749a9"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.1",
- "windows-interface 0.59.2",
- "windows-link 0.2.0",
- "windows-result 0.4.0",
- "windows-strings 0.5.0",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -9755,13 +9755,13 @@ dependencies = [
 
 [[package]]
 name = "windows-future"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f3db6b24b120200d649cd4811b4947188ed3a8d2626f7075146c5d178a9a4a"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.62.1",
- "windows-link 0.2.0",
- "windows-threading 0.2.0",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -9777,9 +9777,9 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.60.1"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edb307e42a74fb6de9bf3a02d9712678b22399c87e6fa869d6dfcd8c1b7754e0"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9799,9 +9799,9 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.59.2"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0abd1ddbc6964ac14db11c7213d6532ef34bd9aa042c2e5935f59d7908b46a5"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9816,9 +9816,9 @@ checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-link"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-numerics"
@@ -9832,12 +9832,12 @@ dependencies = [
 
 [[package]]
 name = "windows-numerics"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce3498fe0aba81e62e477408383196b4b0363db5e0c27646f932676283b43d8"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.62.1",
- "windows-link 0.2.0",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -9860,11 +9860,11 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -9899,11 +9899,11 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -9948,7 +9948,7 @@ version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -9988,7 +9988,7 @@ version = "0.53.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d42b7b7f66d2a06854650af09cfdf8713e427a439c97ad65a6375318033ac4b"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -10010,11 +10010,11 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab47f085ad6932defa48855254c758cdd0e2f2d48e62a34118a268d8f345e118"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -10243,8 +10243,8 @@ dependencies = [
  "log",
  "serde",
  "thiserror 2.0.17",
- "windows 0.62.1",
- "windows-core 0.62.1",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -195,7 +195,7 @@ vergen-gitcl = { version = "1.0.8", default-features = false }
 webpki-roots = "0.26"
 which = "8.0"
 widestring = "1.2"
-windows = "0.61"
+windows = "0.62.2"
 windows-service = "0.8.0"
 winreg = "0.55"
 wiremock = "0.6.4"

--- a/nym-vpn-core/crates/nym-dns/src/windows/iphlpapi.rs
+++ b/nym-vpn-core/crates/nym-dns/src/windows/iphlpapi.rs
@@ -85,7 +85,7 @@ impl IphlpApi {
         let set_interface_dns_settings =
             unsafe { GetProcAddress(module, s!("SetInterfaceDnsSettings")) };
         let set_interface_dns_settings = set_interface_dns_settings.ok_or_else(|| {
-            let error = windows::core::Error::from_win32();
+            let error = windows::core::Error::from_thread();
 
             if error.code() != ERROR_PROC_NOT_FOUND.to_hresult() {
                 tracing::error!(

--- a/nym-vpn-core/crates/nym-dns/src/windows/netsh.rs
+++ b/nym-vpn-core/crates/nym-dns/src/windows/netsh.rs
@@ -218,7 +218,7 @@ fn get_system_dir() -> windows::core::Result<PathBuf> {
     let mut sysdir = [0u16; MAX_PATH as usize];
     let len = unsafe { GetSystemDirectoryW(Some(&mut sysdir)) };
     if len == 0 {
-        Err(windows::core::Error::from_win32())
+        Err(windows::core::Error::from_thread())
     } else {
         Ok(PathBuf::from(OsString::from_wide(
             &sysdir[0..(len as usize)],

--- a/nym-vpn-core/crates/nym-firewall/src/windows/mod.rs
+++ b/nym-vpn-core/crates/nym-firewall/src/windows/mod.rs
@@ -489,7 +489,7 @@ fn multibyte_to_wide(mb_string: &CStr, codepage: u32) -> Result<Vec<u16>, window
     };
 
     if wc_size == 0 {
-        return Err(windows::core::Error::from_win32());
+        return Err(windows::core::Error::from_thread());
     }
 
     let wc_buffer_len = usize::try_from(wc_size).unwrap();
@@ -507,7 +507,7 @@ fn multibyte_to_wide(mb_string: &CStr, codepage: u32) -> Result<Vec<u16>, window
     };
 
     if chars_written == 0 {
-        return Err(windows::core::Error::from_win32());
+        return Err(windows::core::Error::from_thread());
     }
 
     wc_buffer.truncate(usize::try_from(chars_written - 1).unwrap());

--- a/nym-vpn-core/crates/nym-platform-metadata/src/windows.rs
+++ b/nym-vpn-core/crates/nym-platform-metadata/src/windows.rs
@@ -48,7 +48,7 @@ impl WindowsVersion {
     pub fn current() -> Result<WindowsVersion, windows::core::Error> {
         let ntdll = unsafe { GetModuleHandleW(w!("ntdll"))? };
         let function_address = unsafe { GetProcAddress(ntdll, s!("RtlGetVersion")) }
-            .ok_or_else(windows::core::Error::from_win32)?;
+            .ok_or_else(windows::core::Error::from_thread)?;
 
         let rtl_get_version: extern "system" fn(*mut RTL_OSVERSIONINFOEXW) =
             unsafe { *(&function_address as *const _ as *const _) };


### PR DESCRIPTION
## Description

Recent update for wmi broke compatibility with windows crate. Hence we need to update windows to the latest to match with wmi

### Breaking changes
- `Error::from_win32()` has been renamed to `Error::from_thread()` (See: https://github.com/microsoft/windows-rs/pull/3701)

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3665)
<!-- Reviewable:end -->
