### PR TITLE
Skip ipv6 metadata endpoint request

### DIFF
--- a/nym-vpn-core/crates/nym-gateway-probe/netstack_ping/lib.go
+++ b/nym-vpn-core/crates/nym-gateway-probe/netstack_ping/lib.go
@@ -192,14 +192,20 @@ func ping(req NetstackRequestGo) (NetstackResponse, error) {
 
 	response.CanHandshake = true
 
-	version, duration, err := queryMetadata(req.MetadataEndpoint, req.MetadataTimeoutSec, tnet)
-	if err != nil {
-		log.Printf("Failed to query metadata URLs: %v\n", err)
-		response.CanQueryMetadata = false
+	// Skip metadata query if endpoint is empty (e.g., for IPv6 where the IPv4 metadata endpoint is not reachable)
+	if req.MetadataEndpoint != "" {
+		version, duration, err := queryMetadata(req.MetadataEndpoint, req.MetadataTimeoutSec, tnet)
+		if err != nil {
+			log.Printf("Failed to query metadata URLs: %v\n", err)
+			response.CanQueryMetadata = false
+		} else {
+			log.Printf("Queried metadata endpoint with version: %v\n", version)
+			log.Printf("Query duration: %v\n", duration)
+			response.CanQueryMetadata = true
+		}
 	} else {
-		log.Printf("Queried metadata endpoint with version: %v\n", version)
-		log.Printf("Query duration: %v\n", duration)
-		response.CanQueryMetadata = true
+		log.Printf("Skipping metadata query (no endpoint provided)")
+		response.CanQueryMetadata = false
 	}
 
 	for _, host := range req.PingHosts {

--- a/nym-vpn-core/crates/nym-gateway-probe/src/netstack.rs
+++ b/nym-vpn-core/crates/nym-gateway-probe/src/netstack.rs
@@ -145,7 +145,8 @@ impl NetstackRequestGo {
             private_key: req.private_key.clone(),
             public_key: req.public_key.clone(),
             endpoint: req.endpoint.clone(),
-            metadata_endpoint: req.metadata_endpoint.clone(),
+            // Skip metadata endpoint for IPv6 as it's an IPv4-only address (10.1.0.1)
+            metadata_endpoint: String::new(),
             dns: req.v6_ping_config.dns.clone(),
             ip_version: 6,
             ping_hosts: req.v6_ping_config.ping_hosts.clone(),


### PR DESCRIPTION
Probing with IPv6, it's still trying to query the metadata endpoint at 10.1.0.1:51830 (an IPv4 address), which fails with "no route to host"

Now we skip that for the ipv6 part of the probe test:

IP version: 4
2025/10/14 11:10:50 Querying metadata encoding: url = http://10.1.0.1:51830/v1/bandwidth/version
2025/10/14 11:10:51 Metadata Content-Type: application/json

Now
WireGuard IP: fc01::6278
IP version: 6
2025/10/14 11:11:27 Skipping metadata query (no endpoint provided)

## Ticket

JIRA-VPN-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3684)
<!-- Reviewable:end -->
