### PR TITLE
Remove nym-gateway-probe from github workflows

### DIFF
--- a/.github/workflows/build-nym-vpn-android.yml
+++ b/.github/workflows/build-nym-vpn-android.yml
@@ -112,7 +112,6 @@ jobs:
           go-version: ${{ vars.REQUIRED_GOLANG_VERSION }}
           cache-dependency-path: |
             wireguard/libwg/go.sum
-            nym-vpn-core/crates/nym-gateway-probe/netstack_ping/go.sum
 
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/build-nym-vpn-core-linux.yml
+++ b/.github/workflows/build-nym-vpn-core-linux.yml
@@ -42,12 +42,6 @@ jobs:
           toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
           components: rustfmt, clippy
 
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ vars.REQUIRED_GOLANG_VERSION }}
-          cache-dependency-path: nym-vpn-core/crates/nym-gateway-probe/netstack_ping/go.sum
-
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
         with:
@@ -80,7 +74,6 @@ jobs:
           SENTRY_DSN: ${{ secrets.VPND_SENTRY_DSN }}
         run: |
           cargo build --release
-          cargo build -p nym-gateway-probe --release
           ls -la nym-vpn-core/target/release/ || true
 
       - name: Get rust version used for build
@@ -93,7 +86,6 @@ jobs:
           SRC_BINARY: nym-vpn-core/target/release/
         run: |
           mkdir ${{ env.UPLOAD_DIR_LINUX }}
-          cp -vpr ${{ env.SRC_BINARY }}/nym-gateway-probe ${{ env.UPLOAD_DIR_LINUX }}
           cp -vpr ${{ env.SRC_BINARY }}/nym-vpnc ${{ env.UPLOAD_DIR_LINUX }}
           cp -vpr ${{ env.SRC_BINARY }}/nym-vpnd ${{ env.UPLOAD_DIR_LINUX }}
 

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -3925,7 +3925,7 @@ dependencies = [
 
 [[package]]
 name = "nym-common"
-version = "1.17.0-beta"
+version = "1.18.0-beta"
 dependencies = [
  "tracing",
  "tracing-test",
@@ -3971,7 +3971,7 @@ dependencies = [
 
 [[package]]
 name = "nym-connection-monitor"
-version = "1.17.0-beta"
+version = "1.18.0-beta"
 dependencies = [
  "bincode",
  "bytes",


### PR DESCRIPTION

## Description

Remove nym-gateway-probe from github workflows as it was moved to `nym` repo in #3648


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3692)
<!-- Reviewable:end -->
