### PR TITLE
cli: add commands to manage sentry and network stats

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add new CLI commands to manage sentry and anonymous network statistics collection (https://github.com/nymtech/nym-vpn-client/pull/3695)
+
 ### Changed
 
 - Use two keypairs (entry & exit) per gateway (https://github.com/nymtech/nym-vpn-client/pull/3591)

--- a/nym-vpn-core/crates/nym-vpnc/src/commands/account.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/commands/account.rs
@@ -11,9 +11,10 @@ pub enum Command {
     Get,
     /// Login with mnemonic
     Set {
+        /// Mnemonic phrase
         #[arg(index = 1)]
         mnemonic: String,
-
+        /// Account mode
         #[clap(long, default_value_t = VpnAccountMode::Api)]
         mode: VpnAccountMode,
     },
@@ -21,6 +22,7 @@ pub enum Command {
     Forget,
     /// Get account links
     Links {
+        /// Locale string (i.e en-US)
         #[arg(long)]
         locale: String,
     },

--- a/nym-vpn-core/crates/nym-vpnc/src/commands/gateway.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/commands/gateway.rs
@@ -96,7 +96,7 @@ pub struct SetArgs {
     pub exit_random: bool,
 
     /// Only select residential exit nodes.
-    #[arg(long, value_parser = BooleanOption::custom_parser("on", "off"))]
+    #[arg(long, value_parser = clap::value_parser!(BooleanOption))]
     pub residential_exit: Option<BooleanOption>,
 }
 

--- a/nym-vpn-core/crates/nym-vpnc/src/commands/gateway.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/commands/gateway.rs
@@ -10,7 +10,9 @@ use nym_vpn_lib_types::{
 };
 use nym_vpn_proto::rpc_client::RpcClient;
 
-use crate::{boolean_option::BooleanOption, table_style::TableStyle};
+use crate::{
+    boolean_option::BooleanOption, display_helpers::display_on_off, table_style::TableStyle,
+};
 
 #[derive(Debug, Clone, clap::Args)]
 pub struct Args {
@@ -147,7 +149,7 @@ impl Args {
                 println!("Exit point: {:?}", config.exit_point);
                 println!(
                     "Residential exit: {}",
-                    if config.residential_exit { "on" } else { "off" }
+                    display_on_off(config.residential_exit)
                 );
                 Ok(())
             }

--- a/nym-vpn-core/crates/nym-vpnc/src/commands/mod.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/commands/mod.rs
@@ -7,4 +7,6 @@ pub mod gateway;
 pub mod lan;
 pub mod legacy;
 pub mod network;
+pub mod network_stats;
+pub mod sentry;
 pub mod tunnel;

--- a/nym-vpn-core/crates/nym-vpnc/src/commands/network.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/commands/network.rs
@@ -7,8 +7,12 @@ use nym_vpn_proto::rpc_client::RpcClient;
 
 #[derive(Debug, Clone, clap::Subcommand)]
 pub enum Command {
+    /// Get current Nym network.
     Get,
+
+    /// Set Nym network.
     Set {
+        /// Network name (i.e: mainnet, sandbox, canary, evil)
         #[arg(index = 1)]
         network_name: String,
     },

--- a/nym-vpn-core/crates/nym-vpnc/src/commands/network_stats.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/commands/network_stats.rs
@@ -1,0 +1,49 @@
+// Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use anyhow::Result;
+
+use nym_vpn_proto::rpc_client::RpcClient;
+
+use crate::boolean_option::BooleanOption;
+
+#[derive(Debug, Clone, clap::Subcommand)]
+pub enum Command {
+    /// Get current status of anonymous network statistics collection
+    Get,
+
+    /// Enable or disable anonymous network statistics collection
+    Set {
+        /// Enable or disable anonymous network statistics collection
+        #[arg(value_parser = clap::value_parser!(BooleanOption))]
+        enable: BooleanOption,
+    },
+}
+
+impl Command {
+    pub async fn execute(self, mut rpc_client: RpcClient) -> Result<()> {
+        match self {
+            Command::Get => {
+                let enabled = rpc_client.is_collect_network_stats_enabled().await?;
+                println!(
+                    "Anonymous network statistics collection: {}",
+                    if enabled { "on" } else { "off" }
+                );
+                Ok(())
+            }
+            Command::Set { enable } => {
+                if *enable {
+                    rpc_client.enable_collect_network_stats().await?;
+                } else {
+                    rpc_client.disable_collect_network_stats().await?;
+                }
+                println!(
+                    "Anonymous network statistics collection: {}",
+                    if *enable { "on" } else { "off" }
+                );
+                println!("You have to restart the daemon for the changes to take effect.");
+                Ok(())
+            }
+        }
+    }
+}

--- a/nym-vpn-core/crates/nym-vpnc/src/commands/network_stats.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/commands/network_stats.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 
 use nym_vpn_proto::rpc_client::RpcClient;
 
-use crate::boolean_option::BooleanOption;
+use crate::{boolean_option::BooleanOption, display_helpers::display_on_off};
 
 #[derive(Debug, Clone, clap::Subcommand)]
 pub enum Command {
@@ -27,7 +27,7 @@ impl Command {
                 let enabled = rpc_client.is_collect_network_stats_enabled().await?;
                 println!(
                     "Anonymous network statistics collection: {}",
-                    if enabled { "on" } else { "off" }
+                    display_on_off(enabled)
                 );
                 Ok(())
             }
@@ -37,10 +37,7 @@ impl Command {
                 } else {
                     rpc_client.disable_collect_network_stats().await?;
                 }
-                println!(
-                    "Anonymous network statistics collection: {}",
-                    if *enable { "on" } else { "off" }
-                );
+                println!("Anonymous network statistics collection: {enable}");
                 println!("You have to restart the daemon for the changes to take effect.");
                 Ok(())
             }

--- a/nym-vpn-core/crates/nym-vpnc/src/commands/sentry.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/commands/sentry.rs
@@ -1,0 +1,44 @@
+// Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use anyhow::Result;
+
+use nym_vpn_proto::rpc_client::RpcClient;
+
+use crate::boolean_option::BooleanOption;
+
+#[derive(Debug, Clone, clap::Subcommand)]
+pub enum Command {
+    /// Get current status of Sentry integration
+    Get,
+
+    /// Enable or disable Sentry integration
+    Set {
+        /// Enable or disable Sentry integration
+        #[arg(value_parser = clap::value_parser!(BooleanOption))]
+        enable: BooleanOption,
+    },
+}
+
+impl Command {
+    pub async fn execute(self, mut rpc_client: RpcClient) -> Result<()> {
+        match self {
+            Command::Get => {
+                let enabled = rpc_client.is_sentry_enabled().await?;
+
+                println!("Sentry integration: {}", if enabled { "on" } else { "off" });
+                Ok(())
+            }
+            Command::Set { enable } => {
+                if *enable {
+                    rpc_client.enable_sentry().await?;
+                } else {
+                    rpc_client.disable_sentry().await?;
+                }
+                println!("Sentry integration: {}", if *enable { "on" } else { "off" });
+                println!("You have to restart the daemon for the changes to take effect");
+                Ok(())
+            }
+        }
+    }
+}

--- a/nym-vpn-core/crates/nym-vpnc/src/commands/sentry.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/commands/sentry.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 
 use nym_vpn_proto::rpc_client::RpcClient;
 
-use crate::boolean_option::BooleanOption;
+use crate::{boolean_option::BooleanOption, display_helpers::display_on_off};
 
 #[derive(Debug, Clone, clap::Subcommand)]
 pub enum Command {
@@ -26,7 +26,7 @@ impl Command {
             Command::Get => {
                 let enabled = rpc_client.is_sentry_enabled().await?;
 
-                println!("Sentry integration: {}", if enabled { "on" } else { "off" });
+                println!("Sentry integration: {}", display_on_off(enabled));
                 Ok(())
             }
             Command::Set { enable } => {
@@ -35,7 +35,7 @@ impl Command {
                 } else {
                     rpc_client.disable_sentry().await?;
                 }
-                println!("Sentry integration: {}", if *enable { "on" } else { "off" });
+                println!("Sentry integration: {enable}");
                 println!("You have to restart the daemon for the changes to take effect");
                 Ok(())
             }

--- a/nym-vpn-core/crates/nym-vpnc/src/commands/tunnel.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/commands/tunnel.rs
@@ -48,6 +48,10 @@ impl Command {
                     if config.enable_two_hop { "on" } else { "off" }
                 );
                 println!("Netstack: {}", if config.netstack { "on" } else { "off" });
+                println!(
+                    "Circumvention transports: {}",
+                    if config.enable_bridges { "on" } else { "off" }
+                );
 
                 Ok(())
             }

--- a/nym-vpn-core/crates/nym-vpnc/src/commands/tunnel.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/commands/tunnel.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 
 use nym_vpn_proto::rpc_client::RpcClient;
 
-use crate::boolean_option::BooleanOption;
+use crate::{boolean_option::BooleanOption, display_helpers::display_on_off};
 
 #[derive(Debug, Clone, clap::Subcommand)]
 pub enum Command {
@@ -42,15 +42,12 @@ impl Command {
         match self {
             Command::Get => {
                 let config = rpc_client.get_config().await?;
-                println!("IPv6: {}", if config.disable_ipv6 { "off" } else { "on" });
-                println!(
-                    "Two-hop: {}",
-                    if config.enable_two_hop { "on" } else { "off" }
-                );
-                println!("Netstack: {}", if config.netstack { "on" } else { "off" });
+                println!("IPv6: {}", display_on_off(!config.disable_ipv6));
+                println!("Two-hop: {}", display_on_off(config.enable_two_hop));
+                println!("Netstack: {}", display_on_off(config.netstack));
                 println!(
                     "Circumvention transports: {}",
-                    if config.enable_bridges { "on" } else { "off" }
+                    display_on_off(config.enable_bridges)
                 );
 
                 Ok(())

--- a/nym-vpn-core/crates/nym-vpnc/src/commands/tunnel.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/commands/tunnel.rs
@@ -20,20 +20,20 @@ pub enum Command {
 #[group(required = true, multiple = true)]
 pub struct SetParams {
     /// Enable or disable IPv6
-    #[arg(long, value_parser = BooleanOption::custom_parser("on", "off"))]
+    #[arg(long, value_parser = clap::value_parser!(BooleanOption))]
     ipv6: Option<BooleanOption>,
 
     /// Enable or disable two-hop mode
-    #[arg(long, value_parser = BooleanOption::custom_parser("on", "off"))]
+    #[arg(long, value_parser = clap::value_parser!(BooleanOption))]
     two_hop: Option<BooleanOption>,
 
     /// Enable or disable netstack in two-hop mode
     /// Normally this is only used for testing purposes and should always be off
-    #[arg(long, value_parser = BooleanOption::custom_parser("on", "off"))]
+    #[arg(long, value_parser = clap::value_parser!(BooleanOption))]
     netstack: Option<BooleanOption>,
 
     /// Enable Circumvention Transport (CT) wrapping for the connection to the entry gateway in two hop wireguard mode.
-    #[arg(long, alias = "ct", value_parser = BooleanOption::custom_parser("on", "off"))]
+    #[arg(long, alias = "ct", value_parser = clap::value_parser!(BooleanOption))]
     circumvention_transports: Option<BooleanOption>,
 }
 

--- a/nym-vpn-core/crates/nym-vpnc/src/display_helpers.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/display_helpers.rs
@@ -1,0 +1,9 @@
+// Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+pub fn display_on_off(value: bool) -> &'static str {
+    match value {
+        true => "on",
+        false => "off",
+    }
+}

--- a/nym-vpn-core/crates/nym-vpnc/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/main.rs
@@ -78,7 +78,7 @@ pub enum Command {
         subcommand: commands::lan::Command,
     },
 
-    /// Tunnel configuration (enable or disable ipv6, two-hop mode)
+    /// Tunnel configuration (enable or disable ipv6, two-hop mode, circumvention transports)
     Tunnel {
         #[command(subcommand)]
         subcommand: commands::tunnel::Command,

--- a/nym-vpn-core/crates/nym-vpnc/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/main.rs
@@ -99,6 +99,18 @@ pub enum Command {
         subcommand: commands::network::Command,
     },
 
+    /// Sentry integration
+    Sentry {
+        #[command(subcommand)]
+        subcommand: commands::sentry::Command,
+    },
+
+    /// Anonymous network statistics collection
+    NetworkStats {
+        #[command(subcommand)]
+        subcommand: commands::network_stats::Command,
+    },
+
     #[command(flatten)]
     Legacy(commands::legacy::Command),
 }
@@ -131,6 +143,8 @@ async fn main() -> Result<()> {
         Command::Network { subcommand } => subcommand.execute(rpc_client).await,
         Command::Account { subcommand } => subcommand.execute(rpc_client).await,
         Command::Device(args) => args.execute(rpc_client).await,
+        Command::Sentry { subcommand } => subcommand.execute(rpc_client).await,
+        Command::NetworkStats { subcommand } => subcommand.execute(rpc_client).await,
         Command::Legacy(subcommand) => subcommand.execute(rpc_client, user_agent).await,
     }
 }

--- a/nym-vpn-core/crates/nym-vpnc/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/main.rs
@@ -3,6 +3,7 @@
 
 mod boolean_option;
 mod commands;
+mod display_helpers;
 mod table_style;
 
 use std::str::FromStr;

--- a/nym-vpn-core/crates/nym-vpnc/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/main.rs
@@ -72,28 +72,28 @@ pub enum Command {
     /// Manage entry and exit gateway nodes, list available gateways
     Gateway(commands::gateway::Args),
 
-    /// View and manage local network policy
+    /// Local network policy
     Lan {
         #[command(subcommand)]
         subcommand: commands::lan::Command,
     },
 
-    /// View and manage tunnel configuration
+    /// Tunnel configuration (enable or disable ipv6, two-hop mode)
     Tunnel {
         #[command(subcommand)]
         subcommand: commands::tunnel::Command,
     },
 
-    /// View and manage account information
+    /// Account information
     Account {
         #[command(subcommand)]
         subcommand: commands::account::Command,
     },
 
-    /// View and manage device information
+    /// Device information
     Device(commands::device::Args),
 
-    /// View and manage Nym network configuration
+    /// Nym network configuration
     Network {
         #[command(subcommand)]
         subcommand: commands::network::Command,


### PR DESCRIPTION
## Ticket

JIRA-VPN-4229

## Description

- New CLI commands to manage sentry and anonymous network stats collection:
  - `nym-vpnc sentry --help`
  - `nym-vpnc network-stats --help`
- `nym-vpnc tunnel get` now prints the status of "circumvention transports"

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3695)
<!-- Reviewable:end -->
