### PR TITLE
Fix MacOS load/remove bug in store

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Don't retry on disappeared entry or exit gateway and return to UI for selecting again (https://github.com/nymtech/nym-vpn-client/pull/3520)
 - Recover from error loop when mixnet client can't reach gateway after a number of retries (https://github.com/nymtech/nym-vpn-client/pull/3694)
+- Fix MacOS load/remove bug in store (https://github.com/nymtech/nym-vpn-client/pull/3711)
 
 ### Removed
 

--- a/nym-vpn-core/crates/nym-dns/src/macos.rs
+++ b/nym-vpn-core/crates/nym-dns/src/macos.rs
@@ -210,9 +210,9 @@ impl State {
             if let Some(settings) = settings {
                 settings.save(store, service_path.as_str())?;
             } else {
-                tracing::debug!("Removing DNS for {}", service_path);
+                tracing::debug!("Removing DNS for {} if it exists", service_path);
                 if !store.remove(CFString::new(&service_path)) {
-                    return Err(Error::SettingDnsFailed);
+                    tracing::debug!("DNS for {} doesn't exist in store", service_path);
                 }
             }
         }


### PR DESCRIPTION

## Ticket

JIRA-VPN-4230

## Description

This bug stems from Mullvad's code, where a previous load error of a key in `read_all_dns` function is pushed as a `None` value in the `HashMap` and later tried to be removed (although the `None` value can signify one of two things, either the value was not there in the first place, or that it was there or it should be removed).
The call of `SCDynamicStoreRemoveValue` (and in general the Apple's `SCDynamicStore` doesn't offer much information on the possible error reasons, but the missing key is the culprit here, since we already do a load before the remove. Hence, this shouldn't be considered an error since the end goal of not having the value in store is achieved. This patch might be useful to be pushed upstream as well, even if only for having a conversation about what's the best way to handle this.


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3711)
<!-- Reviewable:end -->
