### PR TITLE
Remove MachServices from net.nymtech.vpn.helper.plist

### DIFF
--- a/nym-vpn-apple/Daemon/net.nymtech.vpn.helper.plist
+++ b/nym-vpn-apple/Daemon/net.nymtech.vpn.helper.plist
@@ -16,10 +16,5 @@
 	<true/>
 	<key>BundleProgram</key>
 	<string>Contents/MacOS/net.nymtech.vpn.helper</string>
-	<key>MachServices</key>
-	<dict>
-		<key>net.nymtech.vpn.helper</key>
-		<true/>
-	</dict>
 </dict>
 </plist>


### PR DESCRIPTION

## Description

Removed `MachServices` key and its associated dictionary from the plist as we don't support/nor use mach service port.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3716)
<!-- Reviewable:end -->
