### PR TITLE
Handle account controller in offline state

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Use two keypairs (entry & exit) per gateway (https://github.com/nymtech/nym-vpn-client/pull/3591)
 
+### Fixed
+
+- Prevent account controller from networking while state machine is in offline state (https://github.com/nymtech/nym-vpn-client/pull/3723)
+
+
 ## [1.17.0] - 2025-10-17
 
 ### Added

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/offline_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/offline_state.rs
@@ -36,22 +36,27 @@ impl OfflineState {
     pub async fn enter(
         reconnect: bool,
         selected_gateways: Option<SelectedGateways>,
-        _shared_state: &mut SharedState,
+        shared_state: &mut SharedState,
     ) -> (Box<dyn TunnelStateHandler>, PrivateTunnelState) {
         #[cfg(target_os = "macos")]
-        if Self::set_local_dns_resolver(_shared_state).await.is_err() {
-            return Box::pin(ErrorState::enter(ErrorStateReason::SetDns, _shared_state)).await;
+        if Self::set_local_dns_resolver(shared_state).await.is_err() {
+            return Box::pin(ErrorState::enter(ErrorStateReason::SetDns, shared_state)).await;
         }
 
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         let firewall_policy_params = BlockedPolicyParameters {
-            allow_lan: _shared_state.tunnel_settings.allow_lan,
+            allow_lan: shared_state.tunnel_settings.allow_lan,
         };
 
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
-        if let Err(e) = Self::set_firewall_policy(_shared_state, &firewall_policy_params) {
+        if let Err(e) = Self::set_firewall_policy(shared_state, &firewall_policy_params) {
             trace_err_chain!(e, "Failed to apply firewall policy for blocked state");
         }
+
+        let _ = shared_state
+            .account_command_tx
+            .set_vpn_api_firewall_up()
+            .await;
 
         (
             Box::new(Self {


### PR DESCRIPTION

## Description

This PR ensures that account controller does not attempt to do any networking before state machine transitions from offline state towards the next one.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3723)
<!-- Reviewable:end -->
