### PR TITLE
Initialize COM on main thread to prevent crash on exit

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -5633,6 +5633,7 @@ dependencies = [
  "vergen-gitcl",
  "windows 0.62.2",
  "windows-service",
+ "wmi",
 ]
 
 [[package]]

--- a/nym-vpn-core/crates/nym-vpnd/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpnd/Cargo.toml
@@ -67,6 +67,7 @@ nym-gateway-directory = { workspace = true }
 nym-vpn-proto = { workspace = true, features = ["conversions"] }
 
 [target.'cfg(windows)'.dependencies]
+wmi.workspace = true
 windows-service.workspace = true
 eventlog.workspace = true
 

--- a/nym-vpn-core/crates/nym-vpnd/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/main.rs
@@ -15,6 +15,7 @@ mod windows_service;
 
 use std::path::PathBuf;
 
+use anyhow::Context;
 use clap::Parser;
 use tokio::{sync::broadcast, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
@@ -29,9 +30,22 @@ use crate::{
 };
 use service::{NymVpnService, NymVpnServiceParameters};
 
-// Are we sure we need 10 worker threads?
-#[tokio::main(flavor = "multi_thread", worker_threads = 10)]
-async fn main() -> anyhow::Result<()> {
+fn main() -> anyhow::Result<()> {
+    // COM must be initialized on main thread to prevent crash in firewall
+    // internals where we use a combination of COM and thread_local
+    // See: https://github.com/ohadravid/wmi-rs/issues/136
+    #[cfg(windows)]
+    let _com = wmi::COMLibrary::new().context("failed to initialize COM")?;
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(10)
+        .enable_all()
+        .build()
+        .context("failed to build tokio runtime")?;
+    rt.block_on(async_main())
+}
+
+async fn async_main() -> anyhow::Result<()> {
     let args = CliArgs::parse();
 
     match args.command.unwrap_or_default() {


### PR DESCRIPTION


## Ticket

JIRA-VPN-XXXX

## Description

It seems that there is a bug in COM + thread_local destructor that causes the daemon to crash on exit. As a workaround, initialize COM on main thread which magically resolves the issue.

See: https://github.com/ohadravid/wmi-rs/issues/136

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3725)
<!-- Reviewable:end -->
