### PR TITLE
cli: fix hang when waiting for disconnect

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix mixnet listener timeout not being set (https://github.com/nymtech/nym-vpn-client/pull/3715)
 - Prevent account controller from networking while state machine is in offline state (https://github.com/nymtech/nym-vpn-client/pull/3723)
 - [macOS] Log error instead of failing when removing keys from dynamic store during DNS reset. (https://github.com/nymtech/nym-vpn-client/pull/3711)
+- CLI: fix hang when calling `nym-vpnc disconnect --wait` in disconnected state. (https://github.com/nymtech/nym-vpn-client/pull/3743)
 
 ## [1.17.0] - 2025-10-17
 

--- a/nym-vpn-core/crates/nym-vpnc/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/main.rs
@@ -214,37 +214,44 @@ async fn wait_until_connected(mut rpc_client: RpcClient) -> Result<()> {
 }
 
 async fn disconnect(mut rpc_client: RpcClient, wait: bool) -> Result<()> {
-    rpc_client.disconnect_tunnel().await?;
-
     if wait {
+        let mut stream = rpc_client.clone().listen_to_events().await?;
+
         println!("Waiting until disconnected");
-        wait_until_disconnected(rpc_client).await
-    } else {
-        Ok(())
-    }
-}
 
-async fn wait_until_disconnected(mut rpc_client: RpcClient) -> Result<()> {
-    let mut stream = rpc_client.listen_to_events().await?;
+        let current_state = rpc_client.get_tunnel_state().await?;
+        println!("{current_state}");
 
-    while let Some(new_state) = stream.next().await {
-        let TunnelEvent::NewState(new_state) = new_state? else {
-            continue;
-        };
+        rpc_client.disconnect_tunnel().await?;
 
-        println!("{new_state}");
+        if matches!(
+            current_state,
+            TunnelState::Disconnected | TunnelState::Offline { .. }
+        ) {
+            return Ok(());
+        }
 
-        match new_state {
-            TunnelState::Disconnected | TunnelState::Offline { .. } => {
-                break;
-            }
-            TunnelState::Error(reason) => {
+        while let Some(new_state) = stream.next().await {
+            let TunnelEvent::NewState(new_state) = new_state? else {
+                continue;
+            };
+
+            println!("{new_state}");
+
+            if matches!(
+                new_state,
+                TunnelState::Disconnected | TunnelState::Offline { .. }
+            ) {
+                return Ok(());
+            } else if let TunnelState::Error(reason) = new_state {
                 bail!("Tunnel entered error state: {reason:?}")
             }
-            _ => {}
         }
+        Ok(())
+    } else {
+        rpc_client.disconnect_tunnel().await?;
+        Ok(())
     }
-    Ok(())
 }
 
 async fn status(mut rpc_client: RpcClient, listen: bool) -> Result<()> {


### PR DESCRIPTION


## Description

- Ensure to subscribe to event stream before issuing "disconnect"
- Consult current tunnel state before entering event loop

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3743)
<!-- Reviewable:end -->
