### PR TITLE
Fallback on mixnet channel if metadata endpoint is not available

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add new CLI commands to manage sentry and anonymous network statistics collection (https://github.com/nymtech/nym-vpn-client/pull/3695)
 - Add tunnel connection monitoring (https://github.com/nymtech/nym-vpn-client/pull/3724)
+- Fallback on mixnet channel if metadata endpoint is not available (https://github.com/nymtech/nym-vpn-client/pull/3747)
 
 ### Changed
 

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
@@ -363,6 +363,7 @@ pub struct WgProbeResults {
     pub can_register: bool,
     pub can_handshake: bool,
     pub can_resolve_dns: bool,
+    pub can_query_metadata_v4: bool,
     pub ping_hosts_performance: f32,
     pub ping_ips_performance: f32,
 }
@@ -468,6 +469,7 @@ impl From<nym_vpn_api_client::response::WgProbeResults> for WgProbeResults {
             can_register: results.can_register,
             can_handshake: results.can_handshake,
             can_resolve_dns: results.can_resolve_dns,
+            can_query_metadata_v4: results.can_query_metadata_v4,
             ping_hosts_performance: results.ping_hosts_performance,
             ping_ips_performance: results.ping_ips_performance,
         }

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
@@ -540,6 +540,7 @@ pub struct WgProbeResults {
     pub can_register: bool,
     pub can_handshake: bool,
     pub can_resolve_dns: bool,
+    pub can_query_metadata_v4: bool,
     pub ping_hosts_performance: f32,
     pub ping_ips_performance: f32,
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
@@ -184,6 +184,12 @@ impl TemporaryBandwidthClient {
             && let Ok(gateway_version) = semver::Version::parse(gateway_version)
             && let Some(update_version) = gateway_metadata_update_version
             && gateway_version >= update_version
+            && gateway
+                .last_probe
+                .as_ref()
+                .and_then(|p| p.outcome.wg.as_ref())
+                .map(|r| r.can_query_metadata_v4)
+                .unwrap_or(false)
         {
             tracing::debug!(
                 "Using latest metadata client for {}'s bandwidth controller",


### PR DESCRIPTION
## Ticket

JIRA-VPN-4304

## Description

As metadata endpoints are still not exposed by all operators, use the mixnet channel as a fallback mechanism so that we don't have to remove those gateways when connecting.


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3747)
<!-- Reviewable:end -->
