### PR TITLE
VPN-4309: Account Controller makes API calls before firewall is open.

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -289,10 +289,10 @@ impl ConnectingState {
             .set_vpn_api_firewall_down()
             .await
         {
-            trace_err_chain!(err, "Failed to set VPN API firewall up");
+            trace_err_chain!(err, "Failed to set VPN API firewall down");
             return NextTunnelState::NewState(
                 ErrorState::enter(
-                    ErrorStateReason::Internal("Failed to set VPN API firewall up".to_owned()),
+                    ErrorStateReason::Internal("Failed to set VPN API firewall down".to_owned()),
                     shared_state,
                 )
                 .await,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -134,6 +134,12 @@ impl ConnectingState {
             firewall_policy_params
         };
 
+        // Tell the Account Controller that the firewall is blocking it.
+        let _ = shared_state
+            .account_command_tx
+            .set_vpn_api_firewall_up()
+            .await;
+
         let resolve_config_fut = Fuse::terminated();
         let reconnect_delay_fut = if retry_attempt > 0 {
             let wait_delay = wait_delay(retry_attempt);
@@ -277,9 +283,10 @@ impl ConnectingState {
             }
         }
 
+        // Tell the Account Controller that the firewall is no longer blocking it.
         if let Err(err) = shared_state
             .account_command_tx
-            .set_vpn_api_firewall_up()
+            .set_vpn_api_firewall_down()
             .await
         {
             trace_err_chain!(err, "Failed to set VPN API firewall up");

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -134,12 +134,6 @@ impl ConnectingState {
             firewall_policy_params
         };
 
-        // If that fails, it's not really important
-        let _ = shared_state
-            .account_command_tx
-            .set_vpn_api_firewall_up()
-            .await;
-
         let resolve_config_fut = Fuse::terminated();
         let reconnect_delay_fut = if retry_attempt > 0 {
             let wait_delay = wait_delay(retry_attempt);
@@ -283,6 +277,21 @@ impl ConnectingState {
             }
         }
 
+        if let Err(err) = shared_state
+            .account_command_tx
+            .set_vpn_api_firewall_up()
+            .await
+        {
+            trace_err_chain!(err, "Failed to set VPN API firewall up");
+            return NextTunnelState::NewState(
+                ErrorState::enter(
+                    ErrorStateReason::Internal("Failed to set VPN API firewall up".to_owned()),
+                    shared_state,
+                )
+                .await,
+            );
+        }
+
         if !resolved_gateway_config.has_resolver_overrides() {
             tracing::warn!(
                 "There are no resolver overrides, which may result in the firewall blocking API requests"
@@ -302,8 +311,7 @@ impl ConnectingState {
                 return NextTunnelState::NewState(
                     ErrorState::enter(
                         ErrorStateReason::Internal(
-                            "Failed to set static NYM API addresses to account controller"
-                                .to_owned(),
+                            "Failed to set resolver overrides for account controller".to_owned(),
                         ),
                         shared_state,
                     )


### PR DESCRIPTION
## Ticket

JIRA-VPN-4309

## Description

Don't tell the Account Controller that the firewall is open until we have received the resolved config in the connecting state.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3756)
<!-- Reviewable:end -->
