### PR TITLE
Remove warning log on expected values

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prevent account controller from networking while state machine is in offline state (https://github.com/nymtech/nym-vpn-client/pull/3723)
 - [macOS] Log error instead of failing when removing keys from dynamic store during DNS reset. (https://github.com/nymtech/nym-vpn-client/pull/3711)
 - CLI: fix hang when calling `nym-vpnc disconnect --wait` in disconnected state. (https://github.com/nymtech/nym-vpn-client/pull/3743)
+- Don't log a warning on some expected value from the API (https://github.com/nymtech/nym-vpn-client/pull/3763)
 
 ## [1.17.0] - 2025-10-17
 

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/system_messages.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/system_messages.rs
@@ -157,19 +157,27 @@ impl From<SystemMessageResponse> for SystemMessage {
             })
             .ok();
 
-        let display_until = OffsetDateTime::parse(&response.display_until, &Rfc3339)
-            .inspect_err(|e| {
-                tracing::warn!(
-                    "Failed to parse display_until ({}): {}",
-                    response.display_until,
-                    e
-                )
-            })
-            .ok();
+        let display_until = if !response.display_until.is_empty() {
+            OffsetDateTime::parse(&response.display_until, &Rfc3339)
+                .inspect_err(|e| {
+                    tracing::warn!(
+                        "Failed to parse display_until ({}): {}",
+                        response.display_until,
+                        e
+                    )
+                })
+                .ok()
+        } else {
+            None
+        };
 
-        let properties = Properties::deserialize(response.properties)
-            .inspect_err(|e| tracing::warn!("Failed to parse properties: {}", e))
-            .ok();
+        let properties = if !response.properties.is_null() {
+            Properties::deserialize(response.properties)
+                .inspect_err(|e| tracing::warn!("Failed to parse properties: {}", e))
+                .ok()
+        } else {
+            None
+        };
 
         Self {
             name: response.name,


### PR DESCRIPTION
Given the server side type:
```
export type SystemMessagesRecord<Tproperties = unknown> = {
  displayFrom: IsoDateString;
  displayUntil?: IsoDateString;
  message: string;
  name: string;
  properties?: null | Tproperties;
};
```
`display_until` is expected to be an empty string, and `properties` can be a `null` value, so this shouldn't be logged as a warning in the library.

## Ticket

JIRA-VPN-4318

## Description

Don't log a warning on some expected value from the API.


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3763)
<!-- Reviewable:end -->
