### PR TITLE
Unset account controller resolver overrides once connected

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
@@ -60,6 +60,11 @@ impl ConnectedState {
             .send(DiscoveryRefresherCommand::Pause(false))
             .await
             .ok();
+        shared_state
+            .account_command_tx
+            .set_resolver_overrides(None)
+            .await
+            .ok();
 
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         let wg_entry_endpoint =

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnected_state.rs
@@ -37,11 +37,6 @@ impl DisconnectedState {
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         Self::reset_firewall_policy(shared_state);
 
-        let _ = shared_state
-            .account_command_tx
-            .set_vpn_api_firewall_down()
-            .await;
-
         if let Err(e) = shared_state
             .account_command_tx
             .set_resolver_overrides(None)
@@ -49,6 +44,10 @@ impl DisconnectedState {
         {
             trace_err_chain!(e, "Failed to unset static API addresses");
         }
+        let _ = shared_state
+            .account_command_tx
+            .set_vpn_api_firewall_down()
+            .await;
 
         // Drop tombstone to close tunnel devices.
         let _ = tombstone;


### PR DESCRIPTION
## Ticket

JIRA-VPN-XXXX

## Description

- Ensure to unset account controller resolver overrides once connected
- When disconnected, reset overrides first, then call `set_vpn_api_firewall_down()`

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3765)
<!-- Reviewable:end -->
