### PR TITLE
Print wireguard public key for debugging purposes

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_selector.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_selector.rs
@@ -174,6 +174,9 @@ pub async fn select_gateways(
         .exit_keypair()
         .clone();
 
+    tracing::debug!("Using entry public key: {}", entry_keys.public_key());
+    tracing::debug!("Using exit public key: {}", exit_keys.public_key());
+
     tracing::info!(
         "Using entry gateway: {}, location: {}, performance: {}",
         entry_gateway.identity(),


### PR DESCRIPTION
## Ticket

JIRA-VPN-3518

## Description

Make it easier to know what entry and exit wireguard keys are being used by printing the public wireguard key for each.



## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3767)
<!-- Reviewable:end -->
