### PR TITLE
Wait for tun interface(s) IP addresses to become usable

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CLI: fix hang when calling `nym-vpnc disconnect --wait` in disconnected state. (https://github.com/nymtech/nym-vpn-client/pull/3743)
 - Don't log a warning on some expected value from the API (https://github.com/nymtech/nym-vpn-client/pull/3763)
 - Fix no gateway id problem (https://github.com/nymtech/nym-vpn-client/pull/3768)
+- [Windows] Wait for network interface addresses become usable before starting the tunnel (https://github.com/nymtech/nym-vpn-client/pull/3773)
 
 ## [1.17.0] - 2025-10-17
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -812,7 +812,8 @@ impl TunnelMonitor {
             self.enable_ipv6()
                 .then_some(assigned_addresses.interface_addresses.ipv6),
             mtu,
-        )?;
+        )
+        .await?;
 
         #[cfg(any(target_os = "ios", target_os = "android"))]
         let tun_device = {
@@ -1168,11 +1169,18 @@ impl TunnelMonitor {
         tracing::info!("Created wintun device: {}", wintun_exit_interface.name);
 
         wintun::setup_wintun_adapter(wintun_exit_interface.windows_luid(), exit_adapter_config)?;
+        wintun::wait_for_interfaces(
+            wintun_exit_interface.windows_luid(),
+            true,
+            self.enable_ipv6(),
+        )
+        .await?;
         wintun::initialize_interfaces(
             wintun_exit_interface.windows_luid(),
             Some(exit_mtu),
             self.enable_ipv6().then_some(exit_mtu),
         )?;
+        wintun::wait_for_addresses(wintun_exit_interface.windows_luid()).await?;
 
         let routing_config = RoutingConfig::WireguardNetstack {
             exit_tun_name: wintun_exit_interface.name.clone(),
@@ -1414,6 +1422,18 @@ impl TunnelMonitor {
         wintun::setup_wintun_adapter(wintun_entry_interface.windows_luid(), entry_adapter_config)?;
         wintun::setup_wintun_adapter(wintun_exit_interface.windows_luid(), exit_adapter_config)?;
 
+        wintun::wait_for_interfaces(
+            wintun_entry_interface.windows_luid(),
+            true,
+            self.enable_ipv6(),
+        )
+        .await?;
+        wintun::wait_for_interfaces(
+            wintun_exit_interface.windows_luid(),
+            true,
+            self.enable_ipv6(),
+        )
+        .await?;
         wintun::initialize_interfaces(
             wintun_entry_interface.windows_luid(),
             Some(entry_tun_mtu),
@@ -1424,6 +1444,8 @@ impl TunnelMonitor {
             Some(exit_tun_mtu),
             self.enable_ipv6().then_some(exit_tun_mtu),
         )?;
+        wintun::wait_for_addresses(wintun_entry_interface.windows_luid()).await?;
+        wintun::wait_for_addresses(wintun_exit_interface.windows_luid()).await?;
 
         // Update interface names in tunnel metadata
         entry_tunnel_metadata.interface = wintun_entry_interface.name.clone();
@@ -1565,25 +1587,27 @@ impl TunnelMonitor {
     }
 
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
-    fn create_mixnet_device(
+    async fn create_mixnet_device(
         interface_ipv4: Ipv4Addr,
         interface_ipv6: Option<Ipv6Addr>,
         mtu: u16,
     ) -> Result<AsyncDevice> {
-        let mut tun_config = tun::Configuration::default();
+        let tun_device = {
+            let mut tun_config = tun::Configuration::default();
 
-        // rust-tun uses the same name for tunnel type.
-        #[cfg(windows)]
-        tun_config.name(MIXNET_WINTUN_NAME);
+            // rust-tun uses the same name for tunnel type.
+            #[cfg(windows)]
+            tun_config.name(MIXNET_WINTUN_NAME);
 
-        tun_config.address(interface_ipv4).mtu(i32::from(mtu)).up();
+            tun_config.address(interface_ipv4).mtu(i32::from(mtu)).up();
 
-        #[cfg(target_os = "linux")]
-        tun_config.platform(|platform_config| {
-            platform_config.packet_information(false);
-        });
+            #[cfg(target_os = "linux")]
+            tun_config.platform(|platform_config| {
+                platform_config.packet_information(false);
+            });
 
-        let tun_device = tun::create_as_async(&tun_config).map_err(Error::CreateTunDevice)?;
+            tun::create_as_async(&tun_config).map_err(Error::CreateTunDevice)?
+        };
 
         let tun_name = tun_device
             .get_ref()
@@ -1604,11 +1628,13 @@ impl TunnelMonitor {
                 wintun::add_ipv6_address(interface_luid, interface_ipv6)?;
             }
 
+            wintun::wait_for_interfaces(interface_luid, true, interface_ipv6.is_some()).await?;
             wintun::initialize_interfaces(
                 interface_luid,
                 Some(mtu),
                 interface_ipv6.is_some().then_some(mtu),
             )?;
+            wintun::wait_for_addresses(interface_luid).await?;
         }
 
         Ok(tun_device)

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/wintun.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/wintun.rs
@@ -32,6 +32,12 @@ pub enum SetupWintunAdapterError {
 
     #[error("failed to obtain interface luid from alias")]
     GetInterfaceLuidFromAlias(#[source] std::io::Error),
+
+    #[error("failed to wait for ip interfaces to attach on network interface")]
+    WaitForInterfaces(#[source] std::io::Error),
+
+    #[error("failed to wait for addresses to be usable on an network adapter")]
+    WaitForInterfaceAddresses(#[source] nym_windows::net::Error),
 }
 
 /// Struct holding wintun adapter IP configuration.
@@ -49,11 +55,10 @@ pub struct WintunAdapterConfig {
     pub gateway_ipv6: Option<Ipv6Addr>,
 }
 
+pub type Result<T, E = SetupWintunAdapterError> = std::result::Result<T, E>;
+
 /// Configure wintun adapter
-pub fn setup_wintun_adapter(
-    luid: NET_LUID_LH,
-    adapter_config: WintunAdapterConfig,
-) -> Result<(), SetupWintunAdapterError> {
+pub fn setup_wintun_adapter(luid: NET_LUID_LH, adapter_config: WintunAdapterConfig) -> Result<()> {
     wnet::add_ip_address_for_interface(luid, IpAddr::V4(adapter_config.interface_ipv4))
         .map_err(SetupWintunAdapterError::SetIpv4Addr)?;
 
@@ -76,10 +81,7 @@ pub fn setup_wintun_adapter(
 }
 
 /// Set IPv6 address only on network interface
-pub fn add_ipv6_address(
-    luid: NET_LUID_LH,
-    interface_ipv6: Ipv6Addr,
-) -> Result<(), SetupWintunAdapterError> {
+pub fn add_ipv6_address(luid: NET_LUID_LH, interface_ipv6: Ipv6Addr) -> Result<()> {
     wnet::add_ip_address_for_interface(luid, IpAddr::V6(interface_ipv6))
         .map_err(SetupWintunAdapterError::SetIpv6Addr)
 }
@@ -90,7 +92,7 @@ pub fn initialize_interfaces(
     luid: NET_LUID_LH,
     ipv4_mtu: Option<u16>,
     ipv6_mtu: Option<u16>,
-) -> Result<(), SetupWintunAdapterError> {
+) -> Result<()> {
     for (family, mtu) in &[
         (AddressFamily::Ipv4, ipv4_mtu),
         (AddressFamily::Ipv6, ipv6_mtu),
@@ -127,9 +129,25 @@ pub fn initialize_interfaces(
 }
 
 /// Returns interface LUID for alias upon success, otherwise error.
-pub fn get_interface_luid_for_alias(
-    interface_alias: &str,
-) -> Result<NET_LUID_LH, SetupWintunAdapterError> {
+pub fn get_interface_luid_for_alias(interface_alias: &str) -> Result<NET_LUID_LH> {
     wnet::luid_from_alias(interface_alias)
         .map_err(SetupWintunAdapterError::GetInterfaceLuidFromAlias)
+}
+
+/// Waits until the specified IP interfaces have attached to a given network interface.
+pub async fn wait_for_interfaces(
+    interface_luid: NET_LUID_LH,
+    ipv4: bool,
+    ipv6: bool,
+) -> Result<()> {
+    wnet::wait_for_interfaces(interface_luid, ipv4, ipv6)
+        .await
+        .map_err(SetupWintunAdapterError::WaitForInterfaces)
+}
+
+/// Wait for addresses to be usable on an network adapter.
+pub async fn wait_for_addresses(interface_luid: NET_LUID_LH) -> Result<()> {
+    wnet::wait_for_addresses(interface_luid)
+        .await
+        .map_err(SetupWintunAdapterError::WaitForInterfaceAddresses)
 }


### PR DESCRIPTION


## Description

Fix error when binding ICMP socket to TUN device by introducing additional step checking whether tun interface(s) IP addresses are usable before creating connection monitor. (Windows only) 

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3773)
<!-- Reviewable:end -->
