### PR TITLE
Retry strategy to fix connection loop

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
@@ -49,23 +49,6 @@ impl ConnectedState {
         tunnel_monitor_event_receiver: TunnelMonitorEventReceiver,
         shared_state: &mut SharedState,
     ) -> (Box<dyn TunnelStateHandler>, PrivateTunnelState) {
-        // Configure Discovery Referesher to not use any resolver overrides and to resume operation
-        shared_state
-            .discovery_refresher_command_tx
-            .send(DiscoveryRefresherCommand::UseResolverOverrides(None))
-            .await
-            .ok();
-        shared_state
-            .discovery_refresher_command_tx
-            .send(DiscoveryRefresherCommand::Pause(false))
-            .await
-            .ok();
-        shared_state
-            .account_command_tx
-            .set_resolver_overrides(None)
-            .await
-            .ok();
-
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         let wg_entry_endpoint =
             if let TunnelConnectionData::Wireguard(ref wg) = connection_data.tunnel {
@@ -116,6 +99,27 @@ impl ConnectedState {
                 shared_state,
             );
         }
+
+        // Configure Discovery Refresher to not use any resolver overrides and to resume operation
+        // This must happen AFTER firewall and DNS are configured
+        shared_state
+            .discovery_refresher_command_tx
+            .send(DiscoveryRefresherCommand::UseResolverOverrides(None))
+            .await
+            .ok();
+        shared_state
+            .discovery_refresher_command_tx
+            .send(DiscoveryRefresherCommand::Pause(false))
+            .await
+            .ok();
+
+        // Remove resolver overrides from Account Controller
+        // This must happen AFTER Discovery Refresher is configured
+        shared_state
+            .account_command_tx
+            .set_resolver_overrides(None)
+            .await
+            .ok();
 
         // We can use slower network fetches now
         shared_state.topology_provider.use_network(true).await;
@@ -187,10 +191,8 @@ impl ConnectedState {
         // Disable forwarding (Blocking mode for captive portal support)
         if *LOCAL_DNS_RESOLVER {
             shared_state.filtering_resolver.disable_forward().await;
-        }
-
-        // Reset system DNS to pre-VPN backup to allow API hostname resolution during reconnection
-        if let Err(error) = shared_state.dns_handler.reset().await {
+        } else if let Err(error) = shared_state.dns_handler.reset().await {
+            // Only reset system DNS if NOT using local resolver
             trace_err_chain!(error, "Failed to reset DNS");
         }
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
@@ -184,9 +184,13 @@ impl ConnectedState {
     #[cfg(target_os = "macos")]
     async fn reset_dns(shared_state: &mut SharedState) {
         // On macOS, configure only the local DNS resolver
+        // Disable forwarding (Blocking mode for captive portal support)
         if *LOCAL_DNS_RESOLVER {
             shared_state.filtering_resolver.disable_forward().await;
-        } else if let Err(error) = shared_state.dns_handler.reset().await {
+        }
+
+        // Reset system DNS to pre-VPN backup to allow API hostname resolution during reconnection
+        if let Err(error) = shared_state.dns_handler.reset().await {
             trace_err_chain!(error, "Failed to reset DNS");
         }
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -53,6 +53,12 @@ const DELAY_MULTIPLIER: u32 = 2;
 /// Max wait delay between retry attempts.
 const MAX_WAIT_DELAY: Duration = Duration::from_secs(15);
 
+/// Number of fast retry attempts before switching to exponential backoff.
+const FAST_RETRY_ATTEMPTS: u32 = 2;
+
+/// Fast retry delay for network recovery scenarios (first FAST_RETRY_ATTEMPTS).
+const NETWORK_RECOVERY_DELAY: Duration = Duration::from_millis(500);
+
 type ResolveApiAddrsFuture = BoxFuture<'static, Result<ResolvedConfig>>;
 type ReconnectDelayFuture = BoxFuture<'static, ()>;
 
@@ -87,17 +93,23 @@ impl ConnectingState {
             .await
             .ok();
 
+        // This prevents hickory resolver from getting confused when system DNS points to
+        // local forwarder but it expects responses from upstream DNS servers.
         #[cfg(target_os = "macos")]
-        if let Err(e) = Self::set_local_dns_resolver(shared_state).await {
-            trace_err_chain!(e, "Failed to configure system to use filtering resolver",);
-            return ErrorState::enter(ErrorStateReason::SetDns, shared_state).await;
+        if retry_attempt > FAST_RETRY_ATTEMPTS {
+            if let Err(e) = Self::set_local_dns_resolver(shared_state).await {
+                trace_err_chain!(e, "Failed to configure system to use filtering resolver",);
+                return ErrorState::enter(ErrorStateReason::SetDns, shared_state).await;
+            }
         }
 
-        if shared_state
-            .connectivity_handle
-            .connectivity()
-            .await
-            .is_offline()
+        // On reconnect attempts (retry_attempt > 0), we do want to check if we're actually offline.
+        if retry_attempt > 0
+            && shared_state
+                .connectivity_handle
+                .connectivity()
+                .await
+                .is_offline()
         {
             // FIXME: Temporary: Nudge route manager to update the default interface
             #[cfg(target_os = "macos")]
@@ -142,7 +154,7 @@ impl ConnectingState {
         let resolve_config_fut = Fuse::terminated();
         let reconnect_delay_fut = if retry_attempt > 0 {
             let wait_delay = wait_delay(retry_attempt);
-            tracing::info!("Waiting {}s before reconnect", wait_delay.as_secs());
+            tracing::info!("Waiting {}ms before reconnect", wait_delay.as_millis());
             tokio::time::sleep(wait_delay).boxed().fuse()
         } else {
             std::future::ready(()).boxed().fuse()
@@ -827,7 +839,16 @@ impl ConnectingPolicyParameters {
 }
 
 fn wait_delay(retry_attempt: u32) -> Duration {
-    let multiplier = retry_attempt.saturating_mul(DELAY_MULTIPLIER);
-    let delay = INITIAL_WAIT_DELAY.saturating_mul(multiplier);
-    std::cmp::min(delay, MAX_WAIT_DELAY)
+    // Use fast retries for the first FAST_RETRY_ATTEMPTS to handle network recovery
+    // Where the network reports as "online" before DNS/routing are ready.
+    if retry_attempt <= FAST_RETRY_ATTEMPTS {
+        NETWORK_RECOVERY_DELAY
+    } else {
+        // After fast retries, use exponential backoff for persistent failures
+        let multiplier = retry_attempt
+            .saturating_sub(FAST_RETRY_ATTEMPTS)
+            .saturating_mul(DELAY_MULTIPLIER);
+        let delay = INITIAL_WAIT_DELAY.saturating_mul(multiplier);
+        std::cmp::min(delay, MAX_WAIT_DELAY)
+    }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnected_state.rs
@@ -19,7 +19,7 @@ impl DisconnectedState {
         tombstone: Option<Tombstone>,
         shared_state: &mut SharedState,
     ) -> (Box<dyn TunnelStateHandler>, PrivateTunnelState) {
-        // Configure Discovery Referesher to not use any resolver overrides and to resume operation
+        // Configure Discovery Refresher to not use any resolver overrides and to resume operation
         shared_state
             .discovery_refresher_command_tx
             .send(DiscoveryRefresherCommand::UseResolverOverrides(None))
@@ -31,7 +31,7 @@ impl DisconnectedState {
             .await
             .ok();
 
-        #[cfg(target_os = "macos")]
+        #[cfg(not(any(target_os = "android", target_os = "ios")))]
         Self::reset_dns(shared_state).await;
 
         #[cfg(not(any(target_os = "android", target_os = "ios")))]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/offline_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/offline_state.rs
@@ -46,13 +46,15 @@ impl OfflineState {
             .await
             .ok();
 
-        // On macOS, disable forwarding and reset DNS to allow API resolution during reconnection
+        // On macOS, configure DNS for offline state
         #[cfg(target_os = "macos")]
         {
             if *LOCAL_DNS_RESOLVER {
+                // Keep system DNS pointing to local resolver, just disable forwarding for captive portal
                 shared_state.filtering_resolver.disable_forward().await;
+            } else {
+                Self::reset_dns(shared_state).await;
             }
-            Self::reset_dns(shared_state).await;
         }
 
         #[cfg(not(any(target_os = "android", target_os = "ios")))]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/offline_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/offline_state.rs
@@ -8,8 +8,6 @@ use tokio_util::sync::CancellationToken;
 use crate::tunnel_state_machine::resolver::LOCAL_DNS_RESOLVER;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use crate::tunnel_state_machine::{Error, Result, states::error_state::BlockedPolicyParameters};
-#[cfg(target_os = "macos")]
-use crate::tunnel_state_machine::{ErrorStateReason, states::ErrorState};
 use crate::tunnel_state_machine::{
     NextTunnelState, PrivateTunnelState, SharedState, TunnelCommand, TunnelStateHandler,
     states::{ConnectingState, DisconnectedState},
@@ -17,8 +15,6 @@ use crate::tunnel_state_machine::{
 };
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use nym_common::trace_err_chain;
-#[cfg(target_os = "macos")]
-use nym_dns::DnsConfig;
 use nym_vpn_network_config::DiscoveryRefresherCommand;
 
 pub struct OfflineState {
@@ -38,7 +34,7 @@ impl OfflineState {
         selected_gateways: Option<SelectedGateways>,
         shared_state: &mut SharedState,
     ) -> (Box<dyn TunnelStateHandler>, PrivateTunnelState) {
-        // Configure Discovery Referesher to not use any resolver overrides and to pause operation
+        // Configure Discovery Refresher to not use any resolver overrides and to pause operation
         shared_state
             .discovery_refresher_command_tx
             .send(DiscoveryRefresherCommand::UseResolverOverrides(None))
@@ -50,9 +46,13 @@ impl OfflineState {
             .await
             .ok();
 
+        // On macOS, disable forwarding and reset DNS to allow API resolution during reconnection
         #[cfg(target_os = "macos")]
-        if Self::set_local_dns_resolver(shared_state).await.is_err() {
-            return Box::pin(ErrorState::enter(ErrorStateReason::SetDns, shared_state)).await;
+        {
+            if *LOCAL_DNS_RESOLVER {
+                shared_state.filtering_resolver.disable_forward().await;
+            }
+            Self::reset_dns(shared_state).await;
         }
 
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
@@ -106,23 +106,6 @@ impl OfflineState {
         if let Err(error) = shared_state.dns_handler.reset().await {
             trace_err_chain!(error, "Unable to reset DNS");
         }
-    }
-
-    #[cfg(target_os = "macos")]
-    async fn set_local_dns_resolver(shared_state: &mut SharedState) -> Result<()> {
-        // Set system DNS to our local DNS resolver
-        let system_dns = DnsConfig::default().resolve(
-            &[shared_state.filtering_resolver.listen_addr().ip()],
-            shared_state.filtering_resolver.listen_addr().port(),
-        );
-        shared_state
-            .dns_handler
-            .set("lo".to_owned(), system_dns)
-            .await
-            .inspect_err(|err| {
-                trace_err_chain!(err, "Failed to configure system to use filtering resolver");
-            })
-            .map_err(Error::SetDns)
     }
 }
 
@@ -181,14 +164,11 @@ impl TunnelStateHandler for OfflineState {
                 if connectivity.is_offline() {
                     NextTunnelState::SameState(self)
                 } else {
-                    #[cfg(target_os = "macos")]
-                    if !*LOCAL_DNS_RESOLVER {
-                        // This is probably unnecessary, since DNS is already configured on the
-                        // primary interface.
-                        Self::reset_dns(shared_state).await;
-                    }
+                    tracing::info!("Network connectivity restored, preparing to reconnect");
 
-                    #[cfg(any(target_os = "linux", target_os = "windows"))]
+                    // Reset DNS to allow ConnectingState to resolve API hostnames.
+                    // The local filtering resolver will be reconfigured by ConnectingState once connection is established.
+                    #[cfg(not(any(target_os = "android", target_os = "ios")))]
                     Self::reset_dns(shared_state).await;
 
                     if self.reconnect {


### PR DESCRIPTION
Delays local DNS setup and implements fast retries to prevent race condition between macOS network reporting and actual stack readiness

- Fast retries: 500ms × 2, then exponential backoff
- Skip initial offline check to avoid synthetic offline loop
- Delay local DNS resolver until network stabilized (attempt 3+)

## Ticket

JIRA-VPN-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3775)
<!-- Reviewable:end -->
