### PR TITLE
add a line that indicates version for nym-vpn-lib in logs

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -484,6 +484,17 @@ pub struct TunnelStateMachine {
     shutdown_token: CancellationToken,
 }
 
+fn log_build_info() {
+    let build_info = nym_bin_common::bin_info_local_vergen!();
+    tracing::info!(
+        "{} {} ({})",
+        build_info.binary_name,
+        build_info.build_version,
+        build_info.commit_sha
+    );
+    tracing::debug!("{:?}", build_info);
+}
+
 impl TunnelStateMachine {
     #[allow(clippy::too_many_arguments)]
     pub async fn spawn(
@@ -590,6 +601,8 @@ impl TunnelStateMachine {
     }
 
     async fn run(mut self) {
+        log_build_info();
+
         loop {
             let next_state = self
                 .current_state_handler


### PR DESCRIPTION

## Description

This PR adds a log line for the nym-vpn-lib to indicate which build version is being used. This is helpful when using logs to debug errors / issues and feature development especially if those logs get connected to long lived tickets. This removes the need to keep track of the library version by word of mouth when debugging. 

```
2025-10-28T17:43:06.534006Z  INFO nym_vpn_lib::tunnel_state_machine: nym-vpn-lib 1.18.0-beta (89a59311bca1e6659fd4158946e00668868d9c36)
2025-10-28T17:43:06.534034Z DEBUG nym_vpn_lib::tunnel_state_machine: BinaryBuildInformation { binary_name: "nym-vpn-lib", build_timestamp: "2025-10-28T16:22:46.341300453Z", build_version: "1.18.0-beta", commit_sha: "89a59311bca1e6659fd4158946e00668868d9c36", commit_timestamp: "2025-10-28T16:27:05.000000000+01:00", commit_branch: "develop", rustc_version: "1.90.0", rustc_channel: "stable", cargo_profile: "debug", cargo_triple: "x86_64-unknown-linux-gnu" }

```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3782)
<!-- Reviewable:end -->
