### PR TITLE
Add back channel for bridge forwarder

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/any_tunnel_handle.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/any_tunnel_handle.rs
@@ -1,8 +1,6 @@
 // Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use tokio_util::sync::CancellationToken;
-
 use super::{Error, Result, Tombstone};
 
 use super::{
@@ -37,15 +35,6 @@ impl AnyTunnelHandle {
             Self::Wireguard(handle) => {
                 handle.cancel();
             }
-        }
-    }
-
-    // Returns the mixnet cancellation token, to monitor mixnet client unexpected stop.
-    // Returns None if we already stopped it (in new Wireguard mode) and we don't need to monitor it.
-    pub fn mixnet_client_token(&self) -> Option<CancellationToken> {
-        match self {
-            AnyTunnelHandle::Mixnet(tunnel_handle) => Some(tunnel_handle.mixnet_cancel_token()),
-            AnyTunnelHandle::Wireguard(tunnel_handle) => tunnel_handle.mixnet_cancel_token(),
         }
     }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mixnet/connected_tunnel.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mixnet/connected_tunnel.rs
@@ -22,7 +22,6 @@ pub async fn start_mixnet_tunnel(
     cancel_token: CancellationToken,
     event_rx: EventReceiver,
 ) -> Result<TunnelHandle> {
-    let mixnet_cancellation_token = mixnet_client.cancellation_token().clone();
     let processor_handle = crate::mixnet::start_processor(
         IpPacketRouterAddress::from(assigned_addresses.exit_mix_address),
         tun_device,
@@ -35,7 +34,6 @@ pub async fn start_mixnet_tunnel(
     Ok(TunnelHandle {
         processor_handle,
         cancel_token,
-        mixnet_cancellation_token,
     })
 }
 
@@ -45,17 +43,12 @@ pub type ProcessorHandle = JoinHandle<Result<AsyncDevice, MixnetError>>;
 pub struct TunnelHandle {
     processor_handle: ProcessorHandle,
     cancel_token: CancellationToken,
-    mixnet_cancellation_token: CancellationToken,
 }
 
 impl TunnelHandle {
     /// Cancel tunnel execution.
     pub fn cancel(&self) {
         self.cancel_token.cancel();
-    }
-
-    pub fn mixnet_cancel_token(&self) -> CancellationToken {
-        self.mixnet_cancellation_token.clone()
     }
 
     /// Wait until the tunnel finished execution.

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/transports/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/transports/mod.rs
@@ -10,6 +10,7 @@ use futures::{Sink, SinkExt, Stream, StreamExt};
 use tokio::{
     io::{AsyncRead, AsyncWrite},
     net::UdpSocket,
+    sync::mpsc::UnboundedSender,
     task::JoinHandle,
 };
 use tokio_util::{codec::LengthDelimitedCodec, sync::CancellationToken};
@@ -103,6 +104,7 @@ impl UdpForwarder {
     pub async fn launch(
         egress_conn: BridgeConn,
         bind_addr: Option<SocketAddr>,
+        close_tx: UnboundedSender<()>,
         token: CancellationToken,
     ) -> Result<(SocketAddr, JoinHandle<()>), TransportError> {
         let bind_addr = bind_addr.unwrap_or(match egress_conn.endpoint.is_ipv4() {
@@ -122,6 +124,7 @@ impl UdpForwarder {
                 egress_conn.writer,
                 socket.clone(),
                 ETHERNET_V2_MTU,
+                close_tx,
                 token,
             )),
         ))
@@ -134,6 +137,7 @@ pub async fn process_udp<R, W>(
     sock: Arc<UdpSocket>,
     mtu: u16,
     // close_hook: Option<fn(SocketAddr)>,
+    close_tx: UnboundedSender<()>,
     token: CancellationToken,
 ) where
     R: AsyncRead + Unpin + Send + 'static,
@@ -154,41 +158,45 @@ pub async fn process_udp<R, W>(
     // receive (and forward) a first message to establish a consistent peer address
     let fwd_initial_recv_fut =
         tokio::time::timeout(INITIAL_CONNECTION_TIMEOUT, sock.recv_buf_from(&mut dn_buf));
-    let fwd_addr = tokio::select!(
-        _ = token.cancelled() => {
-            debug!("forwarder cancelled before initial receive");
-            return;
-        }
-        res = fwd_initial_recv_fut => {
+
+    let fwd_addr = match token.run_until_cancelled(fwd_initial_recv_fut).await {
+        Some(res) => {
             match res {
                 Ok(Ok((len, src))) => {
                     trace!(" <- [fw] read {len}B");
                     if let Err(e) = framed_writer.send(dn_buf.copy_to_bytes(len)).await {
                         debug!("error sending to transport connection: {e}");
-                        token.cancel();
-                        return;
-                    };
-                    trace!("[tr] <- wrote {len}B");
-                    // keep track of the address of the sender for the initial write
-                    src
+                        None
+                    } else {
+                        trace!("[tr] <- wrote {len}B");
+                        // keep track of the address of the sender for the initial write
+                        Some(src)
+                    }
                 }
                 Ok(Err(e)) => {
                     debug!("error receiving from egress socket: {e}");
-                    token.cancel();
-                    return;
+                    None
                 }
                 Err(_) => {
                     debug!("forwarder timed out");
-                    token.cancel();
-                    return;
+                    None
                 }
             }
         }
-    );
+        None => {
+            debug!("forwarder cancelled before initial receive");
+            None
+        }
+    };
+
+    let Some(fwd_addr) = fwd_addr else {
+        close_tx.send(()).ok();
+        return;
+    };
 
     if let Err(e) = sock.connect(fwd_addr).await {
         error!("udp sock config failure: {e}");
-        token.cancel();
+        close_tx.send(()).ok();
         return;
     }
 
@@ -198,21 +206,33 @@ pub async fn process_udp<R, W>(
         framed_writer,
         fwd_addr,
         mtu,
-        token.clone(),
+        token.child_token(),
     ));
     tasks.spawn(transport_to_udp_task(
         framed_reader,
         sock.clone(),
         fwd_addr,
-        token.clone(),
+        token.child_token(),
     ));
 
-    // Wait for both tasks to complete, if either one exits it _should_ cancel the other as well.
-    for res in tasks.join_all().await {
-        if let Err(e) = res {
-            tracing::error!("bridge udp forwarder error: {e}");
+    let mut token = Some(token);
+
+    // Wait for both tasks to complete, if either one exits, make sure to cancel the other as well.
+    while let Some(res) = tasks.join_next().await {
+        if let Err(err) = res {
+            tracing::error!("bridge udp forwarder join error: {err}");
+        } else if let Ok(Err(err)) = res {
+            tracing::error!("bridge udp forwarder error: {err}");
+        }
+
+        // Cancel all tasks if any of sub-tasks exit for any reason
+        if let Some(token) = token.take() {
+            token.cancel();
         }
     }
+
+    close_tx.send(()).ok();
+
     info!("transport udp forwarder shutdown");
 }
 
@@ -235,14 +255,12 @@ where
             res = sock.recv_buf(&mut dn_buf) => {
                 let len = res.map_err(|e| {
                     error!("error receiving from forward socket: {e}");
-                    token.cancel();
                     e
                 })?;
 
                 trace!(" <-{fwd_addr} read {len}B");
                 framed_writer.send(dn_buf.copy_to_bytes(len)).await.map_err(|e| {
                     error!("error sending to transport connection: {e}");
-                    token.cancel();
                     e
                 })?;
                 trace!(" [tr]<- wrote {len}B");
@@ -288,7 +306,6 @@ where
                         while sent < len {
                             let len_sent = sock.send(&buf[sent..len]).await.map_err(|e| {
                                 error!("error sending to egress socket: {e}");
-                                token.cancel();
                                 e
                             })?;
                             sent += len_sent;
@@ -298,7 +315,6 @@ where
                     }
                     Some(Err(e)) => {
                         error!("error reading from transport conn: {e}");
-                        token.cancel();
                         return Err(e);
                     }
                 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
@@ -13,7 +13,6 @@ use dispatch2::{DispatchQueue, DispatchQueueAttr};
 use ipnetwork::IpNetwork;
 #[cfg(target_os = "ios")]
 use nym_apple_network::PathMonitor;
-use nym_authenticator_client::AuthClientMixnetListenerHandle;
 use nym_crypto::asymmetric::x25519;
 #[cfg(windows)]
 use nym_routing::{Callback, CallbackHandle, EventType};
@@ -61,9 +60,6 @@ pub struct ConnectedTunnel {
     entry_wg_keypair: Arc<x25519::KeyPair>,
     exit_wg_keypair: Arc<x25519::KeyPair>,
     connection_data: ConnectionData,
-    bandwidth_controller_handle: JoinHandle<()>,
-    transport_fwd_handle: Option<JoinHandle<()>>,
-    auth_client_mixnet_listener_handle: Option<AuthClientMixnetListenerHandle>,
 }
 
 impl ConnectedTunnel {
@@ -71,17 +67,11 @@ impl ConnectedTunnel {
         entry_wg_keypair: Arc<x25519::KeyPair>,
         exit_wg_keypair: Arc<x25519::KeyPair>,
         connection_data: ConnectionData,
-        bandwidth_controller_handle: JoinHandle<()>,
-        transport_fwd_handle: Option<JoinHandle<()>>,
-        auth_client_mixnet_listener_handle: Option<AuthClientMixnetListenerHandle>,
     ) -> Self {
         Self {
             entry_wg_keypair,
             exit_wg_keypair,
             connection_data,
-            bandwidth_controller_handle,
-            transport_fwd_handle,
-            auth_client_mixnet_listener_handle,
         }
     }
 
@@ -250,9 +240,6 @@ impl ConnectedTunnel {
         Ok(TunnelHandle {
             shutdown_token,
             event_handler_task,
-            bandwidth_controller_handle: self.bandwidth_controller_handle,
-            transport_fwd_handle: self.transport_fwd_handle,
-            auth_client_mixnet_listener_handle: self.auth_client_mixnet_listener_handle,
             #[cfg(windows)]
             wintun_entry_interface: Some(wintun_entry_interface),
             #[cfg(windows)]
@@ -467,9 +454,6 @@ impl ConnectedTunnel {
         Ok(TunnelHandle {
             shutdown_token,
             event_handler_task,
-            bandwidth_controller_handle: self.bandwidth_controller_handle,
-            transport_fwd_handle: self.transport_fwd_handle,
-            auth_client_mixnet_listener_handle: self.auth_client_mixnet_listener_handle,
             #[cfg(windows)]
             wintun_entry_interface: None,
             #[cfg(windows)]
@@ -596,9 +580,6 @@ pub struct NetstackTunnelOptions {
 pub struct TunnelHandle {
     shutdown_token: CancellationToken,
     event_handler_task: JoinHandle<Tombstone>,
-    bandwidth_controller_handle: JoinHandle<()>,
-    transport_fwd_handle: Option<JoinHandle<()>>,
-    auth_client_mixnet_listener_handle: Option<AuthClientMixnetListenerHandle>,
     #[cfg(windows)]
     wintun_entry_interface: Option<WintunInterface>,
     #[cfg(windows)]
@@ -611,29 +592,10 @@ impl TunnelHandle {
         self.shutdown_token.cancel();
     }
 
-    pub fn mixnet_cancel_token(&self) -> Option<CancellationToken> {
-        self.auth_client_mixnet_listener_handle
-            .as_ref()
-            .map(|listener| listener.mixnet_cancel_token())
-    }
-
     /// Wait until the tunnel finished execution.
     ///
     /// Returns a tombstone containing the no longer used tunnel devices and wireguard tunnels (on Windows).
     pub async fn wait(self) -> Result<Tombstone, JoinError> {
-        if let Err(e) = self.bandwidth_controller_handle.await {
-            tracing::error!("Failed to join on bandwidth controller: {}", e);
-        }
-        if let Some(auth_client_handle) = self.auth_client_mixnet_listener_handle {
-            auth_client_handle.stop().await;
-        }
-
-        if let Some(handle) = self.transport_fwd_handle
-            && let Err(e) = handle.await
-        {
-            tracing::error!("Failed to join on transport forwarder: {}", e);
-        }
-
         self.event_handler_task.await
     }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/mod.rs
@@ -14,6 +14,7 @@ pub mod dns64;
 pub mod fd;
 pub mod two_hop_config;
 
+#[derive(Debug, Clone)]
 pub struct ConnectionData {
     pub entry_bridge_addr: Option<SocketAddr>,
     pub entry: GatewayData,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -917,7 +917,7 @@ impl TunnelMonitor {
             registration_result.mixnet_client,
             assigned_addresses,
             tun_device,
-            self.shutdown_token.clone(),
+            self.shutdown_token.child_token(),
             registration_result.event_rx,
         )
         .await
@@ -971,7 +971,7 @@ impl TunnelMonitor {
                 .nym_config
                 .network_env
                 .gw_update_version(),
-            self.shutdown_token.clone(),
+            self.shutdown_token.child_token(),
         )
         .await
         .map_err(|e| Box::new(tunnel::Error::from(e)))?;
@@ -1009,15 +1009,16 @@ impl TunnelMonitor {
 
             let bridge_conn = transports::BridgeConn::try_connect(
                 entry_bridge_params,
-                self.shutdown_token.clone(),
+                self.shutdown_token.child_token(),
             )
-            .await
-            .inspect_err(|_| self.shutdown_token.cancel())?;
+            .await?;
             connection_data.entry_bridge_addr = Some(bridge_conn.endpoint);
-            let (local_fwd_listen_addr, fwd_handle) =
-                transports::UdpForwarder::launch(bridge_conn, None, self.shutdown_token.clone())
-                    .await
-                    .inspect_err(|_| self.shutdown_token.cancel())?;
+            let (local_fwd_listen_addr, fwd_handle) = transports::UdpForwarder::launch(
+                bridge_conn,
+                None,
+                self.shutdown_token.child_token(),
+            )
+            .await?;
             tracing::info!(
                 "quic transport connected, udp forwarder open on {local_fwd_listen_addr:?}"
             );

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -781,8 +781,12 @@ impl TunnelMonitor {
                         }
                     }
                 }
-                _ = bridge_close_rx.recv() => {
-                    tracing::info!("Bridge channel is closed. Exiting");
+                close_event = bridge_close_rx.recv() => {
+                    if close_event.is_some() {
+                        tracing::info!("Bridge close signal received. Exiting");
+                    } else {
+                        tracing::info!("Bridge channel is closed. Exiting");
+                    }
                     break;
                 }
                 _  = &mut mixnet_monitoring_token => {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -616,7 +616,7 @@ impl TunnelMonitor {
         let (exit_metadata_tx, exit_metadata_rx) = tokio::sync::oneshot::channel::<MetadataEvent>();
 
         let (entry_metadata_addr_tx, entry_metadata_addr_rx) = tokio::sync::oneshot::channel();
-        let (bridge_close_tx, mut bridge_close_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
+        let (bridge_close_tx, mut bridge_close_rx) = tokio::sync::mpsc::unbounded_channel();
 
         // todo: refactor
         let (
@@ -627,6 +627,7 @@ impl TunnelMonitor {
             },
             wg_tunnel_runtime,
             mixnet_client_token,
+            _bridge_close_tx,
         ) = match registration_result {
             RegistrationResult::Mixnet(inner_result) => {
                 let mixnet_client_token = inner_result.mixnet_client.cancellation_token();
@@ -635,6 +636,8 @@ impl TunnelMonitor {
                     self.start_mixnet_tunnel(*inner_result).await?,
                     None,
                     Some(mixnet_client_token),
+                    // Return sender back to avoid it being dropped
+                    Some(bridge_close_tx),
                 )
             }
             RegistrationResult::Wireguard(inner_result) => {
@@ -679,6 +682,7 @@ impl TunnelMonitor {
                     start_tunnel_result,
                     Some(wg_tunnel_runtime),
                     mixnet_client_token,
+                    None,
                 )
             }
         };

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -3,6 +3,7 @@
 
 use futures::{FutureExt, future::Fuse, pin_mut};
 
+use nym_authenticator_client::AuthClientMixnetListenerHandle;
 use nym_connection_monitor::{
     ConnectionEvent, ConnectionMonitor, ConnectionStatusEvent, IcmpProbe, IcmpProbeConfig,
     TimingConfig,
@@ -81,6 +82,7 @@ use crate::{
             transports::{self, TransportError},
             wireguard::{
                 self, ConnectionData as WgConnectionData, MetadataEvent, MetadataReceiver,
+                connected_tunnel::ConnectedTunnel,
             },
         },
     },
@@ -614,26 +616,45 @@ impl TunnelMonitor {
         let (exit_metadata_tx, exit_metadata_rx) = tokio::sync::oneshot::channel::<MetadataEvent>();
 
         let (entry_metadata_addr_tx, entry_metadata_addr_rx) = tokio::sync::oneshot::channel();
+        let (bridge_close_tx, mut bridge_close_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
 
-        let StartTunnelResult {
-            tunnel_interface,
-            tunnel_conn_data,
-            mut tunnel_handle,
-        } = match registration_result {
+        // todo: refactor
+        let (
+            StartTunnelResult {
+                tunnel_interface,
+                tunnel_conn_data,
+                mut tunnel_handle,
+            },
+            wg_tunnel_runtime,
+            mixnet_client_token,
+        ) = match registration_result {
             RegistrationResult::Mixnet(inner_result) => {
-                self.start_mixnet_tunnel(*inner_result).await?
+                let mixnet_client_token = inner_result.mixnet_client.cancellation_token();
+
+                (
+                    self.start_mixnet_tunnel(*inner_result).await?,
+                    None,
+                    Some(mixnet_client_token),
+                )
             }
             RegistrationResult::Wireguard(inner_result) => {
-                let connected_tunnel = self
+                let (connection_data, wg_tunnel_runtime) = self
                     .setup_wireguard_tunnel(
                         *inner_result,
                         entry_metadata_rx,
                         exit_metadata_rx,
+                        bridge_close_tx,
                         selected_gateways.clone(),
                     )
                     .await?;
 
-                match self
+                let connected_tunnel = ConnectedTunnel::new(
+                    selected_gateways.entry_keypair().clone(),
+                    selected_gateways.exit_keypair().clone(),
+                    connection_data,
+                );
+
+                let start_tunnel_result = match self
                     .tunnel_parameters
                     .tunnel_settings
                     .wireguard_tunnel_options
@@ -650,7 +671,15 @@ impl TunnelMonitor {
                         )
                         .await?
                     }
-                }
+                };
+
+                let mixnet_client_token = wg_tunnel_runtime.mixnet_client_token();
+
+                (
+                    start_tunnel_result,
+                    Some(wg_tunnel_runtime),
+                    mixnet_client_token,
+                )
             }
         };
 
@@ -698,8 +727,7 @@ impl TunnelMonitor {
             }
         }
 
-        let mixnet_monitoring_token = tunnel_handle
-            .mixnet_client_token()
+        let mixnet_monitoring_token = mixnet_client_token
             .map(|token| token.cancelled_owned().fuse())
             .unwrap_or(Fuse::terminated());
         pin_mut!(mixnet_monitoring_token);
@@ -753,6 +781,10 @@ impl TunnelMonitor {
                         }
                     }
                 }
+                _ = bridge_close_rx.recv() => {
+                    tracing::info!("Bridge channel is closed. Exiting");
+                    break;
+                }
                 _  = &mut mixnet_monitoring_token => {
                     tracing::error!("MixnetClient exited unexpectedly");
                     break;
@@ -765,6 +797,25 @@ impl TunnelMonitor {
 
         // Trigger cancellation since many other tasks depend on shutdown token
         drop(shutdown_guard);
+
+        // Shutdown WireGuard tunnel runtime
+        if let Some(wg_tunnel_runtime) = wg_tunnel_runtime {
+            if let Err(err) = wg_tunnel_runtime.bandwidth_controller_handle.await {
+                tracing::error!("Failed to await bandwidth controller handle: {}", err);
+            }
+
+            if let Some(transport_fwd_handle) = wg_tunnel_runtime.transport_fwd_handle
+                && let Err(err) = transport_fwd_handle.await
+            {
+                tracing::error!("Failed to await transport forward handle: {}", err);
+            }
+
+            if let Some(authenticator_listener_handle) =
+                wg_tunnel_runtime.authenticator_listener_handle
+            {
+                authenticator_listener_handle.stop().await;
+            }
+        }
 
         if let Err(e) = tunnel_connection_monitor_handle.await {
             tracing::error!("Tunnel connection monitor exited with error: {}", e);
@@ -935,8 +986,9 @@ impl TunnelMonitor {
         registration_result: WireguardRegistrationResult,
         entry_metadata_rx: MetadataReceiver,
         exit_metadata_rx: MetadataReceiver,
+        bridge_close_tx: mpsc::UnboundedSender<()>,
         selected_gateways: SelectedGateways,
-    ) -> Result<wireguard::connected_tunnel::ConnectedTunnel> {
+    ) -> Result<(WgConnectionData, WgTunnelRuntime)> {
         let (entry_signal_tx, entry_signal_rx) = tokio::sync::oneshot::channel();
         let (exit_signal_tx, exit_signal_rx) = tokio::sync::oneshot::channel();
 
@@ -1016,6 +1068,7 @@ impl TunnelMonitor {
             let (local_fwd_listen_addr, fwd_handle) = transports::UdpForwarder::launch(
                 bridge_conn,
                 None,
+                bridge_close_tx,
                 self.shutdown_token.child_token(),
             )
             .await?;
@@ -1028,14 +1081,13 @@ impl TunnelMonitor {
             None
         };
 
-        Ok(wireguard::connected_tunnel::ConnectedTunnel::new(
-            selected_gateways.entry_keypair().clone(),
-            selected_gateways.exit_keypair().clone(),
-            connection_data,
+        let rt = WgTunnelRuntime {
             bandwidth_controller_handle,
             transport_fwd_handle,
             authenticator_listener_handle,
-        ))
+        };
+
+        Ok((connection_data, rt))
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]
@@ -1792,8 +1844,24 @@ impl TunnelMonitor {
     }
 }
 
-pub struct StartTunnelResult {
+struct StartTunnelResult {
     tunnel_interface: TunnelInterface,
     tunnel_conn_data: TunnelConnectionData,
     tunnel_handle: AnyTunnelHandle,
+}
+
+struct WgTunnelRuntime {
+    bandwidth_controller_handle: JoinHandle<()>,
+    transport_fwd_handle: Option<JoinHandle<()>>,
+    authenticator_listener_handle: Option<AuthClientMixnetListenerHandle>,
+}
+
+impl WgTunnelRuntime {
+    // Returns the mixnet cancellation token, to monitor mixnet client unexpected stop.
+    // Returns None if we already stopped it (in new Wireguard mode) and we don't need to monitor it.
+    fn mixnet_client_token(&self) -> Option<CancellationToken> {
+        self.authenticator_listener_handle
+            .as_ref()
+            .map(|handle| handle.mixnet_cancel_token())
+    }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -641,15 +641,31 @@ impl TunnelMonitor {
                 )
             }
             RegistrationResult::Wireguard(inner_result) => {
-                let (connection_data, wg_tunnel_runtime) = self
+                let (mut connection_data, mut wg_tunnel_runtime) = self
                     .setup_wireguard_tunnel(
                         *inner_result,
                         entry_metadata_rx,
                         exit_metadata_rx,
-                        bridge_close_tx,
-                        selected_gateways.clone(),
+                        &selected_gateways,
                     )
                     .await?;
+
+                let (transport_fwd_handle, bridge_close_tx) = if self
+                    .tunnel_parameters
+                    .tunnel_settings
+                    .bridges_enabled()
+                {
+                    let transport_fwd_handle = self
+                        .start_bridges(&selected_gateways, &mut connection_data, bridge_close_tx)
+                        .await?;
+
+                    (Some(transport_fwd_handle), None)
+                } else {
+                    // Return bridge_close_tx back to avoid it being dropped
+                    (None, Some(bridge_close_tx))
+                };
+
+                wg_tunnel_runtime.transport_fwd_handle = transport_fwd_handle;
 
                 let connected_tunnel = ConnectedTunnel::new(
                     selected_gateways.entry_keypair().clone(),
@@ -682,7 +698,7 @@ impl TunnelMonitor {
                     start_tunnel_result,
                     Some(wg_tunnel_runtime),
                     mixnet_client_token,
-                    None,
+                    bridge_close_tx,
                 )
             }
         };
@@ -994,8 +1010,7 @@ impl TunnelMonitor {
         registration_result: WireguardRegistrationResult,
         entry_metadata_rx: MetadataReceiver,
         exit_metadata_rx: MetadataReceiver,
-        bridge_close_tx: mpsc::UnboundedSender<()>,
-        selected_gateways: SelectedGateways,
+        selected_gateways: &SelectedGateways,
     ) -> Result<(WgConnectionData, WgTunnelRuntime)> {
         let (entry_signal_tx, entry_signal_rx) = tokio::sync::oneshot::channel();
         let (exit_signal_tx, exit_signal_rx) = tokio::sync::oneshot::channel();
@@ -1020,7 +1035,7 @@ impl TunnelMonitor {
 
         let bw = BandwidthController::create(
             bw_controller,
-            &selected_gateways,
+            selected_gateways,
             entry_gateway_client,
             exit_gateway_client,
             entry_gateway_data.clone(),
@@ -1048,54 +1063,55 @@ impl TunnelMonitor {
         };
         let bandwidth_controller_handle = tokio::spawn(bw.run());
 
-        let mut connection_data = WgConnectionData {
+        let rt = WgTunnelRuntime {
+            bandwidth_controller_handle,
+            transport_fwd_handle: None,
+            authenticator_listener_handle,
+        };
+
+        let connection_data = WgConnectionData {
             entry_bridge_addr: None,
             entry: entry_gateway_data,
             exit: exit_gateway_data,
         };
 
-        let transport_fwd_handle = if self.tunnel_parameters.tunnel_settings.bridges_enabled() {
-            let entry_bridge_params = selected_gateways
-                .entry_gateway()
-                .get_bridge_params()
-                .ok_or(TransportError::config_err(
-                    "attempted to open transport connection without bridge params",
-                ))?;
-
-            // Attempt transport Connection. If successful a listening UDP connection is created
-            // and the bind address of that UDP listener is provided to the entry wireguard tunnel
-            // as the endpoint address.
-            tracing::info!("Establishing DVPN QUIC transport tunnel");
-
-            let bridge_conn = transports::BridgeConn::try_connect(
-                entry_bridge_params,
-                self.shutdown_token.child_token(),
-            )
-            .await?;
-            connection_data.entry_bridge_addr = Some(bridge_conn.endpoint);
-            let (local_fwd_listen_addr, fwd_handle) = transports::UdpForwarder::launch(
-                bridge_conn,
-                None,
-                bridge_close_tx,
-                self.shutdown_token.child_token(),
-            )
-            .await?;
-            tracing::info!(
-                "quic transport connected, udp forwarder open on {local_fwd_listen_addr:?}"
-            );
-            connection_data.entry.endpoint = local_fwd_listen_addr;
-            Some(fwd_handle)
-        } else {
-            None
-        };
-
-        let rt = WgTunnelRuntime {
-            bandwidth_controller_handle,
-            transport_fwd_handle,
-            authenticator_listener_handle,
-        };
-
         Ok((connection_data, rt))
+    }
+
+    async fn start_bridges(
+        &self,
+        selected_gateways: &SelectedGateways,
+        connection_data: &mut WgConnectionData,
+        bridge_close_tx: mpsc::UnboundedSender<()>,
+    ) -> Result<JoinHandle<()>> {
+        let entry_bridge_params = selected_gateways
+            .entry_gateway()
+            .get_bridge_params()
+            .ok_or(TransportError::config_err(
+                "attempted to open transport connection without bridge params",
+            ))?;
+
+        // Attempt transport Connection. If successful a listening UDP connection is created
+        // and the bind address of that UDP listener is provided to the entry wireguard tunnel
+        // as the endpoint address.
+        tracing::info!("Establishing DVPN QUIC transport tunnel");
+
+        let bridge_conn = transports::BridgeConn::try_connect(
+            entry_bridge_params,
+            self.shutdown_token.child_token(),
+        )
+        .await?;
+        connection_data.entry_bridge_addr = Some(bridge_conn.endpoint);
+        let (local_fwd_listen_addr, fwd_handle) = transports::UdpForwarder::launch(
+            bridge_conn,
+            None,
+            bridge_close_tx,
+            self.shutdown_token.child_token(),
+        )
+        .await?;
+        tracing::info!("quic transport connected, udp forwarder open on {local_fwd_listen_addr:?}");
+        connection_data.entry.endpoint = local_fwd_listen_addr;
+        Ok(fwd_handle)
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]

--- a/nym-vpn-core/crates/nym-vpnd/src/logging.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/logging.rs
@@ -38,7 +38,7 @@ static INFO_CRATES: &[&str; 14] = &[
     "nym_client_core::client::received_buffer",
 ];
 
-static WARN_CRATES: &[&str; 1] = &["hickory_server"];
+static WARN_CRATES: &[&str; 2] = &["hickory_server", "quinn::connection"];
 
 pub struct Options {
     pub verbosity_level: Level,


### PR DESCRIPTION
## Description

This PR focuses around adding a back channel into UDP forwarder for bridges along with some improvements with regards of separation of concern for `ConnectedTunnel` which is now 

- Add back channel to bridge forwarder to learn when it exits with error
- Move supporting services from `TunnelHandle` into `WgTunnelRuntime` and hold it in `TunnelMonitor`. No need to drag them into `ConnectedTunnel` and then into `TunnelHandle`
- Remove `mixnet_client_token()` from `TunnelHandle`, move it to `WgTunnelRuntime`
- Add  "quinn::connection" to warn crates since it logs every new connection in the console log which is pretty spammy

Further thoughts: we can get rid of `TunnelHandle` because it's essentially cancellation token + join handle.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3783)
<!-- Reviewable:end -->
