### PR TITLE
[bandaid] Upper bound the time spent to send disconnect message

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/processor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/processor.rs
@@ -180,6 +180,7 @@ impl MixnetProcessor {
                             continue;
                         }
                     };
+                    //Fixme : bandaid, the disconnect logic has to be taken out of that loop and properly upper bounded
                     if let Err(err) = tokio::time::timeout(Duration::from_secs(2),mixnet_sender.send(input_message)).await {
                         tracing::error!("Failed to send disconnect message: {err}");
                         tokio::time::sleep(IPR_DISCONNECT_RETRY_DELAY).await;

--- a/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/processor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/processor.rs
@@ -180,7 +180,7 @@ impl MixnetProcessor {
                             continue;
                         }
                     };
-                    if let Err(err) = mixnet_sender.send(input_message).await {
+                    if let Err(err) = tokio::time::timeout(Duration::from_secs(2),mixnet_sender.send(input_message)).await {
                         tracing::error!("Failed to send disconnect message: {err}");
                         tokio::time::sleep(IPR_DISCONNECT_RETRY_DELAY).await;
                         started_sleep_timeout = true;


### PR DESCRIPTION
## Ticket

JIRA-VPN-4327

## Description

Set an upper bound to the time spent trying to send the IPR disconnect message
THIS IS TEMPORARY AND HAS TO BE REVAMPED SOON


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3792)
<!-- Reviewable:end -->
