### PR TITLE
Fix stale discovery

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -29,6 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Don't log a warning on some expected value from the API (https://github.com/nymtech/nym-vpn-client/pull/3763)
 - Fix no gateway id problem (https://github.com/nymtech/nym-vpn-client/pull/3768)
 - [Windows] Wait for network interface addresses become usable before starting the tunnel (https://github.com/nymtech/nym-vpn-client/pull/3773)
+- Fix network environment updates not being made available for grpc clients (https://github.com/nymtech/nym-vpn-client/pull/3805)
+- Ensure that default discovery when written to disk is always considered stale (https://github.com/nymtech/nym-vpn-client/pull/3805)
+- Make discovery refresh aware of network connectivity (https://github.com/nymtech/nym-vpn-client/pull/3805)
 
 ## [1.17.0] - 2025-10-17
 

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -5485,6 +5485,7 @@ dependencies = [
  "nym-common",
  "nym-http-api-client",
  "nym-network-defaults",
+ "nym-offline-monitor",
  "nym-sdk",
  "nym-validator-client",
  "nym-vpn-api-client",

--- a/nym-vpn-core/crates/nym-connection-monitor/src/connection_monitor.rs
+++ b/nym-vpn-core/crates/nym-connection-monitor/src/connection_monitor.rs
@@ -344,7 +344,6 @@ mod tests {
         let events = collect_events(&mut event_rx, (PROBE_RETRY_COUNT + 1) as usize).await;
         let relative_pace = events
             .windows(2)
-            .into_iter()
             .map(|w| w[1].start_timestamp.duration_since(w[0].start_timestamp))
             .collect::<Vec<_>>();
 
@@ -369,7 +368,6 @@ mod tests {
         let events = collect_events(&mut event_rx, 4).await;
         let relative_pace = events
             .windows(2)
-            .into_iter()
             .map(|w| w[1].start_timestamp.duration_since(w[0].end_timestamp))
             .collect::<Vec<_>>();
 

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/lib.rs
@@ -453,7 +453,7 @@ async fn start_vpn_inner(config: Box<VPNConfig>) -> Result<(), VpnError> {
     // Once we have established that the account is ready, we can start the state machine.
     state_machine::init_state_machine(
         config,
-        network_env,
+        Box::new(network_env),
         account_controller_tx,
         account_controller_state,
         statistics_event_sender,

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/state_machine.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/state_machine.rs
@@ -16,8 +16,11 @@ use nym_vpn_lib::{
     },
 };
 use nym_vpn_lib_types::TunnelType;
-use nym_vpn_network_config::{Network, start_discovery_refresher};
-use tokio::{sync::mpsc, task::JoinHandle};
+use nym_vpn_network_config::{DiscoveryRefresher, DiscoveryRefresherEvent, Network};
+use tokio::{
+    sync::{mpsc, watch},
+    task::JoinHandle,
+};
 use tokio_util::sync::CancellationToken;
 
 use crate::gateway_cache;
@@ -26,7 +29,7 @@ use super::{STATE_MACHINE_HANDLE, VPNConfig, error::VpnError};
 
 pub(super) async fn init_state_machine(
     config: Box<VPNConfig>,
-    network_env: Network,
+    network_env: Box<Network>,
     account_controller_tx: AccountCommandSender,
     account_controller_state: AccountStateReceiver,
     statistics_event_sender: StatisticsSender,
@@ -57,7 +60,7 @@ pub(super) async fn init_state_machine(
 
 pub(super) async fn start_state_machine(
     config: Box<VPNConfig>,
-    network_env: Network,
+    network_env: Box<Network>,
     account_controller_tx: AccountCommandSender,
     account_controller_state: AccountStateReceiver,
     statistics_event_sender: StatisticsSender,
@@ -76,11 +79,13 @@ pub(super) async fn start_state_machine(
     let gateway_cache_handle = gateway_cache::get_gateway_cache_handle().await?;
     let gateway_config = gateway_cache::get_gateway_config().await?;
 
+    let (network_tx, network_rx) = watch::channel(network_env.clone());
+
     let nym_config = NymConfig {
         config_path: config.config_path.clone(),
         data_path: config.credential_data_path,
         gateway_config,
-        network_env: network_env.clone(),
+        network_rx,
     };
 
     let user_agent = nym_sdk::UserAgent::from(config.user_agent.clone());
@@ -150,13 +155,15 @@ pub(super) async fn start_state_machine(
         });
     };
 
-    let (discovery_refresher_events_tx, discovery_refresher_events_rx) = mpsc::channel(1);
-    let (discovery_refresher_commands_tx, discovery_refresher_commands_rx) = mpsc::channel(1);
-    let discovery_refresher_handle = start_discovery_refresher(
+    let (discovery_refresher_event_tx, mut discovery_refresher_event_rx) =
+        mpsc::unbounded_channel();
+    let (discovery_refresher_command_tx, discovery_refresher_command_rx) =
+        mpsc::unbounded_channel();
+    let discovery_refresher_handle = DiscoveryRefresher::spawn(
         config_path,
         network_env.clone(),
-        discovery_refresher_commands_rx,
-        discovery_refresher_events_tx,
+        discovery_refresher_command_rx,
+        discovery_refresher_event_tx,
         shutdown_token.child_token(),
     )
     .await
@@ -166,6 +173,28 @@ pub(super) async fn start_state_machine(
             details: format!("Failed to start Discovery Refresher: {err}"),
         }
     })?;
+
+    let discovery_watch_token = shutdown_token.child_token();
+    let discovery_watch_handle = tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                Some(event) = discovery_refresher_event_rx.recv() => {
+                    match event {
+                        DiscoveryRefresherEvent::NewNetwork(new_network) => {
+                            tracing::info!("Network environment updated");
+                            let _ = network_tx.send_replace(new_network);
+                        }
+                        DiscoveryRefresherEvent::Error(_error) => {
+                            // todo: handle error?
+                        }
+                    }
+                }
+                _ = discovery_watch_token.cancelled() => {
+                    break;
+                }
+            }
+        }
+    });
 
     let state_machine_handle = TunnelStateMachine::spawn(
         command_receiver,
@@ -179,8 +208,7 @@ pub(super) async fn start_state_machine(
         gateway_cache_handle,
         topology_provider,
         connectivity_handle,
-        discovery_refresher_commands_tx,
-        discovery_refresher_events_rx,
+        discovery_refresher_command_tx,
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         route_handler,
         #[cfg(target_os = "ios")]
@@ -197,6 +225,7 @@ pub(super) async fn start_state_machine(
         state_machine_handle,
         event_broadcaster_handle,
         discovery_refresher_handle,
+        discovery_watch_handle,
         command_sender,
         shutdown_token,
     })
@@ -206,6 +235,7 @@ pub(super) struct StateMachineHandle {
     state_machine_handle: JoinHandle<()>,
     event_broadcaster_handle: JoinHandle<()>,
     discovery_refresher_handle: JoinHandle<()>,
+    discovery_watch_handle: JoinHandle<()>,
     command_sender: mpsc::UnboundedSender<TunnelCommand>,
     shutdown_token: CancellationToken,
 }
@@ -230,6 +260,10 @@ impl StateMachineHandle {
 
         if let Err(e) = self.discovery_refresher_handle.await {
             tracing::error!("Failed to join on discovery refresher handle: {}", e);
+        }
+
+        if let Err(e) = self.discovery_watch_handle.await {
+            tracing::error!("Failed to join on discovery watch handle: {}", e);
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/state_machine.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/state_machine.rs
@@ -164,6 +164,7 @@ pub(super) async fn start_state_machine(
         network_env.clone(),
         discovery_refresher_command_rx,
         discovery_refresher_event_tx,
+        connectivity_handle.clone(),
         shutdown_token.child_token(),
     )
     .await

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -35,10 +35,10 @@ use nym_offline_monitor::ConnectivityHandle;
 use nym_registration_client::MixnetClientConfig;
 use nym_statistics::{StatisticsSender, events::StatisticsEvent};
 use nym_vpn_account_controller::{AccountCommandSender, AccountStateReceiver};
-use nym_vpn_network_config::{DiscoveryRefresherCommand, DiscoveryRefresherEvent, Network};
+use nym_vpn_network_config::{DiscoveryRefresherCommand, Network};
 use nym_vpn_store::keys::wireguard::WireguardKeysDb;
 use tokio::{
-    sync::{mpsc, oneshot},
+    sync::{mpsc, oneshot, watch},
     task::JoinHandle,
 };
 use tokio_util::sync::CancellationToken;
@@ -444,8 +444,7 @@ pub struct SharedState {
     statistics_event_sender: StatisticsSender,
     gateway_cache_handle: GatewayCacheHandle,
     topology_provider: VpnTopologyProvider,
-    discovery_refresher_command_tx: mpsc::Sender<DiscoveryRefresherCommand>,
-    discovery_refresher_event_rx: mpsc::Receiver<DiscoveryRefresherEvent>,
+    discovery_refresher_command_tx: mpsc::UnboundedSender<DiscoveryRefresherCommand>,
     wg_keys_db: WireguardKeysDb,
 }
 
@@ -467,7 +466,7 @@ pub struct NymConfig {
     pub config_path: Option<PathBuf>,
     pub data_path: Option<PathBuf>,
     pub gateway_config: GatewayDirectoryConfig,
-    pub network_env: Network,
+    pub network_rx: watch::Receiver<Box<Network>>,
 }
 
 pub struct TunnelStateMachine {
@@ -498,8 +497,7 @@ impl TunnelStateMachine {
         gateway_cache_handle: GatewayCacheHandle,
         topology_provider: VpnTopologyProvider,
         connectivity_handle: ConnectivityHandle,
-        discovery_refresher_command_tx: mpsc::Sender<DiscoveryRefresherCommand>,
-        discovery_refresher_event_rx: mpsc::Receiver<DiscoveryRefresherEvent>,
+        discovery_refresher_command_tx: mpsc::UnboundedSender<DiscoveryRefresherCommand>,
         #[cfg(not(any(target_os = "android", target_os = "ios")))] route_handler: RouteHandler,
         #[cfg(target_os = "ios")] tun_provider: Arc<dyn OSTunProvider>,
         #[cfg(target_os = "android")] tun_provider: Arc<dyn AndroidTunProvider>,
@@ -557,7 +555,6 @@ impl TunnelStateMachine {
             gateway_cache_handle,
             topology_provider,
             discovery_refresher_command_tx,
-            discovery_refresher_event_rx,
             wg_keys_db,
         };
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
@@ -26,7 +26,7 @@ use nym_common::trace_err_chain;
 use nym_firewall::{AllowedClients, AllowedEndpoint, Endpoint, FirewallPolicy, TransportProtocol};
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use nym_vpn_lib_types::TunnelConnectionData;
-use nym_vpn_network_config::{DiscoveryRefresherCommand, DiscoveryRefresherEvent};
+use nym_vpn_network_config::DiscoveryRefresherCommand;
 
 use super::ErrorState;
 
@@ -104,12 +104,10 @@ impl ConnectedState {
         shared_state
             .discovery_refresher_command_tx
             .send(DiscoveryRefresherCommand::UseResolverOverrides(None))
-            .await
             .ok();
         shared_state
             .discovery_refresher_command_tx
             .send(DiscoveryRefresherCommand::Pause(false))
-            .await
             .ok();
         shared_state
             .account_command_tx
@@ -302,18 +300,6 @@ impl TunnelStateHandler for ConnectedState {
                     self.disconnect(after_disconnect, shared_state).await
                 } else {
                     NextTunnelState::SameState(self)
-                }
-            }
-            Some(discovery_event) = shared_state.discovery_refresher_event_rx.recv() => {
-                match discovery_event {
-                   DiscoveryRefresherEvent::NewNetwork(network) => {
-                        shared_state.nym_config.network_env = *network;
-                        NextTunnelState::SameState(self)
-                    }
-                    DiscoveryRefresherEvent::Error(error) => {
-                        trace_err_chain!(error, "Discovery refresher reported an error");
-                        NextTunnelState::SameState(self)
-                    }
                 }
             }
             _ = shutdown_token.cancelled() => {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
@@ -21,6 +21,7 @@ use crate::tunnel_state_machine::{
 };
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use crate::tunnel_state_machine::{Error, Result, gateway_ext::GatewayExt};
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 use nym_common::trace_err_chain;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use nym_firewall::{AllowedClients, AllowedEndpoint, Endpoint, FirewallPolicy, TransportProtocol};

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -42,7 +42,7 @@ use nym_gateway_directory::ResolvedConfig;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use nym_vpn_lib_types::TunnelConnectionData;
 use nym_vpn_lib_types::{EstablishConnectionData, EstablishConnectionState, GatewayId};
-use nym_vpn_network_config::{DiscoveryRefresherCommand, DiscoveryRefresherEvent};
+use nym_vpn_network_config::DiscoveryRefresherCommand;
 
 /// Initial delay between retry attempts.
 const INITIAL_WAIT_DELAY: Duration = Duration::from_secs(2);
@@ -79,7 +79,6 @@ impl ConnectingState {
         shared_state
             .discovery_refresher_command_tx
             .send(DiscoveryRefresherCommand::Pause(true))
-            .await
             .ok();
         shared_state
             .account_command_tx
@@ -320,13 +319,11 @@ impl ConnectingState {
                             .clone(),
                     ),
                 )))
-                .await
                 .ok();
 
             shared_state
                 .discovery_refresher_command_tx
                 .send(DiscoveryRefresherCommand::Pause(false))
-                .await
                 .ok();
         }
 
@@ -675,18 +672,6 @@ impl TunnelStateHandler for ConnectingState {
                     }
                 } else {
                     NextTunnelState::SameState(self)
-                }
-            }
-            Some(discovery_event) = shared_state.discovery_refresher_event_rx.recv() => {
-                match discovery_event {
-                   DiscoveryRefresherEvent::NewNetwork(network) => {
-                        shared_state.nym_config.network_env = *network;
-                        NextTunnelState::SameState(self)
-                    }
-                    DiscoveryRefresherEvent::Error(error) => {
-                        trace_err_chain!(error, "Discovery refresher reported an error");
-                        NextTunnelState::SameState(self)
-                    }
                 }
             }
             _ = shutdown_token.cancelled() => {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnected_state.rs
@@ -23,12 +23,10 @@ impl DisconnectedState {
         shared_state
             .discovery_refresher_command_tx
             .send(DiscoveryRefresherCommand::UseResolverOverrides(None))
-            .await
             .ok();
         shared_state
             .discovery_refresher_command_tx
             .send(DiscoveryRefresherCommand::Pause(false))
-            .await
             .ok();
 
         #[cfg(target_os = "macos")]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/offline_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/offline_state.rs
@@ -42,12 +42,10 @@ impl OfflineState {
         shared_state
             .discovery_refresher_command_tx
             .send(DiscoveryRefresherCommand::UseResolverOverrides(None))
-            .await
             .ok();
         shared_state
             .discovery_refresher_command_tx
             .send(DiscoveryRefresherCommand::Pause(true))
-            .await
             .ok();
 
         #[cfg(target_os = "macos")]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -539,6 +539,13 @@ impl TunnelMonitor {
             keys: selected_gateways.exit_keypair().clone(),
         };
 
+        let network_env = self
+            .tunnel_parameters
+            .nym_config
+            .network_rx
+            .borrow()
+            .clone();
+        let nym_network = network_env.nym_network.network.clone();
         let rcb_config_builder = RegistrationClientBuilderConfig::builder()
             .entry_node(entry_node)
             .exit_node(exit_node)
@@ -548,14 +555,7 @@ impl TunnelMonitor {
             .two_hops(self.tunnel_parameters.tunnel_settings.tunnel_type == TunnelType::Wireguard)
             .user_agent(user_agent)
             .custom_topology_provider(Box::new(self.custom_topology_provider.clone()))
-            .network_env(
-                self.tunnel_parameters
-                    .nym_config
-                    .network_env
-                    .nym_network
-                    .network
-                    .clone(),
-            )
+            .network_env(nym_network)
             .cancel_token(self.shutdown_token.child_token());
 
         #[cfg(unix)]
@@ -1033,6 +1033,13 @@ impl TunnelMonitor {
             bw_controller,
         } = registration_result;
 
+        let gw_update_version = self
+            .tunnel_parameters
+            .nym_config
+            .network_rx
+            .borrow()
+            .gw_update_version();
+
         let bw = BandwidthController::create(
             bw_controller,
             selected_gateways,
@@ -1042,10 +1049,7 @@ impl TunnelMonitor {
             exit_gateway_data.clone(),
             entry_signal_rx,
             exit_signal_rx,
-            self.tunnel_parameters
-                .nym_config
-                .network_env
-                .gw_update_version(),
+            gw_update_version,
             self.shutdown_token.child_token(),
         )
         .await

--- a/nym-vpn-core/crates/nym-vpn-network-config/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-network-config/Cargo.toml
@@ -22,6 +22,7 @@ nym-network-defaults.workspace = true
 nym-sdk.workspace = true
 nym-validator-client.workspace = true
 nym-vpn-api-client.workspace = true
+nym-offline-monitor.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/discovery.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/discovery.rs
@@ -4,6 +4,7 @@
 use std::{
     path::{Path, PathBuf},
     sync::LazyLock,
+    time::SystemTime,
 };
 
 use crate::{
@@ -121,11 +122,23 @@ impl Discovery {
         crate::serialization::deserialize_from_json_file(path)
     }
 
-    pub(super) fn write_to_file(&self, config_dir: &Path) -> Result<()> {
+    pub(super) fn write_to_file(
+        &self,
+        config_dir: &Path,
+        modified_at: Option<SystemTime>,
+    ) -> Result<()> {
         let path = Self::path(config_dir, &self.network_name);
         tracing::debug!("Writing discovery file to: {}", path.display());
 
-        crate::serialization::serialize_to_json_file(path, self)
+        let file = crate::serialization::serialize_to_json_file(path, self)?;
+
+        if let Some(modified_at) = modified_at
+            && let Err(e) = file.set_modified(modified_at)
+        {
+            tracing::error!("Failed to set modified time for discovery file: {e}");
+        }
+
+        Ok(())
     }
 
     pub(super) async fn ensure_exists(config_dir: &Path, network_name: &str) -> Result<Self> {
@@ -140,12 +153,28 @@ impl Discovery {
 
                 let client = Self::create_client(None).await?;
 
-                let discovery = Self::fetch(&client, network_name).await.or_else(|e| {
-                    match Self::default_discovery(network_name) {
+                match Self::fetch(&client, network_name).await {
+                    Ok(discovery) => {
+                        discovery
+                            .write_to_file(config_dir, None)
+                            .inspect_err(|err| {
+                                trace_err_chain!(err, "Failed to write discovery file");
+                            })?;
+                        Ok(discovery)
+                    }
+                    Err(e) => match Self::default_discovery(network_name) {
                         Some(default_discovery) => {
                             tracing::warn!(
                                 "Failed to fetch remote discovery file: {e}, creating a default one"
                             );
+                            // Ensure that discovery cache created from default discovery is always considered stale.
+                            let modified_at = SystemTime::now().checked_sub(MAX_FILE_AGE);
+
+                            default_discovery
+                                .write_to_file(config_dir, modified_at)
+                                .inspect_err(|err| {
+                                    trace_err_chain!(err, "Failed to write default discovery file");
+                                })?;
                             Ok(default_discovery)
                         }
                         None => {
@@ -154,14 +183,8 @@ impl Discovery {
                             );
                             Err(e)
                         }
-                    }
-                })?;
-
-                discovery.write_to_file(config_dir).inspect_err(|err| {
-                    trace_err_chain!(err, "Failed to write discovery file");
-                })?;
-
-                Ok(discovery)
+                    },
+                }
             }
             Err(e) => {
                 trace_err_chain!(e, "Failed to read discovery file");
@@ -200,7 +223,7 @@ impl Discovery {
     pub async fn update_nym_network_file(&self, config_dir: &Path) -> Result<()> {
         self.fetch_nym_network_details()
             .await?
-            .write_to_file(config_dir)
+            .write_to_file(config_dir, None)
     }
 
     fn default_discovery(network_name: &str) -> Option<Self> {

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/discovery_refresher.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/discovery_refresher.rs
@@ -178,7 +178,7 @@ impl DiscoveryRefresher {
     async fn refresh_discovery_file(&self, network_name: &str) -> Result<Option<Discovery>> {
         if Discovery::path_is_stale(self.config_path.as_path(), network_name)? {
             let discovery = Discovery::fetch(&self.client, network_name).await?;
-            discovery.write_to_file(self.config_path.as_path())?;
+            discovery.write_to_file(self.config_path.as_path(), None)?;
             Ok(Some(discovery))
         } else {
             Ok(None)

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/discovery_refresher.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/discovery_refresher.rs
@@ -10,33 +10,35 @@ use crate::{
 use nym_common::trace_err_chain;
 use nym_vpn_api_client::{ResolverOverrides, VpnApiClient};
 use tokio::{
-    sync::mpsc::{Receiver, Sender},
+    sync::mpsc::{UnboundedReceiver, UnboundedSender},
     task::JoinHandle,
 };
 use tokio_util::sync::CancellationToken;
 
 const CHECK_INTERVAL: Duration = Duration::from_secs(60 * 60);
 
-struct DiscoveryRefresher {
+pub struct DiscoveryRefresher {
     client: VpnApiClient,
     config_path: PathBuf,
-    commands_rx: Receiver<DiscoveryRefresherCommand>,
-    events_tx: Sender<DiscoveryRefresherEvent>,
+    commands_rx: UnboundedReceiver<DiscoveryRefresherCommand>,
+    events_tx: UnboundedSender<DiscoveryRefresherEvent>,
     cancel_token: CancellationToken,
     current_resolver_overrides: Option<ResolverOverrides>,
     paused: bool,
 }
 
 impl DiscoveryRefresher {
-    async fn new(
+    pub async fn spawn(
         config_path: PathBuf,
-        commands_rx: Receiver<DiscoveryRefresherCommand>,
-        events_tx: Sender<DiscoveryRefresherEvent>,
+        network: Box<Network>,
+        commands_rx: UnboundedReceiver<DiscoveryRefresherCommand>,
+        events_tx: UnboundedSender<DiscoveryRefresherEvent>,
         cancel_token: CancellationToken,
-    ) -> Result<Self> {
+    ) -> Result<JoinHandle<()>> {
         let current_resolver_overrides = None;
         let client = Discovery::create_client(current_resolver_overrides).await?;
-        Ok(Self {
+
+        let refresher = Self {
             client,
             config_path,
             commands_rx,
@@ -44,36 +46,12 @@ impl DiscoveryRefresher {
             cancel_token,
             current_resolver_overrides: current_resolver_overrides.cloned(),
             paused: false,
-        })
+        };
+
+        Ok(tokio::spawn(refresher.run(network)))
     }
 
-    async fn refresh_discovery_file(&self, network_name: &str) -> Result<Option<Discovery>> {
-        if Discovery::path_is_stale(self.config_path.as_path(), network_name)? {
-            let discovery = Discovery::fetch(&self.client, network_name).await?;
-            discovery.write_to_file(self.config_path.as_path())?;
-            Ok(Some(discovery))
-        } else {
-            Ok(None)
-        }
-    }
-
-    async fn refresh_nym_network_file(
-        &self,
-        network_name: &str,
-        discovery: &Discovery,
-    ) -> Result<()> {
-        if NymNetwork::path_is_stale(self.config_path.as_path(), network_name)? {
-            discovery.update_nym_network_file(&self.config_path).await?;
-        }
-
-        Ok(())
-    }
-
-    async fn refresh_envs_file(&self) -> Result<()> {
-        RegisteredNetworks::try_update_file(&self.config_path).await
-    }
-
-    async fn run(mut self, mut network: Network) {
+    async fn run(mut self, mut network: Box<Network>) {
         tracing::debug!("Discovery Refresher started");
 
         let mut interval = tokio::time::interval(CHECK_INTERVAL);
@@ -108,7 +86,6 @@ impl DiscoveryRefresher {
                                         tracing::error!("Failed to create new client with {enabled} resolver overrides: {err:?}");
                                         self.events_tx
                                             .send(DiscoveryRefresherEvent::Error(err))
-                                            .await
                                             .ok();
                                     }
                                 }
@@ -123,7 +100,6 @@ impl DiscoveryRefresher {
                                 tracing::error!("Inconsistent network");
                                 self.events_tx
                                     .send(DiscoveryRefresherEvent::Error(Error::InconsistentNetwork))
-                                    .await
                                     .ok();
                             }
                             Ok(true) => {
@@ -144,7 +120,6 @@ impl DiscoveryRefresher {
                             trace_err_chain!(err, "Failed to refresh discovery file");
                             self.events_tx
                                 .send(DiscoveryRefresherEvent::Error(Error::RefreshDiscoveryFile))
-                                .await
                                 .ok();
                         }
                         Ok(Some(discovery)) => {
@@ -163,17 +138,18 @@ impl DiscoveryRefresher {
                                     trace_err_chain!(err, "Failed to parse refreshed discovery file");
                                     self.events_tx
                                         .send(DiscoveryRefresherEvent::Error(Error::ParseDiscoveryFile))
-                                        .await
                                         .ok();
                                 }
                                 Ok(new_network) => {
-                                    network = new_network.clone();
-                                    self.events_tx
-                                        .send(DiscoveryRefresherEvent::NewNetwork(Box::new(
-                                            new_network,
-                                        )))
-                                        .await
-                                        .ok();
+                                    // Only propagate new network environment when it really changed.
+                                    if *network == new_network {
+                                        tracing::info!("Network environment is up to date");
+                                    } else {
+                                        network = Box::new(new_network);
+                                        self.events_tx
+                                            .send(DiscoveryRefresherEvent::NewNetwork(network.clone()))
+                                            .ok();
+                                    }
                                 }
                             }
                         }
@@ -185,21 +161,32 @@ impl DiscoveryRefresher {
 
         tracing::debug!("Discovery Refresher exiting");
     }
-}
 
-pub async fn start_discovery_refresher(
-    config_path: PathBuf,
-    network: Network,
-    commands_rx: Receiver<DiscoveryRefresherCommand>,
-    events_tx: Sender<DiscoveryRefresherEvent>,
-    cancel_token: CancellationToken,
-) -> Result<JoinHandle<()>> {
-    let refresher =
-        DiscoveryRefresher::new(config_path, commands_rx, events_tx, cancel_token).await?;
+    async fn refresh_discovery_file(&self, network_name: &str) -> Result<Option<Discovery>> {
+        if Discovery::path_is_stale(self.config_path.as_path(), network_name)? {
+            let discovery = Discovery::fetch(&self.client, network_name).await?;
+            discovery.write_to_file(self.config_path.as_path())?;
+            Ok(Some(discovery))
+        } else {
+            Ok(None)
+        }
+    }
 
-    let join_handle = tokio::spawn(refresher.run(network));
+    async fn refresh_nym_network_file(
+        &self,
+        network_name: &str,
+        discovery: &Discovery,
+    ) -> Result<()> {
+        if NymNetwork::path_is_stale(self.config_path.as_path(), network_name)? {
+            discovery.update_nym_network_file(&self.config_path).await?;
+        }
 
-    Ok(join_handle)
+        Ok(())
+    }
+
+    async fn refresh_envs_file(&self) -> Result<()> {
+        RegisteredNetworks::try_update_file(&self.config_path).await
+    }
 }
 
 #[derive(Debug)]

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/discovery_refresher.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/discovery_refresher.rs
@@ -3,17 +3,20 @@
 
 use std::{path::PathBuf, time::Duration};
 
-use crate::{
-    Error, Network, NymNetwork, Result, discovery::Discovery, envs::RegisteredNetworks,
-    network_from_discovery,
-};
-use nym_common::trace_err_chain;
-use nym_vpn_api_client::{ResolverOverrides, VpnApiClient};
 use tokio::{
     sync::mpsc::{UnboundedReceiver, UnboundedSender},
     task::JoinHandle,
 };
 use tokio_util::sync::CancellationToken;
+
+use nym_common::trace_err_chain;
+use nym_offline_monitor::ConnectivityMonitor;
+use nym_vpn_api_client::{ResolverOverrides, VpnApiClient};
+
+use crate::{
+    Error, Network, NymNetwork, Result, discovery::Discovery, envs::RegisteredNetworks,
+    network_from_discovery,
+};
 
 const CHECK_INTERVAL: Duration = Duration::from_secs(60 * 60);
 
@@ -33,6 +36,7 @@ impl DiscoveryRefresher {
         network: Box<Network>,
         commands_rx: UnboundedReceiver<DiscoveryRefresherCommand>,
         events_tx: UnboundedSender<DiscoveryRefresherEvent>,
+        connectivity_monitor: impl ConnectivityMonitor + 'static,
         cancel_token: CancellationToken,
     ) -> Result<JoinHandle<()>> {
         let current_resolver_overrides = None;
@@ -48,14 +52,20 @@ impl DiscoveryRefresher {
             paused: false,
         };
 
-        Ok(tokio::spawn(refresher.run(network)))
+        Ok(tokio::spawn(refresher.run(network, connectivity_monitor)))
     }
 
-    async fn run(mut self, mut network: Box<Network>) {
+    async fn run(
+        mut self,
+        mut network: Box<Network>,
+        mut connectivity_monitor: impl ConnectivityMonitor + 'static,
+    ) {
         tracing::debug!("Discovery Refresher started");
 
         let mut interval = tokio::time::interval(CHECK_INTERVAL);
         let mut checked_consistency = false;
+
+        let mut current_connectivity = connectivity_monitor.connectivity().await;
 
         loop {
             tokio::select! {
@@ -92,7 +102,10 @@ impl DiscoveryRefresher {
                         }
                     }
                 }
-                _ = interval.tick(), if !self.paused => {
+                Some(connectivity) = connectivity_monitor.next() => {
+                    current_connectivity = connectivity;
+                }
+                _ = interval.tick(), if !self.paused && current_connectivity.is_online() => {
                     if !checked_consistency {
                         match network.check_consistency().await {
                             Err(e) => tracing::warn!("Discovery refresher could not check consistency: {e:?}"),
@@ -116,12 +129,6 @@ impl DiscoveryRefresher {
                         .refresh_discovery_file(&network.nym_network.network.network_name)
                         .await
                     {
-                        Err(err) => {
-                            trace_err_chain!(err, "Failed to refresh discovery file");
-                            self.events_tx
-                                .send(DiscoveryRefresherEvent::Error(Error::RefreshDiscoveryFile))
-                                .ok();
-                        }
                         Ok(Some(discovery)) => {
                             if let Err(err) = self
                                 .refresh_nym_network_file(
@@ -134,12 +141,6 @@ impl DiscoveryRefresher {
                             }
 
                             match network_from_discovery(&self.config_path, discovery).await {
-                                Err(err) => {
-                                    trace_err_chain!(err, "Failed to parse refreshed discovery file");
-                                    self.events_tx
-                                        .send(DiscoveryRefresherEvent::Error(Error::ParseDiscoveryFile))
-                                        .ok();
-                                }
                                 Ok(new_network) => {
                                     // Only propagate new network environment when it really changed.
                                     if *network == new_network {
@@ -151,7 +152,19 @@ impl DiscoveryRefresher {
                                             .ok();
                                     }
                                 }
+                                Err(err) => {
+                                    trace_err_chain!(err, "Failed to parse refreshed discovery file");
+                                    self.events_tx
+                                        .send(DiscoveryRefresherEvent::Error(Error::ParseDiscoveryFile))
+                                        .ok();
+                                }
                             }
+                        }
+                        Err(err) => {
+                            trace_err_chain!(err, "Failed to refresh discovery file");
+                            self.events_tx
+                                .send(DiscoveryRefresherEvent::Error(Error::RefreshDiscoveryFile))
+                                .ok();
                         }
                         _ => {}
                     }

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/envs.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/envs.rs
@@ -5,6 +5,7 @@ use std::{
     collections::HashSet,
     fmt,
     path::{Path, PathBuf},
+    time::SystemTime,
 };
 
 use crate::{Error, MAX_FILE_AGE, NETWORKS_SUBDIR, Result, discovery::Discovery};
@@ -98,16 +99,24 @@ impl RegisteredNetworks {
         crate::serialization::deserialize_from_json_file(path)
     }
 
-    fn write_to_file(&self, config_dir: &Path) -> Result<()> {
+    fn write_to_file(&self, config_dir: &Path, modified_at: Option<SystemTime>) -> Result<()> {
         let path = Self::path(config_dir);
         tracing::debug!("Writing registered networks to file: {}", path.display());
 
-        crate::serialization::serialize_to_json_file(&path, self)
+        let file = crate::serialization::serialize_to_json_file(&path, self)?;
+
+        if let Some(modified_at) = modified_at
+            && let Err(e) = file.set_modified(modified_at)
+        {
+            tracing::error!("Failed to set modified time for registered networks file: {e}");
+        }
+
+        Ok(())
     }
 
     pub(super) async fn try_update_file(config_dir: &Path) -> Result<()> {
         if Self::path_is_stale(config_dir)? {
-            Self::fetch().await?.write_to_file(config_dir)?;
+            Self::fetch().await?.write_to_file(config_dir, None)?;
         }
 
         Ok(())
@@ -122,9 +131,12 @@ impl RegisteredNetworks {
                 }
 
                 let default_envs = Self::default();
-                default_envs.write_to_file(config_dir).inspect_err(|err| {
-                    trace_err_chain!(err, "Failed to write default envs file");
-                })?;
+                let modified_at = SystemTime::now().checked_sub(MAX_FILE_AGE);
+                default_envs
+                    .write_to_file(config_dir, modified_at)
+                    .inspect_err(|err| {
+                        trace_err_chain!(err, "Failed to write default envs file");
+                    })?;
 
                 Ok(default_envs)
             }
@@ -179,7 +191,7 @@ mod tests {
         let config_dir = temp_dir.path();
 
         let registered_networks = RegisteredNetworks::default();
-        registered_networks.write_to_file(config_dir).unwrap();
+        registered_networks.write_to_file(config_dir, None).unwrap();
 
         let read_registered_networks = RegisteredNetworks::read_from_file(config_dir).unwrap();
         assert_eq!(registered_networks, read_registered_networks);

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/filetime.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/filetime.rs
@@ -17,10 +17,10 @@ pub enum FileTimeError {
 
 pub type Result<T, E = FileTimeError> = std::result::Result<T, E>;
 
-/// Returns true if time elapsed since last file modification exceeds the value specified in `max_age` or if file does not exist.
+/// Returns true if time elapsed since last file modification is equal or exceeds the value specified in `max_age` or if file does not exist.
 pub fn is_stale_file(file_path: impl AsRef<Path>, max_age: Duration) -> Result<bool> {
     Ok(match time_since_modification(file_path)? {
-        Some(elapsed) => elapsed > max_age,
+        Some(elapsed) => elapsed >= max_age,
         None => true, // If the file does not exist, consider it stale
     })
 }

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/lib.rs
@@ -17,7 +17,7 @@ mod system_configuration;
 
 pub use account_management::{AccountManagement, ParsedAccountLinks};
 pub use discovery_refresher::{
-    DiscoveryRefresherCommand, DiscoveryRefresherEvent, start_discovery_refresher,
+    DiscoveryRefresher, DiscoveryRefresherCommand, DiscoveryRefresherEvent,
 };
 pub use feature_flags::{FeatureFlags, FlagValue};
 use futures_util::FutureExt;
@@ -55,7 +55,7 @@ const MAX_FILE_AGE: Duration = Duration::from_secs(60 * 60);
 
 pub type ApiUrl = nym_vpn_api_client::response::ApiUrl;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Network {
     pub nym_network: NymNetwork,
     pub nyxd_url: url::Url,

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/nym_network.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/nym_network.rs
@@ -10,7 +10,7 @@ use crate::MAX_FILE_AGE;
 
 use super::{Error, NETWORKS_SUBDIR, Result, discovery::Discovery};
 
-#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct NymNetwork {
     pub network: NymNetworkDetails,
 }

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/nym_network.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/nym_network.rs
@@ -1,7 +1,10 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::path::{Path, PathBuf};
+use std::{
+    path::{Path, PathBuf},
+    time::SystemTime,
+};
 
 use nym_common::trace_err_chain;
 use nym_network_defaults::NymNetworkDetails;
@@ -42,11 +45,22 @@ impl NymNetwork {
         Ok(Self { network })
     }
 
-    pub(super) fn write_to_file(&self, config_dir: &Path) -> Result<()> {
+    pub(super) fn write_to_file(
+        &self,
+        config_dir: &Path,
+        modified_at: Option<SystemTime>,
+    ) -> Result<()> {
         let network = &self.network;
         let path = Self::path(config_dir, &network.network_name);
 
-        crate::serialization::serialize_to_json_file(path, network)
+        let file = crate::serialization::serialize_to_json_file(path, network)?;
+        if let Some(modified_at) = modified_at
+            && let Err(e) = file.set_modified(modified_at)
+        {
+            tracing::error!("Failed to set modified time for nym network file: {e}");
+        }
+
+        Ok(())
     }
 
     pub(super) async fn ensure_exists(config_dir: &Path, discovery: &Discovery) -> Result<Self> {
@@ -57,23 +71,38 @@ impl NymNetwork {
                     trace_err_chain!(e, "Failed to read nym network file");
                 }
 
-                let nym_network = discovery.fetch_nym_network_details().await.or_else(|e| {
-                    if discovery.network_name == "mainnet" {
-                        tracing::warn!(
-                            "Failed to fetch remote nym network file: {e}, creating a default one"
-                        );
-                        Ok(Self::default())
-                    } else {
-                        trace_err_chain!(e, "Failed to fetch remote nym network file, no default one for {} environment", discovery.network_name);
-                        Err(e)
+                match discovery.fetch_nym_network_details().await {
+                    Ok(nym_network) => {
+                        nym_network
+                            .write_to_file(config_dir, None)
+                            .inspect_err(|err| {
+                                trace_err_chain!(err, "Failed to write nym network file");
+                            })?;
+                        Ok(nym_network)
                     }
-                })?;
-
-                nym_network.write_to_file(config_dir).inspect_err(|err| {
-                    trace_err_chain!(err, "Failed to write nym network file");
-                })?;
-
-                Ok(nym_network)
+                    Err(e) => {
+                        if discovery.network_name == "mainnet" {
+                            tracing::warn!(
+                                "Failed to fetch remote nym network file: {e}, creating a default one"
+                            );
+                            let default_nym_network = Self::default();
+                            let modified_at = SystemTime::now().checked_sub(MAX_FILE_AGE);
+                            default_nym_network
+                                .write_to_file(config_dir, modified_at)
+                                .inspect_err(|err| {
+                                    trace_err_chain!(err, "Failed to write nym network file");
+                                })?;
+                            Ok(default_nym_network)
+                        } else {
+                            trace_err_chain!(
+                                e,
+                                "Failed to fetch remote nym network file, no default one for {} environment",
+                                discovery.network_name
+                            );
+                            Err(e)
+                        }
+                    }
+                }
             }
             Err(e) => {
                 trace_err_chain!(e, "Failed to read nym network file");

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/nym_vpn_network.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/nym_vpn_network.rs
@@ -10,7 +10,7 @@ use crate::{
     account_management::AccountLinksConversionError, discovery::Discovery,
 };
 
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct NymVpnNetwork {
     pub nym_vpn_api_urls: Vec<ApiUrl>,
     pub account_management: Option<AccountManagement>,

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/serialization.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/serialization.rs
@@ -4,7 +4,7 @@
 use serde::{de::DeserializeOwned, ser::Serialize};
 
 use crate::{Error, Result};
-use std::path::Path;
+use std::{fs::File, path::Path};
 
 /// Deserialize a value from JSON file.
 pub fn deserialize_from_json_file<S, T>(path: S) -> Result<T>
@@ -26,7 +26,7 @@ where
 
 /// Serialize a value to a JSON file.
 /// Creates parent directories if they do not exist.
-pub fn serialize_to_json_file<S, T>(path: S, value: &T) -> Result<()>
+pub fn serialize_to_json_file<S, T>(path: S, value: &T) -> Result<File>
 where
     T: ?Sized + Serialize,
     S: AsRef<Path>,
@@ -51,5 +51,7 @@ where
     serde_json::to_writer_pretty(&file, &value).map_err(|source| Error::Serialize {
         path: path.as_ref().to_path_buf(),
         source,
-    })
+    })?;
+
+    Ok(file)
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -7,7 +7,7 @@ use bip39::Mnemonic;
 use futures::{FutureExt, StreamExt, future::Fuse, pin_mut};
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 use tokio::{
-    sync::{broadcast, mpsc, oneshot},
+    sync::{broadcast, mpsc, oneshot, watch},
     task::JoinHandle,
     time::{Duration, Instant},
 };
@@ -36,7 +36,7 @@ use nym_vpn_lib_types::{
     NymVpnDevice, NymVpnNetwork, NymVpnUsage, ParsedAccountLinks, StoreAccountRequest,
     SystemMessage, TargetState, TunnelEvent, TunnelState, VpnServiceConfig, VpnServiceInfo,
 };
-use nym_vpn_network_config::{Network, start_discovery_refresher};
+use nym_vpn_network_config::{DiscoveryRefresher, DiscoveryRefresherEvent, Network};
 use nym_vpn_store::types::{StorableAccount, StoredAccountMode};
 
 use super::{
@@ -147,7 +147,7 @@ pub struct NymVpnServiceParameters {
 
 pub struct NymVpnService {
     // The network environment
-    network_env: Box<Network>,
+    network_tx: watch::Sender<Box<Network>>,
 
     // The user agent used for HTTP request
     user_agent: UserAgent,
@@ -207,7 +207,10 @@ pub struct NymVpnService {
     // Gateway cache handle
     gateway_cache_handle: GatewayCacheHandle,
 
-    // Discovery Refresher join handle
+    // Discovery refresher event receiver
+    discovery_refresher_event_rx: mpsc::UnboundedReceiver<DiscoveryRefresherEvent>,
+
+    // Discovery refresher join handle
     discovery_refresher_join_handle: JoinHandle<()>,
 
     // VPN service shutdown token.
@@ -409,11 +412,12 @@ impl NymVpnService {
                     reason: e.to_string(),
                 })?;
 
+        let (network_tx, network_rx) = watch::channel(parameters.network_env.clone());
         let nym_config = NymConfig {
             config_path: Some(config_dir.clone()),
             data_path: Some(network_data_dir.clone()),
             gateway_config: gateway_config.clone(),
-            network_env: *parameters.network_env.clone(),
+            network_rx,
         };
 
         let gateway_directory_client =
@@ -447,13 +451,15 @@ impl NymVpnService {
         .await?;
         topology_provider.fetch().await;
 
-        let (discovery_refresher_events_tx, discovery_refresher_events_rx) = mpsc::channel(1);
-        let (discovery_refresher_commands_tx, discovery_refresher_commands_rx) = mpsc::channel(1);
-        let discovery_refresher_join_handle = start_discovery_refresher(
+        let (discovery_refresher_event_tx, discovery_refresher_event_rx) =
+            mpsc::unbounded_channel();
+        let (discovery_refresher_command_tx, discovery_refresher_command_rx) =
+            mpsc::unbounded_channel();
+        let discovery_refresher_join_handle = DiscoveryRefresher::spawn(
             config_dir.clone(),
-            *parameters.network_env.clone(),
-            discovery_refresher_commands_rx,
-            discovery_refresher_events_tx,
+            parameters.network_env,
+            discovery_refresher_command_rx,
+            discovery_refresher_event_tx,
             services_shutdown_token.child_token(),
         )
         .await
@@ -476,8 +482,7 @@ impl NymVpnService {
             gateway_cache_handle.clone(),
             topology_provider,
             connectivity_handle,
-            discovery_refresher_commands_tx,
-            discovery_refresher_events_rx,
+            discovery_refresher_command_tx,
             #[cfg(not(any(target_os = "android", target_os = "ios")))]
             route_handler,
             state_machine_shutdown_token.child_token(),
@@ -486,7 +491,7 @@ impl NymVpnService {
         .map_err(Error::StateMachine)?;
 
         Ok(Self {
-            network_env: parameters.network_env,
+            network_tx,
             user_agent: parameters.user_agent,
             vpn_command_rx,
             tunnel_event_tx,
@@ -509,6 +514,7 @@ impl NymVpnService {
             state_machine_shutdown_token,
             gateway_cache_handle,
             gateway_cache_join_handle,
+            discovery_refresher_event_rx,
             discovery_refresher_join_handle,
             sentry_enabled: parameters.sentry_enabled,
             network_statistics_enabled: parameters.netstats_enabled,
@@ -530,6 +536,9 @@ impl NymVpnService {
                 }
                 Some(account_state) = account_state_rx.next() => {
                     self.handle_account_state_change(account_state);
+                }
+                Some(event) = self.discovery_refresher_event_rx.recv() => {
+                    self.handle_discovery_refresher_event(event);
                 }
                 _ = &mut self.tunnel_settings_update_timer => {
                     self.update_tunnel_settings();
@@ -655,6 +664,18 @@ impl NymVpnService {
             .is_err()
         {
             tracing::error!("Failed to send tunnel event");
+        }
+    }
+
+    fn handle_discovery_refresher_event(&mut self, event: DiscoveryRefresherEvent) {
+        match event {
+            DiscoveryRefresherEvent::NewNetwork(new_network) => {
+                tracing::info!("Network environment updated");
+                let _ = self.network_tx.send_replace(new_network);
+            }
+            DiscoveryRefresherEvent::Error(_error) => {
+                // todo: handle error?
+            }
         }
     }
 
@@ -821,6 +842,7 @@ impl NymVpnService {
 
     async fn handle_info(&self) -> VpnServiceInfo {
         let bin_info = nym_bin_common::bin_info_local_vergen!();
+        let network_env = self.network_tx.borrow();
 
         VpnServiceInfo {
             version: bin_info.build_version.to_string(),
@@ -828,8 +850,8 @@ impl NymVpnService {
             triple: bin_info.cargo_triple.to_string(),
             platform: self.user_agent.platform.clone(),
             git_commit: bin_info.commit_sha.to_string(),
-            nym_network: NymNetworkDetails::from(self.network_env.nym_network.clone()),
-            nym_vpn_network: NymVpnNetwork::from(self.network_env.nym_vpn_network.clone()),
+            nym_network: NymNetworkDetails::from(network_env.nym_network.clone()),
+            nym_vpn_network: NymVpnNetwork::from(network_env.nym_vpn_network.clone()),
         }
     }
 
@@ -908,7 +930,8 @@ impl NymVpnService {
     }
 
     async fn handle_get_system_messages(&self) -> Vec<SystemMessage> {
-        self.network_env
+        self.network_tx
+            .borrow()
             .nym_vpn_network
             .system_messages
             .messages
@@ -919,7 +942,8 @@ impl NymVpnService {
     }
 
     async fn handle_get_network_compatibility(&self) -> Option<NetworkCompatibility> {
-        self.network_env
+        self.network_tx
+            .borrow()
             .system_configuration
             .as_ref()
             .and_then(|sc| sc.min_supported_app_versions.clone())
@@ -927,7 +951,8 @@ impl NymVpnService {
     }
 
     async fn handle_get_feature_flags(&self) -> Option<FeatureFlags> {
-        self.network_env
+        self.network_tx
+            .borrow()
             .feature_flags
             .clone()
             .map(FeatureFlags::from)
@@ -1121,7 +1146,8 @@ impl NymVpnService {
             .await
             .map_err(|_| AccountLinksError::FailedToParseAccountLinks)?;
 
-        self.network_env
+        self.network_tx
+            .borrow()
             .nym_vpn_network
             .account_management
             .clone()

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -460,6 +460,7 @@ impl NymVpnService {
             parameters.network_env,
             discovery_refresher_command_rx,
             discovery_refresher_event_tx,
+            connectivity_handle.clone(),
             services_shutdown_token.child_token(),
         )
         .await


### PR DESCRIPTION
## Ticket

JIRA-VPN-4335

## Description

- Fix network environment updates not being made available for grpc clients
- Ensure that default discovery when written to disk is always considered stale
- Make discovery refresh aware of network connectivity

### Testing procedure to verify that default environment is refreshed once network is available

- Start the daemon and switch to mainnet, then shutdown the daemon
- Edit `mainnet_discovery.json`, set `quic` to `false` under feature flags and run `cargo build` to rebuild the daemon
- Wipe discovery cache to simulate the first run: `sudo rm -rf /etc/nym/networks`
- Turn off wifi and start the daemon
- Daemon should write the default discovery to `/etc/nym/networks`
- Run `./target/debug/nym-vpnc internal get-feature-flags` to verify
- Turn on wifi and wait until you see the following log message in console: `nym_vpnd::service::vpn_service: Network environment updated`
- Run `./target/debug/nym-vpnc internal get-feature-flags` to verify that quic is true

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3805)
<!-- Reviewable:end -->
