### PR TITLE
Fix tunnel state output when connecting over bridge

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/connection_data.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/connection_data.rs
@@ -236,8 +236,26 @@ pub struct MixnetConnectionData {
 )]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "typescript-bindings", serde(rename_all = "camelCase"))]
+pub struct BridgeAddress {
+    /// Local forwarder listen address
+    pub listen_addr: SocketAddr,
+
+    /// Remote bridge address
+    pub remote_addr: SocketAddr,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "uniffi-bindings", derive(uniffi::Record))]
+#[cfg_attr(
+    feature = "typescript-bindings",
+    derive(TS),
+    ts(export),
+    ts(export_to = "bindings.ts")
+)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "typescript-bindings", serde(rename_all = "camelCase"))]
 pub struct WireguardConnectionData {
-    pub entry_bridge_addr: Option<SocketAddr>,
+    pub entry_bridge_addr: Option<BridgeAddress>,
     pub entry: WireguardNode,
     pub exit: WireguardNode,
 }

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
@@ -54,7 +54,7 @@ pub use account::{
     ticketbooks::AvailableTickets,
 };
 pub use connection_data::{
-    ConnectionData, EstablishConnectionData, EstablishConnectionState, GatewayId,
+    BridgeAddress, ConnectionData, EstablishConnectionData, EstablishConnectionState, GatewayId,
     MixnetConnectionData, NymAddress, TunnelConnectionData, WireguardConnectionData, WireguardNode,
 };
 pub use device::{NymVpnDevice, NymVpnDeviceStatus, NymVpnUsage};

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
@@ -108,15 +108,19 @@ impl std::fmt::Display for TunnelState {
                     Some(TunnelConnectionData::Wireguard(ref data)) => {
                         write!(
                             f,
-                            "Connecting {} to {} [{}] → {} [{}], {}, try #{}",
+                            "Connecting {} to {} [{}] → {} [{}]",
                             tunnel_type.short_name(),
                             data.entry.endpoint,
                             connection_data.entry_gateway.id,
                             data.exit.endpoint,
                             connection_data.exit_gateway.id,
-                            state,
-                            retry_attempt,
-                        )
+                        )?;
+
+                        if let Some(bridge_addr) = data.entry_bridge_addr {
+                            write!(f, " via bridge {bridge_addr}")?;
+                        }
+
+                        write!(f, ", {}, try #{}", state, retry_attempt)
                     }
                     None => {
                         write!(
@@ -159,7 +163,13 @@ impl std::fmt::Display for TunnelState {
                         connection_data.entry_gateway.id,
                         data.exit.endpoint,
                         connection_data.exit_gateway.id,
-                    )
+                    )?;
+
+                    if let Some(bridge_addr) = data.entry_bridge_addr {
+                        write!(f, " via bridge {bridge_addr}")
+                    } else {
+                        Ok(())
+                    }
                 }
             },
             Self::Disconnecting { after_disconnect } => match after_disconnect {

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
@@ -116,8 +116,8 @@ impl std::fmt::Display for TunnelState {
                             connection_data.exit_gateway.id,
                         )?;
 
-                        if let Some(bridge_addr) = data.entry_bridge_addr {
-                            write!(f, " via bridge {bridge_addr}")?;
+                        if let Some(bridge_addr) = data.entry_bridge_addr.as_ref() {
+                            write!(f, " via bridge {}", bridge_addr.remote_addr,)?;
                         }
 
                         write!(f, ", {}, try #{}", state, retry_attempt)
@@ -165,8 +165,8 @@ impl std::fmt::Display for TunnelState {
                         connection_data.exit_gateway.id,
                     )?;
 
-                    if let Some(bridge_addr) = data.entry_bridge_addr {
-                        write!(f, " via bridge {bridge_addr}")
+                    if let Some(bridge_addr) = data.entry_bridge_addr.as_ref() {
+                        write!(f, " via bridge {}", bridge_addr.remote_addr)
                     } else {
                         Ok(())
                     }

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
@@ -120,7 +120,7 @@ impl std::fmt::Display for TunnelState {
                             write!(f, " via bridge {}", bridge_addr.remote_addr,)?;
                         }
 
-                        write!(f, ", {}, try #{}", state, retry_attempt)
+                        write!(f, ", {state}, try #{retry_attempt}")
                     }
                     None => {
                         write!(

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
@@ -55,7 +55,7 @@ impl ConnectedState {
             if let TunnelConnectionData::Wireguard(ref wg) = connection_data.tunnel {
                 if shared_state.tunnel_settings.bridges_enabled() {
                     // this will be `Some` if we get to the connected state with bridges enabled.
-                    wg.entry_bridge_addr
+                    wg.entry_bridge_addr.as_ref().map(|addr| addr.remote_addr)
                 } else {
                     Some(wg.entry.endpoint)
                 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
@@ -132,7 +132,7 @@ impl ConnectedTunnel {
         entry_amnezia: bool,
     ) -> Result<TunnelHandle> {
         let mut wg_entry_config = WgNodeConfig::with_gateway_data(
-            self.connection_data.entry.clone(),
+            self.connection_data.effective_entry_gateway_data(),
             self.entry_wg_keypair.private_key(),
             AllowedIps::Specific(vec![
                 IpNetwork::from(self.connection_data.exit.endpoint.ip()),
@@ -256,7 +256,7 @@ impl ConnectedTunnel {
         entry_amnezia: bool,
     ) -> Result<TunnelHandle> {
         let mut wg_entry_config = WgNodeConfig::with_gateway_data(
-            self.connection_data.entry.clone(),
+            self.connection_data.effective_entry_gateway_data(),
             self.entry_wg_keypair.private_key(),
             AllowedIps::Specific(vec![
                 IpNetwork::from(self.connection_data.exit.endpoint.ip()),

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/mod.rs
@@ -6,6 +6,8 @@ use std::net::SocketAddr;
 use crate::tunnel_state_machine::TunnelMetadata;
 use nym_registration_common::GatewayData;
 
+use nym_vpn_lib_types::BridgeAddress;
+
 pub mod connected_tunnel;
 
 #[cfg(target_os = "ios")]
@@ -36,15 +38,6 @@ impl ConnectionData {
         gateway_data.endpoint = self.effective_entry_endpoint();
         gateway_data
     }
-}
-
-#[derive(Debug, Clone)]
-pub struct BridgeAddress {
-    /// Local listening endpoint used for forwarding traffic
-    pub listen_addr: SocketAddr,
-
-    /// Remote bridge endpoint
-    pub remote_address: SocketAddr,
 }
 
 pub enum MetadataEvent {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/mod.rs
@@ -16,9 +16,35 @@ pub mod two_hop_config;
 
 #[derive(Debug, Clone)]
 pub struct ConnectionData {
-    pub entry_bridge_addr: Option<SocketAddr>,
+    pub entry_bridge_addr: Option<BridgeAddress>,
     pub entry: GatewayData,
     pub exit: GatewayData,
+}
+
+impl ConnectionData {
+    /// Returns effective entry endpoint set to bridge listen endpoint when entry bridge address is available.
+    pub fn effective_entry_endpoint(&self) -> SocketAddr {
+        self.entry_bridge_addr
+            .as_ref()
+            .map(|addr| addr.listen_addr)
+            .unwrap_or(self.entry.endpoint)
+    }
+
+    /// Returns effective entry gateway data set to bridge listen endpoint when entry bridge address is available.
+    pub fn effective_entry_gateway_data(&self) -> GatewayData {
+        let mut gateway_data = self.entry.clone();
+        gateway_data.endpoint = self.effective_entry_endpoint();
+        gateway_data
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct BridgeAddress {
+    /// Local listening endpoint used for forwarding traffic
+    pub listen_addr: SocketAddr,
+
+    /// Remote bridge endpoint
+    pub remote_address: SocketAddr,
 }
 
 pub enum MetadataEvent {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/mod.rs
@@ -24,7 +24,7 @@ pub struct ConnectionData {
 }
 
 impl ConnectionData {
-    /// Returns effective entry endpoint set to bridge listen endpoint when entry bridge address is available.
+    /// Returns effective entry endpoint set to bridge listen endpoint when entry bridge address is available. Otherwise, returns the wireguard entry endpoint.
     pub fn effective_entry_endpoint(&self) -> SocketAddr {
         self.entry_bridge_addr
             .as_ref()
@@ -37,6 +37,14 @@ impl ConnectionData {
         let mut gateway_data = self.entry.clone();
         gateway_data.endpoint = self.effective_entry_endpoint();
         gateway_data
+    }
+
+    /// Returns effective *remote* entry endpoint set to bridge remote endpoint when entry bridge address is available. Otherwise, returns the wireguard entry endpoint.
+    pub fn effective_remote_entry_endpoint(&self) -> SocketAddr {
+        self.entry_bridge_addr
+            .as_ref()
+            .map(|addr| addr.remote_addr)
+            .unwrap_or(self.entry.endpoint)
     }
 }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -59,9 +59,9 @@ use super::{
 };
 use nym_common::trace_err_chain;
 use nym_vpn_lib_types::{
-    AccountControllerError, ConnectionData, ErrorStateReason, EstablishConnectionData, GatewayId,
-    MixnetConnectionData, NymAddress, TunnelConnectionData, TunnelType, WireguardConnectionData,
-    WireguardNode,
+    AccountControllerError, BridgeAddress, ConnectionData, ErrorStateReason,
+    EstablishConnectionData, GatewayId, MixnetConnectionData, NymAddress, TunnelConnectionData,
+    TunnelType, WireguardConnectionData, WireguardNode,
 };
 use nym_vpn_store::keys::wireguard::WireguardKeysDb;
 
@@ -81,8 +81,8 @@ use crate::{
             mixnet,
             transports::{self, TransportError},
             wireguard::{
-                self, BridgeAddress, ConnectionData as WgConnectionData, MetadataEvent,
-                MetadataReceiver, connected_tunnel::ConnectedTunnel,
+                self, ConnectionData as WgConnectionData, MetadataEvent, MetadataReceiver,
+                connected_tunnel::ConnectedTunnel,
             },
         },
     },
@@ -1101,7 +1101,7 @@ impl TunnelMonitor {
             self.shutdown_token.child_token(),
         )
         .await?;
-        let remote_address = bridge_conn.endpoint;
+        let remote_addr = bridge_conn.endpoint;
         let (listen_addr, join_handle) = transports::UdpForwarder::launch(
             bridge_conn,
             None,
@@ -1114,7 +1114,7 @@ impl TunnelMonitor {
 
         let bridge_addr = BridgeAddress {
             listen_addr,
-            remote_address,
+            remote_addr,
         };
 
         Ok((bridge_addr, join_handle))
@@ -1145,10 +1145,10 @@ impl TunnelMonitor {
             conn_data
                 .entry_bridge_addr
                 .as_ref()
+                .map(|bridge_addr| bridge_addr.remote_addr)
                 .ok_or(TransportError::other(
                     "missing bridge address after connect", // this should not be possible
                 ))?
-                .remote_address
         } else {
             conn_data.entry.endpoint
         };
@@ -1163,11 +1163,7 @@ impl TunnelMonitor {
         self.set_routes(routing_config, self.enable_ipv6()).await?;
 
         let tunnel_conn_data = TunnelConnectionData::Wireguard(WireguardConnectionData {
-            // todo: provide QUIC endpoint too
-            entry_bridge_addr: conn_data
-                .entry_bridge_addr
-                .as_ref()
-                .map(|addr| addr.listen_addr),
+            entry_bridge_addr: conn_data.entry_bridge_addr.clone(),
             entry: WireguardNode::from(conn_data.entry.clone()),
             exit: WireguardNode::from(conn_data.exit.clone()),
         });
@@ -1249,9 +1245,13 @@ impl TunnelMonitor {
 
         #[cfg(not(target_os = "linux"))]
         let entry_endpoint = if use_bridges {
-            conn_data.entry_bridge_addr.ok_or(TransportError::other(
-                "missing bridge address after connect", // this should not be possible
-            ))?
+            conn_data
+                .entry_bridge_addr
+                .as_ref()
+                .map(|bridge_addr| bridge_addr.remote_addr)
+                .ok_or(TransportError::other(
+                    "missing bridge address after connect", // this should not be possible
+                ))?
         } else {
             conn_data.entry.endpoint
         };
@@ -1383,10 +1383,10 @@ impl TunnelMonitor {
             conn_data
                 .entry_bridge_addr
                 .as_ref()
+                .map(|bridge_addr| bridge_addr.remote_addr)
                 .ok_or(TransportError::other(
                     "missing bridge address after connect", // this should not be possible
                 ))?
-                .remote_address
         } else {
             conn_data.entry.endpoint
         };
@@ -1407,11 +1407,7 @@ impl TunnelMonitor {
         self.set_routes(routing_config, self.enable_ipv6()).await?;
 
         let tunnel_conn_data = TunnelConnectionData::Wireguard(WireguardConnectionData {
-            // todo: provide QUIC endpoint too
-            entry_bridge_addr: conn_data
-                .entry_bridge_addr
-                .as_ref()
-                .map(|addr| addr.listen_addr),
+            entry_bridge_addr: conn_data.entry_bridge_addr.clone(),
             entry: WireguardNode::from(conn_data.entry.clone()),
             exit: WireguardNode::from(conn_data.exit.clone()),
         });

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -81,8 +81,8 @@ use crate::{
             mixnet,
             transports::{self, TransportError},
             wireguard::{
-                self, ConnectionData as WgConnectionData, MetadataEvent, MetadataReceiver,
-                connected_tunnel::ConnectedTunnel,
+                self, BridgeAddress, ConnectionData as WgConnectionData, MetadataEvent,
+                MetadataReceiver, connected_tunnel::ConnectedTunnel,
             },
         },
     },
@@ -650,22 +650,19 @@ impl TunnelMonitor {
                     )
                     .await?;
 
-                let (transport_fwd_handle, bridge_close_tx) = if self
-                    .tunnel_parameters
-                    .tunnel_settings
-                    .bridges_enabled()
-                {
-                    let transport_fwd_handle = self
-                        .start_bridges(&selected_gateways, &mut connection_data, bridge_close_tx)
+                let bridge_close_tx = if self.tunnel_parameters.tunnel_settings.bridges_enabled() {
+                    let (entry_bridge_addr, transport_fwd_handle) = self
+                        .start_bridges(&selected_gateways, bridge_close_tx)
                         .await?;
 
-                    (Some(transport_fwd_handle), None)
+                    wg_tunnel_runtime.transport_fwd_handle = Some(transport_fwd_handle);
+                    connection_data.entry_bridge_addr = Some(entry_bridge_addr);
+
+                    None
                 } else {
                     // Return bridge_close_tx back to avoid it being dropped
-                    (None, Some(bridge_close_tx))
+                    Some(bridge_close_tx)
                 };
-
-                wg_tunnel_runtime.transport_fwd_handle = transport_fwd_handle;
 
                 let connected_tunnel = ConnectedTunnel::new(
                     selected_gateways.entry_keypair().clone(),
@@ -1085,9 +1082,8 @@ impl TunnelMonitor {
     async fn start_bridges(
         &self,
         selected_gateways: &SelectedGateways,
-        connection_data: &mut WgConnectionData,
         bridge_close_tx: mpsc::UnboundedSender<()>,
-    ) -> Result<JoinHandle<()>> {
+    ) -> Result<(BridgeAddress, JoinHandle<()>)> {
         let entry_bridge_params = selected_gateways
             .entry_gateway()
             .get_bridge_params()
@@ -1105,17 +1101,23 @@ impl TunnelMonitor {
             self.shutdown_token.child_token(),
         )
         .await?;
-        connection_data.entry_bridge_addr = Some(bridge_conn.endpoint);
-        let (local_fwd_listen_addr, fwd_handle) = transports::UdpForwarder::launch(
+        let remote_address = bridge_conn.endpoint;
+        let (listen_addr, join_handle) = transports::UdpForwarder::launch(
             bridge_conn,
             None,
             bridge_close_tx,
             self.shutdown_token.child_token(),
         )
         .await?;
-        tracing::info!("quic transport connected, udp forwarder open on {local_fwd_listen_addr:?}");
-        connection_data.entry.endpoint = local_fwd_listen_addr;
-        Ok(fwd_handle)
+
+        tracing::info!("quic transport connected, udp forwarder open on {listen_addr}");
+
+        let bridge_addr = BridgeAddress {
+            listen_addr,
+            remote_address,
+        };
+
+        Ok((bridge_addr, join_handle))
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]
@@ -1140,9 +1142,13 @@ impl TunnelMonitor {
 
         #[cfg(not(target_os = "linux"))]
         let entry_endpoint = if use_bridges {
-            conn_data.entry_bridge_addr.ok_or(TransportError::other(
-                "missing bridge address after connect", // this should not be possible
-            ))?
+            conn_data
+                .entry_bridge_addr
+                .as_ref()
+                .ok_or(TransportError::other(
+                    "missing bridge address after connect", // this should not be possible
+                ))?
+                .remote_address
         } else {
             conn_data.entry.endpoint
         };
@@ -1157,7 +1163,11 @@ impl TunnelMonitor {
         self.set_routes(routing_config, self.enable_ipv6()).await?;
 
         let tunnel_conn_data = TunnelConnectionData::Wireguard(WireguardConnectionData {
-            entry_bridge_addr: conn_data.entry_bridge_addr,
+            // todo: provide QUIC endpoint too
+            entry_bridge_addr: conn_data
+                .entry_bridge_addr
+                .as_ref()
+                .map(|addr| addr.listen_addr),
             entry: WireguardNode::from(conn_data.entry.clone()),
             exit: WireguardNode::from(conn_data.exit.clone()),
         });
@@ -1370,9 +1380,13 @@ impl TunnelMonitor {
 
         #[cfg(not(target_os = "linux"))]
         let entry_endpoint = if use_bridges {
-            conn_data.entry_bridge_addr.ok_or(TransportError::other(
-                "missing bridge address after connect", // this should not be possible
-            ))?
+            conn_data
+                .entry_bridge_addr
+                .as_ref()
+                .ok_or(TransportError::other(
+                    "missing bridge address after connect", // this should not be possible
+                ))?
+                .remote_address
         } else {
             conn_data.entry.endpoint
         };
@@ -1393,7 +1407,11 @@ impl TunnelMonitor {
         self.set_routes(routing_config, self.enable_ipv6()).await?;
 
         let tunnel_conn_data = TunnelConnectionData::Wireguard(WireguardConnectionData {
-            entry_bridge_addr: conn_data.entry_bridge_addr,
+            // todo: provide QUIC endpoint too
+            entry_bridge_addr: conn_data
+                .entry_bridge_addr
+                .as_ref()
+                .map(|addr| addr.listen_addr),
             entry: WireguardNode::from(conn_data.entry.clone()),
             exit: WireguardNode::from(conn_data.exit.clone()),
         });
@@ -1440,9 +1458,11 @@ impl TunnelMonitor {
         let entry_gateway_address = if use_bridges {
             conn_data
                 .entry_bridge_addr
+                .as_ref()
                 .ok_or(TransportError::other(
                     "missing bridge address after connect", // this should not be possible
                 ))?
+                .remote_address
                 .ip()
         } else {
             conn_data.entry.endpoint.ip()

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -1141,17 +1141,7 @@ impl TunnelMonitor {
         tracing::info!("Created exit tun device: {}", exit_tun_name);
 
         #[cfg(not(target_os = "linux"))]
-        let entry_endpoint = if use_bridges {
-            conn_data
-                .entry_bridge_addr
-                .as_ref()
-                .map(|bridge_addr| bridge_addr.remote_addr)
-                .ok_or(TransportError::other(
-                    "missing bridge address after connect", // this should not be possible
-                ))?
-        } else {
-            conn_data.entry.endpoint
-        };
+        let entry_endpoint = conn_data.effective_remote_entry_endpoint();
 
         let routing_config = RoutingConfig::WireguardNetstack {
             exit_tun_name: exit_tun_name.clone(),
@@ -1244,17 +1234,7 @@ impl TunnelMonitor {
         });
 
         #[cfg(not(target_os = "linux"))]
-        let entry_endpoint = if use_bridges {
-            conn_data
-                .entry_bridge_addr
-                .as_ref()
-                .map(|bridge_addr| bridge_addr.remote_addr)
-                .ok_or(TransportError::other(
-                    "missing bridge address after connect", // this should not be possible
-                ))?
-        } else {
-            conn_data.entry.endpoint
-        };
+        let entry_endpoint = conn_data.effective_remote_entry_endpoint();
 
         let dns_config = self.tunnel_parameters.tunnel_settings.resolved_dns_config();
         let tunnel_options = TunnelOptions::Netstack(NetstackTunnelOptions {
@@ -1379,17 +1359,7 @@ impl TunnelMonitor {
         };
 
         #[cfg(not(target_os = "linux"))]
-        let entry_endpoint = if use_bridges {
-            conn_data
-                .entry_bridge_addr
-                .as_ref()
-                .map(|bridge_addr| bridge_addr.remote_addr)
-                .ok_or(TransportError::other(
-                    "missing bridge address after connect", // this should not be possible
-                ))?
-        } else {
-            conn_data.entry.endpoint
-        };
+        let entry_endpoint = conn_data.effective_remote_entry_endpoint();
 
         let routing_config = RoutingConfig::Wireguard {
             entry_tun_name: entry_tunnel_metadata.interface.clone(),
@@ -1451,18 +1421,7 @@ impl TunnelMonitor {
         let exit_tun_mtu = connected_tunnel.exit_mtu();
 
         let exit_gateway_address = conn_data.exit.endpoint.ip();
-        let entry_gateway_address = if use_bridges {
-            conn_data
-                .entry_bridge_addr
-                .as_ref()
-                .ok_or(TransportError::other(
-                    "missing bridge address after connect", // this should not be possible
-                ))?
-                .remote_address
-                .ip()
-        } else {
-            conn_data.entry.endpoint.ip()
-        };
+        let entry_gateway_address = conn_data.effective_remote_entry_endpoint();
 
         let entry_adapter_config = WintunAdapterConfig {
             interface_ipv4: conn_data.entry.private_ipv4,
@@ -1620,16 +1579,7 @@ impl TunnelMonitor {
             )));
         }
 
-        let entry_endpoint = if use_bridges {
-            conn_data
-                .entry_bridge_addr
-                .ok_or(TransportError::other(
-                    "missing bridge address after connect", // this should not be possible
-                ))?
-                .ip()
-        } else {
-            conn_data.entry.endpoint.ip()
-        };
+        let entry_endpoint = conn_data.effective_remote_entry_endpoint().ip();
 
         let packet_tunnel_settings = crate::tunnel_provider::TunnelSettings {
             dns_servers: self

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -1228,7 +1228,7 @@ impl TunnelMonitor {
         };
 
         let tunnel_conn_data = TunnelConnectionData::Wireguard(WireguardConnectionData {
-            entry_bridge_addr: conn_data.entry_bridge_addr,
+            entry_bridge_addr: conn_data.entry_bridge_addr.clone(),
             entry: WireguardNode::from(conn_data.entry.clone()),
             exit: WireguardNode::from(conn_data.exit.clone()),
         });
@@ -1421,7 +1421,7 @@ impl TunnelMonitor {
         let exit_tun_mtu = connected_tunnel.exit_mtu();
 
         let exit_gateway_address = conn_data.exit.endpoint.ip();
-        let entry_gateway_address = conn_data.effective_remote_entry_endpoint();
+        let entry_gateway_address = conn_data.effective_remote_entry_endpoint().ip();
 
         let entry_adapter_config = WintunAdapterConfig {
             interface_ipv4: conn_data.entry.private_ipv4,
@@ -1459,7 +1459,7 @@ impl TunnelMonitor {
         };
 
         let tunnel_conn_data = TunnelConnectionData::Wireguard(WireguardConnectionData {
-            entry_bridge_addr: conn_data.entry_bridge_addr,
+            entry_bridge_addr: conn_data.entry_bridge_addr.clone(),
             entry: WireguardNode::from(conn_data.entry.clone()),
             exit: WireguardNode::from(conn_data.exit.clone()),
         });
@@ -1610,7 +1610,7 @@ impl TunnelMonitor {
         tracing::info!("Created tun device: {}", tunnel_metadata.interface);
 
         let tunnel_conn_data = TunnelConnectionData::Wireguard(WireguardConnectionData {
-            entry_bridge_addr: conn_data.entry_bridge_addr,
+            entry_bridge_addr: conn_data.entry_bridge_addr.clone(),
             entry: WireguardNode::from(conn_data.entry.clone()),
             exit: WireguardNode::from(conn_data.exit.clone()),
         });

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -400,10 +400,15 @@ message MixnetConnectionData {
   string exit_ip = 6;
 }
 
+message BridgeAddress {
+  SocketAddr listen_addr = 1;
+  SocketAddr remote_addr = 2;
+}
+
 message WireguardConnectionData {
   WireguardNode entry = 1;
   WireguardNode exit = 2;
-  optional string entry_bridge_addr = 3;
+  optional BridgeAddress entry_bridge_addr = 3;
 }
 
 message WireguardNode {

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/tunnel_state.rs
@@ -7,9 +7,9 @@ use std::{
 };
 
 use nym_vpn_lib_types::{
-    ActionAfterDisconnect, ConnectionData, ErrorStateReason, EstablishConnectionData,
-    EstablishConnectionState, GatewayId, MixnetConnectionData, NymAddress, TunnelConnectionData,
-    TunnelState, TunnelType, WireguardConnectionData, WireguardNode,
+    ActionAfterDisconnect, BridgeAddress, ConnectionData, ErrorStateReason,
+    EstablishConnectionData, EstablishConnectionState, GatewayId, MixnetConnectionData, NymAddress,
+    TunnelConnectionData, TunnelState, TunnelType, WireguardConnectionData, WireguardNode,
 };
 
 use crate::{conversions::ConversionError, proto};
@@ -465,8 +465,35 @@ impl TryFrom<proto::WireguardConnectionData> for WireguardConnectionData {
             )?,
             entry_bridge_addr: value
                 .entry_bridge_addr
-                .and_then(|str| SocketAddr::from_str(&str).ok()),
+                .map(BridgeAddress::try_from)
+                .transpose()?,
         })
+    }
+}
+
+impl TryFrom<proto::BridgeAddress> for BridgeAddress {
+    type Error = ConversionError;
+
+    fn try_from(value: proto::BridgeAddress) -> Result<Self, Self::Error> {
+        let listen_addr = value
+            .listen_addr
+            .ok_or(ConversionError::NoValueSet("BridgeAddress.local_addr"))?;
+        let remote_addr = value
+            .remote_addr
+            .ok_or(ConversionError::NoValueSet("BridgeAddress.remote_addr"))?;
+        Ok(Self {
+            listen_addr: SocketAddr::try_from(listen_addr)?,
+            remote_addr: SocketAddr::try_from(remote_addr)?,
+        })
+    }
+}
+
+impl From<BridgeAddress> for proto::BridgeAddress {
+    fn from(value: BridgeAddress) -> Self {
+        Self {
+            listen_addr: Some(proto::SocketAddr::from(value.listen_addr)),
+            remote_addr: Some(proto::SocketAddr::from(value.remote_addr)),
+        }
     }
 }
 
@@ -475,7 +502,7 @@ impl From<WireguardConnectionData> for proto::WireguardConnectionData {
         proto::WireguardConnectionData {
             entry: Some(proto::WireguardNode::from(value.entry)),
             exit: Some(proto::WireguardNode::from(value.exit)),
-            entry_bridge_addr: value.entry_bridge_addr.map(|s| s.to_string()),
+            entry_bridge_addr: value.entry_bridge_addr.map(proto::BridgeAddress::from),
         }
     }
 }


### PR DESCRIPTION
## Ticket

JIRA-VPN-4339

## Description

- Pass both local listen addr and remote QUIC endpoint via tunnel state
- Print bridge endpoint in tunnel state output
- Add helpers to rewire wireguard configuration in order to preserve the original entry, exit
- Add a few helpers for easier access of QUIC endpoint or local forwarder endpoint with fallback to wg entry gateway endpoint

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3811)
<!-- Reviewable:end -->
