### PR TITLE
Fix database cleanup when forgetting account

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix network environment updates not being made available for grpc clients (https://github.com/nymtech/nym-vpn-client/pull/3805)
 - Ensure that default discovery when written to disk is always considered stale (https://github.com/nymtech/nym-vpn-client/pull/3805)
 - Make discovery refresh aware of network connectivity (https://github.com/nymtech/nym-vpn-client/pull/3805)
+- Fix database cleanup when forgetting account (https://github.com/nymtech/nym-vpn-client/pull/3825)
 
 ## [1.17.0] - 2025-10-17
 

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/handler.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/handler.rs
@@ -9,7 +9,7 @@ use nym_vpn_api_client::{
     types::{DeviceStatus, Platform, VpnAccount},
 };
 use nym_vpn_lib_types::{AccountCommandError, RegisterAccountResponse, VpnApiError};
-use nym_vpn_store::account::StorableAccount;
+use nym_vpn_store::{account::StorableAccount, keys::wireguard::WireguardKeyStore};
 use tracing::info;
 
 // The onus of making sure the conditions are right to call these handlers is on the caller
@@ -137,11 +137,20 @@ pub(crate) async fn handle_forget_account<C: ConnectivityMonitor>(
             AccountCommandError::Storage(source.to_string())
         })?;
 
+    shared_state
+        .wireguard_keys_storage
+        .clear_keys()
+        .await
+        .map_err(|source| {
+            tracing::error!("Failed to clear wireguard keys storage: {source:?}");
+            AccountCommandError::Storage(source.to_string())
+        })?;
+
     // Purge all files in the data directory that we are not explicitly deleting through it's
     // owner. Ideally we should strive for this to be removed.
     // If this fails, we still need to continue with the remaining steps
     let remove_files_result =
-        crate::storage::remove_files_for_account(&shared_state.config.data_dir)
+        crate::storage::remove_files_for_account(&shared_state.config.data_dir, false)
             .await
             .inspect_err(|err| {
                 tracing::error!("Failed to remove files for account: {err:?}");

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
@@ -5,7 +5,7 @@ use nym_offline_monitor::ConnectivityMonitor;
 
 use nym_vpn_api_client::VpnApiClient;
 use nym_vpn_lib_types::{AccountControllerEvent, AccountControllerState};
-use nym_vpn_store::VpnStorage;
+use nym_vpn_store::{VpnStorage, keys::wireguard::WireguardKeysDb};
 use tokio::sync::{
     mpsc::{self, UnboundedReceiver, UnboundedSender},
     watch,
@@ -97,11 +97,14 @@ where
         let vpn_api_account = account_storage.load_vpn_account().await?;
         let device_keys = account_storage.load_device_keys().await?;
 
+        let wireguard_keys_storage = WireguardKeysDb::init(Some(config.data_dir.clone())).await?;
+
         // Shared_state
         let shared_state = SharedAccountState::new(
             connectivity_handle,
             config,
             credential_storage,
+            wireguard_keys_storage,
             nym_vpn_api_client,
             nyxd_client,
             vpn_api_account,
@@ -145,6 +148,11 @@ where
     /// Get the channel used to keep track of the controller state.
     pub fn get_state_receiver(&self) -> AccountStateReceiver {
         AccountStateReceiver::new(self.state_channel.1.clone())
+    }
+
+    /// Get the wireguard keys database storage
+    pub fn get_wireguard_keys_storage(&self) -> WireguardKeysDb {
+        self.shared_state.wireguard_keys_storage.clone()
     }
 
     fn print_info(&self) {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/error.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/error.rs
@@ -23,6 +23,9 @@ pub enum Error {
     CredentialStorage(#[from] nym_credential_storage::error::StorageError),
 
     #[error(transparent)]
+    WireguardKeysStorage(#[from] nym_vpn_store::keys::wireguard::KeysDbError),
+
+    #[error(transparent)]
     PendingCredentialRequestsStorage(#[from] crate::storage::PendingCredentialRequestsStorageError),
 
     #[error("failed to setup credential storage")]

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/shared_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/shared_state.rs
@@ -7,6 +7,7 @@ use nym_vpn_api_client::{
     types::{Device, VpnAccount},
 };
 
+use nym_vpn_store::keys::wireguard::WireguardKeysDb;
 use tokio::sync::mpsc;
 
 use crate::{
@@ -27,6 +28,9 @@ pub(crate) struct SharedAccountState<C: ConnectivityMonitor> {
     // This is bound to live in the bandwidth controller in a near future
     /// Zk-nym storage
     pub(crate) credential_storage: VpnCredentialStorage,
+
+    /// Wireguard keys database storage
+    pub(crate) wireguard_keys_storage: WireguardKeysDb,
 
     /// VPN API client
     pub(crate) vpn_api_client: VpnApiClient,
@@ -53,6 +57,7 @@ impl<C: ConnectivityMonitor> SharedAccountState<C> {
         connectivity_handle: C,
         config: AccountControllerConfig,
         credential_storage: VpnCredentialStorage,
+        wireguard_keys_storage: WireguardKeysDb,
         vpn_api_client: VpnApiClient,
         nyxd_client: NyxdClient,
         vpn_api_account: Option<VpnAccount>,
@@ -63,6 +68,7 @@ impl<C: ConnectivityMonitor> SharedAccountState<C> {
             connectivity_handle,
             config,
             credential_storage,
+            wireguard_keys_storage,
             vpn_api_client,
             nyxd_client,
             vpn_api_account,

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/cleanup.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/cleanup.rs
@@ -21,19 +21,21 @@ use crate::Error;
 // TODO: implement functionality where the owning code of these files delete them instead. To
 // protect us against the names drifting out of sync.
 
-pub async fn remove_files_for_account(data_dir: &Path) -> Result<(), Error> {
+pub async fn remove_files_for_account(
+    data_dir: &Path,
+    remove_wireguard_keys_db: bool,
+) -> Result<(), Error> {
     // Files specific to the VPN client
-    let device_key = [
+    let mut vpn_paths = vec![
         DEFAULT_PRIVATE_DEVICE_KEY_FILENAME,
         DEFAULT_PUBLIC_DEVICE_KEY_FILENAME,
     ];
 
-    let wireguard_keys = [DB_NAME];
+    if remove_wireguard_keys_db {
+        vpn_paths.push(DB_NAME);
+    }
 
-    let vpn_paths = device_key
-        .iter()
-        .chain(wireguard_keys.iter())
-        .map(|file| data_dir.join(file));
+    let vpn_paths = vpn_paths.iter().map(|file| data_dir.join(file));
 
     // Files specific to the mixnet client
     let storage_paths =

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/account.rs
@@ -10,7 +10,10 @@ use nym_vpn_api_client::types::{Platform, VpnAccount};
 use nym_vpn_lib::storage::VpnClientOnDiskStorage;
 use nym_vpn_lib_types::{AccountControllerState, RegisterAccountResponse};
 use nym_vpn_network_config::Network;
-use nym_vpn_store::{account::Mnemonic, keys::device::DeviceKeyStore};
+use nym_vpn_store::{
+    account::Mnemonic,
+    keys::{device::DeviceKeyStore, wireguard::WireguardKeysDb},
+};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
@@ -99,11 +102,13 @@ async fn start_account_controller(
 
     let command_sender = account_controller.get_command_sender();
     let state_receiver = account_controller.get_state_receiver();
+    let wireguard_key_db = account_controller.get_wireguard_keys_storage();
     let account_controller_handle = tokio::spawn(account_controller.run());
 
     Ok(AccountControllerHandle {
         command_sender,
         state_receiver,
+        wireguard_key_db,
         handle: account_controller_handle,
         shutdown_token,
     })
@@ -112,6 +117,7 @@ async fn start_account_controller(
 pub(super) struct AccountControllerHandle {
     command_sender: AccountCommandSender,
     state_receiver: AccountStateReceiver,
+    wireguard_key_db: WireguardKeysDb,
     handle: JoinHandle<()>,
     shutdown_token: CancellationToken,
 }
@@ -153,6 +159,16 @@ pub(super) async fn get_command_sender() -> Result<AccountCommandSender, VpnErro
 pub(super) async fn get_state_receiver() -> Result<AccountStateReceiver, VpnError> {
     if let Some(guard) = &*ACCOUNT_CONTROLLER_HANDLE.lock().await {
         Ok(guard.state_receiver.clone())
+    } else {
+        Err(VpnError::InvalidStateError {
+            details: "Account controller is not running.".to_owned(),
+        })
+    }
+}
+
+pub(super) async fn get_wireguard_key_db() -> Result<WireguardKeysDb, VpnError> {
+    if let Some(guard) = &*ACCOUNT_CONTROLLER_HANDLE.lock().await {
+        Ok(guard.wireguard_key_db.clone())
     } else {
         Err(VpnError::InvalidStateError {
             details: "Account controller is not running.".to_owned(),
@@ -478,7 +494,7 @@ pub(crate) mod raw {
         remove_credential_storage_raw(&path_buf).await?;
 
         // Then remove the rest of the files, that we own indirectly
-        nym_vpn_account_controller::remove_files_for_account(&path_buf)
+        nym_vpn_account_controller::remove_files_for_account(&path_buf, true)
             .await
             .map_err(|err| VpnError::Storage {
                 details: err.to_string(),

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/lib.rs
@@ -72,6 +72,7 @@ use std::{
 use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
 use lazy_static::lazy_static;
 use nym_platform_metadata::SysInfo;
+use nym_vpn_store::keys::wireguard::WireguardKeysDb;
 use sentry::ClientInitGuard;
 use tokio::{runtime::Runtime, sync::Mutex};
 
@@ -105,6 +106,7 @@ lazy_static! {
     static ref OFFLINE_MONITOR_HANDLE: Mutex<Option<OfflineMonitorHandle>> = Mutex::new(None);
     static ref STATE_MACHINE_HANDLE: Mutex<Option<StateMachineHandle>> = Mutex::new(None);
     static ref ACCOUNT_CONTROLLER_HANDLE: Mutex<Option<AccountControllerHandle>> = Mutex::new(None);
+    static ref WIREGUARD_KEYS_DB: Mutex<Option<WireguardKeysDb>> = Mutex::new(None);
     static ref STATISTICS_CONTROLLER_HANDLE: Mutex<Option<StatisticsControllerHandle>> =
         Mutex::new(None);
     static ref NETWORK_ENVIRONMENT: Mutex<Option<nym_vpn_network_config::Network>> =
@@ -447,6 +449,7 @@ async fn start_vpn_inner(config: Box<VPNConfig>) -> Result<(), VpnError> {
 
     let account_controller_tx = account::get_command_sender().await?;
     let account_controller_state = account::get_state_receiver().await?;
+    let wireguard_key_db = account::get_wireguard_key_db().await?;
 
     let statistics_event_sender = stats::get_events_sender().await?;
 
@@ -456,6 +459,7 @@ async fn start_vpn_inner(config: Box<VPNConfig>) -> Result<(), VpnError> {
         Box::new(network_env),
         account_controller_tx,
         account_controller_state,
+        wireguard_key_db,
         statistics_event_sender,
     )
     .await

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/state_machine.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/state_machine.rs
@@ -17,6 +17,7 @@ use nym_vpn_lib::{
 };
 use nym_vpn_lib_types::TunnelType;
 use nym_vpn_network_config::{DiscoveryRefresher, DiscoveryRefresherEvent, Network};
+use nym_vpn_store::keys::wireguard::WireguardKeysDb;
 use tokio::{
     sync::{mpsc, watch},
     task::JoinHandle,
@@ -32,6 +33,7 @@ pub(super) async fn init_state_machine(
     network_env: Box<Network>,
     account_controller_tx: AccountCommandSender,
     account_controller_state: AccountStateReceiver,
+    wireguard_key_db: WireguardKeysDb,
     statistics_event_sender: StatisticsSender,
 ) -> Result<(), VpnError> {
     let mut guard = STATE_MACHINE_HANDLE.lock().await;
@@ -45,6 +47,7 @@ pub(super) async fn init_state_machine(
             network_env,
             account_controller_tx,
             account_controller_state,
+            wireguard_key_db,
             statistics_event_sender,
         )
         .await?;
@@ -63,6 +66,7 @@ pub(super) async fn start_state_machine(
     network_env: Box<Network>,
     account_controller_tx: AccountCommandSender,
     account_controller_state: AccountStateReceiver,
+    wireguard_key_db: WireguardKeysDb,
     statistics_event_sender: StatisticsSender,
 ) -> Result<StateMachineHandle, VpnError> {
     let tunnel_type = if config.enable_two_hop {
@@ -210,6 +214,7 @@ pub(super) async fn start_state_machine(
         topology_provider,
         connectivity_handle,
         discovery_refresher_command_tx,
+        wireguard_key_db,
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         route_handler,
         #[cfg(target_os = "ios")]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -498,6 +498,7 @@ impl TunnelStateMachine {
         topology_provider: VpnTopologyProvider,
         connectivity_handle: ConnectivityHandle,
         discovery_refresher_command_tx: mpsc::UnboundedSender<DiscoveryRefresherCommand>,
+        wg_keys_db: WireguardKeysDb,
         #[cfg(not(any(target_os = "android", target_os = "ios")))] route_handler: RouteHandler,
         #[cfg(target_os = "ios")] tun_provider: Arc<dyn OSTunProvider>,
         #[cfg(target_os = "android")] tun_provider: Arc<dyn AndroidTunProvider>,
@@ -519,10 +520,6 @@ impl TunnelStateMachine {
             dns_handler_shutdown_token.child_token(),
         )
         .map_err(Error::CreateDnsHandler)?;
-
-        let wg_keys_db = WireguardKeysDb::init(nym_config.data_path.clone())
-            .await
-            .map_err(Error::WireguardKeyDb)?;
 
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         let firewall = Firewall::from_args(FirewallArguments {

--- a/nym-vpn-core/crates/nym-vpn-store/src/keys/wireguard/key_store.rs
+++ b/nym-vpn-core/crates/nym-vpn-store/src/keys/wireguard/key_store.rs
@@ -13,4 +13,6 @@ pub trait WireguardKeyStore {
         &self,
         gateway_id: &str,
     ) -> Result<WireguardKeys, Self::StorageError>;
+
+    async fn clear_keys(&self) -> Result<(), Self::StorageError>;
 }

--- a/nym-vpn-core/crates/nym-vpn-store/src/keys/wireguard/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-store/src/keys/wireguard/mod.rs
@@ -63,4 +63,14 @@ impl WireguardKeyStore for WireguardKeysDb {
         };
         Ok(ret)
     }
+
+    async fn clear_keys(&self) -> Result<(), Self::StorageError> {
+        match self {
+            WireguardKeysDb::OnDisk(on_disk_keys) => on_disk_keys.clear_keys().await?,
+            WireguardKeysDb::Ephemeral(in_mem_ephemeral_keys) => {
+                in_mem_ephemeral_keys.clear_keys().await?
+            }
+        };
+        Ok(())
+    }
 }

--- a/nym-vpn-core/crates/nym-vpn-store/src/keys/wireguard/persistence/ephemeral.rs
+++ b/nym-vpn-core/crates/nym-vpn-store/src/keys/wireguard/persistence/ephemeral.rs
@@ -34,4 +34,9 @@ impl WireguardKeyStore for InMemEphemeralKeys {
             Ok(keys)
         }
     }
+
+    async fn clear_keys(&self) -> Result<(), Self::StorageError> {
+        self.keys.lock().await.clear();
+        Ok(())
+    }
 }

--- a/nym-vpn-core/crates/nym-vpn-store/src/keys/wireguard/persistence/on_disk.rs
+++ b/nym-vpn-core/crates/nym-vpn-store/src/keys/wireguard/persistence/on_disk.rs
@@ -67,6 +67,11 @@ impl WireguardKeyStore for OnDiskKeys {
         };
         Ok(keys)
     }
+
+    async fn clear_keys(&self) -> Result<(), Self::StorageError> {
+        self.delete_keys().await?;
+        Ok(())
+    }
 }
 
 // all SQL goes here
@@ -128,6 +133,17 @@ impl OnDiskKeys {
             keys.gateway_id_bs58,
             keys.entry_private_key_bs58,
             keys.exit_private_key_bs58,
+        )
+        .execute(&self.connection_pool)
+        .await?;
+        Ok(())
+    }
+
+    pub(crate) async fn delete_keys(&self) -> Result<(), sqlx::Error> {
+        sqlx::query!(
+            r#"
+                DELETE FROM wireguard_gateway_keys;
+            "#,
         )
         .execute(&self.connection_pool)
         .await?;

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -361,6 +361,7 @@ impl NymVpnService {
         // These are used to interact with the account controller
         let account_command_tx = account_controller.get_command_sender();
         let account_state_rx = account_controller.get_state_receiver();
+        let wireguard_keys_db = account_controller.get_wireguard_keys_storage();
         let account_controller_handle = tokio::task::spawn(account_controller.run());
 
         // Statistics collection setup
@@ -484,6 +485,7 @@ impl NymVpnService {
             topology_provider,
             connectivity_handle,
             discovery_refresher_command_tx,
+            wireguard_keys_db,
             #[cfg(not(any(target_os = "android", target_os = "ios")))]
             route_handler,
             state_machine_shutdown_token.child_token(),


### PR DESCRIPTION
## Ticket

JIRA-VPN-4338

## Description

Do cleanup on forget account command by removing all the entries in the database and keeping the SQL connection alive in the Account Controller.
For the platforms that don't keep the account controller running (iOS), keep the old way of deleting the database file, since the connection initialization is done in the state machine, and iOS also restarts the state machine with each VPN connection, so the database connection is also restarted.


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3825)
<!-- Reviewable:end -->
