### PR TITLE
[WIP] - Android QUIC (validated locally)

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/transports/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/transports/mod.rs
@@ -469,7 +469,9 @@ pub async fn transport_conn(
 
     let alt_names = options.host.clone().map(|h| vec![h]);
     let verifier = IdentityBasedVerifier::new_with_alt_names(&options.id_pubkey, alt_names)
-        .map_err(|e| TransportError::config_err(format!("failed to create certificate verifier: {e}")))?;
+        .map_err(|e| {
+            TransportError::config_err(format!("failed to create certificate verifier: {e}"))
+        })?;
 
     let mut client_crypto = rustls::ClientConfig::builder()
         .dangerous()
@@ -580,17 +582,29 @@ fn make_socket(
     let addr = addr.unwrap_or((Ipv4Addr::UNSPECIFIED, 0).into());
     let socket = std::net::UdpSocket::bind(addr)?;
     socket.set_nonblocking(true)?;
-    
+
     let fd = socket.as_raw_fd();
-    let local_addr = socket.local_addr()
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("failed to get socket local address: {e}")))?;
-    
+    let local_addr = socket.local_addr().map_err(|e| {
+        io::Error::new(
+            io::ErrorKind::Other,
+            format!("failed to get socket local address: {e}"),
+        )
+    })?;
+
     if let Some(provider) = tun_provider {
-        tracing::debug!("QUIC socket created: fd={}, addr={}, bypassing...", fd, local_addr);
+        tracing::debug!(
+            "QUIC socket created: fd={}, addr={}, bypassing...",
+            fd,
+            local_addr
+        );
         provider.bypass(fd);
         tracing::debug!("QUIC socket fd={} bypassed successfully", fd);
     } else {
-        tracing::warn!("QUIC socket created: fd={}, addr={}, but NO tun_provider - socket NOT bypassed!", fd, local_addr);
+        tracing::warn!(
+            "QUIC socket created: fd={}, addr={}, but NO tun_provider - socket NOT bypassed!",
+            fd,
+            local_addr
+        );
     }
 
     Ok(socket)

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/transports/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/transports/mod.rs
@@ -564,8 +564,6 @@ use nix::sys::socket::{SetSockOpt, sockopt::Mark};
 use std::os::fd::AsFd;
 #[cfg(target_os = "android")]
 use std::os::fd::AsRawFd;
-#[cfg(target_os = "android")]
-use std::sync::Arc;
 
 use std::io;
 
@@ -577,11 +575,16 @@ fn make_socket(
     let addr = addr.unwrap_or((Ipv4Addr::UNSPECIFIED, 0).into());
     let socket = std::net::UdpSocket::bind(addr)?;
     socket.set_nonblocking(true)?;
-
+    
+    let fd = socket.as_raw_fd();
+    let local_addr = socket.local_addr().unwrap_or_else(|_| SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0)));
+    
     if let Some(provider) = tun_provider {
-        let fd = socket.as_raw_fd();
-        tracing::debug!("Bypassing QUIC socket fd: {}", fd);
+        tracing::info!("QUIC socket created: fd={}, addr={}, bypassing...", fd, local_addr);
         provider.bypass(fd);
+        tracing::info!("QUIC socket fd={} bypassed successfully", fd);
+    } else {
+        tracing::warn!("QUIC socket created: fd={}, addr={}, but NO tun_provider - socket NOT bypassed!", fd, local_addr);
     }
 
     Ok(socket)

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/transports/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/transports/mod.rs
@@ -560,7 +560,7 @@ use crate::tunnel_provider::AndroidTunProvider;
 use crate::tunnel_state_machine::tunnel::wireguard::two_hop_config::ETHERNET_V2_MTU;
 #[cfg(target_os = "linux")]
 use nix::sys::socket::{SetSockOpt, sockopt::Mark};
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(target_os = "linux")]
 use std::os::fd::AsFd;
 #[cfg(target_os = "android")]
 use std::os::fd::AsRawFd;

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/transports/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/transports/mod.rs
@@ -64,6 +64,43 @@ pub struct BridgeConn {
     pub(crate) writer: Box<dyn AsyncWrite + Send + Unpin>,
 }
 
+#[cfg(target_os = "android")]
+impl BridgeConn {
+    pub async fn try_connect(
+        params: BridgeParameters,
+        token: CancellationToken,
+        tun_provider: Option<Arc<dyn AndroidTunProvider>>,
+    ) -> Result<Self, TransportError> {
+        let start = Instant::now();
+
+        match params {
+            BridgeParameters::QuicPlain(ref opts) => {
+                let opts = ClientOptions::try_from(opts)?;
+
+                let conn = token
+                    .run_until_cancelled(transport_conn(&opts, tun_provider))
+                    .await
+                    .ok_or(TransportError::Cancelled)??;
+                let endpoint = conn.remote_address();
+                // .context("failed to connect to transport conn")?;
+                let (writer, reader) = token
+                    .run_until_cancelled(conn.open_bi())
+                    .await
+                    .ok_or(TransportError::Cancelled)??;
+                // .context("failed to connect to transport stream")?;
+                info!("quic transport connected in {:?}", start.elapsed());
+                Ok(Self {
+                    reader: Box::new(reader),
+                    writer: Box::new(writer),
+                    params,
+                    endpoint,
+                })
+            }
+        }
+    }
+}
+
+#[cfg(not(target_os = "android"))]
 impl BridgeConn {
     pub async fn try_connect(
         params: BridgeParameters,
@@ -100,6 +137,41 @@ impl BridgeConn {
 
 pub struct UdpForwarder {}
 
+#[cfg(target_os = "android")]
+impl UdpForwarder {
+    pub async fn launch(
+        egress_conn: BridgeConn,
+        bind_addr: Option<SocketAddr>,
+        close_tx: UnboundedSender<()>,
+        token: CancellationToken,
+        tun_provider: Option<Arc<dyn AndroidTunProvider>>,
+    ) -> Result<(SocketAddr, JoinHandle<()>), TransportError> {
+        let bind_addr = bind_addr.unwrap_or(match egress_conn.endpoint.is_ipv4() {
+            true => (Ipv4Addr::LOCALHOST, 0).into(),
+            false => (Ipv6Addr::LOCALHOST, 0).into(),
+        });
+        let socket =
+            make_socket(Some(bind_addr), tun_provider).map_err(TransportError::SocketIo)?;
+        let socket = Arc::new(UdpSocket::from_std(socket).map_err(TransportError::SocketIo)?);
+        let local_addr = socket.local_addr().map_err(TransportError::SocketIo)?;
+
+        info!("udp forwarder started listening on: {local_addr}",);
+
+        Ok((
+            local_addr,
+            tokio::spawn(process_udp(
+                egress_conn.reader,
+                egress_conn.writer,
+                socket.clone(),
+                ETHERNET_V2_MTU,
+                close_tx,
+                token,
+            )),
+        ))
+    }
+}
+
+#[cfg(not(target_os = "android"))]
 impl UdpForwarder {
     pub async fn launch(
         egress_conn: BridgeConn,
@@ -379,6 +451,59 @@ pub const ALPN_QUIC_HTTP: &[&[u8]] = &[b"hq-29"];
 use ed25519_dalek::VerifyingKey;
 use quinn_proto::crypto::rustls::QuicClientConfig;
 
+#[cfg(target_os = "android")]
+pub async fn transport_conn(
+    options: &ClientOptions,
+    tun_provider: Option<Arc<dyn AndroidTunProvider>>,
+) -> Result<quinn::Connection, TransportError> {
+    info!("initialising from transport identity pubkey");
+
+    let transport_endpoint = options
+        .get_ipv4()
+        .ok_or(TransportError::config_err("No IPv4 endpoint provided"))?;
+
+    let alt_names = options.host.clone().map(|h| vec![h]);
+    let verifier =
+        IdentityBasedVerifier::new_with_alt_names(&options.id_pubkey, alt_names).unwrap();
+
+    let mut client_crypto = rustls::ClientConfig::builder()
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(verifier))
+        .with_no_client_auth();
+
+    client_crypto.alpn_protocols = ALPN_QUIC_HTTP.iter().map(|&x| x.into()).collect();
+    let quic_client_config = QuicClientConfig::try_from(client_crypto)
+        .map_err(|e| TransportError::config_err(format!("invalid tls crypto config: {e}")))?;
+
+    let client_config = quinn::ClientConfig::new(Arc::new(quic_client_config));
+    let bind_addr = match transport_endpoint.is_ipv4() {
+        true => (Ipv4Addr::UNSPECIFIED, 0).into(),
+        false => (Ipv6Addr::UNSPECIFIED, 0).into(),
+    };
+    let socket = make_socket(Some(bind_addr), tun_provider).map_err(TransportError::SocketIo)?;
+    let runtime =
+        quinn::default_runtime().ok_or_else(|| TransportError::other("no async runtime found"))?;
+    let mut endpoint = quinn::Endpoint::new_with_abstract_socket(
+        Default::default(),
+        None,
+        runtime
+            .wrap_udp_socket(socket)
+            .map_err(TransportError::SocketIo)?,
+        runtime,
+    )
+    .map_err(TransportError::SocketIo)?;
+    endpoint.set_default_client_config(client_config);
+
+    let addr_host = transport_endpoint.ip().to_string();
+    let host = options.host.as_deref().unwrap_or(&addr_host);
+
+    endpoint
+        .connect(transport_endpoint, host)?
+        .await
+        .map_err(TransportError::QuicProto)
+}
+
+#[cfg(not(target_os = "android"))]
 pub async fn transport_conn(options: &ClientOptions) -> Result<quinn::Connection, TransportError> {
     info!("initializing from transport identity pubkey");
 
@@ -430,14 +555,39 @@ pub async fn transport_conn(options: &ClientOptions) -> Result<quinn::Connection
 
 #[cfg(target_os = "linux")]
 use crate::TUNNEL_FWMARK;
+#[cfg(target_os = "android")]
+use crate::tunnel_provider::AndroidTunProvider;
 use crate::tunnel_state_machine::tunnel::wireguard::two_hop_config::ETHERNET_V2_MTU;
 #[cfg(target_os = "linux")]
 use nix::sys::socket::{SetSockOpt, sockopt::Mark};
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 use std::os::fd::AsFd;
+#[cfg(target_os = "android")]
+use std::os::fd::AsRawFd;
+#[cfg(target_os = "android")]
+use std::sync::Arc;
 
 use std::io;
 
+#[cfg(target_os = "android")]
+fn make_socket(
+    addr: Option<SocketAddr>,
+    tun_provider: Option<Arc<dyn AndroidTunProvider>>,
+) -> io::Result<std::net::UdpSocket> {
+    let addr = addr.unwrap_or((Ipv4Addr::UNSPECIFIED, 0).into());
+    let socket = std::net::UdpSocket::bind(addr)?;
+    socket.set_nonblocking(true)?;
+
+    if let Some(provider) = tun_provider {
+        let fd = socket.as_raw_fd();
+        tracing::debug!("Bypassing QUIC socket fd: {}", fd);
+        provider.bypass(fd);
+    }
+
+    Ok(socket)
+}
+
+#[cfg(not(target_os = "android"))]
 fn make_socket(addr: Option<SocketAddr>) -> io::Result<std::net::UdpSocket> {
     let addr = addr.unwrap_or((Ipv4Addr::UNSPECIFIED, 0).into());
     let socket = std::net::UdpSocket::bind(addr)?;

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/transports/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/transports/mod.rs
@@ -96,6 +96,11 @@ impl BridgeConn {
                     endpoint,
                 })
             }
+            // Exhaustive match: BridgeParameters only has QuicPlain variant
+            #[allow(unreachable_patterns)]
+            _ => Err(TransportError::config_err(
+                "unsupported bridge parameter type",
+            )),
         }
     }
 }
@@ -463,8 +468,8 @@ pub async fn transport_conn(
         .ok_or(TransportError::config_err("No IPv4 endpoint provided"))?;
 
     let alt_names = options.host.clone().map(|h| vec![h]);
-    let verifier =
-        IdentityBasedVerifier::new_with_alt_names(&options.id_pubkey, alt_names).unwrap();
+    let verifier = IdentityBasedVerifier::new_with_alt_names(&options.id_pubkey, alt_names)
+        .map_err(|e| TransportError::config_err(format!("failed to create certificate verifier: {e}")))?;
 
     let mut client_crypto = rustls::ClientConfig::builder()
         .dangerous()
@@ -577,12 +582,13 @@ fn make_socket(
     socket.set_nonblocking(true)?;
     
     let fd = socket.as_raw_fd();
-    let local_addr = socket.local_addr().unwrap_or_else(|_| SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0)));
+    let local_addr = socket.local_addr()
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("failed to get socket local address: {e}")))?;
     
     if let Some(provider) = tun_provider {
-        tracing::info!("QUIC socket created: fd={}, addr={}, bypassing...", fd, local_addr);
+        tracing::debug!("QUIC socket created: fd={}, addr={}, bypassing...", fd, local_addr);
         provider.bypass(fd);
-        tracing::info!("QUIC socket fd={} bypassed successfully", fd);
+        tracing::debug!("QUIC socket fd={} bypassed successfully", fd);
     } else {
         tracing::warn!("QUIC socket created: fd={}, addr={}, but NO tun_provider - socket NOT bypassed!", fd, local_addr);
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -1079,6 +1079,52 @@ impl TunnelMonitor {
         Ok((connection_data, rt))
     }
 
+    #[cfg(target_os = "android")]
+    async fn start_bridges(
+        &self,
+        selected_gateways: &SelectedGateways,
+        bridge_close_tx: mpsc::UnboundedSender<()>,
+    ) -> Result<(BridgeAddress, JoinHandle<()>)> {
+        let entry_bridge_params = selected_gateways
+            .entry_gateway()
+            .get_bridge_params()
+            .ok_or(TransportError::config_err(
+                "attempted to open transport connection without bridge params",
+            ))?;
+
+        // Attempt transport Connection. If successful a listening UDP connection is created
+        // and the bind address of that UDP listener is provided to the entry wireguard tunnel
+        // as the endpoint address.
+        tracing::info!("Establishing DVPN QUIC transport tunnel");
+
+        let tun_provider = Some(self.tun_provider.clone());
+        let bridge_conn = transports::BridgeConn::try_connect(
+            entry_bridge_params,
+            self.shutdown_token.child_token(),
+            tun_provider.clone(),
+        )
+        .await?;
+        let remote_addr = bridge_conn.endpoint;
+        let (listen_addr, join_handle) = transports::UdpForwarder::launch(
+            bridge_conn,
+            None,
+            bridge_close_tx,
+            self.shutdown_token.child_token(),
+            tun_provider,
+        )
+        .await?;
+
+        tracing::info!("quic transport connected, udp forwarder open on {listen_addr}");
+
+        let bridge_addr = BridgeAddress {
+            listen_addr,
+            remote_addr,
+        };
+
+        Ok((bridge_addr, join_handle))
+    }
+
+    #[cfg(not(target_os = "android"))]
     async fn start_bridges(
         &self,
         selected_gateways: &SelectedGateways,


### PR DESCRIPTION
## Ticket

JIRA-VPN-XXXX

Build & Install
```
cd nym-vpn-client/nym-vpn-android
./gradlew assembleDebug
adb install -r app/build/outputs/apk/debug/app-debug.apk
```
Steps to test:
1. Open app -> Settings -> Anti-censorship -> Enable "Enhanced connection (QUIC)"
2. Use DVPN (Two-hop)
3. Connect with QUIC enabled node

```
adb logcat | grep --line-buffered -iE   "(Establishing DVPN|QUIC socket|quic transport|UdpForwarder|bypassing socket)"   --color=always
10-31 11:17:07.189  4150  4204 D VpnService: Bypassing socket: 142
10-31 11:17:09.066  4150  4204 D VpnService: Bypassing socket: 168
10-31 11:17:12.206  4150  4204 D VpnService: Bypassing socket: 198
10-31 11:17:12.216  4150  4204 D VpnService: Bypassing socket: 204
10-31 11:24:03.756  4991  5040 D VpnService: Bypassing socket: 122
10-31 11:24:04.205  4991  5040 D VpnService: Bypassing socket: 192
10-31 11:24:07.398  4991  5040 I libnymvpn: nym_vpn_lib::tunnel_state_machine::tunnel_monitor: Establishing DVPN QUIC transport tunnel
10-31 11:24:07.399  4991  5040 I libnymvpn: nym_vpn_lib::tunnel_state_machine::tunnel::transports: QUIC socket created: fd=163, addr=0.0.0.0:54296, bypassing...
10-31 11:24:07.400  4991  5040 D VpnService: Bypassing socket: 163
10-31 11:24:07.400  4991  5040 I libnymvpn: nym_vpn_lib::tunnel_state_machine::tunnel::transports: QUIC socket fd=163 bypassed successfully
10-31 11:24:07.447  4991  5040 I libnymvpn: nym_vpn_lib::tunnel_state_machine::tunnel::transports: quic transport connected in 48.416917ms
10-31 11:24:07.447  4991  5040 I libnymvpn: nym_vpn_lib::tunnel_state_machine::tunnel::transports: QUIC socket created: fd=152, addr=127.0.0.1:53143, bypassing...
10-31 11:24:07.448  4991  5040 D VpnService: Bypassing socket: 152
10-31 11:24:07.449  4991  5040 I libnymvpn: nym_vpn_lib::tunnel_state_machine::tunnel::transports: QUIC socket fd=152 bypassed successfully
10-31 11:24:07.449  4991  5040 I libnymvpn: nym_vpn_lib::tunnel_state_machine::tunnel_monitor: quic transport connected, udp forwarder open on 127.0.0.1:53143
```

Verified
- Only QUIC-compatible gateways shown in Entry gateway selection
- Connection establishes successfully
- ICMP health checks pass (no routing loop)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3833)
<!-- Reviewable:end -->
