### PR TITLE
android: export helpers to query feature flags

### DIFF
--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/manager/environment/EnvironmentManager.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/manager/environment/EnvironmentManager.kt
@@ -1,7 +1,5 @@
 package net.nymtech.nymvpn.manager.environment
 
-import nym_vpn_lib_types.FeatureFlags
-
 interface EnvironmentManager {
 	suspend fun isQuicEnabled(): Boolean
 	suspend fun isDomainFrontingEnabled(): Boolean

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/manager/environment/EnvironmentManager.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/manager/environment/EnvironmentManager.kt
@@ -3,6 +3,6 @@ package net.nymtech.nymvpn.manager.environment
 import nym_vpn_lib_types.FeatureFlags
 
 interface EnvironmentManager {
-	suspend fun getFeatureFlags(): FeatureFlags?
-	suspend fun isFeatureFlagEnabled(flag: String): Boolean
+	suspend fun isQuicEnabled(): Boolean
+	suspend fun isDomainFrontingEnabled(): Boolean
 }

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/manager/environment/NymEnvironmentManager.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/manager/environment/NymEnvironmentManager.kt
@@ -2,7 +2,6 @@ package net.nymtech.nymvpn.manager.environment
 
 import net.nymtech.nymvpn.manager.backend.BackendManager
 import nym_vpn_lib_types.FeatureFlags
-import nym_vpn_lib_types.FlagValue
 import timber.log.Timber
 import javax.inject.Inject
 

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/manager/environment/NymEnvironmentManager.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/manager/environment/NymEnvironmentManager.kt
@@ -10,32 +10,20 @@ class NymEnvironmentManager @Inject constructor(
 	private val backendManager: BackendManager,
 ) : EnvironmentManager {
 
-	override suspend fun getFeatureFlags(): FeatureFlags? {
+	override suspend fun isDomainFrontingEnabled(): Boolean {
+		return getFeatureFlags()?.isDomainFrontingEnabled() ?: false
+	}
+
+	override suspend fun isQuicEnabled(): Boolean {
+		return getFeatureFlags()?.isQuicEnabled() ?: false
+	}
+
+	suspend fun getFeatureFlags(): FeatureFlags? {
 		return try {
 			backendManager.getBackend().getCurrentEnvironment().featureFlags
 		} catch (e: Exception) {
 			Timber.e(e)
 			null
-		}
-	}
-
-	override suspend fun isFeatureFlagEnabled(flag: String): Boolean {
-		return try {
-			val featureFlags = getFeatureFlags() ?: return false
-			val flagValue = featureFlags.flags[flag] ?: return false
-
-			when (flagValue) {
-				is FlagValue.Value -> {
-					flagValue.v1.equals("true", ignoreCase = true)
-				}
-				is FlagValue.Group -> {
-					val enabled = flagValue.v1["enabled"]
-					enabled?.equals("true", ignoreCase = true) ?: flagValue.v1.isNotEmpty()
-				}
-			}
-		} catch (e: Exception) {
-			Timber.e(e)
-			false
 		}
 	}
 }

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/manager/environment/model/FeatureFlagKeys.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/manager/environment/model/FeatureFlagKeys.kt
@@ -1,6 +1,0 @@
-package net.nymtech.nymvpn.manager.environment.model
-
-object FeatureFlagKeys {
-	const val DOMAIN_FRONTING = "domain_fronting"
-	const val QUIC = "quic"
-}

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/details/DetailsViewModel.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/details/DetailsViewModel.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import net.nymtech.nymvpn.data.SettingsRepository
 import net.nymtech.nymvpn.manager.environment.EnvironmentManager
-import net.nymtech.nymvpn.manager.environment.model.FeatureFlagKeys
 import net.nymtech.nymvpn.ui.screens.hop.GatewayLocation
 import net.nymtech.vpn.model.NymGateway
 import net.nymtech.vpn.util.extensions.asEntryPoint
@@ -27,7 +26,7 @@ class DetailsViewModel @Inject constructor(
 
 	fun filterGateways(id: String, gateways: List<NymGateway>) = viewModelScope.launch {
 		gateways.firstOrNull { gateway -> gateway.identity == id }?.let {
-			val isQuicFeatureFlagEnabled = environmentManager.isFeatureFlagEnabled(FeatureFlagKeys.QUIC)
+			val isQuicFeatureFlagEnabled = environmentManager.isQuicEnabled()
 			_uiState.value = DetailsUiState.from(it).copy(
 				isQuicFeatureFlagEnabled = isQuicFeatureFlagEnabled,
 			)

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/SettingsViewModel.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/SettingsViewModel.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import net.nymtech.nymvpn.data.SettingsRepository
 import net.nymtech.nymvpn.manager.environment.EnvironmentManager
-import net.nymtech.nymvpn.manager.environment.model.FeatureFlagKeys
 import javax.inject.Inject
 
 @HiltViewModel
@@ -25,8 +24,8 @@ constructor(
 
 	init {
 		viewModelScope.launch {
-			val domainFronting = environmentManager.isFeatureFlagEnabled(FeatureFlagKeys.DOMAIN_FRONTING)
-			val quic = environmentManager.isFeatureFlagEnabled(FeatureFlagKeys.QUIC)
+			val domainFronting = environmentManager.isDomainFrontingEnabled()
+			val quic = environmentManager.isQuicEnabled()
 			_uiState.update { it.copy(showCensorshipSection = (domainFronting || quic)) }
 		}
 	}

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/censorship/CensorshipViewModel.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/censorship/CensorshipViewModel.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import net.nymtech.nymvpn.data.SettingsRepository
 import net.nymtech.nymvpn.manager.environment.EnvironmentManager
-import net.nymtech.nymvpn.manager.environment.model.FeatureFlagKeys
 import javax.inject.Inject
 
 @HiltViewModel
@@ -23,8 +22,8 @@ class CensorshipViewModel @Inject constructor(
 
 	init {
 		viewModelScope.launch {
-			val domainFronting = environmentManager.isFeatureFlagEnabled(FeatureFlagKeys.DOMAIN_FRONTING)
-			val quic = environmentManager.isFeatureFlagEnabled(FeatureFlagKeys.QUIC)
+			val domainFronting = environmentManager.isDomainFrontingEnabled()
+			val quic = environmentManager.isQuicEnabled()
 			_uiState.update { it.copy(showQUICSection = quic, showDomainSection = domainFronting) }
 		}
 	}

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/login/LoginViewModel.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/login/LoginViewModel.kt
@@ -31,6 +31,7 @@ constructor(
 			backendManager.storeMnemonic(mnemonic.trim())
 			Timber.d("Imported account successfully")
 			SnackbarController.showMessage(StringValue.StringResource(R.string.device_added_success))
+			backendManager.refreshAccount()
 			_success.emit(true)
 		}.onFailure {
 			Timber.e(it)

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/network.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/network.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -140,12 +140,12 @@ pub struct Network {
     pub nym_network: NymNetworkDetails,
     pub nyxd_url: String,
     pub nym_vpn_network: NymVpnNetwork,
-    pub feature_flags: Option<FeatureFlags>,
+    pub feature_flags: Option<Arc<FeatureFlags>>,
     pub system_configuration: Option<SystemConfiguration>,
 }
 
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "uniffi-bindings", derive(uniffi::Record))]
+#[cfg_attr(feature = "uniffi-bindings", derive(uniffi::Object))]
 #[cfg_attr(
     feature = "typescript-bindings",
     derive(TS),
@@ -159,17 +159,18 @@ pub struct FeatureFlags {
 }
 
 #[cfg(feature = "uniffi-bindings")]
+#[cfg_attr(feature = "uniffi-bindings", uniffi::export)]
 impl FeatureFlags {
     /// If domain fronting is enabled or not, if set
     #[uniffi::method]
-    pub fn domain_fronting_enabled(&self) -> Option<bool> {
+    pub fn is_domain_fronting_enabled(&self) -> Option<bool> {
         // todo: harmonize with nym-vpn-network-config/src/feature_flags.rs
         self.get_group_flag("domain_fronting", "enabled")
     }
 
     /// If quic is enabled or not, if set
     #[uniffi::method]
-    pub fn quic_enabled(&self) -> Option<bool> {
+    pub fn is_quic_enabled(&self) -> Option<bool> {
         // todo: harmonize with nym-vpn-network-config/src/feature_flags.rs
         self.get_group_flag("quic", "enabled")
     }
@@ -346,7 +347,7 @@ impl From<nym_vpn_network_config::Network> for Network {
             nym_network: NymNetworkDetails::from(value.nym_network),
             nyxd_url: value.nyxd_url.to_string(),
             nym_vpn_network: NymVpnNetwork::from(value.nym_vpn_network),
-            feature_flags: value.feature_flags.map(FeatureFlags::from),
+            feature_flags: value.feature_flags.map(FeatureFlags::from).map(Arc::from),
             system_configuration: value.system_configuration.map(SystemConfiguration::from),
         }
     }


### PR DESCRIPTION
## Ticket

JIRA-VPN-4389

## Description

- This PR exports uniffi methods that were meant to be visible over uniffi, but weren't due to missing export statement.
- Remove `FeatureFlagKeys` and use exported methods instead.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3843)
<!-- Reviewable:end -->
