### PR TITLE
DNS min TTL in default resolver

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/resolver.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/resolver.rs
@@ -497,8 +497,12 @@ impl LocalResolver {
             NameServerConfigGroup::from_ips_clear(&dns_servers, DNS_LISTEN_PORT, true);
 
         let forward_config = ResolverConfig::from_parts(None, vec![], forward_server_config);
+        let mut opts = ResolverOpts::default();
+        // Set a 30 min minimum TTL for caching DNS responses.
+        opts.positive_min_ttl = Some(Duration::from_secs(1800));
         let resolver =
             TokioResolver::builder_with_config(forward_config, TokioConnectionProvider::default())
+                .with_options(opts)
                 .build();
 
         self.inner_resolver = Resolver::Forwarding(Box::new(resolver));

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/resolver.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/resolver.rs
@@ -31,7 +31,7 @@ use hickory_server::{
     },
     resolver::{
         ResolveError, TokioResolver,
-        config::{NameServerConfigGroup, ResolverConfig},
+        config::{NameServerConfigGroup, ResolverConfig, ResolverOpts},
         lookup::Lookup,
         name_server::TokioConnectionProvider,
     },


### PR DESCRIPTION
## Description

This PR adds a default minimum TTL for positive lookups in the default DNS resolver. 

If a DNS record lookup succeeds it will now be cached for a minimum of 30 minutes. Records with longer TTLs will keep the value configured in the record.

Considerations:
- The addresisng for Nym APIs are relatively static, but have short timeouts currently resulting in constant use of DNS.
  - `nymvpn.com` and `validator.nymtech.net` use 30s TTL for `A` records and 10800s (3d) for `AAAA`
- Should addresses change in the future, clients should be able to adapt in a reasonable amount of time.
- I believe the cache is per instance of the resolver, so if the daemon is shutdown and relaunched the cache should start from a clean slate.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3849)
<!-- Reviewable:end -->
