### PR TITLE
Manually rotate wireguard keys

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add tunnel connection monitoring (https://github.com/nymtech/nym-vpn-client/pull/3724)
 - Backend QUIC filtering for desktop (https://github.com/nymtech/nym-vpn-client/pull/3746)
 - Fallback on mixnet channel if metadata endpoint is not available (https://github.com/nymtech/nym-vpn-client/pull/3747)
+- Library exposing the command for manual wireguard key rotation (https://github.com/nymtech/nym-vpn-client/pull/3870)
 
 ### Changed
 

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/command_sender.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/command_sender.rs
@@ -82,6 +82,14 @@ impl AccountCommandSender {
         rx.await.map_err(AccountCommandError::internal)?
     }
 
+    pub async fn rotate_keys(&self) -> Result<(), AccountCommandError> {
+        let (tx, rx) = ReturnSender::new();
+        self.command_tx
+            .send(AccountCommand::RotateKeys(tx))
+            .map_err(AccountCommandError::internal)?;
+        rx.await.map_err(AccountCommandError::internal)?
+    }
+
     pub async fn background_refresh_account_state(&self) -> Result<(), AccountCommandError> {
         let (tx, rx) = ReturnSender::new();
         self.command_tx

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/dispatch.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/dispatch.rs
@@ -32,6 +32,9 @@ pub enum AccountCommand {
     /// Delete the stored account and every associated data
     ForgetAccount(ReturnSender<(), AccountCommandError>),
 
+    /// Rotate the wireguard keys
+    RotateKeys(ReturnSender<(), AccountCommandError>),
+
     /// Retrieve current, on-chain, balance of the account. Only applicable for decentralised accounts
     AccountBalance(ReturnSender<Vec<Coin>, AccountCommandError>),
 
@@ -61,6 +64,7 @@ impl AccountCommand {
             AccountCommand::StoreAccount(return_sender, _) => return_sender.send(Err(error)),
             AccountCommand::RegisterAccount(return_sender, _, _) => return_sender.send(Err(error)),
             AccountCommand::ForgetAccount(return_sender) => return_sender.send(Err(error)),
+            AccountCommand::RotateKeys(return_sender) => return_sender.send(Err(error)),
             AccountCommand::AccountBalance(return_sender) => return_sender.send(Err(error)),
             AccountCommand::ObtainTicketbooks(return_sender, _) => return_sender.send(Err(error)),
             AccountCommand::ResetDeviceIdentity(return_sender, _) => return_sender.send(Err(error)),

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/handler.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/handler.rs
@@ -184,6 +184,19 @@ pub(crate) async fn handle_forget_account<C: ConnectivityMonitor>(
     Ok(())
 }
 
+pub(crate) async fn handle_rotate_keys<C: ConnectivityMonitor>(
+    shared_state: &mut SharedAccountState<C>,
+) -> Result<(), AccountCommandError> {
+    shared_state
+        .wireguard_keys_storage
+        .clear_keys()
+        .await
+        .map_err(|source| {
+            tracing::error!("Failed to clear wireguard keys storage: {source:?}");
+            AccountCommandError::Storage(source.to_string())
+        })
+}
+
 // TODO: With the erorr rework we are now losing information about the original error cause, this needs to be addressed, but errors rework is a pretty gnarly thing to do, so we need to plan it a bit more carefully
 pub(crate) async fn handle_unregister_device<C: ConnectivityMonitor>(
     shared_state: &mut SharedAccountState<C>,

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/decentralised_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/decentralised_state.rs
@@ -67,6 +67,10 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for DecentralisedS
                             return NextAccountControllerState::NewState(LoggedOutState::enter())
                         }
                     },
+                    AccountCommand::RotateKeys(return_sender) => {
+                        let res = handler::handle_rotate_keys(shared_state).await;
+                        return_sender.send(res);
+                    },
                     AccountCommand::AccountBalance(return_sender) => {
                         return_sender.send(decentralised_zknym_handler::handle_account_balance(shared_state).await);
                     }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/error_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/error_state.rs
@@ -87,6 +87,10 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ErrorState {
                             return NextAccountControllerState::NewState(LoggedOutState::enter());
                         }
                     },
+                    AccountCommand::RotateKeys(return_sender) => {
+                        let res = handler::handle_rotate_keys(shared_state).await;
+                        return_sender.send(res);
+                    },
                     AccountCommand::AccountBalance(return_sender) => return_sender.send(Err(AccountCommandError::AccountNotDecentralised)),
                     AccountCommand::ObtainTicketbooks(return_sender, _) => return_sender.send(Err(AccountCommandError::AccountNotDecentralised)),
                     AccountCommand::ResetDeviceIdentity(return_sender, seed) => {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/logged_out_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/logged_out_state.rs
@@ -65,6 +65,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for LoggedOutState
                         }
                     },
                     AccountCommand::ForgetAccount(return_sender) => return_sender.send(Ok(())),
+                    AccountCommand::RotateKeys(return_sender) => return_sender.send(Ok(())),
                     AccountCommand::AccountBalance(return_sender) => return_no_account(return_sender),
                     AccountCommand::ObtainTicketbooks(return_sender, _) => return_no_account(return_sender),
                     // We don't even have an identity at this point, so we might as well not do anything

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/offline_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/offline_state.rs
@@ -59,7 +59,10 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for OfflineState {
                     // Before that command gets sent to the AC, the tunnel must be in Disconnected state, so we shouldn't ever end up here
                     // If we nevertheless do, we can't forget the account, because maybe the tunnel is in Offline {reconnect : true} state, and we shouldn't remove the account if it's the case
                     AccountCommand::ForgetAccount(return_sender) => return_no_connectivity(return_sender),
-                                        AccountCommand::AccountBalance(return_sender) => return_no_connectivity(return_sender),
+                    AccountCommand::RotateKeys(return_sender) => {
+                        return_sender.send(handler::handle_rotate_keys(shared_state).await)
+                    },
+                    AccountCommand::AccountBalance(return_sender) => return_no_connectivity(return_sender),
                     AccountCommand::ObtainTicketbooks(return_sender, _) => return_no_connectivity(return_sender),
                     // Same comment as above
                     AccountCommand::ResetDeviceIdentity(return_sender, _) => return_no_connectivity(return_sender),

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/ready_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/ready_state.rs
@@ -80,6 +80,10 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ReadyState {
                             return NextAccountControllerState::NewState(LoggedOutState::enter());
                         }
                     },
+                    AccountCommand::RotateKeys(return_sender) => {
+                        let res = handler::handle_rotate_keys(shared_state).await;
+                        return_sender.send(res);
+                    },
                     AccountCommand::AccountBalance(return_sender) => return_sender.send(Err(AccountCommandError::AccountNotDecentralised)),
                     AccountCommand::ObtainTicketbooks(return_sender, _) => return_sender.send(Err(AccountCommandError::AccountNotDecentralised)),
                     AccountCommand::ResetDeviceIdentity(return_sender, seed) => {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
@@ -254,6 +254,10 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingState {
                             return NextAccountControllerState::NewState(LoggedOutState::enter());
                         }
                     },
+                    AccountCommand::RotateKeys(return_sender) => {
+                        let res = handler::handle_rotate_keys(shared_state).await;
+                        return_sender.send(res);
+                    },
                     AccountCommand::AccountBalance(return_sender) => return_sender.send(Err(AccountCommandError::AccountNotDecentralised)),
                     AccountCommand::ObtainTicketbooks(return_sender, _) => return_sender.send(Err(AccountCommandError::AccountNotDecentralised)),
                     AccountCommand::RefreshAccountState(return_sender) => {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/requesting_zknym_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/requesting_zknym_state.rs
@@ -239,6 +239,10 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for RequestingZkNy
                             return NextAccountControllerState::NewState(LoggedOutState::enter());
                         }
                     },
+                    AccountCommand::RotateKeys(return_sender) => {
+                        let res = handler::handle_rotate_keys(shared_state).await;
+                        return_sender.send(res);
+                    },
                         AccountCommand::AccountBalance(return_sender) => return_sender.send(Err(AccountCommandError::AccountNotDecentralised)),
                     AccountCommand::ObtainTicketbooks(return_sender, _) => return_sender.send(Err(AccountCommandError::AccountNotDecentralised)),
                     AccountCommand::ResetDeviceIdentity(return_sender, seed) => {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/commands.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/commands.rs
@@ -31,6 +31,7 @@ async fn logged_out_state_command() -> anyhow::Result<()> {
     );
 
     assert_eq!(test_bench.command_sender.forget_account().await, Ok(()));
+    assert_eq!(test_bench.command_sender.rotate_keys().await, Ok(()));
     assert_eq!(test_bench.command_sender.get_account_id().await, Ok(None));
     assert_eq!(
         test_bench.command_sender.get_stored_account().await,
@@ -126,6 +127,8 @@ async fn offline_state_command() -> anyhow::Result<()> {
         test_bench.command_sender.forget_account().await,
         Err(AccountCommandError::Offline)
     );
+
+    assert_eq!(test_bench.command_sender.rotate_keys().await, Ok(()));
 
     assert_eq!(
         test_bench.command_sender.get_active_devices().await,
@@ -322,6 +325,7 @@ async fn ready_state_command() -> anyhow::Result<()> {
     );
 
     assert_eq!(test_bench.command_sender.forget_account().await, Ok(()));
+    assert_eq!(test_bench.command_sender.rotate_keys().await, Ok(()));
     test_bench
         .assert_state(AccountControllerState::LoggedOut)
         .await;
@@ -437,6 +441,7 @@ async fn error_state_command() -> anyhow::Result<()> {
     );
 
     assert_eq!(test_bench.command_sender.forget_account().await, Ok(()));
+    assert_eq!(test_bench.command_sender.rotate_keys().await, Ok(()));
     test_bench
         .assert_state(AccountControllerState::LoggedOut)
         .await;

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/account.rs
@@ -245,6 +245,14 @@ pub(super) async fn forget_account() -> Result<(), VpnError> {
         .map_err(VpnError::from)
 }
 
+pub(super) async fn rotate_keys() -> Result<(), VpnError> {
+    get_command_sender()
+        .await?
+        .rotate_keys()
+        .await
+        .map_err(VpnError::from)
+}
+
 pub(super) async fn get_account_id() -> Result<Option<String>, VpnError> {
     Ok(get_command_sender().await?.get_account_id().await?)
 }
@@ -294,7 +302,7 @@ pub(crate) mod raw {
         response::{NymVpnAccountResponse, NymVpnRegisterAccountResponse},
         types::{Device, DeviceStatus, VpnAccountMode},
     };
-    use nym_vpn_store::account::AccountInformationStorage;
+    use nym_vpn_store::{account::AccountInformationStorage, keys::wireguard::DB_NAME};
 
     async fn setup_account_storage(path: &str) -> Result<VpnClientOnDiskStorage, VpnError> {
         assert_account_controller_not_running().await?;
@@ -405,6 +413,24 @@ pub(crate) mod raw {
         Ok(())
     }
 
+    async fn remove_wireguard_keys_storage_raw(data_dir: &Path) -> Result<(), VpnError> {
+        let db_path = data_dir.join(DB_NAME);
+        match tokio::fs::remove_file(&db_path).await {
+            Ok(_) => tracing::trace!("Removed file: {}", db_path.display()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                tracing::trace!("File not found: {}", db_path.display())
+            }
+            Err(e) => {
+                trace_err_chain!(e, "Failed to remove file: {}", db_path.display());
+
+                return Err(VpnError::InternalError {
+                    details: e.to_string(),
+                });
+            }
+        }
+        Ok(())
+    }
+
     async fn create_vpn_api_client() -> Result<VpnApiClient, VpnError> {
         let network_env = environment::current_environment_details().await?;
         let user_agent = crate::user_agent::construct_user_agent();
@@ -499,6 +525,16 @@ pub(crate) mod raw {
             .map_err(|err| VpnError::Storage {
                 details: err.to_string(),
             })?;
+
+        Ok(())
+    }
+
+    pub(crate) async fn rotate_keys_raw(path: &str) -> Result<(), VpnError> {
+        let path_buf =
+            PathBuf::from_str(path).map_err(|err| VpnError::InvalidAccountStoragePath {
+                details: err.to_string(),
+            })?;
+        remove_wireguard_keys_storage_raw(&path_buf).await?;
 
         Ok(())
     }

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/lib.rs
@@ -357,6 +357,21 @@ pub fn forgetAccountRaw(path: String) -> Result<(), VpnError> {
     RUNTIME.block_on(account::raw::forget_account_raw(&path))
 }
 
+/// Force a rotation of the wireguard keys
+#[allow(non_snake_case)]
+#[uniffi::export]
+pub fn rotateKeys() -> Result<(), VpnError> {
+    RUNTIME.block_on(account::rotate_keys())
+}
+
+/// Force a rotation of the wireguard keys
+/// This is a version that can be called when the account controller is not running.
+#[allow(non_snake_case)]
+#[uniffi::export]
+pub fn rotateKeysRaw(path: String) -> Result<(), VpnError> {
+    RUNTIME.block_on(account::raw::rotate_keys_raw(&path))
+}
+
 /// Get the device identity
 #[allow(non_snake_case)]
 #[uniffi::export]

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -865,6 +865,9 @@ service NymVpnService {
   // credential storage, mixnet keys, gateway registrations.
   rpc ForgetAccount (google.protobuf.Empty) returns (AccountCommandResponse) {}
 
+  // Force a rotation of the wireguard keys.
+  rpc RotateKeys (google.protobuf.Empty) returns (AccountCommandResponse) {}
+
   // Get the account identity of the locally stored recovery phrase
   rpc GetAccountIdentity (google.protobuf.Empty) returns (GetAccountIdentityResponse) {}
 

--- a/nym-vpn-core/crates/nym-vpn-proto/src/rpc_client.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/rpc_client.rs
@@ -312,6 +312,17 @@ impl RpcClient {
         AccountCommandResponse::try_from(response).map_err(Error::InvalidResponse)
     }
 
+    pub async fn rotate_keys(&mut self) -> Result<AccountCommandResponse> {
+        let response = self
+            .0
+            .rotate_keys(())
+            .await
+            .map_err(Error::Rpc)?
+            .into_inner();
+
+        AccountCommandResponse::try_from(response).map_err(Error::InvalidResponse)
+    }
+
     pub async fn get_account_identity(&mut self) -> Result<Option<String>> {
         self.0
             .get_account_identity(())

--- a/nym-vpn-core/crates/nym-vpnc/src/commands/account.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/commands/account.rs
@@ -20,6 +20,8 @@ pub enum Command {
     },
     /// Forget account
     Forget,
+    /// Force wireguard key rotation
+    RotateKeys,
     /// Get account links
     Links {
         /// Locale string (i.e en-US)
@@ -84,6 +86,16 @@ impl Command {
                     return Err(err.into());
                 } else {
                     println!("Account forgotten successfully");
+                }
+                Ok(())
+            }
+            Command::RotateKeys => {
+                let response = rpc_client.rotate_keys().await?;
+                if let Some(err) = response.error {
+                    println!("Failed to rotate keys: {err}");
+                    return Err(err.into());
+                } else {
+                    println!("Keys rotated successfully");
                 }
                 Ok(())
             }

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface.rs
@@ -416,6 +416,21 @@ impl NymVpnService for CommandInterface {
         Ok(tonic::Response::new(response))
     }
 
+    async fn rotate_keys(
+        &self,
+        _request: tonic::Request<()>,
+    ) -> Result<tonic::Response<proto::AccountCommandResponse>> {
+        let result = self
+            .send_and_wait(VpnServiceCommand::RotateKeys, ())
+            .await?;
+
+        let response = proto::AccountCommandResponse {
+            error: result.err().map(proto::AccountCommandError::from),
+        };
+
+        Ok(tonic::Response::new(response))
+    }
+
     async fn get_account_identity(
         &self,
         _request: tonic::Request<()>,

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -94,6 +94,7 @@ pub enum VpnServiceCommand {
     ),
     IsAccountStored(oneshot::Sender<bool>, ()),
     ForgetAccount(oneshot::Sender<Result<(), AccountCommandError>>, ()),
+    RotateKeys(oneshot::Sender<Result<(), AccountCommandError>>, ()),
     GetAccountIdentity(
         oneshot::Sender<Result<Option<String>, AccountCommandError>>,
         (),
@@ -787,6 +788,9 @@ impl NymVpnService {
             VpnServiceCommand::ForgetAccount(tx, ()) => {
                 let _ = tx.send(self.handle_forget_account().await);
             }
+            VpnServiceCommand::RotateKeys(tx, ()) => {
+                let _ = tx.send(self.handle_rotate_keys().await);
+            }
             VpnServiceCommand::GetAccountIdentity(tx, ()) => {
                 let _ = tx.send(self.handle_get_account_identity().await);
             }
@@ -1134,6 +1138,17 @@ impl NymVpnService {
             .report(StatisticsEvent::remove_seed());
 
         self.account_command_tx.forget_account().await
+    }
+
+    async fn handle_rotate_keys(&mut self) -> Result<(), AccountCommandError> {
+        // TODO: temporary, until key rotation can be done while connected
+        if self.tunnel_state != TunnelState::Disconnected {
+            return Err(AccountCommandError::internal(
+                "Unable to rotate keys while connected",
+            ));
+        }
+
+        self.account_command_tx.rotate_keys().await
     }
 
     async fn handle_get_account_identity(&self) -> Result<Option<String>, AccountCommandError> {


### PR DESCRIPTION
## Ticket

JIRA-VPN-3570

## Description

Expose a command for manually rotating wireguard keys, by either clearing the key database (when account controller is available) or removing the database file completely (when AC is not available). This is similar to what we do on log out, but just doing it for the wireguard keys.


## Checklist: 

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3870)
<!-- Reviewable:end -->
