### PR TITLE
Faster retry policy

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -53,6 +53,12 @@ const DELAY_MULTIPLIER: u32 = 2;
 /// Max wait delay between retry attempts.
 const MAX_WAIT_DELAY: Duration = Duration::from_secs(15);
 
+/// Number of fast retry attempts before switching to exponential backoff.
+const FAST_RETRY_ATTEMPTS: u32 = 2;
+
+/// Fast retry delay for network recovery scenarios (first FAST_RETRY_ATTEMPTS).
+const NETWORK_RECOVERY_DELAY: Duration = Duration::from_millis(500);
+
 type ResolveApiAddrsFuture = BoxFuture<'static, Result<ResolvedConfig>>;
 type ReconnectDelayFuture = BoxFuture<'static, ()>;
 
@@ -86,17 +92,23 @@ impl ConnectingState {
             .await
             .ok();
 
+        // This prevents hickory resolver from getting confused when system DNS points to
+        // local forwarder but it expects responses from upstream DNS servers.
         #[cfg(target_os = "macos")]
-        if let Err(e) = Self::set_local_dns_resolver(shared_state).await {
+        if retry_attempt > FAST_RETRY_ATTEMPTS
+            && let Err(e) = Self::set_local_dns_resolver(shared_state).await
+        {
             trace_err_chain!(e, "Failed to configure system to use filtering resolver",);
             return ErrorState::enter(ErrorStateReason::SetDns, shared_state).await;
         }
 
-        if shared_state
-            .connectivity_handle
-            .connectivity()
-            .await
-            .is_offline()
+        // On reconnect attempts (retry_attempt > 0), we do want to check if we're actually offline.
+        if retry_attempt > 0
+            && shared_state
+                .connectivity_handle
+                .connectivity()
+                .await
+                .is_offline()
         {
             // FIXME: Temporary: Nudge route manager to update the default interface
             #[cfg(target_os = "macos")]
@@ -141,7 +153,7 @@ impl ConnectingState {
         let resolve_config_fut = Fuse::terminated();
         let reconnect_delay_fut = if retry_attempt > 0 {
             let wait_delay = wait_delay(retry_attempt);
-            tracing::info!("Waiting {}s before reconnect", wait_delay.as_secs());
+            tracing::info!("Waiting {}ms before reconnect", wait_delay.as_millis());
             tokio::time::sleep(wait_delay).boxed().fuse()
         } else {
             std::future::ready(()).boxed().fuse()
@@ -813,7 +825,16 @@ impl ConnectingPolicyParameters {
 }
 
 fn wait_delay(retry_attempt: u32) -> Duration {
-    let multiplier = retry_attempt.saturating_mul(DELAY_MULTIPLIER);
-    let delay = INITIAL_WAIT_DELAY.saturating_mul(multiplier);
-    std::cmp::min(delay, MAX_WAIT_DELAY)
+    // Use fast retries for the first FAST_RETRY_ATTEMPTS to handle network recovery
+    // where the network reports as "online" before DNS/routing are ready.
+    if retry_attempt <= FAST_RETRY_ATTEMPTS {
+        NETWORK_RECOVERY_DELAY
+    } else {
+        // After fast retries, use exponential backoff for persistent failures
+        let multiplier = retry_attempt
+            .saturating_sub(FAST_RETRY_ATTEMPTS)
+            .saturating_mul(DELAY_MULTIPLIER);
+        let delay = INITIAL_WAIT_DELAY.saturating_mul(multiplier);
+        std::cmp::min(delay, MAX_WAIT_DELAY)
+    }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -92,23 +92,17 @@ impl ConnectingState {
             .await
             .ok();
 
-        // This prevents hickory resolver from getting confused when system DNS points to
-        // local forwarder but it expects responses from upstream DNS servers.
         #[cfg(target_os = "macos")]
-        if retry_attempt > FAST_RETRY_ATTEMPTS
-            && let Err(e) = Self::set_local_dns_resolver(shared_state).await
-        {
+        if let Err(e) = Self::set_local_dns_resolver(shared_state).await {
             trace_err_chain!(e, "Failed to configure system to use filtering resolver",);
             return ErrorState::enter(ErrorStateReason::SetDns, shared_state).await;
         }
 
-        // On reconnect attempts (retry_attempt > 0), we do want to check if we're actually offline.
-        if retry_attempt > 0
-            && shared_state
-                .connectivity_handle
-                .connectivity()
-                .await
-                .is_offline()
+        if shared_state
+            .connectivity_handle
+            .connectivity()
+            .await
+            .is_offline()
         {
             // FIXME: Temporary: Nudge route manager to update the default interface
             #[cfg(target_os = "macos")]
@@ -836,5 +830,33 @@ fn wait_delay(retry_attempt: u32) -> Duration {
             .saturating_mul(DELAY_MULTIPLIER);
         let delay = INITIAL_WAIT_DELAY.saturating_mul(multiplier);
         std::cmp::min(delay, MAX_WAIT_DELAY)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn wait_delay_sequence() {
+        let retry_attempt_values: Vec<u32> = (0..10).collect();
+        let expected_delays: [Duration; 10] = [
+            NETWORK_RECOVERY_DELAY,
+            NETWORK_RECOVERY_DELAY,
+            NETWORK_RECOVERY_DELAY,
+            Duration::from_secs(4),
+            Duration::from_secs(8),
+            Duration::from_secs(12),
+            MAX_WAIT_DELAY,
+            MAX_WAIT_DELAY,
+            MAX_WAIT_DELAY,
+            MAX_WAIT_DELAY,
+        ];
+
+        let delay_values: Vec<Duration> = retry_attempt_values
+            .iter()
+            .map(|i| wait_delay(*i))
+            .collect();
+        assert_eq!(delay_values, expected_delays);
     }
 }


### PR DESCRIPTION
## Ticket

[JIRA-NET-718](https://nymtech.atlassian.net/browse/NET-718)

## Description

Changes:
- Add 500ms fast retry for first 2 attempts (vs 2s/4s exponential)
- Keep exponential backoff for persistent failures (attempt 3+)

```text
before:
[0ns, 4s, 8s, 12s, 15s, 15s, 15s, 15s, 15s, 15s... ]

after
[500ms, 500ms, 500ms, 4s, 8s, 12s, 15s, 15s, 15s, 15s...]
```


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3875)
<!-- Reviewable:end -->
