### PR TITLE
fix compile errors encountered after updating rustc to latest (1.91.0)

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-store/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-store/Cargo.toml
@@ -25,9 +25,10 @@ sqlx = { workspace = true, features = [
     "sqlite",
     "macros",
     "migrate",
+    "time",
 ] }
 thiserror.workspace = true
-time.workspace = true
+time = {workspace = true, features=["serde"]}
 tokio = { workspace = true, features = ["sync"] }
 tracing.workspace = true
 zeroize.workspace = true
@@ -39,6 +40,7 @@ sqlx = { workspace = true, features = [
     "sqlite",
     "macros",
     "migrate",
+    "time",
 ] }
 
 [dev-dependencies]


### PR DESCRIPTION
Encountered errors relating to `OffsetDateTime` wrt compatibility for sqlx `Type<Sqlite>` and serde after updating rustc to the latest (1.91.0) . It seems like this just needs explicit features that already exist.

```
error[E0277]: the trait bound `OffsetDateTime: Type<Sqlite>` is not satisfied
   --> crates/nym-vpn-store/src/keys/wireguard/persistence/on_disk.rs:131:14
    |
131 |             .fetch_optional(&self.connection_pool)
    |              ^^^^^^^^^^^^^^ the trait `Type<Sqlite>` is not implemented for `OffsetDateTime`
```

```
error[E0277]: the trait bound `OffsetDateTime: serde::Deserialize<'de>` is not satisfied
  --> crates/nym-vpn-store/src/types.rs:8:35
   |
 8 | #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
   |                                   ^^^^^^^^^^^ the trait `Deserialize<'_>` is not implemented for `OffsetDateTime`
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3887)
<!-- Reviewable:end -->
