### PR TITLE
Fix compilation on Windows and Linux.

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib-types/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/Cargo.toml
@@ -33,7 +33,7 @@ serde = ["dep:serde"]
 
 [dependencies]
 time = { workspace = true, features = ["serde", "parsing", "formatting"] }
-serde = { workspace = true, features = ["derive"], optional = true }
+serde = { workspace = true, features = ["derive", "rc"], optional = true }
 si-scale.workspace = true
 thiserror.workspace = true
 ts-rs = { workspace = true, optional = true }


### PR DESCRIPTION
The `serde` `rc` feature is required to compile on Windows and Linux, but for some reason not on macOS.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3890)
<!-- Reviewable:end -->
