### PR TITLE
Add QUIC section on Censorship screen even if user select mixnet.

### DIFF
--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/censorship/CensorshipViewModel.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/censorship/CensorshipViewModel.kt
@@ -11,7 +11,6 @@ import net.nymtech.nymvpn.data.SettingsRepository
 import net.nymtech.nymvpn.manager.backend.BackendManager
 import net.nymtech.nymvpn.manager.environment.EnvironmentManager
 import net.nymtech.nymvpn.manager.environment.model.FeatureFlagKeys
-import net.nymtech.vpn.backend.Tunnel
 import javax.inject.Inject
 
 @HiltViewModel
@@ -28,8 +27,7 @@ class CensorshipViewModel @Inject constructor(
 		viewModelScope.launch {
 			val domainFronting = environmentManager.isFeatureFlagEnabled(FeatureFlagKeys.DOMAIN_FRONTING)
 			val isQuicFeatureFlagEnabled = environmentManager.isFeatureFlagEnabled(FeatureFlagKeys.QUIC)
-			val isFastTunnel = settingsRepository.getVpnMode() == Tunnel.Mode.TWO_HOP_MIXNET
-			_uiState.update { it.copy(showQUICSection = isQuicFeatureFlagEnabled && isFastTunnel, showDomainSection = domainFronting) }
+			_uiState.update { it.copy(showQUICSection = isQuicFeatureFlagEnabled, showDomainSection = domainFronting) }
 		}
 	}
 

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/censorship/components/ConnectionStatus.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/censorship/components/ConnectionStatus.kt
@@ -2,6 +2,7 @@ package net.nymtech.nymvpn.ui.screens.settings.censorship.components
 
 import net.nymtech.nymvpn.ui.AppUiState
 import net.nymtech.nymvpn.util.extensions.isQuicSupported
+import net.nymtech.vpn.backend.Tunnel
 import nym_vpn_lib_types.TunnelState
 
 enum class ConnectionStatus {
@@ -11,6 +12,7 @@ enum class ConnectionStatus {
 }
 
 internal fun getConnectionStatus(appUiState: AppUiState): ConnectionStatus {
+	if (appUiState.settings.vpnMode != Tunnel.Mode.TWO_HOP_MIXNET) return ConnectionStatus.Disconnected
 	return when (appUiState.managerState.tunnelState) {
 		TunnelState.Connected -> {
 			val isQuicSupported = appUiState.managerState.connectionData?.entryGateway?.id?.let { connectedGatewayId ->


### PR DESCRIPTION
## Ticket

JIRA-VPN-4382

## Description

Android: When mixnet is selected, the Anti-censorship menu is empty

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3897)
<!-- Reviewable:end -->
