### PR TITLE
refactor(tauri): simplify os info type

### DIFF
--- a/nym-vpn-app/src-tauri/src/main.rs
+++ b/nym-vpn-app/src-tauri/src/main.rs
@@ -94,10 +94,9 @@ async fn main() -> Result<()> {
 
     let os = sys::OsInfo::new();
     info!("os: {}", os);
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "openbsd"))]
     {
-        info!("display server: {}", os.display_server.as_ref());
-        info!("gpu: {}", os.gpu.as_ref());
+        os.print_linux_info();
         os.linux_check();
     }
 

--- a/nym-vpn-app/src-tauri/src/sentry.rs
+++ b/nym-vpn-app/src-tauri/src/sentry.rs
@@ -53,10 +53,14 @@ pub fn init(os: &OsInfo) -> Option<ClientInitGuard> {
     ));
     sentry::configure_scope(|scope| {
         scope.set_tag("os_version", &os.version);
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "openbsd"))]
         {
-            scope.set_tag("display_server", os.display_server.as_ref());
-            scope.set_tag("gpu", os.gpu.as_ref());
+            if let Some(ds) = &os.display_server {
+                scope.set_tag("display_server", ds.as_ref());
+            }
+            if let Some(gpu) = &os.gpu {
+                scope.set_tag("gpu", gpu.as_ref());
+            }
         }
         scope.set_user(Some(User {
             id: Some(os.hash.clone()), // anonymized user identifier

--- a/nym-vpn-app/src-tauri/src/sys.rs
+++ b/nym-vpn-app/src-tauri/src/sys.rs
@@ -1,12 +1,9 @@
 use nym_platform_metadata::SysInfo;
 use serde::Serialize;
-#[cfg(any(target_os = "linux", target_os = "openbsd"))]
 use std::{env, process::Command};
-#[cfg(any(target_os = "linux", target_os = "openbsd"))]
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 use ts_rs::TS;
 
-#[cfg(any(target_os = "linux", target_os = "openbsd"))]
 #[derive(Debug, Clone, Serialize, TS, strum::AsRefStr)]
 #[serde(rename_all = "kebab-case")]
 #[ts(export, export_to = "tauri.ts")]
@@ -19,20 +16,21 @@ pub enum GpuType {
     Unknown(Option<String>),
 }
 
-#[cfg(any(target_os = "linux", target_os = "openbsd"))]
-#[derive(Debug, Clone, Default, Serialize, TS, strum::AsRefStr, Eq, PartialEq)]
+#[derive(Debug, Clone, Serialize, TS, strum::AsRefStr, Eq, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 #[ts(export, export_to = "tauri.ts")]
 pub enum DisplayServer {
     X11,
     Wayland,
-    #[default]
-    Unknown,
+    Unknown(Option<String>),
 }
 
-#[cfg(any(target_os = "linux", target_os = "openbsd"))]
-fn get_display_server() -> DisplayServer {
-    match env::var("XDG_SESSION_TYPE")
+fn get_display_server() -> Option<DisplayServer> {
+    if !cfg!(any(target_os = "linux", target_os = "openbsd")) {
+        return None;
+    }
+
+    let display_server = match env::var("XDG_SESSION_TYPE")
         .inspect_err(|e| warn!("XDG_SESSION_TYPE not set or not valid: {e}"))
         .map(|s| s.to_lowercase())
     {
@@ -40,10 +38,11 @@ fn get_display_server() -> DisplayServer {
         Ok(s) if s == "wayland" => DisplayServer::Wayland,
         Ok(s) => {
             warn!("unknown display server: {}", s);
-            DisplayServer::Unknown
+            DisplayServer::Unknown(Some(s))
         }
-        _ => DisplayServer::Unknown,
-    }
+        _ => DisplayServer::Unknown(None),
+    };
+    Some(display_server)
 }
 
 #[derive(Debug, Clone, Default, Serialize, TS)]
@@ -54,11 +53,10 @@ pub struct OsInfo {
     pub version: String,
     pub kernel: String,
     pub arch: String,
-    #[cfg(any(target_os = "linux", target_os = "openbsd"))]
-    pub display_server: DisplayServer,
-    #[cfg(any(target_os = "linux", target_os = "openbsd"))]
-    pub gpu: GpuType,
     pub hash: String,
+    // set on Linux only
+    pub display_server: Option<DisplayServer>,
+    pub gpu: Option<GpuType>,
 }
 
 impl OsInfo {
@@ -70,9 +68,7 @@ impl OsInfo {
             version: system.os_version,
             kernel,
             arch: system.arch,
-            #[cfg(any(target_os = "linux", target_os = "openbsd"))]
             display_server: get_display_server(),
-            #[cfg(any(target_os = "linux", target_os = "openbsd"))]
             gpu: gpu_info(),
             hash,
         }
@@ -82,27 +78,39 @@ impl OsInfo {
     pub fn linux_check(&self) {
         // with NVIDIA gpu, there is an upstream issue with webkit dmabuf renderer
         // see https://github.com/tauri-apps/tauri/issues/9304
-        if matches!(self.gpu, GpuType::Nvidia) {
+        if matches!(self.gpu, Some(GpuType::Nvidia)) {
             info!("NVIDIA gpu detected, disabling webkit dmabuf renderer");
             unsafe {
                 env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
             }
         }
     }
+
+    #[cfg(any(target_os = "linux", target_os = "openbsd"))]
+    pub fn print_linux_info(&self) {
+        if let Some(ds) = &self.display_server {
+            info!("display server: {}", ds.as_ref());
+        }
+        if let Some(gpu) = &self.gpu {
+            info!("gpu: {}", gpu.as_ref());
+        }
+    }
 }
 
-#[cfg(any(target_os = "linux", target_os = "openbsd"))]
-fn gpu_info() -> GpuType {
-    use tracing::debug;
+/// Linux only
+fn gpu_info() -> Option<GpuType> {
+    if !cfg!(any(target_os = "linux", target_os = "openbsd")) {
+        return None;
+    }
 
     let Ok(output) = Command::new("lspci").arg("-nn").output().inspect_err(|e| {
         error!("failed to run lspci: {}", e);
     }) else {
-        return GpuType::Unknown(None);
+        return Some(GpuType::Unknown(None));
     };
     if !output.status.success() {
         error!("lspci failed: {}", String::from_utf8_lossy(&output.stderr));
-        return GpuType::Unknown(None);
+        return Some(GpuType::Unknown(None));
     }
     let output = String::from_utf8_lossy(&output.stdout);
     let Some(info) = output
@@ -110,18 +118,18 @@ fn gpu_info() -> GpuType {
         .find(|line| line.to_lowercase().contains("vga compatible controller"))
     else {
         warn!("no VGA device found in lspci output");
-        return GpuType::Unknown(None);
+        return Some(GpuType::Unknown(None));
     };
     debug!("GPU info: {}", info);
     if info.to_lowercase().contains("nvidia") {
-        return GpuType::Nvidia;
+        return Some(GpuType::Nvidia);
     } else if info.to_lowercase().contains("amd") || info.contains("radeon") {
-        return GpuType::Amd;
+        return Some(GpuType::Amd);
     } else if info.to_lowercase().contains("intel") {
-        return GpuType::Intel;
+        return Some(GpuType::Intel);
     }
     info!("unknown GPU type: {}", info);
-    GpuType::Unknown(Some(info.to_string()))
+    Some(GpuType::Unknown(Some(info.to_string())))
 }
 
 impl std::fmt::Display for OsInfo {
@@ -130,7 +138,6 @@ impl std::fmt::Display for OsInfo {
     }
 }
 
-#[cfg(any(target_os = "linux", target_os = "openbsd"))]
 impl Default for GpuType {
     fn default() -> Self {
         GpuType::Unknown(None)

--- a/nym-vpn-app/src-tauri/src/window.rs
+++ b/nym-vpn-app/src-tauri/src/window.rs
@@ -159,7 +159,7 @@ impl AppWindow {
     #[instrument(skip_all)]
     pub fn set_max_size(
         &self,
-        #[cfg(target_os = "linux")] display_server: DisplayServer,
+        #[cfg(target_os = "linux")] display_server: Option<DisplayServer>,
     ) -> Result<()> {
         let Some(monitor) = self.0.current_monitor().inspect_err(|e| {
             error!("failed to get current monitor: {e}");
@@ -169,7 +169,7 @@ impl AppWindow {
             {
                 // On Wayland it is expected failing to detected monitor info
                 // especially when the window is not yet visible
-                if display_server == DisplayServer::Wayland {
+                if display_server == Some(DisplayServer::Wayland) {
                     tracing::info!("failed to get current monitor details");
                 } else {
                     warn!("failed to get current monitor details");
@@ -244,7 +244,7 @@ pub fn handle_event(#[allow(unused_variables)] os: &OsInfo, win: &Window, event:
             // Toggling the resizable property appears to resolve this issue.
             // see https://github.com/safing/portmaster/issues/1909
             // https://github.com/tauri-apps/tauri/issues/6162#issuecomment-1423304398
-            if os.display_server == DisplayServer::Wayland {
+            if os.display_server == Some(DisplayServer::Wayland) {
                 trace!("toggle resizable");
                 win.set_resizable(false).ok();
                 win.set_resizable(true).ok();

--- a/nym-vpn-app/src/types/tauri.ts
+++ b/nym-vpn-app/src/types/tauri.ts
@@ -80,7 +80,7 @@ export type DbKey =
   | 'cache-device-id'
   | 'streaming-optimized-label-seen';
 
-export type DisplayServer = 'x11' | 'wayland' | 'unknown';
+export type DisplayServer = 'x11' | 'wayland' | { unknown: string | null };
 
 export type DownloadUpdateEvent =
   | { event: 'started'; data: { contentLength: bigint } }
@@ -214,9 +214,9 @@ export type OsInfo = {
   version: string;
   kernel: string;
   arch: string;
-  displayServer: DisplayServer;
-  gpu: GpuType;
   hash: string;
+  displayServer: DisplayServer | null;
+  gpu: GpuType | null;
 };
 
 export type Performance = {


### PR DESCRIPTION
Do not conditionally gate some properties of `OsInfo` and expose them as common type.
As `OsInfo` is TS exported, this remove the previous and annoying differences of the produced TS when generating from Linux, macOS, or Windows.

JIRA-VPN-4418

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3898)
<!-- Reviewable:end -->
