### PR TITLE
PF: prevent state reset for non-tunnel DNS

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Rotate wireguard keys every 1-2 weeks, if disconnected (https://github.com/nymtech/nym-vpn-client/pull/3788)
 
+### Fixed
+
+- [macOS] Prevent resetting state for non-tunnel DNS connections (https://github.com/nymtech/nym-vpn-client/pull/3899)
+
 ## [1.18.0] - 2025-11-03
 
 ### Added

--- a/nym-vpn-core/crates/nym-firewall/src/lib.rs
+++ b/nym-vpn-core/crates/nym-firewall/src/lib.rs
@@ -218,6 +218,14 @@ impl FirewallPolicy {
             | FirewallPolicy::Blocked { allow_lan, .. } => *allow_lan,
         }
     }
+
+    pub fn dns_config(&self) -> Option<&ResolvedDnsConfig> {
+        match self {
+            FirewallPolicy::Connecting { dns_config, .. }
+            | FirewallPolicy::Connected { dns_config, .. } => Some(dns_config),
+            FirewallPolicy::Blocked { .. } => None,
+        }
+    }
 }
 
 impl fmt::Display for FirewallPolicy {

--- a/nym-vpn-core/crates/nym-firewall/src/macos.rs
+++ b/nym-vpn-core/crates/nym-firewall/src/macos.rs
@@ -127,9 +127,29 @@ impl Firewall {
             return Ok(false);
         }
 
-        if [5353, 53].contains(&remote_address.port()) {
-            // Ignore DNS states. The local resolver takes care of everything,
-            // and PQ seems to timeout if these states are flushed
+        // Socket addresses for Multicast DNS.
+        const MDNS_PORT: u16 = 5353;
+        if remote_address.port() == MDNS_PORT {
+            // Blocking mDNS sometimes causes the tunnel to fail. Seemingly by interferring with
+            // configd, mDNSResponder, or another macOS service.
+            return Ok(false);
+        }
+
+        // Do not reset state for non-tunnel DNS traffic
+        if policy.dns_config().is_some_and(|dns| {
+            let is_non_tunnel_dns = dns.non_tunnel_config().iter().any(|ip| {
+                *ip == remote_address.ip() && DNS_TCP_PORTS.contains(&remote_address.port())
+            }) && proto == pfctl::Proto::Tcp;
+
+            // Local DNS resolver is configured with the same hosts
+            // as non-tunnel DNS but uses TCP/UDP port 53
+            let is_local_resolver_dns = dns
+                .non_tunnel_config()
+                .iter()
+                .any(|ip| *ip == remote_address.ip() && remote_address.port() == 53);
+
+            is_non_tunnel_dns || is_local_resolver_dns
+        }) {
             return Ok(false);
         }
 


### PR DESCRIPTION

## JIRA ticket

JIRA-VPN-4438

## Description

Prevent resetting state for non-tunnel DNS connections which would otherwise result into connection reset.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3899)
<!-- Reviewable:end -->
