### PR TITLE
Remove unnecessary DNS resolutions on mobile

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [macOS] Prevent resetting state for non-tunnel DNS connections (https://github.com/nymtech/nym-vpn-client/pull/3899)
 
+### Removed
+
+- Remove unnecessary DNS resolutions on mobile platforms where there is no configurable firewall. (https://github.com/nymtech/nym-vpn-client/pull/3913)
+
 ## [1.18.0] - 2025-11-03
 
 ### Added

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -21,13 +21,8 @@ mod tunnel_monitor;
 #[cfg(windows)]
 mod wintun;
 
-#[cfg(any(target_os = "ios", target_os = "android"))]
-use std::sync::Arc;
-use std::{
-    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
-    path::PathBuf,
-};
-
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+use nym_common::trace_err_chain;
 use nym_config::defaults::{WG_METADATA_PORT, WG_TUN_DEVICE_IP_ADDRESS_V4};
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use nym_dns::ResolvedDnsConfig;
@@ -35,8 +30,16 @@ use nym_offline_monitor::ConnectivityHandle;
 use nym_registration_client::MixnetClientConfig;
 use nym_statistics::{StatisticsSender, events::StatisticsEvent};
 use nym_vpn_account_controller::{AccountCommandSender, AccountStateReceiver};
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+use nym_vpn_api_client::ResolverOverrides;
 use nym_vpn_network_config::{DiscoveryRefresherCommand, Network};
 use nym_vpn_store::keys::wireguard::WireguardKeysDb;
+#[cfg(any(target_os = "ios", target_os = "android"))]
+use std::sync::Arc;
+use std::{
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    path::PathBuf,
+};
 use tokio::{
     sync::{mpsc, oneshot, watch},
     task::JoinHandle,
@@ -455,6 +458,63 @@ impl SharedState {
         } else {
             self.tunnel_settings.allow_lan = allow_lan;
             true
+        }
+    }
+
+    /// Notify discovery and account controller when network is unrestricted.
+    async fn allow_networking(&self) {
+        self.discovery_refresher_command_tx
+            .send(DiscoveryRefresherCommand::Pause(false))
+            .ok();
+        self.account_command_tx
+            .set_vpn_api_firewall_down()
+            .await
+            .ok();
+    }
+
+    /// Notify discovery and account controller when network is restricted.
+    async fn disallow_networking(&self) {
+        self.discovery_refresher_command_tx
+            .send(DiscoveryRefresherCommand::Pause(true))
+            .ok();
+        self.account_command_tx.set_vpn_api_firewall_up().await.ok();
+    }
+
+    /// Set DNS resolver overrides on HTTP clients used by discovery and account controller
+    /// Returns `true` on success, otherwise `false`
+    #[cfg(not(any(target_os = "android", target_os = "ios")))]
+    async fn set_resolver_overrides(
+        &self,
+        nym_vpn_api_resolver_overrides: ResolverOverrides,
+    ) -> bool {
+        self.discovery_refresher_command_tx
+            .send(DiscoveryRefresherCommand::UseResolverOverrides(Some(
+                Box::new(nym_vpn_api_resolver_overrides.clone()),
+            )))
+            .ok();
+        if let Err(err) = self
+            .account_command_tx
+            .set_resolver_overrides(Some(nym_vpn_api_resolver_overrides))
+            .await
+        {
+            trace_err_chain!(
+                err,
+                "Failed to set resolver overrides for account controller"
+            );
+            false
+        } else {
+            true
+        }
+    }
+
+    /// Reset DNS resolver overrides on HTTP clients used by discovery and account controller
+    #[cfg(not(any(target_os = "android", target_os = "ios")))]
+    async fn reset_resolver_overrides(&self) {
+        self.discovery_refresher_command_tx
+            .send(DiscoveryRefresherCommand::UseResolverOverrides(None))
+            .ok();
+        if let Err(err) = self.account_command_tx.set_resolver_overrides(None).await {
+            trace_err_chain!(err, "Failed to unset static API addresses");
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
@@ -27,7 +27,6 @@ use nym_common::trace_err_chain;
 use nym_firewall::{AllowedClients, AllowedEndpoint, Endpoint, FirewallPolicy, TransportProtocol};
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use nym_vpn_lib_types::TunnelConnectionData;
-use nym_vpn_network_config::DiscoveryRefresherCommand;
 
 use super::ErrorState;
 
@@ -91,30 +90,21 @@ impl ConnectedState {
                 PrivateActionAfterDisconnect::Error(ErrorStateReason::SetFirewallPolicy),
                 connected_state.tunnel_monitor_handle,
                 shared_state,
-            );
+            )
+            .await;
         } else if let Err(e) = connected_state.set_dns(shared_state).await {
             trace_err_chain!(e, "failed to set dns");
             return DisconnectingState::enter(
                 PrivateActionAfterDisconnect::Error(ErrorStateReason::SetDns),
                 connected_state.tunnel_monitor_handle,
                 shared_state,
-            );
+            )
+            .await;
         }
 
-        // Configure Discovery Referesher to not use any resolver overrides and to resume operation
-        shared_state
-            .discovery_refresher_command_tx
-            .send(DiscoveryRefresherCommand::UseResolverOverrides(None))
-            .ok();
-        shared_state
-            .discovery_refresher_command_tx
-            .send(DiscoveryRefresherCommand::Pause(false))
-            .ok();
-        shared_state
-            .account_command_tx
-            .set_resolver_overrides(None)
-            .await
-            .ok();
+        // Reset DNS resolver overrides since connections can be established over the tunnel
+        #[cfg(not(any(target_os = "android", target_os = "ios")))]
+        shared_state.reset_resolver_overrides().await;
 
         // We can use slower network fetches now
         shared_state.topology_provider.use_network(true).await;
@@ -206,11 +196,10 @@ impl ConnectedState {
             Self::reset_routes(shared_state).await;
         }
 
-        NextTunnelState::NewState(DisconnectingState::enter(
-            after_disconnect,
-            self.tunnel_monitor_handle,
-            shared_state,
-        ))
+        NextTunnelState::NewState(
+            DisconnectingState::enter(after_disconnect, self.tunnel_monitor_handle, shared_state)
+                .await,
+        )
     }
 
     async fn handle_tunnel_down(

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -14,15 +14,15 @@ use futures::{
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
-use nym_common::trace_err_chain;
-
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+use crate::tunnel_state_machine::Error;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use crate::tunnel_state_machine::gateway_ext::GatewayExt;
 #[cfg(target_os = "macos")]
 use crate::tunnel_state_machine::resolver::LOCAL_DNS_RESOLVER;
 use crate::tunnel_state_machine::{
-    Error, ErrorStateReason, NextTunnelState, PrivateActionAfterDisconnect, PrivateTunnelState,
-    Result, SharedState, TunnelCommand, TunnelInterface, TunnelStateHandler,
+    ErrorStateReason, NextTunnelState, PrivateActionAfterDisconnect, PrivateTunnelState, Result,
+    SharedState, TunnelCommand, TunnelInterface, TunnelStateHandler,
     states::{ConnectedState, DisconnectedState, DisconnectingState, ErrorState, OfflineState},
     tunnel::{SelectedGateways, Tombstone},
     tunnel_monitor::{
@@ -31,6 +31,7 @@ use crate::tunnel_state_machine::{
     },
 };
 
+use nym_common::trace_err_chain;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use nym_dns::DnsConfig;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
@@ -42,7 +43,6 @@ use nym_gateway_directory::ResolvedConfig;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use nym_vpn_lib_types::TunnelConnectionData;
 use nym_vpn_lib_types::{EstablishConnectionData, EstablishConnectionState, GatewayId};
-use nym_vpn_network_config::DiscoveryRefresherCommand;
 
 /// Initial delay between retry attempts.
 const INITIAL_WAIT_DELAY: Duration = Duration::from_secs(2);
@@ -81,16 +81,13 @@ impl ConnectingState {
         selected_gateways: Option<SelectedGateways>,
         shared_state: &mut SharedState,
     ) -> (Box<dyn TunnelStateHandler>, PrivateTunnelState) {
-        // Pause Discovery Refresher until we have resolved all the domains
-        shared_state
-            .discovery_refresher_command_tx
-            .send(DiscoveryRefresherCommand::Pause(true))
-            .ok();
-        shared_state
-            .account_command_tx
-            .set_vpn_api_firewall_up()
-            .await
-            .ok();
+        // Disallow networking until firewall exceptions and resolver overrides are configured
+        #[cfg(not(any(target_os = "android", target_os = "ios")))]
+        shared_state.disallow_networking().await;
+
+        // Always allow networking on mobile since there is no configurable firewall
+        #[cfg(any(target_os = "android", target_os = "ios"))]
+        shared_state.allow_networking().await;
 
         #[cfg(target_os = "macos")]
         if let Err(e) = Self::set_local_dns_resolver(shared_state).await {
@@ -144,7 +141,6 @@ impl ConnectingState {
             firewall_policy_params
         };
 
-        let resolve_config_fut = Fuse::terminated();
         let reconnect_delay_fut = if retry_attempt > 0 {
             let wait_delay = wait_delay(retry_attempt);
             tracing::info!("Waiting {}ms before reconnect", wait_delay.as_millis());
@@ -171,7 +167,7 @@ impl ConnectingState {
             retry_attempt,
             selected_gateways,
             connection_data: initial_connection_data.clone(),
-            resolve_api_addrs_fut: resolve_config_fut,
+            resolve_api_addrs_fut: Fuse::terminated(),
             reconnect_delay_fut,
             #[cfg(not(any(target_os = "android", target_os = "ios")))]
             firewall_policy_params,
@@ -244,11 +240,9 @@ impl ConnectingState {
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         Self::reset_routes(shared_state).await;
 
-        NextTunnelState::NewState(DisconnectingState::enter(
-            after_disconnect,
-            tunnel_monitor_handle,
-            shared_state,
-        ))
+        NextTunnelState::NewState(
+            DisconnectingState::enter(after_disconnect, tunnel_monitor_handle, shared_state).await,
+        )
     }
 
     async fn handle_tunnel_close(tombstone: Tombstone, _shared_state: &mut SharedState) {
@@ -259,6 +253,33 @@ impl ConnectingState {
         let _ = tombstone;
     }
 
+    async fn handle_reconnect_delay(
+        #[allow(unused_mut)] mut self: Box<Self>,
+        shared_state: &mut SharedState,
+    ) -> NextTunnelState {
+        #[cfg(not(any(target_os = "android", target_os = "ios")))]
+        {
+            let gateway_config = shared_state.nym_config.gateway_config.clone();
+
+            self.resolve_api_addrs_fut = async move {
+                nym_gateway_directory::resolve_config(&gateway_config)
+                    .await
+                    .map_err(|err| Error::ResolveApiHostnames(Box::new(err)))
+            }
+            .boxed()
+            .fuse();
+
+            NextTunnelState::SameState(self)
+        }
+
+        #[cfg(any(target_os = "android", target_os = "ios"))]
+        {
+            // Start tunnel monitor immediately since there is no configurable firewall on mobile
+            self.start_tunnel_monitor(None, shared_state).await
+        }
+    }
+
+    #[cfg(not(any(target_os = "android", target_os = "ios")))]
     async fn handle_resolved_gateway_config(
         mut self: Box<Self>,
         resolver_result: Result<ResolvedConfig>,
@@ -275,69 +296,68 @@ impl ConnectingState {
             }
         };
 
-        #[cfg(not(any(target_os = "android", target_os = "ios")))]
-        {
-            self.firewall_policy_params.api_endpoints = resolved_gateway_config.all_socket_addrs();
-            if let Err(err) = Self::set_firewall_policy(shared_state, &self.firewall_policy_params)
-            {
-                trace_err_chain!(err, "failed to set firewall policy");
-                return NextTunnelState::NewState(
-                    ErrorState::enter(ErrorStateReason::SetFirewallPolicy, shared_state).await,
-                );
-            }
+        self.firewall_policy_params.api_endpoints = resolved_gateway_config.all_socket_addrs();
+        if let Err(err) = Self::set_firewall_policy(shared_state, &self.firewall_policy_params) {
+            trace_err_chain!(err, "failed to set firewall policy");
+            return NextTunnelState::NewState(
+                ErrorState::enter(ErrorStateReason::SetFirewallPolicy, shared_state).await,
+            );
         }
 
-        if !resolved_gateway_config.has_resolver_overrides() {
-            tracing::warn!(
-                "There are no resolver overrides, which may result in the firewall blocking API requests"
-            );
-        } else {
-            // Tell the Account Controller about the resolver overrrides
-            if let Err(e) = shared_state
-                .account_command_tx
-                .set_resolver_overrides(Some(
-                    resolved_gateway_config
-                        .nym_vpn_api_resolver_overrides
-                        .clone(),
-                ))
+        if resolved_gateway_config.has_resolver_overrides() {
+            let resolver_overrides = resolved_gateway_config
+                .nym_vpn_api_resolver_overrides
+                .clone();
+
+            // Set DNS resolver overrides to ensure that HTTP clients use IP addresses specified in firewall exceptions.
+            if !shared_state
+                .set_resolver_overrides(resolver_overrides)
                 .await
             {
-                trace_err_chain!(e, "Failed to set resolver overrides for account controller");
                 return NextTunnelState::NewState(
                     ErrorState::enter(
-                        ErrorStateReason::Internal(
-                            "Failed to set static NYM API addresses to account controller"
-                                .to_owned(),
-                        ),
+                        ErrorStateReason::Internal("Failed to set resolver overrides".to_owned()),
                         shared_state,
                     )
                     .await,
                 );
             }
-
-            // Tell the Discovery Refresher about the resolver overrides and resume it
-            shared_state
-                .discovery_refresher_command_tx
-                .send(DiscoveryRefresherCommand::UseResolverOverrides(Some(
-                    Box::new(
-                        resolved_gateway_config
-                            .nym_vpn_api_resolver_overrides
-                            .clone(),
-                    ),
-                )))
-                .ok();
-
-            shared_state
-                .discovery_refresher_command_tx
-                .send(DiscoveryRefresherCommand::Pause(false))
-                .ok();
+        } else {
+            tracing::warn!(
+                "There are no resolver overrides, which may result in the firewall blocking API requests"
+            );
         }
 
-        let _ = shared_state
-            .account_command_tx
-            .set_vpn_api_firewall_down()
-            .await;
+        // Allow networking now when firewall and resolver overrides are configured.
+        shared_state.allow_networking().await;
 
+        self.start_tunnel_monitor(Some(resolved_gateway_config), shared_state)
+            .await
+    }
+
+    #[cfg(any(target_os = "android", target_os = "ios"))]
+    async fn handle_resolved_gateway_config(
+        self: Box<Self>,
+        _resolver_result: Result<ResolvedConfig>,
+        shared_state: &mut SharedState,
+    ) -> NextTunnelState {
+        NextTunnelState::NewState(
+            ErrorState::enter(
+                ErrorStateReason::Internal(
+                    "DNS resolution must not be performed on mobile. This is a logical error."
+                        .to_owned(),
+                ),
+                shared_state,
+            )
+            .await,
+        )
+    }
+
+    async fn start_tunnel_monitor(
+        mut self: Box<Self>,
+        resolved_gateway_config: Option<ResolvedConfig>,
+        shared_state: &mut SharedState,
+    ) -> NextTunnelState {
         let Some(tunnel_monitor_event_sender) = self.tunnel_monitor_event_sender.take() else {
             return NextTunnelState::NewState(
                 ErrorState::enter(
@@ -355,11 +375,11 @@ impl ConnectingState {
 
         let tunnel_parameters = TunnelParameters {
             nym_config: shared_state.nym_config.clone(),
-            resolved_gateway_config: resolved_gateway_config.clone(),
             tunnel_settings: shared_state.tunnel_settings.clone(),
             tunnel_constants: shared_state.tunnel_constants,
             selected_gateways: self.selected_gateways.clone(),
             user_agent: shared_state.user_agent.clone(),
+            resolved_gateway_config,
         };
         let tunnel_monitor_handle = TunnelMonitor::start(
             tunnel_parameters,
@@ -474,18 +494,7 @@ impl TunnelStateHandler for ConnectingState {
     ) -> NextTunnelState {
         tokio::select! {
             _ = &mut self.reconnect_delay_fut => {
-                let gateway_config = shared_state.nym_config.gateway_config.clone();
-
-                self.resolve_api_addrs_fut = async move {
-                    nym_gateway_directory::resolve_config(&gateway_config)
-                        .await
-                        .map_err(Box::new)
-                        .map_err(Error::ResolveApiHostnames)
-                }
-                .boxed()
-                .fuse();
-
-                NextTunnelState::SameState(self)
+                self.handle_reconnect_delay(shared_state).await
             },
             resolved_gateway_config = &mut self.resolve_api_addrs_fut => {
                 self.handle_resolved_gateway_config(resolved_gateway_config, shared_state).await
@@ -522,7 +531,7 @@ impl TunnelStateHandler for ConnectingState {
                                         PrivateActionAfterDisconnect::Error(ErrorStateReason::SetFirewallPolicy),
                                         tunnel_monitor_handle,
                                         shared_state
-                                    ))
+                                    ).await)
                                 } else {
                                     NextTunnelState::NewState(ErrorState::enter(ErrorStateReason::SetFirewallPolicy, shared_state).await)
                                 }
@@ -544,7 +553,7 @@ impl TunnelStateHandler for ConnectingState {
                                         PrivateActionAfterDisconnect::Error(ErrorStateReason::SetFirewallPolicy),
                                         tunnel_monitor_handle,
                                         shared_state
-                                    ))
+                                    ).await)
                                 } else {
                                     NextTunnelState::NewState(ErrorState::enter(ErrorStateReason::SetFirewallPolicy, shared_state).await)
                                 }
@@ -568,7 +577,7 @@ impl TunnelStateHandler for ConnectingState {
                                         PrivateActionAfterDisconnect::Error(ErrorStateReason::SetFirewallPolicy),
                                         tunnel_monitor_handle,
                                         shared_state
-                                    ))
+                                    ).await)
                                 } else {
                                     NextTunnelState::NewState(ErrorState::enter(ErrorStateReason::SetFirewallPolicy, shared_state).await)
                                 }
@@ -596,7 +605,7 @@ impl TunnelStateHandler for ConnectingState {
                                 PrivateActionAfterDisconnect::Error(error_state_reason),
                                 self.tunnel_monitor_handle.expect("monitor handle must be set!"),
                                 shared_state
-                            ))
+                            ).await)
                         } else {
                             if let Some(tunnel_monitor_handle) = self.tunnel_monitor_handle.take() {
                                 let tombstone = tunnel_monitor_handle.wait().await;

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnected_state.rs
@@ -26,7 +26,7 @@ impl DisconnectedState {
         Self::reset_firewall_policy(shared_state);
 
         // Drop tombstone to close tunnel devices.
-        let _ = tombstone;
+        drop(tombstone);
 
         // Reset resolver overrides and allow all networking since firewall is no longer active
         #[cfg(not(any(target_os = "android", target_os = "ios")))]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnected_state.rs
@@ -9,8 +9,8 @@ use crate::tunnel_state_machine::{
     states::{ConnectingState, OfflineState},
     tunnel::Tombstone,
 };
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 use nym_common::trace_err_chain;
-use nym_vpn_network_config::DiscoveryRefresherCommand;
 
 pub struct DisconnectedState;
 
@@ -19,36 +19,19 @@ impl DisconnectedState {
         tombstone: Option<Tombstone>,
         shared_state: &mut SharedState,
     ) -> (Box<dyn TunnelStateHandler>, PrivateTunnelState) {
-        // Configure Discovery Referesher to not use any resolver overrides and to resume operation
-        shared_state
-            .discovery_refresher_command_tx
-            .send(DiscoveryRefresherCommand::UseResolverOverrides(None))
-            .ok();
-        shared_state
-            .discovery_refresher_command_tx
-            .send(DiscoveryRefresherCommand::Pause(false))
-            .ok();
-
         #[cfg(target_os = "macos")]
         Self::reset_dns(shared_state).await;
 
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         Self::reset_firewall_policy(shared_state);
 
-        if let Err(e) = shared_state
-            .account_command_tx
-            .set_resolver_overrides(None)
-            .await
-        {
-            trace_err_chain!(e, "Failed to unset static API addresses");
-        }
-        let _ = shared_state
-            .account_command_tx
-            .set_vpn_api_firewall_down()
-            .await;
-
         // Drop tombstone to close tunnel devices.
         let _ = tombstone;
+
+        // Reset resolver overrides and allow all networking since firewall is no longer active
+        #[cfg(not(any(target_os = "android", target_os = "ios")))]
+        shared_state.reset_resolver_overrides().await;
+        shared_state.allow_networking().await;
 
         (Box::new(Self), PrivateTunnelState::Disconnected)
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnecting_state.rs
@@ -21,11 +21,14 @@ pub struct DisconnectingState {
 }
 
 impl DisconnectingState {
-    pub fn enter(
+    pub async fn enter(
         after_disconnect: PrivateActionAfterDisconnect,
         tunnel_monitor_handle: TunnelMonitorHandle,
         shared_state: &mut SharedState,
     ) -> (Box<dyn TunnelStateHandler>, PrivateTunnelState) {
+        // Disallow networking when disconnecting to prevent new connections during tunnel shutdown
+        shared_state.disallow_networking().await;
+
         // It's safe to abort status listener as it's stateless.
         if let Some(status_listener_handle) = shared_state.status_listener_handle.take() {
             status_listener_handle.abort();

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
@@ -57,6 +57,9 @@ impl ErrorState {
         reason: ErrorStateReason,
         shared_state: &mut SharedState,
     ) -> (Box<dyn TunnelStateHandler>, PrivateTunnelState) {
+        // Disallow networking in error state since there are no configured firewall exceptions
+        shared_state.disallow_networking().await;
+
         #[cfg(target_os = "macos")]
         if !reason.prevents_filtering_resolver() {
             // Set system DNS to our local DNS resolver
@@ -69,6 +72,8 @@ impl ErrorState {
         {
             Self::set_blocking_network_settings(shared_state.tun_provider.clone()).await;
         }
+
+        // todo: activate kill switch on Android
 
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         let firewall_policy_params = BlockedPolicyParameters {
@@ -85,10 +90,6 @@ impl ErrorState {
             firewall_policy_params,
         };
 
-        let _ = shared_state
-            .account_command_tx
-            .set_vpn_api_firewall_up()
-            .await;
         (Box::new(blocked_state), PrivateTunnelState::Error(reason))
     }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/offline_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/offline_state.rs
@@ -19,7 +19,6 @@ use crate::tunnel_state_machine::{
 use nym_common::trace_err_chain;
 #[cfg(target_os = "macos")]
 use nym_dns::DnsConfig;
-use nym_vpn_network_config::DiscoveryRefresherCommand;
 
 pub struct OfflineState {
     /// Whether to connect the tunnel once online
@@ -38,15 +37,7 @@ impl OfflineState {
         selected_gateways: Option<SelectedGateways>,
         shared_state: &mut SharedState,
     ) -> (Box<dyn TunnelStateHandler>, PrivateTunnelState) {
-        // Configure Discovery Referesher to not use any resolver overrides and to pause operation
-        shared_state
-            .discovery_refresher_command_tx
-            .send(DiscoveryRefresherCommand::UseResolverOverrides(None))
-            .ok();
-        shared_state
-            .discovery_refresher_command_tx
-            .send(DiscoveryRefresherCommand::Pause(true))
-            .ok();
+        shared_state.disallow_networking().await;
 
         #[cfg(target_os = "macos")]
         if Self::set_local_dns_resolver(shared_state).await.is_err() {
@@ -62,11 +53,6 @@ impl OfflineState {
         if let Err(e) = Self::set_firewall_policy(shared_state, &firewall_policy_params) {
             trace_err_chain!(e, "Failed to apply firewall policy for blocked state");
         }
-
-        let _ = shared_state
-            .account_command_tx
-            .set_vpn_api_firewall_up()
-            .await;
 
         (
             Box::new(Self {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -212,7 +212,7 @@ impl TunnelMonitorHandle {
 #[derive(Debug, Clone)]
 pub struct TunnelParameters {
     pub nym_config: NymConfig,
-    pub resolved_gateway_config: ResolvedConfig,
+    pub resolved_gateway_config: Option<ResolvedConfig>,
     pub tunnel_settings: TunnelSettings,
     pub tunnel_constants: TunnelConstants,
     pub selected_gateways: Option<SelectedGateways>,
@@ -354,19 +354,17 @@ impl TunnelMonitor {
         }
 
         let user_agent = self.tunnel_parameters.user_agent.clone();
-        let resolver_overrides = Some(
-            &self
-                .tunnel_parameters
-                .resolved_gateway_config
-                .nym_api_resolver_overrides,
-        );
+        let resolver_overrides = self
+            .tunnel_parameters
+            .resolved_gateway_config
+            .as_ref()
+            .map(|v| &v.nym_api_resolver_overrides);
 
-        let vpn_resolver_overrides = Some(
-            &self
-                .tunnel_parameters
-                .resolved_gateway_config
-                .nym_vpn_api_resolver_overrides,
-        );
+        let vpn_resolver_overrides = self
+            .tunnel_parameters
+            .resolved_gateway_config
+            .as_ref()
+            .map(|v| &v.nym_vpn_api_resolver_overrides);
 
         let gateway_directory_client = GatewayClient::new_with_resolver_overrides(
             gateway_config.clone(),
@@ -456,12 +454,10 @@ impl TunnelMonitor {
                 mixnet_client_config
                     .min_gateway_performance
                     .unwrap_or(DEFAULT_MIN_GATEWAY_PERFORMANCE),
-                Some(
-                    self.tunnel_parameters
-                        .resolved_gateway_config
-                        .nym_api_resolver_overrides
-                        .clone(),
-                ),
+                self.tunnel_parameters
+                    .resolved_gateway_config
+                    .as_ref()
+                    .map(|v| v.nym_api_resolver_overrides.clone()),
             )
             .await;
 


### PR DESCRIPTION
## Ticket

JIRA-VPN-4446

## Description

There is no configurable firewall on mobile, therefore there is no reason for us to resolve domains like we do on desktop platforms where those IPs are used for creation of firewall exceptions.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3913)
<!-- Reviewable:end -->
