### PR TITLE
Split RequestingZkNyms from Syncing in returned states

### DIFF
--- a/nym-vpn-app/src-tauri/src/grpc/account.rs
+++ b/nym-vpn-app/src-tauri/src/grpc/account.rs
@@ -23,6 +23,7 @@ pub enum AccountState {
     StatusNotActive,
     NoSubscription,
     MaxDeviceReached,
+    RequestingZkNyms,
     Error(BackendError),
 }
 
@@ -34,6 +35,7 @@ impl AccountState {
             State::ReadyToConnect(_) => AccountState::Ready,
             State::Decentralised(_) => AccountState::Decentralised,
             State::Offline(_) => AccountState::Offline,
+            State::RequestingZkNyms(_) => AccountState::RequestingZkNyms,
             State::Error(error) => match error.reason() {
                 ErrorStateReason::BandwidthExceeded => AccountState::BandwidthExceeded,
                 ErrorStateReason::AccountStatusNotActive => AccountState::StatusNotActive,

--- a/nym-vpn-app/src/i18n/en/settings.json
+++ b/nym-vpn-app/src/i18n/en/settings.json
@@ -98,6 +98,7 @@
     "bandwidth-exceeded": "Bandwidth exceeded",
     "max-device-reached": "Max devices reached",
     "status-inactive": "Account is inactive",
+    "requesting-zknyms": "Requesting ZkNyms",
     "error": "Internal error"
   }
 }

--- a/nym-vpn-app/src/screens/settings/account/Account.tsx
+++ b/nym-vpn-app/src/screens/settings/account/Account.tsx
@@ -60,6 +60,8 @@ function Account() {
         return t('account.status-inactive');
       case 'bandwidth-exceeded':
         return t('account.bandwidth-exceeded');
+      case 'requesting-zk-nyms':
+        return t('account.requesting-zknyms');
       case 'offline':
       case 'error':
         return t('account.error');

--- a/nym-vpn-app/src/types/tauri.ts
+++ b/nym-vpn-app/src/types/tauri.ts
@@ -267,6 +267,7 @@ export type TAccountState =
   | 'status-not-active'
   | 'no-subscription'
   | 'max-device-reached'
+  | 'requesting-zk-nyms'
   | { error: TBackendError };
 
 /**

--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -7,11 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- Implement a TCP-based probe as a fallback for connection monitoring when ICMP is unavailable. (https://github.com/nymtech/nym-vpn-client/pull/3868)
-- Expose A/C's `RequestingZkNyms` state to UI for in app payment flows (https://github.com/nymtech/nym-vpn-client/pull/3925)
-
 ### Changed
 
 - Rotate wireguard keys every 1-2 weeks, if disconnected (https://github.com/nymtech/nym-vpn-client/pull/3788)
@@ -23,6 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Remove unnecessary DNS resolutions on mobile platforms where there is no configurable firewall. (https://github.com/nymtech/nym-vpn-client/pull/3913)
+
+## [1.18.1] - TBD
+
+### Added
+
+- Implement a TCP-based probe as a fallback for connection monitoring when ICMP is unavailable. (https://github.com/nymtech/nym-vpn-client/pull/3868)
+- Expose A/C's `RequestingZkNyms` state to UI for in app payment flows (https://github.com/nymtech/nym-vpn-client/pull/3925)
 
 ## [1.18.0] - 2025-11-03
 

--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Implement a TCP-based probe as a fallback for connection monitoring when ICMP is unavailable. (https://github.com/nymtech/nym-vpn-client/pull/3868)
-- Expose A/C's `RequestingZkNyms` state to UI for in app payment flows
+- Expose A/C's `RequestingZkNyms` state to UI for in app payment flows (https://github.com/nymtech/nym-vpn-client/pull/3925)
 
 ### Changed
 

--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Implement a TCP-based probe as a fallback for connection monitoring when ICMP is unavailable. (https://github.com/nymtech/nym-vpn-client/pull/3868)
+- Expose A/C's `RequestingZkNyms` state to UI for in app payment flows
 
 ### Changed
 

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/mod.rs
@@ -67,7 +67,7 @@ impl From<PrivateAccountControllerState> for AccountControllerState {
             PrivateAccountControllerState::ReadyToConnect => Self::ReadyToConnect,
             PrivateAccountControllerState::Decentralised => Self::Decentralised,
             PrivateAccountControllerState::Error(reason) => Self::Error(reason),
-            PrivateAccountControllerState::RequestingZkNyms => Self::Syncing,
+            PrivateAccountControllerState::RequestingZkNyms => Self::RequestingZkNyms,
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
@@ -322,7 +322,9 @@ impl SyncError {
     fn is_retryable(&self) -> bool {
         matches!(
             self,
-            SyncError::ApiRequestError(_) | SyncError::DeviceTimeDesynced
+            SyncError::ApiRequestError(_)
+                | SyncError::DeviceTimeDesynced
+                | SyncError::InactiveSubscription // in the case of IAP, it might take a while for the subscription to become active
         )
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_receiver.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_receiver.rs
@@ -19,8 +19,9 @@ impl AccountStateReceiver {
     pub async fn wait_for_account_ready_to_connect(
         &mut self,
     ) -> Result<(), AccountControllerError> {
+        let state = self.get_state();
         loop {
-            match self.get_state() {
+            match state {
                 AccountControllerState::Offline => {
                     return Err(AccountControllerError::Offline);
                 }
@@ -31,7 +32,7 @@ impl AccountStateReceiver {
                     return Err(AccountControllerError::ErrorState(reason));
                 }
                 AccountControllerState::Syncing | AccountControllerState::RequestingZkNyms => {
-                    tracing::debug!("Account controller is syncing, waiting for the next state");
+                    tracing::debug!("Account controller is {state}, waiting for the next state");
 
                     self.inner.changed().await.map_err(|_| {
                         AccountControllerError::Internal(

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_receiver.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_receiver.rs
@@ -30,7 +30,7 @@ impl AccountStateReceiver {
                 AccountControllerState::Error(reason) => {
                     return Err(AccountControllerError::ErrorState(reason));
                 }
-                AccountControllerState::Syncing => {
+                AccountControllerState::Syncing | AccountControllerState::RequestingZkNyms => {
                     tracing::debug!("Account controller is syncing, waiting for the next state");
 
                     self.inner.changed().await.map_err(|_| {

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/account/controller_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/account/controller_state.rs
@@ -30,6 +30,9 @@ pub enum AccountControllerState {
     /// Not logged in with a mnemonic
     LoggedOut,
 
+    /// Logged in, registered device, zk-nyms not available
+    RequestingZkNyms,
+
     /// Logged in, registered device, available zk-nyms
     ReadyToConnect,
 
@@ -51,6 +54,9 @@ impl fmt::Display for AccountControllerState {
             }
             Self::LoggedOut => {
                 write!(f, "Logged Out")
+            }
+            Self::RequestingZkNyms => {
+                write!(f, "Requesting zk-nyms")
             }
             Self::ReadyToConnect => {
                 write!(f, "Ready to connect")

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -628,6 +628,7 @@ message AccountControllerState {
 
   message LoggedOut {}
   message ReadyToConnect {}
+  message RequestingZkNyms {}
   message Syncing {}
   message Error {
     ErrorStateReason reason = 1;
@@ -641,6 +642,7 @@ message AccountControllerState {
   oneof state {
     LoggedOut logged_out = 1;
     Syncing syncing = 2;
+    RequestingZkNyms requesting_zk_nyms = 7;
     ReadyToConnect ready_to_connect = 3;
     Error error = 4;
     Offline offline = 5;

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/account_controller_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/account_controller_state.rs
@@ -131,7 +131,11 @@ impl From<AccountControllerState> for proto::AccountControllerState {
             AccountControllerState::Syncing => proto::account_controller_state::State::Syncing(
                 proto::account_controller_state::Syncing {},
             ),
-
+            AccountControllerState::RequestingZkNyms => {
+                proto::account_controller_state::State::RequestingZkNyms(
+                    proto::account_controller_state::RequestingZkNyms {},
+                )
+            }
             AccountControllerState::Offline => proto::account_controller_state::State::Offline(
                 proto::account_controller_state::Offline {},
             ),
@@ -166,6 +170,9 @@ impl TryFrom<proto::AccountControllerState> for AccountControllerState {
             proto::account_controller_state::State::ReadyToConnect(
                 proto::account_controller_state::ReadyToConnect {},
             ) => Self::ReadyToConnect,
+            proto::account_controller_state::State::RequestingZkNyms(
+                proto::account_controller_state::RequestingZkNyms {},
+            ) => Self::RequestingZkNyms,
             proto::account_controller_state::State::Syncing(
                 proto::account_controller_state::Syncing {},
             ) => Self::Syncing,


### PR DESCRIPTION
## Ticket

JIRA-VPN-4448

## Description

Expose the existing `RequestingZkNyms` state to UI so that it can know when to end the IAP flow.


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3925)
<!-- Reviewable:end -->
