### PR TITLE
Filter out gateways that might be blacklisted by mixnet

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [macOS] Prevent resetting state for non-tunnel DNS connections (https://github.com/nymtech/nym-vpn-client/pull/3899)
+- Filter out gateways that might be blacklisted by mixnet (https://github.com/nymtech/nym-vpn-client/pull/3948)
 
 ### Removed
 

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway.rs
@@ -218,6 +218,14 @@ impl Gateway {
         }
     }
 
+    pub fn not_mixnet_blacklisted(&self) -> bool {
+        // Currently the mixnet blacklisting threshold is 50%, so let's take a slightly bigger number
+        // in case of caching differences between VPN API and mixnet API
+        self.mixnet_performance
+            .as_ref()
+            .is_some_and(|p| p.round_to_integer() > 55)
+    }
+
     /// Tests whether the gateway matches a specific filter.
     pub fn matches_filter(&self, gw_type: Option<GatewayType>, filter: &GatewayFilter) -> bool {
         match filter {

--- a/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
@@ -446,6 +446,8 @@ impl GatewayClient {
                     .inspect_err(|err| error!("Failed to parse gateway: {err}"))
                     .ok()
             })
+            // we need to filter for possible mixnet blacklisting, as the mixnet channel is a prerequisite for VPN connection too
+            .filter(|gw| gw.not_mixnet_blacklisted())
             .collect();
 
         tracing::debug!(


### PR DESCRIPTION
## Ticket

JIRA-VPN-4396

## Description

Under 50% mixnet performance gateways will be blacklisted by the mixnet infrastructure. We need to filter them out for both mixnet AND wireguard mode, since the latter is also using the mixnet for registration.


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3948)
<!-- Reviewable:end -->
