### PR TITLE
Cherry-pick: Make SM move when connecing in RequestingZkNyms phase

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_receiver.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_receiver.rs
@@ -19,7 +19,7 @@ impl AccountStateReceiver {
     pub async fn wait_for_account_ready_to_connect(
         &mut self,
     ) -> Result<(), AccountControllerError> {
-        let state = self.get_state();
+        let mut state = self.get_state();
         loop {
             match state {
                 AccountControllerState::Offline => {
@@ -39,6 +39,7 @@ impl AccountStateReceiver {
                             "Account controller state receiver has closed".into(),
                         )
                     })?;
+                    state = self.get_state();
                 }
                 AccountControllerState::ReadyToConnect | AccountControllerState::Decentralised => {
                     return Ok(());


### PR DESCRIPTION
## Ticket

JIRA-VPN-4468

## Description

Make the AC state machine advance when trying to connect in the `RequestingZkNyms` phase 



## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3955)
<!-- Reviewable:end -->
