### PR TITLE
cancel waiting for account readiness

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_receiver.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_receiver.rs
@@ -19,8 +19,8 @@ impl AccountStateReceiver {
     pub async fn wait_for_account_ready_to_connect(
         &mut self,
     ) -> Result<(), AccountControllerError> {
-        let mut state = self.get_state();
         loop {
+            let state = self.get_state();
             match state {
                 AccountControllerState::Offline => {
                     return Err(AccountControllerError::Offline);
@@ -39,7 +39,6 @@ impl AccountStateReceiver {
                             "Account controller state receiver has closed".into(),
                         )
                     })?;
-                    state = self.get_state();
                 }
                 AccountControllerState::ReadyToConnect | AccountControllerState::Decentralised => {
                     return Ok(());

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -302,27 +302,11 @@ impl TunnelMonitor {
 
         self.send_event(TunnelMonitorEvent::AwaitingAccountReadiness);
 
-        match self
-            .account_controller_state
-            .wait_for_account_ready_to_connect()
+        self.shutdown_token
+            .clone()
+            .run_until_cancelled(self.await_account_readiness_with_retry())
             .await
-        {
-            Ok(()) => Ok(()),
-            Err(AccountControllerError::ErrorState(reason)) if reason.is_retryable() => {
-                tracing::debug!(
-                    "Account controller is in a retryable error state : {reason}. Forcing a refresh"
-                );
-                self.account_command_tx
-                    .background_refresh_account_state()
-                    .await
-                    .map_err(|e| Error::Account(account::Error::Command(e)))?;
-                self.account_controller_state
-                    .wait_for_account_ready_to_connect()
-                    .await
-            }
-            Err(e) => Err(e),
-        }
-        .map_err(|e| Error::Account(account::Error::ControllerState(e)))?;
+            .ok_or(tunnel::Error::Cancelled)??;
 
         self.send_event(TunnelMonitorEvent::RefreshingGateways);
 
@@ -846,6 +830,30 @@ impl TunnelMonitor {
         tracing::info!("Tunnel monitor finished");
 
         Ok(tun_devices)
+    }
+
+    async fn await_account_readiness_with_retry(&mut self) -> Result<(), Error> {
+        match self
+            .account_controller_state
+            .wait_for_account_ready_to_connect()
+            .await
+        {
+            Ok(()) => Ok(()),
+            Err(AccountControllerError::ErrorState(reason)) if reason.is_retryable() => {
+                tracing::debug!(
+                    "Account controller is in a retryable error state : {reason}. Forcing a refresh"
+                );
+                self.account_command_tx
+                    .background_refresh_account_state()
+                    .await
+                    .map_err(|e| Error::Account(account::Error::Command(e)))?;
+                self.account_controller_state
+                    .wait_for_account_ready_to_connect()
+                    .await
+            }
+            Err(e) => Err(e),
+        }
+        .map_err(|e| Error::Account(account::Error::ControllerState(e)))
     }
 
     fn send_event(&mut self, event: TunnelMonitorEvent) {


### PR DESCRIPTION
## Ticket

JIRA-VPN-XXXX

## Description

The tunnel isn't responding to disconnection when waiting on the Account to be ready. 
This PR fixes that


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3964)
<!-- Reviewable:end -->
