### PR TITLE
Update client for DNS resolver IPv6 timeout fixes

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-api-client/src/resolve_host.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/resolve_host.rs
@@ -13,9 +13,7 @@ const HOSTNAME_RESOLUTION_TIMEOUT: Duration = Duration::from_secs(10);
 
 async fn try_resolve_hostname(hostname: &str) -> Result<Vec<IpAddr>> {
     tracing::debug!("Trying to resolve hostname: {hostname}");
-    let mut resolver = HickoryDnsResolver::default();
-    // Disable system resolver because it's typically blocked by firewall anyway.
-    resolver.disable_system_fallback();
+    let resolver = HickoryDnsResolver::default();
 
     let addrs =
         match tokio::time::timeout(HOSTNAME_RESOLUTION_TIMEOUT, resolver.resolve_str(hostname))

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/types/resolver_overrides.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/types/resolver_overrides.rs
@@ -3,10 +3,11 @@
 use std::{
     collections::{HashMap, HashSet},
     net::SocketAddr,
+    sync::Arc,
 };
 
 use itertools::{Either, Itertools};
-use tokio::task::JoinSet;
+use tokio::{sync::Semaphore, task::JoinSet};
 
 use nym_http_api_client::Url;
 use nym_network_defaults::ApiUrl;
@@ -19,6 +20,8 @@ pub struct ResolverOverrides {
 }
 
 impl ResolverOverrides {
+    const MAX_PARALLEL_RESOLUTIONS: usize = 8;
+
     /// Create a new set of resolver overrides from the provided URLs.
     /// Resolves all domains in parallel for faster startup and reconnection.
     pub async fn from_urls(urls: &[Url]) -> Result<Self, VpnApiClientError> {
@@ -33,6 +36,8 @@ impl ResolverOverrides {
             })
             .collect::<HashSet<_>>();
 
+        let semaphore = Arc::new(Semaphore::new(Self::MAX_PARALLEL_RESOLUTIONS));
+
         for url in urls_to_resolve {
             let Some(domain) = url.domain().map(|s| s.to_owned()) else {
                 tracing::warn!(
@@ -42,7 +47,12 @@ impl ResolverOverrides {
                 continue;
             };
 
+            let semaphore = semaphore.clone();
             join_set.spawn(async move {
+                let _permit = semaphore
+                    .acquire_owned()
+                    .await
+                    .expect("semaphore should not be closed");
                 let result = url_to_socket_addr(&url, Some((1, 1)))
                     .await
                     .inspect_err(|err| {


### PR DESCRIPTION
- Uses DNS resolver relies on this [change](https://github.com/nymtech/nym/pull/6206)
- IPv6 timeouts, resulting in faster gateway selection and connection.
- Improving parallel DNS resolution performance

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3965)
<!-- Reviewable:end -->
