### PR TITLE
feat(tauri): show quic label only when connected in bridge mode

### DIFF
--- a/nym-vpn-app/src/screens/home/HopSelect.tsx
+++ b/nym-vpn-app/src/screens/home/HopSelect.tsx
@@ -14,7 +14,7 @@ import { useLang } from '../../hooks';
 import { useGateways, useMainState } from '../../contexts';
 import { countriesWithRegions } from '../../constants';
 import { QuicTag } from '../node';
-import { useActionToast } from './util';
+import { isBridgeMode, useActionToast } from './util';
 
 type HopSelectProps = {
   node: SelectedNode;
@@ -33,13 +33,18 @@ export default function HopSelect({
   disabled,
   locked,
 }: HopSelectProps) {
-  const { backendFlags, quic, vpnMode } = useMainState();
+  const { backendFlags, vpnMode, tunnel, connectingState } = useMainState();
   const { lookupGw } = useGateways();
   const { t } = useTranslation('home');
   const { getCountryName } = useLang();
   const toast = useActionToast('node-select');
+  const quicConnection =
+    isBridgeMode(tunnel?.data) || isBridgeMode(connectingState?.tunnel);
   const quicTag =
-    vpnMode === 'wg' && nodeHop === 'entry' && backendFlags.quic && quic;
+    vpnMode === 'wg' &&
+    nodeHop === 'entry' &&
+    backendFlags.quic &&
+    quicConnection;
 
   const handleClick = () => {
     if (disabled) {

--- a/nym-vpn-app/src/screens/home/util.ts
+++ b/nym-vpn-app/src/screens/home/util.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useInAppNotify, useMainState } from '../../contexts';
-import { StateDispatch } from '../../types';
+import { StateDispatch, TunnelData, isWireguardData } from '../../types';
 import { kvSet } from '../../kvStore';
 
 export function useActionToast(action: 'node-select' | 'mode-select') {
@@ -49,3 +49,10 @@ export const setStreamOptimizedLabelSeen = (dispatch: StateDispatch) => {
   dispatch({ type: 'set-streaming-optimized-label-seen', seen: true });
   kvSet('streaming-optimized-label-seen', true);
 };
+
+export function isBridgeMode(data?: TunnelData | null) {
+  if (!data) {
+    return false;
+  }
+  return isWireguardData(data) && data.entryBridgeAddr;
+}


### PR DESCRIPTION
cherrypick

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/3973)
<!-- Reviewable:end -->
