### PR TITLE
VPN-4521: Handle `get_remote_time` error.

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
@@ -1,13 +1,12 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use crate::state_machine::DecentralisedState;
 use crate::{
     SharedAccountState,
     commands::{AccountCommand, UpgradeModeCommand, common_handler, handler},
     state_machine::{
-        AccountControllerStateHandler, ErrorState, LoggedOutState, NextAccountControllerState,
-        OfflineState, PrivateAccountControllerState,
+        AccountControllerStateHandler, DecentralisedState, ErrorState, LoggedOutState,
+        NextAccountControllerState, OfflineState, PrivateAccountControllerState,
     },
 };
 use nym_offline_monitor::ConnectivityMonitor;
@@ -109,7 +108,6 @@ impl SyncingState {
             }
         };
 
-
         // Make sure time isn't too much desynced, othersiwe Zk-nyms will fail to verify on gateways
         match vpn_api_client.get_remote_time().await {
             Ok(remote_time) => {
@@ -160,9 +158,7 @@ impl SyncingState {
                 }
             }
 
-            Err(e) => {
-                handle_vpn_api_error(e)
-            }
+            Err(e) => handle_vpn_api_error(e),
         }
     }
 

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
@@ -91,13 +91,35 @@ impl SyncingState {
         vpn_api_account: &VpnAccount,
         device: &Device,
     ) -> Result<bool, SyncError> {
+        let handle_vpn_api_error = |e: VpnApiClientError| -> Result<bool, SyncError> {
+            let error_response = NymErrorResponse::try_from(e)?;
+            // SW Use UUID when it will be available
+            if error_response.status == "access_denied"
+                && error_response.message == "Account not found"
+            {
+                // Request was fine, but account is unregistered
+                // Later down the line we can maybe register it here
+                Err(SyncError::UnregisteredAccount)
+            } else {
+                Err(SyncError::ApiResponseError {
+                    details: error_response
+                        .code_reference_id
+                        .unwrap_or(error_response.message),
+                })
+            }
+        };
+
+
         // Make sure time isn't too much desynced, othersiwe Zk-nyms will fail to verify on gateways
-        if !vpn_api_client
-            .get_remote_time()
-            .await?
-            .is_acceptable_synced()
-        {
-            return Err(SyncError::DeviceTimeDesynced);
+        match vpn_api_client.get_remote_time().await {
+            Ok(remote_time) => {
+                if !remote_time.is_acceptable_synced() {
+                    return Err(SyncError::DeviceTimeDesynced);
+                }
+            }
+            Err(e) => {
+                return handle_vpn_api_error(e);
+            }
         }
 
         match vpn_api_client
@@ -139,21 +161,7 @@ impl SyncingState {
             }
 
             Err(e) => {
-                let error_response = NymErrorResponse::try_from(e)?;
-                // SW Use UUID when it will be available
-                if error_response.status == "access_denied"
-                    && error_response.message == "Account not found"
-                {
-                    // Request was fine, but account is unregistered
-                    // Later down the line we can maybe register it here
-                    Err(SyncError::UnregisteredAccount)
-                } else {
-                    Err(SyncError::ApiResponseError {
-                        details: error_response
-                            .code_reference_id
-                            .unwrap_or(error_response.message),
-                    })
-                }
+                handle_vpn_api_error(e)
             }
         }
     }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/requesting_zknym_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/requesting_zknym_state.rs
@@ -8,7 +8,6 @@ use nym_vpn_api_client::{
     types::{Device, VpnAccount},
 };
 
-use crate::state_machine::UpgradeModeState;
 use crate::{
     SharedAccountState,
     commands::{
@@ -17,7 +16,7 @@ use crate::{
     },
     state_machine::{
         AccountControllerStateHandler, ErrorState, LoggedOutState, NextAccountControllerState,
-        OfflineState, PrivateAccountControllerState, ReadyState, SyncingState,
+        OfflineState, PrivateAccountControllerState, ReadyState, SyncingState, UpgradeModeState,
     },
     storage::VpnCredentialStorage,
 };

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/upgrade_mode_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/upgrade_mode_state.rs
@@ -1,24 +1,20 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use crate::commands::{UpgradeModeCommand, common_handler, handler};
-use crate::state_machine::{
-    ErrorState, LoggedOutState, RequestingZkNymsState, SyncingState,
-    UPGRADE_MODE_DEFAULT_REFRESH_INTERVAL,
-};
 use crate::{
-    commands::AccountCommand,
+    commands::{AccountCommand, UpgradeModeCommand, common_handler, handler},
     shared_state::SharedAccountState,
     state_machine::{
-        AccountControllerStateHandler, NextAccountControllerState, PrivateAccountControllerState,
+        AccountControllerStateHandler, ErrorState, LoggedOutState, NextAccountControllerState,
+        PrivateAccountControllerState, RequestingZkNymsState, SyncingState,
+        UPGRADE_MODE_DEFAULT_REFRESH_INTERVAL,
     },
 };
 use nym_offline_monitor::ConnectivityMonitor;
 use nym_vpn_lib_types::{AccountCommandError, AccountControllerErrorStateReason};
 use std::pin::Pin;
 use time::OffsetDateTime;
-use tokio::sync::mpsc;
-use tokio::time::Sleep;
+use tokio::{sync::mpsc, time::Sleep};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
@@ -15,8 +15,7 @@ use nym_gateway_directory::Gateway;
 
 use crate::tunnel_state_machine::tunnel::SelectedGateways;
 use nym_vpn_account_controller::AccountCommandSender;
-use nym_wg_metadata_client::error::MetadataClientError;
-use nym_wg_metadata_client::{MetadataClient, TunUpReceiver};
+use nym_wg_metadata_client::{MetadataClient, TunUpReceiver, error::MetadataClientError};
 use nym_wireguard_types::DEFAULT_PEER_TIMEOUT_CHECK;
 use tracing::{debug, error, info, trace, warn};
 use url::Url;


### PR DESCRIPTION
## Ticket

JIRA-VPN-4521

## Description

When syncing the account, handle errors from `get_remote_time()` in the same way we handle errors from `get_account_summary_with_device()`.

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4007)
<!-- Reviewable:end -->
