### PR TITLE
VPN-4349: Let user view the server details from the home screen

### DIFF
--- a/nym-vpn-app/src/screens/home/Home.tsx
+++ b/nym-vpn-app/src/screens/home/Home.tsx
@@ -236,6 +236,7 @@ function Home() {
                   onClick={() => goToNodeList('entry')}
                   nodeHop="entry"
                   disabled={hopSelectDisabled}
+                  locked={daemonStatus === 'down'}
                 />
                 <HopSelect
                   node={exitNode}
@@ -243,6 +244,7 @@ function Home() {
                   onClick={() => goToNodeList('exit')}
                   nodeHop="exit"
                   disabled={hopSelectDisabled}
+                  locked={daemonStatus === 'down'}
                 />
               </div>
             </div>

--- a/nym-vpn-app/src/screens/home/Home.tsx
+++ b/nym-vpn-app/src/screens/home/Home.tsx
@@ -236,7 +236,6 @@ function Home() {
                   onClick={() => goToNodeList('entry')}
                   nodeHop="entry"
                   disabled={hopSelectDisabled}
-                  locked={daemonStatus === 'down'}
                 />
                 <HopSelect
                   node={exitNode}
@@ -244,7 +243,6 @@ function Home() {
                   onClick={() => goToNodeList('exit')}
                   nodeHop="exit"
                   disabled={hopSelectDisabled}
-                  locked={daemonStatus === 'down'}
                 />
               </div>
             </div>

--- a/nym-vpn-app/src/screens/home/HopSelect.tsx
+++ b/nym-vpn-app/src/screens/home/HopSelect.tsx
@@ -25,6 +25,7 @@ type HopSelectProps = {
   onClick: () => void;
   nodeHop: NodeHop;
   disabled?: boolean;
+  locked?: boolean;
 };
 
 export default function HopSelect({
@@ -33,6 +34,7 @@ export default function HopSelect({
   gatewayId,
   onClick,
   disabled,
+  locked,
 }: HopSelectProps) {
   const { backendFlags, vpnMode, tunnel, connectingState } = useMainState();
   const { lookupGw } = useGateways();
@@ -57,7 +59,9 @@ export default function HopSelect({
   };
 
   const handleDetailsClick = () => {
-    if (node.type === 'gateway' && gateway) {
+    if (disabled) {
+      toast();
+    } else if (node.type === 'gateway' && gateway) {
       navigate(routes.nodeDetails, {
         state: { gateway, hop: nodeHop, resetScroll: true },
       });
@@ -222,7 +226,7 @@ export default function HopSelect({
         'text-baltic-sea dark:text-white',
         'border border-bombay dark:border-iron rounded-lg',
         'relative transition select-none cursor-default',
-        disabled && 'opacity-50',
+        locked && 'opacity-50',
       ])}
       role="presentation"
     >
@@ -232,7 +236,6 @@ export default function HopSelect({
           'bg-faded-lavender dark:bg-ash text-xs',
           disabled && 'cursor-default',
         ])}
-        data-testid={`hop-select-label-${nodeHop}`}
       >
         {nodeHop === 'entry' ? t('first-hop') : t('last-hop')}
       </div>
@@ -240,9 +243,8 @@ export default function HopSelect({
       <Button
         className={clsx([
           'flex flex-1 pl-4 items-center justify-center h-full py-3 rounded-none rounded-l-lg',
-          !disabled && ['hover:text-white/80'],
+          !locked && 'hover:text-white/80',
         ])}
-        disabled={disabled}
         onClick={handleClick}
         onKeyDown={handleClick}
       >
@@ -252,9 +254,8 @@ export default function HopSelect({
         <Button
           className={clsx(
             'h-11 w-11 my-2 mr-2 flex items-center justify-center rounded-full',
-            !disabled && ['hover:bg-mercury dark:hover:bg-mine-shaft'],
+            !locked && 'hover:bg-mercury dark:hover:bg-mine-shaft',
           )}
-          disabled={disabled}
           onClick={handleDetailsClick}
           onKeyDown={handleDetailsClick}
         >

--- a/nym-vpn-app/src/screens/home/HopSelect.tsx
+++ b/nym-vpn-app/src/screens/home/HopSelect.tsx
@@ -2,6 +2,8 @@ import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AnimatePresence, motion } from 'motion/react';
 import clsx from 'clsx';
+import { useNavigate } from 'react-router';
+import { Button } from '@headlessui/react';
 import {
   Country,
   Gateway,
@@ -14,6 +16,7 @@ import { useLang } from '../../hooks';
 import { useGateways, useMainState } from '../../contexts';
 import { countriesWithRegions } from '../../constants';
 import { QuicTag } from '../node';
+import { routes } from '../../router';
 import { isBridgeMode, useActionToast } from './util';
 
 type HopSelectProps = {
@@ -22,7 +25,6 @@ type HopSelectProps = {
   onClick: () => void;
   nodeHop: NodeHop;
   disabled?: boolean;
-  locked?: boolean;
 };
 
 export default function HopSelect({
@@ -31,13 +33,13 @@ export default function HopSelect({
   gatewayId,
   onClick,
   disabled,
-  locked,
 }: HopSelectProps) {
   const { backendFlags, vpnMode, tunnel, connectingState } = useMainState();
   const { lookupGw } = useGateways();
   const { t } = useTranslation('home');
   const { getCountryName } = useLang();
   const toast = useActionToast('node-select');
+  const navigate = useNavigate();
   const quicConnection =
     isBridgeMode(tunnel?.data) || isBridgeMode(connectingState?.tunnel);
   const quicTag =
@@ -51,6 +53,14 @@ export default function HopSelect({
       toast();
     } else {
       onClick();
+    }
+  };
+
+  const handleArrowClick = () => {
+    if (node.type === 'gateway' && gateway) {
+      navigate(routes.nodeDetails, {
+        state: { gateway, hop: nodeHop, resetScroll: true },
+      });
     }
   };
 
@@ -148,7 +158,7 @@ export default function HopSelect({
     return (
       <div className="flex flex-row items-center gap-3 overflow-hidden w-full">
         <FlagIcon code={countryCode} alt={countryCode} />
-        <div className={clsx('flex flex-col justify-center truncate')}>
+        <div className={clsx('flex flex-col items-start truncate')}>
           <div
             className={clsx([
               'text-base truncate',
@@ -208,22 +218,13 @@ export default function HopSelect({
   return (
     <div
       className={clsx([
-        'w-full flex flex-row justify-between items-center py-3 px-4 h-[3.75rem]',
+        'w-full flex flex-row justify-between items-center px-4 h-[3.75rem]',
         'text-baltic-sea dark:text-white',
         'border border-bombay dark:border-iron rounded-lg',
-        !locked && [
-          'hover:border-baltic-sea hover:ring-baltic-sea',
-          'dark:hover:border-white dark:hover:ring-white',
-        ],
         'relative transition select-none cursor-default',
-        locked && 'opacity-50',
+        disabled && 'opacity-50',
       ])}
-      onKeyDown={handleClick}
       role="presentation"
-      onClick={handleClick}
-      data-testid={`hop-select-${nodeHop}`}
-      data-disabled={disabled}
-      data-locked={locked}
     >
       <div
         className={clsx([
@@ -235,12 +236,38 @@ export default function HopSelect({
       >
         {nodeHop === 'entry' ? t('first-hop') : t('last-hop')}
       </div>
-      <SelectedNode {...nodeData(node, gateway)} />
-      <MsIcon
-        icon="arrow_right"
-        className="pointer-events-none"
-        data-testid={`hop-select-arrow-${nodeHop}`}
-      />
+
+      <Button
+        className={clsx([
+          'flex items-center justify-center h-full w-full py-3 rounded-none rounded-l-lg',
+          !disabled && [
+            'hover:cursor-pointer hover:text-black/80 dark:hover:text-white/80',
+          ],
+        ])}
+        disabled={disabled}
+        onClick={handleClick}
+        onKeyDown={handleClick}
+      >
+        <SelectedNode {...nodeData(node, gateway)} />
+      </Button>
+      {node.type === 'gateway' && (
+        <Button
+          className={clsx(
+            'h-6 w-6 flex items-center justify-center rounded-sm',
+            !disabled && [
+              'hover:cursor-pointer hover:bg-mercury dark:hover:bg-mine-shaft',
+            ],
+          )}
+          disabled={disabled}
+          onClick={handleArrowClick}
+          onKeyDown={handleArrowClick}
+        >
+          <MsIcon
+            icon="arrow_right"
+            className="text-baltic-sea dark:text-white"
+          />
+        </Button>
+      )}
     </div>
   );
 }

--- a/nym-vpn-app/src/screens/home/HopSelect.tsx
+++ b/nym-vpn-app/src/screens/home/HopSelect.tsx
@@ -218,7 +218,7 @@ export default function HopSelect({
   return (
     <div
       className={clsx([
-        'w-full flex flex-row justify-between items-center px-4 h-[3.75rem]',
+        'w-full flex flex-row justify-between items-center h-[3.75rem]',
         'text-baltic-sea dark:text-white',
         'border border-bombay dark:border-iron rounded-lg',
         'relative transition select-none cursor-default',
@@ -239,10 +239,8 @@ export default function HopSelect({
 
       <Button
         className={clsx([
-          'flex items-center justify-center h-full w-full py-3 rounded-none rounded-l-lg',
-          !disabled && [
-            'hover:cursor-pointer hover:text-black/80 dark:hover:text-white/80',
-          ],
+          'flex flex-1 pl-4 items-center justify-center h-full py-3 rounded-none rounded-l-lg',
+          !disabled && ['hover:text-white/80'],
         ])}
         disabled={disabled}
         onClick={handleClick}
@@ -253,10 +251,8 @@ export default function HopSelect({
       {node.type === 'gateway' && (
         <Button
           className={clsx(
-            'h-6 w-6 flex items-center justify-center rounded-sm',
-            !disabled && [
-              'hover:cursor-pointer hover:bg-mercury dark:hover:bg-mine-shaft',
-            ],
+            'h-11 w-11 my-2 mr-2 flex items-center justify-center rounded-full',
+            !disabled && ['hover:bg-mercury dark:hover:bg-mine-shaft'],
           )}
           disabled={disabled}
           onClick={handleDetailsClick}
@@ -264,7 +260,7 @@ export default function HopSelect({
         >
           <MsIcon
             icon="arrow_right"
-            className="text-baltic-sea dark:text-white"
+            className="text-baltic-sea dark:text-white leading-none"
           />
         </Button>
       )}

--- a/nym-vpn-app/src/screens/home/HopSelect.tsx
+++ b/nym-vpn-app/src/screens/home/HopSelect.tsx
@@ -56,7 +56,7 @@ export default function HopSelect({
     }
   };
 
-  const handleArrowClick = () => {
+  const handleDetailsClick = () => {
     if (node.type === 'gateway' && gateway) {
       navigate(routes.nodeDetails, {
         state: { gateway, hop: nodeHop, resetScroll: true },
@@ -259,8 +259,8 @@ export default function HopSelect({
             ],
           )}
           disabled={disabled}
-          onClick={handleArrowClick}
-          onKeyDown={handleArrowClick}
+          onClick={handleDetailsClick}
+          onKeyDown={handleDetailsClick}
         >
           <MsIcon
             icon="arrow_right"

--- a/nym-vpn-app/src/screens/node/list/FoldButton.tsx
+++ b/nym-vpn-app/src/screens/node/list/FoldButton.tsx
@@ -13,17 +13,21 @@ const FoldButton = ({ html, state }: FoldButtonProps) => {
   return (
     <Button
       className={clsx(
-        'w-14 h-full flex justify-center items-center mr-3',
-        'border-l-1 border-bombay dark:border-iron',
+        'w-6 h-6 flex justify-center items-center mr-3 rounded-sm',
         'text-baltic-sea/80 dark:text-white/80',
         'hover:text-baltic-sea dark:hover:text-white',
+        'hover:bg-mercury dark:hover:bg-mine-shaft',
         'focus:outline-none',
       )}
       data-testid="fold-button"
       {...html}
     >
       <MsIcon
-        icon={state.open ? 'arrow_drop_up' : 'arrow_drop_down'}
+        icon="keyboard_arrow_down"
+        className={clsx(
+          'transition-transform duration-200 leading-none',
+          state.open && 'rotate-180',
+        )}
         data-testid="fold-button-icon"
       />
     </Button>

--- a/nym-vpn-app/src/screens/node/list/FoldButton.tsx
+++ b/nym-vpn-app/src/screens/node/list/FoldButton.tsx
@@ -13,7 +13,7 @@ const FoldButton = ({ html, state }: FoldButtonProps) => {
   return (
     <Button
       className={clsx(
-        'w-6 h-6 flex justify-center items-center mr-3 rounded-sm',
+        'w-11 h-11 flex justify-center items-center rounded-full',
         'text-baltic-sea/80 dark:text-white/80',
         'hover:text-baltic-sea dark:hover:text-white',
         'hover:bg-mercury dark:hover:bg-mine-shaft',

--- a/nym-vpn-app/src/screens/node/list/FoldButton.tsx
+++ b/nym-vpn-app/src/screens/node/list/FoldButton.tsx
@@ -13,22 +13,20 @@ const FoldButton = ({ html, state }: FoldButtonProps) => {
   return (
     <Button
       className={clsx(
-        'w-11 h-11 flex justify-center items-center rounded-full',
+        'w-12 h-12 flex justify-center items-center rounded-full',
         'text-baltic-sea/80 dark:text-white/80',
         'hover:text-baltic-sea dark:hover:text-white',
         'hover:bg-mercury dark:hover:bg-mine-shaft',
         'focus:outline-none',
       )}
-      data-testid="fold-button"
       {...html}
     >
       <MsIcon
         icon="keyboard_arrow_down"
         className={clsx(
-          'transition-transform duration-200 leading-none',
+          'transition-transform duration-150 leading-none',
           state.open && 'rotate-180',
         )}
-        data-testid="fold-button-icon"
       />
     </Button>
   );

--- a/nym-vpn-app/src/screens/node/list/GatewayItem.tsx
+++ b/nym-vpn-app/src/screens/node/list/GatewayItem.tsx
@@ -101,16 +101,16 @@ const GatewayItem = ({
       <div className="flex py-2 self-stretch items-center">
         <Button
           className={clsx(
-            'w-14 flex justify-center items-center mr-3 shrink-0',
-            'text-baltic-sea/80 dark:text-white/80',
-            'hover:text-baltic-sea dark:hover:text-white',
+            'w-6 h-6 flex justify-center items-center mr-3 shrink-0',
+            'text-baltic-sea dark:text-white',
+            'hover:bg-faded-lavender dark:hover:bg-charcoal rounded-sm',
             'focus:outline-none',
           )}
           onClick={() => onNodeDetails(gateway)}
           data-testid={`gateway-info-button-${gateway.id.substring(0, 8)}`}
         >
           <MsIcon
-            icon="info"
+            icon="arrow_right"
             data-testid={`gateway-info-icon-${gateway.id.substring(0, 8)}`}
           />
         </Button>

--- a/nym-vpn-app/src/screens/node/list/GatewayItem.tsx
+++ b/nym-vpn-app/src/screens/node/list/GatewayItem.tsx
@@ -61,13 +61,10 @@ const GatewayItem = ({
         'flex flex-row justify-between items-center select-none',
         'hover:bg-mercury hover:dark:bg-mine-shaft',
       )}
-      data-testid={`gateway-item-${gateway.id.substring(0, 8)}`}
-      data-selected={isSelected ? isSelected : 'none'}
     >
       <Button
         className="flex items-center overflow-hidden w-full pr-2 focus:outline-none"
         onClick={handleSelect}
-        data-testid={`gateway-select-button-${gateway.id.substring(0, 8)}`}
       >
         <div
           className={clsx(
@@ -75,19 +72,13 @@ const GatewayItem = ({
             isSelected === node && 'bg-malachite',
             isSelected && isSelected !== node && 'bg-iron',
           )}
-          data-testid={`gateway-selection-indicator-${gateway.id.substring(0, 8)}`}
         />
         <div className="flex flex-row items-center p-2 gap-4 overflow-hidden">
           <div className="flex">
             <ScoreIndicator score={score} />
           </div>
           <div className="flex flex-col text-start overflow-hidden">
-            <p
-              className="truncate"
-              data-testid={`gateway-name-${gateway.id.substring(0, 8)}`}
-            >
-              {gateway.name}
-            </p>
+            <p className="truncate">{gateway.name}</p>
             <p className="text-sm text-iron dark:text-bombay truncate">
               {location()}
             </p>
@@ -101,18 +92,14 @@ const GatewayItem = ({
       <div className="flex p-2 self-stretch items-center">
         <Button
           className={clsx(
-            'w-11 h-11 flex justify-center items-center shrink-0 rounded-full',
+            'w-12 h-12 flex justify-center items-center shrink-0 rounded-full',
             'text-baltic-sea dark:text-white',
             'hover:bg-faded-lavender dark:hover:bg-charcoal',
             'focus:outline-none',
           )}
           onClick={() => onNodeDetails(gateway)}
-          data-testid={`gateway-info-button-${gateway.id.substring(0, 8)}`}
         >
-          <MsIcon
-            icon="arrow_right"
-            data-testid={`gateway-info-icon-${gateway.id.substring(0, 8)}`}
-          />
+          <MsIcon icon="arrow_right" />
         </Button>
       </div>
     </div>

--- a/nym-vpn-app/src/screens/node/list/GatewayItem.tsx
+++ b/nym-vpn-app/src/screens/node/list/GatewayItem.tsx
@@ -98,12 +98,12 @@ const GatewayItem = ({
       {streamOptimized && (
         <MsIcon icon="smart_display" className="text-cornflower" />
       )}
-      <div className="flex py-2 self-stretch items-center">
+      <div className="flex p-2 self-stretch items-center">
         <Button
           className={clsx(
-            'w-6 h-6 flex justify-center items-center mr-3 shrink-0',
+            'w-11 h-11 flex justify-center items-center shrink-0 rounded-full',
             'text-baltic-sea dark:text-white',
-            'hover:bg-faded-lavender dark:hover:bg-charcoal rounded-sm',
+            'hover:bg-faded-lavender dark:hover:bg-charcoal',
             'focus:outline-none',
           )}
           onClick={() => onNodeDetails(gateway)}

--- a/nym-vpn-app/src/screens/node/list/RowHeader.tsx
+++ b/nym-vpn-app/src/screens/node/list/RowHeader.tsx
@@ -54,7 +54,7 @@ function RowHeader({
           <LocationInfo node={node} name={node.name} gwCount={gwCount} />
         )}
       </div>
-      <Accordion.Header className="flex py-2 items-center justify-center">
+      <Accordion.Header className="flex p-2 items-center justify-center">
         <Accordion.Trigger
           render={(props, state) => <FoldButton html={props} state={state} />}
         />

--- a/nym-vpn-app/src/screens/node/list/RowHeader.tsx
+++ b/nym-vpn-app/src/screens/node/list/RowHeader.tsx
@@ -54,7 +54,7 @@ function RowHeader({
           <LocationInfo node={node} name={node.name} gwCount={gwCount} />
         )}
       </div>
-      <Accordion.Header className="flex py-2">
+      <Accordion.Header className="flex py-2 items-center justify-center">
         <Accordion.Trigger
           render={(props, state) => <FoldButton html={props} state={state} />}
         />


### PR DESCRIPTION
## Ticket

[JIRA-VPN-4349](https://nymtech.atlassian.net/browse/VPN-4349)

## Description

- Update icons indicating **server details**,
- Update icons indicating **drop down**
- Update navigation on home screen to allow viewing server details


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)
<img width="451" height="772" alt="image" src="https://github.com/user-attachments/assets/4cd16ef6-dfe1-47aa-966b-c02e39d8a164" />
<img width="454" height="776" alt="image" src="https://github.com/user-attachments/assets/dd772702-c84e-45d3-bbfe-796835d13a5b" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4009)
<!-- Reviewable:end -->
