### PR TITLE
[bugfix] AC firewall down command can cause useless sync

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
@@ -259,9 +259,12 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingState {
                     },
 
                     AccountCommand::VpnApiFirewallDown(return_sender) =>  {
-                        shared_state.firewall_active = false;
                         return_sender.send(Ok(()));
-                        return NextAccountControllerState::NewState(SyncingState::enter(shared_state, self.attempts));
+                        // No-op if the firewall was already down
+                        if shared_state.firewall_active {
+                            shared_state.firewall_active = false;
+                            return NextAccountControllerState::NewState(SyncingState::enter(shared_state, self.attempts));
+                        }
                     },
 
                     AccountCommand::VpnApiFirewallUp(return_sender) => {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/requesting_zknym_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/requesting_zknym_state.rs
@@ -357,19 +357,21 @@ impl RequestingZkNymsState {
                 };
             }
             AccountCommand::VpnApiFirewallDown(return_sender) => {
-                // no need to abort the fetching handle, as per @SW:
-                // "In theory, if we get VpnApiFirewallDown, it means we got the up version before, so no handle is running"
                 // as a side note, firewall handling could use some improvements as well,
                 // because the current solution is suboptimal to say the least
                 // and is causing a number of weird edge cases
-                shared_state.firewall_active = false;
                 return_sender.send(Ok(()));
-                return NextAccountControllerState::NewState(RequestingZkNymsState::enter(
-                    shared_state,
-                    self.attempts,
-                    self.fair_usage_left,
-                    false,
-                ));
+                // No-op if firewall was already down
+                if shared_state.firewall_active {
+                    // If firewall is indeed active, no handle should be running, so nothing to abort
+                    shared_state.firewall_active = false;
+                    return NextAccountControllerState::NewState(RequestingZkNymsState::enter(
+                        shared_state,
+                        self.attempts,
+                        self.fair_usage_left,
+                        false,
+                    ));
+                }
             }
             AccountCommand::VpnApiFirewallUp(return_sender) => {
                 shared_state.firewall_active = true;


### PR DESCRIPTION
## Description

If the AC receives a `FirewallDown` command with an already down firewall, it still sync again, which is useless. 
This PR acts on that command only if the firewall was up beforehand. 

(Daemon startup resets a firewall causing that command to be sent on an already down firewall from the AC standpoint)

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4027)
<!-- Reviewable:end -->
