### PR TITLE
[bugfix] eliminate zk-nym log spamming

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/zknym_handler/request.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/zknym_handler/request.rs
@@ -88,7 +88,7 @@ impl RequestZkNymTask {
         self.resume_request_zk_nym_ticketbook(response.id).await
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all)]
     async fn import_retrieved_zk_nym(
         &self,
         response: NymVpnZkNym,


### PR DESCRIPTION
## Ticket

JIRA-VPN-XXXX

## Description

Zk-nyms share are being printed entirely in the log, producing lots of spam. 
This PR removes it


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4085)
<!-- Reviewable:end -->
