### PR TITLE
Allow default DNS when connecting

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -180,12 +180,16 @@ impl TunnelSettings {
                 .filter(|ip| ip.is_ipv4() || (ip.is_ipv6() && self.enable_ipv6))
                 .copied()
                 .collect(),
-            DnsOptions::Default => crate::DEFAULT_DNS_SERVERS
-                .iter()
-                .filter(|ip| ip.is_ipv4() || (ip.is_ipv6() && self.enable_ipv6))
-                .copied()
-                .collect(),
+            DnsOptions::Default => self.default_dns_ips(),
         }
+    }
+
+    pub fn default_dns_ips(&self) -> Vec<IpAddr> {
+        crate::DEFAULT_DNS_SERVERS
+            .iter()
+            .filter(|ip| ip.is_ipv4() || (ip.is_ipv6() && self.enable_ipv6))
+            .copied()
+            .collect()
     }
 
     pub fn bridges_enabled(&self) -> bool {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -130,7 +130,8 @@ impl ConnectingState {
                     .map(|v| v.entry_gateway().endpoints())
                     .unwrap_or_default(),
                 api_endpoints: Vec::new(),
-                dns_servers: shared_state.tunnel_settings.dns_ips(),
+                // Allow default DNS servers since hickory does not rely on custom DNS
+                dns_servers: shared_state.tunnel_settings.default_dns_ips(),
                 tunnel_interface: None,
             };
 


### PR DESCRIPTION
## Description

Allow default DNS when connecting since hickory does not rely on custom DNS

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4108)
<!-- Reviewable:end -->
