### PR TITLE
Strip comment section containing android/linker information

### DIFF
--- a/wireguard/libwg/build-android.sh
+++ b/wireguard/libwg/build-android.sh
@@ -54,7 +54,7 @@ for arch in ${ARCHITECTURES:-armv7 aarch64 x86_64}; do
     # the directories afterwards
     mkdir -m 777 -p "$(dirname "$STRIPPED_LIB_PATH")"
 
-    $ANDROID_STRIP_TOOL --strip-unneeded --strip-debug -o "$STRIPPED_LIB_PATH" "$UNSTRIPPED_LIB_PATH"
+    $ANDROID_STRIP_TOOL --strip-unneeded --strip-debug --remove-section=.comment -o "$STRIPPED_LIB_PATH" "$UNSTRIPPED_LIB_PATH"
 
     # Set permissions so that the build server can clean the outputs afterwards
     chmod 777 "$STRIPPED_LIB_PATH"


### PR DESCRIPTION

## Description

Android/LLVM embeds toolchain information into binary via comment section, we can strip that out as per linsui suggestion.

See: https://gitlab.com/fdroid/fdroiddata/-/merge_requests/29031#note_2932439021

```
# Check comment sections
llvm-readelf --wide --decompress --string-dump=.comment ../build/lib/aarch64-linux-android/libwg.so
String dump of section '.comment':
[     0] Android (13065274, +pgo, -bolt, +lto, -mlgo, based on r547379) clang version 20.0.0 (https://android.googlesource.com/toolchain/llvm-project b718bcaf8c198c82f3021447d943401e3ab5bd54)
[    b8] Linker: LLD 20.0.0 (/Volumes/Android/buildbot/src/android/llvm-r547379-release/out/llvm-project/llvm b718bcaf8c198c82f3021447d943401e3ab5bd54)

# Strip comment sections
llvm-strip --strip-unneeded --strip-debug --remove-section=.comment -o stripped.so ../build/lib/aarch64-linux-android/libwg.so 

# Verify that it worked
llvm-readelf --wide --decompress --string-dump=.comment stripped.so 
llvm-readelf: warning: 'stripped.so': could not find section '.comment'
```

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4116)
<!-- Reviewable:end -->
