### PR TITLE
Strip comment section from nym-vpn-lib binaries

### DIFF
--- a/.github/workflows/build-nym-vpn-core-android.yml
+++ b/.github/workflows/build-nym-vpn-core-android.yml
@@ -88,8 +88,7 @@ jobs:
           ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
           VPNLIB_SENTRY_DSN: ${{ secrets.VPND_SENTRY_DSN }}
         run: |
-          make -f Android.mk build RELEASE=true
-          make -f Android.mk uniffi RELEASE=true
+          make -f Android.mk RELEASE=true
 
       - name: Get rust version used for build
         id: rust-version

--- a/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/NymBackend.kt
+++ b/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/NymBackend.kt
@@ -332,17 +332,18 @@ class NymBackend private constructor(private val context: Context) : Backend, Tu
 			try {
 				startVpn(
 					VpnConfig(
-						tunnel.entryPoint,
-						tunnel.exitPoint,
-						tunnel.mode.isTwoHop(),
-						enableBridges,
-						false,
-						vpnService.await(),
-						storagePath,
-						storagePath,
-						this@NymBackend,
-						null,
-						userAgent,
+						entryGateway = tunnel.entryPoint,
+						exitRouter = tunnel.exitPoint,
+						enableTwoHop = tunnel.mode.isTwoHop(),
+						enableBridges = enableBridges,
+						residentialExit = false,
+						tunProvider = vpnService.await(),
+						configPath = storagePath,
+						credentialDataPath = storagePath,
+						tunStatusListener = this@NymBackend,
+						userAgent = userAgent,
+						customDns = listOf(),
+						statisticsRecipient = null,
 					),
 				)
 			} catch (e: VpnException) {

--- a/nym-vpn-core/Android.mk
+++ b/nym-vpn-core/Android.mk
@@ -22,26 +22,46 @@ ifeq ($(DOCKER), true)
 DOCKER_FLAG := --docker
 endif
 
+ARCH_ARM64_V8 := arm64-v8a
+STRIP_TOOL_BIN := llvm-strip
+
+ifneq ($(strip $(NDK_TOOLCHAIN_DIR)),)
+STRIP_TOOL := $(NDK_TOOLCHAIN_DIR)/$(STRIP_TOOL_BIN)
+else
+# Infer location of llvm-strip
+STRIP_TOOL := $(dir $(shell cargo ndk-env --json -t $(ARCH_ARM64_V8) | jq -r .CLANG_PATH))/$(STRIP_TOOL_BIN)
+endif
+
 ANDROID_DIR := $(CURDIR)/../nym-vpn-android
 UNIFFI_OUT_DIR := $(ANDROID_DIR)/core/src/main/java/net/nymtech/vpn
 JNI_LIBS_DIR := $(ANDROID_DIR)/core/src/main/jniLibs
-ARM64_V8_BUILD_DIR := $(JNI_LIBS_DIR)/arm64-v8a
+ARM64_V8_BUILD_DIR := $(JNI_LIBS_DIR)/$(ARCH_ARM64_V8)
 
 DYNAMIC_LIB_PATH := $(CURDIR)/target/aarch64-linux-android/$(TARGET_DIR)/libnym_vpn_lib_uniffi.so
 WIREGUARD_DIR := $(CURDIR)/../wireguard
 LICENSES_FILE := $(ANDROID_DIR)/core/src/main/assets/licenses_rust.json
 
+STRIP_TARGETS := libnym_vpn_lib.so libnym_vpn_lib_types.so
+
 # todo: consider migrating libwg builds to makefile to avoid rebuilds but for now this should make this makefile aware of changes to go sources
 LIBWG_SOURCES := $(wildcard $(WIREGUARD_DIR)/libwg/*.go) $(wildcard $(WIREGUARD_DIR)/libwg/*/*.go)
 
-.PHONY: build uniffi libwg clean
+.PHONY: build uniffi libwg strip clean
 
-all: $(ARM64_V8_BUILD_DIR)/libwg.so build uniffi $(LICENSES_FILE)
+all: $(ARM64_V8_BUILD_DIR)/libwg.so build uniffi strip $(LICENSES_FILE)
 
 build: $(ARM64_V8_BUILD_DIR)/libwg.so
-	$(ALL_IDEMPOTENT_FLAGS) cargo ndk -t arm64-v8a -o $(JNI_LIBS_DIR) build --package nym-vpn-lib-uniffi $(RELEASE_FLAG)
+	$(ALL_IDEMPOTENT_FLAGS) cargo ndk -t $(ARCH_ARM64_V8) -o $(JNI_LIBS_DIR) build --package nym-vpn-lib-uniffi $(RELEASE_FLAG)
 	cd $(ARM64_V8_BUILD_DIR) ; \
 	mv libnym_vpn_lib_uniffi.so libnym_vpn_lib.so
+
+strip: build
+	cd $(ARM64_V8_BUILD_DIR) ; \
+	for target in $(STRIP_TARGETS); do \
+		echo "Stripping $${target}" ; \
+        $(STRIP_TOOL) --strip-unneeded --strip-debug --remove-section=.comment -o "stripped_$${target}" "$${target}" ; \
+        mv stripped_$${target} $${target} ; \
+    done
 
 uniffi: build
 	cargo run --bin uniffi-bindgen generate \


### PR DESCRIPTION

## Description

Similar to https://github.com/nymtech/nym-vpn-client/pull/4116 but strips comment section from `nym-vpn-lib` and nym-vpn-lib-types`. But ensures that rust binaries are stripped of additional comments containing linker/compiler versions

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4119)
<!-- Reviewable:end -->
