### PR TITLE
Improve DNS handling

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-api-client/src/error.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/error.rs
@@ -129,12 +129,6 @@ pub enum VpnApiClientError {
         source: nym_http_api_client::ResolveError,
     },
 
-    #[error("resolved hostname {0} but no IP address found")]
-    ResolvedHostnameButNoIp(String),
-
-    #[error("timed out while attempting to resolve hostname: {hostname}")]
-    HostnameResolutionTimeout { hostname: String },
-
     #[error("Failed to resolve hostname(s): {hostnames:?}")]
     HostnamesResolutionError { hostnames: HashSet<String> },
 

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/error.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/error.rs
@@ -123,8 +123,8 @@ pub enum VpnApiClientError {
     #[error("failed to post account")]
     PostAccount(#[source] Box<HttpClientError>),
 
-    #[error("failed to resolve gateway hostname: {hostname}")]
-    FailedToDnsResolveGateway {
+    #[error("failed to resolve hostname: {hostname}")]
+    DnsResolutionFailure {
         hostname: String,
         source: nym_http_api_client::ResolveError,
     },

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/resolve_host.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/resolve_host.rs
@@ -25,6 +25,7 @@ async fn try_resolve_hostname(hostname: &str) -> Result<Vec<IpAddr>> {
         .collect::<Vec<_>>();
 
     tracing::debug!("Resolved {hostname} to: {ips:?}");
+    // Safety: `HickoryDnsResolver::resolve_str()` always returns at least one IP address on success, otherwise an error.
     assert!(!ips.is_empty());
     Ok(ips)
 }

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/resolve_host.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/resolve_host.rs
@@ -1,49 +1,32 @@
-use std::{
-    net::{IpAddr, SocketAddr},
-    time::Duration,
-};
+// Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use std::net::{IpAddr, SocketAddr};
 
 use nym_common::trace_err_chain;
 use nym_http_api_client::HickoryDnsResolver;
 
 use crate::error::{Result, VpnApiClientError};
 
-// be generous with the resolution timeout
-const HOSTNAME_RESOLUTION_TIMEOUT: Duration = Duration::from_secs(10);
-
 async fn try_resolve_hostname(hostname: &str) -> Result<Vec<IpAddr>> {
     tracing::debug!("Trying to resolve hostname: {hostname}");
-    let mut resolver = HickoryDnsResolver::default();
-    // Disable system resolver because it's typically blocked by firewall anyway.
-    resolver.disable_system_fallback();
+    let resolver = HickoryDnsResolver::default();
 
-    let addrs =
-        match tokio::time::timeout(HOSTNAME_RESOLUTION_TIMEOUT, resolver.resolve_str(hostname))
-            .await
-        {
-            Ok(Ok(addrs)) => addrs,
-            Ok(Err(err)) => {
-                trace_err_chain!(err, "Failed to resolve hostname");
-                return Err(VpnApiClientError::FailedToDnsResolveGateway {
-                    hostname: hostname.to_string(),
-                    source: err,
-                });
+    let ips = resolver
+        .resolve_str(hostname)
+        .await
+        .map_err(|err| {
+            trace_err_chain!(err, "Failed to resolve hostname");
+            VpnApiClientError::FailedToDnsResolveGateway {
+                hostname: hostname.to_string(),
+                source: err,
             }
-            Err(_timeout) => {
-                return Err(VpnApiClientError::HostnameResolutionTimeout {
-                    hostname: hostname.to_string(),
-                });
-            }
-        };
+        })?
+        .into_iter()
+        .collect::<Vec<_>>();
 
-    let ips: Vec<IpAddr> = addrs.into_iter().collect();
     tracing::debug!("Resolved to: {ips:?}");
-    if ips.is_empty() {
-        return Err(VpnApiClientError::ResolvedHostnameButNoIp(
-            hostname.to_string(),
-        ));
-    }
-
+    assert!(!ips.is_empty());
     Ok(ips)
 }
 

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/resolve_host.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/resolve_host.rs
@@ -22,7 +22,6 @@ async fn try_resolve_hostname(hostname: &str) -> Result<Vec<IpAddr>> {
                 source: err,
             }
         })?
-        .into_iter()
         .collect::<Vec<_>>();
 
     tracing::debug!("Resolved to: {ips:?}");

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/resolve_host.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/resolve_host.rs
@@ -17,7 +17,7 @@ async fn try_resolve_hostname(hostname: &str) -> Result<Vec<IpAddr>> {
         .await
         .map_err(|err| {
             trace_err_chain!(err, "Failed to resolve hostname");
-            VpnApiClientError::FailedToDnsResolveGateway {
+            VpnApiClientError::DnsResolutionFailure {
                 hostname: hostname.to_string(),
                 source: err,
             }

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/resolve_host.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/resolve_host.rs
@@ -24,7 +24,7 @@ async fn try_resolve_hostname(hostname: &str) -> Result<Vec<IpAddr>> {
         })?
         .collect::<Vec<_>>();
 
-    tracing::debug!("Resolved to: {ips:?}");
+    tracing::debug!("Resolved {hostname} to: {ips:?}");
     assert!(!ips.is_empty());
     Ok(ips)
 }

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/types/resolver_overrides.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/types/resolver_overrides.rs
@@ -49,7 +49,7 @@ impl ResolverOverrides {
                     .inspect_err(|err| {
                         tracing::warn!(
                             "{}",
-                            err.display_chain_with_msg(&format!(
+                            err.display_chain_with_msg(format!(
                                 "Failed to resolve domain {domain}"
                             ))
                         );

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/types/resolver_overrides.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/types/resolver_overrides.rs
@@ -8,6 +8,7 @@ use std::{
 use itertools::{Either, Itertools};
 use tokio::task::JoinSet;
 
+use nym_common::ErrorExt;
 use nym_http_api_client::Url;
 use nym_network_defaults::ApiUrl;
 
@@ -46,7 +47,12 @@ impl ResolverOverrides {
                 let result = url_to_socket_addr(&url, Some((1, 1)))
                     .await
                     .inspect_err(|err| {
-                        tracing::warn!("Failed to resolve domain {}: {}", domain, err);
+                        tracing::warn!(
+                            "{}",
+                            err.display_chain_with_msg(&format!(
+                                "Failed to resolve domain {domain}"
+                            ))
+                        );
                     });
                 (domain, result)
             });

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/discovery_refresher.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/discovery_refresher.rs
@@ -146,7 +146,7 @@ impl DiscoveryRefresher {
                                     if *network == new_network {
                                         tracing::info!("Network environment is up to date");
                                     } else {
-                                        network = Box::new(new_network);
+                                        *network = new_network;
                                         self.events_tx
                                             .send(DiscoveryRefresherEvent::NewNetwork(network.clone()))
                                             .ok();


### PR DESCRIPTION


## Description

- Remove DNS timeout handling since [`HickoryDnsResolver`](https://github.com/nymtech/nym/blob/8383a35352ada1fcc5f6a329312d4a0c29e5f0ed/common/http-api-client/src/dns.rs#L165) already handles that.
- Remove unnecessary `ResolvedHostnameButNoIp` error variant which is impossible. Internally, no records situation is already translated into error.
- Unroll error chain for dns resolution errors

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4124)
<!-- Reviewable:end -->
