### PR TITLE
Move dns limit to vpn service

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-proto/src/rpc_client.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/rpc_client.rs
@@ -21,8 +21,6 @@ type ServiceClient = NymVpnServiceClient<tonic::transport::Channel>;
 pub struct RpcClient(ServiceClient);
 
 impl RpcClient {
-    const MAX_CUSTOM_DNS_SERVERS: usize = 5;
-
     pub async fn new() -> Result<RpcClient> {
         let socket_path = get_rpc_socket_path();
         let channel = Endpoint::from_static("unix://placeholder")
@@ -142,11 +140,9 @@ impl RpcClient {
     }
 
     pub async fn set_custom_dns(&mut self, ips: Vec<IpAddr>) -> Result<()> {
-        let request: proto::IpAddrList = ips
-            .into_iter()
-            .take(Self::MAX_CUSTOM_DNS_SERVERS)
-            .collect::<Vec<_>>()
-            .into();
+        let request = proto::IpAddrList {
+            ips: ips.into_iter().map(proto::IpAddr::from).collect(),
+        };
 
         self.0
             .set_custom_dns(request)

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -998,7 +998,14 @@ impl NymVpnService {
         self.update_tunnel_settings_with_throttle();
     }
 
-    async fn handle_set_custom_dns(&mut self, custom_dns: Vec<IpAddr>) {
+    async fn handle_set_custom_dns(&mut self, mut custom_dns: Vec<IpAddr>) {
+        const MAX_CUSTOM_DNS_SERVERS: usize = 5;
+
+        if custom_dns.len() > MAX_CUSTOM_DNS_SERVERS {
+            tracing::warn!("Only the first {MAX_CUSTOM_DNS_SERVERS} DNS servers will be used");
+            custom_dns.truncate(MAX_CUSTOM_DNS_SERVERS);
+        }
+
         self.config_manager.set_custom_dns(custom_dns).await;
         self.update_tunnel_settings_with_throttle();
     }


### PR DESCRIPTION
## Description

Let's apply custom DNS limit in the VPN service where it seems to be more appropriate than in rpc layer preoccupied with protobuf

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4126)
<!-- Reviewable:end -->
