### PR TITLE
Handle no-op changes to custom DNS

### DIFF
--- a/nym-vpn-core/crates/nym-vpnd/src/service/config/config_manager.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/config/config_manager.rs
@@ -146,17 +146,29 @@ impl VpnServiceConfigManager {
         }
     }
 
-    pub async fn set_enable_custom_dns(&mut self, enable_custom_dns: bool) {
-        if self.config.enable_custom_dns != enable_custom_dns {
+    /// Enable or disable custom DNS servers
+    ///
+    /// Returns true if the setting has changed, otherwise false if it's the same
+    pub async fn set_enable_custom_dns(&mut self, enable_custom_dns: bool) -> bool {
+        if self.config.enable_custom_dns == enable_custom_dns {
+            false
+        } else {
             self.config.enable_custom_dns = enable_custom_dns;
             self.save_config_and_send_event().await;
+            true
         }
     }
 
-    pub async fn set_custom_dns(&mut self, custom_dns: Vec<IpAddr>) {
-        if self.config.custom_dns != custom_dns {
+    /// Update custom DNS servers
+    ///
+    /// Returns true if custom DNS servers have changed, otherwise false if they're the same
+    pub async fn set_custom_dns(&mut self, custom_dns: Vec<IpAddr>) -> bool {
+        if self.config.custom_dns == custom_dns {
+            false
+        } else {
             self.config.custom_dns = custom_dns;
             self.save_config_and_send_event().await;
+            true
         }
     }
 

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -999,7 +999,7 @@ impl NymVpnService {
         {
             let config = self.config_manager.config();
             // Ignore reconnect if custom DNS is enabled but custom DNS addresses aren't set
-            if (enable_custom_dns && !config.custom_dns.is_empty()) || !enable_custom_dns {
+            if !enable_custom_dns || !config.custom_dns.is_empty() {
                 self.update_tunnel_settings_with_throttle();
             }
         }

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -992,10 +992,17 @@ impl NymVpnService {
     }
 
     async fn handle_set_enable_custom_dns(&mut self, enable_custom_dns: bool) {
-        self.config_manager
+        if self
+            .config_manager
             .set_enable_custom_dns(enable_custom_dns)
-            .await;
-        self.update_tunnel_settings_with_throttle();
+            .await
+        {
+            let config = self.config_manager.config();
+            // Ignore reconnect if custom DNS is enabled but custom DNS addresses aren't set
+            if (enable_custom_dns && !config.custom_dns.is_empty()) || !enable_custom_dns {
+                self.update_tunnel_settings_with_throttle();
+            }
+        }
     }
 
     async fn handle_set_custom_dns(&mut self, mut custom_dns: Vec<IpAddr>) {
@@ -1006,8 +1013,13 @@ impl NymVpnService {
             custom_dns.truncate(MAX_CUSTOM_DNS_SERVERS);
         }
 
-        self.config_manager.set_custom_dns(custom_dns).await;
-        self.update_tunnel_settings_with_throttle();
+        if self.config_manager.set_custom_dns(custom_dns).await {
+            let config = self.config_manager.config();
+            // Only issue reconnect if custom DNS is enabled
+            if config.enable_custom_dns {
+                self.update_tunnel_settings_with_throttle();
+            }
+        }
     }
 
     async fn handle_set_network(&self, network: String) -> Result<(), SetNetworkError> {


### PR DESCRIPTION


## Description

This PR ensures that reconnects due to changes to custom DNS configuration only happen if they result into effective tunnel configuration to be different.

This PR also ensures that reconnects are not issued if:

-  The same setting applied twice, i.e when enabling custom DNS twice in a row or sending the same list of custom DNS addresses
- Updating custom DNS addresses but without custom DNS being enabled

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4132)
<!-- Reviewable:end -->
