### PR TITLE
Reset selected gateways when changing gateways in offline

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/offline_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/offline_state.rs
@@ -156,6 +156,10 @@ impl TunnelStateHandler for OfflineState {
                             }
                         }
 
+                        if diff.entry_point_changed() || diff.exit_point_changed() {
+                            self.selected_gateways = None;
+                        };
+
                         #[cfg(any(target_os = "android", target_os = "ios"))]
                         let _ = diff;
 


### PR DESCRIPTION
## Description

Offline state preserves gateways selected prior to going offline and reuses them to reconnect the tunnel upon entering back online.

It seems however, that it would continue reconnecting to the same gateways even if gateway config has changed while in offline. This PR ensures that new gateways are selected if entry and exit points change while offline.

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4135)
<!-- Reviewable:end -->
