### PR TITLE
VPN-4608: Support macOS SOCKS5 proxy settings.

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-rpc-uniffi/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-rpc-uniffi/src/lib.rs
@@ -13,8 +13,9 @@ use tokio_util::sync::CancellationToken;
 
 use nym_vpn_lib_types::{
     AccountCommandError, AccountControllerState, EntryPoint, ExitPoint, FeatureFlags, Gateway,
-    GatewayType, LogPath, NetworkCompatibility, NymVpnDevice, NymVpnUsage, ParsedAccountLinks,
-    SystemMessage, TunnelEvent, TunnelState, VpnServiceConfig, VpnServiceInfo,
+    GatewayType, HttpRpcSettings, LogPath, NetworkCompatibility, NymVpnDevice, NymVpnUsage,
+    ParsedAccountLinks, Socks5Settings, Socks5Status, SystemMessage, TunnelEvent, TunnelState,
+    VpnServiceConfig, VpnServiceInfo,
 };
 
 uniffi::use_remote_type!(nym_vpn_lib_types::IpAddr);
@@ -298,6 +299,29 @@ impl RpcClient {
             .network_stats_allow_disconnected(allow_disconnected)
             .await?;
         Ok(())
+    }
+
+    pub async fn enable_socks5(
+        &self,
+        socks5_settings: Socks5Settings,
+        http_rpc_settings: HttpRpcSettings,
+        exit_point: ExitPoint,
+    ) -> Result<()> {
+        self.inner
+            .clone()
+            .enable_socks5(socks5_settings, http_rpc_settings, exit_point)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn disable_socks5(&self) -> Result<()> {
+        self.inner.clone().disable_socks5().await?;
+        Ok(())
+    }
+
+    pub async fn get_socks5_status(&self) -> Result<Socks5Status> {
+        let status = self.inner.clone().get_socks5_status().await?;
+        Ok(status)
     }
 }
 


### PR DESCRIPTION
## Ticket

JIRA-VPN-4608

## Description

Add Socks5 Proxy-related calls to uniffi RPC client.

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4136)
<!-- Reviewable:end -->
