### PR TITLE
Avoid cloning the RPC client.

### DIFF
--- a/nym-vpn-app/src-tauri/Cargo.lock
+++ b/nym-vpn-app/src-tauri/Cargo.lock
@@ -3641,6 +3641,7 @@ dependencies = [
  "prost-types",
  "thiserror 2.0.17",
  "time",
+ "tokio",
  "tokio-stream",
  "tonic",
  "tonic-prost",

--- a/nym-vpn-app/src-tauri/src/vpnd/client.rs
+++ b/nym-vpn-app/src-tauri/src/vpnd/client.rs
@@ -79,6 +79,7 @@ impl VpndClient {
     }
 
     /// Get the rpc client
+    /// TODO: Avoid creating a new client for every request!
     #[instrument(skip_all)]
     pub async fn vpnd(&self) -> Result<RpcClient, VpndError> {
         let client = RpcClient::new().await.map_err(|e| {
@@ -97,7 +98,7 @@ impl VpndClient {
     /// Get daemon info
     #[instrument(skip_all)]
     pub async fn vpnd_info(&mut self) -> Result<VpndInfo, VpndError> {
-        let mut vpnd = self.vpnd().await?;
+        let vpnd = self.vpnd().await?;
 
         let info: VpndInfo = vpnd
             .get_info()
@@ -121,7 +122,7 @@ impl VpndClient {
     /// Get daemon log path
     #[instrument(skip_all)]
     pub async fn vpnd_log_path(&self) -> Result<PathBuf, VpndError> {
-        let mut vpnd = self.vpnd().await?;
+        let vpnd = self.vpnd().await?;
 
         let log_path = vpnd
             .get_log_path()
@@ -138,7 +139,7 @@ impl VpndClient {
     /// Get the current tunnel state and update the app state
     #[instrument(skip_all)]
     pub async fn tunnel_state(&self, app: &AppHandle) -> Result<TunnelState, VpndError> {
-        let mut vpnd = self.vpnd().await?;
+        let vpnd = self.vpnd().await?;
 
         let tun_state = vpnd.get_tunnel_state().await?;
         let tunnel = TunnelState::from_lib(tun_state);
@@ -167,8 +168,7 @@ impl VpndClient {
     /// Watch tunnel state, account state and vpn config updates
     #[instrument(skip_all)]
     pub async fn watch_events(&self, app: &AppHandle) -> Result<()> {
-        let mut vpnd = self.vpnd().await?;
-
+        let vpnd = self.vpnd().await?;
         let mut stream = vpnd.listen_to_events().await.inspect_err(|e| {
             error!("listen to events failed: {}", e);
         })?;
@@ -257,7 +257,7 @@ impl VpndClient {
     /// Get the current daemon configuration
     #[instrument(skip_all)]
     pub async fn config(&self) -> Result<VpndConfig, VpndError> {
-        let mut vpnd = self.vpnd().await?;
+        let vpnd = self.vpnd().await?;
         let config = vpnd
             .get_config()
             .await
@@ -272,7 +272,7 @@ impl VpndClient {
 
     #[instrument(skip_all)]
     pub async fn set_entry_node(&self, node: Node) -> Result<(), VpndError> {
-        let mut vpnd = self.vpnd().await?;
+        let vpnd = self.vpnd().await?;
 
         vpnd.set_entry_point(node.try_into()?)
             .await
@@ -286,8 +286,7 @@ impl VpndClient {
 
     #[instrument(skip_all)]
     pub async fn set_exit_node(&self, node: Node) -> Result<(), VpndError> {
-        let mut vpnd = self.vpnd().await?;
-
+        let vpnd = self.vpnd().await?;
         vpnd.set_exit_point(node.try_into()?)
             .await
             .map_err(VpndError::RpcClient)
@@ -301,7 +300,7 @@ impl VpndClient {
     /// Enable or disable two-hop mode (aka wg)
     #[instrument(skip_all)]
     pub async fn set_two_hop(&self, enabled: bool) -> Result<(), VpndError> {
-        let mut vpnd = self.vpnd().await?;
+        let vpnd = self.vpnd().await?;
         vpnd.set_enable_two_hop(enabled)
             .await
             .map_err(VpndError::RpcClient)
@@ -315,7 +314,7 @@ impl VpndClient {
     /// Enable or disable QUIC mode (aka bridges)
     #[instrument(skip_all)]
     pub async fn set_quic(&self, enabled: bool) -> Result<(), VpndError> {
-        let mut vpnd = self.vpnd().await?;
+        let vpnd = self.vpnd().await?;
         vpnd.set_enable_bridges(enabled)
             .await
             .map_err(VpndError::RpcClient)
@@ -329,7 +328,7 @@ impl VpndClient {
     /// Enable or disable no-IPv6 mode
     #[instrument(skip_all)]
     pub async fn set_no_ipv6(&self, enabled: bool) -> Result<(), VpndError> {
-        let mut vpnd = self.vpnd().await?;
+        let vpnd = self.vpnd().await?;
         vpnd.set_disable_ipv6(enabled)
             .await
             .map_err(VpndError::RpcClient)
@@ -343,7 +342,7 @@ impl VpndClient {
     /// Allow or disallow LAN access while connected to the VPN
     #[instrument(skip_all)]
     pub async fn set_allow_lan(&self, enabled: bool) -> Result<(), VpndError> {
-        let mut vpnd = self.vpnd().await?;
+        let vpnd = self.vpnd().await?;
         vpnd.set_allow_lan(enabled)
             .await
             .map_err(VpndError::RpcClient)
@@ -358,7 +357,7 @@ impl VpndClient {
     #[instrument(skip_all)]
     #[allow(clippy::too_many_arguments)]
     pub async fn vpn_connect(&self) -> Result<(), VpndError> {
-        let mut vpnd = self.vpnd().await?;
+        let vpnd = self.vpnd().await?;
 
         vpnd.connect_tunnel()
             .await
@@ -372,8 +371,7 @@ impl VpndClient {
     /// Disconnect from the VPN
     #[instrument(skip_all)]
     pub async fn vpn_disconnect(&self) -> Result<(), VpndError> {
-        let mut vpnd = self.vpnd().await?;
-
+        let vpnd = self.vpnd().await?;
         vpnd.disconnect_tunnel()
             .await
             .map_err(VpndError::RpcClient)
@@ -387,7 +385,7 @@ impl VpndClient {
     /// Store an account
     #[instrument(skip_all)]
     pub async fn store_account(&self, mnemonic: String) -> Result<(), VpndError> {
-        let mut vpnd = self.vpnd().await?;
+        let vpnd = self.vpnd().await?;
 
         let response = vpnd
             .store_account(lib::StoreAccountRequest::Vpn { mnemonic })
@@ -408,7 +406,7 @@ impl VpndClient {
     /// credential storage, mixnet keys, gateway registrations
     #[instrument(skip_all)]
     pub async fn forget_account(&self) -> Result<(), VpndError> {
-        let mut vpnd = self.vpnd().await?;
+        let vpnd = self.vpnd().await?;
 
         let response = vpnd
             .forget_account()
@@ -428,7 +426,7 @@ impl VpndClient {
     /// Check if an account is stored
     #[instrument(skip_all)]
     pub async fn is_account_stored(&self) -> Result<bool, VpndError> {
-        let mut vpnd = self.vpnd().await?;
+        let vpnd = self.vpnd().await?;
 
         let is_stored = vpnd
             .is_account_stored()
@@ -445,7 +443,7 @@ impl VpndClient {
     /// public key derived from the mnemonic
     #[instrument(skip_all)]
     pub async fn account_id(&self) -> Result<Option<String>, VpndError> {
-        let mut vpnd = self.vpnd().await?;
+        let vpnd = self.vpnd().await?;
 
         let id = vpnd
             .get_account_identity()
@@ -461,7 +459,7 @@ impl VpndClient {
     /// Get the device identity
     #[instrument(skip_all)]
     pub async fn device_id(&self) -> Result<Option<String>, VpndError> {
-        let mut vpnd = self.vpnd().await?;
+        let vpnd = self.vpnd().await?;
 
         let id = vpnd
             .get_device_identity()
@@ -477,7 +475,7 @@ impl VpndClient {
     /// Get the account links
     #[instrument(skip_all)]
     pub async fn account_links(&self, _locale: &str) -> Result<AccountLinks, VpndError> {
-        let mut vpnd = self.vpnd().await?;
+        let vpnd = self.vpnd().await?;
 
         // TODO use the user local once website is i18n ready
         let locale = "en".to_string();
@@ -496,7 +494,7 @@ impl VpndClient {
     /// Get the list of available gateways
     #[instrument(skip(self))]
     pub async fn gateways(&self, gw_type: GatewayType) -> Result<Vec<Gateway>, VpndError> {
-        let mut vpnd = self.vpnd().await?;
+        let vpnd = self.vpnd().await?;
 
         let options = lib::ListGatewaysOptions {
             gw_type: gw_type.into(),
@@ -545,7 +543,7 @@ impl VpndClient {
     /// ⚠ This requires to restart the daemon to take effect.
     #[instrument(skip(self))]
     pub async fn set_network(&self, network: &str) -> Result<(), VpndError> {
-        let mut vpnd = self.vpnd().await?;
+        let vpnd = self.vpnd().await?;
 
         vpnd.set_network(network.to_owned())
             .await
@@ -560,7 +558,7 @@ impl VpndClient {
     /// Get messages affecting the whole system, fetched from nym-vpn-api
     #[instrument(skip_all)]
     pub async fn system_messages(&self) -> Result<Vec<SystemMessage>, VpndError> {
-        let mut vpnd = self.vpnd().await?;
+        let vpnd = self.vpnd().await?;
 
         let messages = vpnd
             .get_system_messages()
@@ -576,7 +574,7 @@ impl VpndClient {
     /// Get the feature flags, fetched from nym-vpn-api
     #[instrument(skip_all)]
     pub async fn feature_flags(&self) -> Result<FeatureFlags, VpndError> {
-        let mut vpnd = self.vpnd().await?;
+        let vpnd = self.vpnd().await?;
 
         let flags = vpnd
             .get_feature_flags()
@@ -592,7 +590,7 @@ impl VpndClient {
     /// Get the network compatibility versions of supported vpn-core and tauri client
     #[instrument(skip_all)]
     pub async fn network_compat(&self) -> Result<Option<NetworkCompatVersions>, VpndError> {
-        let mut vpnd = self.vpnd().await?;
+        let vpnd = self.vpnd().await?;
 
         let net_compat = vpnd
             .get_network_compatibility()
@@ -608,7 +606,7 @@ impl VpndClient {
     /// Is sentry enabled at daemon level
     #[instrument(skip_all)]
     pub async fn sentry_enabled(&self) -> Result<bool, VpndError> {
-        let mut vpnd = self.vpnd().await?;
+        let vpnd = self.vpnd().await?;
 
         let enabled = vpnd
             .is_sentry_enabled()
@@ -628,7 +626,7 @@ impl VpndClient {
     /// Enable sentry at daemon level
     #[instrument(skip_all)]
     pub async fn enable_sentry(&self) -> Result<(), VpndError> {
-        let mut vpnd = self.vpnd().await?;
+        let vpnd = self.vpnd().await?;
 
         vpnd.enable_sentry()
             .await
@@ -650,7 +648,7 @@ impl VpndClient {
         http_rpc_settings: HttpRpcSettings,
         exit_node: Node,
     ) -> Result<(), VpndError> {
-        let mut vpnd = self.vpnd().await?;
+        let vpnd = self.vpnd().await?;
 
         let exit_point: lib::ExitPoint = exit_node.try_into()?;
 
@@ -676,7 +674,7 @@ impl VpndClient {
     /// Disable SOCKS5 proxy
     #[instrument(skip_all)]
     pub async fn disable_socks5(&self) -> Result<(), VpndError> {
-        let mut vpnd = self.vpnd().await?;
+        let vpnd = self.vpnd().await?;
 
         vpnd.disable_socks5().await.map_err(|e| {
             error!("failed to disable SOCKS5 proxy: {}", e);
@@ -690,7 +688,7 @@ impl VpndClient {
     /// Get SOCKS5 proxy status
     #[instrument(skip_all)]
     pub async fn get_socks5_status(&self) -> Result<Socks5Status, VpndError> {
-        let mut vpnd = self.vpnd().await?;
+        let vpnd = self.vpnd().await?;
 
         let response = vpnd.get_socks5_status().await.map_err(|e| {
             error!("failed to get SOCKS5 status: {}", e);
@@ -705,7 +703,7 @@ impl VpndClient {
     /// Disable sentry at daemon level
     #[instrument(skip_all)]
     pub async fn disable_sentry(&self) -> Result<(), VpndError> {
-        let mut vpnd = self.vpnd().await?;
+        let vpnd = self.vpnd().await?;
 
         vpnd.disable_sentry()
             .await
@@ -722,7 +720,7 @@ impl VpndClient {
     /// Is network statistics collection enabled at daemon level
     #[instrument(skip_all)]
     pub async fn netstats_enabled(&self) -> Result<bool, VpndError> {
-        let mut vpnd = self.vpnd().await?;
+        let vpnd = self.vpnd().await?;
 
         let config = vpnd
             .get_config()
@@ -743,7 +741,7 @@ impl VpndClient {
     /// Enable network statistics collection at daemon level
     #[instrument(skip_all)]
     pub async fn enable_netstats(&self) -> Result<(), VpndError> {
-        let mut vpnd = self.vpnd().await?;
+        let vpnd = self.vpnd().await?;
 
         vpnd.network_stats_set_enabled(true)
             .await
@@ -759,7 +757,7 @@ impl VpndClient {
     /// Disable network statistics collection at daemon level
     #[instrument(skip_all)]
     pub async fn disable_netstats(&self) -> Result<(), VpndError> {
-        let mut vpnd = self.vpnd().await?;
+        let vpnd = self.vpnd().await?;
 
         vpnd.network_stats_set_enabled(false)
             .await

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -5646,6 +5646,7 @@ dependencies = [
  "prost-types",
  "thiserror 2.0.17",
  "time",
+ "tokio",
  "tokio-stream",
  "tonic",
  "tonic-prost",

--- a/nym-vpn-core/crates/nym-vpn-proto/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-proto/Cargo.toml
@@ -16,6 +16,7 @@ prost-types.workspace = true
 prost.workspace = true
 tonic-prost.workspace = true
 tonic.workspace = true
+tokio.workspace = true
 tokio-stream = { workspace = true, optional = true, features = ["net"] }
 tower = { workspace = true, optional = true }
 thiserror = { workspace = true, optional = true }

--- a/nym-vpn-core/crates/nym-vpn-proto/src/rpc_client.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/rpc_client.rs
@@ -8,7 +8,8 @@ use nym_vpn_lib_types::{
     NymVpnUsage, ParsedAccountLinks, Socks5Settings, Socks5Status, StoreAccountRequest,
     SystemMessage, TunnelEvent, TunnelState, VpnServiceConfig, VpnServiceInfo,
 };
-use std::{net::IpAddr, path::PathBuf};
+use std::{net::IpAddr, path::PathBuf, sync::Arc};
+use tokio::sync::Mutex;
 use tokio_stream::{Stream, StreamExt};
 use tonic::transport::{Endpoint, Uri};
 use tower::service_fn;
@@ -17,8 +18,8 @@ use crate::proto::{self, nym_vpn_service_client::NymVpnServiceClient};
 
 type ServiceClient = NymVpnServiceClient<tonic::transport::Channel>;
 
-#[derive(Debug, Clone)]
-pub struct RpcClient(ServiceClient);
+#[derive(Debug)]
+pub struct RpcClient(Arc<Mutex<ServiceClient>>);
 
 impl RpcClient {
     pub async fn new() -> Result<RpcClient> {
@@ -28,18 +29,27 @@ impl RpcClient {
                 nym_ipc::client::connect(socket_path.clone())
             }))
             .await?;
-        Ok(RpcClient(ServiceClient::new(channel)))
+        Ok(RpcClient(Arc::new(Mutex::new(ServiceClient::new(channel)))))
     }
 
-    pub async fn get_info(&mut self) -> Result<VpnServiceInfo> {
-        let response = self.0.info(()).await.map_err(Error::Rpc)?.into_inner();
+    pub async fn get_info(&self) -> Result<VpnServiceInfo> {
+        let response = self
+            .0
+            .lock()
+            .await
+            .info(())
+            .await
+            .map_err(Error::Rpc)?
+            .into_inner();
 
         VpnServiceInfo::try_from(response).map_err(Error::InvalidResponse)
     }
 
-    pub async fn get_config(&mut self) -> Result<VpnServiceConfig> {
+    pub async fn get_config(&self) -> Result<VpnServiceConfig> {
         let response = self
             .0
+            .lock()
+            .await
             .get_config(())
             .await
             .map_err(Error::Rpc)?
@@ -52,10 +62,12 @@ impl RpcClient {
         VpnServiceConfig::try_from(config).map_err(Error::InvalidResponse)
     }
 
-    pub async fn set_entry_point(&mut self, entry_point: EntryPoint) -> Result<()> {
+    pub async fn set_entry_point(&self, entry_point: EntryPoint) -> Result<()> {
         let entry_node = proto::EntryNode::from(entry_point);
 
         self.0
+            .lock()
+            .await
             .set_entry_point(entry_node)
             .await
             .map_err(Error::Rpc)?
@@ -64,10 +76,12 @@ impl RpcClient {
         Ok(())
     }
 
-    pub async fn set_exit_point(&mut self, exit_point: ExitPoint) -> Result<()> {
+    pub async fn set_exit_point(&self, exit_point: ExitPoint) -> Result<()> {
         let exit_node = proto::ExitNode::from(exit_point);
 
         self.0
+            .lock()
+            .await
             .set_exit_point(exit_node)
             .await
             .map_err(Error::Rpc)?
@@ -76,8 +90,10 @@ impl RpcClient {
         Ok(())
     }
 
-    pub async fn set_disable_ipv6(&mut self, disable_ipv6: bool) -> Result<()> {
+    pub async fn set_disable_ipv6(&self, disable_ipv6: bool) -> Result<()> {
         self.0
+            .lock()
+            .await
             .set_disable_ipv6(disable_ipv6)
             .await
             .map_err(Error::Rpc)?
@@ -85,8 +101,10 @@ impl RpcClient {
         Ok(())
     }
 
-    pub async fn set_enable_two_hop(&mut self, enable_two_hop: bool) -> Result<()> {
+    pub async fn set_enable_two_hop(&self, enable_two_hop: bool) -> Result<()> {
         self.0
+            .lock()
+            .await
             .set_enable_two_hop(enable_two_hop)
             .await
             .map_err(Error::Rpc)?
@@ -94,8 +112,10 @@ impl RpcClient {
         Ok(())
     }
 
-    pub async fn set_netstack(&mut self, netstack: bool) -> Result<()> {
+    pub async fn set_netstack(&self, netstack: bool) -> Result<()> {
         self.0
+            .lock()
+            .await
             .set_netstack(netstack)
             .await
             .map_err(Error::Rpc)?
@@ -103,8 +123,10 @@ impl RpcClient {
         Ok(())
     }
 
-    pub async fn set_allow_lan(&mut self, allow_lan: bool) -> Result<()> {
+    pub async fn set_allow_lan(&self, allow_lan: bool) -> Result<()> {
         self.0
+            .lock()
+            .await
             .set_allow_lan(allow_lan)
             .await
             .map_err(Error::Rpc)?
@@ -112,8 +134,10 @@ impl RpcClient {
         Ok(())
     }
 
-    pub async fn set_enable_bridges(&mut self, enable_bridges: bool) -> Result<()> {
+    pub async fn set_enable_bridges(&self, enable_bridges: bool) -> Result<()> {
         self.0
+            .lock()
+            .await
             .set_enable_bridges(enable_bridges)
             .await
             .map_err(Error::Rpc)?
@@ -121,8 +145,10 @@ impl RpcClient {
         Ok(())
     }
 
-    pub async fn set_residential_exit(&mut self, residential_exit: bool) -> Result<()> {
+    pub async fn set_residential_exit(&self, residential_exit: bool) -> Result<()> {
         self.0
+            .lock()
+            .await
             .set_residential_exit(residential_exit)
             .await
             .map_err(Error::Rpc)?
@@ -130,8 +156,10 @@ impl RpcClient {
         Ok(())
     }
 
-    pub async fn set_enable_custom_dns(&mut self, enable: bool) -> Result<()> {
+    pub async fn set_enable_custom_dns(&self, enable: bool) -> Result<()> {
         self.0
+            .lock()
+            .await
             .set_enable_custom_dns(enable)
             .await
             .map_err(Error::Rpc)?
@@ -139,12 +167,14 @@ impl RpcClient {
         Ok(())
     }
 
-    pub async fn set_custom_dns(&mut self, ips: Vec<IpAddr>) -> Result<()> {
+    pub async fn set_custom_dns(&self, ips: Vec<IpAddr>) -> Result<()> {
         let request = proto::IpAddrList {
             ips: ips.into_iter().map(proto::IpAddr::from).collect(),
         };
 
         self.0
+            .lock()
+            .await
             .set_custom_dns(request)
             .await
             .map_err(Error::Rpc)?
@@ -152,8 +182,10 @@ impl RpcClient {
         Ok(())
     }
 
-    pub async fn set_network(&mut self, network: String) -> Result<()> {
+    pub async fn set_network(&self, network: String) -> Result<()> {
         self.0
+            .lock()
+            .await
             .set_network(network)
             .await
             .map_err(Error::Rpc)?
@@ -161,9 +193,11 @@ impl RpcClient {
         Ok(())
     }
 
-    pub async fn get_system_messages(&mut self) -> Result<Vec<SystemMessage>> {
+    pub async fn get_system_messages(&self) -> Result<Vec<SystemMessage>> {
         let response = self
             .0
+            .lock()
+            .await
             .get_system_messages(())
             .await
             .map_err(Error::Rpc)?
@@ -178,9 +212,11 @@ impl RpcClient {
         Ok(messages)
     }
 
-    pub async fn get_network_compatibility(&mut self) -> Result<Option<NetworkCompatibility>> {
+    pub async fn get_network_compatibility(&self) -> Result<Option<NetworkCompatibility>> {
         let response = self
             .0
+            .lock()
+            .await
             .get_network_compatibility(())
             .await
             .map_err(Error::Rpc)?
@@ -191,9 +227,11 @@ impl RpcClient {
             .map(NetworkCompatibility::from))
     }
 
-    pub async fn get_feature_flags(&mut self) -> Result<FeatureFlags> {
+    pub async fn get_feature_flags(&self) -> Result<FeatureFlags> {
         let response = self
             .0
+            .lock()
+            .await
             .get_feature_flags(())
             .await
             .map_err(Error::Rpc)?
@@ -202,9 +240,11 @@ impl RpcClient {
         Ok(FeatureFlags::from(response))
     }
 
-    pub async fn get_default_dns(&mut self) -> Result<Vec<IpAddr>> {
+    pub async fn get_default_dns(&self) -> Result<Vec<IpAddr>> {
         let response = self
             .0
+            .lock()
+            .await
             .get_default_dns(())
             .await
             .map_err(Error::Rpc)?
@@ -213,33 +253,41 @@ impl RpcClient {
         Ok(ip_vec)
     }
 
-    pub async fn connect_tunnel(&mut self) -> Result<bool> {
+    pub async fn connect_tunnel(&self) -> Result<bool> {
         self.0
+            .lock()
+            .await
             .connect_tunnel(())
             .await
             .map(|v| v.into_inner())
             .map_err(Error::Rpc)
     }
 
-    pub async fn reconnect_tunnel(&mut self) -> Result<bool> {
+    pub async fn reconnect_tunnel(&self) -> Result<bool> {
         self.0
+            .lock()
+            .await
             .reconnect_tunnel(())
             .await
             .map(|v| v.into_inner())
             .map_err(Error::Rpc)
     }
 
-    pub async fn disconnect_tunnel(&mut self) -> Result<bool> {
+    pub async fn disconnect_tunnel(&self) -> Result<bool> {
         self.0
+            .lock()
+            .await
             .disconnect_tunnel(())
             .await
             .map(|v| v.into_inner())
             .map_err(Error::Rpc)
     }
 
-    pub async fn get_tunnel_state(&mut self) -> Result<TunnelState> {
+    pub async fn get_tunnel_state(&self) -> Result<TunnelState> {
         let state = self
             .0
+            .lock()
+            .await
             .get_tunnel_state(())
             .await
             .map_err(Error::Rpc)?
@@ -249,10 +297,12 @@ impl RpcClient {
     }
 
     pub async fn listen_to_events(
-        &mut self,
+        &self,
     ) -> Result<impl Stream<Item = Result<TunnelEvent>> + 'static> {
         let listener = self
             .0
+            .lock()
+            .await
             .listen_to_events(())
             .await
             .map_err(Error::Rpc)?
@@ -265,12 +315,14 @@ impl RpcClient {
         }))
     }
 
-    pub async fn list_gateways(&mut self, options: ListGatewaysOptions) -> Result<Vec<Gateway>> {
+    pub async fn list_gateways(&self, options: ListGatewaysOptions) -> Result<Vec<Gateway>> {
         let request =
             proto::ListGatewaysRequest::try_from(options).map_err(Error::InvalidRequest)?;
 
         let gateways = self
             .0
+            .lock()
+            .await
             .list_gateways(request)
             .await
             .map(|v| v.into_inner().gateways)
@@ -282,14 +334,13 @@ impl RpcClient {
             .collect::<Result<Vec<_>>>()
     }
 
-    pub async fn list_filtered_gateways(
-        &mut self,
-        filters: GatewayFilters,
-    ) -> Result<Vec<Gateway>> {
+    pub async fn list_filtered_gateways(&self, filters: GatewayFilters) -> Result<Vec<Gateway>> {
         let request = proto::GatewayFilters::from(filters);
 
         let gateways = self
             .0
+            .lock()
+            .await
             .list_filtered_gateways(request)
             .await
             .map(|v| v.into_inner().gateways)
@@ -302,12 +353,14 @@ impl RpcClient {
     }
 
     pub async fn store_account(
-        &mut self,
+        &self,
         store_request: StoreAccountRequest,
     ) -> Result<AccountCommandResponse> {
         let request = proto::StoreAccountRequest::from(store_request);
         let response = self
             .0
+            .lock()
+            .await
             .store_account(request)
             .await
             .map_err(Error::Rpc)?
@@ -316,17 +369,21 @@ impl RpcClient {
         AccountCommandResponse::try_from(response).map_err(Error::InvalidResponse)
     }
 
-    pub async fn is_account_stored(&mut self) -> Result<bool> {
+    pub async fn is_account_stored(&self) -> Result<bool> {
         self.0
+            .lock()
+            .await
             .is_account_stored(())
             .await
             .map(|v| v.into_inner())
             .map_err(Error::Rpc)
     }
 
-    pub async fn forget_account(&mut self) -> Result<AccountCommandResponse> {
+    pub async fn forget_account(&self) -> Result<AccountCommandResponse> {
         let response = self
             .0
+            .lock()
+            .await
             .forget_account(())
             .await
             .map_err(Error::Rpc)?
@@ -335,9 +392,11 @@ impl RpcClient {
         AccountCommandResponse::try_from(response).map_err(Error::InvalidResponse)
     }
 
-    pub async fn rotate_keys(&mut self) -> Result<AccountCommandResponse> {
+    pub async fn rotate_keys(&self) -> Result<AccountCommandResponse> {
         let response = self
             .0
+            .lock()
+            .await
             .rotate_keys(())
             .await
             .map_err(Error::Rpc)?
@@ -346,18 +405,22 @@ impl RpcClient {
         AccountCommandResponse::try_from(response).map_err(Error::InvalidResponse)
     }
 
-    pub async fn get_account_identity(&mut self) -> Result<Option<String>> {
+    pub async fn get_account_identity(&self) -> Result<Option<String>> {
         self.0
+            .lock()
+            .await
             .get_account_identity(())
             .await
             .map(|v| v.into_inner().account_identity)
             .map_err(Error::Rpc)
     }
 
-    pub async fn get_account_links(&mut self, locale: String) -> Result<ParsedAccountLinks> {
+    pub async fn get_account_links(&self, locale: String) -> Result<ParsedAccountLinks> {
         let request = proto::GetAccountLinksRequest { locale };
         let response = self
             .0
+            .lock()
+            .await
             .get_account_links(request)
             .await
             .map(|v| v.into_inner())
@@ -366,9 +429,11 @@ impl RpcClient {
         Ok(ParsedAccountLinks::from(response))
     }
 
-    pub async fn account_balance(&mut self) -> Result<AccountBalanceResponse> {
+    pub async fn account_balance(&self) -> Result<AccountBalanceResponse> {
         let response = self
             .0
+            .lock()
+            .await
             .account_balance(())
             .await
             .map_err(Error::Rpc)?
@@ -378,12 +443,14 @@ impl RpcClient {
     }
 
     pub async fn decentralised_obtain_ticketbooks(
-        &mut self,
+        &self,
         amount: u64,
     ) -> Result<AccountCommandResponse> {
         let request = proto::DecentralisedObtainTicketbooksRequest { amount };
         let response = self
             .0
+            .lock()
+            .await
             .decentralised_obtain_ticketbooks(request)
             .await
             .map_err(Error::Rpc)?
@@ -392,9 +459,11 @@ impl RpcClient {
         AccountCommandResponse::try_from(response).map_err(Error::InvalidResponse)
     }
 
-    pub async fn get_account_state(&mut self) -> Result<AccountControllerState> {
+    pub async fn get_account_state(&self) -> Result<AccountControllerState> {
         let state = self
             .0
+            .lock()
+            .await
             .get_account_state(())
             .await
             .map_err(Error::Rpc)?
@@ -403,8 +472,10 @@ impl RpcClient {
         AccountControllerState::try_from(state).map_err(Error::InvalidResponse)
     }
 
-    pub async fn refresh_account_state(&mut self) -> Result<()> {
+    pub async fn refresh_account_state(&self) -> Result<()> {
         self.0
+            .lock()
+            .await
             .refresh_account_state(())
             .await
             .map_err(Error::Rpc)?
@@ -412,9 +483,11 @@ impl RpcClient {
         Ok(())
     }
 
-    pub async fn get_account_usage(&mut self) -> Result<Vec<NymVpnUsage>> {
+    pub async fn get_account_usage(&self) -> Result<Vec<NymVpnUsage>> {
         let response = self
             .0
+            .lock()
+            .await
             .get_account_usage(())
             .await
             .map_err(Error::Rpc)?
@@ -423,9 +496,11 @@ impl RpcClient {
         Ok(response.account_usages.map(Vec::from).unwrap_or_default())
     }
 
-    pub async fn reset_device_identity(&mut self, seed: Option<Vec<u8>>) -> Result<()> {
+    pub async fn reset_device_identity(&self, seed: Option<Vec<u8>>) -> Result<()> {
         let request = proto::ResetDeviceIdentityRequest { seed };
         self.0
+            .lock()
+            .await
             .reset_device_identity(request)
             .await
             .map_err(Error::Rpc)?
@@ -433,9 +508,11 @@ impl RpcClient {
         Ok(())
     }
 
-    pub async fn get_device_identity(&mut self) -> Result<Option<String>> {
+    pub async fn get_device_identity(&self) -> Result<Option<String>> {
         let response = self
             .0
+            .lock()
+            .await
             .get_device_identity(())
             .await
             .map_err(Error::Rpc)?
@@ -444,9 +521,11 @@ impl RpcClient {
         Ok(response.device_identity)
     }
 
-    pub async fn get_devices(&mut self) -> Result<Vec<NymVpnDevice>> {
+    pub async fn get_devices(&self) -> Result<Vec<NymVpnDevice>> {
         let response = self
             .0
+            .lock()
+            .await
             .get_devices(())
             .await
             .map_err(Error::Rpc)?
@@ -464,9 +543,11 @@ impl RpcClient {
         Ok(devices)
     }
 
-    pub async fn get_active_devices(&mut self) -> Result<Vec<NymVpnDevice>> {
+    pub async fn get_active_devices(&self) -> Result<Vec<NymVpnDevice>> {
         let response = self
             .0
+            .lock()
+            .await
             .get_active_devices(())
             .await
             .map_err(Error::Rpc)?
@@ -483,9 +564,11 @@ impl RpcClient {
 
         Ok(devices)
     }
-    pub async fn get_available_tickets(&mut self) -> Result<AvailableTickets> {
+    pub async fn get_available_tickets(&self) -> Result<AvailableTickets> {
         let response = self
             .0
+            .lock()
+            .await
             .get_available_tickets(())
             .await
             .map_err(Error::Rpc)?
@@ -494,9 +577,11 @@ impl RpcClient {
         Ok(AvailableTickets::from(response))
     }
 
-    pub async fn get_log_path(&mut self) -> Result<LogPath> {
+    pub async fn get_log_path(&self) -> Result<LogPath> {
         let response = self
             .0
+            .lock()
+            .await
             .get_log_path(())
             .await
             .map(|v| v.into_inner())
@@ -505,60 +590,71 @@ impl RpcClient {
         Ok(LogPath::from(response))
     }
 
-    pub async fn delete_log_file(&mut self) -> Result<()> {
+    pub async fn delete_log_file(&self) -> Result<()> {
         self.0
+            .lock()
+            .await
             .delete_log_file(())
             .await
             .map(|v| v.into_inner())
             .map_err(Error::Rpc)
     }
 
-    pub async fn is_sentry_enabled(&mut self) -> Result<bool> {
+    pub async fn is_sentry_enabled(&self) -> Result<bool> {
         self.0
+            .lock()
+            .await
             .is_sentry_enabled(())
             .await
             .map(|v| v.into_inner())
             .map_err(Error::Rpc)
     }
 
-    pub async fn enable_sentry(&mut self) -> Result<()> {
+    pub async fn enable_sentry(&self) -> Result<()> {
         self.0
+            .lock()
+            .await
             .enable_sentry(())
             .await
             .map(|v| v.into_inner())
             .map_err(Error::Rpc)
     }
 
-    pub async fn disable_sentry(&mut self) -> Result<()> {
+    pub async fn disable_sentry(&self) -> Result<()> {
         self.0
+            .lock()
+            .await
             .disable_sentry(())
             .await
             .map(|v| v.into_inner())
             .map_err(Error::Rpc)
     }
 
-    pub async fn network_stats_set_enabled(&mut self, enabled: bool) -> Result<()> {
+    pub async fn network_stats_set_enabled(&self, enabled: bool) -> Result<()> {
         self.0
+            .lock()
+            .await
             .network_stats_set_enabled(enabled)
             .await
             .map(|v| v.into_inner())
             .map_err(Error::Rpc)
     }
 
-    pub async fn network_stats_allow_disconnected(
-        &mut self,
-        allow_disconnected: bool,
-    ) -> Result<()> {
+    pub async fn network_stats_allow_disconnected(&self, allow_disconnected: bool) -> Result<()> {
         self.0
+            .lock()
+            .await
             .network_stats_allow_disconnected(allow_disconnected)
             .await
             .map(|v| v.into_inner())
             .map_err(Error::Rpc)
     }
 
-    pub async fn network_stats_reset_seed(&mut self, seed: Option<String>) -> Result<()> {
+    pub async fn network_stats_reset_seed(&self, seed: Option<String>) -> Result<()> {
         let request = proto::NetworkStatsResetSeedRequest { seed };
         self.0
+            .lock()
+            .await
             .network_stats_reset_seed(request)
             .await
             .map(|v| v.into_inner())
@@ -566,7 +662,7 @@ impl RpcClient {
     }
 
     pub async fn enable_socks5(
-        &mut self,
+        &self,
         socks5_settings: Socks5Settings,
         http_rpc_settings: HttpRpcSettings,
         exit_point: ExitPoint,
@@ -582,23 +678,29 @@ impl RpcClient {
         };
 
         self.0
+            .lock()
+            .await
             .enable_socks5(request)
             .await
             .map(|v| v.into_inner())
             .map_err(Error::Rpc)
     }
 
-    pub async fn disable_socks5(&mut self) -> Result<()> {
+    pub async fn disable_socks5(&self) -> Result<()> {
         self.0
+            .lock()
+            .await
             .disable_socks5(())
             .await
             .map(|v| v.into_inner())
             .map_err(Error::Rpc)
     }
 
-    pub async fn get_socks5_status(&mut self) -> Result<Socks5Status> {
+    pub async fn get_socks5_status(&self) -> Result<Socks5Status> {
         let response = self
             .0
+            .lock()
+            .await
             .get_socks5_status(())
             .await
             .map_err(Error::Rpc)?
@@ -607,9 +709,11 @@ impl RpcClient {
         Socks5Status::try_from(response).map_err(Error::InvalidResponse)
     }
 
-    pub async fn network_stats_get_seed(&mut self) -> Result<NetworkStatisticsIdentity> {
+    pub async fn network_stats_get_seed(&self) -> Result<NetworkStatisticsIdentity> {
         let response = self
             .0
+            .lock()
+            .await
             .network_stats_get_seed(())
             .await
             .map(|v| v.into_inner())

--- a/nym-vpn-core/crates/nym-vpn-rpc-uniffi/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-rpc-uniffi/src/lib.rs
@@ -20,7 +20,7 @@ use nym_vpn_lib_types::{
 
 uniffi::use_remote_type!(nym_vpn_lib_types::IpAddr);
 
-#[derive(Clone, uniffi::Object)]
+#[derive(uniffi::Object)]
 struct RpcClient {
     inner: DaemonRpcClient,
 }
@@ -35,100 +35,94 @@ impl RpcClient {
     }
 
     pub async fn get_info(&self) -> Result<VpnServiceInfo> {
-        Ok(self.inner.clone().get_info().await?)
+        Ok(self.inner.get_info().await?)
     }
 
     pub async fn get_config(&self) -> Result<VpnServiceConfig> {
-        Ok(self.inner.clone().get_config().await?)
+        Ok(self.inner.get_config().await?)
     }
 
     pub async fn set_entry_point(&self, entry_point: EntryPoint) -> Result<()> {
-        self.inner.clone().set_entry_point(entry_point).await?;
+        self.inner.set_entry_point(entry_point).await?;
         Ok(())
     }
 
     pub async fn set_exit_point(&self, exit_point: ExitPoint) -> Result<()> {
-        self.inner.clone().set_exit_point(exit_point).await?;
+        self.inner.set_exit_point(exit_point).await?;
         Ok(())
     }
 
     pub async fn set_disable_ipv6(&self, disable_ipv6: bool) -> Result<()> {
-        self.inner.clone().set_disable_ipv6(disable_ipv6).await?;
+        self.inner.set_disable_ipv6(disable_ipv6).await?;
         Ok(())
     }
 
     pub async fn set_enable_two_hop(&self, enable_two_hop: bool) -> Result<()> {
-        self.inner
-            .clone()
-            .set_enable_two_hop(enable_two_hop)
-            .await?;
+        self.inner.set_enable_two_hop(enable_two_hop).await?;
         Ok(())
     }
 
     pub async fn set_netstack(&self, netstack: bool) -> Result<()> {
-        self.inner.clone().set_netstack(netstack).await?;
+        self.inner.set_netstack(netstack).await?;
         Ok(())
     }
 
     pub async fn set_allow_lan(&self, allow_lan: bool) -> Result<()> {
-        self.inner.clone().set_allow_lan(allow_lan).await?;
+        self.inner.set_allow_lan(allow_lan).await?;
         Ok(())
     }
 
     pub async fn set_enable_bridges(&self, enable_bridges: bool) -> Result<()> {
-        self.inner
-            .clone()
-            .set_enable_bridges(enable_bridges)
-            .await?;
+        self.inner.set_enable_bridges(enable_bridges).await?;
         Ok(())
     }
 
     pub async fn set_enable_custom_dns(&self, enable: bool) -> Result<()> {
-        self.inner.clone().set_enable_custom_dns(enable).await?;
+        self.inner.set_enable_custom_dns(enable).await?;
         Ok(())
     }
 
     pub async fn set_custom_dns(&self, dns_servers: Vec<IpAddr>) -> Result<()> {
-        self.inner.clone().set_custom_dns(dns_servers).await?;
+        self.inner.set_custom_dns(dns_servers).await?;
         Ok(())
     }
 
     pub async fn set_network(&self, network: String) -> Result<()> {
-        self.inner.clone().set_network(network).await?;
+        self.inner.set_network(network).await?;
         Ok(())
     }
 
     pub async fn get_system_messages(&self) -> Result<Vec<SystemMessage>> {
-        let system_messages = self.inner.clone().get_system_messages().await?;
+        let system_messages = self.inner.get_system_messages().await?;
         Ok(system_messages.into_iter().collect())
     }
 
     pub async fn get_network_compatibility(&self) -> Result<Option<NetworkCompatibility>> {
-        let network_compatibility = self.inner.clone().get_network_compatibility().await?;
+        let network_compatibility = self.inner.get_network_compatibility().await?;
         Ok(network_compatibility)
     }
 
     pub async fn get_feature_flags(&self) -> Result<FeatureFlags> {
-        Ok(self.inner.clone().get_feature_flags().await?)
+        Ok(self.inner.get_feature_flags().await?)
     }
 
     pub async fn get_default_dns(&self) -> Result<Vec<IpAddr>> {
-        let ips = self.inner.clone().get_default_dns().await?;
+        let ips = self.inner.get_default_dns().await?;
         Ok(ips)
     }
 
     pub async fn connect_tunnel(&self) -> Result<()> {
-        self.inner.clone().connect_tunnel().await?;
+        self.inner.connect_tunnel().await?;
         Ok(())
     }
 
     pub async fn disconnect_tunnel(&self) -> Result<()> {
-        self.inner.clone().disconnect_tunnel().await?;
+        self.inner.disconnect_tunnel().await?;
         Ok(())
     }
 
     pub async fn get_tunnel_state(&self) -> Result<TunnelState> {
-        Ok(self.inner.clone().get_tunnel_state().await?)
+        Ok(self.inner.get_tunnel_state().await?)
     }
 
     pub async fn listen_to_events(
@@ -137,7 +131,7 @@ impl RpcClient {
     ) -> Result<StreamObserver> {
         let cancel_token = CancellationToken::new();
         let child_token = cancel_token.child_token();
-        let mut event_stream = self.inner.clone().listen_to_events().await?;
+        let mut event_stream = self.inner.listen_to_events().await?;
 
         tokio::spawn(async move {
             loop {
@@ -169,7 +163,6 @@ impl RpcClient {
         };
         let gateways = self
             .inner
-            .clone()
             .list_gateways(options)
             .await?
             .into_iter()
@@ -180,7 +173,6 @@ impl RpcClient {
     pub async fn store_account(&self, mnemonic: String) -> Result<()> {
         let response = self
             .inner
-            .clone()
             .store_account(nym_vpn_lib_types::StoreAccountRequest::Vpn { mnemonic })
             .await?;
 
@@ -192,11 +184,11 @@ impl RpcClient {
     }
 
     pub async fn is_account_stored(&self) -> Result<bool> {
-        Ok(self.inner.clone().is_account_stored().await?)
+        Ok(self.inner.is_account_stored().await?)
     }
 
     pub async fn forget_account(&self) -> Result<()> {
-        let response = self.inner.clone().forget_account().await?;
+        let response = self.inner.forget_account().await?;
         if let Some(err) = response.error {
             Err(RpcError::from(Arc::new(err)))
         } else {
@@ -205,26 +197,25 @@ impl RpcClient {
     }
 
     pub async fn get_account_identity(&self) -> Result<Option<String>> {
-        Ok(self.inner.clone().get_account_identity().await?)
+        Ok(self.inner.get_account_identity().await?)
     }
 
     pub async fn get_account_links(&self, locale: String) -> Result<ParsedAccountLinks> {
-        Ok(self.inner.clone().get_account_links(locale).await?)
+        Ok(self.inner.get_account_links(locale).await?)
     }
 
     pub async fn get_account_state(&self) -> Result<AccountControllerState> {
-        Ok(self.inner.clone().get_account_state().await?)
+        Ok(self.inner.get_account_state().await?)
     }
 
     pub async fn refresh_account_state(&self) -> Result<()> {
-        self.inner.clone().refresh_account_state().await?;
+        self.inner.refresh_account_state().await?;
         Ok(())
     }
 
     pub async fn get_account_usage(&self) -> Result<Vec<NymVpnUsage>> {
         let usage = self
             .inner
-            .clone()
             .get_account_usage()
             .await?
             .into_iter()
@@ -233,69 +224,53 @@ impl RpcClient {
     }
 
     pub async fn reset_device_identity(&self, seed: Option<Vec<u8>>) -> Result<()> {
-        self.inner.clone().reset_device_identity(seed).await?;
+        self.inner.reset_device_identity(seed).await?;
         Ok(())
     }
 
     pub async fn get_device_identity(&self) -> Result<Option<String>> {
-        Ok(self.inner.clone().get_device_identity().await?)
+        Ok(self.inner.get_device_identity().await?)
     }
 
     pub async fn get_devices(&self) -> Result<Vec<NymVpnDevice>> {
-        Ok(self
-            .inner
-            .clone()
-            .get_devices()
-            .await?
-            .into_iter()
-            .collect())
+        Ok(self.inner.get_devices().await?.into_iter().collect())
     }
 
     pub async fn get_active_devices(&self) -> Result<Vec<NymVpnDevice>> {
-        Ok(self
-            .inner
-            .clone()
-            .get_active_devices()
-            .await?
-            .into_iter()
-            .collect())
+        Ok(self.inner.get_active_devices().await?.into_iter().collect())
     }
 
     pub async fn get_log_path(&self) -> Result<LogPath> {
-        let log_path = self.inner.clone().get_log_path().await?;
+        let log_path = self.inner.get_log_path().await?;
         Ok(log_path)
     }
 
     pub async fn delete_log_file(&self) -> Result<()> {
-        self.inner.clone().delete_log_file().await?;
+        self.inner.delete_log_file().await?;
         Ok(())
     }
 
     pub async fn is_sentry_enabled(&self) -> Result<bool> {
-        Ok(self.inner.clone().is_sentry_enabled().await?)
+        Ok(self.inner.is_sentry_enabled().await?)
     }
 
     pub async fn enable_sentry(&self) -> Result<()> {
-        self.inner.clone().enable_sentry().await?;
+        self.inner.enable_sentry().await?;
         Ok(())
     }
 
     pub async fn disable_sentry(&self) -> Result<()> {
-        self.inner.clone().disable_sentry().await?;
+        self.inner.disable_sentry().await?;
         Ok(())
     }
 
     pub async fn network_stats_set_enabled(&self, enabled: bool) -> Result<()> {
-        self.inner
-            .clone()
-            .network_stats_set_enabled(enabled)
-            .await?;
+        self.inner.network_stats_set_enabled(enabled).await?;
         Ok(())
     }
 
     pub async fn network_stats_allow_disconnected(&self, allow_disconnected: bool) -> Result<()> {
         self.inner
-            .clone()
             .network_stats_allow_disconnected(allow_disconnected)
             .await?;
         Ok(())
@@ -308,19 +283,18 @@ impl RpcClient {
         exit_point: ExitPoint,
     ) -> Result<()> {
         self.inner
-            .clone()
             .enable_socks5(socks5_settings, http_rpc_settings, exit_point)
             .await?;
         Ok(())
     }
 
     pub async fn disable_socks5(&self) -> Result<()> {
-        self.inner.clone().disable_socks5().await?;
+        self.inner.disable_socks5().await?;
         Ok(())
     }
 
     pub async fn get_socks5_status(&self) -> Result<Socks5Status> {
-        let status = self.inner.clone().get_socks5_status().await?;
+        let status = self.inner.get_socks5_status().await?;
         Ok(status)
     }
 }

--- a/nym-vpn-core/crates/nym-vpnc/src/commands/account.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/commands/account.rs
@@ -48,7 +48,7 @@ pub enum Command {
 }
 
 impl Command {
-    pub async fn execute(self, mut rpc_client: RpcClient) -> Result<()> {
+    pub async fn execute(self, rpc_client: &RpcClient) -> Result<()> {
         match self {
             Command::Get => {
                 let account_id = rpc_client.get_account_identity().await?;

--- a/nym-vpn-core/crates/nym-vpnc/src/commands/device.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/commands/device.rs
@@ -35,7 +35,7 @@ pub enum Command {
 }
 
 impl Args {
-    pub async fn execute(self, mut rpc_client: RpcClient) -> Result<()> {
+    pub async fn execute(self, rpc_client: &RpcClient) -> Result<()> {
         match self.command.unwrap_or(Command::Get) {
             Command::Get => {
                 let identity = rpc_client.get_device_identity().await?;

--- a/nym-vpn-core/crates/nym-vpnc/src/commands/dns.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/commands/dns.rs
@@ -27,7 +27,7 @@ pub enum Command {
 }
 
 impl Command {
-    pub async fn execute(self, mut rpc_client: RpcClient) -> Result<()> {
+    pub async fn execute(self, rpc_client: &RpcClient) -> Result<()> {
         match self {
             Command::Get => {
                 let config = rpc_client.get_config().await?;

--- a/nym-vpn-core/crates/nym-vpnc/src/commands/gateway.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/commands/gateway.rs
@@ -145,7 +145,7 @@ pub struct FilterArgs {
 }
 
 impl Args {
-    pub async fn execute(self, mut rpc_client: RpcClient) -> Result<()> {
+    pub async fn execute(self, rpc_client: &RpcClient) -> Result<()> {
         match self.command {
             Command::Get => {
                 let config = rpc_client.get_config().await?;
@@ -190,7 +190,7 @@ impl Args {
         }
     }
 
-    async fn list_gateways(&self, mut rpc_client: RpcClient, gw_type: GatewayType) -> Result<()> {
+    async fn list_gateways(&self, rpc_client: &RpcClient, gw_type: GatewayType) -> Result<()> {
         let gateways = rpc_client
             .list_gateways(ListGatewaysOptions {
                 gw_type: gw_type.into(),
@@ -212,7 +212,7 @@ impl Args {
 
     async fn list_filtered_gateways(
         &self,
-        mut rpc_client: RpcClient,
+        rpc_client: &RpcClient,
         gw_type: GatewayType,
         filters: FilterArgs,
     ) -> Result<()> {

--- a/nym-vpn-core/crates/nym-vpnc/src/commands/lan.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/commands/lan.rs
@@ -21,7 +21,7 @@ pub enum Command {
 }
 
 impl Command {
-    pub async fn execute(self, mut rpc_client: RpcClient) -> Result<()> {
+    pub async fn execute(self, rpc_client: &RpcClient) -> Result<()> {
         match self {
             Command::Get => {
                 let config = rpc_client.get_config().await?;

--- a/nym-vpn-core/crates/nym-vpnc/src/commands/network.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/commands/network.rs
@@ -19,7 +19,7 @@ pub enum Command {
 }
 
 impl Command {
-    pub async fn execute(self, mut rpc_client: RpcClient) -> Result<()> {
+    pub async fn execute(self, rpc_client: &RpcClient) -> Result<()> {
         match self {
             Command::Get => {
                 let network_name = rpc_client.get_info().await?.nym_network.network_name;

--- a/nym-vpn-core/crates/nym-vpnc/src/commands/network_stats.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/commands/network_stats.rs
@@ -36,7 +36,7 @@ pub struct SetParams {
 }
 
 impl Command {
-    pub async fn execute(self, mut rpc_client: RpcClient) -> Result<()> {
+    pub async fn execute(self, rpc_client: &RpcClient) -> Result<()> {
         match self {
             Command::Get => {
                 let config = rpc_client.get_config().await?;
@@ -92,7 +92,7 @@ pub enum SeedCommand {
 }
 
 impl SeedCommand {
-    pub async fn execute(self, mut rpc_client: RpcClient) -> Result<()> {
+    pub async fn execute(self, rpc_client: &RpcClient) -> Result<()> {
         match self {
             SeedCommand::Get => {
                 let identity = rpc_client.network_stats_get_seed().await?;

--- a/nym-vpn-core/crates/nym-vpnc/src/commands/sentry.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/commands/sentry.rs
@@ -21,7 +21,7 @@ pub enum Command {
 }
 
 impl Command {
-    pub async fn execute(self, mut rpc_client: RpcClient) -> Result<()> {
+    pub async fn execute(self, rpc_client: &RpcClient) -> Result<()> {
         match self {
             Command::Get => {
                 let enabled = rpc_client.is_sentry_enabled().await?;

--- a/nym-vpn-core/crates/nym-vpnc/src/commands/tunnel.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/commands/tunnel.rs
@@ -38,7 +38,7 @@ pub struct SetParams {
 }
 
 impl Command {
-    pub async fn execute(self, mut rpc_client: RpcClient) -> Result<()> {
+    pub async fn execute(self, rpc_client: &RpcClient) -> Result<()> {
         match self {
             Command::Get => {
                 let config = rpc_client.get_config().await?;

--- a/nym-vpn-core/crates/nym-vpnc/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/main.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<()> {
         .await
         .context("Failed to create RPC client")?;
 
-    args.command.execute(rpc_client).await
+    args.command.execute(&rpc_client).await
 }
 
 #[derive(Parser, Debug)]
@@ -121,7 +121,7 @@ pub enum Command {
 }
 
 impl Command {
-    pub async fn execute(self, rpc_client: RpcClient) -> Result<()> {
+    pub async fn execute(self, rpc_client: &RpcClient) -> Result<()> {
         match self {
             Command::Connect { wait } => Self::connect(rpc_client, wait).await,
             Command::Reconnect => Self::reconnect(rpc_client).await,
@@ -141,7 +141,7 @@ impl Command {
         }
     }
 
-    async fn connect(mut rpc_client: RpcClient, wait: bool) -> Result<()> {
+    async fn connect(rpc_client: &RpcClient, wait: bool) -> Result<()> {
         rpc_client.connect_tunnel().await?;
 
         if wait {
@@ -152,12 +152,12 @@ impl Command {
         }
     }
 
-    async fn reconnect(mut rpc_client: RpcClient) -> Result<()> {
+    async fn reconnect(rpc_client: &RpcClient) -> Result<()> {
         let _accepted = rpc_client.reconnect_tunnel().await?;
         Ok(())
     }
 
-    async fn wait_until_connected(mut rpc_client: RpcClient) -> Result<()> {
+    async fn wait_until_connected(rpc_client: &RpcClient) -> Result<()> {
         let mut stream = rpc_client.listen_to_events().await?;
         while let Some(new_state) = stream.next().await {
             let TunnelEvent::NewState(new_state) = new_state? else {
@@ -185,9 +185,9 @@ impl Command {
         Ok(())
     }
 
-    async fn disconnect(mut rpc_client: RpcClient, wait: bool) -> Result<()> {
+    async fn disconnect(rpc_client: &RpcClient, wait: bool) -> Result<()> {
         if wait {
-            let mut stream = rpc_client.clone().listen_to_events().await?;
+            let mut stream = rpc_client.listen_to_events().await?;
 
             println!("Waiting until disconnected");
 
@@ -226,7 +226,7 @@ impl Command {
         }
     }
 
-    async fn status(mut rpc_client: RpcClient, listen: bool) -> Result<()> {
+    async fn status(rpc_client: &RpcClient, listen: bool) -> Result<()> {
         let state = rpc_client.get_tunnel_state().await?;
         println!("State: {state}");
 
@@ -253,13 +253,13 @@ impl Command {
         Ok(())
     }
 
-    async fn info(mut rpc_client: RpcClient) -> Result<()> {
+    async fn info(rpc_client: &RpcClient) -> Result<()> {
         let service_info = rpc_client.get_info().await?;
         Self::print_service_info(service_info);
         Ok(())
     }
 
-    async fn get_config(mut rpc_client: RpcClient) -> Result<()> {
+    async fn get_config(rpc_client: &RpcClient) -> Result<()> {
         let config = rpc_client.get_config().await?;
         println!("{config:#?}");
         Ok(())

--- a/nym-vpn-core/crates/nym-vpnd/src/service/config/mod.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/config/mod.rs
@@ -25,8 +25,10 @@ use tokio::{
     io::{self, AsyncWriteExt},
 };
 
-use crate::service::config::entry_exit::v2::{EntryPoint, ExitPoint};
-use crate::service::config::network_stats::v1::NetworkStatisticsConfig;
+use crate::service::config::{
+    entry_exit::v2::{EntryPoint, ExitPoint},
+    network_stats::v1::NetworkStatisticsConfig,
+};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 


### PR DESCRIPTION
Avoid cloning the RPC client and instead use interior mutability and pass the rpc client around by reference.

Only tested on macOS.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4137)
<!-- Reviewable:end -->
