### PR TITLE
Support BUILD_TOP environment for sandboxed builds

### DIFF
--- a/nym-vpn-core/crates/nym-wg-go/build.rs
+++ b/nym-vpn-core/crates/nym-wg-go/build.rs
@@ -4,22 +4,29 @@
 use std::{env, fs, path::PathBuf};
 
 fn main() {
-    let manifest_path = env::var_os("CARGO_MANIFEST_DIR").expect("manifest dir is not set");
     let target = env::var("TARGET").expect("target is not set");
     let target_os = env::var("CARGO_CFG_TARGET_OS").expect("target os is not set");
 
-    let build_dir = PathBuf::from(manifest_path).join("../../../build/lib");
+    // Support BUILD_TOP for sandbox builds where the source directory is read-only.
+    // Falls back to the traditional relative path from CARGO_MANIFEST_DIR.
+    let build_dir = if let Ok(build_top) = env::var("BUILD_TOP") {
+        PathBuf::from(build_top).join("build/lib")
+    } else {
+        let manifest_path = env::var_os("CARGO_MANIFEST_DIR").expect("manifest dir is not set");
+        let build_dir = PathBuf::from(manifest_path).join("../../../build/lib");
 
-    // canonicalize() will fail if the build directory does not exist
-    if !build_dir.exists() {
-        fs::create_dir_all(&build_dir).expect("failed to create build dir");
-    }
+        // canonicalize() will fail if the build directory does not exist
+        if !build_dir.exists() {
+            fs::create_dir_all(&build_dir).expect("failed to create build dir");
+        }
 
-    let mut build_dir = build_dir
-        .canonicalize()
-        .expect("failed to canonicalize build dir path");
+        build_dir
+            .canonicalize()
+            .expect("failed to canonicalize build dir path")
+    };
 
-    build_dir.push(target);
+    let mut build_dir = build_dir;
+    build_dir.push(&target);
 
     // CI may only provide universal builds
     if target_os == "macos" {


### PR DESCRIPTION
## Description

The build.rs assumes the source directory is writable, which breaks sandboxed builds like nix. Support BUILD_TOP environment variable, so build systems can simply set it to their build directory.

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4140)
<!-- Reviewable:end -->
