### PR TITLE
Stop creating dirs from build.rs

### DIFF
--- a/nym-vpn-core/crates/nym-firewall/build.rs
+++ b/nym-vpn-core/crates/nym-firewall/build.rs
@@ -1,7 +1,10 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{env, fs, path::PathBuf};
+use std::{
+    env,
+    path::{self, PathBuf},
+};
 
 fn main() {
     let target_os = env::var("CARGO_CFG_TARGET_OS").expect("target os is not set");
@@ -13,16 +16,8 @@ fn main() {
     let arch = env::var("CARGO_CFG_TARGET_ARCH").expect("target arch is not set");
     let profile = env::var("PROFILE").expect("profile is not set");
 
-    let build_dir = PathBuf::from(manifest_path).join("../../../build/winfw");
-
-    // canonicalize() will fail if the build directory does not exist
-    if !build_dir.exists() {
-        fs::create_dir_all(&build_dir).expect("failed to create build dir");
-    }
-
-    let build_dir = build_dir
-        .canonicalize()
-        .expect("failed to canonicalize build dir path");
+    let build_dir = path::absolute(PathBuf::from(manifest_path).join("../../../build/winfw"))
+        .expect("failed to get absolute path to build directory");
 
     let cpp_arch = match arch.as_str() {
         "x86_64" => "x64",

--- a/nym-vpn-core/crates/nym-wg-go/build.rs
+++ b/nym-vpn-core/crates/nym-wg-go/build.rs
@@ -1,7 +1,10 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{env, fs, path::PathBuf};
+use std::{
+    env,
+    path::{self, PathBuf},
+};
 
 fn main() {
     let target = env::var("TARGET").expect("target is not set");
@@ -9,23 +12,14 @@ fn main() {
 
     // Support BUILD_TOP for sandbox builds where the source directory is read-only.
     // Falls back to the traditional relative path from CARGO_MANIFEST_DIR.
-    let build_dir = if let Ok(build_top) = env::var("BUILD_TOP") {
+    let mut build_dir = path::absolute(if let Ok(build_top) = env::var("BUILD_TOP") {
         PathBuf::from(build_top).join("build/lib")
     } else {
         let manifest_path = env::var_os("CARGO_MANIFEST_DIR").expect("manifest dir is not set");
-        let build_dir = PathBuf::from(manifest_path).join("../../../build/lib");
+        PathBuf::from(manifest_path).join("../../../build/lib")
+    })
+    .expect("failed to get absolute path to build directory");
 
-        // canonicalize() will fail if the build directory does not exist
-        if !build_dir.exists() {
-            fs::create_dir_all(&build_dir).expect("failed to create build dir");
-        }
-
-        build_dir
-            .canonicalize()
-            .expect("failed to canonicalize build dir path")
-    };
-
-    let mut build_dir = build_dir;
     build_dir.push(&target);
 
     // CI may only provide universal builds


### PR DESCRIPTION
## Description

Use `std::path::absolute()` instead of `canonicalize()` to remove the requirement for directories to exist before being able to expand to the path.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4168)
<!-- Reviewable:end -->
