### PR TITLE
APPLE: Remove VPN connection requirement for socks5 proxy

### DIFF
--- a/nym-vpn-apple/NymVPN/Resources/Localizable.xcstrings
+++ b/nym-vpn-apple/NymVPN/Resources/Localizable.xcstrings
@@ -28637,17 +28637,6 @@
         }
       }
     },
-    "proxy.snackbar.connectionRequired" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connect to NymVPN before enabling the proxy."
-          }
-        }
-      }
-    },
     "proxy.snackbar.successfullyEnabled" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -28692,17 +28681,6 @@
         }
       }
     },
-    "proxy.status.subtitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Requires an active NymVPN connection"
-          }
-        }
-      }
-    },
     "proxy.status.title" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -28721,17 +28699,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Routes app and wallet traffic through the Nym mixnet for enhanced privacy via a SOCKS5 proxy for apps and HTTP RPC proxy for wallets."
-          }
-        }
-      }
-    },
-    "proxy.vpnStatus" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "NymVPN status:"
           }
         }
       }

--- a/nym-vpn-apple/Settings/Sources/Settings/Proxy/ProxyView.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/Proxy/ProxyView.swift
@@ -74,7 +74,6 @@ private extension ProxyView {
                     )
                 ),
                 title: "proxy.status.title".localizedString,
-                subtitle: "proxy.status.subtitle".localizedString,
                 position: .init(isFirst: true, isLast: true),
                 action: {}
             ),
@@ -98,25 +97,12 @@ private extension ProxyView {
 private extension ProxyView {
     func vpnAndProxyStatusDetails() -> some View {
         VStack {
-            let statusButtonConfig = StatusButtonConfig(
-                tunnelStatus: viewModel.connectionManager.currentTunnelStatus,
-                hasInternet: true
-            )
-            detailsSection(
-                title: "proxy.vpnStatus".localizedString,
-                details: statusButtonConfig.title,
-                color: vpnStatusColor()
-            )
-            .padding(.bottom, 12)
-            Divider()
-                .frame(height: 1)
-                .overlay(NymColor.gray2)
             detailsSection(
                 title: "proxy.proxyStatus".localizedString,
                 details: proxyStatusText(),
                 color: proxyStatusColor()
             )
-            .padding(.vertical, 12)
+            .padding(.bottom, 12)
             Divider()
                 .frame(height: 1)
                 .overlay(NymColor.gray2)
@@ -139,17 +125,6 @@ private extension ProxyView {
             Text(details)
                 .foregroundStyle(color)
                 .textStyle(.Body.Medium.bold)
-        }
-    }
-
-    func vpnStatusColor() -> Color {
-        switch viewModel.connectionManager.currentTunnelStatus {
-        case .connected:
-            NymColor.action
-        case .disconnected:
-            NymColor.error
-        default:
-            NymColor.warning
         }
     }
 

--- a/nym-vpn-apple/Settings/Sources/Settings/Proxy/ProxyView.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/Proxy/ProxyView.swift
@@ -81,7 +81,7 @@ private extension ProxyView {
                 vpnAndProxyStatusDetails()
             }
         )
-        .padding(.bottom, 24)
+        .padding(.bottom, 16)
     }
 
     @ViewBuilder
@@ -113,7 +113,8 @@ private extension ProxyView {
             )
             .padding(.top, 12)
         }
-        .padding(.vertical, 16)
+        .padding(.top, 8)
+        .padding(.bottom, 16)
     }
 
     func detailsSection(title: String, details: String, color: Color) -> some View {

--- a/nym-vpn-apple/Settings/Sources/Settings/Proxy/ProxyViewModel.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/Proxy/ProxyViewModel.swift
@@ -108,18 +108,6 @@ import Theme
     }
 
     func toggleProxy() async {
-        guard connectionManager.currentTunnelStatus == .connected else {
-            if !isSnackbarDisplayed {
-                isSnackbarDisplayed = true
-                snackbarMessage = "proxy.snackbar.connectionRequired".localizedString
-                Task { @MainActor in
-                    try? await Task.sleep(for: .seconds(3))
-                    isSnackbarDisplayed = false
-                }
-            }
-            return
-        }
-
         do {
             proxyStatusLoading = true
             if proxyIsOn {


### PR DESCRIPTION
## Ticket

JIRA-VPN-XXXX

## Description

Remove requirement of having an active VPN connection in order to enable the proxy

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

Proxy disabled
![Screenshot 2025-12-10 at 1 12 48 PM](https://github.com/user-attachments/assets/b6456348-0181-4873-ab93-70bd528a9a41)

Proxy enabled
![Screenshot 2025-12-10 at 1 14 28 PM](https://github.com/user-attachments/assets/b7a54315-0146-4774-9273-0211335f1ef4)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4170)
<!-- Reviewable:end -->
