### PR TITLE
APPLE: Fix spacing issues for quic/streaming icon on hop selection button

### DIFF
--- a/nym-vpn-apple/UIComponents/Sources/UIComponents/Buttons/HopButton/HopButton.swift
+++ b/nym-vpn-apple/UIComponents/Sources/UIComponents/Buttons/HopButton/HopButton.swift
@@ -121,7 +121,7 @@ public struct HopButton: View {
             strokeTitleLeftMargin: 30,
             isHovered: $isButtonHovered
         ) {
-            HStack {
+            HStack(spacing: 0) {
                 button().onHover { isButtonHovered = $0 }
                 if gatewayId != nil {
                     accessory().onHover { isAccessoryHovered = $0 }
@@ -204,12 +204,17 @@ private extension HopButton {
             titleSubtitleText(with: titleText, subtitle: subtitleText)
 
             Spacer()
-            if shouldShowQuic {
-                QuicLabel()
-            } else if shouldShowStreaming {
-                StreamingIcon()
+
+            HStack {
+                if shouldShowQuic {
+                    QuicLabel()
+                } else if shouldShowStreaming {
+                    StreamingIcon()
+                }
             }
+            .padding(.trailing, 12)
         }
+        .frame(maxWidth: .infinity)
         .onTapGesture(perform: buttonAction)
         .accessibilityElement(children: .combine)
         .accessibilityAction(.default, buttonAction)


### PR DESCRIPTION
## Ticket

JIRA-VPN-XXXX

## Description

Fixes spacing issue with quic/streaming icon for hop selection


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

![Screenshot 2025-12-12 at 10 54 43 AM](https://github.com/user-attachments/assets/41818746-f36d-4547-a729-18614965f096)

![Screenshot 2025-12-12 at 10 54 25 AM](https://github.com/user-attachments/assets/f2fc212d-ee68-4e58-a60c-0f329dce620f)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4200)
<!-- Reviewable:end -->
