### PR TITLE
APPLE: Make full hop button area tappable

### DIFF
--- a/nym-vpn-apple/UIComponents/Sources/UIComponents/Buttons/HopButton/HopButton.swift
+++ b/nym-vpn-apple/UIComponents/Sources/UIComponents/Buttons/HopButton/HopButton.swift
@@ -210,7 +210,13 @@ private extension HopButton {
                 StreamingIcon()
             }
         }
-        .onTapGesture(perform: buttonAction)
+        .overlay {
+            Rectangle()
+                .fill((isButtonHovered ? NymColor.backgroundHover : NymColor.background).opacity(0.1))
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .onTapGesture(perform: buttonAction)
+                .accessibilityHidden(true)
+        }
         .accessibilityElement(children: .combine)
         .accessibilityAction(.default, buttonAction)
         .accessibilityAddTraits([.isButton])


### PR DESCRIPTION
## Ticket

JIRA-VPN-XXXX

## Description

SwiftUI has this fun little feature where the .onTapGesture modifier won't fire if you tap/click on empty space.
The solution is to have an _almost_ completely transparent overlay to act as the tap target.
Forgot about this one 🥲

## Checklist:

- [ ] Changelog

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4202)
<!-- Reviewable:end -->
