### PR TITLE
VPN-4703: Remove the one SOCKS5 connection restriction.

### DIFF
--- a/nym-vpn-core/crates/nym-vpnd/src/service/socks5/lazy_socks5.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/socks5/lazy_socks5.rs
@@ -194,17 +194,7 @@ impl LazySocks5 {
         info!("Routing connection from {client_addr} via existing Mixnet tunnel");
 
         // Create connection guard - will automatically decrement on drop
-        let (_guard, active_connections) =
-            ConnectionGuard::new_with_count(self.active_connections.clone()).await;
-        if active_connections > 1 {
-            warn!(
-                "Blocking new SOCKS5 connection as only one concurrent connection is currently supported"
-            );
-            let _ = Self::send_socks5_error(&mut client_stream).await;
-            return Err(LazySocks5Error::Internal(
-                "Too many concurrent connections".to_string(),
-            ));
-        }
+        let _guard = ConnectionGuard::new(self.active_connections.clone()).await;
 
         // Parse SOCKS5 handshake and request
         let target_addr = match Self::socks5_handshake(&mut client_stream).await {
@@ -438,17 +428,7 @@ impl LazySocks5 {
         info!("Routing connection from {client_addr} via new Mixnet tunnel");
 
         // Create connection guard - will automatically decrement on drop
-        let (_guard, active_connections) =
-            ConnectionGuard::new_with_count(self.active_connections.clone()).await;
-        if active_connections > 1 {
-            warn!(
-                "Blocking new SOCKS5 connection as only one concurrent connection is currently supported"
-            );
-            let _ = Self::send_socks5_error(&mut client_stream).await;
-            return Err(LazySocks5Error::Internal(
-                "Too many concurrent connections".to_string(),
-            ));
-        }
+        let _guard = ConnectionGuard::new(self.active_connections.clone()).await;
 
         // Ensure backend is started (lazy initialization) with retries
         if let Err(e) = Box::pin(self.ensure_backend_started_with_retry(client_addr)).await {

--- a/nym-vpn-core/crates/nym-vpnd/src/service/socks5/util.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/socks5/util.rs
@@ -8,7 +8,6 @@ pub struct ConnectionGuard {
 }
 
 impl ConnectionGuard {
-    #[allow(dead_code)]
     pub async fn new(active_connections: Arc<RwLock<u32>>) -> Self {
         {
             let mut count = active_connections.write().await;
@@ -18,6 +17,7 @@ impl ConnectionGuard {
         Self { active_connections }
     }
 
+    #[allow(dead_code)]
     pub async fn new_with_count(active_connections: Arc<RwLock<u32>>) -> (Self, u32) {
         let current = {
             let mut count = active_connections.write().await;


### PR DESCRIPTION
## Ticket

JIRA-VPN-4703

## Description

Remove the restriction on the number of SOCKS5 connections.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4216)
<!-- Reviewable:end -->
