### PR TITLE
Add Privy feature flag and remove unused credential mode flag

### DIFF
--- a/nym-vpn-app/src-tauri/src/vpnd/feature_flags.rs
+++ b/nym-vpn-app/src-tauri/src/vpnd/feature_flags.rs
@@ -5,6 +5,7 @@ use ts_rs::TS;
 
 const KEY_QUIC: &str = "quic";
 const KEY_DOMAIN_FRONTING: &str = "domain_fronting";
+const PRIVY: &str = "privy";
 const KEY_ZKNYMS: &str = "zkNyms";
 
 #[derive(Clone, Serialize, TS)]
@@ -14,6 +15,7 @@ pub struct FeatureFlags {
     pub quic: bool,
     pub domain_fronting: bool,
     pub zknym_credential: bool,
+    pub privy: bool,
 }
 
 impl From<lib::FeatureFlags> for FeatureFlags {
@@ -24,6 +26,7 @@ impl From<lib::FeatureFlags> for FeatureFlags {
                 .unwrap_or(false),
             zknym_credential: get_group_flag(&fflags, KEY_ZKNYMS, "credentialMode")
                 .unwrap_or(false),
+            privy: get_group_flag(&fflags, PRIVY, "enabled").unwrap_or(false),
         }
     }
 }

--- a/nym-vpn-app/src-tauri/src/vpnd/feature_flags.rs
+++ b/nym-vpn-app/src-tauri/src/vpnd/feature_flags.rs
@@ -5,7 +5,6 @@ use ts_rs::TS;
 
 const KEY_QUIC: &str = "quic";
 const KEY_DOMAIN_FRONTING: &str = "domain_fronting";
-const PRIVY: &str = "privy";
 const KEY_ZKNYMS: &str = "zkNyms";
 
 #[derive(Clone, Serialize, TS)]
@@ -15,7 +14,6 @@ pub struct FeatureFlags {
     pub quic: bool,
     pub domain_fronting: bool,
     pub zknym_credential: bool,
-    pub privy: bool,
 }
 
 impl From<lib::FeatureFlags> for FeatureFlags {
@@ -26,7 +24,6 @@ impl From<lib::FeatureFlags> for FeatureFlags {
                 .unwrap_or(false),
             zknym_credential: get_group_flag(&fflags, KEY_ZKNYMS, "credentialMode")
                 .unwrap_or(false),
-            privy: get_group_flag(&fflags, PRIVY, "enabled").unwrap_or(false),
         }
     }
 }

--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -8,10 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added privy UI feature flag (https://github.com/nymtech/nym-vpn-client/pull/4223)
 
 ### Fixed
 
 ### Removed
+- Removed credentials mode feature flag from code base (https://github.com/nymtech/nym-vpn-client/pull/4223)
 
 ## [1.21.0] - 2025-12-15
 

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/config.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/config.rs
@@ -9,19 +9,6 @@ pub struct AccountControllerConfig {
     // The data directory where we store the account and device keys.
     pub data_dir: PathBuf,
 
-    // Credentials mode is a feature flag that determines if we should automatically request
-    // zk-nyms.
-    pub credentials_mode: Option<bool>,
-
     // The network environment that the controller is running in.
     pub network_env: Network,
-}
-
-impl AccountControllerConfig {
-    // Determine if the credentials mode is enabled. This is determined by the credentials_mode
-    // field in the config, if it is set. Else the network environment feature flag is used.
-    pub fn credentials_mode(&self) -> bool {
-        self.credentials_mode
-            .unwrap_or_else(|| self.network_env.credential_mode().unwrap_or(false))
-    }
 }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/requesting_zknym_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/requesting_zknym_state.rs
@@ -81,14 +81,12 @@ impl RequestingZkNymsState {
 
         // can we make that unique to that state?
         let storage = shared_state.credential_storage.clone();
-        let credential_mode = shared_state.config.credentials_mode();
         let zk_nym_fetching_handle = tokio::spawn(async move {
             RequestingZkNymsState::fetch_zk_nyms(
                 vpn_api_client,
                 vpn_api_account,
                 device,
                 storage,
-                credential_mode,
                 fair_usage_left,
             )
             .await
@@ -109,13 +107,8 @@ impl RequestingZkNymsState {
         vpn_api_account: Arc<VpnAccount>,
         device: Device,
         storage: VpnCredentialStorage,
-        credential_mode: bool,
         fair_usage_left: bool,
     ) -> Result<ZkNymFetchResult, ZkNymError> {
-        if !credential_mode {
-            return Ok(ZkNymFetchResult::DisabledCredentials);
-        }
-
         if !fair_usage_left {
             return Err(ZkNymError::BandwidthExceeded);
         }
@@ -296,9 +289,7 @@ impl RequestingZkNymsState {
         };
 
         match retrieval_result {
-            ZkNymFetchResult::DisabledCredentials
-            | ZkNymFetchResult::SufficientBandwidth
-            | ZkNymFetchResult::FetchedTickets { .. } => {
+            ZkNymFetchResult::SufficientBandwidth | ZkNymFetchResult::FetchedTickets { .. } => {
                 NextAccountControllerState::NewState(ReadyState::enter())
             }
             ZkNymFetchResult::UpgradeMode => {
@@ -471,7 +462,6 @@ impl From<ZkNymError> for AccountControllerErrorStateReason {
 }
 
 enum ZkNymFetchResult {
-    DisabledCredentials,
     SufficientBandwidth,
     FetchedTickets {
         #[allow(unused)]

--- a/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/commands.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/commands.rs
@@ -4,7 +4,7 @@
 use crate::common::{TestBench, account_summary::*, endpoints, mock_account, mock_account_id};
 
 use nym_vpn_account_controller::AvailableTicketbooks;
-use nym_vpn_api_client::ResolverOverrides;
+use nym_vpn_api_client::{ResolverOverrides, response::NymVpnDeviceStatus};
 use nym_vpn_lib_types::{
     AccountCommandError, AccountControllerErrorStateReason, AccountControllerState,
 };
@@ -13,12 +13,20 @@ use nym_vpn_store::account::StoredAccountMode;
 #[tokio::test]
 async fn logged_out_state_command() -> anyhow::Result<()> {
     // Get the test_bench without credential for easier testing
-    let mut test_bench = TestBench::new_no_credentials().await?;
+    let mut test_bench = TestBench::new().await?;
+    let credential_proxy = test_bench.credential_proxy.clone();
 
     // Adding behavior to the VPN API
     let mocks = vec![
         endpoints::synced_health(),
         endpoints::account_summary_with_device_200(account_ready_to_connect()),
+        endpoints::register_account_200(mock_api_device(NymVpnDeviceStatus::Active)),
+        endpoints::zknym_available_200(credential_proxy.clone()),
+        endpoints::zknym_post(credential_proxy.clone()),
+        endpoints::zknym_id(credential_proxy.clone()),
+        endpoints::partial_verification_key_200(credential_proxy.clone()),
+        endpoints::confirm_zk_nym_download_by_id_200(credential_proxy.clone()),
+        endpoints::account_update_device_200(mock_api_device(NymVpnDeviceStatus::DeleteMe)),
     ];
     test_bench.register_vpn_api_mocks(mocks).await;
 
@@ -100,12 +108,19 @@ async fn logged_out_state_command() -> anyhow::Result<()> {
 #[tokio::test]
 async fn offline_state_command() -> anyhow::Result<()> {
     // Get the test_bench without credential for easier testing
-    let mut test_bench = TestBench::new_no_credentials().await?;
+    let mut test_bench = TestBench::new().await?;
+    let credential_proxy = test_bench.credential_proxy.clone();
 
     // Adding behavior to the VPN API
     let mocks = vec![
         endpoints::synced_health(),
         endpoints::account_summary_with_device_200(account_ready_to_connect()),
+        endpoints::register_account_200(mock_api_device(NymVpnDeviceStatus::Active)),
+        endpoints::zknym_available_200(credential_proxy.clone()),
+        endpoints::zknym_post(credential_proxy.clone()),
+        endpoints::zknym_id(credential_proxy.clone()),
+        endpoints::partial_verification_key_200(credential_proxy.clone()),
+        endpoints::confirm_zk_nym_download_by_id_200(credential_proxy.clone()),
     ];
     test_bench.register_vpn_api_mocks(mocks).await;
 
@@ -226,7 +241,8 @@ async fn offline_state_command() -> anyhow::Result<()> {
 #[tokio::test]
 async fn ready_state_command() -> anyhow::Result<()> {
     // Get the test_bench without credential for easier testing
-    let mut test_bench = TestBench::new_no_credentials().await?;
+    let mut test_bench = TestBench::new().await?;
+    let credential_proxy = test_bench.credential_proxy.clone();
 
     // Adding behavior to the VPN API
     let mocks = vec![
@@ -235,6 +251,13 @@ async fn ready_state_command() -> anyhow::Result<()> {
         endpoints::get_usage_200(),
         endpoints::get_devices_200(),
         endpoints::get_active_devices_200(),
+        endpoints::register_account_200(mock_api_device(NymVpnDeviceStatus::Active)),
+        endpoints::zknym_available_200(credential_proxy.clone()),
+        endpoints::zknym_post(credential_proxy.clone()),
+        endpoints::zknym_id(credential_proxy.clone()),
+        endpoints::partial_verification_key_200(credential_proxy.clone()),
+        endpoints::confirm_zk_nym_download_by_id_200(credential_proxy.clone()),
+        endpoints::account_update_device_200(mock_api_device(NymVpnDeviceStatus::DeleteMe)),
     ];
     test_bench.register_vpn_api_mocks(mocks).await;
 
@@ -286,10 +309,14 @@ async fn ready_state_command() -> anyhow::Result<()> {
         Ok(mock_usage_response().items)
     );
     assert_eq!(
-        test_bench.command_sender.get_available_tickets().await,
-        Ok(AvailableTicketbooks {
-            ticketbooks: Vec::new()
-        })
+        test_bench
+            .command_sender
+            .get_available_tickets()
+            .await
+            .unwrap()
+            .ticketbooks
+            .len(),
+        3
     );
 
     assert_eq!(
@@ -336,7 +363,7 @@ async fn ready_state_command() -> anyhow::Result<()> {
 #[tokio::test]
 async fn error_state_command() -> anyhow::Result<()> {
     // Get the test_bench without credential for easier testing
-    let mut test_bench = TestBench::new_no_credentials().await?;
+    let mut test_bench = TestBench::new().await?;
 
     // Adding behavior to the VPN API
     let mocks = vec![

--- a/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/common/endpoints.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/common/endpoints.rs
@@ -65,6 +65,14 @@ pub fn account_summary_with_device_403(error_response: NymErrorResponse) -> Mock
         .respond_with(ResponseTemplate::new(403).set_body_json(error_response))
 }
 
+pub fn account_update_device_200(response: NymVpnDevice) -> Mock {
+    Mock::given(method("PATCH"))
+        .and(path_regex(format!(
+            "^/public/v1/account/{ACCOUNT_REGEX}/device/{DEVICE_REGEX}$"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(response))
+}
+
 pub fn register_account_200(response: NymVpnDevice) -> Mock {
     Mock::given(method("POST"))
         .and(path_regex(format!(

--- a/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/common/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/common/mod.rs
@@ -194,15 +194,6 @@ pub struct TestBench {
 impl TestBench {
     /// Sets up a new testbench. The VPN API has no route
     pub async fn new() -> anyhow::Result<TestBench> {
-        Self::new_with_credential(true).await
-    }
-
-    /// Sets up a new testbench without credential, for easier setup. The VPN API has no route
-    pub async fn new_no_credentials() -> anyhow::Result<TestBench> {
-        Self::new_with_credential(false).await
-    }
-
-    async fn new_with_credential(credential_enabled: bool) -> anyhow::Result<TestBench> {
         // Enable logging as early as possible so setup emits logs if needed
         init_tracing();
 
@@ -233,7 +224,6 @@ impl TestBench {
         let tempdir = tempfile::tempdir()?;
         let account_controller_config = AccountControllerConfig {
             data_dir: tempdir.path().to_owned(),
-            credentials_mode: Some(credential_enabled),
             network_env,
         };
 

--- a/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/paths.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/paths.rs
@@ -19,12 +19,20 @@ use nym_vpn_lib_types::{AccountControllerErrorStateReason, AccountControllerStat
 #[tokio::test]
 async fn offline_test() -> anyhow::Result<()> {
     // Get the test_bench
-    let mut test_bench = TestBench::new_no_credentials().await?;
+    let mut test_bench = TestBench::new().await?;
+    let credential_proxy = test_bench.credential_proxy.clone();
 
     // Adding behavior to the VPN API
     let mocks = vec![
         endpoints::synced_health(),
         endpoints::account_summary_with_device_200(account_ready_to_connect()),
+        endpoints::register_account_200(mock_api_device(NymVpnDeviceStatus::Active)),
+        endpoints::zknym_available_200(credential_proxy.clone()),
+        endpoints::zknym_post(credential_proxy.clone()),
+        endpoints::zknym_id(credential_proxy.clone()),
+        endpoints::partial_verification_key_200(credential_proxy.clone()),
+        endpoints::confirm_zk_nym_download_by_id_200(credential_proxy.clone()),
+        endpoints::account_update_device_200(mock_api_device(NymVpnDeviceStatus::DeleteMe)),
     ];
     test_bench.register_vpn_api_mocks(mocks).await;
 
@@ -303,7 +311,7 @@ async fn e2e_new_device_test() -> anyhow::Result<()> {
 #[tokio::test]
 async fn decentralised_account_test() -> anyhow::Result<()> {
     // Get the test_bench
-    let mut test_bench = TestBench::new_no_credentials().await?;
+    let mut test_bench = TestBench::new().await?;
 
     let mocks = vec![nyxd_endpoints::get_account_exists()];
     test_bench.register_nyxd_mocks(mocks).await;

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/network.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/network.rs
@@ -175,6 +175,13 @@ impl FeatureFlags {
         self.get_group_flag("quic", "enabled")
     }
 
+    /// If privy is enabled or not, if set
+    #[uniffi::method]
+    pub fn is_privy_enabled(&self) -> Option<bool> {
+        // todo: harmonize with nym-vpn-network-config/src/feature_flags.rs
+        self.get_group_flag("privy", "enabled")
+    }
+
     fn get_group_flag(&self, group_name: &str, flag_name: &str) -> Option<bool> {
         if let Some(FlagValue::Group(group)) = self.flags.get(group_name)
             && let Some(value) = group.get(flag_name)

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/account.rs
@@ -23,7 +23,6 @@ use crate::offline_monitor;
 
 pub(super) async fn init_account_controller(
     data_dir: PathBuf,
-    credential_mode: Option<bool>,
     network: Network,
 ) -> Result<(), VpnError> {
     let mut guard = ACCOUNT_CONTROLLER_HANDLE.lock().await;
@@ -31,7 +30,6 @@ pub(super) async fn init_account_controller(
     if guard.is_none() {
         let account_controller_handle = start_account_controller(
             data_dir,
-            credential_mode,
             network,
             offline_monitor::get_connectivity_handle().await?,
         )
@@ -61,7 +59,6 @@ pub(super) async fn stop_account_controller() -> Result<(), VpnError> {
 
 async fn start_account_controller(
     data_dir: PathBuf,
-    credential_mode: Option<bool>,
     network_env: Network,
     connectivity_handle: ConnectivityHandle,
 ) -> Result<AccountControllerHandle, VpnError> {
@@ -84,7 +81,6 @@ async fn start_account_controller(
 
     let account_controller_config = nym_vpn_account_controller::AccountControllerConfig {
         data_dir,
-        credentials_mode: credential_mode,
         network_env,
     };
 

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/lib.rs
@@ -184,7 +184,6 @@ async fn configure_lib(config: NymVpnLibConfig) -> Result<(), VpnError> {
     .await?;
     Box::pin(account::init_account_controller(
         PathBuf::from(config.data_dir),
-        config.credential_mode,
         network,
     ))
     .await?;
@@ -577,7 +576,6 @@ pub trait TunnelStatusListener: Send + Sync {
 #[derive(uniffi::Record)]
 pub struct NymVpnLibConfig {
     pub data_dir: String,
-    pub credential_mode: Option<bool>,
     pub sentry_monitoring: bool,
     pub statistics_enabled: bool,
     #[cfg(target_os = "android")]

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/feature_flags.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/feature_flags.rs
@@ -57,6 +57,11 @@ impl FeatureFlags {
     pub fn quic_enabled(&self) -> Option<bool> {
         self.get_group_flag("quic", "enabled")
     }
+
+    /// If privy is enabled or not, if set
+    pub fn privy_enabled(&self) -> Option<bool> {
+        self.get_group_flag("privy", "enabled")
+    }
 }
 
 impl From<HashMap<String, FlagValue>> for FeatureFlags {

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/feature_flags.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/feature_flags.rs
@@ -38,11 +38,6 @@ impl FeatureFlags {
         self.flags
     }
 
-    /// If credential mode is enabled or not, if set
-    pub fn credential_mode(&self) -> Option<bool> {
-        self.get_group_flag("zkNyms", "credentialMode")
-    }
-
     /// Get statistics recipient, if set
     pub fn stats_recipient(&self) -> Option<Recipient> {
         self.get_group_flag("statistics", "recipient")

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/lib.rs
@@ -191,6 +191,12 @@ impl Network {
         self.feature_flags.as_ref().and_then(|ff| ff.quic_enabled())
     }
 
+    pub fn privy_enabled(&self) -> Option<bool> {
+        self.feature_flags
+            .as_ref()
+            .and_then(|ff| ff.privy_enabled())
+    }
+
     pub async fn vpn_api_addresses(&self) -> Vec<SocketAddr> {
         let mut unique: HashSet<SocketAddr> = HashSet::with_capacity(16);
 

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/lib.rs
@@ -168,12 +168,6 @@ impl Network {
             })
     }
 
-    pub fn credential_mode(&self) -> Option<bool> {
-        self.feature_flags
-            .as_ref()
-            .and_then(|ff| ff.credential_mode())
-    }
-
     pub fn stats_recipient(&self) -> Option<Recipient> {
         self.feature_flags
             .as_ref()

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -334,7 +334,6 @@ impl NymVpnService {
 
         let account_controller_config = AccountControllerConfig {
             data_dir: network_data_dir.clone(),
-            credentials_mode: None,
             network_env: *parameters.network_env.clone(),
         };
 


### PR DESCRIPTION
## Ticket

JIRA-VPN-4665

## Description

Add a UI Privy feature flag, to enable testing in lower envs without exposing the Privy UI in current releases.
Also remove the credential mode flag since we're already using that as `true` everywhere. Some account controller integration tests need to mock zk nym API calls for that, as the feature flag was used to gate keep some testing.


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4223)
<!-- Reviewable:end -->
