### PR TITLE
Export Display for RpcError

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-rpc-uniffi/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-rpc-uniffi/src/lib.rs
@@ -342,6 +342,7 @@ impl std::fmt::Display for InnerRpcError {
 }
 
 #[derive(Debug, uniffi::Object)]
+#[uniffi::export(Display)]
 pub struct RpcError {
     inner: InnerRpcError,
 }
@@ -354,11 +355,6 @@ impl RpcError {
 
 #[uniffi::export]
 impl RpcError {
-    /// Returns the error message.
-    pub fn message(&self) -> String {
-        self.inner.to_string()
-    }
-
     /// Returns the account error if the underlying error is an account error.
     pub fn account_error(&self) -> Option<AccountCommandError> {
         match &self.inner {


### PR DESCRIPTION
## Description

- Export `Display` implementation for `RpcError` to Swift which makes `uniffi` generate `CustomDebugStringConvertible` conformance in Swift making errors printable.
- Remove `message()`; just print error as normal

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4225)
<!-- Reviewable:end -->
