### PR TITLE
VPN-4721: Custom dns toggle handler update

### DIFF
--- a/nym-vpn-app/src/screens/settings/custom-dns/CustomDNS.tsx
+++ b/nym-vpn-app/src/screens/settings/custom-dns/CustomDNS.tsx
@@ -73,7 +73,7 @@ function CustomDNS() {
             header={t('dns.details.title')}
             checked={customDnsEnabled}
             onClick={handleDnsSwitchChange}
-            disabled={customDns.length === 0 && customDnsList.length === 0}
+            disabled={customDns.length === 0}
           />
         }
       >

--- a/nym-vpn-app/src/screens/settings/custom-dns/CustomDNS.tsx
+++ b/nym-vpn-app/src/screens/settings/custom-dns/CustomDNS.tsx
@@ -32,6 +32,9 @@ function CustomDNS() {
   }, [customDnsList, customDns]);
 
   const applyChanges = async () => {
+    if (customDnsList.length === 0) {
+      await toggleCustomDns(false);
+    }
     await setCustomDns(customDnsList.map((item) => item.dns));
     push({
       message: t('dns.details.applied'),
@@ -70,6 +73,7 @@ function CustomDNS() {
             header={t('dns.details.title')}
             checked={customDnsEnabled}
             onClick={handleDnsSwitchChange}
+            disabled={customDns.length === 0 && customDnsList.length === 0}
           />
         }
       >

--- a/nym-vpn-app/src/state/useTauriEvents.ts
+++ b/nym-vpn-app/src/state/useTauriEvents.ts
@@ -126,6 +126,14 @@ export function useTauriEvents(
         type: 'update-tunnel-config',
         config: payload,
       });
+      dispatch({
+        type: 'set-custom-dns-enabled',
+        enabled: payload.enableCustomDns,
+      });
+      dispatch({
+        type: 'set-custom-dns',
+        dns: payload.customDns ?? [],
+      });
     });
   }, [dispatch]);
 


### PR DESCRIPTION
## Ticket

[JIRA-VPN-4721](https://nymtech.atlassian.net/browse/VPN-4721)

## Description

- Disable custom dns setting when custom dns list is empty
- Don't allow for turning custom dns on when custom dns list is empty


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)
### Switch is disabled, no custom dns entries
<img width="504" height="772" alt="image" src="https://github.com/user-attachments/assets/2e4b20b8-def3-4e4e-a907-741cb5417f01" />

### Switch is enabled, custom dns entries present
<img width="497" height="771" alt="image" src="https://github.com/user-attachments/assets/f15c87d7-e118-4699-b88b-20adb17737c2" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4233)
<!-- Reviewable:end -->
