### PR TITLE
Use vpn gateways and firewall rules for 2-hop mode

### DIFF
--- a/nym-vpn-core/crates/nym-statistics/src/handler/report_sending.rs
+++ b/nym-vpn-core/crates/nym-statistics/src/handler/report_sending.rs
@@ -58,7 +58,7 @@ impl SendingConfig {
             SendingConfig::BIG_SENDING_DELAY_MAX_MINS,
         )
         .sample(&mut rand::thread_rng());
-        Duration::from_mins(random_delay_mins)
+        Duration::from_secs(random_delay_mins * 60)
     }
 
     // Return Some(new_value) if `allows_sending` changed, None otherwise

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
@@ -63,13 +63,22 @@ impl ConnectedState {
             };
 
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
-        let firewall_policy_params = ConnectedPolicyParameters {
-            enable_ipv6: _shared_state.tunnel_settings.enable_ipv6,
-            allow_lan: _shared_state.tunnel_settings.allow_lan,
-            wg_entry_endpoint,
-            ws_entry_endpoints: selected_gateways.entry_gateway().endpoints(),
-            dns_config: _shared_state.tunnel_settings.resolved_dns_config(),
-            tunnel_interface: tunnel_interface.clone(),
+        let firewall_policy_params = {
+            // Include entry gateway WebSocket endpoints
+            let mut ws_endpoints = selected_gateways.entry_gateway().endpoints();
+            // Also include exit gateway WebSocket endpoints for SOCKS5 support in 2-hop mode.
+            // These endpoints are whitelisted in firewall rules (peer_endpoints), allowing SOCKS5
+            // to establish direct connections to the exit gateway
+            ws_endpoints.extend(selected_gateways.exit_gateway().endpoints());
+
+            ConnectedPolicyParameters {
+                enable_ipv6: _shared_state.tunnel_settings.enable_ipv6,
+                allow_lan: _shared_state.tunnel_settings.allow_lan,
+                wg_entry_endpoint,
+                ws_entry_endpoints: ws_endpoints,
+                dns_config: _shared_state.tunnel_settings.resolved_dns_config(),
+                tunnel_interface: tunnel_interface.clone(),
+            }
         };
 
         let connected_state = Self {
@@ -373,5 +382,118 @@ impl ConnectedPolicyParameters {
             #[cfg(target_os = "macos")]
             redirect_interface: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nym_firewall::TransportProtocol;
+    use std::net::{IpAddr, Ipv4Addr};
+
+    fn create_mock_gateway_with_websocket_endpoints(
+        ip: Ipv4Addr,
+        ws_port: u16,
+        wss_port: u16,
+    ) -> nym_gateway_directory::Gateway {
+        use nym_gateway_directory::Gateway;
+        use nym_sdk::mixnet::NodeIdentity;
+
+        // Create a dummy identity for testing
+        let dummy_identity =
+            NodeIdentity::from_base58_string("7CWjY3QFoA9dgE535u9bQiXCfzgMZvSpJu842GA1Wn42")
+                .expect("Valid test identity");
+
+        Gateway::builder()
+            .identity(dummy_identity)
+            .ips(vec![IpAddr::V4(ip)])
+            .clients_ws_port(Some(ws_port))
+            .clients_wss_port(Some(wss_port))
+            .build()
+    }
+
+    #[test]
+    #[cfg(not(any(target_os = "android", target_os = "ios")))]
+    fn test_firewall_policy_includes_exit_gateway_endpoints() {
+        // Create mock entry gateway with WebSocket on port 9000 (WS) and 9001 (WSS)
+        let entry_gateway =
+            create_mock_gateway_with_websocket_endpoints(Ipv4Addr::new(192, 168, 1, 1), 9000, 9001);
+        let entry_endpoints = entry_gateway.endpoints();
+
+        // Create mock exit gateway with WebSocket on port 9000 (WS) and 9001 (WSS)
+        let exit_gateway =
+            create_mock_gateway_with_websocket_endpoints(Ipv4Addr::new(192, 168, 1, 2), 9000, 9001);
+        let exit_endpoints = exit_gateway.endpoints();
+
+        // Create ConnectedPolicyParameters (simulating what happens in enter())
+        // We'll directly test with the endpoints without needing SelectedGateways
+        let mut ws_endpoints = entry_endpoints.clone();
+        ws_endpoints.extend(exit_endpoints.clone());
+
+        // Create a minimal TunnelInterface for testing
+        use crate::tunnel_state_machine::TunnelMetadata;
+        use ipnetwork::IpNetwork;
+        let tunnel_metadata = TunnelMetadata {
+            interface: "test0".to_string(),
+            ips: vec![
+                IpNetwork::new(Ipv4Addr::new(10, 0, 0, 1).into(), 24)
+                    .unwrap()
+                    .network(),
+            ],
+            ipv4_gateway: Some(Ipv4Addr::new(10, 0, 0, 1)),
+            ipv6_gateway: None,
+        };
+        let tunnel_interface = TunnelInterface::One(tunnel_metadata);
+
+        // Create ResolvedDnsConfig using DnsConfig::default().resolve()
+        use nym_dns::DnsConfig;
+        let dns_config = DnsConfig::default().resolve(
+            &[IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))],
+            #[cfg(target_os = "macos")]
+            53,
+        );
+
+        let params = ConnectedPolicyParameters {
+            enable_ipv6: false,
+            allow_lan: false,
+            wg_entry_endpoint: None,
+            ws_entry_endpoints: ws_endpoints,
+            dns_config,
+            tunnel_interface,
+        };
+
+        // Build firewall policy
+        let policy = params.as_policy();
+
+        // Extract peer endpoints
+        let peer_endpoints = policy.peer_endpoints();
+
+        // Verify entry gateway endpoints are included
+        assert!(
+            entry_endpoints.iter().any(|entry_ep| {
+                peer_endpoints.iter().any(|allowed_ep| {
+                    allowed_ep.endpoint.address == *entry_ep
+                        && allowed_ep.endpoint.protocol == TransportProtocol::Tcp
+                })
+            }),
+            "Entry gateway endpoints should be in peer_endpoints"
+        );
+
+        // Verify exit gateway endpoints are included
+        assert!(
+            exit_endpoints.iter().any(|exit_ep| {
+                peer_endpoints.iter().any(|allowed_ep| {
+                    allowed_ep.endpoint.address == *exit_ep
+                        && allowed_ep.endpoint.protocol == TransportProtocol::Tcp
+                })
+            }),
+            "Exit gateway endpoints should be in peer_endpoints for SOCKS5 support"
+        );
+
+        // Verify we have endpoints from both gateways
+        assert!(
+            peer_endpoints.len() >= entry_endpoints.len() + exit_endpoints.len(),
+            "peer_endpoints should contain endpoints from both entry and exit gateways"
+        );
     }
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/service/socks5/lazy_socks5.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/socks5/lazy_socks5.rs
@@ -573,20 +573,33 @@ impl LazySocks5 {
         );
 
         // Build the mixnet client with shared credentials but different identity
-        let mixnet_client: nym_sdk::mixnet::DisconnectedMixnetClient<
-            nym_sdk::mixnet::OnDiskPersistent,
-        > = MixnetClientBuilder::new_with_default_storage(socks5_storage_paths)
+        // When dVPN is connected (WireGuard mode), use entry gateway to ensure firewall compatibility.
+        // The firewall rules include the entry gateway endpoints, so using the same gateway
+        // prevents connection failures.
+        let tunnel_state = self.tunnel_state_shared.read().await.clone();
+        let mut builder = MixnetClientBuilder::new_with_default_storage(socks5_storage_paths)
             .await
             .map_err(|e| {
                 error!("Failed to create mixnet client builder: {}", e);
                 LazySocks5Error::Internal(e.to_string())
-            })?
-            .socks5_config(socks5_config)
-            .build()
-            .map_err(|e| {
-                error!("Failed to build mixnet client: {}", e);
-                LazySocks5Error::Internal(e.to_string())
             })?;
+
+        // Configure entry gateway if VPN is connected
+        if let TunnelState::Connected { connection_data } = tunnel_state {
+            let entry_gateway_id = &connection_data.entry_gateway.id;
+            info!(
+                "VPN is connected to entry gateway {}, configuring mixnet client to use same gateway for firewall compatibility",
+                entry_gateway_id
+            );
+            builder = builder.request_gateway(entry_gateway_id.clone());
+        }
+
+        let mixnet_client: nym_sdk::mixnet::DisconnectedMixnetClient<
+            nym_sdk::mixnet::OnDiskPersistent,
+        > = builder.socks5_config(socks5_config).build().map_err(|e| {
+            error!("Failed to build mixnet client: {}", e);
+            LazySocks5Error::Internal(e.to_string())
+        })?;
 
         // Connect to the mixnet via SOCKS5
         info!("Connecting to mixnet via SOCKS5...");
@@ -756,39 +769,81 @@ impl LazySocks5 {
         }
     }
 
-    /// Monitor tunnel state and shut down mixnet backend when dVPN is available
+    /// Monitor tunnel state and manage mixnet backend lifecycle
     async fn monitor_tunnel_state(&self) {
-        let mut last_dvpn_available = false;
+        let mut last_vpn_state: Option<TunnelState> = None;
+        let mut interval = tokio::time::interval(Duration::from_secs(2));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
         loop {
-            // Wait a bit before checking
-            sleep(Duration::from_secs(2)).await;
+            interval.tick().await;
 
-            // Check if dVPN is currently available
-            let dvpn_available = {
-                let tunnel_state = self.tunnel_state_shared.read().await;
-                matches!(
-                    *tunnel_state,
-                    TunnelState::Connected { ref connection_data }
-                    if matches!(connection_data.tunnel, TunnelConnectionData::Mixnet(_))
-                )
-            };
+            let current_state = self.tunnel_state_shared.read().await.clone();
+
+            // Check if dVPN is currently available (Mixnet mode)
+            let dvpn_available = matches!(
+                current_state,
+                TunnelState::Connected { ref connection_data }
+                if matches!(connection_data.tunnel, TunnelConnectionData::Mixnet(_))
+            );
+
+            // Check if VPN is connected in WireGuard mode
+            let vpn_connected_wireguard = matches!(
+                current_state,
+                TunnelState::Connected { ref connection_data }
+                if matches!(connection_data.tunnel, TunnelConnectionData::Wireguard(_))
+            );
 
             // React to state transitions
+            let last_dvpn_available = last_vpn_state
+                .as_ref()
+                .map(|s| {
+                    matches!(
+                        s,
+                        TunnelState::Connected { connection_data }
+                        if matches!(connection_data.tunnel, TunnelConnectionData::Mixnet(_))
+                    )
+                })
+                .unwrap_or(false);
+
+            let last_vpn_connected_wireguard = last_vpn_state
+                .as_ref()
+                .map(|s| {
+                    matches!(
+                        s,
+                        TunnelState::Connected { connection_data }
+                        if matches!(connection_data.tunnel, TunnelConnectionData::Wireguard(_))
+                    )
+                })
+                .unwrap_or(false);
+
             if dvpn_available && !last_dvpn_available {
-                // dVPN just became available - shut down mixnet backend
+                // dVPN just became available (Mixnet mode) - shut down mixnet backend
                 info!(
-                    "dVPN tunnel is now available, shutting down mixnet SOCKS5 backend to save bandwidth"
+                    "dVPN tunnel is now available (Mixnet mode), shutting down mixnet SOCKS5 backend to save bandwidth"
                 );
                 self.shutdown_backend().await;
-            } else if !dvpn_available && last_dvpn_available {
-                // dVPN just became unavailable
+            } else if vpn_connected_wireguard && !last_vpn_connected_wireguard {
+                // VPN just connected in WireGuard mode - if mixnet client is running, shut it down
+                // so it will be recreated with VPN's entry gateway on next connection
+                let is_running = self.is_mixnet_running().await;
+                if is_running {
+                    info!(
+                        "VPN connected in WireGuard mode while mixnet client is running, shutting down mixnet client to ensure it uses VPN's entry gateway (firewall compatibility)"
+                    );
+                    self.shutdown_backend().await;
+                }
+            } else if !dvpn_available
+                && !vpn_connected_wireguard
+                && (last_dvpn_available || last_vpn_connected_wireguard)
+            {
+                // VPN just disconnected
                 info!(
-                    "dVPN tunnel is no longer available, mixnet SOCKS5 backend will be lazily initialized on next connection"
+                    "VPN disconnected, mixnet SOCKS5 backend will be lazily initialized on next connection"
                 );
             }
 
-            last_dvpn_available = dvpn_available;
+            last_vpn_state = Some(current_state);
 
             // Check for cancellation
             if self.cancel_token.is_cancelled() {

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -678,6 +678,16 @@ impl NymVpnService {
                     }
                 });
             }
+
+            // When VPN connects, if SOCKS5 is already enabled, warn that it may not work
+            // because SOCKS5 might be using a different gateway than VPN
+            if matches!(new_state, TunnelState::Connected { .. })
+                && self.socks5_service.is_enabled()
+            {
+                tracing::warn!(
+                    "VPN connected while SOCKS5 proxy was already active. SOCKS5 may be using a different gateway than VPN, which can cause connection failures. Consider disabling and re-enabling SOCKS5 to use the VPN's gateway."
+                );
+            }
         }
         if self.tunnel_event_tx.send(event).is_err() {
             tracing::error!("Failed to send tunnel event");
@@ -1130,35 +1140,111 @@ impl NymVpnService {
             ExitPoint::Address { address } => NodeIdentity::from(*address.gateway().inner()),
             ExitPoint::Gateway { identity } => NodeIdentity::from(*identity.inner()),
             ExitPoint::Country { .. } | ExitPoint::Region { .. } | ExitPoint::Random => {
-                // For non-specific exit points, select a gateway the same way the VPN does
-                tracing::debug!("Selecting SOCKS5 exit node for exit point: {exit_point:?}",);
+                // For non-specific exit points, check if VPN is connected first
+                // If connected, use VPN's actual gateway to avoid firewall routing issues
+                let tunnel_state = self.tunnel_state.read().await.clone();
 
-                // Convert to gateway_directory types for lookup
-                let exit_point: nym_gateway_directory::ExitPoint = exit_point.clone().into();
+                let selected_identity = if let TunnelState::Connected { connection_data } =
+                    tunnel_state
+                {
+                    // VPN is connected - try to use its actual exit gateway
+                    let vpn_gateway_id = &connection_data.exit_gateway.id;
+                    tracing::info!(
+                        "VPN is connected to exit gateway {}, checking if it supports SOCKS5",
+                        vpn_gateway_id
+                    );
 
-                let exit_filters = if self.config_manager.config().residential_exit {
-                    GatewayFilters::from(&[GatewayFilter::Residential, GatewayFilter::Exit])
+                    // Validate that VPN's gateway supports SOCKS5 and has nr_address
+                    match NodeIdentity::from_base58_string(vpn_gateway_id) {
+                        Ok(vpn_gateway_identity) => {
+                            // Look up the gateway directly (VPN uses Wg type, but gateway might also support MixnetExit)
+                            let gateway_full = self
+                                .gateway_cache_handle
+                                .lookup_nymnode_by_identity(vpn_gateway_identity)
+                                .await
+                                .ok();
+
+                            if let Some(gateway_full) = gateway_full {
+                                // Check if gateway supports SOCKS5 (has nr_address and can connect as exit)
+                                let supports_socks5 = gateway_full.nr_address.is_some()
+                                    && gateway_full
+                                        .last_probe
+                                        .as_ref()
+                                        .and_then(|probe| probe.outcome.as_exit.as_ref())
+                                        .map(|exit_point| exit_point.can_connect)
+                                        .unwrap_or(false);
+
+                                if supports_socks5 {
+                                    // Gateway supports SOCKS5 - use it directly even if not in filtered MixnetExit list
+                                    // (VPN uses Wg gateways, but they may also support MixnetExit/SOCKS5)
+                                    tracing::info!(
+                                        "Using VPN's exit gateway {} for SOCKS5 (same gateway, firewall rules should allow connection)",
+                                        vpn_gateway_id
+                                    );
+                                    // Use VPN's gateway identity - skip selection
+                                    Some(vpn_gateway_identity)
+                                } else {
+                                    tracing::debug!(
+                                        "VPN's exit gateway {} does not support SOCKS5 (no nr_address or cannot connect as exit), selecting different gateway",
+                                        vpn_gateway_id
+                                    );
+                                    None
+                                }
+                            } else {
+                                tracing::debug!(
+                                    "VPN's exit gateway {} not found in cache, selecting different gateway",
+                                    vpn_gateway_id
+                                );
+                                None
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                "Failed to parse VPN's exit gateway identity {}: {}. Selecting new gateway.",
+                                vpn_gateway_id,
+                                e
+                            );
+                            None
+                        }
+                    }
                 } else {
-                    GatewayFilters::default()
+                    None
                 };
 
-                let selected_gateway = exit_gateways
-                    .find_best_socks5_gateway(&exit_point, &exit_filters)
-                    .map_err(|e| {
-                        Socks5Error::InvalidConfig(format!(
-                            "Failed to select SOCKS5 exit gateway: {e}"
-                        ))
-                    })?;
+                // Use VPN's gateway if available, otherwise do selection
+                if let Some(gateway_identity) = selected_identity {
+                    gateway_identity
+                } else {
+                    // VPN not connected or gateway doesn't support SOCKS5 - do selection
+                    tracing::debug!("Selecting SOCKS5 exit node for exit point: {exit_point:?}",);
 
-                tracing::info!(
-                    "Selected SOCKS5 exit gateway: {}, location: {}",
-                    selected_gateway.identity(),
-                    selected_gateway
-                        .two_letter_iso_country_code()
-                        .map_or_else(|| "unknown".to_string(), |code| code.to_string()),
-                );
+                    // Convert to gateway_directory types for lookup
+                    let exit_point: nym_gateway_directory::ExitPoint = exit_point.clone().into();
 
-                selected_gateway.identity()
+                    let exit_filters = if self.config_manager.config().residential_exit {
+                        GatewayFilters::from(&[GatewayFilter::Residential, GatewayFilter::Exit])
+                    } else {
+                        GatewayFilters::default()
+                    };
+
+                    let selected_gateway = exit_gateways
+                        .find_best_socks5_gateway(&exit_point, &exit_filters)
+                        .map_err(|e| {
+                            Socks5Error::InvalidConfig(format!(
+                                "Failed to select SOCKS5 exit gateway: {e}"
+                            ))
+                        })?;
+
+                    tracing::info!(
+                        "Selected SOCKS5 exit gateway: {}, location: {}",
+                        selected_gateway.identity(),
+                        selected_gateway
+                            .two_letter_iso_country_code()
+                            .map_or_else(|| "unknown".to_string(), |code| code.to_string()),
+                    );
+
+                    selected_gateway.identity()
+                }
             }
         };
 


### PR DESCRIPTION
- Add exit gateway websockt endpoints to firewall policy when vpn connects
- Configure mixnet client to use vpns entry gateway when vpn is connected
- Select exit gateway for SOCKS5 when vpn is connected
- Add tests for the connected state

## Ticket

JIRA-VPN-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4236)
<!-- Reviewable:end -->
