### PR TITLE
Dynamic vpn reconnection for setting changes

### DIFF
--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/manager/backend/BackendManager.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/manager/backend/BackendManager.kt
@@ -14,7 +14,7 @@ interface BackendManager {
 	suspend fun getBackend(): Backend
 	suspend fun stopTunnel()
 	suspend fun startTunnel()
-	suspend fun restartTunnel()
+	suspend fun restartTunnel(shouldResetConnectionTime: Boolean = false)
 	suspend fun storeMnemonic(mnemonic: String)
 	suspend fun isMnemonicStored(): Boolean
 	suspend fun removeMnemonic()

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/manager/backend/NymBackendManager.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/manager/backend/NymBackendManager.kt
@@ -8,11 +8,13 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.dropWhile
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
@@ -140,12 +142,16 @@ class NymBackendManager @Inject constructor(
 	}
 
 	override suspend fun startTunnel() {
+		Timber.d("startTunnel: called")
+		val entryPoint = getEntryPoint()
+		val exitPoint = getExitPoint()
+		Timber.d("startTunnel: using entryPoint: $entryPoint, exitPoint: $exitPoint")
 		notificationService.clearNotifications()
 		runCatching {
 			emitBackendUiEvent(null)
 			val tunnel = NymTunnel(
-				entryPoint = getEntryPoint(),
-				exitPoint = getExitPoint(),
+				entryPoint = entryPoint,
+				exitPoint = exitPoint,
 				mode = settingsRepository.getVpnMode(),
 				stateChange = ::onStateChange,
 				backendEvent = ::onBackendEvent,
@@ -154,35 +160,67 @@ class NymBackendManager @Inject constructor(
 			)
 			val enableBridges = isQuicEnabled()
 			val restrictedAppsPackages = getRestrictedAppsPackages()
+			Timber.d("startTunnel: calling backend.start()")
 			backend.await().start(tunnel, context.toUserAgent(), enableBridges, restrictedAppsPackages)
+			Timber.d("startTunnel: backend.start() completed successfully")
 		}.onFailure {
 			if (it is BackendException) {
 				when (it) {
-					is BackendException.VpnAlreadyRunning -> Timber.w("Vpn already running")
+					is BackendException.VpnAlreadyRunning -> {
+						Timber.w("startTunnel: Vpn already running - backend state may be out of sync")
+					}
 					is BackendException.VpnPermissionDenied -> {
+						Timber.w("startTunnel: Vpn permission denied")
 						launchVpnPermissionNotification()
 						stopTunnel()
 					}
 				}
 			} else {
-				Timber.e(it)
+				Timber.e(it, "startTunnel: failed with exception")
 			}
 		}
 	}
 
 	private val restartMutex = Mutex()
-	override suspend fun restartTunnel() = restartMutex.withLock {
-		if (getState() != Tunnel.State.Down) {
-			stopTunnel()
-			try {
-				withTimeout(15_000) {
-					stateFlow.first { it.tunnelState == Tunnel.State.Down }
-				}
-			} catch (e: Exception) {
-				Timber.e("Tunnel did not stop in time")
-			}
+	override suspend fun restartTunnel(shouldResetConnectionTime: Boolean) = restartMutex.withLock {
+		val currentState = getState()
+		Timber.d("restartTunnel: current state is $currentState, shouldResetConnectionTime: $shouldResetConnectionTime")
+
+		val preservedConnectionData = if (shouldResetConnectionTime) null else _state.value.connectionData
+		
+		_state.update { 
+			it.copy(
+				isRestarting = true,
+				connectionData = preservedConnectionData
+			)
 		}
+
+		if (currentState != Tunnel.State.Down) {
+			Timber.d("restartTunnel: stopping tunnel (current state: $currentState)")
+			val initialState = _state.value.tunnelState
+			stopTunnel()
+
+			if (initialState != Tunnel.State.Down) {
+				try {
+					withTimeout(15_000) {
+						stateFlow.dropWhile { it.tunnelState != Tunnel.State.Down }.first()
+						Timber.d("restartTunnel: tunnel is now Down")
+					}
+				} catch (e: Exception) {
+					Timber.e(e, "restartTunnel: tunnel did not stop in time, proceeding anyway")
+				}
+			}
+		} else {
+			Timber.d("restartTunnel: tunnel is already Down")
+		}
+
+		// Delay to allow database cleanup (sqlx_pool_guard timeout is 2s, so wait 2.5s to be safe)
+		// Issue is being looked at for registration lockups // Remove once fixed
+		kotlinx.coroutines.delay(2_500)
+
+		Timber.d("restartTunnel: starting tunnel with entryPoint: ${settingsRepository.getEntryPoint()}, exitPoint: ${settingsRepository.getExitPoint()}")
 		startTunnel()
+		// Note: isRestarting is cleared in emitState() when tunnel reaches InitializingClient/EstablishingConnection/Up
 	}
 
 	private suspend fun getRestrictedAppsPackages() = splitTunnelingRepository.getAppInfoList().filter { !it.passThroughVpn }.map { it.packageName }
@@ -323,8 +361,22 @@ class NymBackendManager @Inject constructor(
 	}
 
 	private fun emitConnectedData(connectionData: ConnectionData?) {
-		_state.update {
-			it.copy(connectionData = connectionData?.toInfo())
+		_state.update { currentState ->
+			val newConnectionInfo = connectionData?.toInfo()
+			// During restart, preserve the original connection time
+			// For new connections (isRestarting = false), use the new connection time
+			val preservedConnectionInfo = if (currentState.isRestarting && currentState.connectionData?.connectedAt != null && newConnectionInfo != null) {
+				// Keep the original connectedAt timestamp during restart
+				Timber.d("Restart: preserving connection time ${currentState.connectionData!!.connectedAt}")
+				newConnectionInfo.copy(connectedAt = currentState.connectionData!!.connectedAt)
+			} else {
+				// New connection: use the new connection time
+				if (newConnectionInfo != null && !currentState.isRestarting) {
+					Timber.d("New connection: using new connection time ${newConnectionInfo.connectedAt}")
+				}
+				newConnectionInfo
+			}
+			currentState.copy(connectionData = preservedConnectionInfo)
 		}
 	}
 
@@ -389,9 +441,25 @@ class NymBackendManager @Inject constructor(
 	}
 
 	private fun emitState(state: Tunnel.State) {
-		_state.update {
-			it.copy(
+		_state.update { currentState ->
+			val isRestarting = currentState.isRestarting
+			// Clear isRestarting flag only when we're actually connecting/connected
+			val shouldClearRestarting = if (isRestarting) {
+				// Clear on Up or when starting to connect; keep true during Down (restart in progress)
+				state == Tunnel.State.Up || 
+				state == Tunnel.State.InitializingClient || 
+				state == Tunnel.State.EstablishingConnection
+			} else {
+				false
+			}
+			currentState.copy(
 				tunnelState = state,
+				isRestarting = if (shouldClearRestarting) {
+					Timber.d("Clearing isRestarting flag (state: $state, previous: ${currentState.tunnelState})")
+					false
+				} else {
+					isRestarting
+				},
 			)
 		}
 	}

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/manager/backend/NymBackendManager.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/manager/backend/NymBackendManager.kt
@@ -188,10 +188,10 @@ class NymBackendManager @Inject constructor(
 
 		val preservedConnectionData = if (shouldResetConnectionTime) null else _state.value.connectionData
 		
-		_state.update { 
+		_state.update {
 			it.copy(
 				isRestarting = true,
-				connectionData = preservedConnectionData
+				connectionData = preservedConnectionData,
 			)
 		}
 
@@ -446,9 +446,9 @@ class NymBackendManager @Inject constructor(
 			// Clear isRestarting flag only when we're actually connecting/connected
 			val shouldClearRestarting = if (isRestarting) {
 				// Clear on Up or when starting to connect; keep true during Down (restart in progress)
-				state == Tunnel.State.Up || 
-				state == Tunnel.State.InitializingClient || 
-				state == Tunnel.State.EstablishingConnection
+				state == Tunnel.State.Up ||
+					state == Tunnel.State.InitializingClient ||
+					state == Tunnel.State.EstablishingConnection
 			} else {
 				false
 			}

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/manager/backend/model/TunnelManagerState.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/manager/backend/model/TunnelManagerState.kt
@@ -18,4 +18,5 @@ data class TunnelManagerState(
 	val accountLinks: ParsedAccountLinks? = null,
 	val isInitialized: Boolean = false,
 	val isNetworkCompatible: Boolean = true,
+	val isRestarting: Boolean = false,
 )

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/details/DetailsViewModel.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/details/DetailsViewModel.kt
@@ -3,12 +3,17 @@ package net.nymtech.nymvpn.ui.screens.details
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import net.nymtech.nymvpn.data.SettingsRepository
+import net.nymtech.nymvpn.di.qualifiers.ApplicationScope
+import net.nymtech.nymvpn.manager.backend.BackendManager
 import net.nymtech.nymvpn.manager.environment.EnvironmentManager
 import net.nymtech.nymvpn.ui.screens.hop.GatewayLocation
+import net.nymtech.vpn.backend.Tunnel
 import net.nymtech.vpn.model.NymGateway
 import net.nymtech.vpn.util.extensions.asEntryPoint
 import net.nymtech.vpn.util.extensions.asExitPoint
@@ -19,6 +24,8 @@ import javax.inject.Inject
 class DetailsViewModel @Inject constructor(
 	private val settingsRepository: SettingsRepository,
 	private val environmentManager: EnvironmentManager,
+	private val backendManager: BackendManager,
+	@ApplicationScope private val applicationScope: CoroutineScope,
 ) : ViewModel() {
 
 	private val _uiState = MutableStateFlow(DetailsUiState())
@@ -35,12 +42,35 @@ class DetailsViewModel @Inject constructor(
 
 	fun onSelected(id: String, gatewayLocation: GatewayLocation) = viewModelScope.launch {
 		runCatching {
+			Timber.d("onSelected: gateway $id, location $gatewayLocation")
+			
+			// Save new gateway selection first
 			when (gatewayLocation) {
-				GatewayLocation.ENTRY -> settingsRepository.setEntryPoint(id.asEntryPoint())
-				GatewayLocation.EXIT -> settingsRepository.setExitPoint(id.asExitPoint())
+				GatewayLocation.ENTRY -> {
+					settingsRepository.setEntryPoint(id.asEntryPoint())
+					Timber.d("onSelected: saved new entry point: ${id.asEntryPoint()}")
+				}
+				GatewayLocation.EXIT -> {
+					settingsRepository.setExitPoint(id.asExitPoint())
+					Timber.d("onSelected: saved new exit point: ${id.asExitPoint()}")
+				}
+			}
+			
+			// If connected, reconnect to apply new gateway selection
+			val currentState = backendManager.stateFlow.first().tunnelState
+			Timber.d("onSelected: current VPN state from stateFlow: $currentState")
+			val wasConnected = currentState == Tunnel.State.Up || currentState == Tunnel.State.EstablishingConnection
+			
+			if (wasConnected) {
+				Timber.d("onSelected: VPN is connected, calling restartTunnel() to apply new ${gatewayLocation.name} gateway selection")
+				applicationScope.launch {
+					backendManager.restartTunnel(shouldResetConnectionTime = true)
+				}
+			} else {
+				Timber.d("onSelected: VPN is not connected (state: $currentState), no restart needed")
 			}
 		}.onFailure {
-			Timber.e(it)
+			Timber.e(it, "Failed to update gateway selection and reconnect")
 		}
 	}
 }

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/hop/HopViewModel.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/hop/HopViewModel.kt
@@ -3,12 +3,16 @@ package net.nymtech.nymvpn.ui.screens.hop
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import net.nymtech.nymvpn.data.GatewayRepository
 import net.nymtech.nymvpn.data.SettingsRepository
+import net.nymtech.nymvpn.di.qualifiers.ApplicationScope
+import net.nymtech.nymvpn.manager.backend.BackendManager
 import net.nymtech.nymvpn.manager.environment.EnvironmentManager
 import net.nymtech.nymvpn.service.gateway.GatewayCacheService
 import net.nymtech.nymvpn.util.extensions.isQuicSupported
@@ -28,8 +32,10 @@ import javax.inject.Inject
 class HopViewModel @Inject constructor(
 	private val settingsRepository: SettingsRepository,
 	private val gatewayCacheService: GatewayCacheService,
+	private val backendManager: BackendManager,
 	private val gatewayRepository: GatewayRepository,
 	private val environmentManager: EnvironmentManager,
+	@ApplicationScope private val applicationScope: CoroutineScope,
 ) : ViewModel() {
 
 	private val _uiState = MutableStateFlow(HopUiState())
@@ -152,12 +158,35 @@ class HopViewModel @Inject constructor(
 
 	fun onSelected(id: String, gatewayLocation: GatewayLocation) = viewModelScope.launch {
 		runCatching {
+			Timber.d("onSelected: gateway $id, location $gatewayLocation")
+			
+			// Save new gateway selection first
 			when (gatewayLocation) {
-				GatewayLocation.ENTRY -> settingsRepository.setEntryPoint(id.asEntryPoint())
-				GatewayLocation.EXIT -> settingsRepository.setExitPoint(id.asExitPoint())
+				GatewayLocation.ENTRY -> {
+					settingsRepository.setEntryPoint(id.asEntryPoint())
+					Timber.d("onSelected: saved new entry point: ${id.asEntryPoint()}")
+				}
+				GatewayLocation.EXIT -> {
+					settingsRepository.setExitPoint(id.asExitPoint())
+					Timber.d("onSelected: saved new exit point: ${id.asExitPoint()}")
+				}
+			}
+			
+			// If connected, reconnect to apply new gateway selection
+			val currentState = backendManager.stateFlow.first().tunnelState
+			Timber.d("onSelected: current VPN state from stateFlow: $currentState")
+			val wasConnected = currentState == Tunnel.State.Up || currentState == Tunnel.State.EstablishingConnection
+			
+			if (wasConnected) {
+				Timber.d("onSelected: VPN is connected, calling restartTunnel() to apply new ${gatewayLocation.name} gateway selection")
+				applicationScope.launch {
+					backendManager.restartTunnel(shouldResetConnectionTime = true)
+				}
+			} else {
+				Timber.d("onSelected: VPN is not connected (state: $currentState), no restart needed")
 			}
 		}.onFailure {
-			Timber.e(it)
+			Timber.e(it, "Failed to update gateway selection and reconnect")
 		}
 	}
 

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/MainScreen.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/MainScreen.kt
@@ -90,12 +90,23 @@ fun MainScreen(appUiState: AppUiState, autoStart: Boolean, viewModel: MainViewMo
 				// Prevent "Connect" button during restart; offline takes precedence
 				managerState.isRestarting && networkStatus == NetworkStatus.Disconnected -> ConnectionState.Offline
 				managerState.isRestarting && managerState.tunnelState == Tunnel.State.Down -> ConnectionState.Disconnecting
-				managerState.isRestarting && managerState.tunnelState == Tunnel.State.InitializingClient -> 
-					ConnectionState.from(managerState.tunnelState, managerState.establishConnectionState)
-				managerState.isRestarting -> ConnectionState.from(managerState.tunnelState, managerState.establishConnectionState)
+				managerState.isRestarting && managerState.tunnelState == Tunnel.State.InitializingClient ->
+					ConnectionState.from(
+						managerState.tunnelState,
+						managerState.establishConnectionState,
+					)
+				managerState.isRestarting ->
+					ConnectionState.from(
+						managerState.tunnelState,
+						managerState.establishConnectionState,
+					)
 				managerState.tunnelState != Tunnel.State.Down && networkStatus == NetworkStatus.Disconnected -> ConnectionState.WaitingForConnection
 				managerState.tunnelState == Tunnel.State.Down && networkStatus == NetworkStatus.Disconnected -> ConnectionState.Offline
-				else -> ConnectionState.from(managerState.tunnelState, managerState.establishConnectionState)
+				else ->
+					ConnectionState.from(
+						managerState.tunnelState,
+						managerState.establishConnectionState,
+					)
 			}
 			val stateMessage = when (val event = managerState.backendUiEvent) {
 				is BackendUiEvent.BandwidthAlert, null -> connectionState.stateMessage

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/MainScreen.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/MainScreen.kt
@@ -87,6 +87,12 @@ fun MainScreen(appUiState: AppUiState, autoStart: Boolean, viewModel: MainViewMo
 	val uiState = remember(appUiState.managerState, appUiState.networkStatus) {
 		with(appUiState) {
 			val connectionState = when {
+				// Prevent "Connect" button during restart; offline takes precedence
+				managerState.isRestarting && networkStatus == NetworkStatus.Disconnected -> ConnectionState.Offline
+				managerState.isRestarting && managerState.tunnelState == Tunnel.State.Down -> ConnectionState.Disconnecting
+				managerState.isRestarting && managerState.tunnelState == Tunnel.State.InitializingClient -> 
+					ConnectionState.from(managerState.tunnelState, managerState.establishConnectionState)
+				managerState.isRestarting -> ConnectionState.from(managerState.tunnelState, managerState.establishConnectionState)
 				managerState.tunnelState != Tunnel.State.Down && networkStatus == NetworkStatus.Disconnected -> ConnectionState.WaitingForConnection
 				managerState.tunnelState == Tunnel.State.Down && networkStatus == NetworkStatus.Disconnected -> ConnectionState.Offline
 				else -> ConnectionState.from(managerState.tunnelState, managerState.establishConnectionState)
@@ -125,8 +131,8 @@ fun MainScreen(appUiState: AppUiState, autoStart: Boolean, viewModel: MainViewMo
 	}
 
 	with(appUiState.managerState) {
-		LaunchedEffect(tunnelState, connectionData?.connectedAt) {
-			viewModel.onTunnelStateChanged(tunnelState, connectionData?.connectedAt)
+		LaunchedEffect(tunnelState, connectionData?.connectedAt, appUiState.networkStatus) {
+			viewModel.onTunnelStateChanged(tunnelState, connectionData?.connectedAt, appUiState.networkStatus)
 		}
 	}
 
@@ -219,21 +225,18 @@ fun MainScreen(appUiState: AppUiState, autoStart: Boolean, viewModel: MainViewMo
 
 	fun onEntryClick() {
 		when (uiState.connectionState) {
-			ConnectionState.Disconnected, ConnectionState.Offline -> navController.goFromRoot(Route.EntryLocation)
-			ConnectionState.WaitingForConnection, is ConnectionState.Connecting -> snackbar.showMessage(context.getString(R.string.disabled_while_connecting))
-			else -> snackbar.showMessage(context.getString(R.string.disabled_while_connected))
+			ConnectionState.WaitingForConnection -> snackbar.showMessage(context.getString(R.string.disabled_while_connecting))
+			else -> navController.goFromRoot(Route.EntryLocation)
 		}
 	}
 
 	fun onExitClick() {
 		when (uiState.connectionState) {
-			ConnectionState.Disconnected, ConnectionState.Offline -> {
+			ConnectionState.WaitingForConnection -> snackbar.showMessage(context.getString(R.string.disabled_while_connecting))
+			else -> {
 				dismissStreamingBanner()
 				navController.goFromRoot(Route.ExitLocation)
 			}
-
-			ConnectionState.WaitingForConnection, is ConnectionState.Connecting -> snackbar.showMessage(context.getString(R.string.disabled_while_connecting))
-			else -> snackbar.showMessage(context.getString(R.string.disabled_while_connected))
 		}
 	}
 

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/MainViewModel.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/MainViewModel.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -19,7 +18,6 @@ import net.nymtech.nymvpn.NymVpn
 import net.nymtech.nymvpn.data.SettingsRepository
 import net.nymtech.nymvpn.manager.backend.BackendManager
 import net.nymtech.nymvpn.manager.environment.EnvironmentManager
-import net.nymtech.nymvpn.ui.AppUiState
 import net.nymtech.vpn.backend.Tunnel
 import timber.log.Timber
 
@@ -174,8 +172,8 @@ constructor(
 					currentNetworkStatus = status
 				}
 			}
-					while (true) {
-						if (currentNetworkStatus == NetworkStatus.Connected) {
+			while (true) {
+				if (currentNetworkStatus == NetworkStatus.Connected) {
 					val nowSeconds = System.currentTimeMillis() / 1000L
 					val elapsedSeconds = nowSeconds - connectedAtSeconds
 					_connectionSeconds.value = elapsedSeconds.coerceAtLeast(0)

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/MainViewModel.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/MainViewModel.kt
@@ -9,13 +9,19 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import net.nymtech.connectivity.NetworkStatus
+import net.nymtech.connectivity.NetworkService
 import net.nymtech.nymvpn.NymVpn
 import net.nymtech.nymvpn.data.SettingsRepository
 import net.nymtech.nymvpn.manager.backend.BackendManager
 import net.nymtech.nymvpn.manager.environment.EnvironmentManager
+import net.nymtech.nymvpn.ui.AppUiState
 import net.nymtech.vpn.backend.Tunnel
+import timber.log.Timber
 
 @HiltViewModel
 class MainViewModel
@@ -24,6 +30,7 @@ constructor(
 	private val settingsRepository: SettingsRepository,
 	private val backendManager: BackendManager,
 	private val environmentManager: EnvironmentManager,
+	private val networkService: NetworkService,
 ) : ViewModel() {
 
 	private val _connectionSeconds = MutableStateFlow<Long?>(null)
@@ -45,11 +52,43 @@ constructor(
 	}
 
 	fun onTwoHopSelected() = viewModelScope.launch {
-		settingsRepository.setVpnMode(Tunnel.Mode.TWO_HOP_MIXNET)
+		runCatching {
+			settingsRepository.setVpnMode(Tunnel.Mode.TWO_HOP_MIXNET)
+			
+			// If VPN is connected, reconnect to apply new VPN mode
+			val currentState = backendManager.stateFlow.first().tunnelState
+			val wasConnected = currentState == Tunnel.State.Up || currentState == Tunnel.State.EstablishingConnection
+			
+			if (wasConnected) {
+				Timber.d("VPN is connected, reconnecting to apply TWO_HOP_MIXNET mode")
+				// Stop timer immediately - new connection will start from 0
+				lastConnectedAt = null
+				stopConnectionTimerInternal()
+				backendManager.restartTunnel(shouldResetConnectionTime = true)
+			}
+		}.onFailure {
+			Timber.e(it, "Failed to update VPN mode and reconnect")
+		}
 	}
 
 	fun onFiveHopSelected() = viewModelScope.launch {
-		settingsRepository.setVpnMode(Tunnel.Mode.FIVE_HOP_MIXNET)
+		runCatching {
+			settingsRepository.setVpnMode(Tunnel.Mode.FIVE_HOP_MIXNET)
+			
+			// If VPN is connected, reconnect to apply new VPN mode
+			val currentState = backendManager.stateFlow.first().tunnelState
+			val wasConnected = currentState == Tunnel.State.Up || currentState == Tunnel.State.EstablishingConnection
+			
+			if (wasConnected) {
+				Timber.d("VPN is connected, reconnecting to apply FIVE_HOP_MIXNET mode")
+				// Stop timer immediately - new connection will start from 0
+				lastConnectedAt = null
+				stopConnectionTimerInternal()
+				backendManager.restartTunnel(shouldResetConnectionTime = true)
+			}
+		}.onFailure {
+			Timber.e(it, "Failed to update VPN mode and reconnect")
+		}
 	}
 
 	fun onConnect() = viewModelScope.launch {
@@ -60,7 +99,6 @@ constructor(
 		lastConnectedAt = null
 		stopConnectionTimerInternal()
 		backendManager.stopTunnel()
-		handleTunnelStateChange(Tunnel.State.Down, null)
 	}
 
 	fun onBatteryOptSkipped() = viewModelScope.launch {
@@ -83,21 +121,27 @@ constructor(
 		settingsRepository.setIsPerAppSecurityBannerDisplayed(true)
 	}
 
-	fun onTunnelStateChanged(tunnelState: Tunnel.State, connectedAt: Long?) {
-		handleTunnelStateChange(tunnelState, connectedAt)
+	fun onTunnelStateChanged(tunnelState: Tunnel.State, connectedAt: Long?, networkStatus: NetworkStatus) {
+		handleTunnelStateChange(tunnelState, connectedAt, networkStatus)
 	}
 
-	private fun handleTunnelStateChange(tunnelState: Tunnel.State, connectedAt: Long?) {
+	private fun handleTunnelStateChange(tunnelState: Tunnel.State, connectedAt: Long?, networkStatus: NetworkStatus) {
 		when (tunnelState) {
 			is Tunnel.State.Up -> {
-				val effectiveConnectedAt = connectedAt ?: lastConnectedAt
+				val effectiveConnectedAt = connectedAt
+				
 				if (effectiveConnectedAt != null) {
 					lastConnectedAt = effectiveConnectedAt
 					startConnectionTimer(effectiveConnectedAt)
 				}
 			}
 
-			is Tunnel.State.Disconnecting,
+			is Tunnel.State.Disconnecting -> {
+				// Manual disconnect - immediately stop timer regardless of connectedAt
+				lastConnectedAt = null
+				stopConnectionTimerInternal()
+			}
+
 			is Tunnel.State.InitializingClient,
 			is Tunnel.State.EstablishingConnection,
 			is Tunnel.State.Offline,
@@ -112,7 +156,9 @@ constructor(
 			}
 
 			is Tunnel.State.Down -> {
-				lastConnectedAt = null
+				if (connectedAt == null) {
+					lastConnectedAt = null
+				}
 				stopConnectionTimerInternal()
 			}
 		}
@@ -121,10 +167,19 @@ constructor(
 	private fun startConnectionTimer(connectedAtSeconds: Long) {
 		timerJob?.cancel()
 		timerJob = viewModelScope.launch {
-			while (true) {
-				val nowSeconds = System.currentTimeMillis() / 1000L
-				val elapsedSeconds = nowSeconds - connectedAtSeconds
-				_connectionSeconds.value = elapsedSeconds.coerceAtLeast(0)
+			var currentNetworkStatus: NetworkStatus = NetworkStatus.Unknown
+			// Observe network status changes
+			launch {
+				networkService.networkStatus.collect { status ->
+					currentNetworkStatus = status
+				}
+			}
+					while (true) {
+						if (currentNetworkStatus == NetworkStatus.Connected) {
+					val nowSeconds = System.currentTimeMillis() / 1000L
+					val elapsedSeconds = nowSeconds - connectedAtSeconds
+					_connectionSeconds.value = elapsedSeconds.coerceAtLeast(0)
+				}
 				delay(1000)
 			}
 		}

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/SettingsViewModel.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/SettingsViewModel.kt
@@ -3,13 +3,18 @@ package net.nymtech.nymvpn.ui.screens.settings
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import net.nymtech.nymvpn.data.SettingsRepository
+import net.nymtech.nymvpn.di.qualifiers.ApplicationScope
 import net.nymtech.nymvpn.manager.backend.BackendManager
 import net.nymtech.nymvpn.manager.environment.EnvironmentManager
+import net.nymtech.vpn.backend.Tunnel
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -19,6 +24,7 @@ constructor(
 	private val settingsRepository: SettingsRepository,
 	private val environmentManager: EnvironmentManager,
 	private val backendManager: BackendManager,
+	@ApplicationScope private val applicationScope: CoroutineScope,
 ) : ViewModel() {
 
 	private val _uiState = MutableStateFlow(SettingsUiState())
@@ -42,6 +48,24 @@ constructor(
 	}
 
 	fun onBypassLanSelected(selected: Boolean) = viewModelScope.launch {
-		settingsRepository.setBypassLan(selected)
+		runCatching {
+			settingsRepository.setBypassLan(selected)
+			
+			// If connected, reconnect to apply new bypass LAN setting
+			val currentState = backendManager.stateFlow.first().tunnelState
+			Timber.d("onBypassLanSelected: current VPN state from stateFlow: $currentState")
+			val wasConnected = currentState == Tunnel.State.Up || currentState == Tunnel.State.EstablishingConnection
+			
+			if (wasConnected) {
+				Timber.d("onBypassLanSelected: VPN is connected, reconnecting to apply new bypass LAN setting: $selected")
+				applicationScope.launch {
+					backendManager.restartTunnel(shouldResetConnectionTime = false)
+				}
+			} else {
+				Timber.d("onBypassLanSelected: VPN is not connected (state: $currentState), no restart needed")
+			}
+		}.onFailure {
+			Timber.e(it, "Failed to update bypass LAN setting and reconnect")
+		}
 	}
 }

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/censorship/CensorshipViewModel.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/censorship/CensorshipViewModel.kt
@@ -13,6 +13,7 @@ import net.nymtech.nymvpn.di.qualifiers.ApplicationScope
 import net.nymtech.nymvpn.manager.backend.BackendManager
 import net.nymtech.nymvpn.manager.environment.EnvironmentManager
 import net.nymtech.vpn.backend.Tunnel
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -36,8 +37,21 @@ class CensorshipViewModel @Inject constructor(
 	}
 
 	fun onQUICEnabled(enabled: Boolean) = viewModelScope.launch {
-		settingsRepository.setQUICEnabled(enabled)
-		_uiState.update { it.copy() }
+		runCatching {
+			settingsRepository.setQUICEnabled(enabled)
+			_uiState.update { it.copy() }
+			
+			// If connected, reconnect to apply new QUIC setting
+			val currentState = backendManager.getState()
+			val wasConnected = currentState == Tunnel.State.Up || currentState == Tunnel.State.EstablishingConnection
+			
+			if (wasConnected) {
+				Timber.d("VPN is connected, reconnecting to apply new QUIC setting: $enabled")
+				backendManager.restartTunnel()
+			}
+		}.onFailure {
+			Timber.e(it, "Failed to update QUIC setting and reconnect")
+		}
 	}
 
 	fun requestReconnect() {

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/dns/DnsScreen.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/dns/DnsScreen.kt
@@ -248,6 +248,7 @@ private fun DnsScreen(
 			onDnsEnable = onDnsEnable,
 			onSave = { listToSave ->
 				onSave(listToSave)
+				customDnsDraft = listToSave
 			},
 			onDnsListChange = { customDnsDraft = it },
 		)

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/dns/DnsViewModel.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/dns/DnsViewModel.kt
@@ -36,6 +36,7 @@ class DnsViewModel @Inject constructor(
 	fun saveDnsList(list: List<String>) {
 		viewModelScope.launch {
 			settingsRepository.saveDnsList(list)
+			_customDns.value = list
 		}
 	}
 

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/login/components/LoginInputSection.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/login/components/LoginInputSection.kt
@@ -77,9 +77,16 @@ fun LoginInputSection(appUiState: AppUiState, viewModel: LoginViewModel, success
 				}
 			},
 			value = mnemonic,
-			onValueChange = {
-				if (success == false) viewModel.resetSuccess()
-				mnemonic = it
+			onValueChange = { newValue ->
+				try {
+					if (success == false) {
+						viewModel.resetSuccess()
+					}
+					mnemonic = newValue
+				} catch (e: Exception) {
+					Timber.e(e, "Error handling text input change")
+					mnemonic = newValue
+				}
 			},
 			keyboardActions = KeyboardActions(
 				onDone = {


### PR DESCRIPTION
Enable automatic vpn reconnection when gateway selections or settings are changed while the vpn is connected

- Add restartTunnel() method to BackendManager interface with shouldResetConnectionTime parameter
- Implement restartTunnel() in NymBackendManager with mutex protection to prevent race conditions
- Add isRestarting flag to TunnelManagerState to track restart state
- Update all ViewModels
- Add 2.5s delay after tunnel stop to allow database cleanup to complete (sqlx_pool_guard has 2s timeout)

## Ticket

[JIRA-VPN-343](https://nymtech.atlassian.net/browse/VPN-343)

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4252)
<!-- Reviewable:end -->
