### PR TITLE
VPN-4655: Quiet-down the grpc logging.

### DIFF
--- a/nym-vpn-app/src/contexts/socks5/provider.tsx
+++ b/nym-vpn-app/src/contexts/socks5/provider.tsx
@@ -27,7 +27,15 @@ export function Socks5Provider({ children }: Socks5ProviderProps) {
       const result = await invoke<Socks5Status>('get_socks5_status');
       setStatus(result);
     } catch (error) {
-      console.error('Failed to get SOCKS5 status:', error);
+      if (
+        !(
+          error !== null &&
+          typeof error === 'object' &&
+          'not-connected-to-daemon' in error
+        )
+      ) {
+        console.error('Failed to get SOCKS5 status:', error);
+      }
     }
   }, []);
 

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -3041,7 +3041,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3829,7 +3829,7 @@ dependencies = [
 [[package]]
 name = "nym-api-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "bs58",
  "cosmrs",
@@ -3878,7 +3878,7 @@ dependencies = [
 [[package]]
 name = "nym-authenticator-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "bincode",
  "futures",
@@ -3901,7 +3901,7 @@ dependencies = [
 [[package]]
 name = "nym-authenticator-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -3925,7 +3925,7 @@ dependencies = [
 [[package]]
 name = "nym-bandwidth-controller"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "async-trait",
  "log",
@@ -3943,7 +3943,7 @@ dependencies = [
 [[package]]
 name = "nym-bin-common"
 version = "0.6.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "const-str",
  "log",
@@ -3958,7 +3958,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core"
 version = "1.1.15"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4017,7 +4017,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-config-types"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "humantime-serde",
  "nym-config",
@@ -4033,7 +4033,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-gateways-storage"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4053,7 +4053,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-surb-storage"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4072,7 +4072,7 @@ dependencies = [
 [[package]]
 name = "nym-coconut-dkg-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -4094,7 +4094,7 @@ dependencies = [
 [[package]]
 name = "nym-compact-ecash"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "bincode",
  "bls12_381",
@@ -4117,7 +4117,7 @@ dependencies = [
 [[package]]
 name = "nym-config"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "dirs",
  "handlebars",
@@ -4150,7 +4150,7 @@ dependencies = [
 [[package]]
 name = "nym-contracts-common"
 version = "0.5.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -4165,7 +4165,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-proxy-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "async-trait",
  "nym-credentials",
@@ -4186,7 +4186,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-storage"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4207,7 +4207,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-utils"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "log",
  "nym-bandwidth-controller",
@@ -4226,7 +4226,7 @@ dependencies = [
 [[package]]
 name = "nym-credentials"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "bincode",
  "bls12_381",
@@ -4250,7 +4250,7 @@ dependencies = [
 [[package]]
 name = "nym-credentials-interface"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "bls12_381",
  "nym-compact-ecash",
@@ -4269,7 +4269,7 @@ dependencies = [
 [[package]]
 name = "nym-crypto"
 version = "0.4.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "aead",
  "aes",
@@ -4335,7 +4335,7 @@ dependencies = [
 [[package]]
 name = "nym-ecash-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -4349,7 +4349,7 @@ dependencies = [
 [[package]]
 name = "nym-ecash-signer-check-types"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "nym-coconut-dkg-common",
  "nym-crypto",
@@ -4365,7 +4365,7 @@ dependencies = [
 [[package]]
 name = "nym-ecash-time"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "nym-compact-ecash",
  "time",
@@ -4374,7 +4374,7 @@ dependencies = [
 [[package]]
 name = "nym-exit-policy"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "serde",
  "serde_json",
@@ -4407,7 +4407,7 @@ dependencies = [
 [[package]]
 name = "nym-gateway-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "futures",
  "getrandom 0.2.16",
@@ -4471,7 +4471,7 @@ dependencies = [
 [[package]]
 name = "nym-gateway-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "bs58",
  "futures",
@@ -4501,7 +4501,7 @@ dependencies = [
 [[package]]
 name = "nym-group-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "cosmwasm-schema",
  "cw-controllers",
@@ -4513,7 +4513,7 @@ dependencies = [
 [[package]]
 name = "nym-http-api-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4545,7 +4545,7 @@ dependencies = [
 [[package]]
 name = "nym-http-api-client-macro"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -4557,7 +4557,7 @@ dependencies = [
 [[package]]
 name = "nym-http-api-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "bincode",
  "serde",
@@ -4568,7 +4568,7 @@ dependencies = [
 [[package]]
 name = "nym-id"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "nym-credential-storage",
  "nym-credentials",
@@ -4581,7 +4581,7 @@ dependencies = [
 [[package]]
 name = "nym-ip-packet-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "bincode",
  "bytes",
@@ -4597,7 +4597,7 @@ dependencies = [
 [[package]]
 name = "nym-ip-packet-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "bincode",
  "bytes",
@@ -4639,7 +4639,7 @@ dependencies = [
 [[package]]
 name = "nym-metrics"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "dashmap",
  "lazy_static",
@@ -4650,7 +4650,7 @@ dependencies = [
 [[package]]
 name = "nym-mixnet-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "dashmap",
  "futures",
@@ -4664,7 +4664,7 @@ dependencies = [
 [[package]]
 name = "nym-mixnet-contract-common"
 version = "0.6.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -4685,7 +4685,7 @@ dependencies = [
 [[package]]
 name = "nym-multisig-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -4701,7 +4701,7 @@ dependencies = [
 [[package]]
 name = "nym-network-defaults"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "cargo_metadata 0.19.2",
  "dotenvy",
@@ -4716,7 +4716,7 @@ dependencies = [
 [[package]]
 name = "nym-node-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "celes",
  "humantime-serde",
@@ -4740,7 +4740,7 @@ dependencies = [
 [[package]]
 name = "nym-noise"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -4761,7 +4761,7 @@ dependencies = [
 [[package]]
 name = "nym-noise-keys"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "nym-crypto",
  "schemars 0.8.22",
@@ -4772,7 +4772,7 @@ dependencies = [
 [[package]]
 name = "nym-nonexhaustive-delayqueue"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -4802,7 +4802,7 @@ dependencies = [
 [[package]]
 name = "nym-ordered-buffer"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "log",
  "thiserror 2.0.17",
@@ -4811,7 +4811,7 @@ dependencies = [
 [[package]]
 name = "nym-outfox"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "blake3",
  "chacha20",
@@ -4829,7 +4829,7 @@ dependencies = [
 [[package]]
 name = "nym-pemstore"
 version = "0.3.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "pem",
  "tracing",
@@ -4839,7 +4839,7 @@ dependencies = [
 [[package]]
 name = "nym-performance-contract-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -4865,7 +4865,7 @@ dependencies = [
 [[package]]
 name = "nym-registration-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "futures",
  "nym-authenticator-client",
@@ -4887,7 +4887,7 @@ dependencies = [
 [[package]]
 name = "nym-registration-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "nym-authenticator-requests",
  "nym-crypto",
@@ -4922,7 +4922,7 @@ dependencies = [
 [[package]]
 name = "nym-sdk"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4977,7 +4977,7 @@ dependencies = [
 [[package]]
 name = "nym-serde-helpers"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -4989,7 +4989,7 @@ dependencies = [
 [[package]]
 name = "nym-service-provider-requests-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "serde",
  "thiserror 2.0.17",
@@ -4998,7 +4998,7 @@ dependencies = [
 [[package]]
 name = "nym-service-providers-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "async-trait",
  "log",
@@ -5022,7 +5022,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-client-core"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "anyhow",
  "dirs",
@@ -5055,7 +5055,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-proxy-helpers"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "bytes",
  "futures",
@@ -5070,7 +5070,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-requests"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "bincode",
  "log",
@@ -5086,7 +5086,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "nym-crypto",
  "nym-metrics",
@@ -5112,7 +5112,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-acknowledgements"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "nym-crypto",
  "nym-pemstore",
@@ -5129,7 +5129,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-addressing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-types",
@@ -5140,7 +5140,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-anonymous-replies"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "bs58",
  "nym-crypto",
@@ -5158,7 +5158,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-chunking"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "dashmap",
  "log",
@@ -5177,7 +5177,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-cover"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-acknowledgements",
@@ -5195,7 +5195,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-forwarding"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "nym-sphinx-addressing",
  "nym-sphinx-anonymous-replies",
@@ -5207,7 +5207,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-framing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "bytes",
  "nym-sphinx-acknowledgements",
@@ -5223,7 +5223,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-params"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-types",
@@ -5234,7 +5234,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-routing"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "nym-sphinx-addressing",
  "nym-sphinx-types",
@@ -5244,7 +5244,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-types"
 version = "0.2.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "nym-outfox",
  "sphinx-packet",
@@ -5289,7 +5289,7 @@ dependencies = [
 [[package]]
 name = "nym-statistics-common"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "futures",
  "log",
@@ -5314,7 +5314,7 @@ dependencies = [
 [[package]]
 name = "nym-task"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "cfg-if",
  "futures",
@@ -5331,7 +5331,7 @@ dependencies = [
 [[package]]
 name = "nym-ticketbooks-merkle"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "nym-credentials-interface",
  "nym-serde-helpers",
@@ -5346,7 +5346,7 @@ dependencies = [
 [[package]]
 name = "nym-topology"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "async-trait",
  "nym-api-requests",
@@ -5366,7 +5366,7 @@ dependencies = [
 [[package]]
 name = "nym-upgrade-mode-check"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "jwt-simple",
  "nym-crypto",
@@ -5383,7 +5383,7 @@ dependencies = [
 [[package]]
 name = "nym-validator-client"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5433,7 +5433,7 @@ dependencies = [
 [[package]]
 name = "nym-vesting-contract-common"
 version = "0.7.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -5862,7 +5862,7 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-private-metadata-client"
 version = "1.0.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "async-trait",
  "nym-http-api-client",
@@ -5873,7 +5873,7 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-private-metadata-shared"
 version = "1.0.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "axum 0.7.9",
  "bincode",
@@ -5887,7 +5887,7 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-types"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "base64 0.22.1",
  "nym-crypto",
@@ -8142,7 +8142,7 @@ dependencies = [
 [[package]]
 name = "sqlx-pool-guard"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "proc_pidinfo",
  "sqlx",
@@ -9827,7 +9827,7 @@ dependencies = [
 [[package]]
 name = "wasm-utils"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=develop#c17a205ada298e3e973d73ab63a882c56db3bd90"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae54e86bf46bbc38243d015c7ad8ebb1227e3c5b"
 dependencies = [
  "futures",
  "getrandom 0.2.16",

--- a/nym-vpn-core/crates/nym-vpnd/src/logging.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/logging.rs
@@ -21,7 +21,7 @@ use nym_vpn_lib_types::LogPath;
 
 use crate::service;
 
-static INFO_CRATES: &[&str; 13] = &[
+static INFO_CRATES: &[&str; 14] = &[
     "hyper",
     "netlink_proto",
     "hickory_proto",
@@ -35,6 +35,7 @@ static INFO_CRATES: &[&str; 13] = &[
     "nym_task::manager",
     "nym_client_core::client::real_messages_control",
     "nym_client_core::client::received_buffer",
+    "tonic::transport::server",
 ];
 
 static WARN_CRATES: &[&str; 2] = &["hickory_server", "quinn::connection"];

--- a/nym-vpn-core/crates/nym-vpnd/src/logging.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/logging.rs
@@ -21,7 +21,7 @@ use nym_vpn_lib_types::LogPath;
 
 use crate::service;
 
-static INFO_CRATES: &[&str; 14] = &[
+static INFO_TARGETS: [&str; 14] = [
     "hyper",
     "netlink_proto",
     "hickory_proto",
@@ -38,7 +38,7 @@ static INFO_CRATES: &[&str; 14] = &[
     "tonic::transport::server",
 ];
 
-static WARN_CRATES: &[&str; 2] = &["hickory_server", "quinn::connection"];
+static WARN_TARGETS: [&str; 2] = ["hickory_server", "quinn::connection"];
 
 pub struct Options {
     pub verbosity_level: Level,
@@ -229,14 +229,14 @@ pub fn setup_logging(options: Options) -> Option<LoggingSetup> {
         .with_default_directive(options.verbosity_level.into())
         .from_env_lossy();
 
-    for crate_name in INFO_CRATES {
+    for crate_name in INFO_TARGETS {
         env_filter = env_filter.add_directive(
             format!("{crate_name}=info")
                 .parse()
                 .expect("failed to parse directive"),
         );
     }
-    for crate_name in WARN_CRATES {
+    for crate_name in WARN_TARGETS {
         env_filter = env_filter.add_directive(
             format!("{crate_name}=warn")
                 .parse()


### PR DESCRIPTION
## Ticket

JIRA-VPN-4655

## Description

Quiet-down the grpc logging to avoid spamming.

As a bonus, the app's logging of cannot `Failed to get SOCKS5 status` when the daemon is not running has been quietened down as well.

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4255)
<!-- Reviewable:end -->
