### PR TITLE
APPLE: Show 'Get started' text on macOS when no credentials

### DIFF
--- a/nym-vpn-apple/Home/Sources/Home/HomeViewModel+iOS.swift
+++ b/nym-vpn-apple/Home/Sources/Home/HomeViewModel+iOS.swift
@@ -28,18 +28,6 @@ extension HomeViewModel {
             .store(in: &cancellables)
     }
 
-    func setupIsMnemonicImportedObserver() {
-        appSettings.$isCredentialImportedPublisher
-            .removeDuplicates()
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
-                MainActor.assumeIsolated {
-                    self?.updateConnectButtonStateIfMnemonicImported()
-                }
-            }
-            .store(in: &cancellables)
-    }
-
     func configureTunnelStatusObservation(with tunnel: Tunnel) {
         tunnelStatusUpdateCancellable = tunnel.$status
             .removeDuplicates()

--- a/nym-vpn-apple/Home/Sources/Home/HomeViewModel.swift
+++ b/nym-vpn-apple/Home/Sources/Home/HomeViewModel.swift
@@ -333,7 +333,11 @@ extension HomeViewModel {
                 hasInternet: networkMonitor.isAvailable,
                 subscriptionDidExpire: isLastErrorSubscriptionExpired()
             )
+            #if os(iOS)
             connectButtonState = ConnectButtonState(tunnelStatus: newStatus)
+            #elseif os(macOS)
+            updateConnectButtonStateIfMnemonicImported()
+            #endif
 
             if let lastError {
                 statusInfoState = .error(message: lastError.localizedDescription)
@@ -351,13 +355,6 @@ extension HomeViewModel {
             }
 
             displayEnableStatisticsSnackBarCTAIfNeeded()
-        }
-    }
-
-    func updateConnectButtonState(with newState: ConnectButtonState) {
-        Task { @MainActor in
-            guard newState != connectButtonState else { return }
-            connectButtonState = newState
         }
     }
 }

--- a/nym-vpn-apple/Home/Sources/Home/HomeViewModel.swift
+++ b/nym-vpn-apple/Home/Sources/Home/HomeViewModel.swift
@@ -233,11 +233,11 @@ private extension HomeViewModel {
         setupUpdateRequiredObserver()
         setupGatewayManagerObserver()
         setupSystemMessageObservers()
+        setupIsMnemonicImportedObserver()
 
 #if os(iOS)
         setupConnectionErrorObservers()
         setupNetworkMonitorObservers()
-        setupIsMnemonicImportedObserver()
 #elseif os(macOS)
         setupGRPCManagerObservers()
 #endif
@@ -304,6 +304,18 @@ private extension HomeViewModel {
         }
         .store(in: &cancellables)
     }
+    
+    func setupIsMnemonicImportedObserver() {
+        appSettings.$isCredentialImportedPublisher
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                MainActor.assumeIsolated {
+                    self?.updateConnectButtonStateIfMnemonicImported()
+                }
+            }
+            .store(in: &cancellables)
+    }
 }
 
 extension HomeViewModel {
@@ -333,11 +345,7 @@ extension HomeViewModel {
                 hasInternet: networkMonitor.isAvailable,
                 subscriptionDidExpire: isLastErrorSubscriptionExpired()
             )
-            #if os(iOS)
             connectButtonState = ConnectButtonState(tunnelStatus: newStatus)
-            #elseif os(macOS)
-            updateConnectButtonStateIfMnemonicImported()
-            #endif
 
             if let lastError {
                 statusInfoState = .error(message: lastError.localizedDescription)


### PR DESCRIPTION
## Description

macOS's behavior on no credentials currently diverges from iOS. Update the macOS app to properly update the connect button to show 'Get started' when no credential has been imported.

Also removes an unused function

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

![Screenshot 2025-12-20 at 10 29 06 AM](https://github.com/user-attachments/assets/269b9c81-fac7-41fc-acf3-55ccbed32c2a)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4283)
<!-- Reviewable:end -->
