### PR TITLE
APPLE: Make StrokeBorderView title support variable width content better

### DIFF
--- a/nym-vpn-apple/Settings/Sources/Settings/Dns/DnsView.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/Dns/DnsView.swift
@@ -318,7 +318,6 @@ private extension DnsView {
     func dnsTextField() -> some View {
         StrokeBorderView(
             strokeTitle: "dns.textfield.title".localizedString,
-            strokeTitleLeftMargin: 60,
             isHovered: $isCustomDnsTextFieldHovered,
             strokeColor: viewModel.customDnsValidationError != nil
                 && !isCustomDnsTextFieldFocused

--- a/nym-vpn-apple/UIComponents/Sources/UIComponents/Buttons/HopButton/HopButton.swift
+++ b/nym-vpn-apple/UIComponents/Sources/UIComponents/Buttons/HopButton/HopButton.swift
@@ -118,7 +118,6 @@ public struct HopButton: View {
     public var body: some View {
         StrokeBorderView(
             strokeTitle: hopType.hopLocalizedTitle,
-            strokeTitleLeftMargin: 30,
             isHovered: $isButtonHovered
         ) {
             HStack(spacing: 0) {

--- a/nym-vpn-apple/UIComponents/Sources/UIComponents/Search/SearchView.swift
+++ b/nym-vpn-apple/UIComponents/Sources/UIComponents/Search/SearchView.swift
@@ -19,7 +19,6 @@ public struct SearchView: View {
     public var body: some View {
         StrokeBorderView(
             strokeTitle: strokeTitle,
-            strokeTitleLeftMargin: 40,
             isHovered: $isHovered
         ) {
             HStack {

--- a/nym-vpn-apple/UIComponents/Sources/UIComponents/StrokeBorderView/StrokeBorderView.swift
+++ b/nym-vpn-apple/UIComponents/Sources/UIComponents/StrokeBorderView/StrokeBorderView.swift
@@ -4,7 +4,6 @@ import Theme
 public struct StrokeBorderView<Content: View>: View {
     @ViewBuilder private let content: Content
     private let strokeTitle: String
-    private let strokeTitleLeftMargin: CGFloat
     private let strokeColor: Color
     private let backgroundColor: Color
     private let backgrounsColorHover: Color
@@ -13,7 +12,6 @@ public struct StrokeBorderView<Content: View>: View {
 
     public init(
         strokeTitle: String,
-        strokeTitleLeftMargin: CGFloat,
         isHovered: Binding<Bool>,
         strokeColor: Color = NymColor.gray2,
         backgroundColor: Color = NymColor.background,
@@ -21,7 +19,6 @@ public struct StrokeBorderView<Content: View>: View {
         @ViewBuilder content: () -> Content
     ) {
         self.strokeTitle = strokeTitle
-        self.strokeTitleLeftMargin = strokeTitleLeftMargin
         self.strokeColor = strokeColor
         self.backgroundColor = backgroundColor
         self.backgrounsColorHover = backgroundColorHover
@@ -42,17 +39,21 @@ public struct StrokeBorderView<Content: View>: View {
                 .stroke(strokeColor.opacity(isHovered ? 0.7 : 1), lineWidth: 1)
         }
         .overlay(alignment: .topLeading) {
-            Text(strokeTitle)
-                .foregroundStyle(NymColor.primary)
-                .textStyle(.Body.Small.regular)
-                .padding(.horizontal, 4)
-                .background(
-                    Rectangle()
-                        .fill(backgroundColor)
-                        .frame(height: 2)
-                )
-                .position(x: strokeTitleLeftMargin, y: 1)
-                .accessibilityHidden(true)
+            HStack {
+                Text(strokeTitle)
+                    .foregroundStyle(NymColor.primary)
+                    .textStyle(.Body.Small.regular)
+                    .padding(.horizontal, 4)
+                    .background(
+                        Rectangle()
+                            .fill(backgroundColor)
+                            .frame(height: 2)
+                    )
+                    .offset(x: 8, y: -7)
+                Spacer()
+            }
+            .frame(maxWidth: .infinity)
+            .accessibilityHidden(true)
         }
     }
 }


### PR DESCRIPTION
## Ticket

JIRA-VPN-XXXX

## Description

Longer content was pushing off to the left of this view. I've updated the view to better adapt to content width and even removed the need for specifying left margins for the various places this view is used.

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

![Screenshot 2025-12-20 at 3 30 17 PM](https://github.com/user-attachments/assets/da7422c8-03d8-4df4-bc01-8da0069834e8)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4285)
<!-- Reviewable:end -->
