### PR TITLE
macOS: fix IPv6 toggle

### DIFF
--- a/nym-vpn-apple/CHANGELOG.md
+++ b/nym-vpn-apple/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- macOS: fix IPv6 toggle not working
+
 ## [2.11.0]
 
 ### Added

--- a/nym-vpn-apple/Services/Sources/Services/AppSettings/AppSettings.swift
+++ b/nym-vpn-apple/Services/Sources/Services/AppSettings/AppSettings.swift
@@ -68,7 +68,9 @@ import CountriesManagerTypes
     public var isPassphraseStored: Bool = false
 
     @AppStorage(AppSettingKey.ipv6TrafficIsEnabled.rawValue)
-    public var isIPv6TrafficEnabled = true
+    public var isIPv6TrafficEnabled = true {
+        didSet { isIPv6TrafficEnabledPublisher = isIPv6TrafficEnabled }
+    }
 
     @AppStorage(AppSettingKey.lanBypass.rawValue)
     public var isLanBypassEnabled = false {
@@ -105,6 +107,7 @@ import CountriesManagerTypes
     @Published public var shouldReconnectPublisher: Bool
     @Published public var isCustomDnsEnabledPublisher: Bool
     @Published public var customDnsPublisher: [String]
+    @Published public var isIPv6TrafficEnabledPublisher: Bool
     @Published public var isLanBypassEnabledPublisher: Bool
 
     // Init ensures the *Publisher mirrors stored values* on launch.
@@ -115,6 +118,7 @@ import CountriesManagerTypes
         self.shouldReconnectPublisher = false
         self.isCustomDnsEnabledPublisher = false
         self.customDnsPublisher = []
+        self.isIPv6TrafficEnabledPublisher = true
         self.isLanBypassEnabledPublisher = false
 
         self.isErrorReportingOnPublisher = self.isErrorReportingOn
@@ -123,6 +127,7 @@ import CountriesManagerTypes
         self.shouldReconnectPublisher = self.shouldReconnect
         self.isCustomDnsEnabledPublisher = self.isCustomDnsEnabled
         self.customDnsPublisher = self.customDns
+        self.isIPv6TrafficEnabledPublisher = self.isIPv6TrafficEnabled
         self.isLanBypassEnabledPublisher = self.isLanBypassEnabled
     }
 }

--- a/nym-vpn-apple/Services/Sources/Services/ConnectionManager/ConnectionManager.swift
+++ b/nym-vpn-apple/Services/Sources/Services/ConnectionManager/ConnectionManager.swift
@@ -230,6 +230,14 @@ private extension ConnectionManager {
             }
             .store(in: &cancellables)
 
+        appSettings.$isIPv6TrafficEnabledPublisher
+            .removeDuplicates()
+            .sink { [weak self] newValue in
+                self?.connectionConfig.disableIpv6 = !newValue
+                self?.updateConnectionConfig()
+            }
+            .store(in: &cancellables)
+
         appSettings.$isLanBypassEnabledPublisher
             .removeDuplicates()
             .sink { [weak self] newValue in


### PR DESCRIPTION
## Ticket

JIRA-VPN-4796

## Description

It seems that IPv6 toggle has not been wired up. This PR fixes this.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4318)
<!-- Reviewable:end -->
