### PR TITLE
APPLE: Add visual separator for hop button on home screen if details arrow is visible

### DIFF
--- a/nym-vpn-apple/UIComponents/Sources/UIComponents/Buttons/HopButton/HopButton.swift
+++ b/nym-vpn-apple/UIComponents/Sources/UIComponents/Buttons/HopButton/HopButton.swift
@@ -123,6 +123,11 @@ public struct HopButton: View {
             HStack(spacing: 0) {
                 button().onHover { isButtonHovered = $0 }
                 if gatewayId != nil, gatewayManager.gateway(with: gatewayId, gatewayType: gatewayType) != nil {
+                    Divider()
+                        .frame(width: 1)
+                        .overlay(NymColor.gray2)
+                        .frame(maxHeight: .infinity)
+                        .padding(.vertical, 8)
                     accessory().onHover { isAccessoryHovered = $0 }
                 }
             }


### PR DESCRIPTION
## Ticket

JIRA-VPN-XXXX

## Description

Distinguish tappable areas on hop buttons

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

Not hovered
![Screenshot 2026-01-10 at 2 36 33 PM](https://github.com/user-attachments/assets/c9b8a363-9c54-43a4-9dd3-cf92d1726c59)

Hovered
![Screenshot 2026-01-10 at 2 36 40 PM](https://github.com/user-attachments/assets/7e0f23e1-68d7-4f1a-9ad5-d1434eceae03)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4339)
<!-- Reviewable:end -->
