### PR TITLE
android: bypass local dns servers

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix discovery propagation bug (https://github.com/nymtech/nym-vpn-client/pull/4226)
 - Ensure that vpn topology is refreshed periodically when connecting (https://github.com/nymtech/nym-vpn-client/pull/4228)
-- [Android]: bypass local DNS servers (https://github.com/nymtech/nym-vpn-client/pull/XXX)
+- [Android] Bypass local DNS servers (https://github.com/nymtech/nym-vpn-client/pull/4347)
 
 ### Removed
 - Removed credentials mode feature flag from code base (https://github.com/nymtech/nym-vpn-client/pull/4223)

--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix discovery propagation bug (https://github.com/nymtech/nym-vpn-client/pull/4226)
 - Ensure that vpn topology is refreshed periodically when connecting (https://github.com/nymtech/nym-vpn-client/pull/4228)
+- [Android]: bypass local DNS servers (https://github.com/nymtech/nym-vpn-client/pull/XXX)
 
 ### Removed
 - Removed credentials mode feature flag from code base (https://github.com/nymtech/nym-vpn-client/pull/4223)

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -4395,6 +4395,7 @@ dependencies = [
  "nix 0.30.1",
  "nym-common",
  "nym-dns",
+ "nym-firewall-config",
  "nym-platform-metadata",
  "pfctl",
  "thiserror 2.0.17",
@@ -4402,6 +4403,13 @@ dependencies = [
  "widestring",
  "windows 0.62.2",
  "wmi",
+]
+
+[[package]]
+name = "nym-firewall-config"
+version = "1.23.0-beta"
+dependencies = [
+ "ipnetwork",
 ]
 
 [[package]]
@@ -5554,6 +5562,7 @@ dependencies = [
  "nym-crypto",
  "nym-dns",
  "nym-firewall",
+ "nym-firewall-config",
  "nym-gateway-directory",
  "nym-http-api-client",
  "nym-ip-packet-client",
@@ -5635,6 +5644,7 @@ dependencies = [
  "log",
  "nym-bin-common",
  "nym-common",
+ "nym-firewall-config",
  "nym-gateway-directory",
  "nym-http-api-client",
  "nym-offline-monitor",

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -31,6 +31,7 @@ members = [
     "crates/uniffi-bindgen",
     "crates/nym-vpn-lib-uniffi",
     "crates/nym-vpn-rpc-uniffi",
+    "crates/nym-firewall-config",
 ]
 
 default-members = [
@@ -185,6 +186,7 @@ nym-connection-monitor = { path = "crates/nym-connection-monitor" }
 nym-dbus = { path = "crates/nym-dbus" }
 nym-dns = { path = "crates/nym-dns" }
 nym-firewall = { path = "crates/nym-firewall" }
+nym-firewall-config = { path = "crates/nym-firewall-config" }
 nym-gateway-directory = { path = "crates/nym-gateway-directory" }
 nym-ipc = { path = "crates/nym-ipc" }
 nym-macos = { path = "crates/nym-macos" }

--- a/nym-vpn-core/crates/nym-firewall-config/Cargo.toml
+++ b/nym-vpn-core/crates/nym-firewall-config/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "nym-firewall-config"
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+ipnetwork.workspace = true
+
+[lints]
+workspace = true

--- a/nym-vpn-core/crates/nym-firewall-config/src/lib.rs
+++ b/nym-vpn-core/crates/nym-firewall-config/src/lib.rs
@@ -1,0 +1,63 @@
+// Copyright 2025 Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use std::{
+    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    sync::LazyLock,
+};
+
+use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
+
+/// When "allow local network" is enabled the app will allow traffic to and from these networks.
+pub static ALLOWED_LAN_NETS: LazyLock<[IpNetwork; 6]> = LazyLock::new(|| {
+    [
+        IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(10, 0, 0, 0), 8).unwrap()),
+        IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(172, 16, 0, 0), 12).unwrap()),
+        IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(192, 168, 0, 0), 16).unwrap()),
+        IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(169, 254, 0, 0), 16).unwrap()),
+        IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 0), 10).unwrap()),
+        IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xfc00, 0, 0, 0, 0, 0, 0, 0), 7).unwrap()),
+    ]
+});
+
+/// When "allow local network" is enabled the app will allow traffic to these networks.
+#[cfg_attr(
+    any(target_os = "windows", target_os = "android", target_os = "ios"),
+    allow(unused)
+)]
+pub static ALLOWED_LAN_MULTICAST_NETS: LazyLock<[IpNetwork; 8]> = LazyLock::new(|| {
+    [
+        // Local network broadcast. Not routable
+        IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(255, 255, 255, 255), 32).unwrap()),
+        // Local subnetwork multicast. Not routable
+        IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(224, 0, 0, 0), 24).unwrap()),
+        // Admin-local IPv4 multicast.
+        IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(239, 0, 0, 0), 8).unwrap()),
+        // Interface-local IPv6 multicast.
+        IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xff01, 0, 0, 0, 0, 0, 0, 0), 16).unwrap()),
+        // Link-local IPv6 multicast. IPv6 equivalent of 224.0.0.0/24
+        IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 0), 16).unwrap()),
+        // Realm-local IPv6 multicast.
+        IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xff03, 0, 0, 0, 0, 0, 0, 0), 16).unwrap()),
+        // Admin-local IPv6 multicast.
+        IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xff04, 0, 0, 0, 0, 0, 0, 0), 16).unwrap()),
+        // Site-local IPv6 multicast.
+        IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xff05, 0, 0, 0, 0, 0, 0, 0), 16).unwrap()),
+    ]
+});
+
+static LOOPBACK_NETS: LazyLock<[IpNetwork; 2]> = LazyLock::new(|| {
+    [
+        IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(127, 0, 0, 0), 8).unwrap()),
+        IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 128).unwrap()),
+    ]
+});
+
+/// Returns whether an address belongs to a private subnet.
+pub fn is_local_address(address: &IpAddr) -> bool {
+    let address = *address;
+    (*ALLOWED_LAN_NETS)
+        .iter()
+        .chain(&*LOOPBACK_NETS)
+        .any(|net| net.contains(address))
+}

--- a/nym-vpn-core/crates/nym-firewall/Cargo.toml
+++ b/nym-vpn-core/crates/nym-firewall/Cargo.toml
@@ -19,6 +19,7 @@ tracing.workspace = true
 
 nym-dns.workspace = true
 nym-common.workspace = true
+nym-firewall-config.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 pfctl.workspace = true

--- a/nym-vpn-core/crates/nym-firewall/src/lib.rs
+++ b/nym-vpn-core/crates/nym-firewall/src/lib.rs
@@ -4,11 +4,11 @@
 use std::{
     borrow::Cow,
     fmt,
-    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    net::{IpAddr, Ipv6Addr},
     sync::LazyLock,
 };
 
-use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
+use ipnetwork::Ipv6Network;
 #[cfg(not(target_os = "android"))]
 use nym_dns::ResolvedDnsConfig;
 
@@ -34,7 +34,6 @@ mod imp;
 
 mod net;
 mod split_tunnel;
-use net::ALLOWED_LAN_NETS;
 pub use net::{
     AllowedClients, AllowedEndpoint, AllowedTunnelTraffic, Endpoint, TransportProtocol,
     TunnelInterface, TunnelMetadata,
@@ -60,12 +59,6 @@ static ROUTER_SOLICITATION_OUT_DST_ADDR: LazyLock<Ipv6Addr> =
 static SOLICITED_NODE_MULTICAST: LazyLock<Ipv6Network> = LazyLock::new(|| {
     Ipv6Network::new(Ipv6Addr::new(0xff02, 0, 0, 0, 0, 1, 0xFF00, 0), 104).unwrap()
 });
-static LOOPBACK_NETS: LazyLock<[IpNetwork; 2]> = LazyLock::new(|| {
-    [
-        IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(127, 0, 0, 0), 8).unwrap()),
-        IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 128).unwrap()),
-    ]
-});
 
 #[cfg(all(unix, not(any(target_os = "android", target_os = "ios"))))]
 const DHCPV4_SERVER_PORT: u16 = 67;
@@ -85,15 +78,6 @@ const ROOT_UID: u32 = 0;
 /// Allowed TCP ports to DNS servers when connecting.
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 const DNS_TCP_PORTS: [u16; 2] = [443, 853];
-
-/// Returns whether an address belongs to a private subnet.
-pub fn is_local_address(address: &IpAddr) -> bool {
-    let address = *address;
-    (*ALLOWED_LAN_NETS)
-        .iter()
-        .chain(&*LOOPBACK_NETS)
-        .any(|net| net.contains(address))
-}
 
 /// A enum that describes network security strategy
 ///

--- a/nym-vpn-core/crates/nym-firewall/src/lib.rs
+++ b/nym-vpn-core/crates/nym-firewall/src/lib.rs
@@ -1,13 +1,11 @@
 // Copyright 2025 Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{
-    borrow::Cow,
-    fmt,
-    net::{IpAddr, Ipv6Addr},
-    sync::LazyLock,
-};
+use std::{borrow::Cow, fmt, net::IpAddr};
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+use std::{net::Ipv6Addr, sync::LazyLock};
 
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 use ipnetwork::Ipv6Network;
 #[cfg(not(target_os = "android"))]
 use nym_dns::ResolvedDnsConfig;

--- a/nym-vpn-core/crates/nym-firewall/src/linux.rs
+++ b/nym-vpn-core/crates/nym-firewall/src/linux.rs
@@ -20,12 +20,10 @@ use nix::net::if_::if_nametoindex;
 
 use super::{
     FirewallArguments, FirewallPolicy,
-    net::{
-        ALLOWED_LAN_MULTICAST_NETS, ALLOWED_LAN_NETS, AllowedEndpoint, AllowedTunnelTraffic,
-        Endpoint, TransportProtocol, TunnelMetadata,
-    },
+    net::{AllowedEndpoint, AllowedTunnelTraffic, Endpoint, TransportProtocol, TunnelMetadata},
     split_tunnel,
 };
+use nym_firewall_config::{ALLOWED_LAN_MULTICAST_NETS, ALLOWED_LAN_NETS};
 
 use crate::{AllowedClients, DNS_TCP_PORTS, TunnelInterface};
 

--- a/nym-vpn-core/crates/nym-firewall/src/macos.rs
+++ b/nym-vpn-core/crates/nym-firewall/src/macos.rs
@@ -12,13 +12,13 @@ use std::{
 
 use ipnetwork::IpNetwork;
 use libc::{c_int, sysctlbyname};
+use nym_firewall_config::{ALLOWED_LAN_MULTICAST_NETS, ALLOWED_LAN_NETS};
 use pfctl::{DropAction, FilterRuleAction, Ip, Uid};
 
 use super::{
     DNS_TCP_PORTS, FirewallArguments, FirewallPolicy,
     net::{
-        ALLOWED_LAN_MULTICAST_NETS, ALLOWED_LAN_NETS, AllowedEndpoint, AllowedTunnelTraffic,
-        TransportProtocol, TunnelInterface, TunnelMetadata,
+        AllowedEndpoint, AllowedTunnelTraffic, TransportProtocol, TunnelInterface, TunnelMetadata,
     },
 };
 

--- a/nym-vpn-core/crates/nym-firewall/src/net.rs
+++ b/nym-vpn-core/crates/nym-firewall/src/net.rs
@@ -8,47 +8,7 @@ use std::{
     fmt,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     str::FromStr,
-    sync::LazyLock,
 };
-
-use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
-
-/// When "allow local network" is enabled the app will allow traffic to and from these networks.
-pub static ALLOWED_LAN_NETS: LazyLock<[IpNetwork; 6]> = LazyLock::new(|| {
-    [
-        IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(10, 0, 0, 0), 8).unwrap()),
-        IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(172, 16, 0, 0), 12).unwrap()),
-        IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(192, 168, 0, 0), 16).unwrap()),
-        IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(169, 254, 0, 0), 16).unwrap()),
-        IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 0), 10).unwrap()),
-        IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xfc00, 0, 0, 0, 0, 0, 0, 0), 7).unwrap()),
-    ]
-});
-/// When "allow local network" is enabled the app will allow traffic to these networks.
-#[cfg_attr(
-    any(target_os = "windows", target_os = "android", target_os = "ios"),
-    allow(unused)
-)]
-pub static ALLOWED_LAN_MULTICAST_NETS: LazyLock<[IpNetwork; 8]> = LazyLock::new(|| {
-    [
-        // Local network broadcast. Not routable
-        IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(255, 255, 255, 255), 32).unwrap()),
-        // Local subnetwork multicast. Not routable
-        IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(224, 0, 0, 0), 24).unwrap()),
-        // Admin-local IPv4 multicast.
-        IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(239, 0, 0, 0), 8).unwrap()),
-        // Interface-local IPv6 multicast.
-        IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xff01, 0, 0, 0, 0, 0, 0, 0), 16).unwrap()),
-        // Link-local IPv6 multicast. IPv6 equivalent of 224.0.0.0/24
-        IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 0), 16).unwrap()),
-        // Realm-local IPv6 multicast.
-        IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xff03, 0, 0, 0, 0, 0, 0, 0), 16).unwrap()),
-        // Admin-local IPv6 multicast.
-        IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xff04, 0, 0, 0, 0, 0, 0, 0), 16).unwrap()),
-        // Site-local IPv6 multicast.
-        IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xff05, 0, 0, 0, 0, 0, 0, 0), 16).unwrap()),
-    ]
-});
 
 /// What [`Endpoint`]s to allow the client to send traffic to and receive from.
 ///

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/Cargo.toml
@@ -66,6 +66,7 @@ tracing-oslog.workspace = true
 android_logger.workspace = true
 log.workspace = true
 rand.workspace = true
+nym-firewall-config.workspace = true
 
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/tunnel_provider/tunnel_settings.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/tunnel_provider/tunnel_settings.rs
@@ -129,8 +129,9 @@ impl From<nym_vpn_lib::tunnel_provider::TunnelSettings> for TunnelNetworkSetting
     fn from(settings: nym_vpn_lib::tunnel_provider::TunnelSettings) -> Self {
         let (interface_addrs_ipv4, interface_addrs_ipv6) =
             Self::split_ipnet_addrs(settings.interface_addresses);
-        let (bypass_addrs_ipv4, bypass_addrs_ipv6) =
-            Self::split_ipnet_addrs(Self::bypass_addresses(settings.remote_addresses));
+        let (bypass_addrs_ipv4, bypass_addrs_ipv6) = Self::split_ipnet_addrs(
+            Self::bypass_addresses(&settings.remote_addresses, &settings.dns_servers),
+        );
 
         let ipv4_settings = if interface_addrs_ipv4.is_empty() {
             None
@@ -216,15 +217,27 @@ impl TunnelNetworkSettings {
     }
 
     #[cfg(target_os = "ios")]
-    fn bypass_addresses(_remote_addresses: Vec<IpAddr>) -> Vec<IpNetwork> {
+    fn bypass_addresses(_remote_addresses: &[IpAddr], _dns_servers: &[IpAddr]) -> Vec<IpNetwork> {
         // Do not bypass remote addresses since connections initiated within the packet tunnel
         // bypass the tunnel interface anyway.
         vec![]
     }
 
     #[cfg(target_os = "android")]
-    fn bypass_addresses(remote_addresses: Vec<IpAddr>) -> Vec<IpNetwork> {
-        remote_addresses.into_iter().map(IpNetwork::from).collect()
+    fn bypass_addresses(remote_addresses: &[IpAddr], dns_servers: &[IpAddr]) -> Vec<IpNetwork> {
+        // Allow local DNS servers to escape the tunnel since local DNS cannot be routed over the tunnel.
+        let local_dns_servers = dns_servers
+            .iter()
+            .filter(|addr| nym_firewall_config::is_local_address(addr))
+            .copied()
+            .collect::<Vec<_>>();
+
+        remote_addresses
+            .iter()
+            .copied()
+            .chain(local_dns_servers)
+            .map(IpNetwork::from)
+            .collect()
     }
 
     fn split_ipnet_addrs(ipnet_addrs: Vec<IpNetwork>) -> (Vec<Ipv4Network>, Vec<Ipv6Network>) {

--- a/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
@@ -109,12 +109,14 @@ nym-windows.workspace = true
 nym-routing.workspace = true
 nym-dns.workspace = true
 nym-firewall.workspace = true
+nym-firewall-config.workspace = true
 
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 hickory-server = { workspace = true, features = ["resolver"] }
 nym-routing.workspace = true
 nym-dns.workspace = true
 nym-firewall.workspace = true
+nym-firewall-config.workspace = true
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_logger.workspace = true

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -364,7 +364,7 @@ impl DnsOptions {
                     let (non_tunnel_config, tunnel_config): (Vec<_>, Vec<_>) = addrs
                         .iter()
                         // Private IP ranges should not be tunneled
-                        .partition(|&addr| nym_firewall::is_local_address(addr));
+                        .partition(|&addr| nym_firewall_config::is_local_address(addr));
                     DnsConfig::from_addresses(&tunnel_config, &non_tunnel_config)
                 }
             }


### PR DESCRIPTION
## Ticket

JIRA-VPN-4801

## Description

- Move code related to detecting local IP addresses to `nym-firewall-config` in order to share it between crates
- Android: bypass custom DNS for local IPs. It goes without saying that we can't guarantee that local DNS servers don't fingerprint user activity in some way.

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4347)
<!-- Reviewable:end -->
