### PR TITLE
Mark SpecificGatewayError with #[source]

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
@@ -32,10 +32,10 @@ const DEFAULT_CLIENT_RETRIES: usize = 1;
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("entry gateway error")]
-    EntryGateway(SpecificGatewayError),
+    EntryGateway(#[source] SpecificGatewayError),
 
     #[error("exit gateway error")]
-    ExitGateway(SpecificGatewayError),
+    ExitGateway(#[source] SpecificGatewayError),
 
     #[error("nyxd client error")]
     Nyxd(#[from] CredentialNyxdClientError),


### PR DESCRIPTION


## Description

We received some logs that end abruptly at:

```
libnymvpn: nym_vpn_lib::tunnel_state_machine::tunnel_monitor: Error: Tunnel monitor exited with error
libnymvpn: Caused by: tunnel error
libnymvpn: Caused by: bandwidth controller error
libnymvpn: Caused by: entry gateway error
```

Let's print the underlying gateway error too so we can get to the bottom of it.


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4355)
<!-- Reviewable:end -->
