### PR TITLE
VPN-4615: Replace "mnemonic" and "access code" by "passphrase".

### DIFF
--- a/nym-vpn-app/src-tauri/src/vpnd/client.rs
+++ b/nym-vpn-app/src-tauri/src/vpnd/client.rs
@@ -35,7 +35,7 @@ use crate::{
     error::BackendError,
     events::AppHandleEventEmitter,
     state::SharedAppState,
-    vpnd::account::{AccountState, log_account_state},
+    vpnd::account::{log_account_state, AccountState},
 };
 
 #[derive(Debug, Clone)]
@@ -431,7 +431,7 @@ impl VpndClient {
             },
             _ => {
                 return Err(VpndError::Response(BackendError::internal(
-                    "either mnemonic or signature must be provided",
+                    "either passphrase or signature must be provided",
                     None,
                 )));
             }

--- a/nym-vpn-app/src-tauri/src/vpnd/client.rs
+++ b/nym-vpn-app/src-tauri/src/vpnd/client.rs
@@ -35,7 +35,7 @@ use crate::{
     error::BackendError,
     events::AppHandleEventEmitter,
     state::SharedAppState,
-    vpnd::account::{log_account_state, AccountState},
+    vpnd::account::{AccountState, log_account_state},
 };
 
 #[derive(Debug, Clone)]

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/account/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/account/mod.rs
@@ -66,7 +66,7 @@ pub enum AccountCommandError {
     #[error("failed to obtain zk-nym: {0}")]
     ZkNymAcquisitionFailure(String),
 
-    #[error("invalid mnemonic: {0}")]
+    #[error("invalid passphrase: {0}")]
     InvalidMnemonic(String),
 
     #[error("invalid secret: {0}")]

--- a/nym-vpn-core/crates/nym-vpn-store/src/account/ephemeral.rs
+++ b/nym-vpn-core/crates/nym-vpn-store/src/account/ephemeral.rs
@@ -12,10 +12,10 @@ pub struct InMemoryAccountStorage {
 
 #[derive(Debug, thiserror::Error)]
 pub enum InMemoryAccountStorageError {
-    #[error("no mnemonic stored")]
+    #[error("no passphrase stored")]
     NoMnemonicStored,
 
-    #[error("mnemonic already stored")]
+    #[error("passphrase already stored")]
     MnemonicAlreadyStored,
 }
 


### PR DESCRIPTION
## Ticket

JIRA-VPN-4615

## Description

Replace "mnemonic" and "access code" by "passphrase".


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4376)
<!-- Reviewable:end -->
