### PR TITLE
Enable debug logs for Android

### DIFF
--- a/nym-vpn-android/core/src/main/java/net/nymtech/vpn/util/Constants.kt
+++ b/nym-vpn-android/core/src/main/java/net/nymtech/vpn/util/Constants.kt
@@ -6,7 +6,7 @@ object Constants {
 	// Add Rust environment vars for lib
 	const val DEFAULT_COUNTRY_ISO = "FR"
 
-	const val LOG_LEVEL = "info"
+	const val LOG_LEVEL = "debug"
 
 	const val STATISTICS_INTERVAL_MILLI = 1_000L
 }

--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - Removed credentials mode feature flag from code base (https://github.com/nymtech/nym-vpn-client/pull/4223)
 
+### Changed
+- [Android] Enable debug logs in production builds for core library (https://github.com/nymtech/nym-vpn-client/pull/4405)
+
 ## [1.21.0] - 2025-12-15
 
 ### Added


### PR DESCRIPTION
## Ticket

JIRA-NYM-147

## Description

Always enable the debug logs on Android's Rust library.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4405)
<!-- Reviewable:end -->
