### PR TITLE
Enable debug logging by default on desktop

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - [Android] Enable debug logs in production builds for core library (https://github.com/nymtech/nym-vpn-client/pull/4405)
+- Enable debug logs by default for desktop platforms (https://github.com/nymtech/nym-vpn-client/pull/4443) 
 
 ## [1.21.0] - 2025-12-15
 

--- a/nym-vpn-core/crates/nym-vpnd/src/cli.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/cli.rs
@@ -39,7 +39,7 @@ pub struct CliArgs {
 impl CliArgs {
     pub fn verbosity_level(&self) -> tracing::Level {
         match self.verbose {
-            0 => tracing::Level::INFO,
+            0 => tracing::Level::DEBUG,
             1 => tracing::Level::DEBUG,
             _ => tracing::Level::TRACE,
         }


### PR DESCRIPTION
## Ticket

JIRA-NYM-321

## Description

As we want to extract more information from logs, we set the default log level to DEBUG on desktop, where storage should be less constrained.


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4443)
<!-- Reviewable:end -->
