### PR TITLE
Fix and invalidate gateway cache and API clients on network environnt switch

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix discovery propagation bug (https://github.com/nymtech/nym-vpn-client/pull/4226)
 - Ensure that vpn topology is refreshed periodically when connecting (https://github.com/nymtech/nym-vpn-client/pull/4228)
 - [Android] Bypass local DNS servers (https://github.com/nymtech/nym-vpn-client/pull/4347)
+- Fix environment switcher failing to update gateway cache and API clients when switching between environments (https://github.com/nymtech/nym-vpn-client/pull/4464)
+
 
 ### Removed
 - Removed credentials mode feature flag from code base (https://github.com/nymtech/nym-vpn-client/pull/4223)

--- a/nym-vpn-core/crates/nym-gateway-directory/src/gateway_cache.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/gateway_cache.rs
@@ -67,9 +67,16 @@ impl GatewayCacheHandle {
         rx.await.map_err(|_| Error::Cancelled)?
     }
 
-    pub fn replace_gateway_client(&mut self, gateway_client: GatewayClient) -> Result<()> {
+    pub fn replace_gateway_client(&self, gateway_client: GatewayClient) -> Result<()> {
         self.tx
             .send(Command::ReplaceGatewayClient(Box::new(gateway_client)))
+            .map_err(|_| Error::Cancelled)
+    }
+
+    /// Clear all cached gateway data. This should be called when the network environment changes.
+    pub fn clear_cache(&self) -> Result<()> {
+        self.tx
+            .send(Command::ClearCache)
             .map_err(|_| Error::Cancelled)
     }
 
@@ -100,6 +107,7 @@ enum Command {
     ),
     LookupNymNodeByIdentity(NodeIdentity, tokio::sync::oneshot::Sender<Result<NymNode>>),
     ReplaceGatewayClient(Box<GatewayClient>),
+    ClearCache,
 }
 
 pub struct GatewayCache {
@@ -174,6 +182,9 @@ impl GatewayCache {
                         Command::ReplaceGatewayClient(gateway_client) => {
                             self.replace_gateway_client(*gateway_client)
                         }
+                        Command::ClearCache => {
+                            self.clear_cache();
+                        }
                     }
                 }
                 Some(status) = self.connectivity_handle.next() => {
@@ -207,6 +218,14 @@ impl GatewayCache {
             self.cached_gateways.clear();
             self.cached_nymnodes = None;
         }
+    }
+
+    fn clear_cache(&mut self) {
+        tracing::debug!("Clearing gateway cache due to environment change");
+        self.cached_gateways.clear();
+        self.cached_nymnodes = None;
+        // Reset the initial refresh flag so we fetch fresh data
+        self.is_performed_initial_refresh = false;
     }
 
     async fn refresh_all(&mut self) {

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/gateway_cache.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/gateway_cache.rs
@@ -118,3 +118,40 @@ pub async fn stop_gateway_cache() -> Result<(), VpnError> {
         }),
     }
 }
+
+/// Clear the gateway cache and update it for the new environment.
+/// This should be called when the network environment changes.
+#[allow(dead_code)]
+pub async fn refresh_gateway_cache_for_environment(
+    user_agent: UserAgent,
+    _connectivity_handle: ConnectivityHandle,
+) -> Result<(), VpnError> {
+    let guard = GATEWAY_CACHE.lock().await;
+    match guard.as_ref() {
+        Some(cache_handle) => {
+            // Clear the cache
+            cache_handle
+                .inner()
+                .clear_cache()
+                .map_err(VpnError::internal)?;
+
+            // Create new gateway config for current environment
+            let new_directory_config = make_gateway_config().await?;
+            let new_gateway_client = GatewayClient::new(new_directory_config, user_agent.into())
+                .await
+                .map_err(VpnError::internal)?;
+
+            // Replace the gateway client (this will also clear cache if performance config changed)
+            cache_handle
+                .inner()
+                .replace_gateway_client(new_gateway_client)
+                .map_err(VpnError::internal)?;
+
+            tracing::info!("Gateway cache refreshed for new environment");
+            Ok(())
+        }
+        None => Err(VpnError::InvalidStateError {
+            details: "Gateway cache is not initialized".to_owned(),
+        }),
+    }
+}

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/state_machine.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/state_machine.rs
@@ -25,6 +25,7 @@ use tokio::{
 use tokio_util::sync::CancellationToken;
 
 use crate::gateway_cache;
+use nym_gateway_directory::{Config as GatewayConfig, GatewayClient};
 
 use super::{STATE_MACHINE_HANDLE, VPNConfig, error::VpnError};
 
@@ -177,6 +178,7 @@ pub(super) async fn start_state_machine(
     })?;
 
     let discovery_watch_token = shutdown_token.child_token();
+    let user_agent_clone = user_agent.clone();
     let discovery_watch_handle = tokio::spawn(async move {
         loop {
             tokio::select! {
@@ -184,7 +186,51 @@ pub(super) async fn start_state_machine(
                     match event {
                         DiscoveryRefresherEvent::NewNetwork(new_network) => {
                             tracing::info!("Network environment updated");
-                            let _ = network_tx.send_replace(new_network);
+                            let _ = network_tx.send_replace(new_network.clone());
+
+                            // Refresh gateway cache for new environment
+                            if let Ok(cache_handle) = gateway_cache::get_gateway_cache_handle().await {
+                                // Clear the cache
+                                if let Err(e) = cache_handle.clear_cache() {
+                                    tracing::warn!("Failed to clear gateway cache on environment change: {e}");
+                                }
+
+                                // Create new gateway client for the new environment
+                                let nyxd_url = new_network.nyxd_url();
+                                let nym_api_urls = new_network.nym_api_urls().unwrap_or_default();
+                                let nym_vpn_api_urls = new_network.nym_vpn_api_urls().unwrap_or_default();
+
+                                let gateway_config = match GatewayConfig::new(
+                                    nyxd_url,
+                                    nym_api_urls,
+                                    nym_vpn_api_urls,
+                                    None,
+                                ) {
+                                    Ok(config) => config,
+                                    Err(e) => {
+                                        tracing::error!("Failed to create gateway config for new environment: {e}");
+                                        continue;
+                                    }
+                                };
+
+                                let new_gateway_client = match GatewayClient::new(
+                                    gateway_config,
+                                    user_agent_clone.clone(),
+                                ).await {
+                                    Ok(client) => client,
+                                    Err(e) => {
+                                        tracing::error!("Failed to create gateway client for new environment: {e}");
+                                        continue;
+                                    }
+                                };
+
+                                // Replace the gateway client in the cache
+                                if let Err(e) = cache_handle.replace_gateway_client(new_gateway_client) {
+                                    tracing::warn!("Failed to replace gateway client on environment change: {e}");
+                                } else {
+                                    tracing::info!("Gateway cache updated for new environment");
+                                }
+                            }
                         }
                         DiscoveryRefresherEvent::Error(_error) => {
                             // todo: handle error?

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/state_machine.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/state_machine.rs
@@ -185,14 +185,27 @@ pub(super) async fn start_state_machine(
                 Some(event) = discovery_refresher_event_rx.recv() => {
                     match event {
                         DiscoveryRefresherEvent::NewNetwork(new_network) => {
-                            tracing::info!("Network environment updated");
+                            let network_name = &new_network.nym_network.network.network_name;
+                            tracing::info!(
+                                network = %network_name,
+                                "Network environment updated"
+                            );
                             let _ = network_tx.send_replace(new_network.clone());
 
                             // Refresh gateway cache for new environment
                             if let Ok(cache_handle) = gateway_cache::get_gateway_cache_handle().await {
+                                tracing::info!(
+                                    network = %network_name,
+                                    "Updating gateway cache for network environment change"
+                                );
+
                                 // Clear the cache
                                 if let Err(e) = cache_handle.clear_cache() {
-                                    tracing::warn!("Failed to clear gateway cache on environment change: {e}");
+                                    tracing::warn!(
+                                        network = %network_name,
+                                        error = %e,
+                                        "Failed to clear gateway cache on environment change"
+                                    );
                                 }
 
                                 // Create new gateway client for the new environment
@@ -200,15 +213,37 @@ pub(super) async fn start_state_machine(
                                 let nym_api_urls = new_network.nym_api_urls().unwrap_or_default();
                                 let nym_vpn_api_urls = new_network.nym_vpn_api_urls().unwrap_or_default();
 
+                                // Validate that we have the necessary URLs
+                                if nym_vpn_api_urls.is_empty() {
+                                    tracing::error!(
+                                        network = %network_name,
+                                        "No VPN API URLs available for new environment, cannot update gateway cache"
+                                    );
+                                    continue;
+                                }
+
+                                if nym_api_urls.is_empty() {
+                                    tracing::warn!(
+                                        network = %network_name,
+                                        "No Nym API URLs available for new environment"
+                                    );
+                                }
+
                                 let gateway_config = match GatewayConfig::new(
                                     nyxd_url,
-                                    nym_api_urls,
-                                    nym_vpn_api_urls,
+                                    nym_api_urls.clone(),
+                                    nym_vpn_api_urls.clone(),
                                     None,
                                 ) {
                                     Ok(config) => config,
                                     Err(e) => {
-                                        tracing::error!("Failed to create gateway config for new environment: {e}");
+                                        tracing::error!(
+                                            network = %network_name,
+                                            error = %e,
+                                            vpn_api_urls = ?nym_vpn_api_urls,
+                                            nym_api_urls = ?nym_api_urls,
+                                            "Failed to create gateway config for new environment"
+                                        );
                                         continue;
                                     }
                                 };
@@ -219,16 +254,27 @@ pub(super) async fn start_state_machine(
                                 ).await {
                                     Ok(client) => client,
                                     Err(e) => {
-                                        tracing::error!("Failed to create gateway client for new environment: {e}");
+                                        tracing::error!(
+                                            network = %network_name,
+                                            error = %e,
+                                            "Failed to create gateway client for new environment"
+                                        );
                                         continue;
                                     }
                                 };
 
                                 // Replace the gateway client in the cache
                                 if let Err(e) = cache_handle.replace_gateway_client(new_gateway_client) {
-                                    tracing::warn!("Failed to replace gateway client on environment change: {e}");
+                                    tracing::warn!(
+                                        network = %network_name,
+                                        error = %e,
+                                        "Failed to replace gateway client on environment change"
+                                    );
                                 } else {
-                                    tracing::info!("Gateway cache updated for new environment");
+                                    tracing::info!(
+                                        network = %network_name,
+                                        "Gateway cache successfully updated for new environment"
+                                    );
                                 }
                             }
                         }

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/discovery.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/discovery.rs
@@ -119,7 +119,17 @@ impl Discovery {
         let path = Self::path(config_dir, network_name);
         tracing::debug!("Reading discovery file from: {}", path.display());
 
-        crate::serialization::deserialize_from_json_file(path)
+        let discovery: Self = crate::serialization::deserialize_from_json_file(path)?;
+
+        // Verify the discovery file matches the expected network name
+        if discovery.network_name != network_name {
+            return Err(Error::NetworkNameMismatch {
+                expected: network_name.to_owned(),
+                actual: discovery.network_name,
+            });
+        }
+
+        Ok(discovery)
     }
 
     pub(super) fn write_to_file(
@@ -143,53 +153,111 @@ impl Discovery {
 
     pub(super) async fn ensure_exists(config_dir: &Path, network_name: &str) -> Result<Self> {
         match Self::read_from_file(config_dir, network_name) {
-            Ok(discovery) => Ok(discovery),
+            Ok(discovery) => {
+                // Verify the discovery we read matches the expected network
+                if discovery.network_name != network_name {
+                    tracing::warn!(
+                        "Discovery file has wrong network name: expected '{}', found '{}'. Will recreate.",
+                        network_name,
+                        discovery.network_name
+                    );
+                    // Fall through to recreate the file
+                } else {
+                    return Ok(discovery);
+                }
+            }
             Err(e) if e.should_overwrite_file() => {
                 if e.is_file_not_found() {
                     tracing::debug!("No discovery file found, creating a new discovery file");
                 } else {
                     trace_err_chain!(e, "Failed to read discovery file");
                 }
-
-                let client = Self::create_client(None).await?;
-
-                match Self::fetch(&client, network_name).await {
-                    Ok(discovery) => {
-                        discovery
-                            .write_to_file(config_dir, None)
-                            .inspect_err(|err| {
-                                trace_err_chain!(err, "Failed to write discovery file");
-                            })?;
-                        Ok(discovery)
-                    }
-                    Err(e) => match Self::default_discovery(network_name) {
-                        Some(default_discovery) => {
-                            tracing::warn!(
-                                "Failed to fetch remote discovery file: {e}, creating a default one"
-                            );
-                            // Ensure that discovery cache created from default discovery is always considered stale.
-                            let modified_at = SystemTime::now().checked_sub(MAX_FILE_AGE);
-
-                            default_discovery
-                                .write_to_file(config_dir, modified_at)
-                                .inspect_err(|err| {
-                                    trace_err_chain!(err, "Failed to write default discovery file");
-                                })?;
-                            Ok(default_discovery)
-                        }
-                        None => {
-                            tracing::error!(
-                                "No default discovery available for {network_name} environment"
-                            );
-                            Err(e)
-                        }
-                    },
-                }
             }
             Err(e) => {
                 trace_err_chain!(e, "Failed to read discovery file");
-                Err(e)
+                return Err(e);
             }
+        }
+
+        // For non-mainnet networks, prefer using default discovery to avoid fetching from wrong API
+        // Only try to fetch from network for mainnet, or if we have a way to fetch for the specific network
+        if network_name != "mainnet"
+            && let Some(default_discovery) = Self::default_discovery(network_name)
+        {
+            tracing::info!(
+                "Using default discovery for network '{}' (non-mainnet networks should use defaults)",
+                network_name
+            );
+            // Ensure that discovery cache created from default discovery is always considered stale.
+            let modified_at = SystemTime::now().checked_sub(MAX_FILE_AGE);
+
+            default_discovery
+                .clone()
+                .write_to_file(config_dir, modified_at)
+                .inspect_err(|err| {
+                    trace_err_chain!(err, "Failed to write default discovery file");
+                })?;
+            return Ok(default_discovery);
+        }
+
+        // For mainnet, try to fetch from network
+        let client = Self::create_client(None).await?;
+
+        match Self::fetch(&client, network_name).await {
+            Ok(discovery) => {
+                // Verify the fetched discovery matches what we requested
+                if discovery.network_name != network_name {
+                    tracing::error!(
+                        "Fetched discovery has wrong network name: expected '{}', got '{}'",
+                        network_name,
+                        discovery.network_name
+                    );
+                    // Fall back to default
+                    if let Some(default_discovery) = Self::default_discovery(network_name) {
+                        tracing::warn!("Using default discovery due to network name mismatch");
+                        let modified_at = SystemTime::now().checked_sub(MAX_FILE_AGE);
+                        default_discovery
+                            .clone()
+                            .write_to_file(config_dir, modified_at)
+                            .inspect_err(|err| {
+                                trace_err_chain!(err, "Failed to write default discovery file");
+                            })?;
+                        return Ok(default_discovery);
+                    }
+                    return Err(Error::NetworkNameMismatch {
+                        expected: network_name.to_owned(),
+                        actual: discovery.network_name,
+                    });
+                }
+                discovery
+                    .write_to_file(config_dir, None)
+                    .inspect_err(|err| {
+                        trace_err_chain!(err, "Failed to write discovery file");
+                    })?;
+                Ok(discovery)
+            }
+            Err(e) => match Self::default_discovery(network_name) {
+                Some(default_discovery) => {
+                    tracing::warn!(
+                        "Failed to fetch remote discovery file: {e}, creating a default one"
+                    );
+                    // Ensure that discovery cache created from default discovery is always considered stale.
+                    let modified_at = SystemTime::now().checked_sub(MAX_FILE_AGE);
+
+                    default_discovery
+                        .write_to_file(config_dir, modified_at)
+                        .inspect_err(|err| {
+                            trace_err_chain!(err, "Failed to write default discovery file");
+                        })?;
+                    Ok(default_discovery)
+                }
+                None => {
+                    tracing::error!(
+                        "No default discovery available for {network_name} environment"
+                    );
+                    Err(e)
+                }
+            },
         }
     }
 

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/lib.rs
@@ -275,13 +275,11 @@ pub async fn network_from_discovery(config_path: &Path, discovery: Discovery) ->
 
     // Patch up the network details with domain fronting
     // TODO: remove once network details contain domain fronting data
-    if nym_network
-        .network
-        .nym_vpn_api_urls
-        .as_ref()
-        .is_none_or(|nym_vpn_api_urls| nym_vpn_api_urls.is_empty())
-    {
-        nym_network.network.nym_vpn_api_urls = Some(discovery.nym_vpn_api_urls().clone());
+    // Always use discovery URLs to ensure we have the correct environment URLs
+    // The file-based nym_network might have stale/wrong URLs from a previous environment
+    let discovery_vpn_api_urls = discovery.nym_vpn_api_urls();
+    if !discovery_vpn_api_urls.is_empty() {
+        nym_network.network.nym_vpn_api_urls = Some(discovery_vpn_api_urls);
     }
 
     let endpoint = nym_network

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -732,10 +732,20 @@ impl NymVpnService {
                 // Clear gateway cache and update gateway client for new environment
                 let gateway_cache_handle = self.gateway_cache_handle.clone();
                 let user_agent = self.user_agent.clone();
+                let network_name = new_network.nym_network.network.network_name.clone();
                 tokio::spawn(async move {
+                    tracing::info!(
+                        network = %network_name,
+                        "Updating gateway cache for network environment change"
+                    );
+
                     // Clear the cache first
                     if let Err(e) = gateway_cache_handle.clear_cache() {
-                        tracing::warn!("Failed to clear gateway cache on environment change: {e}");
+                        tracing::warn!(
+                            network = %network_name,
+                            error = %e,
+                            "Failed to clear gateway cache on environment change"
+                        );
                     }
 
                     // Create new gateway client for the new environment
@@ -743,16 +753,36 @@ impl NymVpnService {
                     let nym_api_urls = new_network.nym_api_urls().unwrap_or_default();
                     let nym_vpn_api_urls = new_network.nym_vpn_api_urls().unwrap_or_default();
 
+                    // Validate that we have the necessary URLs
+                    if nym_vpn_api_urls.is_empty() {
+                        tracing::error!(
+                            network = %network_name,
+                            "No VPN API URLs available for new environment, cannot update gateway cache"
+                        );
+                        return;
+                    }
+
+                    if nym_api_urls.is_empty() {
+                        tracing::warn!(
+                            network = %network_name,
+                            "No Nym API URLs available for new environment"
+                        );
+                    }
+
                     let gateway_config = match gateway_directory::Config::new(
                         nyxd_url,
-                        nym_api_urls,
-                        nym_vpn_api_urls,
+                        nym_api_urls.clone(),
+                        nym_vpn_api_urls.clone(),
                         None,
                     ) {
                         Ok(config) => config,
                         Err(e) => {
                             tracing::error!(
-                                "Failed to create gateway config for new environment: {e}"
+                                network = %network_name,
+                                error = %e,
+                                vpn_api_urls = ?nym_vpn_api_urls,
+                                nym_api_urls = ?nym_api_urls,
+                                "Failed to create gateway config for new environment"
                             );
                             return;
                         }
@@ -763,7 +793,9 @@ impl NymVpnService {
                             Ok(client) => client,
                             Err(e) => {
                                 tracing::error!(
-                                    "Failed to create gateway client for new environment: {e}"
+                                    network = %network_name,
+                                    error = %e,
+                                    "Failed to create gateway client for new environment"
                                 );
                                 return;
                             }
@@ -773,10 +805,15 @@ impl NymVpnService {
                     if let Err(e) = gateway_cache_handle.replace_gateway_client(new_gateway_client)
                     {
                         tracing::warn!(
-                            "Failed to replace gateway client on environment change: {e}"
+                            network = %network_name,
+                            error = %e,
+                            "Failed to replace gateway client on environment change"
                         );
                     } else {
-                        tracing::info!("Gateway cache updated for new environment");
+                        tracing::info!(
+                            network = %network_name,
+                            "Gateway cache successfully updated for new environment"
+                        );
                     }
                 });
             }

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -358,8 +358,9 @@ impl NymVpnService {
             network_env: *parameters.network_env.clone(),
         };
 
+        let network_details = parameters.network_env.nym_network_details();
         let nym_vpn_api_client = nym_vpn_api_client::VpnApiClient::from_network(
-            parameters.network_env.nym_network_details(),
+            network_details,
             parameters.user_agent.clone(),
             None,
         )
@@ -726,7 +727,58 @@ impl NymVpnService {
         match event {
             DiscoveryRefresherEvent::NewNetwork(new_network) => {
                 tracing::info!("Network environment updated");
-                let _ = self.network_tx.send_replace(new_network);
+                let _ = self.network_tx.send_replace(new_network.clone());
+
+                // Clear gateway cache and update gateway client for new environment
+                let gateway_cache_handle = self.gateway_cache_handle.clone();
+                let user_agent = self.user_agent.clone();
+                tokio::spawn(async move {
+                    // Clear the cache first
+                    if let Err(e) = gateway_cache_handle.clear_cache() {
+                        tracing::warn!("Failed to clear gateway cache on environment change: {e}");
+                    }
+
+                    // Create new gateway client for the new environment
+                    let nyxd_url = new_network.nyxd_url();
+                    let nym_api_urls = new_network.nym_api_urls().unwrap_or_default();
+                    let nym_vpn_api_urls = new_network.nym_vpn_api_urls().unwrap_or_default();
+
+                    let gateway_config = match gateway_directory::Config::new(
+                        nyxd_url,
+                        nym_api_urls,
+                        nym_vpn_api_urls,
+                        None,
+                    ) {
+                        Ok(config) => config,
+                        Err(e) => {
+                            tracing::error!(
+                                "Failed to create gateway config for new environment: {e}"
+                            );
+                            return;
+                        }
+                    };
+
+                    let new_gateway_client =
+                        match GatewayClient::new(gateway_config, user_agent).await {
+                            Ok(client) => client,
+                            Err(e) => {
+                                tracing::error!(
+                                    "Failed to create gateway client for new environment: {e}"
+                                );
+                                return;
+                            }
+                        };
+
+                    // Replace the gateway client in the cache
+                    if let Err(e) = gateway_cache_handle.replace_gateway_client(new_gateway_client)
+                    {
+                        tracing::warn!(
+                            "Failed to replace gateway client on environment change: {e}"
+                        );
+                    } else {
+                        tracing::info!("Gateway cache updated for new environment");
+                    }
+                });
             }
             DiscoveryRefresherEvent::Error(_error) => {
                 // todo: handle error?


### PR DESCRIPTION
Fixes environment switcher failing to update gateway lists and API endpoints when switching between mainnet/sandbox/canary environments.

- Add clear_cache() to GatewayCache to invalidate cached gateways on env change
- Handle DiscoveryRefresherEvent::NewNetwork to recreate GatewayClient with correct URLs
- Prefer default discovery files for non-mainnet envs to avoid mainnet API fallback
- Always patch VPN API URLs from discovery to prevent stale cached URLs

Resolves gateway cache returning wrong environment data and account authentication failures when switching environments.

## Ticket

JIRA-VPN-VPN-4819

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4464)
<!-- Reviewable:end -->
