### PR TITLE
ci: escape ` within a string

### DIFF
--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -169,6 +169,6 @@ jobs:
             git commit -a -m "ci: bump develop to v${{ steps.next-version.outputs.next_version }}"
             git push origin "${{ env.BRANCH_NAME }}"
             gh pr create \
-                --title "Bump develop to `v${{ steps.next-version.outputs.next_version }}`" \
-                --body "This PR bumps develop to `v${{ steps.next-version.outputs.next_version }}`"
+                --title 'Bump develop to `v${{ steps.next-version.outputs.next_version }}`' \
+                --body 'This PR bumps develop to `v${{ steps.next-version.outputs.next_version }}`'
           fi


### PR DESCRIPTION


## Description

It seems that backticks within a double-quoted string are interpreted as a shell sub-command. Enclose string into single quotes to prevent misinterpretation.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4474)
<!-- Reviewable:end -->
