### PR TITLE
VPN-4644: Add support for socks5 in nym-vpi-api-client. (#4186)

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -9452,9 +9452,9 @@ dependencies = [
 
 [[package]]
 name = "tun"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1527bfc1f78acb1287bbd132ee44bdbf9d064c9f3ca176cb2635253f891f76"
+checksum = "b35f176015650e3bd849e85808d809e5b54da2ba7df983c5c3b601a2a8f1095e"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -9467,7 +9467,7 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "tokio-util",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.1",
  "wintun-bindings",
 ]
 

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/mod.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/mod.rs
@@ -508,6 +508,16 @@ impl From<nym_vpn_api_client::response::ProbeOutcome> for ProbeOutcome {
     }
 }
 
+impl From<nym_vpn_api_client::response::Socks5> for Socks5 {
+    fn from(exit: nym_vpn_api_client::response::Socks5) -> Self {
+        Socks5 {
+            can_proxy_https: exit.can_proxy_https,
+            score: exit.score.map(ScoreValue::from),
+            errors: exit.errors,
+        }
+    }
+}
+
 impl From<nym_vpn_api_client::response::Entry> for Entry {
     fn from(entry: nym_vpn_api_client::response::Entry) -> Self {
         Entry {
@@ -525,7 +535,7 @@ impl From<nym_vpn_api_client::response::Exit> for Exit {
             can_route_ip_external_v4: exit.can_route_ip_external_v4,
             can_route_ip_v6: exit.can_route_ip_v6,
             can_route_ip_external_v6: exit.can_route_ip_external_v6,
-            socks5: None, // TODO: Fill from exit.socks5 when available
+            socks5: exit.socks5.map(Socks5::from),
         }
     }
 }

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/tests.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/tests.rs
@@ -551,7 +551,7 @@ fn create_response_nym_gateway(
                     can_route_ip_external_v4: false,
                     can_route_ip_v6: false,
                     can_route_ip_external_v6: false,
-                    //socks5: None,
+                    socks5: None,
                 }),
                 wg: None,
             },

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
@@ -331,7 +331,7 @@ impl IntoIterator for NymDirectoryGatewaysResponse {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ScoreValue {
     Offline,
@@ -532,6 +532,13 @@ pub struct ProbeOutcome {
     pub wg: Option<WgProbeResults>,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Socks5 {
+    pub can_proxy_https: bool,
+    pub score: Option<ScoreValue>,
+    pub errors: Option<Vec<String>>,
+}
+
 impl ProbeOutcome {
     pub fn is_fully_operational_entry(&self) -> bool {
         self.as_entry.can_connect && self.as_entry.can_route
@@ -563,6 +570,7 @@ pub struct Exit {
     pub can_route_ip_external_v4: bool,
     pub can_route_ip_v6: bool,
     pub can_route_ip_external_v6: bool,
+    pub socks5: Option<Socks5>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]


### PR DESCRIPTION
## Ticket

JIRA-VPN-4644

## Description

VPN-4644: Add support for socks5 score etc in nym-vpi-api-client.

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4479)
<!-- Reviewable:end -->
