### PR TITLE
NYM-254: Add `set_mixnet_traffic_config()` to uniffi rpc.

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-rpc-uniffi/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-rpc-uniffi/src/lib.rs
@@ -13,9 +13,10 @@ use tokio_util::sync::CancellationToken;
 
 use nym_vpn_lib_types::{
     AccountCommandError, AccountControllerState, EntryPoint, ExitPoint, FeatureFlags, Gateway,
-    GatewayType, GetDeeplinkParams, HttpRpcSettings, LogPath, NetworkCompatibility, NymVpnDevice,
-    NymVpnUsage, ParsedAccountLinks, PrivyDerivationMessage, Socks5Settings, Socks5Status,
-    StoreAccountRequest, SystemMessage, TunnelEvent, TunnelState, VpnServiceConfig, VpnServiceInfo,
+    GatewayType, GetDeeplinkParams, HttpRpcSettings, LogPath, MixnetTrafficConfig,
+    NetworkCompatibility, NymVpnDevice, NymVpnUsage, ParsedAccountLinks, PrivyDerivationMessage,
+    Socks5Settings, Socks5Status, StoreAccountRequest, SystemMessage, TunnelEvent, TunnelState,
+    VpnServiceConfig, VpnServiceInfo,
 };
 
 uniffi::use_remote_type!(nym_vpn_lib_types::IpAddr);
@@ -98,6 +99,17 @@ impl RpcClient {
 
     pub async fn set_custom_dns(&self, dns_servers: Vec<IpAddr>) -> Result<()> {
         self.inner.clone().set_custom_dns(dns_servers).await?;
+        Ok(())
+    }
+
+    pub async fn set_mixnet_traffic_config(
+        &self,
+        mixnet_traffic_config: MixnetTrafficConfig,
+    ) -> Result<()> {
+        self.inner
+            .clone()
+            .set_mixnet_traffic_config(mixnet_traffic_config)
+            .await?;
         Ok(())
     }
 

--- a/nym-vpn-core/crates/nym-vpnd/src/service/socks5/lazy_socks5.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/socks5/lazy_socks5.rs
@@ -2,8 +2,10 @@
 
 use super::util::ConnectionGuard;
 use nym_gateway_directory::GatewayCacheHandle;
-use nym_sdk::NymNetworkDetails;
-use nym_sdk::mixnet::{MixnetClientBuilder, Socks5, Socks5MixnetClient, StoragePaths};
+use nym_sdk::{
+    NymNetworkDetails,
+    mixnet::{MixnetClientBuilder, Socks5, Socks5MixnetClient, StoragePaths},
+};
 use nym_vpn_lib_types::{TunnelConnectionData, TunnelState};
 use rand::seq::SliceRandom;
 use std::{


### PR DESCRIPTION
## Ticket

JIRA-NYM-254

## Description

Add `set_mixnet_traffic_config()` to uniffi rpc.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4490)
<!-- Reviewable:end -->
