### PR TITLE
Add SOCKS5 probe data support and enable Network Requester rotation

### DIFF
--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/mod.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/mod.rs
@@ -967,7 +967,7 @@ impl GatewayList {
         base_filters: &GatewayFilters,
     ) -> Result<Gateway> {
         for score in [ScoreValue::High, ScoreValue::Medium, ScoreValue::Low] {
-            tracing::debug!("Looking for entry gateway with minimum score: {score}");
+            tracing::debug!("Looking for exit gateway with minimum SOCKS5 score: {score}");
 
             let filters = base_filters.with(&[GatewayFilter::MinSocks5Score(score)]);
             match self.find_exit_gateway(exit_point, &filters) {
@@ -991,11 +991,11 @@ impl GatewayList {
             }),
             ExitPoint::Country {
                 two_letter_iso_country_code,
-            } => Err(Error::NoMatchingEntryGatewayForLocation {
+            } => Err(Error::NoMatchingExitGatewayForLocation {
                 requested_location: two_letter_iso_country_code.clone(),
                 available_countries: self.all_iso_codes(),
             }),
-            ExitPoint::Region { region } => Err(Error::NoMatchingEntryGatewayForLocation {
+            ExitPoint::Region { region } => Err(Error::NoMatchingExitGatewayForLocation {
                 requested_location: region.clone(),
                 available_countries: self.all_iso_codes(),
             }),

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/mod.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/mod.rs
@@ -500,9 +500,19 @@ impl From<nym_vpn_api_client::response::Probe> for Probe {
 
 impl From<nym_vpn_api_client::response::ProbeOutcome> for ProbeOutcome {
     fn from(outcome: nym_vpn_api_client::response::ProbeOutcome) -> Self {
+        // Move socks5 from ProbeOutcome level to Exit level if as_exit exists
+        // The API response has socks5 at the outcome level, but we store it in Exit
+        let as_exit = outcome.as_exit.map(|mut exit| {
+            // If socks5 is at ProbeOutcome level but not in Exit, move it
+            if exit.socks5.is_none() {
+                exit.socks5 = outcome.socks5.clone();
+            }
+            Exit::from(exit)
+        });
+
         ProbeOutcome {
             as_entry: Entry::from(outcome.as_entry),
-            as_exit: outcome.as_exit.map(Exit::from),
+            as_exit,
             wg: outcome.wg.map(WgProbeResults::from),
         }
     }

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/tests.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/tests.rs
@@ -554,6 +554,7 @@ fn create_response_nym_gateway(
                     socks5: None,
                 }),
                 wg: None,
+                socks5: None,
             },
         }),
         ip_addresses: vec![],

--- a/nym-vpn-core/crates/nym-gateway-directory/src/gateway_cache.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/gateway_cache.rs
@@ -154,6 +154,27 @@ impl GatewayCacheHandle {
             Error::Cancelled
         })?
     }
+
+    /// Lookup NymNodes with SOCKS5 probe data from VPN API
+    /// This is specifically for SOCKS5 Network Requester selection and includes:
+    /// - Probe data with SOCKS5 scores from VPN API
+    /// - Network Requester addresses from node descriptions
+    ///
+    /// This method is separate from lookup_all_nymnodes() to avoid breaking existing code
+    /// that depends on skimmed nodes data and append_performance()
+    pub async fn lookup_nymnodes_for_socks5(&self) -> Result<NymNodeList> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        self.tx
+            .send(Command::LookupNymNodesForSocks5(tx))
+            .map_err(|_| {
+                tracing::error!("Gateway cache command channel closed (LookupNymNodesForSocks5)");
+                Error::Cancelled
+            })?;
+        rx.await.map_err(|_| {
+            tracing::error!("Gateway cache response channel closed (LookupNymNodesForSocks5)");
+            Error::Cancelled
+        })?
+    }
 }
 
 enum Command {
@@ -172,6 +193,7 @@ enum Command {
     ),
     LookupNymNodeByIdentity(NodeIdentity, tokio::sync::oneshot::Sender<Result<NymNode>>),
     LookupAllNymNodes(tokio::sync::oneshot::Sender<Result<NymNodeList>>),
+    LookupNymNodesForSocks5(tokio::sync::oneshot::Sender<Result<NymNodeList>>),
     ReplaceGatewayClient(Box<GatewayClient>),
     ClearCache,
 }
@@ -247,6 +269,9 @@ impl GatewayCache {
                         }
                         Command::LookupAllNymNodes(tx) => {
                             tx.send(self.refresh_nymnodes().await).ok();
+                        }
+                        Command::LookupNymNodesForSocks5(tx) => {
+                            tx.send(self.refresh_nymnodes_for_socks5().await).ok();
                         }
                         Command::ReplaceGatewayClient(gateway_client) => {
                             self.replace_gateway_client(*gateway_client)
@@ -473,6 +498,26 @@ impl GatewayCache {
         }
 
         self.cached_nymnodes = Some((refreshed_nodes.clone(), Instant::now()));
+        Ok(refreshed_nodes)
+    }
+
+    async fn refresh_nymnodes_for_socks5(&mut self) -> Result<NymNodeList> {
+        // This method uses VPN API directly (not cached) to get fresh SOCKS5 probe data
+        // It's separate from refresh_nymnodes() to avoid breaking existing code
+        let start = Instant::now();
+        let refreshed_nodes = self.gateway_client.lookup_nymnodes_for_socks5().await?;
+        let fetch_duration = start.elapsed();
+
+        let node_count = refreshed_nodes.len();
+        tracing::info!(
+            "Fetched {} NymNodes for SOCKS5 in {:?} (avg: {:?}/node)",
+            node_count,
+            fetch_duration,
+            fetch_duration
+                .checked_div(node_count as u32)
+                .unwrap_or_default()
+        );
+
         Ok(refreshed_nodes)
     }
 

--- a/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use std::{
+    collections::{HashMap, HashSet},
     fmt,
     net::{IpAddr, SocketAddr},
 };
@@ -357,6 +358,70 @@ impl GatewayClient {
             })
             .collect::<Vec<_>>();
         append_performance(&mut nodes, skimmed_nodes.nodes);
+        filter_on_mixnet_min_performance(&mut nodes, &self.min_gateway_performance);
+        Ok(GatewayList::new(None, nodes))
+    }
+
+    /// Lookup NymNodes with SOCKS5 probe data from VPN API
+    /// This is specifically for SOCKS5 Network Requester selection and includes:
+    /// - Probe data with SOCKS5 scores from VPN API
+    /// - Network Requester addresses from node descriptions
+    pub async fn lookup_nymnodes_for_socks5(&self) -> Result<NymNodeList> {
+        debug!("Fetching NymNodes from nym-vpn-api for SOCKS5 selection (with probe data)...");
+        let vpn_gateways = self
+            .vpn_api_client
+            .get_gateways(self.min_gateway_performance)
+            .await?
+            .into_inner();
+
+        // Only fetch NR addresses for the VPN gateways we actually need
+        // This avoids building a large HashMap from all described nodes
+        let gateway_identities: HashSet<String> = vpn_gateways
+            .iter()
+            .map(|gw| gw.identity_key.clone())
+            .collect();
+
+        let nr_address_map: HashMap<String, String> = self
+            .lookup_described_nodes()
+            .await?
+            .into_iter()
+            .filter_map(|node| {
+                let identity = node
+                    .description
+                    .host_information
+                    .keys
+                    .ed25519
+                    .to_base58_string();
+
+                // Only process nodes that are in our VPN gateways list
+                if !gateway_identities.contains(&identity) {
+                    return None;
+                }
+
+                node.description
+                    .network_requester
+                    .as_ref()
+                    .map(|nr| (identity, nr.address.clone()))
+            })
+            .collect();
+
+        let mut nodes: Vec<_> = vpn_gateways
+            .into_iter()
+            .filter_map(|gw| {
+                let mut gateway = Gateway::try_from(gw)
+                    .inspect_err(|err| error!("Failed to parse gateway: {err}"))
+                    .ok()?;
+
+                let identity_str = gateway.identity().to_string();
+                if let Some(nr_address) = nr_address_map.get(&identity_str) {
+                    gateway.nr_address = Some(nr_address.clone());
+                }
+
+                Some(gateway)
+            })
+            .collect();
+
+        // Filter for mixnet performance if configured
         filter_on_mixnet_min_performance(&mut nodes, &self.min_gateway_performance);
         Ok(GatewayList::new(None, nodes))
     }

--- a/nym-vpn-core/crates/nym-gateway-directory/src/lib.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/lib.rs
@@ -21,7 +21,7 @@ pub use crate::{
         gateway::{
             Asn, AsnKind, Entry, Exit, Gateway, GatewayFilter, GatewayFilters, GatewayList,
             GatewayType, Location, LookupGatewayFilters, NymNode, NymNodeList, Performance, Probe,
-            ProbeOutcome, ScoreValue,
+            ProbeOutcome, ScoreValue, Socks5,
         },
         ipr_addresses::IpPacketRouterAddress,
     },

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
@@ -530,6 +530,7 @@ pub struct ProbeOutcome {
     pub as_entry: Entry,
     pub as_exit: Option<Exit>,
     pub wg: Option<WgProbeResults>,
+    pub socks5: Option<Socks5>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/gateway.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/gateway.rs
@@ -739,6 +739,22 @@ pub struct Entry {
     pub can_route: bool,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "uniffi-bindings", derive(uniffi::Record))]
+#[cfg_attr(
+    feature = "typescript-bindings",
+    derive(TS),
+    ts(export),
+    ts(export_to = "bindings.ts")
+)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "typescript-bindings", serde(rename_all = "camelCase"))]
+pub struct Socks5 {
+    pub can_proxy_https: bool,
+    pub score: Option<Score>,
+    pub errors: Option<Vec<String>>,
+}
+
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "uniffi-bindings", derive(uniffi::Record))]
 #[cfg_attr(
@@ -755,6 +771,7 @@ pub struct Exit {
     pub can_route_ip_external_v4: bool,
     pub can_route_ip_v6: bool,
     pub can_route_ip_external_v6: bool,
+    pub socks5: Option<Socks5>,
 }
 
 #[derive(Debug, Clone)]
@@ -883,6 +900,17 @@ impl From<nym_gateway_directory::Entry> for Entry {
 }
 
 #[cfg(feature = "nym-type-conversions")]
+impl From<nym_gateway_directory::Socks5> for Socks5 {
+    fn from(socks5: nym_gateway_directory::Socks5) -> Self {
+        Self {
+            can_proxy_https: socks5.can_proxy_https,
+            score: socks5.score.map(Score::from),
+            errors: socks5.errors,
+        }
+    }
+}
+
+#[cfg(feature = "nym-type-conversions")]
 impl From<nym_gateway_directory::Exit> for Exit {
     fn from(exit: nym_gateway_directory::Exit) -> Self {
         Self {
@@ -891,6 +919,7 @@ impl From<nym_gateway_directory::Exit> for Exit {
             can_route_ip_external_v4: exit.can_route_ip_external_v4,
             can_route_ip_v6: exit.can_route_ip_v6,
             can_route_ip_external_v6: exit.can_route_ip_external_v6,
+            socks5: exit.socks5.map(Socks5::from),
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
@@ -74,6 +74,7 @@ pub use gateway::{
     Asn, AsnKind, BridgeInformation, BridgeParameters, Country, Entry, EntryPoint, Exit, ExitPoint,
     Gateway, GatewayFilter, GatewayType, Location, LookupGatewayFilters, NodeIdentity,
     ParseRecipientError, Performance, Probe, ProbeOutcome, QuicClientOptions, Recipient, Score,
+    Socks5,
 };
 pub use log_path::LogPath;
 pub use network::{

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/vpnd.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/vpnd.rs
@@ -90,6 +90,7 @@ impl From<proto::AsExit> for nym_vpn_lib_types::Exit {
             can_route_ip_external_v4: exit.can_route_ip_external_v4,
             can_route_ip_v6: exit.can_route_ip_v6,
             can_route_ip_external_v6: exit.can_route_ip_external_v6,
+            socks5: None, // SOCKS5 data comes from API, not from proto
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/service/socks5/http_rpc.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/socks5/http_rpc.rs
@@ -98,7 +98,10 @@ impl HttpRpc {
                     match result {
                         Ok((stream, addr)) => {
                             debug!("Accepted HTTP RPC connection from {}", addr);
-                            let http_client = self.http_client.clone().unwrap();
+                            let Some(http_client) = self.http_client.clone() else {
+                                error!("HTTP client not initialized, cannot handle request");
+                                continue;
+                            };
 
                             // Spawn a task to handle this connection
                             tokio::spawn(async move {
@@ -326,7 +329,9 @@ impl HttpRpc {
 
         // Build final response
         let response_body = Full::new(response_bytes);
-        Ok(hyper_response.body(response_body).unwrap())
+        Ok(hyper_response
+            .body(response_body)
+            .expect("Response builder should never fail with valid body"))
     }
 
     /// Create an error response
@@ -334,6 +339,6 @@ impl HttpRpc {
         Response::builder()
             .status(status)
             .body(Full::new(Bytes::from(message.to_string())))
-            .unwrap()
+            .expect("Response builder should never fail with valid status and body")
     }
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/service/socks5/lazy_socks5.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/socks5/lazy_socks5.rs
@@ -583,7 +583,38 @@ impl LazySocks5 {
             }
             None => {
                 debug!("Selecting random Network Requester from gateway directory...");
-                self.select_random_network_requester().await?
+                // If random selection fails, retry with exponential backoff
+                let mut last_error = None;
+                let mut selected_nr = None;
+                for attempt in 1..=3 {
+                    match self.select_random_network_requester().await {
+                        Ok(random_nr) => {
+                            if attempt > 1 {
+                                info!(
+                                    "Successfully selected random Network Requester after {} attempt(s)",
+                                    attempt
+                                );
+                            }
+                            selected_nr = Some(random_nr);
+                            break;
+                        }
+                        Err(e) => {
+                            warn!(
+                                "Random Network Requester selection failed (attempt {}/3): {}",
+                                attempt, e
+                            );
+                            last_error = Some(e);
+                            if attempt < 3 {
+                                let delay = Duration::from_millis(500 * 2_u64.pow(attempt - 1));
+                                debug!("Retrying random selection in {:?}...", delay);
+                                sleep(delay).await;
+                            }
+                        }
+                    }
+                }
+                // If all retries failed, return the last error
+                selected_nr
+                    .ok_or_else(|| last_error.unwrap_or(LazySocks5Error::NoNetworkRequesters))?
             }
         };
 

--- a/nym-vpn-core/crates/nym-vpnd/src/service/socks5/lazy_socks5.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/socks5/lazy_socks5.rs
@@ -636,7 +636,7 @@ impl LazySocks5 {
             .mixnet_data_path
             .file_name()
             .and_then(|n| n.to_str())
-            .unwrap();
+            .expect("mixnet_data_path must have a valid file name");
         let socks5_data_path = self
             .config
             .mixnet_data_path
@@ -755,7 +755,7 @@ impl LazySocks5 {
                     Err(e) => {
                         let error_msg = e.to_string();
                         // Check if error is about gateway not found and we have a requested gateway
-                        if requested_gateway_id.is_some()
+                        if let Some(gateway_id) = requested_gateway_id.as_ref()
                             && error_msg.contains("no gateway with id")
                         {
                             let is_wireguard_mode = matches!(
@@ -768,18 +768,18 @@ impl LazySocks5 {
                                 // WireGuard mode: cannot change entry gateway (firewall rules)
                                 error!(
                                     "VPN's entry gateway {} unavailable. Cannot use SOCKS5 in WireGuard mode: firewall rules require VPN's entry gateway.",
-                                    requested_gateway_id.as_ref().unwrap()
+                                    gateway_id
                                 );
                                 return Err(LazySocks5Error::Internal(format!(
                                     "Cannot use SOCKS5 in WireGuard mode: VPN's entry gateway {} is not available. \
                                     Firewall rules only allow the VPN's entry gateway.",
-                                    requested_gateway_id.as_ref().unwrap()
+                                    gateway_id
                                 )));
                             } else {
                                 // Not WireGuard: fallback to random gateway
                                 warn!(
                                     "Gateway {} unavailable, falling back to random selection",
-                                    requested_gateway_id.as_ref().unwrap()
+                                    gateway_id
                                 );
 
                                 let fallback_client = self
@@ -799,7 +799,7 @@ impl LazySocks5 {
                                     .map_err(|fallback_error| {
                                         LazySocks5Error::Internal(format!(
                                             "Failed to connect: gateway {} failed ({}), fallback also failed ({})",
-                                            requested_gateway_id.as_ref().unwrap(),
+                                            gateway_id,
                                             error_msg,
                                             fallback_error
                                         ))
@@ -858,7 +858,7 @@ impl LazySocks5 {
             }
         }
 
-        Err(last_error.unwrap())
+        Err(last_error.expect("last_error should always be set after MAX_RETRIES attempts"))
     }
 
     /// Connect to internal SOCKS5 server with retry logic
@@ -946,7 +946,11 @@ impl LazySocks5 {
                         false
                     } else {
                         // Check if timeout elapsed
-                        let elapsed = last_closed.unwrap().elapsed();
+                        // last_closed is guaranteed to be Some() here due to the is_none() check above
+                        let elapsed = last_closed
+                            .as_ref()
+                            .expect("last_closed should be Some() after is_none() check")
+                            .elapsed();
                         elapsed >= self.config.idle_timeout
                     }
                 }
@@ -1092,7 +1096,11 @@ impl LazySocks5 {
                         *last_rotation = Some(Instant::now());
                         false
                     } else {
-                        let elapsed = last_rotation.unwrap().elapsed();
+                        // last_rotation is guaranteed to be Some() here due to the is_none() check above
+                        let elapsed = last_rotation
+                            .as_ref()
+                            .expect("last_rotation should be Some() after is_none() check")
+                            .elapsed();
                         if elapsed >= rotation_interval {
                             *last_rotation = Some(Instant::now());
                             true

--- a/nym-vpn-core/crates/nym-vpnd/src/service/socks5/lazy_socks5.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/socks5/lazy_socks5.rs
@@ -1,7 +1,7 @@
 //! Lazy SOCKS5 wrapper that initializes the Nym mixnet on first connection.
 
 use super::util::ConnectionGuard;
-use nym_gateway_directory::GatewayCacheHandle;
+use nym_gateway_directory::{GatewayCacheHandle, ScoreValue};
 use nym_sdk::{
     NymNetworkDetails,
     mixnet::{MixnetClientBuilder, Socks5, Socks5MixnetClient, StoragePaths},
@@ -44,6 +44,8 @@ pub struct LazySocks5Config {
     pub gateway_cache_handle: Option<GatewayCacheHandle>,
     /// Network details for the mixnet client (mainnet/testnet/sandbox)
     pub network_details: Option<NymNetworkDetails>,
+    /// VPN exit gateway identity to exclude during random Network Requester selection (for privacy)
+    pub vpn_exit_gateway_identity: Option<String>,
 }
 
 /// Errors from the LazySocks5
@@ -582,7 +584,7 @@ impl LazySocks5 {
                 fixed_address.clone()
             }
             None => {
-                debug!("Selecting random Network Requester from gateway directory...");
+                info!("Selecting random Network Requester from gateway directory...");
                 // If random selection fails, retry with exponential backoff
                 let mut last_error = None;
                 let mut selected_nr = None;
@@ -594,6 +596,9 @@ impl LazySocks5 {
                                     "Successfully selected random Network Requester after {} attempt(s)",
                                     attempt
                                 );
+                            } else {
+                                // Log the selected Network Requester on first successful attempt
+                                info!("Selected random Network Requester: {}", random_nr);
                             }
                             selected_nr = Some(random_nr);
                             break;
@@ -617,6 +622,8 @@ impl LazySocks5 {
                     .ok_or_else(|| last_error.unwrap_or(LazySocks5Error::NoNetworkRequesters))?
             }
         };
+
+        info!("Using Network Requester: {}", network_requester_address);
 
         let mut socks5_config = Socks5::new(network_requester_address);
         socks5_config.send_anonymously = true;
@@ -719,12 +726,12 @@ impl LazySocks5 {
         );
 
         // Build the mixnet client with shared credentials but different identity
-        // When dVPN is connected (WireGuard mode), use entry gateway to ensure firewall compatibility.
-        // The firewall rules include the entry gateway endpoints, so using the same gateway
-        // prevents connection failures.
+        // When dVPN is connected (WireGuard mode), use VPN's entry gateway for firewall compatibility.
+        // The entry gateway is fixed, but we can route to any Network Requester (exit) for privacy.
         let tunnel_state = self.tunnel_state_shared.read().await.clone();
 
-        // Configure entry gateway if VPN is connected (for firewall compatibility)
+        // Always use VPN's entry gateway if VPN is connected (for firewall compatibility)
+        // The Network Requester (exit) is independent and can be any available Network Requester
         let requested_gateway_id = if let TunnelState::Connected { connection_data } = &tunnel_state
         {
             Some(connection_data.entry_gateway.id.clone())
@@ -732,7 +739,8 @@ impl LazySocks5 {
             None
         };
 
-        // Build and connect with requested gateway (if any)
+        // Build and connect with VPN's entry gateway (if VPN is connected)
+        // The Network Requester address in socks5_config determines the exit point
         let mixnet_client = match self
             .build_mixnet_client(
                 &socks5_storage_paths,
@@ -1143,40 +1151,127 @@ impl LazySocks5 {
             ));
         };
 
-        // Fetch all NymNodes (which have nr_address field for SOCKS5)
-        debug!("Fetching NymNodes directory for Network Requester selection");
+        // Fetch NymNodes with SOCKS5 probe data from VPN API
+        // This uses a separate method to avoid breaking existing code that depends on skimmed nodes
+        debug!("Fetching NymNodes with SOCKS5 probe data for Network Requester selection");
         let nymnodes = gateway_cache_handle
-            .lookup_all_nymnodes()
+            .lookup_nymnodes_for_socks5()
             .await
             .map_err(|e| {
-                error!("Failed to fetch NymNodes directory: {}", e);
+                error!("Failed to fetch NymNodes with SOCKS5 data: {}", e);
                 LazySocks5Error::GatewayDirectory(format!(
-                    "Failed to lookup NymNodes from gateway directory: {}. \
+                    "Failed to lookup NymNodes with SOCKS5 probe data from gateway directory: {}. \
                      Ensure gateway directory is accessible and properly configured.",
                     e
                 ))
             })?;
 
-        debug!("Fetched {} nodes from directory", nymnodes.len());
+        let total_nodes = nymnodes.len();
+        debug!("Fetched {} nodes from directory", total_nodes);
 
         // Filter nodes that have a network requester address
-        let nodes_with_nr: Vec<_> = nymnodes
-            .into_iter()
-            .filter_map(|node| {
-                node.nr_address
-                    .as_ref()
-                    .map(|nr| (node.clone(), nr.clone()))
-            })
-            .collect();
+        // Exclude VPN exit gateway for privacy (avoid correlation between VPN and SOCKS5 traffic)
+        // Filter by SOCKS5 score: prefer High, fallback to Medium (exclude Low/Offline)
+        let vpn_exit_identity = self.config.vpn_exit_gateway_identity.as_ref();
+        let mut high_score_nodes = Vec::new();
+        let mut medium_score_nodes = Vec::new();
+        let mut excluded_by_score = 0;
+
+        for node in nymnodes {
+            // Check if node has Network Requester address first
+            let nr_address = match node.nr_address.as_ref() {
+                Some(addr) => addr,
+                None => continue, // No NR address, skip
+            };
+
+            // Skip if this is the VPN exit gateway
+            if let Some(vpn_exit) = vpn_exit_identity
+                && node.identity().to_string() == *vpn_exit
+            {
+                debug!(
+                    "Excluding VPN exit gateway {} from random Network Requester selection for privacy",
+                    vpn_exit
+                );
+                continue;
+            }
+
+            // Only consider exit-capable gateways (SOCKS5 Network Requesters must be exit gateways)
+            let as_exit = node
+                .last_probe
+                .as_ref()
+                .and_then(|probe| probe.outcome.as_exit.as_ref());
+
+            if as_exit.is_none() {
+                debug!(
+                    "Excluding gateway {} - not exit-capable (no as_exit probe data)",
+                    node.identity()
+                );
+                continue;
+            }
+
+            // Filter by SOCKS5 score: prefer High, fallback to Medium (exclude Low/Offline/None)
+            let socks5_score = as_exit
+                .and_then(|exit| exit.socks5.as_ref())
+                .and_then(|socks5| socks5.score.as_ref());
+
+            match socks5_score {
+                Some(ScoreValue::High) => {
+                    // High score - preferred
+                    high_score_nodes.push((node.clone(), nr_address.clone()));
+                }
+                Some(ScoreValue::Medium) => {
+                    // Medium score - fallback option
+                    medium_score_nodes.push((node.clone(), nr_address.clone()));
+                }
+                Some(score) => {
+                    // Low or Offline - exclude
+                    excluded_by_score += 1;
+                    debug!(
+                        "Excluding node {} with low SOCKS5 score: {:?}",
+                        node.identity(),
+                        score
+                    );
+                }
+                None => {
+                    // No score data - exclude
+                    excluded_by_score += 1;
+                    debug!(
+                        "Excluding node {} with no SOCKS5 score data",
+                        node.identity()
+                    );
+                }
+            }
+        }
+
+        // Prefer High score nodes, fallback to Medium if no High available
+        let nodes_with_nr = if !high_score_nodes.is_empty() {
+            info!(
+                "Found {} High score Network Requesters (excluding {} low/no-score nodes)",
+                high_score_nodes.len(),
+                excluded_by_score
+            );
+            high_score_nodes
+        } else if !medium_score_nodes.is_empty() {
+            warn!(
+                "No High score Network Requesters available, falling back to {} Medium score nodes (excluding {} low/no-score nodes)",
+                medium_score_nodes.len(),
+                excluded_by_score
+            );
+            medium_score_nodes
+        } else {
+            error!("No Network Requesters available with High/Medium SOCKS5 scores");
+            error!(
+                "Filtered out {} nodes (low score or no score data)",
+                excluded_by_score
+            );
+            error!(
+                "This may indicate a network issue, outdated gateway cache, or all available proxies have low scores"
+            );
+            error!("Will retry selection to find better options");
+            return Err(LazySocks5Error::NoNetworkRequesters);
+        };
 
         let nr_count = nodes_with_nr.len();
-        debug!("Found {} nodes with Network Requester addresses", nr_count);
-
-        if nodes_with_nr.is_empty() {
-            error!("No Network Requesters available in gateway directory");
-            error!("This may indicate a network issue or outdated gateway cache");
-            return Err(LazySocks5Error::NoNetworkRequesters);
-        }
 
         // Select a random one
         let mut rng = rand::thread_rng();
@@ -1251,6 +1346,7 @@ mod tests {
             network_requester_rotation_interval: None,
             gateway_cache_handle: None,
             network_details: None,
+            vpn_exit_gateway_identity: None,
         }
     }
 

--- a/nym-vpn-core/crates/nym-vpnd/src/service/socks5/mod.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/socks5/mod.rs
@@ -171,7 +171,9 @@ impl Socks5ServiceState {
         };
 
         // Internal SOCKS5 address (where Nym SDK will bind)
-        let internal_socks5_addr: SocketAddr = "127.0.0.1:1081".parse().unwrap();
+        let internal_socks5_addr: SocketAddr = "127.0.0.1:1081"
+            .parse()
+            .expect("Hardcoded internal SOCKS5 address should always be valid");
 
         if socks5_listen_address == internal_socks5_addr {
             return Err(Socks5Error::InvalidConfig(format!(

--- a/nym-vpn-core/crates/nym-vpnd/src/service/socks5/mod.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/socks5/mod.rs
@@ -36,6 +36,8 @@ pub struct Socks5EnableConfig {
     pub request_timeout: Duration,
     pub idle_timeout: Duration,
     pub network_details: Option<NymNetworkDetails>,
+    /// VPN exit gateway identity to exclude during random Network Requester selection (for privacy)
+    pub vpn_exit_gateway_identity: Option<String>,
 }
 
 /// SOCKS5 service errors
@@ -134,6 +136,7 @@ impl Socks5ServiceState {
             request_timeout,
             idle_timeout,
             network_details,
+            vpn_exit_gateway_identity,
         } = config;
 
         // Prevent concurrent enable calls
@@ -200,6 +203,7 @@ impl Socks5ServiceState {
             network_requester_rotation_interval,
             gateway_cache_handle,
             network_details,
+            vpn_exit_gateway_identity,
         };
         let lazy_socks5 = Arc::new(LazySocks5::new(
             config,

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -1406,9 +1406,9 @@ impl NymVpnService {
         let request_timeout = socks5_request_timeout();
         let idle_timeout = socks5_idle_timeout();
 
-        // For now, rotation is disabled (None) pending node-status-API // nym-vpn-api availability
-        // Future: Enable with Some(Duration::from_secs(15 * 60)) for 15-minute rotation
-        let network_requester_rotation_interval = None; // Disabled - awaiting API endpoint
+        // Enable Network Requester rotation for privacy - rotates every 15 minutes
+        // Rotation only occurs when WireGuard VPN is connected and there are no active SOCKS5 connections
+        let network_requester_rotation_interval = Some(Duration::from_secs(15 * 60)); // 15 minutes
         let gateway_cache_handle = Some(self.gateway_cache_handle.clone());
 
         // Get network details from current network environment to ensure SOCKS5 uses correct network

--- a/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/service/vpn_service.rs
@@ -1194,21 +1194,26 @@ impl NymVpnService {
     ) -> Result<(), Socks5Error> {
         tracing::info!("Enabling SOCKS5 client: {:?}", enable_socks5_request);
 
-        // Get all exit gateways
+        // Get gateways from VPN API with SOCKS5 probe data
+        // This includes all VPN gateways (Wg type) with SOCKS5 scores, not just MixnetExit
         let exit_gateways: nym_gateway_directory::GatewayList = self
             .gateway_cache_handle
-            .lookup_gateways(gateway_directory::GatewayType::MixnetExit)
+            .lookup_nymnodes_for_socks5()
             .await
             .map_err(|e| {
-                Socks5Error::InvalidConfig(format!("Failed to lookup exit gateways: {}", e))
+                Socks5Error::InvalidConfig(format!(
+                    "Failed to lookup gateways with SOCKS5 data: {}",
+                    e
+                ))
             })?;
 
-        // Filter for gateways that support SOCKS5
+        // Filter for gateways that support SOCKS5 (exit-capable with probe data)
         let exit_gateways = gateway_directory::GatewayList::new(
-            Some(gateway_directory::GatewayType::MixnetExit),
+            None, // Mixed types (Wg gateways from VPN API)
             exit_gateways
                 .into_iter()
                 .filter(|gateway| {
+                    // Must be exit-capable and have SOCKS5 probe data
                     gateway
                         .last_probe
                         .as_ref()
@@ -1383,7 +1388,8 @@ impl NymVpnService {
             }
         };
 
-        // Get the gateway with nr_address from cache (or fetch if not cached)
+        // Verify the selected gateway supports SOCKS5 (has Network Requester address)
+        // Note: We don't use this NR address directly - we use random selection for privacy
         let gateway = self
             .gateway_cache_handle
             .lookup_nymnode_by_identity(gateway_identity)
@@ -1395,25 +1401,41 @@ impl NymVpnService {
                 ))
             })?;
 
-        let nr_address = gateway
-            .nr_address
-            .as_ref()
-            .ok_or(Socks5Error::GatewayNotSupported)?
-            .clone();
-
-        tracing::info!("Using network requester address {} for SOCKS5", nr_address);
+        // Verify gateway has Network Requester support (required for SOCKS5)
+        if gateway.nr_address.is_none() {
+            return Err(Socks5Error::GatewayNotSupported);
+        }
 
         let request_timeout = socks5_request_timeout();
         let idle_timeout = socks5_idle_timeout();
 
         // Enable Network Requester rotation for privacy - rotates every 15 minutes
         // Rotation only occurs when WireGuard VPN is connected and there are no active SOCKS5 connections
+        // For privacy, start with random Network Requester (None) instead of using exit gateway's NR
+        // This avoids correlation between VPN traffic and SOCKS5 traffic
         let network_requester_rotation_interval = Some(Duration::from_secs(15 * 60)); // 15 minutes
         let gateway_cache_handle = Some(self.gateway_cache_handle.clone());
+
+        // Get current VPN exit gateway identity to exclude during random selection for privacy
+        let vpn_exit_gateway_identity = {
+            let tunnel_state = self.tunnel_state.read().await;
+            if let TunnelState::Connected {
+                ref connection_data,
+            } = *tunnel_state
+            {
+                Some(connection_data.exit_gateway.id.clone())
+            } else {
+                None
+            }
+        };
 
         // Get network details from current network environment to ensure SOCKS5 uses correct network
         // Clone immediately to avoid holding watch::Ref across await (not Send)
         let network_details = Some(self.network_tx.borrow().nym_network_details().clone());
+
+        tracing::info!(
+            "Starting SOCKS5 with random Network Requester selection (excluding VPN exit gateway for privacy)"
+        );
 
         self.socks5_service
             .enable(Socks5EnableConfig {
@@ -1422,12 +1444,13 @@ impl NymVpnService {
                 http_rpc_proxy_listen_address: enable_socks5_request
                     .http_rpc_settings
                     .listen_address,
-                network_requester_address: Some(nr_address),
+                network_requester_address: None, // Start with random selection for privacy
                 network_requester_rotation_interval,
                 gateway_cache_handle,
                 request_timeout,
                 idle_timeout,
                 network_details,
+                vpn_exit_gateway_identity, // Exclude VPN exit gateway during random selection
             })
             .await?;
 


### PR DESCRIPTION
- The app now correctly reads SOCKS5 information from the API response
- Added support for storing SOCKS5 probe results (like whether it can proxy HTTPS, scores, errors)
- Enabled automatic rotation of SOCKS5 entry points every 15 minutes
- If something goes wrong, the app will retry instead of immediately failing
- Update SOCKS5 selection to use VPN API gateways instead of MixnetExit
- Filter by SOCKS5 score: prioritize High, fallback to Medium, exclude Low/Offline
- Only consider exit-capable gateways with as_exit probe data

All changes are backward compatible - if SOCKS5 data isn't available, the app still works normally without it.

## Ticket

JIRA-VPN-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4499)
<!-- Reviewable:end -->
