### PR TITLE
Make more raw uniffi methods available over service interface

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/account/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/account/mod.rs
@@ -12,6 +12,40 @@ pub mod ticketbooks;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "uniffi-bindings", derive(uniffi::Record))]
+#[cfg_attr(
+    feature = "typescript-bindings",
+    derive(TS),
+    ts(export),
+    ts(export_to = "bindings.ts")
+)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "typescript-bindings", serde(rename_all = "camelCase"))]
+#[cfg(any(target_os = "ios", target_os = "android"))]
+pub struct RegisterAccountRequest {
+    #[cfg(target_os = "android")]
+    pub purchase_token: String,
+}
+
+#[cfg(feature = "nym-type-conversions")]
+#[cfg(any(target_os = "ios", target_os = "android"))]
+impl From<RegisterAccountRequest> for nym_vpn_api_client::types::Platform {
+    fn from(_value: RegisterAccountRequest) -> Self {
+        #[cfg(target_os = "ios")]
+        {
+            Self::Apple
+        }
+
+        #[cfg(target_os = "android")]
+        {
+            Self::Android {
+                purchase_token: _value.purchase_token,
+            }
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "uniffi-bindings", derive(uniffi::Record))]
 pub struct RegisterAccountResponse {

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
@@ -50,6 +50,8 @@ mod tunnel_state;
 mod uniffi_std_types;
 mod user_agent;
 
+#[cfg(any(target_os = "android", target_os = "ios"))]
+pub use account::RegisterAccountRequest;
 pub use account::{
     AccountCommandError, RegisterAccountResponse, VpnAccountSummary, VpnApiError,
     VpnApiErrorResponse,

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/account.rs
@@ -11,7 +11,8 @@ use nym_vpn_api_client::types::Platform;
 use nym_vpn_lib::storage::VpnClientOnDiskStorage;
 use nym_vpn_lib_types::{
     AccountControllerState, DeeplinkClient, DeeplinkKind, GetDeeplinkParams,
-    RegisterAccountResponse, StoreAccountRequest, UserAgent, VpnAccountSummary,
+    RegisterAccountRequest, RegisterAccountResponse, StoreAccountRequest, UserAgent,
+    VpnAccountSummary,
 };
 
 use crate::{environment::NymEnvironment, error::VpnError, offline_monitor::NymOfflineMonitor};
@@ -193,7 +194,7 @@ impl NymAccountController {
     /// Register the stored account.
     pub async fn register_account(
         &self,
-        args: AccountRegistrationArgs,
+        request: RegisterAccountRequest,
     ) -> Result<RegisterAccountResponse, VpnError> {
         let mnemonic = self
             .command_sender
@@ -201,7 +202,7 @@ impl NymAccountController {
             .await
             .map_err(VpnError::from)?
             .ok_or(VpnError::NoAccountStored)?;
-        let platform = Platform::try_from(args)?;
+        let platform = Platform::from(request);
         self.command_sender
             .register_account(mnemonic, platform)
             .await
@@ -252,28 +253,5 @@ impl NymAccountController {
             .get_device_identity()
             .await?
             .ok_or(VpnError::NoAccountStored)
-    }
-}
-
-#[derive(uniffi::Record)]
-pub struct AccountRegistrationArgs {
-    #[cfg(target_os = "android")]
-    pub purchase_token: String,
-}
-
-impl TryFrom<AccountRegistrationArgs> for nym_vpn_api_client::types::Platform {
-    type Error = VpnError;
-
-    fn try_from(_value: AccountRegistrationArgs) -> Result<Self, Self::Error> {
-        #[cfg(target_os = "ios")]
-        return Ok(nym_vpn_api_client::types::Platform::Apple);
-        #[cfg(target_os = "android")]
-        return Ok(nym_vpn_api_client::types::Platform::Android {
-            purchase_token: _value.purchase_token,
-        });
-        #[cfg(not(any(target_os = "android", target_os = "ios")))]
-        Err(VpnError::InternalError {
-            details: "only iOS and Android supported for now".to_string(),
-        })
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/account.rs
@@ -52,7 +52,7 @@ impl NymAccountController {
             details: err.to_string(),
         })?;
 
-        let nyxd_client = NyxdClient::new(&network_env.inner());
+        let nyxd_client = NyxdClient::new(network_env.inner());
         let account_controller_config = nym_vpn_account_controller::AccountControllerConfig {
             data_dir,
             network_env: network_env.inner().clone(),

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/lib.rs
@@ -225,8 +225,8 @@ pub struct VPNConfig {
 impl VPNConfig {
     fn as_vpn_service_config(&self) -> Box<VpnServiceConfig> {
         Box::new(VpnServiceConfig {
-            entry_point: self.entry_gateway.clone().into(),
-            exit_point: self.exit_router.clone().into(),
+            entry_point: self.entry_gateway.clone(),
+            exit_point: self.exit_router.clone(),
             // Does not have effect on mobile platforms
             allow_lan: true,
             disable_ipv6: false,

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/offline_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/offline_monitor.rs
@@ -1,6 +1,7 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+#[cfg(target_os = "android")]
 use std::sync::Arc;
 
 #[cfg(target_os = "android")]

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/tunnel_provider/tunnel_settings.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/tunnel_provider/tunnel_settings.rs
@@ -24,7 +24,9 @@ pub enum Ipv4Route {
     },
 }
 
+// todo: allow unused for now; we should expose these methods for Android/iOS after migration to uniffi 0.31
 impl Ipv4Route {
+    #[allow(unused)]
     pub fn prefix_length(&self) -> u8 {
         match self {
             Self::Default => 0,
@@ -34,6 +36,7 @@ impl Ipv4Route {
         }
     }
 
+    #[allow(unused)]
     pub fn destination(&self) -> Ipv4Addr {
         match self {
             Self::Default => Ipv4Addr::UNSPECIFIED,
@@ -76,7 +79,9 @@ pub enum Ipv6Route {
     },
 }
 
+// todo: allow unused for now; we should expose these methods for Android/iOS after migration to uniffi 0.31
 impl Ipv6Route {
+    #[allow(unused)]
     pub fn destination(&self) -> Ipv6Addr {
         match self {
             Self::Default => Ipv6Addr::UNSPECIFIED,
@@ -84,6 +89,7 @@ impl Ipv6Route {
         }
     }
 
+    #[allow(unused)]
     pub fn prefix_length(&self) -> u8 {
         match self {
             Self::Default => 0,

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_service_command_sender.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_service_command_sender.rs
@@ -147,7 +147,7 @@ impl NymVpnServiceCommandSender {
     pub async fn get_feature_flags(&self) -> Result<Option<Arc<FeatureFlags>>> {
         self.send_and_wait(VpnServiceCommand::GetFeatureFlags, ())
             .await
-            .map(|v| v.map(|v| Arc::new(v)))
+            .map(|v| v.map(Arc::new))
     }
 
     pub async fn get_default_dns(&self) -> Result<Vec<IpAddr>> {

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_service_command_sender.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_service_command_sender.rs
@@ -10,8 +10,8 @@ use tokio::sync::{mpsc, oneshot};
 use nym_vpn_lib_types::{
     AccountCommandError, AccountControllerState, EntryPoint, ExitPoint, FeatureFlags, Gateway,
     GetDeeplinkParams, ListGatewaysOptions, NetworkCompatibility, ParsedAccountLinks,
-    StoreAccountRequest, SystemMessage, TargetState, TunnelState, VpnAccountSummary,
-    VpnServiceConfig, VpnServiceInfo,
+    RegisterAccountRequest, RegisterAccountResponse, StoreAccountRequest, SystemMessage,
+    TargetState, TunnelState, VpnAccountSummary, VpnServiceConfig, VpnServiceInfo,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -181,6 +181,23 @@ impl NymVpnServiceCommandSender {
             .await
     }
 
+    pub async fn register_account(
+        &self,
+        request: RegisterAccountRequest,
+    ) -> Result<RegisterAccountResponse> {
+        Ok(self
+            .send_and_wait(VpnServiceCommand::RegisterAccount, request)
+            .await?
+            .map_err(NymVpnServiceCommandInnerError::Account)?)
+    }
+
+    pub async fn create_account(&self) -> Result<()> {
+        Ok(self
+            .send_and_wait(VpnServiceCommand::CreateAccount, ())
+            .await?
+            .map_err(NymVpnServiceCommandInnerError::Account)?)
+    }
+
     pub async fn store_account(&self, request: StoreAccountRequest) -> Result<()> {
         self.send_and_wait(VpnServiceCommand::StoreAccount, request)
             .await?
@@ -191,6 +208,13 @@ impl NymVpnServiceCommandSender {
     pub async fn is_account_stored(&self) -> Result<bool> {
         self.send_and_wait(VpnServiceCommand::IsAccountStored, ())
             .await
+    }
+
+    pub async fn get_stored_mnemonic(&self) -> Result<String> {
+        Ok(self
+            .send_and_wait(VpnServiceCommand::GetStoredMnemonic, ())
+            .await?
+            .map_err(NymVpnServiceCommandInnerError::Account)?)
     }
 
     pub async fn forget_account(&self) -> Result<()> {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
@@ -33,6 +33,8 @@ use nym_vpn_lib_types::{
     StoreAccountRequest, SystemMessage, TargetState, TunnelEvent, TunnelState, VpnAccountSummary,
     VpnServiceConfig, VpnServiceInfo,
 };
+#[cfg(any(target_os = "android", target_os = "ios"))]
+use nym_vpn_lib_types::{RegisterAccountRequest, RegisterAccountResponse};
 use nym_vpn_network_config::{DiscoveryRefresher, Network, NetworkCache};
 use nym_vpn_store::types::{StorableAccount, StoredAccountMode};
 
@@ -101,10 +103,17 @@ pub enum VpnServiceCommand {
     SetTargetState(oneshot::Sender<bool>, TargetState),
     Reconnect(oneshot::Sender<bool>, ()),
     GetTunnelState(oneshot::Sender<TunnelState>, ()),
+    #[cfg(any(target_os = "android", target_os = "ios"))]
+    RegisterAccount(
+        oneshot::Sender<Result<RegisterAccountResponse, AccountCommandError>>,
+        RegisterAccountRequest,
+    ),
+    CreateAccount(oneshot::Sender<Result<(), AccountCommandError>>, ()),
     StoreAccount(
         oneshot::Sender<Result<(), AccountCommandError>>,
         StoreAccountRequest,
     ),
+    GetStoredMnemonic(oneshot::Sender<Result<String, AccountCommandError>>, ()),
     DecentralisedBalance(oneshot::Sender<AccountBalanceResponse>, ()),
     DecentralisedObtainTicketbooks(
         oneshot::Sender<Result<(), AccountCommandError>>,
@@ -889,8 +898,18 @@ impl NymVpnService {
                 let result = self.handle_get_tunnel_state().await;
                 let _ = tx.send(result);
             }
+            #[cfg(any(target_os = "android", target_os = "ios"))]
+            VpnServiceCommand::RegisterAccount(tx, request) => {
+                let _ = tx.send(self.handle_register_account(request).await);
+            }
+            VpnServiceCommand::CreateAccount(tx, ()) => {
+                let _ = tx.send(self.handle_create_account().await);
+            }
             VpnServiceCommand::StoreAccount(tx, account) => {
                 let _ = tx.send(self.handle_store_account(account).await);
+            }
+            VpnServiceCommand::GetStoredMnemonic(tx, ()) => {
+                let _ = tx.send(self.handle_get_stored_mnemonic().await);
             }
             VpnServiceCommand::DecentralisedBalance(tx, ()) => {
                 let _ = tx.send(self.handle_decentralised_balance().await);
@@ -1506,6 +1525,29 @@ impl NymVpnService {
         self.tunnel_state.read().await.clone()
     }
 
+    #[cfg(any(target_os = "android", target_os = "ios"))]
+    async fn handle_register_account(
+        &self,
+        request: RegisterAccountRequest,
+    ) -> Result<RegisterAccountResponse, AccountCommandError> {
+        let stored_account = self
+            .account_command_tx
+            .get_stored_account()
+            .await?
+            .ok_or(AccountCommandError::NoAccountStored)?;
+
+        self.account_command_tx
+            .register_account(
+                stored_account,
+                nym_vpn_api_client::types::Platform::from(request),
+            )
+            .await
+    }
+
+    async fn handle_create_account(&self) -> Result<(), AccountCommandError> {
+        self.account_command_tx.create_account_command().await
+    }
+
     async fn handle_store_account(
         &mut self,
         store_request: StoreAccountRequest,
@@ -1524,6 +1566,16 @@ impl NymVpnService {
                 ))
                 .await
         }
+    }
+
+    async fn handle_get_stored_mnemonic(&mut self) -> Result<String, AccountCommandError> {
+        let stored_account = self
+            .account_command_tx
+            .get_stored_account()
+            .await?
+            .ok_or(AccountCommandError::NoAccountStored)?;
+
+        Ok(stored_account.mnemonic.to_string())
     }
 
     async fn handle_decentralised_balance(&mut self) -> AccountBalanceResponse {


### PR DESCRIPTION
## Description

- This PR makes methods to create and register account, get mnemonic available over service interface.
- Renames `AccountRegistrationArgs` to `RegisterAccountRequest` since the return type is called `RegisterAccountResponse`

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4509)
<!-- Reviewable:end -->
