### PR TITLE
Enable pnet/std

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -3354,6 +3354,15 @@ dependencies = [
 
 [[package]]
 name = "ipnetwork"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "ipnetwork"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763"
@@ -4793,7 +4802,7 @@ dependencies = [
 name = "nym-firewall"
 version = "1.24.0-beta"
 dependencies = [
- "ipnetwork",
+ "ipnetwork 0.21.1",
  "libc",
  "log",
  "mnl",
@@ -4815,7 +4824,7 @@ dependencies = [
 name = "nym-firewall-config"
 version = "1.24.0-beta"
 dependencies = [
- "ipnetwork",
+ "ipnetwork 0.21.1",
 ]
 
 [[package]]
@@ -5392,7 +5401,7 @@ version = "1.24.0-beta"
 dependencies = [
  "bitflags 2.9.4",
  "futures",
- "ipnetwork",
+ "ipnetwork 0.21.1",
  "libc",
  "nix 0.30.1",
  "nym-common",
@@ -6033,7 +6042,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.7.0",
  "hyper-util",
- "ipnetwork",
+ "ipnetwork 0.21.1",
  "itertools 0.14.0",
  "log-panics",
  "nix 0.30.1",
@@ -6116,7 +6125,7 @@ dependencies = [
 name = "nym-vpn-lib-types"
 version = "1.24.0-beta"
 dependencies = [
- "ipnetwork",
+ "ipnetwork 0.21.1",
  "nym-bandwidth-controller",
  "nym-crypto",
  "nym-gateway-directory",
@@ -6142,7 +6151,7 @@ version = "1.24.0-beta"
 dependencies = [
  "async-trait",
  "ipnet",
- "ipnetwork",
+ "ipnetwork 0.21.1",
  "iprange",
  "itertools 0.14.0",
  "log",
@@ -6300,7 +6309,7 @@ version = "1.24.0-beta"
 dependencies = [
  "base64 0.22.1",
  "hex",
- "ipnetwork",
+ "ipnetwork 0.21.1",
  "nym-windows",
  "rand 0.8.5",
  "thiserror 2.0.18",
@@ -6733,7 +6742,7 @@ checksum = "944d2c073758b6bda57f517cff54cf69d74eae3593fe1e9aa9918666543456a9"
 dependencies = [
  "derive_builder",
  "ioctl-sys",
- "ipnetwork",
+ "ipnetwork 0.21.1",
  "libc",
 ]
 
@@ -6874,8 +6883,12 @@ version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "682396b533413cc2e009fbb48aadf93619a149d3e57defba19ff50ce0201bd0d"
 dependencies = [
+ "ipnetwork 0.20.0",
  "pnet_base 0.35.0",
+ "pnet_datalink",
  "pnet_packet 0.35.0",
+ "pnet_sys",
+ "pnet_transport",
 ]
 
 [[package]]
@@ -6894,6 +6907,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffc190d4067df16af3aba49b3b74c469e611cad6314676eaf1157f31aa0fb2f7"
 dependencies = [
  "no-std-net",
+]
+
+[[package]]
+name = "pnet_datalink"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79e70ec0be163102a332e1d2d5586d362ad76b01cec86f830241f2b6452a7b7"
+dependencies = [
+ "ipnetwork 0.20.0",
+ "libc",
+ "pnet_base 0.35.0",
+ "pnet_sys",
+ "winapi",
 ]
 
 [[package]]
@@ -6960,6 +6986,28 @@ dependencies = [
  "pnet_base 0.35.0",
  "pnet_macros 0.35.0",
  "pnet_macros_support 0.35.0",
+]
+
+[[package]]
+name = "pnet_sys"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d4643d3d4db6b08741050c2f3afa9a892c4244c085a72fcda93c9c2c9a00f4b"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "pnet_transport"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f604d98bc2a6591cf719b58d3203fd882bdd6bf1db696c4ac97978e9f4776bf"
+dependencies = [
+ "libc",
+ "pnet_base 0.35.0",
+ "pnet_packet 0.35.0",
+ "pnet_sys",
 ]
 
 [[package]]

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -4700,8 +4700,7 @@ dependencies = [
  "nym-vpn-api-client",
  "nym-vpn-lib-types",
  "nym-vpn-network-config",
- "pnet",
- "pnet_base 0.35.0",
+ "pnet_packet 0.35.0",
  "rand 0.8.5",
  "serde_json",
  "thiserror 2.0.18",
@@ -6867,16 +6866,6 @@ dependencies = [
  "quick-xml",
  "serde",
  "time",
-]
-
-[[package]]
-name = "pnet"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "682396b533413cc2e009fbb48aadf93619a149d3e57defba19ff50ce0201bd0d"
-dependencies = [
- "pnet_base 0.35.0",
- "pnet_packet 0.35.0",
 ]
 
 [[package]]

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -3354,15 +3354,6 @@ dependencies = [
 
 [[package]]
 name = "ipnetwork"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "ipnetwork"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763"
@@ -4710,6 +4701,7 @@ dependencies = [
  "nym-vpn-lib-types",
  "nym-vpn-network-config",
  "pnet",
+ "pnet_base 0.35.0",
  "rand 0.8.5",
  "serde_json",
  "thiserror 2.0.18",
@@ -4802,7 +4794,7 @@ dependencies = [
 name = "nym-firewall"
 version = "1.24.0-beta"
 dependencies = [
- "ipnetwork 0.21.1",
+ "ipnetwork",
  "libc",
  "log",
  "mnl",
@@ -4824,7 +4816,7 @@ dependencies = [
 name = "nym-firewall-config"
 version = "1.24.0-beta"
 dependencies = [
- "ipnetwork 0.21.1",
+ "ipnetwork",
 ]
 
 [[package]]
@@ -5401,7 +5393,7 @@ version = "1.24.0-beta"
 dependencies = [
  "bitflags 2.9.4",
  "futures",
- "ipnetwork 0.21.1",
+ "ipnetwork",
  "libc",
  "nix 0.30.1",
  "nym-common",
@@ -6042,7 +6034,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.7.0",
  "hyper-util",
- "ipnetwork 0.21.1",
+ "ipnetwork",
  "itertools 0.14.0",
  "log-panics",
  "nix 0.30.1",
@@ -6125,7 +6117,7 @@ dependencies = [
 name = "nym-vpn-lib-types"
 version = "1.24.0-beta"
 dependencies = [
- "ipnetwork 0.21.1",
+ "ipnetwork",
  "nym-bandwidth-controller",
  "nym-crypto",
  "nym-gateway-directory",
@@ -6151,7 +6143,7 @@ version = "1.24.0-beta"
 dependencies = [
  "async-trait",
  "ipnet",
- "ipnetwork 0.21.1",
+ "ipnetwork",
  "iprange",
  "itertools 0.14.0",
  "log",
@@ -6309,7 +6301,7 @@ version = "1.24.0-beta"
 dependencies = [
  "base64 0.22.1",
  "hex",
- "ipnetwork 0.21.1",
+ "ipnetwork",
  "nym-windows",
  "rand 0.8.5",
  "thiserror 2.0.18",
@@ -6742,7 +6734,7 @@ checksum = "944d2c073758b6bda57f517cff54cf69d74eae3593fe1e9aa9918666543456a9"
 dependencies = [
  "derive_builder",
  "ioctl-sys",
- "ipnetwork 0.21.1",
+ "ipnetwork",
  "libc",
 ]
 
@@ -6883,12 +6875,8 @@ version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "682396b533413cc2e009fbb48aadf93619a149d3e57defba19ff50ce0201bd0d"
 dependencies = [
- "ipnetwork 0.20.0",
  "pnet_base 0.35.0",
- "pnet_datalink",
  "pnet_packet 0.35.0",
- "pnet_sys",
- "pnet_transport",
 ]
 
 [[package]]
@@ -6907,19 +6895,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffc190d4067df16af3aba49b3b74c469e611cad6314676eaf1157f31aa0fb2f7"
 dependencies = [
  "no-std-net",
-]
-
-[[package]]
-name = "pnet_datalink"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79e70ec0be163102a332e1d2d5586d362ad76b01cec86f830241f2b6452a7b7"
-dependencies = [
- "ipnetwork 0.20.0",
- "libc",
- "pnet_base 0.35.0",
- "pnet_sys",
- "winapi",
 ]
 
 [[package]]
@@ -6986,28 +6961,6 @@ dependencies = [
  "pnet_base 0.35.0",
  "pnet_macros 0.35.0",
  "pnet_macros_support 0.35.0",
-]
-
-[[package]]
-name = "pnet_sys"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d4643d3d4db6b08741050c2f3afa9a892c4244c085a72fcda93c9c2c9a00f4b"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "pnet_transport"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f604d98bc2a6591cf719b58d3203fd882bdd6bf1db696c4ac97978e9f4776bf"
-dependencies = [
- "libc",
- "pnet_base 0.35.0",
- "pnet_packet 0.35.0",
- "pnet_sys",
 ]
 
 [[package]]

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -110,7 +110,7 @@ objc2-foundation = "0.3.2"
 once_cell = "1.21"
 opentelemetry = "0.31.0"
 opentelemetry_sdk = "0.31.0"
-pnet = { version = "0.35.0", default-features = false }
+pnet_packet = "0.35.0"
 plist = "1.8.0"
 pfctl = "0.7.0"
 prost = "0.14.3"

--- a/nym-vpn-core/crates/nym-diagnostic/Cargo.toml
+++ b/nym-vpn-core/crates/nym-diagnostic/Cargo.toml
@@ -41,7 +41,8 @@ boringtun.workspace = true
 clap.workspace = true
 futures.workspace = true
 hickory-resolver.workspace = true
-pnet = { workspace = true, features = ["std"] }
+pnet.workspace = true
+pnet_base = { version = "0.35", features = ["std"] }
 rand.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/nym-vpn-core/crates/nym-diagnostic/Cargo.toml
+++ b/nym-vpn-core/crates/nym-diagnostic/Cargo.toml
@@ -41,8 +41,7 @@ boringtun.workspace = true
 clap.workspace = true
 futures.workspace = true
 hickory-resolver.workspace = true
-pnet.workspace = true
-pnet_base = { version = "0.35", features = ["std"] }
+pnet_packet.workspace = true
 rand.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/nym-vpn-core/crates/nym-diagnostic/Cargo.toml
+++ b/nym-vpn-core/crates/nym-diagnostic/Cargo.toml
@@ -41,7 +41,7 @@ boringtun.workspace = true
 clap.workspace = true
 futures.workspace = true
 hickory-resolver.workspace = true
-pnet.workspace = true
+pnet = { workspace = true, features = ["std"] }
 rand.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/registration/wireguard.rs
+++ b/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/registration/wireguard.rs
@@ -6,7 +6,7 @@ use nym_sdk::mixnet::x25519;
 use nym_vpn_lib_types::{DiagnosticResult, PingReport};
 
 use boringtun::noise::{Tunn, TunnResult};
-use pnet::packet::{Packet, ip::IpNextHeaderProtocols};
+use pnet_packet::{Packet, ip::IpNextHeaderProtocols};
 use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
     result::Result::Ok,
@@ -175,7 +175,7 @@ impl WireguardDiagnostic {
 }
 
 pub fn build_icmp_ipv4_packet(src: Ipv4Addr, dst: Ipv4Addr, seq: u16) -> Vec<u8> {
-    use pnet::packet::{
+    use pnet_packet::{
         icmp::{IcmpCode, IcmpTypes, echo_request::MutableEchoRequestPacket},
         ipv4::MutableIpv4Packet,
         util::checksum,
@@ -214,7 +214,7 @@ pub fn build_icmp_ipv4_packet(src: Ipv4Addr, dst: Ipv4Addr, seq: u16) -> Vec<u8>
 }
 
 pub fn build_icmp_ipv6_packet(src: Ipv6Addr, dst: Ipv6Addr, seq: u16) -> Vec<u8> {
-    use pnet::packet::{
+    use pnet_packet::{
         icmpv6::{Icmpv6Code, Icmpv6Types, echo_request::MutableEchoRequestPacket},
         ipv6::MutableIpv6Packet,
         util::ipv6_checksum,
@@ -258,7 +258,7 @@ pub fn build_icmp_ipv6_packet(src: Ipv6Addr, dst: Ipv6Addr, seq: u16) -> Vec<u8>
 }
 
 pub fn check_ipv4_reply(packet: &[u8], seq: u16) -> anyhow::Result<()> {
-    use pnet::packet::{icmp::echo_reply::EchoReplyPacket, ipv4::Ipv4Packet};
+    use pnet_packet::{icmp::echo_reply::EchoReplyPacket, ipv4::Ipv4Packet};
 
     if let Some(ip) = Ipv4Packet::new(packet)
         && ip.get_next_level_protocol() == IpNextHeaderProtocols::Icmp
@@ -279,7 +279,7 @@ pub fn check_ipv4_reply(packet: &[u8], seq: u16) -> anyhow::Result<()> {
 }
 
 pub fn check_ipv6_reply(packet: &[u8], seq: u16) -> anyhow::Result<()> {
-    use pnet::packet::{icmpv6::echo_reply::EchoReplyPacket, ipv6::Ipv6Packet};
+    use pnet_packet::{icmpv6::echo_reply::EchoReplyPacket, ipv6::Ipv6Packet};
     if let Some(ip) = Ipv6Packet::new(packet)
         && ip.get_next_header() == IpNextHeaderProtocols::Icmpv6
         && let Some(reply) = EchoReplyPacket::new(ip.payload())


### PR DESCRIPTION
## Description

Replace `pnet` with `pnet_packet` to avoid compilation issues and avoid dependence on winpcap (`Packet.lib`) on Windows

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4531)
<!-- Reviewable:end -->
