### PR TITLE
Add mixnet tuning params and network stats to VPNConfig

### DIFF
--- a/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/controller/VpnCoreController.kt
+++ b/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/controller/VpnCoreController.kt
@@ -317,6 +317,8 @@ class VpnCoreController(
 			enableLewesProtocol = false,
 			customDns = emptyList(),
 			residentialExit = false,
+			mixnetTraffic = null,
+			networkStats = null,
 			userAgent = ua,
 			tunProvider = service,
 			connectivityMonitor = service,

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/lib.rs
@@ -213,6 +213,8 @@ pub struct VPNConfig {
     /// Custom DNS used when set.
     /// Leave empty to use default DNS servers.
     pub custom_dns: Vec<IpAddr>,
+    pub mixnet_traffic: Option<MixnetTrafficConfig>,
+    pub network_stats: Option<NetworkStatisticsConfig>,
     pub user_agent: UserAgent,
     #[cfg(target_os = "ios")]
     tun_provider: Arc<dyn OSTunProvider>,
@@ -239,8 +241,8 @@ impl VPNConfig {
             enable_custom_dns: !self.custom_dns.is_empty(),
             custom_dns: self.custom_dns.clone(),
             min_gateway_vpn_performance: None,
-            mixnet_traffic: MixnetTrafficConfig::default(),
-            network_stats: NetworkStatisticsConfig::default(),
+            mixnet_traffic: self.mixnet_traffic.clone().unwrap_or_default(),
+            network_stats: self.network_stats.clone().unwrap_or_default(),
         })
     }
 }


### PR DESCRIPTION

## Description

This PR adds mixnet tuning params and network stats to `VPNConfig`. Pass `None` to get default configurations.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4549)
<!-- Reviewable:end -->
