### PR TITLE
Fix mnemonic paths

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/account.rs
@@ -40,7 +40,8 @@ impl NymAccountController {
         network_env: Arc<NymEnvironment>,
         offline_monitor: Arc<NymOfflineMonitor>,
     ) -> Result<Self, VpnError> {
-        let storage = VpnClientOnDiskStorage::new(data_dir.clone());
+        let storage_path = data_dir.join(network_env.network_name());
+        let storage = VpnClientOnDiskStorage::new(&storage_path);
         let shutdown_token = CancellationToken::new();
 
         let nym_vpn_api_client = nym_vpn_api_client::VpnApiClient::from_network(
@@ -55,7 +56,7 @@ impl NymAccountController {
 
         let nyxd_client = NyxdClient::new(network_env.inner());
         let account_controller_config = nym_vpn_account_controller::AccountControllerConfig {
-            data_dir,
+            data_dir: storage_path,
             network_env: network_env.inner().clone(),
         };
 

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/environment.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/environment.rs
@@ -70,6 +70,10 @@ impl NymEnvironment {
         // todo: remove after updating to uniffi 0.31
     }
 
+    pub fn network_name(&self) -> String {
+        self.network.nym_network.network_name.clone()
+    }
+
     /// Returns the currently set network environment
     pub fn current(&self) -> Network {
         Network::from(*self.network.clone())

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_account_storage.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_account_storage.rs
@@ -41,8 +41,9 @@ pub struct NymVpnAccountStorage {
 #[uniffi::export(async_runtime = "tokio")]
 impl NymVpnAccountStorage {
     #[uniffi::constructor]
-    pub fn new(storage_path: PathBuf, environment: Arc<NymEnvironment>) -> Self {
+    pub fn new(data_dir: PathBuf, environment: Arc<NymEnvironment>) -> Self {
         // todo: ensure account controller is not running?
+        let storage_path = data_dir.join(environment.network_name());
         Self {
             storage: VpnClientOnDiskStorage::new(&storage_path),
             storage_path,


### PR DESCRIPTION

## Description

This PR ensures that account storage and account controller are initialized with `data_dir/network_name` directory.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4554)
<!-- Reviewable:end -->
