### PR TITLE
Wrap VPN service into multi-threaded tokio runtime

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_service.rs
@@ -13,7 +13,8 @@ use tokio::{
 use tokio_util::sync::{CancellationToken, DropGuard};
 
 use crate::{
-    NymEnvironment, VPNConfig, VpnError, vpn_service_command_sender::NymVpnServiceCommandSender,
+    NymEnvironment, TOKIO_RUNTIME, VPNConfig, VpnError,
+    vpn_service_command_sender::NymVpnServiceCommandSender,
 };
 
 struct State {
@@ -41,74 +42,86 @@ impl NymVpnService {
         environment: Arc<NymEnvironment>,
         event_listener: Arc<dyn TunnelStatusListener>,
     ) -> Result<Self, VpnError> {
-        // Export environment first!
-        environment.export_to_env();
+        // Uniffi async adapter runs on single-threaded runtime
+        // Create vpn service on multi-threaded runtime to ensure that it has enough resources
+        TOKIO_RUNTIME
+            .spawn(async move {
+                // Export environment first!
+                environment.export_to_env();
 
-        let service_storage_type =
-            ServiceConfigStorageType::Ephemeral(config.as_vpn_service_config());
+                let service_storage_type =
+                    ServiceConfigStorageType::Ephemeral(config.as_vpn_service_config());
 
-        #[cfg(target_os = "android")]
-        let tun_provider = Arc::new(
-            crate::tunnel_provider::android::AndroidTunProviderImpl::new(config.tun_provider),
-        );
-        #[cfg(target_os = "ios")]
-        let tun_provider = Arc::new(crate::tunnel_provider::ios::OSTunProviderImpl::new(
-            config.tun_provider,
-        ));
-        #[cfg(target_os = "android")]
-        let connectivity_monitor =
-            crate::offline_monitor::register_connectivity_observer(config.connectivity_monitor);
+                #[cfg(target_os = "android")]
+                let tun_provider = Arc::new(
+                    crate::tunnel_provider::android::AndroidTunProviderImpl::new(
+                        config.tun_provider,
+                    ),
+                );
+                #[cfg(target_os = "ios")]
+                let tun_provider = Arc::new(crate::tunnel_provider::ios::OSTunProviderImpl::new(
+                    config.tun_provider,
+                ));
+                #[cfg(target_os = "android")]
+                let connectivity_monitor = crate::offline_monitor::register_connectivity_observer(
+                    config.connectivity_monitor,
+                );
 
-        let shutdown_token = CancellationToken::new();
-        let network_cache = NetworkCache::new(
-            config.config_dir.clone(),
-            &environment.current().nym_network.network_name,
-            Some(config.user_agent.clone().into()),
-            None,
-        )
-        .await
-        .map_err(VpnError::internal)?;
+                let shutdown_token = CancellationToken::new();
+                let network_cache = NetworkCache::new(
+                    config.config_dir.clone(),
+                    &environment.current().nym_network.network_name,
+                    Some(config.user_agent.clone().into()),
+                    None,
+                )
+                .await
+                .map_err(VpnError::internal)?;
 
-        let vpn_service_params = nym_vpn_lib::service::NymVpnServiceParameters {
-            // This is only needed for log removal helper
-            log_path: None,
-            config_dir: config.config_dir.clone(),
-            data_dir: config.data_dir.clone(),
-            network_cache,
-            sentry_enabled: crate::logging::is_sentry_enabled(),
-            user_agent: config.user_agent.clone().into(),
-            service_storage_type,
-            #[cfg(any(target_os = "android", target_os = "ios"))]
-            tun_provider,
-            #[cfg(target_os = "android")]
-            connectivity_monitor: Box::new(connectivity_monitor),
-        };
+                let vpn_service_params = nym_vpn_lib::service::NymVpnServiceParameters {
+                    // This is only needed for log removal helper
+                    log_path: None,
+                    config_dir: config.config_dir.clone(),
+                    data_dir: config.data_dir.clone(),
+                    network_cache,
+                    sentry_enabled: crate::logging::is_sentry_enabled(),
+                    user_agent: config.user_agent.clone().into(),
+                    service_storage_type,
+                    #[cfg(any(target_os = "android", target_os = "ios"))]
+                    tun_provider,
+                    #[cfg(target_os = "android")]
+                    connectivity_monitor: Box::new(connectivity_monitor),
+                };
 
-        let (vpn_command_tx, vpn_command_rx) = mpsc::unbounded_channel();
-        let (tunnel_event_tx, mut tunnel_event_rx) = broadcast::channel(10);
+                let (vpn_command_tx, vpn_command_rx) = mpsc::unbounded_channel();
+                let (tunnel_event_tx, mut tunnel_event_rx) = broadcast::channel(10);
 
-        let vpn_service_handle = nym_vpn_lib::service::NymVpnService::spawn(
-            vpn_command_rx,
-            tunnel_event_tx,
-            None,
-            vpn_service_params,
-            shutdown_token.child_token(),
-        );
+                let vpn_service_handle = nym_vpn_lib::service::NymVpnService::spawn(
+                    vpn_command_rx,
+                    tunnel_event_tx,
+                    None,
+                    vpn_service_params,
+                    shutdown_token.child_token(),
+                );
 
-        let event_handler = tokio::spawn(async move {
-            while let Ok(event) = tunnel_event_rx.recv().await {
-                event_listener.on_event(event);
-            }
-        });
+                let event_handler = tokio::spawn(async move {
+                    while let Ok(event) = tunnel_event_rx.recv().await {
+                        event_listener.on_event(event);
+                    }
+                });
 
-        Ok(NymVpnService {
-            command_sender: Arc::new(NymVpnServiceCommandSender::new(vpn_command_tx)),
-            state: Arc::new(Mutex::new(Some(State {
-                event_handler,
-                vpn_service_handle,
-                shutdown_drop_guard: shutdown_token.drop_guard(),
-            }))),
-        })
+                Ok(NymVpnService {
+                    command_sender: Arc::new(NymVpnServiceCommandSender::new(vpn_command_tx)),
+                    state: Arc::new(Mutex::new(Some(State {
+                        event_handler,
+                        vpn_service_handle,
+                        shutdown_drop_guard: shutdown_token.drop_guard(),
+                    }))),
+                })
+            })
+            .await
+            .map_err(|err| VpnError::InternalError {
+                details: format!("failed to join on multi-threaded tokio runtime: {}", err),
+            })?
     }
 
     pub fn get_command_sender(&self) -> Arc<NymVpnServiceCommandSender> {


### PR DESCRIPTION


## Description

This PR ensures that `NymVpnService` runs on multi-threaded tokio runtime. The rest of code in uniffi can rely on default single-threaded tokio runtime.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4564)
<!-- Reviewable:end -->
