### PR TITLE
tauri: mixnet tuning fixes

### DIFF
--- a/nym-vpn-app/src/i18n/config.ts
+++ b/nym-vpn-app/src/i18n/config.ts
@@ -24,8 +24,8 @@ export const ns = [
 ] as const;
 
 export const languages = [
-  { code: 'ar', name: 'العربية (Arabic)' }, // rtl
-  { code: 'fa', name: 'فارسی (Persian)' }, // rtl
+  { code: 'ar', name: 'العربية' }, // rtl
+  { code: 'fa', name: 'فارسی' }, // rtl
   { code: 'bn', name: 'বাংলা' },
   { code: 'de', name: 'Deutsch' },
   { code: 'en', name: 'English' },

--- a/nym-vpn-app/src/i18n/en/settings.json
+++ b/nym-vpn-app/src/i18n/en/settings.json
@@ -120,13 +120,16 @@
         "use-less-battery-and-data": "Use less battery & data",
         "max-anonymity": "Max. anonymity",
         "low": {
-          "label": "Low"
+          "label": "Low",
+          "speed": "{{value}} Mbps"
         },
         "balanced": {
-          "label": "Balanced"
+          "label": "Balanced",
+          "speed": "{{value}} Mbps"
         },
         "high": {
-          "label": "High"
+          "label": "High",
+          "speed": "{{value}} Mbps"
         }
       },
       "background-cover-traffic": {

--- a/nym-vpn-app/src/screens/settings/mixnet-tuning/ContinuousTrafficCard.tsx
+++ b/nym-vpn-app/src/screens/settings/mixnet-tuning/ContinuousTrafficCard.tsx
@@ -89,13 +89,13 @@ function BackgroundCoverTrafficRateSlider({
   );
 }
 
-const CONTINUOUS_LEVELS: {
+export const CONTINUOUS_LEVELS: {
   label: 'low' | 'balanced' | 'high';
   speed: string;
 }[] = [
-  { label: 'low', speed: '0.7 Mbps' },
-  { label: 'balanced', speed: '1 Mbps' },
-  { label: 'high', speed: '2 Mbps' },
+  { label: 'low', speed: '0.7' },
+  { label: 'balanced', speed: '1' },
+  { label: 'high', speed: '2' },
 ];
 
 // Slider index → Config value mappings
@@ -122,7 +122,7 @@ const BACKGROUND_COVER_TRAFFIC_TO_SLIDER = new Map<number, number>(
 const sliderToContinuousTrafficValue = (sliderValue: number): number =>
   CONTINUOUS_TRAFFIC_VALUES[sliderValue] ?? CONTINUOUS_TRAFFIC_VALUES[0];
 
-const continuousTrafficValueToSlider = (configValue: number): number =>
+export const continuousTrafficValueToSlider = (configValue: number): number =>
   CONTINUOUS_TRAFFIC_TO_SLIDER.get(configValue) ?? 0;
 
 const sliderToBackgroundCoverTrafficValue = (sliderValue: number): number =>
@@ -184,7 +184,14 @@ function ContinuousTrafficSlider({
                 `mixnet-tuning.continuous-traffic.continuous.${item.label}.label`,
               )}
             </span>
-            <span className="whitespace-nowrap">{item.speed}</span>
+            <span className="whitespace-nowrap">
+              {t(
+                `mixnet-tuning.continuous-traffic.continuous.${item.label}.speed`,
+                {
+                  value: item.speed,
+                },
+              )}
+            </span>
           </button>
         ))}
       />

--- a/nym-vpn-app/src/screens/settings/mixnet-tuning/PerformanceCard.tsx
+++ b/nym-vpn-app/src/screens/settings/mixnet-tuning/PerformanceCard.tsx
@@ -9,13 +9,26 @@ import {
   CardNewFooter,
   CardNewHeader,
 } from '../../../ui';
-import { useMixnetTrafficConfig } from './context';
+import {
+  DEFAULT_MIXNET_TRAFFIC_CONFIG,
+  useMixnetTrafficConfig,
+} from './context';
+import {
+  CONTINUOUS_LEVELS,
+  continuousTrafficValueToSlider,
+} from './ContinuousTrafficCard';
 
 export function PerformanceCard() {
   const { t } = useTranslation('settings');
   const { state } = useMixnetTrafficConfig();
 
-  const speed = state.messageSendingAverageDelay;
+  const speed =
+    CONTINUOUS_LEVELS[
+      continuousTrafficValueToSlider(
+        state.messageSendingAverageDelay ??
+          DEFAULT_MIXNET_TRAFFIC_CONFIG.messageSendingAverageDelay!,
+      )
+    ].speed;
 
   const [privacy, setPrivacy] = useState(0);
 


### PR DESCRIPTION
## Ticket

JIRA-VPN-XXXX

## Description

- Fix performance card `Speed` display value. Now it displays the same value as the slider labels instead of mapped values
- Remove english labels from new languages


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)
<img width="526" height="679" alt="image" src="https://github.com/user-attachments/assets/8172aebd-e2a0-4d58-a6e3-cf893917eee2" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4570)
<!-- Reviewable:end -->
