### PR TITLE
Add graceful shutdown for NymVpnService

### DIFF
--- a/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/controller/VpnCoreController.kt
+++ b/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/controller/VpnCoreController.kt
@@ -23,7 +23,6 @@ import nym_vpn_lib.NymVpnServiceCommandException
 import nym_vpn_lib.NymVpnServiceCommandSender
 import nym_vpn_lib.VpnConfig
 import nym_vpn_lib.initLogger
-import nym_vpn_lib.initializeTokioRuntime
 import nym_vpn_lib_types.EntryPoint
 import nym_vpn_lib_types.ExitPoint
 import nym_vpn_lib_types.MixnetTrafficConfig
@@ -285,12 +284,6 @@ class VpnCoreController(
 		return runCatching { block(sender) }.getOrNull()
 	}
 
-	private suspend fun ensureTokioAndLogger(storagePath: String, enableDebugLog: Boolean, sentry: Boolean) {
-		initializeTokioRuntime()
-		val level = if (enableDebugLog) LogLevel.DEBUG else LogLevel.INFO
-		initLogger(storagePath, level, sentryMonitoring = sentry)
-	}
-
 	private suspend fun ensureCoreInitialized(
 		networkName: String?,
 		enableDebugLog: Boolean,
@@ -302,7 +295,8 @@ class VpnCoreController(
 		if (initialized.isCompleted && commandSender != null && nymEnvironment != null && nymVpnService != null) return
 
 		val storagePath = service.filesDir.absolutePath
-		ensureTokioAndLogger(storagePath, enableDebugLog, sentry)
+		val level = if (enableDebugLog) LogLevel.DEBUG else LogLevel.INFO
+		initLogger(storagePath, level, sentryMonitoring = sentry)
 
 		val env =
 			if (useMainnetFallback) {

--- a/nym-vpn-apple/NymMixnetTunnel/PacketTunnelProvider.swift
+++ b/nym-vpn-apple/NymMixnetTunnel/PacketTunnelProvider.swift
@@ -53,13 +53,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     override func stopTunnel(with reason: NEProviderStopReason) async {
         logger.info("Stop tunnel... \(reason.rawValue)")
 
-        do {
-            _ = try await commandSender?.disconnectTunnel()
-            await vpnService?.shutdownAndWait()
-        } catch {
-            logger.error("Failed to stop the tunnel: \(error)")
-        }
-
+        await vpnService?.shutdownAndWait()
         await tunnelActor.setTunnelProvider(nil)
         vpnService = nil
         commandSender = nil

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/lib.rs
@@ -184,14 +184,6 @@ static TOKIO_RUNTIME: LazyLock<Runtime> = LazyLock::new(|| {
         .expect("failed to initialize tokio runtime")
 });
 
-/// Initialize tokio runtime once before interacting with nym-vpn-lib.
-/// Repeat calls do nothing.
-#[allow(non_snake_case)]
-#[uniffi::export]
-pub fn initializeTokioRuntime() {
-    let _rt = &*TOKIO_RUNTIME;
-}
-
 /// Get the message to be signed using the Privy signing API.
 #[allow(non_snake_case)]
 #[uniffi::export]

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/lib.rs
@@ -13,17 +13,33 @@
 //! ```swift
 //! import NymVpnLib
 //!
-//! // Somewhere in main()
-//! // Setup tokio runtime used by Rust library
-//! initializeTokioRuntime()
-//!
 //! // Configure logging
-//! await initLogger("/path/to/log/dir", LogLevel::Info, /* enable sentry */ true)
+//! initLogger(logDir: "/path/to/log/dir", logLevel: LogLevel::Info, sentryMonitoring: true)
 //! ```
 //!
 //! ## Environment initialization
 //!
 //! Initialize the environment: `NymEnvironment::new_with_cache_dir(cache_dir, network_name)` or `NymEnvironment::new_with_mainnet_fallback()`.
+//!
+//! ```swift
+//! import NymVpnLib
+//!
+//! // create mainnet fallback environment
+//! let mainnetFallback = try! await NymEnvironment.newWithMainnetFallback()
+//!
+//! // create environment with cache dir
+//! let userAgent = UserAgent {
+//!     application: "MyApp",
+//!     version: "1.0",
+//!     platform: "ios",
+//!     git_commit: "",
+//! }
+//! let environment = try! await NymEnvironment.newWithCacheDir(
+//!     cacheDir: "/path/to/cache/dir",
+//!     networkName: "mainnet",
+//!     userAgent: userAgent
+//! )
+//! ```
 //!
 //! ## Query gateways
 //!
@@ -32,17 +48,25 @@
 //! ```swift
 //! import NymVpnLib
 //!
-//! let environment = try! await NymEnvironment("/path/to/config/dir", "mainnet");
-//! let offlineMonitor = try! await OfflineMonitor);
-//!
 //! let userAgent = UserAgent {
 //!     application: "MyApp",
 //!     version: "1.0",
 //!     platform: "ios",
 //!     git_commit: "",
 //! }
-//! let gatewayCache = await NymGatewayCache(userAgent, environment, offlineMonitor);
-//! let gateways = try! await gatewayCache.getGateways(GatewayType::Wg);
+//! let environment = try! await NymEnvironment.newWithCacheDir(
+//!     cacheDir: "/path/to/cache/dir",
+//!     networkName: "mainnet",
+//!     userAgent: userAgent
+//! )
+//! let offlineMonitor = await NymOfflineMonitor()
+//!
+//! let gatewayCache = try await NymGatewayCache(
+//!     userAgent: userAgent,
+//!     environment: environment,
+//!     offlineMonitor: offlineMonitor
+//! )
+//! let gateways = try! await gatewayCache.getGateways(gwType: .wg);
 //!
 //! // Destroy gateway cache when no longer needed
 //! // Or simply release all references to it
@@ -56,10 +80,20 @@
 //! ```swift
 //! import NymVpnLib
 //!
-//! let environment = try! await NymEnvironment("/path/to/config/dir", "mainnet")
-//! let accountStorage = try! await NymVpnAccountStorage("/path/to/config/dir", environment)
+//! let userAgent = UserAgent {
+//!     application: "MyApp",
+//!     version: "1.0",
+//!     platform: "ios",
+//!     git_commit: "",
+//! }
+//! let environment = try! await NymEnvironment.newWithCacheDir(
+//!     cacheDir: "/path/to/cache/dir",
+//!     networkName: "mainnet",
+//!     userAgent: userAgent
+//! )
+//! let accountStorage = try! await NymVpnAccountStorage(dataDir: "/path/to/config/dir", environment: environment)
 //!
-//! try! await accountStorage.login(.vpn(mnemonic: "my awesome mnemonic!"))
+//! try! await accountStorage.login(request: .vpn(mnemonic: "my awesome mnemonic!"))
 //! ```
 //!
 //! ## Interact with account controller
@@ -69,22 +103,30 @@
 //! ```swift
 //! import NymVpnLib
 //!
-//! let environment = try! await NymEnvironment("/path/to/config/dir", "mainnet")
-//! let offlineMonitor = try! await OfflineMonitor()
-//!
 //! let userAgent = UserAgent {
 //!     application: "MyApp",
 //!     version: "1.0",
 //!     platform: "ios",
 //!     git_commit: "",
 //! }
-//! let accountController = try! await NymAccountController("/path/to/data/dir", userAgent, environment, offlineMonitor);
+//! let environment = try! await NymEnvironment.newWithCacheDir(
+//!     cacheDir: "/path/to/cache/dir",
+//!     networkName: "mainnet",
+//!     userAgent: userAgent
+//! )
+//! let offlineMonitor = await NymOfflineMonitor()
+//! let accountController = try! await NymAccountController(
+//!     data_dir: "/path/to/data/dir",
+//!     userAgent: userAgent,
+//!     environment: environment,
+//!     offlineMonitor: offlineMonitor
+//! );
 //!
 //! // Log in
-//! try! await accountController.login(.vpn(mnemonic: "my awesome mnemonic!"))
+//! try! await accountController.login(request: .vpn(mnemonic: "my awesome mnemonic!"))
 //!
 //! // Wait for account to be ready to connect
-//! try! await accountController.waitForAccountReadyToConnect()
+//! try! await accountController.waitForAccountReadyToConnect(timeout: 3600)
 //!
 //! // Destroy account controller when no longer needed
 //! await accountController.shutdownAndWait()
@@ -110,13 +152,17 @@
 //! let tunnelEventHandler = TunnelStatusListener()
 //!
 //! // Create VPN service and retain it throughout the application lifecycle
-//! let vpnService = NymVpnService(config, environment, tunnelEventHandler)
+//! let vpnService = NymVpnService.newService(
+//!     config: config,
+//!     environment: environment,
+//!     eventListener: tunnelEventHandler
+//! )
 //!
 //! // Create command sender
 //! let commandSender = vpnService.getCommandSender()
 //!
 //! // Manage VPN service
-//! try! await commandSender.setEnableTwoHop(true)
+//! try! await commandSender.setEnableTwoHop(enableTwoHop: true)
 //! try! await commandSender.connectTunnel()
 //!
 //! // When no longer needed, release the VPN service

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_service.rs
@@ -1,10 +1,10 @@
 // Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use nym_vpn_lib::service::ServiceConfigStorageType;
-use nym_vpn_lib_types::TunnelEvent;
+use nym_vpn_lib_types::{TunnelEvent, TunnelState};
 use nym_vpn_network_config::NetworkCache;
 use tokio::{
     sync::{Mutex, broadcast, mpsc},
@@ -17,10 +17,14 @@ use crate::{
     vpn_service_command_sender::NymVpnServiceCommandSender,
 };
 
+/// Max amount of time to wait for the VPN to disconnect before shutting down.
+const DISCONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
 struct State {
     event_handler: JoinHandle<()>,
     vpn_service_handle: JoinHandle<()>,
     shutdown_drop_guard: DropGuard,
+    tunnel_state: tokio::sync::watch::Receiver<Option<TunnelState>>,
 }
 
 #[uniffi::export(with_foreign)]
@@ -103,8 +107,12 @@ impl NymVpnService {
                     shutdown_token.child_token(),
                 );
 
+                let (tunnel_state_tx, tunnel_state_rx) = tokio::sync::watch::channel(None);
                 let event_handler = tokio::spawn(async move {
                     while let Ok(event) = tunnel_event_rx.recv().await {
+                        if let TunnelEvent::NewState(tunnel_state) = &event {
+                            let _ = tunnel_state_tx.send_replace(Some(tunnel_state.clone()));
+                        }
                         event_listener.on_event(event);
                     }
                 });
@@ -115,6 +123,7 @@ impl NymVpnService {
                         event_handler,
                         vpn_service_handle,
                         shutdown_drop_guard: shutdown_token.drop_guard(),
+                        tunnel_state: tunnel_state_rx,
                     }))),
                 })
             })
@@ -133,9 +142,28 @@ impl NymVpnService {
             return;
         };
 
+        let _ = self.command_sender.disconnect_tunnel().await;
+        self.wait_for_disconnect(state.tunnel_state).await;
+
         drop(state.shutdown_drop_guard);
 
         state.event_handler.await.unwrap();
         state.vpn_service_handle.await.unwrap();
+    }
+}
+
+impl NymVpnService {
+    async fn wait_for_disconnect(
+        &self,
+        mut tunnel_state_rx: tokio::sync::watch::Receiver<Option<TunnelState>>,
+    ) {
+        let _ = tokio::time::timeout(
+            DISCONNECT_TIMEOUT,
+            tunnel_state_rx.wait_for(|tunnel_state| match tunnel_state {
+                Some(TunnelState::Disconnected { .. } | TunnelState::Offline { .. }) => true,
+                _ => false,
+            }),
+        )
+        .await;
     }
 }


### PR DESCRIPTION
## Description

- Ensure that `NymVpnService` calls disconnect and performs graceful shutdown before dropping cancellation tokens. Max 5 seconds is spent waiting for disconnected state.
- Android: remove call to `initializeTokioRuntime()` as it happens automatically behind the scenes
- Update uniffi documentation

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4573)
<!-- Reviewable:end -->
