### PR TITLE
APPLE: don't push tag release if same tag exists

### DIFF
--- a/.github/workflows/build-nym-vpn-apple.yml
+++ b/.github/workflows/build-nym-vpn-apple.yml
@@ -1064,8 +1064,23 @@ jobs:
             - Commit: ${{ github.sha }}
             - Built at: ${{ github.run_started_at }}
 
-      - name: Publish macOS GitHub Release
+      - name: Check if macOS release tag already exists
         if: ${{ env.RELEASE_TYPE == 'ship' && env.BUILD_MACOS == 'true' }}
+        id: macos_tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="nym-vpn-macOS-v${MACOS_VERSION}"
+          if git ls-remote --tags origin "refs/tags/${TAG}" | grep -q .; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Tag already exists: ${TAG}"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "Tag does not exist: ${TAG}"
+          fi
+
+      - name: Publish macOS GitHub Release
+        if: ${{ env.RELEASE_TYPE == 'ship' && env.BUILD_MACOS == 'true' && steps.macos_tag.outputs.exists != 'true' }}
         uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Ticket

JIRA-VPN-XXXX

## Description

This checks if tag exists. This is to help avoid a scenario, where running the workflow overwrites the existing tag files.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4594)
<!-- Reviewable:end -->
