### PR TITLE
Streamline cut release, update tauri.conf.json

### DIFF
--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -130,12 +130,16 @@ jobs:
 
           # put -beta suffix back
           BETA_VERSION="$VERSION-beta"
+          # export ~beta version for debian
+          BETA_TILDE_VERSION="$VERSION~beta"
+
           # cargo set-version doesn't allow downgrades, patch toml directly
           toml set Cargo.toml workspace.package.version "$BETA_VERSION" > Cargo-patched.toml
           mv Cargo-patched.toml Cargo.toml
 
           echo "::notice:: Next version: $BETA_VERSION"
           echo "next_version=$BETA_VERSION" >> "$GITHUB_OUTPUT"
+          echo "next_version_tilde=$BETA_TILDE_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Update nym-vpn-core/Cargo.toml
         working-directory: nym-vpn-core
@@ -156,6 +160,22 @@ jobs:
         run: |
           toml set vpnd_compat.toml version ">=${{ steps.next-version.outputs.next_version }}" > new_vpnd_compat.toml
           mv new_vpnd_compat.toml vpnd_compat.toml
+
+      - name: Update nym-vpn-app/src-tauri/tauri.conf.json
+        working-directory: nym-vpn-app/src-tauri
+        run: |
+          # replace version of deb dependency on nym-vpnd
+          QUERY=$(cat <<- 'EOD'
+              .bundle.linux.deb.depends[] |= if (. | startswith("nym-vpnd"))
+              then
+                  "nym-vpnd (>= ${{ steps.next-version.outputs.next_version_tilde }})"
+              else
+                  .
+              end
+          EOD
+          )
+          jq -r "$QUERY" tauri.conf.json > new_tauri.conf.json
+          mv new_tauri.conf.json tauri.conf.json
 
       - name: Create PR to bump develop to v${{ steps.next-version.outputs.next_version }}
         env:

--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -61,7 +61,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: develop
-          fetch-depth: 0 # may need this for `git branch -r`
           ssh-key: ${{ secrets.CI_RELEASE_DEPLOY_KEY }}
 
       - name: Create release branch
@@ -69,10 +68,9 @@ jobs:
           RELEASE_BRANCH: release/${{ inputs.release_version }}-${{ inputs.release_name }}
         run: |
           # match any i.e `yyyy.xx-*`
-          if git branch -r | grep -qn origin/release/${{ inputs.release_version }}-; then
-              echo "::error:: 'release/${{ inputs.release_version }}-*' branch already exists but it must not!"
-              exit 1
-          else
+          HEAD_COUNT=$(git ls-remote --heads origin 'refs/heads/release/${{ inputs.release_version }}-*' | wc -l | tr -d ' ')
+
+          if [ "$HEAD_COUNT" -eq "0" ]; then
             # create release branch and push it to remote
             git checkout -b "${{ env.RELEASE_BRANCH }}"
             echo "::notice:: Created release branch: ${{ env.RELEASE_BRANCH }}"
@@ -81,6 +79,9 @@ jobs:
             else
               git push origin "${{ env.RELEASE_BRANCH }}"
             fi
+          else
+            echo "::error:: 'release/${{ inputs.release_version }}-*' branch already exists but it must not!"
+            exit 1
           fi
 
   bump-develop:


### PR DESCRIPTION
## JIRA

NYM-486

## Description

- Use `git ls-remote` instead of `git branch -r` to avoid fetching the entire repo (fetch-depth: 0)
- Update `tauri.conf.json` when cutting the release branch

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4596)
<!-- Reviewable:end -->
