### PR TITLE
APPLE: fix initial wrong tunnel state on connect

### DIFF
--- a/nym-vpn-apple/NymMixnetTunnel/PacketTunnelProvider.swift
+++ b/nym-vpn-apple/NymMixnetTunnel/PacketTunnelProvider.swift
@@ -48,6 +48,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         try await setup(vpnConfig: vpnConfig)
 
         _ = try await commandSender?.connectTunnel()
+        try await tunnelActor.waitUntilStarted()
     }
 
     override func stopTunnel(with reason: NEProviderStopReason) async {


### PR DESCRIPTION
## Ticket

JIRA-NYM-490

## Description

Fix initial wrong state emitted. 


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4599)
<!-- Reviewable:end -->
