### PR TITLE
Make skew testable

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -6175,6 +6175,7 @@ dependencies = [
 name = "nym-vpn-api-client"
 version = "1.25.0-beta"
 dependencies = [
+ "async-trait",
  "backon",
  "base64-url",
  "bip39",
@@ -6201,6 +6202,7 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
+ "tracing-test",
  "url",
  "zeroize",
 ]

--- a/nym-vpn-core/crates/nym-vpn-api-client/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-api-client/Cargo.toml
@@ -37,7 +37,6 @@ strum.workspace = true
 strum_macros.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
-tracing-test.workspace = true
 time = { workspace = true, features = [
     "serde-human-readable",
     "serde-well-known",
@@ -48,6 +47,7 @@ zeroize.workspace = true
 
 [dev-dependencies]
 bip39 = { workspace = true, features = ["zeroize"] }
+tracing-test.workspace = true
 
 [features]
 default = ["network-defaults"]

--- a/nym-vpn-core/crates/nym-vpn-api-client/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-api-client/Cargo.toml
@@ -12,6 +12,7 @@ license.workspace = true
 workspace = true
 
 [dependencies]
+async-trait.workspace = true
 backon.workspace = true
 base64-url.workspace = true
 bip39 = { workspace = true, features = ["zeroize"] }
@@ -35,7 +36,8 @@ sha256.workspace = true
 strum.workspace = true
 strum_macros.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio.workspace = true
+tracing-test.workspace = true
 time = { workspace = true, features = [
     "serde-human-readable",
     "serde-well-known",

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
@@ -1,10 +1,7 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::{sync::Arc, time::Duration};
 
 use backon::Retryable;
 use nym_credential_proxy_requests::api::v1::ticketbook::models::PartialVerificationKeysResponse;
@@ -12,7 +9,7 @@ use nym_http_api_client::{
     ApiClient, Client, HttpClientError, NO_PARAMS, Params, PathSegments, Url, UserAgent,
 };
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
-use time::{Duration as TimeDuration, OffsetDateTime};
+use time::OffsetDateTime;
 use tokio::sync::RwLock;
 
 use crate::{
@@ -34,9 +31,9 @@ use crate::{
         NymVpnZkNymPost, NymVpnZkNymResponse, NymWellknownDiscoveryItem, StatusOk,
     },
     routes,
+    skew_manager::{RemoteTimeProvider, SkewManager},
     types::{
         Device, DeviceStatus, GatewayMinPerformance, GatewayType, Platform, VpnAccount, VpnApiTime,
-        VpnApiTimeSynced,
     },
 };
 
@@ -45,54 +42,12 @@ pub(crate) const DEVICE_AUTHORIZATION_HEADER: &str = "x-device-authorization";
 // GET requests can unfortunately take a long time over the mixnet
 pub(crate) const NYM_VPN_API_TIMEOUT: Duration = Duration::from_secs(30);
 
-// Number of retries for remote time synchronization (not including the initial attempt)
-const REMOTE_TIME_MAX_RETRIES: u8 = 2;
-
-// Wait delay between retries for remote time synchronization
-const REMOTE_TIME_WAIT_DELAY: Duration = Duration::from_secs(1);
-
-const SKEW_CACHE_TTL: Duration = Duration::from_secs(4 * 60 * 60); // 4 hours
-
-#[derive(Debug)]
-struct SkewState {
-    skew: TimeDuration,
-    expires_at: Instant,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum SkewStatus {
-    Expired(),
-    Valid(TimeDuration),
-}
-
-impl SkewState {
-    fn new(skew: TimeDuration, now: Instant) -> Self {
-        Self {
-            skew,
-            expires_at: now + SKEW_CACHE_TTL,
-        }
-    }
-
-    fn update(&mut self, skew: TimeDuration, now: Instant) {
-        self.skew = skew;
-        self.expires_at = now + SKEW_CACHE_TTL;
-    }
-
-    fn status(&self, now: Instant) -> SkewStatus {
-        if self.expires_at > now {
-            SkewStatus::Valid(self.skew)
-        } else {
-            SkewStatus::Expired()
-        }
-    }
-}
-
 #[derive(Clone, Debug)]
 pub struct VpnApiClient {
     inner: Client,
     urls: Vec<Url>,
     user_agent: Option<UserAgent>,
-    skew_state: Arc<RwLock<Option<SkewState>>>,
+    skew_manager: Arc<RwLock<SkewManager>>,
 }
 
 impl VpnApiClient {
@@ -108,11 +63,13 @@ impl VpnApiClient {
             resolver_overrides,
         )?;
 
+        let time_provider = VpnApiRemoteTimeProvider::new(inner.clone());
+
         Ok(Self {
             inner,
             urls,
             user_agent,
-            skew_state: Arc::new(RwLock::new(None)),
+            skew_manager: Arc::new(RwLock::new(SkewManager::new(time_provider))),
         })
     }
 
@@ -139,11 +96,13 @@ impl VpnApiClient {
             resolver_overrides,
         )?;
 
+        let time_provider = VpnApiRemoteTimeProvider::new(inner.clone());
+
         Ok(Self {
             inner,
             urls,
             user_agent,
-            skew_state: Arc::new(RwLock::new(None)),
+            skew_manager: Arc::new(RwLock::new(SkewManager::new(time_provider))),
         })
     }
 
@@ -170,119 +129,7 @@ impl VpnApiClient {
     }
 
     pub async fn get_remote_time(&self) -> Result<VpnApiTime> {
-        let mut last_error: Option<VpnApiClientError> = None;
-
-        for retry in 0..=REMOTE_TIME_MAX_RETRIES {
-            let time_before = OffsetDateTime::now_utc();
-            match self.get_health_no_retry().await {
-                Ok(res) => {
-                    let remote_timestamp = res.timestamp_utc;
-                    let time_after = OffsetDateTime::now_utc();
-                    let request_time = time_after - time_before;
-
-                    // Detect sleep or time travel and retry the request
-                    if request_time.is_negative() {
-                        tracing::warn!(
-                            "Request time is negative. Time traveling? ({}/{REMOTE_TIME_MAX_RETRIES})",
-                            retry + 1
-                        );
-                        tokio::time::sleep(REMOTE_TIME_WAIT_DELAY).await;
-                    } else if request_time > NYM_VPN_API_TIMEOUT {
-                        tracing::warn!(
-                            "Request time exceeds the timeout. Device fell asleep? ({}/{REMOTE_TIME_MAX_RETRIES})",
-                            retry + 1
-                        );
-                        tokio::time::sleep(REMOTE_TIME_WAIT_DELAY).await;
-                    } else {
-                        return Ok(VpnApiTime::from_remote_timestamp(
-                            time_before,
-                            remote_timestamp,
-                            time_after,
-                        ));
-                    }
-                }
-                Err(err) => {
-                    last_error = Some(err);
-                }
-            }
-        }
-        Err(last_error.unwrap_or(VpnApiClientError::TimeTravelTooMuch))
-    }
-
-    fn use_remote_time(remote_time: VpnApiTime) -> bool {
-        match remote_time.is_synced() {
-            VpnApiTimeSynced::AlmostSame => {
-                tracing::debug!("{remote_time}");
-                false
-            }
-            VpnApiTimeSynced::AcceptableSynced => {
-                tracing::info!("{remote_time}");
-                false
-            }
-            VpnApiTimeSynced::NotSynced => {
-                tracing::warn!(
-                    "The time skew between the local and remote time is too large, we'll use remote instead for JWT ({remote_time})."
-                );
-                true
-            }
-        }
-    }
-
-    async fn refresh_skew(&self) -> Result<VpnApiTime> {
-        let remote_time = self.get_remote_time().await?;
-        let skew = remote_time.local_time_ahead_skew();
-        let now = Instant::now();
-
-        {
-            let mut skew_state = self.skew_state.write().await;
-            match skew_state.as_mut() {
-                Some(state) => state.update(skew, now),
-                None => *skew_state = Some(SkewState::new(skew, now)),
-            }
-        }
-
-        tracing::debug!(skew = ?skew, "Refreshed VPN API time skew");
-
-        Ok(remote_time)
-    }
-
-    async fn current_remote_time(&self) -> Result<Option<VpnApiTime>> {
-        let now = Instant::now();
-        let status = {
-            let state = self.skew_state.read().await;
-            state.as_ref().map(|state| state.status(now))
-        };
-
-        let cached_remote_time = match status {
-            Some(SkewStatus::Valid(skew)) => {
-                tracing::debug!("Valid VPN API time skew");
-                let local_time = OffsetDateTime::now_utc();
-                let estimated_remote_time = local_time - skew;
-
-                VpnApiTime::from_estimated_remote_time(local_time, estimated_remote_time)
-            }
-            Some(SkewStatus::Expired()) | None => {
-                tracing::debug!("VPN API time skew expired or not present, refreshing");
-
-                self.refresh_skew().await?
-            }
-        };
-
-        Ok(if Self::use_remote_time(cached_remote_time) {
-            Some(cached_remote_time)
-        } else {
-            None
-        })
-    }
-
-    async fn sync_with_remote_time(&self) -> Result<Option<VpnApiTime>> {
-        let remote_time = self.refresh_skew().await?;
-
-        if Self::use_remote_time(remote_time) {
-            Ok(Some(remote_time))
-        } else {
-            Ok(None)
-        }
+        self.skew_manager.write().await.get_remote_time().await
     }
 
     async fn get_query<T>(
@@ -320,13 +167,19 @@ impl VpnApiClient {
     where
         T: DeserializeOwned,
     {
-        let jwt = self.current_remote_time().await.unwrap_or_else(|err| {
-            tracing::debug!(
-                error = %err,
-                "Failed to determine cached remote time"
-            );
-            None
-        });
+        let jwt = self
+            .skew_manager
+            .write()
+            .await
+            .current_remote_time()
+            .await
+            .unwrap_or_else(|err| {
+                tracing::debug!(
+                    error = %err,
+                    "Failed to determine cached remote time"
+                );
+                None
+            });
 
         match self.get_query::<T>(path, account, device, jwt).await {
             Ok(response) => Ok(response),
@@ -337,9 +190,16 @@ impl VpnApiClient {
                     tracing::warn!(
                         "Encountered possible JWT error: {error}. Retrying query with remote time"
                     );
-                    if let Ok(Some(jwt)) = self.sync_with_remote_time().await.inspect_err(|err| {
-                        tracing::error!("Failed to get remote time: {err}. Not retring anymore")
-                    }) {
+                    if let Ok(Some(jwt)) = self
+                        .skew_manager
+                        .write()
+                        .await
+                        .sync_with_remote_time()
+                        .await
+                        .inspect_err(|err| {
+                            tracing::error!("Failed to get remote time: {err}. Not retring anymore")
+                        })
+                    {
                         // retry with remote vpn api time, and return that only if it succeeds,
                         // otherwise return the initial error
                         let res = self.get_query(path, account, device, Some(jwt)).await;
@@ -494,13 +354,19 @@ impl VpnApiClient {
         T: DeserializeOwned,
         B: Serialize,
     {
-        let jwt = self.current_remote_time().await.unwrap_or_else(|err| {
-            tracing::debug!(
-                error = %err,
-                "Failed to determine cached remote time"
-            );
-            None
-        });
+        let jwt = self
+            .skew_manager
+            .write()
+            .await
+            .current_remote_time()
+            .await
+            .unwrap_or_else(|err| {
+                tracing::debug!(
+                    error = %err,
+                    "Failed to determine cached remote time"
+                );
+                None
+            });
 
         match self
             .post_query::<T, B>(path, json_body, account, device, jwt)
@@ -514,9 +380,18 @@ impl VpnApiClient {
                     tracing::warn!(
                         "Encountered possible JWT error: {error}. Retrying query with remote time"
                     );
-                    if let Ok(Some(jwt)) = self.sync_with_remote_time().await.inspect_err(|err| {
-                        tracing::error!("Failed to get remote time: {err}. Not retrying anymore")
-                    }) {
+                    if let Ok(Some(jwt)) = self
+                        .skew_manager
+                        .write()
+                        .await
+                        .sync_with_remote_time()
+                        .await
+                        .inspect_err(|err| {
+                            tracing::error!(
+                                "Failed to get remote time: {err}. Not retrying anymore"
+                            )
+                        })
+                    {
                         // retry with remote vpn api time, and return that only if it succeeds,
                         // otherwise return the initial error
                         let res = self
@@ -576,9 +451,16 @@ impl VpnApiClient {
                     tracing::warn!(
                         "Encountered possible JWT error: {error}. Retrying query with remote time"
                     );
-                    if let Ok(Some(jwt)) = self.sync_with_remote_time().await.inspect_err(|err| {
-                        tracing::error!("Failed to get remote time: {err}. Not retring anymore")
-                    }) {
+                    if let Ok(Some(jwt)) = self
+                        .skew_manager
+                        .write()
+                        .await
+                        .sync_with_remote_time()
+                        .await
+                        .inspect_err(|err| {
+                            tracing::error!("Failed to get remote time: {err}. Not retring anymore")
+                        })
+                    {
                         // retry with remote vpn api time, and return that only if it succeeds,
                         // otherwise return the initial error
                         let res = self.delete_query(path, account, device, Some(jwt)).await;
@@ -643,9 +525,16 @@ impl VpnApiClient {
                     tracing::warn!(
                         "Encountered possible JWT error: {error}. Retrying query with remote time"
                     );
-                    if let Ok(Some(jwt)) = self.sync_with_remote_time().await.inspect_err(|err| {
-                        tracing::error!("Failed to get remote time: {err}. Not retring anymore")
-                    }) {
+                    if let Ok(Some(jwt)) = self
+                        .skew_manager
+                        .write()
+                        .await
+                        .sync_with_remote_time()
+                        .await
+                        .inspect_err(|err| {
+                            tracing::error!("Failed to get remote time: {err}. Not retring anymore")
+                        })
+                    {
                         // retry with remote vpn api time, and return that only if it succeeds,
                         // otherwise return the initial error
                         let res = self
@@ -737,14 +626,6 @@ impl VpnApiClient {
 
     pub async fn get_health(&self) -> Result<NymVpnHealthResponse> {
         self.get_json_with_retry(&[routes::PUBLIC, routes::V1, routes::HEALTH], NO_PARAMS)
-            .await
-            .map_err(Box::new)
-            .map_err(VpnApiClientError::GetHealth)
-    }
-
-    pub async fn get_health_no_retry(&self) -> Result<NymVpnHealthResponse> {
-        self.inner
-            .get_json(&[routes::PUBLIC, routes::V1, routes::HEALTH], NO_PARAMS)
             .await
             .map_err(Box::new)
             .map_err(VpnApiClientError::GetHealth)
@@ -1495,4 +1376,29 @@ impl VpnApiClient {
 
 fn jwt_error(error: &str) -> bool {
     error.to_lowercase().contains("jwt")
+}
+
+#[derive(Debug)]
+struct VpnApiRemoteTimeProvider {
+    inner: Client,
+}
+
+impl VpnApiRemoteTimeProvider {
+    pub fn new(inner: Client) -> Self {
+        Self { inner }
+    }
+}
+
+#[async_trait::async_trait]
+impl RemoteTimeProvider for VpnApiRemoteTimeProvider {
+    async fn request_remote_time(&self) -> Result<OffsetDateTime> {
+        let res: NymVpnHealthResponse = self
+            .inner
+            .get_json(&[routes::PUBLIC, routes::V1, routes::HEALTH], NO_PARAMS)
+            .await
+            .map_err(Box::new)
+            .map_err(VpnApiClientError::GetHealth)?;
+
+        Ok(res.timestamp_utc)
+    }
 }

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/lib.rs
@@ -13,6 +13,7 @@ pub(crate) mod jwt;
 mod client;
 mod network_compatibility;
 mod routes;
+mod skew_manager;
 
 pub use client::VpnApiClient;
 pub use fronted_http_client::{

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/skew_manager.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/skew_manager.rs
@@ -1,0 +1,302 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use std::time::Duration;
+
+use time::{Duration as TimeDuration, OffsetDateTime};
+use tokio::time::Instant;
+
+use crate::{
+    client::NYM_VPN_API_TIMEOUT,
+    error::{Result, VpnApiClientError},
+    types::{VpnApiTime, VpnApiTimeSynced},
+};
+
+// Number of retries for remote time synchronization (not including the initial attempt)
+const REMOTE_TIME_MAX_RETRIES: u8 = 2;
+
+// Wait delay between retries for remote time synchronization
+const REMOTE_TIME_WAIT_DELAY: Duration = Duration::from_secs(1);
+
+const SKEW_CACHE_TTL: Duration = Duration::from_secs(4 * 60 * 60); // 4 hours
+
+/// Type providing access to the current device time.
+pub trait DeviceTimeProvider: std::fmt::Debug {
+    /// Returns the current device time in UTC.
+    fn device_time(&self) -> OffsetDateTime;
+}
+
+/// Type providing access to the current device time of API server.
+#[async_trait::async_trait]
+pub trait RemoteTimeProvider: std::fmt::Debug {
+    /// Returns remote time at the API server
+    ///
+    /// Internally, this call should not implement retry logic to
+    /// prevent caller from making wrong assumptions about how much time passed.
+    async fn request_remote_time(&self) -> Result<OffsetDateTime>;
+}
+
+/// Default device time provider
+#[derive(Debug)]
+struct DefaultDeviceTimeProvider;
+impl DeviceTimeProvider for DefaultDeviceTimeProvider {
+    fn device_time(&self) -> OffsetDateTime {
+        OffsetDateTime::now_utc()
+    }
+}
+
+/// Type managing skew between device time and API server time.
+#[derive(Debug)]
+pub struct SkewManager {
+    skew_state: Option<SkewState>,
+    device_time_provider: Box<dyn DeviceTimeProvider + Send + Sync>,
+    remote_time_provider: Box<dyn RemoteTimeProvider + Send + Sync>,
+}
+
+impl SkewManager {
+    pub fn new(remote_time_provider: impl RemoteTimeProvider + Send + Sync + 'static) -> Self {
+        Self {
+            skew_state: None,
+            device_time_provider: Box::new(DefaultDeviceTimeProvider),
+            remote_time_provider: Box::new(remote_time_provider),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn new_for_testing(
+        device_time_provider: impl DeviceTimeProvider + Send + Sync + 'static,
+        remote_time_provider: impl RemoteTimeProvider + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            skew_state: None,
+            device_time_provider: Box::new(device_time_provider),
+            remote_time_provider: Box::new(remote_time_provider),
+        }
+    }
+
+    pub async fn current_remote_time(&mut self) -> Result<Option<VpnApiTime>> {
+        let now = Instant::now();
+        let status = self.skew_state.as_ref().map(|state| state.status(now));
+
+        let cached_remote_time = match status {
+            Some(SkewStatus::Valid(skew)) => {
+                tracing::debug!("Valid VPN API time skew");
+                let local_time = self.now();
+                let estimated_remote_time = local_time - skew;
+
+                VpnApiTime::from_estimated_remote_time(local_time, estimated_remote_time)
+            }
+            Some(SkewStatus::Expired()) | None => {
+                tracing::debug!("VPN API time skew expired or not present, refreshing");
+
+                self.refresh_skew().await?
+            }
+        };
+
+        Ok(if Self::use_remote_time(cached_remote_time) {
+            Some(cached_remote_time)
+        } else {
+            None
+        })
+    }
+
+    pub async fn sync_with_remote_time(&mut self) -> Result<Option<VpnApiTime>> {
+        let remote_time = self.refresh_skew().await?;
+
+        if Self::use_remote_time(remote_time) {
+            Ok(Some(remote_time))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub async fn get_remote_time(&mut self) -> Result<VpnApiTime> {
+        let mut last_error: Option<VpnApiClientError> = None;
+
+        for retry in 0..=REMOTE_TIME_MAX_RETRIES {
+            let time_before = self.now();
+            match self.remote_time_provider.request_remote_time().await {
+                Ok(remote_timestamp) => {
+                    let time_after = self.now();
+                    let request_time = time_after - time_before;
+
+                    // Detect sleep or time travel and retry the request
+                    if request_time.is_negative() {
+                        tracing::warn!(
+                            "Request time is negative. Time traveling? ({}/{REMOTE_TIME_MAX_RETRIES})",
+                            retry + 1
+                        );
+                        tokio::time::sleep(REMOTE_TIME_WAIT_DELAY).await;
+                    } else if request_time > NYM_VPN_API_TIMEOUT {
+                        tracing::warn!(
+                            "Request time exceeds the timeout. Device fell asleep? ({}/{REMOTE_TIME_MAX_RETRIES})",
+                            retry + 1
+                        );
+                        tokio::time::sleep(REMOTE_TIME_WAIT_DELAY).await;
+                    } else {
+                        return Ok(VpnApiTime::from_remote_timestamp(
+                            time_before,
+                            remote_timestamp,
+                            time_after,
+                        ));
+                    }
+                }
+                Err(err) => {
+                    last_error = Some(err);
+                }
+            }
+        }
+        Err(last_error.unwrap_or(VpnApiClientError::TimeTravelTooMuch))
+    }
+
+    fn use_remote_time(remote_time: VpnApiTime) -> bool {
+        match remote_time.is_synced() {
+            VpnApiTimeSynced::AlmostSame => {
+                tracing::debug!("{remote_time}");
+                false
+            }
+            VpnApiTimeSynced::AcceptableSynced => {
+                tracing::info!("{remote_time}");
+                false
+            }
+            VpnApiTimeSynced::NotSynced => {
+                tracing::warn!(
+                    "The time skew between the local and remote time is too large, we'll use remote instead for JWT ({remote_time})."
+                );
+                true
+            }
+        }
+    }
+
+    async fn refresh_skew(&mut self) -> Result<VpnApiTime> {
+        let remote_time = self.get_remote_time().await?;
+        let skew = remote_time.local_time_ahead_skew();
+        let now = Instant::now();
+
+        match &mut self.skew_state {
+            Some(state) => {
+                state.update(skew, now);
+            }
+            skew_state @ None => {
+                skew_state.replace(SkewState::new(skew, now));
+            }
+        }
+
+        tracing::debug!(skew = ?skew, "Refreshed VPN API time skew");
+
+        Ok(remote_time)
+    }
+
+    fn now(&self) -> OffsetDateTime {
+        self.device_time_provider.device_time()
+    }
+}
+
+#[derive(Debug)]
+struct SkewState {
+    skew: TimeDuration,
+    expires_at: Instant,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SkewStatus {
+    Expired(),
+    Valid(TimeDuration),
+}
+
+impl SkewState {
+    fn new(skew: TimeDuration, now: Instant) -> Self {
+        Self {
+            skew,
+            expires_at: now + SKEW_CACHE_TTL,
+        }
+    }
+
+    fn update(&mut self, skew: TimeDuration, now: Instant) {
+        self.skew = skew;
+        self.expires_at = now + SKEW_CACHE_TTL;
+    }
+
+    fn status(&self, now: Instant) -> SkewStatus {
+        if self.expires_at > now {
+            SkewStatus::Valid(self.skew)
+        } else {
+            SkewStatus::Expired()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn test_time_travel() {
+        let device_time_provider = MockDeviceTimeProvider::new(
+            vec![
+                OffsetDateTime::now_utc(),
+                OffsetDateTime::now_utc() - Duration::from_hours(1),
+            ]
+            .repeat(3),
+        );
+        let mut skew_manager = SkewManager::new_for_testing(device_time_provider, MockTimeProvider);
+        let time_result = skew_manager.current_remote_time().await;
+        assert!(matches!(
+            time_result,
+            Err(VpnApiClientError::TimeTravelTooMuch)
+        ));
+    }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn test_device_sleep() {
+        let device_time_provider = MockDeviceTimeProvider::new(
+            vec![
+                OffsetDateTime::now_utc(),
+                OffsetDateTime::now_utc() + NYM_VPN_API_TIMEOUT + Duration::from_secs(1),
+            ]
+            .repeat(3),
+        );
+        let mut skew_manager = SkewManager::new_for_testing(device_time_provider, MockTimeProvider);
+        let time_result = skew_manager.current_remote_time().await;
+        assert!(matches!(
+            time_result,
+            Err(VpnApiClientError::TimeTravelTooMuch)
+        ));
+    }
+
+    #[derive(Debug)]
+    struct MockTimeProvider;
+
+    #[async_trait::async_trait]
+    impl RemoteTimeProvider for MockTimeProvider {
+        async fn request_remote_time(&self) -> Result<OffsetDateTime> {
+            Ok(OffsetDateTime::now_utc())
+        }
+    }
+
+    #[derive(Debug)]
+    struct MockDeviceTimeProvider {
+        timestamps: std::sync::Mutex<Vec<OffsetDateTime>>,
+    }
+
+    impl MockDeviceTimeProvider {
+        fn new(timestamps: Vec<OffsetDateTime>) -> Self {
+            Self {
+                timestamps: std::sync::Mutex::new(timestamps),
+            }
+        }
+    }
+
+    impl DeviceTimeProvider for MockDeviceTimeProvider {
+        fn device_time(&self) -> OffsetDateTime {
+            let mut timestamps = self.timestamps.lock().unwrap();
+            if timestamps.is_empty() {
+                OffsetDateTime::now_utc()
+            } else {
+                timestamps.remove(0)
+            }
+        }
+    }
+}

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/skew_manager.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/skew_manager.rs
@@ -86,7 +86,7 @@ impl SkewManager {
 
                 VpnApiTime::from_estimated_remote_time(local_time, estimated_remote_time)
             }
-            Some(SkewStatus::Expired()) | None => {
+            Some(SkewStatus::Expired) | None => {
                 tracing::debug!("VPN API time skew expired or not present, refreshing");
 
                 self.refresh_skew().await?
@@ -173,15 +173,7 @@ impl SkewManager {
         let skew = remote_time.local_time_ahead_skew();
         let now = Instant::now();
 
-        match &mut self.skew_state {
-            Some(state) => {
-                state.update(skew, now);
-            }
-            skew_state @ None => {
-                skew_state.replace(SkewState::new(skew, now));
-            }
-        }
-
+        self.skew_state.replace(SkewState::new(skew, now));
         tracing::debug!(skew = ?skew, "Refreshed VPN API time skew");
 
         Ok(remote_time)
@@ -200,7 +192,7 @@ struct SkewState {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum SkewStatus {
-    Expired(),
+    Expired,
     Valid(TimeDuration),
 }
 
@@ -212,16 +204,11 @@ impl SkewState {
         }
     }
 
-    fn update(&mut self, skew: TimeDuration, now: Instant) {
-        self.skew = skew;
-        self.expires_at = now + SKEW_CACHE_TTL;
-    }
-
     fn status(&self, now: Instant) -> SkewStatus {
         if self.expires_at > now {
             SkewStatus::Valid(self.skew)
         } else {
-            SkewStatus::Expired()
+            SkewStatus::Expired
         }
     }
 }


### PR DESCRIPTION

## Description

- Move skew related management out of `VpnApiClient` into `SkewManager` type
- Add tests for when time jumps backwards after finishing request or exceeds timeout (jumps forward, i.e device sleep)

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4611)
<!-- Reviewable:end -->
