### PR TITLE
Export mixnet params to frontends

### DIFF
--- a/nym-vpn-app/src-tauri/Cargo.lock
+++ b/nym-vpn-app/src-tauri/Cargo.lock
@@ -3595,6 +3595,8 @@ dependencies = [
  "nym-crypto",
  "serde",
  "si-scale",
+ "strum",
+ "strum_macros",
  "thiserror 2.0.18",
  "time",
  "uniffi",

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -6300,6 +6300,8 @@ dependencies = [
  "nym-vpn-store",
  "serde",
  "si-scale 0.3.0",
+ "strum",
+ "strum_macros",
  "thiserror 2.0.18",
  "time",
  "ts-rs",

--- a/nym-vpn-core/crates/nym-vpn-lib-types/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/Cargo.toml
@@ -36,6 +36,8 @@ serde = ["dep:serde"]
 [dependencies]
 bip39 = { workspace = true, optional = true }
 si-scale = { workspace = true, features = ["lossy-conversions"] }
+strum.workspace = true
+strum_macros.workspace = true
 time = { workspace = true, features = ["serde", "parsing", "formatting"] }
 serde = { workspace = true, features = ["derive", "rc"], optional = true }
 thiserror.workspace = true

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
@@ -91,7 +91,8 @@ pub use rpc_requests::{
     ListGatewaysOptions, StoreAccountRequest,
 };
 pub use service::{
-    MixnetTrafficConfig, MixnetTrafficConfigValidationError, TargetState, VpnServiceConfig,
+    BackgroundCoverTrafficRate, ContinuousTrafficSendingRate, MixingDelay, MixnetTrafficConfig,
+    MixnetTrafficConfigValidationError, MixnetTrafficDefaults, TargetState, VpnServiceConfig,
     VpnServiceInfo,
 };
 pub use socks5::{EnableSocks5Request, HttpRpcSettings, Socks5Settings, Socks5State, Socks5Status};

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/service.rs
@@ -3,6 +3,9 @@
 
 use std::{fmt, net::IpAddr, ops::RangeInclusive};
 
+use strum::IntoEnumIterator;
+use strum_macros::EnumIter;
+
 const LOOP_COVER_DELAY_RANGE: RangeInclusive<u32> = 0..=200;
 const AVG_PACKET_DELAY_RANGE: RangeInclusive<u32> = 0..=200;
 const MESSAGE_SENDING_DELAY_RANGE: RangeInclusive<u32> = 5..=50;
@@ -236,6 +239,153 @@ impl MixnetTrafficConfig {
         let latency = 2.0 * (NUM_HOPS * BASE_HOP_DELAY_MS + NUM_MIX_NODES * mixing_delay);
 
         (latency / 10.0).round() * 10.0
+    }
+}
+
+/// Type providing default values and constraints for mixnet traffic configuration.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[cfg_attr(feature = "uniffi-bindings", derive(uniffi::Object))]
+pub struct MixnetTrafficDefaults;
+
+#[allow(unused)]
+#[cfg_attr(feature = "uniffi-bindings", uniffi::export)]
+impl MixnetTrafficDefaults {
+    #[cfg(feature = "uniffi-bindings")]
+    #[uniffi::constructor]
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn default_mixing_delay(&self) -> MixingDelay {
+        MixingDelay::default()
+    }
+
+    pub fn default_disable_poission_rate(&self) -> bool {
+        false
+    }
+
+    pub fn default_background_traffic(&self) -> BackgroundCoverTrafficRate {
+        BackgroundCoverTrafficRate::default()
+    }
+
+    pub fn default_continuous_traffic(&self) -> ContinuousTrafficSendingRate {
+        ContinuousTrafficSendingRate::default()
+    }
+
+    pub fn all_background_traffic(&self) -> Vec<BackgroundCoverTrafficRate> {
+        BackgroundCoverTrafficRate::iter().collect()
+    }
+
+    pub fn all_continuous_traffic(&self) -> Vec<ContinuousTrafficSendingRate> {
+        ContinuousTrafficSendingRate::iter().collect()
+    }
+}
+
+// Maps to average_packet_delay
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "uniffi-bindings", derive(uniffi::Record))]
+#[cfg_attr(
+    feature = "typescript-bindings",
+    derive(TS),
+    ts(export),
+    ts(export_to = "bindings.ts")
+)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "typescript-bindings", serde(rename_all = "camelCase"))]
+pub struct MixingDelay {
+    pub min_value: u32,
+    pub max_value: u32,
+    pub default_value: u32,
+}
+
+impl Default for MixingDelay {
+    fn default() -> Self {
+        Self {
+            min_value: *AVG_PACKET_DELAY_RANGE.start(),
+            max_value: *AVG_PACKET_DELAY_RANGE.end(),
+            default_value: 15, // DEFAULT_AVERAGE_PACKET_DELAY
+        }
+    }
+}
+
+// Maps to poisson_parameter_for_loop_cover_stream
+#[derive(Clone, Debug, Default, Eq, PartialEq, EnumIter)]
+#[cfg_attr(feature = "uniffi-bindings", derive(uniffi::Enum))]
+#[cfg_attr(
+    feature = "typescript-bindings",
+    derive(TS),
+    ts(export),
+    ts(export_to = "bindings.ts")
+)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "typescript-bindings", serde(rename_all = "camelCase"))]
+pub enum BackgroundCoverTrafficRate {
+    #[default]
+    Ms200, // DEFAULT_LOOP_COVER_STREAM_AVERAGE_DELAY
+    Ms40,
+    Ms20,
+    Ms10,
+}
+
+#[allow(unused)]
+#[cfg_attr(feature = "uniffi-bindings", uniffi::export)]
+impl BackgroundCoverTrafficRate {
+    pub fn value(&self) -> u32 {
+        match self {
+            Self::Ms10 => 10,
+            Self::Ms20 => 20,
+            Self::Ms40 => 40,
+            Self::Ms200 => 200,
+        }
+    }
+
+    pub fn multiplier(&self) -> String {
+        match self {
+            Self::Ms200 => "Base",
+            Self::Ms40 => "5x",
+            Self::Ms20 => "10x",
+            Self::Ms10 => "20x",
+        }
+        .to_owned()
+    }
+}
+
+// Maps to message_sending_average_delay
+#[derive(Clone, Debug, Default, Eq, PartialEq, EnumIter)]
+#[cfg_attr(feature = "uniffi-bindings", derive(uniffi::Enum))]
+#[cfg_attr(
+    feature = "typescript-bindings",
+    derive(TS),
+    ts(export),
+    ts(export_to = "bindings.ts")
+)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "typescript-bindings", serde(rename_all = "camelCase"))]
+pub enum ContinuousTrafficSendingRate {
+    Ms30,
+    #[default]
+    Ms20,
+    Ms10,
+}
+
+#[allow(unused)]
+#[cfg_attr(feature = "uniffi-bindings", uniffi::export)]
+impl ContinuousTrafficSendingRate {
+    pub fn value(&self) -> u32 {
+        match self {
+            Self::Ms10 => 10,
+            Self::Ms20 => 20,
+            Self::Ms30 => 30,
+        }
+    }
+
+    pub fn throughput(&self) -> String {
+        match self {
+            Self::Ms10 => "2 Mpbs",
+            Self::Ms20 => "1 Mpbs",
+            Self::Ms30 => "0.7 Mpbs",
+        }
+        .to_owned()
     }
 }
 


### PR DESCRIPTION
## Ticket

JIRA-NYM-498

## Description

This PR moves constants related to mixnet tuning into `nym-vpn-lib-types`.

- `MixingDelay` - provides defaults for mixing delays, min, max range, default value
- `BackgroundCoverTrafficRate` maps to `poisson_parameter_for_loop_cover_stream`.
    -  Methods available: 
        - `value() -> u32`,  - returns underlying value in milliseconds.
        - `multiplier() -> String` - returns multiplier string, i.e Base, 5x, 10x, etc..
- `ContinuousTrafficSendingRate` - maps to `message_sending_average_delay` 
    -  Methods available: 
        - `value() -> u32`,  - returns underlying value in milliseconds.
        - `throughput() -> String` - returns throughput in Mbps i.e `2 Mbps`
- `MixnetTrafficDefaults` - object that provides convenient access to all defaults.
    -  Methods available: 
        - `default_mixing_delay() -> MixingDelay`,  - returns struct describing constraints for mixing delay
        - `default_disable_poission_rate() -> bool` - returns bool whether poisson is disabled by default
        - `default_background_traffic() -> BackgroundCoverTrafficRate` - returns default value
        - `default_continuous_traffic() -> ContinuousTrafficSendingRate` - returns default value
        - `all_background_traffic() -> Vec<BackgroundCoverTrafficRate>` - returns ordered array of all variants of `BackgroundCoverTrafficRate`
        - `all_continuous_traffic() -> Vec<ContinuousTrafficSendingRate>` - returns ordered array of all variants of `ContinuousTrafficSendingRate`
       
### Example in Swift

```swift
let defaults = MixnetTrafficDefaults()
let mixingDelay = defaults.defaultMixingDelay()
mixingDelay.minValue // 0
mixingDelay.maxValue // 200
mixingDelay.defaultValue // 15

let backgroundTraffic = defaults.defaultBackgroundTraffic() // 200

let continuousTraffic = defaults.defaultContinuousTraffic() // 20

let allBackgroundTrafficItems = defaults.allBackgroundTraffic()
for item in allBackgroundTrafficItems {
  print("\(item.multiplier()) \(item.value()) ms") // i.e 5x 10 ms
}

let allContinuousTrafficItems = defaults.allContinuousTraffic()
for item in allContinuousTrafficItems {
  print("\(item.throughput()) = \(item.value()) ms") // i.e: 0.7 Mbps = 10 ms
}
```

### Example in Kotlin

```kotlin
val defaults = MixnetTrafficDefaults()
val mixingDelay = defaults.defaultMixingDelay()

mixingDelay.minValue
mixingDelay.maxValue
mixingDelay.defaultValue

val backgroundTraffic = defaults.defaultBackgroundTraffic() // 200

val continuousTraffic = defaults.defaultContinuousTraffic() // 20

val allBackgroundTrafficItems = defaults.allBackgroundTraffic()
allBackgroundTrafficItems.forEach {
	println("${it.multiplier()} ${it.value()} ms") // i.e 5x 10 ms
}

val allContinuousTrafficItems = defaults.allContinuousTraffic()
allContinuousTrafficItems.forEach {
	print("${it.throughput()} = ${it.value()} ms") // i.e: 0.7 Mbps = 10 ms
}
```

### Example in Rust

```rs
let defaults = MixnetTrafficDefaults;
let mixing_delay = defaults.default_mixing_delay(); // or MixingDelay::default()

mixing_delay.min_value;
mixing_delay.max_value;
mixing_delay.default_value;

// Same as BackgroundCoverTrafficRate::default()
let background_traffic = defaults.default_background_traffic(); // 200

// Same as ContinuousTrafficSendingRate::default()
let continuous_traffic = defaults.default_continuous_traffic(); // 20

let all_background_traffic_items = defaults.all_background_traffic();
for it in all_background_traffic_items {
    println!("{} {} ms", it.multiplier(), it.value()); // i.e 5x 10 ms
}

let all_continuous_traffic_items = defaults.all_continuous_traffic();
for it in all_continuous_traffic_items {
    println!("${} = ${} ms", it.throughput(), it.value()); // i.e: 0.7 Mbps = 10 ms
}
```

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4612)
<!-- Reviewable:end -->
