### PR TITLE
Replace `pin_mut!` with `std::pin::pin!`

### DIFF
--- a/nym-vpn-core/crates/nym-statistics/src/handler/report_sending.rs
+++ b/nym-vpn-core/crates/nym-statistics/src/handler/report_sending.rs
@@ -1,7 +1,14 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use futures::{FutureExt, future::Fuse, pin_mut};
+use std::{pin::pin, time::Duration};
+
+use futures::{FutureExt, future::Fuse};
+use rand::{distributions::Uniform, prelude::Distribution};
+use sysinfo::System;
+use tokio::sync::mpsc::{self, Receiver, Sender};
+use tokio_util::sync::CancellationToken;
+
 use nym_statistics_api_client::StatisticsApiClient;
 use nym_statistics_common::{
     generate_vpn_client_stats_id,
@@ -12,12 +19,6 @@ use nym_vpn_lib_types::NetworkStatisticsConfig;
 use crate::{
     commands::ConfigCommand, error::Error, events::ReportSendingEvent, storage::StatsStorage,
 };
-
-use rand::{distributions::Uniform, prelude::Distribution};
-use std::time::Duration;
-use sysinfo::System;
-use tokio::sync::mpsc::{self, Receiver, Sender};
-use tokio_util::sync::CancellationToken;
 
 #[derive(Default, Clone, Copy, PartialEq, Eq)]
 enum TunnelState {
@@ -272,8 +273,8 @@ impl InnerHandler {
         } else {
             Fuse::terminated()
         };
-        pin_mut!(timer);
-        pin_mut!(sending_task);
+        let mut timer = pin!(timer);
+        let mut sending_task = pin!(sending_task);
         loop {
             tokio::select! {
                 biased;

--- a/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/processor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/processor.rs
@@ -1,10 +1,10 @@
 // Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{ops::Deref, result::Result, time::Duration};
+use std::{ops::Deref, pin::pin, result::Result, time::Duration};
 
 use bytes::{Bytes, BytesMut};
-use futures::{FutureExt, StreamExt, future::Fuse, pin_mut};
+use futures::{FutureExt, StreamExt, future::Fuse};
 use nym_gateway_directory::IpPacketRouterAddress;
 use nym_ip_packet_requests::{
     codec::{IprPacket, MultiIpPacketCodec},
@@ -127,7 +127,7 @@ impl MixnetProcessor {
 
         // Ipr disconnect timeout future set upon cancellation
         let ipr_disconnect_timeout = Fuse::terminated();
-        pin_mut!(ipr_disconnect_timeout);
+        let mut ipr_disconnect_timeout = pin!(ipr_disconnect_timeout);
 
         let mut payload_topup_interval =
             tokio::time::interval(nym_ip_packet_requests::codec::BUFFER_TIMEOUT);

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
@@ -1,9 +1,15 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use futures::{FutureExt, StreamExt, future::Fuse, pin_mut};
+use std::{
+    net::IpAddr,
+    path::PathBuf,
+    pin::{Pin, pin},
+    sync::Arc,
+};
+
+use futures::{FutureExt, StreamExt, future::Fuse};
 use nym_diagnostic::DiagnosticHandler;
-use std::{net::IpAddr, path::PathBuf, pin::Pin, sync::Arc};
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 use tokio::{
     sync::{RwLock, broadcast, mpsc, oneshot, watch},
@@ -631,7 +637,7 @@ impl NymVpnService {
         if let Some(state_machine_handle) = self.state_machine_handle.take() {
             // Drain tunnel events channel and wait for the tunnel state machine to quit
             let fused_state_machine_handle = state_machine_handle.fuse();
-            pin_mut!(fused_state_machine_handle);
+            let mut fused_state_machine_handle = pin!(fused_state_machine_handle);
 
             loop {
                 tokio::select! {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -3,9 +3,6 @@
 
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use std::net::{Ipv4Addr, Ipv6Addr};
-
-use std::ops::Deref;
-
 #[cfg(any(target_os = "linux", target_os = "ios", target_os = "android"))]
 use std::os::fd::BorrowedFd;
 #[cfg(any(target_os = "android", target_os = "ios"))]
@@ -14,12 +11,14 @@ use std::os::fd::{AsRawFd, IntoRawFd};
 use std::os::fd::{FromRawFd, OwnedFd};
 use std::{
     net::{IpAddr, SocketAddr},
+    ops::Deref,
+    pin::pin,
     time::Duration,
 };
 #[cfg(unix)]
 use std::{os::fd::RawFd, sync::Arc};
 
-use futures::{FutureExt, future::Fuse, pin_mut};
+use futures::{FutureExt, future::Fuse};
 #[cfg(any(target_os = "ios", target_os = "android"))]
 use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
 #[cfg(target_os = "linux")]
@@ -741,7 +740,7 @@ impl TunnelMonitor {
         let mixnet_monitoring_token = mixnet_client_token
             .map(|token| token.cancelled_owned().fuse())
             .unwrap_or(Fuse::terminated());
-        pin_mut!(mixnet_monitoring_token);
+        let mut mixnet_monitoring_token = pin!(mixnet_monitoring_token);
 
         let (tunnel_connection_monitor_tx, mut tunnel_connection_monitor_rx) =
             mpsc::unbounded_channel();


### PR DESCRIPTION

## Description

`futures::pin_mut!` and `futures_util::pin_mut!` are soft-deprecated. See https://github.com/nymtech/nym-vpn-client/pull/4644

This PR replaces all uses of `pin_mut!` with `std::pin::pin!` as per suggestion from the maintainers of `futures` crate.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4648)
<!-- Reviewable:end -->
