### PR TITLE
Remove the extra layer on authentication error

### DIFF
--- a/nym-vpn-app/src-tauri/src/vpnd/client.rs
+++ b/nym-vpn-app/src-tauri/src/vpnd/client.rs
@@ -97,6 +97,7 @@ impl VpndClient {
                 c
             }
             Err(nym_vpn_proto::rpc_client::Error::AuthenticationRequired) => {
+                self.log_connect_failed("need to authenticate").await;
                 return Err(VpndError::AuthenticationRequired);
             }
             Err(e) => {

--- a/nym-vpn-core/crates/nym-vpn-proto/src/rpc_client.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/rpc_client.rs
@@ -35,8 +35,9 @@ impl RpcClient {
             .map_err(|err| {
                 if let Some(std::io::ErrorKind::PermissionDenied) = err
                     .source()
-                    .and_then(|source| source.downcast_ref::<std::io::Error>())
-                    .map(|s| s.kind())
+                    .and_then(|err| err.source())
+                    .and_then(|err| err.downcast_ref::<std::io::Error>())
+                    .map(|err| err.kind())
                 {
                     Error::AuthenticationRequired
                 } else {


### PR DESCRIPTION
There is an extra source layer that needs to be removed before finding the proto typed error which shows if the connection did not succeed because of authentication failure.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4651)
<!-- Reviewable:end -->
