### PR TITLE
Support UI triggered connections

### DIFF
--- a/nym-vpn-app/CHANGELOG.md
+++ b/nym-vpn-app/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- RPC client connection retries are triggered by UI
+
 ## [1.25.0] - 2026-03-02
 
 ### Added

--- a/nym-vpn-app/src-tauri/src/commands/daemon.rs
+++ b/nym-vpn-app/src-tauri/src/commands/daemon.rs
@@ -118,3 +118,10 @@ pub async fn delete_logs(vpnd: State<'_, VpndClient>) -> Result<(), BackendError
         })
         .map_err(|e| e.into())
 }
+
+#[instrument(skip_all)]
+#[tauri::command]
+pub async fn retry_authentication(vpnd: State<'_, VpndClient>) -> Result<(), BackendError> {
+    vpnd.retry_daemon_authentication().await;
+    Ok(())
+}

--- a/nym-vpn-app/src-tauri/src/main.rs
+++ b/nym-vpn-app/src-tauri/src/main.rs
@@ -318,6 +318,7 @@ async fn main() -> Result<()> {
             cmd_daemon::network_compat,
             cmd_daemon::vpnd_log_dir,
             cmd_daemon::delete_logs,
+            cmd_daemon::retry_authentication,
             cmd_fs::log_dir,
             cmd_fs::delete_app_logs,
             cmd_fs::zip_logs,

--- a/nym-vpn-app/src-tauri/src/vpnd/client.rs
+++ b/nym-vpn-app/src-tauri/src/vpnd/client.rs
@@ -40,8 +40,15 @@ use crate::{
 };
 
 #[derive(Debug, Clone)]
+enum ConnectionState {
+    Connected(RpcClient),
+    Trying,
+    AuthenticationDenied,
+}
+
+#[derive(Debug, Clone)]
 pub struct VpndClient {
-    rpc_client: Arc<Mutex<Option<RpcClient>>>,
+    rpc_client: Arc<Mutex<ConnectionState>>,
     connect_fail_logged: Arc<Mutex<bool>>,
     pkg_info: PackageInfo,
     user_agent: UserAgent,
@@ -51,7 +58,7 @@ impl VpndClient {
     #[instrument(skip_all)]
     pub fn new(pkg: &PackageInfo) -> Self {
         VpndClient {
-            rpc_client: Arc::new(Mutex::new(None)),
+            rpc_client: Arc::new(Mutex::new(ConnectionState::Trying)),
             connect_fail_logged: Arc::new(Mutex::new(false)),
             pkg_info: pkg.clone(),
             user_agent: VpndClient::user_agent(pkg, None),
@@ -84,10 +91,14 @@ impl VpndClient {
     /// Get the rpc client
     #[instrument(skip_all)]
     pub async fn vpnd(&self) -> Result<RpcClient, VpndError> {
-        // fast path: already created
         let mut guard = self.rpc_client.lock().await;
-        if let Some(client) = &*guard {
-            return Ok(client.clone());
+        match &*guard {
+            // fast path: already created
+            ConnectionState::Connected(rpc_client) => return Ok(rpc_client.clone()),
+            // tried before, but authentication didn't succeed
+            ConnectionState::AuthenticationDenied => return Err(VpndError::AuthenticationRequired),
+            // got signal to try again
+            ConnectionState::Trying => {}
         }
 
         // slow path: create new client
@@ -98,6 +109,7 @@ impl VpndClient {
             }
             Err(nym_vpn_proto::rpc_client::Error::AuthenticationRequired) => {
                 self.log_connect_failed("need to authenticate").await;
+                *guard = ConnectionState::AuthenticationDenied;
                 return Err(VpndError::AuthenticationRequired);
             }
             Err(e) => {
@@ -109,13 +121,18 @@ impl VpndClient {
 
         debug!("connected to the daemon");
 
-        *guard = Some(client.clone());
+        *guard = ConnectionState::Connected(client.clone());
         Ok(client)
+    }
+
+    pub async fn retry_daemon_authentication(&self) {
+        let mut guard = self.rpc_client.lock().await;
+        *guard = ConnectionState::Trying;
     }
 
     async fn drop_rpc_client(&self) {
         let mut guard = self.rpc_client.lock().await;
-        *guard = None;
+        *guard = ConnectionState::Trying;
         debug!("dropped daemon connection");
     }
 


### PR DESCRIPTION


## Ticket

JIRA-NYM-559

## Description

Support in Rust side for UI triggered connections to daemon, which will trigger only one password prompt to the user.


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4652)
<!-- Reviewable:end -->
