### PR TITLE
APPLE: fix reset button height

### DIFF
--- a/nym-vpn-apple/Settings/Sources/Settings/MixnetTuning/MixnetTuningView.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/MixnetTuning/MixnetTuningView.swift
@@ -375,7 +375,7 @@ private extension MixnetTuningView {
         }
         Spacer()
             .frame(height: 24)
-        GenericButton(title: "mixnetTuning.reset".localizedString, style: .primaryBorderOnly, height: 36)
+        GenericButton(title: "mixnetTuning.reset".localizedString, style: .primaryBorderOnly, height: 42)
             .onTapGesture {
                 resetToDefaults()
             }


### PR DESCRIPTION
## Ticket

JIRA-NYM-491

## Description

Fix reset button height. New height - 42


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4668)
<!-- Reviewable:end -->
