### PR TITLE
VPN-4866: Display proper error message is social account is already linked

### DIFF
--- a/nym-vpn-app/src-tauri/src/error.rs
+++ b/nym-vpn-app/src-tauri/src/error.rs
@@ -146,6 +146,7 @@ pub enum ErrorKey {
     GetMixnetEntryCountriesQuery,
     GetMixnetExitCountriesQuery,
     GetWgCountriesQuery,
+    AccountAlreadyLinked,
 }
 
 impl From<GatewayType> for ErrorKey {

--- a/nym-vpn-app/src-tauri/src/vpnd/account_error.rs
+++ b/nym-vpn-app/src-tauri/src/vpnd/account_error.rs
@@ -129,6 +129,8 @@ impl From<lib::VpnApiError> for BackendError {
     }
 }
 
+const ACCOUNT_ALREADY_LINKED_ID: &str = "e8cccbba-f4ef-49a3-be89-be835c60f289";
+
 impl From<lib::VpnApiErrorResponse> for BackendError {
     fn from(error: lib::VpnApiErrorResponse) -> Self {
         let mut detail = format!("VPN API response error: {}", error.message);
@@ -137,7 +139,16 @@ impl From<lib::VpnApiErrorResponse> for BackendError {
         }
         if let Some(id) = error.code_reference_id {
             detail.push_str(&format!(" (code: {id})"));
+
+            if id == ACCOUNT_ALREADY_LINKED_ID {
+                return BackendError::with_detail(
+                    "Account already linked",
+                    ErrorKey::AccountAlreadyLinked,
+                    detail,
+                );
+            }
         }
+
         BackendError::internal_with_detail("VPN API response error", detail)
     }
 }

--- a/nym-vpn-app/src/hooks/useI18nError.ts
+++ b/nym-vpn-app/src/hooks/useI18nError.ts
@@ -59,6 +59,8 @@ function useI18nError() {
           return t('account.device-time-out-of-sync');
         case 'bandwidth-exceeded':
           return t('account.bandwidth-exceeded');
+        case 'account-already-linked':
+          return t('account.already-linked');
       }
 
       console.warn('unhandled backend error', error);

--- a/nym-vpn-app/src/i18n/en/errors.json
+++ b/nym-vpn-app/src/i18n/en/errors.json
@@ -43,7 +43,8 @@
     "existing-account": "Account already exists",
     "no-subscription": "You don’t have an active plan. Tap Get started to begin anonymous browsing.",
     "status-not-active": "Your account is inactive",
-    "device-time-out-of-sync": "Device time is out of sync. Please synchronize your device's time with the internet."
+    "device-time-out-of-sync": "Device time is out of sync. Please synchronize your device's time with the internet.",
+    "already-linked": "This device is already linked to an account. Please log out of the current account and log in with a different account."
   },
   "countries-request": {
     "entry": "Failed to fetch the available entry node countries",

--- a/nym-vpn-app/src/i18n/en/errors.json
+++ b/nym-vpn-app/src/i18n/en/errors.json
@@ -44,7 +44,7 @@
     "no-subscription": "You don’t have an active plan. Tap Get started to begin anonymous browsing.",
     "status-not-active": "Your account is inactive",
     "device-time-out-of-sync": "Device time is out of sync. Please synchronize your device's time with the internet.",
-    "already-linked": "This device is already linked to an account. Please log out of the current account and log in with a different account."
+    "already-linked": "This device is already linked to an account."
   },
   "countries-request": {
     "entry": "Failed to fetch the available entry node countries",

--- a/nym-vpn-app/src/screens/settings/account/Account.tsx
+++ b/nym-vpn-app/src/screens/settings/account/Account.tsx
@@ -15,7 +15,6 @@ import {
   Spinner,
 } from '../../../ui';
 import SettingsGroup from '../SettingsGroup';
-import { CCache } from '../../../cache';
 import {
   useInAppNotify,
   useMainDispatch,
@@ -24,9 +23,8 @@ import {
 import { routes } from '../../../router';
 import { useDeepLink, useI18nError, useLogout } from '../../../hooks';
 import { BackendError, StateDispatch, TAccountMode } from '../../../types';
+import { getAccountId, getDeviceId } from '../../../utils';
 import { getAccountColor, getAccountDescription } from './utils';
-
-const IdsTimeToLive = 120; // sec
 
 function Account() {
   const { t, i18n } = useTranslation('settings');
@@ -59,39 +57,9 @@ function Account() {
   const { startListening } = useDeepLink();
   const { push } = useInAppNotify();
 
-  const getAccountId = async () => {
-    const accountId = await CCache.get<string>('cache-account-id');
-    if (accountId) {
-      setAccountId(accountId);
-      return;
-    }
-    try {
-      const accountId = await invoke<string>('get_account_id');
-      setAccountId(accountId);
-      CCache.set('cache-account-id', accountId, IdsTimeToLive);
-    } catch {
-      setAccountId(null);
-    }
-  };
-
-  const getDeviceId = async () => {
-    const deviceId = await CCache.get<string>('cache-device-id');
-    if (deviceId) {
-      setDeviceId(deviceId);
-      return;
-    }
-    try {
-      const deviceId = await invoke<string>('get_device_id');
-      setDeviceId(deviceId);
-      CCache.set('cache-device-id', deviceId, IdsTimeToLive);
-    } catch {
-      setDeviceId(null);
-    }
-  };
-
   useEffect(() => {
-    getAccountId();
-    getDeviceId();
+    getAccountId().then(setAccountId);
+    getDeviceId().then(setDeviceId);
   }, []);
 
   useEffect(() => {

--- a/nym-vpn-app/src/screens/settings/account/Account.tsx
+++ b/nym-vpn-app/src/screens/settings/account/Account.tsx
@@ -22,14 +22,16 @@ import {
   useMainState,
 } from '../../../contexts';
 import { routes } from '../../../router';
-import { useDeepLink, useLogout } from '../../../hooks';
-import { StateDispatch, TAccountMode } from '../../../types';
+import { useDeepLink, useI18nError, useLogout } from '../../../hooks';
+import { BackendError, StateDispatch, TAccountMode } from '../../../types';
 import { getAccountColor, getAccountDescription } from './utils';
 
 const IdsTimeToLive = 120; // sec
 
 function Account() {
   const { t, i18n } = useTranslation('settings');
+  const { tE } = useI18nError();
+
   const navigate = useNavigate();
 
   const { logout, loading } = useLogout();
@@ -122,23 +124,21 @@ function Account() {
         callbackUrl: deeplinkUrl,
       });
       await refreshAccountMode();
-    } catch (error) {
+    } catch (error: unknown) {
       console.error('Account login error: ', error);
+      let message = '';
+
       if (error instanceof Error && error.message === 'Login timeout') {
-        push({
-          message: t('account-linking-timeout', { ns: 'notifications' }),
-          type: 'error',
-          duration: 3000,
-          close: true,
-        });
+        message = t('account-linking-timeout', { ns: 'notifications' });
       } else {
-        push({
-          message: t('account-linking-error', { ns: 'notifications' }),
-          type: 'error',
-          duration: 3000,
-          close: true,
-        });
+        message = tE((error as BackendError).key);
       }
+      push({
+        message,
+        type: 'error',
+        duration: 3000,
+        close: true,
+      });
     } finally {
       setIsAccountLinking(false);
     }

--- a/nym-vpn-app/src/screens/settings/info-data/AccountData.tsx
+++ b/nym-vpn-app/src/screens/settings/info-data/AccountData.tsx
@@ -1,13 +1,10 @@
 import { useEffect, useState } from 'react';
 import clsx from 'clsx';
-import { invoke } from '@tauri-apps/api/core';
 import { useTranslation } from 'react-i18next';
 import { useMainState } from '../../../contexts';
-import { CCache } from '../../../cache';
 import { useClipboard } from '../../../hooks';
 import { ButtonText } from '../../../ui';
-
-const IdsTimeToLive = 120; // sec
+import { getAccountId, getDeviceId } from '../../../utils';
 
 function AccountData() {
   const [accountId, setAccountId] = useState<string | null>(null);
@@ -17,40 +14,10 @@ function AccountData() {
 
   const { t } = useTranslation('settings');
 
-  const getAccountId = async () => {
-    const id = await CCache.get<string>('cache-account-id');
-    if (id) {
-      setAccountId(id);
-      return;
-    }
-    try {
-      const id = await invoke<string | null>('get_account_id');
-      setAccountId(id);
-      CCache.set('cache-account-id', id, IdsTimeToLive);
-    } catch {
-      setAccountId(null);
-    }
-  };
-
-  const getDeviceId = async () => {
-    const id = await CCache.get<string>('cache-device-id');
-    if (id) {
-      setDeviceId(id);
-      return;
-    }
-    try {
-      const id = await invoke<string | null>('get_device_id');
-      setDeviceId(id);
-      await CCache.set('cache-device-id', id, IdsTimeToLive);
-    } catch {
-      setDeviceId(null);
-    }
-  };
-
   useEffect(() => {
     if (account) {
-      getAccountId();
-      getDeviceId();
+      getAccountId().then(setAccountId);
+      getDeviceId().then(setDeviceId);
     }
   }, [account]);
 

--- a/nym-vpn-app/src/types/tauri.ts
+++ b/nym-vpn-app/src/types/tauri.ts
@@ -112,7 +112,8 @@ export type ErrorKey =
   | 'device-time-desync'
   | 'get-mixnet-entry-countries-query'
   | 'get-mixnet-exit-countries-query'
-  | 'get-wg-countries-query';
+  | 'get-wg-countries-query'
+  | 'account-already-linked';
 
 export type FeatureFlags = {
   quic: boolean;

--- a/nym-vpn-app/src/utils/cache.ts
+++ b/nym-vpn-app/src/utils/cache.ts
@@ -1,0 +1,32 @@
+import { invoke } from '@tauri-apps/api/core';
+import { CCache } from '../cache';
+
+const IdsTimeToLive = 120; // sec
+
+export const getAccountId = async () => {
+  const accountId = await CCache.get<string>('cache-account-id');
+  if (accountId) {
+    return accountId;
+  }
+  try {
+    const accountId = await invoke<string>('get_account_id');
+    CCache.set('cache-account-id', accountId, IdsTimeToLive);
+    return accountId;
+  } catch {
+    return null;
+  }
+};
+
+export const getDeviceId = async () => {
+  const deviceId = await CCache.get<string>('cache-device-id');
+  if (deviceId) {
+    return deviceId;
+  }
+  try {
+    const deviceId = await invoke<string>('get_device_id');
+    CCache.set('cache-device-id', deviceId, IdsTimeToLive);
+    return deviceId;
+  } catch {
+    return null;
+  }
+};

--- a/nym-vpn-app/src/utils/index.ts
+++ b/nym-vpn-app/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './regex';
 export * from './types';
+export * from './cache';


### PR DESCRIPTION
## Ticket

[JIRA-VPN-4866](https://nymtech.atlassian.net/browse/VPN-4866)

## Description

- Handle situation when social account is already linked by checking if `code_reference_id == "e8cccbba-f4ef-49a3-be89-be835c60f289"` (code reference from [vpn-api](https://github.com/nymtech/websites/blob/145499632a5a3d922a55d387585890d1b99cd09e/www/vpn-api/src/app/api/public/v1/account/%5BaccountId%5D/auth-method/route.ts#L109))
- Move account and device getting functions to a single place


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)
<img width="331" height="753" alt="image" src="https://github.com/user-attachments/assets/275c86d7-02db-45e0-b545-3d7849baa6bd" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4686)
<!-- Reviewable:end -->
