### PR TITLE
NYM-575: Rename linked account label from "Social Login".

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/handler.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/handler.rs
@@ -204,7 +204,7 @@ pub(crate) async fn handle_link_account<C: ConnectivityMonitor>(
 
         let _status_ok = shared_state
             .vpn_api_client
-            .link_account(current_account, &privy_vpn_account, "Social login")
+            .link_account(current_account, &privy_vpn_account, "Passphrase")
             .await
             .inspect_err(|err| {
                 tracing::error!("Failed to link Privy account with API account: {err:?}")


### PR DESCRIPTION
## Ticket

JIRA-NYM-575

## Description

Rename Privy linked account type from "Social login" to "Passphrase".


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4709)
<!-- Reviewable:end -->
