### PR TITLE
Re-enable colors in console on Windows

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/logging.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/logging.rs
@@ -344,12 +344,7 @@ pub fn setup_logging(options: Options) -> Option<LoggingSetup> {
     };
 
     if options.enable_stdout_log {
-        // When debugging using WinDBG, the ANSI escape codes play havoc with the terminal output.
-        let with_ansi = !(cfg!(debug_assertions) && cfg!(windows));
-
-        let console_layer = tracing_subscriber::fmt::layer()
-            .with_span_events(FmtSpan::CLOSE)
-            .with_ansi(with_ansi);
+        let console_layer = tracing_subscriber::fmt::layer().with_span_events(FmtSpan::CLOSE);
         if options.enable_json_log {
             let console_layer = console_layer.json().event_format(JsonLogFormatter {
                 enable_opentelemetry,


### PR DESCRIPTION

## Description

- Tracing will automatically decide whether colors can be used in console
- Use `NO_COLOR=1` environment variable to suppress colored output

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4713)
<!-- Reviewable:end -->
