### PR TITLE
Reuse dns resolver flush from nym-dns

### DIFF
--- a/nym-vpn-core/crates/nym-dns/src/lib.rs
+++ b/nym-vpn-core/crates/nym-dns/src/lib.rs
@@ -27,6 +27,8 @@ mod imp;
 mod imp;
 
 pub use self::imp::Error;
+#[cfg(windows)]
+pub use imp::flush_resolver_cache;
 
 /// DNS configuration
 #[derive(Debug, Clone, PartialEq)]

--- a/nym-vpn-core/crates/nym-dns/src/windows/mod.rs
+++ b/nym-vpn-core/crates/nym-dns/src/windows/mod.rs
@@ -12,6 +12,8 @@ mod iphlpapi;
 mod netsh;
 mod tcpip;
 
+pub use dnsapi::flush_resolver_cache;
+
 /// Errors that can happen when configuring DNS on Windows.
 #[derive(thiserror::Error, Debug)]
 pub enum Error {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/resolver/windows.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/resolver/windows.rs
@@ -6,10 +6,7 @@ use async_trait::async_trait;
 use nym_windows::net::{
     add_ip_address_for_interface, loopback_luid, remove_ip_address_for_interface,
 };
-use std::{
-    net::{IpAddr, Ipv4Addr},
-    process::Command,
-};
+use std::net::{IpAddr, Ipv4Addr};
 use tokio::{net::UdpSocket, task::JoinHandle};
 use tokio_util::sync::{CancellationToken, DropGuard};
 
@@ -128,5 +125,7 @@ pub(crate) async fn new_random_socket(
 
 pub(crate) fn flush_system_cache() {
     // Best-effort. If this fails we still keep running.
-    let _ = Command::new("ipconfig").arg("/flushdns").output();
+    if let Err(err) = nym_dns::flush_resolver_cache() {
+        tracing::warn!("Failed to flush dns: {err}");
+    }
 }


### PR DESCRIPTION
## Description

It's not particularly pretty, but we can expose the function to flush dns on Windows from `nym-dns` in order to avoid shelling out.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4715)
<!-- Reviewable:end -->
