### PR TITLE
Flush dns when toggling adblock

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/adblocker/task.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/adblocker/task.rs
@@ -218,6 +218,7 @@ impl AdBlockerTask {
             .downcast_mut::<AdBlocker>()
             .expect("Failed to downcast to AdBlocker");
         adblocker.use_filter_set(filter_set).await;
+        crate::resolver::flush_system_cache();
     }
 
     async fn clear_filter_set(&self) {
@@ -227,6 +228,7 @@ impl AdBlockerTask {
             .downcast_mut::<AdBlocker>()
             .expect("Failed to downcast to AdBlocker");
         adblocker.clear_filter_set().await;
+        crate::resolver::flush_system_cache();
     }
 }
 


### PR DESCRIPTION
## Description

It's not pretty but this is a quick fix for release. I think that it's necessary to reset DNS cache when enabling or disabling adblock so that the interested apps could receive fresh results and not cached.

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4716)
<!-- Reviewable:end -->
