### PR TITLE
Remove Translation step for app-js CI

### DIFF
--- a/.github/workflows/ci-nym-vpn-app-js.yml
+++ b/.github/workflows/ci-nym-vpn-app-js.yml
@@ -4,50 +4,50 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
-      - '.github/workflows/ci-nym-vpn-app-js.yml'
-      - 'nym-vpn-app/**'
+      - ".github/workflows/ci-nym-vpn-app-js.yml"
+      - "nym-vpn-app/**"
   workflow_dispatch:
 
 jobs:
-  translations:
-    runs-on: arc-linux-latest
+  # translations:
+  #   runs-on: arc-linux-latest
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          sparse-checkout: |
-            nym-vpn-app
-            crowdin-configs
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v6
+  #       with:
+  #         sparse-checkout: |
+  #           nym-vpn-app
+  #           crowdin-configs
 
-      - name: Install Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
+  #     - name: Install Node
+  #       uses: actions/setup-node@v6
+  #       with:
+  #         node-version: 24
 
-      - name: Install Crowdin CLI
-        run: npm install -g @crowdin/cli
+  #     - name: Install Crowdin CLI
+  #       run: npm install -g @crowdin/cli
 
-      - name: Verify Crowdin install
-        run: crowdin --version
+  #     - name: Verify Crowdin install
+  #       run: crowdin --version
 
-      - name: Download translations from Crowdin
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
-          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
-        run: |
-          crowdin download translations \
-            --config crowdin-configs/linux-windows.yml
+  #     - name: Download translations from Crowdin
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #         CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+  #         CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+  #       run: |
+  #         crowdin download translations \
+  #           --config crowdin-configs/linux-windows.yml
 
-      - name: Upload translations artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: crowdin-translations
-          path: nym-vpn-app/src/i18n
+  #     - name: Upload translations artifact
+  #       uses: actions/upload-artifact@v7
+  #       with:
+  #         name: crowdin-translations
+  #         path: nym-vpn-app/src/i18n
 
   check:
-    needs: translations
+    # needs: translations
     strategy:
       fail-fast: false
       matrix:
@@ -72,11 +72,11 @@ jobs:
         working-directory: nym-vpn-app
         run: npm ci
 
-      - name: Download translations artifact
-        uses: actions/download-artifact@v8
-        with:
-          name: crowdin-translations
-          path: nym-vpn-app/src/i18n
+      # - name: Download translations artifact
+      #   uses: actions/download-artifact@v8
+      #   with:
+      #     name: crowdin-translations
+      #     path: nym-vpn-app/src/i18n
 
       - name: Typecheck
         working-directory: nym-vpn-app

--- a/.github/workflows/ci-nym-vpn-app-js.yml
+++ b/.github/workflows/ci-nym-vpn-app-js.yml
@@ -9,45 +9,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  # translations:
-  #   runs-on: arc-linux-latest
-
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v6
-  #       with:
-  #         sparse-checkout: |
-  #           nym-vpn-app
-  #           crowdin-configs
-
-  #     - name: Install Node
-  #       uses: actions/setup-node@v6
-  #       with:
-  #         node-version: 24
-
-  #     - name: Install Crowdin CLI
-  #       run: npm install -g @crowdin/cli
-
-  #     - name: Verify Crowdin install
-  #       run: crowdin --version
-
-  #     - name: Download translations from Crowdin
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #         CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
-  #         CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
-  #       run: |
-  #         crowdin download translations \
-  #           --config crowdin-configs/linux-windows.yml
-
-  #     - name: Upload translations artifact
-  #       uses: actions/upload-artifact@v7
-  #       with:
-  #         name: crowdin-translations
-  #         path: nym-vpn-app/src/i18n
-
   check:
-    # needs: translations
     strategy:
       fail-fast: false
       matrix:
@@ -71,12 +33,6 @@ jobs:
       - name: Install dependencies
         working-directory: nym-vpn-app
         run: npm ci
-
-      # - name: Download translations artifact
-      #   uses: actions/download-artifact@v8
-      #   with:
-      #     name: crowdin-translations
-      #     path: nym-vpn-app/src/i18n
 
       - name: Typecheck
         working-directory: nym-vpn-app


### PR DESCRIPTION
## Ticket

JIRA-VPN-XXXX

## Description

Remove crowdin translation step from app-js CI. Due to recent translations logic update in the app the translations are not needed for the build to pass. This will unblock dependabot checks. Because they fail due to missing secrets. Like here for example: https://github.com/nymtech/nym-vpn-client/actions/runs/22481219144/job/65119621586?pr=4757

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4758)
<!-- Reviewable:end -->
