### PR TITLE
Remove no longer needed call to sed to strip iOS from swift package

### DIFF
--- a/nym-vpn-core/macOS.mk
+++ b/nym-vpn-core/macOS.mk
@@ -49,8 +49,7 @@ $(LIBWG_BUILD_DIR)/libwg.a: $(LIBWG_SOURCES)
 
 rpc-swift-package:
 	cd $(RPC_CRATE_DIR); \
-	$(ALL_IDEMPOTENT_FLAGS) $(CARGO) swift package --accept-all --platforms macos --name NymVPNRpc --xcframework-name NymVPNRpcUniffi $(RELEASE_FLAG) ; \
-	sed -i '' -e '/\.iOS(\.v13)/d' "NymVPNRpc/Package.swift"
+	$(ALL_IDEMPOTENT_FLAGS) $(CARGO) swift package --accept-all --platforms macos --name NymVPNRpc --xcframework-name NymVPNRpcUniffi $(RELEASE_FLAG)
 
 $(BIN_TARGETS): create-upload-dir
 	@echo "🔨 Building $@ binaries (x86_64)…"


### PR DESCRIPTION
## Description

Package.swift is used to be generated with `iOS` even when building for `macOS` only, however that has been fixed in cargo-swift.

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4782)
<!-- Reviewable:end -->
