### PR TITLE
Add rpc call to fetch FDA status

### DIFF
--- a/nym-vpn-core/crates/nym-split-tunnel/src/macos/process.rs
+++ b/nym-vpn-core/crates/nym-split-tunnel/src/macos/process.rs
@@ -26,7 +26,7 @@ use nym_platform_metadata::AppleVersion;
 use serde::{Deserialize, de::Error as _};
 use tokio::{
     io::{AsyncBufReadExt, AsyncRead, BufReader},
-    sync::{OnceCell, oneshot},
+    sync::oneshot,
 };
 
 use crate::SplitTunnelErrorCause;
@@ -107,20 +107,18 @@ impl ProcessMonitor {
 /// Return whether the process has full-disk access
 /// If it cannot be determined that access is available, it is assumed to be available
 pub async fn has_full_disk_access() -> bool {
-    static HAS_TCC_APPROVAL: OnceCell<bool> = OnceCell::const_new();
-    *HAS_TCC_APPROVAL
-        .get_or_try_init(|| async {
-            let mut proc = spawn_eslogger()?;
+    has_full_disk_access_inner().await.unwrap_or(true)
+}
 
-            let stdout = proc.stdout.take().unwrap();
-            let stderr = proc.stderr.take().unwrap();
-            drop(proc.stdin.take());
+async fn has_full_disk_access_inner() -> Result<bool, Error> {
+    let mut proc = spawn_eslogger()?;
 
-            let has_full_disk_access = parse_logger_status(stdout, stderr).await == NeedFda::No;
-            Ok::<bool, Error>(has_full_disk_access)
-        })
-        .await
-        .unwrap_or(&true)
+    let stdout = proc.stdout.take().unwrap();
+    let stderr = proc.stderr.take().unwrap();
+    drop(proc.stdin.take());
+
+    let has_full_disk_access = parse_logger_status(stdout, stderr).await == NeedFda::No;
+    Ok(has_full_disk_access)
 }
 
 #[derive(Debug, PartialEq)]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
@@ -206,6 +206,8 @@ pub enum VpnServiceCommand {
     RemoveSplitTunnelApp(oneshot::Sender<()>, SplitApp),
     #[cfg(target_os = "macos")]
     ClearSplitTunnelApps(oneshot::Sender<()>, ()),
+    #[cfg(target_os = "macos")]
+    NeedFullDiskPermissions(oneshot::Sender<bool>, ()),
 }
 
 /// Type of service configuration storage used by the VPN service.
@@ -1072,6 +1074,11 @@ impl NymVpnService {
             VpnServiceCommand::ClearSplitTunnelApps(tx, ()) => {
                 self.handle_clear_split_tunnel_apps().await;
                 let _ = tx.send(());
+            }
+            #[cfg(target_os = "macos")]
+            VpnServiceCommand::NeedFullDiskPermissions(tx, ()) => {
+                let has_fda = nym_split_tunnel::has_full_disk_access().await;
+                let _ = tx.send(!has_fda);
             }
         }
     }

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -1133,4 +1133,7 @@ service NymVpnService {
   rpc AddSplitTunnelApp(SplitApp) returns (google.protobuf.Empty) {}
   rpc RemoveSplitTunnelApp(SplitApp) returns (google.protobuf.Empty) {}
   rpc ClearSplitTunnelApps(google.protobuf.Empty) returns (google.protobuf.Empty) {}
+
+  // Check whether the app needs TCC approval for split tunneling (macOS)
+  rpc NeedFullDiskPermissions(google.protobuf.Empty) returns (google.protobuf.BoolValue) {}
 }

--- a/nym-vpn-core/crates/nym-vpn-proto/src/rpc_client.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/rpc_client.rs
@@ -814,6 +814,15 @@ impl RpcClient {
             .map(|v| v.into_inner())
             .map_err(Error::Rpc)
     }
+
+    #[cfg(target_os = "macos")]
+    pub async fn need_full_disk_permissions(&mut self) -> Result<bool> {
+        self.0
+            .need_full_disk_permissions(())
+            .await
+            .map(|v| v.into_inner())
+            .map_err(Error::Rpc)
+    }
 }
 
 pub fn get_rpc_socket_path() -> PathBuf {

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface.rs
@@ -1082,6 +1082,22 @@ impl NymVpnService for CommandInterface {
         #[cfg(not(target_os = "macos"))]
         Err(tonic::Status::internal("Unsupported platform"))
     }
+
+    async fn need_full_disk_permissions(
+        &self,
+        _request: tonic::Request<()>,
+    ) -> Result<tonic::Response<bool>> {
+        #[cfg(target_os = "macos")]
+        {
+            let need_fda = self
+                .send_and_wait(VpnServiceCommand::NeedFullDiskPermissions, ())
+                .await?;
+            Ok(tonic::Response::new(need_fda))
+        }
+
+        #[cfg(not(target_os = "macos"))]
+        Err(tonic::Status::internal("Unsupported platform"))
+    }
 }
 
 pub async fn start_command_interface(


### PR DESCRIPTION


## Description

Add rpc method to return the status of FDA check on macOS. Take user to `com.apple.preference.security?Privacy_AllFiles` if FDA is not approved. This is only needed before enabling split-tunnel.

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4783)
<!-- Reviewable:end -->
