### PR TITLE
NYM-132: Add subscription kind to account summary

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/common/account_summary.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/common/account_summary.rs
@@ -28,6 +28,7 @@ pub fn mock_subscription_summary_with_device(
             valid_from_utc: "2025-07-21 13:46:26.572Z".to_string(),
             status: NymVpnSubscriptionStatus::Active,
             kind: NymVpnSubscriptionKind::Freepass,
+            is_recurring: false,
         })
     } else {
         None

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
@@ -291,6 +291,8 @@ pub enum NymVpnSubscriptionKind {
     OneYear,
     TwoYears,
     Freepass,
+    #[serde(untagged)]
+    Other(String),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
@@ -274,8 +274,8 @@ pub struct NymVpnSubscription {
     pub valid_from_utc: String,
     pub status: NymVpnSubscriptionStatus,
     pub kind: NymVpnSubscriptionKind,
-    #[serde(default)]
-    pub isRecurring: bool,
+    #[serde(default, rename = "isRecurring")]
+    pub is_recurring: bool,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
@@ -274,6 +274,7 @@ pub struct NymVpnSubscription {
     pub valid_from_utc: String,
     pub status: NymVpnSubscriptionStatus,
     pub kind: NymVpnSubscriptionKind,
+    #[serde(default)]
     pub is_recurring: bool,
 }
 

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
@@ -275,7 +275,7 @@ pub struct NymVpnSubscription {
     pub status: NymVpnSubscriptionStatus,
     pub kind: NymVpnSubscriptionKind,
     #[serde(default)]
-    pub is_recurring: bool,
+    pub isRecurring: bool,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
@@ -274,6 +274,7 @@ pub struct NymVpnSubscription {
     pub valid_from_utc: String,
     pub status: NymVpnSubscriptionStatus,
     pub kind: NymVpnSubscriptionKind,
+    pub is_recurring: bool,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/account/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/account/mod.rs
@@ -374,7 +374,7 @@ impl TryFrom<&nym_vpn_api_client::response::NymVpnAccountSummaryResponse> for Vp
                 .subscription
                 .active
                 .as_ref()
-                .map(|s| s.is_recurring)
+                .map(|s| s.isRecurring)
                 .unwrap_or(false),
         })
     }

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/account/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/account/mod.rs
@@ -410,6 +410,8 @@ pub enum NymVpnSubscriptionKind {
     OneYear,
     TwoYears,
     Freepass,
+    #[serde(untagged)]
+    Other(String),
 }
 
 #[cfg(feature = "nym-type-conversions")]
@@ -427,6 +429,9 @@ impl From<nym_vpn_api_client::response::NymVpnSubscriptionKind> for NymVpnSubscr
             }
             nym_vpn_api_client::response::NymVpnSubscriptionKind::Freepass => {
                 NymVpnSubscriptionKind::Freepass
+            }
+            nym_vpn_api_client::response::NymVpnSubscriptionKind::Other(value) => {
+                NymVpnSubscriptionKind::Other(value)
             }
         }
     }

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/account/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/account/mod.rs
@@ -360,8 +360,6 @@ impl TryFrom<&nym_vpn_api_client::response::NymVpnAccountSummaryResponse> for Vp
             .map(TryInto::try_into)
             .collect::<Result<Vec<_>, _>>()?;
 
-        // let is_recurring = value.subscription.active.as_ref().map(|f| f.is_recurring).unwrap_or(false);
-
         Ok(Self {
             subscription_valid_until,
             traffic_used_gb: value.fair_usage.usedGB,
@@ -376,7 +374,7 @@ impl TryFrom<&nym_vpn_api_client::response::NymVpnAccountSummaryResponse> for Vp
                 .subscription
                 .active
                 .as_ref()
-                .map(|f| f.is_recurring)
+                .map(|s| s.is_recurring)
                 .unwrap_or(false),
         })
     }

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/account/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/account/mod.rs
@@ -274,6 +274,7 @@ pub struct VpnAccountSummary {
     pub canonical_account_addr: Option<String>,
     pub auth_methods: Vec<VpnAccountAuthMethod>,
     pub account_mode: Option<StoredAccountMode>,
+    pub subscription_kind: Option<NymVpnSubscriptionKind>,
 }
 
 // Exported methods
@@ -331,6 +332,9 @@ impl TryFrom<&nym_vpn_api_client::response::NymVpnAccountSummaryResponse> for Vp
                     subscription_valid_unti_str.unwrap()
                 ))
             })?;
+        // let subscription_kind = value.subscription.active.as_ref().map(|a| a.kind.clone());
+        // let subscription_kind = value.subscription.active.as_ref().cloned().map(TryInto::try_into);
+        let subscription_kind = value.subscription.active.as_ref().map(|a| a.kind.clone().into());
 
         let traffic_reset_time_str = value.fair_usage.resetsOnUtc.clone();
         let traffic_reset_time = traffic_reset_time_str
@@ -361,6 +365,7 @@ impl TryFrom<&nym_vpn_api_client::response::NymVpnAccountSummaryResponse> for Vp
             canonical_account_addr: value.account.canonical_account_addr.clone(),
             auth_methods,
             account_mode: None,
+            subscription_kind,
         })
     }
 }
@@ -385,6 +390,35 @@ pub struct VpnAccountAuthMethod {
     #[cfg_attr(feature = "typescript-bindings", ts(as = "String"))]
     #[cfg_attr(feature = "serde", serde(with = "time::serde::iso8601"))]
     pub created: OffsetDateTime,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "uniffi-bindings", derive(uniffi::Enum))]
+#[cfg_attr(
+    feature = "typescript-bindings",
+    derive(TS),
+    ts(export),
+    ts(export_to = "bindings.ts")
+)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "typescript-bindings", serde(rename_all = "camelCase"))]
+pub enum NymVpnSubscriptionKind {
+    OneMonth,
+    OneYear,
+    TwoYears,
+    Freepass,
+}
+
+#[cfg(feature = "nym-type-conversions")]
+impl From<nym_vpn_api_client::response::NymVpnSubscriptionKind> for NymVpnSubscriptionKind {
+    fn from(value: nym_vpn_api_client::response::NymVpnSubscriptionKind) -> Self {
+        match value {
+            nym_vpn_api_client::response::NymVpnSubscriptionKind::OneMonth => NymVpnSubscriptionKind::OneMonth,
+            nym_vpn_api_client::response::NymVpnSubscriptionKind::OneYear => NymVpnSubscriptionKind::OneYear,
+            nym_vpn_api_client::response::NymVpnSubscriptionKind::TwoYears => NymVpnSubscriptionKind::TwoYears,
+            nym_vpn_api_client::response::NymVpnSubscriptionKind::Freepass => NymVpnSubscriptionKind::Freepass,
+        }
+    }
 }
 
 #[cfg(feature = "nym-type-conversions")]

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/account/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/account/mod.rs
@@ -275,6 +275,7 @@ pub struct VpnAccountSummary {
     pub auth_methods: Vec<VpnAccountAuthMethod>,
     pub account_mode: Option<StoredAccountMode>,
     pub subscription_kind: Option<NymVpnSubscriptionKind>,
+    pub is_recurring: bool,
 }
 
 // Exported methods
@@ -359,6 +360,8 @@ impl TryFrom<&nym_vpn_api_client::response::NymVpnAccountSummaryResponse> for Vp
             .map(TryInto::try_into)
             .collect::<Result<Vec<_>, _>>()?;
 
+        // let is_recurring = value.subscription.active.as_ref().map(|f| f.is_recurring).unwrap_or(false);
+
         Ok(Self {
             subscription_valid_until,
             traffic_used_gb: value.fair_usage.usedGB,
@@ -369,6 +372,12 @@ impl TryFrom<&nym_vpn_api_client::response::NymVpnAccountSummaryResponse> for Vp
             auth_methods,
             account_mode: None,
             subscription_kind,
+            is_recurring: value
+                .subscription
+                .active
+                .as_ref()
+                .map(|f| f.is_recurring)
+                .unwrap_or(false),
         })
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/account/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/account/mod.rs
@@ -332,9 +332,12 @@ impl TryFrom<&nym_vpn_api_client::response::NymVpnAccountSummaryResponse> for Vp
                     subscription_valid_unti_str.unwrap()
                 ))
             })?;
-        // let subscription_kind = value.subscription.active.as_ref().map(|a| a.kind.clone());
-        // let subscription_kind = value.subscription.active.as_ref().cloned().map(TryInto::try_into);
-        let subscription_kind = value.subscription.active.as_ref().map(|a| a.kind.clone().into());
+
+        let subscription_kind = value
+            .subscription
+            .active
+            .as_ref()
+            .map(|a| a.kind.clone().into());
 
         let traffic_reset_time_str = value.fair_usage.resetsOnUtc.clone();
         let traffic_reset_time = traffic_reset_time_str
@@ -413,10 +416,18 @@ pub enum NymVpnSubscriptionKind {
 impl From<nym_vpn_api_client::response::NymVpnSubscriptionKind> for NymVpnSubscriptionKind {
     fn from(value: nym_vpn_api_client::response::NymVpnSubscriptionKind) -> Self {
         match value {
-            nym_vpn_api_client::response::NymVpnSubscriptionKind::OneMonth => NymVpnSubscriptionKind::OneMonth,
-            nym_vpn_api_client::response::NymVpnSubscriptionKind::OneYear => NymVpnSubscriptionKind::OneYear,
-            nym_vpn_api_client::response::NymVpnSubscriptionKind::TwoYears => NymVpnSubscriptionKind::TwoYears,
-            nym_vpn_api_client::response::NymVpnSubscriptionKind::Freepass => NymVpnSubscriptionKind::Freepass,
+            nym_vpn_api_client::response::NymVpnSubscriptionKind::OneMonth => {
+                NymVpnSubscriptionKind::OneMonth
+            }
+            nym_vpn_api_client::response::NymVpnSubscriptionKind::OneYear => {
+                NymVpnSubscriptionKind::OneYear
+            }
+            nym_vpn_api_client::response::NymVpnSubscriptionKind::TwoYears => {
+                NymVpnSubscriptionKind::TwoYears
+            }
+            nym_vpn_api_client::response::NymVpnSubscriptionKind::Freepass => {
+                NymVpnSubscriptionKind::Freepass
+            }
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/account/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/account/mod.rs
@@ -374,7 +374,7 @@ impl TryFrom<&nym_vpn_api_client::response::NymVpnAccountSummaryResponse> for Vp
                 .subscription
                 .active
                 .as_ref()
-                .map(|s| s.isRecurring)
+                .map(|s| s.is_recurring)
                 .unwrap_or(false),
         })
     }

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
@@ -54,7 +54,7 @@ mod user_agent;
 pub use account::RegisterAccountRequest;
 pub use account::{
     AccountCommandError, RegisterAccountResponse, StoredAccountMode, VpnAccountAuthMethod,
-    VpnAccountStatus, VpnAccountSummary, VpnApiError, VpnApiErrorResponse,
+    VpnAccountStatus, VpnAccountSummary, VpnApiError, VpnApiErrorResponse, NymVpnSubscriptionKind,
     controller_error::{AccountControllerError, AccountControllerErrorStateReason},
     controller_event::AccountControllerEvent,
     controller_state::AccountControllerState,

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
@@ -53,8 +53,8 @@ mod user_agent;
 #[cfg(any(target_os = "android", target_os = "ios"))]
 pub use account::RegisterAccountRequest;
 pub use account::{
-    AccountCommandError, RegisterAccountResponse, StoredAccountMode, VpnAccountAuthMethod,
-    VpnAccountStatus, VpnAccountSummary, VpnApiError, VpnApiErrorResponse, NymVpnSubscriptionKind,
+    AccountCommandError, NymVpnSubscriptionKind, RegisterAccountResponse, StoredAccountMode,
+    VpnAccountAuthMethod, VpnAccountStatus, VpnAccountSummary, VpnApiError, VpnApiErrorResponse,
     controller_error::{AccountControllerError, AccountControllerErrorStateReason},
     controller_event::AccountControllerEvent,
     controller_state::AccountControllerState,

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -853,6 +853,7 @@ message VpnAccountSummary {
   repeated VpnAccountAuthMethod auth_methods = 7;
   optional StoredAccountMode account_mode = 8;
   optional NymVpnSubscriptionKind subscription_kind = 9;
+  bool is_recurring = 10;
 }
 
 message VpnAccountAuthMethod {

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -870,11 +870,22 @@ enum VpnAccountStatus {
   DELETE_ME = 2;
 }
 
-enum NymVpnSubscriptionKind {
-    OneMonth = 0;
-    OneYear = 1;
-    TwoYears = 2;
-    Freepass = 3;
+message NymVpnSubscriptionKind {
+    message OneMonth {}
+    message OneYear {}
+    message TwoYears {}
+    message Freepass {}
+    message Other {
+      string other = 1;
+    }
+
+    oneof kind {
+      OneMonth one_month = 1;
+      OneYear one_year = 2;
+      TwoYears two_years = 3;
+      Freepass free_pass = 4;
+      Other other = 5;
+    }
 }
 
 message DeleteLogFileResponse {

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -852,6 +852,7 @@ message VpnAccountSummary {
   optional string canonical_account_addr = 6;
   repeated VpnAccountAuthMethod auth_methods = 7;
   optional StoredAccountMode account_mode = 8;
+  optional NymVpnSubscriptionKind subscription_kind = 9;
 }
 
 message VpnAccountAuthMethod {
@@ -867,6 +868,13 @@ enum VpnAccountStatus {
   ACTIVE = 0;
   INACTIVE = 1;
   DELETE_ME = 2;
+}
+
+enum NymVpnSubscriptionKind {
+    OneMonth = 0;
+    OneYear = 1;
+    TwoYears = 2;
+    Freepass = 3;
 }
 
 message DeleteLogFileResponse {

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/account.rs
@@ -299,7 +299,6 @@ impl TryFrom<proto::VpnAccountSummary> for VpnAccountSummary {
 
         let subscription_kind = value
             .subscription_kind
-            // .map(|kind| NymVpnSubscriptionKind::try_from(kind))
             .map(NymVpnSubscriptionKind::try_from)
             .transpose()?;
 

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/account.rs
@@ -299,7 +299,8 @@ impl TryFrom<proto::VpnAccountSummary> for VpnAccountSummary {
 
         let subscription_kind = value
             .subscription_kind
-            .map(|kind| NymVpnSubscriptionKind::try_from(kind))
+            // .map(|kind| NymVpnSubscriptionKind::try_from(kind))
+            .map(NymVpnSubscriptionKind::try_from)
             .transpose()?;
 
         Ok(Self {

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/account.rs
@@ -3,8 +3,8 @@
 
 use nym_vpn_lib_types::{
     AccountCommandError, AvailableTickets, DeeplinkClient, DeeplinkKind, GetDeeplinkParams,
-    StoredAccountMode, VpnAccountAuthMethod, VpnAccountStatus, VpnAccountSummary, VpnApiError,
-    VpnApiErrorResponse, NymVpnSubscriptionKind,
+    NymVpnSubscriptionKind, StoredAccountMode, VpnAccountAuthMethod, VpnAccountStatus,
+    VpnAccountSummary, VpnApiError, VpnApiErrorResponse,
 };
 
 use crate::{
@@ -301,8 +301,8 @@ impl TryFrom<proto::VpnAccountSummary> for VpnAccountSummary {
             .subscription_kind
             .map(|kind| {
                 proto::NymVpnSubscriptionKind::try_from(kind)
-                .map(NymVpnSubscriptionKind::from)
-                .map_err(|_| ConversionError::NoValueSet("VpnAccountSummary.subscription_kind"))
+                    .map(NymVpnSubscriptionKind::from)
+                    .map_err(|_| ConversionError::NoValueSet("VpnAccountSummary.subscription_kind"))
             })
             .transpose()?;
 
@@ -340,7 +340,6 @@ impl From<VpnAccountSummary> for proto::VpnAccountSummary {
         let account_mode = value
             .account_mode
             .map(|mode| proto::StoredAccountMode::from(mode) as i32);
-
 
         let subscription_kind = value
             .subscription_kind
@@ -545,7 +544,7 @@ impl From<proto::NymVpnSubscriptionKind> for NymVpnSubscriptionKind {
 }
 
 impl From<NymVpnSubscriptionKind> for proto::NymVpnSubscriptionKind {
-    fn from (value: NymVpnSubscriptionKind) -> Self {
+    fn from(value: NymVpnSubscriptionKind) -> Self {
         match value {
             NymVpnSubscriptionKind::OneMonth => proto::NymVpnSubscriptionKind::OneMonth,
             NymVpnSubscriptionKind::OneYear => proto::NymVpnSubscriptionKind::OneYear,

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/account.rs
@@ -299,11 +299,7 @@ impl TryFrom<proto::VpnAccountSummary> for VpnAccountSummary {
 
         let subscription_kind = value
             .subscription_kind
-            .map(|kind| {
-                proto::NymVpnSubscriptionKind::try_from(kind)
-                    .map(NymVpnSubscriptionKind::from)
-                    .map_err(|_| ConversionError::NoValueSet("VpnAccountSummary.subscription_kind"))
-            })
+            .map(|kind| NymVpnSubscriptionKind::try_from(kind))
             .transpose()?;
 
         Ok(Self {
@@ -343,7 +339,7 @@ impl From<VpnAccountSummary> for proto::VpnAccountSummary {
 
         let subscription_kind = value
             .subscription_kind
-            .map(|kind| proto::NymVpnSubscriptionKind::from(kind) as i32);
+            .map(proto::NymVpnSubscriptionKind::from);
 
         Self {
             subscription_valid_until,
@@ -532,24 +528,53 @@ impl TryFrom<proto::GetAccountModeResponse> for Option<StoredAccountMode> {
     }
 }
 
-impl From<proto::NymVpnSubscriptionKind> for NymVpnSubscriptionKind {
-    fn from(value: proto::NymVpnSubscriptionKind) -> Self {
-        match value {
-            proto::NymVpnSubscriptionKind::OneMonth => NymVpnSubscriptionKind::OneMonth,
-            proto::NymVpnSubscriptionKind::OneYear => NymVpnSubscriptionKind::OneYear,
-            proto::NymVpnSubscriptionKind::TwoYears => NymVpnSubscriptionKind::TwoYears,
-            proto::NymVpnSubscriptionKind::Freepass => NymVpnSubscriptionKind::Freepass,
-        }
+impl TryFrom<proto::NymVpnSubscriptionKind> for NymVpnSubscriptionKind {
+    type Error = ConversionError;
+
+    fn try_from(value: proto::NymVpnSubscriptionKind) -> Result<Self, Self::Error> {
+        let state = value
+            .kind
+            .ok_or(ConversionError::NoValueSet("NymVpnSubscriptionKind.kind"))?;
+        Ok(match state {
+            proto::nym_vpn_subscription_kind::Kind::OneMonth(
+                proto::nym_vpn_subscription_kind::OneMonth {},
+            ) => NymVpnSubscriptionKind::OneMonth,
+            proto::nym_vpn_subscription_kind::Kind::OneYear(
+                proto::nym_vpn_subscription_kind::OneYear {},
+            ) => NymVpnSubscriptionKind::OneYear,
+            proto::nym_vpn_subscription_kind::Kind::TwoYears(
+                proto::nym_vpn_subscription_kind::TwoYears {},
+            ) => NymVpnSubscriptionKind::TwoYears,
+            proto::nym_vpn_subscription_kind::Kind::FreePass(
+                proto::nym_vpn_subscription_kind::Freepass {},
+            ) => NymVpnSubscriptionKind::Freepass,
+            proto::nym_vpn_subscription_kind::Kind::Other(
+                proto::nym_vpn_subscription_kind::Other { other },
+            ) => NymVpnSubscriptionKind::Other(other),
+        })
     }
 }
 
 impl From<NymVpnSubscriptionKind> for proto::NymVpnSubscriptionKind {
     fn from(value: NymVpnSubscriptionKind) -> Self {
-        match value {
-            NymVpnSubscriptionKind::OneMonth => proto::NymVpnSubscriptionKind::OneMonth,
-            NymVpnSubscriptionKind::OneYear => proto::NymVpnSubscriptionKind::OneYear,
-            NymVpnSubscriptionKind::TwoYears => proto::NymVpnSubscriptionKind::TwoYears,
-            NymVpnSubscriptionKind::Freepass => proto::NymVpnSubscriptionKind::Freepass,
-        }
+        let kind: proto::nym_vpn_subscription_kind::Kind = match value {
+            NymVpnSubscriptionKind::OneMonth => proto::nym_vpn_subscription_kind::Kind::OneMonth(
+                proto::nym_vpn_subscription_kind::OneMonth {},
+            ),
+            NymVpnSubscriptionKind::OneYear => proto::nym_vpn_subscription_kind::Kind::OneYear(
+                proto::nym_vpn_subscription_kind::OneYear {},
+            ),
+            NymVpnSubscriptionKind::TwoYears => proto::nym_vpn_subscription_kind::Kind::TwoYears(
+                proto::nym_vpn_subscription_kind::TwoYears {},
+            ),
+            NymVpnSubscriptionKind::Freepass => proto::nym_vpn_subscription_kind::Kind::FreePass(
+                proto::nym_vpn_subscription_kind::Freepass {},
+            ),
+            NymVpnSubscriptionKind::Other(other) => proto::nym_vpn_subscription_kind::Kind::Other(
+                proto::nym_vpn_subscription_kind::Other { other },
+            ),
+        };
+
+        proto::NymVpnSubscriptionKind { kind: Some(kind) }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/account.rs
@@ -312,6 +312,7 @@ impl TryFrom<proto::VpnAccountSummary> for VpnAccountSummary {
             auth_methods,
             account_mode,
             subscription_kind,
+            is_recurring: value.is_recurring,
         })
     }
 }
@@ -351,6 +352,7 @@ impl From<VpnAccountSummary> for proto::VpnAccountSummary {
             auth_methods,
             account_mode,
             subscription_kind,
+            is_recurring: value.is_recurring,
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/account.rs
@@ -4,7 +4,7 @@
 use nym_vpn_lib_types::{
     AccountCommandError, AvailableTickets, DeeplinkClient, DeeplinkKind, GetDeeplinkParams,
     StoredAccountMode, VpnAccountAuthMethod, VpnAccountStatus, VpnAccountSummary, VpnApiError,
-    VpnApiErrorResponse,
+    VpnApiErrorResponse, NymVpnSubscriptionKind,
 };
 
 use crate::{
@@ -297,6 +297,15 @@ impl TryFrom<proto::VpnAccountSummary> for VpnAccountSummary {
             .map(TryInto::try_into)
             .collect::<Result<_, ConversionError>>()?;
 
+        let subscription_kind = value
+            .subscription_kind
+            .map(|kind| {
+                proto::NymVpnSubscriptionKind::try_from(kind)
+                .map(NymVpnSubscriptionKind::from)
+                .map_err(|_| ConversionError::NoValueSet("VpnAccountSummary.subscription_kind"))
+            })
+            .transpose()?;
+
         Ok(Self {
             subscription_valid_until,
             traffic_used_gb: value.traffic_used_gb,
@@ -306,6 +315,7 @@ impl TryFrom<proto::VpnAccountSummary> for VpnAccountSummary {
             canonical_account_addr: value.canonical_account_addr,
             auth_methods,
             account_mode,
+            subscription_kind,
         })
     }
 }
@@ -331,6 +341,11 @@ impl From<VpnAccountSummary> for proto::VpnAccountSummary {
             .account_mode
             .map(|mode| proto::StoredAccountMode::from(mode) as i32);
 
+
+        let subscription_kind = value
+            .subscription_kind
+            .map(|kind| proto::NymVpnSubscriptionKind::from(kind) as i32);
+
         Self {
             subscription_valid_until,
             traffic_used_gb: value.traffic_used_gb,
@@ -340,6 +355,7 @@ impl From<VpnAccountSummary> for proto::VpnAccountSummary {
             canonical_account_addr: value.canonical_account_addr,
             auth_methods,
             account_mode,
+            subscription_kind,
         }
     }
 }
@@ -513,6 +529,28 @@ impl TryFrom<proto::GetAccountModeResponse> for Option<StoredAccountMode> {
                 Ok(Some(mode.into()))
             }
             None => Ok(None),
+        }
+    }
+}
+
+impl From<proto::NymVpnSubscriptionKind> for NymVpnSubscriptionKind {
+    fn from(value: proto::NymVpnSubscriptionKind) -> Self {
+        match value {
+            proto::NymVpnSubscriptionKind::OneMonth => NymVpnSubscriptionKind::OneMonth,
+            proto::NymVpnSubscriptionKind::OneYear => NymVpnSubscriptionKind::OneYear,
+            proto::NymVpnSubscriptionKind::TwoYears => NymVpnSubscriptionKind::TwoYears,
+            proto::NymVpnSubscriptionKind::Freepass => NymVpnSubscriptionKind::Freepass,
+        }
+    }
+}
+
+impl From<NymVpnSubscriptionKind> for proto::NymVpnSubscriptionKind {
+    fn from (value: NymVpnSubscriptionKind) -> Self {
+        match value {
+            NymVpnSubscriptionKind::OneMonth => proto::NymVpnSubscriptionKind::OneMonth,
+            NymVpnSubscriptionKind::OneYear => proto::NymVpnSubscriptionKind::OneYear,
+            NymVpnSubscriptionKind::TwoYears => proto::NymVpnSubscriptionKind::TwoYears,
+            NymVpnSubscriptionKind::Freepass => proto::NymVpnSubscriptionKind::Freepass,
         }
     }
 }


### PR DESCRIPTION
## Ticket

[JIRA-NYM-132](https://nymtech.atlassian.net/browse/NYM-132)

## Description

Extend the `VpnAccountSummary` with:
- `is_recurring`
- `subscription_kind`:
```
pub enum NymVpnSubscriptionKind {
    OneMonth,
    OneYear,
    TwoYears,
    Freepass,
    Other(String),
}
```

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4794)
<!-- Reviewable:end -->
