### PR TITLE
Include account kind label when registering with in-app payment for mobile

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
@@ -17,10 +17,10 @@ use crate::{
     error::{Result, VpnApiClientError},
     fronted_http_client,
     request::{
-        ApplyFreepassRequestBody, CreateAndroidAccountRequestBody, CreateAppleAccountRequestBody,
-        CreateSubscriptionKind, CreateSubscriptionRequestBody, LinkAccountRequestBody,
-        RegisterDeviceRequestBody, RequestZkNymRequestBody, UpdateDeviceRequestBody,
-        UpdateDeviceRequestStatus,
+        AccountKind, ApplyFreepassRequestBody, CreateAndroidAccountRequestBody,
+        CreateAppleAccountRequestBody, CreateSubscriptionKind, CreateSubscriptionRequestBody,
+        LinkAccountRequestBody, RegisterDeviceRequestBody, RequestZkNymRequestBody,
+        UpdateDeviceRequestBody, UpdateDeviceRequestStatus,
     },
     response::{
         NymDirectoryGatewayCountriesResponse, NymDirectoryGatewaysResponse, NymVpnAccountResponse,
@@ -601,6 +601,11 @@ impl VpnApiClient {
         platform: Platform,
     ) -> Result<NymVpnRegisterAccountResponse> {
         let account_addr = account.id().to_string();
+        let kind = if account.mode().is_privy() {
+            AccountKind::PrivySecp256k1
+        } else {
+            AccountKind::UserGeneratedSecp256k1
+        };
         let pub_key = account.pub_key().to_string();
         let signature_base64 = account.signature_base64().to_string();
         match platform {
@@ -609,6 +614,7 @@ impl VpnApiClient {
                     account_addr,
                     pub_key,
                     signature_base64,
+                    kind,
                 })
                 .await
             }
@@ -618,6 +624,7 @@ impl VpnApiClient {
                     pub_key,
                     signature_base64,
                     purchase_token,
+                    kind,
                 })
                 .await
             }

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/request.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/request.rs
@@ -4,11 +4,19 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AccountKind {
+    PrivySecp256k1,
+    UserGeneratedSecp256k1,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct CreateAndroidAccountRequestBody {
     pub account_addr: String,
     pub pub_key: String,
     pub signature_base64: String,
     pub purchase_token: String,
+    pub kind: AccountKind,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -16,6 +24,7 @@ pub struct CreateAppleAccountRequestBody {
     pub account_addr: String,
     pub pub_key: String,
     pub signature_base64: String,
+    pub kind: AccountKind,
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION


## Ticket

JIRA-VPN-731

## Description

As we want to track fresh account creations done with Privy, the application-side generated accounts need to be explicitly labeled as privy or user generated when paying for the subscription with in-app payments for mobile.


## Checklist:


## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4801)
<!-- Reviewable:end -->
