### PR TITLE
Add lp field, move socks5 field to another level

### DIFF
--- a/nym-vpn-app/src-tauri/Cargo.lock
+++ b/nym-vpn-app/src-tauri/Cargo.lock
@@ -3491,7 +3491,9 @@ dependencies = [
  "cc",
  "hyper-util",
  "objc2",
+ "objc2-core-foundation",
  "objc2-foundation",
+ "objc2-security",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -3668,7 +3670,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.10.0",
+ "block2",
  "dispatch2",
+ "libc",
  "objc2",
 ]
 
@@ -3820,6 +3824,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
 dependencies = [
  "bitflags 2.10.0",
+ "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/mod.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/mod.rs
@@ -14,7 +14,7 @@ use nym_vpn_api_client::{
 };
 use rand::seq::IteratorRandom;
 use std::{
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     fmt,
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
     str::FromStr,
@@ -64,6 +64,8 @@ pub struct Gateway {
     pub performance: Option<Performance>,
     #[builder(default)]
     pub version: Option<String>,
+    #[builder(default)]
+    pub lewes_protocol_details: Option<LewesProtocolDetails>,
 }
 
 impl Gateway {
@@ -145,6 +147,7 @@ impl Gateway {
             mixnet_performance: None,
             performance: None,
             version,
+            lewes_protocol_details: None,
         })
     }
 
@@ -443,6 +446,42 @@ pub struct WgProbeResults {
     pub ping_ips_performance: f32,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct LewesProtocolDetails {
+    pub content: LewesProtocolDetailsData,
+    pub signature: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct LewesProtocolDetailsData {
+    pub enabled: bool,
+    pub control_port: u16,
+    pub data_port: u16,
+    pub x25519: String,
+    pub kem_keys: HashMap<String, HashMap<String, String>>,
+}
+
+impl From<nym_vpn_api_client::response::LewesProtocolDetailsV1> for LewesProtocolDetails {
+    fn from(value: nym_vpn_api_client::response::LewesProtocolDetailsV1) -> Self {
+        Self {
+            content: value.content.into(),
+            signature: value.signature,
+        }
+    }
+}
+
+impl From<nym_vpn_api_client::response::LewesProtocolDetailsDataV1> for LewesProtocolDetailsData {
+    fn from(value: nym_vpn_api_client::response::LewesProtocolDetailsDataV1) -> Self {
+        Self {
+            enabled: value.enabled,
+            control_port: value.control_port,
+            data_port: value.data_port,
+            x25519: value.x25519,
+            kem_keys: value.kem_keys,
+        }
+    }
+}
+
 impl From<nym_vpn_api_client::response::AsnKind> for AsnKind {
     fn from(value: nym_vpn_api_client::response::AsnKind) -> Self {
         match value {
@@ -654,6 +693,9 @@ impl TryFrom<nym_vpn_api_client::response::NymDirectoryGateway> for Gateway {
             mixnet_performance: Some(gateway.performance),
             performance,
             version: gateway.build_information.map(|info| info.build_version),
+            lewes_protocol_details: gateway
+                .lewes_protocol_details
+                .map(LewesProtocolDetails::from),
         })
     }
 }

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/mod.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/mod.rs
@@ -248,11 +248,11 @@ impl Gateway {
         self.last_probe
             .as_ref()
             .and_then(|probe| {
-                probe.outcome.as_exit.as_ref().and_then(|exit| {
-                    exit.socks5
-                        .as_ref()
-                        .and_then(|socks5| socks5.score.as_ref())
-                })
+                probe
+                    .outcome
+                    .socks5
+                    .as_ref()
+                    .and_then(|socks5| socks5.score.as_ref())
             })
             .is_some_and(|score| *score >= min_socks5_score)
     }
@@ -399,6 +399,8 @@ pub struct ProbeOutcome {
     pub as_entry: Entry,
     pub as_exit: Option<Exit>,
     pub wg: Option<WgProbeResults>,
+    pub socks5: Option<Socks5>,
+    pub lp: Option<Lp>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -406,6 +408,14 @@ pub struct Socks5 {
     pub can_proxy_https: bool,
     pub score: Option<ScoreValue>,
     pub errors: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Lp {
+    pub can_connect: bool,
+    pub can_handshake: bool,
+    pub can_register: bool,
+    pub error: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -421,7 +431,6 @@ pub struct Exit {
     pub can_route_ip_external_v4: bool,
     pub can_route_ip_v6: bool,
     pub can_route_ip_external_v6: bool,
-    pub socks5: Option<Socks5>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -514,16 +523,29 @@ impl From<nym_vpn_api_client::response::ProbeOutcome> for ProbeOutcome {
             as_entry: Entry::from(outcome.as_entry),
             as_exit,
             wg: outcome.wg.map(WgProbeResults::from),
+            socks5: outcome.socks5.map(From::from),
+            lp: outcome.lp.map(From::from),
         }
     }
 }
 
 impl From<nym_vpn_api_client::response::Socks5> for Socks5 {
     fn from(exit: nym_vpn_api_client::response::Socks5) -> Self {
-        Socks5 {
+        Self {
             can_proxy_https: exit.can_proxy_https,
             score: exit.score.map(ScoreValue::from),
             errors: exit.errors,
+        }
+    }
+}
+
+impl From<nym_vpn_api_client::response::Lp> for Lp {
+    fn from(lp: nym_vpn_api_client::response::Lp) -> Self {
+        Self {
+            can_connect: lp.can_connect,
+            can_handshake: lp.can_handshake,
+            can_register: lp.can_register,
+            error: lp.error,
         }
     }
 }
@@ -545,7 +567,6 @@ impl From<nym_vpn_api_client::response::Exit> for Exit {
             can_route_ip_external_v4: exit.can_route_ip_external_v4,
             can_route_ip_v6: exit.can_route_ip_v6,
             can_route_ip_external_v6: exit.can_route_ip_external_v6,
-            socks5: exit.socks5.map(Socks5::from),
         }
     }
 }
@@ -621,10 +642,9 @@ impl TryFrom<nym_vpn_api_client::response::NymDirectoryGateway> for Gateway {
                 }
             };
 
-        if let Some(probe) = last_probe.as_mut()
-            && let Some(exit) = probe.outcome.as_exit.as_mut()
-        {
-            exit.socks5 = socks5_score_from_mixnet(exit.socks5.clone(), performance.as_ref());
+        if let Some(probe) = last_probe.as_mut() {
+            probe.outcome.socks5 =
+                socks5_score_from_mixnet(probe.outcome.socks5.clone(), performance.as_ref());
         }
 
         Ok(Gateway {

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/mod.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/mod.rs
@@ -509,19 +509,9 @@ impl From<nym_vpn_api_client::response::Probe> for Probe {
 
 impl From<nym_vpn_api_client::response::ProbeOutcome> for ProbeOutcome {
     fn from(outcome: nym_vpn_api_client::response::ProbeOutcome) -> Self {
-        // Move socks5 from ProbeOutcome level to Exit level if as_exit exists
-        // The API response has socks5 at the outcome level, but we store it in Exit
-        let as_exit = outcome.as_exit.map(|mut exit| {
-            // If socks5 is at ProbeOutcome level but not in Exit, move it
-            if exit.socks5.is_none() {
-                exit.socks5 = outcome.socks5.clone();
-            }
-            Exit::from(exit)
-        });
-
         ProbeOutcome {
             as_entry: Entry::from(outcome.as_entry),
-            as_exit,
+            as_exit: outcome.as_exit.map(Exit::from),
             wg: outcome.wg.map(WgProbeResults::from),
             socks5: outcome.socks5.map(From::from),
             lp: outcome.lp.map(From::from),

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/tests.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/tests.rs
@@ -369,9 +369,6 @@ fn test_socks5_score_from_mixnet_score() {
                 .as_ref()
                 .unwrap()
                 .outcome
-                .as_exit
-                .as_ref()
-                .unwrap()
                 .socks5
                 .as_ref()
                 .unwrap()
@@ -555,6 +552,7 @@ fn create_response_nym_gateway(
                 }),
                 wg: None,
                 socks5: None,
+                lp: None,
             },
         }),
         ip_addresses: vec![],

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/tests.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/tests.rs
@@ -481,6 +481,7 @@ fn sample_gateway_list(gw_type: GatewayType) -> GatewayList {
                     uptime_percentage_last_24_hours: 0.75,
                 }),
                 version: None,
+                lewes_protocol_details: None,
             }
         })
         .collect();
@@ -514,6 +515,7 @@ fn create_test_gateway(identity: &str, country: &str, score: ScoreValue) -> Gate
             uptime_percentage_last_24_hours: 0.99,
         }),
         version: None,
+        lewes_protocol_details: None,
     }
 }
 
@@ -573,5 +575,6 @@ fn create_response_nym_gateway(
             uptime_percentage_last_24_hours: 0.75,
         }),
         build_information: None,
+        lewes_protocol_details: None,
     }
 }

--- a/nym-vpn-core/crates/nym-gateway-directory/src/lib.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/lib.rs
@@ -20,8 +20,8 @@ pub use crate::{
         exit_point::ExitPoint,
         gateway::{
             Asn, AsnKind, Entry, Exit, Gateway, GatewayFilter, GatewayFilters, GatewayList,
-            GatewayType, Location, LookupGatewayFilters, NymNode, NymNodeList, Performance, Probe,
-            ProbeOutcome, ScoreValue, Socks5,
+            GatewayType, Location, LookupGatewayFilters, Lp, NymNode, NymNodeList, Performance,
+            Probe, ProbeOutcome, ScoreValue, Socks5,
         },
         ipr_addresses::IpPacketRouterAddress,
     },

--- a/nym-vpn-core/crates/nym-gateway-directory/src/lib.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/lib.rs
@@ -20,8 +20,9 @@ pub use crate::{
         exit_point::ExitPoint,
         gateway::{
             Asn, AsnKind, Entry, Exit, Gateway, GatewayFilter, GatewayFilters, GatewayList,
-            GatewayType, Location, LookupGatewayFilters, Lp, NymNode, NymNodeList, Performance,
-            Probe, ProbeOutcome, ScoreValue, Socks5,
+            GatewayType, LewesProtocolDetails, LewesProtocolDetailsData, Location,
+            LookupGatewayFilters, Lp, NymNode, NymNodeList, Performance, Probe, ProbeOutcome,
+            ScoreValue, Socks5,
         },
         ipr_addresses::IpPacketRouterAddress,
     },

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use std::{
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     fmt,
     net::{IpAddr, SocketAddr},
 };
@@ -392,6 +392,22 @@ pub struct NymDirectoryGateway {
     // about the node in a user-friendly way
     pub performance_v2: Option<DVpnGatewayPerformance>,
     pub build_information: Option<BuildInformation>,
+    pub lewes_protocol_details: Option<LewesProtocolDetailsV1>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct LewesProtocolDetailsV1 {
+    pub content: LewesProtocolDetailsDataV1,
+    pub signature: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct LewesProtocolDetailsDataV1 {
+    pub enabled: bool,
+    pub control_port: u16,
+    pub data_port: u16,
+    pub x25519: String,
+    pub kem_keys: HashMap<String, HashMap<String, String>>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
@@ -558,6 +558,7 @@ pub struct ProbeOutcome {
     pub as_exit: Option<Exit>,
     pub wg: Option<WgProbeResults>,
     pub socks5: Option<Socks5>,
+    pub lp: Option<Lp>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -565,6 +566,14 @@ pub struct Socks5 {
     pub can_proxy_https: bool,
     pub score: Option<ScoreValue>,
     pub errors: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Lp {
+    pub can_connect: bool,
+    pub can_handshake: bool,
+    pub can_register: bool,
+    pub error: Option<String>,
 }
 
 impl ProbeOutcome {

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/gateway.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/gateway.rs
@@ -909,6 +909,7 @@ impl From<nym_validator_client::models::NymNodeDescriptionV1> for Gateway {
     }
 }
 
+#[cfg(feature = "nym-type-conversions")]
 impl From<nym_validator_client::models::NymNodeDescriptionV2> for Gateway {
     fn from(node_description: nym_validator_client::models::NymNodeDescriptionV2) -> Self {
         let build_version = Some(node_description.version().to_owned());

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/gateway.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/gateway.rs
@@ -771,7 +771,6 @@ pub struct Exit {
     pub can_route_ip_external_v4: bool,
     pub can_route_ip_v6: bool,
     pub can_route_ip_external_v6: bool,
-    pub socks5: Option<Socks5>,
 }
 
 #[derive(Debug, Clone)]
@@ -919,7 +918,6 @@ impl From<nym_gateway_directory::Exit> for Exit {
             can_route_ip_external_v4: exit.can_route_ip_external_v4,
             can_route_ip_v6: exit.can_route_ip_v6,
             can_route_ip_external_v6: exit.can_route_ip_external_v6,
-            socks5: exit.socks5.map(Socks5::from),
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/gateway.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/gateway.rs
@@ -722,6 +722,8 @@ impl From<nym_gateway_directory::ScoreValue> for Score {
 pub struct ProbeOutcome {
     pub as_entry: Entry,
     pub as_exit: Option<Exit>,
+    pub socks5: Option<Socks5>,
+    pub lp: Option<Lp>,
 }
 
 #[derive(Debug, Clone)]
@@ -753,6 +755,23 @@ pub struct Socks5 {
     pub can_proxy_https: bool,
     pub score: Option<Score>,
     pub errors: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "uniffi-bindings", derive(uniffi::Record))]
+#[cfg_attr(
+    feature = "typescript-bindings",
+    derive(TS),
+    ts(export),
+    ts(export_to = "bindings.ts")
+)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "typescript-bindings", serde(rename_all = "camelCase"))]
+pub struct Lp {
+    pub can_connect: bool,
+    pub can_handshake: bool,
+    pub can_register: bool,
+    pub error: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -910,6 +929,18 @@ impl From<nym_gateway_directory::Socks5> for Socks5 {
 }
 
 #[cfg(feature = "nym-type-conversions")]
+impl From<nym_gateway_directory::Lp> for Lp {
+    fn from(lp: nym_gateway_directory::Lp) -> Self {
+        Self {
+            can_connect: lp.can_connect,
+            can_handshake: lp.can_handshake,
+            can_register: lp.can_register,
+            error: lp.error,
+        }
+    }
+}
+
+#[cfg(feature = "nym-type-conversions")]
 impl From<nym_gateway_directory::Exit> for Exit {
     fn from(exit: nym_gateway_directory::Exit) -> Self {
         Self {
@@ -928,6 +959,8 @@ impl From<nym_gateway_directory::ProbeOutcome> for ProbeOutcome {
         Self {
             as_entry: Entry::from(outcome.as_entry),
             as_exit: outcome.as_exit.map(Exit::from),
+            socks5: outcome.socks5.map(Socks5::from),
+            lp: outcome.lp.map(Lp::from),
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/gateway.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/gateway.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use std::{
+    collections::HashMap,
     fmt,
     net::{Ipv4Addr, Ipv6Addr, SocketAddr},
     str::FromStr,
@@ -525,6 +526,7 @@ pub struct Gateway {
     pub exit_ipv4s: Vec<Ipv4Addr>,
     pub exit_ipv6s: Vec<Ipv6Addr>,
     pub build_version: Option<String>,
+    pub lewes_protocol_details: Option<LewesProtocolDetails>,
 }
 
 #[derive(Debug, Clone)]
@@ -784,6 +786,39 @@ pub struct Lp {
 )]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "typescript-bindings", serde(rename_all = "camelCase"))]
+pub struct LewesProtocolDetails {
+    pub content: LewesProtocolDetailsData,
+    pub signature: String,
+}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "uniffi-bindings", derive(uniffi::Record))]
+#[cfg_attr(
+    feature = "typescript-bindings",
+    derive(TS),
+    ts(export),
+    ts(export_to = "bindings.ts")
+)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "typescript-bindings", serde(rename_all = "camelCase"))]
+pub struct LewesProtocolDetailsData {
+    pub enabled: bool,
+    pub control_port: u16,
+    pub data_port: u16,
+    pub x25519: String,
+    pub kem_keys: HashMap<String, HashMap<String, String>>,
+}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "uniffi-bindings", derive(uniffi::Record))]
+#[cfg_attr(
+    feature = "typescript-bindings",
+    derive(TS),
+    ts(export),
+    ts(export_to = "bindings.ts")
+)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "typescript-bindings", serde(rename_all = "camelCase"))]
 pub struct Exit {
     pub can_connect: bool,
     pub can_route_ip_v4: bool,
@@ -868,6 +903,37 @@ impl From<nym_validator_client::models::NymNodeDescriptionV1> for Gateway {
             exit_ipv4s,
             exit_ipv6s,
             build_version,
+            // v1 has no lp details
+            lewes_protocol_details: None,
+        }
+    }
+}
+
+impl From<nym_validator_client::models::NymNodeDescriptionV2> for Gateway {
+    fn from(node_description: nym_validator_client::models::NymNodeDescriptionV2) -> Self {
+        let build_version = Some(node_description.version().to_owned());
+        let (exit_ipv4s, exit_ipv6s) = nym_gateway_directory::split_ips(
+            node_description.description.host_information.ip_address,
+        );
+        Self {
+            identity_key: node_description
+                .description
+                .host_information
+                .keys
+                .ed25519
+                .to_string(),
+            name: "".to_owned(),
+            description: None,
+            location: None,
+            last_probe: None,
+            mixnet_performance: None,
+            bridge_params: None,
+            performance: None,
+            exit_ipv4s,
+            exit_ipv6s,
+            build_version,
+            // TODO why are all other fields None? should this be initialized?
+            lewes_protocol_details: None,
         }
     }
 }
@@ -941,6 +1007,29 @@ impl From<nym_gateway_directory::Lp> for Lp {
 }
 
 #[cfg(feature = "nym-type-conversions")]
+impl From<nym_gateway_directory::LewesProtocolDetails> for LewesProtocolDetails {
+    fn from(value: nym_gateway_directory::LewesProtocolDetails) -> Self {
+        Self {
+            content: value.content.into(),
+            signature: value.signature,
+        }
+    }
+}
+
+#[cfg(feature = "nym-type-conversions")]
+impl From<nym_gateway_directory::LewesProtocolDetailsData> for LewesProtocolDetailsData {
+    fn from(value: nym_gateway_directory::LewesProtocolDetailsData) -> Self {
+        Self {
+            enabled: value.enabled,
+            control_port: value.control_port,
+            data_port: value.data_port,
+            x25519: value.x25519,
+            kem_keys: value.kem_keys,
+        }
+    }
+}
+
+#[cfg(feature = "nym-type-conversions")]
 impl From<nym_gateway_directory::Exit> for Exit {
     fn from(exit: nym_gateway_directory::Exit) -> Self {
         Self {
@@ -992,6 +1081,9 @@ impl From<nym_gateway_directory::Gateway> for Gateway {
             exit_ipv4s,
             exit_ipv6s,
             build_version: gateway.version,
+            lewes_protocol_details: gateway
+                .lewes_protocol_details
+                .map(LewesProtocolDetails::from),
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
@@ -74,9 +74,9 @@ pub use diagnostic::{
 };
 pub use gateway::{
     Asn, AsnKind, BridgeInformation, BridgeParameters, Country, Entry, EntryPoint, Exit, ExitPoint,
-    Gateway, GatewayFilter, GatewayType, Location, LookupGatewayFilters, Lp, NodeIdentity,
-    ParseRecipientError, Performance, Probe, ProbeOutcome, QuicClientOptions, Recipient, Score,
-    Socks5,
+    Gateway, GatewayFilter, GatewayType, LewesProtocolDetails, LewesProtocolDetailsData, Location,
+    LookupGatewayFilters, Lp, NodeIdentity, ParseRecipientError, Performance, Probe, ProbeOutcome,
+    QuicClientOptions, Recipient, Score, Socks5,
 };
 pub use log_path::LogPath;
 pub use network::{

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
@@ -74,7 +74,7 @@ pub use diagnostic::{
 };
 pub use gateway::{
     Asn, AsnKind, BridgeInformation, BridgeParameters, Country, Entry, EntryPoint, Exit, ExitPoint,
-    Gateway, GatewayFilter, GatewayType, Location, LookupGatewayFilters, NodeIdentity,
+    Gateway, GatewayFilter, GatewayType, Location, LookupGatewayFilters, Lp, NodeIdentity,
     ParseRecipientError, Performance, Probe, ProbeOutcome, QuicClientOptions, Recipient, Score,
     Socks5,
 };

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/socks5/lazy_socks5.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/socks5/lazy_socks5.rs
@@ -75,7 +75,7 @@ pub struct LazySocks5 {
     tunnel_state_shared: Arc<RwLock<TunnelState>>,
     /// Cancellation token for shutdown
     cancel_token: CancellationToken,
-    /// Active connection counter   
+    /// Active connection counter
     active_connections: Arc<RwLock<u32>>,
     /// Last connection closed timestamp
     last_connection_closed: Arc<RwLock<Option<Instant>>>,
@@ -1185,43 +1185,31 @@ impl LazySocks5 {
         let mut medium_score_nodes = Vec::new();
         let mut excluded_by_score = 0;
 
-        for node in nymnodes {
-            // Check if node has Network Requester address first
-            let nr_address = match node.nr_address.as_ref() {
-                Some(addr) => addr,
-                None => continue, // No NR address, skip
-            };
-
-            // Skip if this is the VPN exit gateway
-            if let Some(vpn_exit) = vpn_exit_identity
-                && node.identity().to_string() == *vpn_exit
-            {
-                debug!(
-                    "Excluding VPN exit gateway {} from random Network Requester selection for privacy",
-                    vpn_exit
-                );
-                continue;
-            }
-
-            // Only consider exit-capable gateways (SOCKS5 Network Requesters must be exit gateways)
-            let as_exit = node
-                .last_probe
-                .as_ref()
-                .and_then(|probe| probe.outcome.as_exit.as_ref());
-
-            if as_exit.is_none() {
-                debug!(
-                    "Excluding gateway {} - not exit-capable (no as_exit probe data)",
-                    node.identity()
-                );
-                continue;
-            }
-
+        for (node, nr_address, socks5_score) in nymnodes
+            .into_iter()
+            .filter_map(|gw| {
+                // Check if node has Network Requester address first
+                // No NR address, skip
+                gw.nr_address.clone().map(|nr_address| (gw, nr_address))
+            })
+            .filter(|(gw, _)| {
+                // only consider gateways that are NOT the VPN exit gateway
+                // unwrap_or_default works because if there's no vpn exit
+                // identity, it resolves to empty string, which will be NOT EQUAL
+                // to any gateway ID, thus preserving those gateways IN the set
+                gw.identity().to_string() != vpn_exit_identity.cloned().unwrap_or_default()
+            })
+            .filter_map(|(gw, nr_address)| {
+                // Only consider exit-capable gateways (SOCKS5 Network Requesters must be exit gateways)
+                let score = gw
+                    .last_probe
+                    .as_ref()
+                    .and_then(|probe| probe.outcome.socks5.as_ref())
+                    .map(|socks5| socks5.score);
+                score.map(|socks5_score| (gw, nr_address, socks5_score))
+            })
+        {
             // Filter by SOCKS5 score: prefer High, fallback to Medium (exclude Low/Offline/None)
-            let socks5_score = as_exit
-                .and_then(|exit| exit.socks5.as_ref())
-                .and_then(|socks5| socks5.score.as_ref());
-
             match socks5_score {
                 Some(ScoreValue::High) => {
                     // High score - preferred

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
@@ -1408,8 +1408,7 @@ impl NymVpnService {
                                 let supports_socks5 = gateway_full
                                     .last_probe
                                     .as_ref()
-                                    .and_then(|probe| probe.outcome.as_exit.as_ref())
-                                    .and_then(|exit| exit.socks5.as_ref())
+                                    .and_then(|probe| probe.outcome.socks5.as_ref())
                                     .map(|socks5| {
                                         // Use VPN API's SOCKS5 data - check if it has a valid score
                                         // (score being Some indicates it was probed and works)

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -352,6 +352,24 @@ message GatewayResponse {
   repeated string exit_ipv4s = 7;
   repeated string exit_ipv6s = 8;
   optional string build_version = 9;
+  optional LewesProtocolDetails lp_details = 13;
+}
+
+message KemKeyDigests {
+  map<string, string> digests = 1;
+}
+
+message LewesProtocolDetailsData {
+  bool enabled = 1;
+  uint32 control_port = 2;
+  uint32 data_port = 3;
+  string x25519 = 4;
+  map<string, KemKeyDigests> kem_keys = 5;
+}
+
+message LewesProtocolDetails {
+  LewesProtocolDetailsData content = 1;
+  string signature = 2;
 }
 
 message BridgeInformation {

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -311,10 +311,28 @@ message WgProbeResult {
   float ping_ips_performance = 5;
 }
 
+message Socks5ProbeResult {
+  bool can_proxy_https = 1;
+  optional Score score = 2;
+  optional ErrorList errors = 3;
+}
+
+message ErrorList {
+  repeated string error = 1;
+}
+message LpProbeResult {
+  bool can_connect = 1;
+  bool can_handshake = 2;
+  bool can_register = 3;
+  optional string error = 4;
+}
+
 message ProbeOutcome {
   AsEntry as_entry = 1;
   AsExit as_exit = 2;
   WgProbeResult wg = 3;
+  Socks5ProbeResult socks5 = 4;
+  LpProbeResult lp = 5;
 }
 
 message Probe {

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/vpnd.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/vpnd.rs
@@ -90,7 +90,6 @@ impl From<proto::AsExit> for nym_vpn_lib_types::Exit {
             can_route_ip_external_v4: exit.can_route_ip_external_v4,
             can_route_ip_v6: exit.can_route_ip_v6,
             can_route_ip_external_v6: exit.can_route_ip_external_v6,
-            socks5: None, // SOCKS5 data comes from API, not from proto
         }
     }
 }
@@ -111,11 +110,16 @@ impl From<nym_vpn_lib_types::ProbeOutcome> for proto::ProbeOutcome {
     fn from(outcome: nym_vpn_lib_types::ProbeOutcome) -> Self {
         let as_entry = Some(proto::AsEntry::from(outcome.as_entry));
         let as_exit = outcome.as_exit.map(proto::AsExit::from);
+        // TODO why is wg None and do we need to initialize those/
         let wg = None;
+        let socks5 = None;
+        let lp = None;
         proto::ProbeOutcome {
             as_entry,
             as_exit,
             wg,
+            socks5,
+            lp,
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/vpnd.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/vpnd.rs
@@ -131,9 +131,14 @@ impl TryFrom<proto::ProbeOutcome> for nym_vpn_lib_types::ProbeOutcome {
         let as_entry = outcome
             .as_entry
             .map(nym_vpn_lib_types::Entry::from)
-            .ok_or(ConversionError::generic("missing as entry"))?;
+            .ok_or(ConversionError::generic("missing as_entry"))?;
         let as_exit = outcome.as_exit.map(nym_vpn_lib_types::Exit::from);
-        Ok(Self { as_entry, as_exit })
+        Ok(Self {
+            as_entry,
+            as_exit,
+            socks5: None, // socks5 data comes from vpn-api, not from proto
+            lp: None,     // LP data comes from vpn-api, not from proto
+        })
     }
 }
 

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/vpnd.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/vpnd.rs
@@ -154,6 +154,30 @@ impl From<nym_vpn_lib_types::Lp> for proto::LpProbeResult {
     }
 }
 
+impl From<proto::Socks5ProbeResult> for nym_vpn_lib_types::Socks5 {
+    fn from(value: proto::Socks5ProbeResult) -> Self {
+        Self {
+            can_proxy_https: value.can_proxy_https,
+            score: value
+                .score
+                .and_then(|s| proto::Score::try_from(s).ok())
+                .map(nym_vpn_lib_types::Score::from),
+            errors: value.errors.map(|e| e.error),
+        }
+    }
+}
+
+impl From<proto::LpProbeResult> for nym_vpn_lib_types::Lp {
+    fn from(value: proto::LpProbeResult) -> Self {
+        Self {
+            can_connect: value.can_connect,
+            can_handshake: value.can_handshake,
+            can_register: value.can_register,
+            error: value.error,
+        }
+    }
+}
+
 impl TryFrom<proto::ProbeOutcome> for nym_vpn_lib_types::ProbeOutcome {
     type Error = ConversionError;
 
@@ -166,8 +190,8 @@ impl TryFrom<proto::ProbeOutcome> for nym_vpn_lib_types::ProbeOutcome {
         Ok(Self {
             as_entry,
             as_exit,
-            socks5: None, // socks5 data comes from vpn-api, not from proto
-            lp: None,     // LP data comes from vpn-api, not from proto
+            socks5: outcome.socks5.map(From::from),
+            lp: outcome.lp.map(From::from),
         })
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/vpnd.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/vpnd.rs
@@ -11,8 +11,9 @@ use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
 use nym_vpn_lib_types::{
     AccountCommandResponse, ApiUrl, BridgeInformation, BridgeParameters, GatewayType,
-    ListGatewaysOptions, LogPath, NymNetworkDetails, NymVpnNetwork, Performance, QuicClientOptions,
-    StoreAccountRequest, SystemMessage, UserAgent, VpnServiceInfo,
+    LewesProtocolDetails, LewesProtocolDetailsData, ListGatewaysOptions, LogPath,
+    NymNetworkDetails, NymVpnNetwork, Performance, QuicClientOptions, StoreAccountRequest,
+    SystemMessage, UserAgent, VpnServiceInfo,
 };
 
 use crate::{conversions::ConversionError, proto};
@@ -110,16 +111,45 @@ impl From<nym_vpn_lib_types::ProbeOutcome> for proto::ProbeOutcome {
     fn from(outcome: nym_vpn_lib_types::ProbeOutcome) -> Self {
         let as_entry = Some(proto::AsEntry::from(outcome.as_entry));
         let as_exit = outcome.as_exit.map(proto::AsExit::from);
-        // TODO why is wg None and do we need to initialize those/
         let wg = None;
-        let socks5 = None;
-        let lp = None;
+        let socks5 = outcome.socks5.map(proto::Socks5ProbeResult::from);
+        let lp = outcome.lp.map(proto::LpProbeResult::from);
         proto::ProbeOutcome {
             as_entry,
             as_exit,
             wg,
             socks5,
             lp,
+        }
+    }
+}
+
+impl From<nym_vpn_lib_types::Socks5> for proto::Socks5ProbeResult {
+    fn from(value: nym_vpn_lib_types::Socks5) -> Self {
+        Self {
+            can_proxy_https: value.can_proxy_https,
+            score: value
+                .score
+                .map(<proto::Score as From<nym_vpn_lib_types::Score>>::from)
+                .map(i32::from),
+            errors: value.errors.map(From::from),
+        }
+    }
+}
+
+impl From<Vec<String>> for proto::ErrorList {
+    fn from(error: Vec<String>) -> Self {
+        Self { error }
+    }
+}
+
+impl From<nym_vpn_lib_types::Lp> for proto::LpProbeResult {
+    fn from(value: nym_vpn_lib_types::Lp) -> Self {
+        Self {
+            can_connect: value.can_connect,
+            can_handshake: value.can_handshake,
+            can_register: value.can_register,
+            error: value.error,
         }
     }
 }
@@ -176,6 +206,61 @@ impl From<nym_vpn_lib_types::Probe> for proto::Probe {
     }
 }
 
+impl From<LewesProtocolDetails> for proto::LewesProtocolDetails {
+    fn from(value: LewesProtocolDetails) -> Self {
+        Self {
+            content: Some(proto::LewesProtocolDetailsData::from(value.content)),
+            signature: value.signature,
+        }
+    }
+}
+
+impl From<LewesProtocolDetailsData> for proto::LewesProtocolDetailsData {
+    fn from(value: LewesProtocolDetailsData) -> Self {
+        Self {
+            enabled: value.enabled,
+            control_port: value.control_port as u32,
+            data_port: value.data_port as u32,
+            x25519: value.x25519,
+            kem_keys: value
+                .kem_keys
+                .into_iter()
+                .map(|(k, v)| (k, proto::KemKeyDigests { digests: v }))
+                .collect(),
+        }
+    }
+}
+
+impl TryFrom<proto::LewesProtocolDetails> for LewesProtocolDetails {
+    type Error = ConversionError;
+
+    fn try_from(value: proto::LewesProtocolDetails) -> Result<Self, Self::Error> {
+        let content = value
+            .content
+            .ok_or_else(|| ConversionError::generic("missing LewesProtocolDetails.content"))?;
+        Ok(Self {
+            content: LewesProtocolDetailsData::from(content),
+            signature: value.signature,
+        })
+    }
+}
+
+impl From<proto::LewesProtocolDetailsData> for LewesProtocolDetailsData {
+    fn from(value: proto::LewesProtocolDetailsData) -> Self {
+        Self {
+            enabled: value.enabled,
+            control_port: value.control_port as u16,
+            data_port: value.data_port as u16,
+            x25519: value.x25519,
+            kem_keys: value
+                .kem_keys
+                .into_iter()
+                .map(|(k, v)| (k, v.digests))
+                .collect(),
+        }
+    }
+}
+
 impl TryFrom<proto::GatewayResponse> for nym_vpn_lib_types::Gateway {
     type Error = ConversionError;
 
@@ -211,6 +296,10 @@ impl TryFrom<proto::GatewayResponse> for nym_vpn_lib_types::Gateway {
             .bridge_params
             .map(BridgeInformation::try_from)
             .transpose()?;
+        let lp_details = gateway
+            .lp_details
+            .map(LewesProtocolDetails::try_from)
+            .transpose()?;
         Ok(Self {
             name: gateway.name,
             description: gateway.description,
@@ -223,6 +312,7 @@ impl TryFrom<proto::GatewayResponse> for nym_vpn_lib_types::Gateway {
             exit_ipv6s,
             build_version,
             bridge_params,
+            lewes_protocol_details: lp_details,
         })
     }
 }
@@ -247,6 +337,9 @@ impl From<nym_vpn_lib_types::Gateway> for proto::GatewayResponse {
             exit_ipv6s,
             build_version: gateway.build_version,
             bridge_params: gateway.bridge_params.map(proto::BridgeInformation::from),
+            lp_details: gateway
+                .lewes_protocol_details
+                .map(proto::LewesProtocolDetails::from),
         }
     }
 }


### PR DESCRIPTION
## Ticket

JIRA-VPN-XXXX

## Description

- add lp field
- move socks5 field to not be part of .as_exit anymore, rather to be a sibling of `wg` and `lp` fields
  - such is the output of nym-gateway-probe so it matches, instead of doing acrobatics moving the field around
  - more consistent with other optional gateway functionality (lp, wg)
- add lewes_protocol_details as defined [here](https://github.com/nymtech/websites/blob/bcdb9a5c5b90006ed46968f6227a3b546f091758/www/vpn-api/src/app/api/public/v1/models.ts#L178) 
  - and all necessary conversions 


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4807)
<!-- Reviewable:end -->
