### PR TITLE
Always store account summary

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
@@ -1,6 +1,8 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use std::sync::Arc;
+
 use crate::{
     SharedAccountState,
     commands::{AccountCommand, UpgradeModeCommand, common_handler, handler},
@@ -13,21 +15,32 @@ use nym_offline_monitor::ConnectivityMonitor;
 use nym_vpn_api_client::{
     VpnApiClient,
     error::VpnApiClientError,
-    response::NymErrorResponse,
+    response::{NymErrorResponse, NymVpnAccountSummaryWithDeviceResponse},
     types::{Device, VpnAccount},
 };
 use nym_vpn_lib_types::{
     AccountCommandError, AccountControllerErrorStateReason, VpnAccountSummary,
 };
 use requesting_zknym_state::RequestingZkNymsState;
-use tokio::{sync::mpsc, task::JoinHandle};
-use tokio_util::sync::CancellationToken;
+use tokio::sync::mpsc;
+use tokio_util::sync::{CancellationToken, DropGuard};
 use tracing::warn;
 
 pub(super) mod requesting_zknym_state;
 
 const MAX_SYNCING_ATTEMPTS: u32 = 10;
 const SYNCING_STATE_CONTEXT: &str = "SYNCING_STATE";
+
+enum SyncEvent {
+    /// Account summary is received
+    AccountSummary(VpnAccountSummary),
+
+    /// Failure to complete synchronization
+    Failure(SyncError),
+
+    /// Finished synchronization without errors
+    Finished,
+}
 
 /// Syncing State
 /// This is the heart of the Account Controller.
@@ -38,7 +51,7 @@ const SYNCING_STATE_CONTEXT: &str = "SYNCING_STATE";
 /// - Is the current device registered ?
 /// - Do we have fair usage left ?
 ///
-/// A retry mechanism is in place, if the error is in the API requests. Other errors lead to the ErrorState since they are not recoverable.  
+/// A retry mechanism is in place, if the error is in the API requests. Other errors lead to the ErrorState since they are not recoverable.
 ///
 /// Possible next state :
 /// - LoggedOutState : No account is stored
@@ -48,8 +61,9 @@ const SYNCING_STATE_CONTEXT: &str = "SYNCING_STATE";
 /// - OfflineState : the connectivity monitor is telling we're not connected
 /// - DecentralisedState : The loaded account is set to "decentralised" mode
 pub struct SyncingState {
-    syncing_state_handle: JoinHandle<Result<VpnAccountSummary, SyncError>>,
     attempts: u32,
+    event_rx: mpsc::UnboundedReceiver<SyncEvent>,
+    sync_cancel_token: Option<DropGuard>,
 }
 
 impl SyncingState {
@@ -74,98 +88,132 @@ impl SyncingState {
 
         let vpn_api_client = shared_state.vpn_api_client.clone();
 
-        let syncing_state_handle = tokio::spawn(async move {
-            SyncingState::syncing_account(&vpn_api_client, &vpn_api_account, &device).await
-        });
+        let (event_tx, event_rx) = mpsc::unbounded_channel();
+        let sync_cancel_token = CancellationToken::new();
+
+        // This handle does not need to be awaited since event channel and cancellation token are sufficient.
+        let _syncing_state_handle =
+            tokio::spawn(sync_cancel_token.child_token().run_until_cancelled_owned(
+                SyncingState::sync_account(event_tx, vpn_api_client, vpn_api_account, device),
+            ));
 
         (
             Box::new(Self {
-                syncing_state_handle,
                 attempts,
+                event_rx,
+                sync_cancel_token: Some(sync_cancel_token.drop_guard()),
             }),
             PrivateAccountControllerState::Syncing,
         )
     }
 
-    async fn syncing_account(
-        vpn_api_client: &VpnApiClient,
+    async fn sync_account(
+        event_tx: mpsc::UnboundedSender<SyncEvent>,
+        vpn_api_client: VpnApiClient,
+        vpn_api_account: Arc<VpnAccount>,
+        device: Device,
+    ) {
+        let final_event =
+            Self::sync_account_inner(event_tx.clone(), vpn_api_client, vpn_api_account, device)
+                .await
+                .map(|_| SyncEvent::Finished)
+                .unwrap_or_else(SyncEvent::Failure);
+        event_tx.send(final_event).ok();
+    }
+
+    async fn sync_account_inner(
+        event_tx: mpsc::UnboundedSender<SyncEvent>,
+        vpn_api_client: VpnApiClient,
+        vpn_api_account: Arc<VpnAccount>,
+        device: Device,
+    ) -> Result<(), SyncError> {
+        // Make sure time isn't too much desynced, othersiwe Zk-nyms will fail to verify on gateways
+        let remote_time = vpn_api_client
+            .get_remote_time()
+            .await
+            .map_err(Self::map_vpn_api_error)?;
+
+        if remote_time.is_acceptable_synced() {
+            let summary = vpn_api_client
+                .get_account_summary_with_device(&vpn_api_account, &device)
+                .await
+                .map_err(Self::map_vpn_api_error)?;
+
+            tracing::debug!("{summary:#?}");
+
+            Self::handle_received_account_summary(
+                event_tx.clone(),
+                vpn_api_client,
+                &vpn_api_account,
+                &device,
+                summary,
+            )
+            .await
+        } else {
+            Err(SyncError::DeviceTimeDesynced)
+        }
+    }
+
+    async fn handle_received_account_summary(
+        event_tx: mpsc::UnboundedSender<SyncEvent>,
+        vpn_api_client: VpnApiClient,
         vpn_api_account: &VpnAccount,
         device: &Device,
-    ) -> Result<VpnAccountSummary, SyncError> {
-        let handle_vpn_api_error = |e: VpnApiClientError| -> Result<VpnAccountSummary, SyncError> {
-            let error_response = NymErrorResponse::try_from(e)?;
-            // SW Use UUID when it will be available
-            if error_response.status == "access_denied"
-                && error_response.message == "Account not found"
-            {
-                // Request was fine, but account is unregistered
-                // Later down the line we can maybe register it here
-                Err(SyncError::UnregisteredAccount)
+        summary: NymVpnAccountSummaryWithDeviceResponse,
+    ) -> Result<(), SyncError> {
+        let mut vpn_account_summary = VpnAccountSummary::try_from(&summary.account_summary)
+            .map_err(|err| SyncError::ApiResponseError {
+                details: format!("Failed to create account summary from API response: {err}"),
+            })?;
+
+        // todo: refactor, this should not be here.
+        vpn_account_summary.account_mode =
+            Some(nym_vpn_store::types::StoredAccountMode::from(vpn_api_account.mode()).into());
+
+        // Propagate account summary even if sync eventually fails.
+        let _ = event_tx.send(SyncEvent::AccountSummary(vpn_account_summary.clone()));
+
+        // Checking that the account is active
+        if !summary.account_active() {
+            Err(SyncError::InactiveAccount(
+                summary.account_summary.account.status.to_string(),
+            ))
+        } else if !summary.subscription_active() {
+            // that there is an active subscription
+            Err(SyncError::InactiveSubscription)
+        } else if summary.active_device.is_none() {
+            // that the device is registered or there is a spot left for it with fair usage
+            if summary.remaining_devices() == 0 {
+                Err(SyncError::MaxDeviceReached) // Early detection of max device reached
+            } else if !vpn_account_summary.fair_usage_left() {
+                Err(SyncError::FairUsageDepleted)
             } else {
-                Err(SyncError::ApiResponseError {
-                    details: error_response
-                        .code_reference_id
-                        .unwrap_or(error_response.message),
-                })
+                SyncingState::register_device(&vpn_api_client, vpn_api_account, device).await
             }
-        };
-
-        // Make sure time isn't too much desynced, othersiwe Zk-nyms will fail to verify on gateways
-        match vpn_api_client.get_remote_time().await {
-            Ok(remote_time) => {
-                if !remote_time.is_acceptable_synced() {
-                    return Err(SyncError::DeviceTimeDesynced);
-                }
-            }
-            Err(e) => {
-                return handle_vpn_api_error(e);
-            }
+        } else {
+            Ok(())
         }
+    }
 
-        match vpn_api_client
-            .get_account_summary_with_device(vpn_api_account, device)
-            .await
-        {
-            Ok(summary) => {
-                tracing::debug!("{summary:#?}");
-
-                let mut vpn_account_summary = VpnAccountSummary::try_from(&summary.account_summary)
-                    .map_err(|e| SyncError::ApiResponseError {
-                        details: format!("Failed to create account summary from API response: {e}"),
-                    })?;
-                vpn_account_summary.account_mode = Some(
-                    nym_vpn_store::types::StoredAccountMode::from(vpn_api_account.mode()).into(),
-                );
-
-                // Checking that the account is active
-                if !summary.account_active() {
-                    return Err(SyncError::InactiveAccount(
-                        summary.account_summary.account.status.to_string(),
-                    ));
-                }
-
-                // that there is an active subscription
-                if !summary.subscription_active() {
-                    return Err(SyncError::InactiveSubscription);
-                }
-
-                // that the device is registered or there is a spot left for it with fair usage
-                if summary.active_device.is_none() {
-                    if summary.remaining_devices() == 0 {
-                        return Err(SyncError::MaxDeviceReached); // Early detection of max device reached
-                    }
-
-                    if !vpn_account_summary.fair_usage_left() {
-                        return Err(SyncError::FairUsageDepleted);
-                    } else {
-                        SyncingState::register_device(vpn_api_client, vpn_api_account, device)
-                            .await?
+    fn map_vpn_api_error(err: VpnApiClientError) -> SyncError {
+        match NymErrorResponse::try_from(err) {
+            Ok(error_response) => {
+                // SW Use UUID when it will be available
+                if error_response.status == "access_denied"
+                    && error_response.message == "Account not found"
+                {
+                    // Request was fine, but account is unregistered
+                    // Later down the line we can maybe register it here
+                    SyncError::UnregisteredAccount
+                } else {
+                    SyncError::ApiResponseError {
+                        details: error_response
+                            .code_reference_id
+                            .unwrap_or(error_response.message),
                     }
                 }
-                Ok(vpn_account_summary)
             }
-
-            Err(e) => handle_vpn_api_error(e),
+            Err(err) => SyncError::from(err),
         }
     }
 
@@ -192,42 +240,33 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingState {
         tokio::select! {
             biased;
             _ = shutdown_token.cancelled() => {
-                self.syncing_state_handle.abort();
                 NextAccountControllerState::Finished
             }
-            syncing_result = &mut self.syncing_state_handle => {
-                match syncing_result {
-                    Ok(result) => {
-                        match result {
-                            Ok(vpn_account_summary) => {
-                                shared_state.vpn_account_summary = Some(vpn_account_summary);
-                                NextAccountControllerState::NewState(RequestingZkNymsState::enter(shared_state, self.attempts, false))
-                            },
-                            Err(e) if e.is_retryable() => {
-                                if self.attempts > MAX_SYNCING_ATTEMPTS {
-                                    tracing::debug!("Error trying to get account summary, exhausted retries : {}", e.to_string());
-                                    NextAccountControllerState::NewState(ErrorState::enter(e.into()))
-                                } else {
-                                    tracing::debug!("Error trying to get account summary, retrying : {}", e.to_string());
-                                    NextAccountControllerState::NewState(SyncingState::enter(shared_state, self.attempts + 1))
-                                }
-                            },
-                            Err(e) => {
-                                tracing::debug!("Error trying to get account summary, not retrying : {}", e.to_string());
-                                NextAccountControllerState::NewState(ErrorState::enter(e.into()))
-                            },
+            Some(sync_event) = self.event_rx.recv() => {
+                match sync_event {
+                    SyncEvent::AccountSummary(vpn_account_summary) => {
+                        shared_state.vpn_account_summary = Some(vpn_account_summary);
+                        NextAccountControllerState::SameState(self)
+                    }
+                    SyncEvent::Failure(err) => {
+                        if err.is_retryable() {
+                            if self.attempts > MAX_SYNCING_ATTEMPTS {
+                                tracing::debug!("Error trying to get account summary, exhausted retries : {}", err.to_string());
+                                NextAccountControllerState::NewState(ErrorState::enter(err.into()))
+                            } else {
+                                tracing::debug!("Error trying to get account summary, retrying : {}", err.to_string());
+                                NextAccountControllerState::NewState(SyncingState::enter(shared_state, self.attempts + 1))
+                            }
+                        } else {
+                            tracing::debug!("Error trying to get account summary, not retrying : {}", err.to_string());
+                            NextAccountControllerState::NewState(ErrorState::enter(err.into()))
                         }
                     }
-                    Err(e) => {
-                        tracing::error!("Failed to join on the syncing task : {e}");
-                        if self.attempts > MAX_SYNCING_ATTEMPTS {
-                            NextAccountControllerState::NewState(ErrorState::enter(SyncError::Internal("Failed to join on the syncing task".into()).into()))
-                        } else {
-                            NextAccountControllerState::NewState(SyncingState::enter(shared_state, self.attempts + 1))
-                        }
+                    SyncEvent::Finished => {
+                        NextAccountControllerState::NewState(RequestingZkNymsState::enter(shared_state, self.attempts, false))
                     }
                 }
-            },
+            }
             Some(command) = command_rx.recv() => {
                 match command {
                     AccountCommand::CreateAccount(return_sender) => return_sender.send(Err(AccountCommandError::ExistingAccount)),
@@ -243,7 +282,6 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingState {
                         return if error {
                             NextAccountControllerState::SameState(self)
                         } else {
-                            self.syncing_state_handle.abort();
                             NextAccountControllerState::NewState(LoggedOutState::enter())
                         }
                     },
@@ -262,13 +300,11 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingState {
                         return if shared_state.firewall_active {
                             NextAccountControllerState::SameState(self)
                         } else {
-                            self.syncing_state_handle.abort();
                             NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0))
                         }
                     },
                     AccountCommand::ResetDeviceIdentity(return_sender, seed) => {
                         return_sender.send(handler::handle_reset_device_identity(shared_state, seed).await);
-                        self.syncing_state_handle.abort();
                         return NextAccountControllerState::NewState(SyncingState::enter(shared_state,0));
                     },
 
@@ -283,7 +319,9 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingState {
 
                     AccountCommand::VpnApiFirewallUp(return_sender) => {
                         shared_state.firewall_active = true;
-                        self.syncing_state_handle.abort();
+                        // Explicitly cancel sync task since the same state persists.
+                        // Sync will restart once firewall permits traffic to flow again.
+                        self.sync_cancel_token.take();
                         return_sender.send(Ok(()));
                     },
 
@@ -306,7 +344,6 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingState {
             }
             Some(connectivity) = shared_state.connectivity_handle.next() => {
                 if connectivity.is_offline() {
-                    self.syncing_state_handle.abort();
                     NextAccountControllerState::NewState(OfflineState::enter())
                 } else {
                     NextAccountControllerState::SameState(self)


### PR DESCRIPTION


## Description

This PR ensures that account summary is always stored by account controller even if any of failure conditions have been met

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4812)
<!-- Reviewable:end -->
