### PR TITLE
Fix test crate manifests

### DIFF
--- a/.github/workflows/build-wireguard-go-android.yml
+++ b/.github/workflows/build-wireguard-go-android.yml
@@ -24,7 +24,7 @@ jobs:
         id: cache
         with:
           path: build/lib
-          key: ${{ runner.os }}-go${{ vars.REQUIRED_GOLANG_VERSION }}-${{ hashFiles('wireguard/libwg/**/*.{go,diff,mod,h}', 'wireguard/build-wireguard-go.sh') }}
+          key: android-go${{ vars.REQUIRED_GOLANG_VERSION }}-${{ hashFiles('wireguard/libwg/**/*.{go,diff,mod,h}', 'wireguard/build-wireguard-go.sh') }}
 
       - name: Install system dependencies
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/build-wireguard-go-ios.yml
+++ b/.github/workflows/build-wireguard-go-ios.yml
@@ -25,7 +25,7 @@ jobs:
         id: cache
         with:
           path: build/lib
-          key: ${{ runner.os }}-go${{ vars.REQUIRED_GOLANG_VERSION }}-${{ hashFiles('wireguard/libwg/**/*.{go,diff,mod,h}', 'wireguard/build-wireguard-go.sh') }}
+          key: ${{ runner.os }}-ios-go${{ vars.REQUIRED_GOLANG_VERSION }}-${{ hashFiles('wireguard/libwg/**/*.{go,diff,mod,h}', 'wireguard/build-wireguard-go.sh') }}
 
       - name: Install Go
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/build-wireguard-go-ios.yml
+++ b/.github/workflows/build-wireguard-go-ios.yml
@@ -25,7 +25,7 @@ jobs:
         id: cache
         with:
           path: build/lib
-          key: ${{ runner.os }}-ios-go${{ vars.REQUIRED_GOLANG_VERSION }}-${{ hashFiles('wireguard/libwg/**/*.{go,diff,mod,h}', 'wireguard/build-wireguard-go.sh') }}
+          key: ios-go${{ vars.REQUIRED_GOLANG_VERSION }}-${{ hashFiles('wireguard/libwg/**/*.{go,diff,mod,h}', 'wireguard/build-wireguard-go.sh') }}
 
       - name: Install Go
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/build-wireguard-go-linux.yml
+++ b/.github/workflows/build-wireguard-go-linux.yml
@@ -36,7 +36,7 @@ jobs:
         id: cache
         with:
           path: build/lib
-          key: ${{ runner.os }}-go${{ vars.REQUIRED_GOLANG_VERSION }}-${{ hashFiles('wireguard/libwg/**/*.{go,diff,mod,h}', 'wireguard/build-wireguard-go.sh') }}
+          key: ${{ matrix.os }}-go${{ vars.REQUIRED_GOLANG_VERSION }}-${{ hashFiles('wireguard/libwg/**/*.{go,diff,mod,h}', 'wireguard/build-wireguard-go.sh') }}
 
       - name: Install system dependencies
         if: steps.cache.outputs.cache-hit != 'true'

--- a/nym-vpn-core/crates/test/test-manager/Cargo.toml
+++ b/nym-vpn-core/crates/test/test-manager/Cargo.toml
@@ -6,7 +6,7 @@ repository.workspace = true
 license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-version = "1.27.0-beta"
+version.workspace = true
 
 [lints]
 workspace = true

--- a/nym-vpn-core/crates/test/test-manager/Cargo.toml
+++ b/nym-vpn-core/crates/test/test-manager/Cargo.toml
@@ -49,7 +49,7 @@ uuid = { workspace = true }
 
 test_macro = { path = "./test_macro" }
 test-rpc = { workspace = true }
-tokio-util = { workspace = true, features = ["codec"]}
+tokio-util = { workspace = true, features = ["codec"] }
 nym-vpn-proto = { workspace = true, features = ["rpc_client"] }
 nym-vpn-lib-types = { workspace = true, features = ["nym-type-conversions"] }
 

--- a/nym-vpn-core/crates/test/test-manager/test_macro/Cargo.toml
+++ b/nym-vpn-core/crates/test/test-manager/test_macro/Cargo.toml
@@ -5,7 +5,7 @@ repository.workspace = true
 license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-version = "1.27.0-beta"
+version.workspace = true
 
 [lib]
 proc-macro = true

--- a/nym-vpn-core/crates/test/test-rpc/Cargo.toml
+++ b/nym-vpn-core/crates/test/test-rpc/Cargo.toml
@@ -18,16 +18,21 @@ colored = { workspace = true }
 futures = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true }
-hyper-rustls = { workspace = true, features = ["logging", "webpki-roots", "http1", "ring"] }
-hyper-util = {workspace = true}
+hyper-rustls = { workspace = true, features = [
+    "logging",
+    "webpki-roots",
+    "http1",
+    "ring",
+] }
+hyper-util = { workspace = true }
 log = { workspace = true }
 rustls-pemfile = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-tarpc = { workspace = true, features = ["tokio1", "serde-transport", "serde1"]}
+tarpc = { workspace = true, features = ["tokio1", "serde-transport", "serde1"] }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-rustls = { workspace = true }
 tokio-serde = { workspace = true }
-tokio-util = { workspace = true, features = ["codec"]}
+tokio-util = { workspace = true, features = ["codec"] }
 webpki-roots = { workspace = true }

--- a/nym-vpn-core/crates/test/test-rpc/Cargo.toml
+++ b/nym-vpn-core/crates/test/test-rpc/Cargo.toml
@@ -6,7 +6,7 @@ repository.workspace = true
 license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-version = "1.27.0-beta"
+version.workspace = true
 
 [lints]
 workspace = true

--- a/nym-vpn-core/crates/test/test-runner/Cargo.toml
+++ b/nym-vpn-core/crates/test/test-runner/Cargo.toml
@@ -6,7 +6,7 @@ repository.workspace = true
 license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-version = "1.27.0-beta"
+version.workspace = true
 
 [lints]
 workspace = true

--- a/nym-vpn-core/crates/test/test-runner/Cargo.toml
+++ b/nym-vpn-core/crates/test/test-runner/Cargo.toml
@@ -24,10 +24,16 @@ socket2 = { workspace = true, features = ["all"] }
 surge-ping = { workspace = true }
 tarpc = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["process", "fs", "net", "rt-multi-thread", "macros"] }
+tokio = { workspace = true, features = [
+    "process",
+    "fs",
+    "net",
+    "rt-multi-thread",
+    "macros",
+] }
 tokio-serde = { workspace = true }
 tokio-serial = { workspace = true }
-tokio-util = { workspace = true, features = ["codec"]}
+tokio-util = { workspace = true, features = ["codec"] }
 
 test-rpc = { workspace = true }
 nym-ipc = { workspace = true }
@@ -36,4 +42,4 @@ nym-ipc = { workspace = true }
 nix = { workspace = true, features = ["user", "net"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-rs-release = {workspace = true}
+rs-release = { workspace = true }


### PR DESCRIPTION


## Description

- Inherit versions from workspace in test crates
- Fix manifest formatting (auto)
- ci: libwg: cache based on `matrix.os` on Linux, use unique keys for other builds.

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4826)
<!-- Reviewable:end -->
