### PR TITLE
ci: add custom cache-key for cargo-install

### DIFF
--- a/.github/workflows/build-nym-vpn-core-deb.yml
+++ b/.github/workflows/build-nym-vpn-core-deb.yml
@@ -50,6 +50,7 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-deb
+          cache-key: ${{ matrix.arch }}
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
@@ -67,6 +68,7 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-edit
+          cache-key: ${{ matrix.arch }}
 
       - name: Append timestamp if it's a dev version
         run: ./scripts/append-timestamp-to-version.sh nym-vpn-core/Cargo.toml ${{ steps.workspace-version.outputs.metadata }}

--- a/.github/workflows/build-nym-vpn-core-linux.yml
+++ b/.github/workflows/build-nym-vpn-core-linux.yml
@@ -69,12 +69,6 @@ jobs:
         with:
           subcommand: workspace.package.version --entry nym-vpn-core
 
-      - name: Install cargo-edit
-        uses: baptiste0928/cargo-install@v3
-        with:
-          crate: cargo-edit
-          cache-key: ${{ matrix.arch }}
-
       - name: Append timestamp if it's a dev version
         run: ./scripts/append-timestamp-to-version.sh nym-vpn-core/Cargo.toml ${{ steps.workspace-version.outputs.metadata }}
 

--- a/.github/workflows/build-nym-vpn-core-linux.yml
+++ b/.github/workflows/build-nym-vpn-core-linux.yml
@@ -61,6 +61,7 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-edit
+          cache-key: ${{ matrix.arch }}
 
       - name: Get workspace version
         id: workspace-version
@@ -72,6 +73,7 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-edit
+          cache-key: ${{ matrix.arch }}
 
       - name: Append timestamp if it's a dev version
         run: ./scripts/append-timestamp-to-version.sh nym-vpn-core/Cargo.toml ${{ steps.workspace-version.outputs.metadata }}


### PR DESCRIPTION


## Description

This PR adds a custom cache-key for cargo-install to prevent cache conflict when building for different CPU archs using matrix. 

Prevents the following warning:
> Failed to save: Unable to reserve cache with key cargo-install-cargo-edit-0.13.9-2a1c6867748cd2a7c5218747, another job may be creating this cache.

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4833)
<!-- Reviewable:end -->
