### PR TITLE
ci: stop building for x86_64 iOS simulator

### DIFF
--- a/.github/workflows/build-nym-vpn-apple.yml
+++ b/.github/workflows/build-nym-vpn-apple.yml
@@ -122,7 +122,7 @@ jobs:
         with:
           toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
           components: rustfmt, clippy
-          targets: x86_64-apple-darwin aarch64-apple-ios x86_64-apple-ios aarch64-apple-ios-sim
+          targets: x86_64-apple-darwin aarch64-apple-ios aarch64-apple-ios-sim
 
       - name: Install cargo-swift
         uses: baptiste0928/cargo-install@v3

--- a/.github/workflows/build-nym-vpn-core-ios.yml
+++ b/.github/workflows/build-nym-vpn-core-ios.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
           components: rustfmt, clippy
-          targets: x86_64-apple-darwin aarch64-apple-ios x86_64-apple-ios aarch64-apple-ios-sim
+          targets: aarch64-apple-ios aarch64-apple-ios-sim
 
       - name: Install cargo-swift
         uses: baptiste0928/cargo-install@v3

--- a/.github/workflows/build-wireguard-go-ios.yml
+++ b/.github/workflows/build-wireguard-go-ios.yml
@@ -45,6 +45,5 @@ jobs:
           path: |
             build/lib/aarch64-apple-ios
             build/lib/aarch64-apple-ios-sim
-            build/lib/x86_64-apple-ios
           if-no-files-found: error
           retention-days: 1

--- a/wireguard/build-wireguard-go.sh
+++ b/wireguard/build-wireguard-go.sh
@@ -254,22 +254,9 @@ function build_ios {
     export CGO_LDFLAGS="-isysroot $SDKROOT -arch $GOARCH"
     create_folder_and_build "aarch64-apple-ios-sim"
 
-    echo "🍎 Building for ios-sim/x86_64"
-    export ARCH=x86_64
-    export GOOS=ios
-    export GOARCH=amd64
-    export SDKROOT=$(xcrun --show-sdk-path --sdk iphonesimulator)
-    export CC="$(xcrun -sdk $SDKROOT --find clang) -arch $ARCH -isysroot $SDKROOT"
-    export CFLAGS="-isysroot $SDKROOT -arch $ARCH -I$SDKROOT/usr/include"
-    export LD_LIBRARY_PATH="$SDKROOT/usr/lib"
-    export CGO_CFLAGS="-isysroot $SDKROOT -arch $ARCH"
-    export CGO_LDFLAGS="-isysroot $SDKROOT -arch $ARCH"
-    create_folder_and_build "x86_64-apple-ios"
-    unset ARCH
-
     echo "🍎 Creating universal ios-sim binary"
     mkdir -p "../../build/lib/universal-apple-ios-sim/"
-    lipo -create -output "../../build/lib/universal-apple-ios-sim/libwg.a"  "../../build/lib/x86_64-apple-ios/libwg.a" "../../build/lib/aarch64-apple-ios-sim/libwg.a"
+    cp "../../build/lib/aarch64-apple-ios-sim/libwg.a" "../../build/lib/universal-apple-ios-sim/libwg.a"
     cp "../../build/lib/aarch64-apple-ios/libwg.h" "../../build/lib/universal-apple-ios-sim/libwg.h"
 
     popd


### PR DESCRIPTION
## Description

It's wasteful to keep building for x86-64 apple sim. Let's drop that target.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4834)
<!-- Reviewable:end -->
