### PR TITLE
Remove uds socket inside nym-ipc

### DIFF
--- a/nym-vpn-core/crates/nym-ipc/src/server.rs
+++ b/nym-vpn-core/crates/nym-ipc/src/server.rs
@@ -8,7 +8,7 @@ use tokio_stream::Stream;
 use tonic::transport::server::Connected;
 
 #[allow(unused)]
-pub fn create_incoming(
+pub async fn create_incoming(
     socket_path: std::path::PathBuf,
     #[cfg(target_os = "windows")] nym_certificate_serial_number: String,
     #[cfg(target_os = "macos")] signing_requirement: String,
@@ -18,7 +18,7 @@ pub fn create_incoming(
     {
         #[cfg(all(debug_assertions, not(feature = "xpc")))]
         {
-            crate::uds::incoming(socket_path, shutdown_token)
+            crate::uds::incoming(socket_path, shutdown_token).await
         }
         #[cfg(any(not(debug_assertions), feature = "xpc"))]
         {
@@ -27,7 +27,7 @@ pub fn create_incoming(
     }
     #[cfg(target_os = "linux")]
     {
-        crate::uds::incoming(socket_path, shutdown_token)
+        crate::uds::incoming(socket_path, shutdown_token).await
     }
 
     #[cfg(target_os = "windows")]

--- a/nym-vpn-core/crates/nym-ipc/src/uds.rs
+++ b/nym-vpn-core/crates/nym-ipc/src/uds.rs
@@ -21,6 +21,22 @@ pub struct Uds {
     inner: UnixListenerStream,
 }
 
+async fn remove_previous_socket_file(socket_path: &std::path::Path) {
+    match tokio::fs::remove_file(socket_path).await {
+        Ok(_) => tracing::info!(
+            "Removed previous command interface socket: {}",
+            socket_path.display()
+        ),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => {
+            tracing::error!(
+                "Failed to remove previous command interface socket: {:?}",
+                err
+            );
+        }
+    }
+}
+
 impl Drop for Uds {
     fn drop(&mut self) {
         if let Ok(()) = fs::remove_file(&self.socket_path) {
@@ -40,10 +56,14 @@ impl Stream for Uds {
     }
 }
 
-pub fn incoming(
+pub async fn incoming(
     socket_path: PathBuf,
     _shutdown_token: CancellationToken,
 ) -> Result<impl Stream<Item = Result<Transport>>> {
+    // Remove previous socket file in case if the daemon crashed in the prior run and could not clean up the socket file.
+    remove_previous_socket_file(&socket_path).await;
+    tracing::info!("Starting socket listener on: {}", socket_path.display());
+
     let listener = UnixListener::bind(&socket_path)?;
     fs::set_permissions(&socket_path, PermissionsExt::from_mode(0o766))?;
     let uds = Uds {

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface.rs
@@ -1112,14 +1112,6 @@ pub async fn start_command_interface(
 
     let (vpn_command_tx, vpn_command_rx) = mpsc::unbounded_channel();
 
-    #[cfg(target_os = "linux")]
-    {
-        let socket_path = default_socket_path();
-        // Remove previous socket file in case if the daemon crashed in the prior run and could not clean up the socket file.
-        remove_previous_socket_file(&socket_path).await;
-        tracing::info!("Starting socket listener on: {}", socket_path.display());
-    }
-
     // Wrap the unix socket or named pipe into a stream that can be used by tonic
     let incoming = nym_ipc::server::create_incoming(
         default_socket_path(),
@@ -1129,7 +1121,8 @@ pub async fn start_command_interface(
         SIGNING_REQUIREMENT.to_string(),
         #[cfg(unix)]
         shutdown_token.child_token(),
-    )?;
+    )
+    .await?;
 
     let server_handle = tokio::spawn(async move {
         let socket_listener_handle = tokio::spawn(async move {
@@ -1163,23 +1156,6 @@ pub async fn start_command_interface(
     });
 
     Ok((server_handle, vpn_command_rx))
-}
-
-#[cfg(target_os = "linux")]
-async fn remove_previous_socket_file(socket_path: &std::path::Path) {
-    match tokio::fs::remove_file(socket_path).await {
-        Ok(_) => tracing::info!(
-            "Removed previous command interface socket: {}",
-            socket_path.display()
-        ),
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
-        Err(err) => {
-            tracing::error!(
-                "Failed to remove previous command interface socket: {:?}",
-                err
-            );
-        }
-    }
 }
 
 fn default_socket_path() -> std::path::PathBuf {


### PR DESCRIPTION
This fixes the bug where the socket removal in cases of previous daemon crash was removed for MacOS UDS builds.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4845)
<!-- Reviewable:end -->
