### PR TITLE
macos: forget last firewall policy on reset

### DIFF
--- a/nym-vpn-core/crates/nym-firewall/src/macos.rs
+++ b/nym-vpn-core/crates/nym-firewall/src/macos.rs
@@ -253,6 +253,8 @@ impl Firewall {
     }
 
     pub fn reset_policy(&mut self) -> Result<()> {
+        self.last_policy = None;
+
         // Implemented this way to not early return on an error.
         // We always want all three methods to run, and then return
         // the first error it encountered, if any.


### PR DESCRIPTION
## Description

Forget last policy on reset. This should prevent logical errors when switching policies.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4864)
<!-- Reviewable:end -->
