### PR TITLE
macos(st): send RST when including or excluding apps from the tunnel

### DIFF
--- a/nym-vpn-core/crates/nym-split-tunnel/src/macos/conn_track.rs
+++ b/nym-vpn-core/crates/nym-split-tunnel/src/macos/conn_track.rs
@@ -1,0 +1,226 @@
+// Copyright 2026 Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use std::{collections::HashMap, fmt::Write, net::SocketAddr, sync::Arc};
+
+use tokio::sync::Mutex;
+
+use libc::pid_t;
+use pnet_packet::{
+    Packet,
+    ethernet::EtherTypes,
+    ip::IpNextHeaderProtocols,
+    ipv4::Ipv4Packet,
+    ipv6::Ipv6Packet,
+    tcp::{TcpFlags, TcpPacket},
+};
+
+use super::tun::PktapPacket;
+
+/// TCP connection identifier
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+pub struct TcpConnectionIdent {
+    pub src: SocketAddr,
+    pub dst: SocketAddr,
+}
+
+/// TCP connection metadata
+#[derive(Debug, Default, Clone, Copy, Hash, Eq, PartialEq)]
+pub struct TcpConnectionMeta {
+    /// Last seen ack of outgoing packet
+    pub ack: u32,
+}
+
+/// TCP connection tracking data
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+pub struct TcpConnectionTrack {
+    /// 4-tuple identifying the TCP connection
+    pub ident: TcpConnectionIdent,
+    /// Metadata associated with TCP connection
+    pub meta: TcpConnectionMeta,
+}
+
+/// Registry of active TCP connections per process
+#[derive(Debug, Clone, Default)]
+pub struct TcpConnectionStates {
+    inner: Arc<Mutex<HashMap<pid_t, HashMap<TcpConnectionIdent, TcpConnectionMeta>>>>,
+}
+
+impl TcpConnectionStates {
+    /// Add connection metadata corresponding to the process and individual TCP connection.
+    pub async fn add(
+        &mut self,
+        pid: pid_t,
+        ident: TcpConnectionIdent,
+        metadata: TcpConnectionMeta,
+    ) {
+        let mut states = self.inner.lock().await;
+
+        let _ = states.entry(pid).or_default().insert(ident, metadata);
+    }
+
+    /// Remove connection metadata corresponding to the process and individual TCP connection.
+    pub async fn remove(&mut self, pid: pid_t, ident: TcpConnectionIdent) {
+        let mut states = self.inner.lock().await;
+
+        if let Some(conns) = states.get_mut(&pid) {
+            conns.remove(&ident);
+            if conns.is_empty() {
+                let _ = states.remove(&pid);
+            }
+        }
+    }
+
+    /// Update connection metadata but only if pid/ident exist
+    pub async fn update_meta(
+        &mut self,
+        pid: pid_t,
+        ident: TcpConnectionIdent,
+        mutator: impl FnOnce(&mut TcpConnectionMeta),
+    ) {
+        let mut states = self.inner.lock().await;
+
+        if let Some(proc_conn_states) = states.get_mut(&pid)
+            && let Some(meta) = proc_conn_states.get_mut(&ident)
+        {
+            mutator(meta)
+        }
+    }
+
+    /// Clear all connection metadata associated with the given processes.
+    ///
+    /// Returns removed connection states.
+    pub async fn clear(&mut self, pids: &[pid_t]) -> Vec<TcpConnectionTrack> {
+        let mut states = self.inner.lock().await;
+
+        pids.iter()
+            .flat_map(|pid| {
+                states.remove(pid).map(|tcp_conns| {
+                    tcp_conns
+                        .into_iter()
+                        .map(|(ident, meta)| TcpConnectionTrack { ident, meta })
+                        .collect::<Vec<TcpConnectionTrack>>()
+                })
+            })
+            .flatten()
+            .collect()
+    }
+
+    /// Clear all connection states for all processes.
+    pub async fn clear_all(&mut self) {
+        let mut states = self.inner.lock().await;
+
+        states.clear();
+    }
+}
+
+/// Update TCP connections state from outgoing packet
+pub async fn track_connection_state(
+    tcp_conn_states: &mut TcpConnectionStates,
+    packet: &PktapPacket,
+) {
+    match packet.frame.get_ethertype() {
+        EtherTypes::Ipv4 => {
+            let Some(ipv4_packet) = Ipv4Packet::new(packet.frame.payload()) else {
+                return;
+            };
+
+            if ipv4_packet.get_next_level_protocol() != IpNextHeaderProtocols::Tcp {
+                return;
+            }
+
+            let Some(tcp_packet) = TcpPacket::new(ipv4_packet.payload()) else {
+                return;
+            };
+
+            let src = SocketAddr::from((ipv4_packet.get_source(), tcp_packet.get_source()));
+            let dst =
+                SocketAddr::from((ipv4_packet.get_destination(), tcp_packet.get_destination()));
+            let ident = TcpConnectionIdent { src, dst };
+
+            handle_tcp_packet(tcp_conn_states, packet.header.pth_pid, ident, tcp_packet).await;
+        }
+        EtherTypes::Ipv6 => {
+            let Some(ipv6_packet) = Ipv6Packet::new(packet.frame.payload()) else {
+                return;
+            };
+
+            if ipv6_packet.get_next_header() != IpNextHeaderProtocols::Tcp {
+                return;
+            }
+
+            let Some(tcp_packet) = TcpPacket::new(ipv6_packet.payload()) else {
+                return;
+            };
+
+            let src = SocketAddr::from((ipv6_packet.get_source(), tcp_packet.get_source()));
+            let dst =
+                SocketAddr::from((ipv6_packet.get_destination(), tcp_packet.get_destination()));
+            let ident = TcpConnectionIdent { src, dst };
+
+            handle_tcp_packet(tcp_conn_states, packet.header.pth_pid, ident, tcp_packet).await;
+        }
+        _ => {}
+    }
+}
+
+async fn handle_tcp_packet<'a>(
+    tcp_conn_states: &mut TcpConnectionStates,
+    pid: pid_t,
+    ident: TcpConnectionIdent,
+    tcp_packet: TcpPacket<'a>,
+) {
+    let tcp_flags = tcp_packet.get_flags();
+
+    tracing::trace!(
+        "TCP {} {} -> {} seq:{} ack:{}",
+        DisplayTcpFlags(tcp_flags),
+        ident.src,
+        ident.dst,
+        tcp_packet.get_sequence(),
+        tcp_packet.get_acknowledgement()
+    );
+
+    // For simplicity, FIN (or RST) immediately remove the state associated with connection.
+    // A follow up ACK sent by the client will not match any state and thus be no-op
+    if (tcp_flags & TcpFlags::FIN) != 0 || (tcp_flags & TcpFlags::RST) != 0 {
+        tcp_conn_states.remove(pid, ident).await;
+    } else if (tcp_flags & TcpFlags::SYN) != 0 {
+        // Initial handshake client -> server
+        tcp_conn_states
+            .add(pid, ident, TcpConnectionMeta::default())
+            .await;
+    } else if (tcp_flags & TcpFlags::ACK) != 0 {
+        // Either received during handshake or during data transfer
+        tcp_conn_states
+            .update_meta(pid, ident, |meta| {
+                meta.ack = tcp_packet.get_acknowledgement();
+            })
+            .await;
+    }
+}
+
+/// Type implementing `Display` trait for raw TCP flags
+#[repr(transparent)]
+pub struct DisplayTcpFlags(pub u8);
+
+impl std::fmt::Display for DisplayTcpFlags {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut matches = 0;
+        for (flag, str) in [
+            (TcpFlags::SYN, "SYN"),
+            (TcpFlags::ACK, "ACK"),
+            (TcpFlags::FIN, "FIN"),
+            (TcpFlags::RST, "RST"),
+        ] {
+            if (self.0 & flag) != 0 {
+                if matches > 0 {
+                    f.write_char('+')?;
+                }
+                f.write_str(str)?;
+                matches += 1;
+            }
+        }
+        Ok(())
+    }
+}

--- a/nym-vpn-core/crates/nym-split-tunnel/src/macos/mod.rs
+++ b/nym-vpn-core/crates/nym-split-tunnel/src/macos/mod.rs
@@ -17,12 +17,17 @@ use self::process::ExclusionStatus;
 #[expect(non_camel_case_types, clippy::allow_attributes)]
 mod bindings;
 mod bpf;
+mod conn_track;
 mod default;
 mod process;
+mod tcp_rst;
 mod tun;
 
 use crate::SplitTunnelErrorCause;
+use conn_track::TcpConnectionStates;
+use process::ProcessStates;
 pub use tun::VpnInterface;
+use tun::{PktapPacket, RoutingDecision};
 
 /// Check whether the current process has full-disk access enabled.
 /// This is required by the process monitor.
@@ -313,6 +318,7 @@ enum State {
         process: process::ProcessMonitorHandle,
         tun_handle: tun::SplitTunnelHandle,
         vpn_interface: VpnInterface,
+        tcp_conn_states: TcpConnectionStates,
     },
     /// State entered when anything at all fails. Users can force a transition out of this state
     /// by disabling/clearing the paths to use.
@@ -397,7 +403,9 @@ impl State {
                 tracing::debug!("Initializing process monitor");
 
                 let process = process::ProcessMonitor::spawn().await?;
-                process.states().exclude_paths(paths);
+
+                // ST is not active, so no affected processes.
+                let _ = process.states().exclude_paths(paths).await;
 
                 Ok(State::ProcessMonitorOnly {
                     route_manager,
@@ -412,7 +420,9 @@ impl State {
                 tracing::debug!("Initializing process monitor");
 
                 let process = process::ProcessMonitor::spawn().await?;
-                process.states().exclude_paths(paths);
+
+                // ST is not initialized, so no affected processes.
+                let _ = process.states().exclude_paths(paths).await;
 
                 State::ProcessMonitorOnly {
                     route_manager,
@@ -431,9 +441,16 @@ impl State {
             State::Active {
                 route_manager,
                 mut process,
-                tun_handle,
+                mut tcp_conn_states,
+                mut tun_handle,
                 vpn_interface,
             } if paths.is_empty() => {
+                let affected_pids = process.states().exclude_paths(paths).await;
+
+                // Collect and reset all TCP connections affected by changes to ST
+                let reset_tcp_conns = tcp_conn_states.clear(&affected_pids).await;
+                tun_handle.reset_tcp_connections(reset_tcp_conns).await;
+
                 if let Err(error) = tun_handle.shutdown().await {
                     tracing::error!("Failed to stop split tunnel: {error}");
                 }
@@ -446,12 +463,23 @@ impl State {
             // If split tunneling is already initialized, or only the process monitor is, update the
             // paths only
             State::Active {
-                ref mut process, ..
+                ref mut process,
+                ref mut tcp_conn_states,
+                ref mut tun_handle,
+                ..
+            } => {
+                let affected_pids = process.states().exclude_paths(paths).await;
+
+                // Collect and reset all TCP connections affected by changes to ST
+                let reset_tcp_conns = tcp_conn_states.clear(&affected_pids).await;
+                tun_handle.reset_tcp_connections(reset_tcp_conns).await;
+
+                Ok(self)
             }
-            | State::ProcessMonitorOnly {
+            State::ProcessMonitorOnly {
                 ref mut process, ..
             } => {
-                process.states().exclude_paths(paths);
+                let _ = process.states().exclude_paths(paths).await;
                 Ok(self)
             }
             // If 'paths' is empty, transition out of the failed state
@@ -490,6 +518,7 @@ impl State {
                 process,
                 tun_handle,
                 vpn_interface: _,
+                tcp_conn_states: _,
             } => {
                 if let Err(error) = tun_handle.shutdown().await {
                     tracing::error!("Failed to stop split tunnel: {error}");
@@ -536,12 +565,17 @@ impl State {
                 mut process,
                 tun_handle,
                 vpn_interface: old_vpn_interface,
+                mut tcp_conn_states,
             } => {
                 // Try to update the default interface first
                 // If this fails, remain in the current state and just fail
                 let default_interface = match default::get_default_interface(&route_manager).await {
                     Ok(default_interface) => default_interface,
                     Err(error) => {
+                        // Clear all connection states when entering error state
+                        // Since connections will likely break anyway
+                        tcp_conn_states.clear_all().await;
+
                         return Err(ErrorWithTransition {
                             error: error.into(),
                             next_state: Some(State::Active {
@@ -549,6 +583,7 @@ impl State {
                                 process,
                                 tun_handle,
                                 vpn_interface: old_vpn_interface,
+                                tcp_conn_states,
                             }),
                         });
                     }
@@ -565,6 +600,7 @@ impl State {
                         process,
                         tun_handle,
                         vpn_interface,
+                        tcp_conn_states,
                     }),
                     Err(error) => {
                         process.shutdown().await;
@@ -594,21 +630,15 @@ impl State {
 
                 tracing::debug!("Initializing split tunnel device");
 
+                let tcp_conn_states = TcpConnectionStates::default();
+
                 let states = process.states().clone();
                 let result = tun::create_split_tunnel(
                     default_interface,
                     Some(vpn_interface.clone()),
                     route_manager.clone(),
-                    Box::new(move |packet| {
-                        match states.get_process_status(packet.header.pth_pid) {
-                            ExclusionStatus::Excluded => tun::RoutingDecision::DefaultInterface,
-                            ExclusionStatus::Included => tun::RoutingDecision::VpnTunnel,
-                            ExclusionStatus::Unknown => {
-                                // TODO: Delay decision until next exec
-                                tun::RoutingDecision::Drop
-                            }
-                        }
-                    }),
+                    tcp_conn_states.clone(),
+                    Box::new(move |packet| Box::pin(classify_packet(packet, states.clone()))),
                 )
                 .await;
 
@@ -618,6 +648,7 @@ impl State {
                         process,
                         tun_handle,
                         vpn_interface,
+                        tcp_conn_states,
                     }),
                     Err(error) => {
                         process.shutdown().await;
@@ -677,6 +708,17 @@ impl State {
                 self.fail(Some(error.clone()));
                 Err(error)
             }
+        }
+    }
+}
+
+async fn classify_packet(packet: &PktapPacket, proc_states: ProcessStates) -> RoutingDecision {
+    match proc_states.get_process_status(packet.header.pth_pid).await {
+        ExclusionStatus::Excluded => RoutingDecision::DefaultInterface,
+        ExclusionStatus::Included => RoutingDecision::VpnTunnel,
+        ExclusionStatus::Unknown => {
+            // TODO: Delay decision until next exec
+            RoutingDecision::Drop
         }
     }
 }

--- a/nym-vpn-core/crates/nym-split-tunnel/src/macos/process.rs
+++ b/nym-vpn-core/crates/nym-split-tunnel/src/macos/process.rs
@@ -15,7 +15,7 @@ use std::{
     path::PathBuf,
     process::Stdio,
     str::FromStr,
-    sync::{Arc, LazyLock, Mutex},
+    sync::{Arc, LazyLock},
     time::Duration,
 };
 
@@ -26,7 +26,7 @@ use nym_platform_metadata::AppleVersion;
 use serde::{Deserialize, de::Error as _};
 use tokio::{
     io::{AsyncBufReadExt, AsyncRead, BufReader},
-    sync::oneshot,
+    sync::{Mutex, oneshot},
 };
 
 use crate::SplitTunnelErrorCause;
@@ -194,7 +194,7 @@ async fn handle_eslogger_output(
                 }
             };
 
-            let mut inner = states.inner.lock().unwrap();
+            let mut inner = states.inner.lock().await;
             inner.handle_message(val);
         }
     });
@@ -324,10 +324,16 @@ impl ProcessStates {
         })
     }
 
-    pub fn exclude_paths(&self, paths: HashSet<PathBuf>) {
-        let mut inner = self.inner.lock().unwrap();
+    /// Exclude given paths to binaries from VPN tunnel.
+    ///
+    /// Returns a list of PIDs of affected processes for which the split-tunnel status will change.
+    /// All TCP connections created by these processes must be closed, for example by sending TCP/RST.
+    /// Otherwise such connections will eventually timeout.
+    pub async fn exclude_paths(&self, paths: HashSet<PathBuf>) -> Vec<pid_t> {
+        let mut inner = self.inner.lock().await;
+        let mut affected_pids = Vec::new();
 
-        for info in inner.processes.values_mut() {
+        for (pid, info) in inner.processes.iter_mut() {
             // Remove no-longer excluded paths from exclusion list
             let mut new_exclude_paths: HashSet<_> = info
                 .excluded_by_paths
@@ -340,14 +346,20 @@ impl ProcessStates {
                 new_exclude_paths.insert(info.exec_path.clone());
             }
 
+            if info.excluded_by_paths != new_exclude_paths {
+                affected_pids.push(*pid);
+            }
+
             info.excluded_by_paths = new_exclude_paths;
         }
 
         inner.exclude_paths = paths;
+
+        affected_pids
     }
 
-    pub fn get_process_status(&self, pid: pid_t) -> ExclusionStatus {
-        let inner = self.inner.lock().unwrap();
+    pub async fn get_process_status(&self, pid: pid_t) -> ExclusionStatus {
+        let inner = self.inner.lock().await;
         match inner.processes.get(&pid) {
             Some(val) if val.is_excluded() => ExclusionStatus::Excluded,
             Some(_) => ExclusionStatus::Included,

--- a/nym-vpn-core/crates/nym-split-tunnel/src/macos/tcp_rst.rs
+++ b/nym-vpn-core/crates/nym-split-tunnel/src/macos/tcp_rst.rs
@@ -1,0 +1,86 @@
+// Copyright 2026 Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use std::net::{SocketAddrV4, SocketAddrV6};
+
+use pnet_packet::{
+    ip::IpNextHeaderProtocols,
+    ipv4::{Ipv4Flags, Ipv4Packet, MutableIpv4Packet},
+    ipv6::{Ipv6Packet, MutableIpv6Packet},
+    tcp::{MutableTcpPacket, TcpFlags, TcpPacket},
+};
+
+const IPV4_HEADER_VERSION: u8 = 4;
+const IPV6_HEADER_VERSION: u8 = 6;
+
+const IPV4_HEADER_LEN: usize = Ipv4Packet::minimum_packet_size();
+/// IPv4 header length measured in 32-bit words
+const IPV4_HEADER_WORD_LEN: u8 = (IPV4_HEADER_LEN / 4) as u8;
+const IPV6_HEADER_LEN: usize = Ipv6Packet::minimum_packet_size();
+
+const TCP_HEADER_LEN: usize = TcpPacket::minimum_packet_size();
+/// TCP header length measured in 32-bit words
+const TCP_HEADER_WORD_LEN: u8 = (TCP_HEADER_LEN / 4) as u8;
+
+pub const IPV4_PACKET_LEN: usize = IPV4_HEADER_LEN + TCP_HEADER_LEN;
+pub const IPV6_PACKET_LEN: usize = IPV6_HEADER_LEN + TCP_HEADER_LEN;
+
+/// Fill buffer with IPv4 header and TCP/RST payload
+pub fn fill_tcp_rst_packet_v4(
+    buf: &mut [u8; IPV4_PACKET_LEN],
+    src: SocketAddrV4,
+    dst: SocketAddrV4,
+    seq: u32,
+) {
+    let mut tcp_header = MutableTcpPacket::new(&mut buf[IPV4_HEADER_LEN..]).unwrap();
+    tcp_header.set_source(src.port());
+    tcp_header.set_destination(dst.port());
+    tcp_header.set_flags(TcpFlags::RST);
+    tcp_header.set_window(0);
+    tcp_header.set_data_offset(TCP_HEADER_WORD_LEN);
+    tcp_header.set_sequence(seq); // no increment, RST does not consume sequence
+    tcp_header.set_acknowledgement(0);
+    let chksum = pnet_packet::tcp::ipv4_checksum(&tcp_header.to_immutable(), src.ip(), dst.ip());
+    tcp_header.set_checksum(chksum);
+
+    let mut ip_header = MutableIpv4Packet::new(&mut buf[..]).unwrap();
+    ip_header.set_version(IPV4_HEADER_VERSION);
+    ip_header.set_header_length(IPV4_HEADER_WORD_LEN);
+    ip_header.set_total_length(IPV4_PACKET_LEN as u16);
+    ip_header.set_ttl(64);
+    ip_header.set_next_level_protocol(IpNextHeaderProtocols::Tcp);
+    ip_header.set_destination(*dst.ip());
+    ip_header.set_source(*src.ip());
+    ip_header.set_flags(Ipv4Flags::DontFragment);
+    ip_header.set_fragment_offset(0);
+    ip_header.set_identification(0); // can be zero since packet is not fragmented?
+    let chksum = pnet_packet::ipv4::checksum(&ip_header.to_immutable());
+    ip_header.set_checksum(chksum);
+}
+
+/// Fill buffer with IPv6 header and TCP/RST payload
+pub fn fill_tcp_rst_packet_v6(
+    buf: &mut [u8; IPV6_PACKET_LEN],
+    src: SocketAddrV6,
+    dst: SocketAddrV6,
+    seq: u32,
+) {
+    let mut ip_header = MutableIpv6Packet::new(&mut buf[..]).unwrap();
+    ip_header.set_version(IPV6_HEADER_VERSION);
+    ip_header.set_payload_length(TCP_HEADER_LEN as u16);
+    ip_header.set_hop_limit(64);
+    ip_header.set_next_header(IpNextHeaderProtocols::Tcp);
+    ip_header.set_destination(*dst.ip());
+    ip_header.set_source(*src.ip());
+
+    let mut tcp_header = MutableTcpPacket::new(&mut buf[IPV6_HEADER_LEN..]).unwrap();
+    tcp_header.set_source(src.port());
+    tcp_header.set_destination(dst.port());
+    tcp_header.set_flags(TcpFlags::RST);
+    tcp_header.set_window(0);
+    tcp_header.set_data_offset(TCP_HEADER_WORD_LEN);
+    tcp_header.set_sequence(seq); // no increment, RST does not consume sequence
+    tcp_header.set_acknowledgement(0);
+    let chksum = pnet_packet::tcp::ipv6_checksum(&tcp_header.to_immutable(), src.ip(), dst.ip());
+    tcp_header.set_checksum(chksum);
+}

--- a/nym-vpn-core/crates/nym-split-tunnel/src/macos/tun.rs
+++ b/nym-vpn-core/crates/nym-split-tunnel/src/macos/tun.rs
@@ -8,10 +8,10 @@
 use std::{
     ffi::c_uint,
     io::Write,
-    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
 };
 
-use futures_util::{Stream, StreamExt};
+use futures_util::{Stream, StreamExt, future::BoxFuture};
 use libc::{AF_INET, AF_INET6};
 use nix::net::if_::if_nametoindex;
 use nym_firewall_config::{ALLOWED_LAN_MULTICAST_NETS, ALLOWED_LAN_NETS};
@@ -28,12 +28,13 @@ use pnet_packet::{
 };
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
-    sync::broadcast,
+    sync::{broadcast, mpsc, oneshot},
 };
 
 use super::{
     bindings::{PTH_FLAG_DIR_OUT, pktap_header},
     bpf,
+    conn_track::{self, TcpConnectionStates, TcpConnectionTrack},
     default::DefaultInterface,
 };
 
@@ -125,6 +126,8 @@ pub struct SplitTunnelHandle {
     /// Task that synchronizes the ST tunnel MTU with the VPN tunnel MTU
     mtu_listener: Option<tokio::task::JoinHandle<()>>,
     route_manager: RouteManagerHandle,
+    /// Channel used for sending RST to TCP connections
+    tcp_conn_reset_tx: mpsc::UnboundedSender<(Vec<TcpConnectionTrack>, oneshot::Sender<()>)>,
 }
 
 impl SplitTunnelHandle {
@@ -161,8 +164,26 @@ impl SplitTunnelHandle {
             default_interface,
             vpn_interface,
             self.route_manager,
+            egress_completion.tcp_conn_states,
             egress_completion.classify,
         )
+    }
+
+    pub async fn reset_tcp_connections(&mut self, connections: Vec<TcpConnectionTrack>) {
+        if connections.is_empty() {
+            return;
+        }
+
+        let (tx, rx) = oneshot::channel();
+
+        match self.tcp_conn_reset_tx.send((connections, tx)) {
+            Ok(()) => {
+                let _ = rx.await;
+            }
+            Err(_) => {
+                tracing::warn!("tcp_conn_reset_tx is closed");
+            }
+        }
     }
 
     async fn abort_mtu_listener(&mut self) {
@@ -184,6 +205,7 @@ pub async fn create_split_tunnel(
     default_interface: DefaultInterface,
     vpn_interface: Option<VpnInterface>,
     route_manager: RouteManagerHandle,
+    tcp_conn_states: TcpConnectionStates,
     classify: ClassifyFn,
 ) -> Result<SplitTunnelHandle, Error> {
     let tun_device = create_utun().await?;
@@ -192,6 +214,7 @@ pub async fn create_split_tunnel(
         default_interface,
         vpn_interface,
         route_manager,
+        tcp_conn_states,
         classify,
     )
 }
@@ -230,7 +253,7 @@ async fn add_ipv6_address(iface: &str, addr: Ipv6Addr) -> Result<(), Error> {
 
 type PktapStream = std::pin::Pin<Box<dyn Stream<Item = Result<PktapPacket, Error>> + Send>>;
 /// A function that is used to classify whether packets should be VPN-tunneled or excluded
-type ClassifyFn = Box<dyn Fn(&PktapPacket) -> RoutingDecision + Send>;
+type ClassifyFn = Box<dyn Fn(&PktapPacket) -> BoxFuture<RoutingDecision> + Send + Sync>;
 
 /// Monitor outgoing traffic on `st_tun_device` using a pktap. A routing decision is
 /// made for each packet using `classify`. Based on this, a packet is forced out on either
@@ -245,6 +268,7 @@ fn redirect_packets(
     default_interface: DefaultInterface,
     vpn_interface: Option<VpnInterface>,
     route_manager: RouteManagerHandle,
+    tcp_conn_states: TcpConnectionStates,
     classify: ClassifyFn,
 ) -> Result<SplitTunnelHandle, Error> {
     let st_tun_name = st_tun_device
@@ -258,7 +282,8 @@ fn redirect_packets(
         default_interface,
         vpn_interface,
         route_manager,
-        Box::new(classify),
+        tcp_conn_states,
+        classify,
     )
 }
 
@@ -276,6 +301,7 @@ fn redirect_packets_for_pktap_stream(
     default_interface: DefaultInterface,
     vpn_interface: Option<VpnInterface>,
     route_manager: RouteManagerHandle,
+    tcp_conn_states: TcpConnectionStates,
     classify: ClassifyFn,
 ) -> Result<SplitTunnelHandle, Error> {
     let mtu_listener = vpn_interface
@@ -304,6 +330,8 @@ fn redirect_packets_for_pktap_stream(
     let (abort_tx, abort_rx) = broadcast::channel(1);
     let abort_read_rx = abort_tx.subscribe();
 
+    let (tcp_conn_reset_tx, tcp_conn_reset_rx) = mpsc::unbounded_channel();
+
     let ingress_task: tokio::task::JoinHandle<tun::AsyncDevice> = tokio::spawn(run_ingress_task(
         st_tun_device,
         default_stream,
@@ -311,11 +339,13 @@ fn redirect_packets_for_pktap_stream(
         vpn_interface.clone(),
         abort_rx,
         abort_read_rx,
+        tcp_conn_reset_rx,
     ));
 
     let egress_abort_rx = abort_tx.subscribe();
     let egress_task = tokio::spawn(run_egress_task(
         pktap_stream,
+        tcp_conn_states.clone(),
         classify,
         default_interface,
         default_write,
@@ -330,6 +360,7 @@ fn redirect_packets_for_pktap_stream(
         egress_task,
         mtu_listener,
         route_manager,
+        tcp_conn_reset_tx,
     })
 }
 
@@ -424,6 +455,7 @@ async fn run_ingress_task(
     vpn_interface: Option<VpnInterface>,
     mut abort_rx: broadcast::Receiver<()>,
     mut abort_read_rx: broadcast::Receiver<()>,
+    mut tcp_conn_reset_rx: mpsc::UnboundedReceiver<(Vec<TcpConnectionTrack>, oneshot::Sender<()>)>,
 ) -> tun::AsyncDevice {
     let mut read_buffer = vec![0u8; read_buffer_size];
     tracing::trace!("Default BPF reader buffer size: {:?}", read_buffer.len());
@@ -469,6 +501,10 @@ async fn run_ingress_task(
                     handle_incoming_data(&mut tun_writer, payload, vpn_v4, vpn_v6).await;
                 }
             }
+            Some((conn_tracks, completion_tx)) = tcp_conn_reset_rx.recv() => {
+                send_tcp_reset(vpn_v4, vpn_v6, &conn_tracks, &mut tun_writer).await;
+                completion_tx.send(()).ok();
+            }
         }
     };
 
@@ -482,6 +518,7 @@ async fn run_ingress_task(
 /// Arguments to `run_egress_task` that are returned when the function succeeds
 struct EgressResult {
     pktap_stream: PktapStream,
+    tcp_conn_states: TcpConnectionStates,
     classify: ClassifyFn,
 }
 
@@ -489,6 +526,7 @@ struct EgressResult {
 /// based on the result of `classify`.
 async fn run_egress_task(
     mut pktap_stream: PktapStream,
+    mut tcp_conn_states: TcpConnectionStates,
     classify: ClassifyFn,
     default_interface: DefaultInterface,
     mut default_write: bpf::WriteHalf,
@@ -505,7 +543,7 @@ async fn run_egress_task(
         tokio::select! {
             biased; Ok(()) | Err(_) = abort_rx.recv() => {
                 tracing::debug!("stopping packet processing");
-                break Ok(EgressResult { pktap_stream, classify });
+                break Ok(EgressResult { pktap_stream, tcp_conn_states, classify });
             }
             packet = pktap_stream.next() => {
                 let mut packet = packet.ok_or_else(|| {
@@ -519,7 +557,9 @@ async fn run_egress_task(
                     _ => unreachable!("missing tun interface or addresses"),
                 };
 
-                classify_and_send(&classify, &mut packet, &default_interface, &mut default_write, vpn_device)
+                conn_track::track_connection_state(&mut tcp_conn_states, &packet).await;
+
+                classify_and_send(&classify, &mut packet, &default_interface, &mut default_write, vpn_device).await
             }
         }
     }
@@ -537,14 +577,14 @@ fn open_vpn_bpf(vpn_interface: &VpnInterface) -> Result<bpf::Bpf, Error> {
     Ok(vpn_dev)
 }
 
-fn classify_and_send(
+async fn classify_and_send(
     classify: &ClassifyFn,
     packet: &mut PktapPacket,
     default_interface: &DefaultInterface,
     default_write: &mut bpf::WriteHalf,
     vpn_interface: Option<(&VpnInterface, &mut bpf::Bpf)>,
 ) {
-    match classify(packet) {
+    match classify(packet).await {
         RoutingDecision::DefaultInterface => match packet.frame.get_ethertype() {
             EtherTypes::Ipv4 => {
                 let Some(ref addrs) = default_interface.v4_addrs else {
@@ -941,5 +981,49 @@ impl PacketCodec for PktapCodec {
             header: header.to_owned(),
             frame,
         })
+    }
+}
+
+async fn send_tcp_reset(
+    vpn_v4: Option<Ipv4Addr>,
+    vpn_v6: Option<Ipv6Addr>,
+    conn_tracks: &[TcpConnectionTrack],
+    tun_writer: &mut tokio::io::WriteHalf<tun::AsyncDevice>,
+) {
+    use super::tcp_rst::{
+        IPV4_PACKET_LEN, IPV6_PACKET_LEN, fill_tcp_rst_packet_v4, fill_tcp_rst_packet_v6,
+    };
+
+    for conn_track in conn_tracks {
+        match conn_track.ident.dst {
+            SocketAddr::V4(dst) => {
+                let Some(vpn_v4) = vpn_v4 else {
+                    continue;
+                };
+                let src = SocketAddrV4::new(vpn_v4, conn_track.ident.src.port());
+                let mut buf = [0u8; IPV4_PACKET_LEN];
+                fill_tcp_rst_packet_v4(&mut buf, dst, src, conn_track.meta.ack);
+
+                tracing::trace!("Send TCP RST {dst} -> {src}");
+
+                if let Err(err) = tun_writer.write(&buf).await {
+                    tracing::error!("Failed to write TCP RST: {err}");
+                }
+            }
+            SocketAddr::V6(dst) => {
+                let Some(vpn_v6) = vpn_v6 else {
+                    continue;
+                };
+                let src = SocketAddrV6::new(vpn_v6, conn_track.ident.src.port(), 0, 0);
+                let mut buf = [0u8; IPV6_PACKET_LEN];
+                fill_tcp_rst_packet_v6(&mut buf, dst, src, conn_track.meta.ack);
+
+                tracing::trace!("Send TCP RST {dst} -> {src}");
+
+                if let Err(err) = tun_writer.write(&buf).await {
+                    tracing::error!("Failed to write TCP RST: {err}");
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Ticket

JIRA-NYM-676

## Description

This PR introduces a TCP sessions reset when switching split-tunnel route for individual apps. It improves the transition between network interfaces by forcing affected apps to re-establish TCP connections much sooner and not wait for timeout.

In order to send TCP/RST packet and terminate existing TCP sessions, split-tunnel needs to keep track of active TCP connections and gather `ack` that can be used to forge the valid packets.

In addition `std::sync::Mutex` was replaced with `tokio::sync::Mutex` which should be better in async contexts.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4870)
<!-- Reviewable:end -->
