### PR TITLE
macos(st): switch to using tokio::sync::Mutex

### DIFF
--- a/nym-vpn-core/crates/nym-split-tunnel/src/macos/mod.rs
+++ b/nym-vpn-core/crates/nym-split-tunnel/src/macos/mod.rs
@@ -22,7 +22,9 @@ mod process;
 mod tun;
 
 use crate::SplitTunnelErrorCause;
+use process::ProcessStates;
 pub use tun::VpnInterface;
+use tun::{PktapPacket, RoutingDecision};
 
 /// Check whether the current process has full-disk access enabled.
 /// This is required by the process monitor.
@@ -397,7 +399,7 @@ impl State {
                 tracing::debug!("Initializing process monitor");
 
                 let process = process::ProcessMonitor::spawn().await?;
-                process.states().exclude_paths(paths);
+                process.states().exclude_paths(paths).await;
 
                 Ok(State::ProcessMonitorOnly {
                     route_manager,
@@ -412,7 +414,7 @@ impl State {
                 tracing::debug!("Initializing process monitor");
 
                 let process = process::ProcessMonitor::spawn().await?;
-                process.states().exclude_paths(paths);
+                process.states().exclude_paths(paths).await;
 
                 State::ProcessMonitorOnly {
                     route_manager,
@@ -451,7 +453,7 @@ impl State {
             | State::ProcessMonitorOnly {
                 ref mut process, ..
             } => {
-                process.states().exclude_paths(paths);
+                process.states().exclude_paths(paths).await;
                 Ok(self)
             }
             // If 'paths' is empty, transition out of the failed state
@@ -599,16 +601,7 @@ impl State {
                     default_interface,
                     Some(vpn_interface.clone()),
                     route_manager.clone(),
-                    Box::new(move |packet| {
-                        match states.get_process_status(packet.header.pth_pid) {
-                            ExclusionStatus::Excluded => tun::RoutingDecision::DefaultInterface,
-                            ExclusionStatus::Included => tun::RoutingDecision::VpnTunnel,
-                            ExclusionStatus::Unknown => {
-                                // TODO: Delay decision until next exec
-                                tun::RoutingDecision::Drop
-                            }
-                        }
-                    }),
+                    Box::new(move |packet| Box::pin(classify_packet(packet, states.clone()))),
                 )
                 .await;
 
@@ -677,6 +670,17 @@ impl State {
                 self.fail(Some(error.clone()));
                 Err(error)
             }
+        }
+    }
+}
+
+async fn classify_packet(packet: &PktapPacket, proc_states: ProcessStates) -> RoutingDecision {
+    match proc_states.get_process_status(packet.header.pth_pid).await {
+        ExclusionStatus::Excluded => RoutingDecision::DefaultInterface,
+        ExclusionStatus::Included => RoutingDecision::VpnTunnel,
+        ExclusionStatus::Unknown => {
+            // TODO: Delay decision until next exec
+            RoutingDecision::Drop
         }
     }
 }

--- a/nym-vpn-core/crates/nym-split-tunnel/src/macos/process.rs
+++ b/nym-vpn-core/crates/nym-split-tunnel/src/macos/process.rs
@@ -15,7 +15,7 @@ use std::{
     path::PathBuf,
     process::Stdio,
     str::FromStr,
-    sync::{Arc, LazyLock, Mutex},
+    sync::{Arc, LazyLock},
     time::Duration,
 };
 
@@ -26,7 +26,7 @@ use nym_platform_metadata::AppleVersion;
 use serde::{Deserialize, de::Error as _};
 use tokio::{
     io::{AsyncBufReadExt, AsyncRead, BufReader},
-    sync::oneshot,
+    sync::{Mutex, oneshot},
 };
 
 use crate::SplitTunnelErrorCause;
@@ -194,7 +194,7 @@ async fn handle_eslogger_output(
                 }
             };
 
-            let mut inner = states.inner.lock().unwrap();
+            let mut inner = states.inner.lock().await;
             inner.handle_message(val);
         }
     });
@@ -324,8 +324,8 @@ impl ProcessStates {
         })
     }
 
-    pub fn exclude_paths(&self, paths: HashSet<PathBuf>) {
-        let mut inner = self.inner.lock().unwrap();
+    pub async fn exclude_paths(&self, paths: HashSet<PathBuf>) {
+        let mut inner = self.inner.lock().await;
 
         for info in inner.processes.values_mut() {
             // Remove no-longer excluded paths from exclusion list
@@ -346,8 +346,8 @@ impl ProcessStates {
         inner.exclude_paths = paths;
     }
 
-    pub fn get_process_status(&self, pid: pid_t) -> ExclusionStatus {
-        let inner = self.inner.lock().unwrap();
+    pub async fn get_process_status(&self, pid: pid_t) -> ExclusionStatus {
+        let inner = self.inner.lock().await;
         match inner.processes.get(&pid) {
             Some(val) if val.is_excluded() => ExclusionStatus::Excluded,
             Some(_) => ExclusionStatus::Included,

--- a/nym-vpn-core/crates/nym-split-tunnel/src/macos/tun.rs
+++ b/nym-vpn-core/crates/nym-split-tunnel/src/macos/tun.rs
@@ -11,7 +11,7 @@ use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
 };
 
-use futures_util::{Stream, StreamExt};
+use futures_util::{Stream, StreamExt, future::BoxFuture};
 use libc::{AF_INET, AF_INET6};
 use nix::net::if_::if_nametoindex;
 use nym_firewall_config::{ALLOWED_LAN_MULTICAST_NETS, ALLOWED_LAN_NETS};
@@ -230,7 +230,7 @@ async fn add_ipv6_address(iface: &str, addr: Ipv6Addr) -> Result<(), Error> {
 
 type PktapStream = std::pin::Pin<Box<dyn Stream<Item = Result<PktapPacket, Error>> + Send>>;
 /// A function that is used to classify whether packets should be VPN-tunneled or excluded
-type ClassifyFn = Box<dyn Fn(&PktapPacket) -> RoutingDecision + Send>;
+type ClassifyFn = Box<dyn Fn(&PktapPacket) -> BoxFuture<RoutingDecision> + Send + Sync>;
 
 /// Monitor outgoing traffic on `st_tun_device` using a pktap. A routing decision is
 /// made for each packet using `classify`. Based on this, a packet is forced out on either
@@ -258,7 +258,7 @@ fn redirect_packets(
         default_interface,
         vpn_interface,
         route_manager,
-        Box::new(classify),
+        classify,
     )
 }
 
@@ -519,7 +519,8 @@ async fn run_egress_task(
                     _ => unreachable!("missing tun interface or addresses"),
                 };
 
-                classify_and_send(&classify, &mut packet, &default_interface, &mut default_write, vpn_device)
+
+                classify_and_send(&classify, &mut packet, &default_interface, &mut default_write, vpn_device).await
             }
         }
     }
@@ -537,14 +538,14 @@ fn open_vpn_bpf(vpn_interface: &VpnInterface) -> Result<bpf::Bpf, Error> {
     Ok(vpn_dev)
 }
 
-fn classify_and_send(
+async fn classify_and_send(
     classify: &ClassifyFn,
     packet: &mut PktapPacket,
     default_interface: &DefaultInterface,
     default_write: &mut bpf::WriteHalf,
     vpn_interface: Option<(&VpnInterface, &mut bpf::Bpf)>,
 ) {
-    match classify(packet) {
+    match classify(packet).await {
         RoutingDecision::DefaultInterface => match packet.frame.get_ethertype() {
             EtherTypes::Ipv4 => {
                 let Some(ref addrs) = default_interface.v4_addrs else {


### PR DESCRIPTION


## Description

Small refactor switching to using tokio in macos split-tunnel.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4881)
<!-- Reviewable:end -->
