### PR TITLE
Resolver Overrides cleanup

### DIFF
--- a/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/http.rs
+++ b/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/http.rs
@@ -16,7 +16,6 @@ impl HttpDiagnostic {
         let nym_vpn_api_client = nym_vpn_api_client::VpnApiClient::from_network(
             network.nym_network_details(),
             Some(new_user_agent!()),
-            None,
         )
         .await?;
 

--- a/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/mod.rs
+++ b/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/mod.rs
@@ -63,5 +63,5 @@ impl DiagnosticHandler {
 
 pub async fn build_api_client(network: &Network) -> Result<Client> {
     let nym_urls = api_urls_to_urls(&network.nym_api_urls().ok_or(Error::MissingApiUrl)?)?;
-    Ok(fronted_http_client(nym_urls, None, None, None)?)
+    Ok(fronted_http_client(nym_urls, None, None)?)
 }

--- a/nym-vpn-core/crates/nym-diagnostic/src/main.rs
+++ b/nym-vpn-core/crates/nym-diagnostic/src/main.rs
@@ -25,7 +25,7 @@ async fn main() -> anyhow::Result<()> {
         // Special case for 99% of cases, skip discovery through network
         Network::mainnet_default().with_context(|| "Missing network config")?
     } else if let Some(discovery) = Discovery::default_discovery(&args.network) {
-        let fetcher = Fetcher::new(discovery.clone(), None, None)
+        let fetcher = Fetcher::new(discovery.clone(), None)
             .context("Failed to build non mainnet env : fetcher")?;
         let network_details = fetcher
             .fetch_network_details()

--- a/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
@@ -177,29 +177,16 @@ pub struct GatewayClient {
 
 impl GatewayClient {
     pub fn new(config: Config, user_agent: UserAgent) -> Result<Self> {
-        Self::new_with_resolver_overrides(config, user_agent, None, None)
-    }
-
-    pub fn new_with_resolver_overrides(
-        config: Config,
-        user_agent: UserAgent,
-        resolver_overrides: Option<&ResolverOverrides>,
-        vpn_resolver_overrides: Option<&ResolverOverrides>,
-    ) -> Result<Self> {
         let nym_urls = api_urls_to_urls(config.nym_api_urls())?;
 
-        let api_client =
-            fronted_http_client(nym_urls, Some(user_agent.clone()), None, resolver_overrides)
-                .map_err(Error::VpnApiClientError)?;
+        let api_client = fronted_http_client(nym_urls, Some(user_agent.clone()), None)
+            .map_err(Error::VpnApiClientError)?;
 
         let nym_vpn_urls = api_urls_to_urls(config.nym_vpn_api_urls())?;
 
-        let vpn_api_client = nym_vpn_api_client::VpnApiClient::new(
-            nym_vpn_urls,
-            Some(user_agent.clone()),
-            vpn_resolver_overrides,
-        )
-        .map_err(Error::VpnApiClientError)?;
+        let vpn_api_client =
+            nym_vpn_api_client::VpnApiClient::new(nym_vpn_urls, Some(user_agent.clone()))
+                .map_err(Error::VpnApiClientError)?;
 
         Ok(GatewayClient {
             api_client,
@@ -212,22 +199,20 @@ impl GatewayClient {
 
     // So this function is pretty much the same as new_with_resolver_overrides(),
     // except it uses the network_details.nym_vpn_api_urls to create the vpn_api_client.
-    pub async fn from_network_with_resolver_overrides(
+    pub async fn from_network(
         config: Config,
         network_details: &nym_network_defaults::NymNetworkDetails,
         user_agent: UserAgent,
-        resolver_overrides: Option<&ResolverOverrides>,
     ) -> Result<Self> {
         let nym_urls = api_urls_to_urls(&config.nym_api_urls)?;
 
         // No resolver overrides for this client?
-        let api_client = fronted_http_client(nym_urls, Some(user_agent.clone()), None, None)
+        let api_client = fronted_http_client(nym_urls, Some(user_agent.clone()), None)
             .map_err(Error::VpnApiClientError)?;
 
         let vpn_api_client = nym_vpn_api_client::VpnApiClient::from_network(
             network_details,
             Some(user_agent.clone()),
-            resolver_overrides,
         )
         .await?;
 

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/command_sender.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/command_sender.rs
@@ -8,7 +8,6 @@ use crate::{
 };
 use nym_validator_client::nyxd::Coin;
 use nym_vpn_api_client::{
-    ResolverOverrides,
     response::{NymVpnDevice, NymVpnUsage},
     types::Platform,
 };
@@ -244,21 +243,6 @@ impl AccountCommandSender {
             .send(AccountCommand::Common(
                 CommonCommand::DeriveDeeplinkMnemonic(tx, deeplink_callback_url),
             ))
-            .map_err(AccountCommandError::internal)?;
-        rx.await.map_err(AccountCommandError::internal)?
-    }
-
-    #[instrument(skip(self))]
-    pub async fn set_resolver_overrides(
-        &self,
-        resolver_overrides: Option<ResolverOverrides>,
-    ) -> Result<(), AccountCommandError> {
-        let (tx, rx) = ReturnSender::new();
-        self.command_tx
-            .send(AccountCommand::Common(CommonCommand::SetResolverOverrides(
-                tx,
-                resolver_overrides,
-            )))
             .map_err(AccountCommandError::internal)?;
         rx.await.map_err(AccountCommandError::internal)?
     }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/common_handler.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/common_handler.rs
@@ -3,7 +3,6 @@
 
 use nym_offline_monitor::ConnectivityMonitor;
 use nym_vpn_api_client::{
-    ResolverOverrides,
     response::{NymVpnDevice, NymVpnUsage},
     types::VpnAccountMode,
 };
@@ -48,12 +47,6 @@ pub(crate) async fn handle_common_command<C: ConnectivityMonitor>(
         }
         CommonCommand::GetAvailableTickets(result_tx) => {
             result_tx.send(handle_get_available_tickets(shared_state).await);
-        }
-        CommonCommand::SetResolverOverrides(result_tx, resolver_overrides) => {
-            result_tx.send(handle_set_resolver_overrides(
-                shared_state,
-                resolver_overrides,
-            ));
         }
         CommonCommand::GetAccountSummary(result_tx) => {
             result_tx.send(handle_get_account_summary(shared_state).await);
@@ -202,18 +195,6 @@ pub(crate) async fn handle_get_available_tickets<C: ConnectivityMonitor>(
         .get_available_ticketbooks()
         .await
         .map_err(|err| AccountCommandError::Storage(err.to_string()))
-}
-
-pub(crate) fn handle_set_resolver_overrides<C: ConnectivityMonitor>(
-    shared_state: &mut SharedAccountState<C>,
-    resolver_overrides: Option<ResolverOverrides>,
-) -> Result<(), AccountCommandError> {
-    shared_state
-        .vpn_api_client
-        .override_resolver(resolver_overrides.as_ref())
-        .map_err(|e| {
-            AccountCommandError::internal(format!("Failed to set resolver overrides: {e}"))
-        })
 }
 
 pub(crate) async fn handle_get_account_summary<C: ConnectivityMonitor>(

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/dispatch.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/dispatch.rs
@@ -7,7 +7,6 @@ use crate::{
 };
 use nym_validator_client::nyxd::Coin;
 use nym_vpn_api_client::{
-    ResolverOverrides,
     response::{NymVpnDevice, NymVpnUsage},
     types::Platform,
 };
@@ -91,9 +90,6 @@ impl AccountCommand {
                 CommonCommand::GetDevices(return_sender) => return_sender.send(Err(error)),
                 CommonCommand::GetActiveDevices(return_sender) => return_sender.send(Err(error)),
                 CommonCommand::GetAvailableTickets(return_sender) => return_sender.send(Err(error)),
-                CommonCommand::SetResolverOverrides(return_sender, _) => {
-                    return_sender.send(Err(error))
-                }
                 CommonCommand::GetAccountSummary(return_sender) => return_sender.send(Err(error)),
                 CommonCommand::GetDeeplink(return_sender, _) => return_sender.send(Err(error)),
                 CommonCommand::DeriveDeeplinkMnemonic(return_sender, _) => {
@@ -141,12 +137,6 @@ pub enum CommonCommand {
 
     /// Returns a list of tickets available in storage
     GetAvailableTickets(ReturnSender<AvailableTicketbooks, AccountCommandError>),
-
-    /// Override the VPN API client resolver to allow him to go through the firewall (with Domain Fronting)
-    SetResolverOverrides(
-        ReturnSender<(), AccountCommandError>,
-        Option<ResolverOverrides>,
-    ),
 
     /// Returns the VPN account summary if the account is logged-in
     GetAccountSummary(ReturnSender<Option<VpnAccountSummary>, AccountCommandError>),

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/decentralised_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/decentralised_state.rs
@@ -85,7 +85,6 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for DecentralisedS
                             CommonCommand::GetAccountIdentity(return_sender) => return_sender.send(common_handler::handle_get_account_identity(shared_state)),
                             CommonCommand::GetCanonicalAccountIdentity(return_sender) => return_sender.send(common_handler::handle_get_canonical_account_identity(shared_state).await),
                             CommonCommand::GetAccountMode(return_sender) => return_sender.send(common_handler::handle_get_account_mode(shared_state)),
-                            CommonCommand::SetResolverOverrides(return_sender, resolver_overrides) => return_sender.send(common_handler::handle_set_resolver_overrides(shared_state, resolver_overrides)),
                             CommonCommand::GetUsage(return_sender) => return_decentralised(return_sender),
                             CommonCommand::GetDevices(return_sender) => return_decentralised(return_sender),
                             CommonCommand::GetActiveDevices(return_sender) => return_decentralised(return_sender),

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/logged_out_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/logged_out_state.rs
@@ -87,8 +87,6 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for LoggedOutState
 
                     AccountCommand::Common(common_command) => {
                         match common_command {
-                            CommonCommand::SetResolverOverrides(return_sender, resolver_overrides) => return_sender.send(common_handler::handle_set_resolver_overrides(shared_state, resolver_overrides)),
-
                             CommonCommand::GetAccountIdentity(return_sender) => return_sender.send(Ok(None)),
                             CommonCommand::GetCanonicalAccountIdentity(return_sender) => return_sender.send(Ok(None)),
                             CommonCommand::GetAccountMode(return_sender) => return_sender.send(Ok(None)),

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/offline_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/offline_state.rs
@@ -89,7 +89,6 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for OfflineState {
                             CommonCommand::GetAccountIdentity(return_sender) => return_sender.send(common_handler::handle_get_account_identity(shared_state)),
                             CommonCommand::GetCanonicalAccountIdentity(return_sender) => return_sender.send(common_handler::handle_get_canonical_account_identity(shared_state).await),
                             CommonCommand::GetAccountMode(return_sender) => return_sender.send(common_handler::handle_get_account_mode(shared_state)),
-                            CommonCommand::SetResolverOverrides(return_sender, resolver_overrides) => return_sender.send(common_handler::handle_set_resolver_overrides(shared_state, resolver_overrides)),
                             CommonCommand::GetUsage(return_sender) => return_no_connectivity(return_sender),
                             CommonCommand::GetDevices(return_sender) => return_no_connectivity(return_sender),
                             CommonCommand::GetActiveDevices(return_sender) => return_no_connectivity(return_sender),

--- a/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/commands.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/commands.rs
@@ -4,7 +4,7 @@
 use crate::common::{TestBench, account_summary::*, endpoints, mock_account, mock_account_id};
 
 use nym_vpn_account_controller::AvailableTicketbooks;
-use nym_vpn_api_client::{ResolverOverrides, response::NymVpnDeviceStatus};
+use nym_vpn_api_client::response::NymVpnDeviceStatus;
 use nym_vpn_lib_types::{
     AccountCommandError, AccountControllerErrorStateReason, AccountControllerState,
 };
@@ -69,13 +69,6 @@ async fn logged_out_state_command() -> anyhow::Result<()> {
 
     assert_eq!(
         test_bench.command_sender.reset_device_identity(None).await,
-        Ok(())
-    );
-    assert_eq!(
-        test_bench
-            .command_sender
-            .set_resolver_overrides(Some(ResolverOverrides::default()))
-            .await,
         Ok(())
     );
 
@@ -165,13 +158,6 @@ async fn offline_state_command() -> anyhow::Result<()> {
     assert_eq!(
         test_bench.command_sender.reset_device_identity(None).await,
         Err(AccountCommandError::Offline)
-    );
-    assert_eq!(
-        test_bench
-            .command_sender
-            .set_resolver_overrides(Some(ResolverOverrides::default()))
-            .await,
-        Ok(())
     );
 
     // Offline, no account stored
@@ -331,14 +317,6 @@ async fn ready_state_command() -> anyhow::Result<()> {
         .await;
 
     assert_eq!(
-        test_bench
-            .command_sender
-            .set_resolver_overrides(Some(ResolverOverrides::default()))
-            .await,
-        Ok(())
-    );
-
-    assert_eq!(
         test_bench.command_sender.create_account_command().await,
         Err(AccountCommandError::ExistingAccount)
     );
@@ -445,14 +423,6 @@ async fn error_state_command() -> anyhow::Result<()> {
             AccountControllerErrorStateReason::MaxDeviceReached,
         ))
         .await;
-
-    assert_eq!(
-        test_bench
-            .command_sender
-            .set_resolver_overrides(Some(ResolverOverrides::default()))
-            .await,
-        Ok(())
-    );
 
     assert_eq!(
         test_bench.command_sender.create_account_command().await,

--- a/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/common/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/common/mod.rs
@@ -213,7 +213,7 @@ impl TestBench {
 
         let urls = api_urls_to_urls(&[api_url])?;
 
-        let nym_vpn_api_client = VpnApiClient::new(urls, Some(mock_user_agent()), None)?;
+        let nym_vpn_api_client = VpnApiClient::new(urls, Some(mock_user_agent()))?;
 
         let nyxd_server = MockServer::start().await;
         let mut network_env = Network::mainnet_default().unwrap();

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
@@ -13,7 +13,7 @@ use time::OffsetDateTime;
 use tokio::sync::RwLock;
 
 use crate::{
-    ResolverOverrides, api_urls_to_urls,
+    api_urls_to_urls,
     error::{Result, VpnApiClientError},
     fronted_http_client,
     request::{
@@ -45,30 +45,18 @@ pub(crate) const NYM_VPN_API_TIMEOUT: Duration = Duration::from_secs(30);
 #[derive(Clone, Debug)]
 pub struct VpnApiClient {
     inner: Client,
-    urls: Vec<Url>,
-    user_agent: Option<UserAgent>,
     skew_manager: Arc<RwLock<SkewManager>>,
 }
 
 impl VpnApiClient {
-    pub fn new(
-        urls: Vec<Url>,
-        user_agent: Option<UserAgent>,
-        resolver_overrides: Option<&ResolverOverrides>,
-    ) -> Result<Self> {
-        let inner = fronted_http_client(
-            urls.clone(),
-            user_agent.clone(),
-            Some(NYM_VPN_API_TIMEOUT),
-            resolver_overrides,
-        )?;
+    pub fn new(urls: Vec<Url>, user_agent: Option<UserAgent>) -> Result<Self> {
+        let inner =
+            fronted_http_client(urls.clone(), user_agent.clone(), Some(NYM_VPN_API_TIMEOUT))?;
 
         let time_provider = VpnApiRemoteTimeProvider::new(inner.clone());
 
         Ok(Self {
             inner,
-            urls,
-            user_agent,
             skew_manager: Arc::new(RwLock::new(SkewManager::new(time_provider))),
         })
     }
@@ -77,7 +65,6 @@ impl VpnApiClient {
     pub async fn from_network(
         network: &nym_network_defaults::NymNetworkDetails,
         user_agent: Option<UserAgent>,
-        resolver_overrides: Option<&ResolverOverrides>,
     ) -> Result<Self> {
         #[allow(deprecated)]
         let api_urls = network.nym_vpn_api_urls.as_ref().ok_or_else(|| {
@@ -89,35 +76,15 @@ impl VpnApiClient {
 
         let urls = api_urls_to_urls(api_urls)?;
 
-        let inner = fronted_http_client(
-            urls.clone(),
-            user_agent.clone(),
-            Some(NYM_VPN_API_TIMEOUT),
-            resolver_overrides,
-        )?;
+        let inner =
+            fronted_http_client(urls.clone(), user_agent.clone(), Some(NYM_VPN_API_TIMEOUT))?;
 
         let time_provider = VpnApiRemoteTimeProvider::new(inner.clone());
 
         Ok(Self {
             inner,
-            urls,
-            user_agent,
             skew_manager: Arc::new(RwLock::new(SkewManager::new(time_provider))),
         })
-    }
-
-    pub fn override_resolver(
-        &mut self,
-        resolver_overrides: Option<&ResolverOverrides>,
-    ) -> Result<()> {
-        self.inner = fronted_http_client(
-            self.urls.clone(),
-            self.user_agent.clone(),
-            Some(NYM_VPN_API_TIMEOUT),
-            resolver_overrides,
-        )?;
-
-        Ok(())
     }
 
     pub fn api_client(&self) -> &impl ApiClient {

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/fronted_http_client.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/fronted_http_client.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use crate::{ResolverOverrides, error::VpnApiClientError};
+use crate::error::VpnApiClientError;
 use nym_http_api_client::{Client, ClientBuilder, FrontPolicy, Url, UserAgent};
 use nym_network_defaults::ApiUrl;
 
@@ -8,9 +8,8 @@ pub fn fronted_http_client(
     urls: Vec<Url>,
     user_agent: Option<UserAgent>,
     timeout: Option<Duration>,
-    resolver_overrides: Option<&ResolverOverrides>,
 ) -> Result<Client, VpnApiClientError> {
-    let builder = fronted_http_client_builder(urls, user_agent, timeout, resolver_overrides)?;
+    let builder = fronted_http_client_builder(urls, user_agent, timeout)?;
 
     let client = builder
         .build()
@@ -24,7 +23,6 @@ pub fn fronted_http_client_builder(
     urls: Vec<Url>,
     user_agent: Option<UserAgent>,
     timeout: Option<Duration>,
-    _resolver_overrides: Option<&ResolverOverrides>,
 ) -> Result<ClientBuilder, VpnApiClientError> {
     let has_front = urls.iter().any(|url| url.has_front());
 

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/account.rs
@@ -47,7 +47,6 @@ impl NymAccountController {
         let nym_vpn_api_client = nym_vpn_api_client::VpnApiClient::from_network(
             network_env.inner().nym_network_details(),
             Some(user_agent.into()),
-            None,
         )
         .await
         .map_err(|err| VpnError::InternalError {

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/environment.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/environment.rs
@@ -35,10 +35,9 @@ impl NymEnvironment {
         network_name: &str,
         user_agent: UserAgent,
     ) -> Result<Self, VpnError> {
-        let mut network_cache =
-            NetworkCache::new(cache_dir, network_name, Some(user_agent.into()))
-                .await
-                .map_err(VpnError::internal)?;
+        let mut network_cache = NetworkCache::new(cache_dir, network_name, Some(user_agent.into()))
+            .await
+            .map_err(VpnError::internal)?;
 
         let network = if let Ok(network) = network_cache.network() {
             network

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/environment.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/environment.rs
@@ -36,7 +36,7 @@ impl NymEnvironment {
         user_agent: UserAgent,
     ) -> Result<Self, VpnError> {
         let mut network_cache =
-            NetworkCache::new(cache_dir, network_name, Some(user_agent.into()), None)
+            NetworkCache::new(cache_dir, network_name, Some(user_agent.into()))
                 .await
                 .map_err(VpnError::internal)?;
 

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_account_storage.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_account_storage.rs
@@ -364,7 +364,6 @@ impl NymVpnAccountStorage {
         let vpn_api_client = VpnApiClient::from_network(
             self.environment.inner().nym_network_details(),
             Some(user_agent),
-            None,
         )
         .await
         .map_err(VpnError::internal)?;

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_service.rs
@@ -76,7 +76,6 @@ impl NymVpnService {
                     config.config_dir.clone(),
                     &environment.current().nym_network.network_name,
                     Some(config.user_agent.clone().into()),
-                    None,
                 )
                 .await
                 .map_err(VpnError::internal)?;

--- a/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/topology_service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/topology_service.rs
@@ -8,7 +8,7 @@ use nym_client_core::{NymTopology, client::topology_control::nym_api_provider::C
 use nym_common::trace_err_chain;
 use nym_http_api_client::{Url, UserAgent};
 use nym_sdk::{NymApiTopologyProvider, TopologyProvider};
-use nym_vpn_api_client::{ResolverOverrides, error::VpnApiClientError, fronted_http_client};
+use nym_vpn_api_client::{error::VpnApiClientError, fronted_http_client};
 use tokio::{
     sync::{
         mpsc::{self, UnboundedReceiver, UnboundedSender},
@@ -40,19 +40,13 @@ impl VpnTopologyServiceHandle {
         }
     }
 
-    pub async fn update_config(
-        &self,
-        min_mixnode_performance: u8,
-        min_gateway_performance: u8,
-        resolver_overrides: Option<ResolverOverrides>,
-    ) {
+    pub async fn update_config(&self, min_mixnode_performance: u8, min_gateway_performance: u8) {
         let (completion_tx, completion_rx) = oneshot::channel();
         if self
             .tx
             .send(Command::UpdateConfig {
                 min_mixnode_performance,
                 min_gateway_performance,
-                resolver_overrides,
                 completion_tx,
             })
             .is_ok()
@@ -89,7 +83,6 @@ pub struct VpnTopologyService {
     latest_topology: Option<CachedTopology>,
     nym_api_urls: Vec<Url>,
     user_agent: UserAgent,
-    resolver_overrides: Option<ResolverOverrides>,
     config: Config,
     shutdown_token: CancellationToken,
 }
@@ -98,7 +91,6 @@ impl VpnTopologyService {
     pub fn spawn(
         nym_api_urls: Vec<Url>,
         user_agent: UserAgent,
-        resolver_overrides: Option<ResolverOverrides>,
         shutdown_token: CancellationToken,
     ) -> (VpnTopologyServiceHandle, JoinHandle<()>) {
         let (tx, rx) = mpsc::unbounded_channel();
@@ -108,7 +100,6 @@ impl VpnTopologyService {
             nym_api_urls,
             user_agent,
             latest_topology: None,
-            resolver_overrides,
             config,
             shutdown_token,
         };
@@ -129,12 +120,10 @@ impl VpnTopologyService {
                     Command::UpdateConfig {
                         min_mixnode_performance,
                         min_gateway_performance,
-                        resolver_overrides,
                         completion_tx,
                     } => {
                         self.config.min_mixnode_performance = min_mixnode_performance;
                         self.config.min_gateway_performance = min_gateway_performance;
-                        self.resolver_overrides = resolver_overrides;
                         completion_tx.send(()).ok();
                     }
                     Command::ClearCache { completion_tx } => {
@@ -201,7 +190,6 @@ impl VpnTopologyService {
             self.nym_api_urls.clone(),
             Some(self.user_agent.clone()),
             None,
-            self.resolver_overrides.as_ref(),
         )
         .map_err(VpnTopologyServiceError::CreateHttpClient)?;
 
@@ -240,7 +228,6 @@ enum Command {
     UpdateConfig {
         min_mixnode_performance: u8,
         min_gateway_performance: u8,
-        resolver_overrides: Option<ResolverOverrides>,
         completion_tx: Sender<()>,
     },
     ClearCache {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
@@ -431,7 +431,6 @@ impl NymVpnService {
         let nym_vpn_api_client = nym_vpn_api_client::VpnApiClient::from_network(
             network_details,
             Some(parameters.user_agent.clone()),
-            None,
         )
         .await
         .map_err(Error::CreateApiClient)?;
@@ -536,7 +535,6 @@ impl NymVpnService {
         let (topology_service, topology_service_join_handle) = VpnTopologyService::spawn(
             urls.clone(),
             parameters.user_agent.clone(),
-            None,
             services_shutdown_token.child_token(),
         );
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -46,8 +46,6 @@ use nym_offline_monitor::ConnectivityHandle;
 use nym_registration_client::MixnetClientConfig;
 use nym_statistics::StatisticsSender;
 use nym_vpn_account_controller::{AccountCommandSender, AccountStateReceiver};
-#[cfg(not(any(target_os = "android", target_os = "ios")))]
-use nym_vpn_api_client::ResolverOverrides;
 use nym_vpn_network_config::{DiscoveryRefresherCommand, Network};
 use nym_vpn_store::keys::wireguard::WireguardKeysDb;
 use tokio::{
@@ -634,50 +632,12 @@ impl SharedState {
         self.account_command_tx.set_vpn_api_firewall_up().await.ok();
     }
 
-    /// Set DNS resolver overrides on HTTP clients used by discovery and account controller
-    /// Returns `true` on success, otherwise `false`
-    #[cfg(not(any(target_os = "android", target_os = "ios")))]
-    async fn set_resolver_overrides(
-        &self,
-        nym_vpn_api_resolver_overrides: ResolverOverrides,
-    ) -> bool {
-        self.discovery_refresher_command_tx
-            .send(DiscoveryRefresherCommand::UseResolverOverrides(Some(
-                nym_vpn_api_resolver_overrides.clone(),
-            )))
-            .ok();
-        if let Err(err) = self
-            .account_command_tx
-            .set_resolver_overrides(Some(nym_vpn_api_resolver_overrides))
-            .await
-        {
-            nym_common::trace_err_chain!(
-                err,
-                "Failed to set resolver overrides for account controller"
-            );
-            false
-        } else {
-            true
-        }
-    }
-
     #[cfg(not(any(target_os = "ios", target_os = "android")))]
     async fn enable_ad_blocking(&self, enable: bool) {
         if enable {
             self.adblocker.enable().await;
         } else {
             self.adblocker.disable().await;
-        }
-    }
-
-    /// Reset DNS resolver overrides on HTTP clients used by discovery and account controller
-    #[cfg(not(any(target_os = "android", target_os = "ios")))]
-    async fn reset_resolver_overrides(&self) {
-        self.discovery_refresher_command_tx
-            .send(DiscoveryRefresherCommand::UseResolverOverrides(None))
-            .ok();
-        if let Err(err) = self.account_command_tx.set_resolver_overrides(None).await {
-            nym_common::trace_err_chain!(err, "Failed to unset static API addresses");
         }
     }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
@@ -120,10 +120,6 @@ impl ConnectedState {
             .await;
         }
 
-        // Reset DNS resolver overrides since connections can be established over the tunnel
-        #[cfg(not(any(target_os = "android", target_os = "ios")))]
-        _shared_state.reset_resolver_overrides().await;
-
         (
             Box::new(connected_state),
             PrivateTunnelState::Connected { connection_data },

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -284,7 +284,7 @@ impl ConnectingState {
         #[cfg(any(target_os = "android", target_os = "ios"))]
         {
             // Start tunnel monitor immediately since there is no configurable firewall on mobile
-            self.start_tunnel_monitor(None, shared_state).await
+            self.start_tunnel_monitor(shared_state).await
         }
     }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -318,35 +318,10 @@ impl ConnectingState {
             );
         }
 
-        if resolved_gateway_config.has_resolver_overrides() {
-            let resolver_overrides = resolved_gateway_config
-                .nym_vpn_api_resolver_overrides
-                .clone();
-
-            // Set DNS resolver overrides to ensure that HTTP clients use IP addresses specified in firewall exceptions.
-            if !shared_state
-                .set_resolver_overrides(resolver_overrides)
-                .await
-            {
-                return NextTunnelState::NewState(
-                    ErrorState::enter(
-                        ErrorStateReason::Internal("Failed to set resolver overrides".to_owned()),
-                        shared_state,
-                    )
-                    .await,
-                );
-            }
-        } else {
-            tracing::warn!(
-                "There are no resolver overrides, which may result in the firewall blocking API requests"
-            );
-        }
-
         // Allow networking now when firewall and resolver overrides are configured.
         shared_state.allow_networking().await;
 
-        self.start_tunnel_monitor(Some(resolved_gateway_config), shared_state)
-            .await
+        self.start_tunnel_monitor(shared_state).await
     }
 
     #[cfg(any(target_os = "android", target_os = "ios"))]
@@ -369,7 +344,6 @@ impl ConnectingState {
 
     async fn start_tunnel_monitor(
         mut self: Box<Self>,
-        resolved_gateway_config: Option<ResolvedConfig>,
         shared_state: &mut SharedState,
     ) -> NextTunnelState {
         let Some(tunnel_monitor_event_sender) = self.tunnel_monitor_event_sender.take() else {
@@ -386,7 +360,6 @@ impl ConnectingState {
 
         let tunnel_parameters = TunnelParameters {
             nym_config: shared_state.nym_config.clone(),
-            resolved_gateway_config,
             tunnel_settings: shared_state.tunnel_settings.clone(),
             tunnel_constants: shared_state.tunnel_constants,
             selected_gateways: self.selected_gateways.clone(),

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnected_state.rs
@@ -34,10 +34,6 @@ impl DisconnectedState {
         // Drop tombstone to close tunnel devices.
         drop(tombstone);
 
-        // Reset resolver overrides and allow all networking since firewall is no longer active
-        #[cfg(not(any(target_os = "android", target_os = "ios")))]
-        shared_state.reset_resolver_overrides().await;
-
         // Clear addresses from the pre-resolve table in the (shared) DNS resolver.
         HickoryDnsResolver::shared().clear_preresolve();
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -24,7 +24,7 @@ use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
 #[cfg(target_os = "linux")]
 use nix::sys::socket::{SetSockOpt, sockopt::Mark};
 use nym_gateway_directory::{
-    BlacklistedGateways, GatewayCacheHandle, GatewayClient, GatewayMinPerformance, ResolvedConfig,
+    BlacklistedGateways, GatewayCacheHandle, GatewayClient, GatewayMinPerformance,
 };
 use time::OffsetDateTime;
 use tokio::{sync::mpsc, task::JoinHandle};
@@ -217,7 +217,6 @@ impl TunnelMonitorHandle {
 #[derive(Debug, Clone)]
 pub struct TunnelParameters {
     pub nym_config: NymConfig,
-    pub resolved_gateway_config: Option<ResolvedConfig>,
     pub tunnel_settings: TunnelSettings,
     pub tunnel_constants: TunnelConstants,
     pub selected_gateways: Option<SelectedGateways>,
@@ -343,25 +342,9 @@ impl TunnelMonitor {
         }
 
         let user_agent = self.tunnel_parameters.user_agent.clone();
-        let resolver_overrides = self
-            .tunnel_parameters
-            .resolved_gateway_config
-            .as_ref()
-            .map(|v| &v.nym_api_resolver_overrides);
-
-        let vpn_resolver_overrides = self
-            .tunnel_parameters
-            .resolved_gateway_config
-            .as_ref()
-            .map(|v| &v.nym_vpn_api_resolver_overrides);
-
-        let gateway_directory_client = GatewayClient::new_with_resolver_overrides(
-            gateway_config.clone(),
-            user_agent.clone(),
-            resolver_overrides,
-            vpn_resolver_overrides,
-        )
-        .map_err(Error::GatewayDirectoryClient)?;
+        let gateway_directory_client =
+            GatewayClient::new(gateway_config.clone(), user_agent.clone())
+                .map_err(Error::GatewayDirectoryClient)?;
 
         self.gateway_cache_handle
             .replace_gateway_client(gateway_directory_client)
@@ -443,10 +426,6 @@ impl TunnelMonitor {
                 mixnet_client_config
                     .min_gateway_performance
                     .unwrap_or(DEFAULT_MIN_GATEWAY_PERFORMANCE),
-                self.tunnel_parameters
-                    .resolved_gateway_config
-                    .as_ref()
-                    .map(|v| v.nym_api_resolver_overrides.clone()),
             )
             .await;
 

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/discovery.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/discovery.rs
@@ -214,7 +214,7 @@ mod tests {
     }
 
     async fn test_discovery_equality(discovery: Discovery) {
-        let fetcher = Fetcher::new(Discovery::default_mainnet(), None, None).unwrap();
+        let fetcher = Fetcher::new(Discovery::default_mainnet(), None).unwrap();
         let fetched = fetcher
             .fetch_discovery(&discovery.network_name)
             .await

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/discovery_refresher.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/discovery_refresher.rs
@@ -11,7 +11,6 @@ use tokio_util::sync::CancellationToken;
 
 use nym_common::trace_err_chain;
 use nym_offline_monitor::ConnectivityMonitor;
-use nym_vpn_api_client::ResolverOverrides;
 
 use crate::{Network, NetworkCache};
 
@@ -62,21 +61,6 @@ impl DiscoveryRefresher {
                                 self.paused = pause;
                             }
                         }
-                        DiscoveryRefresherCommand::UseResolverOverrides(resolver_overrides) => {
-                            let enabled = if resolver_overrides.is_some() {"enabled"} else {"disabled"};
-                            match self.network_cache.set_resolver_overrides(resolver_overrides) {
-                                Ok(is_changed) => {
-                                    if is_changed {
-                                        tracing::debug!("Discovery refresher using {enabled} resolver overrides");
-                                    } else {
-                                        tracing::debug!("Discovery refresher received identical resolver overrides; ignoring");
-                                    }
-                                }
-                                Err(err) => {
-                                    trace_err_chain!(err, "failed to apply new resolver overrides");
-                                }
-                            }
-                        }
                     }
                 }
                 Some(connectivity) = connectivity_monitor.next() => {
@@ -113,5 +97,4 @@ impl DiscoveryRefresher {
 #[derive(Debug)]
 pub enum DiscoveryRefresherCommand {
     Pause(bool),
-    UseResolverOverrides(Option<ResolverOverrides>),
 }

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/envs.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/envs.rs
@@ -84,7 +84,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_envs_default_same_as_fetched() {
-        let fetcher = Fetcher::new(Discovery::default_mainnet(), None, None).unwrap();
+        let fetcher = Fetcher::new(Discovery::default_mainnet(), None).unwrap();
         let default_envs = RegisteredNetworks::default();
         let fetched_envs = fetcher.fetch_registered_networks().await.unwrap();
 

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/fetcher.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/fetcher.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use nym_http_api_client::Client as HttpApiClient;
 use nym_sdk::{NymNetworkDetails, UserAgent};
 use nym_validator_client::nym_api::NymApiClientExt;
-use nym_vpn_api_client::{ResolverOverrides, VpnApiClient, api_urls_to_urls, fronted_http_client};
+use nym_vpn_api_client::{VpnApiClient, api_urls_to_urls, fronted_http_client};
 
 use crate::{Error, Result, discovery::Discovery, envs::RegisteredNetworks};
 
@@ -19,21 +19,15 @@ pub struct Fetcher {
     vpn_api_client: VpnApiClient,
     user_agent: Option<UserAgent>,
     discovery: Box<Discovery>,
-    resolver_overrides: Option<ResolverOverrides>,
 }
 
 impl Fetcher {
     /// Create an instance of `Fetcher` using HTTP API endpoints from the given discovery.
-    pub fn new(
-        discovery: Discovery,
-        user_agent: Option<UserAgent>,
-        resolver_overrides: Option<&ResolverOverrides>,
-    ) -> Result<Self> {
+    pub fn new(discovery: Discovery, user_agent: Option<UserAgent>) -> Result<Self> {
         Ok(Self {
             user_agent: user_agent.clone(),
-            resolver_overrides: resolver_overrides.cloned(),
-            api_client: build_api_client(&discovery, user_agent.clone(), resolver_overrides)?,
-            vpn_api_client: build_vpn_api_client(&discovery, user_agent, resolver_overrides)?,
+            api_client: build_api_client(&discovery, user_agent.clone())?,
+            vpn_api_client: build_vpn_api_client(&discovery, user_agent)?,
             discovery: Box::new(discovery),
         })
     }
@@ -45,43 +39,11 @@ impl Fetcher {
             return Ok(());
         }
 
-        self.api_client = build_api_client(
-            &new_discovery,
-            self.user_agent.clone(),
-            self.resolver_overrides.as_ref(),
-        )?;
-        self.vpn_api_client = build_vpn_api_client(
-            &new_discovery,
-            self.user_agent.clone(),
-            self.resolver_overrides.as_ref(),
-        )?;
+        self.api_client = build_api_client(&new_discovery, self.user_agent.clone())?;
+        self.vpn_api_client = build_vpn_api_client(&new_discovery, self.user_agent.clone())?;
         *self.discovery = new_discovery;
 
         Ok(())
-    }
-
-    /// Update resolver overrides used by the fetcher.
-    /// This causes recreation of the underlying HTTP API clients.
-    pub fn set_resolver_overrides(
-        &mut self,
-        new_overrides: Option<ResolverOverrides>,
-    ) -> Result<bool> {
-        if self.resolver_overrides == new_overrides {
-            return Ok(false);
-        }
-
-        self.api_client = build_api_client(
-            &self.discovery,
-            self.user_agent.clone(),
-            new_overrides.as_ref(),
-        )?;
-
-        self.vpn_api_client
-            .override_resolver(new_overrides.as_ref())
-            .map_err(Error::SetResolverOverrides)?;
-        self.resolver_overrides = new_overrides;
-
-        Ok(true)
     }
 
     /// Fetch registered networks from the API.
@@ -116,33 +78,22 @@ impl Fetcher {
     }
 }
 
-fn build_api_client(
-    discovery: &Discovery,
-    user_agent: Option<UserAgent>,
-    resolver_overrides: Option<&ResolverOverrides>,
-) -> Result<HttpApiClient> {
+fn build_api_client(discovery: &Discovery, user_agent: Option<UserAgent>) -> Result<HttpApiClient> {
     let api_urls =
         api_urls_to_urls(&discovery.nym_api_urls()).map_err(Error::CreateVpnApiClient)?;
 
-    fronted_http_client::fronted_http_client(
-        api_urls,
-        user_agent,
-        Some(NETWORK_TIMEOUT),
-        resolver_overrides,
-    )
-    .map_err(Error::CreateVpnApiClient)
+    fronted_http_client::fronted_http_client(api_urls, user_agent, Some(NETWORK_TIMEOUT))
+        .map_err(Error::CreateVpnApiClient)
 }
 
 fn build_vpn_api_client(
     discovery: &Discovery,
     user_agent: Option<UserAgent>,
-    resolver_overrides: Option<&ResolverOverrides>,
 ) -> Result<VpnApiClient> {
     let vpn_api_urls =
         api_urls_to_urls(&discovery.nym_vpn_api_urls()).map_err(Error::CreateVpnApiClient)?;
 
-    VpnApiClient::new(vpn_api_urls, user_agent, resolver_overrides)
-        .map_err(Error::CreateVpnApiClient)
+    VpnApiClient::new(vpn_api_urls, user_agent).map_err(Error::CreateVpnApiClient)
 }
 
 #[cfg(test)]
@@ -152,7 +103,7 @@ mod tests {
     #[tokio::test]
     async fn test_discovery_fetch() {
         let network_name = "mainnet";
-        let fetcher = Fetcher::new(Discovery::default_mainnet(), None, None).unwrap();
+        let fetcher = Fetcher::new(Discovery::default_mainnet(), None).unwrap();
         let discovery = fetcher.fetch_discovery(network_name).await.unwrap();
         assert_eq!(discovery.network_name, network_name);
     }

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/lib.rs
@@ -42,7 +42,7 @@ pub use system_messages::{SystemMessage, SystemMessages};
 use nym_common::trace_err_chain;
 use nym_http_api_client::HttpClientError;
 use nym_sdk::{UserAgent, mixnet::Recipient};
-use nym_vpn_api_client::{ResolverOverrides, str_to_socket_addr};
+use nym_vpn_api_client::str_to_socket_addr;
 
 use crate::{
     discovery::DiscoveryFromNymWellknownDiscoveryError,
@@ -219,12 +219,6 @@ impl Network {
 
         unique.into_iter().collect()
     }
-
-    pub async fn resolver_overrides(&self) -> Result<ResolverOverrides> {
-        ResolverOverrides::from_api_urls(&self.nym_vpn_network.nym_vpn_api_urls)
-            .await
-            .map_err(Error::CreateResolverOverrides)
-    }
 }
 
 /// Supervisor type over persistent stores concerning network configuration, such as registered network environments, discovery, and network details.
@@ -242,7 +236,6 @@ impl NetworkCache {
         cache_dir: PathBuf,
         network_name: &str,
         user_agent: Option<UserAgent>,
-        resolver_overrides: Option<&ResolverOverrides>,
     ) -> Result<Self> {
         Self::clean_up_change_introduced_in_pr4226(&cache_dir).await;
 
@@ -261,11 +254,7 @@ impl NetworkCache {
                     }
                 })?;
 
-        let fetcher = Fetcher::new(
-            persistent_discovery.value().clone(),
-            user_agent,
-            resolver_overrides,
-        )?;
+        let fetcher = Fetcher::new(persistent_discovery.value().clone(), user_agent)?;
 
         Ok(Self {
             cache_dir,
@@ -274,13 +263,6 @@ impl NetworkCache {
             persistent_network_details,
             fetcher,
         })
-    }
-
-    pub fn set_resolver_overrides(
-        &mut self,
-        new_overrides: Option<ResolverOverrides>,
-    ) -> Result<bool> {
-        self.fetcher.set_resolver_overrides(new_overrides)
     }
 
     pub async fn fetch_if_stale(&mut self) -> Result<()> {
@@ -405,12 +387,6 @@ pub enum Error {
 
     #[error("network name mismatch between requested and fetched discovery")]
     NetworkNameMismatch { expected: String, actual: String },
-
-    #[error("failed to create resolver overrides")]
-    CreateResolverOverrides(#[source] nym_vpn_api_client::error::VpnApiClientError),
-
-    #[error("failed to set resolver overrides")]
-    SetResolverOverrides(#[source] nym_vpn_api_client::error::VpnApiClientError),
 
     #[error("failed to create vpn api client")]
     CreateVpnApiClient(#[source] nym_vpn_api_client::error::VpnApiClientError),
@@ -561,10 +537,9 @@ mod tests {
 
         let _ = tokio::fs::File::create(cache_dir.path().join("test.txt")).await;
 
-        let _network_cache =
-            NetworkCache::new(cache_dir.path().to_path_buf(), "mainnet", None, None)
-                .await
-                .unwrap();
+        let _network_cache = NetworkCache::new(cache_dir.path().to_path_buf(), "mainnet", None)
+            .await
+            .unwrap();
 
         // ensure network cache removed old directories
         for env in envs {

--- a/nym-vpn-core/crates/nym-vpnd/src/environment.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/environment.rs
@@ -12,8 +12,7 @@ pub async fn setup_environment(
 
     tracing::info!("Setting up environment for {network_name}");
 
-    let mut network_cache =
-        NetworkCache::new(cache_dir, network_name, Some(user_agent), None).await?;
+    let mut network_cache = NetworkCache::new(cache_dir, network_name, Some(user_agent)).await?;
 
     if let Ok(network) = network_cache.network() {
         network.export_to_env();


### PR DESCRIPTION
## Ticket

JIRA NYM-595

## Description

clear out now unused plumbing for setting DNS overrides used by various HTTP clients. This infrastructure previously provided a way to tell all http clients about the specific addresses that had exceptions added to the firewall to be used for each domain during the connecting phase. The work of NYM-407 (https://github.com/nymtech/nym/pull/6423) and NYM-594 (https://github.com/nymtech/nym-vpn-client/pull/4815) mean that this tooling is no longer used. Removing is cleans up code and reduced functional confusion down the road. 

* Tested working for linux mixnet and dvpn. 
* changes should not impact mobile platforms 

## Checklist:

- [X] `ResolverOverrides` Plumbing removed
- [X] Connections working using new dns-preresolve.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4887)
<!-- Reviewable:end -->
