### PR TITLE
macos: remove obsolete test that no longer fails on macOS 26

### DIFF
--- a/nym-vpn-core/crates/nym-apple-network/src/endpoint.rs
+++ b/nym-vpn-core/crates/nym-apple-network/src/endpoint.rs
@@ -410,11 +410,6 @@ mod tests {
     }
 
     #[test]
-    fn create_invalid_host_endpoint() {
-        assert!(HostEndpoint::new("", 0).is_err());
-    }
-
-    #[test]
     fn create_address_endpoint() {
         let ep = AddressEndpoint::new_with_socket_addr(SocketAddr::new(
             IpAddr::V4(Ipv4Addr::LOCALHOST),


### PR DESCRIPTION


## Description

See the title

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4889)
<!-- Reviewable:end -->
