### PR TITLE
AccountController Syncing retry delay

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
@@ -33,7 +33,7 @@ pub(super) mod requesting_zknym_state;
 const MAX_SYNCING_ATTEMPTS: u32 = 10;
 const SYNCING_STATE_CONTEXT: &str = "SYNCING_STATE";
 
-// bounded exponential backoff for retries [0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 8.0, 8.0, 8.0, 8.0, 8.0]
+// bounded exponential backoff for retries [0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 8.0, 8.0, 8.0, 8.0, 8.0] = 55.75s max wait
 const RETRY_BACKOFF: Duration = Duration::from_millis(250);
 const MAX_BACKOFF_EXPONENT: u32 = 5;
 const BACKOFF_BASE: u32 = 2;
@@ -262,7 +262,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingState {
                                 NextAccountControllerState::NewState(ErrorState::enter(err.into()))
                             } else {
                                 let delay = RETRY_BACKOFF * BACKOFF_BASE.pow(min(self.attempts, MAX_BACKOFF_EXPONENT));
-                                tracing::debug!("Error trying to get account summary, retrying after {:?} : {}", delay, err.to_string());
+                                tracing::debug!("Error trying to get account summary attempt {}, retrying after {:?} : {}", self.attempts, delay, err.to_string());
                                 let _ = shutdown_token.run_until_cancelled(tokio::time::sleep(delay)).await;
                                 NextAccountControllerState::NewState(SyncingState::enter(shared_state, self.attempts + 1))
                             }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
@@ -101,7 +101,13 @@ impl SyncingState {
         // This handle does not need to be awaited since event channel and cancellation token are sufficient.
         let _syncing_state_handle =
             tokio::spawn(sync_cancel_token.child_token().run_until_cancelled_owned(
-                SyncingState::sync_account(event_tx, vpn_api_client, vpn_api_account, device),
+                SyncingState::sync_account(
+                    event_tx,
+                    vpn_api_client,
+                    vpn_api_account,
+                    device,
+                    attempts,
+                ),
             ));
 
         (
@@ -119,7 +125,12 @@ impl SyncingState {
         vpn_api_client: VpnApiClient,
         vpn_api_account: Arc<VpnAccount>,
         device: Device,
+        attempts: u32,
     ) {
+        if attempts > 0 {
+            tokio::time::sleep(Self::get_delay(attempts)).await;
+        }
+
         let final_event =
             Self::sync_account_inner(event_tx.clone(), vpn_api_client, vpn_api_account, device)
                 .await
@@ -234,6 +245,11 @@ impl SyncingState {
             .await?;
         Ok(()) // We can register a device, we have fair usage
     }
+
+    /// The attempt retries should  start with attempt 1
+    fn get_delay(attempts: u32) -> Duration {
+        RETRY_BACKOFF * BACKOFF_BASE.pow(min(attempts - 1, MAX_BACKOFF_EXPONENT))
+    }
 }
 
 #[async_trait::async_trait]
@@ -261,9 +277,12 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingState {
                                 tracing::debug!("Error trying to get account summary, exhausted retries : {}", err.to_string());
                                 NextAccountControllerState::NewState(ErrorState::enter(err.into()))
                             } else {
-                                let delay = RETRY_BACKOFF * BACKOFF_BASE.pow(min(self.attempts, MAX_BACKOFF_EXPONENT));
-                                tracing::debug!("Error trying to get account summary attempt {}, retrying after {:?} : {}", self.attempts, delay, err.to_string());
-                                let _ = shutdown_token.run_until_cancelled(tokio::time::sleep(delay)).await;
+                                tracing::debug!(
+                                    "Error trying to get account summary attempt {}, retrying after {:?} : {}",
+                                    self.attempts,
+                                    Self::get_delay(self.attempts+1),
+                                    err.to_string()
+                                );
                                 NextAccountControllerState::NewState(SyncingState::enter(shared_state, self.attempts + 1))
                             }
                         } else {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
@@ -1,7 +1,9 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use std::cmp::min;
 use std::sync::Arc;
+use std::time::Duration;
 
 use crate::{
     SharedAccountState,
@@ -30,6 +32,11 @@ pub(super) mod requesting_zknym_state;
 
 const MAX_SYNCING_ATTEMPTS: u32 = 10;
 const SYNCING_STATE_CONTEXT: &str = "SYNCING_STATE";
+
+// plateauing exponential backoff for retries [0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 8.0, 8.0, 8.0, 8.0, 8.0]
+const RETRY_BACKOFF: Duration = Duration::from_millis(250);
+const MAX_BACKOFF_EXPONENT: u32 = 5;
+const BACKOFF_BASE: u32 = 2;
 
 enum SyncEvent {
     /// Account summary is received
@@ -254,7 +261,9 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingState {
                                 tracing::debug!("Error trying to get account summary, exhausted retries : {}", err.to_string());
                                 NextAccountControllerState::NewState(ErrorState::enter(err.into()))
                             } else {
-                                tracing::debug!("Error trying to get account summary, retrying : {}", err.to_string());
+                                let delay = RETRY_BACKOFF * BACKOFF_BASE.pow(min(self.attempts, MAX_BACKOFF_EXPONENT));
+                                tracing::debug!("Error trying to get account summary, retrying after {:?} : {}", delay, err.to_string());
+                                tokio::time::sleep(delay).await;
                                 NextAccountControllerState::NewState(SyncingState::enter(shared_state, self.attempts + 1))
                             }
                         } else {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
@@ -33,7 +33,7 @@ pub(super) mod requesting_zknym_state;
 const MAX_SYNCING_ATTEMPTS: u32 = 10;
 const SYNCING_STATE_CONTEXT: &str = "SYNCING_STATE";
 
-// plateauing exponential backoff for retries [0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 8.0, 8.0, 8.0, 8.0, 8.0]
+// bounded exponential backoff for retries [0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 8.0, 8.0, 8.0, 8.0, 8.0]
 const RETRY_BACKOFF: Duration = Duration::from_millis(250);
 const MAX_BACKOFF_EXPONENT: u32 = 5;
 const BACKOFF_BASE: u32 = 2;
@@ -263,7 +263,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingState {
                             } else {
                                 let delay = RETRY_BACKOFF * BACKOFF_BASE.pow(min(self.attempts, MAX_BACKOFF_EXPONENT));
                                 tracing::debug!("Error trying to get account summary, retrying after {:?} : {}", delay, err.to_string());
-                                tokio::time::sleep(delay).await;
+                                let _ = shutdown_token.run_until_cancelled(tokio::time::sleep(delay)).await;
                                 NextAccountControllerState::NewState(SyncingState::enter(shared_state, self.attempts + 1))
                             }
                         } else {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/common/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/common/mod.rs
@@ -259,9 +259,12 @@ impl TestBench {
         })
     }
 
-    /// Assert that we are in a given state within 15 seconds.
+    /// Assert that we are in a given state within 60 seconds.
     /// This is needed to avoid tokio::sleep and yield_now everywhere
-    /// If after the 15sec delay, the expected state is not reached, the `assert_eq` call will fail, with a normal failure
+    /// If after the 60sec delay, the expected state is not reached, the `assert_eq` call will fail, with a normal failure
+    ///
+    /// The delay allows tests that require exhausting syncing state retries to
+    /// proceed through all delays to the expected error.
     pub async fn assert_state(&mut self, expected_state: AccountControllerState) {
         // Make sure we're not running right away
         tokio::task::yield_now().await;

--- a/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/common/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/common/mod.rs
@@ -259,12 +259,14 @@ impl TestBench {
         })
     }
 
-    /// Assert that we are in a given state within 60 seconds.
-    /// This is needed to avoid tokio::sleep and yield_now everywhere
-    /// If after the 60sec delay, the expected state is not reached, the `assert_eq` call will fail, with a normal failure
+    /// Assert that we are in a given state within 60 seconds. This is needed to avoid tokio::sleep
+    /// and yield_now everywhere.
     ///
-    /// The delay allows tests that require exhausting syncing state retries to
-    /// proceed through all delays to the expected error.
+    /// If after the 60sec delay, the expected state is not reached, the `assert_eq` call will fail,
+    /// with a normal failure
+    ///
+    /// The delay allows tests that require exhausting syncing state retries to proceed through all
+    /// delays to the expected error.
     pub async fn assert_state(&mut self, expected_state: AccountControllerState) {
         // Make sure we're not running right away
         tokio::task::yield_now().await;

--- a/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/common/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/common/mod.rs
@@ -270,7 +270,7 @@ impl TestBench {
 
         let wait_for_state_fut = state_watcher.wait_for(|state| *state == expected_state);
 
-        let _ = tokio::time::timeout(Duration::from_secs(15), wait_for_state_fut).await;
+        let _ = tokio::time::timeout(Duration::from_secs(60), wait_for_state_fut).await;
 
         // For the nice output in tests
         assert_eq!(self.state_receiver.get_state(), expected_state);


### PR DESCRIPTION
## Description

Add delay in accont controller retry to prevent rapid error spam. Currently the account controller has a finite number of attempts, but no delay between them. So if an error occurs it will immediately retry. I saw this during the disconnecting state where the account controller attempts to sync. It spams network requests that fail because the network is unreachable. 

This PR adds a bounded exponential backoff delay to the retry attempts. 

```
// before 
2026-03-13T19:50:59.932644Z DEBUG nym_vpn_account_controller::state_machine::syncing_state: Error trying to get account summary, retrying : ApiRequestError

// after
2026-03-13T19:50:59.932644Z DEBUG nym_vpn_account_controller::state_machine::syncing_state: Error trying to get account summary attempt 10, retrying after 8s : ApiRequestError
```

The timeout for the mocked integration tests is also increased to 60 seconds as there are (currently) two tests that require exhausting the retries in order to assert a failure:

```rust
async fn desynced_device_test() -> anyhow::Result<()> {}

async fn account_with_inactive_sub_test() -> anyhow::Result<()> {}
```

## Checklist:

- [x] add in reasonable delay parameters to the account controller syncing state retry logic

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4898)
<!-- Reviewable:end -->
