### PR TITLE
Set `PBKDF2_ITERATIONS` to `210_000` iterations

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/deeplink.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/deeplink.rs
@@ -257,7 +257,7 @@ impl PinCode {
     const IV_LEN: usize = 12;
     const TAG_LEN: usize = 16;
     const KEY_LEN: usize = 32;
-    const PBKDF2_ITERATIONS: u32 = 600_000;
+    const PBKDF2_ITERATIONS: u32 = 210_000;
 
     fn new(length: usize) -> Result<Self, DeeplinkError> {
         let mut random = vec![0u8; length];


### PR DESCRIPTION
## Ticket

JIRA-VPN-XXXX

## Description

Set `PBKDF2_ITERATIONS` to `210_000` iterations. 

Since `Sha512` is used, the iterations can be reduced to `210_000`

This reduced encryption time ~2x


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4902)
<!-- Reviewable:end -->
