### PR TITLE
Add missing get_autologin_deeplink to rpcClient and vpn_account_storage

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_account_storage.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_account_storage.rs
@@ -6,6 +6,7 @@ use std::{path::PathBuf, sync::Arc};
 use nym_common::{ErrorExt, trace_err_chain};
 use nym_platform_metadata::new_user_agent;
 use nym_sdk::mixnet::StoragePaths;
+use nym_vpn_account_controller::{CreateDeeplinkParams, Deeplink};
 use nym_vpn_api_client::{
     VpnApiClient,
     response::NymVpnRegisterAccountResponse,
@@ -13,8 +14,8 @@ use nym_vpn_api_client::{
 };
 use nym_vpn_lib::storage::VpnClientOnDiskStorage;
 use nym_vpn_lib_types::{
-    DeeplinkKind, ParsedAccountLinks, RegisterAccountResponse, StoreAccountRequest,
-    VpnAccountSummary,
+    AutologinResponse, DeeplinkClient, DeeplinkKind, GetDeeplinkParams, ParsedAccountLinks,
+    RegisterAccountResponse, StoreAccountRequest, VpnAccountSummary,
 };
 use nym_vpn_store::{
     account::AccountInformationStorage,
@@ -146,6 +147,43 @@ impl NymVpnAccountStorage {
                 })
             }
         }
+    }
+
+    // Get deeplink for autologin
+    pub async fn get_autologin_deeplink(
+        &self,
+        params: GetDeeplinkParams,
+    ) -> Result<AutologinResponse, VpnError> {
+        let Some(ref account_management) =
+            self.environment.inner().nym_vpn_network.account_management
+        else {
+            return Err(VpnError::DeeplinkError {
+                details: "No account management data is available at this time".to_owned(),
+            });
+        };
+
+        let base_url = match params.client {
+            DeeplinkClient::Mobile => account_management.autologin_mobile_url(&params.locale),
+            DeeplinkClient::Desktop => account_management.autologin_desktop_url(&params.locale),
+            DeeplinkClient::Web => account_management.autologin_web_url(&params.locale),
+        }
+        .ok_or(VpnError::DeeplinkError {
+            details: "The autologin path could not be determined".to_owned(),
+        })?;
+
+        let mnemonic = self.get_stored_mnemonic().await?;
+
+        let deeplink_params = CreateDeeplinkParams {
+            kind: params.kind,
+            name: params.name,
+            base_url: base_url.clone(),
+        };
+        let deeplink = Deeplink::new(&deeplink_params);
+        deeplink
+            .create_autologin_url(&base_url, mnemonic)
+            .map_err(|err| VpnError::DeeplinkError {
+                details: err.to_string(),
+            })
     }
 
     /// Generate the account mnemonic locally and store it.

--- a/nym-vpn-core/crates/nym-vpn-rpc-uniffi/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-rpc-uniffi/src/lib.rs
@@ -14,11 +14,11 @@ use tokio_util::sync::CancellationToken;
 #[cfg(target_os = "macos")]
 use nym_vpn_lib_types::SplitApp;
 use nym_vpn_lib_types::{
-    AccountCommandError, AccountControllerState, EntryPoint, ExitPoint, FeatureFlags, Gateway,
-    GatewayType, GetDeeplinkParams, HttpRpcSettings, LogPath, MixnetTrafficConfig,
-    NetworkCompatibility, NymVpnDevice, NymVpnUsage, ParsedAccountLinks, PrivyDerivationMessage,
-    Socks5Settings, Socks5Status, StoreAccountRequest, StoredAccountMode, SystemMessage,
-    TunnelEvent, TunnelState, VpnAccountSummary, VpnServiceConfig, VpnServiceInfo,
+    AccountCommandError, AccountControllerState, AutologinResponse, EntryPoint, ExitPoint,
+    FeatureFlags, Gateway, GatewayType, GetDeeplinkParams, HttpRpcSettings, LogPath,
+    MixnetTrafficConfig, NetworkCompatibility, NymVpnDevice, NymVpnUsage, ParsedAccountLinks,
+    PrivyDerivationMessage, Socks5Settings, Socks5Status, StoreAccountRequest, StoredAccountMode,
+    SystemMessage, TunnelEvent, TunnelState, VpnAccountSummary, VpnServiceConfig, VpnServiceInfo,
 };
 
 uniffi::use_remote_type!(nym_vpn_lib_types::IpAddr);
@@ -281,6 +281,13 @@ impl RpcClient {
             .deeplink_store_account(deeplink_callback_url)
             .await?;
         Ok(())
+    }
+
+    pub async fn get_autologin_deeplink(
+        &self,
+        params: GetDeeplinkParams,
+    ) -> Result<AutologinResponse> {
+        Ok(self.inner.clone().get_autologin_deeplink(params).await?)
     }
 
     pub async fn reset_device_identity(&self, seed: Option<Vec<u8>>) -> Result<()> {


### PR DESCRIPTION
## Ticket

JIRA-VPN-XXXX

## Description

Add missing get_autologin_deeplink to rpcClient for macOS.
Not sure about the get_autologin_deeplink in vpn_account_storage. It feels like it should be part of `deeplinks.rs`, but that part is missing the mnemonic storage.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4907)
<!-- Reviewable:end -->
