### PR TITLE
(tauri) Autologin button copies and opens web

### DIFF
--- a/nym-vpn-app/src/contexts/autologin/PincodeDialog.tsx
+++ b/nym-vpn-app/src/contexts/autologin/PincodeDialog.tsx
@@ -1,5 +1,6 @@
 import { DialogTitle } from '@headlessui/react';
 import { useTranslation } from 'react-i18next';
+import { openUrl } from '@tauri-apps/plugin-opener';
 import { useClipboard } from '../../hooks';
 import { Button, ButtonIcon, Dialog, MsIcon } from '../../ui';
 
@@ -25,15 +26,22 @@ function PinCodeDigits({ code }: { code: string }) {
 
 export function PincodeDialog({
   code,
+  url,
   open,
   setOpen,
 }: {
   code: string;
+  url: string;
   open: boolean;
   setOpen: (open: boolean) => void;
 }) {
   const { t } = useTranslation('account');
   const { copy } = useClipboard();
+
+  const handleClick = () => {
+    copy(code);
+    openUrl(url);
+  };
 
   return (
     <Dialog open={open} onClose={() => setOpen(false)}>
@@ -65,7 +73,7 @@ export function PincodeDialog({
 
         <PinCodeDigits code={code} />
 
-        <Button className="w-full mt-3" onClick={() => copy(code)}>
+        <Button className="w-full mt-3" onClick={handleClick}>
           <div className="flex items-center justify-center gap-2">
             <MsIcon icon="content_copy" className="text-xl!" />
             <span>{t('autologin.copy-code')}</span>

--- a/nym-vpn-app/src/contexts/autologin/PincodeDialog.tsx
+++ b/nym-vpn-app/src/contexts/autologin/PincodeDialog.tsx
@@ -38,8 +38,8 @@ export function PincodeDialog({
   const { t } = useTranslation('account');
   const { copy } = useClipboard();
 
-  const handleClick = () => {
-    copy(code);
+  const handleClick = async () => {
+    await copy(code);
     openUrl(url);
   };
 

--- a/nym-vpn-app/src/contexts/autologin/provider.tsx
+++ b/nym-vpn-app/src/contexts/autologin/provider.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { openUrl } from '@tauri-apps/plugin-opener';
 import { invoke } from '@tauri-apps/api/core';
 import { TAutologinResponse } from '../../types/tauri';
 import { useInAppNotify } from '../in-app-notification';
@@ -11,6 +10,7 @@ export function AutologinProvider({ children }: { children: React.ReactNode }) {
   const { i18n, t } = useTranslation('account');
 
   const [pinCode, setPinCode] = useState('');
+  const [url, setUrl] = useState('');
   const [open, setOpen] = useState(false);
 
   const { push } = useInAppNotify();
@@ -27,9 +27,8 @@ export function AutologinProvider({ children }: { children: React.ReactNode }) {
         );
 
         setPinCode(response['pin-code']);
+        setUrl(response.url);
         setOpen(true);
-
-        openUrl(response.url);
       } catch (error) {
         console.error('Failed to get autologin deeplink', error);
         push({
@@ -47,7 +46,7 @@ export function AutologinProvider({ children }: { children: React.ReactNode }) {
   return (
     <AutologinContext.Provider value={ctx}>
       {children}
-      <PincodeDialog code={pinCode} open={open} setOpen={setOpen} />
+      <PincodeDialog code={pinCode} url={url} open={open} setOpen={setOpen} />
     </AutologinContext.Provider>
   );
 }

--- a/nym-vpn-app/src/i18n/en/account.json
+++ b/nym-vpn-app/src/i18n/en/account.json
@@ -20,7 +20,7 @@
   "autologin": {
     "title": "Pin code",
     "description": "Enter this code in web",
-    "copy-code": "Copy Code",
+    "copy-code": "Copy code and open web",
     "initialization-error": "Failed to initiate autologin"
   }
 }


### PR DESCRIPTION
## Ticket

JIRA-VPN-XXXX

## Description

Autologin dialog button now controls opening the web browser for autologin. Upon clicking the app copies the code to clipboard and then opens the web


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)
<img width="374" height="697" alt="image" src="https://github.com/user-attachments/assets/d42f6740-590d-4d6b-89ea-c05ece84287d" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4916)
<!-- Reviewable:end -->
