### PR TITLE
NYM-786: Account creation autologin

### DIFF
--- a/nym-vpn-app/CHANGELOG.md
+++ b/nym-vpn-app/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Autologin new user to the app upon account creation on web
+
 ## [1.26.0] - 2026-03-17
 
 ### Changed

--- a/nym-vpn-app/src-tauri/src/vpnd/deeplink.rs
+++ b/nym-vpn-app/src-tauri/src/vpnd/deeplink.rs
@@ -10,6 +10,7 @@ pub enum DeeplinkKind {
     PrivyLink,
     AutologinRenew,
     AutologinView,
+    CreateAccount,
 }
 
 impl From<lib::DeeplinkKind> for DeeplinkKind {
@@ -19,6 +20,7 @@ impl From<lib::DeeplinkKind> for DeeplinkKind {
             lib::DeeplinkKind::PrivyLink => DeeplinkKind::PrivyLink,
             lib::DeeplinkKind::AutologinRenew => DeeplinkKind::AutologinRenew,
             lib::DeeplinkKind::AutologinView => DeeplinkKind::AutologinView,
+            lib::DeeplinkKind::CreateAccount => DeeplinkKind::CreateAccount,
         }
     }
 }
@@ -30,6 +32,7 @@ impl From<DeeplinkKind> for lib::DeeplinkKind {
             DeeplinkKind::PrivyLink => lib::DeeplinkKind::PrivyLink,
             DeeplinkKind::AutologinRenew => lib::DeeplinkKind::AutologinRenew,
             DeeplinkKind::AutologinView => lib::DeeplinkKind::AutologinView,
+            DeeplinkKind::CreateAccount => lib::DeeplinkKind::CreateAccount,
         }
     }
 }

--- a/nym-vpn-app/src/screens/sign-up/Signup.tsx
+++ b/nym-vpn-app/src/screens/sign-up/Signup.tsx
@@ -32,10 +32,16 @@ function Login() {
       kind: 'CreateAccount',
     });
 
+    // openUrl(
+    //   url.replace(
+    //     'https://nymcom-git-deploy-sandbox-nyx-network-staging.vercel.app',
+    //     'http://localhost:3000',
+    //   ),
+    // );
     openUrl(
       url.replace(
         'https://nymcom-git-deploy-sandbox-nyx-network-staging.vercel.app',
-        'http://localhost:3000',
+        'https://nymcom-git-nym-788-deeplink-back-nyx-network-staging.vercel.app',
       ),
     );
 

--- a/nym-vpn-app/src/screens/sign-up/Signup.tsx
+++ b/nym-vpn-app/src/screens/sign-up/Signup.tsx
@@ -86,14 +86,7 @@ function Login() {
           <p className="mt-2 text-iron dark:text-bombay whitespace-pre-line">
             {t('signup.maximum-privacy.description')}
           </p>
-          <Button
-            // onClick={() => {
-            //   openUrl(NymVpnPricingUrl);
-            //   navigate(routes.login);
-            // }}
-            onClick={handleCreateAccount}
-            className="mt-4"
-          >
+          <Button onClick={handleCreateAccount} className="mt-4">
             <div className="flex items-center gap-2 whitespace-pre-wrap">
               {t('signup.create-account')} <MsIcon icon="open_in_new" />
             </div>

--- a/nym-vpn-app/src/screens/sign-up/Signup.tsx
+++ b/nym-vpn-app/src/screens/sign-up/Signup.tsx
@@ -4,15 +4,72 @@ import { Trans, useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
 import { NymSplash } from '../../assets';
 import { Button, ButtonText, Link, MsIcon, PageAnim } from '../../ui';
-import { useMainState } from '../../contexts';
+import { useMainDispatch, useMainState } from '../../contexts';
 import { NymVpnPricingUrl, PrivacyPolicyUrl, ToSUrl } from '../../constants';
 import { routes } from '../../router';
 import { PrivyButton } from '../../components';
+import { invoke } from '@tauri-apps/api/core';
+import { TAccountMode } from '../../types/tauri';
+import { useRef } from 'react';
+import { useDeepLink } from '../../hooks/index';
+import { CCache } from '../../cache/index';
+import { StateDispatch } from '../../types/index';
 
 function Login() {
   const { uiTheme } = useMainState();
-  const { t } = useTranslation('login');
+  const { t, i18n } = useTranslation('login');
   const navigate = useNavigate();
+
+  const timeoutIdRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const { startListening } = useDeepLink();
+
+  const dispatch = useMainDispatch() as StateDispatch;
+
+  const handleCreateAccount = async () => {
+    const url = await invoke<string>('get_deep_link', {
+      locale: i18n.language,
+      kind: 'CreateAccount',
+    });
+
+    openUrl(
+      url.replace(
+        'https://nymcom-git-deploy-sandbox-nyx-network-staging.vercel.app',
+        'http://localhost:3000',
+      ),
+    );
+
+    try {
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timeoutIdRef.current = setTimeout(
+          () => reject(new Error('Login timeout')),
+          300000,
+        );
+      });
+
+      const deeplinkurl = await Promise.race([
+        startListening(),
+        timeoutPromise,
+      ]);
+
+      await invoke('store_deeplink_account', {
+        callbackUrl: deeplinkurl,
+      });
+
+      dispatch({ type: 'set-account', stored: true });
+      // await refreshAccountMode();
+      await CCache.del('cache-account-id');
+      await CCache.del('cache-device-id');
+      dispatch({ type: 'reset-error' });
+    } catch (error) {
+      console.error('Create account error: ', error);
+    } finally {
+      if (timeoutIdRef.current !== null) {
+        clearTimeout(timeoutIdRef.current);
+        timeoutIdRef.current = null;
+      }
+    }
+  };
 
   return (
     <PageAnim className="relative h-full flex flex-col justify-end items-center gap-6 select-none cursor-default">
@@ -27,10 +84,11 @@ function Login() {
             {t('signup.maximum-privacy.description')}
           </p>
           <Button
-            onClick={() => {
-              openUrl(NymVpnPricingUrl);
-              navigate(routes.login);
-            }}
+            // onClick={() => {
+            //   openUrl(NymVpnPricingUrl);
+            //   navigate(routes.login);
+            // }}
+            onClick={handleCreateAccount}
             className="mt-4"
           >
             <div className="flex items-center gap-2 whitespace-pre-wrap">

--- a/nym-vpn-app/src/screens/sign-up/Signup.tsx
+++ b/nym-vpn-app/src/screens/sign-up/Signup.tsx
@@ -16,7 +16,7 @@ import { CCache } from '../../cache';
 import { StateDispatch } from '../../types';
 
 function Login() {
-  const { uiTheme } = useMainState();
+  const { uiTheme, welcomeChecked } = useMainState();
   const { t, i18n } = useTranslation('login');
   const navigate = useNavigate();
 
@@ -64,6 +64,12 @@ function Login() {
       await CCache.del('cache-account-id');
       await CCache.del('cache-device-id');
       dispatch({ type: 'reset-error' });
+
+      if (!welcomeChecked) {
+        navigate(routes.welcome);
+      } else {
+        navigate(routes.root);
+      }
     } catch (error) {
       console.error('[Signup] Create account error: ', error);
     } finally {

--- a/nym-vpn-app/src/screens/sign-up/Signup.tsx
+++ b/nym-vpn-app/src/screens/sign-up/Signup.tsx
@@ -2,18 +2,18 @@ import clsx from 'clsx';
 import { openUrl } from '@tauri-apps/plugin-opener';
 import { Trans, useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
+import { useCallback, useRef } from 'react';
+import { invoke } from '@tauri-apps/api/core';
 import { NymSplash } from '../../assets';
 import { Button, ButtonText, Link, MsIcon, PageAnim } from '../../ui';
 import { useMainDispatch, useMainState } from '../../contexts';
-import { NymVpnPricingUrl, PrivacyPolicyUrl, ToSUrl } from '../../constants';
+import { PrivacyPolicyUrl, ToSUrl } from '../../constants';
 import { routes } from '../../router';
 import { PrivyButton } from '../../components';
-import { invoke } from '@tauri-apps/api/core';
-import { TAccountMode } from '../../types/tauri';
-import { useRef } from 'react';
-import { useDeepLink } from '../../hooks/index';
-import { CCache } from '../../cache/index';
-import { StateDispatch } from '../../types/index';
+import { TAccountSummary } from '../../types/tauri';
+import { useDeepLink } from '../../hooks';
+import { CCache } from '../../cache';
+import { StateDispatch } from '../../types';
 
 function Login() {
   const { uiTheme } = useMainState();
@@ -23,8 +23,16 @@ function Login() {
   const timeoutIdRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const { startListening } = useDeepLink();
-
   const dispatch = useMainDispatch() as StateDispatch;
+
+  const refreshAccount = useCallback(async () => {
+    try {
+      const summary = await invoke<TAccountSummary>('get_account_summary');
+      dispatch({ type: 'set-account-summary', summary });
+    } catch (err) {
+      console.error('Failed to get account summary', err);
+    }
+  }, [dispatch]);
 
   const handleCreateAccount = async () => {
     const url = await invoke<string>('get_deep_link', {
@@ -32,24 +40,13 @@ function Login() {
       kind: 'CreateAccount',
     });
 
-    // openUrl(
-    //   url.replace(
-    //     'https://nymcom-git-deploy-sandbox-nyx-network-staging.vercel.app',
-    //     'http://localhost:3000',
-    //   ),
-    // );
-    openUrl(
-      url.replace(
-        'https://nymcom-git-deploy-sandbox-nyx-network-staging.vercel.app',
-        'https://nymcom-git-nym-788-deeplink-back-nyx-network-staging.vercel.app',
-      ),
-    );
+    openUrl(url);
 
     try {
       const timeoutPromise = new Promise<never>((_, reject) => {
         timeoutIdRef.current = setTimeout(
           () => reject(new Error('Login timeout')),
-          300000,
+          600000, // 10 minutes
         );
       });
 
@@ -63,12 +60,12 @@ function Login() {
       });
 
       dispatch({ type: 'set-account', stored: true });
-      // await refreshAccountMode();
+      await refreshAccount();
       await CCache.del('cache-account-id');
       await CCache.del('cache-device-id');
       dispatch({ type: 'reset-error' });
     } catch (error) {
-      console.error('Create account error: ', error);
+      console.error('[Signup] Create account error: ', error);
     } finally {
       if (timeoutIdRef.current !== null) {
         clearTimeout(timeoutIdRef.current);

--- a/nym-vpn-app/src/screens/sign-up/Signup.tsx
+++ b/nym-vpn-app/src/screens/sign-up/Signup.tsx
@@ -72,6 +72,9 @@ function Login() {
       }
     } catch (error) {
       console.error('[Signup] Create account error: ', error);
+      // if error, then most likely the deeplink call timed out.
+      // But the user might still finish the purchase on the website.
+      navigate(routes.login);
     } finally {
       if (timeoutIdRef.current !== null) {
         clearTimeout(timeoutIdRef.current);

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/deeplink.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/deeplink.rs
@@ -8,7 +8,7 @@ use nym_vpn_lib_types::{AutologinResponse, DeeplinkKind};
 use pbkdf2::pbkdf2_hmac;
 use rand::{RngCore, rngs::OsRng};
 use sha2::{Sha256, Sha512};
-use std::{collections::HashMap};
+use std::collections::HashMap;
 use tokio::time::{Duration, Instant};
 use url::Url;
 
@@ -103,8 +103,6 @@ impl Deeplinks {
         let now = Instant::now();
         self.0.retain(|_, deeplink| deeplink.expiry_time > now);
     }
-
-
 
     pub fn derive_mnemonic(&mut self, url_str: &str) -> Result<DeeplinkMnemonic, DeeplinkError> {
         let url =

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/deeplink.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/deeplink.rs
@@ -47,17 +47,21 @@ impl Deeplink {
     pub fn create_url(&self, base_url: &Url) -> Url {
         let deeplink_id = self.id.to_string();
         let pubkey = bs58::encode(self.keypair.public_key().to_bytes()).into_string();
-        let link_account = if self.kind == DeeplinkKind::PrivyLink {
-            "1"
-        } else {
-            "0"
-        };
         let mut url = base_url.clone();
-        url.query_pairs_mut()
-            .append_pair("deeplink_id", &deeplink_id)
-            .append_pair("pubkey", &pubkey)
-            .append_pair("link_account", link_account);
-
+        {
+            let mut pairs = url.query_pairs_mut();
+            pairs.append_pair("deeplink_id", &deeplink_id);
+            pairs.append_pair("pubkey", &pubkey);
+            match self.kind {
+                DeeplinkKind::Privy => {
+                    pairs.append_pair("link_account", "0");
+                }
+                DeeplinkKind::PrivyLink => {
+                    pairs.append_pair("link_account", "1");
+                }
+                _ => {}
+            }
+        }
         url
     }
 

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/deeplink.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/deeplink.rs
@@ -8,9 +8,10 @@ use nym_vpn_lib_types::{AutologinResponse, DeeplinkKind};
 use pbkdf2::pbkdf2_hmac;
 use rand::{RngCore, rngs::OsRng};
 use sha2::{Sha256, Sha512};
-use std::collections::HashMap;
+use std::{collections::HashMap, str::FromStr};
 use tokio::time::{Duration, Instant};
 use url::Url;
+use tracing::info;
 
 pub struct Deeplink {
     id: u64,
@@ -27,6 +28,10 @@ impl Deeplink {
         let id = rng.next_u64();
         let kind = params.kind;
         let keypair = KeyPair::new(&mut rng);
+
+        info!("Deeplink keypair public key: {}", bs58::encode(keypair.public_key().to_bytes()).into_string());
+        info!("Deeplink keypair private key: {}", bs58::encode(keypair.private_key().to_bytes()).into_string());
+        
         let expiry_time = Instant::now() + Duration::from_secs(Self::TTL_SECS);
 
         // Note: CreateDeeplinkParams.name is not used.
@@ -103,6 +108,8 @@ impl Deeplinks {
         self.0.retain(|_, deeplink| deeplink.expiry_time > now);
     }
 
+
+
     pub fn derive_mnemonic(&mut self, url_str: &str) -> Result<DeeplinkMnemonic, DeeplinkError> {
         let url =
             Url::parse(url_str).map_err(|_| DeeplinkError::InvalidUrl(url_str.to_string()))?;
@@ -151,6 +158,12 @@ impl Deeplinks {
 
         let decrypted_bytes = cipher_packet.decrypt(&deeplink.keypair, &sender_public_key)?;
 
+        // if let Ok(decrypted_str) = std::str::from_utf8(&decrypted_bytes) {
+        //     println!("decrypted_str: {}", decrypted_str);
+        // } else {
+        //     println!("Failed to cast decrypted_bytes to a valid UTF-8 string");
+        // }
+
         if decrypted_bytes.len() != 32 {
             return Err(DeeplinkError::InvalidPayload(
                 "invalid x25519 private key length".to_string(),
@@ -160,6 +173,66 @@ impl Deeplinks {
         let mnemonic = bip39::Mnemonic::from_entropy(&decrypted_bytes)
             .map_err(|_| DeeplinkError::InvalidPayload("failed to create mnemonic".to_string()))?;
 
+        Ok(DeeplinkMnemonic {
+            mnemonic,
+            kind: deeplink.kind,
+        })
+    }
+
+    pub fn decrypt_mnemonic(&mut self, url_str: &str) -> Result<DeeplinkMnemonic, DeeplinkError> {
+        let url =
+            Url::parse(url_str).map_err(|_| DeeplinkError::InvalidUrl(url_str.to_string()))?;
+
+        let url_params: HashMap<String, String> = url
+            .query_pairs()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+
+        let Some(deeplink_id_str) = url_params.get("deeplink_id") else {
+            return Err(DeeplinkError::MissingDeeplinkId(url_str.to_string()));
+        };
+
+        let Ok(deeplink_id) = deeplink_id_str.parse::<u64>() else {
+            return Err(DeeplinkError::InvalidDeeplinkId(deeplink_id_str.clone()));
+        };
+
+        let Some(payload_b58) = url_params.get("payload") else {
+            return Err(DeeplinkError::MissingPayload(url_str.to_string()));
+        };
+
+        let Some(deeplink) = self.0.remove(&deeplink_id) else {
+            return Err(DeeplinkError::DeeplinkNotFound(deeplink_id));
+        };
+
+        if deeplink.is_expired() {
+            return Err(DeeplinkError::DeeplinkExpired(deeplink_id));
+        }
+
+        let payload_bytes = bs58::decode(payload_b58)
+            .into_vec()
+            .map_err(|_| DeeplinkError::InvalidPayload("base-58 encoding".to_string()))?;
+
+        if payload_bytes.len() < 60 {
+            return Err(DeeplinkError::InvalidPayload("too short".to_string()));
+        }
+
+        let sender_public_key_bytes = payload_bytes[0..32].try_into().map_err(|_| {
+            DeeplinkError::InvalidPayload("invalid sender public key length".to_string())
+        })?;
+
+        let sender_public_key = PublicKey::from_bytes(sender_public_key_bytes)
+            .map_err(|_| DeeplinkError::InvalidPayload("invalid sender public key".to_string()))?;
+
+        let cipher_packet = CipherPacket::from_bytes(&payload_bytes[32..])?;
+
+        let decrypted_bytes = cipher_packet.decrypt(&deeplink.keypair, &sender_public_key)?;
+
+        let tmp = String::from_utf8(decrypted_bytes)
+            .map_err(|_| DeeplinkError::InvalidPayload("failed to create mnemonic".to_string()))?;
+
+        let mnemonic = bip39::Mnemonic::from_str(&tmp)
+            .map_err(|_| DeeplinkError::InvalidPayload("failed to create mnemonic".to_string()))?;
+            
         Ok(DeeplinkMnemonic {
             mnemonic,
             kind: deeplink.kind,

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/deeplink.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/deeplink.rs
@@ -8,10 +8,9 @@ use nym_vpn_lib_types::{AutologinResponse, DeeplinkKind};
 use pbkdf2::pbkdf2_hmac;
 use rand::{RngCore, rngs::OsRng};
 use sha2::{Sha256, Sha512};
-use std::{collections::HashMap, str::FromStr};
+use std::{collections::HashMap};
 use tokio::time::{Duration, Instant};
 use url::Url;
-use tracing::info;
 
 pub struct Deeplink {
     id: u64,
@@ -29,9 +28,6 @@ impl Deeplink {
         let kind = params.kind;
         let keypair = KeyPair::new(&mut rng);
 
-        info!("Deeplink keypair public key: {}", bs58::encode(keypair.public_key().to_bytes()).into_string());
-        info!("Deeplink keypair private key: {}", bs58::encode(keypair.private_key().to_bytes()).into_string());
-        
         let expiry_time = Instant::now() + Duration::from_secs(Self::TTL_SECS);
 
         // Note: CreateDeeplinkParams.name is not used.
@@ -158,12 +154,6 @@ impl Deeplinks {
 
         let decrypted_bytes = cipher_packet.decrypt(&deeplink.keypair, &sender_public_key)?;
 
-        // if let Ok(decrypted_str) = std::str::from_utf8(&decrypted_bytes) {
-        //     println!("decrypted_str: {}", decrypted_str);
-        // } else {
-        //     println!("Failed to cast decrypted_bytes to a valid UTF-8 string");
-        // }
-
         if decrypted_bytes.len() != 32 {
             return Err(DeeplinkError::InvalidPayload(
                 "invalid x25519 private key length".to_string(),
@@ -173,66 +163,6 @@ impl Deeplinks {
         let mnemonic = bip39::Mnemonic::from_entropy(&decrypted_bytes)
             .map_err(|_| DeeplinkError::InvalidPayload("failed to create mnemonic".to_string()))?;
 
-        Ok(DeeplinkMnemonic {
-            mnemonic,
-            kind: deeplink.kind,
-        })
-    }
-
-    pub fn decrypt_mnemonic(&mut self, url_str: &str) -> Result<DeeplinkMnemonic, DeeplinkError> {
-        let url =
-            Url::parse(url_str).map_err(|_| DeeplinkError::InvalidUrl(url_str.to_string()))?;
-
-        let url_params: HashMap<String, String> = url
-            .query_pairs()
-            .map(|(k, v)| (k.to_string(), v.to_string()))
-            .collect();
-
-        let Some(deeplink_id_str) = url_params.get("deeplink_id") else {
-            return Err(DeeplinkError::MissingDeeplinkId(url_str.to_string()));
-        };
-
-        let Ok(deeplink_id) = deeplink_id_str.parse::<u64>() else {
-            return Err(DeeplinkError::InvalidDeeplinkId(deeplink_id_str.clone()));
-        };
-
-        let Some(payload_b58) = url_params.get("payload") else {
-            return Err(DeeplinkError::MissingPayload(url_str.to_string()));
-        };
-
-        let Some(deeplink) = self.0.remove(&deeplink_id) else {
-            return Err(DeeplinkError::DeeplinkNotFound(deeplink_id));
-        };
-
-        if deeplink.is_expired() {
-            return Err(DeeplinkError::DeeplinkExpired(deeplink_id));
-        }
-
-        let payload_bytes = bs58::decode(payload_b58)
-            .into_vec()
-            .map_err(|_| DeeplinkError::InvalidPayload("base-58 encoding".to_string()))?;
-
-        if payload_bytes.len() < 60 {
-            return Err(DeeplinkError::InvalidPayload("too short".to_string()));
-        }
-
-        let sender_public_key_bytes = payload_bytes[0..32].try_into().map_err(|_| {
-            DeeplinkError::InvalidPayload("invalid sender public key length".to_string())
-        })?;
-
-        let sender_public_key = PublicKey::from_bytes(sender_public_key_bytes)
-            .map_err(|_| DeeplinkError::InvalidPayload("invalid sender public key".to_string()))?;
-
-        let cipher_packet = CipherPacket::from_bytes(&payload_bytes[32..])?;
-
-        let decrypted_bytes = cipher_packet.decrypt(&deeplink.keypair, &sender_public_key)?;
-
-        let tmp = String::from_utf8(decrypted_bytes)
-            .map_err(|_| DeeplinkError::InvalidPayload("failed to create mnemonic".to_string()))?;
-
-        let mnemonic = bip39::Mnemonic::from_str(&tmp)
-            .map_err(|_| DeeplinkError::InvalidPayload("failed to create mnemonic".to_string()))?;
-            
         Ok(DeeplinkMnemonic {
             mnemonic,
             kind: deeplink.kind,

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
@@ -1,9 +1,7 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::cmp::min;
-use std::sync::Arc;
-use std::time::Duration;
+use std::{cmp::min, sync::Arc, time::Duration};
 
 use crate::{
     SharedAccountState,

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
@@ -759,6 +759,7 @@ pub struct AccountManagementPathsResponse {
     pub account: String,
     pub privy: AccountManagementPrivyPathsResponse,
     pub autologin: AccountManagementAutologinPathsResponse,
+    pub pricing: String,
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq)]

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/account/deeplink.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/account/deeplink.rs
@@ -71,6 +71,7 @@ pub enum DeeplinkKind {
     PrivyLink,
     AutologinRenew,
     AutologinView,
+    CreateAccount,
 }
 
 impl FromStr for DeeplinkKind {
@@ -85,6 +86,9 @@ impl FromStr for DeeplinkKind {
             }
             "autologin_view" | "autologin-view" | "autologinview" => {
                 Ok(DeeplinkKind::AutologinView)
+            }
+            "create_account" | "create-account" | "createaccount" => {
+                Ok(DeeplinkKind::CreateAccount)
             }
             _ => Err(format!("Unknown deeplink kind: {s}")),
         }

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/account.rs
@@ -174,7 +174,7 @@ impl NymAccountController {
         };
 
         match deeplink_mnemonic.kind {
-            DeeplinkKind::Privy => self
+            DeeplinkKind::Privy | DeeplinkKind::CreateAccount => self
                 .command_sender
                 .store_account(privy_account)
                 .await

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/deeplink.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/deeplink.rs
@@ -37,14 +37,30 @@ impl NymDeeplinks {
             });
         };
 
-        let base_url = match params.client {
-            DeeplinkClient::Mobile => account_management.privy_mobile_url(&params.locale),
-            DeeplinkClient::Desktop => account_management.privy_desktop_url(&params.locale),
-            DeeplinkClient::Web => account_management.privy_web_url(&params.locale),
-        }
-        .ok_or(VpnError::DeeplinkError {
-            details: "The privy path could not be determined".to_owned(),
-        })?;
+        let base_url = match params.kind {
+            DeeplinkKind::Privy | DeeplinkKind::PrivyLink => {
+                let url = match params.client {
+                    DeeplinkClient::Mobile => account_management.privy_mobile_url(&params.locale),
+                    DeeplinkClient::Desktop => account_management.privy_desktop_url(&params.locale),
+                    DeeplinkClient::Web => account_management.privy_web_url(&params.locale),
+                };
+                url.ok_or(VpnError::DeeplinkError {
+                    details: "The privy path could not be determined".to_owned(),
+                })?
+            }
+            DeeplinkKind::CreateAccount => {
+                account_management
+                    .pricing_url(&params.locale)
+                    .ok_or(VpnError::DeeplinkError {
+                        details: "The pricing path could not be determined".to_owned(),
+                    })?
+            }
+            _ => {
+                return Err(VpnError::DeeplinkError {
+                    details: "Invalid deeplink kind".to_owned(),
+                });
+            }
+        };
 
         let mut deeplink_guard = self.deep_links.lock().await;
         let params = CreateDeeplinkParams {

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/deeplink.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/deeplink.rs
@@ -8,22 +8,24 @@ use tokio::sync::Mutex;
 use nym_vpn_account_controller::{CreateDeeplinkParams, DeeplinkMnemonic, Deeplinks};
 use nym_vpn_lib_types::{DeeplinkClient, GetDeeplinkParams};
 
-use crate::{NymEnvironment, error::VpnError};
+use crate::{NymEnvironment, account::NymAccountController, error::VpnError};
 
 /// Thread-safe deep link handler.
 #[derive(uniffi::Object)]
 pub struct NymDeeplinks {
     deep_links: Arc<Mutex<Deeplinks>>,
     network_env: Arc<NymEnvironment>,
+    account_controller: Arc<NymAccountController>,
 }
 
 #[uniffi::export(async_runtime = "tokio")]
 impl NymDeeplinks {
     #[uniffi::constructor]
-    pub fn new(network_env: Arc<NymEnvironment>) -> Self {
+    pub fn new(network_env: Arc<NymEnvironment>, account_controller: Arc<NymAccountController>) -> Self {
         Self {
             deep_links: Arc::new(Mutex::new(Deeplinks::default())),
             network_env,
+            account_controller,
         }
     }
 

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/deeplink.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/deeplink.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 
 use nym_vpn_account_controller::{CreateDeeplinkParams, DeeplinkMnemonic, Deeplinks};
-use nym_vpn_lib_types::{DeeplinkClient, GetDeeplinkParams};
+use nym_vpn_lib_types::{DeeplinkClient, GetDeeplinkParams, DeeplinkKind};
 
 use crate::{NymEnvironment, error::VpnError};
 

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/deeplink.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/deeplink.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 
 use nym_vpn_account_controller::{CreateDeeplinkParams, DeeplinkMnemonic, Deeplinks};
-use nym_vpn_lib_types::{DeeplinkClient, GetDeeplinkParams, DeeplinkKind};
+use nym_vpn_lib_types::{DeeplinkClient, DeeplinkKind, GetDeeplinkParams};
 
 use crate::{NymEnvironment, error::VpnError};
 

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/deeplink.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/deeplink.rs
@@ -8,24 +8,22 @@ use tokio::sync::Mutex;
 use nym_vpn_account_controller::{CreateDeeplinkParams, DeeplinkMnemonic, Deeplinks};
 use nym_vpn_lib_types::{DeeplinkClient, GetDeeplinkParams};
 
-use crate::{NymEnvironment, account::NymAccountController, error::VpnError};
+use crate::{NymEnvironment, error::VpnError};
 
 /// Thread-safe deep link handler.
 #[derive(uniffi::Object)]
 pub struct NymDeeplinks {
     deep_links: Arc<Mutex<Deeplinks>>,
     network_env: Arc<NymEnvironment>,
-    account_controller: Arc<NymAccountController>,
 }
 
 #[uniffi::export(async_runtime = "tokio")]
 impl NymDeeplinks {
     #[uniffi::constructor]
-    pub fn new(network_env: Arc<NymEnvironment>, account_controller: Arc<NymAccountController>) -> Self {
+    pub fn new(network_env: Arc<NymEnvironment>) -> Self {
         Self {
             deep_links: Arc::new(Mutex::new(Deeplinks::default())),
             network_env,
-            account_controller,
         }
     }
 

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/lib.rs
@@ -304,8 +304,10 @@ impl VPNConfig {
 
 #[cfg(target_os = "android")]
 pub mod android_init {
-    use jni::JNIEnv;
-    use jni::objects::{JClass, JObject};
+    use jni::{
+        JNIEnv,
+        objects::{JClass, JObject},
+    };
 
     #[unsafe(no_mangle)]
     #[allow(non_snake_case)]

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_account_storage.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_account_storage.rs
@@ -78,21 +78,21 @@ impl NymVpnAccountStorage {
     ) -> Result<(), VpnError> {
         let deeplink_mnemonic = deeplink_mnemonic.inner();
 
-        let privy_account = StorableAccount {
+        let account = StorableAccount {
             mnemonic: deeplink_mnemonic.mnemonic.clone(),
             mode: StoredAccountMode::Privy,
         };
 
         match deeplink_mnemonic.kind {
-            DeeplinkKind::Privy => {
+            DeeplinkKind::Privy | DeeplinkKind::CreateAccount => {
                 tracing::info!("Storing Privy account");
 
-                self.storage.store_account(privy_account).await?;
+                self.storage.store_account(account).await?;
                 self.storage.init_keys(None).await?;
                 Ok(())
             }
             DeeplinkKind::PrivyLink => {
-                let privy_vpn_account = VpnAccount::try_from(privy_account).map_err(|err| {
+                let privy_vpn_account = VpnAccount::try_from(account).map_err(|err| {
                     VpnError::InvalidMnemonic {
                         details: err.to_string(),
                     }

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_account_storage.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_account_storage.rs
@@ -92,11 +92,10 @@ impl NymVpnAccountStorage {
                 Ok(())
             }
             DeeplinkKind::PrivyLink => {
-                let privy_vpn_account = VpnAccount::try_from(account).map_err(|err| {
-                    VpnError::InvalidMnemonic {
+                let privy_vpn_account =
+                    VpnAccount::try_from(account).map_err(|err| VpnError::InvalidMnemonic {
                         details: err.to_string(),
-                    }
-                })?;
+                    })?;
 
                 let vpn_api_client = self.create_vpn_api_client().await?;
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
@@ -1828,14 +1828,43 @@ impl NymVpnService {
                 "No account management data is available at this time".to_string(),
             ))?;
 
-        let base_url = match params.client {
-            DeeplinkClient::Mobile => account_management.privy_mobile_url(&params.locale),
-            DeeplinkClient::Desktop => account_management.privy_desktop_url(&params.locale),
-            DeeplinkClient::Web => account_management.privy_web_url(&params.locale),
-        }
-        .ok_or(AccountCommandError::DeeplinkError(
-            "The privy path could not be determined".to_string(),
-        ))?;
+        let base_url = match params.kind {
+            DeeplinkKind::Privy | DeeplinkKind::PrivyLink => match params.client {
+                DeeplinkClient::Mobile => account_management
+                    .privy_mobile_url(&params.locale)
+                    .ok_or(AccountCommandError::DeeplinkError(
+                        "The privy path could not be determined".to_string(),
+                    ))?,
+                DeeplinkClient::Desktop => account_management
+                    .privy_desktop_url(&params.locale)
+                    .ok_or(AccountCommandError::DeeplinkError(
+                        "The privy path could not be determined".to_string(),
+                    ))?,
+                DeeplinkClient::Web => account_management
+                    .privy_web_url(&params.locale)
+                    .ok_or(AccountCommandError::DeeplinkError(
+                        "The privy path could not be determined".to_string(),
+                    ))?,
+            },
+            DeeplinkKind::CreateAccount => account_management
+                .create_account_url(&params.locale)
+                .ok_or(AccountCommandError::DeeplinkError(
+                    "The create account path could not be determined".to_string(),
+                ))?,
+            _ => {
+                return Err(AccountCommandError::DeeplinkError(
+                    "Invalid deeplink kind".to_string(),
+                ))
+            }
+        };
+        // let base_url = match params.client {
+        //     DeeplinkClient::Mobile => account_management.privy_mobile_url(&params.locale),
+        //     DeeplinkClient::Desktop => account_management.privy_desktop_url(&params.locale),
+        //     DeeplinkClient::Web => account_management.privy_web_url(&params.locale),
+        // }
+        // .ok_or(AccountCommandError::DeeplinkError(
+        //     "The privy path could not be determined".to_string(),
+        // ))?;
 
         self.account_command_tx
             .get_deeplink(params.kind, params.name, base_url)
@@ -1886,7 +1915,7 @@ impl NymVpnService {
         };
 
         match deeplink_mnemonic.kind {
-            DeeplinkKind::Privy => self.account_command_tx.store_account(privy_account).await,
+            DeeplinkKind::Privy | DeeplinkKind::CreateAccount => self.account_command_tx.store_account(privy_account).await,
             DeeplinkKind::PrivyLink => self.account_command_tx.link_account(privy_account).await,
             _ => Err(AccountCommandError::DeeplinkError(
                 "Invalid deeplink kind".to_string(),

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
@@ -1829,23 +1829,16 @@ impl NymVpnService {
             ))?;
 
         let base_url = match params.kind {
-            DeeplinkKind::Privy | DeeplinkKind::PrivyLink => match params.client {
-                DeeplinkClient::Mobile => account_management
-                    .privy_mobile_url(&params.locale)
-                    .ok_or(AccountCommandError::DeeplinkError(
-                        "The privy path could not be determined".to_string(),
-                    ))?,
-                DeeplinkClient::Desktop => account_management
-                    .privy_desktop_url(&params.locale)
-                    .ok_or(AccountCommandError::DeeplinkError(
-                        "The privy path could not be determined".to_string(),
-                    ))?,
-                DeeplinkClient::Web => account_management.privy_web_url(&params.locale).ok_or(
-                    AccountCommandError::DeeplinkError(
-                        "The privy path could not be determined".to_string(),
-                    ),
-                )?,
-            },
+            DeeplinkKind::Privy | DeeplinkKind::PrivyLink => {
+                let url = match params.client {
+                    DeeplinkClient::Mobile => account_management.privy_mobile_url(&params.locale),
+                    DeeplinkClient::Desktop => account_management.privy_desktop_url(&params.locale),
+                    DeeplinkClient::Web => account_management.privy_web_url(&params.locale),
+                };
+                url.ok_or(AccountCommandError::DeeplinkError(
+                    "The privy path could not be determined".to_string(),
+                ))?
+            }
             DeeplinkKind::CreateAccount => account_management.pricing_url(&params.locale).ok_or(
                 AccountCommandError::DeeplinkError(
                     "The create account path could not be determined".to_string(),

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
@@ -1840,21 +1840,21 @@ impl NymVpnService {
                     .ok_or(AccountCommandError::DeeplinkError(
                         "The privy path could not be determined".to_string(),
                     ))?,
-                DeeplinkClient::Web => account_management
-                    .privy_web_url(&params.locale)
-                    .ok_or(AccountCommandError::DeeplinkError(
+                DeeplinkClient::Web => account_management.privy_web_url(&params.locale).ok_or(
+                    AccountCommandError::DeeplinkError(
                         "The privy path could not be determined".to_string(),
-                    ))?,
+                    ),
+                )?,
             },
-            DeeplinkKind::CreateAccount => account_management
-                .pricing_url(&params.locale)
-                .ok_or(AccountCommandError::DeeplinkError(
+            DeeplinkKind::CreateAccount => account_management.pricing_url(&params.locale).ok_or(
+                AccountCommandError::DeeplinkError(
                     "The create account path could not be determined".to_string(),
-                ))?,
+                ),
+            )?,
             _ => {
                 return Err(AccountCommandError::DeeplinkError(
                     "Invalid deeplink kind".to_string(),
-                ))
+                ));
             }
         };
 
@@ -1907,7 +1907,9 @@ impl NymVpnService {
         };
 
         match deeplink_mnemonic.kind {
-            DeeplinkKind::Privy | DeeplinkKind::CreateAccount => self.account_command_tx.store_account(account).await,
+            DeeplinkKind::Privy | DeeplinkKind::CreateAccount => {
+                self.account_command_tx.store_account(account).await
+            }
             DeeplinkKind::PrivyLink => self.account_command_tx.link_account(account).await,
             _ => Err(AccountCommandError::DeeplinkError(
                 "Invalid deeplink kind".to_string(),

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
@@ -1847,7 +1847,7 @@ impl NymVpnService {
                     ))?,
             },
             DeeplinkKind::CreateAccount => account_management
-                .create_account_url(&params.locale)
+                .pricing_url(&params.locale)
                 .ok_or(AccountCommandError::DeeplinkError(
                     "The create account path could not be determined".to_string(),
                 ))?,
@@ -1857,14 +1857,6 @@ impl NymVpnService {
                 ))
             }
         };
-        // let base_url = match params.client {
-        //     DeeplinkClient::Mobile => account_management.privy_mobile_url(&params.locale),
-        //     DeeplinkClient::Desktop => account_management.privy_desktop_url(&params.locale),
-        //     DeeplinkClient::Web => account_management.privy_web_url(&params.locale),
-        // }
-        // .ok_or(AccountCommandError::DeeplinkError(
-        //     "The privy path could not be determined".to_string(),
-        // ))?;
 
         self.account_command_tx
             .get_deeplink(params.kind, params.name, base_url)
@@ -1909,14 +1901,14 @@ impl NymVpnService {
             .derive_deeplink_mnemonic(deeplink_url)
             .await?;
 
-        let privy_account = StorableAccount {
+        let account = StorableAccount {
             mnemonic: deeplink_mnemonic.mnemonic,
             mode: StoredAccountMode::Privy,
         };
 
         match deeplink_mnemonic.kind {
-            DeeplinkKind::Privy | DeeplinkKind::CreateAccount => self.account_command_tx.store_account(privy_account).await,
-            DeeplinkKind::PrivyLink => self.account_command_tx.link_account(privy_account).await,
+            DeeplinkKind::Privy | DeeplinkKind::CreateAccount => self.account_command_tx.store_account(account).await,
+            DeeplinkKind::PrivyLink => self.account_command_tx.link_account(account).await,
             _ => Err(AccountCommandError::DeeplinkError(
                 "Invalid deeplink kind".to_string(),
             )),

--- a/nym-vpn-core/crates/nym-vpn-network-config/default/canary_discovery.json
+++ b/nym-vpn-core/crates/nym-vpn-network-config/default/canary_discovery.json
@@ -36,7 +36,8 @@
         "mobile": "{locale}/account/login/autologin/mobile",
         "desktop": "{locale}/account/login/autologin/desktop",
         "web": "{locale}/account/login/autologin/web"
-      }
+      },
+      "pricing": "{locale}/pricing"
     }
   },
   "system_configuration": {

--- a/nym-vpn-core/crates/nym-vpn-network-config/default/evil_discovery.json
+++ b/nym-vpn-core/crates/nym-vpn-network-config/default/evil_discovery.json
@@ -31,7 +31,8 @@
         "mobile": "{locale}/account/login/autologin/mobile",
         "desktop": "{locale}/account/login/autologin/desktop",
         "web": "{locale}/account/login/autologin/web"
-      }
+      },
+      "pricing": "{locale}/pricing"
     }
   },
   "system_messages": [

--- a/nym-vpn-core/crates/nym-vpn-network-config/default/mainnet_discovery.json
+++ b/nym-vpn-core/crates/nym-vpn-network-config/default/mainnet_discovery.json
@@ -40,7 +40,8 @@
         "mobile": "{locale}/account/login/autologin/mobile",
         "desktop": "{locale}/account/login/autologin/desktop",
         "web": "{locale}/account/login/autologin/web"
-      }
+      },
+      "pricing": "{locale}/pricing"
     }
   },
   "system_configuration": {

--- a/nym-vpn-core/crates/nym-vpn-network-config/default/sandbox_discovery.json
+++ b/nym-vpn-core/crates/nym-vpn-network-config/default/sandbox_discovery.json
@@ -36,7 +36,8 @@
         "mobile": "{locale}/account/login/autologin/mobile",
         "desktop": "{locale}/account/login/autologin/desktop",
         "web": "{locale}/account/login/autologin/web"
-      }
+      },
+      "pricing": "{locale}/pricing"
     }
   },
   "system_messages": [

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/account_management.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/account_management.rs
@@ -59,6 +59,12 @@ impl AccountManagement {
             .ok()
     }
 
+    pub fn create_account_url(&self, locale: &str) -> Option<Url> {
+        self.url
+            .join(&format!("{}/pricing", locale))
+            .ok()
+    }
+
     pub fn autologin_mobile_url(&self, locale: &str) -> Option<Url> {
         self.url
             .join(&self.paths.autologin.mobile.replace("{locale}", locale))

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/account_management.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/account_management.rs
@@ -59,9 +59,9 @@ impl AccountManagement {
             .ok()
     }
 
-    pub fn create_account_url(&self, locale: &str) -> Option<Url> {
+    pub fn pricing_url(&self, locale: &str) -> Option<Url> {
         self.url
-            .join(&format!("{}/pricing", locale))
+            .join(&self.paths.pricing.replace("{locale}", locale))
             .ok()
     }
 
@@ -118,6 +118,9 @@ impl AccountManagement {
                     .autologin_web_url(locale)
                     .ok_or(AccountLinksConversionError::ParseAutologinWebUrl)?,
             },
+            pricing: self
+                .pricing_url(locale)
+                .ok_or(AccountLinksConversionError::ParsePricingUrl)?,
         })
     }
 }
@@ -148,6 +151,9 @@ pub enum AccountLinksConversionError {
 
     #[error("Failed to parse autologin web URL")]
     ParseAutologinWebUrl,
+
+    #[error("Failed to parse pricing URL")]
+    ParsePricingUrl,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -157,6 +163,7 @@ pub(crate) struct AccountManagementPaths {
     pub(crate) account: String,
     pub(crate) privy: AccountManagementPrivyPaths,
     pub(crate) autologin: AccountManagementAutologinPaths,
+    pub(crate) pricing: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -180,6 +187,7 @@ pub struct ParsedAccountLinks {
     pub account: Option<Url>,
     pub privy: ParsedAccountPrivyLinks,
     pub autologin: ParsedAccountAutologinLinks,
+    pub pricing: Url,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -210,6 +218,7 @@ impl fmt::Display for ParsedAccountLinks {
             desktop = self.autologin.desktop
         )?;
         write!(f, "\nautologin: {web}", web = self.autologin.web)?;
+        write!(f, "\npricing: {pricing}", pricing = self.pricing)?;
         Ok(())
     }
 }
@@ -245,6 +254,7 @@ impl From<AccountManagementPathsResponse> for AccountManagementPaths {
             account: response.account,
             privy: response.privy.into(),
             autologin: response.autologin.into(),
+            pricing: response.pricing,
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/discovery.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/discovery.rs
@@ -261,7 +261,8 @@ mod tests {
                         "mobile": "{locale}/account/login/autologin/mobile",
                         "desktop": "{locale}/account/login/autologin/desktop",
                         "web": "{locale}/account/login/autologin/web"
-                    }
+                    },
+                    "pricing": "{locale}/pricing"
                 }
             },
             "feature_flags": {
@@ -322,6 +323,7 @@ mod tests {
                         desktop: "{locale}/account/login/autologin/desktop".to_owned(),
                         web: "{locale}/account/login/autologin/web".to_owned(),
                     },
+                    pricing: "{locale}/pricing".to_owned(),
                 },
             }),
             feature_flags: Some(FeatureFlags::from(HashMap::from([

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -1024,6 +1024,7 @@ enum DeeplinkKind {
   KIND_PRIVY_LINK = 1;
   AutologinRenew = 2;
   AutologinView = 3;
+  CreateAccount = 4;
 }
 
 service NymVpnService {

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/account.rs
@@ -497,6 +497,7 @@ impl From<DeeplinkKind> for proto::DeeplinkKind {
             DeeplinkKind::PrivyLink => proto::DeeplinkKind::KindPrivyLink,
             DeeplinkKind::AutologinRenew => proto::DeeplinkKind::AutologinRenew,
             DeeplinkKind::AutologinView => proto::DeeplinkKind::AutologinView,
+            DeeplinkKind::CreateAccount => proto::DeeplinkKind::CreateAccount,
         }
     }
 }
@@ -508,6 +509,7 @@ impl From<proto::DeeplinkKind> for DeeplinkKind {
             proto::DeeplinkKind::KindPrivyLink => DeeplinkKind::PrivyLink,
             proto::DeeplinkKind::AutologinRenew => DeeplinkKind::AutologinRenew,
             proto::DeeplinkKind::AutologinView => DeeplinkKind::AutologinView,
+            proto::DeeplinkKind::CreateAccount => DeeplinkKind::CreateAccount,
         }
     }
 }


### PR DESCRIPTION
## Ticket

[JIRA-NYM-786](https://nymtech.atlassian.net/browse/NYM-786)

## Description

**App**
- handle account creation deeplink (very similar to handling privy deeplink)

**core**
- Add new enum entry `DeeplinkKind::CreateAccount` that open `/{locale}/pricing` url that acts as entry route for creating new account. It passes `pubkey`, `deeplink_id` & `link_account`. (_The same scheme as for privy_)
- Handles deeplink response the same way as for privy related


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4919)
<!-- Reviewable:end -->
