### PR TITLE
Update quinn to 0.11.14

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -7439,7 +7439,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.36.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8242,9 +8242,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "aws-lc-rs",
  "bytes",

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -150,7 +150,7 @@ quinn = { version = "0.11", default-features = false, features = [
     "rustls",
     "runtime-tokio",
 ] }
-quinn-proto = { version = "0.11", default-features = false, features = [
+quinn-proto = { version = "0.11.14", default-features = false, features = [
     "rustls",
 ] }
 quote = "1.0"


### PR DESCRIPTION

## Description

Update due to vulnerability alert. Supersedes https://github.com/nymtech/nym-vpn-client/pull/4851 which seems to include unrelated changes to `syn` package.

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4931)
<!-- Reviewable:end -->
