### PR TITLE
Fix reference to `bash.exe` when code signing app.

### DIFF
--- a/.github/workflows/build-nym-vpn-app-windows.yml
+++ b/.github/workflows/build-nym-vpn-app-windows.yml
@@ -281,7 +281,7 @@ jobs:
           yq eval --inplace '.bundle.windows +=
           {
             "signCommand": {
-              "cmd": "C:\Program Files\Git\bin\bash.EXE",
+              "cmd": "C:/Program Files/Git/bin/bash.EXE",
               "args": [
                 "/c/actions-runner/_work/nym-vpn-client/nym-vpn-client/nym-vpn-app/src-tauri/scripts/sign.sh",
                 "%1",


### PR DESCRIPTION
Fix code signing app.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4965)
<!-- Reviewable:end -->
