### PR TITLE
macOS: split-tunnel: resolve symlinks to align user and system paths

### DIFF
--- a/nym-vpn-core/crates/nym-split-tunnel/Cargo.toml
+++ b/nym-vpn-core/crates/nym-split-tunnel/Cargo.toml
@@ -23,7 +23,7 @@ serde_json.workspace = true
 tun = { workspace = true, features = ["async"] }
 thiserror.workspace = true
 tracing.workspace = true
-tokio = { workspace = true, features = ["test-util"] }
+tokio = { workspace = true, features = ["test-util", "fs"] }
 tokio-util.workspace = true
 
 nym-platform-metadata.workspace = true
@@ -39,9 +39,7 @@ bitflags.workspace = true
 memoffset.workspace = true
 nym-windows.workspace = true
 windows-service.workspace = true
-windows = { workspace = true, features = [
-    "Win32_Foundation",
-] }
+windows = { workspace = true, features = ["Win32_Foundation"] }
 windows-sys = { workspace = true, features = [
     "Win32_Foundation",
     "Win32_Globalization",

--- a/nym-vpn-core/crates/nym-split-tunnel/src/macos/process.rs
+++ b/nym-vpn-core/crates/nym-split-tunnel/src/macos/process.rs
@@ -20,6 +20,7 @@ use std::{
 };
 
 use either::Either;
+use futures_util::{StreamExt, stream};
 use libc::pid_t;
 use nym_macos::process::{list_pids, process_path};
 use nym_platform_metadata::AppleVersion;
@@ -337,6 +338,25 @@ impl ProcessStates {
 
     pub async fn exclude_paths(&self, paths: HashSet<PathBuf>) {
         let mut inner = self.inner.lock().await;
+
+        // Resolve symlinks and canonicalize paths to align user and system paths
+        let paths: HashSet<PathBuf> = stream::iter(paths)
+            .then(|path| async move {
+                tokio::fs::canonicalize(&path)
+                    .await
+                    .inspect_err(|err| {
+                        if err.kind() != std::io::ErrorKind::NotFound {
+                            tracing::warn!(
+                                "Failed to canonicalize path: {}. Error: {}",
+                                path.display(),
+                                err
+                            );
+                        }
+                    })
+                    .unwrap_or(path)
+            })
+            .collect()
+            .await;
 
         for info in inner.processes.values_mut() {
             // Remove no-longer excluded paths from exclusion list


### PR DESCRIPTION
## Ticket

JIRA-NYM-937

## Description

- Canonicalize paths to align user and system paths since system paths are always canonical.
- Paths that cannot be canonicalized at the time of configuring ST are treated as is.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4969)
<!-- Reviewable:end -->
