### PR TITLE
On Windows, don't fail if Split Tunnel is unavailable.

### DIFF
--- a/nym-vpn-core/crates/nym-split-tunnel/src/windows/mod.rs
+++ b/nym-vpn-core/crates/nym-split-tunnel/src/windows/mod.rs
@@ -151,8 +151,10 @@ impl SplitTunnel {
                 initialized.set_exclude_paths(paths)
             }
             State::Failed => {
+                // If we return `Error::Unavailable` here, we will break the tunnel connect logic,
+                // so instead just pretend everything is OK.
                 tracing::debug!("Split tunnel disabled; ignoring excluded paths");
-                Err(Error::Unavailable)
+                Ok(())
             }
         }
     }
@@ -166,8 +168,10 @@ impl SplitTunnel {
                 initialized.set_tunnel(tunnel)
             }
             State::Failed => {
+                // If we return `Error::Unavailable` here, we will break the tunnel connect logic,
+                // so instead just pretend everything is OK.
                 tracing::debug!("Split tunnel disabled; ignoring set tunnel request");
-                Err(Error::Unavailable)
+                Ok(())
             }
         }
     }
@@ -180,8 +184,10 @@ impl SplitTunnel {
                 initialized.reset_tunnel()
             }
             State::Failed => {
+                // If we return `Error::Unavailable` here, we will break the tunnel connect logic,
+                // so instead just pretend everything is OK.
                 tracing::debug!("Split tunnel disabled; ignoring reset tunnel request");
-                Err(Error::Unavailable)
+                Ok(())
             }
         }
     }


### PR DESCRIPTION
At the moment Split Tunnel cannot work at all as the driver will not load due to signature failure.  Therefore when it's unavailable, don't return an error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4971)
<!-- Reviewable:end -->
