### PR TITLE
Signal shutdown on connection invalidation

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -5,15 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [1.27.0] - TBD
+
+- [macOS] XPC as transport layer between clients and daemon (https://github.com/nymtech/nym-vpn-client/pull/4695)
+- [macOS] Authentication layer for windows, feature gated (https://github.com/nymtech/nym-vpn-client/pull/4802)
+- Activate authentication layer on all desktop platforms (https://github.com/nymtech/nym-vpn-client/pull/4856)
+
+### Fixed
+
+- [macOS] XPC client stall when daemon is not running (https://github.com/nymtech/nym-vpn-client/pull/4973)
+
+
 ## [1.26.0] - 2026-03-17
 
 ### Added
 
-- [macOS] XPC as transport layer between clients and daemon (https://github.com/nymtech/nym-vpn-client/pull/4695)
 - [CLI] `nym-vpnc account set` now uses `--location blockchain`; aliases keep legacy `--mode decentralised` and `--mode decentralized` working.
 - [CLI] `nym-vpnc account obtain-ticketbooks` subcommand renamed (legacy alias `decentralised-obtain-ticketbooks` still works). `--source` (currently parsed but all sources route to smartcontract backend).
-- [macOS] Authentication layer for windows, feature gated (https://github.com/nymtech/nym-vpn-client/pull/4802)
-- Activate authentication layer on all desktop platforms (https://github.com/nymtech/nym-vpn-client/pull/4856)
 
 
 ## [1.25.0] - 2026-03-02

--- a/nym-vpn-core/crates/nym-ipc/src/auth_result.rs
+++ b/nym-vpn-core/crates/nym-ipc/src/auth_result.rs
@@ -52,8 +52,9 @@ impl AuthenticaticationQuery {
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(test, derive(strum::EnumIter))]
 pub enum AuthenticaticationResult {
-    Accepted = 0,
-    Denied = 1,
+    Closed = 0,
+    Accepted = 1,
+    Denied = 2,
 }
 
 impl From<AuthenticaticationResult> for u8 {
@@ -65,6 +66,8 @@ impl From<AuthenticaticationResult> for u8 {
 impl From<u8> for AuthenticaticationResult {
     fn from(value: u8) -> Self {
         if value == 0 {
+            AuthenticaticationResult::Closed
+        } else if value == 1 {
             AuthenticaticationResult::Accepted
         } else {
             AuthenticaticationResult::Denied
@@ -82,11 +85,7 @@ impl AuthenticaticationResult {
             .read_u8()
             .await
             .map(Into::into)
-            .unwrap_or(Self::Denied)
-    }
-
-    pub fn accepted(&self) -> bool {
-        matches!(self, Self::Accepted)
+            .unwrap_or(Self::Closed)
     }
 }
 
@@ -121,12 +120,12 @@ mod tests {
         }
 
         let zero = AuthenticaticationResult::from(0);
-        assert!(matches!(zero, AuthenticaticationResult::Accepted));
-        assert!(zero.accepted());
-        for idx in 1u8..255 {
+        assert!(matches!(zero, AuthenticaticationResult::Closed));
+        let one = AuthenticaticationResult::from(1);
+        assert!(matches!(one, AuthenticaticationResult::Accepted));
+        for idx in 2u8..255 {
             let other = AuthenticaticationResult::from(idx);
             assert!(matches!(other, AuthenticaticationResult::Denied));
-            assert!(!other.accepted());
         }
     }
 
@@ -148,10 +147,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn no_value_means_denied() {
+    async fn no_value_means_closed() {
         let (mut client, _) = tokio::io::duplex(64);
         let received = AuthenticaticationResult::recv(&mut client).await;
-        assert_eq!(received, AuthenticaticationResult::Denied);
+        assert_eq!(received, AuthenticaticationResult::Closed);
     }
 
     #[tokio::test]

--- a/nym-vpn-core/crates/nym-ipc/src/client.rs
+++ b/nym-vpn-core/crates/nym-ipc/src/client.rs
@@ -17,10 +17,10 @@ async fn accepted<T: AsyncWrite + AsyncRead + Unpin>(mut conn: T) -> Result<Toki
     // connection is initiated, so best to do it on all platforms
     AuthenticaticationQuery::query(&mut conn).await;
     let auth_res = AuthenticaticationResult::recv(&mut conn).await;
-    if auth_res.accepted() {
-        Ok(TokioIo::new(conn))
-    } else {
-        Err(std::io::ErrorKind::PermissionDenied.into())
+    match auth_res {
+        AuthenticaticationResult::Accepted => Ok(TokioIo::new(conn)),
+        AuthenticaticationResult::Denied => Err(std::io::ErrorKind::PermissionDenied.into()),
+        AuthenticaticationResult::Closed => Err(std::io::ErrorKind::ConnectionRefused.into()),
     }
 }
 

--- a/nym-vpn-core/crates/nym-ipc/src/xpc/client.rs
+++ b/nym-vpn-core/crates/nym-ipc/src/xpc/client.rs
@@ -4,7 +4,6 @@
 use std::{
     fmt::Debug,
     io::{Error, Result},
-    sync::{Arc, atomic::AtomicBool},
 };
 
 use objc2::{AnyThread, rc::Retained, runtime::ProtocolObject};
@@ -53,11 +52,8 @@ async fn xpc_connect(
     conn_obj.setExportedInterface(Some(&interface));
     conn_obj.setRemoteObjectInterface(Some(&interface));
 
-    let xpc_conn_invalidated = Arc::new(AtomicBool::new(false));
-    let xpc_conn_invalidated_cloned = xpc_conn_invalidated.clone();
     let shutdown_token_cloned = shutdown_token.clone();
     let invalidation_handler = block2::RcBlock::new(move || {
-        xpc_conn_invalidated_cloned.store(true, std::sync::atomic::Ordering::SeqCst);
         shutdown_token_cloned.cancel();
     });
     conn_obj.setInvalidationHandler(Some(&invalidation_handler));
@@ -71,7 +67,7 @@ async fn xpc_connect(
 
     conn_obj.resume();
 
-    let xpc_conn = XpcConnection::new(proxy, data_rx.into(), xpc_conn_invalidated);
+    let xpc_conn = XpcConnection::new(proxy, data_rx.into(), shutdown_token.clone());
     // The receiver is waiting in XpcClient::connect
     conn_sender.send(xpc_conn).ok();
 

--- a/nym-vpn-core/crates/nym-ipc/src/xpc/client.rs
+++ b/nym-vpn-core/crates/nym-ipc/src/xpc/client.rs
@@ -55,8 +55,10 @@ async fn xpc_connect(
 
     let xpc_conn_invalidated = Arc::new(AtomicBool::new(false));
     let xpc_conn_invalidated_cloned = xpc_conn_invalidated.clone();
+    let shutdown_token_cloned = shutdown_token.clone();
     let invalidation_handler = block2::RcBlock::new(move || {
         xpc_conn_invalidated_cloned.store(true, std::sync::atomic::Ordering::SeqCst);
+        shutdown_token_cloned.cancel();
     });
     conn_obj.setInvalidationHandler(Some(&invalidation_handler));
 

--- a/nym-vpn-core/crates/nym-ipc/src/xpc/common.rs
+++ b/nym-vpn-core/crates/nym-ipc/src/xpc/common.rs
@@ -1,10 +1,7 @@
 // Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{
-    pin::Pin,
-    sync::{Arc, atomic::AtomicBool},
-};
+use std::pin::Pin;
 
 use objc2::{
     AnyThread, DefinedClass as _, define_class, extern_protocol, msg_send,
@@ -17,7 +14,7 @@ use tokio::{
     sync::mpsc::UnboundedSender,
 };
 use tokio_stream::{Stream, wrappers::UnboundedReceiverStream};
-use tokio_util::sync::DropGuard;
+use tokio_util::sync::{CancellationToken, DropGuard};
 use tonic::transport::server::Connected;
 
 pub(crate) const DAEMON_BUNDLE_IDENTIFIER: &str = "net.nymtech.vpn.daemon";
@@ -87,7 +84,7 @@ pub struct XpcConnection {
     // as is the case for client connections, a shutdown token is needed to keep
     // alive the XPC connection objects
     drop_guard: Option<DropGuard>,
-    xpc_conn_invalidated: Arc<AtomicBool>,
+    shutdown_token: CancellationToken,
 
     data_stream_rx: UnboundedReceiverStream<Vec<u8>>,
     to_be_copied: Option<Vec<u8>>,
@@ -97,12 +94,12 @@ impl XpcConnection {
     pub(crate) fn new(
         proxy: Retained<ProtocolObject<dyn NSConnectionInterface + Send + Sync>>,
         data_stream_rx: UnboundedReceiverStream<Vec<u8>>,
-        xpc_conn_invalidated: Arc<AtomicBool>,
+        shutdown_token: CancellationToken,
     ) -> Self {
         XpcConnection {
             proxy: Some(proxy),
             drop_guard: None,
-            xpc_conn_invalidated,
+            shutdown_token,
             data_stream_rx,
             to_be_copied: None,
         }
@@ -130,10 +127,7 @@ impl XpcConnection {
     }
 
     fn underlaying_conn_invalidated(&mut self) -> bool {
-        if self
-            .xpc_conn_invalidated
-            .load(std::sync::atomic::Ordering::SeqCst)
-        {
+        if self.shutdown_token.is_cancelled() {
             // consume the proxy object interface, since there's no point in
             // making RPC calls on a non existing connection
             self.proxy.take();
@@ -234,11 +228,8 @@ mod tests {
                 ConnectionInterfaceObj::new(remote_tx),
             )
         };
-        let mut own_conn = XpcConnection::new(
-            remote_proxy,
-            own_rx.into(),
-            Arc::new(AtomicBool::new(false)),
-        );
+        let mut own_conn =
+            XpcConnection::new(remote_proxy, own_rx.into(), CancellationToken::new());
 
         let data = vec![42];
         own_conn.write_all(&data).await.unwrap();
@@ -255,11 +246,8 @@ mod tests {
                 ConnectionInterfaceObj::new(remote_tx),
             )
         };
-        let mut own_conn = XpcConnection::new(
-            remote_proxy,
-            own_rx.into(),
-            Arc::new(AtomicBool::new(false)),
-        );
+        let mut own_conn =
+            XpcConnection::new(remote_proxy, own_rx.into(), CancellationToken::new());
 
         let data = vec![1, 2, 3, 4, 5];
         own_tx.send(data.clone()).unwrap();

--- a/nym-vpn-core/crates/nym-ipc/src/xpc/daemon.rs
+++ b/nym-vpn-core/crates/nym-ipc/src/xpc/daemon.rs
@@ -1,11 +1,7 @@
 // Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{
-    pin::Pin,
-    ptr::NonNull,
-    sync::{Arc, atomic::AtomicBool},
-};
+use std::{pin::Pin, ptr::NonNull};
 
 use objc2::{
     AnyThread, DefinedClass as _, define_class, msg_send, rc::Retained, runtime::ProtocolObject,
@@ -62,10 +58,10 @@ define_class!(
             new_connection.setExportedInterface(Some(&self.ivars().connection_interface));
             new_connection.setRemoteObjectInterface(Some(&self.ivars().connection_interface));
 
-            let xpc_conn_invalidated = Arc::new(AtomicBool::new(false));
-            let xpc_conn_invalidated_cloned = xpc_conn_invalidated.clone();
+            let shutdown_token = CancellationToken::new();
+            let shutdown_token_cloned = shutdown_token.clone();
             let invalidation_handler = block2::RcBlock::new(move || {
-                xpc_conn_invalidated_cloned.store(true, std::sync::atomic::Ordering::SeqCst);
+                shutdown_token_cloned.cancel();
             });
             new_connection.setInvalidationHandler(Some(&invalidation_handler));
 
@@ -76,7 +72,7 @@ define_class!(
                 )
             };
 
-            let xpc_conn = XpcConnection::new(proxy, data_rx.into(), xpc_conn_invalidated);
+            let xpc_conn = XpcConnection::new(proxy, data_rx.into(), shutdown_token);
             let forwarded = self.ivars().conn_sender.send(xpc_conn);
 
             if let Some(signing_requirement) = self.ivars().signing_requirement.as_ref() {


### PR DESCRIPTION
## Ticket

JIRA-NYM-960

## Description

When the client connection is started over XPC, if the daemon is not running, the client still keeps the connection with no-op for reads and writes.
The invalidation handler offers that information immediately, so it needs to be consumed to figure out that the connection wasn't actually established, so it can be instantly dropped and the initial connection test resolves with no response, signifying that the daemon is not up.


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4973)
<!-- Reviewable:end -->
