### PR TITLE
Fix nym-vpn-app CI workflow

### DIFF
--- a/.pkg/repack_deb.sh
+++ b/.pkg/repack_deb.sh
@@ -22,7 +22,7 @@ fi
 
 deb_file="$SRC_DEB"
 version="$PKGVER"
-arch=$(echo "$SRC_DEB" | awk -F. '{print $1}' | awk -F_ '{print $NF}')
+arch=$(basename -s '.deb' "$SRC_DEB" | sed 's/.*_//')
 pkgname="nym-vpn-app"
 
 # Check if the file exists


### PR DESCRIPTION
## Ticket

JIRA-NYM-968

## Description

- The original deb has the following name: `NymVPN_1.27.0-beta_arm64.deb`
- `repack_deb.sh` stores output as `nym-vpn-app_1.27.0-dev_1.deb` instead of `nym-vpn-app_1.27.0-dev_arm64.deb`

This PR ensures that the arch suffix is properly extracted from the original deb filename.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4979)
<!-- Reviewable:end -->
