### PR TITLE
Fix bash script to extract the architecture suffix from filename (#4979)

### DIFF
--- a/.pkg/repack_deb.sh
+++ b/.pkg/repack_deb.sh
@@ -22,7 +22,7 @@ fi
 
 deb_file="$SRC_DEB"
 version="$PKGVER"
-arch=$(echo "$SRC_DEB" | awk -F. '{print $1}' | awk -F_ '{print $NF}')
+arch=$(basename -s '.deb' "$SRC_DEB" | sed 's/.*_//')
 pkgname="nym-vpn-app"
 
 # Check if the file exists


### PR DESCRIPTION


## Description

Cherry-pick of #4979

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4980)
<!-- Reviewable:end -->
