### PR TITLE
Integrated testing for circumvention scenarios

### DIFF
--- a/nym-vpn-core/crates/test/scripts/blocking/delayed_ip_block.sh
+++ b/nym-vpn-core/crates/test/scripts/blocking/delayed_ip_block.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+# Allow connections for the IP address of `validator.nymtech.net` to send 36kB then drop traffic after
+
+
+function block_addr_port_v4 {
+    printf "b %s %s\n" $1 $2
+    iptables -A OUTPUT -p tcp -d $1 --dport $2 -j DROP
+	iptables -A INPUT -p tcp --sport $2 -s $1  -m connbytes --connbytes 0:36000 --connbytes-mode bytes --connbytes-dir reply -j ACCEPT
+	iptables -A INPUT -p tcp --sport $2 -s $1  -j DROP
+}
+
+function block_addr_port_v6 {
+    printf "b %s %s\n" $1 $2
+	ip6tables -A INPUT -p tcp --sport $2 -s $1  -m connbytes --connbytes 0:36000 --connbytes-mode bytes --connbytes-dir reply -j ACCEPT
+	ip6tables -A INPUT -p tcp --sport $2 -s $1  -j DROP
+}
+
+function unblock_addr_port_v4 {
+    printf "u %s %s\n" $1 $2
+	iptables -D INPUT -p tcp --sport $2 -s $1  -m connbytes --connbytes 0:36000 --connbytes-mode bytes --connbytes-dir reply -j ACCEPT
+	iptables -D INPUT -p tcp --sport $2 -s $1  -j DROP
+}
+
+function unblock_addr_port_v6 {
+    printf "u %s %s\n" $1 $2         
+    ip6tables -D OUTPUT -p tcp -d $1 --dport $2 -j DROP
+	ip6tables -D INPUT -p tcp --sport $2 -s $1  -m connbytes --connbytes 0:36000 --connbytes-mode bytes --connbytes-dir reply -j ACCEPT
+	ip6tables -D INPUT -p tcp --sport $2 -s $1  -j DROP
+}
+
+function process_socket_addresses {
+    local action=$1
+    shift # Remove the first argument (action)
+    
+    for socket_addr in "$@"; do
+        # Check if it's IPv6 format [address]:port
+        if [[ $socket_addr =~ ^\[(.+)\]:([0-9]+)$ ]]; then
+            local addr="${BASH_REMATCH[1]}"
+            local port="${BASH_REMATCH[2]}"
+            printf "Processing IPv6 socket address: %s:%s\n" "$addr" "$port"
+            if [[ $action == "block" ]]; then
+                block_addr_port_v6 "$addr" "$port"
+            elif [[ $action == "unblock" ]]; then
+                unblock_addr_port_v6 "$addr" "$port"
+            fi
+        # Check if it's IPv4 format address:port
+        elif [[ $socket_addr =~ ^([^:]+):([0-9]+)$ ]]; then
+            local addr="${BASH_REMATCH[1]}"
+            local port="${BASH_REMATCH[2]}"
+            printf "Processing IPv4 socket address: %s:%s\n" "$addr" "$port"
+            if [[ $action == "block" ]]; then
+                block_addr_port_v4 "$addr" "$port"
+            elif [[ $action == "unblock" ]]; then
+                unblock_addr_port_v4 "$addr" "$port"
+            fi
+        else
+            printf "Invalid socket address format: %s (expected IPv4:port or [IPv6]:port)\n" "$socket_addr"
+        fi
+    done
+}
+
+case $1 in
+    "block" )
+        if [[ $# -gt 1 ]]; then
+            printf "blocking specified addresses... \n"
+            process_socket_addresses "$@"
+        fi
+        ;;
+
+    "unblock" )
+        if [[ $# -gt 1 ]]; then
+            printf "unblocking specified addresses... \n"
+            process_socket_addresses "$@"
+        fi
+        ;;
+    *)
+        printf "unknown arg $1\n"; ;;
+esac
+

--- a/nym-vpn-core/crates/test/scripts/blocking/delayed_ip_block.sh
+++ b/nym-vpn-core/crates/test/scripts/blocking/delayed_ip_block.sh
@@ -4,29 +4,49 @@
 
 
 function block_addr_port_v4 {
-    printf "b %s %s\n" $1 $2
-    iptables -A OUTPUT -p tcp -d $1 --dport $2 -j DROP
-	iptables -A INPUT -p tcp --sport $2 -s $1  -m connbytes --connbytes 0:36000 --connbytes-mode bytes --connbytes-dir reply -j ACCEPT
-	iptables -A INPUT -p tcp --sport $2 -s $1  -j DROP
+    local addr="$1"
+    local port="$2"
+    
+    printf "b %s %s\n" "$addr" "$port"
+    iptables -A OUTPUT -p tcp -d "$addr" --dport "$port" -j DROP
+	iptables -A INPUT -p tcp --sport "$port" -s "$addr"  -m connbytes --connbytes 0:36000 --connbytes-mode bytes --connbytes-dir reply -j ACCEPT
+	iptables -A INPUT -p tcp --sport "$port" -s "$addr"  -j DROP
+	
+	return 0
 }
 
 function block_addr_port_v6 {
-    printf "b %s %s\n" $1 $2
-	ip6tables -A INPUT -p tcp --sport $2 -s $1  -m connbytes --connbytes 0:36000 --connbytes-mode bytes --connbytes-dir reply -j ACCEPT
-	ip6tables -A INPUT -p tcp --sport $2 -s $1  -j DROP
+    local addr="$1"
+    local port="$2"
+    
+    printf "b %s %s\n" "$addr" "$port"
+	ip6tables -A INPUT -p tcp --sport "$port" -s "$addr"  -m connbytes --connbytes 0:36000 --connbytes-mode bytes --connbytes-dir reply -j ACCEPT
+	ip6tables -A INPUT -p tcp --sport "$port" -s "$addr"  -j DROP
+	
+	return 0
 }
 
 function unblock_addr_port_v4 {
-    printf "u %s %s\n" $1 $2
-	iptables -D INPUT -p tcp --sport $2 -s $1  -m connbytes --connbytes 0:36000 --connbytes-mode bytes --connbytes-dir reply -j ACCEPT
-	iptables -D INPUT -p tcp --sport $2 -s $1  -j DROP
+    local addr="$1"
+    local port="$2"
+    
+    printf "u %s %s\n" "$addr" "$port"
+	iptables -D INPUT -p tcp --sport "$port" -s "$addr"  -m connbytes --connbytes 0:36000 --connbytes-mode bytes --connbytes-dir reply -j ACCEPT
+	iptables -D INPUT -p tcp --sport "$port" -s "$addr"  -j DROP
+	
+	return 0
 }
 
 function unblock_addr_port_v6 {
-    printf "u %s %s\n" $1 $2         
-    ip6tables -D OUTPUT -p tcp -d $1 --dport $2 -j DROP
-	ip6tables -D INPUT -p tcp --sport $2 -s $1  -m connbytes --connbytes 0:36000 --connbytes-mode bytes --connbytes-dir reply -j ACCEPT
-	ip6tables -D INPUT -p tcp --sport $2 -s $1  -j DROP
+    local addr="$1"
+    local port="$2"
+    
+    printf "u %s %s\n" "$addr" "$port"
+    ip6tables -D OUTPUT -p tcp -d "$addr" --dport "$port" -j DROP
+	ip6tables -D INPUT -p tcp --sport "$port" -s "$addr"  -m connbytes --connbytes 0:36000 --connbytes-mode bytes --connbytes-dir reply -j ACCEPT
+	ip6tables -D INPUT -p tcp --sport "$port" -s "$addr"  -j DROP
+	
+	return 0
 }
 
 function process_socket_addresses {
@@ -56,8 +76,11 @@ function process_socket_addresses {
             fi
         else
             printf "Invalid socket address format: %s (expected IPv4:port or [IPv6]:port)\n" "$socket_addr"
+            return 1
         fi
     done
+    
+    return 0
 }
 
 case $1 in

--- a/nym-vpn-core/crates/test/scripts/blocking/ip_block.sh
+++ b/nym-vpn-core/crates/test/scripts/blocking/ip_block.sh
@@ -1,23 +1,43 @@
 #!/usr/bin/env bash
 
 function block_addr_port_v4 {
-    printf "b %s %s\n" $1 $2
-    iptables -A OUTPUT -p tcp -d $1 --dport $2 -j DROP
+    local addr="$1"
+    local port="$2"
+    
+    printf "b %s %s\n" "$addr" "$port"
+    iptables -A OUTPUT -p tcp -d "$addr" --dport "$port" -j DROP
+    
+    return 0
 }
 
 function block_addr_port_v6 {
-    printf "b %s %s\n" $1 $2
-    ip6tables -A OUTPUT -p tcp -d $1 --dport $2 -j DROP
+    local addr="$1"
+    local port="$2"
+    
+    printf "b %s %s\n" "$addr" "$port"
+    ip6tables -A OUTPUT -p tcp -d "$addr" --dport "$port" -j DROP
+    
+    return 0
 }
 
 function unblock_addr_port_v4 {
-    printf "u %s %s\n" $1 $2
-    iptables -D OUTPUT -p tcp -d $1 --dport $2 -j DROP
+    local addr="$1"
+    local port="$2"
+    
+    printf "u %s %s\n" "$addr" "$port"
+    iptables -D OUTPUT -p tcp -d "$addr" --dport "$port" -j DROP
+    
+    return 0
 }
 
 function unblock_addr_port_v6 {
-    printf "u %s %s\n" $1 $2         
-    ip6tables -D OUTPUT -p tcp -d $1 --dport $2 -j DROP
+    local addr="$1"
+    local port="$2"
+    
+    printf "u %s %s\n" "$addr" "$port"
+    ip6tables -D OUTPUT -p tcp -d "$addr" --dport "$port" -j DROP
+    
+    return 0
 }
 
 function process_socket_addresses {
@@ -47,8 +67,11 @@ function process_socket_addresses {
             fi
         else
             printf "Invalid socket address format: %s (expected IPv4:port or [IPv6]:port)\n" "$socket_addr"
+            return 1
         fi
     done
+    
+    return 0
 }
 
 case $1 in

--- a/nym-vpn-core/crates/test/scripts/blocking/ip_block.sh
+++ b/nym-vpn-core/crates/test/scripts/blocking/ip_block.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+function block_addr_port_v4 {
+    printf "b %s %s\n" $1 $2
+    iptables -A OUTPUT -p tcp -d $1 --dport $2 -j DROP
+}
+
+function block_addr_port_v6 {
+    printf "b %s %s\n" $1 $2
+    ip6tables -A OUTPUT -p tcp -d $1 --dport $2 -j DROP
+}
+
+function unblock_addr_port_v4 {
+    printf "u %s %s\n" $1 $2
+    iptables -D OUTPUT -p tcp -d $1 --dport $2 -j DROP
+}
+
+function unblock_addr_port_v6 {
+    printf "u %s %s\n" $1 $2         
+    ip6tables -D OUTPUT -p tcp -d $1 --dport $2 -j DROP
+}
+
+function process_socket_addresses {
+    local action=$1
+    shift # Remove the first argument (action)
+    
+    for socket_addr in "$@"; do
+        # Check if it's IPv6 format [address]:port
+        if [[ $socket_addr =~ ^\[(.+)\]:([0-9]+)$ ]]; then
+            local addr="${BASH_REMATCH[1]}"
+            local port="${BASH_REMATCH[2]}"
+            printf "Processing IPv6 socket address: %s:%s\n" "$addr" "$port"
+            if [[ $action == "block" ]]; then
+                block_addr_port_v6 "$addr" "$port"
+            elif [[ $action == "unblock" ]]; then
+                unblock_addr_port_v6 "$addr" "$port"
+            fi
+        # Check if it's IPv4 format address:port
+        elif [[ $socket_addr =~ ^([^:]+):([0-9]+)$ ]]; then
+            local addr="${BASH_REMATCH[1]}"
+            local port="${BASH_REMATCH[2]}"
+            printf "Processing IPv4 socket address: %s:%s\n" "$addr" "$port"
+            if [[ $action == "block" ]]; then
+                block_addr_port_v4 "$addr" "$port"
+            elif [[ $action == "unblock" ]]; then
+                unblock_addr_port_v4 "$addr" "$port"
+            fi
+        else
+            printf "Invalid socket address format: %s (expected IPv4:port or [IPv6]:port)\n" "$socket_addr"
+        fi
+    done
+}
+
+case $1 in
+    "block" )
+        if [[ $# -gt 1 ]]; then
+            printf "blocking specified addresses... \n"
+            process_socket_addresses "$@"
+        fi
+        ;;
+
+    "unblock" )
+        if [[ $# -gt 1 ]]; then
+            printf "unblocking specified addresses... \n"
+            process_socket_addresses "$@"
+        fi
+        ;;
+    *)
+        printf "unknown arg $1\n"; ;;
+esac
+

--- a/nym-vpn-core/crates/test/scripts/blocking/sni_block.sh
+++ b/nym-vpn-core/crates/test/scripts/blocking/sni_block.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+function block_sni {
+    local domain=$1
+    local port=$2
+    
+    if [[ -n "$port" ]]; then
+        printf "b %s %s\n" "$domain" "$port"
+        iptables -A OUTPUT -p tcp --dport "$port" -m string --string "$domain" --algo kmp -j DROP
+        ip6tables -A OUTPUT -p tcp --dport "$port" -m string --string "$domain" --algo kmp -j DROP
+    else
+        printf "b %s (all ports)\n" "$domain"
+        iptables -A OUTPUT -p tcp -m string --string "$domain" --algo kmp -j DROP
+        ip6tables -A OUTPUT -p tcp -m string --string "$domain" --algo kmp -j DROP
+    fi
+}
+
+function unblock_sni {
+    local domain=$1
+    local port=$2
+    
+    if [[ -n "$port" ]]; then
+        printf "u %s %s\n" "$domain" "$port"
+        iptables -D OUTPUT -p tcp --dport "$port" -m string --string "$domain" --algo kmp -j DROP
+        ip6tables -D OUTPUT -p tcp --dport "$port" -m string --string "$domain" --algo kmp -j DROP
+    else
+        printf "u %s (all ports)\n" "$domain"
+        iptables -D OUTPUT -p tcp -m string --string "$domain" --algo kmp -j DROP
+        ip6tables -D OUTPUT -p tcp -m string --string "$domain" --algo kmp -j DROP
+    fi
+}
+
+function process_domain_addresses {
+    local action=$1
+    shift # Remove the first argument (action)
+    
+    for domain_addr in "$@"; do
+        # Check if it contains a port (domain:port format)
+        if [[ $domain_addr =~ ^([^:]+):([0-9]+)$ ]]; then
+            local domain="${BASH_REMATCH[1]}"
+            local port="${BASH_REMATCH[2]}"
+            printf "Processing domain with port: %s:%s\n" "$domain" "$port"
+            if [[ $action == "block" ]]; then
+                block_sni "$domain" "$port"
+            elif [[ $action == "unblock" ]]; then
+                unblock_sni "$domain" "$port"
+            fi
+        # Domain without port - no port restriction
+        elif [[ $domain_addr =~ ^[a-zA-Z0-9.-]+$ ]]; then
+            local domain="$domain_addr"
+            printf "Processing domain (any port): %s\n" "$domain"
+            if [[ $action == "block" ]]; then
+                block_sni "$domain" ""
+            elif [[ $action == "unblock" ]]; then
+                unblock_sni "$domain" ""
+            fi
+        else
+            printf "Invalid domain format: %s (expected domain.com or domain.com:port)\n" "$domain_addr"
+        fi
+    done
+}
+
+case $1 in
+    "block" )
+        if [[ $# -gt 1 ]]; then
+            printf "blocking specified domains... \n"
+            process_domain_addresses "$@"
+        else
+            printf "No domains specified for blocking\n"
+        fi
+        ;;
+
+    "unblock" )
+        if [[ $# -gt 1 ]]; then
+            printf "unblocking specified domains... \n"
+            process_domain_addresses "$@"
+        else
+            printf "No domains specified for unblocking\n"
+        fi
+        ;;
+    *)
+        printf "Usage: $0 {block|unblock} domain1[:port] [domain2[:port] ...]\n"
+        printf "Examples:\n"
+        printf "  $0 block example.com\n"
+        printf "  $0 block example.com:443 domain.example.com\n"
+        printf "  $0 unblock example.org:8443\n"
+        ;;
+esac

--- a/nym-vpn-core/crates/test/scripts/blocking/sni_block.sh
+++ b/nym-vpn-core/crates/test/scripts/blocking/sni_block.sh
@@ -13,6 +13,8 @@ function block_sni {
         iptables -A OUTPUT -p tcp -m string --string "$domain" --algo kmp -j DROP
         ip6tables -A OUTPUT -p tcp -m string --string "$domain" --algo kmp -j DROP
     fi
+    
+    return 0
 }
 
 function unblock_sni {
@@ -28,6 +30,8 @@ function unblock_sni {
         iptables -D OUTPUT -p tcp -m string --string "$domain" --algo kmp -j DROP
         ip6tables -D OUTPUT -p tcp -m string --string "$domain" --algo kmp -j DROP
     fi
+    
+    return 0
 }
 
 function process_domain_addresses {
@@ -56,8 +60,11 @@ function process_domain_addresses {
             fi
         else
             printf "Invalid domain format: %s (expected domain.com or domain.com:port)\n" "$domain_addr"
+            return 1
         fi
     done
+    
+    return 0
 }
 
 case $1 in

--- a/nym-vpn-core/crates/test/test-manager/src/tests/blocking_tests.rs
+++ b/nym-vpn-core/crates/test/test-manager/src/tests/blocking_tests.rs
@@ -1,0 +1,381 @@
+//! Censorship scenario tests
+
+use crate::tests::{
+    TestContext,
+    helpers_nym::{self},
+    nym_test::dc_and_ensure_logged_in,
+};
+use anyhow::{Context, ensure};
+use helpers_nym::ExpectedTunnelState;
+use nym_vpn_proto::rpc_client::RpcClient as NymProxyClient;
+use test_macro::test_function_nym;
+use test_rpc::NymServiceClient;
+
+/// get socket addresses for default dns nameservers used by the vpn client
+fn get_default_nameserver_sockaddrs() -> Vec<String> {
+    let dns_nameservers = [
+        "1.1.1.1",
+        "1.0.0.1",
+        "2606:4700:4700::1111",
+        "2606:4700:4700::1001",
+        "9.9.9.9",
+        "149.112.112.112",
+        "2620:00fe::00fe",
+        "2620:00fe::00fe:0009",
+    ];
+    let dns_proto_ports = [443, 853];
+
+    dns_nameservers
+        .iter()
+        .flat_map(|&addr| {
+            let formatted_addr = if addr.contains(':') {
+                format!("[{}]", addr) // IPv6 needs brackets
+            } else {
+                addr.to_string() // IPv4
+            };
+            dns_proto_ports
+                .iter()
+                .map(move |&port| format!("{}:{}", formatted_addr, port))
+        })
+        .collect()
+}
+
+/// Verify that the VPN tunnel is working by performing DNS resolution tests
+async fn verify_tunnel_connectivity(rpc: &NymServiceClient) -> anyhow::Result<()> {
+    let hostnames_to_test = ["nym.com", "google.com"];
+    for host in &hostnames_to_test {
+        log::info!("Resolving {} inside VM via VPN tunnel...", host);
+        let addrs = rpc
+            .resolve_hostname(host.to_string())
+            .await
+            .context(format!("DNS resolution failed for {} inside VM", host))?;
+        log::info!("Resolved {} to {:?}", host, addrs);
+        ensure!(
+            !addrs.is_empty(),
+            "DNS resolution returned no addresses for {} inside VM",
+            host
+        );
+    }
+    Ok(())
+}
+
+/// Ensure connection with default DNS Nameservers blocklisted
+#[test_function_nym]
+pub async fn test_tunnel_blocklisted_dns_nameservers_by_ip(
+    _: TestContext,
+    rpc: NymServiceClient,
+    mut nym_client: NymProxyClient,
+) -> Result<(), anyhow::Error> {
+    // Common DNS nameservers to block
+    let dns_nameservers = get_default_nameserver_sockaddrs();
+
+    // Block DNS nameservers
+    log::debug!("Blocking DNS nameservers: {:?}", dns_nameservers);
+    block_socket_addrs(&rpc, &dns_nameservers).await?;
+
+    // Ensure proper login state
+    dc_and_ensure_logged_in(&mut nym_client, false).await?;
+
+    // connect with wg
+    nym_client.set_enable_two_hop(true).await?;
+
+    // Connect tunnel
+    log::info!("Connecting tunnel...");
+    nym_client.connect_tunnel().await?;
+    helpers_nym::wait_for_tunnel_state(&mut nym_client, ExpectedTunnelState::Connected).await?;
+
+    // Verify tunnel connectivity
+    verify_tunnel_connectivity(&rpc).await?;
+
+    // Disconnect tunnel
+    log::info!("Disconnecting tunnel...");
+    nym_client.disconnect_tunnel().await?;
+    helpers_nym::wait_for_tunnel_state(&mut nym_client, ExpectedTunnelState::Disconnected).await?;
+
+    // Clean up: unblock DNS nameservers
+    log::debug!("Unblocking DNS nameservers...");
+    unblock_socket_addrs(&rpc, &dns_nameservers).await?;
+
+    Ok(())
+}
+
+/// Test Connection with default VPN API host blocklisted
+#[test_function_nym]
+pub async fn test_tunnel_blocklisted_vpn_api(
+    _: TestContext,
+    rpc: NymServiceClient,
+    mut nym_client: NymProxyClient,
+) -> Result<(), anyhow::Error> {
+    // TODO: Determine the actual VPN API endpoints to block
+    let vpn_api_hosts = ["nymvpn.com:443"];
+
+    // Block VPN API hosts
+    log::debug!("Adding blocking rule for the VPN API: {:?}", vpn_api_hosts);
+    block_server_name_indicators(&rpc, &vpn_api_hosts).await?;
+
+    // Ensure we're logged out first
+    dc_and_ensure_logged_in(&mut nym_client, false).await?;
+
+    // connect with wg
+    nym_client.set_enable_two_hop(true).await?;
+
+    // Attempt to connect - this should either fail or bypass the blocking
+    log::info!("Attempting to connect tunnel with VPN API blocked...");
+    nym_client.connect_tunnel().await?;
+    helpers_nym::wait_for_tunnel_state(&mut nym_client, ExpectedTunnelState::Connected).await?;
+
+    // Verify tunnel connectivity
+    verify_tunnel_connectivity(&rpc).await?;
+
+    // Disconnect tunnel
+    log::info!("Disconnecting tunnel...");
+    nym_client.disconnect_tunnel().await?;
+    helpers_nym::wait_for_tunnel_state(&mut nym_client, ExpectedTunnelState::Disconnected).await?;
+
+    // Clean up: unblock the VPN API hosts
+    log::debug!("Removing SNI based blocking rule for the VPN API ...");
+    unblock_server_name_indicators(&rpc, &vpn_api_hosts).await?;
+
+    Ok(())
+}
+
+/// Test Connection with default NYM API host blocklisted
+#[test_function_nym]
+pub async fn test_tunnel_blocklisted_nym_api(
+    _: TestContext,
+    rpc: NymServiceClient,
+    mut nym_client: NymProxyClient,
+) -> Result<(), anyhow::Error> {
+    // TODO: Determine the actual Nym API endpoints to block
+    let nym_api_hosts = ["validator.nymtech.net:443"];
+
+    // Block Nym API hosts
+    log::debug!("Adding blocking rule for the Nym API: {:?}", nym_api_hosts);
+    block_server_name_indicators(&rpc, &nym_api_hosts).await?;
+
+    // Ensure we're logged out first
+    dc_and_ensure_logged_in(&mut nym_client, false).await?;
+
+    // connect with wg
+    nym_client.set_enable_two_hop(true).await?;
+
+    // Attempt to connect - this should either fail or bypass the blocking
+    log::info!("Attempting to connect tunnel with Nym API blocked...");
+    nym_client.connect_tunnel().await?;
+    helpers_nym::wait_for_tunnel_state(&mut nym_client, ExpectedTunnelState::Connected).await?;
+
+    // Verify tunnel connectivity
+    verify_tunnel_connectivity(&rpc).await?;
+
+    // Disconnect tunnel
+    log::info!("Disconnecting tunnel...");
+    nym_client.disconnect_tunnel().await?;
+    helpers_nym::wait_for_tunnel_state(&mut nym_client, ExpectedTunnelState::Disconnected).await?;
+
+    // Clean up: unblock the Nym API hosts
+    log::debug!("Removing SNI based blocking rule for the Nym API ...");
+    unblock_server_name_indicators(&rpc, &nym_api_hosts).await?;
+
+    Ok(())
+}
+
+/// Test connection establishment with conditions seen in Russian ISP in Feb 2026.
+///
+/// Connections to the API that only transfered a small amount of data would be allowed, but
+/// connections that exceeded around 3kB transfer would have traffic dropped. This resulted in a
+/// Read error within the client. See NYM-349 for more details including logs and changes.
+///
+/// This test should result in a Read error during topology fetching that enables domain fronting
+/// and then successfully connects. I block DNS to force usage of the  default fallback address for
+/// the Nym API.
+#[test_function_nym]
+pub async fn test_tunnel_delayed_blocklisted_nym_api(
+    _: TestContext,
+    rpc: NymServiceClient,
+    mut nym_client: NymProxyClient,
+) -> Result<(), anyhow::Error> {
+    let default_nym_api_socket_addr = ["212.71.233.232:443"];
+
+    // Common DNS nameservers to block
+    let dns_nameservers = get_default_nameserver_sockaddrs();
+
+    // Block DNS nameservers
+    log::debug!("Blocking DNS nameservers: {:?}", dns_nameservers);
+    block_socket_addrs(&rpc, &dns_nameservers).await?;
+
+    // Block DNS nameservers
+    log::debug!(
+        "Adding Delayed Blocking rule for Nym API: {:?}",
+        default_nym_api_socket_addr
+    );
+    block_socket_addrs_delayed(&rpc, &default_nym_api_socket_addr).await?;
+
+    // Ensure we're logged out first
+    dc_and_ensure_logged_in(&mut nym_client, false).await?;
+
+    // connect with wg
+    nym_client.set_enable_two_hop(true).await?;
+
+    // Attempt to connect - this should either fail or bypass the blocking
+    log::info!("Attempting to connect tunnel with Nym API blocked...");
+    nym_client.connect_tunnel().await?;
+    helpers_nym::wait_for_tunnel_state(&mut nym_client, ExpectedTunnelState::Connected).await?;
+
+    // Verify tunnel connectivity
+    verify_tunnel_connectivity(&rpc).await?;
+
+    // Disconnect tunnel
+    log::info!("Disconnecting tunnel...");
+    nym_client.disconnect_tunnel().await?;
+    helpers_nym::wait_for_tunnel_state(&mut nym_client, ExpectedTunnelState::Disconnected).await?;
+
+    // Block DNS nameservers
+    log::debug!("Removing Delayed Blocking rule for Nym API...");
+    unblock_socket_addrs_delayed(&rpc, &default_nym_api_socket_addr).await?;
+
+    // Clean up: unblock DNS nameservers
+    log::debug!("Unblocking DNS nameservers...");
+    unblock_socket_addrs(&rpc, &dns_nameservers).await?;
+
+    Ok(())
+}
+async fn block_socket_addrs<T: AsRef<str> + std::fmt::Debug>(
+    rpc: &NymServiceClient,
+    socket_addrs: &[T],
+) -> anyhow::Result<()> {
+    let mut args = vec!["block"];
+    args.extend(socket_addrs.iter().map(|s| s.as_ref()));
+
+    let result = rpc
+        .exec("/tmp/ip_block.sh", args)
+        .await
+        .context("Failed to execute ip_block.sh")?;
+
+    if !result.success() {
+        let stderr = String::from_utf8_lossy(&result.stderr);
+        anyhow::bail!("ip_block.sh failed to block socket addresses: {}", stderr);
+    }
+
+    log::info!("Successfully blocked socket addresses: {:?}", socket_addrs);
+    Ok(())
+}
+
+async fn block_server_name_indicators<T: AsRef<str> + std::fmt::Debug>(
+    rpc: &NymServiceClient,
+    domains: &[T],
+) -> anyhow::Result<()> {
+    let mut args = vec!["block"];
+    args.extend(domains.iter().map(|d| d.as_ref()));
+
+    let result = rpc
+        .exec("/tmp/sni_block.sh", args)
+        .await
+        .context("Failed to execute sni_block.sh")?;
+
+    if !result.success() {
+        let stderr = String::from_utf8_lossy(&result.stderr);
+        anyhow::bail!("sni_block.sh failed to block domains: {}", stderr);
+    }
+
+    log::info!("Successfully blocked domains: {:?}", domains);
+    Ok(())
+}
+
+async fn block_socket_addrs_delayed<T: AsRef<str> + std::fmt::Debug>(
+    rpc: &NymServiceClient,
+    socket_addrs: &[T],
+) -> anyhow::Result<()> {
+    let mut args = vec!["block"];
+    args.extend(socket_addrs.iter().map(|s| s.as_ref()));
+
+    let result = rpc
+        .exec("/tmp/delayed_ip_block.sh", args)
+        .await
+        .context("Failed to execute delayed_ip_block.sh")?;
+
+    if !result.success() {
+        let stderr = String::from_utf8_lossy(&result.stderr);
+        anyhow::bail!(
+            "delayed_ip_block.sh failed to block socket addresses: {}",
+            stderr
+        );
+    }
+
+    log::info!(
+        "Successfully blocked socket addresses (delayed): {:?}",
+        socket_addrs
+    );
+    Ok(())
+}
+
+async fn unblock_socket_addrs<T: AsRef<str> + std::fmt::Debug>(
+    rpc: &NymServiceClient,
+    socket_addrs: &[T],
+) -> anyhow::Result<()> {
+    let mut args = vec!["unblock"];
+    args.extend(socket_addrs.iter().map(|s| s.as_ref()));
+
+    let result = rpc
+        .exec("/tmp/ip_block.sh", args)
+        .await
+        .context("Failed to execute ip_block.sh")?;
+
+    if !result.success() {
+        let stderr = String::from_utf8_lossy(&result.stderr);
+        anyhow::bail!("ip_block.sh failed to unblock socket addresses: {}", stderr);
+    }
+
+    log::info!(
+        "Successfully unblocked socket addresses: {:?}",
+        socket_addrs
+    );
+    Ok(())
+}
+
+async fn unblock_server_name_indicators<T: AsRef<str> + std::fmt::Debug>(
+    rpc: &NymServiceClient,
+    domains: &[T],
+) -> anyhow::Result<()> {
+    let mut args = vec!["unblock"];
+    args.extend(domains.iter().map(|d| d.as_ref()));
+
+    let result = rpc
+        .exec("/tmp/sni_block.sh", args)
+        .await
+        .context("Failed to execute sni_block.sh")?;
+
+    if !result.success() {
+        let stderr = String::from_utf8_lossy(&result.stderr);
+        anyhow::bail!("sni_block.sh failed to unblock domains: {}", stderr);
+    }
+
+    log::info!("Successfully unblocked domains: {:?}", domains);
+    Ok(())
+}
+
+async fn unblock_socket_addrs_delayed<T: AsRef<str> + std::fmt::Debug>(
+    rpc: &NymServiceClient,
+    socket_addrs: &[T],
+) -> anyhow::Result<()> {
+    let mut args = vec!["unblock"];
+    args.extend(socket_addrs.iter().map(|s| s.as_ref()));
+
+    let result = rpc
+        .exec("/tmp/delayed_ip_block.sh", args)
+        .await
+        .context("Failed to execute delayed_ip_block.sh")?;
+
+    if !result.success() {
+        let stderr = String::from_utf8_lossy(&result.stderr);
+        anyhow::bail!(
+            "delayed_ip_block.sh failed to unblock socket addresses: {}",
+            stderr
+        );
+    }
+
+    log::info!(
+        "Successfully unblocked socket addresses (delayed): {:?}",
+        socket_addrs
+    );
+    Ok(())
+}

--- a/nym-vpn-core/crates/test/test-manager/src/tests/mod.rs
+++ b/nym-vpn-core/crates/test/test-manager/src/tests/mod.rs
@@ -2,6 +2,7 @@
 // Copyright 2025 Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+mod blocking_tests;
 pub mod config_nym;
 mod envs;
 mod helpers_nym;

--- a/nym-vpn-core/crates/test/test-manager/src/vm/provision.rs
+++ b/nym-vpn-core/crates/test/test-manager/src/vm/provision.rs
@@ -144,6 +144,20 @@ fn blocking_ssh(
     ssh_send_file_with_opts(&session, &source, temp_dir, FileOpts { executable: true })
         .with_context(|| format!("Failed to send '{source:?}' to remote"))?;
 
+    // Transfer blocking scripts
+    if matches!(os_type, OsType::Linux | OsType::Macos) {
+        let blocking_scripts_dir =
+            Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/../scripts/blocking"));
+        let scripts = ["ip_block.sh", "sni_block.sh", "delayed_ip_block.sh"];
+
+        for script in &scripts {
+            let source = blocking_scripts_dir.join(script);
+            log::debug!("Source: {}", source.display());
+            ssh_send_file_with_opts(&session, &source, temp_dir, FileOpts { executable: true })
+                .with_context(|| format!("Failed to send blocking script '{script}' to remote"))?;
+        }
+    }
+
     // Transfer setup script
     if matches!(os_type, OsType::Linux | OsType::Macos) {
         // TODO: Move this name to a constant somewhere?


### PR DESCRIPTION
## Ticket

NYM-168

## Description

First pass on circumvention integration testing using the testing harness.

Includes tests for _wireguard_ connections where:

* All DNS Nameservers are blocklisted
* VPN API blocked by SNI
* Nym API blocked by SNI 
* Nym API byte limited blocking blocked by IP (as seen in NYM-349)

NOTE: I have not actually been able to run these tests inside the test harness yet as there are currently RPC auth issues. 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4983)
<!-- Reviewable:end -->
