### PR TITLE
Fix xpc read

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Windows] App Split Tunnelling (https://github.com/nymtech/nym-vpn-client/pull/4908).
 
+### Fixed
+
+- [macOS] Fix bug in XPC buffering between XPC and gRPC layers (https://github.com/nymtech/nym-vpn-client/pull/4985)
+
+
 ## [1.27.0] - TBD
 
 - [macOS] XPC as transport layer between clients and daemon (https://github.com/nymtech/nym-vpn-client/pull/4695)

--- a/nym-vpn-core/crates/nym-ipc/src/xpc/common.rs
+++ b/nym-vpn-core/crates/nym-ipc/src/xpc/common.rs
@@ -110,19 +110,15 @@ impl XpcConnection {
         self
     }
 
-    // Tries to fill the destination buffer and returns true if it got filled
-    // and there is not more data to be copied, and false if there's still left
-    // data to be copied
-    fn try_to_fill(&mut self, mut src: Vec<u8>, dst: &mut tokio::io::ReadBuf<'_>) -> bool {
+    // Tries to fill the destination buffer
+    fn try_to_fill(&mut self, mut src: Vec<u8>, dst: &mut tokio::io::ReadBuf<'_>) {
         if dst.remaining() >= src.len() {
             // we can consume the entire data
             dst.put_slice(&src);
-            false
         } else {
             // we have to store some of it for a later call
             self.to_be_copied = Some(src.split_off(dst.remaining()));
             dst.put_slice(&src);
-            true
         }
     }
 
@@ -147,9 +143,8 @@ impl AsyncRead for XpcConnection {
         // we check for invalidation, but we could still consume the buffered
         // data, so don't take any action on possible invalidation
         self.underlaying_conn_invalidated();
-        if let Some(to_be_copied) = self.to_be_copied.take()
-            && self.try_to_fill(to_be_copied, buf)
-        {
+        if let Some(to_be_copied) = self.to_be_copied.take() {
+            self.try_to_fill(to_be_copied, buf);
             return std::task::Poll::Ready(Ok(()));
         }
         match Pin::new(&mut self.data_stream_rx).poll_next(cx) {

--- a/nym-vpn-core/crates/nym-ipc/src/xpc/common.rs
+++ b/nym-vpn-core/crates/nym-ipc/src/xpc/common.rs
@@ -210,11 +210,12 @@ impl Connected for XpcConnection {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use tokio::{
-        io::{AsyncReadExt, AsyncWriteExt},
+        io::{AsyncReadExt, AsyncWriteExt, ReadBuf},
         sync::mpsc,
     };
-    use tokio_util::bytes::BytesMut;
 
     use super::*;
 
@@ -236,8 +237,13 @@ mod tests {
         assert_eq!(remote_rx.recv().await.unwrap(), data);
     }
 
+    // simulate 100 gRPC calls of 100 bytes per call, and the same 8KB buffer reused until full,
+    // at which point it gets re-created
+    // this behavior follows what was observed when running 100 calls with vpnc
+    // reproducing bug NYM-967 where the second read would hang even though the last piece of data
+    // was being written into the buffer, but Pending was being returned
     #[tokio::test]
-    async fn read_from_conn() {
+    async fn fixed_buf_multiple_big_sends() {
         let (own_tx, own_rx) = mpsc::unbounded_channel();
         let _own_interface = ConnectionInterfaceObj::new(own_tx.clone());
         let (remote_tx, _remote_rx) = mpsc::unbounded_channel();
@@ -249,23 +255,114 @@ mod tests {
         let mut own_conn =
             XpcConnection::new(remote_proxy, own_rx.into(), CancellationToken::new());
 
-        let data = vec![1, 2, 3, 4, 5];
-        own_tx.send(data.clone()).unwrap();
+        let fut = async move {
+            let data: Vec<u8> = (1u8..=100).collect();
+            let mut read_buf = [0; 8192];
+            let mut buffer = ReadBuf::new(&mut read_buf);
+            for _ in 0..100 {
+                own_tx.send(data.clone()).unwrap();
 
-        let mut buffer = BytesMut::with_capacity(2);
-        own_conn.read_buf(&mut buffer).await.unwrap();
-        assert_eq!(buffer, vec![1, 2]);
+                let remaining = buffer.remaining();
+                if remaining < 100 {
+                    own_conn.read_buf(&mut buffer).await.unwrap();
+                    buffer = ReadBuf::new(&mut read_buf);
+                    own_conn.read_buf(&mut buffer).await.unwrap();
+                } else {
+                    own_conn.read_buf(&mut buffer).await.unwrap();
+                }
+            }
+        };
+        // if a read happens correctly but the data is written without returning Ready,
+        // the read call will stall and the timeout will trigger
+        tokio::time::timeout(Duration::from_secs(1), fut)
+            .await
+            .unwrap();
+    }
 
-        // reactivate the poll
-        own_tx.send(vec![]).unwrap();
-        let mut buffer = BytesMut::with_capacity(2);
-        own_conn.read_buf(&mut buffer).await.unwrap();
-        assert_eq!(buffer, vec![3, 4]);
+    // simulate 100 gRPC calls of 50 + 50 bytes per call, and the same 8KB buffer reused until full,
+    // at which point it gets re-created
+    // this behavior follows what was observed when running 100 calls with vpnc
+    // reproducing bug NYM-967 where the third read when having buffer capacity >50 and <100 would not only take
+    // the data from the previous send (which was addressed to the current read iteration) but also data from the
+    // next iteration's write. The overlap caused corruption of data
+    #[tokio::test]
+    async fn fixed_buf_multiple_couple_sends() {
+        const READ_BUF_SIZE: usize = 8192;
+        let (own_tx, own_rx) = mpsc::unbounded_channel();
+        let _own_interface = ConnectionInterfaceObj::new(own_tx.clone());
+        let (remote_tx, _remote_rx) = mpsc::unbounded_channel();
+        let remote_proxy = unsafe {
+            Retained::cast_unchecked::<ProtocolObject<dyn NSConnectionInterface + Send + Sync>>(
+                ConnectionInterfaceObj::new(remote_tx),
+            )
+        };
+        let mut own_conn =
+            XpcConnection::new(remote_proxy, own_rx.into(), CancellationToken::new());
 
-        // reactivate the poll
-        own_tx.send(vec![]).unwrap();
-        let mut buffer = BytesMut::with_capacity(2);
-        own_conn.read_buf(&mut buffer).await.unwrap();
-        assert_eq!(buffer, vec![5]);
+        tokio::spawn(async move {
+            let data1: Vec<u8> = (1u8..=50).collect();
+            let data2: Vec<u8> = (51u8..=100).collect();
+            for _ in 0..100 {
+                own_tx.send(data1.clone()).unwrap();
+                own_tx.send(data2.clone()).unwrap();
+            }
+        })
+        .await
+        .unwrap();
+        let fut = async move {
+            let mut read_buf = [0; READ_BUF_SIZE];
+            // use a double sized buffer to more easily verify data that otherwise
+            // gets wrapped and written to the beginning of a new buffer
+            let mut expected_buf = [0u8; 2 * READ_BUF_SIZE].to_vec();
+            let mut reinited = false;
+            let mut buffer = ReadBuf::new(&mut read_buf);
+            for i in 0..100 {
+                // compute and place the 1, 2, ..., 100 bytes we expect to get
+                // in this iteration
+                for idx in 0..100 {
+                    expected_buf[100 * i + idx] = (idx % 100 + 1) as u8;
+                }
+
+                let remaining = buffer.remaining();
+                if remaining < 50 {
+                    // this branch doesn't happen in this case because 8192 % 100 = 92 > 50
+                    // but we'll just keep it around for completion
+                    own_conn.read_buf(&mut buffer).await.unwrap();
+
+                    assert_eq!(buffer.initialized(), &expected_buf[..READ_BUF_SIZE]);
+                    read_buf = [0; READ_BUF_SIZE];
+                    buffer = ReadBuf::new(&mut read_buf);
+                    reinited = true;
+                    own_conn.read_buf(&mut buffer).await.unwrap();
+                } else if remaining < 100 {
+                    // we read the first write correctly, the second write gets partially read...
+                    own_conn.read_buf(&mut buffer).await.unwrap();
+                    own_conn.read_buf(&mut buffer).await.unwrap();
+
+                    // we verify the first half before moving to the next wrapped partial read..
+                    assert_eq!(buffer.initialized(), &expected_buf[..READ_BUF_SIZE]);
+                    read_buf = [0; READ_BUF_SIZE];
+                    buffer = ReadBuf::new(&mut read_buf);
+                    reinited = true;
+                    // we read the remaining part of the second write
+                    own_conn.read_buf(&mut buffer).await.unwrap();
+                } else {
+                    // reads and writes have enough buffer space to be matched
+                    own_conn.read_buf(&mut buffer).await.unwrap();
+                    own_conn.read_buf(&mut buffer).await.unwrap();
+                }
+                if reinited {
+                    // the first half of the buffer has been completely verified, it's time we verify the second half
+                    assert_eq!(buffer.initialized(), &expected_buf[READ_BUF_SIZE..]);
+                } else {
+                    // we haven't reached the end of the initial 8KB buffer, so we only verify the first half
+                    assert_eq!(buffer.initialized(), &expected_buf[..READ_BUF_SIZE]);
+                }
+            }
+        };
+        // not needed in this test but good to have a timeout just in case
+        tokio::time::timeout(Duration::from_secs(1), fut)
+            .await
+            .unwrap();
     }
 }


### PR DESCRIPTION
## Ticket

JIRA-NYM-967

## Description

Fix the bug that caused a read of buffered data while still returning `Pending` to the `AsyncReader` caller. This manifested in two scenarios:
1. The `Pending` wasn't followed by any other write on the producer side, because all the data was sent in one go, causing the stall of the reader unnecessarily. A timeout unit test has been added for this (`fixed_buf_multiple_big_sends`)
2. The `Pending` was followed by a write call on the producer side, but for a different RPC call, making the initial RPC call to read the entire data, discard what it didn't need and the second RPC call would lose those bytes and get a corrupted response. A unit test has been added for this (`fixed_buf_multiple_couple_sends`).

The fix is to return `Ready` when the buffered data was being copied, without trying to enter a new iteration of read which might be from a different RPC call.


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4985)
<!-- Reviewable:end -->
