### PR TITLE
APPLE: fix no active plan text when acc summary is not available yet

### DIFF
--- a/nym-vpn-apple/NymVPN/Resources/Localizable.xcstrings
+++ b/nym-vpn-apple/NymVPN/Resources/Localizable.xcstrings
@@ -24044,6 +24044,17 @@
         }
       }
     },
+    "requestingZkNyms" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Requesting ZkNyms..."
+          }
+        }
+      }
+    },
     "noActivePlan" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/nym-vpn-apple/Services/Sources/Services/CredentialsManager/CredentialsManager.swift
+++ b/nym-vpn-apple/Services/Sources/Services/CredentialsManager/CredentialsManager.swift
@@ -233,7 +233,7 @@ import PathManager
         isUpdatingAccountSummary = true
         defer { isUpdatingAccountSummary = false }
 
-        let delays: [Duration] = [.zero, .seconds(1), .seconds(3), .seconds(9)]
+        let delays: [Duration] = [.zero, .seconds(2), .seconds(6), .seconds(8), .seconds(10)]
         for delay in delays {
             if delay != .zero {
                 try? await Task.sleep(for: delay)

--- a/nym-vpn-apple/Settings/Sources/Settings/SettingsViewModel.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/SettingsViewModel.swift
@@ -240,6 +240,15 @@ private extension SettingsViewModel {
                 }
             }
             .store(in: &cancellables)
+
+        credentialsManager.$accountSummary
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                MainActor.assumeIsolated {
+                    self?.reloadSections()
+                }
+            }
+            .store(in: &cancellables)
     }
 
     /// Configures sections, to reload all the content - use reloadSections
@@ -291,22 +300,25 @@ private extension SettingsViewModel {
 private extension SettingsViewModel {
     func accountSection() -> AppSettingsSection {
         let subtitle: AttributedString
-        if let accountSummary = credentialsManager.accountSummary,
-           let planText = accountSummary.planValidUntilAttributedString {
-            if accountSummary.isActive,
-               isAutoRenewEnabled(accountSummary: accountSummary),
-               !accountSummary.isExpiringSoon,
-               !accountSummary.isExpiringWarning {
-                var second = AttributedString("* \("autoRenews".localizedString)")
-                second.foregroundColor = NymColor.gray1
-                subtitle = planText + AttributedString("\n") + second
+        if let accountSummary = credentialsManager.accountSummary {
+            if let planText = accountSummary.planValidUntilAttributedString {
+                if accountSummary.isActive,
+                   isAutoRenewEnabled(accountSummary: accountSummary),
+                   !accountSummary.isExpiringSoon,
+                   !accountSummary.isExpiringWarning {
+                    var second = AttributedString("* \("autoRenews".localizedString)")
+                    second.foregroundColor = NymColor.gray1
+                    subtitle = planText + AttributedString("\n") + second
+                } else {
+                    subtitle = planText
+                }
             } else {
-                subtitle = planText
+                var first = AttributedString("noActivePlan".localizedString)
+                first.foregroundColor = NymColor.error
+                subtitle = first
             }
         } else {
-            var first = AttributedString("noActivePlan".localizedString)
-            first.foregroundColor = NymColor.error
-            subtitle = first
+            subtitle = AttributedString("requestingZkNyms".localizedString)
         }
 
         var viewModels = [


### PR DESCRIPTION
Cherry-pick of #4997 to `release/2026.6-pilatus`.

## Summary
- Show "Requesting ZkNyms..." instead of "No active plan" when account summary is not yet available in settings view
- Add observer for `accountSummary` changes to auto-update the account row

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/4999)
<!-- Reviewable:end -->
