### PR TITLE
Connection middleware layer

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Windows] App Split Tunnelling (https://github.com/nymtech/nym-vpn-client/pull/4908).
 - CLI: add command to list processes excluded from VPN tunnel: `nym-vpnc split-tunnel excluded-processes`
+- Connection middleware layer (https://github.com/nymtech/nym-vpn-client/pull/5000)
 
 ### Fixed
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/connection_middleware/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/connection_middleware/mod.rs
@@ -1,0 +1,147 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+//! Middleware interface between the user and the tunnel state machine
+//!
+//! This layer tries to reflect the user's connection desire, and it's currently
+//! composed of the following possibilities:
+//!
+//! 1. The user whishes to connect to a specific group of gateways and with a
+//!    specific hop mode. In this case, this layer acts only as a forwarder for
+//!    commands from user and events from tunnel state machine.
+//!
+//! 2. (WIP) The user whishes to connect and remain connected, without specifying
+//!    more information. In this case, this layer will forward the relevant commands
+//!    and events and even create tunnel state machine commands on its own, such that
+//!    connection retries are transparent to the user and the connection is maintained
+//!    as much as possible.
+
+use nym_vpn_lib_types::{TargetState, TunnelEvent};
+use tokio::{
+    sync::{broadcast, mpsc},
+    task::JoinHandle,
+};
+use tokio_util::sync::CancellationToken;
+
+use crate::service::{
+    VpnServiceCommand,
+    connection_middleware::state_machine::{
+        ConnectionMiddlewareCommand, ConnectionMiddlewareStateMachine,
+        disconnected::DisconnectedState,
+    },
+};
+
+mod state_machine;
+
+pub(super) struct ConnectionMiddleware {
+    connection_middleware_sm_handle: JoinHandle<()>,
+    conn_middleware_command_tx: mpsc::UnboundedSender<ConnectionMiddlewareCommand>,
+
+    vpn_command_rx: mpsc::UnboundedReceiver<VpnServiceCommand>,
+    forwarded_vpn_command_tx: mpsc::UnboundedSender<VpnServiceCommand>,
+
+    forwarded_tunnel_event_tx: broadcast::Sender<TunnelEvent>,
+    tunnel_event_rx: broadcast::Receiver<TunnelEvent>,
+
+    shutdown_token: CancellationToken,
+    sm_shutdown_token: CancellationToken,
+}
+
+impl ConnectionMiddleware {
+    pub(super) fn new(
+        vpn_command_rx: mpsc::UnboundedReceiver<VpnServiceCommand>,
+        forwarded_tunnel_event_tx: broadcast::Sender<TunnelEvent>,
+        shutdown_token: CancellationToken,
+    ) -> (
+        Self,
+        mpsc::UnboundedReceiver<VpnServiceCommand>,
+        broadcast::Sender<TunnelEvent>,
+    ) {
+        let (forwarded_vpn_command_tx, forwarded_vpn_command_rx) = mpsc::unbounded_channel();
+        let (tunnel_event_tx, tunnel_event_rx) = broadcast::channel(10);
+        let (conn_middleware_command_tx, conn_middleware_command_rx) = mpsc::unbounded_channel();
+        let sm_shutdown_token = CancellationToken::new();
+
+        let (current_state_handler, initial_state) = DisconnectedState::enter();
+        tracing::info!("Initial ConnectionMiddleware state: {initial_state:?}");
+
+        let connection_middleware_sm_handle = ConnectionMiddlewareStateMachine::spawn(
+            current_state_handler,
+            conn_middleware_command_rx,
+            tunnel_event_tx.subscribe(),
+            sm_shutdown_token.clone(),
+        );
+
+        (
+            Self {
+                connection_middleware_sm_handle,
+                conn_middleware_command_tx,
+                vpn_command_rx,
+                forwarded_vpn_command_tx,
+                forwarded_tunnel_event_tx,
+                tunnel_event_rx,
+                shutdown_token,
+                sm_shutdown_token,
+            },
+            forwarded_vpn_command_rx,
+            tunnel_event_tx,
+        )
+    }
+
+    fn handle_command(&self, command: VpnServiceCommand) {
+        if let VpnServiceCommand::SetTargetState(_, target_state) = &command {
+            match target_state {
+                TargetState::Unsecured => {
+                    if self
+                        .conn_middleware_command_tx
+                        .send(ConnectionMiddlewareCommand::Stop)
+                        .is_err()
+                    {
+                        tracing::error!("ConnectionMiddleware state machine died")
+                    }
+                }
+                TargetState::Secured => {
+                    if self
+                        .conn_middleware_command_tx
+                        .send(ConnectionMiddlewareCommand::Start)
+                        .is_err()
+                    {
+                        tracing::error!("ConnectionMiddleware state machine died")
+                    }
+                }
+            }
+        }
+
+        if self.forwarded_vpn_command_tx.send(command).is_err() {
+            tracing::error!("Command channel is closed");
+        }
+    }
+
+    fn handle_event(&self, event: TunnelEvent) {
+        if self.forwarded_tunnel_event_tx.send(event).is_err() {
+            tracing::error!("Failed to send tunnel event");
+        }
+    }
+
+    pub(super) async fn run(mut self) {
+        loop {
+            tokio::select! {
+                biased;
+                _ = self.shutdown_token.cancelled() => {
+                    tracing::debug!("ConnectionMiddleware : Received cancellation signal");
+                    self.sm_shutdown_token.cancel();
+                    if let Err(err) = self.connection_middleware_sm_handle.await {
+                        tracing::warn!("ConnectionMiddleware state machine didn't finish correctly: {err:?}");
+                    }
+                    break;
+                },
+                Some(command) = self.vpn_command_rx.recv() => {
+                    self.handle_command(command);
+                }
+                Ok(event) = self.tunnel_event_rx.recv() => {
+                    self.handle_event(event);
+                }
+            }
+        }
+    }
+}

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/connection_middleware/state_machine/connected.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/connection_middleware/state_machine/connected.rs
@@ -1,0 +1,65 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+//! Connected state happens when the user clicked the connect button and the
+//! tunnel state machine managed to obtain a connection.
+//! It expresses the user’s desired target state is to be connected, which is
+//! currently achieved.
+
+use nym_vpn_lib_types::{TunnelEvent, TunnelState};
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+use crate::service::connection_middleware::state_machine::{
+    ConnectionMiddlewareCommand, ConnectionMiddlewareStateHandler, NextConnectionMiddlewareState,
+    PrivateConnectionMiddlewareState, SharedState, connecting::ConnectingState,
+    disconnected::DisconnectedState,
+};
+
+pub struct ConnectedState {}
+
+impl ConnectedState {
+    pub fn enter() -> (
+        Box<dyn ConnectionMiddlewareStateHandler>,
+        PrivateConnectionMiddlewareState,
+    ) {
+        (
+            Box::new(Self {}),
+            PrivateConnectionMiddlewareState::Connected,
+        )
+    }
+}
+
+#[async_trait::async_trait]
+impl ConnectionMiddlewareStateHandler for ConnectedState {
+    async fn handle_event(
+        mut self: Box<Self>,
+        shutdown_token: &CancellationToken,
+        command_rx: &'async_trait mut mpsc::UnboundedReceiver<ConnectionMiddlewareCommand>,
+        shared_state: &'async_trait mut SharedState,
+    ) -> NextConnectionMiddlewareState {
+        tokio::select! {
+            biased;
+            _ = shutdown_token.cancelled() => {
+                NextConnectionMiddlewareState::Finished
+            }
+            Some(command) = command_rx.recv() => {
+                match command {
+                    ConnectionMiddlewareCommand::Start => NextConnectionMiddlewareState::SameState(self),
+                    ConnectionMiddlewareCommand::Stop => NextConnectionMiddlewareState::NewState(DisconnectedState::enter()),
+                }
+            }
+            Ok(event) = shared_state.tunnel_event_rx.recv() => {
+                match event {
+                    TunnelEvent::NewState(tunnel_state) => {
+                        match tunnel_state {
+                            TunnelState::Disconnected | TunnelState::Disconnecting {..} | TunnelState::Connecting { .. } |  TunnelState::Error(_) | TunnelState::Offline {..} => NextConnectionMiddlewareState::NewState(ConnectingState::enter()),
+                            TunnelState::Connected { .. } => NextConnectionMiddlewareState::SameState(self),
+                        }
+                    },
+                    _ => NextConnectionMiddlewareState::SameState(self),
+                }
+            }
+        }
+    }
+}

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/connection_middleware/state_machine/connecting.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/connection_middleware/state_machine/connecting.rs
@@ -1,0 +1,64 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+//! Connecting state happens when the user clicks connect button.
+//! It expresses the user’s desired target state is to be connected, which is
+//! not achieved yet.
+
+use nym_vpn_lib_types::{TunnelEvent, TunnelState};
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+use crate::service::connection_middleware::state_machine::{
+    ConnectionMiddlewareCommand, ConnectionMiddlewareStateHandler, NextConnectionMiddlewareState,
+    PrivateConnectionMiddlewareState, SharedState, connected::ConnectedState,
+    disconnected::DisconnectedState,
+};
+
+pub struct ConnectingState {}
+
+impl ConnectingState {
+    pub fn enter() -> (
+        Box<dyn ConnectionMiddlewareStateHandler>,
+        PrivateConnectionMiddlewareState,
+    ) {
+        (
+            Box::new(Self {}),
+            PrivateConnectionMiddlewareState::Connecting,
+        )
+    }
+}
+
+#[async_trait::async_trait]
+impl ConnectionMiddlewareStateHandler for ConnectingState {
+    async fn handle_event(
+        mut self: Box<Self>,
+        shutdown_token: &CancellationToken,
+        command_rx: &'async_trait mut mpsc::UnboundedReceiver<ConnectionMiddlewareCommand>,
+        shared_state: &'async_trait mut SharedState,
+    ) -> NextConnectionMiddlewareState {
+        tokio::select! {
+            biased;
+            _ = shutdown_token.cancelled() => {
+                NextConnectionMiddlewareState::Finished
+            }
+            Some(command) = command_rx.recv() => {
+                match command {
+                    ConnectionMiddlewareCommand::Start => NextConnectionMiddlewareState::SameState(self),
+                    ConnectionMiddlewareCommand::Stop => NextConnectionMiddlewareState::NewState(DisconnectedState::enter()),
+                }
+            }
+            Ok(event) = shared_state.tunnel_event_rx.recv() => {
+                match event {
+                    TunnelEvent::NewState(tunnel_state) => {
+                        match tunnel_state {
+                            TunnelState::Disconnected | TunnelState::Disconnecting {..} | TunnelState::Connecting { .. } |  TunnelState::Error(_) | TunnelState::Offline {..} => NextConnectionMiddlewareState::SameState(self),
+                            TunnelState::Connected { .. } => NextConnectionMiddlewareState::NewState(ConnectedState::enter()),
+                        }
+                    },
+                    _ => NextConnectionMiddlewareState::SameState(self),
+                }
+            }
+        }
+    }
+}

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/connection_middleware/state_machine/disconnected.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/connection_middleware/state_machine/disconnected.rs
@@ -1,0 +1,63 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+//! Disconnected state is the default state.
+//! It expresses the user’s desired state is to not be connected.
+
+use nym_vpn_lib_types::{TunnelEvent, TunnelState};
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+use crate::service::connection_middleware::state_machine::{
+    ConnectionMiddlewareCommand, ConnectionMiddlewareStateHandler, NextConnectionMiddlewareState,
+    PrivateConnectionMiddlewareState, SharedState, connected::ConnectedState,
+    connecting::ConnectingState,
+};
+
+pub struct DisconnectedState {}
+
+impl DisconnectedState {
+    pub fn enter() -> (
+        Box<dyn ConnectionMiddlewareStateHandler>,
+        PrivateConnectionMiddlewareState,
+    ) {
+        (
+            Box::new(Self {}),
+            PrivateConnectionMiddlewareState::Disconnected,
+        )
+    }
+}
+
+#[async_trait::async_trait]
+impl ConnectionMiddlewareStateHandler for DisconnectedState {
+    async fn handle_event(
+        mut self: Box<Self>,
+        shutdown_token: &CancellationToken,
+        command_rx: &'async_trait mut mpsc::UnboundedReceiver<ConnectionMiddlewareCommand>,
+        shared_state: &'async_trait mut SharedState,
+    ) -> NextConnectionMiddlewareState {
+        tokio::select! {
+            biased;
+            _ = shutdown_token.cancelled() => {
+                NextConnectionMiddlewareState::Finished
+            }
+            Some(command) = command_rx.recv() => {
+                match command {
+                    ConnectionMiddlewareCommand::Start => NextConnectionMiddlewareState::NewState(ConnectingState::enter()),
+                    ConnectionMiddlewareCommand::Stop => NextConnectionMiddlewareState::SameState(self),
+                }
+            }
+            Ok(event) = shared_state.tunnel_event_rx.recv() => {
+                match event {
+                    TunnelEvent::NewState(tunnel_state) => {
+                        match tunnel_state {
+                            TunnelState::Disconnected | TunnelState::Disconnecting {..} | TunnelState::Connecting { .. } |  TunnelState::Error(_) | TunnelState::Offline {..} => NextConnectionMiddlewareState::SameState(self),
+                            TunnelState::Connected { .. } => NextConnectionMiddlewareState::NewState(ConnectedState::enter()),
+                        }
+                    },
+                    _ => NextConnectionMiddlewareState::SameState(self),
+                }
+            }
+        }
+    }
+}

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/connection_middleware/state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/connection_middleware/state_machine/mod.rs
@@ -1,0 +1,127 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+//! ```text
+//! Connection middleware's state machine.
+//! It tries to follow the user's desired target state and only uses the tunnel
+//! event data to determine if the user's desired target is reached
+//!
+//!                tunnel connects by itself for some reason (tunnel connected happens)
+//!        | =================================================================================== |
+//!        ||                                                                                   ||
+//!        ||                                                                                   ||
+//!        ||        user wants to connect                    tunnel manages to connect         ||
+//!        ||         (connect is clicked)                (tunnel connected event happens)      v
+//! +--------------+  ==================>  +------------+  =============================> +-----------+
+//! | Disconnected |                       | Connecting |                                 | Connected |
+//! +--------------+  <==================  +------------+  <============================= +-----------+
+//!        A          user doesn't want to                         tunnel disconnects           ||
+//!        ||            connect anymore                             for some reason            ||
+//!        ||       (disconnect is clicked)              (tunnel non-connected event happens)   ||
+//!        ||                                                                                   ||
+//!        ||                                                                                   ||
+//!        | =================================================================================== |
+//!                  user doesn't want to be connected anymore (disconnect is clicked)
+//! ```
+
+use nym_vpn_lib_types::TunnelEvent;
+use tokio::{
+    sync::{broadcast, mpsc},
+    task::JoinHandle,
+};
+use tokio_util::sync::CancellationToken;
+
+pub mod connected;
+pub mod connecting;
+pub mod disconnected;
+
+#[derive(Debug)]
+pub(super) enum ConnectionMiddlewareCommand {
+    /// Start trying to connect the tunnel.
+    Start,
+
+    /// Stop trying to connect the tunnel or disconnect if already connected.
+    Stop,
+}
+
+pub(super) struct SharedState {
+    tunnel_event_rx: broadcast::Receiver<TunnelEvent>,
+}
+
+pub(super) enum NextConnectionMiddlewareState {
+    NewState(
+        (
+            Box<dyn ConnectionMiddlewareStateHandler>,
+            PrivateConnectionMiddlewareState,
+        ),
+    ),
+    SameState(Box<dyn ConnectionMiddlewareStateHandler>),
+    Finished,
+}
+
+#[async_trait::async_trait]
+pub(super) trait ConnectionMiddlewareStateHandler: Send {
+    async fn handle_event(
+        mut self: Box<Self>,
+        shutdown_token: &CancellationToken,
+        command_rx: &'async_trait mut mpsc::UnboundedReceiver<ConnectionMiddlewareCommand>,
+        shared_state: &'async_trait mut SharedState,
+    ) -> NextConnectionMiddlewareState;
+}
+
+pub(super) struct ConnectionMiddlewareStateMachine {
+    current_state_handler: Box<dyn ConnectionMiddlewareStateHandler>,
+    command_rx: mpsc::UnboundedReceiver<ConnectionMiddlewareCommand>,
+    shutdown_token: CancellationToken,
+    shared_state: SharedState,
+}
+
+impl ConnectionMiddlewareStateMachine {
+    pub fn spawn(
+        current_state_handler: Box<dyn ConnectionMiddlewareStateHandler>,
+        command_rx: mpsc::UnboundedReceiver<ConnectionMiddlewareCommand>,
+        tunnel_event_rx: broadcast::Receiver<TunnelEvent>,
+        shutdown_token: CancellationToken,
+    ) -> JoinHandle<()> {
+        let shared_state = SharedState { tunnel_event_rx };
+        let conn_middlware_state_machine = ConnectionMiddlewareStateMachine {
+            current_state_handler,
+            command_rx,
+            shutdown_token,
+            shared_state,
+        };
+
+        tokio::spawn(conn_middlware_state_machine.run())
+    }
+
+    async fn run(mut self) {
+        loop {
+            let next_state = self
+                .current_state_handler
+                .handle_event(
+                    &self.shutdown_token,
+                    &mut self.command_rx,
+                    &mut self.shared_state,
+                )
+                .await;
+
+            match next_state {
+                NextConnectionMiddlewareState::NewState((new_state_handler, new_state)) => {
+                    self.current_state_handler = new_state_handler;
+                    tracing::info!("New connection middleware state: {new_state:?}");
+                }
+                NextConnectionMiddlewareState::SameState(same_state) => {
+                    self.current_state_handler = same_state;
+                }
+                NextConnectionMiddlewareState::Finished => break,
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(super) enum PrivateConnectionMiddlewareState {
+    Disconnected,
+    Connecting,
+    Connected,
+}

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 mod config;
+mod connection_middleware;
 mod error;
 mod socks5;
 mod vpn_service;

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
@@ -66,6 +66,7 @@ use crate::{
     config::GlobalConfig,
     gateway_directory::{self, GatewayCache, GatewayCacheHandle, GatewayClient},
     logging::LogFileRemoverHandle,
+    service::connection_middleware::ConnectionMiddleware,
     tunnel_state_machine::{NymConfig, TunnelCommand, TunnelConstants, TunnelStateMachine},
 };
 
@@ -348,6 +349,8 @@ pub struct NymVpnService {
     split_tunnel_shutdown_token: CancellationToken,
     #[cfg(any(windows, target_os = "macos"))]
     split_tunnel_join_handle: JoinHandle<()>,
+
+    connection_middleware_handle: JoinHandle<()>,
 }
 
 impl NymVpnService {
@@ -602,6 +605,13 @@ impl NymVpnService {
             },
         );
 
+        let (connection_middleware, vpn_command_rx, tunnel_event_tx) = ConnectionMiddleware::new(
+            vpn_command_rx,
+            tunnel_event_tx,
+            services_shutdown_token.child_token(),
+        );
+        let connection_middleware_handle = tokio::spawn(connection_middleware.run());
+
         let state_machine_handle = TunnelStateMachine::spawn(
             command_receiver,
             event_sender,
@@ -667,6 +677,7 @@ impl NymVpnService {
             split_tunnel_join_handle,
             #[cfg(any(windows, target_os = "macos"))]
             split_tunnel_shutdown_token,
+            connection_middleware_handle,
         })
     }
 
@@ -758,6 +769,10 @@ impl NymVpnService {
 
         if let Err(e) = self.topology_service_join_handle.await {
             tracing::error!("Failed to join on statistics controller handle: {e}");
+        }
+
+        if let Err(e) = self.connection_middleware_handle.await {
+            tracing::error!("Failed to join on connection middleware handle: {e}");
         }
 
         tracing::info!("Exiting vpn service run loop");


### PR DESCRIPTION
## Ticket

JIRA-NYM-817

## Description

Introduce a connection middleware layer which, for now, only forwards commands and events between user and tunnel state machines.
In a future iteration, this layer will get more involved in the connection management, for a specific connection requirement like 1 click i.e. the user wants to connect without specifying connection parameters, so a specific algorithm in this layer will fill that gap.


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5000)
<!-- Reviewable:end -->
