### PR TITLE
APPLE: chore fix BuildCore.sh script

### DIFF
--- a/nym-vpn-apple/NymVPN/Resources/Localizable.xcstrings
+++ b/nym-vpn-apple/NymVPN/Resources/Localizable.xcstrings
@@ -34887,6 +34887,17 @@
         }
       }
     },
+    "splitTunnel.betaFeature" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beta feature"
+          }
+        }
+      }
+    },
     "splitTunnel.apps" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -35979,6 +35990,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "订阅已到期"
+          }
+        }
+      }
+    },
+    "subscriptionPayment.received" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Payment received\nRequesting ZkNyms..."
           }
         }
       }

--- a/nym-vpn-apple/Scripts/BuildCore.sh
+++ b/nym-vpn-apple/Scripts/BuildCore.sh
@@ -56,6 +56,20 @@ rm -rf "${LIB_DEST}"
 cp -R "${LIB_SRC}" "${LIB_DEST}"
 echo "[BuildCore] Copied NymVPNLib → ${LIB_DEST}"
 
+# 2b) Flatten xcframework headers for Xcode 26+ explicit module builds
+XCODE_VER="$(xcodebuild -version 2>/dev/null | head -1 | awk '{print $2}')"
+if [[ "$(printf '%s\n' "26.4" "${XCODE_VER}" | sort -V | head -1)" == "26.4" ]]; then
+  for HEADERS_DIR in "${LIB_DEST}"/NymVPNLibUniffi.xcframework/*/Headers; do
+    for SUBDIR in "${HEADERS_DIR}"/*/; do
+      [[ -d "${SUBDIR}" ]] || continue
+      cp -n "${SUBDIR}"* "${HEADERS_DIR}/" 2>/dev/null || true
+    done
+  done
+  echo "[BuildCore] Flattened NymVPNLib xcframework headers (Xcode ${XCODE_VER})"
+else
+  echo "[BuildCore] Skipping header flatten (Xcode ${XCODE_VER} < 26.4)"
+fi
+
 # 3) Build macOS (produces upload/mac/nym-vpnd if macOS.mk has vpnd targets)
 make -f macOS.mk libwg nym-setup nym-vpnd rpc-swift-package RELEASE="${RELEASE}"
 
@@ -65,6 +79,19 @@ RPC_DEST="${APPLE_ROOT}/NymVPNRpc"
 rm -rf "${RPC_DEST}"
 cp -R "${RPC_SRC}" "${RPC_DEST}"
 echo "[BuildCore] Copied NymVPNRpc → ${RPC_DEST}"
+
+# 4b) Flatten xcframework headers for Xcode 26+ explicit module builds
+if [[ "$(printf '%s\n' "26.4" "${XCODE_VER}" | sort -V | head -1)" == "26.4" ]]; then
+  for HEADERS_DIR in "${RPC_DEST}"/NymVPNRpcUniffi.xcframework/*/Headers; do
+    for SUBDIR in "${HEADERS_DIR}"/*/; do
+      [[ -d "${SUBDIR}" ]] || continue
+      cp -n "${SUBDIR}"* "${HEADERS_DIR}/" 2>/dev/null || true
+    done
+  done
+  echo "[BuildCore] Flattened NymVPNRpc xcframework headers (Xcode ${XCODE_VER})"
+else
+  echo "[BuildCore] Skipping header flatten (Xcode ${XCODE_VER} < 26.4)"
+fi
 
 # 5) Copy the universal nym-vpnd → apple Daemon
 VPND_SRC="${CORE_ROOT}/upload/mac/nym-vpnd"

--- a/nym-vpn-apple/Settings/Sources/Settings/SplitTunneling/SplitTunnelView.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/SplitTunneling/SplitTunnelView.swift
@@ -104,7 +104,7 @@ private extension SplitTunnelView {
 
     var changesText: some View {
         HStack {
-            Text("\("splitTunel.apps.exclude".localizedString) \n\("splitTunnel.apps.unprotected".localizedString)")
+            Text("⚠️ \("splitTunnel.betaFeature".localizedString)\n\("splitTunel.apps.exclude".localizedString) \n\("splitTunnel.apps.unprotected".localizedString)")
                 .foregroundStyle(NymColor.gray1)
                 .textStyle(.Body.Medium.regular)
             Spacer()


### PR DESCRIPTION
## Ticket

JIRA-VPN-XXXX

## Description

Xcode 26.4 requires the headers to be flattened in our home build rpc lib and iOS lib.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5011)
<!-- Reviewable:end -->
