### PR TITLE
(tauri) Fix windows st include/exclude logic

### DIFF
--- a/nym-vpn-app/src/screens/settings/account/AccountDescription.tsx
+++ b/nym-vpn-app/src/screens/settings/account/AccountDescription.tsx
@@ -35,7 +35,11 @@ export function AccountDescription() {
     return (
       <span
         className={clsx(
-          getAccountDescriptionColor(accountSyncing, accountState, accountSummary),
+          getAccountDescriptionColor(
+            accountSyncing,
+            accountState,
+            accountSummary,
+          ),
         )}
       >
         {accountStateDescription}

--- a/nym-vpn-app/src/screens/settings/account/AccountDescription.tsx
+++ b/nym-vpn-app/src/screens/settings/account/AccountDescription.tsx
@@ -19,10 +19,15 @@ export function AccountDescription() {
   const { t } = useTranslation('settings');
   const { accountSyncing, accountState, accountSummary } = useMainState();
 
+  console.log("[AccountDescription] accountSummary", accountSummary);
+  console.log("[AccountDescription] accountState", accountState);
+  console.log("[AccountDescription] accountSyncing", accountSyncing);
+
   const accountStateDescription = getAccountStateDescription(
     t,
     accountSyncing,
     accountState,
+    accountSummary,
   );
 
   const status = useMemo(
@@ -34,7 +39,7 @@ export function AccountDescription() {
     return (
       <span
         className={clsx(
-          getAccountDescriptionColor(accountSyncing, accountState),
+          getAccountDescriptionColor(accountSyncing, accountState, accountSummary),
         )}
       >
         {accountStateDescription}
@@ -42,7 +47,7 @@ export function AccountDescription() {
     );
   }
 
-  if (!accountSummary) {
+  if (!accountSummary?.['subscription-valid-until']) {
     return null;
   }
 

--- a/nym-vpn-app/src/screens/settings/account/AccountDescription.tsx
+++ b/nym-vpn-app/src/screens/settings/account/AccountDescription.tsx
@@ -19,10 +19,6 @@ export function AccountDescription() {
   const { t } = useTranslation('settings');
   const { accountSyncing, accountState, accountSummary } = useMainState();
 
-  console.log("[AccountDescription] accountSummary", accountSummary);
-  console.log("[AccountDescription] accountState", accountState);
-  console.log("[AccountDescription] accountSyncing", accountSyncing);
-
   const accountStateDescription = getAccountStateDescription(
     t,
     accountSyncing,

--- a/nym-vpn-app/src/screens/settings/account/account-status/AccountStatus.tsx
+++ b/nym-vpn-app/src/screens/settings/account/account-status/AccountStatus.tsx
@@ -14,8 +14,9 @@ export function AccountStatus() {
   const needsSubscription = useMemo(
     () =>
       accountState === 'no-subscription' ||
-      accountState === 'status-not-active',
-    [accountState],
+      accountState === 'status-not-active' ||
+      !accountSummary?.['is-subscription-active'],
+    [accountState, accountSummary],
   );
 
   if (!accountState || accountState === 'error' || accountState === 'offline') {

--- a/nym-vpn-app/src/screens/settings/account/utils.ts
+++ b/nym-vpn-app/src/screens/settings/account/utils.ts
@@ -5,6 +5,7 @@ import { AccountState, TAccountSummary } from '../../../types';
 export const getAccountDescriptionColor = (
   accountSyncing: boolean,
   state?: AccountState | null,
+  accountSummary?: TAccountSummary | null,
 ) => {
   if (accountSyncing) {
     return 'text-iron dark:text-bombay';
@@ -20,6 +21,9 @@ export const getAccountDescriptionColor = (
   if (state === 'offline' || state === 'status-not-active') {
     return 'text-cheddar dark:text-king-nacho ';
   }
+  if (!accountSummary?.['is-subscription-active']) {
+    return 'text-aphrodisiac';
+  }
   return 'text-iron dark:text-bombay';
 };
 
@@ -27,6 +31,7 @@ export const getAccountStateDescription = (
   t: TFunction<'settings', undefined>,
   accountSyncing: boolean,
   state?: AccountState | null,
+  accountSummary?: TAccountSummary | null,
 ) => {
   if (accountSyncing) {
     return t('account.syncing');
@@ -51,9 +56,14 @@ export const getAccountStateDescription = (
       return t('account.offline', { ns: 'errors' });
     case 'error':
       return t('account.internal', { ns: 'errors' });
-    default:
-      return null;
   }
+
+  if (!accountSummary?.['is-subscription-active']) {
+    return t('account.no-plan');
+  }
+
+  // Global default
+  return null;
 };
 
 export const getAccountStatus = (accountSummary?: TAccountSummary | null) => {

--- a/nym-vpn-app/src/screens/settings/split-tunneling/AppItem.tsx
+++ b/nym-vpn-app/src/screens/settings/split-tunneling/AppItem.tsx
@@ -9,14 +9,13 @@ export type AppEntry = App & {
 
 type AppItemProps = {
   app: AppEntry;
-  enabled: boolean;
   onStateChange: (
     app: AppEntry,
     state: 'excluded' | 'included',
   ) => Promise<void>;
 };
 
-function AppItem({ app, enabled, onStateChange }: AppItemProps) {
+function AppItem({ app, onStateChange }: AppItemProps) {
   return (
     <div className="flex items-center gap-3 px-4 py-3 bg-white dark:bg-charcoal">
       <div className="w-7 h-7 flex items-center justify-center">
@@ -40,28 +39,24 @@ function AppItem({ app, enabled, onStateChange }: AppItemProps) {
         <button
           className={clsx(
             'px-2  h-full w-full flex items-center justify-center cursor-default transition-noborder border-r border-r-iron dark:border-r-bombay rounded-l-lg',
-            app.state === 'excluded'
+            app.state === 'included'
               ? 'bg-aphrodisiac/20 text-aphrodisiac'
               : 'text-iron dark:text-bombay',
-            !enabled && 'opacity-50 cursor-not-allowed',
           )}
-          onClick={() => onStateChange(app, 'excluded')}
+          onClick={() => onStateChange(app, 'included')}
           aria-label={`Exclude ${app.name} from VPN`}
-          disabled={!enabled}
         >
           <MsIcon icon="block" className="text-base" />
         </button>
         <button
           className={clsx(
             'px-2  h-full w-full  flex items-center justify-center cursor-default transition-noborder rounded-r-lg',
-            app.state === 'included'
+            app.state === 'excluded'
               ? 'bg-malachite-moss/15 dark:bg-malachite/15 text-malachite-moss dark:text-malachite'
               : 'text-iron dark:text-bombay',
-            !enabled && 'opacity-50 cursor-not-allowed',
           )}
-          onClick={() => onStateChange(app, 'included')}
+          onClick={() => onStateChange(app, 'excluded')}
           aria-label={`Include ${app.name} in VPN`}
-          disabled={!enabled}
         >
           <MsIcon icon="shield" className="text-base" />
         </button>

--- a/nym-vpn-app/src/screens/settings/split-tunneling/SplitTunneling.tsx
+++ b/nym-vpn-app/src/screens/settings/split-tunneling/SplitTunneling.tsx
@@ -104,10 +104,7 @@ function SplitTunneling() {
                     {/* Apps in this section */}
                     {groupedApps[letter].map((app, i) => (
                       <div key={app.name}>
-                        <AppItem
-                          app={app}
-                          onStateChange={handleStateChange}
-                        />
+                        <AppItem app={app} onStateChange={handleStateChange} />
                         {i < groupedApps[letter].length - 1 && (
                           <div className="mx-4 h-px bg-mercury/60 dark:bg-white/5" />
                         )}

--- a/nym-vpn-app/src/screens/settings/split-tunneling/SplitTunneling.tsx
+++ b/nym-vpn-app/src/screens/settings/split-tunneling/SplitTunneling.tsx
@@ -106,7 +106,6 @@ function SplitTunneling() {
                       <div key={app.name}>
                         <AppItem
                           app={app}
-                          enabled={enabled}
                           onStateChange={handleStateChange}
                         />
                         {i < groupedApps[letter].length - 1 && (

--- a/nym-vpn-app/src/screens/settings/split-tunneling/utils/useSplitTunnel.ts
+++ b/nym-vpn-app/src/screens/settings/split-tunneling/utils/useSplitTunnel.ts
@@ -68,6 +68,7 @@ export const useSplitTunnel = () => {
   };
 
   const add = async (app: AppEntry) => {
+    console.log("[add] app", app);
     if (app.state === 'included') return;
     try {
       await invoke('add_app_to_split_tunnel', {
@@ -88,6 +89,7 @@ export const useSplitTunnel = () => {
   };
 
   const remove = async (app: AppEntry) => {
+    console.log("[remove] app", app);
     if (app.state === 'excluded') return;
     try {
       await invoke('remove_app_from_split_tunnel', {

--- a/nym-vpn-app/src/screens/settings/split-tunneling/utils/useSplitTunnel.ts
+++ b/nym-vpn-app/src/screens/settings/split-tunneling/utils/useSplitTunnel.ts
@@ -68,7 +68,6 @@ export const useSplitTunnel = () => {
   };
 
   const add = async (app: AppEntry) => {
-    console.log("[add] app", app);
     if (app.state === 'included') return;
     try {
       await invoke('add_app_to_split_tunnel', {
@@ -89,7 +88,6 @@ export const useSplitTunnel = () => {
   };
 
   const remove = async (app: AppEntry) => {
-    console.log("[remove] app", app);
     if (app.state === 'excluded') return;
     try {
       await invoke('remove_app_from_split_tunnel', {


### PR DESCRIPTION
## Ticket

JIRA-VPN-XXXX

## Description

- Reverse the include/exclude logic
- Allow including/excluding apps when ST is disabled
- Use `accountSummary.is-subscription-active` inside Account settings page to get rid of showing date in the past (1970) if the account summary doesn't return subscription related dates

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5029)
<!-- Reviewable:end -->
