### PR TITLE
(core) account summary `is_linked` fix

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/handler.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/handler.rs
@@ -204,7 +204,7 @@ pub(crate) async fn handle_link_account<C: ConnectivityMonitor>(
 
         let _status_ok = shared_state
             .vpn_api_client
-            .link_account(current_account, &privy_vpn_account, "Passphrase")
+            .link_account(current_account, &privy_vpn_account, "Social login")
             .await
             .inspect_err(|err| {
                 tracing::error!("Failed to link Privy account with API account: {err:?}")

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
@@ -705,7 +705,7 @@ impl VpnApiClient {
         let request = LinkAccountRequestBody {
             pubkey,
             signature,
-            kind: "user_generated_secp256k1".to_string(),
+            kind: "privy_secp256k1".to_string(),
             label: label.to_string(),
         };
 

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/account/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/account/mod.rs
@@ -385,7 +385,6 @@ pub struct VpnAccountAuthMethod {
     pub kind: String,
     pub label: String,
     pub status: VpnAccountStatus,
-    pub is_canonical: bool,
 
     #[cfg_attr(feature = "typescript-bindings", ts(as = "String"))]
     #[cfg_attr(feature = "serde", serde(with = "time::serde::iso8601"))]
@@ -461,7 +460,6 @@ impl TryFrom<nym_vpn_api_client::response::NymVpnAccountAuthMethodResponse>
             label: value.label,
             status: value.status.into(),
             created,
-            is_canonical: value.is_canonical,
         })
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/account/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/account/mod.rs
@@ -294,20 +294,9 @@ impl VpnAccountSummary {
     }
 
     pub fn is_linked(&self) -> bool {
-        let canonical_differs = self
-            .canonical_account_addr
-            .as_ref()
-            .map(|canonical| canonical != &self.account_addr)
-            .unwrap_or(false);
-
-        let has_social_or_passphrase = self
-            .auth_methods
+        self.auth_methods
             .iter()
-            .any(|method| method.label == "Social login" || method.label == "Passphrase");
-
-        let is_privy_mode = self.account_mode == Some(StoredAccountMode::Privy);
-
-        canonical_differs || has_social_or_passphrase || is_privy_mode
+            .any(|method| method.kind == "privy_secp256k1")
     }
 }
 
@@ -396,6 +385,7 @@ pub struct VpnAccountAuthMethod {
     pub kind: String,
     pub label: String,
     pub status: VpnAccountStatus,
+    pub is_canonical: bool,
 
     #[cfg_attr(feature = "typescript-bindings", ts(as = "String"))]
     #[cfg_attr(feature = "serde", serde(with = "time::serde::iso8601"))]
@@ -471,6 +461,7 @@ impl TryFrom<nym_vpn_api_client::response::NymVpnAccountAuthMethodResponse>
             label: value.label,
             status: value.status.into(),
             created,
+            is_canonical: value.is_canonical,
         })
     }
 }


### PR DESCRIPTION
## Ticket

JIRA-VPN-XXXX

## Description

- Check if `privy_secp256k1` is present in account summary `auth_methods` array
- Use `privy_secp256k1` for `DeeplinkKind::PrivyLink`
- Update label for linking accounts, set it to `Social login`


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5034)
<!-- Reviewable:end -->
