### PR TITLE
Stream SelectedGateways via buffered selection

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Windows] App Split Tunnelling (https://github.com/nymtech/nym-vpn-client/pull/4908).
 - CLI: add command to list processes excluded from VPN tunnel: `nym-vpnc split-tunnel excluded-processes`
 
+### Changed
+
+- Stream SelectedGateways via buffered selection (https://github.com/nymtech/nym-vpn-client/pull/5037)
+
 ### Fixed
 
 - [macOS] Fix bug in XPC buffering between XPC and gRPC layers (https://github.com/nymtech/nym-vpn-client/pull/4985)

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -57,9 +57,7 @@ use tokio_util::sync::CancellationToken;
 use nym_dns::DnsConfig;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use nym_firewall::{Firewall, FirewallArguments, InitialFirewallState};
-use nym_gateway_directory::{
-    BlacklistedGateways, Config as GatewayDirectoryConfig, GatewayCacheHandle,
-};
+use nym_gateway_directory::{Config as GatewayDirectoryConfig, GatewayCacheHandle};
 use nym_vpn_lib_types::{
     AccountControllerErrorStateReason, ActionAfterDisconnect, ConnectionData, EntryPoint,
     ErrorStateReason, EstablishConnectionData, EstablishConnectionState, ExitPoint,
@@ -69,6 +67,7 @@ use nym_vpn_lib_types::{
 use crate::{
     GatewayDirectoryError, UserAgent, bandwidth_controller::Error as BandwidthControllerError,
     mixnet::VpnTopologyServiceHandle,
+    tunnel_state_machine::tunnel::gateway_provider::GatewayProvider,
 };
 
 use tunnel::SelectedGateways;
@@ -613,12 +612,10 @@ pub struct SharedState {
     account_command_tx: AccountCommandSender,
     account_controller_state: AccountStateReceiver,
     statistics_event_sender: StatisticsSender,
-    gateway_cache_handle: GatewayCacheHandle,
+    gateway_provider: GatewayProvider<GatewayCacheHandle>,
     topology_service: VpnTopologyServiceHandle,
     discovery_refresher_command_tx: mpsc::UnboundedSender<DiscoveryRefresherCommand>,
-    wg_keys_db: WireguardKeysDb,
     user_agent: UserAgent,
-    blacklisted_entry_gateways: BlacklistedGateways,
 }
 
 impl SharedState {
@@ -753,6 +750,7 @@ pub struct TunnelStateMachine {
     filtering_resolver_handle: JoinHandle<()>,
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     adblocker_handle: JoinHandle<()>,
+    gateway_provider_handle: JoinHandle<()>,
     shutdown_token: CancellationToken,
 }
 
@@ -840,6 +838,9 @@ impl TunnelStateMachine {
             nym_common::trace_err_chain!(err, "failed to set initial split tunnel paths");
         }
 
+        let (gateway_provider, gateway_provider_handle) =
+            GatewayProvider::new(gateway_cache_handle, wg_keys_db, shutdown_token.clone());
+
         let mut shared_state = SharedState {
             #[cfg(not(any(target_os = "android", target_os = "ios")))]
             route_handler,
@@ -863,12 +864,10 @@ impl TunnelStateMachine {
             account_command_tx,
             account_controller_state,
             statistics_event_sender,
-            gateway_cache_handle,
+            gateway_provider,
             topology_service,
             discovery_refresher_command_tx,
-            wg_keys_db,
             user_agent,
-            blacklisted_entry_gateways: BlacklistedGateways::new(),
         };
 
         let (current_state_handler, _) = if shared_state
@@ -895,6 +894,7 @@ impl TunnelStateMachine {
             filtering_resolver_handle,
             #[cfg(not(any(target_os = "android", target_os = "ios")))]
             adblocker_handle,
+            gateway_provider_handle,
             shutdown_token,
         };
 
@@ -947,6 +947,9 @@ impl TunnelStateMachine {
             if let Err(e) = self.adblocker_handle.await {
                 tracing::error!("Failed to join on ad-blocker task: {}", e)
             }
+        }
+        if let Err(e) = self.gateway_provider_handle.await {
+            tracing::error!("Failed to join on gateway provider task: {}", e)
         }
     }
 }
@@ -1053,6 +1056,9 @@ pub enum Error {
     // Temporary until we support `RegistrationResult::Lp()`
     #[error("invalid tunnel type")]
     InvalidTunnelType,
+
+    #[error("gateway provider shut down")]
+    GatewayProviderDown,
 }
 
 impl Error {
@@ -1100,6 +1106,7 @@ impl Error {
             Self::CreateTcpProbe(e) => ErrorStateReason::Internal(e.to_string()),
             Self::ProbeRequiresIPv4Addr => ErrorStateReason::Internal(self.to_string()),
             Self::InvalidTunnelType => ErrorStateReason::Internal(self.to_string()),
+            Self::GatewayProviderDown => ErrorStateReason::Internal(self.to_string()),
         })
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -368,16 +368,14 @@ impl ConnectingState {
             tunnel_constants: shared_state.tunnel_constants,
             selected_gateways: self.selected_gateways.clone(),
             user_agent: shared_state.user_agent.clone(),
-            blacklisted_entry_gateways: shared_state.blacklisted_entry_gateways.clone(),
         };
         let tunnel_monitor_handle = TunnelMonitor::start(
             tunnel_parameters,
             shared_state.account_controller_state.clone(),
             shared_state.account_command_tx.clone(),
-            shared_state.gateway_cache_handle.clone(),
+            shared_state.gateway_provider.clone(),
             shared_state.topology_service.clone(),
             tunnel_monitor_event_sender,
-            shared_state.wg_keys_db.clone(),
             #[cfg(not(any(target_os = "android", target_os = "ios")))]
             shared_state.route_handler.clone(),
             #[cfg(any(target_os = "ios", target_os = "android"))]
@@ -477,6 +475,44 @@ impl ConnectingState {
         gateways: Box<SelectedGateways>,
         _shared_state: &mut SharedState,
     ) -> Result<()> {
+        let entry_gateway = gateways.entry_gateway();
+        let exit_gateway = gateways.exit_gateway();
+        tracing::debug!(
+            "Using entry public key: {}",
+            gateways.entry_keypair().public_key()
+        );
+        tracing::debug!(
+            "Using exit public key: {}",
+            gateways.exit_keypair().public_key()
+        );
+
+        tracing::info!(
+            "Using entry gateway: {}, location: {}, performance: {}",
+            entry_gateway.identity(),
+            entry_gateway
+                .two_letter_iso_country_code()
+                .map_or_else(|| "unknown".to_string(), |code| code.to_string()),
+            entry_gateway
+                .mixnet_performance
+                .map_or_else(|| "unknown".to_string(), |perf| perf.to_string()),
+        );
+        tracing::info!(
+            "Using exit gateway: {}, location: {}, performance: {}",
+            exit_gateway.identity(),
+            exit_gateway
+                .two_letter_iso_country_code()
+                .map_or_else(|| "unknown".to_string(), |code| code.to_string()),
+            exit_gateway
+                .mixnet_performance
+                .map_or_else(|| "unknown".to_string(), |perf| perf.to_string()),
+        );
+        tracing::info!(
+            "Using exit router address {}",
+            exit_gateway
+                .ipr_address
+                .map_or_else(|| "none".to_string(), |ipr| ipr.to_string())
+        );
+
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         let set_policy_result = {
             if _shared_state.tunnel_settings.bridges_enabled()
@@ -594,15 +630,7 @@ impl TunnelStateHandler for ConnectingState {
                     }
                     TunnelMonitorEvent::Up { tunnel_interface, connection_data } => {
                         // We have successfully connected, clear any blacklisted entry gateways
-                        match shared_state.blacklisted_entry_gateways.is_empty() {
-                            Ok(is_empty) => if !is_empty {
-                                tracing::info!("Clearing blacklisted entry gateways");
-                                if let Err(e) = shared_state.blacklisted_entry_gateways.clear() {
-                                    tracing::error!("Failed to clear blacklisted entry gateway list: {e}");
-                                }
-                            }
-                            Err(e) => tracing::error!("Failed to read blacklisted entry gateway list: {e}")
-                        }
+                        shared_state.gateway_provider.clear_blacklisted_entry_gateways();
 
                         NextTunnelState::NewState(ConnectedState::enter(
                             tunnel_interface,
@@ -639,11 +667,7 @@ impl TunnelStateHandler for ConnectingState {
                         // entry gateways for a while and force gateway re-selection.
                         if let Some(ref selected_gateways) = self.selected_gateways {
                             let entry_gateway_identifier = selected_gateways.entry_gateway().identity;
-                            if let Err(e) = shared_state.blacklisted_entry_gateways.add(entry_gateway_identifier) {
-                                tracing::error!("Failed to add gateway {} to blacklisted entry gateway list: {e}", entry_gateway_identifier);
-                            } else {
-                                tracing::warn!("Blacklisted entry gateway {} due to repeated connection failure", entry_gateway_identifier);
-                            }
+                            shared_state.gateway_provider.add_blacklisted_entry_gateway(entry_gateway_identifier);
                             self.selected_gateways = None;
                         }
                         NextTunnelState::SameState(self)

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/algorithm.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/algorithm.rs
@@ -1,0 +1,199 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use futures::future::pending;
+use nym_gateway_directory::BlacklistedGateways;
+use nym_vpn_store::keys::wireguard::WireguardKeysDb;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+use crate::tunnel_state_machine::{
+    TunnelSettings,
+    tunnel::{
+        self,
+        gateway_provider::{
+            SelectionResultSender, gateway_cache::GatewayCache, selector::select_gateways,
+        },
+    },
+};
+
+#[derive(Clone)]
+pub struct SelectAndSend {
+    pub tunnel_settings: TunnelSettings,
+    pub selection_tx: SelectionResultSender,
+}
+
+async fn continuous_select<C: GatewayCache>(
+    select_and_send: Option<SelectAndSend>,
+    gateway_cache: C,
+    blacklisted_entry_gateways: &BlacklistedGateways,
+    wg_keys_db: WireguardKeysDb,
+) {
+    let Some(SelectAndSend {
+        tunnel_settings,
+        selection_tx,
+    }) = select_and_send
+    else {
+        // not settings so nothing to send yet
+        return pending().await;
+    };
+    loop {
+        // make sure the buffer is not full before deciding on other possible selections
+        let Ok(selection_tx) = selection_tx.reserve().await else {
+            tracing::debug!("GatewayProvider shut down during selection algorithm");
+            return;
+        };
+        selection_tx.send(
+            select_gateways(
+                gateway_cache.clone(),
+                blacklisted_entry_gateways,
+                &tunnel_settings,
+                wg_keys_db.clone(),
+            )
+            .await
+            .map_err(|err| tunnel::Error::SelectGateways(Box::new(err))),
+        );
+    }
+}
+
+pub struct SelectionAlgorithm<C: GatewayCache> {
+    tunnel_settings_rx: mpsc::Receiver<SelectAndSend>,
+    gateway_cache: C,
+    blacklisted_entry_gateways: BlacklistedGateways,
+    wg_keys_db: WireguardKeysDb,
+    shutdown_token: CancellationToken,
+}
+
+impl<C: GatewayCache> SelectionAlgorithm<C> {
+    pub fn new(
+        tunnel_settings_rx: mpsc::Receiver<SelectAndSend>,
+        gateway_cache: C,
+        blacklisted_entry_gateways: BlacklistedGateways,
+        wg_keys_db: WireguardKeysDb,
+        shutdown_token: CancellationToken,
+    ) -> Self {
+        Self {
+            tunnel_settings_rx,
+            gateway_cache,
+            blacklisted_entry_gateways,
+            wg_keys_db,
+            shutdown_token,
+        }
+    }
+
+    pub async fn run(mut self) {
+        let mut latest_tunnel_settings = None;
+        loop {
+            tokio::select! {
+                _ = self.shutdown_token.cancelled() => {
+                    tracing::info!("SelectionAlgorithm shut down");
+                    return;
+                }
+                settings = self.tunnel_settings_rx.recv() => {
+                    if settings.is_none() {
+                        tracing::debug!(
+                            "GatewayProvider shut down before starting the selection algorithm"
+                        );
+                        return;
+                    };
+                    // store the received tunnel settings received for the next loop iteration
+                    latest_tunnel_settings = settings;
+                }
+                // consume the tunnel settings received in the previous loop iteration
+                _ = continuous_select(latest_tunnel_settings.take(), self.gateway_cache.clone(), &self.blacklisted_entry_gateways, self.wg_keys_db.clone()) => {},
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use tokio::sync::RwLock;
+
+    use crate::tunnel_state_machine::tunnel::gateway_provider::{
+        SelectionResult,
+        gateway_cache::tests::MockGatewayCache,
+        tests::{default_tunnel_settings, gateway_id_to_gateway},
+    };
+
+    use super::*;
+
+    async fn reset_default_settings(
+        tunnel_settings_tx: &mpsc::Sender<SelectAndSend>,
+    ) -> mpsc::Receiver<SelectionResult> {
+        let (selection_tx, selection_rx) = mpsc::channel(1);
+        tunnel_settings_tx
+            .send(SelectAndSend {
+                tunnel_settings: default_tunnel_settings(),
+                selection_tx,
+            })
+            .await
+            .unwrap();
+        selection_rx
+    }
+
+    #[tokio::test]
+    async fn run_algo() {
+        let (tunnel_settings_tx, tunnel_settings_rx) = mpsc::channel(1);
+        let shutdown_token = CancellationToken::new();
+        let possible_gateways_ids = [
+            "2zHiExNRKiCXVKS35SNKtK4apGfZELMpA1jJ2gVevJoz",
+            "38zcSsvjXsAX7C28ko2H3Lt55X4TYxfZYkPADxKXZHUj",
+        ];
+        let possible_gateways = possible_gateways_ids.map(gateway_id_to_gateway);
+
+        let gateways = Arc::new(RwLock::new(None));
+        let algo = SelectionAlgorithm::new(
+            tunnel_settings_rx,
+            MockGatewayCache::new(gateways.clone()),
+            BlacklistedGateways::new(),
+            WireguardKeysDb::Ephemeral(Default::default()),
+            shutdown_token.clone(),
+        );
+        let handle = tokio::spawn(algo.run());
+
+        // set some default settings
+        let mut selection_rx = reset_default_settings(&tunnel_settings_tx).await;
+        // error when no gateway available
+        *gateways.write().await = Some(vec![]);
+        assert!(selection_rx.recv().await.unwrap().is_err());
+
+        // re-set some default settings because there are continuous retries with errors in the stream
+        let mut selection_rx = reset_default_settings(&tunnel_settings_tx).await;
+        // error when not enough gateways
+        *gateways.write().await = Some(vec![possible_gateways[0].clone()]);
+        assert!(selection_rx.recv().await.unwrap().is_err());
+
+        // re-set some default settings because there are continuous retries with errors in the stream
+        let mut selection_rx = reset_default_settings(&tunnel_settings_tx).await;
+        // 2 gateways should be minimally functional
+        *gateways.write().await = Some(possible_gateways.to_vec());
+        // check that the stream is infinite, as long as there are valid available choices
+        for _ in 0..100 {
+            let selected_gateways = selection_rx.recv().await.unwrap().unwrap();
+            assert!(
+                possible_gateways_ids.contains(
+                    &selected_gateways
+                        .entry_gateway()
+                        .identity()
+                        .to_base58_string()
+                        .as_str()
+                )
+            );
+            assert!(
+                possible_gateways_ids.contains(
+                    &selected_gateways
+                        .exit_gateway()
+                        .identity()
+                        .to_base58_string()
+                        .as_str()
+                )
+            );
+        }
+
+        shutdown_token.cancel();
+        handle.await.unwrap();
+    }
+}

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/gateway_cache.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/gateway_cache.rs
@@ -1,0 +1,65 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use nym_gateway_directory::{Error, GatewayCacheHandle, GatewayClient, GatewayList, GatewayType};
+
+#[async_trait::async_trait]
+pub trait GatewayCache: Clone + Send + Sync + 'static {
+    async fn lookup_gateways(&self, gw_type: GatewayType) -> Result<GatewayList, Error>;
+    fn replace_gateway_client(&self, gateway_client: GatewayClient) -> Result<(), Error>;
+    async fn refresh_all(&self) -> Result<(), Error>;
+}
+
+#[async_trait::async_trait]
+impl GatewayCache for GatewayCacheHandle {
+    async fn lookup_gateways(&self, gw_type: GatewayType) -> Result<GatewayList, Error> {
+        self.lookup_gateways(gw_type).await
+    }
+
+    fn replace_gateway_client(&self, gateway_client: GatewayClient) -> Result<(), Error> {
+        self.replace_gateway_client(gateway_client)
+    }
+
+    async fn refresh_all(&self) -> Result<(), Error> {
+        self.refresh_all().await
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use std::sync::Arc;
+
+    use nym_gateway_directory::Gateway;
+    use tokio::sync::RwLock;
+
+    use super::*;
+
+    #[derive(Clone)]
+    pub struct MockGatewayCache {
+        gateways: Arc<RwLock<Option<Vec<Gateway>>>>,
+    }
+
+    impl MockGatewayCache {
+        pub fn new(gateways: Arc<RwLock<Option<Vec<Gateway>>>>) -> Self {
+            Self { gateways }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl GatewayCache for MockGatewayCache {
+        async fn lookup_gateways(&self, gw_type: GatewayType) -> Result<GatewayList, Error> {
+            Ok(GatewayList::new(
+                Some(gw_type),
+                self.gateways.read().await.clone().unwrap_or_default(),
+            ))
+        }
+
+        fn replace_gateway_client(&self, _gateway_client: GatewayClient) -> Result<(), Error> {
+            Ok(())
+        }
+
+        async fn refresh_all(&self) -> Result<(), Error> {
+            Ok(())
+        }
+    }
+}

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/mod.rs
@@ -1,0 +1,239 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+mod algorithm;
+mod gateway_cache;
+mod selector;
+
+use std::{sync::Arc, task::Poll};
+
+use futures::{FutureExt, Stream, StreamExt};
+use nym_gateway_directory::{BlacklistedGateways, GatewayClient, NodeIdentity};
+use nym_vpn_store::keys::wireguard::WireguardKeysDb;
+use tokio::{
+    sync::{Mutex, mpsc},
+    task::JoinHandle,
+};
+use tokio_stream::wrappers::ReceiverStream;
+use tokio_util::sync::CancellationToken;
+
+use crate::tunnel_state_machine::{
+    TunnelSettings,
+    tunnel::{
+        self,
+        gateway_provider::{
+            algorithm::{SelectAndSend, SelectionAlgorithm},
+            gateway_cache::GatewayCache,
+        },
+    },
+};
+
+pub use selector::SelectedGateways;
+
+type SelectionResult = Result<SelectedGateways, tunnel::Error>;
+type SelectionResultSender = mpsc::Sender<SelectionResult>;
+type SelectedGatewaysStream = Arc<Mutex<ReceiverStream<Result<SelectedGateways, tunnel::Error>>>>;
+
+#[derive(Clone)]
+pub struct GatewayProvider<C: GatewayCache> {
+    gateway_cache: C,
+    tunnel_settings_tx: mpsc::Sender<SelectAndSend>,
+    selected_gateways_stream: Option<SelectedGatewaysStream>,
+    blacklisted_entry_gateways: BlacklistedGateways,
+}
+
+impl<C: GatewayCache> Stream for GatewayProvider<C> {
+    type Item = SelectionResult;
+
+    fn poll_next(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        let Some(selected_gateways_stream) = self.selected_gateways_stream.as_ref() else {
+            return Poll::Pending;
+        };
+        let Poll::Ready(mut selected_gateways_stream) =
+            Box::pin(selected_gateways_stream.lock()).poll_unpin(cx)
+        else {
+            return Poll::Pending;
+        };
+        selected_gateways_stream.poll_next_unpin(cx)
+    }
+}
+
+impl<C: GatewayCache> GatewayProvider<C> {
+    pub fn new(
+        gateway_cache: C,
+        wg_keys_db: WireguardKeysDb,
+        shutdown_token: CancellationToken,
+    ) -> (Self, JoinHandle<()>) {
+        let (tunnel_settings_tx, tunnel_settings_rx) = mpsc::channel(1);
+        let blacklisted_entry_gateways = BlacklistedGateways::new();
+        let selection_algorithm_handle = tokio::spawn(
+            SelectionAlgorithm::new(
+                tunnel_settings_rx,
+                gateway_cache.clone(),
+                blacklisted_entry_gateways.clone(),
+                wg_keys_db,
+                shutdown_token,
+            )
+            .run(),
+        );
+
+        (
+            Self {
+                gateway_cache,
+                tunnel_settings_tx,
+                selected_gateways_stream: None,
+                blacklisted_entry_gateways,
+            },
+            selection_algorithm_handle,
+        )
+    }
+
+    pub async fn set_tunnel_settings(
+        &mut self,
+        tunnel_settings: TunnelSettings,
+    ) -> Result<(), crate::tunnel_state_machine::Error> {
+        // Pre-compute at most 10 different possibilities of selected gateways
+        let (selection_tx, selection_rx) = mpsc::channel(10);
+        self.selected_gateways_stream =
+            Some(Arc::new(Mutex::new(ReceiverStream::new(selection_rx))));
+        self.tunnel_settings_tx
+            .send(SelectAndSend {
+                tunnel_settings,
+                selection_tx,
+            })
+            .await
+            .map_err(|_| crate::tunnel_state_machine::Error::GatewayProviderDown)
+    }
+
+    pub async fn replace_gateway_client(&self, gateway_client: GatewayClient) {
+        self.gateway_cache
+            .replace_gateway_client(gateway_client)
+            .ok();
+        self.gateway_cache.refresh_all().await.ok();
+    }
+
+    pub fn clear_blacklisted_entry_gateways(&self) {
+        match self.blacklisted_entry_gateways.is_empty() {
+            Ok(is_empty) => {
+                if !is_empty {
+                    tracing::info!("Clearing blacklisted entry gateways");
+                    if let Err(e) = self.blacklisted_entry_gateways.clear() {
+                        tracing::error!("Failed to clear blacklisted entry gateway list: {e}");
+                    }
+                }
+            }
+            Err(e) => tracing::error!("Failed to read blacklisted entry gateway list: {e}"),
+        }
+    }
+
+    pub fn add_blacklisted_entry_gateway(&self, entry_gateway_identifier: NodeIdentity) {
+        if let Err(e) = self
+            .blacklisted_entry_gateways
+            .add(entry_gateway_identifier)
+        {
+            tracing::error!(
+                "Failed to add gateway {} to blacklisted entry gateway list: {e}",
+                entry_gateway_identifier
+            );
+        } else {
+            tracing::warn!(
+                "Blacklisted entry gateway {} due to repeated connection failure",
+                entry_gateway_identifier
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use std::time::Duration;
+
+    use nym_gateway_directory::{Gateway, Performance, ScoreValue};
+    use nym_vpn_lib_types::{EntryPoint, ExitPoint, TunnelType};
+    use tokio::sync::RwLock;
+
+    use crate::tunnel_state_machine::tunnel::gateway_provider::gateway_cache::tests::MockGatewayCache;
+
+    use super::*;
+
+    pub fn default_tunnel_settings() -> TunnelSettings {
+        TunnelSettings {
+            enable_ipv6: false,
+            tunnel_type: TunnelType::Wireguard,
+            allow_lan: false,
+            enable_ad_blocking: false,
+            residential_exit: false,
+            enable_lewes_protocol: false,
+            mixnet_tunnel_options: Default::default(),
+            wireguard_tunnel_options: Default::default(),
+            gateway_performance_options: Default::default(),
+            mixnet_client_config: None,
+            entry_point: Box::new(EntryPoint::Random),
+            exit_point: Box::new(ExitPoint::Random),
+            dns: Default::default(),
+            split_tunnel: Default::default(),
+        }
+    }
+
+    pub fn gateway_id_to_gateway(id: &str) -> Gateway {
+        Gateway::builder()
+            .identity(id.parse().unwrap())
+            .performance(Performance {
+                last_updated_utc: Default::default(),
+                score: ScoreValue::High,
+                mixnet_score: ScoreValue::High,
+                load: ScoreValue::Low,
+                uptime_percentage_last_24_hours: Default::default(),
+            })
+            .build()
+    }
+
+    #[tokio::test]
+    async fn empty_stream() {
+        let shutdown_token = CancellationToken::new();
+        let gateways = Arc::new(RwLock::new(None));
+        let (mut gw_provider, handle) = GatewayProvider::new(
+            MockGatewayCache::new(gateways),
+            WireguardKeysDb::Ephemeral(Default::default()),
+            shutdown_token.child_token(),
+        );
+        // No gateways come out of the stream when there are no tunnel settings
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), gw_provider.next())
+                .await
+                .is_err()
+        );
+        shutdown_token.cancel();
+        handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn set_and_stream() {
+        let shutdown_token = CancellationToken::new();
+        let possible_gateways = [
+            "2zHiExNRKiCXVKS35SNKtK4apGfZELMpA1jJ2gVevJoz",
+            "38zcSsvjXsAX7C28ko2H3Lt55X4TYxfZYkPADxKXZHUj",
+        ]
+        .map(gateway_id_to_gateway);
+        let gateways = Arc::new(RwLock::new(Some(possible_gateways.to_vec())));
+        let (mut gw_provider, handle) = GatewayProvider::new(
+            MockGatewayCache::new(gateways),
+            WireguardKeysDb::Ephemeral(Default::default()),
+            shutdown_token.child_token(),
+        );
+        gw_provider
+            .set_tunnel_settings(default_tunnel_settings())
+            .await
+            .unwrap();
+        // check we have "infinite" stream
+        for _ in 0..100 {
+            gw_provider.next().await.unwrap().unwrap();
+        }
+
+        shutdown_token.cancel();
+        handle.await.unwrap();
+    }
+}

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/selector.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/selector.rs
@@ -5,8 +5,8 @@ use std::{net::SocketAddr, sync::Arc};
 
 use nym_crypto::asymmetric::x25519::KeyPair;
 use nym_gateway_directory::{
-    BlacklistedGateways, EntryPoint, ExitPoint, Gateway, GatewayCacheHandle, GatewayFilter,
-    GatewayFilters, GatewayList, GatewayType,
+    BlacklistedGateways, EntryPoint, ExitPoint, Gateway, GatewayFilter, GatewayFilters,
+    GatewayList, GatewayType,
 };
 use nym_registration_client::RegistrationNymNode;
 use nym_registration_common::{NymNodeInformation, NymNodeLPInformation};
@@ -14,7 +14,10 @@ use nym_vpn_store::keys::wireguard::{WireguardKeyStore, WireguardKeysDb};
 
 use crate::{
     GatewayDirectoryError,
-    tunnel_state_machine::{TunnelSettings, TunnelType, tunnel},
+    tunnel_state_machine::{
+        TunnelSettings, TunnelType,
+        tunnel::{self, gateway_provider::gateway_cache::GatewayCache},
+    },
 };
 
 #[derive(Clone)]
@@ -119,7 +122,7 @@ impl SelectedGateways {
 }
 
 pub async fn select_gateways(
-    gateway_cache_handle: GatewayCacheHandle,
+    gateway_cache: impl GatewayCache,
     blacklisted_entry_gateways: &BlacklistedGateways,
     tunnel_settings: &TunnelSettings,
     wg_keys_db: WireguardKeysDb,
@@ -147,7 +150,7 @@ pub async fn select_gateways(
 
     let (mut entry_gateways, exit_gateways) = match tunnel_settings.tunnel_type {
         TunnelType::Wireguard => {
-            let all_gateways = gateway_cache_handle
+            let all_gateways = gateway_cache
                 .lookup_gateways(GatewayType::Wg)
                 .await
                 .map_err(GatewayDirectoryError::LookupGateways)?;
@@ -169,21 +172,18 @@ pub async fn select_gateways(
         }
         TunnelType::Mixnet => {
             // Setup the gateway that we will use as the exit point
-            let exit_gateways = gateway_cache_handle
+            let exit_gateways = gateway_cache
                 .lookup_gateways(GatewayType::MixnetExit)
                 .await
                 .map_err(GatewayDirectoryError::LookupGateways)?;
             // Setup the gateway that we will use as the entry point
-            let entry_gateways = gateway_cache_handle
+            let entry_gateways = gateway_cache
                 .lookup_gateways(GatewayType::MixnetEntry)
                 .await
                 .map_err(GatewayDirectoryError::LookupGateways)?;
             (entry_gateways, exit_gateways)
         }
     };
-
-    tracing::info!("Found {} entry gateways", entry_gateways.len());
-    tracing::info!("Found {} exit gateways", exit_gateways.len());
 
     let exit_filters = if tunnel_settings.residential_exit {
         GatewayFilters::from(&[GatewayFilter::Residential, GatewayFilter::Exit])
@@ -228,36 +228,6 @@ pub async fn select_gateways(
         })?
         .exit_keypair()
         .clone();
-
-    tracing::debug!("Using entry public key: {}", entry_keys.public_key());
-    tracing::debug!("Using exit public key: {}", exit_keys.public_key());
-
-    tracing::info!(
-        "Using entry gateway: {}, location: {}, performance: {}",
-        entry_gateway.identity(),
-        entry_gateway
-            .two_letter_iso_country_code()
-            .map_or_else(|| "unknown".to_string(), |code| code.to_string()),
-        entry_gateway
-            .mixnet_performance
-            .map_or_else(|| "unknown".to_string(), |perf| perf.to_string()),
-    );
-    tracing::info!(
-        "Using exit gateway: {}, location: {}, performance: {}",
-        exit_gateway.identity(),
-        exit_gateway
-            .two_letter_iso_country_code()
-            .map_or_else(|| "unknown".to_string(), |code| code.to_string()),
-        exit_gateway
-            .mixnet_performance
-            .map_or_else(|| "unknown".to_string(), |perf| perf.to_string()),
-    );
-    tracing::info!(
-        "Using exit router address {}",
-        exit_gateway
-            .ipr_address
-            .map_or_else(|| "none".to_string(), |ipr| ipr.to_string())
-    );
 
     Ok(SelectedGateways {
         entry: Box::new(GatewayWithKeys {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
@@ -2,43 +2,19 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 mod any_tunnel_handle;
-mod gateway_selector;
+pub mod gateway_provider;
 pub mod mixnet;
 mod tombstone;
 pub mod transports;
 pub mod wireguard;
 
-pub use gateway_selector::SelectedGateways;
-use nym_gateway_directory::{BlacklistedGateways, GatewayCacheHandle};
-use nym_vpn_store::keys::wireguard::WireguardKeysDb;
-use tokio_util::sync::CancellationToken;
+pub use gateway_provider::SelectedGateways;
 
 #[cfg(windows)]
 use super::route_handler;
-use crate::{GatewayDirectoryError, MixnetError, tunnel_state_machine::TunnelSettings};
+use crate::{GatewayDirectoryError, MixnetError};
 pub use any_tunnel_handle::AnyTunnelHandle;
 pub use tombstone::Tombstone;
-
-pub async fn select_gateways(
-    gateway_cache_handle: GatewayCacheHandle,
-    blacklisted_entry_gateways: &BlacklistedGateways,
-    tunnel_settings: &TunnelSettings,
-    wg_keys_db: WireguardKeysDb,
-    cancel_token: CancellationToken,
-) -> Result<SelectedGateways> {
-    let select_gateways_fut = gateway_selector::select_gateways(
-        gateway_cache_handle,
-        blacklisted_entry_gateways,
-        tunnel_settings,
-        wg_keys_db,
-    );
-
-    cancel_token
-        .run_until_cancelled(select_gateways_fut)
-        .await
-        .ok_or(Error::Cancelled)?
-        .map_err(|err| Error::SelectGateways(Box::new(err)))
-}
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -18,14 +18,12 @@ use std::{
 #[cfg(unix)]
 use std::{os::fd::RawFd, sync::Arc};
 
-use futures::{FutureExt, future::Fuse};
+use futures::{FutureExt, StreamExt, future::Fuse};
 #[cfg(any(target_os = "ios", target_os = "android"))]
 use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
 #[cfg(target_os = "linux")]
 use nix::sys::socket::{SetSockOpt, sockopt::Mark};
-use nym_gateway_directory::{
-    BlacklistedGateways, GatewayCacheHandle, GatewayClient, GatewayMinPerformance,
-};
+use nym_gateway_directory::{GatewayCacheHandle, GatewayClient, GatewayMinPerformance};
 use time::OffsetDateTime;
 use tokio::{sync::mpsc, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
@@ -49,7 +47,6 @@ use nym_vpn_lib_types::{
     EstablishConnectionData, GatewayLightInfo, MixnetConnectionData, NymAddress,
     TunnelConnectionData, TunnelType, WireguardConnectionData, WireguardNode,
 };
-use nym_vpn_store::keys::wireguard::WireguardKeysDb;
 
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use super::route_handler::{RouteHandler, RoutingConfig};
@@ -79,6 +76,7 @@ use crate::{
     tunnel_state_machine::{
         TunnelConstants, WireguardMultihopMode, account, ipv6_availability,
         tunnel::{
+            gateway_provider::GatewayProvider,
             mixnet,
             transports::{self, TransportError},
             wireguard::{
@@ -220,7 +218,6 @@ pub struct TunnelParameters {
     pub tunnel_constants: TunnelConstants,
     pub selected_gateways: Option<SelectedGateways>,
     pub user_agent: UserAgent,
-    pub blacklisted_entry_gateways: BlacklistedGateways,
 }
 
 pub struct TunnelMonitor {
@@ -234,9 +231,8 @@ pub struct TunnelMonitor {
     tun_provider: Arc<dyn AndroidTunProvider>,
     account_controller_state: AccountStateReceiver,
     account_command_tx: AccountCommandSender,
-    gateway_cache_handle: GatewayCacheHandle,
+    gateway_provider: GatewayProvider<GatewayCacheHandle>,
     custom_topology_provider: VpnTopologyServiceHandle,
-    wg_keys_db: WireguardKeysDb,
     shutdown_token: CancellationToken,
 }
 
@@ -246,10 +242,9 @@ impl TunnelMonitor {
         tunnel_parameters: TunnelParameters,
         account_controller_state: AccountStateReceiver,
         account_command_tx: AccountCommandSender,
-        gateway_cache_handle: GatewayCacheHandle,
+        gateway_provider: GatewayProvider<GatewayCacheHandle>,
         custom_topology_provider: VpnTopologyServiceHandle,
         monitor_event_sender: mpsc::UnboundedSender<TunnelMonitorEvent>,
-        wg_keys_db: WireguardKeysDb,
         #[cfg(not(any(target_os = "android", target_os = "ios")))] route_handler: RouteHandler,
         #[cfg(target_os = "ios")] tun_provider: Arc<dyn OSTunProvider>,
         #[cfg(target_os = "android")] tun_provider: Arc<dyn AndroidTunProvider>,
@@ -264,9 +259,8 @@ impl TunnelMonitor {
             tun_provider,
             account_controller_state,
             account_command_tx,
-            gateway_cache_handle,
+            gateway_provider,
             custom_topology_provider,
-            wg_keys_db,
             shutdown_token: shutdown_token.clone(),
         };
         let join_handle = tokio::spawn(tunnel_monitor.run());
@@ -345,10 +339,9 @@ impl TunnelMonitor {
             GatewayClient::new(gateway_config.clone(), user_agent.clone())
                 .map_err(Error::GatewayDirectoryClient)?;
 
-        self.gateway_cache_handle
+        self.gateway_provider
             .replace_gateway_client(gateway_directory_client)
-            .ok();
-        self.gateway_cache_handle.refresh_all().await.ok();
+            .await;
 
         let selected_gateways =
             if let Some(ref selected_gateways) = self.tunnel_parameters.selected_gateways {
@@ -356,14 +349,14 @@ impl TunnelMonitor {
             } else {
                 self.send_event(TunnelMonitorEvent::SelectingGateways);
 
-                let new_gateways = tunnel::select_gateways(
-                    self.gateway_cache_handle.clone(),
-                    &self.tunnel_parameters.blacklisted_entry_gateways,
-                    &self.tunnel_parameters.tunnel_settings,
-                    self.wg_keys_db.clone(),
-                    self.shutdown_token.child_token(),
-                )
-                .await?;
+                self.gateway_provider
+                    .set_tunnel_settings(self.tunnel_parameters.tunnel_settings.clone())
+                    .await?;
+                let new_gateways = self
+                    .gateway_provider
+                    .next()
+                    .await
+                    .ok_or(Error::GatewayProviderDown)??;
 
                 let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
                 self.send_event(TunnelMonitorEvent::SelectedGateways {


### PR DESCRIPTION
## Ticket

JIRA-NYM-817

## Description

Use a stream of `SelectedGateways` that can get recreated on different tunnel settings and get buffered for faster retries.
This prepares the work for 1 click algorithm, where the gateway selection will be pre-computed and selected based on a new tunnel setting.


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5037)
<!-- Reviewable:end -->
