### PR TITLE
NYM-915: More Split Tunnel Driver signing.

### DIFF
--- a/.github/workflows/sign-st-driver-windows.yml
+++ b/.github/workflows/sign-st-driver-windows.yml
@@ -1,0 +1,112 @@
+name: sign-st-driver-windows
+on:
+  workflow_dispatch:
+  workflow_call:
+    secrets:
+      SSL_COM_USERNAME:
+        required: true
+      SSL_COM_PASSWORD:
+        required: true
+      SSL_COM_TOTP_SECRET:
+        required: true
+    outputs:
+      UPLOAD_DIR_WINDOWS:
+        value: ${{ jobs.sign-cab.outputs.UPLOAD_DIR_WINDOWS }}
+
+env:
+  UPLOAD_DIR_WINDOWS: signed-st-driver
+
+jobs:
+  build-driver:
+    uses: ./.github/workflows/build-st-driver-windows.yml
+
+  sign-cab:
+    needs: build-driver
+    runs-on: custom-windows-11
+    outputs:
+      UPLOAD_DIR_WINDOWS: ${{ env.UPLOAD_DIR_WINDOWS }}
+
+    steps:
+      - name: Cleanup working directory
+        shell: bash
+        run: |
+          ls -la ./
+          rm -rf ./* || true
+          rm -rf ./.??* || true
+          ls -la ./
+
+      - name: Download driver artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: st-driver
+          path: st-driver
+
+      - name: List downloaded files
+        shell: bash
+        run: ls -la st-driver/
+
+      - name: Build CAB file
+        shell: pwsh
+        run: |
+          $lines = @(
+            '.OPTION EXPLICIT',
+            '.Set CabinetNameTemplate=nymvpn-split-tunnel.cab',
+            '.Set DiskDirectoryTemplate=.',
+            '.Set CompressionType=MSZIP',
+            '"st-driver\nymvpn-split-tunnel.sys"',
+            '"st-driver\nymvpn-split-tunnel.cat"',
+            '"st-driver\nymvpn-split-tunnel.inf"'
+          )
+          $lines | Set-Content -Path nymvpn-split-tunnel.ddf
+          makecab /F nymvpn-split-tunnel.ddf
+
+      - name: Download EV CodeSignTool from ssl.com
+        shell: bash
+        run: |
+          curl -L0 https://www.ssl.com/download/codesigntool-for-linux-and-macos/ -o codesigntool.zip
+          unzip codesigntool.zip
+
+      - name: Get EV certificate credential id
+        id: get_credential_ids
+        shell: bash
+        run: |
+          echo "SSL_COM_CREDENTIAL_ID=$(./CodeSignTool.sh get_credential_ids -username=${{ secrets.SSL_COM_USERNAME }} -password=${{ secrets.SSL_COM_PASSWORD }} | sed -n '1!p' | sed 's/- //')" >> "$GITHUB_OUTPUT"
+
+      - name: Sign CAB file
+        shell: bash
+        env:
+          SSL_COM_USERNAME: ${{ secrets.SSL_COM_USERNAME }}
+          SSL_COM_PASSWORD: ${{ secrets.SSL_COM_PASSWORD }}
+          SSL_COM_TOTP_SECRET: ${{ secrets.SSL_COM_TOTP_SECRET }}
+          SSL_COM_CREDENTIAL_ID: ${{ steps.get_credential_ids.outputs.SSL_COM_CREDENTIAL_ID }}
+        run: |
+          mkdir -p signed
+          ./CodeSignTool.sh sign \
+            -username="$SSL_COM_USERNAME" \
+            -password="$SSL_COM_PASSWORD" \
+            -totp_secret="$SSL_COM_TOTP_SECRET" \
+            -credential_id="$SSL_COM_CREDENTIAL_ID" \
+            -input_file_path=nymvpn-split-tunnel.cab \
+            -output_dir_path=signed
+
+      - name: Move things around to prepare for upload
+        shell: bash
+        run: |
+          rm -rf ${{ env.UPLOAD_DIR_WINDOWS }} || true
+          mkdir ${{ env.UPLOAD_DIR_WINDOWS }}
+          cp -vp signed/nymvpn-split-tunnel.cab ${{ env.UPLOAD_DIR_WINDOWS }}/
+
+      - name: Upload artifact
+        id: upload_artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ env.UPLOAD_DIR_WINDOWS }}
+          path: ${{ env.UPLOAD_DIR_WINDOWS }}
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Print download link
+        shell: bash
+        run: |
+          echo "Signed CAB artifact ready for submission to Microsoft."
+          echo "Download from: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/sign-st-driver-windows.yml
+++ b/.github/workflows/sign-st-driver-windows.yml
@@ -13,6 +13,9 @@ on:
       UPLOAD_DIR_WINDOWS:
         value: ${{ jobs.sign-cab.outputs.UPLOAD_DIR_WINDOWS }}
 
+permissions:
+  contents: read
+
 env:
   UPLOAD_DIR_WINDOWS: signed-st-driver
 

--- a/nym-vpn-core/Windows.mk
+++ b/nym-vpn-core/Windows.mk
@@ -103,6 +103,11 @@ libwg: create_target_dir create_version_header
 	Copy-Item "$(LIBWG_BUILD_DIR)/$(LIBWG_DLL)" -Destination "$(TARGET_DIR)/$(LIBWG_DLL)" -Force
 
 winfw: create_target_dir create_version_header
+# Ensure the old binaries are removed to avoid build issues
+	if (Test-Path "$(CURDIR)/../nym-vpn-windows/winfw/bin") { #\
+		Remove-Item "$(CURDIR)/../nym-vpn-windows/winfw/bin" -Recurse -Force ; #\
+	}
+
 # Setup environment and build winfw
 	MSBuild.exe /m "$(CURDIR)/../nym-vpn-windows/winfw/winfw.sln" /p:Configuration=$(MSVC_CONFIG) /p:Platform=$(WINFW_PLATFORM)
 

--- a/nym-vpn-windows/winfw/src/winfw/version.h
+++ b/nym-vpn-windows/winfw/src/winfw/version.h
@@ -1,8 +1,0 @@
-#ifndef VERSION_H
-#define VERSION_H
-#define MAJOR_VERSION 1
-#define MINOR_VERSION 27
-#define PATCH_VERSION 0
-#define PRODUCT_VERSION "1.27.0"
-#endif
-

--- a/wireguard/libwg/version.h
+++ b/wireguard/libwg/version.h
@@ -1,8 +1,0 @@
-#ifndef VERSION_H
-#define VERSION_H
-#define MAJOR_VERSION 1
-#define MINOR_VERSION 27
-#define PATCH_VERSION 0
-#define PRODUCT_VERSION "1.27.0"
-#endif
-


### PR DESCRIPTION
## Ticket

JIRA-NYM-915

## Description

- Add a GitHub Actions workflow to sign the ST driver on Windows using the EV CodeSignTool from SSL.com.
- Ensure `winfw` binaries are cleaned before building to avoid build errors related to pre-compiled headers.
- Remove the version header files from the driver projects, as they are no longer needed.

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5045)
<!-- Reviewable:end -->
