### PR TITLE
Fix signing of `nym-vpnd.exe`.

### DIFF
--- a/nym-vpn-app/src-tauri/scripts/sign.sh
+++ b/nym-vpn-app/src-tauri/scripts/sign.sh
@@ -34,6 +34,16 @@ function sign {
 	fi
 }
 
-sign "$1"
+exe=$1
+
+# If we are signing the Tauri app, then also sign the daemon.
+if [[ "$exe" == *NymVPN.exe ]]; then
+	# shellcheck disable=SC2043
+	for additonal in "nym-vpnd.exe"; do
+		sign "$additonal"
+	done
+fi
+
+sign "$exe"
 
 exit 0


### PR DESCRIPTION
During Split Tunnel signing work, I broke the signing of `nym-vpnd.exe`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5060)
<!-- Reviewable:end -->
