### PR TITLE
Finalize x86_64 Android support for native libraries

### DIFF
--- a/.github/workflows/build-nym-vpn-android.yml
+++ b/.github/workflows/build-nym-vpn-android.yml
@@ -163,7 +163,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
-          targets: aarch64-linux-android
+          targets: aarch64-linux-android,x86_64-linux-android
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/build-nym-vpn-core-android.yml
+++ b/.github/workflows/build-nym-vpn-core-android.yml
@@ -37,7 +37,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
-          targets: aarch64-linux-android
+          targets: aarch64-linux-android,x86_64-linux-android
 
       - name: Setup NDK
         uses: nttld/setup-ndk@v1
@@ -76,11 +76,17 @@ jobs:
       - name: Append timestamp if it's a dev version
         run: ./scripts/append-timestamp-to-version.sh nym-vpn-core/Cargo.toml ${{ steps.workspace-version.outputs.metadata }}
 
-      - name: Download wireguard-go artifacts
+      - name: Download wireguard-go artifacts (aarch64)
         uses: actions/download-artifact@v8
         with:
           name: wireguard-go_aarch64-linux-android
           path: build/lib/aarch64-linux-android
+
+      - name: Download wireguard-go artifacts (x86_64)
+        uses: actions/download-artifact@v8
+        with:
+          name: wireguard-go_x86_64-linux-android
+          path: build/lib/x86_64-linux-android
 
       - name: Build nym-vpn-core for android
         working-directory: nym-vpn-core
@@ -96,12 +102,14 @@ jobs:
           echo "rustc=$(rustc -V)" >> $GITHUB_OUTPUT
 
       - name: Move things around to prepare for upload
-        env:
-          BUILD_DIR: nym-vpn-android/core/src/main/jniLibs/arm64-v8a
         run: |
           mkdir ${{ env.UPLOAD_DIR_ANDROID }}
-          cp ${{ env.BUILD_DIR }}/libnym_vpn_lib.so ${{ env.UPLOAD_DIR_ANDROID }}
-          cp ${{ env.BUILD_DIR }}/libnym_vpn_lib_types.so ${{ env.UPLOAD_DIR_ANDROID }}
+          mkdir ${{ env.UPLOAD_DIR_ANDROID }}/arm64-v8a
+          mkdir ${{ env.UPLOAD_DIR_ANDROID }}/x86_64
+          cp nym-vpn-android/core/src/main/jniLibs/arm64-v8a/libnym_vpn_lib.so ${{ env.UPLOAD_DIR_ANDROID }}/arm64-v8a/
+          cp nym-vpn-android/core/src/main/jniLibs/arm64-v8a/libnym_vpn_lib_types.so ${{ env.UPLOAD_DIR_ANDROID }}/arm64-v8a/
+          cp nym-vpn-android/core/src/main/jniLibs/x86_64/libnym_vpn_lib.so ${{ env.UPLOAD_DIR_ANDROID }}/x86_64/
+          cp nym-vpn-android/core/src/main/jniLibs/x86_64/libnym_vpn_lib_types.so ${{ env.UPLOAD_DIR_ANDROID }}/x86_64/
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build-wireguard-go-android.yml
+++ b/.github/workflows/build-wireguard-go-android.yml
@@ -56,10 +56,18 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: ./wireguard/build-wireguard-go.sh --android
 
-      - name: Upload artifacts
+      - name: Upload aarch64 artifacts
         uses: actions/upload-artifact@v7
         with:
           name: wireguard-go_aarch64-linux-android
           path: build/lib/aarch64-linux-android
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload x86_64 artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: wireguard-go_x86_64-linux-android
+          path: build/lib/x86_64-linux-android
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/build-wireguard-go-android.yml
+++ b/.github/workflows/build-wireguard-go-android.yml
@@ -54,6 +54,8 @@ jobs:
 
       - name: Build wireguard
         if: steps.cache.outputs.cache-hit != 'true'
+        env:
+          ARCHITECTURES: aarch64 x86_64
         run: ./wireguard/build-wireguard-go.sh --android
 
       - name: Upload aarch64 artifacts

--- a/.github/workflows/ci-nym-vpn-core-android.yml
+++ b/.github/workflows/ci-nym-vpn-core-android.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
           components: rustfmt, clippy
-          targets: aarch64-linux-android
+          targets: aarch64-linux-android,x86_64-linux-android
 
       - name: Install cargo-ndk
         uses: baptiste0928/cargo-install@v3

--- a/.github/workflows/publish-nym-vpn-android.yml
+++ b/.github/workflows/publish-nym-vpn-android.yml
@@ -338,7 +338,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
-          targets: aarch64-linux-android
+          targets: aarch64-linux-android,x86_64-linux-android
 
       - name: Install cargo-ndk
         uses: baptiste0928/cargo-install@v3

--- a/nym-vpn-core/Android.mk
+++ b/nym-vpn-core/Android.mk
@@ -23,6 +23,7 @@ DOCKER_FLAG := --docker
 endif
 
 ARCH_ARM64_V8 := arm64-v8a
+ARCH_X86_64 := x86_64
 STRIP_TOOL_BIN := llvm-strip
 
 ifneq ($(strip $(NDK_TOOLCHAIN_DIR)),)
@@ -36,6 +37,7 @@ ANDROID_DIR := $(CURDIR)/../nym-vpn-android
 UNIFFI_OUT_DIR := $(ANDROID_DIR)/core/src/main/java/net/nymtech/vpn
 JNI_LIBS_DIR := $(ANDROID_DIR)/core/src/main/jniLibs
 ARM64_V8_BUILD_DIR := $(JNI_LIBS_DIR)/$(ARCH_ARM64_V8)
+X86_64_BUILD_DIR := $(JNI_LIBS_DIR)/$(ARCH_X86_64)
 
 DYNAMIC_LIB_PATH := $(CURDIR)/target/aarch64-linux-android/$(TARGET_DIR)/libnym_vpn_lib_uniffi.so
 WIREGUARD_DIR := $(CURDIR)/../wireguard
@@ -48,15 +50,23 @@ LIBWG_SOURCES := $(wildcard $(WIREGUARD_DIR)/libwg/*.go) $(wildcard $(WIREGUARD_
 
 .PHONY: build uniffi libwg strip clean
 
-all: $(ARM64_V8_BUILD_DIR)/libwg.so build uniffi strip $(LICENSES_FILE)
+all: $(ARM64_V8_BUILD_DIR)/libwg.so $(X86_64_BUILD_DIR)/libwg.so build uniffi strip $(LICENSES_FILE)
 
-build: $(ARM64_V8_BUILD_DIR)/libwg.so
-	$(ALL_IDEMPOTENT_FLAGS) cargo ndk -t $(ARCH_ARM64_V8) -o $(JNI_LIBS_DIR) build --package nym-vpn-lib-uniffi --package nym-vpn-lib-types $(RELEASE_FLAG)
+build: $(ARM64_V8_BUILD_DIR)/libwg.so $(X86_64_BUILD_DIR)/libwg.so
+	$(ALL_IDEMPOTENT_FLAGS) cargo ndk -t $(ARCH_ARM64_V8) -t $(ARCH_X86_64) -o $(JNI_LIBS_DIR) build --package nym-vpn-lib-uniffi --package nym-vpn-lib-types $(RELEASE_FLAG)
 	cd $(ARM64_V8_BUILD_DIR) ; \
+	mv libnym_vpn_lib_uniffi.so libnym_vpn_lib.so
+	cd $(X86_64_BUILD_DIR) ; \
 	mv libnym_vpn_lib_uniffi.so libnym_vpn_lib.so
 
 strip: build
 	cd $(ARM64_V8_BUILD_DIR) ; \
+	for target in $(STRIP_TARGETS); do \
+		echo "Stripping $${target}" ; \
+        $(STRIP_TOOL) --strip-unneeded --strip-debug --remove-section=.comment -o "stripped_$${target}" "$${target}" ; \
+        mv stripped_$${target} $${target} ; \
+    done
+	cd $(X86_64_BUILD_DIR) ; \
 	for target in $(STRIP_TARGETS); do \
 		echo "Stripping $${target}" ; \
         $(STRIP_TOOL) --strip-unneeded --strip-debug --remove-section=.comment -o "stripped_$${target}" "$${target}" ; \
@@ -71,10 +81,14 @@ uniffi: build
 $(ARM64_V8_BUILD_DIR)/libwg.so: $(LIBWG_SOURCES)
 	$(WIREGUARD_DIR)/build-wireguard-go.sh --android $(DOCKER_FLAG)
 
-libwg: $(ARM64_V8_BUILD_DIR)/libwg.so
+$(X86_64_BUILD_DIR)/libwg.so: $(ARM64_V8_BUILD_DIR)/libwg.so
+	@# built as a side effect of the arm64 wireguard build above
+
+libwg: $(ARM64_V8_BUILD_DIR)/libwg.so $(X86_64_BUILD_DIR)/libwg.so
 
 clean:
 	rm -rf $(ARM64_V8_BUILD_DIR) || true
+	rm -rf $(X86_64_BUILD_DIR) || true
 	rm -rf $(JNI_LIBS_DIR) || true
 
 $(LICENSES_FILE): $(CURDIR)/Cargo.lock

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tun_name.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tun_name.rs
@@ -43,7 +43,9 @@ pub fn get_tun_name(fd: &BorrowedFd) -> Result<String> {
         .map_err(GetTunNameError::Syscall)?;
 
     // SAFETY: reinterpreting [i8; N] as [u8; N] is safe — same size/alignment, no invalid values.
-    let ifr_name_bytes: &[u8] = unsafe { std::slice::from_raw_parts(ifr.ifr_name.as_ptr() as *const u8, ifr.ifr_name.len()) };
+    let ifr_name_bytes: &[u8] = unsafe {
+        std::slice::from_raw_parts(ifr.ifr_name.as_ptr() as *const u8, ifr.ifr_name.len())
+    };
     CStr::from_bytes_until_nul(ifr_name_bytes)
         .map_err(GetTunNameError::CopyInterfaceName)?
         .to_str()

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tun_name.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tun_name.rs
@@ -42,7 +42,9 @@ pub fn get_tun_name(fd: &BorrowedFd) -> Result<String> {
     unsafe { tungetiff(fd.as_raw_fd(), &mut ifr as *mut _ as _) }
         .map_err(GetTunNameError::Syscall)?;
 
-    CStr::from_bytes_until_nul(&ifr.ifr_name)
+    // SAFETY: reinterpreting [i8; N] as [u8; N] is safe — same size/alignment, no invalid values.
+    let ifr_name_bytes: &[u8] = unsafe { std::slice::from_raw_parts(ifr.ifr_name.as_ptr() as *const u8, ifr.ifr_name.len()) };
+    CStr::from_bytes_until_nul(ifr_name_bytes)
         .map_err(GetTunNameError::CopyInterfaceName)?
         .to_str()
         .map(|s| s.to_owned())


### PR DESCRIPTION
## Ticket

JIRA-NYM-1100

## Description

### Summary

Fixes UnsatisfiedLinkError: Unable to load library 'nym_vpn_lib' on x86_64 Android tablets:

dlopen failed: library "libnym_vpn_lib.so" not found
Native library (android-x86-64/libnym_vpn_lib.so) not found in resource path (.)
→ ERROR core-vpn: InitCoreFailed

### Problem
The app declared x86_64 as a supported ABI in app/build.gradle.kts (for bundle builds), but libnym_vpn_lib.so was never compiled for that architecture. The build system only targeted aarch64-linux-android, leaving x86_64 devices (tablets, emulators, Chrome OS) unable to load the native library at runtime.

Note: wireguard/libwg/build-android.sh already built libwg.so for x86_64 by default — it just wasn't being uploaded or consumed downstream.        

### Changes

nym-vpn-core/Android.mk

- Add ARCH_X86_64 := x86_64 and X86_64_BUILD_DIR
- Pass -t arm64-v8a -t x86_64 to cargo ndk so both ABIs are compiled in one pass
- Strip and rename libnym_vpn_lib_uniffi.so → libnym_vpn_lib.so for both ABI output dirs
- Add $(X86_64_BUILD_DIR)/libwg.so rule (produced as a side effect of the existing arm64 wireguard build)
- clean now removes both ABI dirs

.github/workflows/build-wireguard-go-android.yml

- Upload the x86_64 libwg.so artifact (wireguard-go_x86_64-linux-android) — it was already being built but silently discarded

.github/workflows/build-nym-vpn-core-android.yml

- Add x86_64-linux-android to the installed Rust targets
- Download the x86_64 wireguard artifact before the Make build
- Upload libnym_vpn_lib.so and libnym_vpn_lib_types.so for both arm64-v8a/ and x86_64/

nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tun_name.rs

- Fix type mismatch when reading ifr_name from an ifreq struct: on x86_64 Android, libc::c_char is i8 (signed), making ifr_name a [i8; 16], whereas CStr::from_bytes_until_nul expects &[u8]. On ARM64 Android c_char is u8 so this was never caught. Fixed with a safe byte reinterpretation via slice::from_raw_parts.                                            

### Motivation

x86_64 Android devices (tablets, foldables, Chrome OS, emulators) are increasingly common, the app installs successfully but login fails for all such devices due to the VPN core being unable to load its native library.


## Checklist:

- this require a patch on libcrux libcrux-psq/src/handshake/initiator/registration.rs

<img width="952" height="603" alt="Screenshot from 2026-04-08 21-21-47" src="https://github.com/user-attachments/assets/4533f61b-afc2-4636-a5af-0911f3e6622f" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5065)
<!-- Reviewable:end -->
