### PR TITLE
fix: reduce fresh-device login latency

### DIFF
--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/login/LoginViewModel.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/login/LoginViewModel.kt
@@ -32,7 +32,7 @@ class LoginViewModel @Inject constructor(private val settingsRepository: Setting
 
 	companion object {
 		private const val TAG = "ui-login-vm"
-		private const val ACCOUNT_READY_TIMEOUT_MS = 20_000L
+		private const val ACCOUNT_READY_TIMEOUT_MS = 90_000L
 	}
 
 	private val _uiState = MutableStateFlow(LoginUiState())

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/zknym_handler/request.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/zknym_handler/request.rs
@@ -672,7 +672,9 @@ impl RequestZkNymTask {
             Ok(ticketbook)
         })
         .await
-        .map_err(|err| RequestZkNymError::internal(format!("unblind_and_aggregate panicked: {err}")))?
+        .map_err(|err| {
+            RequestZkNymError::internal(format!("unblind_and_aggregate panicked: {err}"))
+        })?
     }
 
     async fn confirm_zk_nym_downloaded(&self, id: &str) -> Result<StatusOk, RequestZkNymError> {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/zknym_handler/request.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/zknym_handler/request.rs
@@ -596,72 +596,83 @@ impl RequestZkNymTask {
             .create_ecash_keypair()
             .map_err(|err| RequestZkNymError::CreateEcashKeyPair(err.to_string()))?;
 
-        tracing::trace!("Setting up decoded keys");
-        let mut decoded_keys = HashMap::new();
-        for key in issuers.keys {
-            let vk = VerificationKeyAuth::try_from_bs58(&key.bs58_encoded_key)
-                .inspect_err(|err| {
-                    tracing::error!("Failed to create VerificationKeyAuth: {err:#?}")
-                })
-                .map_err(|err| RequestZkNymError::InvalidVerificationKey(err.to_string()))?;
-            decoded_keys.insert(key.node_index, vk);
-        }
+        // Clone request_info so it can be moved into spawn_blocking (which requires 'static).
+        let request_info = request_info.clone();
 
-        tracing::trace!("Verifying zk-nym shares");
-        let mut partial_wallets = Vec::new();
-        for share in shares.shares {
-            tracing::trace!("Creating blinded signature");
-            let blinded_sig =
-                BlindedSignature::try_from_bs58(&share.bs58_encoded_share).map_err(|err| {
-                    tracing::error!("Failed to create BlindedSignature: {err:#?}");
-                    RequestZkNymError::DeserializeBlindedSignature(err.to_string())
-                })?;
+        // The key decoding + issue_verify loop + aggregate_wallets are all CPU-intensive
+        // EC cryptographic operations. Running them on the async executor blocks tokio worker
+        // threads and serialises the three concurrent ticket-type tasks on mobile. Moving
+        // this work to the blocking thread pool lets all three run truly in parallel.
+        tokio::task::spawn_blocking(move || {
+            tracing::trace!("Setting up decoded keys");
+            let mut decoded_keys = HashMap::new();
+            for key in issuers.keys {
+                let vk = VerificationKeyAuth::try_from_bs58(&key.bs58_encoded_key)
+                    .inspect_err(|err| {
+                        tracing::error!("Failed to create VerificationKeyAuth: {err:#?}")
+                    })
+                    .map_err(|err| RequestZkNymError::InvalidVerificationKey(err.to_string()))?;
+                decoded_keys.insert(key.node_index, vk);
+            }
 
-            let Some(vk) = decoded_keys.get(&share.node_index) else {
-                return Err(RequestZkNymError::DecodedKeysMissingIndex);
-            };
+            tracing::trace!("Verifying zk-nym shares");
+            let mut partial_wallets = Vec::new();
+            for share in shares.shares {
+                tracing::trace!("Creating blinded signature");
+                let blinded_sig = BlindedSignature::try_from_bs58(&share.bs58_encoded_share)
+                    .map_err(|err| {
+                        tracing::error!("Failed to create BlindedSignature: {err:#?}");
+                        RequestZkNymError::DeserializeBlindedSignature(err.to_string())
+                    })?;
 
-            tracing::trace!("Calling issue_verify");
-            match nym_credentials_interface::issue_verify(
-                vk,
-                ecash_keypair.secret_key(),
-                &blinded_sig,
-                request_info,
-                share.node_index,
-            ) {
-                Ok(partial_wallet) => {
-                    tracing::trace!("Partial wallet created and appended");
-                    partial_wallets.push(partial_wallet)
-                }
-                Err(err) => {
-                    tracing::error!("Failed to issue verify: {err:#?}");
-                    return Err(RequestZkNymError::ImportZkNym {
-                        ticket_type: ticketbook_type.to_string(),
-                        error: err.to_string(),
-                    });
+                let Some(vk) = decoded_keys.get(&share.node_index) else {
+                    return Err(RequestZkNymError::DecodedKeysMissingIndex);
+                };
+
+                tracing::trace!("Calling issue_verify");
+                match nym_credentials_interface::issue_verify(
+                    vk,
+                    ecash_keypair.secret_key(),
+                    &blinded_sig,
+                    &request_info,
+                    share.node_index,
+                ) {
+                    Ok(partial_wallet) => {
+                        tracing::trace!("Partial wallet created and appended");
+                        partial_wallets.push(partial_wallet)
+                    }
+                    Err(err) => {
+                        tracing::error!("Failed to issue verify: {err:#?}");
+                        return Err(RequestZkNymError::ImportZkNym {
+                            ticket_type: ticketbook_type.to_string(),
+                            error: err.to_string(),
+                        });
+                    }
                 }
             }
-        }
 
-        tracing::trace!("Aggregating wallets");
-        let aggregated_wallets = nym_credentials_interface::aggregate_wallets(
-            &master_vk,
-            ecash_keypair.secret_key(),
-            &partial_wallets,
-            request_info,
-        )
-        .map_err(|err| RequestZkNymError::AggregateWallets(err.to_string()))?;
+            tracing::trace!("Aggregating wallets");
+            let aggregated_wallets = nym_credentials_interface::aggregate_wallets(
+                &master_vk,
+                ecash_keypair.secret_key(),
+                &partial_wallets,
+                &request_info,
+            )
+            .map_err(|err| RequestZkNymError::AggregateWallets(err.to_string()))?;
 
-        tracing::trace!("Creating ticketbook");
-        let ticketbook = IssuedTicketBook::new(
-            aggregated_wallets.into_wallet_signatures(),
-            shares.epoch_id,
-            ecash_keypair.into(),
-            ticketbook_type,
-            expiration_date,
-        );
+            tracing::trace!("Creating ticketbook");
+            let ticketbook = IssuedTicketBook::new(
+                aggregated_wallets.into_wallet_signatures(),
+                shares.epoch_id,
+                ecash_keypair.into(),
+                ticketbook_type,
+                expiration_date,
+            );
 
-        Ok(ticketbook)
+            Ok(ticketbook)
+        })
+        .await
+        .map_err(|err| RequestZkNymError::internal(format!("unblind_and_aggregate panicked: {err}")))?
     }
 
     async fn confirm_zk_nym_downloaded(&self, id: &str) -> Result<StatusOk, RequestZkNymError> {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/requesting_zknym_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/requesting_zknym_state.rs
@@ -359,7 +359,9 @@ impl RequestingZkNymsState {
                     .is_all_ticket_types_above_minimal_threshold()
                     .await
                 {
-                    info!("RefreshAccountState: tickets already sufficient, transitioning to ReadyState");
+                    info!(
+                        "RefreshAccountState: tickets already sufficient, transitioning to ReadyState"
+                    );
                     self.zk_nym_fetching_handle.abort();
                     return NextAccountControllerState::NewState(ReadyState::enter());
                 }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/requesting_zknym_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/requesting_zknym_state.rs
@@ -348,12 +348,23 @@ impl RequestingZkNymsState {
             }
             AccountCommand::RefreshAccountState(return_sender) => {
                 return_sender.send(Ok(()));
-                return if shared_state.firewall_active {
-                    NextAccountControllerState::SameState(self)
-                } else {
+                if shared_state.firewall_active {
+                    return NextAccountControllerState::SameState(self);
+                }
+                // If tickets are already sufficient (written by the in-progress fetch),
+                // skip the full SyncingState round-trip and go directly to ReadyState.
+                // This makes foreground-resume refreshes instant once tickets are available.
+                if let Ok(true) = shared_state
+                    .credential_storage
+                    .is_all_ticket_types_above_minimal_threshold()
+                    .await
+                {
+                    info!("RefreshAccountState: tickets already sufficient, transitioning to ReadyState");
                     self.zk_nym_fetching_handle.abort();
-                    NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0))
-                };
+                    return NextAccountControllerState::NewState(ReadyState::enter());
+                }
+                self.zk_nym_fetching_handle.abort();
+                return NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0));
             }
             AccountCommand::VpnApiFirewallDown(return_sender) => {
                 // as a side note, firewall handling could use some improvements as well,


### PR DESCRIPTION
## Ticket

JIRA-VPN-1101

## Description

### Summary                                                                                     

Reduces fresh-device login latency on Android by addressing three client-side bottlenecks in the zk-nym ticketbook issuance flow.

### Changes:                                                  

- Raise account-ready timeout (LoginViewModel.kt): Increased ACCOUNT_READY_TIMEOUT_MS from 20s to 90s. On a fresh device, ticketbook issuance for all three ticket types can take longer than 20s, causing the UI to time out and fall through to a subscription check before  the account controller reaches ReadyToConnect.
- Skip redundant sync cycle on foreground resume (requesting_zknym_state.rs): When a RefreshAccountState event arrives while already in RequestingZkNyms, the state machine previously aborted and restarted the full sync cycle. It now checks credential storage first  — if tickets are already above the minimum threshold it transitions directly to ReadyState, making foreground-resume re-login near-instant. 
- Parallelize ticketbook crypto (request.rs): The unblind_and_aggregate function performs CPU-intensive EC cryptographic operations (key decoding, issue_verify per share, aggregate_wallets). Running this synchronously on tokio worker threads caused the three concurrently-spawned ticket-type tasks to serialize on mobile's limited thread pool. Moving the work into tokio::task::spawn_blocking lets all three run truly in parallel.

### Motivation

Fresh-device login was taking ~37s, making the onboarding experience feel broken. The timeout caused premature navigation, the redundant sync cycle added unnecessary round trips on resume, and the crypto serialization negated the existing JoinSet-based concurrency for  ticket types.                                             

### Result

Login time reduced from ~37s to ~29s on a fresh device. The remaining time is server-side zk-nym generation latency, which is not client-controllable.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5066)
<!-- Reviewable:end -->
