### PR TITLE
NYM-1112: (core + tauri) Handle stacked subscriptions

### DIFF
--- a/nym-vpn-app/src-tauri/src/vpnd/account.rs
+++ b/nym-vpn-app/src-tauri/src/vpnd/account.rs
@@ -172,6 +172,7 @@ pub struct AccountSummary {
     pub fair_usage_left: bool,
     pub is_subscription_active: bool,
     pub subscription: Option<Subscription>,
+    pub is_subscription_stacked: bool,
 }
 
 impl From<lib::VpnAccountSummary> for AccountSummary {
@@ -195,6 +196,7 @@ impl From<lib::VpnAccountSummary> for AccountSummary {
             fair_usage_left,
             is_subscription_active,
             subscription: summary.subscription.map(Subscription::from),
+            is_subscription_stacked: summary.is_subscription_stacked,
         }
     }
 }

--- a/nym-vpn-app/src/screens/settings/account/account-status/ActivePlan.tsx
+++ b/nym-vpn-app/src/screens/settings/account/account-status/ActivePlan.tsx
@@ -70,7 +70,8 @@ export function ActivePlan({
           </p>
         </div>
       </CardNewBody>
-      {!accountSummary.subscription?.subscription?.isRecurring && (
+      {(!accountSummary.subscription?.subscription?.isRecurring ||
+        accountSummary.isSubscriptionStacked) && (
         <RenewButton accountSummary={accountSummary} />
       )}
     </>

--- a/nym-vpn-app/src/screens/settings/account/account-status/ActivePlan.tsx
+++ b/nym-vpn-app/src/screens/settings/account/account-status/ActivePlan.tsx
@@ -71,7 +71,7 @@ export function ActivePlan({
         </div>
       </CardNewBody>
       {(!accountSummary.subscription?.subscription?.isRecurring ||
-        accountSummary.isSubscriptionStacked) && (
+        !accountSummary.isSubscriptionStacked) && (
         <RenewButton accountSummary={accountSummary} />
       )}
     </>

--- a/nym-vpn-app/src/screens/settings/account/utils.ts
+++ b/nym-vpn-app/src/screens/settings/account/utils.ts
@@ -71,7 +71,11 @@ export const getAccountStateDescription = (
 
 export const getAccountStatus = (accountSummary?: TAccountSummary | null) => {
   const subscription = accountSummary?.subscription?.subscription;
-  if (!accountSummary || subscription?.isRecurring) {
+  if (
+    !accountSummary ||
+    subscription?.isRecurring ||
+    accountSummary.isSubscriptionStacked
+  ) {
     return 'green';
   }
 

--- a/nym-vpn-app/src/types/tauri.ts
+++ b/nym-vpn-app/src/types/tauri.ts
@@ -340,6 +340,7 @@ export type TAccountSummary = {
   fairUsageLeft: boolean;
   isSubscriptionActive: boolean;
   subscription: TSubscription | null;
+  isSubscriptionStacked: boolean;
 };
 
 export type TApiTimeSkew = {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/common/account_summary.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/common/account_summary.rs
@@ -70,6 +70,7 @@ pub fn mock_subscription_summary_with_device(
                 is_active: active_sub,
                 active: subscription,
                 pending: pending_subscription,
+                is_stacked: false,
             },
             devices: NymVpnAccountSummaryDevices {
                 active: device_nb,

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
@@ -112,6 +112,7 @@ pub struct NymVpnAccountSummarySubscription {
     pub is_active: bool,
     pub active: Option<NymVpnSubscription>,
     pub pending: Option<NymVpnSubscription>,
+    #[serde(default)]
     pub is_stacked: bool,
 }
 

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
@@ -112,6 +112,7 @@ pub struct NymVpnAccountSummarySubscription {
     pub is_active: bool,
     pub active: Option<NymVpnSubscription>,
     pub pending: Option<NymVpnSubscription>,
+    pub is_stacked: bool,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/account/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/account/mod.rs
@@ -271,6 +271,7 @@ pub struct VpnAccountSummary {
     pub auth_methods: Vec<VpnAccountAuthMethod>,
     pub account_mode: Option<StoredAccountMode>,
     pub subscription: Option<Subscription>,
+    pub is_subscription_stacked: bool,
 }
 
 // Exported methods
@@ -355,6 +356,7 @@ impl TryFrom<&nym_vpn_api_client::response::NymVpnAccountSummaryResponse> for Vp
             auth_methods,
             account_mode: None,
             subscription,
+            is_subscription_stacked: value.subscription.is_stacked,
         })
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -890,6 +890,7 @@ message VpnAccountSummary {
   repeated VpnAccountAuthMethod auth_methods = 7;
   optional StoredAccountMode account_mode = 8;
   optional Subscription subscription = 12;
+  bool is_subscription_stacked = 13;
 }
 
 message NymVpnSubscription {

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/account.rs
@@ -300,6 +300,7 @@ impl TryFrom<proto::VpnAccountSummary> for VpnAccountSummary {
             auth_methods,
             account_mode,
             subscription,
+            is_subscription_stacked: value.is_subscription_stacked,
         })
     }
 }
@@ -332,6 +333,7 @@ impl From<VpnAccountSummary> for proto::VpnAccountSummary {
             auth_methods,
             account_mode,
             subscription,
+            is_subscription_stacked: value.is_subscription_stacked,
         }
     }
 }


### PR DESCRIPTION
## Ticket

[JIRA-NYM-1112](https://nymtech.atlassian.net/browse/NYM-1112)
## Description

- Add `VpnAccountSummary ::is_subscription_stacked`
- Handle stacked subscriptions in tauri

_Add `#[serde(default)]` for NymVpnAccountSummarySubscription::is_stacked so the stack subscriptions can be tested on sandbox first without breaking mainnet_

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5099)
<!-- Reviewable:end -->
