### PR TITLE
(tauri) Split app exec path into individual segments

### DIFF
--- a/nym-vpn-app/src/screens/settings/split-tunneling/AppItem.tsx
+++ b/nym-vpn-app/src/screens/settings/split-tunneling/AppItem.tsx
@@ -25,9 +25,10 @@ function AppItem({ app, onStateChange }: AppItemProps) {
   const handleClick = async () => {
     if (os === 'linux') {
       try {
-        const result = await Command.create('nym-exclude', [
-          app.executable_path,
-        ]).execute();
+        const result = await Command.create(
+          'nym-exclude',
+          app.executable_path.split(' '),
+        ).execute();
         console.info('[nym-exclude] stdout', result.stdout);
         console.info('[nym-exclude] stderr', result.stderr);
       } catch (error) {


### PR DESCRIPTION
## Ticket

JIRA-VPN-XXXX

## Description

For linux, split app exec path into individual segments. That fixes launching flatpak apps


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5100)
<!-- Reviewable:end -->
