### PR TITLE
NYM-1126: (tauri) Fix Linux st apps not appearing

### DIFF
--- a/nym-vpn-app/src/screens/settings/split-tunneling/SplitTunneling.tsx
+++ b/nym-vpn-app/src/screens/settings/split-tunneling/SplitTunneling.tsx
@@ -92,7 +92,7 @@ function SplitTunneling() {
 
       {/* Apps section */}
       <AnimatePresence initial={false}>
-        {enabled && (
+        {(enabled || os === 'linux') && (
           <motion.div
             key="apps-section"
             initial={{ opacity: 0 }}


### PR DESCRIPTION
## Ticket

[JIRA-NYM-1126](https://nymtech.atlassian.net/browse/NYM-1126)

## Description

- Always display list of apps for Linux split tunneling despite of the `enabled` toggle


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5105)
<!-- Reviewable:end -->
