### PR TITLE
APPLE: Enable UI toggle in iOS settings for ad blocking

### DIFF
--- a/nym-vpn-apple/Settings/Sources/Settings/SettingsViewModel.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/SettingsViewModel.swift
@@ -403,7 +403,6 @@ private extension SettingsViewModel {
                 action: {}
             )
         )
-#if os(macOS)
         let adBlockSubtitle = appSettings.isAdBlockerEnabled
         ? "settings.adblock.subtitle.on".localizedString
         : "settings.adblock.subtitle.off".localizedString
@@ -432,6 +431,7 @@ private extension SettingsViewModel {
             }
             .store(in: &cancellables)
         viewModels.append(adBlockViewModel)
+#if os(macOS)
         viewModels.append(
             SettingsListItemViewModel(
                 accessory: .toggle(


### PR DESCRIPTION
## Ticket

JIRA-NYM-769

## Description

Enable UI toggle in iOS settings for ad blocking

## Screenshots (optional, if UI related)

<img width="1179" height="2556" alt="Screenshot 2026-04-16 at 21 25 01" src="https://github.com/user-attachments/assets/c84b58ea-074b-49d7-b346-3525e9c63052" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5107)
<!-- Reviewable:end -->
