### PR TITLE
NYM-1147: (tauri) Default app language to OS locale

### DIFF
--- a/nym-vpn-app/src/App.tsx
+++ b/nym-vpn-app/src/App.tsx
@@ -71,7 +71,7 @@ function App({ init }: { init: InitState }) {
       }
     };
     setLng();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (

--- a/nym-vpn-app/src/App.tsx
+++ b/nym-vpn-app/src/App.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useEffect, useRef } from 'react';
+import { Suspense, useEffect } from 'react';
 import { RouterProvider } from 'react-router';
 import { invoke } from '@tauri-apps/api/core';
 import { type } from '@tauri-apps/plugin-os';
@@ -36,7 +36,6 @@ function App({ init }: { init: InitState }) {
   dayjs.extend(customParseFormat);
 
   const { set } = useLang();
-  const langInitialized = useRef(false);
   const intro =
     os === 'windows' ? (
       <IntroAnim theme={init.uiTheme} />
@@ -58,9 +57,6 @@ function App({ init }: { init: InitState }) {
   }, []);
 
   useEffect(() => {
-    if (langInitialized.current) return;
-    langInitialized.current = true;
-
     const setLng = async () => {
       const stored = await kvGet<string | undefined>('ui-language');
       if (stored) {
@@ -71,8 +67,7 @@ function App({ init }: { init: InitState }) {
       }
     };
     setLng();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [set]);
 
   return (
     <>

--- a/nym-vpn-app/src/App.tsx
+++ b/nym-vpn-app/src/App.tsx
@@ -18,7 +18,7 @@ import {
   TrayProvider,
 } from './contexts';
 import { useLang } from './hooks';
-import { LngTag } from './i18n';
+import { LngTag, detectSystemLocale } from './i18n';
 import { kvGet } from './kvStore';
 import router from './router';
 import './i18n/config';
@@ -58,9 +58,12 @@ function App({ init }: { init: InitState }) {
 
   useEffect(() => {
     const setLng = async () => {
-      const lng = await kvGet<string | undefined>('ui-language');
-      if (lng) {
-        await set(lng as LngTag, false);
+      const stored = await kvGet<string | undefined>('ui-language');
+      if (stored) {
+        await set(stored as LngTag, false);
+      } else {
+        const lng = await detectSystemLocale();
+        await set(lng, false);
       }
     };
     setLng();

--- a/nym-vpn-app/src/App.tsx
+++ b/nym-vpn-app/src/App.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useEffect } from 'react';
+import { Suspense, useEffect, useRef } from 'react';
 import { RouterProvider } from 'react-router';
 import { invoke } from '@tauri-apps/api/core';
 import { type } from '@tauri-apps/plugin-os';
@@ -36,6 +36,7 @@ function App({ init }: { init: InitState }) {
   dayjs.extend(customParseFormat);
 
   const { set } = useLang();
+  const langInitialized = useRef(false);
   const intro =
     os === 'windows' ? (
       <IntroAnim theme={init.uiTheme} />
@@ -57,6 +58,9 @@ function App({ init }: { init: InitState }) {
   }, []);
 
   useEffect(() => {
+    if (langInitialized.current) return;
+    langInitialized.current = true;
+
     const setLng = async () => {
       const stored = await kvGet<string | undefined>('ui-language');
       if (stored) {
@@ -67,7 +71,8 @@ function App({ init }: { init: InitState }) {
       }
     };
     setLng();
-  }, [i18n, set]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <>

--- a/nym-vpn-app/src/hooks/useLang.ts
+++ b/nym-vpn-app/src/hooks/useLang.ts
@@ -1,8 +1,8 @@
 import dayjs from 'dayjs';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { LngTag, loadLocale } from '../i18n';
-import { kvSet } from '../kvStore';
+import { LngTag, detectSystemLocale, loadLocale } from '../i18n';
+import { kvDel, kvSet } from '../kvStore';
 
 /**
  * Hook to set the i18n language
@@ -82,7 +82,16 @@ function useLang() {
     [collator],
   );
 
-  return { compare, set, getCountryName };
+  /**
+   * Clears any stored language preference and applies the OS system language.
+   */
+  const setSystem = useCallback(async () => {
+    await kvDel('ui-language');
+    const lng = await detectSystemLocale();
+    await set(lng, false);
+  }, [set]);
+
+  return { compare, set, setSystem, getCountryName };
 }
 
 export default useLang;

--- a/nym-vpn-app/src/i18n/config.ts
+++ b/nym-vpn-app/src/i18n/config.ts
@@ -70,10 +70,9 @@ export const loadLocale = async (locale: LngTag) => {
       const acc = await accPromise;
       try {
         acc[namespace] = await loadLocaleNs(locale, namespace);
-      } catch (error) {
-        console.error(
-          `Failed to load namespace ${namespace} for locale ${locale}:`,
-          error,
+      } catch {
+        console.warn(
+          `Missing translations for namespace "${namespace}" in locale "${locale}", falling back to English.`,
         );
       }
       return acc;

--- a/nym-vpn-app/src/i18n/en/settings.json
+++ b/nym-vpn-app/src/i18n/en/settings.json
@@ -208,6 +208,7 @@
   },
   "faq": "FAQ",
   "display-theme": "Display mode",
+  "language-system": "System language",
   "logout-confirmation": {
     "title": "Log out of this device?",
     "description": "You’ll need your 24-word passphrase to sign in again.",

--- a/nym-vpn-app/src/i18n/index.ts
+++ b/nym-vpn-app/src/i18n/index.ts
@@ -1,2 +1,3 @@
 export * from './types';
 export * from './config';
+export * from './utils';

--- a/nym-vpn-app/src/i18n/utils.ts
+++ b/nym-vpn-app/src/i18n/utils.ts
@@ -1,0 +1,45 @@
+import { loadLocale, supportedLngs } from './config';
+import { LngTag } from './types';
+
+/**
+ * Matches an OS locale string (e.g. "en-US", "zh-Hans-CN") to the closest
+ * supported language tag. Falls back to 'en' if no match is found.
+ */
+export function matchSupportedLocale(osLocale: string): LngTag {
+  // Try exact match first (e.g. "en" → "en")
+  const lower = osLocale.toLowerCase();
+  if ((supportedLngs as readonly string[]).includes(lower)) {
+    return lower as LngTag;
+  }
+
+  // Try matching just the primary language subtag (e.g. "en-US" → "en", "zh-Hans-CN" → "zh")
+  const lang = osLocale.split(/[-_]/)[0].toLowerCase();
+  if ((supportedLngs as readonly string[]).includes(lang)) {
+    return lang as LngTag;
+  }
+
+  return 'en';
+}
+
+/**
+ * Detects the system locale and returns the best matching supported language tag.
+ * Uses navigator.language as the locale source.
+ * Falls back to 'en' if no translations are available for the detected locale.
+ */
+export async function detectSystemLocale(): Promise<LngTag> {
+  const matched = matchSupportedLocale(navigator.language);
+  if (matched === 'en') return 'en';
+
+  // Verify that translation files exist for this locale before returning it.
+  // Falls back to 'en' if the locale has no bundled translations.
+  try {
+    const resources = await loadLocale(matched);
+    if (Object.keys(resources).length > 0) {
+      return matched;
+    }
+  } catch {
+    // translation files missing
+  }
+
+  return 'en';
+}

--- a/nym-vpn-app/src/screens/settings/appearance/lang/Lang.tsx
+++ b/nym-vpn-app/src/screens/settings/appearance/lang/Lang.tsx
@@ -118,7 +118,8 @@ function Lang() {
                 ])}
                 data-testid={`language-selected-indicator-${lang.code}`}
               >
-                {!isSystemLang && i18n.language === lang.code &&
+                {!isSystemLang &&
+                  i18n.language === lang.code &&
                   t('selected', { ns: 'glossary' })}
               </div>
             </Button>

--- a/nym-vpn-app/src/screens/settings/appearance/lang/Lang.tsx
+++ b/nym-vpn-app/src/screens/settings/appearance/lang/Lang.tsx
@@ -1,15 +1,34 @@
 import { Button } from '@headlessui/react';
 import clsx from 'clsx';
 import { openUrl } from '@tauri-apps/plugin-opener';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLang } from '../../../../hooks';
-import { languages } from '../../../../i18n';
+import { LngTag, languages } from '../../../../i18n';
+import { kvGet } from '../../../../kvStore';
 import { PageAnim, SettingsMenuCard } from '../../../../ui';
 import { TranslationHelpUrl } from '../../../../constants';
 
 function Lang() {
   const { t, i18n } = useTranslation();
-  const { set } = useLang();
+  const { set, setSystem } = useLang();
+  const [isSystemLang, setIsSystemLang] = useState<boolean>(false);
+
+  useEffect(() => {
+    kvGet<string>('ui-language').then((stored) => {
+      setIsSystemLang(!stored);
+    });
+  }, []);
+
+  const handleSystemLang = async () => {
+    setIsSystemLang(true);
+    await setSystem();
+  };
+
+  const handleLangSelect = async (code: LngTag) => {
+    setIsSystemLang(false);
+    await set(code);
+  };
 
   return (
     <PageAnim
@@ -35,6 +54,40 @@ function Lang() {
         className="flex flex-col w-full items-stretch gap-1"
         data-testid="language-list"
       >
+        <li
+          key="system"
+          className="list-none w-full"
+          data-testid="language-item-system"
+        >
+          <Button
+            role="presentation"
+            className={clsx([
+              'flex flex-row justify-between items-center w-full',
+              'hover:bg-iron/10 dark:hover:bg-bombay/10',
+              'rounded-lg px-3 py-1 transition duration-75 cursor-default',
+            ])}
+            onClick={handleSystemLang}
+            data-testid="language-button-system"
+            data-selected={isSystemLang}
+          >
+            <div
+              className="flex flex-row items-center m-1 gap-3 p-1 overflow-hidden"
+              data-testid="language-name-system"
+            >
+              {t('language-system', { ns: 'settings' })}
+            </div>
+            <div
+              className={clsx([
+                'pr-4 ml-2 flex items-center font-medium text-xs',
+                'text-iron dark:text-bombay',
+              ])}
+              data-testid="language-selected-indicator-system"
+            >
+              {isSystemLang && t('selected', { ns: 'glossary' })}
+            </div>
+          </Button>
+        </li>
+
         {languages.map((lang) => (
           <li
             key={lang.code}
@@ -48,9 +101,9 @@ function Lang() {
                 'hover:bg-iron/10 dark:hover:bg-bombay/10',
                 'rounded-lg px-3 py-1 transition duration-75 cursor-default',
               ])}
-              onClick={() => set(lang.code)}
+              onClick={() => handleLangSelect(lang.code)}
               data-testid={`language-button-${lang.code}`}
-              data-selected={i18n.language === lang.code}
+              data-selected={!isSystemLang && i18n.language === lang.code}
             >
               <div
                 className="flex flex-row items-center m-1 gap-3 p-1 overflow-hidden"
@@ -65,7 +118,7 @@ function Lang() {
                 ])}
                 data-testid={`language-selected-indicator-${lang.code}`}
               >
-                {i18n.language === lang.code &&
+                {!isSystemLang && i18n.language === lang.code &&
                   t('selected', { ns: 'glossary' })}
               </div>
             </Button>


### PR DESCRIPTION
## Ticket

[JIRA-NYM-1147](https://nymtech.atlassian.net/browse/NYM-1147)

## Description:

### Summary

- On first launch (no stored language preference), detect the OS locale  via `@tauri-apps/plugin-os` `locale()` — falling back to `navigator.language` — and apply the closest supported language.  If no translations exist for the detected locale (Crowdin-synced builds only), silently falls back to English.
- Adds a **System language** entry at the top of the language picker that clears the stored preference and re-applies OS detection.
- Fixes a double-initialization bug where the startup language effect re-ran every time `i18n` updated, causing `set()` to be called twice.
- Downgrades missing-translation-namespace log from `error` to `warn` since non-English files are only present in Crowdin-synced builds.

Android already defaults to OS language via AppCompat. iOS/macOS already do so via the `Localizable.xcstrings` system. This PR closes the gap for the desktop (Linux, Windows, macOS via Tauri).

### Test plan

- [ ] First launch with no stored `ui-language` key: app should open in the OS language (or English if that language has no translations)
- [ ] Language picker → **System language**: clears stored preference, re-applies OS-detected language, shows "selected" indicator
- [ ] Language picker → explicit language: stores preference, survives restart, no double `set language:` log line on startup
- [ ] Non-English OS locale with no translation files: no `ERROR` in logs, app shows English without console spam


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)
<img width="474" height="846" alt="Screenshot from 2026-04-18 11-40-18" src="https://github.com/user-attachments/assets/8e328a6d-442e-4e63-8b0c-37b49c5ee9cf" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5119)
<!-- Reviewable:end -->
