### PR TITLE
fix(ipc): remove execute bit from UDS socket permissions

### DIFF
--- a/nym-vpn-core/crates/nym-ipc/src/uds.rs
+++ b/nym-vpn-core/crates/nym-ipc/src/uds.rs
@@ -67,7 +67,7 @@ pub async fn incoming(
     tracing::info!("Starting socket listener on: {}", socket_path.display());
 
     let listener = UnixListener::bind(&socket_path)?;
-    fs::set_permissions(&socket_path, PermissionsExt::from_mode(0o766))?;
+    fs::set_permissions(&socket_path, PermissionsExt::from_mode(0o666))?;
     let uds = Uds {
         socket_path,
         inner: UnixListenerStream::new(listener),


### PR DESCRIPTION
## Ticket

JIRA-VPN-XXXX

##   Description:

### Summary

- Change UDS socket mode from `0o766` to `0o666`
- The execute bit has no meaning on socket files and was misleading
- World-writable access is intentional: any local process must be able to connect so that Polkit can retrieve `PeerCredentials` (PID/UID) and perform authorization via the `com.nymvpn.vpnd.unix-access` action 
- Add comment explaining the security model so future readers don't "fix" the permissions and break Polkit authentication                                     
                                                                                              
### Test plan                                                                                
                                                                                              
- [ ] Daemon starts and socket is created with `srw-rw-rw-` permissions                     
- [ ] Desktop app connects successfully and Polkit prompt appears      
- [ ] Unauthorized process is denied after failed Polkit check

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5121)
<!-- Reviewable:end -->
