### PR TITLE
NYM-1153: (tauri) Handle spaces in linux app exec path

### DIFF
--- a/nym-vpn-app/src/screens/settings/split-tunneling/SplitTunneling.tsx
+++ b/nym-vpn-app/src/screens/settings/split-tunneling/SplitTunneling.tsx
@@ -12,7 +12,7 @@ import { Spinner } from '../../../ui';
 import InfoDialog from './InfoDialog';
 import LaunchConfirmDialog from './LaunchConfirmDialog';
 import AppItem, { AppEntry } from './AppItem';
-import { useSplitTunnel } from './utils';
+import { parseExecArgs, useSplitTunnel } from './utils';
 import { PROBLEMATIC_APPS } from './utils/constants';
 
 function SplitTunneling() {
@@ -35,7 +35,7 @@ function SplitTunneling() {
       try {
         const command = Command.create(
           'nym-exclude',
-          app.executable_path.split(' '),
+          parseExecArgs(app.executable_path),
         );
 
         command.on('close', (data) => {

--- a/nym-vpn-app/src/screens/settings/split-tunneling/utils/index.ts
+++ b/nym-vpn-app/src/screens/settings/split-tunneling/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './useSplitTunnel';
+export * from './parseExec';

--- a/nym-vpn-app/src/screens/settings/split-tunneling/utils/parseExec.ts
+++ b/nym-vpn-app/src/screens/settings/split-tunneling/utils/parseExec.ts
@@ -1,0 +1,29 @@
+/**
+ * Parses a desktop entry Exec= value into an argument list suitable for
+ * passing to Command.create().
+ *
+ * Per the XDG Desktop Entry Specification:
+ * - If the executable path contains spaces it MUST be wrapped in double quotes
+ *   and spaces inside the quoted path MUST be escaped as \s.
+ * - Arguments following the executable are separated by regular spaces.
+ *
+ * Examples:
+ *   '/usr/bin/firefox'               → ['/usr/bin/firefox']
+ *   '/usr/bin/app --flag'            → ['/usr/bin/app', '--flag']
+ *   '"/opt/My\sApp/app" --flag'      → ['/opt/My App/app', '--flag']
+ */
+export function parseExecArgs(exec: string): string[] {
+  const trimmed = exec.trim();
+
+  if (trimmed.startsWith('"')) {
+    const closingQuote = trimmed.indexOf('"', 1);
+    if (closingQuote !== -1) {
+      const path = trimmed.slice(1, closingQuote).replace(/\\s/g, ' ');
+      const rest = trimmed.slice(closingQuote + 1).trim();
+      return [path, ...rest.split(' ').filter(Boolean)];
+    }
+  }
+
+  // Unquoted path: split on spaces as before
+  return trimmed.split(' ').filter(Boolean);
+}


### PR DESCRIPTION
## Ticket

[JIRA-NYM-1153](https://nymtech.atlassian.net/browse/NYM-1153)

  Description:                                                                                
  ## Summary                                                                                  
                                                            
  - Replace `executable_path.split(' ')` with a proper `parseExecArgs()`
    function that follows the XDG Desktop Entry Specification                                 
  - Quoted paths (`"/opt/My\sApp/app"`) are correctly unescaped and
    extracted before splitting arguments                                                      
  - Unquoted paths without spaces continue to work as before                                  
  - Fixes launching any application whose installation path contains spaces                   
                                                                                              
  ## Details                                                
                                                                                              
  Per the spec, spaces inside an `Exec=` path must be escaped as `\s` and
  the path must be wrapped in double quotes. Arguments after the executable                   
  are separated by regular spaces. The previous `split(' ')` would break   
  the quoted path into invalid fragments, causing `nym-exclude` to receive                    
  garbage arguments.                                                                          
                                                                                              
  ## Test plan                                                                                
                                                                                              
  - [ ] App with a space-free path launches correctly from the split tunnel screen
  - [ ] App installed in a path containing spaces (e.g. `/opt/My App/`) launches correctly    
  - [ ] App with arguments in `Exec=` (e.g. `"/opt/app" --flag`) passes arguments through

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5122)
<!-- Reviewable:end -->
