### PR TITLE
Title: fix(connecting): clear DNS preresolve cache on gateway resolution failure

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -307,6 +307,10 @@ impl ConnectingState {
             }
             Err(e) => {
                 trace_err_chain!(e, "Failed to resolve gateway config");
+                // Clear the static preresolve table so the next attempt
+                // performs a fresh DNS lookup instead of reusing IPs that
+                // may have caused the failure (e.g. a dead Fastly edge node).
+                HickoryDnsResolver::shared().clear_preresolve();
                 return self.reconnect(shared_state).await;
             }
         };


### PR DESCRIPTION
## Ticket

JIRA-VPN-XXXX

##Description:

  ### Problem

  When the gateway resolution step fails during a connection attempt (e.g.
  because a dead Fastly edge IP was pinned in the static preresolve table),
  the reconnect loop would retry immediately using the same cached IP,
  guaranteeing repeated failures until the cache expired.

  ### Changes

  - Call `HickoryDnsResolver::shared().clear_preresolve()` before
    re-entering the reconnect loop when `handle_resolved_gateway_config`
    receives an error, so the next attempt triggers a fresh DNS lookup

  ### Related

  Companion to `nymtech/nym#<PR>` which reduces the Hickory cache TTL
  from 1800s to 60s and adds per-host invalidation APIs.

  ### Test plan

  - [ ] Connect to VPN, block the resolved gateway IP at the firewall,
    confirm the client recovers on the next retry rather than looping
    on the dead IP

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5124)
<!-- Reviewable:end -->
