### PR TITLE
Introduce builder for wireguard_go::Tunnel

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -7137,6 +7137,7 @@ dependencies = [
  "rand 0.8.5",
  "thiserror 2.0.18",
  "tracing",
+ "typed-builder",
  "windows 0.62.2",
 ]
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
@@ -18,6 +18,8 @@ use nym_apple_network::PathMonitor;
 use nym_crypto::asymmetric::x25519;
 #[cfg(windows)]
 use nym_routing::{Callback, CallbackHandle, EventType};
+#[cfg(not(windows))]
+use nym_wg_go::wireguard_go::TunnelFd;
 #[cfg(windows)]
 use nym_wg_go::wireguard_go::WintunInterface;
 use nym_wg_go::{amnezia::AmneziaConfig, netstack, wireguard_go};
@@ -167,32 +169,44 @@ impl ConnectedTunnel {
             None,
         );
 
+        let builder = wireguard_go::TunnelConfig::builder();
+        #[cfg(unix)]
+        let builder = builder.tun_fd(TunnelFd::Tun(
+            options.entry_tun.deref().dup_fd().map_err(Error::DupFd)?,
+        ));
+        #[cfg(windows)]
+        let builder = {
+            builder
+                .interface_name(options.entry_tun_name)
+                .requested_guid(options.entry_tun_guid)
+                .wintun_tunnel_type(options.wintun_tunnel_type.clone())
+        };
+        let entry_tunnel_config = builder.build();
+
         #[allow(unused_mut)]
         let mut entry_tunnel = wireguard_go::Tunnel::start(
             wg_entry_config.into_wireguard_config(),
-            #[cfg(unix)]
-            options.entry_tun.deref().dup_fd().map_err(Error::DupFd)?,
-            #[cfg(windows)]
-            &options.entry_tun_name,
-            #[cfg(windows)]
-            &options.entry_tun_guid,
-            #[cfg(windows)]
-            &options.wintun_tunnel_type,
+            entry_tunnel_config,
         )
         .map_err(Error::Wireguard)?;
 
-        let exit_tunnel = wireguard_go::Tunnel::start(
-            wg_exit_config.into_wireguard_config(),
-            #[cfg(unix)]
+        let builder = wireguard_go::TunnelConfig::builder();
+        #[cfg(unix)]
+        let builder = builder.tun_fd(TunnelFd::Tun(
             options.exit_tun.deref().dup_fd().map_err(Error::DupFd)?,
-            #[cfg(windows)]
-            &options.exit_tun_name,
-            #[cfg(windows)]
-            &options.exit_tun_guid,
-            #[cfg(windows)]
-            &options.wintun_tunnel_type,
-        )
-        .map_err(Error::Wireguard)?;
+        ));
+        #[cfg(windows)]
+        let builder = {
+            builder
+                .interface_name(options.exit_tun_name)
+                .requested_guid(options.exit_tun_guid)
+                .wintun_tunnel_type(options.wintun_tunnel_type)
+        };
+        let exit_tunnel_config = builder.build();
+
+        let exit_tunnel =
+            wireguard_go::Tunnel::start(wg_exit_config.into_wireguard_config(), exit_tunnel_config)
+                .map_err(Error::Wireguard)?;
 
         let shutdown_token = CancellationToken::new();
         let child_shutdown_token = shutdown_token.child_token();
@@ -337,47 +351,45 @@ impl ConnectedTunnel {
         )?;
 
         let shutdown_token = CancellationToken::new();
-
-        #[cfg(target_os = "android")]
-        let (wg_exit_fd, proxy_join_handle, android_tombstone_tun) = if let Some(dns_filter) =
-            options.dns_filter
-        {
-            let proxy =
-                DnsFilterProxy::start(options.exit_tun, dns_filter, shutdown_token.child_token())
-                    .map_err(Error::CreateDnsFilterProxy)?;
-            (proxy.wg_fd, Some(proxy.join_handle), None)
-        } else {
-            let fd = options.exit_tun.deref().dup_fd().map_err(Error::DupFd)?;
-            (fd, None, Some(options.exit_tun))
-        };
-
-        #[cfg(all(unix, not(target_os = "android")))]
-        let (wg_exit_fd, tombstone_exit_tun) = (
-            options.exit_tun.deref().dup_fd().map_err(Error::DupFd)?,
-            options.exit_tun,
-        );
-
         let exit_wg_config = two_hop_config.exit.into_wireguard_config();
 
+        let builder = wireguard_go::TunnelConfig::builder();
+
         #[cfg(target_os = "android")]
-        #[allow(unused_mut)]
-        let mut exit_tunnel = if proxy_join_handle.is_some() {
-            wireguard_go::Tunnel::start_with_proxy_fd(exit_wg_config, wg_exit_fd)?
-        } else {
-            wireguard_go::Tunnel::start(exit_wg_config, wg_exit_fd)?
+        let (builder, proxy_join_handle, android_exit_tun) = {
+            if let Some(dns_filter) = options.dns_filter {
+                let proxy = DnsFilterProxy::start(
+                    options.exit_tun,
+                    dns_filter,
+                    shutdown_token.child_token(),
+                )
+                .map_err(Error::CreateDnsFilterProxy)?;
+
+                let builder = builder.tun_fd(TunnelFd::Proxy(proxy.wg_fd));
+                (builder, Some(proxy.join_handle), None)
+            } else {
+                let tun_fd = options.exit_tun.deref().dup_fd().map_err(Error::DupFd)?;
+                let builder = builder.tun_fd(TunnelFd::Tun(tun_fd));
+
+                (builder, None, Some(options.exit_tun))
+            }
         };
 
-        #[cfg(all(unix, not(target_os = "android")))]
-        #[allow(unused_mut)]
-        let mut exit_tunnel = wireguard_go::Tunnel::start(exit_wg_config, wg_exit_fd)?;
-
         #[cfg(windows)]
-        let exit_tunnel = wireguard_go::Tunnel::start(
-            exit_wg_config,
-            &options.exit_tun_name,
-            &options.exit_tun_guid,
-            &options.wintun_tunnel_type,
-        )?;
+        let builder = builder
+            .interface_name(options.exit_tun_name)
+            .requested_guid(options.exit_tun_guid)
+            .wintun_tunnel_type(options.wintun_tunnel_type);
+
+        #[cfg(all(unix, not(target_os = "android")))]
+        let builder = builder.tun_fd(TunnelFd::Tun(
+            options.exit_tun.deref().dup_fd().map_err(Error::DupFd)?,
+        ));
+
+        let exit_tunnel_config = builder.build();
+
+        #[allow(unused_mut)]
+        let mut exit_tunnel = wireguard_go::Tunnel::start(exit_wg_config, exit_tunnel_config)?;
 
         if options
             .metadata_proxy_tx
@@ -413,12 +425,6 @@ impl ConnectedTunnel {
                         }
                     }
                 }
-            }
-
-            #[cfg(not(any(windows, target_os = "ios")))]
-            {
-                child_shutdown_token.cancelled().await;
-                tracing::debug!("Received tunnel shutdown event. Exiting event loop.");
             }
 
             #[cfg(target_os = "ios")]
@@ -476,6 +482,12 @@ impl ConnectedTunnel {
                 }
             }
 
+            #[cfg(not(any(windows, target_os = "ios")))]
+            {
+                child_shutdown_token.cancelled().await;
+                tracing::debug!("Received tunnel shutdown event. Exiting event loop.");
+            }
+
             // Windows: do not drop exit tunnel as it owns the underlying tunnel device.
             #[cfg(not(windows))]
             exit_tunnel.stop();
@@ -484,23 +496,30 @@ impl ConnectedTunnel {
             exit_in_tunnel_udp_proxy.close();
 
             #[cfg(target_os = "android")]
-            if let Some(handle) = proxy_join_handle {
-                if let Err(e) = handle.await {
-                    tracing::error!("DNS filter proxy task panicked: {e}");
+            {
+                if let Some(proxy_join_handle) = proxy_join_handle {
+                    match proxy_join_handle.await {
+                        Ok(tun_device) => Tombstone::with_tun_device(tun_device),
+                        Err(err) => {
+                            tracing::error!("DNS filter proxy task panicked: {err}");
+                            Tombstone::default()
+                        }
+                    }
+                } else {
+                    android_exit_tun
+                        .map(Tombstone::with_tun_device)
+                        .unwrap_or_default()
                 }
             }
 
-            #[cfg(all(not(windows), not(target_os = "android")))]
-            let tun_devices = vec![tombstone_exit_tun];
-            #[cfg(target_os = "android")]
-            let tun_devices: Vec<_> = android_tombstone_tun.into_iter().collect();
             #[cfg(windows)]
-            let tun_devices = vec![];
+            {
+                Tombstone::with_wg_instances(vec![exit_tunnel])
+            }
 
-            Tombstone {
-                tun_devices,
-                #[cfg(windows)]
-                wg_instances: vec![exit_tunnel],
+            #[cfg(not(any(windows, target_os = "android")))]
+            {
+                Tombstone::with_tun_device(options.exit_tun)
             }
         });
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/dns_filter_proxy.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/dns_filter_proxy.rs
@@ -63,7 +63,7 @@ pub struct DnsFilterProxy {
     /// File descriptor to hand to wireguard-go as its "tun device".
     pub wg_fd: OwnedFd,
     /// Background task handle — the proxy keeps running until `shutdown_token` is cancelled.
-    pub join_handle: JoinHandle<()>,
+    pub join_handle: JoinHandle<AsyncDevice>,
 }
 
 impl DnsFilterProxy {
@@ -125,7 +125,7 @@ async fn run_proxy(
     filter_socket: UnixDatagram,
     dns_filter: DnsFilter,
     shutdown_token: CancellationToken,
-) {
+) -> AsyncDevice {
     tracing::debug!("DNS filter proxy started");
 
     let mut tun_buf = vec![0u8; MAX_PACKET_SIZE];
@@ -180,6 +180,7 @@ async fn run_proxy(
     }
 
     tracing::debug!("DNS filter proxy stopped");
+    tun_device
 }
 
 async fn maybe_nxdomain(packet: &[u8], dns_filter: &DnsFilter) -> Option<Vec<u8>> {

--- a/nym-vpn-core/crates/nym-wg-go/Cargo.toml
+++ b/nym-vpn-core/crates/nym-wg-go/Cargo.toml
@@ -19,6 +19,7 @@ amnezia = []
 ipnetwork.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+typed-builder.workspace = true
 hex.workspace = true
 rand.workspace = true
 nym-crypto.workspace = true

--- a/nym-vpn-core/crates/nym-wg-go/src/wireguard_go.rs
+++ b/nym-vpn-core/crates/nym-wg-go/src/wireguard_go.rs
@@ -12,6 +12,7 @@ use std::{
 use nym_crypto::asymmetric::x25519;
 #[cfg(windows)]
 use nym_windows::net::AddressFamily;
+use typed_builder::TypedBuilder;
 #[cfg(windows)]
 use windows::Win32::NetworkManagement::Ndis::NET_LUID_LH;
 
@@ -106,6 +107,38 @@ impl WintunInterface {
     }
 }
 
+/// Tunnel file descriptor
+#[cfg(not(windows))]
+#[derive(Debug)]
+pub enum TunnelFd {
+    /// Tunnel device
+    Tun(OwnedFd),
+
+    /// Proxy device using unix domain socket
+    #[cfg(target_os = "android")]
+    Proxy(OwnedFd),
+}
+
+#[derive(Debug, TypedBuilder)]
+pub struct TunnelConfig {
+    /// Tunnel file descriptor
+    #[cfg(not(windows))]
+    tun_fd: TunnelFd,
+
+    /// Interface name
+    #[cfg(windows)]
+    interface_name: String,
+
+    /// Interface GUID
+    #[cfg(windows)]
+    requested_guid: String,
+
+    /// Tunnel type identifier
+    /// Passed during WinTun initialization
+    #[cfg(windows)]
+    wintun_tunnel_type: String,
+}
+
 /// Classic WireGuard tunnel.
 #[derive(Debug)]
 pub struct Tunnel {
@@ -116,8 +149,30 @@ pub struct Tunnel {
 
 impl Tunnel {
     /// Start new WireGuard tunnel
+    pub fn start(wg_config: Config, tun_config: TunnelConfig) -> Result<Self> {
+        #[cfg(not(windows))]
+        {
+            match tun_config.tun_fd {
+                TunnelFd::Tun(tun_fd) => Self::start_with_tun(wg_config, tun_fd),
+                #[cfg(target_os = "android")]
+                TunnelFd::Proxy(proxy_fd) => Self::start_with_proxy_fd(wg_config, proxy_fd),
+            }
+        }
+
+        #[cfg(windows)]
+        {
+            Self::start_inner(
+                wg_config,
+                &tun_config.interface_name,
+                &tun_config.requested_guid,
+                &tun_config.wintun_tunnel_type,
+            )
+        }
+    }
+
+    /// Start new WireGuard tunnel with TUN fd.
     #[cfg(not(windows))]
-    pub fn start(config: Config, tun_fd: OwnedFd) -> Result<Self> {
+    fn start_with_tun(config: Config, tun_fd: OwnedFd) -> Result<Self> {
         #[cfg(any(target_os = "linux", target_os = "macos"))]
         let interface_mtu = config.interface.mtu;
         let settings = CString::new(config.into_uapi_config())
@@ -142,36 +197,9 @@ impl Tunnel {
         }
     }
 
-    /// Start a new WireGuard tunnel backed by a raw proxy socket fd (Android only).
-    ///
-    /// Unlike [`start`], this calls `wgTurnOnWithProxyFd` which wraps the fd as a "dumb" I/O
-    /// device without calling `TUNGETIFF`, making it safe to use with a Unix socket fd.
-    #[cfg(target_os = "android")]
-    pub fn start_with_proxy_fd(config: Config, proxy_fd: OwnedFd) -> Result<Self> {
-        let mtu = config.interface.mtu;
-        let settings = CString::new(config.into_uapi_config())
-            .map_err(|_| Error::ConvertToCString("uapi config"))?;
-
-        let tunnel_handle = unsafe {
-            wgTurnOnWithProxyFd(
-                settings.as_ptr(),
-                proxy_fd.into_raw_fd(),
-                i32::from(mtu),
-                wg_logger_callback,
-                std::ptr::null_mut(),
-            )
-        };
-
-        if tunnel_handle >= 0 {
-            Ok(Self { tunnel_handle })
-        } else {
-            Err(Error::StartTunnel(tunnel_handle))
-        }
-    }
-
+    /// Start new WireGuard tunnel with wintun interface.
     #[cfg(windows)]
-    /// Start new WireGuard tunnel
-    pub fn start(
+    fn start_inner(
         config: Config,
         interface_name: &str,
         requested_guid: &str,
@@ -229,6 +257,33 @@ impl Tunnel {
                 tunnel_handle,
                 wintun_interface,
             })
+        } else {
+            Err(Error::StartTunnel(tunnel_handle))
+        }
+    }
+
+    /// Start a new WireGuard tunnel backed by a raw proxy socket fd (Android only).
+    ///
+    /// Unlike [`start`], this calls `wgTurnOnWithProxyFd` which wraps the fd as a "dumb" I/O
+    /// device without calling `TUNGETIFF`, making it safe to use with a Unix socket fd.
+    #[cfg(target_os = "android")]
+    fn start_with_proxy_fd(config: Config, proxy_fd: OwnedFd) -> Result<Self> {
+        let mtu = config.interface.mtu;
+        let settings = CString::new(config.into_uapi_config())
+            .map_err(|_| Error::ConvertToCString("uapi config"))?;
+
+        let tunnel_handle = unsafe {
+            wgTurnOnWithProxyFd(
+                settings.as_ptr(),
+                proxy_fd.into_raw_fd(),
+                i32::from(mtu),
+                wg_logger_callback,
+                std::ptr::null_mut(),
+            )
+        };
+
+        if tunnel_handle >= 0 {
+            Ok(Self { tunnel_handle })
         } else {
             Err(Error::StartTunnel(tunnel_handle))
         }


### PR DESCRIPTION
## Description

This PR introduces a builder for `wireguard_go::Tunnel` to shift platform differences into `wireguard_go::TunnelConfig`.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5144)
<!-- Reviewable:end -->
