### PR TITLE
Disable shared reqwest client and hickory in tests

### DIFF
--- a/.github/workflows/ci-nym-vpn-core-linux.yml
+++ b/.github/workflows/ci-nym-vpn-core-linux.yml
@@ -10,6 +10,7 @@ on:
   workflow_dispatch:
 
 env:
+  CI_TESTING: true
   CARGO_TERM_COLOR: always
   AGENT_ISSELFHOSTED: 1 # https://github.com/actions/setup-go/issues/432
 

--- a/.github/workflows/ci-nym-vpn-core-macos.yml
+++ b/.github/workflows/ci-nym-vpn-core-macos.yml
@@ -10,6 +10,7 @@ on:
   workflow_dispatch:
 
 env:
+  CI_TESTING: true
   CARGO_TERM_COLOR: always
   AGENT_ISSELFHOSTED: 1 # https://github.com/actions/setup-go/issues/432
 
@@ -52,8 +53,7 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-          key:
-            ${{ runner.os }}-cargo-${{ hashFiles('nym-vpn-core/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('nym-vpn-core/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
 
@@ -61,8 +61,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: nym-vpn-core/target/
-          key:
-            ${{ runner.os }}-cargo-build-${{
+          key: ${{ runner.os }}-cargo-build-${{
             hashFiles('nym-vpn-core/Cargo.lock') }}-${{
             hashFiles('nym-vpn-core/**/*.rs') }}
           restore-keys: |

--- a/.github/workflows/ci-nym-vpn-core-windows.yml
+++ b/.github/workflows/ci-nym-vpn-core-windows.yml
@@ -11,6 +11,7 @@ on:
   workflow_dispatch:
 
 env:
+  CI_TESTING: true
   CARGO_TERM_COLOR: always
   LIBS_PATH: build/lib/x86_64-pc-windows-msvc
   WINFW_PATH: build/winfw/x64-Debug

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -10652,9 +10652,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -195,7 +195,7 @@ tap = "1.0.1"
 tempfile = "3.27"
 thiserror = "2.0"
 time = "0.3.47"
-tokio = "1.51.1"
+tokio = "1.52.1"
 tokio-rustls = { version = "0.26", default-features = false }
 tokio-stream = "0.1.18"
 tokio-tungstenite = { version = "0.29.0" }

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/fronted_http_client.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/fronted_http_client.rs
@@ -30,6 +30,15 @@ pub fn fronted_http_client_builder(
         .map_err(Box::new)
         .map_err(VpnApiClientError::CreateVpnApiClient)?;
 
+    // By default, HTTP client uses a singleton instance of reqwest client and hickory resolver.
+    // This is not going to work in test environment since singletons are tied to single runtime and each test case uses a new runtime.
+    if option_env!("CI_TESTING")
+        .and_then(|s| <bool as std::str::FromStr>::from_str(s).ok())
+        .unwrap_or_default()
+    {
+        builder = builder.no_hickory_dns();
+    }
+
     if let Some(user_agent) = user_agent {
         builder = builder.with_user_agent(user_agent.clone());
     }


### PR DESCRIPTION


## Description

Fix "runtime gone" error related to reuse of  shared reqwest client when testing. In tests the new runtime is created per test case.

Unfortunately in order to disable shared reqwest client, we need some way to compile a branch of code. Unfortunately `cfg(test)` only applies to the tested crate so that's a no go. 

Instead let's use `CI_TESTING` environment variable set at compile time to determine when to disable the shared HTTP client. 

https://github.com/nymtech/nym/blob/61d6aca/common/http-api-client/src/lib.rs#L216-L232


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5146)
<!-- Reviewable:end -->
