### PR TITLE
Enable adblocking on iOS

### DIFF
--- a/nym-vpn-apple/Settings/Sources/Settings/SettingsViewModel.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/SettingsViewModel.swift
@@ -407,7 +407,6 @@ private extension SettingsViewModel {
                 action: {}
             )
         )
-#if os(macOS)
         let adBlockSubtitle = appSettings.isAdBlockerEnabled
         ? "settings.adblock.subtitle.on".localizedString
         : "settings.adblock.subtitle.off".localizedString
@@ -436,6 +435,7 @@ private extension SettingsViewModel {
             }
             .store(in: &cancellables)
         viewModels.append(adBlockViewModel)
+#if os(macOS)
         viewModels.append(
             SettingsListItemViewModel(
                 accessory: .toggle(

--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add TCP listener for local DNS resolver (https://github.com/nymtech/nym-vpn-client/pull/5113)
 - Add SOCKS5 Proxy process to implement Airporting (https://github.com/nymtech/nym-vpn-client/pull/5078)
 - Disable client verifications on daemon flag for debug purposes (https://github.com/nymtech/nym-vpn-client/pull/5148)
+- Add ad-blocking on iOS (https://github.com/nymtech/nym-vpn-client/pull/5153)
 
 ### Changed
 

--- a/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
@@ -171,6 +171,8 @@ tracing-android.workspace = true
 [target.'cfg(target_os = "ios")'.dependencies]
 debounced.workspace = true
 dispatch2.workspace = true
+hickory-proto.workspace = true
+pnet_packet.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/nym-vpn-core/crates/nym-vpn-lib/src/adblocker/task.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/adblocker/task.rs
@@ -218,7 +218,7 @@ impl AdBlockerTask {
             .downcast_mut::<AdBlocker>()
             .expect("Failed to downcast to AdBlocker");
         adblocker.use_filter_set(filter_set).await;
-        #[cfg(not(target_os = "android"))]
+        #[cfg(not(any(target_os = "android", target_os = "ios")))]
         crate::resolver::flush_system_cache();
     }
 
@@ -229,7 +229,7 @@ impl AdBlockerTask {
             .downcast_mut::<AdBlocker>()
             .expect("Failed to downcast to AdBlocker");
         adblocker.clear_filter_set().await;
-        #[cfg(not(target_os = "android"))]
+        #[cfg(not(any(target_os = "android", target_os = "ios")))]
         crate::resolver::flush_system_cache();
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/lib.rs
@@ -3,13 +3,11 @@
 
 pub mod storage;
 
-#[cfg(not(target_os = "ios"))]
 mod adblocker;
 mod bandwidth_controller;
 pub mod cache_refresh;
 pub mod config;
-#[cfg(not(target_os = "ios"))]
-pub(crate) mod dns_filter;
+mod dns_filter;
 mod error;
 pub mod logging;
 mod mixnet;

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -29,12 +29,11 @@ use std::{
 
 #[cfg(target_os = "android")]
 use crate::tunnel_provider::AndroidTunProvider;
-#[cfg(target_os = "ios")]
+#[cfg(any(target_os = "android", target_os = "ios"))]
 use crate::tunnel_provider::OSTunProvider;
 
-#[cfg(not(target_os = "ios"))]
 use crate::adblocker;
-#[cfg(target_os = "android")]
+#[cfg(any(target_os = "android", target_os = "ios"))]
 use crate::dns_filter::DnsFilter;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use crate::resolver;
@@ -663,7 +662,6 @@ pub struct SharedState {
     connectivity_handle: ConnectivityHandle,
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     filtering_resolver: resolver::ResolverHandle,
-    #[cfg(not(target_os = "ios"))]
     adblocker: adblocker::AdBlockerTaskHandle,
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     socks5_proxy_manager: Socks5ProxyManager,
@@ -708,7 +706,6 @@ impl SharedState {
         self.account_command_tx.set_vpn_api_firewall_up().await.ok();
     }
 
-    #[cfg(not(target_os = "ios"))]
     async fn enable_ad_blocking(&self, enable: bool) {
         if enable {
             self.adblocker.enable().await;
@@ -718,7 +715,7 @@ impl SharedState {
     }
 
     /// Get the current DNS filter from the adblocker (Android only).
-    #[cfg(target_os = "android")]
+    #[cfg(any(target_os = "android", target_os = "ios"))]
     pub async fn get_dns_filter(&self) -> Option<DnsFilter> {
         self.adblocker.get_dns_filter().await
     }
@@ -912,7 +909,6 @@ pub struct TunnelStateMachine {
     dns_handler_shutdown_token: CancellationToken,
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     filtering_resolver_handle: JoinHandle<()>,
-    #[cfg(not(target_os = "ios"))]
     adblocker_handle: JoinHandle<()>,
     gateway_provider_handle: JoinHandle<()>,
     shutdown_token: CancellationToken,
@@ -952,7 +948,6 @@ impl TunnelStateMachine {
                 .await
                 .map_err(Error::StartLocalDnsResolver)?;
 
-        #[cfg(not(target_os = "ios"))]
         let (adblocker, adblocker_handle) = {
             let Some(data_path) = nym_config.data_path.as_ref() else {
                 tracing::error!("Ad-blocking cannot be enabled without a data path configured");
@@ -961,9 +956,9 @@ impl TunnelStateMachine {
                 ));
             };
 
-            #[cfg(not(target_os = "android"))]
+            #[cfg(not(any(target_os = "android", target_os = "ios")))]
             let token = dns_handler_shutdown_token.child_token();
-            #[cfg(target_os = "android")]
+            #[cfg(any(target_os = "android", target_os = "ios"))]
             let token = shutdown_token.child_token();
 
             adblocker::AdBlockerTask::spawn(data_path, user_agent.to_string(), token)
@@ -1017,7 +1012,6 @@ impl TunnelStateMachine {
             connectivity_handle,
             #[cfg(not(any(target_os = "android", target_os = "ios")))]
             filtering_resolver,
-            #[cfg(not(target_os = "ios"))]
             adblocker,
             #[cfg(not(any(target_os = "android", target_os = "ios")))]
             socks5_proxy_manager: Socks5ProxyManager::new(),
@@ -1072,7 +1066,6 @@ impl TunnelStateMachine {
             dns_handler_shutdown_token,
             #[cfg(not(any(target_os = "android", target_os = "ios")))]
             filtering_resolver_handle,
-            #[cfg(not(target_os = "ios"))]
             adblocker_handle,
             gateway_provider_handle,
             shutdown_token,
@@ -1126,17 +1119,12 @@ impl TunnelStateMachine {
             if let Err(e) = self.filtering_resolver_handle.await {
                 tracing::error!("Failed to join on filtering resolver task: {}", e)
             }
-
-            if let Err(e) = self.adblocker_handle.await {
-                tracing::error!("Failed to join on ad-blocker task: {}", e)
-            }
         }
 
         if let Err(e) = self.gateway_provider_handle.await {
             tracing::error!("Failed to join on gateway provider task: {}", e)
         }
 
-        #[cfg(target_os = "android")]
         if let Err(e) = self.adblocker_handle.await {
             tracing::error!("Failed to join on ad-blocker task: {}", e)
         }
@@ -1168,7 +1156,6 @@ pub enum Error {
     #[error("failed to start local dns resolver")]
     StartLocalDnsResolver(#[source] resolver::Error),
 
-    #[cfg(not(target_os = "ios"))]
     #[error("failed to start ad blocker task")]
     StartAdBlockerTask(#[source] adblocker::AdBlockerError),
 
@@ -1278,7 +1265,6 @@ impl Error {
             Self::ResolveApiHostnames(_) => None?,
             #[cfg(not(any(target_os = "android", target_os = "ios")))]
             Self::StartLocalDnsResolver(_) => None?,
-            #[cfg(not(target_os = "ios"))]
             Self::StartAdBlockerTask(_) => None?,
             #[cfg(not(any(target_os = "android", target_os = "ios")))]
             Self::DataPathUnavailable => None?,
@@ -1361,7 +1347,7 @@ impl tunnel::Error {
             Self::DupFd(_) => Some(ErrorStateReason::Internal(
                 "Failed to dup tunnel fd".to_owned(),
             )),
-            #[cfg(target_os = "android")]
+            #[cfg(any(target_os = "android", target_os = "ios"))]
             Self::CreateDnsFilterProxy(e) => Some(ErrorStateReason::Internal(
                 format!("Failed to create DNS filter proxy: {e}")
             )),

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -330,8 +330,18 @@ impl TunnelSettingsDiffFields {
             | Self::ExitPoint
             | Self::GatewayPerformanceOptions
             | Self::Dns => true,
+            Self::EnableAdBlocking => {
+                // The tunnel needs to be re-created when toggling ad-block, but only on iOS
+                if cfg!(target_os = "ios") {
+                    true
+                } else if cfg!(target_os = "android") {
+                    // todo: kotlin initiates reconnect for now, but it should happen here!
+                    false
+                } else {
+                    false
+                }
+            }
             Self::AllowLan
-            | Self::EnableAdBlocking
             | Self::SplitTunnel
             | Self::Airporting
             | Self::AirportingEnabled

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
@@ -334,7 +334,6 @@ impl TunnelStateHandler for ConnectedState {
                                 .await;
                         }
 
-                        #[cfg(not(target_os = "ios"))]
                         if diff.enable_ad_blocking_changed() {
                             shared_state.enable_ad_blocking(shared_state.tunnel_settings.enable_ad_blocking).await;
                         }
@@ -475,6 +474,7 @@ impl ConnectedPolicyParameters {
 }
 
 #[cfg(test)]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 mod tests {
     use super::*;
     use nym_dns::DnsConfig;
@@ -502,7 +502,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(any(target_os = "android", target_os = "ios")))]
     fn test_firewall_policy_includes_exit_gateway_endpoints() {
         // Create mock entry gateway with WebSocket on port 9000 (WS) and 9001 (WSS)
         let entry_gateway =

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -377,7 +377,7 @@ impl ConnectingState {
             selected_gateways: self.selected_gateways.clone(),
             user_agent: shared_state.user_agent.clone(),
         };
-        #[cfg(target_os = "android")]
+        #[cfg(any(target_os = "android", target_os = "ios"))]
         let dns_filter = if shared_state.tunnel_settings.enable_ad_blocking {
             shared_state.get_dns_filter().await
         } else {
@@ -395,7 +395,7 @@ impl ConnectingState {
             shared_state.route_handler.clone(),
             #[cfg(any(target_os = "ios", target_os = "android"))]
             shared_state.tun_provider.clone(),
-            #[cfg(target_os = "android")]
+            #[cfg(any(target_os = "android", target_os = "ios"))]
             dns_filter,
         );
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
@@ -43,7 +43,7 @@ pub enum Error {
     #[error("failed to dup tunnel file descriptor")]
     DupFd(#[source] std::io::Error),
 
-    #[cfg(target_os = "android")]
+    #[cfg(any(target_os = "android", target_os = "ios"))]
     #[error("failed to create DNS filter proxy")]
     CreateDnsFilterProxy(#[source] std::io::Error),
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
@@ -34,13 +34,13 @@ use tokio_util::sync::CancellationToken;
 #[cfg(unix)]
 use tun::AsyncDevice;
 
-#[cfg(target_os = "android")]
+#[cfg(any(target_os = "android", target_os = "ios"))]
 use crate::dns_filter::DnsFilter;
 #[cfg(target_os = "android")]
 use crate::tunnel_provider::AndroidTunProvider;
 #[cfg(windows)]
 use crate::tunnel_state_machine::route_handler::RouteHandler;
-#[cfg(target_os = "android")]
+#[cfg(any(target_os = "android", target_os = "ios"))]
 use crate::tunnel_state_machine::tunnel::wireguard::dns_filter_proxy::DnsFilterProxy;
 #[cfg(target_os = "ios")]
 use crate::tunnel_state_machine::tunnel::wireguard::dns64::Dns64Resolution;
@@ -355,7 +355,7 @@ impl ConnectedTunnel {
 
         let builder = wireguard_go::TunnelConfig::builder();
 
-        #[cfg(target_os = "android")]
+        #[cfg(any(target_os = "android", target_os = "ios"))]
         let (builder, proxy_join_handle, android_exit_tun) = {
             if let Some(dns_filter) = options.dns_filter {
                 let proxy = DnsFilterProxy::start(
@@ -381,7 +381,7 @@ impl ConnectedTunnel {
             .requested_guid(options.exit_tun_guid)
             .wintun_tunnel_type(options.wintun_tunnel_type);
 
-        #[cfg(all(unix, not(target_os = "android")))]
+        #[cfg(all(unix, not(target_os = "android"), not(target_os = "ios")))]
         let builder = builder.tun_fd(TunnelFd::Tun(
             options.exit_tun.deref().dup_fd().map_err(Error::DupFd)?,
         ));
@@ -495,7 +495,7 @@ impl ConnectedTunnel {
             entry_magic_bandwidth_tcp_proxy.close();
             exit_in_tunnel_udp_proxy.close();
 
-            #[cfg(target_os = "android")]
+            #[cfg(any(target_os = "android", target_os = "ios"))]
             {
                 if let Some(proxy_join_handle) = proxy_join_handle {
                     match proxy_join_handle.await {
@@ -517,7 +517,7 @@ impl ConnectedTunnel {
                 Tombstone::with_wg_instances(vec![exit_tunnel])
             }
 
-            #[cfg(not(any(windows, target_os = "android")))]
+            #[cfg(not(any(windows, target_os = "android", target_os = "ios")))]
             {
                 Tombstone::with_tun_device(options.exit_tun)
             }
@@ -649,7 +649,7 @@ pub struct NetstackTunnelOptions {
     pub dns: Vec<IpAddr>,
 
     /// DNS filter for ad-blocking (Android only).
-    #[cfg(target_os = "android")]
+    #[cfg(any(target_os = "android", target_os = "ios"))]
     pub dns_filter: Option<DnsFilter>,
 }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/dns_filter_proxy.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/dns_filter_proxy.rs
@@ -43,10 +43,11 @@ use crate::dns_filter::{DnsFilter, DnsFilterDecision};
 /// Maximum IP packet size we handle.
 const MAX_PACKET_SIZE: usize = 65536;
 
-/// UDP port used by DNS.
+/// UDP/TCP port used by DNS.
 const DNS_PORT: u16 = 53;
 
-/// Port for RST
+/// DNS-over-TLS port.
+#[cfg(target_os = "android")]
 const DOT_PORT: u16 = 853;
 
 /// IPv4 version nibble.
@@ -228,6 +229,7 @@ async fn maybe_nxdomain_v4(packet: &[u8], dns_filter: &DnsFilter) -> Option<Vec<
                 return None;
             };
             match tcp.get_destination() {
+                #[cfg(target_os = "android")]
                 DOT_PORT => {
                     // Always RST DoT connections to force Android back to UDP/53.
                     tracing::trace!("DNS proxy: RST TCP/853 (DoT) from IPv4");
@@ -283,6 +285,7 @@ async fn maybe_nxdomain_v6(packet: &[u8], dns_filter: &DnsFilter) -> Option<Vec<
                 return None;
             };
             match tcp.get_destination() {
+                #[cfg(target_os = "android")]
                 DOT_PORT => {
                     tracing::trace!("DNS proxy: RST TCP/853 (DoT) from IPv6");
                     Some(build_tcp_rst_response_v6(&ip, &tcp))

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/mod.rs
@@ -11,7 +11,7 @@ pub mod connected_tunnel;
 
 #[cfg(target_os = "ios")]
 pub mod dns64;
-#[cfg(target_os = "android")]
+#[cfg(any(target_os = "android", target_os = "ios"))]
 pub mod dns_filter_proxy;
 #[cfg(unix)]
 pub mod fd;

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -229,7 +229,7 @@ pub struct TunnelMonitor {
     tun_provider: Arc<dyn OSTunProvider>,
     #[cfg(target_os = "android")]
     tun_provider: Arc<dyn AndroidTunProvider>,
-    #[cfg(target_os = "android")]
+    #[cfg(any(target_os = "android", target_os = "ios"))]
     dns_filter: Option<crate::dns_filter::DnsFilter>,
     account_controller_state: AccountStateReceiver,
     account_command_tx: AccountCommandSender,
@@ -250,7 +250,9 @@ impl TunnelMonitor {
         #[cfg(not(any(target_os = "android", target_os = "ios")))] route_handler: RouteHandler,
         #[cfg(target_os = "ios")] tun_provider: Arc<dyn OSTunProvider>,
         #[cfg(target_os = "android")] tun_provider: Arc<dyn AndroidTunProvider>,
-        #[cfg(target_os = "android")] dns_filter: Option<crate::dns_filter::DnsFilter>,
+        #[cfg(any(target_os = "android", target_os = "ios"))] dns_filter: Option<
+            crate::dns_filter::DnsFilter,
+        >,
     ) -> TunnelMonitorHandle {
         let shutdown_token = CancellationToken::new();
         let tunnel_monitor = Self {
@@ -260,7 +262,7 @@ impl TunnelMonitor {
             route_handler,
             #[cfg(any(target_os = "ios", target_os = "android"))]
             tun_provider,
-            #[cfg(target_os = "android")]
+            #[cfg(any(target_os = "android", target_os = "ios"))]
             dns_filter,
             account_controller_state,
             account_command_tx,
@@ -1614,7 +1616,7 @@ impl TunnelMonitor {
             metadata_proxy_tx: entry_metadata_tx,
             exit_tun: tun_device,
             dns: dns_servers,
-            #[cfg(target_os = "android")]
+            #[cfg(any(target_os = "android", target_os = "ios"))]
             dns_filter: self.dns_filter.clone(),
         });
 

--- a/nym-vpn-core/crates/nym-wg-go/src/wireguard_go.rs
+++ b/nym-vpn-core/crates/nym-wg-go/src/wireguard_go.rs
@@ -115,7 +115,7 @@ pub enum TunnelFd {
     Tun(OwnedFd),
 
     /// Proxy device using unix domain socket
-    #[cfg(target_os = "android")]
+    #[cfg(any(target_os = "android", target_os = "ios"))]
     Proxy(OwnedFd),
 }
 
@@ -154,7 +154,7 @@ impl Tunnel {
         {
             match tun_config.tun_fd {
                 TunnelFd::Tun(tun_fd) => Self::start_with_tun(wg_config, tun_fd),
-                #[cfg(target_os = "android")]
+                #[cfg(any(target_os = "android", target_os = "ios"))]
                 TunnelFd::Proxy(proxy_fd) => Self::start_with_proxy_fd(wg_config, proxy_fd),
             }
         }
@@ -262,11 +262,11 @@ impl Tunnel {
         }
     }
 
-    /// Start a new WireGuard tunnel backed by a raw proxy socket fd (Android only).
+    /// Start a new WireGuard tunnel backed by a raw proxy socket fd (Android, iOS only).
     ///
     /// Unlike [`start`], this calls `wgTurnOnWithProxyFd` which wraps the fd as a "dumb" I/O
     /// device without calling `TUNGETIFF`, making it safe to use with a Unix socket fd.
-    #[cfg(target_os = "android")]
+    #[cfg(any(target_os = "android", target_os = "ios"))]
     fn start_with_proxy_fd(config: Config, proxy_fd: OwnedFd) -> Result<Self> {
         let mtu = config.interface.mtu;
         let settings = CString::new(config.into_uapi_config())
@@ -347,9 +347,9 @@ impl Drop for Tunnel {
 }
 
 unsafe extern "C" {
-    /// Start a WireGuard tunnel using a raw proxy socket fd (Android only).
+    /// Start a WireGuard tunnel using a raw proxy socket fd (Android, iOS only).
     /// Wraps the fd without calling TUNGETIFF so it works with Unix socket fds.
-    #[cfg(target_os = "android")]
+    #[cfg(any(target_os = "android", target_os = "ios"))]
     unsafe fn wgTurnOnWithProxyFd(
         settings: *const c_char,
         fd: RawFd,

--- a/wireguard/libwg/libwg_android.go
+++ b/wireguard/libwg/libwg_android.go
@@ -10,9 +10,7 @@ package main
 import (
 	"C"
 	"bufio"
-	"os"
 	"strings"
-	"sync"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
@@ -70,114 +68,6 @@ func wgTurnOn(cSettings *C.char, fd int, logSink LogSink, logContext LogContext)
 	if err != nil {
 		logger.Errorf("%s\n", err)
 		device.Close()
-		return ERROR_GENERAL_FAILURE
-	}
-
-	return handle
-}
-
-// socketTun is a tun.Device backed by a raw file descriptor (e.g. a Unix-domain socket).
-// Unlike NativeTun it does NOT call TUNGETIFF, so it is safe to use with non-TUN fds on Android.
-type socketTun struct {
-	file      *os.File
-	mtu       int
-	events    chan tun.Event
-	closeOnce sync.Once
-}
-
-func newSocketTunFromFD(fd int, mtu int) (*socketTun, error) {
-	if err := unix.SetNonblock(fd, true); err != nil {
-		return nil, err
-	}
-	file := os.NewFile(uintptr(fd), "wg-proxy-socket")
-	st := &socketTun{
-		file:   file,
-		mtu:    mtu,
-		events: make(chan tun.Event, 5),
-	}
-	st.events <- tun.EventUp
-	return st, nil
-}
-
-func (st *socketTun) File() *os.File { return st.file }
-
-func (st *socketTun) Name() (string, error) { return "wg-proxy", nil }
-
-func (st *socketTun) MTU() (int, error) { return st.mtu, nil }
-
-func (st *socketTun) Events() <-chan tun.Event { return st.events }
-
-func (st *socketTun) BatchSize() int { return 1 }
-
-func (st *socketTun) Read(bufs [][]byte, sizes []int, offset int) (int, error) {
-	n, err := st.file.Read(bufs[0][offset:])
-	if err != nil {
-		return 0, err
-	}
-	sizes[0] = n
-	return 1, nil
-}
-
-func (st *socketTun) Write(bufs [][]byte, offset int) (int, error) {
-	for i, buf := range bufs {
-		if _, err := st.file.Write(buf[offset:]); err != nil {
-			return i, err
-		}
-	}
-	return len(bufs), nil
-}
-
-func (st *socketTun) Close() error {
-	var err error
-	st.closeOnce.Do(func() {
-		close(st.events)
-		err = st.file.Close()
-	})
-	return err
-}
-
-// wgTurnOnWithProxyFd starts a WireGuard tunnel backed by a raw socket fd (e.g. the wg end of a
-// DNS-filter proxy socket pair). Unlike wgTurnOn it does NOT call TUNGETIFF, so it works on
-// Android with non-TUN file descriptors. mtu must be the MTU configured for the exit tunnel.
-//
-//export wgTurnOnWithProxyFd
-func wgTurnOnWithProxyFd(cSettings *C.char, fd int, mtu int32, logSink LogSink, logContext LogContext) int32 {
-	logger := logging.NewLogger(logSink, logContext)
-
-	if cSettings == nil {
-		logger.Errorf("cSettings is null\n")
-		return ERROR_GENERAL_FAILURE
-	}
-	settings := C.GoString(cSettings)
-
-	tunDevice, err := newSocketTunFromFD(fd, int(mtu))
-	if err != nil {
-		logger.Errorf("wgTurnOnWithProxyFd: failed to create socket tun: %s\n", err)
-		unix.Close(fd)
-		return ERROR_GENERAL_FAILURE
-	}
-
-	dev := device.NewDevice(tunDevice, conn.NewStdNetBind(), logger)
-
-	setErr := dev.IpcSetOperation(bufio.NewReader(strings.NewReader(settings)))
-	if setErr != nil {
-		logger.Errorf("%s\n", setErr)
-		dev.Close()
-		return ERROR_INTERMITTENT_FAILURE
-	}
-
-	dev.DisableSomeRoamingForBrokenMobileSemantics()
-	dev.Up()
-
-	context := TunnelContext{
-		Device: dev,
-		Logger: logger,
-	}
-
-	handle, err := tunnels.Insert(context)
-	if err != nil {
-		logger.Errorf("%s\n", err)
-		dev.Close()
 		return ERROR_GENERAL_FAILURE
 	}
 

--- a/wireguard/libwg/libwg_mobile.go
+++ b/wireguard/libwg/libwg_mobile.go
@@ -12,8 +12,124 @@ import "C"
 
 import (
 	"bufio"
+	"os"
 	"strings"
+	"sync"
+
+	"github.com/amnezia-vpn/amneziawg-go/conn"
+	"github.com/amnezia-vpn/amneziawg-go/device"
+	"github.com/amnezia-vpn/amneziawg-go/tun"
+	"github.com/nymtech/nym-vpn-client/wireguard/libwg/logging"
+	"golang.org/x/sys/unix"
 )
+
+// socketTun is a tun.Device backed by a raw file descriptor (e.g. a Unix-domain socket).
+// Unlike NativeTun it does NOT call TUNGETIFF, so it is safe to use with non-TUN fds on Android.
+type socketTun struct {
+	file      *os.File
+	mtu       int
+	events    chan tun.Event
+	closeOnce sync.Once
+}
+
+func newSocketTunFromFD(fd int, mtu int) (*socketTun, error) {
+	if err := unix.SetNonblock(fd, true); err != nil {
+		return nil, err
+	}
+	file := os.NewFile(uintptr(fd), "wg-proxy-socket")
+	st := &socketTun{
+		file:   file,
+		mtu:    mtu,
+		events: make(chan tun.Event, 5),
+	}
+	st.events <- tun.EventUp
+	return st, nil
+}
+
+func (st *socketTun) File() *os.File { return st.file }
+
+func (st *socketTun) Name() (string, error) { return "wg-proxy", nil }
+
+func (st *socketTun) MTU() (int, error) { return st.mtu, nil }
+
+func (st *socketTun) Events() <-chan tun.Event { return st.events }
+
+func (st *socketTun) BatchSize() int { return 1 }
+
+func (st *socketTun) Read(bufs [][]byte, sizes []int, offset int) (int, error) {
+	n, err := st.file.Read(bufs[0][offset:])
+	if err != nil {
+		return 0, err
+	}
+	sizes[0] = n
+	return 1, nil
+}
+
+func (st *socketTun) Write(bufs [][]byte, offset int) (int, error) {
+	for i, buf := range bufs {
+		if _, err := st.file.Write(buf[offset:]); err != nil {
+			return i, err
+		}
+	}
+	return len(bufs), nil
+}
+
+func (st *socketTun) Close() error {
+	var err error
+	st.closeOnce.Do(func() {
+		close(st.events)
+		err = st.file.Close()
+	})
+	return err
+}
+
+// wgTurnOnWithProxyFd starts a WireGuard tunnel backed by a raw socket fd (e.g. the wg end of a
+// DNS-filter proxy socket pair). Unlike wgTurnOn it does NOT call TUNGETIFF, so it works on
+// Android with non-TUN file descriptors. mtu must be the MTU configured for the exit tunnel.
+//
+//export wgTurnOnWithProxyFd
+func wgTurnOnWithProxyFd(cSettings *C.char, fd int, mtu int32, logSink LogSink, logContext LogContext) int32 {
+	logger := logging.NewLogger(logSink, logContext)
+
+	if cSettings == nil {
+		logger.Errorf("cSettings is null\n")
+		return ERROR_GENERAL_FAILURE
+	}
+	settings := C.GoString(cSettings)
+
+	tunDevice, err := newSocketTunFromFD(fd, int(mtu))
+	if err != nil {
+		logger.Errorf("wgTurnOnWithProxyFd: failed to create socket tun: %s\n", err)
+		unix.Close(fd)
+		return ERROR_GENERAL_FAILURE
+	}
+
+	dev := device.NewDevice(tunDevice, conn.NewStdNetBind(), logger)
+
+	setErr := dev.IpcSetOperation(bufio.NewReader(strings.NewReader(settings)))
+	if setErr != nil {
+		logger.Errorf("%s\n", setErr)
+		dev.Close()
+		return ERROR_INTERMITTENT_FAILURE
+	}
+
+	dev.DisableSomeRoamingForBrokenMobileSemantics()
+	dev.Up()
+
+	context := TunnelContext{
+		Device: dev,
+		Logger: logger,
+	}
+
+	handle, err := tunnels.Insert(context)
+	if err != nil {
+		logger.Errorf("%s\n", err)
+		dev.Close()
+		return ERROR_GENERAL_FAILURE
+	}
+
+	return handle
+}
 
 //export wgSetConfig
 func wgSetConfig(tunnelHandle int32, cSettings *C.char) int32 {


### PR DESCRIPTION
## Ticket

JIRA-VPN-1139

## Description

- Extend Android solution for adblocking to iOS
- Limit blocking of port 853 to Android only (for tackling Android Private DNS)

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5153)
<!-- Reviewable:end -->
