### PR TITLE
APPLE: use SFSafariViewController for login

### DIFF
--- a/nym-vpn-apple/Home/Sources/Home/HomeViewModel+Connection.swift
+++ b/nym-vpn-apple/Home/Sources/Home/HomeViewModel+Connection.swift
@@ -1,5 +1,9 @@
 public extension HomeViewModel {
     @MainActor func connectDisconnect() async {
+        guard !isConnectDisconnectInFlight else { return }
+        isConnectDisconnectInFlight = true
+        defer { isConnectDisconnectInFlight = false }
+
         guard connectionManager.currentTunnelStatus != .disconnecting
         else {
             return

--- a/nym-vpn-apple/Home/Sources/Home/HomeViewModel.swift
+++ b/nym-vpn-apple/Home/Sources/Home/HomeViewModel.swift
@@ -58,6 +58,7 @@ import GRPCManager
     var tunnelConnectingStateCancellable: AnyCancellable?
     var lastTunnelStatus = TunnelStatus.disconnected
     var lastError: Error?
+    var isConnectDisconnectInFlight = false
 
 #if os(macOS)
     public var isServing = false

--- a/nym-vpn-apple/NymVPN/NymVPNApp.swift
+++ b/nym-vpn-apple/NymVPN/NymVPNApp.swift
@@ -3,6 +3,7 @@ import Logging
 import AppSettings
 import ConfigurationManager
 import ConnectionManager
+import Constants
 import CredentialsManager
 import DeeplinkManager
 import ExternalLinkManager
@@ -76,6 +77,7 @@ struct NymVPNApp: App {
             .onChange(of: scenePhase) { _, newPhase in
                 configureSecureScreen(with: newPhase)
             }
+            .inAppSafari(using: externalLinkManager)
             .overlay {
                 if isSecureScreenVisible {
                     LogoView()
@@ -87,6 +89,9 @@ struct NymVPNApp: App {
                 configureScreenSize()
             }
             .onOpenURL { incomingURL in
+                if incomingURL.scheme == Constants.appUrlScheme.rawValue {
+                    externalLinkManager.inAppSafariURL = nil
+                }
                 deeplinkManager.handle(url: incomingURL)
             }
             .environmentObject(appSettings)

--- a/nym-vpn-apple/Services/Sources/Services/ExternalLinkManager/ExternalLinkManager.swift
+++ b/nym-vpn-apple/Services/Sources/Services/ExternalLinkManager/ExternalLinkManager.swift
@@ -12,6 +12,8 @@ import Constants
     public static let shared = ExternalLinkManager()
 
 #if os(iOS)
+    @Published public var inAppSafariURL: InAppSafariURL?
+
     public func openExternalURL(urlString: String?) throws {
         guard let urlString, let url = URL(string: urlString)
         else {
@@ -22,6 +24,24 @@ import Constants
 
     public func openExternalURL(_ url: URL) {
         UIApplication.shared.open(url)
+    }
+
+    public func openInAppBrowser(urlString: String?) throws {
+        guard let urlString, let url = URL(string: urlString)
+        else {
+            throw GeneralNymError.invalidUrl
+        }
+        openInAppBrowser(url)
+    }
+
+    public func openInAppBrowser(_ url: URL) {
+        guard let scheme = url.scheme?.lowercased(),
+              scheme == "https"
+        else {
+            openExternalURL(url)
+            return
+        }
+        inAppSafariURL = InAppSafariURL(url: url)
     }
 #endif
 

--- a/nym-vpn-apple/Services/Sources/Services/ExternalLinkManager/SafariView.swift
+++ b/nym-vpn-apple/Services/Sources/Services/ExternalLinkManager/SafariView.swift
@@ -1,0 +1,34 @@
+#if os(iOS)
+import SafariServices
+import SwiftUI
+
+public struct InAppSafariURL: Identifiable, Equatable {
+    public let id = UUID()
+    public let url: URL
+
+    public init(url: URL) {
+        self.url = url
+    }
+}
+
+public struct SafariView: UIViewControllerRepresentable {
+    private let url: URL
+
+    public init(url: URL) {
+        self.url = url
+    }
+
+    public func makeUIViewController(context: Context) -> SFSafariViewController {
+        let configuration = SFSafariViewController.Configuration()
+        configuration.entersReaderIfAvailable = false
+        configuration.barCollapsingEnabled = true
+
+        let viewController = SFSafariViewController(url: url, configuration: configuration)
+        viewController.dismissButtonStyle = .done
+        viewController.modalPresentationStyle = .pageSheet
+        return viewController
+    }
+
+    public func updateUIViewController(_ uiViewController: SFSafariViewController, context: Context) {}
+}
+#endif

--- a/nym-vpn-apple/Services/Sources/Services/ExternalLinkManager/View+InAppSafari.swift
+++ b/nym-vpn-apple/Services/Sources/Services/ExternalLinkManager/View+InAppSafari.swift
@@ -1,0 +1,21 @@
+#if os(iOS)
+import SwiftUI
+
+extension View {
+    public func inAppSafari(using manager: ExternalLinkManager) -> some View {
+        modifier(InAppSafariModifier(manager: manager))
+    }
+}
+
+private struct InAppSafariModifier: ViewModifier {
+    @ObservedObject var manager: ExternalLinkManager
+
+    func body(content: Content) -> some View {
+        content
+            .sheet(item: $manager.inAppSafariURL) { identifier in
+                SafariView(url: identifier.url)
+                    .ignoresSafeArea()
+            }
+    }
+}
+#endif

--- a/nym-vpn-apple/Settings/Sources/Settings/AccountAndDevices/AccountAndDevicesView.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/AccountAndDevices/AccountAndDevicesView.swift
@@ -323,7 +323,11 @@ extension AccountAndDevicesView {
     func linkAccount() async {
         impactGenerator.softImpact()
         let link = try? await credentialsManager.privyLogin(kind: .privyLink)
+#if os(iOS)
+        try? externalLinkManager.openInAppBrowser(urlString: link)
+#else
         try? externalLinkManager.openExternalURL(urlString: link)
+#endif
     }
 
     func logout() async {

--- a/nym-vpn-apple/Settings/Sources/Settings/Autologin/PinCodeView.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/Autologin/PinCodeView.swift
@@ -130,11 +130,12 @@ private extension PinCodeView {
 #if os(iOS)
         UIPasteboard.general.string = pinCode
         ImpactGenerator.shared.impact()
+        try? externalLinkManager.openInAppBrowser(urlString: url)
 #elseif os(macOS)
         NSPasteboard.general.prepareForNewContents()
         NSPasteboard.general.setString(pinCode, forType: .string)
-#endif
         try? externalLinkManager.openExternalURL(urlString: url)
+#endif
         withAnimation(.easeInOut) {
             didCopy = true
         }

--- a/nym-vpn-apple/Settings/Sources/Settings/CreateAccount/AccountWelcomeView.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/CreateAccount/AccountWelcomeView.swift
@@ -288,7 +288,11 @@ private extension AccountWelcomeView {
         Task {
             do {
                 let loginURL = try await credentialsManager.privyLogin(kind: .privy)
+#if os(iOS)
+                try externalLinkManager.openInAppBrowser(urlString: loginURL)
+#else
                 try externalLinkManager.openExternalURL(urlString: loginURL)
+#endif
             } catch {
                 alertTitle = error.localizedDescription
                 isDisplayingAlert = true


### PR DESCRIPTION
## Ticket

JIRA-NYM-1159

## Description

Use SFSafariVC for login/create account/management.
Do not allow multiple clicks on get started to open payment page.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5158)
<!-- Reviewable:end -->
