### PR TITLE
fix(daemon): ship polkit policy via packaging, fall back to /etc on read-only /usr

### DIFF
--- a/.pkg/linux/install
+++ b/.pkg/linux/install
@@ -88,6 +88,7 @@ vpnd_deb_ver_url=$vpnd_version
 vpnd_raw_url="https://github.com/nymtech/nym-vpn-client/releases/download/$vpnd_tag/nym-vpn-core-v${vpnd_version}_linux_${arch}.tar.gz"
 vpnd_deb_url="https://github.com/nymtech/nym-vpn-client/releases/download/$vpnd_tag/nym-vpnd_${vpnd_deb_ver_url}_${deb_arch}.deb"
 unit_url="https://raw.githubusercontent.com/nymtech/nym-vpn-client/fb526935/nym-vpn-core/crates/nym-vpnd/.pkg/aur/nym-vpnd.service"
+polkit_policy_url="https://raw.githubusercontent.com/nymtech/nym-vpn-client/$vpnd_tag/nym-vpn-core/crates/nym-ipc/.pkg/com.nymvpn.vpnd.unix-access.policy"
 ##################################################################
 
 # function called when an error occurs, will print the exit
@@ -178,6 +179,9 @@ core_archive="nym-vpn-core-v${vpnd_version}_linux_${arch}.tar.gz"
 vpnd_bin="nym-vpnd"
 socks5_proxy_bin="nym-socks5-proxy"
 vpnd_service="nym-vpnd.service"
+polkit_policy_file="com.nymvpn.vpnd.unix-access.policy"
+polkit_policy_dir="/usr/share/polkit-1/actions"
+polkit_policy_fallback_dir="/etc/polkit-1/actions"
 vpnd_deb="nym-vpnd_${vpnd_deb_ver}_${deb_arch}.deb"
 units_dir="/usr/lib/systemd/system"
 desktop_exec='env RUST_LOG=info,nym_vpn_app=debug NymVPN.AppImage -l %U'
@@ -350,6 +354,8 @@ download_vpnd_raw() {
   log "   ${BI_MGT}ok$RS"
   log "  ${B_GRN}Downloading$RS unit file"
   curl -fL -# "$unit_url" -o nym-vpnd.service
+  log "  ${B_GRN}Downloading$RS polkit policy"
+  curl -fL -# "$polkit_policy_url" -o "$polkit_policy_file"
   log "  ${B_GRN}Unarchiving$RS nym-vpnd"
   tar -xzf "$core_archive"
   mv "${core_archive%.tar.gz}/$vpnd_bin" $vpnd_bin
@@ -532,10 +538,14 @@ install_vpnd_raw() {
   log "  ${B_GRN}Installing$RS systemd service"
   sudo install -Dm644 "$temp_dir/$vpnd_service" "$units_dir/$vpnd_service"
 
+  log "  ${B_GRN}Installing$RS polkit action policy"
+  sudo install -Dm644 "$temp_dir/$polkit_policy_file" "$polkit_policy_dir/$polkit_policy_file"
+
   log "  ${B_GRN}Installed$RS files"
   log "   ${I_YLW}$(tilded "$install_dir/$vpnd_bin")$RS"
   log "   ${I_YLW}$(tilded "$install_dir/$socks5_proxy_bin")$RS"
   log "   ${I_YLW}$(tilded "$units_dir/$vpnd_service")$RS"
+  log "   ${I_YLW}$(tilded "$polkit_policy_dir/$polkit_policy_file")$RS"
 }
 
 install_vpnd_deb() {
@@ -666,6 +676,8 @@ _uninstall_raw() {
       "/usr/bin/nym-socks5-proxy"
       "/usr/lib/systemd/system/nym-vpnd.service"
       "/etc/nym/nym-vpnd.toml"
+      "$polkit_policy_dir/$polkit_policy_file"
+      "$polkit_policy_fallback_dir/$polkit_policy_file"
     )
   fi
   if [ "$_app" == 0 ]; then

--- a/nym-vpn-app/CHANGELOG.md
+++ b/nym-vpn-app/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- [Linux] Authentication-denied modal now includes troubleshooting copy and a link pointing to the daemon log file location, so users hitting a stuck "Authenticate" button can diagnose using the GitHub issues.
+
+### Fixed
+
+- Drop a stray `console.log` from `SystemAuthentication`.
+
 ## [1.28.0] - 2026-04-14
 
 ### Added

--- a/nym-vpn-app/src/constants.ts
+++ b/nym-vpn-app/src/constants.ts
@@ -63,3 +63,6 @@ export const CustomDnsHelpUrl = 'https://nym.com/features/custom-dns';
 export const MixnetParametersLearnMoreUrl =
   'https://nym.com/features/mixnet-customization';
 export const DocsUrl = 'https://nym.com/docs';
+// TODO: replace with a dedicated support article once one exists.
+export const LinuxAuthTroubleshootingUrl =
+  'https://nym.com/go/github/nym-vpn-client/issues';

--- a/nym-vpn-app/src/i18n/en/system-authentication.json
+++ b/nym-vpn-app/src/i18n/en/system-authentication.json
@@ -6,6 +6,8 @@
   "modal": {
     "title": "Authentication required",
     "description": "You need to authenticate with your password to secure your connection.",
+    "troubleshooting": "If clicking Authenticate has no effect, check the GitHub issues for troubleshooting.",
+    "github-issues-link": "Open GitHub issues",
     "authenticate-button": "Authenticate"
   }
 }

--- a/nym-vpn-app/src/screens/SystemAuthentication.tsx
+++ b/nym-vpn-app/src/screens/SystemAuthentication.tsx
@@ -2,18 +2,16 @@ import { DialogTitle } from '@headlessui/react';
 import { useTranslation } from 'react-i18next';
 import { useEffect, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
-import { Button, ButtonIcon, Dialog, MsIcon } from '../ui';
+import { Button, ButtonIcon, Dialog, Link, MsIcon } from '../ui';
 import { useMainState } from '../contexts';
+import { LinuxAuthTroubleshootingUrl } from '../constants';
 
 export function SystemAuthentication() {
   const { daemonStatus } = useMainState();
-  console.log('[SystemAuthentication] daemonStatus', daemonStatus);
-
   const { t } = useTranslation('system-authentication');
 
   const [isOpen, setIsOpen] = useState(false);
   const [loading, setLoading] = useState(false);
-
   useEffect(() => {
     setIsOpen(daemonStatus === 'auth-denied');
   }, [daemonStatus]);
@@ -53,6 +51,14 @@ export function SystemAuthentication() {
         <div className="p-3 flex flex-row items-center gap-3 border border-cheddar dark:border-king-nacho rounded-lg text-cheddar dark:text-king-nacho bg-cheddar/10 dark:bg-king-nacho/10">
           <MsIcon icon="report" />
           <p>{t('modal.description')}</p>
+        </div>
+        <div className="flex flex-col items-start gap-2 text-sm text-iron dark:text-bombay">
+          <p>{t('modal.troubleshooting')}</p>
+          <Link
+            url={LinuxAuthTroubleshootingUrl}
+            text={t('modal.github-issues-link')}
+            icon
+          />
         </div>
         <Button
           onClick={handleAuthenticate}

--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -12,15 +12,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add TCP listener for local DNS resolver (https://github.com/nymtech/nym-vpn-client/pull/5113)
 - Add SOCKS5 Proxy process to implement Airporting (https://github.com/nymtech/nym-vpn-client/pull/5078)
 - Disable client verifications on daemon flag for debug purposes (https://github.com/nymtech/nym-vpn-client/pull/5148)
+- [Linux] Ship the polkit action policy `com.nymvpn.vpnd.unix-access.policy` as a packaging asset (deb, AUR, raw install script) under `/usr/share/polkit-1/actions/` so the daemon no longer relies on a runtime write to a path that may be read-only on immutable distros.
 
 ### Changed
 
 - [macOS] Use endpoint-security framework directly instead of parsing eslogger output (https://github.com/nymtech/nym-vpn-client/pull/4749)
+- [Linux] Promote the IPC auth-denied log line in `nym-ipc` from `debug` to `warn` so the reason for a failed daemon connection appears in the default log level.
 
 ### Fixed
 
 - Unify `VpnAccountSummary` timestamp parsing through a single `parse_timestamp` helper that warns on malformed input. Only `fair_usage.resetsOnUtc` soft-fails to `None`; subscription and auth-method timestamps now propagate `PayloadError` so a bad payload fails loudly instead of silently flipping subscriptions to inactive (root cause of NYM-1156 "Requesting ZkNyms" / "Get Started" hangs on v2.22.0 iOS).
 - [iOS/macOS] Stop swallowing errors from `fetchAccountSummary` with `try?`; log a sanitized line (error type only, no raw payload string) and set `accountSummaryLastFetchFailed` so the UI can observe failure without parsing device logs.
+- [Linux] `nym-vpnd` polkit action install no longer fails silently on read-only `/usr` filesystems (Fedora Silverblue, MicroOS, NixOS, etc.). The daemon now falls back to `/etc/polkit-1/actions/` when `/usr/share/polkit-1/actions/` is unwritable, with full per-attempt tracing of the install path so failures are diagnosable from `/var/log/nym-vpnd/nym-vpnd.log`.
 
 
 ### Fixed

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -5733,6 +5733,7 @@ dependencies = [
  "objc2-foundation",
  "objc2-security",
  "strum",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -184,7 +184,7 @@ signature = "2.2.0"
 sqlx = "0.8.6"
 socket2 = "0.6.3"
 surge-ping = "0.8.4"
-strum = "0.28.0"
+strum = { version = "0.28.0", features = ["derive"] }
 strum_macros = "0.28.0"
 syn = "=1.0"
 sysinfo = "0.38"

--- a/nym-vpn-core/crates/nym-ipc/.pkg/com.nymvpn.vpnd.unix-access.policy
+++ b/nym-vpn-core/crates/nym-ipc/.pkg/com.nymvpn.vpnd.unix-access.policy
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<policyconfig>
+  <action id="com.nymvpn.vpnd.unix-access">
+    <description>Connect via unix socket</description>
+    <message>Authentication is required to connect to the daemon</message>
+
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_self</allow_active>
+    </defaults>
+  </action>
+</policyconfig>

--- a/nym-vpn-core/crates/nym-ipc/Cargo.toml
+++ b/nym-vpn-core/crates/nym-ipc/Cargo.toml
@@ -44,6 +44,7 @@ nym-windows = { workspace = true, optional = true }
 
 [dev-dependencies]
 strum.workspace = true
+tempfile.workspace = true
 
 [build-dependencies]
 cc = { workspace = true }

--- a/nym-vpn-core/crates/nym-ipc/src/authentication/linux.rs
+++ b/nym-vpn-core/crates/nym-ipc/src/authentication/linux.rs
@@ -4,7 +4,7 @@
 use std::time::Duration;
 
 use nix::sys::socket::{UnixCredentials, getsockopt, sockopt::PeerCredentials};
-use tokio::{fs::File, io::AsyncWriteExt, net::UnixStream};
+use tokio::{io::AsyncWriteExt, net::UnixStream};
 use tokio_stream::Stream;
 use tokio_util::sync::CancellationToken;
 use zbus::Connection;
@@ -23,20 +23,18 @@ pub(crate) type Transport = tokio::net::UnixStream;
 const ACTION_ID: &str = "com.nymvpn.vpnd.unix-access";
 const CANCELLATION_ID: &str = "com.nymvpn.vpnd.cancel";
 const USER_INTERACTION_TIMEOUT: Duration = Duration::from_secs(60);
-const POLKIT_POLICY: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
-<policyconfig>
-  <action id="com.nymvpn.vpnd.unix-access">
-    <description>Connect via unix socket</description>
-    <message>Authentication is required to connect to the daemon</message>
 
-    <defaults>
-      <allow_any>auth_admin</allow_any>
-      <allow_inactive>auth_admin</allow_inactive>
-      <allow_active>auth_self</allow_active>
-    </defaults>
-  </action>
-</policyconfig>
-"#;
+// Single source of truth for the polkit action XML. The same file is shipped
+// by the deb / AUR / raw install packaging into /usr/share/polkit-1/actions/
+// so that on properly-packaged installs the runtime install path is a no-op.
+const POLKIT_POLICY: &str = include_str!("../../.pkg/com.nymvpn.vpnd.unix-access.policy");
+
+// Polkit's documented action search path is /usr/share/polkit-1/actions/.
+// Most distros also scan /etc/polkit-1/actions/, which we use as a fallback
+// when /usr/share is not writable (e.g. Fedora Silverblue, MicroOS, NixOS,
+// other ostree-based images) so a daemon installed by hand can still register
+// its action without root having to relayer the OS image.
+const POLICY_DIRS: &[&str] = &["/usr/share/polkit-1/actions", "/etc/polkit-1/actions"];
 
 #[async_trait::async_trait]
 trait AuthorizationChecker {
@@ -60,21 +58,21 @@ struct AuthProxy<'a> {
 #[async_trait::async_trait]
 impl AuthorizationChecker for AuthProxy<'_> {
     async fn check_authorization(&self) -> Result<AuthorizationResult, AuthenticationError> {
-        if !self
+        let already_registered = self
             .proxy
             .enumerate_actions("")
             .await
             .map_err(AuthenticationError::EnumerateActions)?
             .iter()
-            .any(|action| action.action_id == ACTION_ID)
-        {
-            let mut file =
-                File::create(format!("/usr/share/polkit-1/actions/{}.policy", ACTION_ID))
-                    .await
-                    .map_err(AuthenticationError::CreateActionPolicy)?;
-            file.write_all(POLKIT_POLICY.as_bytes())
-                .await
-                .map_err(AuthenticationError::WriteActionPolicy)?;
+            .any(|action| action.action_id == ACTION_ID);
+
+        if already_registered {
+            tracing::debug!(
+                action = ACTION_ID,
+                "polkit action already registered; skipping install",
+            );
+        } else {
+            install_polkit_policy(POLICY_DIRS).await?;
         }
 
         // details might be useful to set some locale-sensitive messages and icon images in the authentication dialog
@@ -96,6 +94,95 @@ impl AuthorizationChecker for AuthProxy<'_> {
             .await
             .map_err(AuthenticationError::CancelAuthorization)
     }
+}
+
+// Try each candidate directory in order and return the first one we managed
+// to write into. A successful install at /usr/share is the architecturally
+// correct outcome (polkit's documented path); /etc is the defensive fallback
+// for read-only-/usr systems.
+async fn install_polkit_policy(dirs: &[&str]) -> Result<String, AuthenticationError> {
+    let mut create_err: Option<std::io::Error> = None;
+    let mut write_err: Option<std::io::Error> = None;
+
+    for dir in dirs {
+        let path = format!("{dir}/{ACTION_ID}.policy");
+        match write_policy_file(&path).await {
+            Ok(()) => {
+                tracing::info!(
+                    path = %path,
+                    "installed polkit action policy",
+                );
+                return Ok(path);
+            }
+            Err(PolicyWriteError::Create(err)) => {
+                tracing::debug!(
+                    path = %path,
+                    error = %err,
+                    "polkit policy create failed, trying next candidate",
+                );
+                create_err = Some(err);
+            }
+            Err(PolicyWriteError::Write(err)) => {
+                tracing::debug!(
+                    path = %path,
+                    error = %err,
+                    "polkit policy write failed, trying next candidate",
+                );
+                write_err = Some(err);
+            }
+        }
+    }
+
+    // Prefer surfacing a Write error if we ever managed to create a file
+    // somewhere; otherwise the failure was always at file creation time.
+    let final_err = if let Some(err) = write_err {
+        tracing::error!(
+            error = %err,
+            candidates = ?dirs,
+            "failed to install polkit policy in any candidate directory; \
+             see the daemon log file at /var/log/nym-vpnd/nym-vpnd.log \
+             and the troubleshooting docs",
+        );
+        AuthenticationError::WriteActionPolicy(err)
+    } else {
+        let err = create_err.expect("at least one path attempted");
+        tracing::error!(
+            error = %err,
+            candidates = ?dirs,
+            "failed to create polkit policy file in any candidate directory; \
+             this typically means /usr/share is read-only \
+             AND /etc/polkit-1/actions/ is not writable.",
+        );
+        AuthenticationError::CreateActionPolicy(err)
+    };
+
+    Err(final_err)
+}
+
+enum PolicyWriteError {
+    Create(std::io::Error),
+    Write(std::io::Error),
+}
+
+async fn write_policy_file(path: &str) -> Result<(), PolicyWriteError> {
+    // Some distros (notably Fedora Silverblue) ship `/etc/polkit-1/rules.d/`
+    // but not `/etc/polkit-1/actions/` because no package installs there by
+    // default. Create the parent on demand so the fallback path works on a
+    // stock install. This is a no-op when the dir already exists.
+    if let Some(parent) = std::path::Path::new(path).parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(PolicyWriteError::Create)?;
+    }
+
+    let mut file = tokio::fs::File::create(path)
+        .await
+        .map_err(PolicyWriteError::Create)?;
+    file.write_all(POLKIT_POLICY.as_bytes())
+        .await
+        .map_err(PolicyWriteError::Write)?;
+    file.flush().await.map_err(PolicyWriteError::Write)?;
+    Ok(())
 }
 
 struct PolkitPrompter {
@@ -416,5 +503,77 @@ mod tests {
     // Test builds are debug and are authorized
     fn unsigned_build_authorized() {
         assert!(skip_authentication_checks(false));
+    }
+
+    #[test]
+    fn embedded_policy_matches_action_id() {
+        assert!(
+            POLKIT_POLICY.contains(ACTION_ID),
+            "the bundled policy XML must declare the action id used at runtime",
+        );
+    }
+
+    #[tokio::test]
+    async fn install_polkit_policy_writes_first_writable_dir() {
+        let primary = tempfile::tempdir().unwrap();
+        let fallback = tempfile::tempdir().unwrap();
+        let primary_path = primary.path().to_str().unwrap().to_owned();
+        let fallback_path = fallback.path().to_str().unwrap().to_owned();
+        let dirs: &[&str] = &[primary_path.as_str(), fallback_path.as_str()];
+
+        let written = install_polkit_policy(dirs).await.unwrap();
+
+        let expected = format!("{primary_path}/{ACTION_ID}.policy");
+        assert_eq!(written, expected);
+        assert!(std::fs::metadata(&expected).is_ok());
+        // Fallback directory must remain untouched when primary succeeds.
+        let fallback_file = format!("{fallback_path}/{ACTION_ID}.policy");
+        assert!(std::fs::metadata(&fallback_file).is_err());
+    }
+
+    #[tokio::test]
+    async fn install_polkit_policy_falls_back_when_primary_unwritable() {
+        let primary = "/nonexistent/nym-vpn-test-readonly-primary";
+        let fallback = tempfile::tempdir().unwrap();
+        let fallback_path = fallback.path().to_str().unwrap().to_owned();
+        let dirs: &[&str] = &[primary, fallback_path.as_str()];
+
+        let written = install_polkit_policy(dirs).await.unwrap();
+
+        let expected = format!("{fallback_path}/{ACTION_ID}.policy");
+        assert_eq!(written, expected);
+        let content = std::fs::read_to_string(&expected).unwrap();
+        assert!(content.contains(ACTION_ID));
+    }
+
+    #[tokio::test]
+    async fn install_polkit_policy_creates_missing_parent_dir() {
+        let parent = tempfile::tempdir().unwrap();
+        // Point at a yet-to-be-created subdirectory under the tempdir so we
+        // exercise the create_dir_all branch without hitting privileged paths.
+        let dir = parent
+            .path()
+            .join("polkit-1/actions")
+            .to_str()
+            .unwrap()
+            .to_owned();
+        let dirs: &[&str] = &[dir.as_str()];
+
+        let written = install_polkit_policy(dirs).await.unwrap();
+
+        let expected = format!("{dir}/{ACTION_ID}.policy");
+        assert_eq!(written, expected);
+        assert!(std::fs::metadata(&expected).is_ok());
+    }
+
+    #[tokio::test]
+    async fn install_polkit_policy_errors_when_no_dir_writable() {
+        let dirs: &[&str] = &[
+            "/nonexistent/nym-vpn-test-readonly-a",
+            "/nonexistent/nym-vpn-test-readonly-b",
+        ];
+
+        let err = install_polkit_policy(dirs).await.unwrap_err();
+        assert!(matches!(err, AuthenticationError::CreateActionPolicy(_)));
     }
 }

--- a/nym-vpn-core/crates/nym-ipc/src/authentication/mod.rs
+++ b/nym-vpn-core/crates/nym-ipc/src/authentication/mod.rs
@@ -110,7 +110,10 @@ async fn authorized_stream(
         }
         Err(err) => {
             deny(stream).await;
-            tracing::debug!("Connection did not get authenticated: {err:?}");
+            // Surface auth failures at warn so they appear in the default
+            // log level. Without this the actual reason for a stuck
+            // "Authentication required" modal is hidden behind RUST_LOG=debug.
+            tracing::warn!("Connection did not get authenticated: {err:?}");
             false
         }
     }

--- a/nym-vpn-core/crates/nym-vpnd/.pkg/aur/PKGBUILD
+++ b/nym-vpn-core/crates/nym-vpnd/.pkg/aur/PKGBUILD
@@ -62,6 +62,8 @@ package() {
   install -Dm755 "target/release/nym-exclude" "$pkgdir/usr/bin/nym-exclude"
   chmod u+s "$pkgdir/usr/bin/nym-exclude"
   install -Dm755 "target/release/nym-socks5-proxy" "$pkgdir/usr/bin/nym-socks5-proxy"
+  install -Dm644 "crates/nym-ipc/.pkg/com.nymvpn.vpnd.unix-access.policy" \
+    "$pkgdir/usr/share/polkit-1/actions/com.nymvpn.vpnd.unix-access.policy"
   popd
 
   install -Dm644 nym-vpnd.service "$pkgdir/usr/lib/systemd/system/nym-vpnd.service"

--- a/nym-vpn-core/crates/nym-vpnd/.pkg/aur/PKGBUILD-bin
+++ b/nym-vpn-core/crates/nym-vpnd/.pkg/aur/PKGBUILD-bin
@@ -18,6 +18,7 @@ provides=('nym-vpnd' 'nym-exclude' 'nym-socks5-proxy')
 conflicts=('nym-vpnd')
 options=(!debug)
 source=("$url/releases/download/$_release_tag/nym-vpn-core-v${_pkgver}_linux_x86_64.tar.gz"
+    "$url/raw/$_release_tag/nym-vpn-core/crates/nym-ipc/.pkg/com.nymvpn.vpnd.unix-access.policy"
     'nym-vpnd.service')
 sha256sums=()
 
@@ -26,5 +27,7 @@ package() {
   install -Dm755 "nym-vpn-core-v${_pkgver}_linux_x86_64/nym-exclude" "$pkgdir/usr/bin/nym-exclude"
   chmod u+s "$pkgdir/usr/bin/nym-exclude"
   install -Dm755 "nym-vpn-core-v${_pkgver}_linux_x86_64/nym-socks5-proxy" "$pkgdir/usr/bin/nym-socks5-proxy"
+  install -Dm644 com.nymvpn.vpnd.unix-access.policy \
+    "$pkgdir/usr/share/polkit-1/actions/com.nymvpn.vpnd.unix-access.policy"
   install -Dm644 nym-vpnd.service "$pkgdir/usr/lib/systemd/system/nym-vpnd.service"
 }

--- a/nym-vpn-core/crates/nym-vpnd/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpnd/Cargo.toml
@@ -85,6 +85,7 @@ assets = [
     "$auto",
     { source = "target/release/nym-exclude", dest = "usr/bin/nym-exclude", mode = "755" },
     { source = "target/release/nym-socks5-proxy", dest = "usr/bin/nym-socks5-proxy", mode = "755" },
+    { source = "../nym-ipc/.pkg/com.nymvpn.vpnd.unix-access.policy", dest = "usr/share/polkit-1/actions/com.nymvpn.vpnd.unix-access.policy", mode = "644" },
 ]
 revision = ""
 


### PR DESCRIPTION
## Ticket

N/A (community contribution)

## Description

**Bug:** on Fedora Silverblue and other immutable-`/usr` distros (MicroOS, NixOS, Bluefin),
`nym-vpnd` silently fails to register its polkit action because it writes
`com.nymvpn.vpnd.unix-access.policy` to `/usr/share/polkit-1/actions/` at runtime, which is
read-only (`EROFS`). Polkit never sees the action, every auth attempt is denied, and the modal
loops with no diagnostic output at the default log level.

**Commit 1 — ship the policy file via packaging**

The standard Linux convention: daemons ship polkit policies through the package manager, not at
runtime. Added `com.nymvpn.vpnd.unix-access.policy` as a packaging asset to the deb
(`Cargo.toml` assets), both AUR PKGBUILDs, and the raw install script. The file is also now the
single source of truth — the daemon embeds it via `include_str!` instead of an inline duplicate
string.

**Commit 2 — runtime fallback + better logging**

Defence-in-depth for raw binary installs (no package manager step). The daemon now tries
`POLICY_DIRS = ["/usr/share/polkit-1/actions", "/etc/polkit-1/actions"]` in order. Notable:
Fedora Silverblue does not ship `/etc/polkit-1/actions/` by default, so `create_dir_all` is
called before opening the file. Per-attempt `debug!` logging, `info!` on success, `error!` when
all candidates fail — all visible at the default log level in `/var/log/nym-vpnd/nym-vpnd.log`.
Auth-denied line in `mod.rs` promoted from `debug` to `warn` for the same reason. Four unit
tests added covering the fallback ordering.

Also fixes a pre-existing bug: `strum` was missing `features = ["derive"]` in the workspace
`Cargo.toml`, breaking `cargo test -p nym-ipc`.

**Commit 3 — client modal UX**

The wire protocol is a single byte (`Accepted`/`Denied`/`Closed`) with no room for an error
reason without a breaking change. As a best-effort: the auth-denied modal now shows a
troubleshooting hint pointing to `/var/log/nym-vpnd/nym-vpnd.log` and a docs link
(`LinuxAuthTroubleshootingUrl` which currently redirects to the issues, happy to update to a dedicated
article). Stray `console.log` removed.

**Reviewer notes**

- `cargo deny check` was already failing on `develop` (pre-existing advisories + unused `ts-rs`
  dep) — nothing introduced by this PR.
- `/etc/polkit-1/actions/` being scanned by polkit is common on most distros but not in upstream
  polkit's documented search path — flagging for reviewer confirmation.
- The runtime install path could be removed entirely in a follow-up once packaging has
  propagated; left in as defence-in-depth for now.
- Wire protocol redesign to pass a structured error reason to the client is intentionally out of
  scope.

## Checklist

- [x] Changelog

## Screenshots

<img width="617" height="1198" alt="image" src="https://github.com/user-attachments/assets/f71ba0c0-69c2-4ead-b268-d989f884fbae" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5161)
<!-- Reviewable:end -->
