### PR TITLE
Fix ad-block update on Android due to TLS issues. (#5159)

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/adblocker/files.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/adblocker/files.rs
@@ -86,7 +86,8 @@ pub(crate) async fn init_files(data_dir: &Path, force: bool) -> Result<()> {
 pub(crate) async fn update_files(data_dir: &Path, user_agent: &str) -> Result<bool> {
     let ad_blocking_path = get_ad_blocking_path(data_dir);
     let mut updated = false;
-    let http_client = reqwest::Client::new();
+    let http_client = nym_http_api_client::registry::build_client()
+        .map_err(|error| AdBlockerError::BuildHttpClient { error })?;
 
     for source in SOURCES.iter() {
         if source

--- a/nym-vpn-core/crates/nym-vpn-lib/src/adblocker/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/adblocker/mod.rs
@@ -133,6 +133,12 @@ pub enum AdBlockerError {
         #[source]
         error: adblock::request::RequestError,
     },
+
+    #[error("failed to build ad-blocker HTTP client")]
+    BuildHttpClient {
+        #[source]
+        error: reqwest::Error,
+    },
 }
 
 pub(crate) type Result<T, E = AdBlockerError> = std::result::Result<T, E>;

--- a/nym-vpn-core/crates/test/test-runner/src/logging.rs
+++ b/nym-vpn-core/crates/test/test-runner/src/logging.rs
@@ -58,7 +58,6 @@ impl log::Log for StdOutBuffer {
                             .unwrap();
                     }
                 }
-                Level::Info => (),
                 _ => (),
             }
             println!("{}", record.args());


### PR DESCRIPTION
* Fix ad-block update on Android due to TLS issues.

Instead of creating a `reqwest` client itself, ad-block now use `nym_http_api_client` to create the client as that has the TLS set-up correctly on Android.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5162)
<!-- Reviewable:end -->
