### PR TITLE
Add `install` script to release build artifacts

### DIFF
--- a/.github/workflows/build-nym-vpn-app-linux.yml
+++ b/.github/workflows/build-nym-vpn-app-linux.yml
@@ -168,6 +168,8 @@ jobs:
           cp -vpr ${{ env.SRC_DEB }} ${{ env.UPLOAD_DIR_LINUX }}
           echo "Copy plain binary"
           cp -vpr ${{ env.SRC_BIN }} ${{ env.UPLOAD_DIR_LINUX }}/${{ env.DST_BIN }}
+          echo "Copy install script"
+          cp -vpr .pkg/linux/install ${{ env.UPLOAD_DIR_LINUX }}/install
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v7

--- a/.pkg/linux/install
+++ b/.pkg/linux/install
@@ -205,7 +205,7 @@ app_dev_setup() {
     -H "Accept: application/vnd.github+json" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
     https://api.github.com/repos/nymtech/nym-vpn-client/releases/tags/"$app_tag" |
-    grep -m1 -oP "(?<=\"name\": \"NymVPN_).+(?=_${arch}\.AppImage)")
+    grep -m1 -oP "(?<=\"name\": \"NymVPN_).+(?=_${app_image_arch}\.AppImage)")
   appimage_url="https://github.com/nymtech/nym-vpn-client/releases/download/$app_tag/NymVPN_${app_version}_${app_image_arch}.AppImage"
   app_deb_url="https://github.com/nymtech/nym-vpn-client/releases/download/$app_tag/nym-vpn-app_${app_version}_${deb_arch}.deb"
   appimage="NymVPN_${app_version}_${app_image_arch}.AppImage"

--- a/.pkg/repack_deb.sh
+++ b/.pkg/repack_deb.sh
@@ -31,15 +31,6 @@ if [ ! -f "$deb_file" ]; then
     exit 1
 fi
 
-echo "version: $version"
-# split version string on - | _
-IFS='-_' read -r base prerel <<<"$version"
-echo "base version: $base"
-if [ -n "$prerel" ]; then
-  echo "prerelease: $prerel"
-  # use ~dev suffix for anything that is not a stable release
-  version="${base}~dev"
-fi
 echo "deb version: $version"
 
 tmpdir=$(mktemp -d)
@@ -53,8 +44,7 @@ sed -i "s|^Version:.*|Version: $version|" "$control_file"
 cat "$control_file"
 
 # Repack the .deb package with the updated control file
-# replace ~ with - in the filename to avoid file renaming by GH
-dest="${pkgname}_${version//\~/-}_${arch}.deb"
+dest="${pkgname}_${version}_${arch}.deb"
 dpkg-deb -Zxz -b "$tmpdir" "$dest"
 
 # Clean up the temporary directory


### PR DESCRIPTION
## Ticket

JIRA-VPN-XXXX

## Description

- Add `install` script to release assets so it can be referenced on website linux download page. So the install script will always correlate with the release.
- Fix linux `install` script
- Remove `-dev` from `.deb` non-release builds 


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5171)
<!-- Reviewable:end -->
