### PR TITLE
Turn on Airporting by default.

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/service.rs
@@ -520,8 +520,8 @@ impl fmt::Display for AirportingSettings {
 
 impl Default for AirportingSettings {
     fn default() -> Self {
-        // Temporary, until there is a way to turn on Airporting on Android
-        let enabled = cfg!(target_os = "android");
+        // Temporary, until there is a way to turn on Airporting on.
+        let enabled = true;
         Self {
             enabled,
             listen_port: 1080,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/config/tests.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/config/tests.rs
@@ -177,7 +177,7 @@ location = "BE"
     "apps": []
   },
   "airporting": {
-    "enabled": false,
+    "enabled": true,
     "listen_port": 1080,
     "excluded_countries": [
       "CN"
@@ -247,7 +247,7 @@ identity = [ 99, 23, 98, 234, 66, 161, 195, 63, 155, 161, 250, 207, 17, 158, 136
     "apps": []
   },
   "airporting": {
-    "enabled": false,
+    "enabled": true,
     "listen_port": 1080,
     "excluded_countries": [
       "CN"
@@ -322,7 +322,7 @@ address = [5, 56, 84, 195, 94, 238, 210, 124, 65, 143, 209, 144, 22, 255, 91, 18
     "apps": []
   },
   "airporting": {
-    "enabled": false,
+    "enabled": true,
     "listen_port": 1080,
     "excluded_countries": [
       "CN"
@@ -386,7 +386,7 @@ exit_point = "Random"
     "apps": []
   },
   "airporting": {
-    "enabled": false,
+    "enabled": true,
     "listen_port": 1080,
     "excluded_countries": [
       "CN"
@@ -457,7 +457,7 @@ async fn test_service_config_migrate_from_v1() {
     "apps": []
   },
   "airporting": {
-    "enabled": false,
+    "enabled": true,
     "listen_port": 1080,
     "excluded_countries": [
       "CN"
@@ -537,7 +537,7 @@ async fn test_service_config_migrate_from_v2() {
     "apps": []
   },
   "airporting": {
-    "enabled": false,
+    "enabled": true,
     "listen_port": 1080,
     "excluded_countries": [
       "CN"
@@ -623,7 +623,7 @@ async fn test_service_config_migrate_from_v3() {
     "apps": []
   },
   "airporting": {
-    "enabled": false,
+    "enabled": true,
     "listen_port": 1080,
     "excluded_countries": [
       "CN"
@@ -673,7 +673,7 @@ async fn test_service_config_migrate_from_v4() {
     "apps": []
   },
   "airporting": {
-    "enabled": false,
+    "enabled": true,
     "listen_port": 1080,
     "excluded_countries": [
       "CN"
@@ -725,7 +725,7 @@ async fn test_service_config_migrate_from_v4() {
     "apps": []
   },
   "airporting": {
-    "enabled": false,
+    "enabled": true,
     "listen_port": 1080,
     "excluded_countries": [
       "CN"
@@ -780,7 +780,7 @@ async fn test_service_config_migrate_from_v5() {
     "apps": []
   },
   "airporting": {
-    "enabled": false,
+    "enabled": true,
     "listen_port": 1080,
     "excluded_countries": [
       "CN"
@@ -832,7 +832,7 @@ async fn test_service_config_migrate_from_v5() {
     "apps": []
   },
   "airporting": {
-    "enabled": false,
+    "enabled": true,
     "listen_port": 1080,
     "excluded_countries": [
       "CN"
@@ -929,7 +929,7 @@ async fn test_service_config_migrate_from_v6() {
     "apps": []
   },
   "airporting": {
-    "enabled": false,
+    "enabled": true,
     "listen_port": 1080,
     "excluded_countries": [
       "CN"
@@ -1088,7 +1088,7 @@ async fn test_service_config_migrate_from_v7() {
     "apps": []
   },
   "airporting": {
-    "enabled": false,
+    "enabled": true,
     "listen_port": 1080,
     "excluded_countries": [
       "CN"
@@ -1184,7 +1184,7 @@ async fn test_service_config_migrate_from_v8() {
     "apps": []
   },
   "airporting": {
-    "enabled": false,
+    "enabled": true,
     "listen_port": 1080,
     "excluded_countries": [
       "CN"

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/config/v8.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/config/v8.rs
@@ -79,7 +79,7 @@ impl TryFrom<VpnServiceConfig> for nym_vpn_lib_types::VpnServiceConfig {
             custom_dns,
             network_stats,
             split_tunnel,
-            airporting: Default::default(),
+            ..Default::default()
         };
 
         Ok(config)


### PR DESCRIPTION
For testing we will turn on Airporting by default, until the client-side is ready.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5177)
<!-- Reviewable:end -->
