### PR TITLE
Drop the query control lock before network calls

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/geo_ip.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/geo_ip.rs
@@ -104,7 +104,8 @@ impl GeoIpProvider {
         client: impl GeoIpClient,
         query_control: Arc<Mutex<QueryControl>>,
     ) -> Self {
-        let latest_location = if query_control.lock().await.can_query() {
+        let can_query = query_control.lock().await.can_query();
+        let latest_location = if can_query {
             client
                 .latest_geo_ip()
                 .await
@@ -122,10 +123,13 @@ impl GeoIpProvider {
     }
 
     pub(crate) async fn update(&mut self) -> Result<(), VpnApiClientError> {
-        let control = self.query_control.lock().await;
-        if control.should_clear_location() {
+        let (should_clear_location, can_query) = {
+            let control = self.query_control.lock().await;
+            (control.should_clear_location(), control.can_query())
+        };
+        if should_clear_location {
             self.latest_location = None;
-        } else if control.can_query() {
+        } else if can_query {
             self.latest_location = Some(self.client.latest_geo_ip().await?.into());
         }
         Ok(())


### PR DESCRIPTION
Make sure the query control lock is dropped as early as possible, so that it doesn't get kept during long network calls.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5182)
<!-- Reviewable:end -->
