### PR TITLE
fix(install): drop nym-socks5-proxy from raw linux installer

### DIFF
--- a/.pkg/linux/install
+++ b/.pkg/linux/install
@@ -176,7 +176,6 @@ app_deb="nym-vpn-app_${app_version}_${deb_arch}.deb"
 target_appimage="NymVPN.AppImage"
 core_archive="nym-vpn-core-v${vpnd_version}_linux_${arch}.tar.gz"
 vpnd_bin="nym-vpnd"
-socks5_proxy_bin="nym-socks5-proxy"
 vpnd_service="nym-vpnd.service"
 vpnd_deb="nym-vpnd_${vpnd_deb_ver}_${deb_arch}.deb"
 units_dir="/usr/lib/systemd/system"
@@ -353,7 +352,6 @@ download_vpnd_raw() {
   log "  ${B_GRN}Unarchiving$RS nym-vpnd"
   tar -xzf "$core_archive"
   mv "${core_archive%.tar.gz}/$vpnd_bin" $vpnd_bin
-  mv "${core_archive%.tar.gz}/$socks5_proxy_bin" $socks5_proxy_bin
   _popd
 }
 
@@ -410,7 +408,7 @@ sanity_check() {
 
   files_check=()
   if [ "$_vpnd" == 0 ]; then
-    files_check+=("$install_dir/$vpnd_bin" "$install_dir/$socks5_proxy_bin" "$units_dir/$vpnd_service")
+    files_check+=("$install_dir/$vpnd_bin" "$units_dir/$vpnd_service")
   fi
   if [ "$_app" == 0 ]; then
     files_check+=("$install_dir/$target_appimage" "$desktop_dir/nym-vpn.desktop" "$icons_dir/nym-vpn.svg")
@@ -527,14 +525,12 @@ install_app_deb() {
 install_vpnd_raw() {
   log "  ${B_GRN}Installing$RS nym-vpnd"
   sudo install -o "$(id -u)" -g "$(id -g)" -Dm755 "$temp_dir/$vpnd_bin" "$install_dir/$vpnd_bin"
-  sudo install -o "$(id -u)" -g "$(id -g)" -Dm755 "$temp_dir/$socks5_proxy_bin" "$install_dir/$socks5_proxy_bin"
 
   log "  ${B_GRN}Installing$RS systemd service"
   sudo install -Dm644 "$temp_dir/$vpnd_service" "$units_dir/$vpnd_service"
 
   log "  ${B_GRN}Installed$RS files"
   log "   ${I_YLW}$(tilded "$install_dir/$vpnd_bin")$RS"
-  log "   ${I_YLW}$(tilded "$install_dir/$socks5_proxy_bin")$RS"
   log "   ${I_YLW}$(tilded "$units_dir/$vpnd_service")$RS"
 }
 


### PR DESCRIPTION
## Summary

The v1.29.0 `nym-vpn-core` release tarball no longer ships the `nym-socks5-proxy` binary — its contents are just `nym-vpnc`, `nym-diagnostic`, and `nym-vpnd`. However, `.pkg/linux/install` still tries to `mv`/install `nym-socks5-proxy` after extraction, so the raw vpnd install path aborts immediately:

```
  Unarchiving nym-vpnd
mv: cannot stat 'nym-vpn-core-v1.29.0_linux_x86_64/nym-socks5-proxy': No such file or directory
✗ unexpected error, [1] download_vpnd_raw L#356
```

This is reproducible by running:

```bash
curl -SsL https://raw.githubusercontent.com/nymtech/nym-vpn-client/refs/heads/develop/.pkg/linux/install | bash
```

and choosing `D` (vpnd only) — or any combo that triggers `download_vpnd_raw` on a non-deb system.

## Changes

- Drop `socks5_proxy_bin` variable
- Drop the `mv` line in `download_vpnd_raw`
- Drop the existence check in `sanity_check`
- Drop the `install` line and log output in `install_vpnd_raw`
- **Keep** the file reference in `_uninstall_raw` so users who installed earlier versions can still clean up `/usr/bin/nym-socks5-proxy`

## Test plan

- [x] `bash -n .pkg/linux/install` passes
- [x] `INSTALL_TYPE=raw` install of vpnd-only succeeds end-to-end on Fedora 43 (extraction + service install)
- [ ] Verify on a deb-based distro (deb path is unchanged, but worth a smoke test)
- [ ] Verify uninstall on a system that originally had `nym-socks5-proxy` still removes it

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5189)
<!-- Reviewable:end -->
