### PR TITLE
Refactor fetch control

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -314,10 +314,18 @@ impl TunnelSettings {
                 diff.add(TunnelSettingsDiffFields::AirportingExcludedCountries);
             }
         }
-        if self.gateway_selection_algorithm_config != other.gateway_selection_algorithm_config {
-            diff.add(TunnelSettingsDiffFields::GatewaySelectionAlgorithm);
+        if self.gateway_selection_algorithm_config.enable_geo_location
+            != other.gateway_selection_algorithm_config.enable_geo_location
+        {
+            diff.add(TunnelSettingsDiffFields::GeoLocationEnabled);
         }
-        if self.gateway_selection_algorithm_config != other.gateway_selection_algorithm_config {
+        if self
+            .gateway_selection_algorithm_config
+            .gateway_selection_algorithm
+            != other
+                .gateway_selection_algorithm_config
+                .gateway_selection_algorithm
+        {
             diff.add(TunnelSettingsDiffFields::GatewaySelectionAlgorithm);
         }
 
@@ -345,6 +353,7 @@ pub enum TunnelSettingsDiffFields {
     Airporting,
     AirportingEnabled,
     AirportingExcludedCountries,
+    GeoLocationEnabled,
     GatewaySelectionAlgorithm,
 }
 
@@ -366,6 +375,7 @@ impl TunnelSettingsDiffFields {
             | Self::Airporting
             | Self::AirportingEnabled
             | Self::AirportingExcludedCountries
+            | Self::GeoLocationEnabled
             | Self::GatewaySelectionAlgorithm => false,
             Self::MixnetTunnelOptions | Self::MixnetPerformanceOptions => {
                 tunnel_type == TunnelType::Mixnet
@@ -428,6 +438,10 @@ impl TunnelSettingsDiff {
 
     pub fn airporting_excluded_countries_changed(&self) -> bool {
         self.is_field_changed(&TunnelSettingsDiffFields::AirportingExcludedCountries)
+    }
+
+    pub fn geo_location_enabled_changed(&self) -> bool {
+        self.is_field_changed(&TunnelSettingsDiffFields::GeoLocationEnabled)
     }
 
     // Returns true if changed tunnel settings should lead to tunnel reconnect

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -742,7 +742,6 @@ impl SharedState {
             .set_vpn_api_firewall_down()
             .await
             .ok();
-        self.gateway_provider.set_active_geo_location(true).await;
     }
 
     /// Notify discovery, account controller and geo-location when network is restricted.

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnected_state.rs
@@ -38,6 +38,10 @@ impl DisconnectedState {
         HickoryDnsResolver::shared().clear_preresolve();
 
         shared_state.allow_networking().await;
+        shared_state
+            .gateway_provider
+            .set_active_geo_location(true)
+            .await;
 
         // Notify the SOCKS5 proxy subprocess that the VPN tunnel is down
         #[cfg(not(target_os = "ios"))]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/algorithm.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/algorithm.rs
@@ -1,9 +1,6 @@
 // Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::time::Duration;
-
-use futures::future::pending;
 use nym_gateway_directory::{BlacklistedGateways, Location};
 use nym_vpn_store::keys::wireguard::WireguardKeysDb;
 use tokio::sync::mpsc;
@@ -20,8 +17,6 @@ use crate::tunnel_state_machine::{
     },
 };
 
-const GEO_IP_UPDATE_INTERVAL: Duration = Duration::from_hours(1);
-
 #[derive(Clone)]
 pub struct SelectAndSend {
     pub tunnel_settings: TunnelSettings,
@@ -29,30 +24,22 @@ pub struct SelectAndSend {
 }
 
 async fn continuous_select<C: GatewayCache>(
-    select_and_send: Option<SelectAndSend>,
+    select_and_send: SelectAndSend,
     gateway_cache: C,
     blacklisted_entry_gateways: &BlacklistedGateways,
     device_location: Option<Location>,
     wg_keys_db: WireguardKeysDb,
 ) {
-    let Some(SelectAndSend {
-        tunnel_settings,
-        selection_tx,
-    }) = select_and_send
-    else {
-        // not settings so nothing to send yet
-        return pending().await;
-    };
     loop {
         // make sure the buffer is not full before deciding on other possible selections
-        let Ok(selection_tx) = selection_tx.reserve().await else {
+        let Ok(selection_tx) = select_and_send.selection_tx.reserve().await else {
             tracing::debug!("GatewayProvider shut down during selection algorithm");
             return;
         };
         let selection = select_gateways(
             gateway_cache.clone(),
             blacklisted_entry_gateways,
-            &tunnel_settings,
+            &select_and_send.tunnel_settings,
             device_location.clone(),
             wg_keys_db.clone(),
         )
@@ -90,41 +77,25 @@ impl<C: GatewayCache> SelectionAlgorithm<C> {
         }
     }
 
-    pub async fn run(mut self) {
-        let mut latest_tunnel_settings = None;
-        let update_timer = tokio::time::sleep(GEO_IP_UPDATE_INTERVAL);
-        tokio::pin!(update_timer);
+    pub async fn run(mut self, mut latest_tunnel_settings: SelectAndSend) {
+        let mut latest_location = None;
         loop {
             tokio::select! {
                 _ = self.shutdown_token.cancelled() => {
                     tracing::info!("SelectionAlgorithm shut down");
                     return;
                 }
-                _ = &mut update_timer => {
-                    if let Err(err) = self.geo_ip_provider.update().await {
-                        tracing::warn!("Could not update the location on timer for determining gateway proximity: {err}");
-                    }
-                    update_timer.set(tokio::time::sleep(GEO_IP_UPDATE_INTERVAL));
+                Some(new_settings) = self.tunnel_settings_rx.recv() => {
+                    latest_tunnel_settings = new_settings;
                 }
-                settings = self.tunnel_settings_rx.recv() => {
-                    if settings.is_none() {
-                        tracing::debug!(
-                            "GatewayProvider shut down before starting the selection algorithm"
-                        );
-                        return;
-                    };
-                    if let Err(err) = self.geo_ip_provider.update().await {
-                        tracing::warn!("Could not update the locationon new settings for determining gateway proximity: {err}");
-                    }
-                    // store the received tunnel settings received for the next loop iteration
-                    latest_tunnel_settings = settings;
+                new_location = self.geo_ip_provider.new_location() => {
+                    latest_location = new_location;
                 }
-                // consume the tunnel settings received in the previous loop iteration
                 _ = continuous_select(
-                        latest_tunnel_settings.take(),
+                        latest_tunnel_settings.clone(),
                         self.gateway_cache.clone(),
                         &self.blacklisted_entry_gateways,
-                        self.geo_ip_provider.latest_location(),
+                        latest_location.clone(),
                         self.wg_keys_db.clone(),
                     ) => {},
             }
@@ -141,7 +112,6 @@ mod tests {
     use crate::tunnel_state_machine::tunnel::gateway_provider::{
         SelectionResult,
         gateway_cache::tests::MockGatewayCache,
-        geo_ip::tests::MockGeoIpClient,
         tests::{default_tunnel_settings, gateway_id_to_gateway},
     };
 
@@ -164,6 +134,8 @@ mod tests {
     #[tokio::test]
     async fn run_algo() {
         let (tunnel_settings_tx, tunnel_settings_rx) = mpsc::channel(1);
+        let (_update_location_tx, update_location_rx) = mpsc::unbounded_channel();
+        let (selection_tx, _selection_rx) = mpsc::channel(10);
         let shutdown_token = CancellationToken::new();
         let possible_gateways_ids = [
             "2zHiExNRKiCXVKS35SNKtK4apGfZELMpA1jJ2gVevJoz",
@@ -175,12 +147,15 @@ mod tests {
         let algo = SelectionAlgorithm::new(
             tunnel_settings_rx,
             MockGatewayCache::new(gateways.clone()),
-            GeoIpProvider::new(MockGeoIpClient::new(), Default::default()).await,
+            GeoIpProvider::new(update_location_rx),
             BlacklistedGateways::new(),
             WireguardKeysDb::Ephemeral(Default::default()),
             shutdown_token.clone(),
         );
-        let handle = tokio::spawn(algo.run());
+        let handle = tokio::spawn(algo.run(SelectAndSend {
+            tunnel_settings: default_tunnel_settings(),
+            selection_tx,
+        }));
 
         // set some default settings
         let mut selection_rx = reset_default_settings(&tunnel_settings_tx).await;

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/geo_ip.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/geo_ip.rs
@@ -1,14 +1,21 @@
 // Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{cmp, sync::Arc};
+use std::{cmp, sync::Arc, time::Duration};
 
 use geo::{Distance, Haversine, Point};
 use nym_gateway_directory::{Gateway, Location};
 use nym_vpn_api_client::{
     VpnApiClient, error::VpnApiClientError, response::NymUserGeoIpLocationResponse,
 };
-use tokio::sync::Mutex;
+use tokio::sync::{
+    RwLock,
+    mpsc::{self, UnboundedReceiver},
+    oneshot,
+};
+use tokio_util::sync::CancellationToken;
+
+const GEO_IP_UPDATE_INTERVAL: Duration = Duration::from_hours(1);
 
 #[async_trait::async_trait]
 pub trait GeoIpClient: Send + Sync + 'static {
@@ -84,59 +91,127 @@ impl QueryControl {
         self.active = active;
     }
 
-    fn can_query(&self) -> bool {
-        self.enabled && self.active
+    pub(crate) fn do_not_query(&self) -> bool {
+        !self.enabled || !self.active
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum State {
+    Nothing,
+    FetchInProgress,
+}
+
+pub(crate) enum FetcherCommand {
+    Fetch,
+    Abort(oneshot::Sender<()>),
+}
+
+pub(crate) struct GeoIpFetcher {
+    state: State,
+    query_control: Arc<RwLock<QueryControl>>,
+    client: Box<dyn GeoIpClient>,
+    command_rx: mpsc::UnboundedReceiver<FetcherCommand>,
+    update_location_tx: mpsc::UnboundedSender<Location>,
+    shutdown_token: CancellationToken,
+}
+
+impl GeoIpFetcher {
+    pub(crate) fn new(
+        enable_geo_location: bool,
+        client: Box<dyn GeoIpClient>,
+        command_rx: mpsc::UnboundedReceiver<FetcherCommand>,
+        update_location_tx: mpsc::UnboundedSender<Location>,
+        shutdown_token: CancellationToken,
+    ) -> Self {
+        let state = if enable_geo_location {
+            State::FetchInProgress
+        } else {
+            State::Nothing
+        };
+        let query_control = Arc::new(RwLock::new(QueryControl::new(enable_geo_location)));
+
+        Self {
+            state,
+            query_control,
+            client,
+            command_rx,
+            update_location_tx,
+            shutdown_token,
+        }
     }
 
-    fn should_clear_location(&self) -> bool {
-        !self.enabled
+    pub(crate) fn query_control(&self) -> Arc<RwLock<QueryControl>> {
+        self.query_control.clone()
+    }
+
+    async fn maybe_start_fetching(&mut self) {
+        if !self.query_control.read().await.do_not_query() {
+            self.state = State::FetchInProgress;
+        }
+    }
+
+    pub(crate) async fn run(mut self) {
+        let update_timer = tokio::time::sleep(GEO_IP_UPDATE_INTERVAL);
+        tokio::pin!(update_timer);
+        loop {
+            tokio::select! {
+                _ = self.shutdown_token.cancelled() => {
+                    tracing::debug!("GeoIpFetcher shut down");
+                    return;
+                }
+                _ = &mut update_timer => {
+                    self.maybe_start_fetching().await;
+                    update_timer.set(tokio::time::sleep(GEO_IP_UPDATE_INTERVAL));
+                }
+                ret = self.client.latest_geo_ip(), if self.state == State::FetchInProgress => {
+                    self.state = State::Nothing;
+                    match ret {
+                        Ok(location) => {
+                            let _ = self.update_location_tx.send(location.into());
+                        }
+                        Err(err) => tracing::warn!("Failed to query VPN API: {err:?}"),
+                    }
+                }
+                Some(command) = self.command_rx.recv() => {
+                    match command {
+                        FetcherCommand::Fetch => self.maybe_start_fetching().await,
+                        FetcherCommand::Abort(done) => {
+                            self.state = State::Nothing;
+                            let _ = done.send(());
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 
 pub(crate) struct GeoIpProvider {
-    client: Box<dyn GeoIpClient>,
-    query_control: Arc<Mutex<QueryControl>>,
-    latest_location: Option<Location>,
+    update_location_rx: UnboundedReceiver<Location>,
+    latest_known_location: Option<Location>,
 }
 
 impl GeoIpProvider {
-    pub(crate) async fn new(
-        client: impl GeoIpClient,
-        query_control: Arc<Mutex<QueryControl>>,
-    ) -> Self {
-        let can_query = query_control.lock().await.can_query();
-        let latest_location = if can_query {
-            client
-                .latest_geo_ip()
-                .await
-                .inspect_err(|err| tracing::warn!("Failed to query VPN API: {err:?}"))
-                .map(|ret| ret.into())
-                .ok()
-        } else {
-            None
-        };
+    pub(crate) fn new(update_location_rx: UnboundedReceiver<Location>) -> Self {
         Self {
-            client: Box::new(client),
-            query_control,
-            latest_location,
+            update_location_rx,
+            latest_known_location: None,
         }
     }
 
-    pub(crate) async fn update(&mut self) -> Result<(), VpnApiClientError> {
-        let (should_clear_location, can_query) = {
-            let control = self.query_control.lock().await;
-            (control.should_clear_location(), control.can_query())
-        };
-        if should_clear_location {
-            self.latest_location = None;
-        } else if can_query {
-            self.latest_location = Some(self.client.latest_geo_ip().await?.into());
+    /// Return whenever there is a new location available, different to what we've already returned
+    /// previously.
+    pub(crate) async fn new_location(&mut self) -> Option<Location> {
+        loop {
+            // if recv() returns None, there will never be a new location because the fetcher is gone
+            // So we should skip the loop
+            let latest_location = Some(self.update_location_rx.recv().await?);
+            if self.latest_known_location != latest_location {
+                self.latest_known_location = latest_location;
+                return self.latest_known_location.clone();
+            }
         }
-        Ok(())
-    }
-
-    pub(crate) fn latest_location(&mut self) -> Option<Location> {
-        self.latest_location.clone()
     }
 }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/mod.rs
@@ -12,7 +12,7 @@ use futures::{FutureExt, Stream, StreamExt};
 use nym_gateway_directory::{BlacklistedGateways, GatewayClient, NodeIdentity};
 use nym_vpn_store::keys::wireguard::WireguardKeysDb;
 use tokio::{
-    sync::{Mutex, mpsc},
+    sync::{Mutex, RwLock, mpsc, oneshot},
     task::JoinHandle,
 };
 use tokio_stream::wrappers::ReceiverStream;
@@ -25,7 +25,7 @@ use crate::tunnel_state_machine::{
         gateway_provider::{
             algorithm::{SelectAndSend, SelectionAlgorithm},
             gateway_cache::GatewayCache,
-            geo_ip::{GeoIpClient, GeoIpProvider, QueryControl},
+            geo_ip::{FetcherCommand, GeoIpClient, GeoIpFetcher, GeoIpProvider, QueryControl},
         },
     },
 };
@@ -42,7 +42,8 @@ pub struct GatewayProvider<C: GatewayCache> {
     tunnel_settings_tx: mpsc::Sender<SelectAndSend>,
     selected_gateways_stream: SelectedGatewaysStream,
     blacklisted_entry_gateways: BlacklistedGateways,
-    query_control: Arc<Mutex<QueryControl>>,
+    query_control: Arc<RwLock<QueryControl>>,
+    query_control_tx: mpsc::UnboundedSender<FetcherCommand>,
 }
 
 impl<C: GatewayCache> Stream for GatewayProvider<C> {
@@ -66,14 +67,28 @@ impl<C: GatewayCache> GatewayProvider<C> {
         gateway_cache: C,
         geo_ip_client: impl GeoIpClient,
         enable_geo_location: bool,
-        initial_tunnel_settings: TunnelSettings,
+        tunnel_settings: TunnelSettings,
         wg_keys_db: WireguardKeysDb,
         shutdown_token: CancellationToken,
     ) -> Result<(Self, JoinHandle<()>), crate::tunnel_state_machine::Error> {
         let (tunnel_settings_tx, tunnel_settings_rx) = mpsc::channel(1);
         let blacklisted_entry_gateways = BlacklistedGateways::new();
-        let query_control = Arc::new(Mutex::new(QueryControl::new(enable_geo_location)));
-        let geo_ip_provider = GeoIpProvider::new(geo_ip_client, query_control.clone()).await;
+        let (query_control_tx, query_control_rx) = mpsc::unbounded_channel();
+        let (update_location_tx, update_location_rx) = mpsc::unbounded_channel();
+
+        let geo_ip_provider = GeoIpProvider::new(update_location_rx);
+        let geo_ip_fetcher = GeoIpFetcher::new(
+            enable_geo_location,
+            Box::new(geo_ip_client),
+            query_control_rx,
+            update_location_tx,
+            shutdown_token.child_token(),
+        );
+        let query_control = geo_ip_fetcher.query_control();
+        let geo_ip_fetcher_handle = tokio::spawn(geo_ip_fetcher.run());
+
+        // Pre-compute at most 10 different possibilities of selected gateways
+        let (selection_tx, selection_rx) = mpsc::channel(10);
         let selection_algorithm_handle = tokio::spawn(
             SelectionAlgorithm::new(
                 tunnel_settings_rx,
@@ -83,10 +98,18 @@ impl<C: GatewayCache> GatewayProvider<C> {
                 wg_keys_db,
                 shutdown_token,
             )
-            .run(),
+            .run(SelectAndSend {
+                tunnel_settings,
+                selection_tx,
+            }),
         );
-        let selected_gateways_stream =
-            Self::inner_set_tunnel_settings(&tunnel_settings_tx, initial_tunnel_settings).await?;
+        let selected_gateways_stream = Arc::new(Mutex::new(ReceiverStream::new(selection_rx)));
+
+        // unify the two local handles into one
+        let gateway_provider_handle = tokio::spawn(async {
+            let _ = geo_ip_fetcher_handle.await;
+            let _ = selection_algorithm_handle.await;
+        });
 
         Ok((
             Self {
@@ -94,9 +117,10 @@ impl<C: GatewayCache> GatewayProvider<C> {
                 tunnel_settings_tx,
                 selected_gateways_stream,
                 blacklisted_entry_gateways,
+                query_control_tx,
                 query_control,
             },
-            selection_algorithm_handle,
+            gateway_provider_handle,
         ))
     }
 
@@ -116,10 +140,39 @@ impl<C: GatewayCache> GatewayProvider<C> {
         Ok(Arc::new(Mutex::new(ReceiverStream::new(selection_rx))))
     }
 
+    async fn start_fetching_again(&self) {
+        if self.query_control_tx.send(FetcherCommand::Fetch).is_err() {
+            tracing::warn!("Could send fetch control message to geo ip fetcher");
+        }
+    }
+
+    async fn abort_any_fetch(&self) {
+        let (done_tx, done_rx) = oneshot::channel();
+        if self
+            .query_control_tx
+            .send(FetcherCommand::Abort(done_tx))
+            .is_err()
+        {
+            tracing::warn!("Could send abort control message to geo ip fetcher");
+        }
+        if done_rx.await.is_err() {
+            tracing::warn!("Geo ip fetcher did not respond to abort command");
+        }
+    }
+
     /// Set if geo-location should be used by the algorithm, based on user's
     /// preference
     async fn set_enabled_geo_location(&self, enabled: bool) {
-        self.query_control.lock().await.set_enabled(enabled);
+        let do_not_query = {
+            let mut query_control = self.query_control.write().await;
+            query_control.set_enabled(enabled);
+            query_control.do_not_query()
+        };
+        if do_not_query {
+            self.abort_any_fetch().await;
+        } else {
+            self.start_fetching_again().await;
+        }
     }
 
     /// Set the activation for geo-location based on connection status, to avoid
@@ -127,7 +180,16 @@ impl<C: GatewayCache> GatewayProvider<C> {
     /// Being active means we try to query the location from the API. We want to
     /// deactivate this in certain states of TSM, when the queries are proxied.
     pub async fn set_active_geo_location(&self, active: bool) {
-        self.query_control.lock().await.set_active(active);
+        let do_not_query = {
+            let mut query_control = self.query_control.write().await;
+            query_control.set_active(active);
+            query_control.do_not_query()
+        };
+        if do_not_query {
+            self.abort_any_fetch().await;
+        } else {
+            self.start_fetching_again().await;
+        }
     }
 
     pub async fn set_tunnel_settings(


### PR DESCRIPTION
## Ticket

JIRA-NYM-1231

## Description

Refactor geo IP localization such that the network queries happen in background, without blocking the TSM boot, state changes or shutdowns.
Trigger fetches on state machine changes and make sure they only happen when in `Disconnected` state, for correct localization.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5190)
<!-- Reviewable:end -->
