### PR TITLE
Fix missing IPv4 address on mixnet tun adapter

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -1657,7 +1657,11 @@ impl TunnelMonitor {
             #[cfg(windows)]
             tun_config.tun_name(MIXNET_WINTUN_NAME);
 
-            tun_config.address(interface_ipv4).mtu(mtu).up();
+            tun_config
+                .address(interface_ipv4)
+                .netmask(Ipv4Addr::BROADCAST)
+                .mtu(mtu)
+                .up();
 
             #[cfg(target_os = "macos")]
             tun_config.platform_config(|platform_config| {


### PR DESCRIPTION

## Description

Tun [no longer configures IPv4 address when netmask is unset](https://github.com/meh/rust-tun/blob/master/src/platform/windows/device.rs#L52-L66). This PR ensures that netmask is set explicitly on tun configuration.

The default behavior for netmask for changed in https://github.com/meh/rust-tun/commit/5ae4b27668fbfdf6fb2a1086a83639c19d1f8953

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5206)
<!-- Reviewable:end -->
