### PR TITLE
fix(discovery): prioritise Fastly over Vercel in mainnet endpoints

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-network-config/default/mainnet_discovery.json
+++ b/nym-vpn-core/crates/nym-vpn-network-config/default/mainnet_discovery.json
@@ -3,26 +3,26 @@
   "nym_api_url": "https://validator.nymtech.net/api/",
   "nym_api_urls": [
     {
+      "url": "https://nym-frontdoor.global.ssl.fastly.net/api/",
+      "fronts": ["yelp.global.ssl.fastly.net"]
+    },
+    {
       "url": "https://validator.nymtech.net/api/"
     },
     {
       "url": "https://nym-frontdoor.vercel.app/api/",
       "fronts": ["vercel.app", "vercel.com"]
-    },
-    {
-      "url": "https://nym-frontdoor.global.ssl.fastly.net/api/",
-      "fronts": ["yelp.global.ssl.fastly.net"]
     }
   ],
   "nym_vpn_api_url": "https://nymvpn.com/api/",
   "nym_vpn_api_urls": [
     {
-      "url": "https://nymvpn.com/api/",
-      "fronts": ["vercel.app", "vercel.com"]
-    },
-    {
       "url": "https://nymvpn-frontdoor.global.ssl.fastly.net/api",
       "fronts": ["yelp.global.ssl.fastly.net"]
+    },
+    {
+      "url": "https://nymvpn.com/api/",
+      "fronts": ["vercel.app", "vercel.com"]
     }
   ],
   "account_management": {


### PR DESCRIPTION
## Ticket

JIRA-VPN-XXXX

## Description
 

 Re-orders nym_api_urls and nym_vpn_api_urls in the mainnet wellknown
  discovery response so the Fastly-fronted endpoints are listed first.
  The client walks the array with FrontPolicy::OnRetry, so order
  controls which endpoint pays the first 30s timeout when a path is
  blocked.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5208)
<!-- Reviewable:end -->
