### PR TITLE
APPLE: iOS exlucde shared folder path from backups

### DIFF
--- a/nym-vpn-apple/Services/Sources/Services/PathManager/PathManager.swift
+++ b/nym-vpn-apple/Services/Sources/Services/PathManager/PathManager.swift
@@ -1,7 +1,10 @@
 import Foundation
+import Logging
 import Constants
 
 public final class PathManager {
+    private static let logger = Logger(label: "PathManager")
+
     /// Group folder, created automatically if does not exists
     /// `/private/var/mobile/Containers/Shared/AppGroup/xxx-xxx-xxx-xxx-xxx/Data/`
     /// - Returns: URL to group data folder
@@ -17,6 +20,13 @@ public final class PathManager {
         if !FileManager.default.fileExists(atPath: dataFolderURL.path()) {
             try FileManager.default.createDirectory(at: dataFolderURL, withIntermediateDirectories: true)
         }
+        if !isExcludedFromBackup(dataFolderURL) {
+            do {
+                try excludeFromBackup(dataFolderURL)
+            } catch {
+                logger.error("Failed to exclude from backups with \(error.localizedDescription)")
+            }
+        }
         return dataFolderURL
     }
 
@@ -26,5 +36,19 @@ public final class PathManager {
 
     public nonisolated static func configFolderURL() throws -> URL {
         try Self.dataFolderURL().appendingPathComponent("Config")
+    }
+}
+
+private extension PathManager {
+    static func isExcludedFromBackup(_ url: URL) -> Bool {
+        let values = try? url.resourceValues(forKeys: [.isExcludedFromBackupKey])
+        return values?.isExcludedFromBackup ?? false
+    }
+
+    static func excludeFromBackup(_ url: URL, isExcluded: Bool = true) throws {
+        var resourceValues = URLResourceValues()
+        resourceValues.isExcludedFromBackup = isExcluded
+        var mutableURL = url
+        try mutableURL.setResourceValues(resourceValues)
     }
 }


### PR DESCRIPTION
## Ticket

JIRA-NYM-1243

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5211)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backup behavior on iOS devices by properly excluding app data from cloud backups.
  * Enhanced error handling in data folder management—failures are now logged gracefully instead of interrupting operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->