### PR TITLE
Prevent hickory from logging resolution details

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/logging.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/logging.rs
@@ -35,10 +35,11 @@ pub const DEFAULT_LOG_FILE: &str = "nym-vpnd.log";
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub const DEFAULT_OLD_LOG_FILE: &str = "nym-vpnd.old.log";
 
-/// Targets which we do not want any logs from under any circumstances. For example the hickory
-/// resolver when configured for use with client traffic can log DNS lookups at the DEBUG level. We
-/// never want information related to client traffic logged.
-static NO_LOGGING: [&str; 2] = [
+/// Targets which we do not want any logs under normal (up to debug) circumstances. For example the
+/// hickory resolver when configured for use with client traffic can log DNS lookups at the DEBUG
+/// level. We do not want information related to client traffic logged except in controlled trace
+/// situations (away from platform apps).
+static TRACE_ONLY_LOGGING: [&str; 2] = [
     "hickory_resolver",
     // proto is probably okay, but disabling for now.
     "hickory_proto",
@@ -313,9 +314,14 @@ pub fn setup_logging(options: Options) -> Option<LoggingSetup> {
         );
     }
 
-    for crate_name in NO_LOGGING {
+    let level = if options.verbosity_level == Level::TRACE {
+        "trace"
+    } else {
+        "off"
+    };
+    for crate_name in TRACE_ONLY_LOGGING {
         env_filter = env_filter.add_directive(
-            format!("{crate_name}=off")
+            format!("{crate_name}={level}")
                 .parse()
                 .expect("failed to parse directive"),
         );

--- a/nym-vpn-core/crates/nym-vpn-lib/src/logging.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/logging.rs
@@ -35,10 +35,18 @@ pub const DEFAULT_LOG_FILE: &str = "nym-vpnd.log";
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub const DEFAULT_OLD_LOG_FILE: &str = "nym-vpnd.old.log";
 
-static INFO_TARGETS: [&str; 14] = [
+/// Targets which we do not want any logs from under any circumstances. For example the hickory
+/// resolver when configured for use with client traffic can log DNS lookups at the DEBUG level. We
+/// never want information related to client traffic logged.
+static NO_LOGGING: [&str; 2] = [
+    "hickory_resolver",
+    // proto is probably okay, but disabling for now.
+    "hickory_proto",
+];
+
+static INFO_TARGETS: [&str; 13] = [
     "hyper",
     "netlink_proto",
-    "hickory_proto",
     "hyper_util",
     "h2",
     "rustls",
@@ -300,6 +308,14 @@ pub fn setup_logging(options: Options) -> Option<LoggingSetup> {
     for crate_name in WARN_TARGETS {
         env_filter = env_filter.add_directive(
             format!("{crate_name}=warn")
+                .parse()
+                .expect("failed to parse directive"),
+        );
+    }
+
+    for crate_name in NO_LOGGING {
+        env_filter = env_filter.add_directive(
+            format!("{crate_name}=off")
                 .parse()
                 .expect("failed to parse directive"),
         );

--- a/nym-vpn-core/crates/nym-vpn-lib/src/resolver/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/resolver/mod.rs
@@ -286,7 +286,7 @@ impl Resolver {
                     RecordType::AAAA => RData::AAAA(rdata::AAAA(Ipv6Addr::LOCALHOST)),
                     RecordType::CNAME => RData::CNAME(rdata::CNAME(Name::from_str("localhost.")?)),
                     other => {
-                        tracing::warn!("Unsupported query type {other} for domain {qname}");
+                        tracing::trace!("Unsupported query type {other} for domain {qname}");
                         return Ok(Box::new(EmptyLookup) as Box<dyn LookupObject>);
                     }
                 };


### PR DESCRIPTION

## Description

In the client application prevent hickory from (client local debug) logging DNS resolution information when custom DNS resolvers are used and debug level logging is enabled

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5219)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Suppressed verbose logs from specific internal modules to reduce log noise and make diagnostics clearer for users.
  * Downgraded a noisy DNS-related warning to a trace-level message to avoid unnecessary warnings while preserving behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->