### PR TITLE
ASO: refresh Google Play en-US metadata

### DIFF
--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,74 +1,70 @@
-7 day free trial: All features, no ads, cancel anytime. Plans starting at $2.39 / month.
+NymVPN: the world's most private VPN. A secure, decentralized, anonymous Swiss dVPN with no logs. WireGuard speed, Noise Generating Mixnet anonymity. No email signup. No ads.
 
-The only VPN that can't spy on you. Made in Switzerland. Built by privacy-advocates. The world's first mixnet for online anonymity.
+🎁 7-DAY FREE VPN TRIAL & PLANS FROM $2.39/MONTH
 
-- NO-NAME SIGNUP: No email required. Zero-knowledge accounts. The most crypto accepted by any VPN. Cash payments accepted for full anonymity.
-- DECENTRALIZED VPN technology
-- MOST CRYPTOCURRENCIES ACCEPTED of any VPN
-- 70+ COUNTRIES with hundreds of independent servers
-- UP TO 10 DEVICES with one anonymous code
+Try free for 7 days, no commitment. Pay in crypto, card, or cash: your choice.
 
-### BROWSE WITHOUT A TRACE
+🛡 PRIVACY BY DESIGN
 
-Tired of wondering who's watching you? Corporations collecting your personal data? Not being able to access information because of where you are?
+Most VPNs say 'no logs' as policy — they can log, they promise not to. Free VPNs track you to sell your data. NymVPN's architecture makes meaningful traffic logs impossible: our decentralized, anonymous network of servers routes your traffic through multiple hops, so no single server sees who you are AND what you do. Even Nym can't connect your identity to your activity. No logs to hand over: none to keep in the first place.
 
-While other VPNs promise not to keep logs, with NymVPN there is no point on the decentralized network that can connect your IP address with what you do online. Your privacy is guaranteed by default. Your online activity cannot be tied back to you by advertisers, network operators, or centralized infrastructure. You can browse and communicate without leaving a data trail  across the internet.
+⚡ TWO VPN MODES, ONE APP
 
-### CHOOSE YOUR PRIVACY LEVEL
+• Fast Mode: AmneziaWG (WireGuard)-based 2-hop dVPN. Fast streaming and browsing on a decentralized network so no single operator can log you.
 
-Fast Mode
+• Anonymous Mode: 5-hop Noise Generating Mixnet, a more private successor to Tor. Routes your traffic through independently operated servers, mixes your packets with others, and adds noise and cover traffic to defeat traffic analysis. The most anonymous consumer VPN available today. Perfect for crypto, email, and private messaging like Signal.
 
-- High-speed browsing and streaming
-- 2-hop decentralized VPN
-- AmneziaWG (WireGuard) protection
+💰 PAY ANONYMOUSLY WITH CRYPTO OR CASH
 
-Anonymous Mode
+NymVPN accepts more cryptocurrencies than any other VPN, plus cash payments. Pay with Bitcoin (BTC), Ethereum (ETH), Monero (XMR), Zcash (ZEC), USDT, USDC, NYM, and many more. Zero-knowledge credentials delink your payment from your VPN use: pay anonymously, use anonymously.
 
-- Maximum anonymity for messaging, email, and financial transactions
-- 5-hop Noise Generating Mixnet
-- Resists advanced traffic analysis
+💎 WHY NYMVPN IS DIFFERENT
 
-### ESSENTIAL FEATURES
+• Zero-knowledge architecture: your identity invisible even to Nym
+• No logs by architecture: the network can't keep meaningful traffic logs
+• Decentralized proxy network: no central server can compromise or surveil your traffic
+• Swiss jurisdiction: outside the 14 Eyes surveillance alliance, protected by the strongest privacy laws in the world
+• WireGuard and mixnet protocols: a fast VPN and the most private way to be online
+• No email signup: no personal data required
+• Fully open source: audited by independent security researchers
+• 70+ countries: servers worldwide for global streaming and access
+• Up to 10 devices on one account
 
-- Entry & exit server selection
-- Multi-layer encryption
-- dVPN AmneziaWG (WireGuard) support
-- Kill switch prevents data leaks
-- Advanced anti-censorship technology
-- Split tunneling
-- Custom DNS
-- Key rotation for cryptographic security
-- Completely ad-free experience
-- 100% open source software
+🔒 PRIVACY & SECURITY FEATURES
 
-### WHY NYMVPN IS DIFFERENT
+• Built-in kill switch: automatic traffic stop if the VPN connection drops
+• Censorship resistance: prevent VPN blocking and access the global internet with QUIC, AmneziaWG, and other techniques
+• Multi-layer onion encryption
+• Entry & exit server selection
+• Split tunneling: route only the apps you choose through the VPN
+• Custom DNS: use any DNS server you trust
+• Ad and tracker blocker
 
-Most VPNs rely on centralized servers and ask you to trust their "no-logs" promises. NymVPN is built differently.
+🌍 WHAT YOU CAN DO WITH NYMVPN
 
-- Decentralized VPN (dVPN) architecture: Traffic is routed through independently operated servers. No one can see both who you are and what you do online.
+• Browse anonymously without leaving a trace
+• Encrypt your traffic on public wifi at airports, cafes, hotels
+• Bypass internet censorship in restrictive regions
+• Protect sensitive communications for journalism, activism, and research
+• Stop ISPs from profiling your browsing for ad targeting
+• Block malicious websites, trackers, and ads at the DNS level
 
-- Metadata protection: NymVPN protects traffic patterns, timing, and routing information. Even encrypted data can leak metadata. Nym prevents that.
+🇨🇭 SWISS PRIVACY, BY DESIGN
 
-- Two privacy modes, one app: The FAST  mode uses a high-performance 2-hop decentralized VPN. The ANONYMOUS  mode uses a 5-hop mixnet for maximum anonymity.
+NymVPN operates under Swiss law, with the strongest privacy protections in the world. Switzerland sits outside the 14 Eyes surveillance alliance, with constitutionally protected privacy rights and no mandatory data retention. With a decentralized, no-logs architecture, your data is protected by both law and design: not by a promise that could be broken or quietly changed in a privacy policy.
 
-- Noise Generating Mixnet technology: Your traffic is mixed with cover traffic, making correlation and AI-driven traffic analysis extremely difficult.
+🎓 BUILT BY ACADEMIC CRYPTOGRAPHERS
 
-- Zero-knowledge accounts by design: No email signup. No personal data. Accounts are unlinkable from usage. Supports crypto and cash payments for full anonymity.
+NymVPN is built by Nym, trusted by journalists, activists, and privacy-conscious users worldwide. Our protocols are open-source and audited by independent security researchers.
 
-- Censorship-resistant networking: Built with AmneziaWG, QUIC, and stealth transport options to work in restrictive environments.
+🚫 WHAT WE DON'T DO
 
-- Open-source and independently audited.
-- Built by academic cryptographers
+• We don't ask for your email or your name
+• We can't track which sites you visit
+• We can't sell, share, or rent your data
 
-### NYMVPN IS PERFECT FOR:
+📲 GET STARTED
 
-- Streaming and browsing without being tracked
-- Secure public WiFi connections
-- Anyone in restrictive countries needing reliable access
-- People who want true anonymity, not just hidden IP addresses
-- Journalists and activists needing untraceable communication
-- Featured in PCMag, TechRadar, Forbes, Bloomberg, Tom's Guide
+Download NymVPN, create an anonymous account without an email or even a name, and start browsing privately.
 
-Download now. Signup anonymously. Go dark with NymVPN.
-
-Terms of Use: https://nym.com/vpn-terms
+Try NymVPN today.

--- a/fastlane/metadata/android/en-US/full_description_medium.txt
+++ b/fastlane/metadata/android/en-US/full_description_medium.txt
@@ -1,0 +1,70 @@
+NymVPN: the world's most private VPN. A secure, decentralized, anonymous Swiss dVPN with no logs. WireGuard speed, Noise Generating Mixnet anonymity. No email signup. No ads.
+
+🎁 7-DAY FREE VPN TRIAL & PLANS FROM $2.39/MONTH
+
+Try free for 7 days, no commitment. Pay in crypto, card, or cash: your choice.
+
+🛡 PRIVACY BY DESIGN
+
+Most VPNs say 'no logs' as policy — they can log, they promise not to. Free VPNs track you to sell your data. NymVPN's architecture makes meaningful traffic logs impossible: no single server sees who you are AND what you do. Even Nym can't connect your identity to your activity.
+
+⚡ TWO VPN MODES, ONE APP
+
+• Fast Mode: AmneziaWG (WireGuard)-based 2-hop dVPN. Fast streaming and browsing on a decentralized network.
+
+• Anonymous Mode: 5-hop Noise Generating Mixnet, a more private successor to Tor. Mixes traffic with others, adds noise and cover traffic. The most anonymous consumer VPN. Perfect for crypto, email, and private messaging like Signal.
+
+💰 PAY ANONYMOUSLY WITH CRYPTO OR CASH
+
+NymVPN accepts more cryptocurrencies than any other VPN, plus cash payments. Pay with Bitcoin (BTC), Ethereum (ETH), Monero (XMR), Zcash (ZEC), USDT, USDC, NYM, and many more. Zero-knowledge credentials delink your payment from your VPN use: pay anonymously, use anonymously.
+
+💎 WHY NYMVPN IS DIFFERENT
+
+• Zero-knowledge architecture: your identity invisible even to Nym
+• No logs by architecture: the network can't keep meaningful traffic logs
+• Decentralized proxy network: no central server to compromise
+• Swiss jurisdiction: outside 14 Eyes, strong privacy laws
+• WireGuard and mixnet protocols
+• No email signup: anonymous account creation
+• Fully open source, audited by independent security researchers
+• 70+ countries: global server network for streaming and access
+• Up to 10 devices on one account
+
+🔒 PRIVACY & SECURITY FEATURES
+
+• Built-in kill switch: automatic traffic stop if VPN drops
+• Censorship resistance: prevent VPN blocking with QUIC, AmneziaWG, and other techniques
+• Multi-layer onion encryption
+• Entry & exit server selection
+• Split tunneling: route only chosen apps through the VPN
+• Custom DNS: use any DNS server you trust
+• Ad and tracker blocker
+
+🌍 WHAT YOU CAN DO WITH NYMVPN
+
+• Browse anonymously without leaving a trace
+• Encrypt your traffic on public wifi at airports, cafes, hotels
+• Bypass internet censorship in restrictive regions
+• Protect sensitive communications for journalism and activism
+• Stop ISPs from profiling your browsing for ad targeting
+• Block malicious sites, trackers, and ads
+
+🇨🇭 SWISS PRIVACY, BY DESIGN
+
+NymVPN operates under Swiss law: outside the 14 Eyes surveillance alliance, with constitutionally protected privacy rights and no mandatory data retention. With our decentralized, no-logs architecture, your data is protected by law and design.
+
+🎓 BUILT BY ACADEMIC CRYPTOGRAPHERS
+
+NymVPN is built by Nym, trusted by journalists, activists, and privacy-conscious users worldwide. Our protocols are open-source and audited by independent security researchers.
+
+🚫 WHAT WE DON'T DO
+
+• We don't ask for your email or your name
+• We can't track which sites you visit
+• We can't sell, share, or rent your data
+
+📲 GET STARTED
+
+Download NymVPN, create an anonymous account without an email or even a name, and start browsing privately.
+
+Try NymVPN today.

--- a/fastlane/metadata/android/en-US/full_description_short.txt
+++ b/fastlane/metadata/android/en-US/full_description_short.txt
@@ -1,0 +1,70 @@
+NymVPN: the world's most private VPN. A secure, decentralized, anonymous Swiss dVPN with no logs. WireGuard speed, Noise Generating Mixnet anonymity. No email signup. No ads.
+
+🎁 7-DAY FREE VPN TRIAL & PLANS FROM $2.39/MONTH
+
+Try free for 7 days, no commitment. Pay in crypto, card, or cash: your choice.
+
+🛡 PRIVACY BY DESIGN
+
+Most VPNs say 'no logs' as policy — they can log, they promise not to. Free VPNs track you to sell your data. NymVPN's architecture makes meaningful traffic logs impossible: no single server sees who you are AND what you do.
+
+⚡ TWO VPN MODES, ONE APP
+
+• Fast Mode: AmneziaWG (WireGuard)-based 2-hop dVPN. Fast streaming and browsing.
+• Anonymous Mode: 5-hop Noise Generating Mixnet, a more private successor to Tor. The most anonymous consumer VPN. Perfect for crypto, email, and private messaging like Signal.
+
+💰 PAY ANONYMOUSLY WITH CRYPTO OR CASH
+
+NymVPN accepts more cryptocurrencies than any other VPN, plus cash payments. Pay with Bitcoin (BTC), Ethereum (ETH), Monero (XMR), Zcash (ZEC), USDT, USDC, NYM, and more. Zero-knowledge credentials delink your payment from your VPN use: pay anonymously, use anonymously.
+
+💎 WHY NYMVPN IS DIFFERENT
+
+• Zero-knowledge architecture: identity invisible to Nym
+• No logs by architecture: the network can't keep meaningful traffic logs
+• Decentralized proxy network: no central server
+• Swiss jurisdiction: outside 14 Eyes
+• WireGuard and mixnet protocols
+• No email signup: anonymous account creation
+• Fully open source, audited by independent security researchers
+• 70+ countries: global server network worldwide
+• Up to 10 devices on one account
+
+🔒 PRIVACY & SECURITY FEATURES
+
+• Built-in kill switch
+• Censorship resistance: QUIC, AmneziaWG, and more prevent VPN blocking
+• Multi-layer onion encryption
+• Entry & exit server selection
+• Split tunneling: route only chosen apps through the VPN
+• Custom DNS: use any DNS server you trust
+• Ad and tracker blocker
+
+🌍 WHAT YOU CAN DO WITH NYMVPN
+
+• Browse anonymously without leaving a trace
+• Stream content from servers worldwide
+• Encrypt your traffic on public wifi
+• Bypass internet censorship in restrictive regions
+• Protect sensitive communications for journalism and activism
+• Stop ISPs from profiling your browsing
+• Block malicious sites, trackers, and ads
+
+🇨🇭 SWISS PRIVACY, BY DESIGN
+
+NymVPN operates under Swiss law: outside the 14 Eyes surveillance alliance, with constitutionally protected privacy rights and no mandatory data retention. Your data is protected by law and design.
+
+🎓 BUILT BY ACADEMIC CRYPTOGRAPHERS
+
+Built by Nym. Trusted by journalists, activists, and privacy-conscious users worldwide.
+
+🚫 WHAT WE DON'T DO
+
+• We don't ask for your email or your name
+• We can't track which sites you visit
+• We can't sell, share, or rent your data
+
+📲 GET STARTED
+
+Download NymVPN, create an anonymous account without an email or even a name, and start browsing privately.
+
+Try NymVPN today.

--- a/fastlane/metadata/android/en-US/short_description.txt
+++ b/fastlane/metadata/android/en-US/short_description.txt
@@ -1,1 +1,1 @@
-The world's most private VPN
+Private, secure Swiss dVPN. WireGuard, mixnet, decentralized proxy, no email.

--- a/fastlane/metadata/android/en-US/title.txt
+++ b/fastlane/metadata/android/en-US/title.txt
@@ -1,1 +1,1 @@
-NymVPN – Anonymous dVPN
+NymVPN – Anonymous No-Log VPN


### PR DESCRIPTION
## Summary

Refreshes the Google Play `en-US` metadata with new ASO-optimized copy.

### Changes

- **`title.txt`**: `NymVPN – Anonymous No-Log VPN` (29 chars) — matches the title currently shipped on Apple App Store for cross-store keyword consistency.
- **`short_description.txt`**: rewritten to carry 8 priority keywords in 77/80 chars.
- **`full_description.txt`**: full replacement with new long-form copy (3997/4000 chars).
- **`full_description_medium.txt`** (new): medium-tier EN source (3330 chars) for translators.
- **`full_description_short.txt`** (new): short-tier EN source (2932 chars) for translators.

### Why three description files?

Translation expansion ratios vary widely by locale (DE +25%, HI +40%, ZH compresses ~50%). A single English source either wastes ASO surface for low-expansion locales or breaks the 4000-char ceiling for high-expansion ones. Three tiers solve this — each English source is sized so the translated output lands at ~3800 chars per locale cluster:

| Source | Locales |
|---|---|
| `full_description.txt` (Long, 3997) | EN, ZH-Hans, ZH-Hant |
| `full_description_medium.txt` (3330) | RU, UK, TR, FR, ES, PT-BR |
| `full_description_short.txt` (2932) | DE, HI |

### Notes for reviewers

- Fastlane reads `full_description.txt` only — the medium and short variants are translation source files, not Fastlane uploads.
- **Crowdin config may need updating** to recognize `full_description_medium.txt` and `full_description_short.txt` as new translation sources. Confirming with engineering before merge.
- A translator brief covering hard rules, ASO consistency, and per-locale notes is staged separately and goes to translators after this lands.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5221)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Android app store metadata with refined marketing copy
  * Repositioned as "No-Log VPN" with emphasis on privacy-by-design architecture
  * Clearly outlined two VPN modes: Fast Mode (2-hop) and Anonymous Mode (5-hop mixnet)
  * Highlighted anonymous payment options, DNS blocking, and censorship resistance features
  * Added Swiss jurisdiction privacy framing and "built by academic cryptographers" messaging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->