### PR TITLE
clippy: fix warning related to c_char type

### DIFF
--- a/nym-vpn-core/Android.mk
+++ b/nym-vpn-core/Android.mk
@@ -53,7 +53,7 @@ STRIP_TARGETS := libnym_vpn_lib.so libnym_vpn_lib_types.so
 # todo: consider migrating libwg builds to makefile to avoid rebuilds but for now this should make this makefile aware of changes to go sources
 LIBWG_SOURCES := $(wildcard $(WIREGUARD_DIR)/libwg/*.go) $(wildcard $(WIREGUARD_DIR)/libwg/*/*.go)
 
-.PHONY: build uniffi libwg strip clean
+.PHONY: build clippy uniffi libwg strip clean
 
 all: $(ARM64_V8_BUILD_DIR)/libwg.so $(X86_64_BUILD_DIR)/libwg.so build uniffi strip $(LICENSES_FILE)
 
@@ -63,6 +63,9 @@ build: $(ARM64_V8_BUILD_DIR)/libwg.so $(X86_64_BUILD_DIR)/libwg.so
 	mv libnym_vpn_lib_uniffi.so libnym_vpn_lib.so
 	cd $(X86_64_BUILD_DIR) ; \
 	mv libnym_vpn_lib_uniffi.so libnym_vpn_lib.so
+
+clippy:
+	$(ALL_IDEMPOTENT_FLAGS) cargo ndk -t $(ARCH_ARM64_V8) -t $(ARCH_X86_64) -o $(JNI_LIBS_DIR) clippy --package nym-vpn-lib-uniffi --package nym-vpn-lib-types $(RELEASE_FLAG)
 
 strip: build
 	cd $(ARM64_V8_BUILD_DIR) ; \

--- a/nym-vpn-core/crates/nym-ifconfig/src/linux/tun.rs
+++ b/nym-vpn-core/crates/nym-ifconfig/src/linux/tun.rs
@@ -96,11 +96,15 @@ impl<T: AsFd> Tun<'_, T> {
         let mut req: ifreq = unsafe { std::mem::zeroed() };
         unsafe { tungetiff(self.tun_fd.as_fd().as_raw_fd(), &mut req as *mut _ as _)? };
 
+        #[cfg(not(target_arch = "aarch64"))]
         let bytes = req
             .ifr_name
             .into_iter()
             .map(|c| c as u8)
             .collect::<Vec<_>>();
+
+        #[cfg(target_arch = "aarch64")]
+        let bytes = req.ifr_name;
 
         CStr::from_bytes_until_nul(&bytes)
             .map_err(|err| TunError::new(TunErrorKind::InterfaceNameIntoString, err))?

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tun_name.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tun_name.rs
@@ -42,11 +42,17 @@ pub fn get_tun_name(fd: &BorrowedFd) -> Result<String> {
     unsafe { tungetiff(fd.as_raw_fd(), &mut ifr as *mut _ as _) }
         .map_err(GetTunNameError::Syscall)?;
 
-    // SAFETY: reinterpreting [i8; N] as [u8; N] is safe — same size/alignment, no invalid values.
-    let ifr_name_bytes: &[u8] = unsafe {
-        std::slice::from_raw_parts(ifr.ifr_name.as_ptr() as *const u8, ifr.ifr_name.len())
-    };
-    CStr::from_bytes_until_nul(ifr_name_bytes)
+    #[cfg(not(target_arch = "aarch64"))]
+    let ifr_name_bytes = ifr
+        .ifr_name
+        .into_iter()
+        .map(|c| c as u8)
+        .collect::<Vec<_>>();
+
+    #[cfg(target_arch = "aarch64")]
+    let ifr_name_bytes = ifr.ifr_name;
+
+    CStr::from_bytes_until_nul(&ifr_name_bytes)
         .map_err(GetTunNameError::CopyInterfaceName)?
         .to_str()
         .map(|s| s.to_owned())


### PR DESCRIPTION


## Description

This PR fixes clippy warnings related to `c_char` being alias for signed or unsigned integer.

- `c_char` is defined as `u8` on Linux aarch64
- `c_char` is defined as `i8` on Linux x64

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5255)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced VPN tunnel interface detection with improved support for ARM64-based devices
  * Refined tunnel initialization process for greater reliability across different processor architectures
  * Fixed potential compatibility issues affecting tunnel setup on ARM-based systems

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nymtech/nym-vpn-client/pull/5255)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->