### PR TITLE
ASO: translator source files — Apple subtitle, promo text, image overlays

### DIFF
--- a/fastlane/metadata/android/en-US/promotional_text.txt
+++ b/fastlane/metadata/android/en-US/promotional_text.txt
@@ -1,0 +1,151 @@
+# ============================================================
+# NymVPN Apple App Store — Promotional Text (English source)
+# Source language: English (en-US)
+# Last updated: 2026-05-12
+# ============================================================
+#
+# This file contains the Apple App Store promotional text for
+# NymVPN. Lines starting with # are context for the translator
+# and should NOT be translated. The translatable content is
+# the 4-line block at the bottom (treated as one string).
+#
+# ============================================================
+# FIELD SPEC
+# ============================================================
+#
+# Field: Apple App Store promotional text
+# Character limit: 170 characters (HARD LIMIT — Apple enforces)
+# Indexed for ASO: NO — promo text is NOT indexed for search
+#   ranking. Its job is purely conversion.
+# Editable without resubmission: YES — Apple allows updating
+#   promo text via App Store Connect without shipping a new
+#   app version. Useful for time-sensitive offers, A/B copy
+#   tests, or quick fixes.
+#
+# Position in listing: Above-the-fold at the top of the app
+#   listing, between the title/subtitle and the description.
+#   Visible without scrolling.
+#
+# Conversion role: This is your hook. Users have arrived at
+#   the listing; promo text is what converts them from browser
+#   to installer. Lead with the strongest claim, prove it,
+#   add the trial offer, close with social proof.
+#
+# ============================================================
+# UNTRANSLATABLE TERMS — keep in English exactly
+# ============================================================
+#
+#   Nym, NymVPN, Tor, App Store
+#   $2.39, $/mo (currency stays $, decimal stays .)
+#   * * * * * (the 5-star pattern — see formatting note below)
+#
+# ============================================================
+# FORMATTING NOTES
+# ============================================================
+#
+# Stars: Use "* * * * *" (asterisks with spaces) instead of
+#   "★★★★★" (Unicode stars). Apple App Store accepts both,
+#   but Google Play doesn't allow special characters, so we
+#   standardize on asterisks for cross-platform consistency.
+#   Keep the spaces between asterisks — improves readability.
+#
+# Quotation marks: Use straight quotes (") for the review
+#   quote line. Translators may swap to locale-appropriate
+#   typographic quotes if natural ("German low/high quotes",
+#   French guillemets, etc.).
+#
+# Line breaks: Keep the 4-line structure. Each line carries
+#   one concept:
+#     Line 1 — Brand slogan / positioning
+#     Line 2 — Architectural privacy claim
+#     Line 3 — Free trial + pricing + payment options
+#     Line 4 — Social proof (review quote with star attribution)
+#
+# Currency formatting: The "$2.39/mo" pattern is the standard.
+#   Some locales use comma decimal ($2,39). Use the comma
+#   form if it's standard in your locale's typography.
+#
+# ============================================================
+# BRAND VOICE NOTES
+# ============================================================
+#
+# - Line 1: "The most private way to be online." — descriptive
+#   superlative ("most private" is defensible vs. "most secure"
+#   which is falsifiable). Find your locale's equivalent
+#   strongest privacy claim that doesn't open legal exposure.
+#
+# - Line 2: "Nym can't log or track you." — architectural verb
+#   (can't), not policy verb (won't). Use your locale's
+#   equivalent of cannot-by-design, not promise-not-to.
+#
+# - Line 4: The review quote is a REAL 5-star review from
+#   the App Store. It's quoted with attribution. Translators
+#   may translate the quote naturally for their locale (the
+#   quote itself can be re-translated; the attribution
+#   "★★★★★ App Store" → "* * * * * App Store" stays English
+#   as a brand-attribution element).
+#
+# Already-shipped reference (translator-finalized in 5 locales):
+#
+#   Hindi (167 chars):
+#     ऑनलाइन रहने का सबसे प्राइवेट उपाय।
+#     Nym आपके डेटा को स्टोर या ट्रैक नहीं कर सकता।
+#     7-दिन मुफ्त ट्रायल। $2.39/महीने से। क्रिप्टो, कार्ड, नकद।
+#     "सुपरचार्ज्ड Tor।" * * * * *
+#
+#   Russian (135 chars):
+#     Nym – приватность без слежки.
+#     7 дней бесплатно. От $2,39/мес.
+#     Крипта, карта, наличные.
+#     «Это как Tor на стероидах» – * * * * * App Store
+#
+#   Turkish (162 chars):
+#     Çevrim içi olmanın en gizli yolu.
+#     Nym sizi takip edemez.
+#     7 gün ücretsiz, aylık 2,39$. Kripto, kart, nakit ödeme.
+#     Tor'un güçlendirilmiş hali. – * * * * * App Store
+#
+#   Ukrainian (156 chars):
+#     Максимальна анонімність.
+#     Nym не збирає дані.
+#     7 днів тест-драйв. Від $2,39/міс. Оплата: крипта, картка, готівка.
+#     "Як Tor на стероїдах." - * * * * * App Store
+#
+#   German (162 chars):
+#     Die privateste Art, online zu sein.
+#     Nym trackt und loggt dich nicht.
+#     7 Tage kostenlos. Ab 2,39 $/Monat. Krypto, Karte, Bargeld.
+#     "Wie Tor auf Steroiden." * * * * *
+#
+# ============================================================
+# CHARACTER LIMIT GUIDANCE
+# ============================================================
+#
+# 170 characters is the hard ceiling. Each of the 4 lines
+# should be punchy enough to scan independently.
+#
+# If your translation exceeds 170, Apple App Store Connect
+# will REJECT the string. Count Unicode codepoints (emoji
+# count as 1; combining marks may count as 1 or more).
+#
+# Compression priorities if you need to cut:
+#   1. Tighten the trial line (line 3) — payment options
+#      can be abbreviated
+#   2. Drop "App Store" attribution from line 4 if needed
+#   3. Tighten line 2 (architectural claim) — but keep the
+#      "cannot" architectural framing
+#   4. Don't touch line 1 (positioning) or line 4's star
+#      pattern (social proof)
+#
+# ============================================================
+
+
+The most private way to be online.
+Nym can't log or track you.
+7-day free trial. From $2.39/mo. Crypto, card, or cash.
+"It's like Tor on steroids." — * * * * * App Store
+
+
+# ============================================================
+# END OF FILE
+# ============================================================

--- a/fastlane/metadata/android/en-US/store_images.txt
+++ b/fastlane/metadata/android/en-US/store_images.txt
@@ -1,0 +1,292 @@
+# ============================================================
+# NymVPN App Store Images — Translator Source File
+# Source language: English (en-US)
+# Last updated: 2026-05-12
+# ============================================================
+#
+# This file contains the text overlays that appear on NymVPN's
+# App Store and Google Play screenshot images. Each block below
+# corresponds to one image. The translatable string is on its
+# own line; lines starting with # are context for the translator
+# and should NOT be translated.
+#
+# ============================================================
+# UNTRANSLATABLE TERMS — keep in English exactly
+# ============================================================
+#
+# Brand and product names:
+#   NymVPN, Nym, VPN, dVPN
+#
+# Protocols and technologies:
+#   WireGuard, AmneziaWG, Mixnet, Noise Generating Mixnet,
+#   Tor, Signal, DNS, QUIC
+#
+# Cryptocurrency names:
+#   Bitcoin (BTC), Ethereum (ETH), Monero (XMR), Zcash (ZEC),
+#   USDT, USDC, NYM
+#
+# Geographic/legal terms:
+#   14 Eyes (the surveillance alliance — keep English)
+#
+# ============================================================
+# BRAND VOICE RULES
+# ============================================================
+#
+# 1. Use your locale's equivalent of "by design" — NOT
+#    "by architecture". Examples of what to aim for:
+#      German: "von Haus aus" or "durch Design"
+#      Russian: "по умолчанию" (by default in this sense)
+#      Spanish: "por diseño"
+#      French: "par conception"
+#    The technical word "architecture" as a noun (e.g., "the
+#    network architecture") is fine; only the slogan-tail
+#    pattern "X by architecture" is replaced by "X by design".
+#
+# 2. Architectural verbs preferred. When translating "can't",
+#    use the equivalent of "cannot" (architectural impossibility)
+#    rather than "won't" (policy promise). The distinction
+#    matters: NymVPN can't log/track because of how it's built,
+#    not because we promise not to.
+#
+# 3. Privacy > security as the lead claim. When choosing
+#    between equivalent locale words for "private" and
+#    "secure", lead with private.
+#
+# ============================================================
+# CHARACTER LENGTH GUIDANCE
+# ============================================================
+#
+# These strings appear as text overlays on screenshot images.
+# No hard character limits enforced by Apple/Google, BUT:
+#
+# - Each string should fit one or two visual lines in the
+#   image design. Match the English source length within
+#   approximately +/-25%.
+#
+# - If your locale naturally expands a lot (e.g., German,
+#   Bengali in formal register), prioritize the headline
+#   punch over completeness. A scannable 5-word translation
+#   beats a complete 12-word one.
+#
+# - Most images have a single translatable string. Image 6
+#   has four (one headline + three badge facts). Translate
+#   each independently — the design team handles how badge
+#   facts are visually arranged.
+#
+# ============================================================
+# STORE COVERAGE
+# ============================================================
+#
+# Images 1–8 + the image-6 badge: BOTH Apple App Store and
+#   Google Play. Translate these for all active locales.
+#
+# Images 9 and 10: APPLE APP STORE ONLY. Translate only for
+#   locales where NymVPN has an Apple App Store listing.
+#
+# ============================================================
+
+
+# ------------------------------------------------------------
+# IMAGE 1 — Hero / cover
+# ------------------------------------------------------------
+# Visual: Brand identity, NymVPN logo, main cover screenshot
+# Context: This is the first image users see in the store
+#   listing. It's the most-viewed line of text in the entire
+#   listing. Translate as a confident, descriptive brand
+#   tagline — not a feature description.
+# Tone: Confident, universal, brand-level
+
+The world's most private VPN
+
+
+# ------------------------------------------------------------
+# IMAGE 2 — Two VPN modes, one app
+# ------------------------------------------------------------
+# Visual: Screenshot of the app's mode-toggle UI. "Fast" and
+#   "Anonymous" appear as labels WITHIN the screenshot itself.
+# Context: Describes the product structure — users can choose
+#   between Fast mode (WireGuard 2-hop) and Anonymous mode
+#   (5-hop Noise Generating Mixnet) within one app.
+# Important: Do NOT translate "Fast" or "Anonymous" here —
+#   those labels are already shown in the screenshot image.
+#   This overlay text is a higher-level description.
+# Tone: Functional, product-structural
+
+Two VPN modes. One app.
+
+
+# ------------------------------------------------------------
+# IMAGE 3 — Architectural privacy claim
+# ------------------------------------------------------------
+# Visual: User browsing/streaming/chatting with a can't-track
+#   metaphor (no-eye, broken-tracking visual, etc.)
+# Context: The brand's core architectural claim — NymVPN
+#   cannot see what users do because of how the network is
+#   designed, not because of a policy promise.
+# Tone: Direct, confident, foundational brand claim
+
+Nym can't log or track you.
+
+
+# ------------------------------------------------------------
+# IMAGE 4 — No-name signup
+# ------------------------------------------------------------
+# Visual: Anonymous account creation flow / signup screen
+# Context: Three claims in a row — no email required, no
+#   name required, leaves no traceable identity.
+# Tone: Rule of three. Three short negations. Scannable.
+# Important: Preserve the three-beat rhythm in your locale
+#   if possible. If your language can't do three short
+#   negations gracefully, two punchy negations are fine.
+
+No email. No name. No trace.
+
+
+# ------------------------------------------------------------
+# IMAGE 5 — Censorship resistance (brand-aspirational)
+# ------------------------------------------------------------
+# Visual: Open-Internet metaphor / wall-piercing / freed
+#   connection. The image carries the meaning emotionally.
+# Context: This is the one image in the set with permission
+#   to be aspirational rather than transactional. Users
+#   looking at this image are typically from restricted-
+#   Internet markets and are emotionally engaged. Brand
+#   vision matters more here than feature comparison.
+# Tone: Aspirational, brand-statement. Different register
+#   from the other images.
+# Important: "Walls" is the metaphor. Preserve it if possible
+#   in your locale — it translates well to most languages and
+#   anchors the image's visual concept. If "walls" doesn't
+#   work in your locale, choose a metaphor that captures
+#   "barriers being removed" or "open access".
+
+An internet without walls.
+
+
+# ------------------------------------------------------------
+# IMAGE 6 — Decentralized network
+# ------------------------------------------------------------
+# Visual: World map with country indicators + decentralized
+#   network diagram showing distributed servers
+# Context: Decentralization is NymVPN's #1 differentiator
+#   versus centralized VPN competitors. Most VPNs route
+#   through company-owned servers; NymVPN routes through
+#   independently-operated decentralized nodes.
+# Tone: Active, agency-framing. "Pick your path" emphasizes
+#   user control.
+# Important: Keep "decentralized" prominent in the translation.
+#   In some locales this word is technical; use it anyway —
+#   it signals serious-privacy-user audience filtering.
+
+Decentralized network. Pick your path.
+
+
+# ------------------------------------------------------------
+# IMAGE 6 — Badge facts (three separate strings)
+# ------------------------------------------------------------
+# Layout: Three short claims that appear on image 6 as badge
+#   facts. Visual arrangement (separator style, horizontal
+#   row vs vertical stack, etc.) is decided at the design
+#   stage — translate each as an independent string.
+# Context: Quick proof points — global reach, multi-device
+#   support, single anonymous subscription.
+
+# Badge fact 1 of 3:
+70+ countries
+
+# Badge fact 2 of 3:
+10 devices
+
+# Badge fact 3 of 3:
+1 account
+
+
+# ------------------------------------------------------------
+# IMAGE 7 — Advanced privacy controls
+# ------------------------------------------------------------
+# Visual: Settings panel showing split tunneling toggle and
+#   custom DNS field
+# Context: Power-user features. "Split tunneling" lets users
+#   route only chosen apps through the VPN. "Custom DNS"
+#   lets users select their own DNS resolver.
+# Tone: Functional, agency-framing
+# Important: "Split tunneling" and "custom DNS" can stay in
+#   English in many locales (they're technical terms that
+#   power users search in English). If your locale has
+#   widely-used native equivalents, use those instead.
+
+Control your privacy: split tunneling and custom DNS.
+
+
+# ------------------------------------------------------------
+# IMAGE 8 — Ad and tracker blocker
+# ------------------------------------------------------------
+# Visual: Blocked ads / clean-interface comparison
+# Context: NymVPN includes an optional ad and tracker
+#   blocker that works across all apps on the device
+#   (not just the browser).
+# Tone: Active verb, universal benefit. "Every app" is the
+#   differentiator vs browser-only ad blockers.
+# Important: Don't translate "block" as "remove" or "delete" —
+#   "block" is the active marketing verb.
+
+Block ads and trackers in every app.
+
+
+# ============================================================
+# APPLE APP STORE ONLY — Images 9 and 10
+# ============================================================
+
+
+# ------------------------------------------------------------
+# IMAGE 9 — Best VPN for crypto (APPLE ONLY)
+# ------------------------------------------------------------
+# Visual: Cryptocurrency logos (Bitcoin, Ethereum, Monero,
+#   Zcash, NYM, USDT, USDC) arranged around the headline
+# Context: Crypto-friendly positioning. NymVPN accepts more
+#   cryptocurrencies than any other VPN. This image targets
+#   the crypto-VPN search audience specifically.
+# Tone: Declarative claim
+# Important: "Best VPN for crypto" is a deliberate SEO
+#   keyword phrase that mirrors how crypto users search.
+#   Translate as the equivalent search-keyword phrase in
+#   your locale — what would a crypto user type into the
+#   App Store search? Use that phrase. Don't translate
+#   word-for-word if your locale's natural search phrase
+#   is different.
+
+Best VPN for crypto.
+
+
+# ------------------------------------------------------------
+# IMAGE 10 — Trust signals (APPLE ONLY)
+# ------------------------------------------------------------
+# Visual: Swiss flag + open-source badge + audit certificate
+#   visual elements
+# Context: Three short verifiable trust claims. Final image
+#   in the Apple App Store screenshot scroll — the closer.
+# Tone: Three staccato facts, period-separated.
+# Layout: Three short clauses. Each scans as its own beat.
+# Important: Preserve the three-beat structure. Each clause
+#   should be short enough to scan in under one second.
+
+Swiss-built. Open source. Independently audited.
+
+
+# ============================================================
+# END OF FILE
+# ============================================================
+#
+# Questions? Direct to: casey@nymtech.net
+#
+# When you're done translating:
+#   1. Keep all the # comments unchanged (don't translate them)
+#   2. Translate only the non-# lines
+#   3. Match the line structure exactly — each image has
+#      a fixed number of translatable lines (most have one;
+#      image 6 has four: headline + 3 badge facts)
+#   4. If a string doesn't fit visually in your locale,
+#      flag it in the Crowdin comment field so Casey can
+#      review with the designer
+#
+# ============================================================

--- a/fastlane/metadata/android/en-US/subtitle.txt
+++ b/fastlane/metadata/android/en-US/subtitle.txt
@@ -1,0 +1,87 @@
+# ============================================================
+# NymVPN Apple App Store — Subtitle (English source)
+# Source language: English (en-US)
+# Last updated: 2026-05-12
+# ============================================================
+#
+# This file contains the Apple App Store subtitle for NymVPN.
+# Lines starting with # are context for the translator and
+# should NOT be translated. The translatable string is the
+# single line at the bottom.
+#
+# ============================================================
+# FIELD SPEC
+# ============================================================
+#
+# Field: Apple App Store subtitle
+# Character limit: 30 characters (HARD LIMIT — Apple enforces)
+# Indexed for ASO: YES — subtitle is one of Apple's highest-
+#   weighted search-ranking fields
+# Editable without resubmission: NO — subtitle changes ship
+#   with a new app version
+#
+# Position in listing: Appears directly below the app title
+#   in the App Store. One of the first three lines a user
+#   sees when they land on the listing.
+#
+# ============================================================
+# UNTRANSLATABLE TERMS — keep in English exactly
+# ============================================================
+#
+#   dVPN  (brand category term)
+#
+# Other product terms can be translated to your locale's
+# natural equivalent (e.g., "Swiss" → your word for Swiss,
+# "Email" → your word for email, "Private" → privacy-leaning
+# adjective in your locale).
+#
+# ============================================================
+# BRAND VOICE NOTES
+# ============================================================
+#
+# - "Private" leads, not "Secure". Privacy is the falsifiable-
+#   resistant claim and the brand's primary positioning.
+# - "Swiss" carries the jurisdictional trust signal —
+#   preserve it (geographic anchor for serious privacy users).
+# - "No Email" is the no-data-collection differentiator.
+#
+# ============================================================
+# CHARACTER LIMIT GUIDANCE
+# ============================================================
+#
+# 30 characters is TIGHT. Many locales will need to drop
+# one of the four concepts (Private / Swiss / dVPN / No Email)
+# to fit. Drop priority (lowest-value first):
+#   1. "No Email" if forced (the long description carries this)
+#   2. "Swiss" if forced (sub-line credibility, can live elsewhere)
+#   3. "Private" — only drop if your locale has a stronger word
+#      that combines private + secure (some Slavic languages do)
+#   4. "dVPN" — NEVER drop. Category-defining term.
+#
+# Already-shipped examples (for reference / consistency):
+#   German:    Privater dVPN, ohne E-Mail
+#   Russian:   Швейцарский dVPN без логов
+#   Ukrainian: Швейцарський dVPN без логів
+#   Turkish:   Özel İsviçre dVPN, e-posta yok
+#   Spanish:   dVPN Suiza Privada, Sin Email
+#   Hindi:     प्राइवेट स्विस dVPN, बिना ईमेल
+#   Chinese:   瑞士隐私 dVPN，免邮箱注册
+#
+# ============================================================
+# COUNT YOUR CHARACTERS BEFORE DELIVERING
+# ============================================================
+#
+# Apple counts Unicode codepoints. Emoji and combining marks
+# generally count as 1. If your translation exceeds 30, the
+# Apple App Store Connect submission will REJECT the string.
+# Count carefully.
+#
+# ============================================================
+
+
+Private Swiss dVPN, No Email
+
+
+# ============================================================
+# END OF FILE
+# ============================================================


### PR DESCRIPTION
## What this adds

Three new translator source files for Crowdin pickup:

- `fastlane/metadata/android/en-US/subtitle.txt` — Apple App Store subtitle (30 chars max, ASO-indexed, ships with new app version)
- `fastlane/metadata/android/en-US/promotional_text.txt` — Apple App Store promotional text (170 chars max, not indexed, editable in App Store Connect without resubmission)
- `fastlane/metadata/android/en-US/store_images.txt` — text overlays on the 10 App Store / Google Play screenshot images (8 shared + 2 Apple-only)

Each file includes inline context comments for translators (untranslatable terms, brand voice rules, char-limit guidance). Crowdin's plain-text parser should be configured to treat `#`-prefixed lines as comments so they don't appear as translatable strings.

## Why under `android/en-US/`

These are translator source files, not Fastlane upload targets for Android. Putting them under the existing en-US directory keeps all en-US Crowdin sources together, and Crowdin's existing config picks them up automatically.

The directory name is slightly misleading semantically (Apple files in an "android" folder) but pragmatically simpler than establishing a new `fastlane/metadata/ios/` tree for files that don't currently feed Fastlane. Can be reorganized later if/when iOS Fastlane metadata gets wired up.

## Translator workflow after merge

1. Crowdin picks up new source files on next sync
2. Translators see context inline (Crowdin renders the `#` comments as string descriptions when parser is configured; or they read the file directly)
3. Translations land per-locale in the existing `fastlane/metadata/android/{locale}/` structure
4. Per-locale strings get applied:
   - Apple subtitle → manually via App Store Connect at next iOS release
   - Apple promo text → manually via App Store Connect any time (no resubmission needed)
   - Store image overlays → handed to design team for image asset production

No Fastlane upload behavior changes from this PR. Source-only.

## QA before merging

Worth confirming with whoever runs the Crowdin config:
- [ ] Plain-text parser configured to strip `#` comments (or the strings will include the comment blocks as translatable content)
- [ ] New source files appear in Crowdin after next sync
- [ ] Existing translator capacity covers the new strings (small additional translation load per locale — three short files)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5259)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated app store listing metadata including promotional messaging, image descriptions, and subtitle to enhance app presentation across app marketplaces.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nymtech/nym-vpn-client/pull/5259)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->