### PR TITLE
Turn off Geo Exclusion by default.

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/service.rs
@@ -549,8 +549,8 @@ impl fmt::Display for GeoExclusionSettings {
 
 impl Default for GeoExclusionSettings {
     fn default() -> Self {
-        // Temporary, until there is a way to turn Geo Exclusion on.
-        let enabled = true;
+        // Temporary, until there is a way to turn Geo Exclusion on or off.
+        let enabled = false;
         Self {
             enabled,
             listen_port: 1080,


### PR DESCRIPTION
Geo Exclusion is turned off, by default, in release as there is no way to turn it on yet.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5264)
<!-- Reviewable:end -->
