### PR TITLE
Stop reloading adblock between reconnects

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/logging.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/logging.rs
@@ -39,10 +39,11 @@ pub const DEFAULT_OLD_LOG_FILE: &str = "nym-vpnd.old.log";
 /// hickory resolver when configured for use with client traffic can log DNS lookups at the DEBUG
 /// level. We do not want information related to client traffic logged except in controlled trace
 /// situations (away from platform apps).
-static TRACE_ONLY_LOGGING: [&str; 2] = [
+static TRACE_ONLY_LOGGING: [&str; 3] = [
     "hickory_resolver",
     // proto is probably okay, but disabling for now.
     "hickory_proto",
+    "hickory_net",
 ];
 
 static INFO_TARGETS: [&str; 13] = [

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -366,8 +366,11 @@ impl TunnelSettingsDiffFields {
             | Self::ExitPoint
             | Self::GatewayPerformanceOptions
             | Self::Dns => true,
+            Self::EnableAdBlocking => {
+                // On android reconnect is necessary due to packet filtering used for adblocking.
+                cfg!(target_os = "android")
+            }
             Self::AllowLan
-            | Self::EnableAdBlocking
             | Self::SplitTunnel
             | Self::GeoExclusion
             | Self::GeoExclusionEnabled
@@ -1005,6 +1008,9 @@ impl TunnelStateMachine {
             nym_config.data_path.join("ad-blocking"),
             user_agent.to_string(),
         );
+        if tunnel_settings.enable_ad_blocking {
+            adblocker.enable().await;
+        }
 
         #[cfg(not(target_os = "android"))]
         {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
@@ -125,12 +125,7 @@ impl ConnectedState {
             .await;
         }
 
-        #[cfg(target_os = "android")]
-        shared_state
-            .enable_ad_blocking(shared_state.tunnel_settings.enable_ad_blocking)
-            .await;
-
-        #[cfg(target_os = "ios")]
+        #[cfg(any(target_os = "android", target_os = "ios"))]
         let _ = shared_state; // Avoid unused variable warning
 
         (
@@ -188,10 +183,6 @@ impl ConnectedState {
                     .await
                     .map_err(Error::SetDns)?;
             }
-
-            if shared_state.tunnel_settings.enable_ad_blocking {
-                shared_state.enable_ad_blocking(true).await;
-            }
         } else {
             #[cfg(not(any(target_os = "android", target_os = "ios")))]
             {
@@ -210,7 +201,6 @@ impl ConnectedState {
     #[cfg(not(target_os = "android"))]
     async fn reset_dns(shared_state: &mut SharedState) {
         if *LOCAL_DNS_RESOLVER {
-            shared_state.enable_ad_blocking(false).await;
             if let Err(err) = shared_state.filtering_resolver.disable_forward().await {
                 trace_err_chain!(err, "failed to disable dns forwarding");
             }
@@ -362,7 +352,6 @@ impl TunnelStateHandler for ConnectedState {
                                 .await;
                         }
 
-                        #[cfg(not(target_os = "ios"))]
                         if diff.enable_ad_blocking_changed() {
                             shared_state.enable_ad_blocking(shared_state.tunnel_settings.enable_ad_blocking).await;
                         }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -782,6 +782,10 @@ impl TunnelStateHandler for ConnectingState {
                                 .await;
                         }
 
+                        if diff.enable_ad_blocking_changed() {
+                            shared_state.enable_ad_blocking(shared_state.tunnel_settings.enable_ad_blocking).await;
+                        }
+
                         #[cfg(not(any(target_os = "android", target_os = "ios")))]
                         {
                             if new_firewall_policy != self.firewall_policy_params {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnected_state.rs
@@ -84,27 +84,24 @@ impl TunnelStateHandler for DisconnectedState {
                     },
                     TunnelCommand::Disconnect => NextTunnelState::SameState(self),
                     TunnelCommand::SetTunnelSettings(tunnel_settings) => {
-                        #[cfg(not(target_os = "ios"))]
-                        {
-                            let Some(diff) = shared_state.tunnel_settings.diff(&tunnel_settings) else {
-                                return NextTunnelState::SameState(self);
-                            };
+                        let Some(diff) = shared_state.tunnel_settings.diff(&tunnel_settings) else {
+                            return NextTunnelState::SameState(self);
+                        };
 
-                            shared_state.set_tunnel_settings(tunnel_settings).await;
+                        shared_state.set_tunnel_settings(tunnel_settings).await;
 
-                            #[cfg(any(target_os = "macos", target_os = "windows"))]
-                            if diff.split_tunnel_changed() || diff.geo_exclusion_enabled_changed() {
-                                let _ = shared_state.set_split_tunnel_exclude_paths().await;
-                            }
-
-                            if diff.geo_exclusion_enabled_changed() {
-                                shared_state.start_or_stop_socks5_proxy().await;
-                            }
+                        #[cfg(any(target_os = "macos", target_os = "windows"))]
+                        if diff.split_tunnel_changed() || diff.geo_exclusion_enabled_changed() {
+                            let _ = shared_state.set_split_tunnel_exclude_paths().await;
                         }
 
-                        #[cfg(target_os = "ios")]
-                        {
-                            shared_state.set_tunnel_settings(tunnel_settings).await;
+                        #[cfg(not(target_os = "ios"))]
+                        if diff.geo_exclusion_enabled_changed() {
+                            shared_state.start_or_stop_socks5_proxy().await;
+                        }
+
+                        if diff.enable_ad_blocking_changed() {
+                            shared_state.enable_ad_blocking(shared_state.tunnel_settings.enable_ad_blocking).await;
                         }
 
                         NextTunnelState::SameState(self)

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnecting_state.rs
@@ -111,27 +111,24 @@ impl TunnelStateHandler for DisconnectingState {
                         NextTunnelState::SameState(self)
                     }
                     TunnelCommand::SetTunnelSettings(tunnel_settings) => {
-                        #[cfg(not(target_os = "ios"))]
-                        {
-                            let Some(diff) = shared_state.tunnel_settings.diff(&tunnel_settings) else {
-                                return NextTunnelState::SameState(self);
-                            };
+                        let Some(diff) = shared_state.tunnel_settings.diff(&tunnel_settings) else {
+                            return NextTunnelState::SameState(self);
+                        };
 
-                            shared_state.set_tunnel_settings(tunnel_settings).await;
+                        shared_state.set_tunnel_settings(tunnel_settings).await;
 
-                            #[cfg(any(target_os = "macos", target_os = "windows"))]
-                            if diff.split_tunnel_changed() || diff.geo_exclusion_enabled_changed() {
-                                let _ = shared_state.set_split_tunnel_exclude_paths().await;
-                            }
-
-                            if diff.geo_exclusion_enabled_changed() {
-                                shared_state.start_or_stop_socks5_proxy().await;
-                            }
+                        #[cfg(any(target_os = "macos", target_os = "windows"))]
+                        if diff.split_tunnel_changed() || diff.geo_exclusion_enabled_changed() {
+                            let _ = shared_state.set_split_tunnel_exclude_paths().await;
                         }
 
-                        #[cfg(target_os = "ios")]
-                        {
-                            shared_state.set_tunnel_settings(tunnel_settings).await;
+                        #[cfg(not(target_os = "ios"))]
+                        if diff.geo_exclusion_enabled_changed() {
+                            shared_state.start_or_stop_socks5_proxy().await;
+                        }
+
+                        if diff.enable_ad_blocking_changed() {
+                            shared_state.enable_ad_blocking(shared_state.tunnel_settings.enable_ad_blocking).await;
                         }
 
                         NextTunnelState::SameState(self)

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
@@ -202,36 +202,33 @@ impl TunnelStateHandler for ErrorState {
                         }
                     },
                     TunnelCommand::SetTunnelSettings(tunnel_settings) => {
-                        #[cfg(not(target_os = "ios"))]
-                        {
-                            let Some(diff) = shared_state.tunnel_settings.diff(&tunnel_settings) else {
-                                return NextTunnelState::SameState(self);
-                            };
+                        let Some(diff) = shared_state.tunnel_settings.diff(&tunnel_settings) else {
+                            return NextTunnelState::SameState(self);
+                        };
 
-                            shared_state.set_tunnel_settings(tunnel_settings).await;
+                        shared_state.set_tunnel_settings(tunnel_settings).await;
 
-                            #[cfg(any(target_os = "macos", target_os = "windows"))]
-                            if diff.split_tunnel_changed() || diff.geo_exclusion_enabled_changed() {
-                                let _ = shared_state.set_split_tunnel_exclude_paths().await;
-                            }
-
-                            if diff.geo_exclusion_enabled_changed() {
-                                shared_state.start_or_stop_socks5_proxy().await;
-                            }
-
-                            #[cfg(not(any(target_os = "android", target_os = "ios")))]
-                            if diff.allow_lan_changed() {
-                                self.firewall_policy_params.allow_lan = shared_state.tunnel_settings.allow_lan;
-
-                                if let Err(e) = Self::set_firewall_policy(shared_state, &self.firewall_policy_params) {
-                                    trace_err_chain!(e, "failed to set firewall policy");
-                                }
-                            }
+                        #[cfg(any(target_os = "macos", target_os = "windows"))]
+                        if diff.split_tunnel_changed() || diff.geo_exclusion_enabled_changed() {
+                            let _ = shared_state.set_split_tunnel_exclude_paths().await;
                         }
 
-                        #[cfg(target_os = "ios")]
-                        {
-                            shared_state.set_tunnel_settings(tunnel_settings).await;
+                        #[cfg(not(target_os = "ios"))]
+                        if diff.geo_exclusion_enabled_changed() {
+                            shared_state.start_or_stop_socks5_proxy().await;
+                        }
+
+                        if diff.enable_ad_blocking_changed() {
+                            shared_state.enable_ad_blocking(shared_state.tunnel_settings.enable_ad_blocking).await;
+                        }
+
+                        #[cfg(not(any(target_os = "android", target_os = "ios")))]
+                        if diff.allow_lan_changed() {
+                            self.firewall_policy_params.allow_lan = shared_state.tunnel_settings.allow_lan;
+
+                            if let Err(e) = Self::set_firewall_policy(shared_state, &self.firewall_policy_params) {
+                                trace_err_chain!(e, "failed to set firewall policy");
+                            }
                         }
 
                         NextTunnelState::SameState(self)

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/offline_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/offline_state.rs
@@ -158,6 +158,10 @@ impl TunnelStateHandler for OfflineState {
                                 .await;
                         }
 
+                        if diff.enable_ad_blocking_changed() {
+                            shared_state.enable_ad_blocking(shared_state.tunnel_settings.enable_ad_blocking).await;
+                        }
+
                         #[cfg(not(any(target_os = "android", target_os = "ios")))]
                         {
                             if diff.allow_lan_changed() {

--- a/nym-vpn-core/crates/nym-vpnc/src/commands/ad_block.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/commands/ad_block.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use anyhow::Result;
+use clap::builder::ValueParserFactory;
 
 use nym_vpn_proto::rpc_client::RpcClient;
 
@@ -15,7 +16,7 @@ pub enum Command {
     /// Set Ad blocking state
     Set {
         /// Enable or disable Ad blocking
-        #[arg(value_parser = BooleanOption::custom_parser("enabled", "disabled"))]
+        #[arg(value_parser = BooleanOption::value_parser())]
         enabled: BooleanOption,
     },
 }

--- a/nym-vpn-core/crates/nym-vpnc/src/commands/ad_block.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/commands/ad_block.rs
@@ -29,9 +29,9 @@ impl Command {
                 println!(
                     "Ad blocking: {}",
                     if config.enable_ad_blocking {
-                        "enabled"
+                        "on"
                     } else {
-                        "disabled"
+                        "off"
                     }
                 );
                 Ok(())

--- a/nym-vpn-core/crates/nym-vpnc/src/commands/geo_exclusion.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/commands/geo_exclusion.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use anyhow::Result;
+use clap::builder::ValueParserFactory;
 use nym_vpn_proto::rpc_client::RpcClient;
 
 use crate::boolean_option::BooleanOption;
@@ -23,7 +24,7 @@ pub enum SetCommand {
     /// Enable or disable Geo Exclusion
     Enabled {
         /// Enable or disable Geo Exclusion
-        #[arg(value_parser = BooleanOption::custom_parser("on", "off"))]
+        #[arg(value_parser = BooleanOption::value_parser())]
         enable: BooleanOption,
     },
 

--- a/nym-vpn-core/crates/nym-vpnc/src/commands/split_tunnel.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/commands/split_tunnel.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use anyhow::Result;
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 use clap::builder::ValueParserFactory;
 
 #[cfg(any(target_os = "macos", target_os = "windows"))]

--- a/nym-vpn-core/crates/nym-vpnc/src/commands/split_tunnel.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/commands/split_tunnel.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use anyhow::Result;
+use clap::builder::ValueParserFactory;
 
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 use nym_vpn_lib_types::SplitApp;
@@ -19,7 +20,7 @@ pub enum Command {
     #[cfg(any(target_os = "macos", target_os = "windows"))]
     Set {
         /// Enable or disable split tunnel
-        #[arg(value_parser = BooleanOption::custom_parser("on", "off"))]
+        #[arg(value_parser = BooleanOption::value_parser())]
         enable: BooleanOption,
     },
 

--- a/nym-vpn-core/crates/nym-vpnc/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/main.rs
@@ -82,6 +82,7 @@ pub enum Command {
     },
 
     /// Ad blocking
+    #[clap(alias = "adblock")]
     AdBlock {
         #[command(subcommand)]
         subcommand: commands::ad_block::Command,


### PR DESCRIPTION
## Ticket

JIRA-NYM-1271

## Description

1. There is no reason to reload adblock in connected state since it's directly connected to dns resolver which is disabled outside of connected state anyway
2. Android: automatically reconnect on changes to adblock
3. Use `BooleanOption::value_parser()` as a shortcut for `on, off`
4. Add `adblock` without hyphen as alias for `nym-vpnc ad-block`
5. Replace ad-block `enabled, disabled` with `on, off`

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5266)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI alias `adblock` for the ad-blocking command.

* **Bug Fixes**
  * Improved ad-blocking conditional enablement and platform-specific behavior.
  * Enhanced handling of ad-blocking changes during connection state transitions.

* **Chores**
  * Refactored tunnel state machine platform-specific logic for consistency.
  * Updated CLI argument parsing for boolean options.
  * Extended trace-level logging support.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nymtech/nym-vpn-client/pull/5266)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->