### PR TITLE
[Android] Remove reconnect for Ad-blocking on Android side

### DIFF
--- a/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/controller/VpnCoreController.kt
+++ b/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/controller/VpnCoreController.kt
@@ -371,8 +371,7 @@ class VpnCoreController(
 
 		val tunSettingsChanged = force ||
 			prev?.bypassLan != cfg.bypassLan ||
-			prev.restrictedApps != cfg.restrictedApps ||
-			prev.adBlockingEnabled != cfg.adBlockingEnabled
+			prev.restrictedApps != cfg.restrictedApps
 
 		syncLocalFieldsFromConfig(cfg)
 


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

Remove reconnect trigger for Ad-blocking option change on Android side


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5269)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ad-blocking settings can now be toggled without triggering unnecessary VPN reconnections.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nymtech/nym-vpn-client/pull/5269)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->