### PR TITLE
[Android] Allow back navigation from revealed passphrase screen

### DIFF
--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/account/passphrase/PassphraseScreen.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/account/passphrase/PassphraseScreen.kt
@@ -3,7 +3,6 @@ package net.nymtech.nymvpn.ui.screens.account.passphrase
 import android.app.Activity
 import android.content.ClipData
 import android.content.Intent
-import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.clickable
@@ -113,8 +112,6 @@ fun PassphraseScreen(onBackButtonVisibilityChange: (Boolean) -> Unit, navBarEven
 	val promptInfo = remember(context) {
 		DeviceAuthHelper.buildPromptInfo(context, title = title, subtitle = subtitle)
 	}
-
-	BackHandler(enabled = showSheet) { }
 
 	LaunchedEffect(showSheet) {
 		onBackButtonVisibilityChange(showSheet)


### PR DESCRIPTION
  The BackHandler swallowed back presses (including the predictive-back
  swipe) while the mnemonic was visible, leaving "Continue" as the only
  exit. Drop it so users can swipe/back out to Settings; the existing
  `remember { showSheet = false }` forces re-authentication if they
  return.

  A user might want to cancel his action and rather come back later
  to make the backup of the mnemonic and indeed confirm it was done
  correctly. Currently the user is blocked into confirming something
  he might not have done.

## Ticket

JIRA-NYM-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5276)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved back-navigation handling implementation on the passphrase screen for better reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nymtech/nym-vpn-client/pull/5276)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->