### PR TITLE
Use the correct `winfw` artifact.

### DIFF
--- a/.github/workflows/ci-nym-vpn-core-windows.yml
+++ b/.github/workflows/ci-nym-vpn-core-windows.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Download winfw artifacts
         uses: actions/download-artifact@v8
         with:
-          name: winfw
+          name: winfw_x64
           path: ${{ env.WINFW_PATH }}
 
       - name: Download st-driver artifacts


### PR DESCRIPTION
Fix the winfw artifact name.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5277)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Windows build artifact handling for enhanced version management.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nymtech/nym-vpn-client/pull/5277)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->