### PR TITLE
[Android] Build libwg.so with 16K page alignment

### DIFF
--- a/wireguard/libwg/Android.mk
+++ b/wireguard/libwg/Android.mk
@@ -13,7 +13,7 @@ NDK_GO_ARCH_MAP_mips := mipsx
 NDK_GO_ARCH_MAP_mips64 := mips64x
 
 export CGO_CFLAGS := $(CFLAGS)
-export CGO_LDFLAGS := $(LDFLAGS)
+export CGO_LDFLAGS := $(LDFLAGS) -Wl,-z,max-page-size=16384
 export CC := $(ANDROID_C_COMPILER)
 export GOARCH := $(NDK_GO_ARCH_MAP_$(ANDROID_ARCH_NAME))
 export GOOS := android


### PR DESCRIPTION
## Description

  Pass -Wl,-z,max-page-size=16384 via CGO_LDFLAGS so wireguard-go's
  LOAD segments are aligned for Android 15+ devices with 16K page
  sizes (Pixel 8+, GrapheneOS). 4K-page devices are unaffected; the
  only cost is a few KB of segment padding per ABI.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5280)
<!-- Reviewable:end -->
