### PR TITLE
Remove superficial `Option` when returning settings diff

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/resolver/tests.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/resolver/tests.rs
@@ -4,10 +4,10 @@
 
 use std::net::SocketAddr;
 
-use super::*;
-use hickory_resolver::config::{ConnectionConfig, ProtocolConfig};
 use hickory_server::resolver::{TokioResolver, config::ResolverConfig};
 use tokio_util::sync::CancellationToken;
+
+use super::*;
 
 /// Test whether we can successfully bind the socket even if the address is already used in
 /// different scenarios.

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -243,7 +243,7 @@ impl TunnelSettings {
             && self.wireguard_tunnel_options.enable_bridges
     }
 
-    pub fn diff(&self, other: &Self) -> Option<TunnelSettingsDiff> {
+    pub fn diff(&self, other: &Self) -> TunnelSettingsDiff {
         let mut diff = TunnelSettingsDiff::default();
 
         if self.enable_ipv6 != other.enable_ipv6 {
@@ -326,7 +326,7 @@ impl TunnelSettings {
             diff.add(TunnelSettingsDiffFields::GatewaySelectionAlgorithm);
         }
 
-        if diff.is_empty() { None } else { Some(diff) }
+        diff
     }
 }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
@@ -298,9 +298,10 @@ impl TunnelStateHandler for ConnectedState {
                         self.disconnect(PrivateActionAfterDisconnect::Nothing, shared_state).await
                     },
                     TunnelCommand::SetTunnelSettings(tunnel_settings) => {
-                        let Some(diff) = shared_state.tunnel_settings.diff(&tunnel_settings) else {
+                        let diff = shared_state.tunnel_settings.diff(&tunnel_settings);
+                        if diff.is_empty() {
                             return NextTunnelState::SameState(self);
-                        };
+                        }
                         shared_state.set_tunnel_settings(tunnel_settings).await;
 
                         #[cfg(not(any(target_os = "android", target_os = "ios")))]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -728,9 +728,10 @@ impl TunnelStateHandler for ConnectingState {
                         self.disconnect(PrivateActionAfterDisconnect::Nothing, shared_state).await
                     },
                     TunnelCommand::SetTunnelSettings(tunnel_settings) => {
-                        let Some(diff) = shared_state.tunnel_settings.diff(&tunnel_settings) else {
+                        let diff = shared_state.tunnel_settings.diff(&tunnel_settings);
+                        if diff.is_empty() {
                             return NextTunnelState::SameState(self);
-                        };
+                        }
                         shared_state.set_tunnel_settings(tunnel_settings).await;
 
                         #[cfg(not(any(target_os = "android", target_os = "ios")))]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnected_state.rs
@@ -84,9 +84,10 @@ impl TunnelStateHandler for DisconnectedState {
                     },
                     TunnelCommand::Disconnect => NextTunnelState::SameState(self),
                     TunnelCommand::SetTunnelSettings(tunnel_settings) => {
-                        let Some(diff) = shared_state.tunnel_settings.diff(&tunnel_settings) else {
+                        let diff = shared_state.tunnel_settings.diff(&tunnel_settings);
+                        if diff.is_empty() {
                             return NextTunnelState::SameState(self);
-                        };
+                        }
 
                         shared_state.set_tunnel_settings(tunnel_settings).await;
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnecting_state.rs
@@ -111,9 +111,10 @@ impl TunnelStateHandler for DisconnectingState {
                         NextTunnelState::SameState(self)
                     }
                     TunnelCommand::SetTunnelSettings(tunnel_settings) => {
-                        let Some(diff) = shared_state.tunnel_settings.diff(&tunnel_settings) else {
+                        let diff = shared_state.tunnel_settings.diff(&tunnel_settings);
+                        if diff.is_empty() {
                             return NextTunnelState::SameState(self);
-                        };
+                        }
 
                         shared_state.set_tunnel_settings(tunnel_settings).await;
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
@@ -202,9 +202,10 @@ impl TunnelStateHandler for ErrorState {
                         }
                     },
                     TunnelCommand::SetTunnelSettings(tunnel_settings) => {
-                        let Some(diff) = shared_state.tunnel_settings.diff(&tunnel_settings) else {
+                        let diff = shared_state.tunnel_settings.diff(&tunnel_settings);
+                        if diff.is_empty() {
                             return NextTunnelState::SameState(self);
-                        };
+                        }
 
                         shared_state.set_tunnel_settings(tunnel_settings).await;
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/offline_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/offline_state.rs
@@ -141,9 +141,11 @@ impl TunnelStateHandler for OfflineState {
                         }
                     },
                     TunnelCommand::SetTunnelSettings(tunnel_settings) => {
-                        let Some(diff) = shared_state.tunnel_settings.diff(&tunnel_settings) else {
+                        let diff = shared_state.tunnel_settings.diff(&tunnel_settings);
+                        if diff.is_empty() {
                             return NextTunnelState::SameState(self);
-                        };
+                        }
+
                         shared_state.set_tunnel_settings(tunnel_settings).await;
 
                         #[cfg(any(target_os = "macos", target_os = "windows"))]


### PR DESCRIPTION


## Description

- Remove superficial `Option` when returning settings diff
- Removed unused imports from resolver test.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5281)
<!-- Reviewable:end -->
