### PR TITLE
re-order default discovery API urls

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-network-config/default/mainnet_discovery.json
+++ b/nym-vpn-core/crates/nym-vpn-network-config/default/mainnet_discovery.json
@@ -17,6 +17,9 @@
   "nym_vpn_api_url": "https://nymvpn.com/api/",
   "nym_vpn_api_urls": [
     {
+      "url": "https://nymvpn.com/api/"
+    },
+    {
       "url": "https://nymvpn-frontdoor.global.ssl.fastly.net/api/",
       "fronts": ["yelp.global.ssl.fastly.net"]
     },

--- a/nym-vpn-core/crates/nym-vpn-network-config/default/mainnet_discovery.json
+++ b/nym-vpn-core/crates/nym-vpn-network-config/default/mainnet_discovery.json
@@ -6,23 +6,23 @@
       "url": "https://validator.nymtech.net/api/"
     },
     {
-      "url": "https://nym-frontdoor.vercel.app/api/",
-      "fronts": ["vercel.app", "vercel.com"]
-    },
-    {
       "url": "https://nym-frontdoor.global.ssl.fastly.net/api/",
       "fronts": ["yelp.global.ssl.fastly.net"]
+    },
+    {
+      "url": "https://nym-frontdoor.vercel.app/api/",
+      "fronts": ["vercel.app", "vercel.com"]
     }
   ],
   "nym_vpn_api_url": "https://nymvpn.com/api/",
   "nym_vpn_api_urls": [
     {
-      "url": "https://nymvpn.com/api/",
-      "fronts": ["vercel.app", "vercel.com"]
-    },
-    {
       "url": "https://nymvpn-frontdoor.global.ssl.fastly.net/api",
       "fronts": ["yelp.global.ssl.fastly.net"]
+    },
+    {
+      "url": "https://nymvpn.com/api/",
+      "fronts": ["vercel.app", "vercel.com"]
     }
   ],
   "account_management": {

--- a/nym-vpn-core/crates/nym-vpn-network-config/default/mainnet_discovery.json
+++ b/nym-vpn-core/crates/nym-vpn-network-config/default/mainnet_discovery.json
@@ -17,7 +17,7 @@
   "nym_vpn_api_url": "https://nymvpn.com/api/",
   "nym_vpn_api_urls": [
     {
-      "url": "https://nymvpn-frontdoor.global.ssl.fastly.net/api",
+      "url": "https://nymvpn-frontdoor.global.ssl.fastly.net/api/",
       "fronts": ["yelp.global.ssl.fastly.net"]
     },
     {


### PR DESCRIPTION
## Ticket

NYM-1310

## Description

Promote the API resources using Fastly to have priority over Vercel while we investigate performace related improvements for vercel services

## Changelog
- [x] Prioritise Fastly API resources over Vercel in default discovery info for the mainnet env 

@coderabbitai ignore

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5283)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated mainnet network discovery endpoint configuration by reordering API service provider lists and refining endpoint URL formatting. These changes enhance service selection sequence and improve connection reliability for more stable network access.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nymtech/nym-vpn-client/pull/5283)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->