### PR TITLE
ANDROID: center spinner in autologin loading dialog

### DIFF
--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/account/info/modal/AutologinLoadingDialog.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/account/info/modal/AutologinLoadingDialog.kt
@@ -37,7 +37,7 @@ fun AutologinLoadingDialog(onCancel: () -> Unit) {
 				modifier = Modifier.fillMaxWidth(),
 			) {
 				CircularProgressIndicator(
-					modifier = Modifier.size(24.dp).padding(end = 12.dp),
+					modifier = Modifier.padding(end = 12.dp).size(24.dp),
 					strokeWidth = 2.dp,
 				)
 				Text(


### PR DESCRIPTION
  Swap modifier order on the CircularProgressIndicator so the 12dp end
  padding sits outside the 24dp size constraint. Previously the padding
  was applied inside the size box, squishing the spinner into the left
  half of its bounds and making it appear off-center next to the
  "Loading" text.

## Ticket

JIRA-NYM-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5287)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the spacing and sizing layout of the loading spinner in the autologin dialog.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nymtech/nym-vpn-client/pull/5287)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->