### PR TITLE
NYM-1317: Simplify Tauri updater logic.

### DIFF
--- a/.github/workflows/build-nym-vpn-app-windows.yml
+++ b/.github/workflows/build-nym-vpn-app-windows.yml
@@ -51,11 +51,6 @@ on:
           - stable
           - dev
         default: dev
-      dev_build:
-        description: 'dev build'
-        required: false
-        type: boolean
-        default: false
   workflow_call:
     inputs:
       cpu_arch:
@@ -89,10 +84,6 @@ on:
         required: false
         type: string
         default: dev
-      dev_build:
-        required: false
-        type: boolean
-        default: false
     secrets:
       SSL_COM_USERNAME:
         required: true
@@ -398,7 +389,7 @@ jobs:
           $nsisDir = "target/" + $(if ($env:TAURI_TARGET) { "$env:TAURI_TARGET/" }) + "release/bundle/nsis"
           if ($env:UPDATER_ENABLED -eq 'true') { Write-Host "Updater endpoint: $env:UPDATER_ENDPOINT" }
           $updaterArgs = if ($env:UPDATER_ENABLED -eq 'true') { @('--config', 'src-tauri/updater.conf.json') } else { @() }
-          $devBuildArgs = if ('${{ inputs.dev_build }}' -eq 'true') { @('--config', 'src-tauri/tauri.conf.dev.json') } else { @() }
+          $devBuildArgs = if ('${{ inputs.dev_mode }}' -eq 'true') { @('--config', 'src-tauri/tauri.conf.dev.json') } else { @() }
           npm run tauri build -- --bundles nsis @targetArgs @updaterArgs @devBuildArgs
           Get-ChildItem "$nsisDir" -ErrorAction SilentlyContinue | Write-Host
 

--- a/.github/workflows/build-nym-vpn-app-windows.yml
+++ b/.github/workflows/build-nym-vpn-app-windows.yml
@@ -135,9 +135,7 @@ jobs:
     env:
       VPN_CORE_BUILDS_URL: https://${{ secrets.CI_WWW_REMOTE_HOST }}/nym-vpn-client/nym-vpn-core
       UPDATER_URL_STABLE: https://raw.githubusercontent.com/nymtech/nym-vpn-client/refs/heads/develop/.pkg/tauri-updater/stable.json
-      UPDATER_URL_STABLE_ARM64: https://raw.githubusercontent.com/nymtech/nym-vpn-client/refs/heads/develop/.pkg/tauri-updater/stable-arm64.json
       UPDATER_URL_DEV: https://raw.githubusercontent.com/nymtech/nym-vpn-client/refs/heads/develop/.pkg/tauri-updater/dev.json
-      UPDATER_URL_DEV_ARM64: https://raw.githubusercontent.com/nymtech/nym-vpn-client/refs/heads/develop/.pkg/tauri-updater/dev-arm64.json
     outputs:
       UPLOAD_DIR_WINDOWS: ${{ env.UPLOAD_DIR_WINDOWS }}
       core_build_url_path: ${{ steps.get_dev_url.outputs.latest_dev_path }}
@@ -382,7 +380,7 @@ jobs:
           TAURI_TARGET: ${{ inputs.cpu_arch == 'ARM64' && 'aarch64-pc-windows-msvc' || '' }}
           DEV_MODE: ${{ inputs.dev_mode == true }}
           UPDATER_ENABLED: ${{ inputs.updater_bundle == true }}
-          UPDATER_ENDPOINT: ${{ inputs.updater_channel == 'stable' && (inputs.cpu_arch == 'ARM64' && env.UPDATER_URL_STABLE_ARM64 || env.UPDATER_URL_STABLE) || (inputs.cpu_arch == 'ARM64' && env.UPDATER_URL_DEV_ARM64 || env.UPDATER_URL_DEV) }}
+          UPDATER_ENDPOINT: ${{ inputs.updater_channel == 'stable' && env.UPDATER_URL_STABLE || env.UPDATER_URL_DEV }}
           CI: true
         run: |
           Write-Host "signing: ${{ inputs.sign }}"

--- a/.github/workflows/build-nym-vpn-app-windows.yml
+++ b/.github/workflows/build-nym-vpn-app-windows.yml
@@ -51,6 +51,11 @@ on:
           - stable
           - dev
         default: dev
+      dev_build:
+        description: 'dev build'
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       cpu_arch:
@@ -84,6 +89,10 @@ on:
         required: false
         type: string
         default: dev
+      dev_build:
+        required: false
+        type: boolean
+        default: false
     secrets:
       SSL_COM_USERNAME:
         required: true
@@ -389,7 +398,8 @@ jobs:
           $nsisDir = "target/" + $(if ($env:TAURI_TARGET) { "$env:TAURI_TARGET/" }) + "release/bundle/nsis"
           if ($env:UPDATER_ENABLED -eq 'true') { Write-Host "Updater endpoint: $env:UPDATER_ENDPOINT" }
           $updaterArgs = if ($env:UPDATER_ENABLED -eq 'true') { @('--config', 'src-tauri/updater.conf.json') } else { @() }
-          npm run tauri build -- --bundles nsis @targetArgs @updaterArgs
+          $devBuildArgs = if ('${{ inputs.dev_build }}' -eq 'true') { @('--config', 'src-tauri/tauri.conf.dev.json') } else { @() }
+          npm run tauri build -- --bundles nsis @targetArgs @updaterArgs @devBuildArgs
           Get-ChildItem "$nsisDir" -ErrorAction SilentlyContinue | Write-Host
 
       - name: Move things around to prepare for upload

--- a/.github/workflows/publish-nym-vpn-app.yml
+++ b/.github/workflows/publish-nym-vpn-app.yml
@@ -29,14 +29,6 @@ on:
         required: true
         type: boolean
         default: false
-      core_release_tag:
-        description: "nym-vpn-core: GitHub release tag (leave empty if using direct link)"
-        required: false
-        type: string
-      core_artifact_url:
-        description: "nym-vpn-core: Direct link to Windows zip archive, eg. https://.._windows_x86_64.zip (leave empty if using GH release tag)"
-        required: false
-        type: string
 
 jobs:
   build-linux:
@@ -44,12 +36,12 @@ jobs:
     with:
       dev_mode: ${{ github.event_name == 'schedule' || contains(github.ref_name, 'dev') || contains(github.ref_name, 'nightly') || inputs.dev_mode == true }}
     secrets: inherit
-  build-windows:
+  build-windows-x64:
     uses: ./.github/workflows/build-nym-vpn-app-windows.yml
     with:
+      cpu_arch: x64
       dev_mode: ${{ github.event_name == 'schedule' || contains(github.ref_name, 'dev') || contains(github.ref_name, 'nightly') || inputs.dev_mode == true  }}
-      core_release_tag: ${{ inputs.core_release_tag }}
-      core_artifact_url: ${{ inputs.core_artifact_url }}
+      core_build_it: true
       sign: ${{ inputs.release_type == 'stable' || inputs.release_type == 'rc' }}
       updater_bundle: ${{ inputs.updater == true || inputs.release_type == 'stable' }}
       updater_channel: ${{ inputs.release_type == 'stable' && 'stable' || 'dev' }}
@@ -58,13 +50,12 @@ jobs:
   build-windows-arm64:
     uses: ./.github/workflows/build-nym-vpn-app-windows.yml
     with:
+      cpu_arch: ARM64
       dev_mode: ${{ github.event_name == 'schedule' || contains(github.ref_name, 'dev') || contains(github.ref_name, 'nightly') || inputs.dev_mode == true  }}
-      core_release_tag: ${{ inputs.core_release_tag }}
-      core_artifact_url: ${{ inputs.core_artifact_url }}
+      core_build_it: true
       sign: ${{ inputs.release_type == 'stable' || inputs.release_type == 'rc' }}
       updater_bundle: ${{ inputs.updater == true || inputs.release_type == 'stable' }}
       updater_channel: ${{ inputs.release_type == 'stable' && 'stable' || 'dev' }}
-      cpu_arch: ARM64
     secrets: inherit
 
   generate-build-info-nym-vpn-app:
@@ -77,7 +68,7 @@ jobs:
   publish:
     needs:
       - build-linux
-      - build-windows
+      - build-windows-x64
       - build-windows-arm64
       - generate-build-info-nym-vpn-app
     runs-on: arc-linux-latest
@@ -85,11 +76,11 @@ jobs:
       release_tag: ${{ steps.set_tag.outputs.tag }}
       release_id: ${{ steps.create_release.outputs.id }}
       version: ${{ steps.cargo-get.outputs.metadata }}
-      win_updater_exe: ${{ steps.win_updater.outputs.exe }}
-      win_updater_sig: ${{ steps.win_updater.outputs.sig }}
+      win_updater_x64_exe: ${{ steps.win_updater_x64.outputs.exe }}
+      win_updater_x64_sig: ${{ steps.win_updater_x64.outputs.sig }}
       win_updater_arm64_exe: ${{ steps.win_updater_arm64.outputs.exe }}
       win_updater_arm64_sig: ${{ steps.win_updater_arm64.outputs.sig }}
-      core_build_url_path: ${{ needs.build-windows.outputs.core_build_url_path }}
+      core_build_url_path: ${{ needs.build-windows-x64.outputs.core_build_url_path }}
     env:
       # stable | nightly | dev
       RELEASE_TYPE: ${{ inputs.release_type || (github.event_name == 'schedule' && 'nightly' || 'dev') }}
@@ -98,7 +89,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       UPLOAD_DIR_LINUX_X86_64: linux_artifacts_x86_64
       UPLOAD_DIR_LINUX_AARCH64: linux_artifacts_aarch64
-      UPLOAD_DIR_WINDOWS: ${{ needs.build-windows.outputs.UPLOAD_DIR_WINDOWS }}
+      UPLOAD_DIR_WINDOWS: ${{ needs.build-windows-x64.outputs.UPLOAD_DIR_WINDOWS }}
       UPLOAD_DIR_WINDOWS_ARM64: ${{ needs.build-windows-arm64.outputs.UPLOAD_DIR_WINDOWS }}
       UPDATER_ENABLED: ${{ inputs.updater == true || inputs.release_type == 'stable' }}
     permissions: write-all
@@ -143,9 +134,9 @@ jobs:
         id: set_tag
         run: echo "tag=${{ env.TAG_NAME }}" >> "$GITHUB_OUTPUT"
 
-      - name: Set output for updater (Windows)
+      - name: Set output for updater (Windows x64)
         if: ${{ env.UPDATER_ENABLED == 'true' }}
-        id: win_updater
+        id: win_updater_x64
         working-directory: ${{ env.UPLOAD_DIR_WINDOWS }}
         run: |
           shopt -s failglob
@@ -262,20 +253,9 @@ jobs:
     with:
       channel: ${{ inputs.release_type == 'stable' && 'stable' || 'dev' }}
       version: ${{ needs.publish.outputs.version }}
-      platform: "windows-x86_64"
-      url: https://github.com/nymtech/nym-vpn-client/releases/download/${{ needs.publish.outputs.release_tag }}/${{ needs.publish.outputs.win_updater_exe }}
-      signature: ${{ needs.publish.outputs.win_updater_sig }}
-
-  windows-arm64-updater:
-    uses: ./.github/workflows/tauri-updater.yml
-    needs: publish
-    if: ${{ inputs.updater == true || inputs.release_type == 'stable' }}
-    with:
-      channel: ${{ inputs.release_type == 'stable' && 'stable' || 'dev' }}
-      version: ${{ needs.publish.outputs.version }}
-      platform: "windows-aarch64"
-      url: https://github.com/nymtech/nym-vpn-client/releases/download/${{ needs.publish.outputs.release_tag }}/${{ needs.publish.outputs.win_updater_arm64_exe }}
-      signature: ${{ needs.publish.outputs.win_updater_arm64_sig }}
+      base_url: https://github.com/nymtech/nym-vpn-client/releases/download/${{ needs.publish.outputs.release_tag }}
+      signature_x64: ${{ needs.publish.outputs.win_updater_x64_sig }}
+      signature_arm64: ${{ needs.publish.outputs.win_updater_arm64_sig }}
 
   update-aur-app:
     uses: ./.github/workflows/publish-aur-nym-vpn-app.yml

--- a/.github/workflows/publish-nym-vpn-app.yml
+++ b/.github/workflows/publish-nym-vpn-app.yml
@@ -45,6 +45,7 @@ jobs:
       sign: ${{ inputs.release_type == 'stable' || inputs.release_type == 'rc' }}
       updater_bundle: ${{ inputs.updater == true || inputs.release_type == 'stable' }}
       updater_channel: ${{ inputs.release_type == 'stable' && 'stable' || 'dev' }}
+      dev_build: ${{ inputs.release_type == 'dev' || inputs.release_type == 'rc' }}
     secrets: inherit
 
   build-windows-arm64:
@@ -56,6 +57,8 @@ jobs:
       sign: ${{ inputs.release_type == 'stable' || inputs.release_type == 'rc' }}
       updater_bundle: ${{ inputs.updater == true || inputs.release_type == 'stable' }}
       updater_channel: ${{ inputs.release_type == 'stable' && 'stable' || 'dev' }}
+      dev_build: ${{ inputs.release_type == 'dev' || inputs.release_type == 'rc' }}
+      cpu_arch: ARM64
     secrets: inherit
 
   generate-build-info-nym-vpn-app:

--- a/.github/workflows/publish-nym-vpn-app.yml
+++ b/.github/workflows/publish-nym-vpn-app.yml
@@ -80,8 +80,8 @@ jobs:
       win_updater_x64_sig: ${{ steps.win_updater_x64.outputs.sig }}
       win_updater_arm64_exe: ${{ steps.win_updater_arm64.outputs.exe }}
       win_updater_arm64_sig: ${{ steps.win_updater_arm64.outputs.sig }}
-      core_build_url_path: ${{ needs.build-windows-x64.outputs.core_build_url_path }}
-      core_build_url_path_arm64: ${{ needs.build-windows-arm64.outputs.core_build_url_path }}
+      core_build_x64_url_path: ${{ needs.build-windows-x64.outputs.core_build_x64_url_path }}
+      core_build_arm64_url_path: ${{ needs.build-windows-arm64.outputs.core_build_x64_url_path }}
     env:
       # stable | nightly | dev
       RELEASE_TYPE: ${{ inputs.release_type || (github.event_name == 'schedule' && 'nightly' || 'dev') }}
@@ -307,8 +307,8 @@ jobs:
       - name: Set vpn-core link
         env:
           NYM_BUILDS_URL: "https://${{ secrets.CI_WWW_REMOTE_HOST }}/nym-vpn-client/nym-vpn-core"
-          CORE_BUILD_URL_PATH: "${{ needs.publish.outputs.core_build_url_path }}"
-          CORE_BUILD_URL_PATH_ARM64: "${{ needs.publish.outputs.core_build_url_path_arm64 }}"
+          core_build_x64_url_path: "${{ needs.publish.outputs.core_build_x64_url_path }}"
+          core_build_arm64_url_path: "${{ needs.publish.outputs.core_build_arm64_url_path }}"
         run: |
           if [[ -n "${{ inputs.core_release_tag }}" ]]; then
             url=https://github.com/nymtech/nym-vpn-client/releases/tag/${{ inputs.core_release_tag }}
@@ -316,9 +316,9 @@ jobs:
           elif [[ -n "${{ inputs.core_artifact_url }}" ]]; then
             url="$(dirname ${{ inputs.core_artifact_url }})/"
             url_arm64=$url
-          elif [[ -n "$CORE_BUILD_URL_PATH" ]]; then
-            url="${{ env.NYM_BUILDS_URL }}${{ env.CORE_BUILD_URL_PATH }}/"
-            url_arm64="${{ env.NYM_BUILDS_URL }}${{ env.CORE_BUILD_URL_PATH_ARM64 }}/"
+          elif [[ -n "$core_build_x64_url_path" ]]; then
+            url="${{ env.NYM_BUILDS_URL }}${{ env.core_build_x64_url_path }}/"
+            url_arm64="${{ env.NYM_BUILDS_URL }}${{ env.core_build_arm64_url_path }}/"
           else
             url="${{ env.NYM_BUILDS_URL }}/develop/"
             url_arm64=$url

--- a/.github/workflows/publish-nym-vpn-app.yml
+++ b/.github/workflows/publish-nym-vpn-app.yml
@@ -311,19 +311,19 @@ jobs:
           core_build_arm64_url_path: "${{ needs.publish.outputs.core_build_arm64_url_path }}"
         run: |
           if [[ -n "${{ inputs.core_release_tag }}" ]]; then
-            url=https://github.com/nymtech/nym-vpn-client/releases/tag/${{ inputs.core_release_tag }}
-            url_arm64=$url
+            url_x64=https://github.com/nymtech/nym-vpn-client/releases/tag/${{ inputs.core_release_tag }}
+            url_arm64=$url_x64
           elif [[ -n "${{ inputs.core_artifact_url }}" ]]; then
-            url="$(dirname ${{ inputs.core_artifact_url }})/"
-            url_arm64=$url
+            url_x64="$(dirname ${{ inputs.core_artifact_url }})/"
+            url_arm64=$url_x64
           elif [[ -n "$core_build_x64_url_path" ]]; then
-            url="${{ env.NYM_BUILDS_URL }}${{ env.core_build_x64_url_path }}/"
+            url_x64="${{ env.NYM_BUILDS_URL }}${{ env.core_build_x64_url_path }}/"
             url_arm64="${{ env.NYM_BUILDS_URL }}${{ env.core_build_arm64_url_path }}/"
           else
-            url="${{ env.NYM_BUILDS_URL }}/develop/"
-            url_arm64=$url
+            url_x64="${{ env.NYM_BUILDS_URL }}/develop/"
+            url_arm64=$url_x64
           fi
-          echo "CORE_LINK_X64=$url" >> "$GITHUB_ENV"
+          echo "CORE_LINK_X64=$url_x64" >> "$GITHUB_ENV"
           echo "CORE_LINK_ARM64=$url_arm64" >> "$GITHUB_ENV"
 
       - name: Set message

--- a/.github/workflows/publish-nym-vpn-app.yml
+++ b/.github/workflows/publish-nym-vpn-app.yml
@@ -58,7 +58,6 @@ jobs:
       updater_bundle: ${{ inputs.updater == true || inputs.release_type == 'stable' }}
       updater_channel: ${{ inputs.release_type == 'stable' && 'stable' || 'dev' }}
       dev_build: ${{ inputs.release_type == 'dev' || inputs.release_type == 'rc' }}
-      cpu_arch: ARM64
     secrets: inherit
 
   generate-build-info-nym-vpn-app:

--- a/.github/workflows/publish-nym-vpn-app.yml
+++ b/.github/workflows/publish-nym-vpn-app.yml
@@ -234,6 +234,7 @@ jobs:
 
       - name: Create release
         id: create_release
+        if: ${{ env.RELEASE_TYPE != 'dev' }}
         uses: softprops/action-gh-release@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-nym-vpn-app.yml
+++ b/.github/workflows/publish-nym-vpn-app.yml
@@ -82,8 +82,7 @@ jobs:
       win_updater_x64_sig: ${{ steps.win_updater_x64.outputs.sig }}
       win_updater_arm64_exe: ${{ steps.win_updater_arm64.outputs.exe }}
       win_updater_arm64_sig: ${{ steps.win_updater_arm64.outputs.sig }}
-      core_build_x64_url_path: ${{ needs.build-windows-x64.outputs.core_build_x64_url_path }}
-      core_build_arm64_url_path: ${{ needs.build-windows-arm64.outputs.core_build_x64_url_path }}
+      core_build_url_path: ${{ needs.build-windows-x64.outputs.core_build_url_path }}
     env:
       # stable | nightly | dev
       RELEASE_TYPE: ${{ inputs.release_type || (github.event_name == 'schedule' && 'nightly' || 'dev') }}
@@ -310,24 +309,18 @@ jobs:
       - name: Set vpn-core link
         env:
           NYM_BUILDS_URL: "https://${{ secrets.CI_WWW_REMOTE_HOST }}/nym-vpn-client/nym-vpn-core"
-          core_build_x64_url_path: "${{ needs.publish.outputs.core_build_x64_url_path }}"
-          core_build_arm64_url_path: "${{ needs.publish.outputs.core_build_arm64_url_path }}"
+          core_build_url_path: "${{ needs.publish.outputs.core_build_url_path }}"
         run: |
           if [[ -n "${{ inputs.core_release_tag }}" ]]; then
-            url_x64=https://github.com/nymtech/nym-vpn-client/releases/tag/${{ inputs.core_release_tag }}
-            url_arm64=$url_x64
+            url=https://github.com/nymtech/nym-vpn-client/releases/tag/${{ inputs.core_release_tag }}
           elif [[ -n "${{ inputs.core_artifact_url }}" ]]; then
-            url_x64="$(dirname ${{ inputs.core_artifact_url }})/"
-            url_arm64=$url_x64
-          elif [[ -n "$core_build_x64_url_path" ]]; then
-            url_x64="${{ env.NYM_BUILDS_URL }}${{ env.core_build_x64_url_path }}/"
-            url_arm64="${{ env.NYM_BUILDS_URL }}${{ env.core_build_arm64_url_path }}/"
+            url="$(dirname ${{ inputs.core_artifact_url }})/"
+          elif [[ -n "$core_build_url_path" ]]; then
+            url="${{ env.NYM_BUILDS_URL }}${{ env.core_build_url_path }}/"
           else
-            url_x64="${{ env.NYM_BUILDS_URL }}/develop/"
-            url_arm64=$url_x64
+            url="${{ env.NYM_BUILDS_URL }}/develop/"
           fi
-          echo "CORE_LINK_X64=$url_x64" >> "$GITHUB_ENV"
-          echo "CORE_LINK_ARM64=$url_arm64" >> "$GITHUB_ENV"
+          echo "CORE_LINK=$url" >> "$GITHUB_ENV"
 
       - name: Set message
         env:
@@ -339,7 +332,7 @@ jobs:
           {
             echo 'MESSAGE<<EOF'
             echo '${{ env.EMOJI }} **${{ env.NAME }}** `${{ env.VERSION }}`
-          [app](https://github.com/nymtech/nym-vpn-client/releases/tag/${{ env.APP_RELEASE_TAG }}) | [core x64](${{ env.CORE_LINK_X64 }}) | [core arm64](${{ env.CORE_LINK_ARM64 }})
+          [app](https://github.com/nymtech/nym-vpn-client/releases/tag/${{ env.APP_RELEASE_TAG }}) | [core](${{ env.CORE_LINK }})
           '
             echo EOF
           } >> "$GITHUB_ENV"

--- a/.github/workflows/publish-nym-vpn-app.yml
+++ b/.github/workflows/publish-nym-vpn-app.yml
@@ -81,6 +81,7 @@ jobs:
       win_updater_arm64_exe: ${{ steps.win_updater_arm64.outputs.exe }}
       win_updater_arm64_sig: ${{ steps.win_updater_arm64.outputs.sig }}
       core_build_url_path: ${{ needs.build-windows-x64.outputs.core_build_url_path }}
+      core_build_url_path_arm64: ${{ needs.build-windows-arm64.outputs.core_build_url_path }}
     env:
       # stable | nightly | dev
       RELEASE_TYPE: ${{ inputs.release_type || (github.event_name == 'schedule' && 'nightly' || 'dev') }}
@@ -307,18 +308,23 @@ jobs:
         env:
           NYM_BUILDS_URL: "https://${{ secrets.CI_WWW_REMOTE_HOST }}/nym-vpn-client/nym-vpn-core"
           CORE_BUILD_URL_PATH: "${{ needs.publish.outputs.core_build_url_path }}"
+          CORE_BUILD_URL_PATH_ARM64: "${{ needs.publish.outputs.core_build_url_path_arm64 }}"
         run: |
           if [[ -n "${{ inputs.core_release_tag }}" ]]; then
             url=https://github.com/nymtech/nym-vpn-client/releases/tag/${{ inputs.core_release_tag }}
+            url_arm64=$url
           elif [[ -n "${{ inputs.core_artifact_url }}" ]]; then
             url="$(dirname ${{ inputs.core_artifact_url }})/"
+            url_arm64=$url
           elif [[ -n "$CORE_BUILD_URL_PATH" ]]; then
             url="${{ env.NYM_BUILDS_URL }}${{ env.CORE_BUILD_URL_PATH }}/"
+            url_arm64="${{ env.NYM_BUILDS_URL }}${{ env.CORE_BUILD_URL_PATH_ARM64 }}/"
           else
             url="${{ env.NYM_BUILDS_URL }}/develop/"
+            url_arm64=$url
           fi
-          echo $url
           echo "CORE_LINK=$url" >> "$GITHUB_ENV"
+          echo "CORE_LINK_ARM64=$url_arm64" >> "$GITHUB_ENV"
 
       - name: Set message
         env:
@@ -330,7 +336,7 @@ jobs:
           {
             echo 'MESSAGE<<EOF'
             echo '${{ env.EMOJI }} **${{ env.NAME }}** `${{ env.VERSION }}`
-          [app](https://github.com/nymtech/nym-vpn-client/releases/tag/${{ env.APP_RELEASE_TAG }}) | [core](${{ env.CORE_LINK }})
+          [app](https://github.com/nymtech/nym-vpn-client/releases/tag/${{ env.APP_RELEASE_TAG }}) | [core x64](${{ env.CORE_LINK }}) | [core arm64](${{ env.CORE_LINK_ARM64 }})
           '
             echo EOF
           } >> "$GITHUB_ENV"

--- a/.github/workflows/publish-nym-vpn-app.yml
+++ b/.github/workflows/publish-nym-vpn-app.yml
@@ -91,7 +91,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       UPLOAD_DIR_LINUX_X86_64: linux_artifacts_x86_64
       UPLOAD_DIR_LINUX_AARCH64: linux_artifacts_aarch64
-      UPLOAD_DIR_WINDOWS: ${{ needs.build-windows-x64.outputs.UPLOAD_DIR_WINDOWS }}
+      UPLOAD_DIR_WINDOWS_X64: ${{ needs.build-windows-x64.outputs.UPLOAD_DIR_WINDOWS }}
       UPLOAD_DIR_WINDOWS_ARM64: ${{ needs.build-windows-arm64.outputs.UPLOAD_DIR_WINDOWS }}
       UPDATER_ENABLED: ${{ inputs.updater == true || inputs.release_type == 'stable' }}
     permissions: write-all
@@ -139,7 +139,7 @@ jobs:
       - name: Set output for updater (Windows x64)
         if: ${{ env.UPDATER_ENABLED == 'true' }}
         id: win_updater_x64
-        working-directory: ${{ env.UPLOAD_DIR_WINDOWS }}
+        working-directory: ${{ env.UPLOAD_DIR_WINDOWS_X64 }}
         run: |
           shopt -s failglob
           exe=(*setup.exe)
@@ -174,7 +174,7 @@ jobs:
             for f in *; do sha256sum "$f" > "$f.sha256sum"; done
           popd
 
-          pushd ${{ env.UPLOAD_DIR_WINDOWS }} || exit 1
+          pushd ${{ env.UPLOAD_DIR_WINDOWS_X64 }} || exit 1
             exe=(*setup.exe)
             sha256sum "${exe[0]}" > "${exe[0]}.sha256sum";
           popd
@@ -187,7 +187,7 @@ jobs:
           echo 'SHA256SUMS<<EOF' >> $GITHUB_ENV
           cat ${{ env.UPLOAD_DIR_LINUX_X86_64 }}/*.sha256sum >> $GITHUB_ENV
           cat ${{ env.UPLOAD_DIR_LINUX_AARCH64 }}/*.sha256sum >> $GITHUB_ENV
-          cat ${{ env.UPLOAD_DIR_WINDOWS }}/*.sha256sum >> $GITHUB_ENV
+          cat ${{ env.UPLOAD_DIR_WINDOWS_X64 }}/*.sha256sum >> $GITHUB_ENV
           cat ${{ env.UPLOAD_DIR_WINDOWS_ARM64 }}/*.sha256sum >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
 
@@ -246,7 +246,7 @@ jobs:
           files: |
             ${{ env.UPLOAD_DIR_LINUX_X86_64 }}/*
             ${{ env.UPLOAD_DIR_LINUX_AARCH64 }}/*
-            ${{ env.UPLOAD_DIR_WINDOWS }}/*
+            ${{ env.UPLOAD_DIR_WINDOWS_X64 }}/*
             ${{ env.UPLOAD_DIR_WINDOWS_ARM64 }}/*
 
   windows-updater:

--- a/.github/workflows/publish-nym-vpn-app.yml
+++ b/.github/workflows/publish-nym-vpn-app.yml
@@ -317,22 +317,37 @@ jobs:
             url="$(dirname ${{ inputs.core_artifact_url }})/"
           elif [[ -n "$core_build_url_path" ]]; then
             url="${{ env.NYM_BUILDS_URL }}${{ env.core_build_url_path }}/"
+          elif [[ "${{ env.RELEASE_TYPE }}" == "dev" ]]; then
+            url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           else
-            url="${{ env.NYM_BUILDS_URL }}/develop/"
+            latest=$(curl -sSL "${{ env.NYM_BUILDS_URL }}/develop/" | grep -oP '(?<=href=")\d+(?=/)' | sort -rn | head -1)
+            if [[ -n "$latest" ]]; then
+              url="${{ env.NYM_BUILDS_URL }}/develop/$latest/"
+            else
+              url="${{ env.NYM_BUILDS_URL }}/develop/"
+            fi
           fi
           echo "CORE_LINK=$url" >> "$GITHUB_ENV"
+
+      - name: Set app link
+        run: |
+          if [[ "${{ env.RELEASE_TYPE }}" == "dev" ]]; then
+            url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          else
+            url="https://github.com/nymtech/nym-vpn-client/releases/tag/${{ needs.publish.outputs.release_tag }}"
+          fi
+          echo "APP_LINK=$url" >> "$GITHUB_ENV"
 
       - name: Set message
         env:
           VERSION: ${{ needs.publish.outputs.version }}
-          APP_RELEASE_TAG: ${{ needs.publish.outputs.release_tag }}
           EMOJI: ${{ (env.RELEASE_TYPE == 'stable' && ':ship:') || (env.RELEASE_TYPE == 'nightly' && ':night:') || ':hammer_and_wrench:' }}
           NAME: ${{ env.RELEASE_TYPE == 'stable' && 'release' || (env.RELEASE_TYPE == 'nightly' && 'nightly build') || 'dev build' }}
         run: |
           {
             echo 'MESSAGE<<EOF'
             echo '${{ env.EMOJI }} **${{ env.NAME }}** `${{ env.VERSION }}`
-          [app](https://github.com/nymtech/nym-vpn-client/releases/tag/${{ env.APP_RELEASE_TAG }}) | [core](${{ env.CORE_LINK }})
+          [app](${{ env.APP_LINK }}) | [core](${{ env.CORE_LINK }})
           '
             echo EOF
           } >> "$GITHUB_ENV"

--- a/.github/workflows/publish-nym-vpn-app.yml
+++ b/.github/workflows/publish-nym-vpn-app.yml
@@ -45,7 +45,6 @@ jobs:
       sign: ${{ inputs.release_type == 'stable' || inputs.release_type == 'rc' }}
       updater_bundle: ${{ inputs.updater == true || inputs.release_type == 'stable' }}
       updater_channel: ${{ inputs.release_type == 'stable' && 'stable' || 'dev' }}
-      dev_build: ${{ inputs.release_type == 'dev' || inputs.release_type == 'rc' }}
     secrets: inherit
 
   build-windows-arm64:
@@ -57,7 +56,6 @@ jobs:
       sign: ${{ inputs.release_type == 'stable' || inputs.release_type == 'rc' }}
       updater_bundle: ${{ inputs.updater == true || inputs.release_type == 'stable' }}
       updater_channel: ${{ inputs.release_type == 'stable' && 'stable' || 'dev' }}
-      dev_build: ${{ inputs.release_type == 'dev' || inputs.release_type == 'rc' }}
     secrets: inherit
 
   generate-build-info-nym-vpn-app:

--- a/.github/workflows/publish-nym-vpn-app.yml
+++ b/.github/workflows/publish-nym-vpn-app.yml
@@ -323,7 +323,7 @@ jobs:
             url="${{ env.NYM_BUILDS_URL }}/develop/"
             url_arm64=$url
           fi
-          echo "CORE_LINK=$url" >> "$GITHUB_ENV"
+          echo "CORE_LINK_X64=$url" >> "$GITHUB_ENV"
           echo "CORE_LINK_ARM64=$url_arm64" >> "$GITHUB_ENV"
 
       - name: Set message
@@ -336,7 +336,7 @@ jobs:
           {
             echo 'MESSAGE<<EOF'
             echo '${{ env.EMOJI }} **${{ env.NAME }}** `${{ env.VERSION }}`
-          [app](https://github.com/nymtech/nym-vpn-client/releases/tag/${{ env.APP_RELEASE_TAG }}) | [core x64](${{ env.CORE_LINK }}) | [core arm64](${{ env.CORE_LINK_ARM64 }})
+          [app](https://github.com/nymtech/nym-vpn-client/releases/tag/${{ env.APP_RELEASE_TAG }}) | [core x64](${{ env.CORE_LINK_X64 }}) | [core arm64](${{ env.CORE_LINK_ARM64 }})
           '
             echo EOF
           } >> "$GITHUB_ENV"

--- a/.github/workflows/tauri-post-release.yml
+++ b/.github/workflows/tauri-post-release.yml
@@ -101,5 +101,10 @@ jobs:
           git add .pkg/linux
           git add nym-vpn-app/.pkg/flatpak
           git commit -m "${{ env.COMMIT_MSG }}"
-          git push origin ${{ env.GIT_BRANCH }}
-          gh pr create --title '${{ env.COMMIT_MSG }}' --body '${{ env.PR_BODY }}' --base develop --reviewer "agentpietrucha"
+          git push --force origin ${{ env.GIT_BRANCH }}
+          existing=$(gh pr list --head "${{ env.GIT_BRANCH }}" --json number --jq 'length')
+          if [[ "$existing" == "0" ]]; then
+            gh pr create --title '${{ env.COMMIT_MSG }}' --body '${{ env.PR_BODY }}' --base develop --reviewer "agentpietrucha"
+          else
+            echo "PR already exists for branch ${{ env.GIT_BRANCH }}, skipping"
+          fi

--- a/.github/workflows/tauri-updater.yml
+++ b/.github/workflows/tauri-updater.yml
@@ -99,5 +99,10 @@ jobs:
           git switch -C ${{ env.GIT_BRANCH }}
           git add .pkg/tauri-updater
           git commit -m "${{ env.COMMIT_MSG }}"
-          git push origin ${{ env.GIT_BRANCH }}
-          gh pr create --title '${{ env.PR_TITLE }}' --body '${{ env.PR_BODY }}' --base develop --reviewer "agentpietrucha"
+          git push --force origin ${{ env.GIT_BRANCH }}
+          EXISTING_PR=$(gh pr view ${{ env.GIT_BRANCH }} --json url --jq '.url' 2>/dev/null || true)
+          if [ -n "$EXISTING_PR" ]; then
+            echo "PR already exists: $EXISTING_PR"
+          else
+            gh pr create --title '${{ env.PR_TITLE }}' --body '${{ env.PR_BODY }}' --base develop --reviewer "agentpietrucha"
+          fi

--- a/.github/workflows/tauri-updater.yml
+++ b/.github/workflows/tauri-updater.yml
@@ -9,13 +9,13 @@ on:
         type: string
         required: true
       # https://v2.tauri.app/plugin/updater/#static-json-file
-      platform: # windows-x86_64 | linux-x86_64
+      base_url:
         type: string
         required: true
-      url:
+      signature_x64:
         type: string
         required: true
-      signature:
+      signature_arm64:
         type: string
         required: true
   workflow_dispatch:
@@ -33,22 +33,18 @@ on:
         type: string
         required: true
         default: "0.0.0"
-      platform:
-        description: "Platform to update"
-        type: choice
-        options:
-          - windows-x86_64
-          - windows-aarch64
-          - linux-x86_64
-        required: true
-        default: "windows-x86_64"
-      url:
-        description: "URL link to the executable (for Windows *setup.exe)"
+      base_url:
+        description: "Base download URL (release asset directory, e.g. .../releases/download/nym-vpn-app-v0.0.0)"
         type: string
         required: true
-        default: "https://github.com/nymtech/nym-vpn-client/releases/download/nym-vpn-app-v0.0.0/NymVPN_0.0.0_x64-setup.exe"
-      signature:
-        description: "Signature of the update bundle (for Windows content of *setup.exe.sig)"
+        default: "https://github.com/nymtech/nym-vpn-client/releases/download/nym-vpn-app-v0.0.0"
+      signature_x64:
+        description: "Signature of the x64 update bundle (content of *setup.exe.sig)"
+        type: string
+        required: true
+        default: ""
+      signature_arm64:
+        description: "Signature of the arm64 update bundle (content of *setup.exe.sig)"
         type: string
         required: true
         default: ""
@@ -60,7 +56,7 @@ jobs:
       contents: write
       pull-requests: write
     env:
-      JSON_FILE: ${{ inputs.platform == 'windows-aarch64' && (inputs.channel == 'stable' && 'stable-arm64.json' || 'dev-arm64.json') || (inputs.channel == 'stable' && 'stable.json' || 'dev.json') }}
+      JSON_FILE: ${{ inputs.channel == 'stable' && 'stable.json' || 'dev.json' }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
@@ -78,8 +74,10 @@ jobs:
         run: |
           yq -i '
             .version = "${{ inputs.version }}" |
-            .platforms.${{ inputs.platform }}.url = "${{ inputs.url }}" |
-            .platforms.${{ inputs.platform }}.signature = "${{ inputs.signature }}"
+            .platforms."windows-x86_64".url = "${{ inputs.base_url }}/NymVPN_${{ inputs.version }}_x64-setup.exe" |
+            .platforms."windows-x86_64".signature = "${{ inputs.signature_x64 }}" |
+            .platforms."windows-aarch64".url = "${{ inputs.base_url }}/NymVPN_${{ inputs.version }}_arm64-setup.exe" |
+            .platforms."windows-aarch64".signature = "${{ inputs.signature_arm64 }}"
           ' ${{ env.JSON_FILE }}
           echo "updated metadata"
           cat ${{ env.JSON_FILE }}
@@ -88,13 +86,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          GIT_BRANCH: "tauri-updater-${{ inputs.channel }}-${{ inputs.platform }}-${{ inputs.version }}"
-          COMMIT_MSG: "tauri-updater: update metadata ${{ inputs.channel }} ${{ inputs.platform }} v${{ inputs.version }}"
-          PR_TITLE: "tauri-updater: update metadata ${{ inputs.channel }} ${{ inputs.platform }} v${{ inputs.version }}"
+          GIT_BRANCH: "tauri-updater-${{ inputs.channel }}-${{ inputs.version }}"
+          COMMIT_MSG: "tauri-updater: update metadata ${{ inputs.channel }} v${{ inputs.version }}"
+          PR_TITLE: "tauri-updater: update metadata ${{ inputs.channel }} v${{ inputs.version }}"
           PR_BODY: |
             Update tauri updater metadata
             - channel: `${{ inputs.channel }}`
-            - platform: `${{ inputs.platform }}`
             - version: `${{ inputs.version }}`
         run: |
           git config --global user.name "NYM_bot"

--- a/.pkg/tauri-updater/dev-arm64.json
+++ b/.pkg/tauri-updater/dev-arm64.json
@@ -1,9 +1,0 @@
-{
-  "version": "1.15.0-cherry-rc.2",
-  "platforms": {
-    "windows-aarch64": {
-      "signature": "",
-      "url": "https://github.com/nymtech/nym-vpn-client/releases/download/nym-vpn-app-v1.15.0-cherry-rc.2/NymVPN_1.15.0-cherry-rc.2_arm64-setup.exe"
-    }
-  }
-}

--- a/.pkg/tauri-updater/dev.json
+++ b/.pkg/tauri-updater/dev.json
@@ -4,6 +4,10 @@
     "windows-x86_64": {
       "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVTTjN5M3FybWZ5VjhBZ1Q2dmlFa0RhNzBJcCtzdFlmRmU3ajhCZ3p2UFBML2FuUzAySGJxdUVXSzd0M1BGcDFqTXM3WTF6Q0dBS3ZUOXJBR1E5dlRIRS8rdmNhQmFYZGdnPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzU3MzQ1NzczCWZpbGU6TnltVlBOXzEuMTUuMC1jaGVycnktcmMuMl94NjQtc2V0dXAuZXhlClFPaUhOREtlaEpNQVpHRnJWWXNlWnhrdVhGY3pOMlJ3ZVFtd1NLWm1GMHBRaHg0d2c0Vk9YSHN5L293VW5hWUt0WTdMUytzL0lIV1ZoSkNEMDYyY0RnPT0K",
       "url": "https://github.com/nymtech/nym-vpn-client/releases/download/nym-vpn-app-v1.15.0-cherry-rc.2/NymVPN_1.15.0-cherry-rc.2_x64-setup.exe"
+    },
+    "windows-aarch64": {
+      "signature": "",
+      "url": "https://github.com/nymtech/nym-vpn-client/releases/download/nym-vpn-app-v1.15.0-cherry-rc.2/NymVPN_1.15.0-cherry-rc.2_arm64-setup.exe"
     }
   }
 }

--- a/.pkg/tauri-updater/stable-arm64.json
+++ b/.pkg/tauri-updater/stable-arm64.json
@@ -1,9 +1,0 @@
-{
-  "version": "1.29.4",
-  "platforms": {
-    "windows-aarch64": {
-      "signature": "",
-      "url": "https://github.com/nymtech/nym-vpn-client/releases/download/nym-vpn-app-v1.29.4/NymVPN_1.29.4_arm64-setup.exe"
-    }
-  }
-}

--- a/.pkg/tauri-updater/stable.json
+++ b/.pkg/tauri-updater/stable.json
@@ -4,6 +4,10 @@
     "windows-x86_64": {
       "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVTTjN5M3FybWZ5VjFpaUR5eWFBNlhCTTFlQ1cxU3hXSFBJbXZSRXRkMW9nLzNpZS9Ja0ppM3krRTFScjkxd0tNeUdrUzdyYnh5L2tOR29XVFlHQzM4ZitmVjB1QVcvS1FrPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzc4MTUyMTYzCWZpbGU6TnltVlBOXzEuMjkuNF94NjQtc2V0dXAuZXhlCjhIeWdwcXBHYnlsTGRTaVFMeDBDU0JYTnhHU2RTUk9MN0lmemFuakN1Q0dFQWxhb3RCMEw0MnlIQnVaa1VXcEdXNitldmsvaTBtZVJoT1VVQVFrL0RnPT0K",
       "url": "https://github.com/nymtech/nym-vpn-client/releases/download/nym-vpn-app-v1.29.4/NymVPN_1.29.4_x64-setup.exe"
+    },
+    "windows-aarch64": {
+      "signature": "",
+      "url": "https://github.com/nymtech/nym-vpn-client/releases/download/nym-vpn-app-v1.29.4/NymVPN_1.29.4_arm64-setup.exe"
     }
   }
 }

--- a/nym-vpn-app/src-tauri/tauri.conf.dev.json
+++ b/nym-vpn-app/src-tauri/tauri.conf.dev.json
@@ -1,0 +1,9 @@
+{
+  "plugins": {
+    "updater": {
+      "endpoints": [
+        "https://raw.githubusercontent.com/nymtech/nym-vpn-client/refs/heads/develop/.pkg/tauri-updater/dev.json"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Ticket

JIRA-NYM-1317

## Description

Simplify Tauri updater logic.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5290)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Split Windows build into separate x64 and ARM64 jobs and export distinct updater artifacts per architecture.
  * Introduced an option to enable development packaging that uses a dev-specific config when enabled.
  * Simplified updater inputs to a shared base URL plus per-architecture signatures; updater metadata now records both x64 and arm64 entries and updated dev/stable manifests.

* **Bug Fixes**
  * Publish flow skips creating a release for dev builds.
  * Release post-processing force-pushes branches and skips creating duplicate PRs when one already exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->