### PR TITLE
ci: sccache: add redis cache

### DIFF
--- a/.github/workflows/build-nym-vpn-android.yml
+++ b/.github/workflows/build-nym-vpn-android.yml
@@ -29,23 +29,6 @@ on:
         description: "Skip Crowdin translations download"
         required: false
         default: false
-    secrets:
-      ANDROID_SIGNING_KEY_ALIAS:
-        required: false
-      ANDROID_SIGNING_KEY_PASSWORD:
-        required: false
-      ANDROID_SIGNING_STORE_PASSWORD:
-        required: false
-      ANDROID_SENTRY_DSN:
-        required: false
-      ANDROID_SERVICE_ACCOUNT_JSON:
-        required: false
-      ANDROID_KEYSTORE:
-        required: false
-      CROWDIN_PROJECT_ID:
-        required: false
-      CROWDIN_PERSONAL_TOKEN:
-        required: false
   workflow_call:
     inputs:
       build_type:
@@ -64,6 +47,10 @@ on:
         required: false
         default: false
     secrets:
+      SCCACHE_REDIS_ENDPOINT:
+        required: false
+      SCCACHE_REDIS_PASSWORD:
+        required: false
       ANDROID_SIGNING_KEY_ALIAS:
         required: false
       ANDROID_SIGNING_KEY_PASSWORD:
@@ -173,8 +160,10 @@ jobs:
       - name: Set Rust caching env vars only for non-release runs
         if: ${{ inputs.build_type == 'debug' }}
         run: |
-          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+          echo "SCCACHE_REDIS_ENDPOINT=${{ secrets.SCCACHE_REDIS_ENDPOINT }}" >> $GITHUB_ENV
+          echo "SCCACHE_REDIS_PASSWORD=${{ secrets.SCCACHE_REDIS_PASSWORD }}" >> $GITHUB_ENV
+          echo "SCCACHE_REDIS_EXPIRATION=86400" >> $GITHUB_ENV
 
       - name: Install cargo-ndk
         uses: baptiste0928/cargo-install@v3

--- a/.github/workflows/ci-nym-vpn-android.yml
+++ b/.github/workflows/ci-nym-vpn-android.yml
@@ -12,6 +12,10 @@ on:
       - ".github/workflows/publish-nym-vpn-android.yml"
   workflow_dispatch:
 
+env:
+  CARGO_TERM_COLOR: always
+  AGENT_ISSELFHOSTED: 1 # https://github.com/actions/setup-go/issues/432
+
 jobs:
   check:
     runs-on: arc-linux-latest
@@ -79,3 +83,6 @@ jobs:
     with:
       build_type: "debug"
       build_format: "apk"
+    secrets:
+      SCCACHE_REDIS_ENDPOINT: ${{ secrets.SCCACHE_REDIS_ENDPOINT }}
+      SCCACHE_REDIS_PASSWORD: ${{ secrets.SCCACHE_REDIS_PASSWORD }}

--- a/.github/workflows/ci-nym-vpn-app-rust.yml
+++ b/.github/workflows/ci-nym-vpn-app-rust.yml
@@ -12,7 +12,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   AGENT_ISSELFHOSTED: 1 # https://github.com/actions/setup-go/issues/432
-  SCCACHE_GHA_ENABLED: true
   RUSTC_WRAPPER: sccache
 
 jobs:
@@ -50,6 +49,18 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
+
+      - name: Enable Redis for sscache
+        if: ${{ matrix.os == 'arc-linux-latest' }}
+        run: |
+          echo "SCCACHE_REDIS_ENDPOINT=${{ secrets.SCCACHE_REDIS_ENDPOINT }}" >> $GITHUB_ENV
+          echo "SCCACHE_REDIS_PASSWORD=${{ secrets.SCCACHE_REDIS_PASSWORD }}" >> $GITHUB_ENV
+          echo "SCCACHE_REDIS_EXPIRATION=86400" >> $GITHUB_ENV
+
+      - name: Enable GHA for sscache
+        if: ${{ matrix.os != 'arc-linux-latest' }}
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
 
       - uses: mozilla-actions/sccache-action@v0.0.10
 

--- a/.github/workflows/ci-nym-vpn-core-android.yml
+++ b/.github/workflows/ci-nym-vpn-core-android.yml
@@ -13,8 +13,10 @@ on:
 env:
   CARGO_TERM_COLOR: always
   AGENT_ISSELFHOSTED: 1 # https://github.com/actions/setup-go/issues/432
-  SCCACHE_GHA_ENABLED: true
   RUSTC_WRAPPER: sccache
+  SCCACHE_REDIS_ENDPOINT: ${{ secrets.SCCACHE_REDIS_ENDPOINT }}
+  SCCACHE_REDIS_PASSWORD: ${{ secrets.SCCACHE_REDIS_PASSWORD }}
+  SCCACHE_REDIS_EXPIRATION: 86400
 
 jobs:
   build-wireguard-go-android:

--- a/.github/workflows/ci-nym-vpn-core-linux.yml
+++ b/.github/workflows/ci-nym-vpn-core-linux.yml
@@ -13,8 +13,10 @@ env:
   CI_TESTING: true
   CARGO_TERM_COLOR: always
   AGENT_ISSELFHOSTED: 1 # https://github.com/actions/setup-go/issues/432
-  SCCACHE_GHA_ENABLED: true
   RUSTC_WRAPPER: sccache
+  SCCACHE_REDIS_ENDPOINT: ${{ secrets.SCCACHE_REDIS_ENDPOINT }}
+  SCCACHE_REDIS_PASSWORD: ${{ secrets.SCCACHE_REDIS_PASSWORD }}
+  SCCACHE_REDIS_EXPIRATION: 86400
 
 jobs:
   build-wireguard-go-linux:


### PR DESCRIPTION
## JIRA ticket

JIRA-NYM-1326

## Description

Add redis cache storage for sccache. Currently only supported by Linux runners, but it will be extended to our macOS and Windows runners.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5292)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration infrastructure to optimize build caching performance across multiple workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nymtech/nym-vpn-client/pull/5292)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->