### PR TITLE
(tauri) Use `dev.json` updater for dev builds

### DIFF
--- a/.github/workflows/build-nym-vpn-app-windows.yml
+++ b/.github/workflows/build-nym-vpn-app-windows.yml
@@ -51,6 +51,11 @@ on:
           - stable
           - dev
         default: dev
+      dev_build:
+        description: 'dev build'
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       cpu_arch:
@@ -84,6 +89,10 @@ on:
         required: false
         type: string
         default: dev
+      dev_build:
+        required: false
+        type: boolean
+        default: false
     secrets:
       SSL_COM_USERNAME:
         required: true
@@ -391,7 +400,8 @@ jobs:
           $nsisDir = "target/" + $(if ($env:TAURI_TARGET) { "$env:TAURI_TARGET/" }) + "release/bundle/nsis"
           if ($env:UPDATER_ENABLED -eq 'true') { Write-Host "Updater endpoint: $env:UPDATER_ENDPOINT" }
           $updaterArgs = if ($env:UPDATER_ENABLED -eq 'true') { @('--config', 'src-tauri/updater.conf.json') } else { @() }
-          npm run tauri build -- --bundles nsis @targetArgs @updaterArgs
+          $devBuildArgs = if ('${{ inputs.dev_build }}' -eq 'true') { @('--config', 'src-tauri/tauri.conf.dev.json') } else { @() }
+          npm run tauri build -- --bundles nsis @targetArgs @updaterArgs @devBuildArgs
           Get-ChildItem "$nsisDir" -ErrorAction SilentlyContinue | Write-Host
 
       - name: Move things around to prepare for upload

--- a/.github/workflows/publish-nym-vpn-app.yml
+++ b/.github/workflows/publish-nym-vpn-app.yml
@@ -53,6 +53,7 @@ jobs:
       sign: ${{ inputs.release_type == 'stable' || inputs.release_type == 'rc' }}
       updater_bundle: ${{ inputs.updater == true || inputs.release_type == 'stable' }}
       updater_channel: ${{ inputs.release_type == 'stable' && 'stable' || 'dev' }}
+      dev_build: ${{ inputs.release_type == 'dev' || inputs.release_type == 'rc' }}
     secrets: inherit
 
   build-windows-arm64:
@@ -64,6 +65,7 @@ jobs:
       sign: ${{ inputs.release_type == 'stable' || inputs.release_type == 'rc' }}
       updater_bundle: ${{ inputs.updater == true || inputs.release_type == 'stable' }}
       updater_channel: ${{ inputs.release_type == 'stable' && 'stable' || 'dev' }}
+      dev_build: ${{ inputs.release_type == 'dev' || inputs.release_type == 'rc' }}
       cpu_arch: ARM64
     secrets: inherit
 

--- a/nym-vpn-app/src-tauri/tauri.conf.dev.json
+++ b/nym-vpn-app/src-tauri/tauri.conf.dev.json
@@ -1,0 +1,9 @@
+{
+  "plugins": {
+    "updater": {
+      "endpoints": [
+        "https://raw.githubusercontent.com/nymtech/nym-vpn-client/refs/heads/develop/.pkg/tauri-updater/dev.json"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

For `dev` and `rc` release builds use `tauri.conf.dev.json` so dev builds update automatically


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5293)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Windows build workflow to support development builds with conditional configuration
  * Updated dev and RC release builds to use a separate update endpoint for testing and development purposes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nymtech/nym-vpn-client/pull/5293)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->