### PR TITLE
HTTP reachability in diagnostic tool testing

### DIFF
--- a/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/http.rs
+++ b/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/http.rs
@@ -49,7 +49,7 @@ impl HttpDiagnostic {
     }
 
     async fn test_nym_apis(network: &Network, parallel: bool) -> Result<()> {
-        tracing::info!("nym apis");
+        tracing::info!("Running Nym api diagnostics");
 
         let api_clients = build_nym_api_clients(network).await?;
 
@@ -73,7 +73,7 @@ impl HttpDiagnostic {
     }
 
     async fn test_vpn_apis(network: &Network, parallel: bool) -> Result<()> {
-        tracing::info!("vpn apis");
+        tracing::info!("Running VPN api diagnostics");
         let api_clients = build_vpn_api_clients(network).await?;
 
         if parallel {

--- a/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/http.rs
+++ b/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/http.rs
@@ -11,12 +11,18 @@ use nym_platform_metadata::new_user_agent;
 use nym_validator_client::nym_api::NymApiClientExt;
 use nym_vpn_api_client::VpnApiClient;
 use nym_vpn_api_client::api_urls_to_urls;
-use nym_vpn_lib_types::{ApiTimeSkew, HttpReport};
+use nym_vpn_lib_types::{
+    ApiTimeSkew, ApiUrl, DiagnosticEndpointResponse, DiagnosticResult, HttpReport,
+};
 use nym_vpn_network_config::Network;
 
 pub struct HttpDiagnostic;
 
 impl HttpDiagnostic {
+    /// Run a series of short tests to check that APIs are reachable.
+    ///
+    /// For the `by_endpoint` tests if there is a front defined in the output
+    /// it means that the FrontPolicy was set to always and fronting was used.
     pub async fn run_diagnostic(network: &Network) -> Result<HttpReport> {
         tracing::info!("Running http diagnostic");
         let nym_vpn_api_client =
@@ -38,61 +44,116 @@ impl HttpDiagnostic {
             .await
             .map(|list| list.len());
 
-        Self::test_nym_apis(network, false).await?;
-        Self::test_vpn_apis(network, false).await?;
+        let mut http_report = Vec::new();
+        http_report.extend_from_slice(&Self::test_nym_apis(network, false).await?);
+        http_report.extend_from_slice(&Self::test_vpn_apis(network, false).await?);
 
         Ok(HttpReport {
             remote_time: remote_time.into(),
             health_response: health_response.into(),
             nb_nymnodes: nb_nodes.into(),
+            by_endpoint: http_report,
         })
     }
 
-    async fn test_nym_apis(network: &Network, parallel: bool) -> Result<()> {
+    async fn test_nym_apis(
+        network: &Network,
+        parallel: bool,
+    ) -> Result<Vec<DiagnosticResult<DiagnosticEndpointResponse>>> {
         tracing::info!("Running Nym api diagnostics");
 
         let api_clients = build_nym_api_clients(network).await?;
+        let mut results = Vec::new();
 
         if parallel {
             let mut jobs = tokio::task::JoinSet::new();
 
             for api_client in api_clients {
                 jobs.spawn(async move {
-                    let _ = api_client.get_network_details().await;
+                    match api_client.health().await {
+                        Ok(res) => DiagnosticResult::from_value(DiagnosticEndpointResponse {
+                            status: res.status.is_up().to_string(),
+                            url: url_from_client(&api_client),
+                        }),
+                        Err(e) => DiagnosticResult::from_err(e),
+                    }
                 });
             }
 
-            while jobs.join_next().await.is_some() {}
+            jobs.join_all()
+                .await
+                .into_iter()
+                .for_each(|r| results.push(r));
         } else {
             for api_client in api_clients {
-                let _ = api_client.get_network_details().await;
+                match api_client.health().await {
+                    Ok(res) => {
+                        results.push(DiagnosticResult::from_value(DiagnosticEndpointResponse {
+                            status: res.status.is_up().to_string(),
+                            url: url_from_client(&api_client),
+                        }))
+                    }
+                    Err(e) => results.push(DiagnosticResult::from_err(e)),
+                }
             }
         }
 
-        Ok(())
+        Ok(results)
     }
 
-    async fn test_vpn_apis(network: &Network, parallel: bool) -> Result<()> {
+    async fn test_vpn_apis(
+        network: &Network,
+        parallel: bool,
+    ) -> Result<Vec<DiagnosticResult<DiagnosticEndpointResponse>>> {
         tracing::info!("Running VPN api diagnostics");
+
         let api_clients = build_vpn_api_clients(network).await?;
+        let mut results = Vec::new();
 
         if parallel {
             let mut jobs = tokio::task::JoinSet::new();
 
             for api_client in api_clients {
                 jobs.spawn(async move {
-                    let _ = api_client.get_health().await;
+                    match api_client.get_health().await {
+                        Ok(res) => DiagnosticResult::from_value(DiagnosticEndpointResponse {
+                            status: res.status,
+                            url: url_from_client(api_client.as_ref()),
+                        }),
+                        Err(e) => DiagnosticResult::from_err(e),
+                    }
                 });
             }
 
-            while jobs.join_next().await.is_some() {}
+            jobs.join_all()
+                .await
+                .into_iter()
+                .for_each(|r| results.push(r));
         } else {
             for api_client in api_clients {
-                let _ = api_client.get_health().await;
+                match api_client.get_health().await {
+                    Ok(res) => {
+                        results.push(DiagnosticResult::from_value(DiagnosticEndpointResponse {
+                            status: res.status,
+                            url: url_from_client(api_client.as_ref()),
+                        }))
+                    }
+                    Err(e) => results.push(DiagnosticResult::from_err(e)),
+                }
             }
         }
 
-        Ok(())
+        Ok(results)
+    }
+}
+
+fn url_from_client(client: &Client) -> ApiUrl {
+    ApiUrl {
+        url: client.current_url().inner_url().to_string(),
+        front_hosts: client
+            .current_url()
+            .fronts()
+            .map(|v| v.iter().map(ToString::to_string).collect()),
     }
 }
 

--- a/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/http.rs
+++ b/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/http.rs
@@ -166,6 +166,7 @@ async fn build_nym_api_clients(network: &Network) -> Result<Vec<Client>> {
         let plain_client = ClientBuilder::new(plain_url)
             .map_err(|_| Error::MissingApiUrl)?
             .no_hickory_dns()
+            .with_user_agent(new_user_agent!())
             .with_retries(0)
             .build()
             .map_err(|_| Error::MissingApiUrl)?;
@@ -181,6 +182,7 @@ async fn build_nym_api_clients(network: &Network) -> Result<Vec<Client>> {
                     .map_err(|_| Error::MissingApiUrl)?
                     .no_hickory_dns()
                     .with_fronting(Some(FrontPolicy::Always))
+                    .with_user_agent(new_user_agent!())
                     .with_retries(0)
                     .build()
                     .map_err(|_| Error::MissingApiUrl)?;

--- a/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/http.rs
+++ b/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/http.rs
@@ -1,10 +1,16 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use crate::{diagnostic::build_api_client, error::Result};
+use crate::{
+    diagnostic::build_api_client,
+    error::{Error, Result},
+};
 
+use nym_http_api_client::{Client, ClientBuilder, FrontPolicy, Url};
 use nym_platform_metadata::new_user_agent;
 use nym_validator_client::nym_api::NymApiClientExt;
+use nym_vpn_api_client::VpnApiClient;
+use nym_vpn_api_client::api_urls_to_urls;
 use nym_vpn_lib_types::{ApiTimeSkew, HttpReport};
 use nym_vpn_network_config::Network;
 
@@ -13,11 +19,9 @@ pub struct HttpDiagnostic;
 impl HttpDiagnostic {
     pub async fn run_diagnostic(network: &Network) -> Result<HttpReport> {
         tracing::info!("Running http diagnostic");
-        let nym_vpn_api_client = nym_vpn_api_client::VpnApiClient::from_network(
-            network.nym_network_details(),
-            Some(new_user_agent!()),
-        )
-        .await?;
+        let nym_vpn_api_client =
+            VpnApiClient::from_network(network.nym_network_details(), Some(new_user_agent!()))
+                .await?;
 
         let api_client = build_api_client(network).await?;
 
@@ -34,10 +38,129 @@ impl HttpDiagnostic {
             .await
             .map(|list| list.len());
 
+        Self::test_nym_apis(network, false).await?;
+        Self::test_vpn_apis(network, false).await?;
+
         Ok(HttpReport {
             remote_time: remote_time.into(),
             health_response: health_response.into(),
             nb_nymnodes: nb_nodes.into(),
         })
     }
+
+    async fn test_nym_apis(network: &Network, parallel: bool) -> Result<()> {
+        tracing::info!("nym apis");
+
+        let api_clients = build_nym_api_clients(network).await?;
+
+        if parallel {
+            let mut jobs = tokio::task::JoinSet::new();
+
+            for api_client in api_clients {
+                jobs.spawn(async move {
+                    let _ = api_client.get_network_details().await;
+                });
+            }
+
+            while jobs.join_next().await.is_some() {}
+        } else {
+            for api_client in api_clients {
+                let _ = api_client.get_network_details().await;
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn test_vpn_apis(network: &Network, parallel: bool) -> Result<()> {
+        tracing::info!("vpn apis");
+        let api_clients = build_vpn_api_clients(network).await?;
+
+        if parallel {
+            let mut jobs = tokio::task::JoinSet::new();
+
+            for api_client in api_clients {
+                jobs.spawn(async move {
+                    let _ = api_client.get_health().await;
+                });
+            }
+
+            while jobs.join_next().await.is_some() {}
+        } else {
+            for api_client in api_clients {
+                let _ = api_client.get_health().await;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+async fn build_nym_api_clients(network: &Network) -> Result<Vec<Client>> {
+    let nym_urls = api_urls_to_urls(&network.nym_api_urls().ok_or(Error::MissingApiUrl)?)?;
+    let mut clients = Vec::new();
+    for url in nym_urls {
+        let plain_url =
+            Url::new(url.inner_url().clone(), None).map_err(|_| Error::MissingApiUrl)?;
+        let plain_client = ClientBuilder::new(plain_url)
+            .map_err(|_| Error::MissingApiUrl)?
+            .no_hickory_dns()
+            .with_retries(0)
+            .build()
+            .map_err(|_| Error::MissingApiUrl)?;
+
+        clients.push(plain_client);
+
+        if let Some(fronts) = url.fronts() {
+            for front in fronts {
+                let fronted_url = Url::new(url.inner_url().clone(), Some(vec![front.clone()]))
+                    .map_err(|_e| Error::MissingApiUrl)?;
+
+                let fronted_client = ClientBuilder::new(fronted_url)
+                    .map_err(|_| Error::MissingApiUrl)?
+                    .no_hickory_dns()
+                    .with_fronting(Some(FrontPolicy::Always))
+                    .with_retries(0)
+                    .build()
+                    .map_err(|_| Error::MissingApiUrl)?;
+
+                clients.push(fronted_client);
+            }
+        }
+    }
+    Ok(clients)
+}
+
+async fn build_vpn_api_clients(network: &Network) -> Result<Vec<VpnApiClient>> {
+    let nym_urls = api_urls_to_urls(&network.nym_vpn_api_urls().ok_or(Error::MissingApiUrl)?)?;
+    let mut clients = Vec::new();
+
+    for url in nym_urls {
+        let plain_url =
+            Url::new(url.inner_url().clone(), None).map_err(|_| Error::MissingApiUrl)?;
+        let mut plain_client = VpnApiClient::new(vec![plain_url], Some(new_user_agent!()))
+            .map_err(|_| Error::MissingApiUrl)?;
+
+        plain_client.as_mut().set_front_policy(FrontPolicy::Off);
+
+        clients.push(plain_client);
+
+        if let Some(fronts) = url.fronts() {
+            for front in fronts {
+                let fronted_url = Url::new(url.inner_url().clone(), Some(vec![front.clone()]))
+                    .map_err(|_e| Error::MissingApiUrl)?;
+
+                let mut fronted_client =
+                    VpnApiClient::new(vec![fronted_url], Some(new_user_agent!()))
+                        .map_err(|_| Error::MissingApiUrl)?;
+                fronted_client
+                    .as_mut()
+                    .set_front_policy(FrontPolicy::Always);
+
+                clients.push(fronted_client);
+            }
+        }
+    }
+
+    Ok(clients)
 }

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
@@ -49,6 +49,18 @@ pub struct VpnApiClient {
     skew_manager: Arc<RwLock<SkewManager>>,
 }
 
+impl AsRef<Client> for VpnApiClient {
+    fn as_ref(&self) -> &Client {
+        &self.inner
+    }
+}
+
+impl AsMut<Client> for VpnApiClient {
+    fn as_mut(&mut self) -> &mut Client {
+        &mut self.inner
+    }
+}
+
 impl VpnApiClient {
     pub fn new(urls: Vec<Url>, user_agent: Option<UserAgent>) -> Result<Self> {
         let inner =

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/diagnostic.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/diagnostic.rs
@@ -1,6 +1,8 @@
 // Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use crate::ApiUrl;
+
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -104,6 +106,15 @@ pub struct HttpReport {
     pub remote_time: DiagnosticResult<ApiTimeSkew>,
     pub health_response: DiagnosticResult<DiagnosticHealthResponse>,
     pub nb_nymnodes: DiagnosticResult<usize>,
+    pub by_endpoint: Vec<DiagnosticResult<DiagnosticEndpointResponse>>,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug)]
+pub struct DiagnosticEndpointResponse {
+    pub status: String,
+    pub url: ApiUrl,
+    // pub front_policy: String,
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/diagnostic.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/diagnostic.rs
@@ -114,7 +114,6 @@ pub struct HttpReport {
 pub struct DiagnosticEndpointResponse {
     pub status: String,
     pub url: ApiUrl,
-    // pub front_policy: String,
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
@@ -72,9 +72,9 @@ pub use connection_data::{
 };
 pub use device::{NymVpnDevice, NymVpnDeviceStatus, NymVpnUsage};
 pub use diagnostic::{
-    ApiTimeSkew, CompleteDnsReport, DiagnosticRegisterParams, DiagnosticReport, DiagnosticResult,
-    DiagnosticRunParams, DnsResolution, GatewayReport, HttpReport, HybridTransportReport,
-    PingReport, RegistrationMode, RegistrationReport,
+    ApiTimeSkew, CompleteDnsReport, DiagnosticEndpointResponse, DiagnosticRegisterParams,
+    DiagnosticReport, DiagnosticResult, DiagnosticRunParams, DnsResolution, GatewayReport,
+    HttpReport, HybridTransportReport, PingReport, RegistrationMode, RegistrationReport,
 };
 pub use gateway::{
     Asn, AsnKind, BridgeInformation, BridgeParameters, Country, Entry, EntryPoint, Exit, ExitPoint,


### PR DESCRIPTION
## Ticket

JIRA-NYM-1328

## Description

Expand the functionality of the diagnostic tools HTTP o a short test where each of the avaiable configurations for HTTP requests is used to make a simple request.

For returned results if a stealth API is defined then the Policy was set such that it was used for the trial.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5300)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTTP diagnostics now include per-endpoint results (status and endpoint URL) instead of only aggregated summaries.
  * Diagnostic checks have been expanded to probe both Nym APIs and VPN APIs, returning detailed per-endpoint outcomes for each tested URL.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nymtech/nym-vpn-client/pull/5300)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->