### PR TITLE
Fix adblocker deactivation caused by remote returning embedded HTTP errors

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix panic when restoring default routes (https://github.com/nymtech/nym-vpn-client/pull/5225)
+- Fix adblocker deactivation caused by remote returning embedded HTTP errors (https://github.com/nymtech/nym-vpn-client/pull/5302)
 
 
 ## [1.29.2] - 2026-05-04

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "adblock"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33eab07cdcfd3577600c27d75df00a6d61a01b5778b9b19ea51264453540212b"
+checksum = "db6fe7702c798519299bcbe011ff6f1dc9e3aedc1f3171178cddf71e1736bf95"
 dependencies = [
  "addr",
  "arrayvec",
@@ -8583,9 +8583,9 @@ dependencies = [
 
 [[package]]
 name = "psl"
-version = "2.1.197"
+version = "2.1.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15ca31b68a87f984f41949f5e4341502dcd2af119b3226ba7285b3fe3e77ea2"
+checksum = "0c187d8a1cb043fbd20b07333314b4644293c0601d0414c0c74f67d0e65a94f4"
 dependencies = [
  "psl-types",
 ]

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -71,11 +71,7 @@ lto = true
 large_futures = "warn"
 
 [workspace.dependencies]
-# We need to turn off the feature "single-thread" to avoid "future cannot be sent between threads safely".
-adblock = { version = "0.12.3", default-features = false, features = [
-    "embedded-domain-resolver",
-] }
-
+adblock = { version = "0.12.5", default-features = false }
 aes-gcm = "0.10"
 anyhow = "1.0.102"
 async-compression = "0.4.42"

--- a/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
@@ -12,7 +12,7 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-adblock.workspace = true
+adblock = { workspace = true, features = ["embedded-domain-resolver"] }
 anyhow.workspace = true
 async-stream.workspace = true
 async-compression = { workspace = true, features = ["tokio", "gzip"] }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/adblocker/file_manager.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/adblocker/file_manager.rs
@@ -235,9 +235,18 @@ impl Source {
                 error,
             })?;
 
-        if response.status() == reqwest::StatusCode::NOT_MODIFIED {
-            tracing::debug!("Ad-blocker data file {} is up to date", self.file_name);
-            return Ok(false);
+        match response.status() {
+            reqwest::StatusCode::OK => {
+                tracing::debug!("Received HTTP/200 for {}", self.url);
+            }
+            reqwest::StatusCode::NOT_MODIFIED => {
+                tracing::debug!("Ad-blocker data file {} is up to date", self.file_name);
+                return Ok(false);
+            }
+            status => {
+                tracing::debug!("Unexpected response for {}: {}", self.url, status);
+                return Ok(false);
+            }
         }
 
         // Grab the new etag from the HTTP response
@@ -276,6 +285,11 @@ impl Source {
             ))
             .await
             .ok_or(AdBlockerError::Cancelled)??;
+
+        if Self::contains_embedded_http_429_error(&temp_data_path).await? {
+            tracing::warn!("Received embedded HTTP/429 for {}", self.url);
+            return Ok(false);
+        }
 
         // Write the new meta data to a temporary file in the ad-blocker directory
         let temp_meta_path = cache_dir.join(Self::TEMP_META_FILE_NAME);
@@ -536,6 +550,18 @@ impl Source {
             .to_string();
         Ok(etag)
     }
+
+    /// Returns `Ok(true)` if the first bytes of the given file contain embedded HTTP/429 error string.
+    async fn contains_embedded_http_429_error(file_path: &Path) -> Result<bool> {
+        const MATCH_ERROR_STRING: &str = "429: too many requests";
+
+        let mut stream = Self::stream_lines(file_path);
+
+        match stream.next().await {
+            Some(res) => Ok(res?.to_lowercase().starts_with(MATCH_ERROR_STRING)),
+            None => Ok(false),
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize)]
@@ -677,6 +703,37 @@ pub(super) mod tests {
         assert!(
             updated,
             "ad-blocker files were not updated when they should have been"
+        );
+    }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn test_contains_embedded_http_429_error() {
+        let temp_dir = init_tests().await.unwrap();
+
+        for source in SOURCES.iter() {
+            let blocking_rules_file_path = temp_dir.path().join(source.file_name);
+            assert!(
+                !Source::contains_embedded_http_429_error(&blocking_rules_file_path)
+                    .await
+                    .unwrap()
+            );
+        }
+
+        let test_file_path = temp_dir.path().join("test.txt.gz");
+        let writer = File::create(&test_file_path).await.unwrap();
+        let mut encoder = GzipEncoder::new(writer);
+        encoder
+            .write_all("429: Too Many Requests".as_bytes())
+            .await
+            .unwrap();
+        encoder.shutdown().await.unwrap();
+        encoder.into_inner().flush().await.unwrap();
+
+        assert!(
+            Source::contains_embedded_http_429_error(&test_file_path)
+                .await
+                .unwrap()
         );
     }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/resolver/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/resolver/mod.rs
@@ -275,9 +275,7 @@ impl Resolver {
     ) -> Result<AuthLookup, NetError> {
         let return_query = query.original().clone();
         let qname = return_query.name().to_ascii();
-
         let decision = dns_filter.should_block(&qname).await;
-
         if decision != DnsFilterDecision::Pass {
             tracing::trace!("Blocking DNS query for {qname} with strategy {decision:?}");
         }


### PR DESCRIPTION
## Ticket

JIRA-NYM-1332

## Description

- Some of CDNs cache embedded 429 errors. Make sure this is handled in the short term. Longer term we should host adblocking rules ourselves
- Handle unexpected HTTP codes


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5302)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of server-side rate limiting when updating ad-blocker lists. The VPN now properly detects and manages rate limit errors to prevent failed blocklist updates.

* **Dependencies**
  * Updated ad-blocker library to latest version for improved compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nymtech/nym-vpn-client/pull/5302)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->