### PR TITLE
[Android] 1-click UI fixes; Private DNS dialog;

### DIFF
--- a/nym-vpn-android/CHANGELOG.md
+++ b/nym-vpn-android/CHANGELOG.md
@@ -14,15 +14,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add auth view (https://github.com/nymtech/nym-vpn-client/pull/5236)
 - Add code formatting (https://github.com/nymtech/nym-vpn-client/pull/5236)
 - Enable domain fronting toggle (https://github.com/nymtech/nym-vpn-client/pull/5272)
+- Add checks for Private DNS state and show dialog when it's not off when turning on the Ad-block toggle (https://github.com/nymtech/nym-vpn-client/pull/5308)
+- Add pulsing effect for app logo (https://github.com/nymtech/nym-vpn-client/pull/5308)
 
 ### Changed
 - Update App theme, colors, typography (https://github.com/nymtech/nym-vpn-client/pull/5236)
 - Clean up unused screens (https://github.com/nymtech/nym-vpn-client/pull/5236)
 - Remove reconnect on Ad-block toggle (https://github.com/nymtech/nym-vpn-client/pull/5269)
 - Remove PQ toggle (https://github.com/nymtech/nym-vpn-client/pull/5272)
+- Allow back press on Passphrase screen when passphrase revealed (https://github.com/nymtech/nym-vpn-client/pull/5276)
+- Remove Continue button and acknowledge text from Passphrase screen (https://github.com/nymtech/nym-vpn-client/pull/5308)
 
 ### Fixed
 - Fix spinner position for Auto login dialog (https://github.com/nymtech/nym-vpn-client/pull/5287)
+- Update Connect panel to fix the positions of server info when connected (https://github.com/nymtech/nym-vpn-client/pull/5308)
+- Fix jumping logo on Splash screen (https://github.com/nymtech/nym-vpn-client/pull/5308)
+- Fix Connection Status view jumps when the connection time showed (https://github.com/nymtech/nym-vpn-client/pull/5308)
+- Fix wrapping of app count label on Split tunneling screen (https://github.com/nymtech/nym-vpn-client/pull/5308)
 
 ## [3.4.0] - 8.05.2026
 

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/MainActivity.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/MainActivity.kt
@@ -219,7 +219,10 @@ class MainActivity : AppCompatActivity() {
 								popEnterTransition = { fadeIn(tween(200)) },
 								popExitTransition = { fadeOut(tween(200)) },
 							) {
-								composable<Route.Splash> { SplashScreen(appViewModel, appState) }
+								composable<Route.Splash>(
+									exitTransition = { fadeOut(tween(150)) },
+									popEnterTransition = { fadeIn(tween(200)) },
+								) { SplashScreen(appViewModel, appState, topOffset = padding.calculateTopPadding()) }
 
 								composable<Route.Main>(
 									enterTransition = { fadeIn() },

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/common/Modal.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/common/Modal.kt
@@ -58,7 +58,7 @@ fun Modal(
 				Icon(
 					icon,
 					description,
-					tint = MaterialTheme.colorScheme.onSurface,
+					tint = MaterialTheme.colorScheme.onBackground,
 					modifier = Modifier.then(
 						if (iconSize != null) {
 							Modifier.size(iconSize)

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/common/navigation/NavBar.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/common/navigation/NavBar.kt
@@ -48,7 +48,7 @@ fun NavBar(
 ) {
 	val keyboardController = LocalSoftwareKeyboardController.current
 	val navBackStackEntry by navController.currentBackStackEntryAsState()
-	var navBarState: NavBarState by remember { mutableStateOf(NavBarState.Hidden) }
+	var navBarState: NavBarState by remember { mutableStateOf(NavBarState.Empty) }
 
 	val currentMainThemeClick by rememberUpdatedState(onMainThemeClick)
 	val currentMainSettingsClick by rememberUpdatedState(onMainSettingsClick)
@@ -56,6 +56,7 @@ fun NavBar(
 	val currentRoute = navBackStackEntry?.destination?.route
 	val backgroundColor = when (navBarState) {
 		is NavBarState.Main -> LocalNymColors.current.navBarTitleBackground
+		is NavBarState.Empty -> MaterialTheme.colorScheme.background
 		else -> MaterialTheme.colorScheme.surface
 	}
 	LaunchedEffect(currentRoute, hideBackButton, logsEnabled) {
@@ -63,8 +64,9 @@ fun NavBar(
 		val route = currentRoute ?: return@LaunchedEffect
 
 		navBarState = when {
-			route.startsWith(Route.Splash::class.qualifiedName!!) ||
-				route.startsWith(Route.LoginScanner::class.qualifiedName!!) ||
+			route.startsWith(Route.Splash::class.qualifiedName!!) -> NavBarState.Empty
+
+			route.startsWith(Route.LoginScanner::class.qualifiedName!!) ||
 				route.startsWith(Route.Technical::class.qualifiedName!!) -> NavBarState.Hidden
 
 			route.startsWith(Route.Generating::class.qualifiedName!!) ||

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/account/passphrase/PassphraseScreen.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/account/passphrase/PassphraseScreen.kt
@@ -5,21 +5,13 @@ import android.content.ClipData
 import android.content.Intent
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Checkbox
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -30,7 +22,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalContext
@@ -41,7 +32,6 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
@@ -49,7 +39,6 @@ import androidx.fragment.app.FragmentActivity
 import androidx.hilt.navigation.compose.hiltViewModel
 import kotlinx.coroutines.launch
 import net.nymtech.nymvpn.R
-import net.nymtech.nymvpn.ui.common.buttons.MainStyledButton
 import net.nymtech.nymvpn.ui.common.navigation.LocalNavController
 import net.nymtech.nymvpn.ui.common.navigation.NavBarEvent
 import net.nymtech.nymvpn.ui.screens.account.passphrase.components.PassphraseActions
@@ -58,9 +47,7 @@ import net.nymtech.nymvpn.ui.screens.account.passphrase.modal.PassphraseInfo
 import net.nymtech.nymvpn.ui.theme.NymVPNTheme
 import net.nymtech.nymvpn.ui.theme.Theme
 import net.nymtech.nymvpn.util.DeviceAuthHelper
-import net.nymtech.nymvpn.util.extensions.safePopBackStack
 import net.nymtech.nymvpn.util.extensions.savePasswordToManager
-import net.nymtech.nymvpn.util.extensions.scaledHeight
 import net.nymtech.nymvpn.util.extensions.scaledWidth
 import timber.log.Timber
 
@@ -156,13 +143,11 @@ fun PassphraseScreen(onBackButtonVisibilityChange: (Boolean) -> Unit, navBarEven
 				savePasswordToManager(context = context, password = passphrase.joinToString(" "))
 			}
 		},
-		onContinueClick = { navController.safePopBackStack() },
 	)
 }
 
 @Composable
-fun PassphraseScreen(passphrase: List<String>, show: Boolean, onShowClick: () -> Unit, onCopyClick: () -> Unit, onDownloadClick: () -> Unit, onSaveClick: () -> Unit, onContinueClick: () -> Unit) {
-	var confirmed by remember { mutableStateOf(false) }
+fun PassphraseScreen(passphrase: List<String>, show: Boolean, onShowClick: () -> Unit, onCopyClick: () -> Unit, onDownloadClick: () -> Unit, onSaveClick: () -> Unit) {
 	Column(
 		modifier = Modifier
 			.fillMaxSize()
@@ -199,50 +184,6 @@ fun PassphraseScreen(passphrase: List<String>, show: Boolean, onShowClick: () ->
 
 		PassphraseCard(passphrase = passphrase, show = show, onShowClick = onShowClick)
 		PassphraseActions(show = show, onCopyClick = onCopyClick, onDownloadClick = onDownloadClick, onSaveClick = onSaveClick)
-
-		if (show) {
-			Spacer(modifier = Modifier.weight(1f))
-			Column(
-				modifier = Modifier
-					.fillMaxWidth()
-					.padding(top = 24.dp),
-			) {
-				Row(
-					verticalAlignment = Alignment.CenterVertically,
-					horizontalArrangement = Arrangement.spacedBy(16.dp),
-					modifier = Modifier
-						.fillMaxWidth()
-						.clickable { confirmed = !confirmed },
-				) {
-					Checkbox(
-						checked = confirmed,
-						onCheckedChange = { confirmed = it },
-						modifier = Modifier.size(20.dp),
-					)
-					Text(
-						text = stringResource(R.string.passphrase_saved),
-						style = MaterialTheme.typography.bodyMedium,
-						color = MaterialTheme.colorScheme.onPrimaryContainer,
-						textAlign = TextAlign.Start,
-						fontFamily = FontFamily(Font(R.font.lab_grotesque_regular)),
-					)
-				}
-				MainStyledButton(
-					enabled = confirmed,
-					onClick = { if (confirmed) onContinueClick() },
-					content = {
-						Text(
-							stringResource(R.string.welcome_continue),
-							style = MaterialTheme.typography.titleMedium,
-						)
-					},
-					modifier = Modifier.fillMaxWidth()
-						.padding(vertical = 16.dp)
-						.height(48.dp.scaledHeight()),
-					shape = RoundedCornerShape(12.dp),
-				)
-			}
-		}
 	}
 }
 
@@ -261,7 +202,6 @@ internal fun PreviewPassphraseScreen() {
 			onCopyClick = {},
 			onDownloadClick = {},
 			onSaveClick = {},
-			onContinueClick = {},
 		)
 	}
 }

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/components/ConnectPanel.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/components/ConnectPanel.kt
@@ -243,7 +243,6 @@ fun ConnectPanel(
 				)
 				ServerRow(
 					node = entryNode,
-					fillTrailingSpace = true,
 					modifier = Modifier.padding(bottom = 16.dp),
 					currentState = panelState,
 					connectionState = connectionState,
@@ -340,7 +339,6 @@ private fun ServerRow(
 	modifier: Modifier = Modifier,
 	onExpand: (() -> Unit)? = null,
 	onCollapse: (() -> Unit)? = null,
-	fillTrailingSpace: Boolean = false,
 	onServerClick: () -> Unit,
 	currentState: PanelState,
 	connectionState: ConnectionState,
@@ -453,7 +451,7 @@ private fun ServerRow(
 						)
 					}
 				}
-			} else if (fillTrailingSpace) {
+			} else {
 				Spacer(modifier = Modifier.size(16.dp))
 			}
 		}

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/components/ConnectPanel.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/components/ConnectPanel.kt
@@ -44,6 +44,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -164,6 +165,7 @@ fun ConnectPanel(
 			Box(
 				modifier = Modifier
 					.size(width = 32.dp, height = 4.dp)
+					.alpha(if (canToggle) 1f else 0f)
 					.clip(RoundedCornerShape(2.dp))
 					.background(MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f)),
 			)

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/components/ConnectionStatus.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/components/ConnectionStatus.kt
@@ -1,6 +1,5 @@
 package net.nymtech.nymvpn.ui.screens.main.components
 
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
@@ -9,8 +8,6 @@ import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.keyframes
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -23,6 +20,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
@@ -175,6 +173,17 @@ fun ConnectionStatus(
 		ConnectionState.Disconnected, ConnectionState.Offline, ConnectionState.WaitingForConnection -> notProtectedLabel
 	}
 
+	val labelAlpha by animateFloatAsState(
+		targetValue = if (currentLabel != null) 1f else 0f,
+		animationSpec = tween(250, easing = FastOutSlowInEasing),
+		label = "labelAlpha",
+	)
+	val timeAlpha by animateFloatAsState(
+		targetValue = if (connectionTime != null) 1f else 0f,
+		animationSpec = tween(250, easing = FastOutSlowInEasing),
+		label = "timeAlpha",
+	)
+
 	Column(
 		horizontalAlignment = Alignment.CenterHorizontally,
 		modifier = modifier,
@@ -250,32 +259,28 @@ fun ConnectionStatus(
 			}
 		}
 
-		// State label
-		AnimatedVisibility(
-			visible = currentLabel != null,
-			enter = fadeIn(tween(200)),
-			exit = fadeOut(tween(300)),
+		// State label — always takes space to keep the circle position fixed
+		Column(
+			horizontalAlignment = Alignment.CenterHorizontally,
+			modifier = Modifier.alpha(labelAlpha),
 		) {
-			Column(horizontalAlignment = Alignment.CenterHorizontally) {
-				Spacer(Modifier.height(LABEL_OFFSET.dp))
-				Text(
-					text = (currentLabel ?: "").uppercase(),
-					style = MaterialTheme.typography.labelSmall,
-					color = when {
-						isError -> MaterialTheme.colorScheme.error
-						isConnected -> MaterialTheme.colorScheme.primary
-						else -> MaterialTheme.colorScheme.onSurfaceVariant
-					},
-				)
-				connectionTime?.let {
-					Spacer(Modifier.height(8.dp))
-					Text(
-						text = it,
-						style = MaterialTheme.typography.labelSmall,
-						color = MaterialTheme.colorScheme.primary,
-					)
-				}
-			}
+			Spacer(Modifier.height(LABEL_OFFSET.dp))
+			Text(
+				text = (currentLabel ?: "").uppercase(),
+				style = MaterialTheme.typography.labelSmall,
+				color = when {
+					isError -> MaterialTheme.colorScheme.error
+					isConnected -> MaterialTheme.colorScheme.primary
+					else -> MaterialTheme.colorScheme.onSurfaceVariant
+				},
+			)
+			Spacer(Modifier.height(8.dp))
+			Text(
+				text = connectionTime ?: "",
+				style = MaterialTheme.typography.labelSmall,
+				color = MaterialTheme.colorScheme.primary,
+				modifier = Modifier.alpha(timeAlpha),
+			)
 		}
 	}
 }

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/SettingsScreen.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/SettingsScreen.kt
@@ -47,12 +47,15 @@ import net.nymtech.nymvpn.ui.screens.settings.components.QuitSection
 import net.nymtech.nymvpn.ui.screens.settings.components.SubscriptionUiState
 import net.nymtech.nymvpn.ui.screens.settings.components.SupportSection
 import net.nymtech.nymvpn.ui.screens.settings.components.VpnSettingsSection
+import net.nymtech.nymvpn.ui.screens.settings.modal.PrivateDnsDialog
 import net.nymtech.nymvpn.ui.theme.NymVPNTheme
 import net.nymtech.nymvpn.ui.theme.Theme
 import net.nymtech.nymvpn.util.DeviceAuthHelper
 import net.nymtech.nymvpn.util.extensions.goFromRoot
+import net.nymtech.nymvpn.util.extensions.isPrivateDnsEnabled
 import net.nymtech.nymvpn.util.extensions.launchBatteryOptSettingsScreen
 import net.nymtech.nymvpn.util.extensions.launchNotificationSettings
+import net.nymtech.nymvpn.util.extensions.launchPrivateDnsSettings
 import net.nymtech.nymvpn.util.extensions.launchVpnSettings
 import net.nymtech.nymvpn.util.extensions.scaledWidth
 import kotlin.Boolean
@@ -66,6 +69,7 @@ fun SettingsScreen(appUiState: AppUiState, appViewModel: AppViewModel, showVpnSe
 
 	var loggingOut by remember { mutableStateOf(false) }
 	var showLogoutDialog by remember { mutableStateOf(false) }
+	var showPrivateDnsDialog by remember { mutableStateOf(false) }
 
 	val shortcutsInfoText = stringResource(R.string.shortcuts_info_message)
 	val lanReconnectingText = stringResource(R.string.settings_event_lan_reconnecting)
@@ -95,6 +99,15 @@ fun SettingsScreen(appUiState: AppUiState, appViewModel: AppViewModel, showVpnSe
 					launchSingleTop = true
 				}
 			}
+		},
+	)
+
+	PrivateDnsDialog(
+		showPrivateDnsDialog = showPrivateDnsDialog,
+		onDismiss = { showPrivateDnsDialog = false },
+		onClickSettings = {
+			showPrivateDnsDialog = false
+			context.launchPrivateDnsSettings()
 		},
 	)
 
@@ -156,7 +169,12 @@ fun SettingsScreen(appUiState: AppUiState, appViewModel: AppViewModel, showVpnSe
 			},
 			onAutoConnectEnable = { viewModel.onAutoConnectSelected(it) },
 			onBypassLanEnable = { viewModel.onBypassLanSelected(it) },
-			onAdBlockingEnable = { viewModel.onAdBlockingSelected(it) },
+			onAdBlockingEnable = {
+				if (it && context.isPrivateDnsEnabled()) {
+					showPrivateDnsDialog = true
+				}
+				viewModel.onAdBlockingSelected(it)
+			},
 			onSupportIPv6Enable = {
 			},
 			onAutoselectServerEnable = {

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/dns/modal/SaveChangesModal.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/dns/modal/SaveChangesModal.kt
@@ -8,7 +8,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
@@ -51,7 +50,7 @@ fun SaveChangesModal(showSaveChangesDialog: Boolean, confirmTextResId: Int, onCl
 		confirmButton = {
 			MainStyledButton(
 				onClick = onClickSave,
-				textColor = Color.Black,
+				textColor = MaterialTheme.colorScheme.onPrimary,
 				content = {
 					Text(
 						stringResource(confirmTextResId),

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/modal/PrivateDnsModal.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/modal/PrivateDnsModal.kt
@@ -1,0 +1,67 @@
+package net.nymtech.nymvpn.ui.screens.settings.modal
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Dns
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import net.nymtech.nymvpn.R
+import net.nymtech.nymvpn.ui.common.Modal
+import net.nymtech.nymvpn.ui.common.buttons.MainStyledButton
+import net.nymtech.nymvpn.ui.theme.CustomTypography
+import net.nymtech.nymvpn.ui.theme.NymVPNTheme
+import net.nymtech.nymvpn.ui.theme.Theme
+import net.nymtech.nymvpn.util.extensions.scaledHeight
+
+@Composable
+fun PrivateDnsDialog(showPrivateDnsDialog: Boolean, onClickSettings: () -> Unit, onDismiss: () -> Unit) {
+	Modal(
+		show = showPrivateDnsDialog,
+		icon = Icons.Outlined.Dns,
+		onDismiss = onDismiss,
+		title = {
+			Text(
+				text = stringResource(R.string.private_dns_title),
+				style = CustomTypography.labelHuge,
+				color = MaterialTheme.colorScheme.onPrimaryContainer,
+				fontFamily = FontFamily(Font(R.font.lab_grotesque_regular)),
+			)
+		},
+		text = {},
+		confirmButton = {
+			MainStyledButton(
+				onClick = onClickSettings,
+				textColor = MaterialTheme.colorScheme.onPrimary,
+				content = {
+					Text(
+						stringResource(R.string.private_dns_button),
+						style = MaterialTheme.typography.titleMedium,
+					)
+				},
+				modifier = Modifier
+					.fillMaxWidth()
+					.height(40.dp.scaledHeight()),
+			)
+		},
+	)
+}
+
+@Preview
+@Composable
+private fun SaveChangesModalPreview() {
+	NymVPNTheme(Theme.default()) {
+		PrivateDnsDialog(
+			true,
+			onClickSettings = {},
+			onDismiss = {},
+		)
+	}
+}

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/tunneling/components/FilterButton.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/tunneling/components/FilterButton.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -52,11 +54,17 @@ fun FilterButton(title: String, noOfApps: Int, description: String, imageVector:
 					text = title,
 					style = MaterialTheme.typography.bodyMedium.copy(fontWeight = if (isSelected) FontWeight(700) else Typography.bodyMedium.fontWeight),
 					color = MaterialTheme.colorScheme.onPrimaryContainer,
+					maxLines = 1,
+					overflow = TextOverflow.Ellipsis,
+					modifier = Modifier.weight(1f),
 				)
 				Text(
 					text = "($noOfApps)",
 					style = MaterialTheme.typography.bodySmall,
 					color = MaterialTheme.colorScheme.onBackground,
+					maxLines = 1,
+					softWrap = false,
+					modifier = Modifier.wrapContentWidth(),
 				)
 			}
 			Spacer(modifier = Modifier.height(4.dp.scaledHeight()))

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/splash/SplashScreen.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/splash/SplashScreen.kt
@@ -1,8 +1,16 @@
 package net.nymtech.nymvpn.ui.screens.splash
 
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -10,9 +18,12 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import net.nymtech.nymvpn.R
 import net.nymtech.nymvpn.ui.AppUiState
@@ -22,7 +33,7 @@ import net.nymtech.nymvpn.ui.common.navigation.LocalNavController
 import net.nymtech.nymvpn.util.extensions.navigateAndForget
 
 @Composable
-fun SplashScreen(appViewModel: AppViewModel, appUiState: AppUiState) {
+fun SplashScreen(appViewModel: AppViewModel, appUiState: AppUiState, topOffset: Dp = 0.dp) {
 	val navController = LocalNavController.current
 	val isAppReady by appViewModel.isAppReady.collectAsStateWithLifecycle()
 
@@ -32,16 +43,37 @@ fun SplashScreen(appViewModel: AppViewModel, appUiState: AppUiState) {
 		}
 	}
 
+	val infiniteTransition = rememberInfiniteTransition(label = "SplashTransition")
+
+	val scale by infiniteTransition.animateFloat(
+		initialValue = 0.995f,
+		targetValue = 1.05f,
+		animationSpec = infiniteRepeatable(
+			animation = tween(durationMillis = 1000, easing = FastOutSlowInEasing),
+			repeatMode = RepeatMode.Reverse,
+		),
+		label = "PulseAnimation",
+	)
+
+	val primaryColor = MaterialTheme.colorScheme.primary
+
 	Box(
 		contentAlignment = Alignment.Center,
 		modifier = Modifier
 			.fillMaxSize()
-			.background(MaterialTheme.colorScheme.background),
+			.background(MaterialTheme.colorScheme.background)
+			.padding(bottom = topOffset),
 	) {
 		Icon(
 			imageVector = ImageVector.vectorResource(R.drawable.app_label),
 			contentDescription = stringResource(R.string.app_name),
-			tint = MaterialTheme.colorScheme.primary,
+			tint = primaryColor,
+			modifier = Modifier
+				.size(140.dp)
+				.graphicsLayer {
+					scaleX = scale
+					scaleY = scale
+				},
 		)
 	}
 }

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/util/extensions/ContextExtensions.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/util/extensions/ContextExtensions.kt
@@ -130,6 +130,29 @@ fun Context.launchBatteryOptSettingsScreen() {
 	this.startActivity(intent)
 }
 
+fun Context.launchPrivateDnsSettings() {
+	if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+		val intent = Intent("android.settings.PRIVATE_DNS_SETTINGS").apply {
+			addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+		}
+		try {
+			startActivity(intent)
+		} catch (e: android.content.ActivityNotFoundException) {
+			startActivity(
+				Intent(Settings.ACTION_WIRELESS_SETTINGS).apply {
+					addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+				},
+			)
+		}
+	}
+}
+
+fun Context.isPrivateDnsEnabled(): Boolean {
+	if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return false
+	val mode = Settings.Global.getString(contentResolver, "private_dns_mode")
+	return mode != "off"
+}
+
 // for localization changes
 fun Activity.resetTile() {
 	try {

--- a/nym-vpn-android/app/src/main/res/values/strings.xml
+++ b/nym-vpn-android/app/src/main/res/values/strings.xml
@@ -592,4 +592,7 @@
 	<!-- Support screen -->
 	<string name="support_protect_title">⚠️ Protect yourself from scams</string>
 	<string name="support_protect_description">Only contact NymVPN support through the official channels listed below. We will never ask for your passphrase or contact you first via direct messages.\n\nReceived unexpected contact? It\'s likely a scam.</string>
+	<!-- Private DNS modal -->
+	<string name="private_dns_title">Disable Private DNS to use ad blocker.</string>
+	<string name="private_dns_button">Open Settings</string>
 </resources>


### PR DESCRIPTION
## Ticket

JIRA-NYM-1331
JIRA-NYM-1329
JIRA-NYM-1180

## Description

- Update `ConnectPanel.kt` to fix the positions of server info when connected.
- Fix jumping logo on `SplashScreen.kt`. Add pulsing effect for app logo.
- Remove `Continue` button and acknowledge text from `PassphraseScreen.kt`.
- Fix `ConnectionStatus` view jumps when the connection time showed.
- Add checks for Private DNS state and show dialog when it's not off when turning on the `Ad-block` toggle.
- Fix wrapping of app count label on `SplitTunnelingScreen.kt`.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5308)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Private DNS compatibility check when enabling ad-blocking, with a modal prompt and direct settings access.
  * Added pulsing animation to splash screen.

* **UI Improvements**
  * Enhanced navigation transitions with smoother fade effects.
  * Improved connection status animations and visibility.
  * Simplified passphrase display interface.
  * Optimized filter button text layout and handling.
  * Updated color theming across dialogs for consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nymtech/nym-vpn-client/pull/5308)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->