### PR TITLE
adblock(android): stop blocking DNS TCP 53 and 853

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/dns_filter_proxy.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/dns_filter_proxy.rs
@@ -27,7 +27,6 @@ use pnet_packet::{
     ip::IpNextHeaderProtocols,
     ipv4::{self, Ipv4Packet, MutableIpv4Packet},
     ipv6::{Ipv6Packet, MutableIpv6Packet},
-    tcp::{self, MutableTcpPacket, TcpFlags, TcpPacket},
     udp::{self, MutableUdpPacket, UdpPacket},
 };
 use tokio::{
@@ -45,9 +44,6 @@ const MAX_PACKET_SIZE: usize = 65536;
 
 /// UDP port used by DNS.
 const DNS_PORT: u16 = 53;
-
-/// Port for RST
-const DOT_PORT: u16 = 853;
 
 /// IPv4 version nibble.
 const IP_VERSION_4: u8 = 4;
@@ -222,25 +218,6 @@ async fn maybe_nxdomain_v4(packet: &[u8], dns_filter: &DnsFilter) -> Option<Vec<
                 None
             }
         }
-        IpNextHeaderProtocols::Tcp => {
-            let Some(tcp) = TcpPacket::new(ip.payload()) else {
-                tracing::debug!("DNS filter proxy: failed to parse TCP packet from IPv4");
-                return None;
-            };
-            match tcp.get_destination() {
-                DOT_PORT => {
-                    // Always RST DoT connections to force Android back to UDP/53.
-                    tracing::trace!("DNS proxy: RST TCP/853 (DoT) from IPv4");
-                    Some(build_tcp_rst_response_v4(&ip, &tcp))
-                }
-                DNS_PORT => {
-                    // Always RST TCP/53 since we don't support it
-                    tracing::trace!("DNS proxy: RST TCP/53 from IPv4");
-                    Some(build_tcp_rst_response_v4(&ip, &tcp))
-                }
-                _ => None,
-            }
-        }
         _ => None,
     }
 }
@@ -275,23 +252,6 @@ async fn maybe_nxdomain_v6(packet: &[u8], dns_filter: &DnsFilter) -> Option<Vec<
                 Some(build_udp_response_v6(&ip, &udp, nxdomain_dns))
             } else {
                 None
-            }
-        }
-        IpNextHeaderProtocols::Tcp => {
-            let Some(tcp) = TcpPacket::new(ip.payload()) else {
-                tracing::debug!("DNS filter proxy: failed to parse TCP packet from IPv6");
-                return None;
-            };
-            match tcp.get_destination() {
-                DOT_PORT => {
-                    tracing::trace!("DNS proxy: RST TCP/853 (DoT) from IPv6");
-                    Some(build_tcp_rst_response_v6(&ip, &tcp))
-                }
-                DNS_PORT => {
-                    tracing::trace!("DNS proxy: RST TCP/53 from IPv6");
-                    Some(build_tcp_rst_response_v6(&ip, &tcp))
-                }
-                _ => None,
             }
         }
         _ => None,
@@ -396,66 +356,5 @@ fn build_udp_response_v6(orig_ip: &Ipv6Packet, orig_udp: &UdpPacket, dns: Vec<u8
         udp.set_payload(&dns);
         udp.set_checksum(udp::ipv6_checksum(&udp.to_immutable(), &dst, &src));
     }
-    buf
-}
-
-fn build_tcp_rst_response_v4(orig_ip: &Ipv4Packet, orig_tcp: &TcpPacket) -> Vec<u8> {
-    let ihl = orig_ip.get_header_length() as usize * 4;
-    let total_len = ihl + TcpPacket::minimum_packet_size();
-    let mut buf = vec![0u8; total_len];
-
-    buf[..ihl].copy_from_slice(&orig_ip.packet()[..ihl]);
-
-    let mut ip = MutableIpv4Packet::new(&mut buf).expect("buf is large enough");
-    ip.set_source(orig_ip.get_destination());
-    ip.set_destination(orig_ip.get_source());
-    ip.set_total_length(total_len as u16);
-    ip.set_checksum(0);
-
-    {
-        let src = ip.get_source();
-        let dst = ip.get_destination();
-        let mut tcp = MutableTcpPacket::new(ip.payload_mut()).expect("buf is large enough");
-        tcp.set_source(orig_tcp.get_destination());
-        tcp.set_destination(orig_tcp.get_source());
-        tcp.set_window(0);
-        tcp.set_data_offset(5);
-        tcp.set_flags(TcpFlags::RST);
-        tcp.set_sequence(orig_tcp.get_acknowledgement());
-        tcp.set_acknowledgement(0);
-        tcp.set_checksum(tcp::ipv4_checksum(&tcp.to_immutable(), &dst, &src));
-    }
-
-    ip.set_checksum(ipv4::checksum(&ip.to_immutable()));
-
-    buf
-}
-
-fn build_tcp_rst_response_v6(orig_ip: &Ipv6Packet, orig_tcp: &TcpPacket) -> Vec<u8> {
-    let tcp_len = TcpPacket::minimum_packet_size();
-    let total_len = IPV6_HEADER_LEN + tcp_len;
-    let mut buf = vec![0u8; total_len];
-
-    buf[..IPV6_HEADER_LEN].copy_from_slice(&orig_ip.packet()[..IPV6_HEADER_LEN]);
-
-    let mut ip = MutableIpv6Packet::new(&mut buf).expect("buf is large enough");
-    ip.set_source(orig_ip.get_destination());
-    ip.set_destination(orig_ip.get_source());
-    ip.set_payload_length(tcp_len as u16);
-
-    {
-        let src = ip.get_source();
-        let dst = ip.get_destination();
-        let mut tcp = MutableTcpPacket::new(ip.payload_mut()).expect("buf is large enough");
-        tcp.set_source(orig_tcp.get_destination());
-        tcp.set_destination(orig_tcp.get_source());
-        tcp.set_window(0);
-        tcp.set_data_offset(5);
-        tcp.set_flags(TcpFlags::RST);
-        tcp.set_sequence(orig_tcp.get_acknowledgement());
-        tcp.set_acknowledgement(0);
-        tcp.set_checksum(tcp::ipv6_checksum(&tcp.to_immutable(), &dst, &src));
-    }
-
     buf
 }


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5313)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * DNS filter proxy now exclusively processes UDP-based DNS queries. TCP DNS support, including DNS over TLS filtering, has been removed. UDP DNS interception behavior remains unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nymtech/nym-vpn-client/pull/5313?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->