### PR TITLE
Add hybrid transport reachability check to nym-diagnostic

### DIFF
--- a/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/api/VpnServiceApiImpl.kt
+++ b/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/api/VpnServiceApiImpl.kt
@@ -106,7 +106,7 @@ internal class VpnServiceApiImpl(private val core: VpnCoreController, override v
 	override suspend fun getAccountMode(): StoredAccountMode? = core.tryWithCoreSender { it.getAccountMode() }
 	override suspend fun getAccountSummary(): VpnAccountSummary? = core.tryWithCoreSender { it.getAccountSummary() }
 	override suspend fun runDiagnostic(): String? = core.tryWithCoreSender {
-		val params = DiagnosticRunParams(null, skipDns = false, skipHttp = false)
+		val params = DiagnosticRunParams(null, skipDns = false, skipHttp = false, skipHybridTransport = false)
 		it.runDiagnostic(params)
 	}
 }

--- a/nym-vpn-app/src-tauri/src/vpnd/diagnostic.rs
+++ b/nym-vpn-app/src-tauri/src/vpnd/diagnostic.rs
@@ -214,6 +214,7 @@ pub struct DiagnosticRunParams {
     pub gateway: Option<String>,
     pub skip_dns: bool,
     pub skip_http: bool,
+    pub skip_hybrid_transport: bool,
 }
 
 impl From<DiagnosticRunParams> for lib::DiagnosticRunParams {
@@ -222,6 +223,7 @@ impl From<DiagnosticRunParams> for lib::DiagnosticRunParams {
             gateway: params.gateway,
             skip_dns: params.skip_dns,
             skip_http: params.skip_http,
+            skip_hybrid_transport: params.skip_hybrid_transport,
         }
     }
 }

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -5650,7 +5650,7 @@ dependencies = [
  "pnet_packet 0.35.0",
  "rand 0.8.5",
  "rand 0.9.2",
- "rustls 0.23.37",
+ "rustls 0.23.40",
  "semver",
  "serde_json",
  "thiserror 2.0.18",

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -5650,17 +5650,20 @@ dependencies = [
  "pnet_packet 0.35.0",
  "rand 0.8.5",
  "rand 0.9.2",
+ "rustls 0.23.37",
  "semver",
  "serde_json",
  "thiserror 2.0.18",
  "time",
  "tokio",
+ "tokio-rustls 0.26.4",
  "tokio-tungstenite 0.29.0",
  "tokio-util",
  "tracing",
  "tracing-subscriber",
  "url",
  "vergen-gitcl",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]

--- a/nym-vpn-core/crates/nym-diagnostic/Cargo.toml
+++ b/nym-vpn-core/crates/nym-diagnostic/Cargo.toml
@@ -52,6 +52,7 @@ hickory-resolver = { workspace = true, features = [
 pnet_packet.workspace = true
 rand09.workspace = true
 rand.workspace = true
+rustls = { workspace = true, features = ["ring"] }
 semver.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
@@ -59,6 +60,8 @@ time.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "net"] }
 tokio-util.workspace = true
 tokio-tungstenite.workspace = true
+tokio-rustls.workspace = true
+webpki-roots.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 url.workspace = true

--- a/nym-vpn-core/crates/nym-diagnostic/src/cli.rs
+++ b/nym-vpn-core/crates/nym-diagnostic/src/cli.rs
@@ -63,6 +63,10 @@ pub struct RunParams {
     /// Skip HTTP diagnostic
     #[clap(long, action = clap::ArgAction::SetTrue)]
     pub skip_http: bool,
+
+    /// Skip CTAP 2.2 Hybrid Transport reachability diagnostic
+    #[clap(long, action = clap::ArgAction::SetTrue)]
+    pub skip_hybrid_transport: bool,
 }
 
 impl From<RunParams> for nym_vpn_lib_types::DiagnosticRunParams {
@@ -71,6 +75,7 @@ impl From<RunParams> for nym_vpn_lib_types::DiagnosticRunParams {
             gateway: value.gateway,
             skip_dns: value.skip_dns,
             skip_http: value.skip_http,
+            skip_hybrid_transport: value.skip_hybrid_transport,
         }
     }
 }

--- a/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/hybrid_transport.rs
+++ b/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/hybrid_transport.rs
@@ -1,0 +1,122 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+//! Reachability check for Google's CTAP 2.2 Hybrid Transport relay
+//! (`cable.ua5v.com`).
+//!
+//! Opens a TLS connection on port 443 and runs a WebSocket upgrade with
+//! `Sec-WebSocket-Protocol: fido.cable` on `/cable/new/<tunnel_id>`. The
+//! socket is closed as soon as the upgrade response arrives — we don't
+//! consume a tunnel slot.
+//!
+//! Success requires both HTTP 101 *and* an `X-Cable-Routing-Id` response
+//! header. 101 alone is not enough: Apple's relay (and any MITM that
+//! terminates TLS and completes a WS upgrade) returns 101 too. The
+//! routing-id header is what proves we reached a working Google bridging
+//! backend.
+
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use nym_vpn_lib_types::HybridTransportReport;
+use rand::RngCore;
+use rustls::{ClientConfig, RootCertStore, pki_types::ServerName};
+use tokio::net::TcpStream;
+use tokio_rustls::TlsConnector;
+use tokio_tungstenite::tungstenite::{handshake::client::generate_key, http::Request};
+
+const RELAY_HOST: &str = "cable.ua5v.com";
+const WS_PATH_PREFIX: &str = "/cable";
+const WS_SUBPROTOCOL: &str = "fido.cable";
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
+
+pub struct HybridTransportDiagnostic;
+
+impl HybridTransportDiagnostic {
+    pub async fn run_diagnostic() -> Result<HybridTransportReport, String> {
+        tracing::info!("Running hybrid transport diagnostic");
+
+        let tls_config = build_tls_config()?;
+        match tokio::time::timeout(HANDSHAKE_TIMEOUT, probe(tls_config)).await {
+            Ok(result) => result,
+            Err(_) => Err(format!("handshake timed out after {HANDSHAKE_TIMEOUT:?}")),
+        }
+    }
+}
+
+fn build_tls_config() -> Result<Arc<ClientConfig>, String> {
+    let root_store = RootCertStore {
+        roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
+    };
+    let provider = rustls::crypto::CryptoProvider::get_default()
+        .cloned()
+        .unwrap_or_else(|| Arc::new(rustls::crypto::ring::default_provider()));
+    let config = ClientConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()
+        .map_err(|e| format!("tls protocol versions: {e}"))?
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+    Ok(Arc::new(config))
+}
+
+async fn probe(tls_config: Arc<ClientConfig>) -> Result<HybridTransportReport, String> {
+    let tunnel_id = random_tunnel_id();
+    let path = format!("{WS_PATH_PREFIX}/new/{tunnel_id}");
+
+    tracing::debug!("hybrid transport probe -> {RELAY_HOST}{path} (tunnel-id {tunnel_id})");
+
+    let start = Instant::now();
+
+    let tcp = TcpStream::connect((RELAY_HOST, 443))
+        .await
+        .map_err(|e| format!("tcp connect: {e}"))?;
+
+    let server_name = ServerName::try_from(RELAY_HOST)
+        .map_err(|e| format!("invalid server name: {e}"))?
+        .to_owned();
+    let tls = TlsConnector::from(tls_config)
+        .connect(server_name, tcp)
+        .await
+        .map_err(|e| format!("tls handshake: {e}"))?;
+
+    let request = Request::builder()
+        .uri(format!("wss://{RELAY_HOST}{path}"))
+        .header("Host", RELAY_HOST)
+        .header("Connection", "Upgrade")
+        .header("Upgrade", "websocket")
+        .header("Sec-WebSocket-Version", "13")
+        .header("Sec-WebSocket-Key", generate_key())
+        .header("Sec-WebSocket-Protocol", WS_SUBPROTOCOL)
+        .body(())
+        .map_err(|e| format!("build ws request: {e}"))?;
+
+    let (_ws, response) = tokio_tungstenite::client_async(request, tls)
+        .await
+        .map_err(|e| format!("ws upgrade: {e}"))?;
+
+    let handshake_duration_ms = start.elapsed().as_millis();
+    let routing_id = response
+        .headers()
+        .get("X-Cable-Routing-Id")
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned)
+        .ok_or("missing X-Cable-Routing-Id header (101 alone is not proof of a working backend)")?;
+
+    tracing::info!(
+        "hybrid transport probe {RELAY_HOST} -> {} routing-id={routing_id} ({handshake_duration_ms}ms)",
+        response.status()
+    );
+
+    Ok(HybridTransportReport {
+        routing_id,
+        handshake_duration_ms,
+    })
+}
+
+fn random_tunnel_id() -> String {
+    let mut bytes = [0u8; 16];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}

--- a/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/mod.rs
+++ b/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/mod.rs
@@ -4,7 +4,7 @@
 use crate::{
     diagnostic::{
         dns::DnsDiagnostic, gateway::GatewayDiagnostic, http::HttpDiagnostic,
-        registration::RegistrationDiagnostic,
+        hybrid_transport::HybridTransportDiagnostic, registration::RegistrationDiagnostic,
     },
     error::{Error, Result},
 };
@@ -19,6 +19,7 @@ use nym_vpn_network_config::Network;
 mod dns;
 mod gateway;
 mod http;
+mod hybrid_transport;
 mod registration;
 
 pub struct DiagnosticHandler;
@@ -46,10 +47,17 @@ impl DiagnosticHandler {
             None => None,
         };
 
+        let hybrid_transport_report = if !parameters.skip_hybrid_transport {
+            Some(HybridTransportDiagnostic::run_diagnostic().await)
+        } else {
+            None
+        };
+
         DiagnosticReport {
             dns: dns_report,
             http: http_report.map(Into::into),
             gateway: gateway_report,
+            hybrid_transport: hybrid_transport_report.map(Into::into),
         }
     }
 

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/diagnostic.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/diagnostic.rs
@@ -68,6 +68,15 @@ pub struct DiagnosticReport {
     pub dns: Option<CompleteDnsReport>,
     pub http: Option<DiagnosticResult<HttpReport>>,
     pub gateway: Option<GatewayReport>,
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
+    pub hybrid_transport: Option<DiagnosticResult<HybridTransportReport>>,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
+pub struct HybridTransportReport {
+    pub routing_id: String,
+    pub handshake_duration_ms: u128,
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -233,6 +242,7 @@ pub struct DiagnosticRunParams {
     pub gateway: Option<String>,
     pub skip_dns: bool,
     pub skip_http: bool,
+    pub skip_hybrid_transport: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/diagnostic.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/diagnostic.rs
@@ -68,7 +68,10 @@ pub struct DiagnosticReport {
     pub dns: Option<CompleteDnsReport>,
     pub http: Option<DiagnosticResult<HttpReport>>,
     pub gateway: Option<GatewayReport>,
-    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, skip_serializing_if = "Option::is_none")
+    )]
     pub hybrid_transport: Option<DiagnosticResult<HybridTransportReport>>,
 }
 

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
@@ -73,8 +73,8 @@ pub use connection_data::{
 pub use device::{NymVpnDevice, NymVpnDeviceStatus, NymVpnUsage};
 pub use diagnostic::{
     ApiTimeSkew, CompleteDnsReport, DiagnosticRegisterParams, DiagnosticReport, DiagnosticResult,
-    DiagnosticRunParams, DnsResolution, GatewayReport, HttpReport, PingReport, RegistrationMode,
-    RegistrationReport,
+    DiagnosticRunParams, DnsResolution, GatewayReport, HttpReport, HybridTransportReport,
+    PingReport, RegistrationMode, RegistrationReport,
 };
 pub use gateway::{
     Asn, AsnKind, BridgeInformation, BridgeParameters, Country, Entry, EntryPoint, Exit, ExitPoint,

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -1047,6 +1047,7 @@ message DiagnosticRunParams {
   bool skip_dns = 1;
   bool skip_http = 2;
   optional GatewayId gateway = 3;
+  bool skip_hybrid_transport = 4;
 }
 
 message DiagnosticRegisterParams {

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/diagnostic.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/diagnostic.rs
@@ -31,6 +31,7 @@ impl From<proto::DiagnosticRunParams> for nym_vpn_lib_types::DiagnosticRunParams
             gateway: value.gateway.map(|g| g.id),
             skip_dns: value.skip_dns,
             skip_http: value.skip_http,
+            skip_hybrid_transport: value.skip_hybrid_transport,
         }
     }
 }
@@ -41,6 +42,7 @@ impl From<nym_vpn_lib_types::DiagnosticRunParams> for proto::DiagnosticRunParams
             gateway: value.gateway.map(|id| proto::GatewayId { id }),
             skip_dns: value.skip_dns,
             skip_http: value.skip_http,
+            skip_hybrid_transport: value.skip_hybrid_transport,
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-rpc-uniffi/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-rpc-uniffi/src/lib.rs
@@ -462,6 +462,7 @@ impl RpcClient {
             gateway: None,
             skip_dns: false,
             skip_http: false,
+            skip_hybrid_transport: false,
         };
         Ok(self.inner.clone().run_diagnostic_raw(params).await?)
     }


### PR DESCRIPTION
## Ticket

JIRA-NYM-1338

## Description
There is a proposed covert rendezvous channel that uses the CTAP 2.2 Standard’s Hybrid Transport feature and the google reference server to tunnel data.

In order to step this towards viability we add a diagnostic test to check if a connection to the reference server could work for clients. 

This is not a test of the CTAP 2.2 hybrid transport as a covert channel. it is just checking if we can etablish a websocket connection to the reference server.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5314)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CTAP 2.2 Hybrid Transport reachability diagnostic to identify connectivity issues with hybrid transport infrastructure.
  * Added CLI flag to optionally skip hybrid transport checks during diagnostic runs.
  * Diagnostic reports now include routing ID and connection handshake duration metrics for hybrid transport connections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nymtech/nym-vpn-client/pull/5314)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->