### PR TITLE
android: disable hickory due to missing JVM

### DIFF
--- a/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/dns.rs
+++ b/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/dns.rs
@@ -27,6 +27,7 @@ pub struct DnsDiagnostic {
 }
 
 impl DnsDiagnostic {
+    #[cfg(not(target_os = "android"))]
     fn system() -> Result<TokioResolver, DnsDiagnosticError> {
         Self::build_resolver(Resolver::builder_tokio()?)
     }
@@ -83,12 +84,17 @@ impl DnsDiagnostic {
         );
 
         tracing::debug!("System DNS diagnostic");
-        let system_resolver = DnsDiagnostic::system();
-        let system = match system_resolver {
+        #[cfg(not(target_os = "android"))]
+        let system = match DnsDiagnostic::system() {
             Ok(resolver) => Ok(many_diagnostic.resolve(&resolver).await),
             Err(e) => Err(e),
         }
         .into();
+        // Hickory fails due to missing JavaVM context
+        // See: https://github.com/hickory-dns/hickory-dns/issues/3625
+        // TODO: FIXME
+        #[cfg(target_os = "android")]
+        let system = DiagnosticResult::from_err("hickory system resolver not working currently");
 
         let single_hostname = many_diagnostic.hostnames[0].clone();
         let ns_diagnostic = DnsDiagnostic {

--- a/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/dns.rs
+++ b/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/dns.rs
@@ -59,12 +59,18 @@ impl DnsDiagnostic {
     pub async fn run_diagnostic(network: &Network) -> CompleteDnsReport {
         tracing::info!("Running DNS diagnostic");
 
+        #[cfg(not(target_os = "android"))]
         let system_dns = hickory_resolver::system_conf::read_system_conf()
             .inspect_err(|err| {
                 tracing::warn!("Failed to obtain system dns config: {err}");
             })
             .map(|(resolver_config, _opts)| resolver_config.name_servers)
             .unwrap_or_default();
+        // Hickory fails due to missing JavaVM context
+        // See: https://github.com/hickory-dns/hickory-dns/issues/3625
+        // TODO: FIXME
+        #[cfg(target_os = "android")]
+        let system_dns = vec![];
 
         let many_diagnostic = DnsDiagnostic {
             hostnames: hostnames(network),


### PR DESCRIPTION


## Description

Need to setup JVM early on but it's not ready yet. As a quick fix let's disable the call causing the issue.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5319)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * DNS diagnostics are now platform-aware: non-Android systems read and use native system DNS settings for diagnostics, while Android devices skip system DNS resolution and return a platform-specific diagnostic result. Per-host and per-nameserver checks continue to run using the available system DNS information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nymtech/nym-vpn-client/pull/5319)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->