### PR TITLE
[Android] Patch for auto-detect release build type

### DIFF
--- a/nym-vpn-android/core/build.gradle.kts
+++ b/nym-vpn-android/core/build.gradle.kts
@@ -113,10 +113,14 @@ dependencies {
 val envNdkProvider = providers.environmentVariable("ANDROID_NDK_HOME")
 val propNdkProvider = providers.gradleProperty("android.ndkDirectory")
 val sdkDirProvider = androidComponents.sdkComponents.sdkDirectory
+val releaseVariants = setOf(Constants.RELEASE, Constants.PRERELEASE, Constants.NIGHTLY)
+val isReleaseBuild = gradle.startParameter.taskRequests
+	.flatMap { it.args }
+	.any { arg -> releaseVariants.any { variant -> arg.contains(variant, ignoreCase = true) } }
 
 val releaseBuildProvider = providers.gradleProperty("releaseBuild")
 	.map { it == "true" }
-	.orElse(false)
+	.orElse(isReleaseBuild)
 
 val skipBuildProvider = providers.gradleProperty(Constants.BUILD_LIB_TASK)
 	.map { it == "false" }


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

Fix auto-detection of release build type for core build.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5328)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build configuration to automatically detect release build variants from Gradle task arguments, enhancing the build system's release variant detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nymtech/nym-vpn-client/pull/5328)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->