### PR TITLE
(tauri) open `tauri-post-release` PR against the release branch

### DIFF
--- a/.github/workflows/tauri-post-release.yml
+++ b/.github/workflows/tauri-post-release.yml
@@ -40,8 +40,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v6
         with:
-          fetch-depth: 1
           ref: "develop"
+          fetch-depth: 0
 
       - name: Install deps
         run: |
@@ -83,7 +83,8 @@ jobs:
         run: |
           ./update_metainfo.sh
 
-      - name: Create PR
+      - name: Create PR against develop
+        id: create_pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
@@ -101,10 +102,36 @@ jobs:
           git add .pkg/linux
           git add nym-vpn-app/.pkg/flatpak
           git commit -m "${{ env.COMMIT_MSG }}"
+          echo "commit_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
           git push --force origin ${{ env.GIT_BRANCH }}
           existing=$(gh pr list --head "${{ env.GIT_BRANCH }}" --json number --jq 'length')
           if [[ "$existing" == "0" ]]; then
             gh pr create --title '${{ env.COMMIT_MSG }}' --body '${{ env.PR_BODY }}' --base develop --reviewer "agentpietrucha"
           else
             echo "PR already exists for branch ${{ env.GIT_BRANCH }}, skipping"
+          fi
+
+      - name: Create PR against release branch
+        if: ${{ github.ref_name != 'develop' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BASE_BRANCH: ${{ github.ref_name }}
+          GIT_BRANCH: "tauri_postrel_${{ inputs.version }}_${{ github.ref_name }}"
+          COMMIT_SHA: ${{ steps.create_pr.outputs.commit_sha }}
+          COMMIT_MSG: "tauri: post release v${{ inputs.version }}"
+          PR_BODY: |
+            - update CHANGELOG.md
+            - bump Linux installer script
+            - update flatpak package metainfo.xml
+        run: |
+          git fetch origin "${BASE_BRANCH}"
+          git switch -C "${GIT_BRANCH}" "origin/${BASE_BRANCH}"
+          git cherry-pick "${COMMIT_SHA}"
+          git push --force origin "${GIT_BRANCH}"
+          existing=$(gh pr list --head "${GIT_BRANCH}" --json number --jq 'length')
+          if [[ "$existing" == "0" ]]; then
+            gh pr create --title "${COMMIT_MSG}" --body "${PR_BODY}" --base "${BASE_BRANCH}" --head "${GIT_BRANCH}" --reviewer "agentpietrucha"
+          else
+            echo "PR already exists for branch ${GIT_BRANCH}, skipping"
           fi


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

Open post release PR against release branch too. This is needed for `install` script. Currently the installer from release branch points to previous release instead of the current one


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5356)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal release automation to improve commit tracking and PR creation reliability during the post-release process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nymtech/nym-vpn-client/pull/5356?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->