### PR TITLE
NYM-583: Avoid database corruption by closing the db pool before drop.

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -7354,6 +7354,7 @@ dependencies = [
  "bip39",
  "nym-crypto",
  "nym-pemstore",
+ "nym-sqlx-pool-guard",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "serde",

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -3758,7 +3758,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -5093,7 +5093,7 @@ dependencies = [
 [[package]]
 name = "nym-api-requests"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "bs58",
  "celes",
@@ -5146,7 +5146,7 @@ dependencies = [
 [[package]]
 name = "nym-authenticator-client"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "bincode",
  "futures",
@@ -5169,7 +5169,7 @@ dependencies = [
 [[package]]
 name = "nym-authenticator-requests"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -5193,7 +5193,7 @@ dependencies = [
 [[package]]
 name = "nym-bandwidth-controller"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "async-trait",
  "log",
@@ -5211,7 +5211,7 @@ dependencies = [
 [[package]]
 name = "nym-bin-common"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "const-str",
  "log",
@@ -5253,7 +5253,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5313,7 +5313,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-config-types"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "humantime-serde",
  "nym-config",
@@ -5329,7 +5329,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-gateways-storage"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5349,7 +5349,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-surb-storage"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5368,7 +5368,7 @@ dependencies = [
 [[package]]
 name = "nym-coconut-dkg-common"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -5382,7 +5382,7 @@ dependencies = [
 [[package]]
 name = "nym-common"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "tracing",
  "tracing-test",
@@ -5399,7 +5399,7 @@ dependencies = [
 [[package]]
 name = "nym-compact-ecash"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "bincode",
  "bs58",
@@ -5422,7 +5422,7 @@ dependencies = [
 [[package]]
 name = "nym-config"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "dirs",
  "handlebars",
@@ -5455,7 +5455,7 @@ dependencies = [
 [[package]]
 name = "nym-contracts-common"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -5470,7 +5470,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-proxy-requests"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "async-trait",
  "nym-credentials",
@@ -5491,7 +5491,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-storage"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5512,7 +5512,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-utils"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "log",
  "nym-bandwidth-controller",
@@ -5531,7 +5531,7 @@ dependencies = [
 [[package]]
 name = "nym-credentials"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "bincode",
  "cosmrs",
@@ -5555,7 +5555,7 @@ dependencies = [
 [[package]]
 name = "nym-credentials-interface"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "nym-bls12_381-fork",
  "nym-compact-ecash",
@@ -5574,7 +5574,7 @@ dependencies = [
 [[package]]
 name = "nym-crypto"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "aead",
  "aes 0.8.4",
@@ -5693,7 +5693,7 @@ dependencies = [
 [[package]]
 name = "nym-ecash-contract-common"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -5707,7 +5707,7 @@ dependencies = [
 [[package]]
 name = "nym-ecash-signer-check-types"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "nym-coconut-dkg-common",
  "nym-crypto",
@@ -5723,7 +5723,7 @@ dependencies = [
 [[package]]
 name = "nym-ecash-time"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "nym-compact-ecash",
  "time",
@@ -5741,7 +5741,7 @@ dependencies = [
 [[package]]
 name = "nym-exit-policy"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "serde",
  "serde_json",
@@ -5783,7 +5783,7 @@ dependencies = [
 [[package]]
 name = "nym-gateway-client"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "futures",
  "getrandom 0.2.17",
@@ -5847,7 +5847,7 @@ dependencies = [
 [[package]]
 name = "nym-gateway-requests"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "bs58",
  "futures",
@@ -5877,7 +5877,7 @@ dependencies = [
 [[package]]
 name = "nym-group-contract-common"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "cosmwasm-schema",
  "cw-controllers",
@@ -5889,7 +5889,7 @@ dependencies = [
 [[package]]
 name = "nym-http-api-client"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5922,7 +5922,7 @@ dependencies = [
 [[package]]
 name = "nym-http-api-client-macro"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5934,7 +5934,7 @@ dependencies = [
 [[package]]
 name = "nym-http-api-common"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "bincode",
  "serde",
@@ -5945,7 +5945,7 @@ dependencies = [
 [[package]]
 name = "nym-id"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "nym-credential-storage",
  "nym-credentials",
@@ -5973,7 +5973,7 @@ dependencies = [
 [[package]]
 name = "nym-ip-packet-client"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "bincode",
  "bytes",
@@ -5990,7 +5990,7 @@ dependencies = [
 [[package]]
 name = "nym-ip-packet-requests"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "bincode",
  "bytes",
@@ -6038,7 +6038,7 @@ dependencies = [
 [[package]]
 name = "nym-kkt"
 version = "0.1.0"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "libcrux-chacha20poly1305",
  "libcrux-ecdh",
@@ -6059,7 +6059,7 @@ dependencies = [
 [[package]]
 name = "nym-kkt-ciphersuite"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "blake3",
  "libcrux-sha3",
@@ -6073,7 +6073,7 @@ dependencies = [
 [[package]]
 name = "nym-kkt-context"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "num_enum",
  "nym-kkt-ciphersuite",
@@ -6083,7 +6083,7 @@ dependencies = [
 [[package]]
 name = "nym-lp"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "bs58",
  "bytes",
@@ -6113,7 +6113,7 @@ dependencies = [
 [[package]]
 name = "nym-metrics"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "dashmap",
  "lazy_static",
@@ -6124,7 +6124,7 @@ dependencies = [
 [[package]]
 name = "nym-mixnet-client"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "dashmap",
  "futures",
@@ -6140,7 +6140,7 @@ dependencies = [
 [[package]]
 name = "nym-mixnet-contract-common"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -6161,7 +6161,7 @@ dependencies = [
 [[package]]
 name = "nym-multisig-contract-common"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -6177,7 +6177,7 @@ dependencies = [
 [[package]]
 name = "nym-network-defaults"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "cargo_metadata 0.19.2",
  "dotenvy",
@@ -6194,7 +6194,7 @@ dependencies = [
 [[package]]
 name = "nym-node-requests"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "celes",
  "humantime-serde",
@@ -6219,7 +6219,7 @@ dependencies = [
 [[package]]
 name = "nym-noise"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -6240,7 +6240,7 @@ dependencies = [
 [[package]]
 name = "nym-noise-keys"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "nym-crypto",
  "schemars 0.8.22",
@@ -6251,7 +6251,7 @@ dependencies = [
 [[package]]
 name = "nym-nonexhaustive-delayqueue"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -6281,7 +6281,7 @@ dependencies = [
 [[package]]
 name = "nym-ordered-buffer"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "log",
  "thiserror 2.0.18",
@@ -6290,7 +6290,7 @@ dependencies = [
 [[package]]
 name = "nym-outfox"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "blake3",
  "chacha20 0.9.1",
@@ -6304,7 +6304,7 @@ dependencies = [
 [[package]]
 name = "nym-pemstore"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "pem",
  "tracing",
@@ -6314,7 +6314,7 @@ dependencies = [
 [[package]]
 name = "nym-performance-contract-common"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -6342,7 +6342,7 @@ dependencies = [
 [[package]]
 name = "nym-registration-client"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "bincode",
  "bytes",
@@ -6369,7 +6369,7 @@ dependencies = [
 [[package]]
 name = "nym-registration-common"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "bincode",
  "nym-authenticator-requests",
@@ -6406,7 +6406,7 @@ dependencies = [
 [[package]]
 name = "nym-sdk"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6464,7 +6464,7 @@ dependencies = [
 [[package]]
 name = "nym-serde-helpers"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -6476,7 +6476,7 @@ dependencies = [
 [[package]]
 name = "nym-service-provider-requests-common"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -6485,7 +6485,7 @@ dependencies = [
 [[package]]
 name = "nym-service-providers-common"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "async-trait",
  "log",
@@ -6509,7 +6509,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-client-core"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "anyhow",
  "dirs",
@@ -6566,7 +6566,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-proxy-helpers"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "bytes",
  "futures",
@@ -6589,7 +6589,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-requests"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "bincode",
  "log",
@@ -6605,7 +6605,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "nym-crypto",
  "nym-metrics",
@@ -6631,7 +6631,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-acknowledgements"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "nym-crypto",
  "nym-pemstore",
@@ -6648,7 +6648,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-addressing"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-types",
@@ -6659,7 +6659,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-anonymous-replies"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "bs58",
  "nym-crypto",
@@ -6677,7 +6677,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-chunking"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "dashmap",
  "log",
@@ -6696,7 +6696,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-cover"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-acknowledgements",
@@ -6714,7 +6714,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-forwarding"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "nym-sphinx-addressing",
  "nym-sphinx-anonymous-replies",
@@ -6726,7 +6726,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-framing"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -6743,7 +6743,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-params"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-types",
@@ -6754,7 +6754,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-routing"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "nym-sphinx-addressing",
  "nym-sphinx-types",
@@ -6764,7 +6764,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-types"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "nym-outfox",
  "sphinx-packet",
@@ -6813,7 +6813,7 @@ dependencies = [
 [[package]]
 name = "nym-sqlx-pool-guard"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "proc_pidinfo",
  "sqlx",
@@ -6857,7 +6857,7 @@ dependencies = [
 [[package]]
 name = "nym-statistics-common"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "futures",
  "log",
@@ -6882,7 +6882,7 @@ dependencies = [
 [[package]]
 name = "nym-task"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "cfg-if",
  "futures",
@@ -6899,7 +6899,7 @@ dependencies = [
 [[package]]
 name = "nym-ticketbooks-merkle"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "nym-credentials-interface",
  "nym-serde-helpers",
@@ -6914,7 +6914,7 @@ dependencies = [
 [[package]]
 name = "nym-topology"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "async-trait",
  "nym-api-requests",
@@ -6934,7 +6934,7 @@ dependencies = [
 [[package]]
 name = "nym-upgrade-mode-check"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "jwt-simple",
  "nym-crypto",
@@ -6951,7 +6951,7 @@ dependencies = [
 [[package]]
 name = "nym-validator-client"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7001,7 +7001,7 @@ dependencies = [
 [[package]]
 name = "nym-vesting-contract-common"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -7415,7 +7415,7 @@ dependencies = [
 [[package]]
 name = "nym-wasm-utils"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "futures",
  "getrandom 0.2.17",
@@ -7477,7 +7477,7 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-private-metadata-client"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "async-trait",
  "nym-http-api-client",
@@ -7488,7 +7488,7 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-private-metadata-shared"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "axum 0.7.9",
  "bincode",
@@ -7502,7 +7502,7 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-types"
 version = "1.20.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#f84de25302e886d4bd97a898885c569724c002a7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.9-venaco#db03ec31b1bab2e00426bd8813f9b32a37d4be99"
 dependencies = [
  "base64 0.22.1",
  "nym-crypto",
@@ -7853,7 +7853,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -8516,7 +8516,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "petgraph",
@@ -8537,7 +8537,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8550,7 +8550,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -9997,7 +9997,7 @@ version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
- "errno 0.3.14",
+ "errno 0.2.8",
  "libc",
 ]
 

--- a/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/http.rs
+++ b/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/http.rs
@@ -9,8 +9,7 @@ use crate::{
 use nym_http_api_client::{Client, ClientBuilder, FrontPolicy, Url};
 use nym_platform_metadata::new_user_agent;
 use nym_validator_client::nym_api::NymApiClientExt;
-use nym_vpn_api_client::VpnApiClient;
-use nym_vpn_api_client::api_urls_to_urls;
+use nym_vpn_api_client::{VpnApiClient, api_urls_to_urls};
 use nym_vpn_lib_types::{
     ApiTimeSkew, ApiUrl, DiagnosticEndpointResponse, DiagnosticResult, HttpReport,
 };

--- a/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/registration/lp_client.rs
+++ b/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/registration/lp_client.rs
@@ -52,6 +52,8 @@ impl LpClientRegistration {
         // Perform handshake with gateway
         if let Err(e) = lp_client.perform_handshake().await {
             registration_report.lp_handshake = Some(DiagnosticResult::from_err(e));
+            // Close credential storage before early return so OS file handles are released promptly.
+            registration_config.bandwidth_provider.close().await;
             return None;
         } else {
             registration_report.lp_handshake = Some(DiagnosticResult::<()>::SUCCESS)
@@ -59,7 +61,7 @@ impl LpClientRegistration {
 
         // dVPN registration
         tracing::info!("Registering with entry gateway");
-        match lp_client
+        let dvpn_result = lp_client
             .register_dvpn(
                 &mut rand09::rngs::StdRng::from_os_rng(),
                 &registration_config.local_wg_keypair,
@@ -67,8 +69,13 @@ impl LpClientRegistration {
                 &registration_config.bandwidth_provider,
                 TicketType::V1WireguardEntry,
             )
-            .await
-        {
+            .await;
+
+        // Explicitly close the credential storage before registration_config is dropped so
+        // that the underlying SQLite pool releases OS file handles promptly (Windows).
+        registration_config.bandwidth_provider.close().await;
+
+        match dvpn_result {
             Ok(response) => {
                 registration_report.lp_based_dvpn_registration =
                     Some(DiagnosticResult::from_value((&response).into()));

--- a/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/registration/mixnet_client.rs
+++ b/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/registration/mixnet_client.rs
@@ -144,7 +144,13 @@ impl MixnetClientRegistration {
 
         tracing::info!("Registering...");
 
-        match Self::wireguard_registration(mixnet_client, &registration_config).await {
+        let registration_result =
+            Self::wireguard_registration(mixnet_client, &registration_config).await;
+        // Explicitly close the credential storage before registration_config is dropped so
+        // that the underlying SQLite pool releases OS file handles promptly (Windows).
+        registration_config.bandwidth_provider.close().await;
+
+        match registration_result {
             Ok(response) => {
                 registration_report.mixnet_based_dvpn_registration =
                     Some(DiagnosticResult::from_value((&response).into()));

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
@@ -89,10 +89,23 @@ where
         let credential_storage =
             VpnCredentialStorage::setup_from_path(config.data_dir.clone()).await?;
 
-        let vpn_api_account = account_storage.load_vpn_account().await?;
-        let device_keys = account_storage.load_device_keys().await?;
-
-        let wireguard_keys_storage = WireguardKeysDb::init(Some(config.data_dir.clone())).await?;
+        // Load remaining state that may fail; close credential_storage on any error so the
+        // underlying db pool is released before we return.
+        let (vpn_api_account, device_keys, wireguard_keys_storage) = match async {
+            let vpn_api_account = account_storage.load_vpn_account().await?;
+            let device_keys = account_storage.load_device_keys().await?;
+            let wireguard_keys_storage =
+                WireguardKeysDb::init(Some(config.data_dir.clone())).await?;
+            Ok::<_, Error>((vpn_api_account, device_keys, wireguard_keys_storage))
+        }
+        .await
+        {
+            Ok(v) => v,
+            Err(e) => {
+                credential_storage.close().await;
+                return Err(e);
+            }
+        };
 
         // Shared_state
         let shared_state = SharedAccountState::new(

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
@@ -216,6 +216,7 @@ where
         }
 
         self.shared_state.credential_storage.close().await;
+        self.shared_state.wireguard_keys_storage.close().await;
         tracing::debug!("Account controller state machine is exiting...");
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
@@ -903,6 +903,10 @@ impl BandwidthController {
             }
         }
 
+        // Explicitly close the credential storage so that the underlying SQLite pool releases
+        // OS file handles promptly (especially important on Windows).
+        self.ticket_provider.close().await;
+
         tracing::debug!("BandwidthController: Exiting");
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/algorithm.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/algorithm.rs
@@ -25,7 +25,7 @@ async fn continuous_select<C: GatewayCache>(
     gateway_cache: C,
     blacklisted_entry_gateways: &BlacklistedGateways,
     device_location: Option<Location>,
-    wg_keys_db: WireguardKeysDb,
+    wg_keys_db: &WireguardKeysDb,
 ) {
     loop {
         // make sure the buffer is not full before deciding on other possible selections
@@ -38,7 +38,7 @@ async fn continuous_select<C: GatewayCache>(
             blacklisted_entry_gateways,
             &select_and_send.tunnel_settings,
             device_location.clone(),
-            wg_keys_db.clone(),
+            wg_keys_db,
         )
         .await;
         selection_tx.send(selection);
@@ -79,7 +79,7 @@ impl<C: GatewayCache> SelectionAlgorithm<C> {
             tokio::select! {
                 _ = self.shutdown_token.cancelled() => {
                     tracing::info!("SelectionAlgorithm shut down");
-                    return;
+                    break;
                 }
                 Some(new_settings) = self.tunnel_settings_rx.recv() => {
                     latest_tunnel_settings = new_settings;
@@ -92,10 +92,11 @@ impl<C: GatewayCache> SelectionAlgorithm<C> {
                         self.gateway_cache.clone(),
                         &self.blacklisted_entry_gateways,
                         latest_location.clone(),
-                        self.wg_keys_db.clone(),
+                        &self.wg_keys_db,
                     ) => {},
             }
         }
+        self.wg_keys_db.close().await;
     }
 }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/selector.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/selector.rs
@@ -308,7 +308,7 @@ pub async fn select_gateways(
     blacklisted_entry_gateways: &BlacklistedGateways,
     tunnel_settings: &TunnelSettings,
     device_location: Option<Location>,
-    wg_keys_db: WireguardKeysDb,
+    wg_keys_db: &WireguardKeysDb,
 ) -> Result<SelectedGateways, GatewayProviderError> {
     // The set of exit gateways is smaller than the set of entry gateways, so we start by selecting
     // the exit gateway and then filter out the exit gateway from the set of entry gateways.
@@ -504,7 +504,7 @@ mod tests {
             &BlacklistedGateways::new(),
             &settings,
             None,
-            WireguardKeysDb::Ephemeral(Default::default()),
+            &WireguardKeysDb::Ephemeral(Default::default()),
         )
         .await;
 
@@ -533,7 +533,7 @@ mod tests {
             &BlacklistedGateways::new(),
             &settings,
             None,
-            WireguardKeysDb::Ephemeral(Default::default()),
+            &WireguardKeysDb::Ephemeral(Default::default()),
         )
         .await;
 
@@ -561,7 +561,7 @@ mod tests {
             &BlacklistedGateways::new(),
             &settings,
             None,
-            WireguardKeysDb::Ephemeral(Default::default()),
+            &WireguardKeysDb::Ephemeral(Default::default()),
         )
         .await;
 

--- a/nym-vpn-core/crates/nym-vpn-store/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-store/Cargo.toml
@@ -16,6 +16,7 @@ async-trait.workspace = true
 bip39 = { workspace = true, features = ["zeroize"] }
 nym-crypto = { workspace = true, features = ["rand", "asymmetric", "serde"] }
 nym-pemstore.workspace = true
+nym-sqlx-pool-guard.workspace = true
 rand.workspace = true
 rand_chacha.workspace = true
 serde = { workspace = true, features = ["derive"] }

--- a/nym-vpn-core/crates/nym-vpn-store/src/keys/wireguard/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-store/src/keys/wireguard/mod.rs
@@ -41,6 +41,13 @@ impl WireguardKeysDb {
         };
         Ok(db)
     }
+
+    pub async fn close(&self) {
+        match self {
+            WireguardKeysDb::OnDisk(on_disk_keys) => on_disk_keys.close().await,
+            WireguardKeysDb::Ephemeral(_) => {}
+        }
+    }
 }
 
 #[async_trait::async_trait]

--- a/nym-vpn-core/crates/nym-vpn-store/src/keys/wireguard/persistence/on_disk.rs
+++ b/nym-vpn-core/crates/nym-vpn-store/src/keys/wireguard/persistence/on_disk.rs
@@ -6,6 +6,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use nym_sqlx_pool_guard::SqlitePoolGuard;
 use sqlx::{
     ConnectOptions,
     sqlite::{SqliteAutoVacuum, SqliteSynchronous},
@@ -22,7 +23,7 @@ use crate::{
 
 #[derive(Debug, Clone)]
 pub struct OnDiskKeys {
-    connection_pool: sqlx::SqlitePool,
+    connection_pool: SqlitePoolGuard,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -104,22 +105,27 @@ impl OnDiskKeys {
             .create_if_missing(true)
             .disable_statement_logging();
 
-        let connection_pool = sqlx::SqlitePool::connect_with(opts)
-            .await
-            .map_err(|source| {
-                tracing::error!("Failed to connect to SQLx database: {source}");
-                OnDiskKeysError::DatabaseConnectionError { source }
-            })?;
+        let connection_pool = SqlitePoolGuard::new(
+            sqlx::SqlitePool::connect_with(opts)
+                .await
+                .map_err(|source| {
+                    tracing::error!("Failed to connect to SQLx database: {source}");
+                    OnDiskKeysError::DatabaseConnectionError { source }
+                })?,
+        );
 
-        sqlx::migrate!("./migrations")
-            .run(&connection_pool)
-            .await
-            .inspect_err(|err| {
-                tracing::error!("Failed to initialize SQLx database: {err}");
-            })?;
+        if let Err(err) = sqlx::migrate!("./migrations").run(&*connection_pool).await {
+            tracing::error!("Failed to initialize SQLx database: {err}");
+            connection_pool.close().await;
+            return Err(err.into());
+        }
 
         tracing::debug!("Database migration finished!");
         Ok(OnDiskKeys { connection_pool })
+    }
+
+    pub async fn close(&self) {
+        self.connection_pool.close().await;
     }
 
     pub(crate) async fn get_keys(
@@ -128,7 +134,7 @@ impl OnDiskKeys {
     ) -> Result<Option<RawWireguardKeys>, sqlx::Error> {
         sqlx::query_as("SELECT * FROM wireguard_gateway_keys WHERE gateway_id_bs58 = ?")
             .bind(gateway_id)
-            .fetch_optional(&self.connection_pool)
+            .fetch_optional(&*self.connection_pool)
             .await
     }
 
@@ -152,7 +158,7 @@ impl OnDiskKeys {
             keys.expiration_time,
             keys.gateway_id_bs58,
         )
-        .execute(&self.connection_pool)
+        .execute(&*self.connection_pool)
         .await?;
         Ok(())
     }
@@ -163,7 +169,7 @@ impl OnDiskKeys {
                 DELETE FROM wireguard_gateway_keys;
             "#,
         )
-        .execute(&self.connection_pool)
+        .execute(&*self.connection_pool)
         .await?;
         Ok(())
     }


### PR DESCRIPTION
## Ticket

JIRA-NYM-583

## Description

This change works along with a change in [`nym`](https://github.com/nymtech/nym/pull/6785).


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5360)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graceful shutdown across components: wireguard key storage, credential/ticket storage, bandwidth/registration providers, and on-disk DB pools now close cleanly to prevent resource leaks and release file handles (notably on Windows).
  * Database pool handling hardened to ensure migrations/errors close pools and free resources promptly.

* **Refactor**
  * Gateway selection updated to avoid unnecessary cloning of key storage, improving efficiency and enabling proper closure of underlying resources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nymtech/nym-vpn-client/pull/5360?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->