### PR TITLE
APPLE: add needsRelaxedIndependenceCriteria error reason

### DIFF
--- a/nym-vpn-apple/NymVPN/Resources/Localizable.xcstrings
+++ b/nym-vpn-apple/NymVPN/Resources/Localizable.xcstrings
@@ -10112,6 +10112,17 @@
         }
       }
     },
+    "errorReason.needsRelaxedIndependenceCriteria" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No gateway pair meets the current independence criteria. Relax the criteria in settings to find a usable pair."
+          }
+        }
+      }
+    },
     "errorReason.noAccountStored" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/nym-vpn-apple/Services/Sources/Services/TunnelMixnet/Config/MixnetConfig.swift
+++ b/nym-vpn-apple/Services/Sources/Services/TunnelMixnet/Config/MixnetConfig.swift
@@ -87,6 +87,7 @@ extension MixnetConfig {
             mixnetTraffic: mixnetTuning.mixnetTrafficConfig(),
             networkStats: nil,
             gatewaySelectionAlgorithmConfig: gatewaySelectionAlgorithmConfig.sdkValue,
+            gatewayIndependence: GatewayIndependence(differentNodeFamily: false, differentAsn: false),
             userAgent: .appUserAgent,
             tunProvider: tunProvider
         )

--- a/nym-vpn-apple/ServicesMacOS/Sources/GRPCManager/GRPCManager+TunnelStatus.swift
+++ b/nym-vpn-apple/ServicesMacOS/Sources/GRPCManager/GRPCManager+TunnelStatus.swift
@@ -153,6 +153,8 @@ extension GRPCManager {
             ErrorReason.needFullDiskPermissions
         case .splitTunnel:
             ErrorReason.splitTunnel
+        case .needsRelaxedIndependenceCriteria:
+            ErrorReason.needsRelaxedIndependenceCriteria
         }
     }
 }
@@ -209,6 +211,8 @@ extension ErrorReason {
             self = .needFullDiskPermissions
         case .splitTunnel:
             self = .splitTunnel
+        case .needsRelaxedIndependenceCriteria:
+            self = .needsRelaxedIndependenceCriteria
         }
     }
 }

--- a/nym-vpn-apple/ServicesMutual/Sources/ErrorReason/ErrorReason.swift
+++ b/nym-vpn-apple/ServicesMutual/Sources/ErrorReason/ErrorReason.swift
@@ -44,6 +44,7 @@ public enum ErrorReason: LocalizedError, Codable {
     case performantExitGatewayUnavailable
     case needFullDiskPermissions
     case splitTunnel
+    case needsRelaxedIndependenceCriteria
     case unknown
 
     private static let somethingWentWrong = "generalNymError.somethingWentWrong".localizedString
@@ -101,6 +102,8 @@ public enum ErrorReason: LocalizedError, Codable {
             self = .needFullDiskPermissions
         case .splitTunnel:
             self = .splitTunnel
+        case .needsRelaxedIndependenceCriteria:
+            self = .needsRelaxedIndependenceCriteria
         }
     }
 #endif
@@ -187,6 +190,8 @@ public enum ErrorReason: LocalizedError, Codable {
         case .existingAccount:
             self = .existingAccount
 #endif
+        case .needsRelaxedIndependenceCriteria:
+            self = .needsRelaxedIndependenceCriteria
         }
     }
 
@@ -287,6 +292,8 @@ private extension ErrorReason {
         case .existingAccount:
             "errorReason.existingAccount".localizedString
 #endif
+        case .needsRelaxedIndependenceCriteria:
+            "errorReason.needsRelaxedIndependenceCriteria".localizedString
         }
     }
 }
@@ -335,6 +342,7 @@ enum ErrorReasonCode: Int, RawRepresentable {
     case performantExiGatewayUnavailable
     case needFullDiskPermissions
     case splitTunnel
+    case needsRelaxedIndependenceCriteria
 
     init?(errorReason: ErrorReason) {
         switch errorReason {
@@ -410,6 +418,8 @@ enum ErrorReasonCode: Int, RawRepresentable {
         case .existingAccount:
             self = .existingAccount
 #endif
+        case .needsRelaxedIndependenceCriteria:
+            self = .needsRelaxedIndependenceCriteria
         }
     }
 }


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5364)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced configurable gateway independence criteria for VPN connections, allowing users to customize how the system selects independent gateway pairs.

* **Bug Fixes**
  * Improved error handling with enhanced messaging that clearly guides users when gateway pair selection fails due to independence constraints, recommending setting adjustments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nymtech/nym-vpn-client/pull/5364?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->