### PR TITLE
Reduce number of Account Controller retries

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
@@ -117,7 +117,7 @@ where
         let (current_state_handler, initial_state) = if is_offline {
             OfflineState::enter()
         } else {
-            SyncingState::enter(&shared_state, 0)
+            SyncingState::enter(&shared_state)
         };
 
         let public_initial_state = AccountControllerState::from(initial_state);

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/error_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/error_state.rs
@@ -66,7 +66,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ErrorState {
                     tracing::debug!("VPN API is firewalled, timed account syncing skipped");
                     return NextAccountControllerState::NewState(ErrorState::enter(self.reason));
                 } else {
-                    return NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0));
+                    return NextAccountControllerState::NewState(SyncingState::enter(shared_state));
                 }
             },
             Some(command) = command_rx.recv() => {
@@ -82,7 +82,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ErrorState {
                         let error = res.is_err();
                         return_sender.send(res);
                         if error {
-                            return NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0));
+                            return NextAccountControllerState::NewState(SyncingState::enter(shared_state));
                         } else {
                             return NextAccountControllerState::NewState(LoggedOutState::enter());
                         }
@@ -104,7 +104,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ErrorState {
                         if error {
                             return NextAccountControllerState::SameState(self);
                         } else {
-                            return NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0));
+                            return NextAccountControllerState::NewState(SyncingState::enter(shared_state));
                         }
                     },
                     AccountCommand::RefreshAccountState(return_sender) => {
@@ -112,7 +112,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ErrorState {
                         if shared_state.firewall_active {
                             return NextAccountControllerState::SameState(self);
                         } else {
-                            return NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0));
+                            return NextAccountControllerState::NewState(SyncingState::enter(shared_state));
                         }
                     },
 

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/logged_out_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/logged_out_state.rs
@@ -55,7 +55,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for LoggedOutState
                 match command {
                     AccountCommand::CreateAccount(return_sender) => {
                         return_sender.send(handler::handle_create_account(shared_state).await);
-                        return NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0));
+                        return NextAccountControllerState::NewState(SyncingState::enter(shared_state));
                     }
                     AccountCommand::StoreAccount(return_sender, storable_account) => {
                         return if let Err(e) = handler::handle_store_account(shared_state, storable_account).await{
@@ -63,7 +63,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for LoggedOutState
                             NextAccountControllerState::SameState(self)
                         } else {
                             return_sender.send(Ok(()));
-                            NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0))
+                            NextAccountControllerState::NewState(SyncingState::enter(shared_state))
                         }
                     },
                     AccountCommand::ForgetAccount(return_sender) => return_sender.send(Ok(())),

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/offline_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/offline_state.rs
@@ -119,7 +119,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for OfflineState {
                 if connectivity.is_offline() {
                     NextAccountControllerState::SameState(self)
                 } else {
-                    NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0))
+                    NextAccountControllerState::NewState(SyncingState::enter(shared_state))
                 }
             }
             _ = shutdown_token.cancelled() => {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/pending_subscription_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/pending_subscription_state.rs
@@ -57,7 +57,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for PendingSubscri
                     tracing::debug!("VPN API is firewalled, timed account syncing skipped");
                     return NextAccountControllerState::NewState(PendingSubscriptionState::enter());
                 } else {
-                    return NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0));
+                    return NextAccountControllerState::NewState(SyncingState::enter(shared_state));
                 }
             },
             Some(command) = command_rx.recv() => {
@@ -73,7 +73,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for PendingSubscri
                         let error = res.is_err();
                         return_sender.send(res);
                         if error {
-                            return NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0));
+                            return NextAccountControllerState::NewState(SyncingState::enter(shared_state));
                         } else {
                             return NextAccountControllerState::NewState(LoggedOutState::enter());
                         }
@@ -95,7 +95,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for PendingSubscri
                         if error {
                             return NextAccountControllerState::SameState(self);
                         } else {
-                            return NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0));
+                            return NextAccountControllerState::NewState(SyncingState::enter(shared_state));
                         }
                     },
                     AccountCommand::RefreshAccountState(return_sender) => {
@@ -103,7 +103,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for PendingSubscri
                         if shared_state.firewall_active {
                             return NextAccountControllerState::SameState(self);
                         } else {
-                            return NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0));
+                            return NextAccountControllerState::NewState(SyncingState::enter(shared_state));
                         }
                     },
                     AccountCommand::VpnApiFirewallDown(return_sender) => {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/ready_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/ready_state.rs
@@ -60,7 +60,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ReadyState {
                     tracing::debug!("VPN API is firewalled, timed account syncing skipped");
                     return NextAccountControllerState::NewState(ReadyState::enter());
                 } else {
-                    return NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0));
+                    return NextAccountControllerState::NewState(SyncingState::enter(shared_state));
                 }
             },
             Some(command) = command_rx.recv() => {
@@ -97,7 +97,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ReadyState {
                         if error {
                             return NextAccountControllerState::SameState(self);
                         } else {
-                            return NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0));
+                            return NextAccountControllerState::NewState(SyncingState::enter(shared_state));
                         }
                     },
                     AccountCommand::RefreshAccountState(return_sender) => {
@@ -105,7 +105,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ReadyState {
                         if shared_state.firewall_active {
                             return NextAccountControllerState::SameState(self);
                         } else {
-                            return NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0));
+                            return NextAccountControllerState::NewState(SyncingState::enter(shared_state));
                         }
                     },
 

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{cmp::min, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 use crate::{
     SharedAccountState,
@@ -29,12 +29,11 @@ use tracing::warn;
 
 pub(super) mod requesting_zknym_state;
 
-const MAX_SYNCING_ATTEMPTS: u32 = 10;
+const MAX_SYNCING_ATTEMPTS: u32 = 2;
 const SYNCING_STATE_CONTEXT: &str = "SYNCING_STATE";
 
-// bounded exponential backoff for retries [0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 8.0, 8.0, 8.0, 8.0, 8.0] = 55.75s max wait
-const RETRY_BACKOFF: Duration = Duration::from_millis(250);
-const MAX_BACKOFF_EXPONENT: u32 = 5;
+// bounded exponential backoff for retries [2, 4] = 6s max wait for 2 retries
+const RETRY_BACKOFF: Duration = Duration::from_secs(2);
 const BACKOFF_BASE: u32 = 2;
 
 enum SyncEvent {
@@ -253,7 +252,7 @@ impl SyncingState {
 
     /// The attempt retries should  start with attempt 1
     fn get_delay(attempts: u32) -> Duration {
-        RETRY_BACKOFF * BACKOFF_BASE.pow(min(attempts - 1, MAX_BACKOFF_EXPONENT))
+        RETRY_BACKOFF * BACKOFF_BASE.pow(attempts - 1)
     }
 }
 

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
@@ -252,7 +252,8 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingState {
                         NextAccountControllerState::SameState(self)
                     }
                     SyncEvent::Failure(err) => {
-                        let err_str = err.to_string();
+                        // debug print the error so that it contains display information about sub error
+                        let err_str = format!("{err:?}");
                         match err.into_error_reason() {
                             None => {
                                 tracing::debug!("Subscription is pending, waiting before retrying");

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
@@ -156,7 +156,7 @@ impl SyncingState {
                 .await
                 .map_err(Self::map_vpn_api_error)?;
 
-            tracing::debug!("{summary:#?}");
+            tracing::debug!("{summary:?}");
 
             Self::handle_received_account_summary(
                 event_tx.clone(),

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
 use crate::{
     SharedAccountState,
@@ -9,7 +9,7 @@ use crate::{
     state_machine::{
         AccountControllerStateHandler, DecentralisedState, ErrorState, LoggedOutState,
         NextAccountControllerState, OfflineState, PendingSubscriptionState,
-        PrivateAccountControllerState,
+        PrivateAccountControllerState, ReadyState,
     },
 };
 use nym_offline_monitor::ConnectivityMonitor;
@@ -25,16 +25,11 @@ use nym_vpn_lib_types::{
 use requesting_zknym_state::RequestingZkNymsState;
 use tokio::sync::mpsc;
 use tokio_util::sync::{CancellationToken, DropGuard};
-use tracing::warn;
+use tracing::{debug, warn};
 
 pub(super) mod requesting_zknym_state;
 
-const MAX_SYNCING_ATTEMPTS: u32 = 2;
 const SYNCING_STATE_CONTEXT: &str = "SYNCING_STATE";
-
-// bounded exponential backoff for retries [2, 4] = 6s max wait for 2 retries
-const RETRY_BACKOFF: Duration = Duration::from_secs(2);
-const BACKOFF_BASE: u32 = 2;
 
 enum SyncEvent {
     /// Account summary is received
@@ -66,7 +61,6 @@ enum SyncEvent {
 /// - OfflineState : the connectivity monitor is telling we're not connected
 /// - DecentralisedState : The loaded account is set to "decentralised" mode
 pub struct SyncingState {
-    attempts: u32,
     event_rx: mpsc::UnboundedReceiver<SyncEvent>,
     sync_cancel_token: Option<DropGuard>,
 }
@@ -74,7 +68,6 @@ pub struct SyncingState {
 impl SyncingState {
     pub fn enter<C: ConnectivityMonitor>(
         shared_state: &SharedAccountState<C>,
-        attempts: u32,
     ) -> (
         Box<dyn AccountControllerStateHandler<C>>,
         PrivateAccountControllerState,
@@ -100,18 +93,11 @@ impl SyncingState {
         // This handle does not need to be awaited since event channel and cancellation token are sufficient.
         let _syncing_state_handle =
             tokio::spawn(sync_cancel_token.child_token().run_until_cancelled_owned(
-                SyncingState::sync_account(
-                    event_tx,
-                    vpn_api_client,
-                    vpn_api_account,
-                    device,
-                    attempts,
-                ),
+                SyncingState::sync_account(event_tx, vpn_api_client, vpn_api_account, device),
             ));
 
         (
             Box::new(Self {
-                attempts,
                 event_rx,
                 sync_cancel_token: Some(sync_cancel_token.drop_guard()),
             }),
@@ -124,12 +110,7 @@ impl SyncingState {
         vpn_api_client: VpnApiClient,
         vpn_api_account: Arc<VpnAccount>,
         device: Device,
-        attempts: u32,
     ) {
-        if attempts > 0 {
-            tokio::time::sleep(Self::get_delay(attempts)).await;
-        }
-
         let final_event =
             Self::sync_account_inner(event_tx.clone(), vpn_api_client, vpn_api_account, device)
                 .await
@@ -249,11 +230,6 @@ impl SyncingState {
             .await?;
         Ok(()) // We can register a device, we have fair usage
     }
-
-    /// The attempt retries should  start with attempt 1
-    fn get_delay(attempts: u32) -> Duration {
-        RETRY_BACKOFF * BACKOFF_BASE.pow(attempts - 1)
-    }
 }
 
 #[async_trait::async_trait]
@@ -276,25 +252,11 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingState {
                         NextAccountControllerState::SameState(self)
                     }
                     SyncEvent::Failure(err) => {
-                        let is_retryable = err.is_retryable();
                         let err_str = err.to_string();
                         match err.into_error_reason() {
                             None => {
                                 tracing::debug!("Subscription is pending, waiting before retrying");
                                 NextAccountControllerState::NewState(PendingSubscriptionState::enter())
-                            }
-                            Some(reason) if is_retryable => {
-                                if self.attempts >= MAX_SYNCING_ATTEMPTS {
-                                    tracing::debug!("Error trying to get account summary, exhausted retries : {err_str}");
-                                    NextAccountControllerState::NewState(ErrorState::enter(reason))
-                                } else {
-                                    tracing::debug!(
-                                        "Error trying to get account summary attempt {}, retrying after {:?} : {err_str}",
-                                        self.attempts,
-                                        Self::get_delay(self.attempts + 1),
-                                    );
-                                    NextAccountControllerState::NewState(SyncingState::enter(shared_state, self.attempts + 1))
-                                }
                             }
                             Some(reason) => {
                                 tracing::debug!("Error trying to get account summary, not retrying : {err_str}");
@@ -303,7 +265,19 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingState {
                         }
                     }
                     SyncEvent::Finished => {
-                        NextAccountControllerState::NewState(RequestingZkNymsState::enter(shared_state, self.attempts, false))
+                        if let Ok(true) =
+                            // If we already have sufficient tickets skip to ready state.
+                            // tickets should be handled by top-up after once connected.
+                            shared_state
+                                .credential_storage
+                                .is_all_ticket_types_above_minimal_threshold().await {
+
+                            debug!("proceeding with existing tickets");
+                            NextAccountControllerState::NewState(ReadyState::enter())
+                        } else {
+                            NextAccountControllerState::NewState(RequestingZkNymsState::enter(shared_state, false))
+                        }
+
                     }
                 }
             }
@@ -340,12 +314,12 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingState {
                         return if shared_state.firewall_active {
                             NextAccountControllerState::SameState(self)
                         } else {
-                            NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0))
+                            NextAccountControllerState::NewState(SyncingState::enter(shared_state))
                         }
                     },
                     AccountCommand::ResetDeviceIdentity(return_sender, seed) => {
                         return_sender.send(handler::handle_reset_device_identity(shared_state, seed).await);
-                        return NextAccountControllerState::NewState(SyncingState::enter(shared_state,0));
+                        return NextAccountControllerState::NewState(SyncingState::enter(shared_state));
                     },
 
                     AccountCommand::VpnApiFirewallDown(return_sender) =>  {
@@ -353,7 +327,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingState {
                         // No-op if the firewall was already down
                         if shared_state.firewall_active {
                             shared_state.firewall_active = false;
-                            return NextAccountControllerState::NewState(SyncingState::enter(shared_state, self.attempts));
+                            return NextAccountControllerState::NewState(SyncingState::enter(shared_state));
                         }
                     },
 
@@ -407,15 +381,6 @@ enum SyncError {
 }
 
 impl SyncError {
-    fn is_retryable(&self) -> bool {
-        matches!(
-            self,
-            SyncError::ApiRequestError(_)
-                | SyncError::DeviceTimeDesynced
-                | SyncError::InactiveSubscription // in the case of IAP, it might take a while for the subscription to become active
-        )
-    }
-
     /// Returns the corresponding error reason for the error state, or `None` if the error
     /// should not result in an error state (e.g. pending subscription has its own state).
     fn into_error_reason(self) -> Option<AccountControllerErrorStateReason> {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
@@ -284,7 +284,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingState {
                                 NextAccountControllerState::NewState(PendingSubscriptionState::enter())
                             }
                             Some(reason) if is_retryable => {
-                                if self.attempts > MAX_SYNCING_ATTEMPTS {
+                                if self.attempts >= MAX_SYNCING_ATTEMPTS {
                                     tracing::debug!("Error trying to get account summary, exhausted retries : {err_str}");
                                     NextAccountControllerState::NewState(ErrorState::enter(reason))
                                 } else {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     state_machine::{
         AccountControllerStateHandler, DecentralisedState, ErrorState, LoggedOutState,
         NextAccountControllerState, OfflineState, PendingSubscriptionState,
-        PrivateAccountControllerState, ReadyState,
+        PrivateAccountControllerState,
     },
 };
 use nym_offline_monitor::ConnectivityMonitor;
@@ -25,7 +25,7 @@ use nym_vpn_lib_types::{
 use requesting_zknym_state::RequestingZkNymsState;
 use tokio::sync::mpsc;
 use tokio_util::sync::{CancellationToken, DropGuard};
-use tracing::{debug, warn};
+use tracing::warn;
 
 pub(super) mod requesting_zknym_state;
 
@@ -266,19 +266,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingState {
                         }
                     }
                     SyncEvent::Finished => {
-                        if let Ok(true) =
-                            // If we already have sufficient tickets skip to ready state.
-                            // tickets should be handled by top-up after once connected.
-                            shared_state
-                                .credential_storage
-                                .is_all_ticket_types_above_minimal_threshold().await {
-
-                            debug!("proceeding with existing tickets");
-                            NextAccountControllerState::NewState(ReadyState::enter())
-                        } else {
-                            NextAccountControllerState::NewState(RequestingZkNymsState::enter(shared_state, false))
-                        }
-
+                        NextAccountControllerState::NewState(RequestingZkNymsState::enter(shared_state, false))
                     }
                 }
             }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/requesting_zknym_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/requesting_zknym_state.rs
@@ -33,14 +33,11 @@ use tokio::{
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
-// The maximum number of zk-nym requests that can fail in a row
 const ZK_NYM_STATE_CONTEXT: &str = "ZK_NYM_STATE";
 
 /// RequestingZkNyms State
 /// That state gets ZK-nyms if needed.
 /// This is a substate of the Syncing State, it will disappear into the future Bandwidth Controller
-///
-/// A retry mechanism is in place, if the error is in the API requests. Other errors lead a single retry, then to the ErrorState since they are not recoverable.  
 ///
 /// Possible next state :
 /// - ReadyState : We have enough tickets already, or we managed to get enough tickets

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/requesting_zknym_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/requesting_zknym_state.rs
@@ -34,7 +34,6 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
 // The maximum number of zk-nym requests that can fail in a row
-const ZK_NYM_MAX_FAILS: u32 = 10;
 const ZK_NYM_STATE_CONTEXT: &str = "ZK_NYM_STATE";
 
 /// RequestingZkNyms State
@@ -52,14 +51,12 @@ const ZK_NYM_STATE_CONTEXT: &str = "ZK_NYM_STATE";
 /// - UpgradeModeState : Instead of retrieving zk-nyms, we have received information about upgrade mode being activated
 pub(crate) struct RequestingZkNymsState {
     zk_nym_fetching_handle: JoinHandle<Result<ZkNymFetchResult, ZkNymError>>,
-    attempts: u32,
     entered_through_upgrade_mode: bool,
 }
 
 impl RequestingZkNymsState {
     pub(crate) fn enter<C: ConnectivityMonitor>(
         shared_state: &SharedAccountState<C>,
-        attempts: u32,
         entered_through_upgrade_mode: bool,
     ) -> (
         Box<dyn AccountControllerStateHandler<C>>,
@@ -100,7 +97,6 @@ impl RequestingZkNymsState {
         (
             Box::new(Self {
                 zk_nym_fetching_handle,
-                attempts,
                 entered_through_upgrade_mode,
             }),
             PrivateAccountControllerState::RequestingZkNyms,
@@ -229,64 +225,46 @@ impl RequestingZkNymsState {
             Ok(join_result) => join_result,
             Err(err) => {
                 error!("Failed to join on the fetching task : {err}");
-                return NextAccountControllerState::NewState(SyncingState::enter(
-                    shared_state,
-                    self.attempts + 1,
-                ));
+                return NextAccountControllerState::NewState(SyncingState::enter(shared_state));
             }
         };
 
         let retrieval_result = match join_result {
             Ok(retrieval_result) => retrieval_result,
-            Err(zk_nym_error) => {
-                if self.attempts > ZK_NYM_MAX_FAILS {
-                    return NextAccountControllerState::NewState(ErrorState::enter(
-                        zk_nym_error.into(),
-                    ));
-                }
-
-                // We have an error, but maybe we still have enough ticketbook to proceed
+            Err(err) => {
                 if let Ok(true) = shared_state
                     .credential_storage
                     .is_all_ticket_types_above_minimal_threshold()
                     .await
                 {
-                    // let's see if next sync fixes it
+                    // proceed as we have enough tickets and requesting tickets
+                    // on the next sync may resolve the issue.
+                    warn!(
+                        "encountered error attempting to retrieve zknyms: {err} -- proceeding with existing tickets"
+                    );
                     return NextAccountControllerState::NewState(ReadyState::enter());
                 }
-                return match zk_nym_error {
-                    ZkNymError::Storage(_) | ZkNymError::Internal(_) => {
-                        // Error is on our side, let's give it one last try though
-                        NextAccountControllerState::NewState(RequestingZkNymsState::enter(
-                            shared_state,
-                            ZK_NYM_MAX_FAILS + 1,
-                            false,
-                        ))
-                    }
-                    ZkNymError::ApiFailure(_) => {
-                        // Error on the API side, let's try again
-                        NextAccountControllerState::NewState(RequestingZkNymsState::enter(
-                            shared_state,
-                            self.attempts + 1,
-                            false,
-                        ))
-                    }
-                    ZkNymError::BandwidthExceeded => {
+
+                if matches!(err, ZkNymError::BandwidthExceeded) {
+                    if let Ok(true) = shared_state
+                        .credential_storage
+                        .is_all_ticket_types_non_empty()
+                        .await
+                    {
+                        tracing::warn!(
+                            "Our fair usage is depleted but we still have some tickets stored locally"
+                        );
+                        return NextAccountControllerState::NewState(ReadyState::enter());
+                    } else {
                         tracing::warn!("Our fair usage is depleted");
-                        if let Ok(true) = shared_state
-                            .credential_storage
-                            .is_all_ticket_types_non_empty()
-                            .await
-                        {
-                            tracing::warn!("We still have some tickets though");
-                            NextAccountControllerState::NewState(ReadyState::enter())
-                        } else {
-                            NextAccountControllerState::NewState(ErrorState::enter(
-                                ZkNymError::BandwidthExceeded.into(),
-                            ))
-                        }
+                        return NextAccountControllerState::NewState(ErrorState::enter(
+                            ZkNymError::BandwidthExceeded.into(),
+                        ));
                     }
-                };
+                }
+
+                error!("failed to retrieve zknyms: {err}");
+                return NextAccountControllerState::NewState(ErrorState::enter(err.into()));
             }
         };
 
@@ -322,7 +300,7 @@ impl RequestingZkNymsState {
                 let error = res.is_err();
                 return_sender.send(res);
                 return if error {
-                    NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0))
+                    NextAccountControllerState::NewState(SyncingState::enter(shared_state))
                 } else {
                     NextAccountControllerState::NewState(LoggedOutState::enter())
                 };
@@ -344,7 +322,7 @@ impl RequestingZkNymsState {
             AccountCommand::ResetDeviceIdentity(return_sender, seed) => {
                 self.zk_nym_fetching_handle.abort();
                 return_sender.send(handler::handle_reset_device_identity(shared_state, seed).await);
-                return NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0));
+                return NextAccountControllerState::NewState(SyncingState::enter(shared_state));
             }
             AccountCommand::RefreshAccountState(return_sender) => {
                 return_sender.send(Ok(()));
@@ -352,7 +330,7 @@ impl RequestingZkNymsState {
                     NextAccountControllerState::SameState(self)
                 } else {
                     self.zk_nym_fetching_handle.abort();
-                    NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0))
+                    NextAccountControllerState::NewState(SyncingState::enter(shared_state))
                 };
             }
             AccountCommand::VpnApiFirewallDown(return_sender) => {
@@ -366,7 +344,6 @@ impl RequestingZkNymsState {
                     shared_state.firewall_active = false;
                     return NextAccountControllerState::NewState(RequestingZkNymsState::enter(
                         shared_state,
-                        self.attempts,
                         false,
                     ));
                 }
@@ -429,11 +406,15 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for RequestingZkNy
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 enum ZkNymError {
+    #[error("Internal issue relating to zknym storage: {0}")]
     Storage(String),
+    #[error("encountered issue with zknym API: {0}")]
     ApiFailure(String),
+    #[error("Internal issue relating to zknym processing: {0}")]
     Internal(String),
+    #[error("fair usage is depleted")]
     BandwidthExceeded,
 }
 

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/requesting_zknym_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/requesting_zknym_state.rs
@@ -224,8 +224,11 @@ impl RequestingZkNymsState {
         let join_result = match zknym_result {
             Ok(join_result) => join_result,
             Err(err) => {
-                error!("Failed to join on the fetching task : {err}");
-                return NextAccountControllerState::NewState(SyncingState::enter(shared_state));
+                let msg = format!("Failed to join zknym fetching task : {err}");
+                error!(msg);
+                return NextAccountControllerState::NewState(ErrorState::enter(
+                    ZkNymError::internal(&msg).into(),
+                ));
             }
         };
 

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/upgrade_mode_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/upgrade_mode_state.rs
@@ -73,7 +73,7 @@ impl UpgradeModeState {
                     // instead of crashing
                     if until_expiration.is_negative() {
                         info!("the retrieved upgrade mode JWT expired immediately");
-                        return SyncingState::enter(shared_state, 0);
+                        return SyncingState::enter(shared_state);
                     }
                     until_expiration.unsigned_abs()
                 } else {
@@ -164,7 +164,7 @@ impl UpgradeModeState {
                     if let Err(error_state) = Self::on_exit(shared_state).await {
                         return error_state.into();
                     }
-                    NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0))
+                    NextAccountControllerState::NewState(SyncingState::enter(shared_state))
                 };
             }
             AccountCommand::RefreshAccountState(return_sender) => {
@@ -176,10 +176,7 @@ impl UpgradeModeState {
                     if let Err(error_state) = Self::on_exit(shared_state).await {
                         return error_state.into();
                     }
-                    return NextAccountControllerState::NewState(SyncingState::enter(
-                        shared_state,
-                        0,
-                    ));
+                    return NextAccountControllerState::NewState(SyncingState::enter(shared_state));
                 }
             }
             AccountCommand::VpnApiFirewallDown(return_sender) => {
@@ -202,10 +199,7 @@ impl UpgradeModeState {
                     if let Err(error_state) = Self::on_exit(shared_state).await {
                         return error_state.into();
                     }
-                    return NextAccountControllerState::NewState(SyncingState::enter(
-                        shared_state,
-                        0,
-                    ));
+                    return NextAccountControllerState::NewState(SyncingState::enter(shared_state));
                 }
             },
         }
@@ -230,7 +224,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for UpgradeModeSta
             _ = &mut self.refresh_timer => {
                 debug!("attempting to retrieve a zk-nym/refresh upgrade mode attestation");
                 // note: we wouldn't have entered `UpgradeModeState` if we didn't have any fair usage left
-                return NextAccountControllerState::NewState(RequestingZkNymsState::enter(shared_state, 0, true))
+                return NextAccountControllerState::NewState(RequestingZkNymsState::enter(shared_state, true))
             }
             Some(command) = command_rx.recv() => {
                 self.handle_account_command(command, shared_state).await


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

The account controller is retrying way to many times way to quickly. 

~~This PR reduces the number of retries down to 2  -- which is actually 9 HTTP request attempts as the  HTTP client is configured with 3 retries per attempt, and inital + 2 sync retry attempts.~~

~~Also the wait between attempts now starts at a 2s delay.~~

This PR removes the retry attempts from the account controller state machine. If the account controller encounters a failed step it transitions to the error state directly.

Also adds a check for stored sufficient zk_nyms before transitioning to the RequestingZkNyms state so we skip an API access if it is not necessary. 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5365)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed repeated retry/backoff during account sync so failures progress faster to pending, error, or ready states.
  * Improved handling of zk-nym and sync failures to reduce stuck states and speed recovery.
  * Reduced verbosity of account debug output for cleaner logs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nymtech/nym-vpn-client/pull/5365?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->