### PR TITLE
[Android] Connect EnableBridges config param to QUIC

### DIFF
--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/censorship/CensorshipScreen.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/censorship/CensorshipScreen.kt
@@ -1,7 +1,6 @@
 package net.nymtech.nymvpn.ui.screens.settings.censorship
 
 import android.content.res.Configuration
-import android.widget.Toast
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -13,20 +12,16 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import kotlinx.coroutines.flow.collectLatest
 import net.nymtech.nymvpn.R
 import net.nymtech.nymvpn.ui.AppUiState
-import net.nymtech.nymvpn.ui.common.events.UiEvent
 import net.nymtech.nymvpn.ui.screens.settings.censorship.components.AmneziaSection
 import net.nymtech.nymvpn.ui.screens.settings.censorship.components.QuicSection
 import net.nymtech.nymvpn.ui.screens.settings.censorship.components.StealthApiSection
@@ -36,18 +31,6 @@ import net.nymtech.nymvpn.util.extensions.scaledWidth
 
 @Composable
 fun CensorshipScreen(appUiState: AppUiState, viewModel: CensorshipViewModel = hiltViewModel()) {
-	val context = LocalContext.current
-
-	LaunchedEffect(viewModel) {
-		viewModel.events.collectLatest { event ->
-			when (event) {
-				UiEvent.ReconnectStarted -> {
-					Toast.makeText(context, context.getString(R.string.censorship_event_reconnecting), Toast.LENGTH_SHORT).show()
-				}
-			}
-		}
-	}
-
 	CensorshipScreen(
 		quicEnabled = appUiState.settings.quicEnabled,
 		onQuicEnable = { enabled -> viewModel.onQUICEnabled(enabled) },

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/censorship/CensorshipViewModel.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/censorship/CensorshipViewModel.kt
@@ -29,6 +29,7 @@ class CensorshipViewModel @Inject constructor(private val backendManager: Backen
 	fun onQUICEnabled(enabled: Boolean) = viewModelScope.launch {
 		runCatching {
 			settingsRepository.setQUICEnabled(enabled)
+			vpnConfigRepository.apply(CoreVpnConfigUpdate.SetEnableBridges(enabled))
 			if (vpnConfigRepository.getConfig().mode == Tunnel.Mode.TWO_HOP_MIXNET) {
 				backendManager.requestReconnect()
 				notifyReconnectIfConnected()

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/censorship/CensorshipViewModel.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/censorship/CensorshipViewModel.kt
@@ -9,16 +9,13 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import net.nymtech.nymvpn.data.SettingsRepository
 import net.nymtech.nymvpn.data.config.VpnConfigRepository
-import net.nymtech.nymvpn.manager.backend.BackendManager
 import net.nymtech.nymvpn.ui.common.events.UiEvent
-import net.nymtech.vpn.backend.Tunnel
 import net.nymtech.vpn.config.CoreVpnConfigUpdate
 import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
-class CensorshipViewModel @Inject constructor(private val backendManager: BackendManager, private val vpnConfigRepository: VpnConfigRepository, private val settingsRepository: SettingsRepository) :
-	ViewModel() {
+class CensorshipViewModel @Inject constructor(private val vpnConfigRepository: VpnConfigRepository, private val settingsRepository: SettingsRepository) : ViewModel() {
 
 	private val _events = MutableSharedFlow<UiEvent>(
 		extraBufferCapacity = 1,
@@ -30,10 +27,6 @@ class CensorshipViewModel @Inject constructor(private val backendManager: Backen
 		runCatching {
 			settingsRepository.setQUICEnabled(enabled)
 			vpnConfigRepository.apply(CoreVpnConfigUpdate.SetEnableBridges(enabled))
-			if (vpnConfigRepository.getConfig().mode == Tunnel.Mode.TWO_HOP_MIXNET) {
-				backendManager.requestReconnect()
-				notifyReconnectIfConnected()
-			}
 		}.onFailure {
 			Timber.e(it, "Failed to update QUIC setting")
 		}
@@ -41,20 +34,9 @@ class CensorshipViewModel @Inject constructor(private val backendManager: Backen
 
 	fun onStealthModeEnabled(enabled: Boolean) = viewModelScope.launch {
 		runCatching {
-			notifyReconnectIfConnected()
 			vpnConfigRepository.apply(CoreVpnConfigUpdate.SetStealthMode(enabled))
-			backendManager.requestReconnect()
 		}.onFailure {
 			Timber.e(it, "Failed to update stealth mode setting")
-		}
-	}
-
-	private fun notifyReconnectIfConnected() {
-		val state = backendManager.getState()
-		val isConnected = state == Tunnel.State.Up || state == Tunnel.State.EstablishingConnection
-
-		if (isConnected) {
-			_events.tryEmit(UiEvent.ReconnectStarted)
 		}
 	}
 }

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/util/extensions/UiExtensions.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/util/extensions/UiExtensions.kt
@@ -158,6 +158,7 @@ fun ErrorStateReason.toUserMessage(context: Context): String = when (this) {
 	ErrorStateReason.SplitTunnel -> ""
 
 	is ErrorStateReason.Internal -> context.getString(R.string.unexpected_error, this.v1)
+	ErrorStateReason.NeedsRelaxedIndependenceCriteria ->  ""
 }
 
 fun VpnException.toUserMessage(context: Context): String = when (this) {

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/util/extensions/UiExtensions.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/util/extensions/UiExtensions.kt
@@ -158,7 +158,7 @@ fun ErrorStateReason.toUserMessage(context: Context): String = when (this) {
 	ErrorStateReason.SplitTunnel -> ""
 
 	is ErrorStateReason.Internal -> context.getString(R.string.unexpected_error, this.v1)
-	ErrorStateReason.NeedsRelaxedIndependenceCriteria ->  ""
+	ErrorStateReason.NeedsRelaxedIndependenceCriteria -> ""
 }
 
 fun VpnException.toUserMessage(context: Context): String = when (this) {

--- a/nym-vpn-android/core/src/main/java/net/nymtech/vpn/util/extensions/LibExtensions.kt
+++ b/nym-vpn-android/core/src/main/java/net/nymtech/vpn/util/extensions/LibExtensions.kt
@@ -87,4 +87,5 @@ fun ErrorStateReason.toHumanReadableString(context: Context): String = when (thi
 	ErrorStateReason.NeedFullDiskPermissions, ErrorStateReason.SplitTunnel -> ""
 
 	is ErrorStateReason.Internal -> context.getString(R.string.error_reason_internal, this.v1)
+	ErrorStateReason.NeedsRelaxedIndependenceCriteria -> ""
 }


### PR DESCRIPTION
## Ticket

JIRA-NYM-1367

## Description

- Connect EnableBridges config param to QUIC
- Remove reconnect logic from Censorship Screen


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5374)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Streamlined QUIC and stealth-mode toggles in Settings: changes now apply directly without triggering reconnect prompts.
  * Error messaging refined so unsupported internal error reasons no longer surface as user-facing text.

* **Bug Fixes**
  * Removed intermittent reconnect Toast that previously appeared when toggling network/privacy options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nymtech/nym-vpn-client/pull/5374?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->