### PR TITLE
Change default entry and exit to random

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Node family restriction and possibility to check for probable gateway selection before connection (https://github.com/nymtech/nym-vpn-client/pull/5285)
 
+### Changed
+
+- Change default entry and exit points to random (https://github.com/nymtech/nym-vpn-client/pull/5378)
+
 
 ## [1.30] - 2026-05-29
 

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
@@ -97,6 +97,8 @@ pub use rpc_requests::{
     AccountBalanceResponse, AccountCommandResponse, Coin, DecentralisedObtainTicketbooksRequest,
     ListGatewaysOptions, StoreAccountRequest,
 };
+#[cfg(feature = "uniffi-bindings")]
+pub use service::default_vpn_service_config;
 pub use service::{
     BackgroundCoverTrafficRate, ContinuousTrafficSendingRate, FrontingMode, GeoExclusionSettings,
     MixingDelay, MixnetTrafficConfig, MixnetTrafficConfigValidationError, MixnetTrafficDefaults,

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/service.rs
@@ -106,12 +106,8 @@ impl fmt::Display for VpnServiceConfig {
 impl Default for VpnServiceConfig {
     fn default() -> Self {
         Self {
-            entry_point: EntryPoint::Country {
-                two_letter_iso_country_code: "CH".to_owned(),
-            },
-            exit_point: ExitPoint::Country {
-                two_letter_iso_country_code: "CH".to_owned(),
-            },
+            entry_point: EntryPoint::Random,
+            exit_point: ExitPoint::Random,
             allow_lan: false,
             disable_ipv6: false,
             enable_two_hop: true,

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/service.rs
@@ -23,7 +23,11 @@ use crate::{
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "uniffi-bindings", derive(uniffi::Record))]
+#[cfg_attr(
+    feature = "uniffi-bindings",
+    derive(uniffi::Record),
+    uniffi::export(Display, Eq)
+)]
 #[cfg_attr(
     feature = "typescript-bindings",
     derive(TS),

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/service.rs
@@ -134,6 +134,12 @@ impl Default for VpnServiceConfig {
     }
 }
 
+/// Returns the default `VpnServiceConfig`.
+#[cfg(feature = "uniffi-bindings")]
+pub fn default_vpn_service_config() -> VpnServiceConfig {
+    VpnServiceConfig::default()
+}
+
 #[cfg(feature = "uniffi-bindings")]
 pub type BoxedVpnServiceConfig = Box<VpnServiceConfig>;
 #[cfg(feature = "uniffi-bindings")]


### PR DESCRIPTION
## Ticket

JIRA-NYM-1382

## Description

- Change default entry and exit to "random"
- Export `default_vpn_service_config()` for mobile apps
- Export `Display` implementation for `VpnServiceConfig` via uniffi interface

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5378)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Default VPN entry and exit points are now randomized instead of using a fixed location, enhancing privacy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nymtech/nym-vpn-client/pull/5378?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->