### PR TITLE
Don't reuse entry gateway when registering fails

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix panic when restoring default routes (https://github.com/nymtech/nym-vpn-client/pull/5225)
 - Fix adblocker deactivation caused by remote returning embedded HTTP errors (https://github.com/nymtech/nym-vpn-client/pull/5302)
+- Don't reuse entry gateway when registering fails (https://github.com/nymtech/nym-vpn-client/pull/5379)
 
 
 ## [1.29.2] - 2026-05-04

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -701,7 +701,7 @@ impl TunnelStateHandler for ConnectingState {
                             self.reconnect(shared_state).await
                         }
                     }
-                    TunnelMonitorEvent::ConnectionFailed => {
+                    TunnelMonitorEvent::ConnectionFailed | TunnelMonitorEvent::RegistrationFailed=> {
                         // We have failed to connect repeatedly; let's blacklist the previously selected
                         // entry gateways for a while and force gateway re-selection.
                         if let Some(ref selected_gateways) = self.selected_gateways {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -155,6 +155,9 @@ pub enum TunnelMonitorEvent {
     /// Registering with gateways
     RegisteringWithGateways,
 
+    /// Registration with gateways failed
+    RegistrationFailed,
+
     /// Finished gateway registration
     RegisteredWithGateways {
         /// Connection data
@@ -489,7 +492,9 @@ impl TunnelMonitor {
         let rc_builder = RegistrationClientBuilder::new(rc_builder_config);
 
         let registration_client = Box::pin(rc_builder.build()).await?;
-        let registration_result = Box::pin(registration_client.register()).await?;
+        let registration_result = Box::pin(registration_client.register())
+            .await
+            .inspect_err(|_| self.send_event(TunnelMonitorEvent::RegistrationFailed))?;
 
         // Send event upon successful gateway registration
         // The receiver should handle the event and add firewall exceptions for entry gateway


### PR DESCRIPTION
## Ticket

JIRA-NYM-1380

## Description

Failure in registration is not considered when blacklisting entry gateways.


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5379)
<!-- Reviewable:end -->
