### PR TITLE
[Android] Fix logout and auth flow states. UI fixes

### DIFF
--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/data/SettingsRepository.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/data/SettingsRepository.kt
@@ -48,6 +48,9 @@ interface SettingsRepository {
 	suspend fun getLogsEnabled(): Boolean
 	suspend fun setLogsEnabled(enabled: Boolean)
 
+	suspend fun isWelcomeShown(): Boolean
+	suspend fun setWelcomeShown(shown: Boolean)
+
 	val settingsFlow: Flow<Settings>
 
 	suspend fun getMixnetTrafficConfig(): MixnetTrafficConfig

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/data/datastore/DataStoreSettingsRepository.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/data/datastore/DataStoreSettingsRepository.kt
@@ -28,6 +28,7 @@ class DataStoreSettingsRepository(private val dataStoreManager: DataStoreManager
 	private val isStreamingServerBannerDisplayed = booleanPreferencesKey("STREAMING_SERVER_DISPLAYED")
 	private val isPerAppSecurityBannerDisplayed = booleanPreferencesKey("DEFAULT_PER_APP_SECURITY_BANNER_DISPLAYED")
 	private val logsEnabled = booleanPreferencesKey("LOGS_ENABLED")
+	private val welcomeShown = booleanPreferencesKey("WELCOME_SHOWN")
 
 	// Keys for Mixnet Configuration
 	private val mixnetPoissonRate = intPreferencesKey("MIXNET_POISSON_RATE")
@@ -126,6 +127,12 @@ class DataStoreSettingsRepository(private val dataStoreManager: DataStoreManager
 		dataStoreManager.saveToDataStore(logsEnabled, enabled)
 	}
 
+	override suspend fun isWelcomeShown(): Boolean = dataStoreManager.getFromStore(welcomeShown) ?: Settings.DEFAULT_WELCOME_SHOWN
+
+	override suspend fun setWelcomeShown(shown: Boolean) {
+		dataStoreManager.saveToDataStore(welcomeShown, shown)
+	}
+
 	override suspend fun getMixnetTrafficConfig(): MixnetTrafficConfig {
 		val poisson = dataStoreManager.getFromStore(mixnetPoissonRate)
 		val avgDelay = dataStoreManager.getFromStore(mixnetAvgPacketDelay)
@@ -183,6 +190,7 @@ class DataStoreSettingsRepository(private val dataStoreManager: DataStoreManager
 						isPerAppSecurityBannerDisplayed = pref[isPerAppSecurityBannerDisplayed] ?: Settings.DEFAULT_PER_APP_SECURITY_BANNER_DISPLAYED,
 						logsEnabled = pref[logsEnabled] ?: Settings.DEFAULT_LOGS_ENABLED,
 						mixnetTrafficConfig = mixnetConfig,
+						isWelcomeShown = pref[welcomeShown] ?: Settings.DEFAULT_WELCOME_SHOWN,
 					)
 				} catch (e: IllegalArgumentException) {
 					Timber.e(e)

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/data/domain/Settings.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/data/domain/Settings.kt
@@ -18,6 +18,7 @@ data class Settings(
 	val isPerAppSecurityBannerDisplayed: Boolean = DEFAULT_PER_APP_SECURITY_BANNER_DISPLAYED,
 	val logsEnabled: Boolean = DEFAULT_LOGS_ENABLED,
 	val mixnetTrafficConfig: MixnetTrafficConfig = MIXNET_CONFIG_DEFAULT,
+	val isWelcomeShown: Boolean = DEFAULT_WELCOME_SHOWN,
 ) {
 	companion object {
 		const val AUTO_START_DEFAULT = false
@@ -30,6 +31,7 @@ data class Settings(
 		const val DEFAULT_STREAMING_SERVER_BANNER_DISPLAYED = false
 		const val DEFAULT_PER_APP_SECURITY_BANNER_DISPLAYED = false
 		const val DEFAULT_LOGS_ENABLED = false
+		const val DEFAULT_WELCOME_SHOWN = false
 
 		val MIXNET_CONFIG_DEFAULT = MixnetTrafficConfig(
 			poissonParameterForLoopCoverStream = 200u,

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/AppViewModel.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/AppViewModel.kt
@@ -56,6 +56,7 @@ constructor(
 	companion object {
 		private const val TAG = "app-vm"
 		private const val ACCOUNT_INIT_TIMEOUT_MS = 30_000L
+		private const val DISCONNECT_AWAIT_TIMEOUT_MS = 10_000L
 	}
 
 	private val _systemMessage = MutableStateFlow<SystemMessage?>(null)
@@ -165,6 +166,10 @@ constructor(
 			if (backendManager.getState() != Tunnel.State.Down) {
 				Timber.tag(TAG).i("LogoutStoppingTunnel")
 				backendManager.stopTunnel()
+				val disconnected = withTimeoutOrNull(DISCONNECT_AWAIT_TIMEOUT_MS) {
+					backendManager.stateFlow.first { it.tunnelState == Tunnel.State.Down }
+				}
+				if (disconnected == null) Timber.tag(TAG).w("LogoutDisconnectTimeout")
 			}
 			performLogout(onComplete)
 			Timber.tag(TAG).i("LogoutSuccess")

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/AppViewModel.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/AppViewModel.kt
@@ -184,6 +184,10 @@ constructor(
 		}
 	}
 
+	fun setWelcomeShown() = viewModelScope.launch {
+		settingsRepository.setWelcomeShown(true)
+	}
+
 	fun onLocaleChange(localeTag: String) = viewModelScope.launch {
 		Timber.tag(TAG).i("LocaleChangeRequested")
 		settingsRepository.setLocale(localeTag)

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/account/info/AccountInfoScreen.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/account/info/AccountInfoScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -187,7 +188,8 @@ fun AccountInfoScreenContent(
 		modifier = Modifier
 			.fillMaxSize()
 			.verticalScroll(rememberScrollState())
-			.padding(horizontal = 16.dp.scaledWidth(), vertical = 24.dp),
+			.padding(horizontal = 16.dp.scaledWidth(), vertical = 24.dp)
+			.navigationBarsPadding(),
 	) {
 		SubscriptionSection(
 			subscriptionState = subscriptionState,

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/auth/AuthBottomSheet.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/auth/AuthBottomSheet.kt
@@ -20,7 +20,15 @@ import androidx.compose.ui.unit.dp
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun AuthBottomSheet(isVisible: Boolean, isMnemonicStored: Boolean, initialRoute: AuthRoute = AuthRoute.Welcome, onDismissRequest: () -> Unit, onAuthSuccess: () -> Unit, onSaveToPasswordManager: (passphrase: String) -> Unit, onWelcomeShown: () -> Unit = {}) {
+fun AuthBottomSheet(
+	isVisible: Boolean,
+	isMnemonicStored: Boolean,
+	initialRoute: AuthRoute = AuthRoute.Welcome,
+	onDismissRequest: () -> Unit,
+	onAuthSuccess: () -> Unit,
+	onSaveToPasswordManager: (passphrase: String) -> Unit,
+	onWelcomeShown: () -> Unit = {},
+) {
 	if (!isVisible || isMnemonicStored) return
 
 	val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/auth/AuthBottomSheet.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/auth/AuthBottomSheet.kt
@@ -20,8 +20,8 @@ import androidx.compose.ui.unit.dp
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun AuthBottomSheet(isVisible: Boolean, initialRoute: AuthRoute = AuthRoute.Welcome, onDismissRequest: () -> Unit, onAuthSuccess: () -> Unit, onSaveToPasswordManager: (passphrase: String) -> Unit) {
-	if (!isVisible) return
+fun AuthBottomSheet(isVisible: Boolean, isMnemonicStored: Boolean, initialRoute: AuthRoute = AuthRoute.Welcome, onDismissRequest: () -> Unit, onAuthSuccess: () -> Unit, onSaveToPasswordManager: (passphrase: String) -> Unit, onWelcomeShown: () -> Unit = {}) {
+	if (!isVisible || isMnemonicStored) return
 
 	val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
@@ -56,6 +56,7 @@ fun AuthBottomSheet(isVisible: Boolean, initialRoute: AuthRoute = AuthRoute.Welc
 				onDismissRequest()
 			},
 			onSaveToPasswordManager = onSaveToPasswordManager,
+			onWelcomeShown = onWelcomeShown,
 		)
 	}
 }

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/auth/AuthComponent.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/auth/AuthComponent.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -28,6 +29,7 @@ fun AuthComponent(
 	initialRoute: AuthRoute,
 	onAuthSuccess: () -> Unit,
 	onSaveToPasswordManager: (passphrase: String) -> Unit,
+	onWelcomeShown: () -> Unit = {},
 	modifier: Modifier = Modifier,
 	viewModel: AuthViewModel = hiltViewModel(),
 ) {
@@ -37,6 +39,7 @@ fun AuthComponent(
 	val rootNavController = LocalNavController.current
 
 	val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+	val currentOnWelcomeShown by rememberUpdatedState(onWelcomeShown)
 
 	LaunchedEffect(Unit) {
 		viewModel.events.collect { event ->
@@ -89,6 +92,7 @@ fun AuthComponent(
 		popExitTransition = { slideOutOfContainer(AnimatedContentTransitionScope.SlideDirection.Right, tween(300)) },
 	) {
 		composable<AuthRoute.Welcome> {
+			LaunchedEffect(Unit) { currentOnWelcomeShown() }
 			WelcomeView(
 				onLoginClick = { localNavController.navigate(AuthRoute.Login) },
 				onSignUpClick = { localNavController.navigate(AuthRoute.SignUp) },

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/MainScreen.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/MainScreen.kt
@@ -173,7 +173,7 @@ fun MainScreen(appViewModel: AppViewModel, appUiState: AppUiState, autoStart: Bo
 	}
 
 	LaunchedEffect(showAuth) {
-		if (showAuth && !appUiState.managerState.isMnemonicStored && !appUiState.settings.isWelcomeShown) {
+		if (showAuth && !appUiState.managerState.isMnemonicStored) {
 			initialAuthRoute = AuthRoute.Welcome
 			showAuthSheet = true
 		}
@@ -463,11 +463,11 @@ fun MainScreen(appViewModel: AppViewModel, appUiState: AppUiState, autoStart: Bo
 		isMnemonicStored = appUiState.managerState.isMnemonicStored,
 		initialRoute = initialAuthRoute,
 		onDismissRequest = {
-			if(!appUiState.settings.isWelcomeShown) {
+			if (!appUiState.settings.isWelcomeShown) {
 				appViewModel.setWelcomeShown()
 			}
 			showAuthSheet = false
-						   },
+		},
 		onAuthSuccess = {
 			showAuthSheet = false
 		},

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/MainScreen.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/MainScreen.kt
@@ -165,12 +165,15 @@ fun MainScreen(appViewModel: AppViewModel, appUiState: AppUiState, autoStart: Bo
 	LaunchedEffect(appUiState.managerState.isInitialized) {
 		if (appUiState.managerState.isInitialized && !authSheetChecked) {
 			authSheetChecked = true
-			showAuthSheet = !appUiState.managerState.isMnemonicStored
+			if (!appUiState.managerState.isMnemonicStored && !appUiState.settings.isWelcomeShown) {
+				initialAuthRoute = AuthRoute.Welcome
+				showAuthSheet = true
+			}
 		}
 	}
 
 	LaunchedEffect(showAuth) {
-		if (showAuth) {
+		if (showAuth && !appUiState.managerState.isMnemonicStored && !appUiState.settings.isWelcomeShown) {
 			initialAuthRoute = AuthRoute.Welcome
 			showAuthSheet = true
 		}
@@ -261,8 +264,10 @@ fun MainScreen(appViewModel: AppViewModel, appUiState: AppUiState, autoStart: Bo
 	}
 
 	fun onGetStartedPressed() {
-		initialAuthRoute = AuthRoute.Welcome
-		showAuthSheet = true
+		if (!appUiState.managerState.isMnemonicStored) {
+			initialAuthRoute = AuthRoute.Welcome
+			showAuthSheet = true
+		}
 	}
 
 	val entryAlertTitle = stringResource(R.string.disabled_while_connecting)
@@ -455,8 +460,14 @@ fun MainScreen(appViewModel: AppViewModel, appUiState: AppUiState, autoStart: Bo
 
 	AuthBottomSheet(
 		isVisible = showAuthSheet,
+		isMnemonicStored = appUiState.managerState.isMnemonicStored,
 		initialRoute = initialAuthRoute,
-		onDismissRequest = { showAuthSheet = false },
+		onDismissRequest = {
+			if(!appUiState.settings.isWelcomeShown) {
+				appViewModel.setWelcomeShown()
+			}
+			showAuthSheet = false
+						   },
 		onAuthSuccess = {
 			showAuthSheet = false
 		},

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/SettingsScreen.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/SettingsScreen.kt
@@ -57,6 +57,7 @@ import net.nymtech.nymvpn.util.extensions.launchBatteryOptSettingsScreen
 import net.nymtech.nymvpn.util.extensions.launchNotificationSettings
 import net.nymtech.nymvpn.util.extensions.launchPrivateDnsSettings
 import net.nymtech.nymvpn.util.extensions.launchVpnSettings
+import androidx.compose.foundation.layout.navigationBarsPadding
 import net.nymtech.nymvpn.util.extensions.scaledWidth
 import kotlin.Boolean
 
@@ -234,7 +235,8 @@ fun SettingsScreen(values: SettingsValues, actions: SettingsActions) {
 				.verticalScroll(rememberScrollState())
 				.fillMaxSize()
 				.padding(top = 24.dp)
-				.padding(horizontal = 24.dp.scaledWidth()),
+				.padding(horizontal = 24.dp.scaledWidth())
+				.navigationBarsPadding(),
 		) {
 			LoginSection(
 				isMnemonicStored = values.isMnemonicStored,


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

Add padding for nav buttons in SettingsScreen and AccountDetailsScreen.
Show welcome only on first start. 
Add a condition for showing AuthView.
Add disconnect timeout when connected.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5381)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Welcome screen is now tracked and persisted; won't appear again after initial viewing
  * Authentication sheet now intelligently displays based on welcome screen state
  * Improved onboarding flow with better state management

* **Style**
  * Enhanced screen layouts with proper navigation bar padding

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nymtech/nym-vpn-client/pull/5381?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->