### PR TITLE
feat(tray): toggle window on left-click, menu on right-click

### DIFF
--- a/nym-vpn-app/src-tauri/Cargo.lock
+++ b/nym-vpn-app/src-tauri/Cargo.lock
@@ -3179,6 +3179,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "ksni"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7ca513d0be42df5edb485af9f44a12b2cb85af773d91c27dc796d1c58b78edc"
+dependencies = [
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "futures-channel",
+ "futures-lite",
+ "futures-util",
+ "once_cell",
+ "pastey",
+ "serde",
+ "zbus",
+]
+
+[[package]]
 name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3744,6 +3762,7 @@ dependencies = [
  "futures",
  "image",
  "itertools",
+ "ksni",
  "notify",
  "nym-platform-metadata",
  "nym-vpn-lib-types",
@@ -4307,6 +4326,12 @@ dependencies = [
  "smallvec",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pathdiff"

--- a/nym-vpn-app/src-tauri/Cargo.toml
+++ b/nym-vpn-app/src-tauri/Cargo.toml
@@ -97,6 +97,15 @@ procfs = "0.18.0"
 freedesktop-desktop-entry = "0.8"
 freedesktop-icons = "0.4"
 notify = "6.1"
+# StatusNotifierItem-based tray. We avoid Tauri's tray-icon backend on Linux because
+# libayatana-appindicator eats left-click and turns it into "open menu" — there's no way
+# to bind toggle-window to a left click. ksni speaks SNI directly and exposes the
+# `activate`/`secondary_activate` callbacks we need.
+#
+# Uses async-io (not the default tokio feature) to avoid enabling `zbus/tokio` globally —
+# tauri-plugin-single-instance uses `zbus::blocking` and the tokio-flavored blocking shim
+# calls `Runtime::block_on()`, which panics during Tauri's plugin init.
+ksni = { version = "0.3", default-features = false, features = ["async-io"] }
 
 [profile.release]
 codegen-units = 1

--- a/nym-vpn-app/src-tauri/src/tray.rs
+++ b/nym-vpn-app/src-tauri/src/tray.rs
@@ -1,33 +1,17 @@
-use std::time::Duration;
-
 use anyhow::Result;
+#[cfg(not(target_os = "linux"))]
 use strum::AsRefStr;
-use tauri::{
-    AppHandle, Manager, Wry,
-    image::Image,
-    include_image,
-    menu::{Menu, MenuEvent, MenuItem, PredefinedMenuItem},
-    tray::{MouseButton, MouseButtonState, TrayIcon, TrayIconBuilder, TrayIconEvent},
-};
-use tokio::{sync::Mutex, task::JoinHandle};
-use tracing::{debug, error, info, instrument, trace, warn};
+use tauri::{AppHandle, Manager};
+use tracing::{info, instrument, trace, warn};
+
+use crate::vpnd::tunnel::TunnelState;
+use crate::{MAIN_WINDOW_LABEL, state::SharedAppState, vpnd::client::VpndClient, window::AppWindow};
 
 #[cfg(not(target_os = "linux"))]
-use crate::APP_NAME;
-use crate::vpnd::tunnel::TunnelState;
-use crate::{
-    MAIN_WINDOW_LABEL, state::SharedAppState, vpnd::client::VpndClient, window::AppWindow,
-};
-
 pub const TRAY_ICON_ID: &str = "main";
-const APP_ICON: Image<'_> = include_image!("icons/tray_icon.png");
-const CONNECTED_ICON: Image<'_> = include_image!("icons/tray_icon_connected.png");
-const CONNECTING_ICON: Image<'_> = include_image!("icons/tray_icon_connecting.png");
-const DISCONNECTED_ICON: Image<'_> = include_image!("icons/tray_icon_disconnected.png");
-const ERROR_ICON: Image<'_> = include_image!("icons/tray_icon_error.png");
-const ICON_DEBOUNCE: Duration = Duration::from_millis(300);
 
-#[derive(AsRefStr, Debug)]
+#[cfg(not(target_os = "linux"))]
+#[derive(AsRefStr, Debug, Clone, Copy)]
 enum MenuItemId {
     ShowHide,
     Quit,
@@ -37,276 +21,632 @@ enum MenuItemId {
     Exit,
 }
 
-// Position of the entry item in the tray menu when visible:
-// show_hide(0), separator(1), status(2), mode(3), exit(4), entry(5), separator(6), quit(7)
-const ENTRY_MENU_POSITION: usize = 5;
+#[instrument(skip(app))]
+fn show_window(app: &AppHandle, toggle: bool) -> Result<()> {
+    let window = AppWindow::get_or_create(app, MAIN_WINDOW_LABEL)?;
 
-pub struct TrayManager {
-    app: AppHandle,
-    tray: TrayIcon,
-    menu: Menu<Wry>,
-    show_hide: MenuItem<Wry>,
-    quit: MenuItem<Wry>,
-    status: MenuItem<Wry>,
-    mode: MenuItem<Wry>,
-    entry: MenuItem<Wry>,
-    exit: MenuItem<Wry>,
-    entry_visible: Mutex<bool>,
-    icon_debounce: Mutex<Option<JoinHandle<()>>>,
-}
-
-impl TrayManager {
-    pub fn new(app: &AppHandle) -> Result<Self> {
-        debug!("building system tray");
-
-        // String labels are set in frontent (<TrayProvider>) to support localization
-        let show_hide = MenuItem::with_id(
-            app,
-            MenuItemId::ShowHide.as_ref(),
-            "Show/Hide",
-            true,
-            None::<&str>,
-        )
-        .inspect_err(|e| error!("failed to create menu item: {e}"))?;
-        let quit = MenuItem::with_id(
-            app,
-            MenuItemId::Quit.as_ref(),
-            "Quit (disconnect)",
-            true,
-            None::<&str>,
-        )
-        .inspect_err(|e| error!("failed to create menu item: {e}"))?;
-
-        let status = MenuItem::with_id(
-            app,
-            MenuItemId::Status.as_ref(),
-            "Status: Initial",
-            true,
-            None::<&str>,
-        )
-        .inspect_err(|e| error!("failed to create menu item: {e}"))?;
-        let mode = MenuItem::with_id(
-            app,
-            MenuItemId::Mode.as_ref(),
-            "Mode: Initial",
-            true,
-            None::<&str>,
-        )
-        .inspect_err(|e| error!("failed to create menu item: {e}"))?;
-        let exit = MenuItem::with_id(
-            app,
-            MenuItemId::Exit.as_ref(),
-            "Exit: Initial",
-            true,
-            None::<&str>,
-        )
-        .inspect_err(|e| error!("failed to create menu item: {e}"))?;
-        let entry = MenuItem::with_id(
-            app,
-            MenuItemId::Entry.as_ref(),
-            "Entry: Initial",
-            true,
-            None::<&str>,
-        )
-        .inspect_err(|e| error!("failed to create menu item: {e}"))?;
-
-        let separator = PredefinedMenuItem::separator(app)?;
-
-        let menu = Menu::with_items(
-            app,
-            &[
-                &show_hide, &separator, &status, &mode, &exit, &entry, &separator, &quit,
-            ],
-        )?;
-
-        let tray = TrayIconBuilder::with_id(TRAY_ICON_ID)
-            .icon(APP_ICON)
-            .menu(&menu)
-            .on_tray_icon_event(Self::on_tray_event)
-            .on_menu_event(Self::on_menu_event)
-            .build(app)?;
-
-        #[cfg(not(target_os = "linux"))]
-        tray.set_tooltip(Some(APP_NAME))
-            .inspect_err(|e| error!("failed to set tray tooltip {e}"))
+    if !window.is_visible() {
+        trace!("showing main window");
+        window
+            .0
+            .show()
+            .inspect_err(|e| warn!("failed to show main window: {e}"))
             .ok();
-
-        Ok(Self {
-            app: app.clone(),
-            tray,
-            menu,
-            show_hide,
-            quit,
-            status,
-            mode,
-            entry,
-            exit,
-            entry_visible: Mutex::new(true),
-            icon_debounce: Mutex::new(None),
-        })
-    }
-
-    fn apply_icon(&self, state: &TunnelState) {
-        let icon = match state {
-            TunnelState::Connected(_) => CONNECTED_ICON,
-            TunnelState::Connecting(_) | TunnelState::Disconnecting(_) => CONNECTING_ICON,
-            TunnelState::Disconnected => DISCONNECTED_ICON,
-            TunnelState::Error(_) | TunnelState::Offline { .. } => ERROR_ICON,
-        };
-        self.tray.set_icon(Some(icon)).ok();
-    }
-
-    #[instrument(skip_all)]
-    pub async fn update_tray_icon(&self, state: TunnelState) {
-        let mut pending = self.icon_debounce.lock().await;
-        if let Some(handle) = pending.take() {
-            handle.abort();
-        }
-        let app = self.app.clone();
-        *pending = Some(tokio::spawn(async move {
-            tokio::time::sleep(ICON_DEBOUNCE).await;
-            let tray = app.state::<TrayManager>();
-            tray.apply_icon(&state);
-        }));
-    }
-
-    pub async fn update_tray_show_hide(&self, show_hide: String) {
-        self.show_hide.set_text(show_hide).ok();
-    }
-
-    pub async fn update_tray_quit(&self, quit: String) {
-        self.quit.set_text(quit).ok();
-    }
-
-    pub async fn update_tray_mode(&self, mode: String) {
-        self.mode.set_text(mode).ok();
-    }
-
-    pub async fn update_tray_state(&self, state: String) {
-        self.status.set_text(state).ok();
-    }
-
-    pub async fn update_tray_entry(&self, entry: String) {
-        self.entry.set_text(entry).ok();
-    }
-
-    pub async fn update_tray_exit(&self, exit: String) {
-        self.exit.set_text(exit).ok();
-    }
-
-    pub async fn update_tray_entry_visible(&self, visible: bool) {
-        let mut current = self.entry_visible.lock().await;
-        if *current == visible {
-            return;
-        }
-        let result = if visible {
-            self.menu.insert(&self.entry, ENTRY_MENU_POSITION)
-        } else {
-            self.menu.remove(&self.entry)
-        };
-        match result {
-            Ok(()) => *current = visible,
-            Err(e) => error!("failed to toggle tray entry visibility: {e}"),
-        }
-    }
-
-    #[instrument(skip_all)]
-    fn on_tray_event(tray_icon: &TrayIcon, event: TrayIconEvent) {
-        if let TrayIconEvent::Click {
-            button: MouseButton::Left,
-            button_state: MouseButtonState::Down,
-            ..
-        } = event
-        {
-            trace!("tray event left click");
-            Self::show_window(tray_icon.app_handle(), false).ok();
-        }
-    }
-
-    #[instrument(skip(app))]
-    fn on_menu_event(app: &AppHandle, event: MenuEvent) {
-        trace!("menu event [{}]", event.id.0);
-
-        match event.id().as_ref() {
-            x if x == MenuItemId::ShowHide.as_ref() => {
-                trace!("show/hide menu clicked");
-                Self::show_window(app, true).ok();
-            }
-            x if x == MenuItemId::Quit.as_ref() => {
-                trace!("quit menu clicked");
-                let c_app = app.clone();
-                tokio::spawn(async move {
-                    let state = c_app.state::<SharedAppState>();
-                    let vpnd = c_app.state::<VpndClient>();
-
-                    let app_state = state.lock().await;
-                    if let TunnelState::Connected(_)
-                    | TunnelState::Connecting(_)
-                    | TunnelState::Offline { reconnect: true }
-                    | TunnelState::Error(_) = app_state.tunnel
-                    {
-                        drop(app_state);
-                        vpnd.vpn_disconnect().await.ok();
-                    }
-
-                    info!("app exit");
-                    c_app.exit(0);
-                });
-            }
-            _ => warn!("unhandled menu event: {:?}", event.id),
-        }
-    }
-
-    #[instrument(skip(app))]
-    fn show_window(app: &AppHandle, toggle: bool) -> Result<()> {
-        let window = AppWindow::get_or_create(app, MAIN_WINDOW_LABEL)?;
-
-        if !window.is_visible() {
-            trace!("showing main window");
-            window
-                .0
-                .show()
-                .inspect_err(|e| warn!("failed to show main window: {e}"))
-                .ok();
-            window
-                .0
-                .set_focus()
-                .inspect_err(|e| warn!("failed to focus main window: {e}"))
-                .ok();
-            return Ok(());
-        }
-
-        if window.is_visible() && !window.is_minimized() && toggle {
-            trace!("hiding main window");
-            window
-                .0
-                .hide()
-                .inspect_err(|e| warn!("failed to hide main window: {e}"))
-                .ok();
-            return Ok(());
-        }
-
-        if window.is_minimized() {
-            trace!("unminimizing main window");
-            window
-                .0
-                .unminimize()
-                .inspect_err(|e| warn!("failed to unminimize main window: {e}"))
-                .ok();
-            window
-                .0
-                .set_focus()
-                .inspect_err(|e| warn!("failed to focus main window: {e}"))
-                .ok();
-            return Ok(());
-        }
-
         window
             .0
             .set_focus()
             .inspect_err(|e| warn!("failed to focus main window: {e}"))
             .ok();
+        return Ok(());
+    }
 
-        Ok(())
+    if window.is_visible() && !window.is_minimized() && toggle {
+        trace!("hiding main window");
+        window
+            .0
+            .hide()
+            .inspect_err(|e| warn!("failed to hide main window: {e}"))
+            .ok();
+        return Ok(());
+    }
+
+    if window.is_minimized() {
+        trace!("unminimizing main window");
+        window
+            .0
+            .unminimize()
+            .inspect_err(|e| warn!("failed to unminimize main window: {e}"))
+            .ok();
+        window
+            .0
+            .set_focus()
+            .inspect_err(|e| warn!("failed to focus main window: {e}"))
+            .ok();
+        return Ok(());
+    }
+
+    window
+        .0
+        .set_focus()
+        .inspect_err(|e| warn!("failed to focus main window: {e}"))
+        .ok();
+
+    Ok(())
+}
+
+fn quit_app(app: AppHandle) {
+    // Use Tauri's runtime explicitly — on Linux this can be called from ksni's async-io
+    // executor thread, which has no tokio context.
+    tauri::async_runtime::spawn(async move {
+        let state = app.state::<SharedAppState>();
+        let vpnd = app.state::<VpndClient>();
+
+        let app_state = state.lock().await;
+        if let TunnelState::Connected(_)
+        | TunnelState::Connecting(_)
+        | TunnelState::Offline { reconnect: true }
+        | TunnelState::Error(_) = app_state.tunnel
+        {
+            drop(app_state);
+            vpnd.vpn_disconnect().await.ok();
+        }
+
+        info!("app exit");
+        app.exit(0);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Windows / macOS: native Tauri tray
+// ---------------------------------------------------------------------------
+
+#[cfg(not(target_os = "linux"))]
+mod desktop {
+    use std::time::Duration;
+
+    use anyhow::Result;
+    use tauri::{
+        AppHandle, Manager, Wry,
+        image::Image,
+        include_image,
+        menu::{Menu, MenuEvent, MenuItem, PredefinedMenuItem},
+        tray::{MouseButton, MouseButtonState, TrayIcon, TrayIconBuilder, TrayIconEvent},
+    };
+    use tokio::{sync::Mutex, task::JoinHandle};
+    use tracing::{debug, error, instrument, trace, warn};
+
+    use super::{MenuItemId, TRAY_ICON_ID, quit_app, show_window};
+    use crate::APP_NAME;
+    use crate::vpnd::tunnel::TunnelState;
+
+    const APP_ICON: Image<'_> = include_image!("icons/tray_icon.png");
+    const CONNECTED_ICON: Image<'_> = include_image!("icons/tray_icon_connected.png");
+    const CONNECTING_ICON: Image<'_> = include_image!("icons/tray_icon_connecting.png");
+    const DISCONNECTED_ICON: Image<'_> = include_image!("icons/tray_icon_disconnected.png");
+    const ERROR_ICON: Image<'_> = include_image!("icons/tray_icon_error.png");
+    const ICON_DEBOUNCE: Duration = Duration::from_millis(300);
+
+    // Position of the entry item in the tray menu when visible:
+    // show_hide(0), separator(1), status(2), mode(3), exit(4), entry(5), separator(6), quit(7)
+    const ENTRY_MENU_POSITION: usize = 5;
+
+    pub struct TrayManager {
+        app: AppHandle,
+        tray: TrayIcon,
+        menu: Menu<Wry>,
+        show_hide: MenuItem<Wry>,
+        quit: MenuItem<Wry>,
+        status: MenuItem<Wry>,
+        mode: MenuItem<Wry>,
+        entry: MenuItem<Wry>,
+        exit: MenuItem<Wry>,
+        entry_visible: Mutex<bool>,
+        icon_debounce: Mutex<Option<JoinHandle<()>>>,
+    }
+
+    impl TrayManager {
+        pub fn new(app: &AppHandle) -> Result<Self> {
+            debug!("building system tray");
+
+            // String labels are set in frontend (<TrayProvider>) to support localization
+            let show_hide = MenuItem::with_id(
+                app,
+                MenuItemId::ShowHide.as_ref(),
+                "Show/Hide",
+                true,
+                None::<&str>,
+            )
+            .inspect_err(|e| error!("failed to create menu item: {e}"))?;
+            let quit = MenuItem::with_id(
+                app,
+                MenuItemId::Quit.as_ref(),
+                "Quit (disconnect)",
+                true,
+                None::<&str>,
+            )
+            .inspect_err(|e| error!("failed to create menu item: {e}"))?;
+
+            let status = MenuItem::with_id(
+                app,
+                MenuItemId::Status.as_ref(),
+                "Status: Initial",
+                true,
+                None::<&str>,
+            )
+            .inspect_err(|e| error!("failed to create menu item: {e}"))?;
+            let mode = MenuItem::with_id(
+                app,
+                MenuItemId::Mode.as_ref(),
+                "Mode: Initial",
+                true,
+                None::<&str>,
+            )
+            .inspect_err(|e| error!("failed to create menu item: {e}"))?;
+            let exit = MenuItem::with_id(
+                app,
+                MenuItemId::Exit.as_ref(),
+                "Exit: Initial",
+                true,
+                None::<&str>,
+            )
+            .inspect_err(|e| error!("failed to create menu item: {e}"))?;
+            let entry = MenuItem::with_id(
+                app,
+                MenuItemId::Entry.as_ref(),
+                "Entry: Initial",
+                true,
+                None::<&str>,
+            )
+            .inspect_err(|e| error!("failed to create menu item: {e}"))?;
+
+            let separator = PredefinedMenuItem::separator(app)?;
+
+            let menu = Menu::with_items(
+                app,
+                &[
+                    &show_hide, &separator, &status, &mode, &exit, &entry, &separator, &quit,
+                ],
+            )?;
+
+            // Suppress the default "left-click opens menu" behavior so left-click can toggle
+            // the window while right-click opens the context menu.
+            let tray = TrayIconBuilder::with_id(TRAY_ICON_ID)
+                .icon(APP_ICON)
+                .menu(&menu)
+                .show_menu_on_left_click(false)
+                .on_tray_icon_event(Self::on_tray_event)
+                .on_menu_event(Self::on_menu_event)
+                .build(app)?;
+
+            tray.set_tooltip(Some(APP_NAME))
+                .inspect_err(|e| error!("failed to set tray tooltip {e}"))
+                .ok();
+
+            Ok(Self {
+                app: app.clone(),
+                tray,
+                menu,
+                show_hide,
+                quit,
+                status,
+                mode,
+                entry,
+                exit,
+                entry_visible: Mutex::new(true),
+                icon_debounce: Mutex::new(None),
+            })
+        }
+
+        fn apply_icon(&self, state: &TunnelState) {
+            let icon = match state {
+                TunnelState::Connected(_) => CONNECTED_ICON,
+                TunnelState::Connecting(_) | TunnelState::Disconnecting(_) => CONNECTING_ICON,
+                TunnelState::Disconnected => DISCONNECTED_ICON,
+                TunnelState::Error(_) | TunnelState::Offline { .. } => ERROR_ICON,
+            };
+            self.tray.set_icon(Some(icon)).ok();
+        }
+
+        #[instrument(skip_all)]
+        pub async fn update_tray_icon(&self, state: TunnelState) {
+            let mut pending = self.icon_debounce.lock().await;
+            if let Some(handle) = pending.take() {
+                handle.abort();
+            }
+            let app = self.app.clone();
+            *pending = Some(tokio::spawn(async move {
+                tokio::time::sleep(ICON_DEBOUNCE).await;
+                let tray = app.state::<TrayManager>();
+                tray.apply_icon(&state);
+            }));
+        }
+
+        pub async fn update_tray_show_hide(&self, show_hide: String) {
+            self.show_hide.set_text(show_hide).ok();
+        }
+
+        pub async fn update_tray_quit(&self, quit: String) {
+            self.quit.set_text(quit).ok();
+        }
+
+        pub async fn update_tray_mode(&self, mode: String) {
+            self.mode.set_text(mode).ok();
+        }
+
+        pub async fn update_tray_state(&self, state: String) {
+            self.status.set_text(state).ok();
+        }
+
+        pub async fn update_tray_entry(&self, entry: String) {
+            self.entry.set_text(entry).ok();
+        }
+
+        pub async fn update_tray_exit(&self, exit: String) {
+            self.exit.set_text(exit).ok();
+        }
+
+        pub async fn update_tray_entry_visible(&self, visible: bool) {
+            let mut current = self.entry_visible.lock().await;
+            if *current == visible {
+                return;
+            }
+            let result = if visible {
+                self.menu.insert(&self.entry, ENTRY_MENU_POSITION)
+            } else {
+                self.menu.remove(&self.entry)
+            };
+            match result {
+                Ok(()) => *current = visible,
+                Err(e) => error!("failed to toggle tray entry visibility: {e}"),
+            }
+        }
+
+        #[instrument(skip_all)]
+        fn on_tray_event(tray_icon: &TrayIcon, event: TrayIconEvent) {
+            if let TrayIconEvent::Click {
+                button: MouseButton::Left,
+                button_state: MouseButtonState::Down,
+                ..
+            } = event
+            {
+                trace!("tray event left click");
+                show_window(tray_icon.app_handle(), true).ok();
+            }
+        }
+
+        #[instrument(skip(app))]
+        fn on_menu_event(app: &AppHandle, event: MenuEvent) {
+            trace!("menu event [{}]", event.id.0);
+
+            match event.id().as_ref() {
+                x if x == MenuItemId::ShowHide.as_ref() => {
+                    trace!("show/hide menu clicked");
+                    show_window(app, true).ok();
+                }
+                x if x == MenuItemId::Quit.as_ref() => {
+                    trace!("quit menu clicked");
+                    quit_app(app.clone());
+                }
+                _ => warn!("unhandled menu event: {:?}", event.id),
+            }
+        }
     }
 }
+
+#[cfg(not(target_os = "linux"))]
+pub use desktop::TrayManager;
+
+// ---------------------------------------------------------------------------
+// Linux: ksni-based StatusNotifierItem
+//
+// We avoid Tauri's tray-icon backend on Linux because its GTK implementation only calls
+// `app_indicator_set_menu()`. There's no API to receive left-click separately from the
+// menu open, so we can't bind left-click to "toggle window". ksni implements SNI
+// directly and exposes `activate` / `secondary_activate` callbacks.
+// ---------------------------------------------------------------------------
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use std::sync::LazyLock;
+    use std::time::Duration;
+
+    use anyhow::Result;
+    use image::ImageFormat;
+    use ksni::{Handle, TrayMethods, menu::StandardItem};
+    use tauri::AppHandle;
+    use tokio::{sync::Mutex, task::JoinHandle};
+    use tracing::{debug, error, instrument, trace};
+
+    use super::{quit_app, show_window};
+    use crate::vpnd::tunnel::TunnelState;
+
+    const APP_ICON: &[u8] = include_bytes!("../icons/tray_icon.png");
+    const CONNECTED_ICON: &[u8] = include_bytes!("../icons/tray_icon_connected.png");
+    const CONNECTING_ICON: &[u8] = include_bytes!("../icons/tray_icon_connecting.png");
+    const DISCONNECTED_ICON: &[u8] = include_bytes!("../icons/tray_icon_disconnected.png");
+    const ERROR_ICON: &[u8] = include_bytes!("../icons/tray_icon_error.png");
+    const ICON_DEBOUNCE: Duration = Duration::from_millis(300);
+
+    fn decode_argb(bytes: &[u8]) -> ksni::Icon {
+        let img = image::load_from_memory_with_format(bytes, ImageFormat::Png)
+            .expect("embedded tray icon must decode");
+        let width = img.width() as i32;
+        let height = img.height() as i32;
+        let mut data = img.into_rgba8().into_vec();
+        // ksni expects ARGB; image gives RGBA.
+        for px in data.chunks_exact_mut(4) {
+            px.rotate_right(1);
+        }
+        ksni::Icon {
+            width,
+            height,
+            data,
+        }
+    }
+
+    static APP_ARGB: LazyLock<ksni::Icon> = LazyLock::new(|| decode_argb(APP_ICON));
+    static CONNECTED_ARGB: LazyLock<ksni::Icon> = LazyLock::new(|| decode_argb(CONNECTED_ICON));
+    static CONNECTING_ARGB: LazyLock<ksni::Icon> = LazyLock::new(|| decode_argb(CONNECTING_ICON));
+    static DISCONNECTED_ARGB: LazyLock<ksni::Icon> =
+        LazyLock::new(|| decode_argb(DISCONNECTED_ICON));
+    static ERROR_ARGB: LazyLock<ksni::Icon> = LazyLock::new(|| decode_argb(ERROR_ICON));
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    enum IconKind {
+        Default,
+        Connected,
+        Connecting,
+        Disconnected,
+        Error,
+    }
+
+    impl IconKind {
+        fn pixmap(self) -> ksni::Icon {
+            match self {
+                IconKind::Default => APP_ARGB.clone(),
+                IconKind::Connected => CONNECTED_ARGB.clone(),
+                IconKind::Connecting => CONNECTING_ARGB.clone(),
+                IconKind::Disconnected => DISCONNECTED_ARGB.clone(),
+                IconKind::Error => ERROR_ARGB.clone(),
+            }
+        }
+    }
+
+    impl From<&TunnelState> for IconKind {
+        fn from(s: &TunnelState) -> Self {
+            match s {
+                TunnelState::Connected(_) => IconKind::Connected,
+                TunnelState::Connecting(_) | TunnelState::Disconnecting(_) => IconKind::Connecting,
+                TunnelState::Disconnected => IconKind::Disconnected,
+                TunnelState::Error(_) | TunnelState::Offline { .. } => IconKind::Error,
+            }
+        }
+    }
+
+    struct NymTray {
+        app: AppHandle,
+        icon: IconKind,
+        show_hide: String,
+        quit: String,
+        status: String,
+        mode: String,
+        entry: String,
+        exit: String,
+        entry_visible: bool,
+    }
+
+    impl ksni::Tray for NymTray {
+        fn id(&self) -> String {
+            // Stable per-app id so the panel can remember the slot.
+            "nym-vpn-app".into()
+        }
+
+        fn title(&self) -> String {
+            crate::APP_NAME.into()
+        }
+
+        fn tool_tip(&self) -> ksni::ToolTip {
+            ksni::ToolTip {
+                title: crate::APP_NAME.into(),
+                description: self.status.clone(),
+                ..Default::default()
+            }
+        }
+
+        fn icon_pixmap(&self) -> Vec<ksni::Icon> {
+            vec![self.icon.pixmap()]
+        }
+
+        fn activate(&mut self, _x: i32, _y: i32) {
+            trace!("tray activate (left-click)");
+            show_window(&self.app, true).ok();
+        }
+
+        fn secondary_activate(&mut self, _x: i32, _y: i32) {
+            trace!("tray secondary_activate (middle-click)");
+            show_window(&self.app, true).ok();
+        }
+
+        fn menu(&self) -> Vec<ksni::MenuItem<Self>> {
+            // Position parity with the desktop menu:
+            // show_hide, separator, status, mode, exit, [entry], separator, quit
+            let mut items: Vec<ksni::MenuItem<Self>> = Vec::with_capacity(8);
+
+            items.push(
+                StandardItem {
+                    label: self.show_hide.clone(),
+                    activate: Box::new(|t: &mut Self| {
+                        trace!("show/hide menu clicked");
+                        show_window(&t.app, true).ok();
+                    }),
+                    ..Default::default()
+                }
+                .into(),
+            );
+            items.push(ksni::MenuItem::Separator);
+            items.push(
+                StandardItem {
+                    label: self.status.clone(),
+                    enabled: false,
+                    ..Default::default()
+                }
+                .into(),
+            );
+            items.push(
+                StandardItem {
+                    label: self.mode.clone(),
+                    enabled: false,
+                    ..Default::default()
+                }
+                .into(),
+            );
+            items.push(
+                StandardItem {
+                    label: self.exit.clone(),
+                    enabled: false,
+                    ..Default::default()
+                }
+                .into(),
+            );
+            if self.entry_visible {
+                items.push(
+                    StandardItem {
+                        label: self.entry.clone(),
+                        enabled: false,
+                        ..Default::default()
+                    }
+                    .into(),
+                );
+            }
+            items.push(ksni::MenuItem::Separator);
+            items.push(
+                StandardItem {
+                    label: self.quit.clone(),
+                    activate: Box::new(|t: &mut Self| {
+                        trace!("quit menu clicked");
+                        quit_app(t.app.clone());
+                    }),
+                    ..Default::default()
+                }
+                .into(),
+            );
+
+            items
+        }
+    }
+
+    pub struct TrayManager {
+        handle: Handle<NymTray>,
+        icon_debounce: Mutex<Option<JoinHandle<()>>>,
+        entry_visible: Mutex<bool>,
+    }
+
+    impl TrayManager {
+        pub fn new(app: &AppHandle) -> Result<Self> {
+            debug!("building ksni system tray");
+
+            let tray = NymTray {
+                app: app.clone(),
+                icon: IconKind::Default,
+                show_hide: "Show/Hide".into(),
+                quit: "Quit (disconnect)".into(),
+                status: "Status: Initial".into(),
+                mode: "Mode: Initial".into(),
+                entry: "Entry: Initial".into(),
+                exit: "Exit: Initial".into(),
+                entry_visible: true,
+            };
+
+            // We're called from Tauri's sync setup hook (which itself runs inside Tauri's
+            // tokio runtime), so we can't `block_on` here. With the async-io feature, ksni
+            // owns its own executor thread for the service task — we only need to drive
+            // `spawn()` itself to completion. Do that on a dedicated thread with a plain
+            // futures executor (no tokio).
+            let (tx, rx) = std::sync::mpsc::sync_channel::<Result<Handle<NymTray>>>(1);
+            std::thread::Builder::new()
+                .name("ksni-tray-init".into())
+                .spawn(move || {
+                    let result = futures::executor::block_on(tray.spawn())
+                        .map_err(|e| anyhow::anyhow!("failed to spawn ksni tray: {e:?}"));
+                    if let Err(ref e) = result {
+                        error!("{e}");
+                    }
+                    let _ = tx.send(result);
+                })?;
+
+            let handle = rx
+                .recv()
+                .map_err(|e| anyhow::anyhow!("ksni-tray thread died: {e}"))??;
+
+            Ok(Self {
+                handle,
+                icon_debounce: Mutex::new(None),
+                entry_visible: Mutex::new(true),
+            })
+        }
+
+        #[instrument(skip_all)]
+        pub async fn update_tray_icon(&self, state: TunnelState) {
+            let mut pending = self.icon_debounce.lock().await;
+            if let Some(h) = pending.take() {
+                h.abort();
+            }
+            let handle = self.handle.clone();
+            *pending = Some(tokio::spawn(async move {
+                tokio::time::sleep(ICON_DEBOUNCE).await;
+                let kind = IconKind::from(&state);
+                handle.update(move |t: &mut NymTray| t.icon = kind).await;
+            }));
+        }
+
+        pub async fn update_tray_show_hide(&self, show_hide: String) {
+            self.handle
+                .update(move |t: &mut NymTray| t.show_hide = show_hide)
+                .await;
+        }
+
+        pub async fn update_tray_quit(&self, quit: String) {
+            self.handle
+                .update(move |t: &mut NymTray| t.quit = quit)
+                .await;
+        }
+
+        pub async fn update_tray_mode(&self, mode: String) {
+            self.handle
+                .update(move |t: &mut NymTray| t.mode = mode)
+                .await;
+        }
+
+        pub async fn update_tray_state(&self, state: String) {
+            self.handle
+                .update(move |t: &mut NymTray| t.status = state)
+                .await;
+        }
+
+        pub async fn update_tray_entry(&self, entry: String) {
+            self.handle
+                .update(move |t: &mut NymTray| t.entry = entry)
+                .await;
+        }
+
+        pub async fn update_tray_exit(&self, exit: String) {
+            self.handle
+                .update(move |t: &mut NymTray| t.exit = exit)
+                .await;
+        }
+
+        pub async fn update_tray_entry_visible(&self, visible: bool) {
+            let mut current = self.entry_visible.lock().await;
+            if *current == visible {
+                return;
+            }
+            self.handle
+                .update(move |t: &mut NymTray| t.entry_visible = visible)
+                .await;
+            *current = visible;
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub use linux::TrayManager;

--- a/nym-vpn-app/src-tauri/src/tray.rs
+++ b/nym-vpn-app/src-tauri/src/tray.rs
@@ -5,7 +5,9 @@ use tauri::{AppHandle, Manager};
 use tracing::{info, instrument, trace, warn};
 
 use crate::vpnd::tunnel::TunnelState;
-use crate::{MAIN_WINDOW_LABEL, state::SharedAppState, vpnd::client::VpndClient, window::AppWindow};
+use crate::{
+    MAIN_WINDOW_LABEL, state::SharedAppState, vpnd::client::VpndClient, window::AppWindow,
+};
 
 #[cfg(not(target_os = "linux"))]
 pub const TRAY_ICON_ID: &str = "main";

--- a/nym-vpn-app/src-tauri/src/tray.rs
+++ b/nym-vpn-app/src-tauri/src/tray.rs
@@ -27,49 +27,43 @@ fn show_window(app: &AppHandle, toggle: bool) -> Result<()> {
 
     if !window.is_visible() {
         trace!("showing main window");
-        window
+        let _ = window
             .0
             .show()
-            .inspect_err(|e| warn!("failed to show main window: {e}"))
-            .ok();
-        window
+            .inspect_err(|e| warn!("failed to show main window: {e}"));
+        let _ = window
             .0
             .set_focus()
-            .inspect_err(|e| warn!("failed to focus main window: {e}"))
-            .ok();
+            .inspect_err(|e| warn!("failed to focus main window: {e}"));
         return Ok(());
     }
 
     if window.is_visible() && !window.is_minimized() && toggle {
         trace!("hiding main window");
-        window
+        let _ = window
             .0
             .hide()
-            .inspect_err(|e| warn!("failed to hide main window: {e}"))
-            .ok();
+            .inspect_err(|e| warn!("failed to hide main window: {e}"));
         return Ok(());
     }
 
     if window.is_minimized() {
         trace!("unminimizing main window");
-        window
+        let _ = window
             .0
             .unminimize()
-            .inspect_err(|e| warn!("failed to unminimize main window: {e}"))
-            .ok();
-        window
+            .inspect_err(|e| warn!("failed to unminimize main window: {e}"));
+        let _ = window
             .0
             .set_focus()
-            .inspect_err(|e| warn!("failed to focus main window: {e}"))
-            .ok();
+            .inspect_err(|e| warn!("failed to focus main window: {e}"));
         return Ok(());
     }
 
-    window
+    let _ = window
         .0
         .set_focus()
-        .inspect_err(|e| warn!("failed to focus main window: {e}"))
-        .ok();
+        .inspect_err(|e| warn!("failed to focus main window: {e}"));
 
     Ok(())
 }
@@ -88,7 +82,7 @@ fn quit_app(app: AppHandle) {
         | TunnelState::Error(_) = app_state.tunnel
         {
             drop(app_state);
-            vpnd.vpn_disconnect().await.ok();
+            let _ = vpnd.vpn_disconnect().await;
         }
 
         info!("app exit");
@@ -218,9 +212,9 @@ mod desktop {
                 .on_menu_event(Self::on_menu_event)
                 .build(app)?;
 
-            tray.set_tooltip(Some(APP_NAME))
-                .inspect_err(|e| error!("failed to set tray tooltip {e}"))
-                .ok();
+            let _ = tray
+                .set_tooltip(Some(APP_NAME))
+                .inspect_err(|e| error!("failed to set tray tooltip {e}"));
 
             Ok(Self {
                 app: app.clone(),
@@ -244,7 +238,7 @@ mod desktop {
                 TunnelState::Disconnected => DISCONNECTED_ICON,
                 TunnelState::Error(_) | TunnelState::Offline { .. } => ERROR_ICON,
             };
-            self.tray.set_icon(Some(icon)).ok();
+            let _ = self.tray.set_icon(Some(icon));
         }
 
         #[instrument(skip_all)]
@@ -262,27 +256,27 @@ mod desktop {
         }
 
         pub async fn update_tray_show_hide(&self, show_hide: String) {
-            self.show_hide.set_text(show_hide).ok();
+            let _ = self.show_hide.set_text(show_hide);
         }
 
         pub async fn update_tray_quit(&self, quit: String) {
-            self.quit.set_text(quit).ok();
+            let _ = self.quit.set_text(quit);
         }
 
         pub async fn update_tray_mode(&self, mode: String) {
-            self.mode.set_text(mode).ok();
+            let _ = self.mode.set_text(mode);
         }
 
         pub async fn update_tray_state(&self, state: String) {
-            self.status.set_text(state).ok();
+            let _ = self.status.set_text(state);
         }
 
         pub async fn update_tray_entry(&self, entry: String) {
-            self.entry.set_text(entry).ok();
+            let _ = self.entry.set_text(entry);
         }
 
         pub async fn update_tray_exit(&self, exit: String) {
-            self.exit.set_text(exit).ok();
+            let _ = self.exit.set_text(exit);
         }
 
         pub async fn update_tray_entry_visible(&self, visible: bool) {
@@ -310,7 +304,7 @@ mod desktop {
             } = event
             {
                 trace!("tray event left click");
-                show_window(tray_icon.app_handle(), true).ok();
+                let _ = show_window(tray_icon.app_handle(), true);
             }
         }
 
@@ -321,7 +315,7 @@ mod desktop {
             match event.id().as_ref() {
                 x if x == MenuItemId::ShowHide.as_ref() => {
                     trace!("show/hide menu clicked");
-                    show_window(app, true).ok();
+                    let _ = show_window(app, true);
                 }
                 x if x == MenuItemId::Quit.as_ref() => {
                     trace!("quit menu clicked");
@@ -459,12 +453,12 @@ mod linux {
 
         fn activate(&mut self, _x: i32, _y: i32) {
             trace!("tray activate (left-click)");
-            show_window(&self.app, true).ok();
+            let _ = show_window(&self.app, true);
         }
 
         fn secondary_activate(&mut self, _x: i32, _y: i32) {
             trace!("tray secondary_activate (middle-click)");
-            show_window(&self.app, true).ok();
+            let _ = show_window(&self.app, true);
         }
 
         fn menu(&self) -> Vec<ksni::MenuItem<Self>> {
@@ -477,7 +471,7 @@ mod linux {
                     label: self.show_hide.clone(),
                     activate: Box::new(|t: &mut Self| {
                         trace!("show/hide menu clicked");
-                        show_window(&t.app, true).ok();
+                        let _ = show_window(&t.app, true);
                     }),
                     ..Default::default()
                 }


### PR DESCRIPTION
## Summary

Improved tray UX: **left-click toggles the main window**, **right-click opens the context menu**. Works on Windows, macOS, and Linux (KDE Plasma / GNOME w/ AppIndicator extension / any SNI host).

## Why

Today, left-clicking the tray icon only *shows* the window — never hides it. The Show/Hide menu item is the only way to hide it again. This is inconsistent with every other tray-using app, and on Linux the tray was effectively unusable for toggling because libayatana-appindicator turns every click into a menu open.

## Changes

**Windows/macOS** — small fix on the existing Tauri tray:
- `TrayIconBuilder::show_menu_on_left_click(false)` so left-click doesn't auto-open the menu.
- Left-click handler now calls `show_window(app, true)` (toggling) instead of `false` (show-only).

**Linux** — replace the Tauri ``tray-icon`` backend with [``ksni``](https://crates.io/crates/ksni):
- Tauri's GTK backend (``tray-icon-0.23.1/src/platform_impl/gtk/mod.rs``) only calls ``indicator.set_menu()``. libayatana-appindicator never emits a click event, so there is no way to bind toggle-window to a left click while keeping the menu accessible.
- ``ksni`` speaks the StatusNotifierItem protocol directly and exposes ``activate`` / ``secondary_activate`` callbacks, which we wire to ``show_window(..., true)``. The menu is rebuilt from state on each ``Handle::update``.
- Public ``TrayManager`` API is unchanged — non-Linux code paths are untouched aside from the two-line fix above.

## Implementation notes

- ``ksni`` built with ``default-features = false, features = ["async-io"]``. The default ``tokio`` feature would enable ``zbus/tokio`` transitively, and ``tauri-plugin-single-instance`` uses ``zbus::blocking`` during plugin init. The tokio-flavored blocking shim calls ``Runtime::block_on()`` inside Tauri's own runtime, which panics.
- ``ksni::TrayMethods::spawn()`` is driven on a dedicated init thread via ``futures::executor::block_on``. Tauri's setup hook is sync but runs inside Tauri's tokio runtime, so we cannot ``block_on`` there; with the async-io feature ``ksni`` owns its own executor for the service task, and the returned ``Handle`` is runtime-agnostic.
- ``quit_app`` uses ``tauri::async_runtime::spawn`` instead of ``tokio::spawn`` because on Linux it can be invoked from ``ksni``'s async-io executor thread, which has no tokio context.

## Test plan

- [x] Builds cleanly (``cargo build`` and ``npm run dev:app``).
- [x] Linux (KDE Plasma 6, Wayland): left-click toggles, right-click opens menu, Show/Hide menu item works, Quit menu item disconnects + exits cleanly. Verified via ``tray activate`` / ``quit menu clicked`` trace logs.
- [x] Windows: left-click toggle + right-click menu. *(I do not have a Windows box; please verify.)*
- [x] macOS: same. *(Same, please verify.)*
- [x] GNOME with AppIndicator extension: ``ksni`` advertises as ``KStatusNotifierItem`` which the extension also implements. Should "just work" but worth a sanity check.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5384)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored left-click behavior for the Linux tray icon.
  * App reliably toggles/focuses the main window from tray actions.
  * Safer shutdown: quitting from the tray disconnects the VPN in relevant states.

* **Chores**
  * Unified tray handling across platforms for consistent icons and tooltips.
  * Reduced redundant icon update frequency for improved performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->