### PR TITLE
Fix DAEMON_SIGNING_REQUIREMENT

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix panic when restoring default routes (https://github.com/nymtech/nym-vpn-client/pull/5225)
 - Fix adblocker deactivation caused by remote returning embedded HTTP errors (https://github.com/nymtech/nym-vpn-client/pull/5302)
 - Don't reuse entry gateway when registering fails (https://github.com/nymtech/nym-vpn-client/pull/5379)
+- [macOS] Daemon checks against the correct ID for its own signature (https://github.com/nymtech/nym-vpn-client/pull/5390)
 
 
 ## [1.29.2] - 2026-05-04

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface.rs
@@ -43,7 +43,7 @@ const NYM_CERTIFICATE_SERIAL_NUMBER: &str = "4ec9356d8c87f9cf3ccf60e7bdad022f";
 #[cfg(target_os = "macos")]
 const CLIENT_SIGNING_REQUIREMENT: &str = r#"anchor apple generic and certificate leaf[subject.OU] = "VW5DZLFHM5" and identifier "net.nymtech.vpn""#;
 #[cfg(target_os = "macos")]
-const DAEMON_SIGNING_REQUIREMENT: &str = r#"anchor apple generic and certificate leaf[subject.OU] = "VW5DZLFHM5" and identifier "nym-vpnd""#;
+const DAEMON_SIGNING_REQUIREMENT: &str = r#"anchor apple generic and certificate leaf[subject.OU] = "VW5DZLFHM5" and identifier "net.nymtech.vpn.daemon""#;
 
 pub struct CommandInterface {
     // Send commands to the VPN service


### PR DESCRIPTION
Adjust the daemon signing ID to the ID used for signing

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5390)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * macOS daemon signature check corrected so the daemon validates its own signature using the proper identifier, improving startup verification and platform security.

* **Chores**
  * Changelog updated to note the macOS signature verification fix.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nymtech/nym-vpn-client/pull/5390?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->