### PR TITLE
NYM-1396: Attempt to fix Windows sleep issue.

### DIFF
--- a/nym-vpn-core/crates/nym-gateway-directory/src/gateway_cache.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/gateway_cache.rs
@@ -295,9 +295,12 @@ impl GatewayCache {
 
     async fn perform_initial_fetch_once(&mut self) {
         if !self.is_performed_initial_refresh {
-            tracing::debug!("Performing initial gateway refresh");
-            self.is_performed_initial_refresh = true;
-            self.refresh_all().await;
+            self.is_performed_initial_refresh = self.refresh_all().await;
+            if self.is_performed_initial_refresh {
+                tracing::debug!("Initial gateway refresh completed successfully");
+            } else {
+                tracing::warn!("Initial gateway refresh failed");
+            }
         }
     }
 
@@ -322,12 +325,14 @@ impl GatewayCache {
         self.is_performed_initial_refresh = false;
     }
 
-    async fn refresh_all(&mut self) {
+    async fn refresh_all(&mut self) -> bool {
         let gw_types = self.get_stale_gateway_list_types();
 
         if !gw_types.is_empty() {
             tracing::debug!("Refreshing gateways: {:?}", gw_types,);
-            self.refresh(gw_types).await;
+            self.refresh(gw_types).await
+        } else {
+            false
         }
     }
 
@@ -337,10 +342,10 @@ impl GatewayCache {
             .collect()
     }
 
-    async fn refresh(&mut self, gw_list_types: Vec<GatewayType>) {
+    async fn refresh(&mut self, gw_list_types: Vec<GatewayType>) -> bool {
         if self.connectivity_handle.connectivity().await.is_offline() {
             tracing::debug!("Not refreshing gateways because we are not connected");
-            return;
+            return false;
         }
 
         tracing::debug!("Refreshing gateway lists: {gw_list_types:?}");
@@ -355,6 +360,8 @@ impl GatewayCache {
             });
         }
 
+        let mut ok = false;
+
         while let Some(res) = tasks.join_next().await {
             match res {
                 Ok((gw_type, r)) => match r {
@@ -362,6 +369,7 @@ impl GatewayCache {
                         tracing::debug!("Refreshed gateways for {gw_type:?}");
                         self.cached_gateways
                             .insert(gw_type, (refreshed_gateways, Instant::now()));
+                        ok = true;
                     }
                     Err(err) => {
                         tracing::debug!("Failed to refresh gateways for {gw_type:?}: {err}");
@@ -372,6 +380,8 @@ impl GatewayCache {
                 }
             }
         }
+
+        ok
     }
 
     fn is_gateways_current(&self, gw_type: &GatewayType) -> bool {

--- a/nym-vpn-core/crates/nym-offline-monitor/src/windows.rs
+++ b/nym-vpn-core/crates/nym-offline-monitor/src/windows.rs
@@ -4,6 +4,12 @@
 
 use std::{io, sync::Arc, time::Duration};
 
+/// How long to wait after a route is added before announcing "Connected".
+/// Windows adds routes to the routing table before the NIC/DHCP/stack is
+/// fully functional after resume from sleep, causing false-positive online
+/// signals. This small grace period lets the stack stabilise.
+const ONLINE_STABILIZATION_DELAY: Duration = Duration::from_secs(3);
+
 use tokio::sync::{Mutex, watch};
 use tokio_util::sync::CancellationToken;
 
@@ -46,6 +52,7 @@ impl BroadcastListener {
                 suspended: false,
             },
             notify_tx,
+            pending_online_cancel: None,
         }));
 
         let state = system_state.clone();
@@ -176,6 +183,8 @@ enum StateChange {
 struct SystemState {
     connectivity: ConnectivityInner,
     notify_tx: watch::Sender<Connectivity>,
+    /// Cancels a pending "Connected" notification during the stabilisation delay.
+    pending_online_cancel: Option<CancellationToken>,
 }
 
 impl SystemState {
@@ -195,9 +204,39 @@ impl SystemState {
 
         let new_state = self.connectivity.is_offline();
         if old_state != new_state {
-            tracing::info!("Connectivity changed: {}", is_offline_str(new_state));
-            if let Err(e) = self.notify_tx.send(self.connectivity.into_connectivity()) {
-                tracing::error!("Failed to send new offline state to daemon: {}", e);
+            if new_state {
+                // Going offline: cancel any pending "Connected" notification and notify immediately.
+                if let Some(cancel) = self.pending_online_cancel.take() {
+                    cancel.cancel();
+                }
+                tracing::info!("Connectivity changed: {}", is_offline_str(new_state));
+                if let Err(e) = self.notify_tx.send(self.connectivity.into_connectivity()) {
+                    tracing::error!("Failed to send new offline state to daemon: {}", e);
+                }
+            } else {
+                // Going online: debounce before notifying. Windows adds routes to the
+                // routing table before the NIC/network stack is fully functional after
+                // resume from sleep, so we wait a short period to avoid false positives.
+                if let Some(cancel) = self.pending_online_cancel.take() {
+                    cancel.cancel();
+                }
+                let cancel = CancellationToken::new();
+                self.pending_online_cancel = Some(cancel.clone());
+                let notify_tx = self.notify_tx.clone();
+                let online_connectivity = self.connectivity.into_connectivity();
+                tokio::spawn(async move {
+                    tokio::select! {
+                        _ = tokio::time::sleep(ONLINE_STABILIZATION_DELAY) => {
+                            tracing::info!("Connectivity changed: Connected");
+                            if let Err(e) = notify_tx.send(online_connectivity) {
+                                tracing::error!("Failed to send online state to daemon: {}", e);
+                            }
+                        }
+                        _ = cancel.cancelled() => {
+                            tracing::debug!("Pending online notification cancelled (went offline during stabilisation)");
+                        }
+                    }
+                });
             }
         }
     }

--- a/nym-vpn-core/crates/nym-offline-monitor/src/windows.rs
+++ b/nym-vpn-core/crates/nym-offline-monitor/src/windows.rs
@@ -204,22 +204,20 @@ impl SystemState {
 
         let new_state = self.connectivity.is_offline();
         if old_state != new_state {
+            // If going offline: cancel any pending "Connected" notification and notify immediately.
+            // If going online: debounce before notifying. Windows adds routes to the routing table
+            // before the network stack is fully functional after resume from sleep, so we wait a
+            // short period to avoid false positives.
+            if let Some(cancel) = self.pending_online_cancel.take() {
+                cancel.cancel();
+            }
+
             if new_state {
-                // Going offline: cancel any pending "Connected" notification and notify immediately.
-                if let Some(cancel) = self.pending_online_cancel.take() {
-                    cancel.cancel();
-                }
                 tracing::info!("Connectivity changed: {}", is_offline_str(new_state));
                 if let Err(e) = self.notify_tx.send(self.connectivity.into_connectivity()) {
                     tracing::error!("Failed to send new offline state to daemon: {}", e);
                 }
             } else {
-                // Going online: debounce before notifying. Windows adds routes to the
-                // routing table before the NIC/network stack is fully functional after
-                // resume from sleep, so we wait a short period to avoid false positives.
-                if let Some(cancel) = self.pending_online_cancel.take() {
-                    cancel.cancel();
-                }
                 let cancel = CancellationToken::new();
                 self.pending_online_cancel = Some(cancel.clone());
                 let notify_tx = self.notify_tx.clone();


### PR DESCRIPTION
## Ticket

JIRA-NYM-1296

## Description

When waking from sleep we were not giving time for the full network stack to recover before declaring ourselves "connected".

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5433)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gateway cache initialization so the app more reliably detects and reports whether gateway list updates actually succeeded, reducing incorrect status reporting.
  * Fixed false-positive online connectivity notifications on Windows after resume from sleep by adding a short debounce before reporting “Connected,” preventing brief spurious online signals.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nymtech/nym-vpn-client/pull/5433?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->