### PR TITLE
Disable RPC and use Explicit for gateway selection algorithm

### DIFF
--- a/nym-vpn-app/src-tauri/src/vpnd/gateway.rs
+++ b/nym-vpn-app/src-tauri/src/vpnd/gateway.rs
@@ -240,7 +240,7 @@ impl From<lib::GatewaySelectionAlgorithmConfig> for GatewaySelectionAlgorithmCon
     fn from(config: lib::GatewaySelectionAlgorithmConfig) -> Self {
         GatewaySelectionAlgorithmConfig {
             enable_geo_location: config.enable_geo_location,
-            gateway_selection_algorithm: config.gateway_selection_algorithm.into(),
+            gateway_selection_algorithm: config.gateway_selection_algorithm().into(),
         }
     }
 }

--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Don't reuse entry gateway when registering fails (https://github.com/nymtech/nym-vpn-client/pull/5379)
 - [macOS] Daemon checks against the correct ID for its own signature (https://github.com/nymtech/nym-vpn-client/pull/5390)
 
+### Changed
+
+- Disable automatic gateway elections and revert back to hard-coded `Explicit` mode (https://github.com/nymtech/nym-vpn-client/pull/5436)
+
 
 ## [1.29.2] - 2026-05-04
 

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/gateway_selection_algorithm.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/gateway_selection_algorithm.rs
@@ -20,12 +20,12 @@ use ts_rs::TS;
 #[cfg_attr(feature = "typescript-bindings", serde(rename_all = "camelCase"))]
 pub enum GatewaySelectionAlgorithm {
     /// Select gateways explicitly using the entry and exit selectors.
+    #[default]
     Explicit,
 
     /// Select gateways explicitly using the exit selector and automatically finding an entry gateway.
     AutoEntryExplicitExit,
 
-    #[default]
     /// Select gateways by automatically finding an entry and an exit gateway.
     /// The hop mode is also automatically set to 2-hop
     Auto,

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/gateway_selection_algorithm.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/gateway_selection_algorithm.rs
@@ -56,7 +56,31 @@ pub struct GatewaySelectionAlgorithmConfig {
     /// Whether selection algorithm uses geo-location is enabled.
     pub enable_geo_location: bool,
     /// The gateway selection algorithm that should be used.
-    pub gateway_selection_algorithm: GatewaySelectionAlgorithm,
+    gateway_selection_algorithm: GatewaySelectionAlgorithm,
+}
+
+impl GatewaySelectionAlgorithmConfig {
+    pub fn new(
+        enable_geo_location: bool,
+        gateway_selection_algorithm: GatewaySelectionAlgorithm,
+    ) -> Self {
+        Self {
+            enable_geo_location,
+            gateway_selection_algorithm,
+        }
+    }
+
+    pub fn gateway_selection_algorithm(&self) -> GatewaySelectionAlgorithm {
+        // hard-code the algorithm to explicit to make sure that disabling it works, regardless of what value might have been persisted
+        GatewaySelectionAlgorithm::Explicit
+    }
+
+    pub fn set_gateway_selection_algorithm(
+        &mut self,
+        gateway_selection_algorithm: GatewaySelectionAlgorithm,
+    ) {
+        self.gateway_selection_algorithm = gateway_selection_algorithm;
+    }
 }
 
 impl Default for GatewaySelectionAlgorithmConfig {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/config/config_manager.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/config/config_manager.rs
@@ -226,19 +226,19 @@ impl VpnServiceConfigManager {
         Ok(())
     }
 
-    pub async fn set_gateway_selection_algorithm(
+    pub async fn _set_gateway_selection_algorithm(
         &mut self,
         gateway_selection_algorithm: nym_vpn_lib_types::GatewaySelectionAlgorithm,
     ) {
         if self
             .config
             .gateway_selection_algorithm_config
-            .gateway_selection_algorithm
+            .gateway_selection_algorithm()
             != gateway_selection_algorithm
         {
             self.config
                 .gateway_selection_algorithm_config
-                .gateway_selection_algorithm = gateway_selection_algorithm;
+                .set_gateway_selection_algorithm(gateway_selection_algorithm);
             self.save_config_and_send_event().await;
         }
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/config/gateway_selection_algorithm.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/config/gateway_selection_algorithm.rs
@@ -44,17 +44,17 @@ pub(crate) mod v9 {
         fn from(value: &nym_vpn_lib_types::GatewaySelectionAlgorithmConfig) -> Self {
             Self {
                 enable_geo_location: value.enable_geo_location,
-                gateway_selection_algorithm: value.gateway_selection_algorithm.into(),
+                gateway_selection_algorithm: value.gateway_selection_algorithm().into(),
             }
         }
     }
 
     impl From<GatewaySelectionAlgorithmConfig> for nym_vpn_lib_types::GatewaySelectionAlgorithmConfig {
         fn from(value: GatewaySelectionAlgorithmConfig) -> Self {
-            Self {
-                enable_geo_location: value.enable_geo_location,
-                gateway_selection_algorithm: value.gateway_selection_algorithm.into(),
-            }
+            Self::new(
+                value.enable_geo_location,
+                value.gateway_selection_algorithm.into(),
+            )
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/config/tests.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/config/tests.rs
@@ -186,7 +186,7 @@ location = "BE"
   },
   "gateway_selection_algorithm_config": {
     "enable_geo_location": true,
-    "gateway_selection_algorithm": "auto"
+    "gateway_selection_algorithm": "explicit"
   }
 }"#;
 
@@ -261,7 +261,7 @@ identity = [ 99, 23, 98, 234, 66, 161, 195, 63, 155, 161, 250, 207, 17, 158, 136
   },
   "gateway_selection_algorithm_config": {
     "enable_geo_location": true,
-    "gateway_selection_algorithm": "auto"
+    "gateway_selection_algorithm": "explicit"
   }
 }"#;
 
@@ -341,7 +341,7 @@ address = [5, 56, 84, 195, 94, 238, 210, 124, 65, 143, 209, 144, 22, 255, 91, 18
   },
   "gateway_selection_algorithm_config": {
     "enable_geo_location": true,
-    "gateway_selection_algorithm": "auto"
+    "gateway_selection_algorithm": "explicit"
   }
 }"#;
 
@@ -410,7 +410,7 @@ exit_point = "Random"
   },
   "gateway_selection_algorithm_config": {
     "enable_geo_location": true,
-    "gateway_selection_algorithm": "auto"
+    "gateway_selection_algorithm": "explicit"
   }
 }"#;
 
@@ -486,7 +486,7 @@ async fn test_service_config_migrate_from_v1() {
   },
   "gateway_selection_algorithm_config": {
     "enable_geo_location": true,
-    "gateway_selection_algorithm": "auto"
+    "gateway_selection_algorithm": "explicit"
   }
 }"#;
 
@@ -571,7 +571,7 @@ async fn test_service_config_migrate_from_v2() {
   },
   "gateway_selection_algorithm_config": {
     "enable_geo_location": true,
-    "gateway_selection_algorithm": "auto"
+    "gateway_selection_algorithm": "explicit"
   }
 }"#;
 
@@ -662,7 +662,7 @@ async fn test_service_config_migrate_from_v3() {
   },
   "gateway_selection_algorithm_config": {
     "enable_geo_location": true,
-    "gateway_selection_algorithm": "auto"
+    "gateway_selection_algorithm": "explicit"
   }
 }"#;
 
@@ -758,7 +758,7 @@ async fn test_service_config_migrate_from_v4() {
   },
   "gateway_selection_algorithm_config": {
     "enable_geo_location": true,
-    "gateway_selection_algorithm": "auto"
+    "gateway_selection_algorithm": "explicit"
   }
 }"#;
 
@@ -859,7 +859,7 @@ async fn test_service_config_migrate_from_v5() {
   },
   "gateway_selection_algorithm_config": {
     "enable_geo_location": true,
-    "gateway_selection_algorithm": "auto"
+    "gateway_selection_algorithm": "explicit"
   }
 }"#;
 
@@ -961,7 +961,7 @@ async fn test_service_config_migrate_from_v6() {
   },
   "gateway_selection_algorithm_config": {
     "enable_geo_location": true,
-    "gateway_selection_algorithm": "auto"
+    "gateway_selection_algorithm": "explicit"
   }
 }"#;
 
@@ -1128,7 +1128,7 @@ async fn test_service_config_migrate_from_v7() {
   },
   "gateway_selection_algorithm_config": {
     "enable_geo_location": true,
-    "gateway_selection_algorithm": "auto"
+    "gateway_selection_algorithm": "explicit"
   }
 }"#;
 
@@ -1229,7 +1229,7 @@ async fn test_service_config_migrate_from_v8() {
   },
   "gateway_selection_algorithm_config": {
     "enable_geo_location": true,
-    "gateway_selection_algorithm": "auto"
+    "gateway_selection_algorithm": "explicit"
   }
 }"#;
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
@@ -994,9 +994,9 @@ impl NymVpnService {
                     .await;
                 let _ = tx.send(res);
             }
-            VpnServiceCommand::SetGatewaySelectionAlgorithm(tx, gateway_selection_algorithm) => {
-                self.handle_set_gateway_selection_algorithm(gateway_selection_algorithm)
-                    .await;
+            VpnServiceCommand::SetGatewaySelectionAlgorithm(tx, _gateway_selection_algorithm) => {
+                // self.handle_set_gateway_selection_algorithm(gateway_selection_algorithm)
+                //     .await;
                 let _ = tx.send(());
             }
             VpnServiceCommand::SetEnableGeoLocation(tx, enable_geo_location) => {
@@ -1366,12 +1366,12 @@ impl NymVpnService {
         Ok(())
     }
 
-    async fn handle_set_gateway_selection_algorithm(
+    async fn _handle_set_gateway_selection_algorithm(
         &mut self,
         gateway_selection_algorithm: GatewaySelectionAlgorithm,
     ) {
         self.config_manager
-            .set_gateway_selection_algorithm(gateway_selection_algorithm)
+            ._set_gateway_selection_algorithm(gateway_selection_algorithm)
             .await;
         self.update_tunnel_settings_with_throttle();
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -199,7 +199,7 @@ impl TunnelSettings {
     pub fn tunnel_type_used(&self) -> TunnelType {
         if matches!(
             self.gateway_selection_algorithm_config
-                .gateway_selection_algorithm,
+                .gateway_selection_algorithm(),
             GatewaySelectionAlgorithm::Auto
         ) {
             TunnelType::Wireguard
@@ -318,10 +318,10 @@ impl TunnelSettings {
         }
         if self
             .gateway_selection_algorithm_config
-            .gateway_selection_algorithm
+            .gateway_selection_algorithm()
             != other
                 .gateway_selection_algorithm_config
-                .gateway_selection_algorithm
+                .gateway_selection_algorithm()
         {
             diff.add(TunnelSettingsDiffFields::GatewaySelectionAlgorithm);
         }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/selector.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/selector.rs
@@ -242,7 +242,7 @@ pub async fn select_gateways(
 
     let gateway_selection_algorithm = tunnel_settings
         .gateway_selection_algorithm_config
-        .gateway_selection_algorithm;
+        .gateway_selection_algorithm();
 
     let entry_ordering_criteria = match (device_location.clone(), gateway_selection_algorithm) {
         (_, GatewaySelectionAlgorithm::Explicit) | (None, _) => {

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/gateway_selection_algorithm.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/gateway_selection_algorithm.rs
@@ -55,7 +55,7 @@ impl From<nym_vpn_lib_types::GatewaySelectionAlgorithmConfig>
         Self {
             enable_geo_location: value.enable_geo_location,
             gateway_selection_algorithm: Some(proto::GatewaySelectionAlgorithm::from(
-                value.gateway_selection_algorithm,
+                value.gateway_selection_algorithm(),
             )),
         }
     }
@@ -73,9 +73,9 @@ impl TryFrom<proto::GatewaySelectionAlgorithmConfig>
                 "GatewaySelectionAlgorithmConfig.gateway_selection_algorithm",
             ))?
             .try_into()?;
-        Ok(Self {
-            enable_geo_location: value.enable_geo_location,
+        Ok(Self::new(
+            value.enable_geo_location,
             gateway_selection_algorithm,
-        })
+        ))
     }
 }


### PR DESCRIPTION
## Ticket

JIRA-NYM-1417

## Description

Disable RPC call for setting gateway selection algorithm.
Move the read and write of the algorithm into functions instead of direct access.
Hard-code the getter function with the `Explicit` variant, so that it is the one used across the board


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5436)
<!-- Reviewable:end -->
