### PR TITLE
Always use local resolver on iOS

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -1636,18 +1636,17 @@ impl TunnelMonitor {
     fn get_mobile_dns_addresses(&self) -> Vec<IpAddr> {
         #[cfg(target_os = "ios")]
         {
-            // Use local filtering resolver if ad blocking is enabled
-            // todo: set custom DNS for forwarding in local resolver
-            if self.tunnel_parameters.tunnel_settings.enable_ad_blocking {
-                return vec![self.tunnel_parameters.filtering_resolver_addr.ip()];
-            }
+            vec![self.tunnel_parameters.filtering_resolver_addr.ip()]
         }
 
-        self.tunnel_parameters
-            .tunnel_settings
-            .dns
-            .ip_addresses(&self.tunnel_parameters.tunnel_settings.dns_ips())
-            .to_vec()
+        #[cfg(target_os = "android")]
+        {
+            self.tunnel_parameters
+                .tunnel_settings
+                .dns
+                .ip_addresses(&self.tunnel_parameters.tunnel_settings.dns_ips())
+                .to_vec()
+        }
     }
 
     #[cfg(not(any(target_os = "android", target_os = "ios")))]


### PR DESCRIPTION


## Description

This should make it possible to enable adblock at runtime even if the tunnel was started with adblock disabled in the first place.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5444)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Updated DNS resolution behavior for iOS and Android to use platform-specific DNS sources consistently, improving DNS handling reliability across mobile platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nymtech/nym-vpn-client/pull/5444?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->