### PR TITLE
NYM-1423: (core) Make `purchase_token` for Android optional

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-api-client/src/request.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/request.rs
@@ -15,7 +15,8 @@ pub struct CreateAndroidAccountRequestBody {
     pub account_addr: String,
     pub pub_key: String,
     pub signature_base64: String,
-    pub purchase_token: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub purchase_token: Option<String>,
     pub kind: AccountKind,
 }
 

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/types/platform.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/types/platform.rs
@@ -4,5 +4,5 @@
 #[derive(Clone, Debug)]
 pub enum Platform {
     Apple,
-    Android { purchase_token: String },
+    Android { purchase_token: Option<String> },
 }

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/account/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/account/mod.rs
@@ -26,8 +26,10 @@ use ts_rs::TS;
 #[cfg_attr(feature = "typescript-bindings", serde(rename_all = "camelCase"))]
 #[cfg(any(target_os = "ios", target_os = "android"))]
 pub struct RegisterAccountRequest {
+    /// Present for Google Play in-app purchases
+    /// Omitted for anonymous registration
     #[cfg(target_os = "android")]
-    pub purchase_token: String,
+    pub purchase_token: Option<String>,
 }
 
 #[cfg(feature = "nym-type-conversions")]


### PR DESCRIPTION
## Ticket

[JIRA-NYM-1423](https://nymtech.atlassian.net/browse/NYM-1423)

## Description

Make `purchase_token` for android optional: `purchase_token: Option<String>`


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5462)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Android registration now supports optional Google Play purchase tokens, allowing users to complete account setup without providing one for anonymous registration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->