### PR TITLE
APPLE: mock acc summary

### DIFF
--- a/.github/workflows/build-nym-vpn-apple.yml
+++ b/.github/workflows/build-nym-vpn-apple.yml
@@ -108,15 +108,22 @@ jobs:
             fi
           fi
 
+          # Santa's-menu QA code is gated behind `#if SANTA`. Compile it in for
+          # `qa` only; left OUT of `pr` and `ship` so it is physically absent
+          # from App Store binaries.
+          if [[ "$mode" == "qa" ]]; then santa=1; else santa=0; fi
+
           # Export environment variables for later steps
           echo "RELEASE_TYPE=$mode" >> "$GITHUB_ENV"
           echo "BUILD_IOS=$ios" >> "$GITHUB_ENV"
           echo "BUILD_MACOS=$macos" >> "$GITHUB_ENV"
+          echo "NYM_SANTA=$santa" >> "$GITHUB_ENV"
 
           echo "✅ Environment successfully configured:"
           echo "   RELEASE_TYPE=$mode"
           echo "   BUILD_IOS=$ios"
           echo "   BUILD_MACOS=$macos"
+          echo "   NYM_SANTA=$santa"
           echo "--------------------------------------------------"
 
       - name: Show selected release type
@@ -195,7 +202,7 @@ jobs:
           if /usr/libexec/PlistBuddy -c "Print :IsCiBuild" "NymVPNDaemon/Resources/Info.plist" >/dev/null 2>&1; then
             /usr/libexec/PlistBuddy -c "Set :IsCiBuild true" "NymVPNDaemon/Resources/Info.plist"
           else
-            /usr/libexec/PlistBuddy -c "Add :IsCiBuild bool true" "NymVPNDaemon/Resources/Info.plist"
+            /usr/libexec/PlistBuddy -c "Add :IsCiBuild string true" "NymVPNDaemon/Resources/Info.plist"
           fi
 
           echo "✅ Updated Info.plist contents:"
@@ -377,53 +384,68 @@ jobs:
       - name: Tests
         if: ${{ env.RELEASE_TYPE == 'pr' }}
         working-directory: nym-vpn-apple/ServicesMutual
-        run: |
-          set -euo pipefail
-          xcodebuild test \
-            -scheme ServicesMutual-Package \
-            -destination 'platform=macOS' \
-            -only-testing:ConnectionTypesTests \
-            -resultBundlePath TestResults.xcresult \
-            | xcbeautify --renderer github-actions
-
-      - name: Test summary
-        if: ${{ env.RELEASE_TYPE == 'pr' && (success() || failure()) }}
-        working-directory: nym-vpn-apple/ServicesMutual
+        env:
+          ACCOUNT_REPORT_PATH: ${{ github.workspace }}/account-report.md
         run: |
           set -uo pipefail
           which jq >/dev/null || brew install jq
+
+          # Run tests — don't abort on failure, we still want summary + report
+          set +e
+          xcodebuild test \
+            -scheme ServicesMutual-Package \
+            -destination 'platform=macOS' \
+            CODE_SIGNING_ALLOWED=NO \
+            -only-testing:ConnectionTypesTests \
+            -resultBundlePath TestResults.xcresult \
+            | xcbeautify --renderer github-actions
+          TEST_STATUS=${PIPESTATUS[0]}
+          set -e
+
+          # Test summary → step summary
           BUNDLE="TestResults.xcresult"
-          if [[ ! -d "$BUNDLE" ]]; then
-            echo "⚠️ No test results bundle found." >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-          JSON="$(xcrun xcresulttool get test-results summary --path "$BUNDLE" --format json 2>/dev/null)"
-          RESULT=$(jq -r '.result // "Unknown"' <<<"$JSON")
-          PASSED=$(jq -r '.passedTests // 0' <<<"$JSON")
-          FAILED=$(jq -r '.failedTests // 0' <<<"$JSON")
-          SKIPPED=$(jq -r '.skippedTests // 0' <<<"$JSON")
-          ICON="✅"; [[ "$RESULT" != "Passed" ]] && ICON="❌"
-          {
-            echo "## 🧪 ConnectionTypes tests"
-            echo ""
-            echo "$ICON **$RESULT** — ${PASSED} passed, ${FAILED} failed, ${SKIPPED} skipped"
-          } >> "$GITHUB_STEP_SUMMARY"
-          if [[ "$FAILED" != "0" ]]; then
+          if [[ -d "$BUNDLE" ]]; then
+            JSON="$(xcrun xcresulttool get test-results summary --path "$BUNDLE" --format json 2>/dev/null)"
+            RESULT=$(jq -r '.result // "Unknown"' <<<"$JSON")
+            PASSED=$(jq -r '.passedTests // 0' <<<"$JSON")
+            FAILED=$(jq -r '.failedTests // 0' <<<"$JSON")
+            SKIPPED=$(jq -r '.skippedTests // 0' <<<"$JSON")
+            ICON="✅"; [[ "$RESULT" != "Passed" ]] && ICON="❌"
             {
+              echo "## 🧪 ConnectionTypes tests"
               echo ""
-              echo "| Test | Failure |"
-              echo "| --- | --- |"
-              jq -r '.testFailures[]? | "| \(.testName) | \((.failureText // "") | gsub("[\r\n]+"; " ")) |"' <<<"$JSON"
+              echo "$ICON **$RESULT** — ${PASSED} passed, ${FAILED} failed, ${SKIPPED} skipped"
             } >> "$GITHUB_STEP_SUMMARY"
+            if [[ "$FAILED" != "0" ]]; then
+              {
+                echo ""
+                echo "| Test | Failure |"
+                echo "| --- | --- |"
+                jq -r '.testFailures[]? | "| \(.testName) | \((.failureText // "") | gsub("[\r\n]+"; " ")) |"' <<<"$JSON"
+              } >> "$GITHUB_STEP_SUMMARY"
+            fi
+          else
+            echo "⚠️ No test results bundle found." >> "$GITHUB_STEP_SUMMARY"
           fi
 
-      - name: Upload test results
-        if: ${{ env.RELEASE_TYPE == 'pr' && (success() || failure()) }}
+          # Account report → step summary
+          if [[ -f "$ACCOUNT_REPORT_PATH" ]]; then
+            cat "$ACCOUNT_REPORT_PATH" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "account-report.md not produced" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          exit "$TEST_STATUS"
+
+      - name: Upload test artifacts
+        if: ${{ always() && env.RELEASE_TYPE == 'pr' }}
         uses: actions/upload-artifact@v7
         with:
-          name: test-results-connectiontypes
-          path: nym-vpn-apple/ServicesMutual/TestResults.xcresult
-          if-no-files-found: ignore
+          name: connectiontypes-tests
+          path: |
+            nym-vpn-apple/ServicesMutual/TestResults.xcresult
+            account-report.md
+          if-no-files-found: warn
           retention-days: 1
 
       - name: Clean up test results

--- a/nym-vpn-apple/NymVPN/Resources/Localizable.xcstrings
+++ b/nym-vpn-apple/NymVPN/Resources/Localizable.xcstrings
@@ -25936,28 +25936,6 @@
         }
       }
     },
-    "settings.account.renewNow.line1" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Renew now to"
-          }
-        }
-      }
-    },
-    "settings.account.renewNow.line2" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "stay protected"
-          }
-        }
-      }
-    },
     "settings.account.resetsOn" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/nym-vpn-apple/NymVPNDaemon/Resources/Info.plist
+++ b/nym-vpn-apple/NymVPNDaemon/Resources/Info.plist
@@ -37,12 +37,12 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>IsCiBuild</key>
 	<string>$(IS_CI_BUILD)</string>
+	<key>LSUIElement</key>
+	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string></string>
 	<key>SUFeedURL</key>
 	<string>https://nymtech.net/.wellknown/macos-vpn/appcast.xml</string>
-	<key>LSUIElement</key>
-	<true/>
 	<key>SUPublicEDKey</key>
 	<string>9OobPkT0p5WGp0wf2aSbADivVllEKZaz0gKhElMocU0=</string>
 </dict>

--- a/nym-vpn-apple/Scripts/BuildCore.sh
+++ b/nym-vpn-apple/Scripts/BuildCore.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Parse flags
-RELEASE="true"
+RELEASE="${RELEASE:-true}"
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --debug)
@@ -33,6 +32,27 @@ CORE_ROOT="$(cd -- "${CLIENT_ROOT}/nym-vpn-core" && pwd)"
 echo "[BuildCore] CORE_ROOT=${CORE_ROOT}"
 echo "[BuildCore] APPLE_ROOT=${APPLE_ROOT}"
 echo "[BuildCore] CLIENT_ROOT=${CLIENT_ROOT}"
+
+# Santa's menu runtime gate (isSantaClaus reads IsCiBuild). A debug build flips
+# it to true so the menu is reachable locally; a release build restores the
+# $(IS_CI_BUILD) build-setting placeholder so the tracked plist stays clean.
+# (The compile-time #if SANTA is handled by Package.swift: debug config defines
+# it locally, ship Release-without-NYM_SANTA strips it.)
+DAEMON_PLIST="${APPLE_ROOT}/NymVPNDaemon/Resources/Info.plist"
+if [[ -f "${DAEMON_PLIST}" ]]; then
+  if [[ "${RELEASE}" == "false" ]]; then
+    # String, not bool: isRunningOnCI reads this via `as? String` (a bool cast
+    # fails → Santa silently off). Tracked plist + CI Set both keep it a string.
+    /usr/libexec/PlistBuddy -c "Set :IsCiBuild true" "${DAEMON_PLIST}" 2>/dev/null \
+      || /usr/libexec/PlistBuddy -c "Add :IsCiBuild string true" "${DAEMON_PLIST}"
+    echo "[BuildCore] 🎅 Santa's menu enabled (IsCiBuild=true)"
+  else
+    /usr/libexec/PlistBuddy -c 'Set :IsCiBuild $(IS_CI_BUILD)' "${DAEMON_PLIST}" 2>/dev/null || true
+    echo "[BuildCore] Santa's menu plist flag restored to \$(IS_CI_BUILD)"
+  fi
+else
+  echo "[BuildCore] ⚠️ ${DAEMON_PLIST} not found, skipping Santa plist flag"
+fi
 
 # Configure sccache if available
 if command -v sccache &>/dev/null; then

--- a/nym-vpn-apple/Services/Package.swift
+++ b/nym-vpn-apple/Services/Package.swift
@@ -2,6 +2,15 @@
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
+import Foundation
+
+// Santa's-menu code is gated behind `#if SANTA`. Define it for `qa` CI builds
+// (NYM_SANTA=1, any config) and for local debug builds (debug config). Release
+// builds without NYM_SANTA (ship/pr) leave it undefined, so the code is compiled
+// out of App Store binaries entirely (not merely hidden at runtime).
+let santaSwiftSettings: [SwiftSetting] = ProcessInfo.processInfo.environment["NYM_SANTA"] == "1"
+    ? [.define("SANTA")]
+    : [.define("SANTA", .when(configuration: .debug))]
 
 let package = Package(
     name: "Services",
@@ -105,7 +114,8 @@ let package = Package(
                 .product(name: "GRPCManager", package: "ServicesMacOS", condition: .when(platforms: [.macOS])),
                 "Theme"
             ],
-            path: "Sources/Services/CredentialsManager"
+            path: "Sources/Services/CredentialsManager",
+            swiftSettings: santaSwiftSettings
         ),
         .target(
             name: "DeeplinkManager",

--- a/nym-vpn-apple/Services/Sources/Services/CredentialsManager/CredentialsManager.swift
+++ b/nym-vpn-apple/Services/Sources/Services/CredentialsManager/CredentialsManager.swift
@@ -39,6 +39,12 @@ import PathManager
     /// True when the last `fetchAccountSummary` attempt failed (use for UI signal).
     @Published public private(set) var accountSummaryLastFetchFailed = false
 
+#if SANTA
+    /// QA only: when true, `accountSummary` holds a Santa's-menu fake and real
+    /// fetches are suppressed. Set exclusively via `applyDebugAccountSummary`.
+    @Published public private(set) var isAccountSummaryOverridden = false
+#endif
+
     @Published public var accountSummary: AccountSummary? = AppSettings.shared.accountSummary {
         didSet { appSettings.accountSummary = accountSummary }
     }
@@ -151,6 +157,9 @@ import PathManager
 #endif
         checkCredentialImport()
         appSettings.accountToken = nil
+#if SANTA
+        isAccountSummaryOverridden = false
+#endif
         accountSummary = nil
     }
 
@@ -252,6 +261,9 @@ import PathManager
     }
 
     public func updateAccountSummary(force: Bool = false, untilActive: Bool = false) async {
+#if SANTA
+        guard !isAccountSummaryOverridden else { return }
+#endif
         guard isValidCredentialImported else { return }
         await Task { [weak self] in
             guard let self else { return }
@@ -273,6 +285,26 @@ import PathManager
             }
         }.value
     }
+
+#if SANTA
+    /// QA only (Santa's menu): swap in a fabricated summary and pin it so polling
+    /// and forced refreshes don't clobber it. Gated to TestFlight/CI builds; a
+    /// no-op in App Store release so it can never get stuck on a fake.
+    public func applyDebugAccountSummary(_ summary: AccountSummary) {
+        guard configurationManager.isSantaClaus else { return }
+        accountSummaryUpdateTask?.cancel()
+        accountSummaryUpdateTask = nil
+        isAccountSummaryOverridden = true
+        accountSummary = summary
+    }
+
+    /// QA only: drop the fake and refetch the real summary.
+    public func clearDebugAccountSummary() {
+        guard isAccountSummaryOverridden else { return }
+        isAccountSummaryOverridden = false
+        Task { await updateAccountSummary(force: true) }
+    }
+#endif
 
     private func performAccountSummaryUpdate(untilActive: Bool) async {
         guard isValidCredentialImported else { return }

--- a/nym-vpn-apple/ServicesMutual/Sources/ConnectionTypes/AccountSummary/AccountButtons.swift
+++ b/nym-vpn-apple/ServicesMutual/Sources/ConnectionTypes/AccountSummary/AccountButtons.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+public enum AccountReportPlatform: String, CaseIterable {
+    case iOS
+    case macOS
+}
+
+public enum AccountActionKind: String {
+    case renewPlan
+    case manageSubscriptionExternal
+    case linkAccount
+    case manageSubscriptionInApp
+    case logout
+
+    /// Human-readable description of what tapping the button does (for the report).
+    public var reportDescription: String {
+        switch self {
+        case .renewPlan:
+            return "Renew → plan purchase (macOS: autologin renew; iOS: passphrase → purchase)"
+        case .manageSubscriptionExternal:
+            return "Manage subscription → autologin to web account"
+        case .linkAccount:
+            return "Link account → Privy auth session"
+        case .manageSubscriptionInApp:
+            return "Manage subscription → iOS native subscriptions sheet"
+        case .logout:
+            return "Logout → disconnect, then remove credential"
+        }
+    }
+}
+
+public struct AccountButton: Equatable {
+    public let titleKey: String
+    public let kind: AccountActionKind
+    public let isDestructive: Bool
+
+    public init(titleKey: String, kind: AccountActionKind, isDestructive: Bool) {
+        self.titleKey = titleKey
+        self.kind = kind
+        self.isDestructive = isDestructive
+    }
+}
+
+/// The ordered set of buttons the Account & Devices view renders for a given
+/// account state. Mirrors `AccountAndDevicesView` render order:
+/// renew (in account-status card) → manage-subscription (web) → link → iOS in-app manage → logout.
+public func accountButtons(
+    for summary: AccountSummary?,
+    platform: AccountReportPlatform,
+    isTestFlight: Bool
+) -> [AccountButton] {
+    guard let summary else { return [] }
+    var buttons: [AccountButton] = []
+
+    if summary.shouldShowRenewRow {
+        buttons.append(AccountButton(titleKey: "settings.account.renewNow", kind: .renewPlan, isDestructive: false))
+    }
+    buttons.append(AccountButton(titleKey: "settings.account.manageSubscription", kind: .manageSubscriptionExternal, isDestructive: false))
+    if summary.shouldShowLinkAccountRow {
+        buttons.append(AccountButton(titleKey: "settings.account.nymAccount", kind: .linkAccount, isDestructive: false))
+    }
+    if platform == .iOS && !isTestFlight {
+        buttons.append(AccountButton(titleKey: "settings.manageSubscription", kind: .manageSubscriptionInApp, isDestructive: false))
+    }
+    buttons.append(AccountButton(titleKey: "settings.logout", kind: .logout, isDestructive: true))
+    return buttons
+}

--- a/nym-vpn-apple/ServicesMutual/Sources/ConnectionTypes/AccountSummary/AccountSummary+Fake.swift
+++ b/nym-vpn-apple/ServicesMutual/Sources/ConnectionTypes/AccountSummary/AccountSummary+Fake.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+public extension AccountSummary {
+    /// Builds a canned account summary for a "time-left" scenario.
+    /// `daysRemaining == nil` ⇒ expired (inactive). Relocated from SantasViewModel
+    /// so QA presets and tests share one factory.
+    static func makeFake(
+        daysRemaining: Int?,
+        kind: VpnSubscriptionKind,
+        isAutoRenew: Bool,
+        baseAddress: String,
+        now: Date = Date()
+    ) -> AccountSummary {
+        let isActive = (daysRemaining ?? -1) >= 0
+        let validUntil = daysRemaining.map { now.addingTimeInterval(TimeInterval($0) * 86_400) }
+        let subscription = Subscription(
+            status: .active,
+            subscription: VpnSubscription(
+                createdOnUtc: now,
+                lastUpdatedUtc: now,
+                id: "fake-subscription",
+                validUntilDate: validUntil ?? now,
+                validFromDate: now,
+                status: isActive ? "active" : "expired",
+                kind: kind,
+                isRecurring: isAutoRenew
+            )
+        )
+        return AccountSummary(
+            validUntilDate: validUntil,
+            trafficUsedGb: nil,
+            trafficLimitGb: nil,
+            trafficResetDate: nil,
+            accountAddress: baseAddress,
+            cannonicalAccountAddress: nil,
+            accountAuthMethod: [],
+            isLinked: true,
+            isActive: isActive,
+            isAutoRenewEnabled: isAutoRenew,
+            subscription: subscription
+        )
+    }
+}

--- a/nym-vpn-apple/ServicesMutual/Sources/ConnectionTypes/AccountSummary/AccountSummary+Visibility.swift
+++ b/nym-vpn-apple/ServicesMutual/Sources/ConnectionTypes/AccountSummary/AccountSummary+Visibility.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+public extension AccountSummary {
+    /// Account-status renew row: shown when active-but-not-auto-renewing, or inactive.
+    /// Mirrors `AccountAndDevicesView+AccountStatus.accountStatusSection`.
+    var shouldShowRenewRow: Bool { !isActive || !isAutoRenewEnabled }
+
+    /// "Account on nym.com" link row: shown while the account is not yet linked.
+    var shouldShowLinkAccountRow: Bool { !isLinked }
+}

--- a/nym-vpn-apple/ServicesMutual/Tests/ConnectionTypesTests/AccountButtonsTests.swift
+++ b/nym-vpn-apple/ServicesMutual/Tests/ConnectionTypesTests/AccountButtonsTests.swift
@@ -1,0 +1,43 @@
+import Testing
+@testable import ConnectionTypes
+
+struct AccountButtonsTests {
+    @Test func nilSummaryHasNoButtons() {
+        #expect(accountButtons(for: nil, platform: .macOS, isTestFlight: false).isEmpty)
+    }
+
+    @Test func activeAutoRenewLinkedMacOS() {
+        var s = AccountSummary.makeFake(daysRemaining: 200, kind: .oneYear, isAutoRenew: true, baseAddress: "a")
+        s.isLinked = true
+        let kinds = accountButtons(for: s, platform: .macOS, isTestFlight: false).map(\.kind)
+        #expect(kinds == [.manageSubscriptionExternal, .logout])
+    }
+
+    @Test func inactiveUnlinkedMacOS() {
+        var s = AccountSummary.makeFake(daysRemaining: nil, kind: .oneYear, isAutoRenew: false, baseAddress: "a")
+        s.isLinked = false
+        let buttons = accountButtons(for: s, platform: .macOS, isTestFlight: false)
+        #expect(buttons.map(\.kind) == [.renewPlan, .manageSubscriptionExternal, .linkAccount, .logout])
+        #expect(buttons.map(\.titleKey) == [
+            "settings.account.renewNow",
+            "settings.account.manageSubscription",
+            "settings.account.nymAccount",
+            "settings.logout"
+        ])
+        #expect(buttons.last?.isDestructive == true)
+    }
+
+    @Test func iOSAddsInAppManageWhenNotTestFlight() {
+        var s = AccountSummary.makeFake(daysRemaining: 200, kind: .oneYear, isAutoRenew: true, baseAddress: "a")
+        s.isLinked = true
+        let kinds = accountButtons(for: s, platform: .iOS, isTestFlight: false).map(\.kind)
+        #expect(kinds == [.manageSubscriptionExternal, .manageSubscriptionInApp, .logout])
+    }
+
+    @Test func iOSHidesInAppManageOnTestFlight() {
+        var s = AccountSummary.makeFake(daysRemaining: 200, kind: .oneYear, isAutoRenew: true, baseAddress: "a")
+        s.isLinked = true
+        let kinds = accountButtons(for: s, platform: .iOS, isTestFlight: true).map(\.kind)
+        #expect(kinds == [.manageSubscriptionExternal, .logout])
+    }
+}

--- a/nym-vpn-apple/ServicesMutual/Tests/ConnectionTypesTests/AccountReportTests.swift
+++ b/nym-vpn-apple/ServicesMutual/Tests/ConnectionTypesTests/AccountReportTests.swift
@@ -1,0 +1,189 @@
+import Foundation
+import Testing
+@testable import ConnectionTypes
+
+/// `.serialized`: the two row-producing tests append to the shared `ReportBuilder`
+/// singleton and each flushes it at the end. Serializing keeps those appends from
+/// interleaving (Swift Testing runs tests in parallel by default) and makes the final
+/// on-disk report deterministic — `markdown()` renders the full accumulated state, so
+/// whichever row-test runs last writes the complete file. (Replaces the old XCTest
+/// class-level `tearDown` flush, which has no Swift Testing equivalent.)
+@Suite(.serialized)
+struct AccountReportTests {
+    struct Scenario {
+        let planLabel: String
+        let daysRemaining: Int?
+        let kind: VpnSubscriptionKind
+    }
+
+    // Mirrors SantasViewModel.yearlyPresets + monthlyPresets.
+    static let scenarios: [Scenario] = [
+        .init(planLabel: "Yearly", daysRemaining: 182, kind: .oneYear),
+        .init(planLabel: "Yearly", daysRemaining: 61, kind: .oneYear),
+        .init(planLabel: "Yearly", daysRemaining: 30, kind: .oneYear),
+        .init(planLabel: "Yearly", daysRemaining: 14, kind: .oneYear),
+        .init(planLabel: "Yearly", daysRemaining: 7, kind: .oneYear),
+        .init(planLabel: "Yearly", daysRemaining: 3, kind: .oneYear),
+        .init(planLabel: "Yearly", daysRemaining: 1, kind: .oneYear),
+        .init(planLabel: "Yearly", daysRemaining: nil, kind: .oneYear),
+        .init(planLabel: "Monthly", daysRemaining: 30, kind: .oneMonth),
+        .init(planLabel: "Monthly", daysRemaining: 14, kind: .oneMonth),
+        .init(planLabel: "Monthly", daysRemaining: 6, kind: .oneMonth),
+        .init(planLabel: "Monthly", daysRemaining: 3, kind: .oneMonth),
+        .init(planLabel: "Monthly", daysRemaining: 1, kind: .oneMonth),
+        .init(planLabel: "Monthly", daysRemaining: nil, kind: .oneMonth)
+    ]
+
+    /// Resolved once; English (source-language) xcstrings values.
+    static let resolver: XCStringsResolver? = try? XCStringsResolver.default()
+
+    /// The branch key the production property selects, under the test bundle (raw keys).
+    private func expectedBranchKey(_ s: AccountSummary) -> String {
+        if !s.isActive { return "noActivePlan" }
+        return (s.isExpiringSoon || s.isExpiringWarning) ? "planExpiresOn" : "planValidUntil"
+    }
+
+    /// Real displayed sentence, rebuilt from the resolved English strings.
+    private func displayedText(_ s: AccountSummary, _ r: XCStringsResolver) -> String {
+        if !s.isActive { return r.string("noActivePlan") }
+        let date = s.formattedValidUntilDate ?? "-"
+        let key = (s.isExpiringSoon || s.isExpiringWarning) ? "planExpiresOn" : "planValidUntil"
+        return "\(r.string(key)) \(date)"
+    }
+
+    private func colorLabel(_ s: AccountSummary) -> String {
+        if !s.isActive { return "error" }
+        if s.isExpiringSoon { return "orange" }
+        if s.isExpiringWarning { return "warning" }
+        return "accent"
+    }
+
+    /// GitHub renders `$\textcolor{…}{…}$` as colored text — the only color
+    /// mechanism GFM tables / step summaries support (inline HTML styles are
+    /// stripped). Source is ASCII, so char-count padding keeps the raw file
+    /// monospace-aligned while the rendered table shows red/green.
+    private func colored(_ text: String, _ color: String) -> String {
+        "$\\textcolor{\(color)}{\\textsf{\(text)}}$"
+    }
+
+    private func yesNo(_ value: Bool) -> String {
+        value ? colored("yes", "green") : colored("no", "red")
+    }
+
+    /// Renders the status-color token in its own colour.
+    private func colorCell(_ label: String) -> String {
+        let map = ["accent": "green", "warning": "orange", "orange": "orange", "error": "red"]
+        return colored(label, map[label] ?? "gray")
+    }
+
+    @Test func textByScenario() throws {
+        let r = try #require(Self.resolver, "xcstrings resolver unavailable")
+        for sc in Self.scenarios {
+            let s = AccountSummary.makeFake(daysRemaining: sc.daysRemaining, kind: sc.kind, isAutoRenew: false, baseAddress: "fake")
+            let branch = expectedBranchKey(s)
+            let text = displayedText(s, r)
+            let daysCell = sc.daysRemaining.map(String.init) ?? "expired"
+
+            ReportBuilder.shared.addTextRow([
+                sc.planLabel,
+                daysCell,
+                yesNo(s.isActive),
+                s.isActive ? yesNo(s.isExpiringSoon) : colored("n/a", "gray"),
+                s.isActive ? yesNo(s.isExpiringWarning) : colored("n/a", "gray"),
+                "`\(branch)`",
+                text,
+                colorCell(colorLabel(s))
+            ])
+
+            let produced = String((s.planValidUntilAttributedString.map { String($0.characters) }) ?? "")
+            if branch == "noActivePlan" {
+                #expect(produced == "noActivePlan", "\(sc.planLabel) \(daysCell)")
+            } else {
+                #expect(produced.hasPrefix(branch),
+                        "\(sc.planLabel) \(daysCell): expected branch \(branch), got \(produced)")
+            }
+        }
+        ReportBuilder.shared.write()
+    }
+
+    @Test func buttonsByScenario() {
+        // macOS scope (per spec). Vary auto-renew + linked to exercise visibility.
+        let variants: [(autoRenew: Bool, linked: Bool)] = [(true, true), (false, false)]
+        for sc in Self.scenarios {
+            for v in variants {
+                var s = AccountSummary.makeFake(daysRemaining: sc.daysRemaining, kind: sc.kind, isAutoRenew: v.autoRenew, baseAddress: "fake")
+                s.isLinked = v.linked
+                let buttons = accountButtons(for: s, platform: .macOS, isTestFlight: false)
+                let daysCell = sc.daysRemaining.map(String.init) ?? "expired"
+                let scenarioLabel = "\(sc.planLabel) · \(daysCell) · autoRenew=\(v.autoRenew) · linked=\(v.linked)"
+
+                ReportBuilder.shared.addButtonRow([
+                    scenarioLabel,
+                    buttons.map { $0.kind.reportDescription }.joined(separator: "; ")
+                ])
+
+                #expect(buttons.last?.kind == .logout, "\(scenarioLabel)")
+                #expect(buttons.last?.isDestructive == true, "\(scenarioLabel)")
+                #expect(buttons.contains(where: { $0.kind == .manageSubscriptionExternal }), "\(scenarioLabel)")
+                #expect(buttons.contains(where: { $0.kind == .renewPlan }) == s.shouldShowRenewRow, "\(scenarioLabel)")
+                #expect(buttons.contains(where: { $0.kind == .linkAccount }) == s.shouldShowLinkAccountRow, "\(scenarioLabel)")
+            }
+        }
+        ReportBuilder.shared.write()
+    }
+
+    /// Guards against "button set drift": the title keys wired into the view must
+    /// equal the title keys the descriptor can emit (iOS superset, non-TestFlight).
+    @Test func descriptorMatchesViewButtonSet() throws {
+        var s = AccountSummary.makeFake(daysRemaining: nil, kind: .oneYear, isAutoRenew: false, baseAddress: "a")
+        s.isLinked = false
+        let descriptorKeys = Set(accountButtons(for: s, platform: .iOS, isTestFlight: false).map(\.titleKey))
+
+        let viewKeys = try Self.viewButtonTitleKeys()
+        #expect(viewKeys == descriptorKeys,
+                "Account view button title-keys diverged from the descriptor. View=\(viewKeys.sorted()) Descriptor=\(descriptorKeys.sorted())")
+    }
+
+    /// Extracts button title keys from the Account view sources:
+    ///  - `title: "KEY".localizedString` on SettingsListItem button rows
+    ///  - the renew row `Text("settings.account.renewNow".localizedString)`
+    ///
+    /// Non-button `title:` args (navbar `CustomNavBar`, copyable `SettingsCopyableContentCell`
+    /// via the `cell(title:…)` helper) are excluded so the extracted set reflects only
+    /// the tappable account buttons the descriptor mirrors.
+    static func viewButtonTitleKeys(file: StaticString = #filePath) throws -> Set<String> {
+        // file = …/nym-vpn-apple/ServicesMutual/Tests/ConnectionTypesTests/AccountReportTests.swift
+        var root = URL(fileURLWithPath: "\(file)")
+        for _ in 0..<4 { root.deleteLastPathComponent() } // → nym-vpn-apple/
+        let dir = root.appendingPathComponent("Settings/Sources/Settings/AccountAndDevices")
+        let files = [
+            dir.appendingPathComponent("AccountAndDevicesView.swift"),
+            dir.appendingPathComponent("AccountAndDevicesView+AccountStatus.swift")
+        ]
+        var source = ""
+        for f in files { source += (try? String(contentsOf: f, encoding: .utf8)) ?? "" }
+
+        // Non-button `title:` args we must NOT treat as buttons:
+        //  - navbar title (CustomNavBar): "settings.account"
+        //  - copyable content cells (cell(title:…) → SettingsCopyableContentCell):
+        //    "settings.accountID", "settings.deviceId"
+        let nonButtonTitleKeys: Set<String> = [
+            "settings.account",
+            "settings.accountID",
+            "settings.deviceId"
+        ]
+
+        var keys = Set<String>()
+        let titleRegex = try NSRegularExpression(pattern: #"title:\s*"([^"]+)"\.localizedString"#)
+        for m in titleRegex.matches(in: source, range: NSRange(source.startIndex..., in: source)) {
+            if let r = Range(m.range(at: 1), in: source) {
+                let key = String(source[r])
+                if !nonButtonTitleKeys.contains(key) { keys.insert(key) }
+            }
+        }
+        if source.contains(#""settings.account.renewNow".localizedString"#) {
+            keys.insert("settings.account.renewNow")
+        }
+        return keys
+    }
+}

--- a/nym-vpn-apple/ServicesMutual/Tests/ConnectionTypesTests/AccountSummaryFakeTests.swift
+++ b/nym-vpn-apple/ServicesMutual/Tests/ConnectionTypesTests/AccountSummaryFakeTests.swift
@@ -1,0 +1,18 @@
+import Testing
+@testable import ConnectionTypes
+
+struct AccountSummaryFakeTests {
+    @Test func expiredFakeIsInactive() {
+        let summary = AccountSummary.makeFake(daysRemaining: nil, kind: .oneYear, isAutoRenew: false, baseAddress: "a")
+        #expect(!summary.isActive)
+        #expect(summary.validUntilDate == nil)
+    }
+
+    @Test func activeFakeHasFutureValidUntil() {
+        let summary = AccountSummary.makeFake(daysRemaining: 7, kind: .oneMonth, isAutoRenew: true, baseAddress: "a")
+        #expect(summary.isActive)
+        #expect(summary.isAutoRenewEnabled)
+        #expect(summary.subscription?.subscription.kind == .oneMonth)
+        #expect(summary.validUntilDate != nil)
+    }
+}

--- a/nym-vpn-apple/ServicesMutual/Tests/ConnectionTypesTests/AccountVisibilityTests.swift
+++ b/nym-vpn-apple/ServicesMutual/Tests/ConnectionTypesTests/AccountVisibilityTests.swift
@@ -1,0 +1,27 @@
+import Testing
+@testable import ConnectionTypes
+
+struct AccountVisibilityTests {
+    @Test func renewRowShownWhenInactive() {
+        let s = AccountSummary.makeFake(daysRemaining: nil, kind: .oneYear, isAutoRenew: false, baseAddress: "a")
+        #expect(s.shouldShowRenewRow)
+    }
+
+    @Test func renewRowShownWhenActiveButNotAutoRenewing() {
+        let s = AccountSummary.makeFake(daysRemaining: 200, kind: .oneYear, isAutoRenew: false, baseAddress: "a")
+        #expect(s.shouldShowRenewRow)
+    }
+
+    @Test func renewRowHiddenWhenActiveAndAutoRenewing() {
+        let s = AccountSummary.makeFake(daysRemaining: 200, kind: .oneYear, isAutoRenew: true, baseAddress: "a")
+        #expect(!s.shouldShowRenewRow)
+    }
+
+    @Test func linkRowShownWhenNotLinked() {
+        var s = AccountSummary.makeFake(daysRemaining: 10, kind: .oneMonth, isAutoRenew: false, baseAddress: "a")
+        s.isLinked = false
+        #expect(s.shouldShowLinkAccountRow)
+        s.isLinked = true
+        #expect(!s.shouldShowLinkAccountRow)
+    }
+}

--- a/nym-vpn-apple/ServicesMutual/Tests/ConnectionTypesTests/ReportBuilder.swift
+++ b/nym-vpn-apple/ServicesMutual/Tests/ConnectionTypesTests/ReportBuilder.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// Accumulates Markdown table rows across tests and writes them once.
+/// Rows are appended BEFORE assertions so the file is complete even if an
+/// assertion fails. Flushed from `AccountReportTests.tearDown` (class-level).
+///
+/// Cells are stored per-column so `markdown()` can pad every column to its
+/// widest cell — the raw `.md` then aligns in a monospace view.
+final class ReportBuilder {
+    static let shared = ReportBuilder()
+
+    /// Single source of truth for the report file name + env override. Shared with
+    /// `WorkflowReportTests`, which asserts the CI workflow wires these exact values —
+    /// so a rename here (or in the workflow) can't silently break report publishing.
+    static let fileName = "account-report.md"
+    static let pathEnvVar = "ACCOUNT_REPORT_PATH"
+
+    private static let textHeader = [
+        "Plan", "Days left", "Active", "Expiring soon",
+        "Expiring warning", "Branch key", "Displayed text", "Color"
+    ]
+    private static let buttonHeader = ["Scenario", "Actions"]
+
+    private(set) var textRows: [[String]] = []
+    private(set) var buttonRows: [[String]] = []
+
+    func addTextRow(_ cells: [String]) { textRows.append(cells) }
+    func addButtonRow(_ cells: [String]) { buttonRows.append(cells) }
+
+    func markdown() -> String {
+        var out = "# Account & Devices — test report\n\n"
+        out += "## Text by scenario (macOS)\n\n"
+        out += Self.renderTable(header: Self.textHeader, rows: textRows)
+        out += "\n## Buttons & actions by scenario\n\n"
+        out += Self.renderTable(header: Self.buttonHeader, rows: buttonRows)
+        return out
+    }
+
+    /// GitHub-flavored Markdown table with each column padded to its widest cell
+    /// so the raw text lines up. (Emoji may render slightly wider than their
+    /// character count, but every column is consistently character-aligned.)
+    private static func renderTable(header: [String], rows: [[String]]) -> String {
+        let columnCount = header.count
+        var widths = header.map { $0.count }
+        for row in rows {
+            for (i, cell) in row.enumerated() where i < columnCount {
+                widths[i] = max(widths[i], cell.count)
+            }
+        }
+
+        func line(_ cells: [String]) -> String {
+            let padded = (0..<columnCount).map { i -> String in
+                let cell = i < cells.count ? cells[i] : ""
+                return cell.padding(toLength: widths[i], withPad: " ", startingAt: 0)
+            }
+            return "| " + padded.joined(separator: " | ") + " |\n"
+        }
+
+        var out = line(header)
+        out += "| " + widths.map { String(repeating: "-", count: $0) }.joined(separator: " | ") + " |\n"
+        for row in rows { out += line(row) }
+        return out
+    }
+
+    func write(file: StaticString = #filePath) {
+        let envPath = ProcessInfo.processInfo.environment[Self.pathEnvVar].flatMap { $0.isEmpty ? nil : $0 }
+        let path = envPath ?? Self.defaultReportPath(file: file)
+        try? markdown().write(toFile: path, atomically: true, encoding: .utf8)
+        FileHandle.standardError.write(Data("account-report written to \(path)\n".utf8))
+    }
+
+    /// repo-root/account-report.md, derived from this test file's on-disk location:
+    /// …/nym-vpn-client/nym-vpn-apple/ServicesMutual/Tests/ConnectionTypesTests/<file>.swift
+    /// → up 5 → repo root (nym-vpn-client), which equals CI's $GITHUB_WORKSPACE.
+    private static func defaultReportPath(file: StaticString) -> String {
+        var url = URL(fileURLWithPath: "\(file)")
+        for _ in 0..<5 { url.deleteLastPathComponent() }
+        return url.appendingPathComponent(Self.fileName).path
+    }
+}

--- a/nym-vpn-apple/ServicesMutual/Tests/ConnectionTypesTests/SmokeTests.swift
+++ b/nym-vpn-apple/ServicesMutual/Tests/ConnectionTypesTests/SmokeTests.swift
@@ -1,0 +1,10 @@
+import Testing
+@testable import ConnectionTypes
+
+struct SmokeTests {
+    @Test func connectionTypesImports() {
+        // Proves the test target compiles + links ConnectionTypes (and, on macOS,
+        // the NymVPNRpc framework produced by BuildCore.sh).
+        #expect(Bool(true))
+    }
+}

--- a/nym-vpn-apple/ServicesMutual/Tests/ConnectionTypesTests/WorkflowReportTests.swift
+++ b/nym-vpn-apple/ServicesMutual/Tests/ConnectionTypesTests/WorkflowReportTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Testing
+
+/// Anti-drift guard for the CI wiring that publishes `AccountReportTests` output.
+///
+/// `ReportBuilder` writes its Markdown to `$ACCOUNT_REPORT_PATH` (falling back to
+/// repo-root/account-report.md, which equals `$GITHUB_WORKSPACE` on CI). For that
+/// report to actually reach a PR, the GitHub Actions workflow must:
+///   1. set `ACCOUNT_REPORT_PATH` (== `ReportBuilder.pathEnvVar`) to a workspace-anchored
+///      file named `account-report.md` (== `ReportBuilder.fileName`),
+///   2. consume that env and surface the file into the job step summary,
+///   3. upload the report + the xcresult bundle as an artifact,
+///   4. run the test step via the SPM scheme, scoped to the ConnectionTypes target.
+///
+/// These tests read the workflow YAML off disk and assert that contract. If the
+/// workflow drifts (env renamed/dropped, scheme swapped, upload removed) — or if the
+/// `ReportBuilder` constants change without a matching workflow edit — this turns red
+/// instead of silently producing no report on CI. (Plain-text scanning, matching the
+/// source-reading style of `AccountReportTests.viewButtonTitleKeys`; Foundation ships
+/// no YAML parser and the assertions don't need full structure.)
+struct WorkflowReportTests {
+    private static let workflowRelativePath = ".github/workflows/build-nym-vpn-apple.yml"
+    private static let scheme = "ServicesMutual-Package"
+    private static let testTarget = "ConnectionTypesTests"
+    private static let xcresultBundle = "TestResults.xcresult"
+
+    /// Loads the workflow YAML, resolving repo root the same way `ReportBuilder` does:
+    /// up 5 from this file → repo root (== `$GITHUB_WORKSPACE`).
+    private func workflowYAML(file: StaticString = #filePath) throws -> String {
+        var root = URL(fileURLWithPath: "\(file)")
+        for _ in 0..<5 { root.deleteLastPathComponent() }
+        let url = root.appendingPathComponent(Self.workflowRelativePath)
+        return try #require(try? String(contentsOf: url, encoding: .utf8),
+                            "workflow not found at \(url.path) — repo layout changed?")
+    }
+
+    /// The value the workflow assigns to `ReportBuilder.pathEnvVar` (rest of the line).
+    private func reportPathEnvValue(in yaml: String) throws -> String {
+        let regex = try NSRegularExpression(pattern: "\(ReportBuilder.pathEnvVar):\\s*(.+)")
+        let range = NSRange(yaml.startIndex..., in: yaml)
+        let match = try #require(regex.firstMatch(in: yaml, range: range),
+                                 "\(ReportBuilder.pathEnvVar) is not set in the workflow")
+        let valueRange = try #require(Range(match.range(at: 1), in: yaml))
+        return String(yaml[valueRange]).trimmingCharacters(in: .whitespaces)
+    }
+
+    @Test func reportPathEnvWiredToWorkspaceFile() throws {
+        let value = try reportPathEnvValue(in: try workflowYAML())
+        // Anchored at the runner workspace (== ReportBuilder's up-5 fallback root)…
+        #expect(value.contains("github.workspace"),
+                "\(ReportBuilder.pathEnvVar) must be anchored at github.workspace, got: \(value)")
+        // …and named exactly what ReportBuilder writes.
+        #expect(value.hasSuffix(ReportBuilder.fileName),
+                "\(ReportBuilder.pathEnvVar) must end in \(ReportBuilder.fileName), got: \(value)")
+    }
+
+    @Test func reportEnvVarIsConsumedAndSurfaced() throws {
+        let yaml = try workflowYAML()
+        // The env must actually be read (not just declared)…
+        let consumed = yaml.contains("$\(ReportBuilder.pathEnvVar)")
+            || yaml.contains("${\(ReportBuilder.pathEnvVar)}")
+        #expect(consumed, "\(ReportBuilder.pathEnvVar) is set but never referenced")
+        // …and routed into the PR's job step summary.
+        #expect(yaml.contains("GITHUB_STEP_SUMMARY"),
+                "report is not surfaced to the job step summary")
+    }
+
+    @Test func reportAndResultsUploadedAsArtifact() throws {
+        let yaml = try workflowYAML()
+        // Locate the upload step by its action (rename-proof), then assert both paths.
+        let uploadStep = try #require(
+            yaml.components(separatedBy: "\n      - name:").first { $0.contains("actions/upload-artifact") },
+            "no upload-artifact step in the workflow")
+        #expect(uploadStep.contains(ReportBuilder.fileName),
+                "\(ReportBuilder.fileName) is not in the upload-artifact paths")
+        #expect(uploadStep.contains(Self.xcresultBundle),
+                "\(Self.xcresultBundle) is not in the upload-artifact paths")
+    }
+
+    @Test func testStepRunsConnectionTypes() throws {
+        let yaml = try workflowYAML()
+        #expect(yaml.contains("-scheme \(Self.scheme)"),
+                "test step does not use scheme \(Self.scheme)")
+        #expect(yaml.contains("-only-testing:\(Self.testTarget)"),
+                "test step does not scope to \(Self.testTarget)")
+    }
+}

--- a/nym-vpn-apple/ServicesMutual/Tests/ConnectionTypesTests/XCStringsResolver.swift
+++ b/nym-vpn-apple/ServicesMutual/Tests/ConnectionTypesTests/XCStringsResolver.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Reads the app's `Localizable.xcstrings` from disk and resolves the English
+/// (source-language) value for a key. Used because `.localizedString` reads
+/// `Bundle.main`, which under the package test bundle has no app strings.
+struct XCStringsResolver {
+    private let strings: [String: Any]
+
+    /// Locates the xcstrings: env override `XCSTRINGS_PATH`, else a path relative
+    /// to this source file (…/ServicesMutual/Tests/ConnectionTypesTests → nym-vpn-apple/).
+    static func defaultURL(file: StaticString = #filePath) -> URL {
+        if let override = ProcessInfo.processInfo.environment["XCSTRINGS_PATH"], !override.isEmpty {
+            return URL(fileURLWithPath: override)
+        }
+        // file = .../nym-vpn-apple/ServicesMutual/Tests/ConnectionTypesTests/XCStringsResolver.swift
+        var url = URL(fileURLWithPath: "\(file)")
+        for _ in 0..<4 { url.deleteLastPathComponent() } // → nym-vpn-apple/
+        return url
+            .appendingPathComponent("NymVPN")
+            .appendingPathComponent("Resources")
+            .appendingPathComponent("Localizable.xcstrings")
+    }
+
+    static func `default`() throws -> XCStringsResolver {
+        try XCStringsResolver(url: defaultURL())
+    }
+
+    init(url: URL) throws {
+        let data = try Data(contentsOf: url)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        strings = (json?["strings"] as? [String: Any]) ?? [:]
+    }
+
+    /// English value for `key`, or `key` itself when missing.
+    func string(_ key: String) -> String {
+        guard
+            let entry = strings[key] as? [String: Any],
+            let locs = entry["localizations"] as? [String: Any],
+            let en = locs["en"] as? [String: Any],
+            let unit = en["stringUnit"] as? [String: Any],
+            let value = unit["value"] as? String
+        else { return key }
+        return value
+    }
+}

--- a/nym-vpn-apple/ServicesMutual/Tests/ConnectionTypesTests/XCStringsResolverTests.swift
+++ b/nym-vpn-apple/ServicesMutual/Tests/ConnectionTypesTests/XCStringsResolverTests.swift
@@ -1,0 +1,16 @@
+import Testing
+
+struct XCStringsResolverTests {
+    @Test func resolvesKnownKeys() throws {
+        let resolver = try XCStringsResolver.default()
+        #expect(resolver.string("planExpiresOn") == "Plan expires on")
+        #expect(resolver.string("planValidUntil") == "Plan valid until")
+        #expect(resolver.string("noActivePlan") == "This account has no active subscription")
+        #expect(resolver.string("settings.logout") == "Logout")
+    }
+
+    @Test func unknownKeyFallsBackToKey() throws {
+        let resolver = try XCStringsResolver.default()
+        #expect(resolver.string("totally.bogus.key") == "totally.bogus.key")
+    }
+}

--- a/nym-vpn-apple/Settings/Package.swift
+++ b/nym-vpn-apple/Settings/Package.swift
@@ -2,6 +2,15 @@
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
+import Foundation
+
+// Santa's-menu code is gated behind `#if SANTA`. Define it for `qa` CI builds
+// (NYM_SANTA=1, any config) and for local debug builds (debug config). Release
+// builds without NYM_SANTA (ship/pr) leave it undefined, so the code is compiled
+// out of App Store binaries entirely (not merely hidden at runtime).
+let santaSwiftSettings: [SwiftSetting] = ProcessInfo.processInfo.environment["NYM_SANTA"] == "1"
+    ? [.define("SANTA")]
+    : [.define("SANTA", .when(configuration: .debug))]
 
 let package = Package(
     name: "Settings",
@@ -53,7 +62,8 @@ let package = Package(
                 .product(name: "Theme", package: "Theme"),
                 .product(name: "UIComponents", package: "UIComponents"),
                 .product(name: "AcknowList", package: "AcknowList")
-            ]
+            ],
+            swiftSettings: santaSwiftSettings
         ),
         .testTarget(
             name: "SettingsTests",

--- a/nym-vpn-apple/Settings/Sources/Settings/AccountAndDevices/AccountAndDevicesView+AccountStatus.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/AccountAndDevices/AccountAndDevicesView+AccountStatus.swift
@@ -14,7 +14,7 @@ extension AccountAndDevicesView {
                 accountStatusBandwidth(accountSummary: accountSummary)
                 sectionDivider()
                 accountStatusResetDate(accountSummary: accountSummary)
-                if !accountSummary.isAutoRenewEnabled {
+                if accountSummary.shouldShowRenewRow {
                     sectionDivider()
                     renewNowRow(color: accountSummary.statusColor, isVisible: true)
                 }

--- a/nym-vpn-apple/Settings/Sources/Settings/AccountAndDevices/AccountAndDevicesView.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/AccountAndDevices/AccountAndDevicesView.swift
@@ -279,7 +279,7 @@ extension AccountAndDevicesView {
     func updateIsAccountLinkAvailable() async {
         await credentialsManager.updateAccountSummary()
         guard let accountSummary = credentialsManager.accountSummary else { return }
-        isLinkAccountAvailable = !accountSummary.isLinked
+        isLinkAccountAvailable = accountSummary.shouldShowLinkAccountRow
     }
 }
 

--- a/nym-vpn-apple/Settings/Sources/Settings/Santa/SantasView.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/Santa/SantasView.swift
@@ -1,3 +1,4 @@
+#if SANTA
 import SwiftUI
 import AppSettings
 import Constants
@@ -26,6 +27,8 @@ public struct SantasView: View {
                     togglesSection()
                     santasSpacer()
                     snackbarSection()
+                    santasSpacer()
+                    accountSummarySection()
                     santasSpacer()
                     logsSection()
                 }
@@ -143,6 +146,53 @@ private extension SantasView {
             .padding(.top, 8)
         }
         .padding(16)
+    }
+
+    func accountSummarySection() -> some View {
+        VStack(spacing: 8) {
+            Text("Account summary fakes:")
+                .foregroundStyle(Color.Nym.primary)
+                .bold()
+                .padding(4)
+            Text("Fakes subscription expiry. Check Settings + Account & Devices.")
+                .font(.caption)
+                .padding(4)
+
+            Toggle(isOn: $viewModel.fakeAutoRenew) {
+                Text("isAutoRenewEnabled")
+            }
+            .tint(Color.Nym.primary)
+            .padding(.horizontal, 4)
+
+            Text("Yearly plan")
+                .foregroundStyle(Color.Nym.primary)
+                .padding(.top, 4)
+            presetRow(viewModel.yearlyPresets)
+
+            Text("Monthly plan")
+                .foregroundStyle(Color.Nym.primary)
+                .padding(.top, 4)
+            presetRow(viewModel.monthlyPresets)
+
+            Button("Clear override") {
+                viewModel.clearAccountSummaryOverride()
+            }
+            .padding(.top, 8)
+        }
+        .padding(16)
+    }
+
+    func presetRow(_ presets: [SantasViewModel.AccountSummaryPreset]) -> some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(presets, id: \.label) { preset in
+                    Button(preset.label) {
+                        viewModel.applyAccountSummaryPreset(preset)
+                    }
+                }
+            }
+            .padding(.horizontal, 4)
+        }
     }
 
     func logsSection() -> some View {
@@ -305,3 +355,4 @@ private extension SantasView {
         return reason + "\n\n" + tail
     }
 }
+#endif

--- a/nym-vpn-apple/Settings/Sources/Settings/Santa/SantasViewModel.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/Santa/SantasViewModel.swift
@@ -1,8 +1,11 @@
+#if SANTA
 import Combine
 import SwiftUI
 import AppSettings
 import AppVersionProvider
 import ConfigurationManager
+import ConnectionTypes
+import CredentialsManager
 import NymLogger
 #if os(iOS)
 import NymVPNLib
@@ -22,6 +25,17 @@ import Theme
     @Binding private var path: NavigationPath
 
     let title = "🎅 Santa's menu 🎅"
+
+    /// QA: when true, applied fake summaries are marked auto-renewing
+    /// (hides the renew CTA, shows the "auto-renews" note). Flipping this while
+    /// an override is active re-fakes the current preset immediately so the
+    /// toggle isn't misleading.
+    @Published var fakeAutoRenew = false {
+        didSet { reapplyAccountSummaryOverrideIfNeeded() }
+    }
+
+    /// The preset currently faked, so a `fakeAutoRenew` flip can re-apply it.
+    private var appliedPreset: AccountSummaryPreset?
 
     var actualEnv: String {
 #if os(iOS)
@@ -76,6 +90,63 @@ import Theme
         objectWillChange.send()
     }
 
+    // MARK: - Account-summary fakes (QA)
+
+    /// A canned subscription "time-left" scenario. `daysRemaining == nil` ⇒ expired.
+    struct AccountSummaryPreset {
+        let label: String
+        let daysRemaining: Int?
+        let kind: VpnSubscriptionKind
+    }
+
+    /// Yearly plan (long-plan thresholds: warning < 60d, soon < 15d).
+    let yearlyPresets: [AccountSummaryPreset] = [
+        .init(label: "6 months", daysRemaining: 182, kind: .oneYear),
+        .init(label: "2 months", daysRemaining: 61, kind: .oneYear),
+        .init(label: "1 month", daysRemaining: 30, kind: .oneYear),
+        .init(label: "2 weeks", daysRemaining: 14, kind: .oneYear),
+        .init(label: "1 week", daysRemaining: 7, kind: .oneYear),
+        .init(label: "3 days", daysRemaining: 3, kind: .oneYear),
+        .init(label: "1 day", daysRemaining: 1, kind: .oneYear),
+        .init(label: "Expired", daysRemaining: nil, kind: .oneYear)
+    ]
+
+    /// Monthly plan (short-plan thresholds: warning < 7d, soon < 2d).
+    let monthlyPresets: [AccountSummaryPreset] = [
+        .init(label: "1 month", daysRemaining: 30, kind: .oneMonth),
+        .init(label: "2 weeks", daysRemaining: 14, kind: .oneMonth),
+        .init(label: "6 days", daysRemaining: 6, kind: .oneMonth),
+        .init(label: "3 days", daysRemaining: 3, kind: .oneMonth),
+        .init(label: "1 day", daysRemaining: 1, kind: .oneMonth),
+        .init(label: "Expired", daysRemaining: nil, kind: .oneMonth)
+    ]
+
+    func applyAccountSummaryPreset(_ preset: AccountSummaryPreset) {
+        let baseAddress = CredentialsManager.shared.accountSummary?.accountAddress ?? "fake-account"
+        let summary = AccountSummary.makeFake(
+            daysRemaining: preset.daysRemaining,
+            kind: preset.kind,
+            isAutoRenew: fakeAutoRenew,
+            baseAddress: baseAddress
+        )
+        appliedPreset = preset
+        CredentialsManager.shared.applyDebugAccountSummary(summary)
+    }
+
+    func clearAccountSummaryOverride() {
+        appliedPreset = nil
+        CredentialsManager.shared.clearDebugAccountSummary()
+    }
+
+    /// Re-fake the active preset (e.g. after `fakeAutoRenew` toggles). No-op
+    /// unless a preset is faked and the override is still live.
+    private func reapplyAccountSummaryOverrideIfNeeded() {
+        guard let appliedPreset,
+              CredentialsManager.shared.isAccountSummaryOverridden
+        else { return }
+        applyAccountSummaryPreset(appliedPreset)
+    }
+
     func navigateBack() {
         if !path.isEmpty { path.removeLast() }
     }
@@ -104,3 +175,4 @@ import Theme
     }
 #endif
 }
+#endif

--- a/nym-vpn-apple/Settings/Sources/Settings/SettingLink.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/SettingLink.swift
@@ -15,7 +15,9 @@ public enum SettingLink: Hashable, Identifiable {
     case systemStatus
     case acknowledgments
     case licence(details: LicenceDetails)
+#if SANTA
     case santasMenu
+#endif
     case privacyAndData
     case dns
     case mixnetTuning

--- a/nym-vpn-apple/Settings/Sources/Settings/SettingsFlowCoordinator.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/SettingsFlowCoordinator.swift
@@ -52,8 +52,10 @@ struct SettingsFlowCoordinator<Content: View>: View {
                     externalLinkManager: .shared
                 )
             )
+#if SANTA
         case .santasMenu:
             santasMenuDestination()
+#endif
 #if os(macOS)
         case .proxy:
             proxyDestination()
@@ -186,6 +188,7 @@ private extension SettingsFlowCoordinator {
         )
     }
 
+#if SANTA
     @ViewBuilder
     func santasMenuDestination() -> some View {
 #if os(iOS)
@@ -207,6 +210,7 @@ private extension SettingsFlowCoordinator {
         )
 #endif
     }
+#endif
 
 #if os(macOS)
     @ViewBuilder

--- a/nym-vpn-apple/Settings/Sources/Settings/SettingsViewModel.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/SettingsViewModel.swift
@@ -104,9 +104,11 @@ import Theme
     }
 
     func navigateToSantasMenu() {
+#if SANTA
         guard configurationManager.isSantaClaus else { return }
         impactGenerator.impact()
         path.append(SettingLink.santasMenu)
+#endif
     }
 
     /// Use to reload sections and acc renewal info


### PR DESCRIPTION
## Ticket

JIRA-NYM-1449

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)
<img width="645" height="1398" alt="Screenshot 2026-06-01 at 15 42 27" src="https://github.com/user-attachments/assets/ad5b4b89-d17f-4d5f-ad82-30dbff5bebd9" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5466)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * QA-only "Santa" menu in Settings to apply/clear fake account summaries for testing.
  * New account-action button set and ordering for renew, subscription management, link account, and logout.

* **Behavior Changes**
  * Renew/link row visibility updated to better reflect account state (active/auto-renew/linked).

* **Chores**
  * CI/build and packaging updated to support QA-mode builds and include test reporting.

* **Documentation & Localization**
  * Removed deprecated account renewal localization strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->