### PR TITLE
Remove deprecated field from Discovery

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
@@ -776,7 +776,6 @@ pub struct NymWellknownDiscoveryItemResponse {
     pub feature_flags: Option<serde_json::Value>,
     pub system_messages: Option<Vec<SystemMessageResponse>>,
     pub system_configuration: Option<SystemConfigurationResponse>,
-    pub network_compatibility: Option<NetworkCompatibilityResponse>,
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq)]

--- a/nym-vpn-core/crates/nym-vpn-network-config/default/canary_discovery.json
+++ b/nym-vpn-core/crates/nym-vpn-network-config/default/canary_discovery.json
@@ -59,13 +59,6 @@
       "tauri": "1.21.0"
     }
   },
-  "network_compatibility": {
-    "core": "1.9.0",
-    "macos": "2.4.0",
-    "ios": "2.7.1",
-    "tauri": "1.9.0",
-    "android": "1.5.0"
-  },
   "feature_flags": {
     "domain_fronting": {
       "enabled": "true"

--- a/nym-vpn-core/crates/nym-vpn-network-config/default/mainnet_discovery.json
+++ b/nym-vpn-core/crates/nym-vpn-network-config/default/mainnet_discovery.json
@@ -71,13 +71,6 @@
     },
     "statistics_api": "https://nym-statistics-api.nymtech.cc"
   },
-  "network_compatibility": {
-    "core": "1.21.0",
-    "macos": "2.15.1",
-    "ios": "2.15.1",
-    "tauri": "1.21.0",
-    "android": "2.6.0"
-  },
   "feature_flags": {
     "domain_fronting": {
       "enabled": "true"

--- a/nym-vpn-core/crates/nym-vpn-network-config/default/sandbox_discovery.json
+++ b/nym-vpn-core/crates/nym-vpn-network-config/default/sandbox_discovery.json
@@ -73,13 +73,6 @@
     },
     "statistics_api": "https://nym-statistics-api-staging.nymte.ch"
   },
-  "network_compatibility": {
-    "core": "1.21.0",
-    "macos": "2.15.1",
-    "ios": "2.15.1",
-    "tauri": "1.21.0",
-    "android": "2.6.0"
-  },
   "feature_flags": {
     "domain_fronting": {
       "enabled": "true"

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/discovery.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/discovery.rs
@@ -268,14 +268,7 @@ mod tests {
                         "modal": "true"
                     }
                 }
-            ],
-            "network_compatibility": {
-                "core": "1.1.1",
-                "ios": "1.1.1",
-                "macos": "1.1.1",
-                "tauri": "1.1.1",
-                "android": "1.1.1"
-            }
+            ]
         }"#;
         let discovery: NymWellknownDiscoveryItemResponse = serde_json::from_str(json).unwrap();
         let network: Discovery = discovery.try_into().unwrap();


### PR DESCRIPTION
## Description

Remove deprecated element of discovery which has been moved to a different place in the configuration structure. 

The `network_compatibility` information was moved into the `system_configuration` structure over a year ago and is no longer referenced in the code.  
Network compatibility added (merged 3/6/25): https://github.com/nymtech/nym-vpn-client/commit/32f19740f69c00bd4a63d8ea3c8dde593028e5aa
Network compatibility moved to `system_configuration` (merged 4/2/25):  https://github.com/nymtech/nym-vpn-client/commit/470012f7374611577faac9fee255c657cd3b18e6

I believe there should be no clients old enough that this could be a breaking change. 


## Checklist:

- [X] Remove deprecated `network_compatibility` field from discovery.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5469)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized discovery endpoint response structure and consolidated system configuration settings.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->