### PR TITLE
NYM-1468: (vpnd) Add `polkitd` ad `nym-vpnd` dependency

### DIFF
--- a/nym-vpn-core/crates/nym-vpnd/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpnd/Cargo.toml
@@ -80,7 +80,7 @@ This package contains the nym-vpnd daemon binary, which runs as a background ser
 End-users should use either the CLI client, nym-vpnc, or the GUI client, nym-vpn-app.'''
 maintainer-scripts = "linux/scripts"
 recommends = "nym-vpnc"
-depends = "$auto, policykit-1 | polkit"
+depends = "$auto, policykit-1 | polkit | polkitd"
 assets = [
     "$auto",
     { source = "target/release/nym-exclude", dest = "usr/bin/nym-exclude", mode = "755" },


### PR DESCRIPTION
## Ticket

[JIRA-NYM-1468](https://nymtech.atlassian.net/browse/NYM-1468)

## Description

Latest Debian 13 and Ubuntu 25 don't provide either `policykit-1` or `polkit`. `polkitd` is added as 3rd alternative to support these latest distros

This PR solves the following errors that users will experience:
```
sudo apt install --only-upgrade nym-vpnd
Solving dependencies... Error!
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

Unsatisfied dependencies:
 nym-vpnd : Depends: policykit-1 but it is not installable or
                     polkit but it is not installable
Error: Unable to correct problems, you have held broken packages.
Error: The following information from --solver 3.0 may provide additional context:
   Unable to satisfy dependencies. Reached two conflicting decisions:
   1. nym-vpnd:amd64=1.30.0 is selected as an upgrade
   2. nym-vpnd:amd64=1.30.0 Depends policykit-1 | polkit
      but none of the choices are installable:
      [no choices]
```


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5470)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependencies to support additional system policykit providers, improving compatibility with different Linux distributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->