### PR TITLE
add an action to get config from external repo

### DIFF
--- a/.github/actions/apply-nym-config-override/action.yml
+++ b/.github/actions/apply-nym-config-override/action.yml
@@ -30,23 +30,14 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Checkout config repo (default ref)
-      if: ${{ inputs.ref == '' }}
-      uses: actions/checkout@v6
-      with:
-        repository: ${{ inputs.repository }}
-        path: .tmp/nym-config-override
-        fetch-depth: 1
-        token: ${{ inputs.checkout_token != '' && inputs.checkout_token || github.token }}
-
-    - name: Checkout config repo (custom ref)
-      if: ${{ inputs.ref != '' }}
+    - name: Checkout config repo
       uses: actions/checkout@v6
       with:
         repository: ${{ inputs.repository }}
         ref: ${{ inputs.ref }}
         path: .tmp/nym-config-override
         fetch-depth: 1
+        persist-credentials: false
         token: ${{ inputs.checkout_token != '' && inputs.checkout_token || github.token }}
 
     - name: Overlay config files into workspace

--- a/.github/actions/apply-nym-config-override/action.yml
+++ b/.github/actions/apply-nym-config-override/action.yml
@@ -1,71 +1,71 @@
-name: Apply nym-config override
-description: Optionally checkout a separate config repo and overlay files into nym-vpn-network-config defaults
+# name: Apply nym-config override
+# description: Optionally checkout a separate config repo and overlay files into nym-vpn-network-config defaults
 
-inputs:
-  repository:
-    description: Owner/repo for the config repository
-    required: false
-    default: nymtech/nym-config
-  ref:
-    description: Optional git ref for the config repository
-    required: false
-    default: ""
-  source_path:
-    description: Path inside the config repository to copy from
-    required: false
-    default: build/discovery
-  target_path:
-    description: Path inside this repository to copy into
-    required: false
-    default: nym-vpn-core/crates/nym-vpn-network-config/default
-  clean_target:
-    description: Set to true to clean target_path before copying
-    required: false
-    default: "false"
-  checkout_token:
-    description: Optional token for checking out private repositories
-    required: false
-    default: ""
+# inputs:
+#   repository:
+#     description: Owner/repo for the config repository
+#     required: false
+#     default: nymtech/nym-config
+#   ref:
+#     description: Optional git ref for the config repository
+#     required: false
+#     default: ""
+#   source_path:
+#     description: Path inside the config repository to copy from
+#     required: false
+#     default: build/discovery
+#   target_path:
+#     description: Path inside this repository to copy into
+#     required: false
+#     default: nym-vpn-core/crates/nym-vpn-network-config/default
+#   clean_target:
+#     description: Set to true to clean target_path before copying
+#     required: false
+#     default: "false"
+#   checkout_token:
+#     description: Optional token for checking out private repositories
+#     required: false
+#     default: ""
 
-runs:
-  using: composite
-  steps:
-    - name: Checkout config repo
-      uses: actions/checkout@v6
-      with:
-        repository: ${{ inputs.repository }}
-        ref: ${{ inputs.ref }}
-        path: .tmp/nym-config-override
-        fetch-depth: 1
-        persist-credentials: false
-        token: ${{ inputs.checkout_token != '' && inputs.checkout_token || github.token }}
+# runs:
+#   using: composite
+#   steps:
+#     - name: Checkout config repo
+#       uses: actions/checkout@v6
+#       with:
+#         repository: ${{ inputs.repository }}
+#         ref: ${{ inputs.ref }}
+#         path: .tmp/nym-config-override
+#         fetch-depth: 1
+#         persist-credentials: false
+#         token: ${{ inputs.checkout_token != '' && inputs.checkout_token || github.token }}
 
-    - name: Overlay config files into workspace
-      shell: bash
-      env:
-        REPOSITORY: ${{ inputs.repository }}
-        SOURCE_PATH: ${{ inputs.source_path }}
-        TARGET_PATH: ${{ inputs.target_path }}
-        CLEAN_TARGET: ${{ inputs.clean_target }}
-      run: |
-        set -euo pipefail
+#     - name: Overlay config files into workspace
+#       shell: bash
+#       env:
+#         REPOSITORY: ${{ inputs.repository }}
+#         SOURCE_PATH: ${{ inputs.source_path }}
+#         TARGET_PATH: ${{ inputs.target_path }}
+#         CLEAN_TARGET: ${{ inputs.clean_target }}
+#       run: |
+#         set -euo pipefail
 
-        src=".tmp/nym-config-override/${SOURCE_PATH}"
-        dst="${TARGET_PATH}"
+#         src=".tmp/nym-config-override/${SOURCE_PATH}"
+#         dst="${TARGET_PATH}"
 
-        if [[ ! -d "$src" ]]; then
-          echo "::error::Source path '$src' does not exist in '${REPOSITORY}'"
-          exit 1
-        fi
+#         if [[ ! -d "$src" ]]; then
+#           echo "::error::Source path '$src' does not exist in '${REPOSITORY}'"
+#           exit 1
+#         fi
 
-        mkdir -p "$dst"
+#         mkdir -p "$dst"
 
-        if [[ "${CLEAN_TARGET}" == "true" ]]; then
-          rm -rf -- "$dst"
-          mkdir -p "$dst"
-        fi
+#         if [[ "${CLEAN_TARGET}" == "true" ]]; then
+#           rm -rf -- "$dst"
+#           mkdir -p "$dst"
+#         fi
 
-        cp -a "$src"/. "$dst"/
+#         cp -a "$src"/. "$dst"/
 
-        echo "Applied nym-config override from '$src' to '$dst'"
-        ls -la "$dst"
+#         echo "Applied nym-config override from '$src' to '$dst'"
+#         ls -la "$dst"

--- a/.github/actions/apply-nym-config-override/action.yml
+++ b/.github/actions/apply-nym-config-override/action.yml
@@ -51,20 +51,25 @@ runs:
 
     - name: Overlay config files into workspace
       shell: bash
+      env:
+        REPOSITORY: ${{ inputs.repository }}
+        SOURCE_PATH: ${{ inputs.source_path }}
+        TARGET_PATH: ${{ inputs.target_path }}
+        CLEAN_TARGET: ${{ inputs.clean_target }}
       run: |
         set -euo pipefail
 
-        src=".tmp/nym-config-override/${{ inputs.source_path }}"
-        dst="${{ inputs.target_path }}"
+        src=".tmp/nym-config-override/${SOURCE_PATH}"
+        dst="${TARGET_PATH}"
 
         if [[ ! -d "$src" ]]; then
-          echo "::error::Source path '$src' does not exist in '${{ inputs.repository }}'"
+          echo "::error::Source path '$src' does not exist in '${REPOSITORY}'"
           exit 1
         fi
 
         mkdir -p "$dst"
 
-        if [[ "${{ inputs.clean_target }}" == "true" ]]; then
+        if [[ "${CLEAN_TARGET}" == "true" ]]; then
           rm -rf -- "$dst"
           mkdir -p "$dst"
         fi

--- a/.github/actions/apply-nym-config-override/action.yml
+++ b/.github/actions/apply-nym-config-override/action.yml
@@ -1,0 +1,75 @@
+name: Apply nym-config override
+description: Optionally checkout a separate config repo and overlay files into nym-vpn-network-config defaults
+
+inputs:
+  repository:
+    description: Owner/repo for the config repository
+    required: false
+    default: nymtech/nym-config
+  ref:
+    description: Optional git ref for the config repository
+    required: false
+    default: ""
+  source_path:
+    description: Path inside the config repository to copy from
+    required: false
+    default: build/discovery
+  target_path:
+    description: Path inside this repository to copy into
+    required: false
+    default: nym-vpn-core/crates/nym-vpn-network-config/default
+  clean_target:
+    description: Set to true to clean target_path before copying
+    required: false
+    default: "false"
+  checkout_token:
+    description: Optional token for checking out private repositories
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout config repo (default ref)
+      if: ${{ inputs.ref == '' }}
+      uses: actions/checkout@v6
+      with:
+        repository: ${{ inputs.repository }}
+        path: .tmp/nym-config-override
+        fetch-depth: 1
+        token: ${{ inputs.checkout_token != '' && inputs.checkout_token || github.token }}
+
+    - name: Checkout config repo (custom ref)
+      if: ${{ inputs.ref != '' }}
+      uses: actions/checkout@v6
+      with:
+        repository: ${{ inputs.repository }}
+        ref: ${{ inputs.ref }}
+        path: .tmp/nym-config-override
+        fetch-depth: 1
+        token: ${{ inputs.checkout_token != '' && inputs.checkout_token || github.token }}
+
+    - name: Overlay config files into workspace
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        src=".tmp/nym-config-override/${{ inputs.source_path }}"
+        dst="${{ inputs.target_path }}"
+
+        if [[ ! -d "$src" ]]; then
+          echo "::error::Source path '$src' does not exist in '${{ inputs.repository }}'"
+          exit 1
+        fi
+
+        mkdir -p "$dst"
+
+        if [[ "${{ inputs.clean_target }}" == "true" ]]; then
+          rm -rf -- "$dst"
+          mkdir -p "$dst"
+        fi
+
+        cp -a "$src"/. "$dst"/
+
+        echo "Applied nym-config override from '$src' to '$dst'"
+        ls -la "$dst"

--- a/.github/workflows/discovery-override.yml
+++ b/.github/workflows/discovery-override.yml
@@ -68,6 +68,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Apply nym-config override
         uses: ./.github/actions/apply-nym-config-override

--- a/.github/workflows/discovery-override.yml
+++ b/.github/workflows/discovery-override.yml
@@ -4,6 +4,11 @@ permissions:
   contents: read
 
 on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
   workflow_dispatch:
     inputs:
       repository:
@@ -67,11 +72,11 @@ jobs:
       - name: Apply nym-config override
         uses: ./.github/actions/apply-nym-config-override
         with:
-          repository: ${{ inputs.repository }}
-          ref: ${{ inputs.ref }}
-          source_path: ${{ inputs.source_path }}
-          target_path: ${{ inputs.target_path }}
-          clean_target: ${{ inputs.clean_target }}
+          repository: ${{ inputs.repository || 'nymtech/nym-config' }}
+          ref: ${{ inputs.ref || '' }}
+          source_path: ${{ inputs.source_path || 'build/discovery' }}
+          target_path: ${{ inputs.target_path || 'nym-vpn-core/crates/nym-vpn-network-config/default' }}
+          clean_target: ${{ inputs.clean_target || false }}
           checkout_token: ${{ secrets.NYM_CONFIG_GITHUB_TOKEN }}
  
       - name: Verify Mainnet

--- a/.github/workflows/discovery-override.yml
+++ b/.github/workflows/discovery-override.yml
@@ -1,5 +1,8 @@
 name: discovery-override
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/discovery-override.yml
+++ b/.github/workflows/discovery-override.yml
@@ -45,7 +45,7 @@ on:
       source_path:
         required: false
         type: string
-        default: .
+        default: build/discovery
       target_path:
         required: false
         type: string

--- a/.github/workflows/discovery-override.yml
+++ b/.github/workflows/discovery-override.yml
@@ -1,0 +1,76 @@
+name: discovery-override
+
+on:
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: "Override repository in owner/repo format"
+        required: false
+        type: string
+        default: nymtech/nym-config
+      ref:
+        description: "Optional branch, tag, or commit"
+        required: false
+        type: string
+        default: ""
+      source_path:
+        description: "Path inside override repository to copy"
+        required: false
+        type: string
+        default: build/discovery
+      target_path:
+        description: "Target path in this repository"
+        required: false
+        type: string
+        default: nym-vpn-core/crates/nym-vpn-network-config/default
+      clean_target:
+        description: "Remove existing files in target before copy"
+        required: false
+        type: boolean
+        default: false
+
+  workflow_call:
+    inputs:
+      repository:
+        required: false
+        type: string
+        default: nymtech/nym-config
+      ref:
+        required: false
+        type: string
+        default: ""
+      source_path:
+        required: false
+        type: string
+        default: .
+      target_path:
+        required: false
+        type: string
+        default: nym-vpn-core/crates/nym-vpn-network-config/default
+      clean_target:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  prepare-discovery-override:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Apply nym-config override
+        uses: ./.github/actions/apply-nym-config-override
+        with:
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
+          source_path: ${{ inputs.source_path }}
+          target_path: ${{ inputs.target_path }}
+          clean_target: ${{ inputs.clean_target }}
+          checkout_token: ${{ secrets.NYM_CONFIG_GITHUB_TOKEN }}
+ 
+      - name: Verify Mainnet
+        run: |
+            cat nym-vpn-core/crates/nym-vpn-network-config/default/mainnet_discovery.json

--- a/.github/workflows/discovery-override.yml
+++ b/.github/workflows/discovery-override.yml
@@ -1,87 +1,87 @@
-name: discovery-override
+# name: discovery-override
 
-permissions:
-  contents: read
+# permissions:
+#   contents: read
 
-on:
-  pull_request_target:
-    types:
-      - opened
-      - synchronize
-      - reopened
-  workflow_dispatch:
-    inputs:
-      repository:
-        description: "Override repository in owner/repo format"
-        required: false
-        type: string
-        default: nymtech/nym-config
-      ref:
-        description: "Optional branch, tag, or commit"
-        required: false
-        type: string
-        default: ""
-      source_path:
-        description: "Path inside override repository to copy"
-        required: false
-        type: string
-        default: build/discovery
-      target_path:
-        description: "Target path in this repository"
-        required: false
-        type: string
-        default: nym-vpn-core/crates/nym-vpn-network-config/default
-      clean_target:
-        description: "Remove existing files in target before copy"
-        required: false
-        type: boolean
-        default: false
+# on:
+#   pull_request_target:
+#     types:
+#       - opened
+#       - synchronize
+#       - reopened
+#   workflow_dispatch:
+#     inputs:
+#       repository:
+#         description: "Override repository in owner/repo format"
+#         required: false
+#         type: string
+#         default: nymtech/nym-config
+#       ref:
+#         description: "Optional branch, tag, or commit"
+#         required: false
+#         type: string
+#         default: ""
+#       source_path:
+#         description: "Path inside override repository to copy"
+#         required: false
+#         type: string
+#         default: build/discovery
+#       target_path:
+#         description: "Target path in this repository"
+#         required: false
+#         type: string
+#         default: nym-vpn-core/crates/nym-vpn-network-config/default
+#       clean_target:
+#         description: "Remove existing files in target before copy"
+#         required: false
+#         type: boolean
+#         default: false
 
-  workflow_call:
-    inputs:
-      repository:
-        required: false
-        type: string
-        default: nymtech/nym-config
-      ref:
-        required: false
-        type: string
-        default: ""
-      source_path:
-        required: false
-        type: string
-        default: build/discovery
-      target_path:
-        required: false
-        type: string
-        default: nym-vpn-core/crates/nym-vpn-network-config/default
-      clean_target:
-        required: false
-        type: boolean
-        default: false
+#   workflow_call:
+#     inputs:
+#       repository:
+#         required: false
+#         type: string
+#         default: nymtech/nym-config
+#       ref:
+#         required: false
+#         type: string
+#         default: ""
+#       source_path:
+#         required: false
+#         type: string
+#         default: build/discovery
+#       target_path:
+#         required: false
+#         type: string
+#         default: nym-vpn-core/crates/nym-vpn-network-config/default
+#       clean_target:
+#         required: false
+#         type: boolean
+#         default: false
 
-jobs:
-  prepare-discovery-override:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
-          persist-credentials: false
+# jobs:
+#   prepare-discovery-override:
+#     runs-on: ubuntu-22.04
+#     steps:
+#       - name: Checkout repo
+#         uses: actions/checkout@v6
+#         with:
+#           fetch-depth: 1
+#           persist-credentials: false
 
-      - name: Apply nym-config override
-        uses: ./.github/actions/apply-nym-config-override
-        with:
-          repository: ${{ inputs.repository || 'nymtech/nym-config' }}
-          ref: ${{ inputs.ref || '' }}
-          source_path: ${{ inputs.source_path || 'build/discovery' }}
-          target_path: ${{ inputs.target_path || 'nym-vpn-core/crates/nym-vpn-network-config/default' }}
-          clean_target: ${{ inputs.clean_target || false }}
-          checkout_token: ${{ secrets.NYM_CONFIG_GITHUB_TOKEN }}
+#       - name: Apply nym-config override
+#         uses: ./.github/actions/apply-nym-config-override
+#         with:
+#           repository: ${{ inputs.repository || 'nymtech/nym-config' }}
+#           ref: ${{ inputs.ref || '' }}
+#           source_path: ${{ inputs.source_path || 'build/discovery' }}
+#           target_path: ${{ inputs.target_path || 'nym-vpn-core/crates/nym-vpn-network-config/default' }}
+#           clean_target: ${{ inputs.clean_target || false }}
+#           checkout_token: ${{ secrets.NYM_CONFIG_GITHUB_TOKEN }}
  
-      - name: Verify Mainnet
-        env:
-          TARGET_PATH: ${{ inputs.target_path || 'nym-vpn-core/crates/nym-vpn-network-config/default' }}
-        run: |
-          cat "${TARGET_PATH}/mainnet_discovery.json"
+#       - name: Verify Mainnet
+#         env:
+#           TARGET_PATH: ${{ inputs.target_path || 'nym-vpn-core/crates/nym-vpn-network-config/default' }}
+#         run: |
+#           cat "${TARGET_PATH}/mainnet_discovery.json"

--- a/.github/workflows/discovery-override.yml
+++ b/.github/workflows/discovery-override.yml
@@ -82,6 +82,6 @@ jobs:
  
       - name: Verify Mainnet
         env:
-          TARGET_PATH: ${{ inputs.target_path }}
+          TARGET_PATH: ${{ inputs.target_path || 'nym-vpn-core/crates/nym-vpn-network-config/default' }}
         run: |
-            cat "${TARGET_PATH}/mainnet_discovery.json"
+          cat "${TARGET_PATH}/mainnet_discovery.json"

--- a/.github/workflows/discovery-override.yml
+++ b/.github/workflows/discovery-override.yml
@@ -75,5 +75,7 @@ jobs:
           checkout_token: ${{ secrets.NYM_CONFIG_GITHUB_TOKEN }}
  
       - name: Verify Mainnet
+        env:
+          TARGET_PATH: ${{ inputs.target_path }}
         run: |
-            cat nym-vpn-core/crates/nym-vpn-network-config/default/mainnet_discovery.json
+            cat "${TARGET_PATH}/mainnet_discovery.json"


### PR DESCRIPTION
## Ticket

JIRA-NYM-928

## Description

Test workflow for applying configuration from an independent repo selectively to CI builds.

This is a Proof-of-Concept for applying production configuration information to at build time. This PR is intended to demonstrate feasability, walk through auth setup, and iron out integration points before hooking into the actual build workflows. 

## Checklist:

- [X] configuration repo PoC job for applying configuration overrides at CI compile time
- [ ] github auth token secrets for accessing configuration repository.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5471)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a workflow and reusable action to fetch a configuration repository/ref and overlay a chosen source into a target path, with options to clean the target and verify the overlay.
* **Chores**
  * Added CI infrastructure to automate and verify configuration overlays for deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->