### PR TITLE
APPLE: add custom app to split tunnel

### DIFF
--- a/.github/workflows/build-nym-vpn-apple.yml
+++ b/.github/workflows/build-nym-vpn-apple.yml
@@ -174,6 +174,9 @@ jobs:
           echo "${RUBY_PREFIX}/bin" >> "$GITHUB_PATH"
           export PATH="${RUBY_PREFIX}/bin:$PATH"
 
+          # Ensure xcbeautify is available for xcodebuild output formatting
+          which xcbeautify || brew install xcbeautify
+
           # Show versions for debugging
           brew --version
           ruby --version
@@ -370,6 +373,63 @@ jobs:
         run: |
           echo "🧱 Using sccache wrapper: $RUSTC_WRAPPER"
           sh BuildCore.sh
+
+      - name: Tests
+        if: ${{ env.RELEASE_TYPE == 'pr' }}
+        working-directory: nym-vpn-apple/ServicesMutual
+        run: |
+          set -euo pipefail
+          xcodebuild test \
+            -scheme ServicesMutual-Package \
+            -destination 'platform=macOS' \
+            -only-testing:ConnectionTypesTests \
+            -resultBundlePath TestResults.xcresult \
+            | xcbeautify --renderer github-actions
+
+      - name: Test summary
+        if: ${{ env.RELEASE_TYPE == 'pr' && (success() || failure()) }}
+        working-directory: nym-vpn-apple/ServicesMutual
+        run: |
+          set -uo pipefail
+          which jq >/dev/null || brew install jq
+          BUNDLE="TestResults.xcresult"
+          if [[ ! -d "$BUNDLE" ]]; then
+            echo "⚠️ No test results bundle found." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          JSON="$(xcrun xcresulttool get test-results summary --path "$BUNDLE" --format json 2>/dev/null)"
+          RESULT=$(jq -r '.result // "Unknown"' <<<"$JSON")
+          PASSED=$(jq -r '.passedTests // 0' <<<"$JSON")
+          FAILED=$(jq -r '.failedTests // 0' <<<"$JSON")
+          SKIPPED=$(jq -r '.skippedTests // 0' <<<"$JSON")
+          ICON="✅"; [[ "$RESULT" != "Passed" ]] && ICON="❌"
+          {
+            echo "## 🧪 ConnectionTypes tests"
+            echo ""
+            echo "$ICON **$RESULT** — ${PASSED} passed, ${FAILED} failed, ${SKIPPED} skipped"
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [[ "$FAILED" != "0" ]]; then
+            {
+              echo ""
+              echo "| Test | Failure |"
+              echo "| --- | --- |"
+              jq -r '.testFailures[]? | "| \(.testName) | \((.failureText // "") | gsub("[\r\n]+"; " ")) |"' <<<"$JSON"
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload test results
+        if: ${{ env.RELEASE_TYPE == 'pr' && (success() || failure()) }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-results-connectiontypes
+          path: nym-vpn-apple/ServicesMutual/TestResults.xcresult
+          if-no-files-found: ignore
+          retention-days: 1
+
+      - name: Clean up test results
+        if: ${{ always() && env.RELEASE_TYPE == 'pr' }}
+        working-directory: nym-vpn-apple/ServicesMutual
+        run: rm -rf TestResults.xcresult
 
       - name: Resolve iOS build number (qa/ship only)
         if: ${{ (env.RELEASE_TYPE == 'qa' || env.RELEASE_TYPE == 'ship') }}

--- a/nym-vpn-apple/.gitignore
+++ b/nym-vpn-apple/.gitignore
@@ -20,6 +20,9 @@ xcshareddata/swiftpm/
 
 .build/
 
+# Xcode test result bundles (e.g. CI -resultBundlePath)
+*.xcresult
+
 NymVPNLib
 NymVPNRpc
 

--- a/nym-vpn-apple/NymVPN.xcodeproj/project.pbxproj
+++ b/nym-vpn-apple/NymVPN.xcodeproj/project.pbxproj
@@ -62,7 +62,6 @@
 		D975F8042CE51097002D42C7 /* ErrorHandler in Frameworks */ = {isa = PBXBuildFile; productRef = D975F8032CE51097002D42C7 /* ErrorHandler */; };
 		D9870CF32BE3A12800551A86 /* Home in Frameworks */ = {isa = PBXBuildFile; productRef = D9870CF22BE3A12800551A86 /* Home */; };
 		D9879AF72CFE166400CF1B5D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D9879AF52CFE166400CF1B5D /* LaunchScreen.storyboard */; };
-		D98B32F22C58F682005A15A3 /* Package.resolved in Resources */ = {isa = PBXBuildFile; fileRef = D98B32F12C58F682005A15A3 /* Package.resolved */; };
 		D98E52312D4005ED00AE92C3 /* ErrorReason in Frameworks */ = {isa = PBXBuildFile; productRef = D98E52302D4005ED00AE92C3 /* ErrorReason */; };
 		D98E52332D40087A00AE92C3 /* ErrorReason in Frameworks */ = {isa = PBXBuildFile; productRef = D98E52322D40087A00AE92C3 /* ErrorReason */; };
 		D98E52352D40096600AE92C3 /* NetworkMonitor in Frameworks */ = {isa = PBXBuildFile; productRef = D98E52342D40096600AE92C3 /* NetworkMonitor */; };
@@ -991,7 +990,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				D9BEF2DA2BEB63320036C566 /* Preview Assets.xcassets in Resources */,
-				D98B32F22C58F682005A15A3 /* Package.resolved in Resources */,
 				D9DE89412CFE54CD006C4071 /* launchLogo@3x.png in Resources */,
 				D9DE89422CFE54CD006C4071 /* launchLogo.png in Resources */,
 				D9DE89432CFE54CD006C4071 /* launchLogo@2x.png in Resources */,

--- a/nym-vpn-apple/NymVPN/Resources/Localizable.xcstrings
+++ b/nym-vpn-apple/NymVPN/Resources/Localizable.xcstrings
@@ -32131,6 +32131,61 @@
         }
       }
     },
+    "splitTunnel.accessibility.excluded" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Excluded from VPN"
+          }
+        }
+      }
+    },
+    "splitTunnel.accessibility.protected" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Protected by VPN"
+          }
+        }
+      }
+    },
+    "splitTunnel.accessibility.toggleHint" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Double tap to toggle VPN protection"
+          }
+        }
+      }
+    },
+    "splitTunnel.addApplication" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Add application"
+          }
+        }
+      }
+    },
+    "splitTunnel.addApplication.prompt" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Add"
+          }
+        }
+      }
+    },
     "splitTunnel.apps" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -32175,6 +32230,17 @@
         }
       }
     },
+    "splitTunnel.exclude.tooltip" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Exclude from VPN"
+          }
+        }
+      }
+    },
     "splitTunnel.fullDiskAccess" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -32182,6 +32248,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "This feature requires Full Disk Access."
+          }
+        }
+      }
+    },
+    "splitTunnel.include.tooltip" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Include in VPN"
           }
         }
       }
@@ -32281,6 +32358,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Open"
+          }
+        }
+      }
+    },
+    "splitTunnel.removeApplication" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Remove"
           }
         }
       }

--- a/nym-vpn-apple/Services/Sources/Services/ConnectionManager/ConnectionManager+macOS.swift
+++ b/nym-vpn-apple/Services/Sources/Services/ConnectionManager/ConnectionManager+macOS.swift
@@ -39,7 +39,9 @@ extension ConnectionManager {
 
         guard let daemonConfig = await grpcManager.config() else { return }
 
+        let preservedCustomAppPaths = connectionConfig.splitTunnelConfig.customAppPaths
         connectionConfig = daemonConfig
+        connectionConfig.splitTunnelConfig.customAppPaths = preservedCustomAppPaths
         connectionType = daemonConfig.enableTwoHop ? .wireguard : .mixnet5hop
         entryGateway = daemonConfig.entry
         exitRouter = daemonConfig.exit

--- a/nym-vpn-apple/ServicesMacOS/Sources/AppDiscoveryService/AppDiscoveryService.swift
+++ b/nym-vpn-apple/ServicesMacOS/Sources/AppDiscoveryService/AppDiscoveryService.swift
@@ -16,6 +16,10 @@ public final class AppDiscoveryService {
                 lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
             }
     }
+
+    public func foundApp(at url: URL) -> FoundApp {
+        makeFoundApp(from: url)
+    }
 }
 
 private extension AppDiscoveryService {

--- a/nym-vpn-apple/ServicesMacOS/Sources/AppDiscoveryService/FoundApp.swift
+++ b/nym-vpn-apple/ServicesMacOS/Sources/AppDiscoveryService/FoundApp.swift
@@ -4,4 +4,10 @@ public struct FoundApp {
     public let name: String
     public let executablePath: String?
     public let icon: URL?
+
+    public init(name: String, executablePath: String?, icon: URL?) {
+        self.name = name
+        self.executablePath = executablePath
+        self.icon = icon
+    }
 }

--- a/nym-vpn-apple/ServicesMutual/Package.swift
+++ b/nym-vpn-apple/ServicesMutual/Package.swift
@@ -79,6 +79,11 @@ let package = Package(
                 "ErrorReason"
             ],
             path: "Sources/TunnelStatus"
+        ),
+        .testTarget(
+            name: "ConnectionTypesTests",
+            dependencies: ["ConnectionTypes"],
+            path: "Tests/ConnectionTypesTests"
         )
     ]
 )

--- a/nym-vpn-apple/ServicesMutual/Sources/ConnectionTypes/SplitTunnelConfig.swift
+++ b/nym-vpn-apple/ServicesMutual/Sources/ConnectionTypes/SplitTunnelConfig.swift
@@ -4,29 +4,47 @@ import NymVPNRpc
 
 public struct SplitTunnelConfig: Codable, Equatable {
     public var isEnabled: Bool
-    public var appPaths: [String]
+    public var appPaths: Set<String>
+    /// Executable paths of apps the user added manually via the file picker.
+    /// These are not produced by `AppDiscoveryService.enumerateApps()`, so they
+    /// are persisted here to keep them visible in the list. UI-only — not sent
+    /// to the daemon (only `appPaths` is synced).
+    public var customAppPaths: Set<String>
 
     public init(
         isEnabled: Bool = false,
-        appPaths: [String] = []
+        appPaths: Set<String> = [],
+        customAppPaths: Set<String> = []
     ) {
         self.isEnabled = isEnabled
         self.appPaths = appPaths
+        self.customAppPaths = customAppPaths
     }
 
 #if os(macOS)
     public init(from settings: SplitTunnelSettings) {
         self.isEnabled = settings.enabled
-        self.appPaths = settings.apps.map { $0.path }
+        self.appPaths = Set(settings.apps.map { $0.path })
+        self.customAppPaths = []
     }
 #endif
 
-    public func diff(comparedTo newConfig: SplitTunnelConfig) -> (added: [String], removed: [String]) {
-        let currentPaths = Set(appPaths)
-        let newPaths = Set(newConfig.appPaths)
+    enum CodingKeys: String, CodingKey {
+        case isEnabled
+        case appPaths
+        case customAppPaths
+    }
 
-        let added = Array(newPaths.subtracting(currentPaths)).sorted()
-        let removed = Array(currentPaths.subtracting(newPaths)).sorted()
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        isEnabled = try container.decode(Bool.self, forKey: .isEnabled)
+        appPaths = try container.decode(Set<String>.self, forKey: .appPaths)
+        customAppPaths = try container.decodeIfPresent(Set<String>.self, forKey: .customAppPaths) ?? []
+    }
+
+    public func diff(comparedTo newConfig: SplitTunnelConfig) -> (added: [String], removed: [String]) {
+        let added = newConfig.appPaths.subtracting(appPaths).sorted()
+        let removed = appPaths.subtracting(newConfig.appPaths).sorted()
 
         return (added: added, removed: removed)
     }

--- a/nym-vpn-apple/ServicesMutual/Tests/ConnectionTypesTests/SplitTunnelConfigTests.swift
+++ b/nym-vpn-apple/ServicesMutual/Tests/ConnectionTypesTests/SplitTunnelConfigTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+@testable import ConnectionTypes
+
+struct SplitTunnelConfigTests {
+    private let decoder = JSONDecoder()
+    private let encoder = JSONEncoder()
+
+    @Test func decodesLegacyJSONWithoutCustomAppPaths() throws {
+        let json = #"{"isEnabled":true,"appPaths":["/Applications/Foo.app/Contents/MacOS/Foo"]}"#
+        let config = try decoder.decode(SplitTunnelConfig.self, from: Data(json.utf8))
+
+        #expect(config.isEnabled)
+        #expect(config.appPaths == ["/Applications/Foo.app/Contents/MacOS/Foo"])
+        #expect(config.customAppPaths.isEmpty)
+    }
+
+    @Test func decodesJSONWithCustomAppPaths() throws {
+        let json = #"{"isEnabled":false,"appPaths":[],"customAppPaths":["/Users/me/Applications/Bar.app/Contents/MacOS/Bar"]}"#
+        let config = try decoder.decode(SplitTunnelConfig.self, from: Data(json.utf8))
+
+        #expect(config.customAppPaths == ["/Users/me/Applications/Bar.app/Contents/MacOS/Bar"])
+    }
+
+    @Test func decodesExplicitNullCustomAppPathsAsEmpty() throws {
+        let json = #"{"isEnabled":false,"appPaths":[],"customAppPaths":null}"#
+        let config = try decoder.decode(SplitTunnelConfig.self, from: Data(json.utf8))
+
+        #expect(config.customAppPaths.isEmpty)
+    }
+
+    @Test func encodeDecodeRoundTripPreservesCustomAppPaths() throws {
+        let original = SplitTunnelConfig(
+            isEnabled: true,
+            appPaths: ["/a/X.app/Contents/MacOS/X"],
+            customAppPaths: ["/b/Y.app/Contents/MacOS/Y"]
+        )
+        let data = try encoder.encode(original)
+        let restored = try decoder.decode(SplitTunnelConfig.self, from: data)
+
+        #expect(restored == original)
+    }
+}

--- a/nym-vpn-apple/Settings/Sources/Settings/SplitTunneling/SplitTunnelView.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/SplitTunneling/SplitTunnelView.swift
@@ -1,6 +1,7 @@
 #if os(macOS)
 import SwiftUI
 import AppKit
+import UniformTypeIdentifiers
 import AppDiscoveryService
 import ConnectionManager
 import ConnectionTypes
@@ -23,6 +24,9 @@ public struct SplitTunnelView: View {
     @State private var foundApps: [FoundApp]?
     @State private var isFullDiskAccessEnabled = true
     @State private var isInfoModalDisplayed = false
+    @State private var swipedAppPath: String?
+    @State private var isImporterPresented = false
+    @State private var pendingScrollID: String?
 
     private var splitTunnelConfig: SplitTunnelConfig {
         connectionManager.connectionConfig.splitTunnelConfig
@@ -120,9 +124,46 @@ private extension SplitTunnelView {
         }
     }
 
+    var addApplicationButton: some View {
+        Button {
+            isImporterPresented = true
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: "plus")
+                    .font(.system(size: 14, weight: .semibold))
+                    .accessibilityHidden(true)
+                Text("splitTunnel.addApplication".localizedString)
+                    .nymTextStyle(.bodyDefaultBold)
+            }
+            .foregroundStyle(Color.Nym.primary)
+            .frame(maxWidth: .infinity)
+            .frame(height: 56)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(
+                        Color.Nym.primary,
+                        style: StrokeStyle(lineWidth: 1, dash: [6, 4])
+                    )
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .fileImporter(
+            isPresented: $isImporterPresented,
+            allowedContentTypes: [.application],
+            allowsMultipleSelection: false
+        ) { result in
+            if case let .success(urls) = result, let url = urls.first {
+                addCustomApp(at: url)
+            }
+        }
+        .fileDialogDefaultDirectory(URL(filePath: "/Applications"))
+        .fileDialogConfirmationLabel("splitTunnel.addApplication.prompt".localizedString)
+    }
+
     @ViewBuilder var scrollContent: some View {
         if let foundApps {
-            let sections = splitTunnelConfig.isEnabled ? makeSections(from: foundApps) : []
+            let sections = splitTunnelConfig.isEnabled ? makeSections(from: displayApps(discovered: foundApps)) : []
 
             ScrollViewReader { proxy in
                 ScrollView {
@@ -135,6 +176,15 @@ private extension SplitTunnelView {
                             sections: sections,
                             scrollProxy: proxy
                         )
+                    }
+                }
+                .onChange(of: pendingScrollID) { _, target in
+                    guard let target else { return }
+                    DispatchQueue.main.async {
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            proxy.scrollTo(target, anchor: .top)
+                        }
+                        pendingScrollID = nil
                     }
                 }
             }
@@ -164,6 +214,10 @@ private extension SplitTunnelView {
                 appsText
                 Spacer()
                     .frame(height: 8)
+                addApplicationButton
+                    .padding(.trailing, 16)
+                Spacer()
+                    .frame(height: 16)
                 sectionList(sections: sections)
                     .padding(.trailing, 16)
             }
@@ -211,6 +265,7 @@ private extension SplitTunnelView {
 
                     ForEach(Array(section.apps.enumerated()), id: \.offset) { _, app in
                         appCell(for: app)
+                            .id(app.executablePath ?? app.name)
                     }
                 }
                 .background(Color.Nym.background)
@@ -219,7 +274,39 @@ private extension SplitTunnelView {
     }
 
     func appCell(for app: FoundApp) -> some View {
-        VStack(spacing: 0) {
+        let path = app.executablePath
+        let isSwiped = path != nil && swipedAppPath == path
+        let canRemove = isCustomApp(app)
+
+        return ZStack(alignment: .trailing) {
+            if canRemove {
+                Button {
+                    withAnimation { swipedAppPath = nil }
+                    removeCustomApp(app)
+                } label: {
+                    Text("splitTunnel.removeApplication".localizedString)
+                        .nymTextStyle(.bodyDefaultBold)
+                        .foregroundStyle(Color.Nym.error)
+                        .frame(width: 80)
+                        .frame(maxHeight: .infinity)
+                }
+                .buttonStyle(.plain)
+            }
+
+            cellContent(for: app)
+                .background(Color.Nym.background)
+                .offset(x: isSwiped ? -80 : 0)
+                .gesture(canRemove ? swipeGesture(path: path) : nil)
+                .onTapGesture {
+                    if isSwiped { withAnimation { swipedAppPath = nil } }
+                }
+        }
+        .clipShape(Rectangle())
+    }
+
+    @ViewBuilder
+    func cellContent(for app: FoundApp) -> some View {
+        let row = VStack(spacing: 0) {
             Spacer()
                 .frame(height: 12)
             HStack(spacing: 0) {
@@ -254,8 +341,40 @@ private extension SplitTunnelView {
             Spacer()
                 .frame(height: 12)
         }
-        .background(Color.Nym.background)
-        .clipShape(Rectangle())
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(app.name)
+        .accessibilityValue(accessibilityValue(for: app))
+        .accessibilityHint("splitTunnel.accessibility.toggleHint".localizedString)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityAction { toggleAppState(app: app) }
+
+        if isCustomApp(app) {
+            row.accessibilityAction(named: Text("splitTunnel.removeApplication".localizedString)) {
+                removeCustomApp(app)
+            }
+        } else {
+            row
+        }
+    }
+
+    func accessibilityValue(for app: FoundApp) -> String {
+        isAppExcluded(app)
+            ? "splitTunnel.accessibility.excluded".localizedString
+            : "splitTunnel.accessibility.protected".localizedString
+    }
+
+    func swipeGesture(path: String?) -> some Gesture {
+        DragGesture(minimumDistance: 10)
+            .onEnded { value in
+                guard let path else { return }
+                withAnimation {
+                    if value.translation.width < -30 {
+                        swipedAppPath = path
+                    } else if value.translation.width > 30 {
+                        swipedAppPath = nil
+                    }
+                }
+            }
     }
 
     func appEnabledButton(isEnabled: Bool, onTap: @escaping () -> Void) -> some View {
@@ -296,6 +415,15 @@ private extension SplitTunnelView {
                 RoundedRectangle(cornerRadius: 12, style: .continuous)
                     .stroke(Color.Nym.textSecondary, lineWidth: 1)
             )
+            // Tooltip lives on the filled label content (solid hover region);
+            // on the outer plain Button it didn't register. State-dependent:
+            // protected → "Exclude", excluded → "Include".
+            .contentShape(Rectangle())
+            .help(
+                isEnabled
+                    ? "splitTunnel.exclude.tooltip".localizedString
+                    : "splitTunnel.include.tooltip".localizedString
+            )
         }
         .buttonStyle(.plain)
     }
@@ -309,12 +437,14 @@ private struct AppSection: Identifiable {
 }
 
 private extension SplitTunnelView {
+    func sectionKey(for app: FoundApp) -> String {
+        guard let first = app.name.first else { return "#" }
+        let uppercased = String(first).uppercased()
+        return uppercased.range(of: "^[A-Z]$", options: .regularExpression) != nil ? uppercased : "#"
+    }
+
     func makeSections(from apps: [FoundApp]) -> [AppSection] {
-        let groupedApps = Dictionary(grouping: apps) { app -> String in
-            guard let first = app.name.first else { return "#" }
-            let uppercased = String(first).uppercased()
-            return uppercased.range(of: "^[A-Z]$", options: .regularExpression) != nil ? uppercased : "#"
-        }
+        let groupedApps = Dictionary(grouping: apps) { sectionKey(for: $0) }
 
         let sortedKeys = groupedApps.keys.sorted { lhs, rhs in
             switch (lhs, rhs) {
@@ -345,27 +475,81 @@ private extension SplitTunnelView {
     func toggleAppState(app: FoundApp) {
         guard let path = app.executablePath else { return }
         var next = splitTunnelConfig
-        if let index = next.appPaths.firstIndex(of: path) {
-            next.appPaths.remove(at: index)
+        if next.appPaths.contains(path) {
+            next.appPaths.remove(path)
         } else {
-            next.appPaths.append(path)
+            next.appPaths.insert(path)
         }
         connectionManager.setSplitTunnelConfig(next)
     }
 
-    func appBundlePath(for app: FoundApp) -> String? {
-        guard let executablePath = app.executablePath else { return nil }
-        let executableURL = URL(filePath: executablePath)
+    func isCustomApp(_ app: FoundApp) -> Bool {
+        guard let path = app.executablePath else { return false }
+        return splitTunnelConfig.customAppPaths.contains(path)
+    }
 
-        // MyApp.app/Contents/MacOS/MyApp -> MyApp.app
+    func removeCustomApp(_ app: FoundApp) {
+        guard let path = app.executablePath else { return }
+        var next = splitTunnelConfig
+        next.customAppPaths.remove(path)
+        next.appPaths.remove(path)
+        connectionManager.setSplitTunnelConfig(next)
+    }
+
+    func addCustomApp(at url: URL) {
+        guard url.lastPathComponent != "NymVPN.app" else { return }
+
+        let didAccess = url.startAccessingSecurityScopedResource()
+        defer { if didAccess { url.stopAccessingSecurityScopedResource() } }
+
+        let app = appDiscoveryService.foundApp(at: url)
+        guard let path = app.executablePath else { return }
+
+        var next = splitTunnelConfig
+        next.customAppPaths.insert(path)
+        next.appPaths.insert(path)
+        connectionManager.setSplitTunnelConfig(next)
+
+        // Scroll to the new app's section
+        pendingScrollID = "section-\(sectionKey(for: app))"
+    }
+
+    func bundleURL(fromExecutablePath executablePath: String) -> URL? {
+        let executableURL = URL(filePath: executablePath)
         guard executableURL.pathComponents.count >= 4 else { return nil }
         let bundleURL = executableURL
             .deletingLastPathComponent() // MacOS
             .deletingLastPathComponent() // Contents
-            .deletingLastPathComponent() // MyApp.app
+            .deletingLastPathComponent() // Foo.app
+        return bundleURL.pathExtension == "app" ? bundleURL : nil
+    }
 
-        guard bundleURL.pathExtension == "app" else { return nil }
-        return bundleURL.path
+    func appBundlePath(for app: FoundApp) -> String? {
+        guard let executablePath = app.executablePath else { return nil }
+        return bundleURL(fromExecutablePath: executablePath)?.path
+    }
+
+    func bundleURL(forExecutable executablePath: String) -> URL {
+        bundleURL(fromExecutablePath: executablePath) ?? URL(filePath: executablePath)
+    }
+
+    func displayApps(discovered: [FoundApp]) -> [FoundApp] {
+        var byPath: [String: FoundApp] = [:]
+        for app in discovered {
+            if let path = app.executablePath { byPath[path] = app }
+        }
+        for path in splitTunnelConfig.customAppPaths where byPath[path] == nil {
+            let resolved = appDiscoveryService.foundApp(at: bundleURL(forExecutable: path))
+            if resolved.executablePath != nil {
+                byPath[path] = resolved
+            } else {
+                // Bundle no longer resolvable (e.g. deleted) — keep a removable placeholder
+                // that still carries the config path so isCustomApp/removeCustomApp work.
+                let name = bundleURL(forExecutable: path).deletingPathExtension().lastPathComponent
+                byPath[path] = FoundApp(name: name, executablePath: path, icon: resolved.icon)
+            }
+        }
+        return Array(byPath.values)
     }
 
     func navigateBack() {
@@ -414,15 +598,15 @@ private struct SectionIndexOverlay: View {
                 }
         )
         .padding(.trailing, -9)
+        .accessibilityHidden(true)
     }
 
     private func letterColor(for letter: String) -> Color {
-        if letter == draggedLetter {
-            return Color.Nym.textPrimary
+        guard sections.contains(where: { $0.title == letter })
+        else {
+            return Color.Nym.textDisabled
         }
-        return sections.contains(where: { $0.title == letter })
-            ? Color.Nym.textSecondary
-            : Color.Nym.textSecondary
+        return letter == draggedLetter ? Color.Nym.textPrimary : Color.Nym.textSecondary
     }
 
     private func letterAtLocation(_ location: CGPoint) -> String {


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

https://github.com/user-attachments/assets/adbb58e7-a4d9-4b0b-a1c4-026fdd1e2a64

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5475)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add/manage custom apps in split-tunnel with an app importer, stable rows, section indexing, animated scrolling, and remove actions.

* **Accessibility**
  * Enhanced labels, hints, actions, and improved section index behavior.

* **Bug Fixes**
  * Preserve custom app paths during daemon bootstrap.

* **Tests**
  * Unit tests for split-tunnel config; CI runs macOS connection-type tests and uploads results.

* **Localization**
  * Added English split-tunnel strings and tooltips.

* **Chores**
  * CI: ensure formatter availability and ignore test result bundles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->