### PR TITLE
[Android] Update colors for split tunneling

### DIFF
--- a/.github/workflows/crowdin-android-upload.yml
+++ b/.github/workflows/crowdin-android-upload.yml
@@ -17,12 +17,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
 
       - name: crowdin action
         uses: crowdin/github-action@v2
         with:
           upload_sources: true
-          upload_translations: true
+          upload_translations: false
           download_translations: false
           config: "crowdin-configs/android.yml"
         env:

--- a/nym-vpn-android/app/build.gradle.kts
+++ b/nym-vpn-android/app/build.gradle.kts
@@ -1,5 +1,6 @@
 import com.android.build.api.variant.BuildConfigField
 import com.android.build.api.variant.ResValue
+import com.android.build.api.variant.impl.VariantOutputImpl
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -26,18 +27,8 @@ val languagesArray: Provider<String> = providers.provider {
 	languageList().joinToString(separator = ", ") { "\"$it\"" }
 }
 
-val versionNameProvider: Provider<String> = providers.provider {
-	val taskName = getBuildTaskName().lowercase()
-	if (taskName.contains(Constants.NIGHTLY) || taskName.contains(Constants.PRERELEASE)) {
-		val hash = currentAbbreviatedHash.getOrElse("unknown")
-		"${Constants.VERSION_NAME}-$hash"
-	} else {
-		Constants.VERSION_NAME
-	}
-}
-
 base {
-	archivesName.set(versionNameProvider.map { v: String -> "${Constants.APP_NAME}-$v" })
+	archivesName.set(Constants.APP_NAME)
 }
 
 kotlin {
@@ -82,7 +73,7 @@ android {
 		minSdk = Constants.MIN_SDK
 		targetSdk = Constants.TARGET_SDK
 		versionCode = Constants.VERSION_CODE
-		versionName = versionNameProvider.get()
+		versionName = Constants.VERSION_NAME
 
 		testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 		vectorDrawables {
@@ -189,8 +180,15 @@ androidComponents {
 	onVariants { variant ->
 		val flavor = variant.flavorName ?: ""
 		val type = variant.buildType ?: ""
-		val version = variant.outputs.first().versionName.getOrElse("")
+		val version = when (type) {
+			Constants.NIGHTLY, Constants.PRERELEASE -> "${Constants.VERSION_NAME}-${currentAbbreviatedHash.getOrElse("unknown")}"
+			else -> Constants.VERSION_NAME
+		}
 		val fullName = "${Constants.APP_NAME}-$flavor-$type-$version"
+
+		variant.outputs.forEach { output ->
+			(output as? VariantOutputImpl)?.outputFileName?.set("$fullName.apk")
+		}
 
 		variant.buildConfigFields?.put("APP_NAME", BuildConfigField("String", "\"$fullName\"", "App Name"))
 		variant.resValues.put(variant.makeResValueKey("string", "fullVersionName"), ResValue(fullName))
@@ -266,5 +264,3 @@ dependencies {
 	// credentials
 	implementation(libs.credentials)
 }
-
-fun determineVersionName(): String = versionNameProvider.get()

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/tunneling/components/AppInfoRow.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/tunneling/components/AppInfoRow.kt
@@ -71,7 +71,7 @@ fun AppInfoRow(appInfo: AppInfo, onTogglePassThrough: (String) -> Unit, mutableI
 				modifier = Modifier
 					.size(50.dp.scaledHeight(), 24.dp.scaledHeight())
 					.background(
-						color = if (!appInfo.passThroughVpn) scheme.errorContainer else scheme.background,
+						color = if (!appInfo.passThroughVpn) scheme.errorContainer else scheme.secondary,
 						shape = RoundedCornerShape(24.dp.scaledHeight()),
 					),
 				contentAlignment = Alignment.Center,
@@ -88,7 +88,7 @@ fun AppInfoRow(appInfo: AppInfo, onTogglePassThrough: (String) -> Unit, mutableI
 				modifier = Modifier
 					.size(50.dp.scaledHeight(), 24.dp.scaledHeight())
 					.background(
-						color = if (appInfo.passThroughVpn) scheme.primaryContainer else scheme.background,
+						color = if (appInfo.passThroughVpn) scheme.primary else scheme.secondary,
 						shape = RoundedCornerShape(24.dp.scaledHeight()),
 					),
 				contentAlignment = Alignment.Center,
@@ -97,7 +97,7 @@ fun AppInfoRow(appInfo: AppInfo, onTogglePassThrough: (String) -> Unit, mutableI
 					imageVector = Icons.Filled.Shield,
 					contentDescription = null,
 					modifier = Modifier.size(16.dp.scaledHeight()),
-					tint = if (appInfo.passThroughVpn) scheme.primary else scheme.onPrimaryContainer,
+					tint = if (appInfo.passThroughVpn) scheme.onPrimary else scheme.onSecondary,
 				)
 			}
 		}


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

- Update colors for Split tunneling toggles.
- Fix crowdin-android-upload.yml to prevent translation uploads.
- Change `.apk` naming format to match F-droid.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5482)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Material3 color theme for the pass-through VPN settings display, enhancing visual consistency in the tunneling configuration UI.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nymtech/nym-vpn-client/pull/5482?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->