### PR TITLE
Check subnet overlap for gateway independence

### DIFF
--- a/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/controller/VpnCoreController.kt
+++ b/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/controller/VpnCoreController.kt
@@ -357,7 +357,7 @@ class VpnCoreController(
 			tunProvider = service,
 			connectivityMonitor = service,
 			gatewaySelectionAlgorithmConfig = GatewaySelectionAlgorithmConfig(false, GatewaySelectionAlgorithm.AUTO),
-			gatewayIndependence = GatewayIndependence(differentNodeFamily = true, differentAsn = true),
+			gatewayIndependence = GatewayIndependence(differentNodeFamily = true, differentAsn = true, differentSubnet = true),
 		)
 
 		val svc = NymVpnService.newService(initialConfig, env, service)

--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Node family restriction and possibility to check for probable gateway selection before connection (https://github.com/nymtech/nym-vpn-client/pull/5285)
 - Enable detection for bad gateways even when specifically selected (https://github.com/nymtech/nym-vpn-client/pull/5429)
 - Add better exit gateway wireguard handshake checking to mitigate ICMP ping failures (https://github.com/nymtech/nym-vpn-client/pull/5481)
+- Gateway subnet check included in subnet independence criteria (https://github.com/nymtech/nym-vpn-client/pull/5484)
 
 ### Changed
 

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -5858,6 +5858,7 @@ name = "nym-gateway-directory"
 version = "2026.10.0-beta"
 dependencies = [
  "anyhow",
+ "ipnetwork",
  "itertools 0.14.0",
  "nym-client-core",
  "nym-http-api-client",

--- a/nym-vpn-core/crates/nym-gateway-directory/Cargo.toml
+++ b/nym-vpn-core/crates/nym-gateway-directory/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 anyhow.workspace = true
+ipnetwork.workspace = true
 itertools.workspace = true
 nym-client-core.workspace = true
 nym-http-api-client.workspace = true

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/mod.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/mod.rs
@@ -4,6 +4,7 @@
 #[cfg(test)]
 mod tests;
 
+use ipnetwork::IpNetwork;
 use itertools::Itertools;
 use nym_sdk::mixnet::NodeIdentity;
 use nym_topology::{NodeId, RoutingNode};
@@ -325,6 +326,7 @@ pub enum AsnKind {
 pub struct Asn {
     pub asn: String,
     pub name: String,
+    pub route: IpNetwork,
     pub kind: AsnKind,
 }
 
@@ -465,32 +467,41 @@ impl From<nym_vpn_api_client::response::AsnKind> for AsnKind {
     }
 }
 
-impl From<nym_vpn_api_client::response::Asn> for Asn {
-    fn from(location: nym_vpn_api_client::response::Asn) -> Self {
-        Asn {
+impl TryFrom<nym_vpn_api_client::response::Asn> for Asn {
+    type Error = Error;
+
+    fn try_from(
+        location: nym_vpn_api_client::response::Asn,
+    ) -> std::result::Result<Self, Self::Error> {
+        Ok(Asn {
             asn: location.asn,
             name: location.name,
+            route: location
+                .route
+                .parse()
+                .map_err(|source| Error::AsnRouteFormattingError {
+                    route: location.route,
+                    source,
+                })?,
             kind: location.kind.into(),
-        }
+        })
     }
 }
 
-impl From<nym_vpn_api_client::response::Location> for Location {
-    fn from(location: nym_vpn_api_client::response::Location) -> Self {
-        Location {
+impl TryFrom<nym_vpn_api_client::response::Location> for Location {
+    type Error = Error;
+
+    fn try_from(
+        location: nym_vpn_api_client::response::Location,
+    ) -> std::result::Result<Self, Self::Error> {
+        Ok(Location {
             two_letter_iso_country_code: location.two_letter_iso_country_code,
             latitude: location.latitude,
             longitude: location.longitude,
             city: location.city,
             region: location.region,
-            asn: location.asn.map(Into::into),
-        }
-    }
-}
-
-impl From<nym_vpn_api_client::response::NymUserGeoIpLocationResponse> for Location {
-    fn from(response: nym_vpn_api_client::response::NymUserGeoIpLocationResponse) -> Self {
-        response.location.into()
+            asn: location.asn.map(TryInto::try_into).transpose()?,
+        })
     }
 }
 
@@ -660,7 +671,7 @@ impl TryFrom<nym_vpn_api_client::response::NymDirectoryGateway> for Gateway {
             identity,
             name: gateway.name,
             description: gateway.description,
-            location: Some(gateway.location.into()),
+            location: Some(gateway.location.try_into()?),
             ipr_address,
             authenticator_address,
             nr_address: None,

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/tests.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/tests.rs
@@ -115,6 +115,7 @@ fn test_matching_residential() {
                 kind: AsnKind::Residential,
                 asn: "".to_owned(),
                 name: "".to_owned(),
+                route: "10.10.10.10/16".parse().unwrap(),
             }),
             ..Default::default()
         })
@@ -132,6 +133,7 @@ fn test_matching_residential() {
                 kind: AsnKind::Other,
                 asn: "".to_owned(),
                 name: "".to_owned(),
+                route: "10.10.10.10/16".parse().unwrap(),
             }),
             ..Default::default()
         })
@@ -423,6 +425,7 @@ fn sample_gateway_list(gw_type: GatewayType) -> GatewayList {
     let asn = Asn {
         asn: "AS12345".to_string(),
         name: "Test ASN".to_string(),
+        route: "10.10.10.10/16".parse().unwrap(),
         kind: AsnKind::Residential,
     };
     let addr = "MNrmKzuKjNdbEhfPUzVNfjw63oBQNSayqoQKGL4JjAV.6fDcSN6faGpvA3pd3riCwjpzXc7RQfWmGMa82UVoEwKE@d5adfJNtcdZW2XwK85JAAU8nXAs9JCPYn2RNvDLZn4e";

--- a/nym-vpn-core/crates/nym-gateway-directory/src/error.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/error.rs
@@ -20,6 +20,12 @@ pub enum Error {
         source: nym_sdk::mixnet::RecipientFormattingError,
     },
 
+    #[error("asn route not formatted correctly: {route}")]
+    AsnRouteFormattingError {
+        route: String,
+        source: ipnetwork::IpNetworkError,
+    },
+
     #[error(transparent)]
     ValidatorClientError(#[from] nym_validator_client::ValidatorClientError),
 

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
@@ -545,6 +545,7 @@ pub enum AsnKind {
 pub struct Asn {
     pub asn: String,
     pub name: String,
+    pub route: String,
     pub kind: AsnKind,
 }
 

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/gateway_independence.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/gateway_independence.rs
@@ -21,6 +21,7 @@ use ts_rs::TS;
 pub struct GatewayIndependence {
     pub different_node_family: bool,
     pub different_asn: bool,
+    pub different_subnet: bool,
 }
 
 impl GatewayIndependence {
@@ -28,11 +29,12 @@ impl GatewayIndependence {
         Self {
             different_node_family: false,
             different_asn: false,
+            different_subnet: false,
         }
     }
 
     pub fn active(&self) -> bool {
-        self.different_node_family || self.different_asn
+        self.different_node_family || self.different_asn || self.different_subnet
     }
 }
 
@@ -41,6 +43,7 @@ impl Default for GatewayIndependence {
         Self {
             different_node_family: true,
             different_asn: true,
+            different_subnet: true,
         }
     }
 }
@@ -85,6 +88,7 @@ mod tests {
         let gi = GatewayIndependence {
             different_asn: true,
             different_node_family: false,
+            different_subnet: false,
         };
         assert!(gi.active());
     }
@@ -94,6 +98,17 @@ mod tests {
         let gi = GatewayIndependence {
             different_asn: false,
             different_node_family: true,
+            different_subnet: false,
+        };
+        assert!(gi.active());
+    }
+
+    #[test]
+    fn active_returns_true_with_only_subnet_enabled() {
+        let gi = GatewayIndependence {
+            different_asn: false,
+            different_node_family: false,
+            different_subnet: true,
         };
         assert!(gi.active());
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/config/gateway_independence.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/config/gateway_independence.rs
@@ -24,6 +24,39 @@ pub(crate) mod v10 {
             Self {
                 different_node_family: value.different_node_family,
                 different_asn: value.different_asn,
+                ..Default::default()
+            }
+        }
+    }
+}
+
+pub(crate) mod v11 {
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    #[serde(rename_all = "snake_case")]
+    pub struct GatewayIndependence {
+        pub different_node_family: bool,
+        pub different_asn: bool,
+        pub different_subnet: bool,
+    }
+
+    impl From<&nym_vpn_lib_types::GatewayIndependence> for GatewayIndependence {
+        fn from(value: &nym_vpn_lib_types::GatewayIndependence) -> Self {
+            Self {
+                different_node_family: value.different_node_family,
+                different_asn: value.different_asn,
+                different_subnet: value.different_subnet,
+            }
+        }
+    }
+
+    impl From<GatewayIndependence> for nym_vpn_lib_types::GatewayIndependence {
+        fn from(value: GatewayIndependence) -> Self {
+            Self {
+                different_node_family: value.different_node_family,
+                different_asn: value.different_asn,
+                different_subnet: value.different_subnet,
             }
         }
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/config/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/config/mod.rs
@@ -13,6 +13,7 @@ mod network_stats;
 mod split_tunnel_settings;
 mod v1;
 mod v10;
+mod v11;
 mod v2;
 mod v3;
 mod v4;
@@ -40,7 +41,7 @@ use tokio::{
 use crate::service::config::{
     circumvention::v9::FrontingMode,
     entry_exit::v2::{EntryPoint, ExitPoint},
-    gateway_independence::v10::GatewayIndependence,
+    gateway_independence::v11::GatewayIndependence,
     gateway_selection_algorithm::v9::GatewaySelectionAlgorithmConfig,
     geo_exclusion_settings::v9::GeoExclusionSettings,
     mixnet_traffic::v5::MixnetTrafficConfig,
@@ -107,12 +108,13 @@ enum VpnServiceConfigVersion {
     V8,
     V9,
     V10,
+    V11,
 }
 
 impl VpnServiceConfigVersion {
     /// Returns the latest version of the config file.
     pub fn latest() -> Self {
-        VpnServiceConfigVersion::V10
+        VpnServiceConfigVersion::V11
     }
 }
 
@@ -129,6 +131,7 @@ impl fmt::Display for VpnServiceConfigVersion {
             VpnServiceConfigVersion::V8 => "v8",
             VpnServiceConfigVersion::V9 => "v9",
             VpnServiceConfigVersion::V10 => "v10",
+            VpnServiceConfigVersion::V11 => "v11",
         })
     }
 }
@@ -147,6 +150,7 @@ enum VpnServiceConfigExt {
     V8(v8::VpnServiceConfig),
     V9(v9::VpnServiceConfig),
     V10(v10::VpnServiceConfig),
+    V11(v11::VpnServiceConfig),
 }
 
 impl VpnServiceConfigExt {
@@ -162,6 +166,7 @@ impl VpnServiceConfigExt {
             VpnServiceConfigExt::V8(_) => VpnServiceConfigVersion::V8,
             VpnServiceConfigExt::V9(_) => VpnServiceConfigVersion::V9,
             VpnServiceConfigExt::V10(_) => VpnServiceConfigVersion::V10,
+            VpnServiceConfigExt::V11(_) => VpnServiceConfigVersion::V11,
         }
     }
 }
@@ -181,6 +186,7 @@ impl TryFrom<VpnServiceConfigExt> for nym_vpn_lib_types::VpnServiceConfig {
             VpnServiceConfigExt::V8(v8) => nym_vpn_lib_types::VpnServiceConfig::try_from(v8),
             VpnServiceConfigExt::V9(v9) => nym_vpn_lib_types::VpnServiceConfig::try_from(v9),
             VpnServiceConfigExt::V10(v10) => nym_vpn_lib_types::VpnServiceConfig::try_from(v10),
+            VpnServiceConfigExt::V11(v11) => nym_vpn_lib_types::VpnServiceConfig::try_from(v11),
         }
     }
 }
@@ -213,7 +219,7 @@ impl TryFrom<&nym_vpn_lib_types::VpnServiceConfig> for VpnServiceConfigExt {
 
         let gateway_independence = GatewayIndependence::from(&value.gateway_independence);
 
-        let v10 = v10::VpnServiceConfig {
+        let v11 = v11::VpnServiceConfig {
             entry_point,
             exit_point,
             allow_lan: value.allow_lan,
@@ -235,7 +241,7 @@ impl TryFrom<&nym_vpn_lib_types::VpnServiceConfig> for VpnServiceConfigExt {
             gateway_independence,
         };
 
-        Ok(VpnServiceConfigExt::V10(v10))
+        Ok(VpnServiceConfigExt::V11(v11))
     }
 }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/config/tests.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/config/tests.rs
@@ -137,7 +137,7 @@ location = "BE"
 "#;
 
     let json_content = r#"{
-  "version": "v10",
+  "version": "v11",
   "entry_point": {
     "country": {
       "two_letter_iso_country_code": "FR"
@@ -189,7 +189,8 @@ location = "BE"
   },
   "gateway_independence": {
     "different_node_family": true,
-    "different_asn": true
+    "different_asn": true,
+    "different_subnet": true
   }
 }"#;
 
@@ -215,7 +216,7 @@ identity = [ 99, 23, 98, 234, 66, 161, 195, 63, 155, 161, 250, 207, 17, 158, 136
 "#;
 
     let json_content = r#"{
-  "version": "v10",
+  "version": "v11",
   "entry_point": {
     "gateway": {
       "identity": "7CWjY3QFoA9dgE535u9bQiXCfzgMZvSpJu842GA1Wn42"
@@ -267,7 +268,8 @@ identity = [ 99, 23, 98, 234, 66, 161, 195, 63, 155, 161, 250, 207, 17, 158, 136
   },
   "gateway_independence": {
     "different_node_family": true,
-    "different_asn": true
+    "different_asn": true,
+    "different_subnet": true
   }
 }"#;
 
@@ -300,7 +302,7 @@ address = [5, 56, 84, 195, 94, 238, 210, 124, 65, 143, 209, 144, 22, 255, 91, 18
 "#;
 
     let json_content = r#"{
-  "version": "v10",
+  "version": "v11",
   "entry_point": {
     "gateway": {
       "identity": "7CWjY3QFoA9dgE535u9bQiXCfzgMZvSpJu842GA1Wn42"
@@ -350,7 +352,8 @@ address = [5, 56, 84, 195, 94, 238, 210, 124, 65, 143, 209, 144, 22, 255, 91, 18
   },
   "gateway_independence": {
     "different_node_family": true,
-    "different_asn": true
+    "different_asn": true,
+    "different_subnet": true
   }
 }"#;
 
@@ -378,7 +381,7 @@ exit_point = "Random"
 "#;
 
     let json_content = r#"{
-  "version": "v10",
+  "version": "v11",
   "entry_point": "random",
   "exit_point": "random",
   "allow_lan": false,
@@ -422,7 +425,8 @@ exit_point = "Random"
   },
   "gateway_independence": {
     "different_node_family": true,
-    "different_asn": true
+    "different_asn": true,
+    "different_subnet": true
   }
 }"#;
 
@@ -449,7 +453,7 @@ async fn test_service_config_migrate_from_v1() {
 }"#;
 
     let json_latest_content = r#"{
-  "version": "v10",
+  "version": "v11",
   "entry_point": {
     "gateway": {
       "identity": "7CWjY3QFoA9dgE535u9bQiXCfzgMZvSpJu842GA1Wn42"
@@ -501,7 +505,8 @@ async fn test_service_config_migrate_from_v1() {
   },
   "gateway_independence": {
     "different_node_family": true,
-    "different_asn": true
+    "different_asn": true,
+    "different_subnet": true
   }
 }"#;
 
@@ -537,7 +542,7 @@ async fn test_service_config_migrate_from_v2() {
 }"#;
 
     let json_latest_content = r#"{
-  "version": "v10",
+  "version": "v11",
   "entry_point": {
     "gateway": {
       "identity": "7CWjY3QFoA9dgE535u9bQiXCfzgMZvSpJu842GA1Wn42"
@@ -589,7 +594,8 @@ async fn test_service_config_migrate_from_v2() {
   },
   "gateway_independence": {
     "different_node_family": true,
-    "different_asn": true
+    "different_asn": true,
+    "different_subnet": true
   }
 }"#;
 
@@ -628,7 +634,7 @@ async fn test_service_config_migrate_from_v3() {
 }"#;
 
     let json_latest_content = r#"{
-  "version": "v10",
+  "version": "v11",
   "entry_point": {
     "gateway": {
       "identity": "7CWjY3QFoA9dgE535u9bQiXCfzgMZvSpJu842GA1Wn42"
@@ -683,7 +689,8 @@ async fn test_service_config_migrate_from_v3() {
   },
   "gateway_independence": {
     "different_node_family": true,
-    "different_asn": true
+    "different_asn": true,
+    "different_subnet": true
   }
 }"#;
 
@@ -738,7 +745,7 @@ async fn test_service_config_migrate_from_v4() {
 }"#;
 
     let json_latest_content = r#"{
-  "version": "v10",
+  "version": "v11",
   "entry_point": {
     "gateway": {
       "identity": "7CWjY3QFoA9dgE535u9bQiXCfzgMZvSpJu842GA1Wn42"
@@ -793,7 +800,8 @@ async fn test_service_config_migrate_from_v4() {
   },
   "gateway_independence": {
     "different_node_family": true,
-    "different_asn": true
+    "different_asn": true,
+    "different_subnet": true
   }
 }"#;
 
@@ -853,7 +861,7 @@ async fn test_service_config_migrate_from_v5() {
 }"#;
 
     let json_latest_content = r#"{
-  "version": "v10",
+  "version": "v11",
   "entry_point": {
     "gateway": {
       "identity": "7CWjY3QFoA9dgE535u9bQiXCfzgMZvSpJu842GA1Wn42"
@@ -908,7 +916,8 @@ async fn test_service_config_migrate_from_v5() {
   },
   "gateway_independence": {
     "different_node_family": true,
-    "different_asn": true
+    "different_asn": true,
+    "different_subnet": true
   }
 }"#;
 
@@ -958,7 +967,7 @@ async fn test_service_config_migrate_from_v6() {
 }"#;
 
     let json_latest_content = r#"{
-  "version": "v10",
+  "version": "v11",
   "entry_point": {
     "gateway": {
       "identity": "7CWjY3QFoA9dgE535u9bQiXCfzgMZvSpJu842GA1Wn42"
@@ -1013,7 +1022,8 @@ async fn test_service_config_migrate_from_v6() {
   },
   "gateway_independence": {
     "different_node_family": true,
-    "different_asn": true
+    "different_asn": true,
+    "different_subnet": true
   }
 }"#;
 
@@ -1088,6 +1098,7 @@ async fn test_service_config_serialize_full() {
         gateway_independence: nym_vpn_lib_types::GatewayIndependence {
             different_node_family: true,
             different_asn: true,
+            different_subnet: true,
         },
     };
     run_serialize_test(config).await;
@@ -1134,7 +1145,7 @@ async fn test_service_config_migrate_from_v7() {
 }"#;
 
     let json_latest_content = r#"{
-  "version": "v10",
+  "version": "v11",
   "entry_point": {
     "gateway": {
       "identity": "7CWjY3QFoA9dgE535u9bQiXCfzgMZvSpJu842GA1Wn42"
@@ -1186,7 +1197,8 @@ async fn test_service_config_migrate_from_v7() {
   },
   "gateway_independence": {
     "different_node_family": true,
-    "different_asn": true
+    "different_asn": true,
+    "different_subnet": true
   }
 }"#;
 
@@ -1238,7 +1250,7 @@ async fn test_service_config_migrate_from_v8() {
 }"#;
 
     let json_latest_content = r#"{
-  "version": "v10",
+  "version": "v11",
   "entry_point": {
     "gateway": {
       "identity": "7CWjY3QFoA9dgE535u9bQiXCfzgMZvSpJu842GA1Wn42"
@@ -1290,7 +1302,8 @@ async fn test_service_config_migrate_from_v8() {
   },
   "gateway_independence": {
     "different_node_family": true,
-    "different_asn": true
+    "different_asn": true,
+    "different_subnet": true
   }
 }"#;
 
@@ -1354,7 +1367,7 @@ async fn test_service_config_migrate_from_v9() {
 }"#;
 
     let json_latest_content = r#"{
-  "version": "v10",
+  "version": "v11",
   "entry_point": {
     "gateway": {
       "identity": "7CWjY3QFoA9dgE535u9bQiXCfzgMZvSpJu842GA1Wn42"
@@ -1406,7 +1419,8 @@ async fn test_service_config_migrate_from_v9() {
   },
   "gateway_independence": {
     "different_node_family": true,
-    "different_asn": true
+    "different_asn": true,
+    "different_subnet": true
   }
 }"#;
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/config/v11.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/config/v11.rs
@@ -1,0 +1,101 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use crate::service::{
+    ConfigSetupError,
+    config::{
+        VpnServiceConfigExt,
+        circumvention::v9::FrontingMode,
+        entry_exit::v2::{EntryPoint, ExitPoint},
+        gateway_independence::v11::GatewayIndependence,
+        gateway_selection_algorithm::v9::GatewaySelectionAlgorithmConfig,
+        geo_exclusion_settings::v9::GeoExclusionSettings,
+        mixnet_traffic::v5::MixnetTrafficConfig,
+        network_stats::v1::NetworkStatisticsConfig,
+        split_tunnel_settings::v8::SplitTunnelSettings,
+    },
+};
+use serde::{Deserialize, Serialize};
+use std::{net::IpAddr, str::FromStr};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct VpnServiceConfig {
+    pub entry_point: EntryPoint,
+    pub exit_point: ExitPoint,
+    pub allow_lan: bool,
+    pub disable_ipv6: bool,
+    pub enable_two_hop: bool,
+    pub enable_bridges: bool,
+    pub enable_ad_blocking: bool,
+    pub fronting_mode: FrontingMode,
+    pub netstack: bool,
+    pub min_gateway_vpn_performance: Option<u8>,
+    pub residential_exit: bool,
+    pub enable_custom_dns: bool,
+    pub custom_dns: Vec<String>,
+    pub mixnet_traffic: MixnetTrafficConfig,
+    pub network_stats: NetworkStatisticsConfig,
+    pub split_tunnel: SplitTunnelSettings,
+    pub geo_exclusion: GeoExclusionSettings,
+    pub gateway_selection_algorithm_config: GatewaySelectionAlgorithmConfig,
+    pub gateway_independence: GatewayIndependence,
+}
+
+impl From<VpnServiceConfig> for VpnServiceConfigExt {
+    fn from(v11: VpnServiceConfig) -> Self {
+        VpnServiceConfigExt::V11(v11)
+    }
+}
+
+impl TryFrom<VpnServiceConfig> for nym_vpn_lib_types::VpnServiceConfig {
+    type Error = ConfigSetupError;
+
+    fn try_from(value: VpnServiceConfig) -> Result<Self, Self::Error> {
+        let entry_point = nym_vpn_lib_types::EntryPoint::try_from(value.entry_point)?;
+
+        let exit_point = nym_vpn_lib_types::ExitPoint::try_from(value.exit_point)?;
+
+        let custom_dns: Vec<IpAddr> = value
+            .custom_dns
+            .iter()
+            .map(|dns_str| {
+                IpAddr::from_str(dns_str)
+                    .map_err(|e| ConfigSetupError::IpAddress { error: Box::new(e) })
+            })
+            .collect::<Result<_, _>>()?;
+
+        let mixnet_traffic = nym_vpn_lib_types::MixnetTrafficConfig::from(value.mixnet_traffic);
+        let network_stats = nym_vpn_lib_types::NetworkStatisticsConfig::from(value.network_stats);
+        let split_tunnel = nym_vpn_lib_types::SplitTunnelSettings::from(value.split_tunnel);
+        let geo_exclusion = nym_vpn_lib_types::GeoExclusionSettings::from(value.geo_exclusion);
+        let gateway_selection_algorithm_config =
+            nym_vpn_lib_types::GatewaySelectionAlgorithmConfig::from(
+                value.gateway_selection_algorithm_config,
+            );
+        let fronting_mode = nym_vpn_lib_types::FrontingMode::from(value.fronting_mode);
+        let gateway_independence =
+            nym_vpn_lib_types::GatewayIndependence::from(value.gateway_independence);
+
+        Ok(nym_vpn_lib_types::VpnServiceConfig {
+            entry_point,
+            exit_point,
+            allow_lan: value.allow_lan,
+            disable_ipv6: value.disable_ipv6,
+            enable_two_hop: value.enable_two_hop,
+            enable_bridges: value.enable_bridges,
+            enable_ad_blocking: value.enable_ad_blocking,
+            fronting_mode,
+            netstack: value.netstack,
+            min_gateway_vpn_performance: value.min_gateway_vpn_performance,
+            residential_exit: value.residential_exit,
+            mixnet_traffic,
+            enable_custom_dns: value.enable_custom_dns,
+            custom_dns,
+            network_stats,
+            split_tunnel,
+            geo_exclusion,
+            gateway_selection_algorithm_config,
+            gateway_independence,
+        })
+    }
+}

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/geo_ip.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/geo_ip.rs
@@ -167,8 +167,12 @@ impl GeoIpFetcher {
                 ret = self.client.latest_geo_ip(), if self.state == State::FetchInProgress => {
                     self.state = State::Nothing;
                     match ret {
-                        Ok(location) => {
-                            let _ = self.update_location_tx.send(location.into());
+                        Ok(geo_ip_location) => {
+                            let Ok(location) = geo_ip_location.location.try_into() else {
+                                tracing::warn!("Failed to convert geo ip location response into location");
+                                continue;
+                            };
+                            let _ = self.update_location_tx.send(location);
                         }
                         Err(err) => tracing::warn!("Failed to query VPN API: {err:?}"),
                     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/independence.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/independence.rs
@@ -31,12 +31,39 @@ pub(crate) fn gateways_are_independent(
     {
         return false;
     }
+    if criteria.different_subnet {
+        let (Some(route1), Some(route2)) = (
+            gw1.location
+                .as_ref()
+                .and_then(|l| l.asn.as_ref())
+                .map(|asn| &asn.route),
+            gw2.location
+                .as_ref()
+                .and_then(|l| l.asn.as_ref())
+                .map(|asn| &asn.route),
+        ) else {
+            // all gateways should have a ASN with a route, if they don't we assume they can't be independent
+            return false;
+        };
+        if match (route1, route2) {
+            (ipnetwork::IpNetwork::V4(v4_route1), ipnetwork::IpNetwork::V4(v4_route2)) => {
+                v4_route1.overlaps(*v4_route2)
+            }
+            (ipnetwork::IpNetwork::V6(v6_route1), ipnetwork::IpNetwork::V6(v6_route2)) => {
+                v6_route1.overlaps(*v6_route2)
+            }
+            _ => false,
+        } {
+            return false;
+        }
+    }
 
     true
 }
 
 #[cfg(test)]
 mod tests {
+    use ipnetwork::IpNetwork;
     use nym_gateway_directory::{Asn, AsnKind, Gateway, Location};
     use nym_vpn_api_client::response::NodeFamily;
 
@@ -56,6 +83,7 @@ mod tests {
                 asn: Some(Asn {
                     asn: asn_number.to_string(),
                     name: "Test ISP".to_string(),
+                    route: "10.10.10.10/16".parse().unwrap(),
                     kind: AsnKind::Other,
                 }),
                 ..Default::default()
@@ -76,10 +104,26 @@ mod tests {
             .build()
     }
 
+    fn make_gateway_with_subnet(id: &str, route: IpNetwork) -> Gateway {
+        Gateway::builder()
+            .identity(id.parse().unwrap())
+            .location(Location {
+                asn: Some(Asn {
+                    asn: "ASTEST".to_string(),
+                    name: "Test ISP".to_string(),
+                    route,
+                    kind: AsnKind::Other,
+                }),
+                ..Default::default()
+            })
+            .build()
+    }
+
     fn asn_only() -> GatewayIndependence {
         GatewayIndependence {
             different_asn: true,
             different_node_family: false,
+            different_subnet: false,
         }
     }
 
@@ -87,6 +131,15 @@ mod tests {
         GatewayIndependence {
             different_asn: false,
             different_node_family: true,
+            different_subnet: false,
+        }
+    }
+
+    fn subnet_only() -> GatewayIndependence {
+        GatewayIndependence {
+            different_asn: false,
+            different_node_family: false,
+            different_subnet: true,
         }
     }
 
@@ -100,6 +153,7 @@ mod tests {
         ));
         assert!(!gateways_are_independent(&gw, &gw, asn_only()));
         assert!(!gateways_are_independent(&gw, &gw, family_only()));
+        assert!(!gateways_are_independent(&gw, &gw, subnet_only()));
         assert!(!gateways_are_independent(
             &gw,
             &gw,
@@ -123,6 +177,34 @@ mod tests {
         let gw1 = make_gateway_with_asn(GW_ID_1, "AS12345");
         let gw2 = make_gateway_with_asn(GW_ID_2, "AS12345");
         assert!(!gateways_are_independent(&gw1, &gw2, asn_only()));
+    }
+
+    #[test]
+    fn different_subnets_independent_when_subnet_criterion_active() {
+        let gw1 = make_gateway_with_subnet(GW_ID_1, "10.10.10.10/16".parse().unwrap());
+        let gw2 = make_gateway_with_subnet(GW_ID_2, "10.11.10.10/16".parse().unwrap());
+        assert!(gateways_are_independent(&gw1, &gw2, subnet_only()));
+    }
+
+    #[test]
+    fn missing_subnet_not_independent_when_subnet_criterion_active() {
+        let gw1 = make_gateway(GW_ID_1);
+        let gw2 = make_gateway(GW_ID_2);
+        assert!(!gateways_are_independent(&gw1, &gw2, subnet_only()));
+    }
+
+    #[test]
+    fn one_missing_subnet_not_independent_when_subnet_criterion_active() {
+        let gw1 = make_gateway_with_asn(GW_ID_1, "AS12345");
+        let gw2 = make_gateway(GW_ID_2);
+        assert!(!gateways_are_independent(&gw1, &gw2, subnet_only()));
+    }
+
+    #[test]
+    fn same_subnet_not_independent_when_subnet_criterion_active() {
+        let gw1 = make_gateway_with_asn(GW_ID_1, "AS12345");
+        let gw2 = make_gateway_with_asn(GW_ID_2, "AS12345");
+        assert!(!gateways_are_independent(&gw1, &gw2, subnet_only()));
     }
 
     #[test]
@@ -168,13 +250,14 @@ mod tests {
     }
 
     #[test]
-    fn full_criteria_passes_when_both_differ() {
+    fn full_criteria_passes_when_all_differ() {
         let gw1 = Gateway::builder()
             .identity(GW_ID_1.parse().unwrap())
             .location(Location {
                 asn: Some(Asn {
                     asn: "AS100".to_string(),
                     name: "ISP A".to_string(),
+                    route: "10.10.10.10/16".parse().unwrap(),
                     kind: AsnKind::Other,
                 }),
                 ..Default::default()
@@ -193,6 +276,7 @@ mod tests {
                 asn: Some(Asn {
                     asn: "AS200".to_string(),
                     name: "ISP B".to_string(),
+                    route: "10.11.10.10/16".parse().unwrap(),
                     kind: AsnKind::Other,
                 }),
                 ..Default::default()
@@ -213,13 +297,14 @@ mod tests {
     }
 
     #[test]
-    fn full_criteria_fails_when_asn_matches_despite_different_family() {
+    fn full_criteria_fails_when_asn_matches_despite_rest_different() {
         let gw1 = Gateway::builder()
             .identity(GW_ID_1.parse().unwrap())
             .location(Location {
                 asn: Some(Asn {
                     asn: "AS100".to_string(),
                     name: "ISP".to_string(),
+                    route: "10.10.10.10/16".parse().unwrap(),
                     kind: AsnKind::Other,
                 }),
                 ..Default::default()
@@ -238,6 +323,54 @@ mod tests {
                 asn: Some(Asn {
                     asn: "AS100".to_string(),
                     name: "ISP".to_string(),
+                    route: "10.11.10.10/16".parse().unwrap(),
+                    kind: AsnKind::Other,
+                }),
+                ..Default::default()
+            })
+            .node_family(Some(NodeFamily {
+                id: 2,
+                name: String::new(),
+                description: String::new(),
+                family_stake: 0,
+                members: 0,
+            }))
+            .build();
+        assert!(!gateways_are_independent(
+            &gw1,
+            &gw2,
+            GatewayIndependence::default()
+        ));
+    }
+
+    #[test]
+    fn full_criteria_fails_when_subnet_matches_despite_rest_different() {
+        let gw1 = Gateway::builder()
+            .identity(GW_ID_1.parse().unwrap())
+            .location(Location {
+                asn: Some(Asn {
+                    asn: "AS100".to_string(),
+                    name: "ISP1".to_string(),
+                    route: "10.10.11.10/16".parse().unwrap(),
+                    kind: AsnKind::Other,
+                }),
+                ..Default::default()
+            })
+            .node_family(Some(NodeFamily {
+                id: 1,
+                name: String::new(),
+                description: String::new(),
+                family_stake: 0,
+                members: 0,
+            }))
+            .build();
+        let gw2 = Gateway::builder()
+            .identity(GW_ID_2.parse().unwrap())
+            .location(Location {
+                asn: Some(Asn {
+                    asn: "AS101".to_string(),
+                    name: "ISP2".to_string(),
+                    route: "10.10.10.10/16".parse().unwrap(),
                     kind: AsnKind::Other,
                 }),
                 ..Default::default()

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/mod.rs
@@ -316,6 +316,7 @@ pub mod tests {
             gateway_independence: GatewayIndependence {
                 different_asn: false,
                 different_node_family: false,
+                different_subnet: false,
             },
         }
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/selector.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/selector.rs
@@ -468,15 +468,11 @@ mod tests {
     const GW_ID_1: &str = "2zHiExNRKiCXVKS35SNKtK4apGfZELMpA1jJ2gVevJoz";
     const GW_ID_2: &str = "38zcSsvjXsAX7C28ko2H3Lt55X4TYxfZYkPADxKXZHUj";
 
-    fn make_gw_with_asn(id: &str, asn: &str) -> Gateway {
+    fn make_gw_with_asn(id: &str, asn: Asn) -> Gateway {
         Gateway::builder()
             .identity(id.parse().unwrap())
             .location(Location {
-                asn: Some(Asn {
-                    asn: asn.to_string(),
-                    name: "ISP".to_string(),
-                    kind: AsnKind::Other,
-                }),
+                asn: Some(asn),
                 ..Default::default()
             })
             .performance(Performance {
@@ -525,8 +521,24 @@ mod tests {
         // (fully active) independence criteria. Without any criteria they CAN be paired, so the
         // selector should suggest relaxing the criteria.
         let gateways = Arc::new(RwLock::new(Some(vec![
-            make_gw_with_asn(GW_ID_1, "AS100"),
-            make_gw_with_asn(GW_ID_2, "AS100"),
+            make_gw_with_asn(
+                GW_ID_1,
+                Asn {
+                    asn: "AS100".to_string(),
+                    name: "ISP".to_string(),
+                    route: "10.10.10.10/16".parse().unwrap(),
+                    kind: AsnKind::Other,
+                },
+            ),
+            make_gw_with_asn(
+                GW_ID_2,
+                Asn {
+                    asn: "AS100".to_string(),
+                    name: "ISP".to_string(),
+                    route: "10.11.10.10/16".parse().unwrap(),
+                    kind: AsnKind::Other,
+                },
+            ),
         ])));
         let gateway_cache = MockGatewayCache::new(gateways);
 
@@ -553,8 +565,24 @@ mod tests {
         // Gateways have different ASNs and no node family, so the full independence criteria
         // is satisfied (missing family is treated as independent).
         let gateways = Arc::new(RwLock::new(Some(vec![
-            make_gw_with_asn(GW_ID_1, "AS100"),
-            make_gw_with_asn(GW_ID_2, "AS200"),
+            make_gw_with_asn(
+                GW_ID_1,
+                Asn {
+                    asn: "AS100".to_string(),
+                    name: "ISP".to_string(),
+                    route: "10.10.10.10/16".parse().unwrap(),
+                    kind: AsnKind::Other,
+                },
+            ),
+            make_gw_with_asn(
+                GW_ID_2,
+                Asn {
+                    asn: "AS200".to_string(),
+                    name: "ISP".to_string(),
+                    route: "10.11.10.10/16".parse().unwrap(),
+                    kind: AsnKind::Other,
+                },
+            ),
         ])));
         let gateway_cache = MockGatewayCache::new(gateways);
 

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -299,6 +299,7 @@ message GatewaySelectionAlgorithmConfig {
 message GatewayIndependence {
   bool different_node_family = 1;
   bool different_asn = 2;
+  bool different_subnet = 3;
 }
 
 message VpnServiceConfig {

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/gateway_independence.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/gateway_independence.rs
@@ -8,6 +8,7 @@ impl From<nym_vpn_lib_types::GatewayIndependence> for proto::GatewayIndependence
         Self {
             different_node_family: value.different_node_family,
             different_asn: value.different_asn,
+            different_subnet: value.different_subnet,
         }
     }
 }
@@ -17,6 +18,7 @@ impl From<proto::GatewayIndependence> for nym_vpn_lib_types::GatewayIndependence
         Self {
             different_node_family: value.different_node_family,
             different_asn: value.different_asn,
+            different_subnet: value.different_subnet,
         }
     }
 }


### PR DESCRIPTION
## Ticket

JIRA-NYM-1224

## Description

Include the subnet check as a gateway independence criterion. This means the `subnet` field must also be consumed from the VPN API.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5484)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added subnet-based independence checking for gateway selection so gateways on overlapping subnets are treated as non-independent.

* **Chores**
  * Service config schema updated to v11 to expose subnet-independence option.
  * Gateway responses now include subnet routing info used for independence checks.
  * Initialization now enables subnet independence by default; geo-IP handling logs and skips invalid location data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->