### PR TITLE
NYM-1349: (tauri) Allow custom split tunnel apps for Windows & Linux

### DIFF
--- a/nym-vpn-app/CHANGELOG.md
+++ b/nym-vpn-app/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Allow adding custom apps (user selected) to split tunneling for Windows & Linux
+
 ## [1.30.0] - 2026-05-29
 
 ### Fixed

--- a/nym-vpn-app/src-tauri/src/commands/tunnel.rs
+++ b/nym-vpn-app/src-tauri/src/commands/tunnel.rs
@@ -278,10 +278,14 @@ pub async fn get_app_list(
         };
 
         if !daemon_paths.is_empty() {
-            let discovered_set: HashSet<String> =
-                discovered.iter().map(|a| a.executable_path.to_ascii_lowercase()).collect();
-            let custom_set: HashSet<String> =
-                custom.iter().map(|a| a.executable_path.to_ascii_lowercase()).collect();
+            let discovered_set: HashSet<String> = discovered
+                .iter()
+                .map(|a| a.executable_path.to_ascii_lowercase())
+                .collect();
+            let custom_set: HashSet<String> = custom
+                .iter()
+                .map(|a| a.executable_path.to_ascii_lowercase())
+                .collect();
 
             let paths_to_import: Vec<String> = daemon_paths
                 .into_iter()
@@ -297,10 +301,7 @@ pub async fn get_app_list(
                     paths_to_import
                         .iter()
                         .filter_map(|path| {
-                            match custom_apps::build_custom_app(
-                                Path::new(path),
-                                Some(&app_clone),
-                            ) {
+                            match custom_apps::build_custom_app(Path::new(path), Some(&app_clone)) {
                                 Ok(new_app) => {
                                     info!(
                                         "importing daemon split-tunnel app into custom list: {path}"

--- a/nym-vpn-app/src-tauri/src/commands/tunnel.rs
+++ b/nym-vpn-app/src-tauri/src/commands/tunnel.rs
@@ -1,8 +1,9 @@
 use crate::commands::gateway::Hop;
 use crate::{
+    db::Db,
     error::{BackendError, ErrorKey},
     events::AppHandleEventEmitter,
-    fs::app_discovery::{App, get_installed_apps},
+    fs::app_discovery::{App, custom_apps, get_installed_apps},
     state::{SharedAppState, app::VpnMode},
     vpnd::{
         client::{Node, VpndClient, VpndError},
@@ -13,6 +14,7 @@ use crate::{
 };
 use std::net::IpAddr;
 use tauri::{Manager, State};
+use tauri_plugin_dialog::DialogExt;
 use tracing::{debug, info, instrument, warn};
 
 #[instrument(skip_all)]
@@ -247,10 +249,64 @@ pub async fn set_enable_split_tunnel(
 
 #[instrument(skip_all)]
 #[tauri::command]
-pub async fn get_app_list(app: tauri::AppHandle) -> Result<Vec<App>, BackendError> {
-    tokio::task::spawn_blocking(move || get_installed_apps(app))
+pub async fn get_app_list(
+    app: tauri::AppHandle,
+    db: State<'_, Db>,
+) -> Result<Vec<App>, BackendError> {
+    let app_handle = app.clone();
+    let discovered = tokio::task::spawn_blocking(move || get_installed_apps(app_handle))
         .await
-        .map_err(|e| BackendError::internal(&e.to_string(), None))?
+        .map_err(|e| BackendError::internal(&e.to_string(), None))??;
+    let mut custom = custom_apps::load(&db)?;
+
+    #[cfg(windows)]
+    {
+        use std::collections::HashSet;
+        use std::path::Path;
+
+        use crate::state::SharedAppState;
+        use tauri::Manager as _;
+
+        let daemon_paths: Vec<String> = {
+            let s_state = app.state::<SharedAppState>();
+            let state = s_state.lock().await;
+            state
+                .vpnd_config
+                .as_ref()
+                .map(|c| c.split_tunnel.apps.iter().map(|a| a.path.clone()).collect())
+                .unwrap_or_default()
+        };
+
+        if !daemon_paths.is_empty() {
+            let discovered_set: HashSet<&str> =
+                discovered.iter().map(|a| a.executable_path.as_str()).collect();
+            let custom_set: HashSet<String> =
+                custom.iter().map(|a| a.executable_path.clone()).collect();
+
+            let mut added = 0usize;
+            for path in &daemon_paths {
+                if discovered_set.contains(path.as_str()) || custom_set.contains(path) {
+                    continue;
+                }
+                match custom_apps::build_custom_app(Path::new(path)) {
+                    Ok(new_app) => {
+                        info!("importing daemon split-tunnel app into custom list: {path}");
+                        custom.push(new_app);
+                        added += 1;
+                    }
+                    Err(e) => {
+                        warn!("skipping daemon split-tunnel app '{path}': {e}");
+                    }
+                }
+            }
+
+            if added > 0 {
+                custom_apps::save(&db, &custom)?;
+            }
+        }
+    }
+
+    Ok(custom_apps::merge(discovered, custom))
 }
 
 #[instrument(skip_all)]
@@ -279,6 +335,59 @@ pub async fn remove_app_from_split_tunnel(
 pub async fn is_split_tunnel_supported(vpnd: State<'_, VpndClient>) -> Result<bool, BackendError> {
     let is_supported = vpnd.is_split_tunnel_supported().await?;
     Ok(is_supported)
+}
+
+#[instrument(skip_all)]
+#[tauri::command]
+pub async fn add_custom_split_tunnel_app(
+    app: tauri::AppHandle,
+    db: State<'_, Db>,
+) -> Result<Option<App>, BackendError> {
+    let picker = app.dialog().file();
+    #[cfg(windows)]
+    let picker = picker.add_filter("Executable files", &["exe"]);
+    let Some(file_path) = picker.blocking_pick_file() else {
+        info!("user cancelled custom split tunnel app dialog");
+        return Ok(None);
+    };
+
+    let path = file_path
+        .as_path()
+        .ok_or_else(|| BackendError::internal("failed to resolve picked file path", None))?
+        .to_path_buf();
+    info!("[command] add_custom_split_tunnel_app: {}", path.display());
+
+    let new_app = custom_apps::build_custom_app(&path)?;
+    let mut apps = custom_apps::load(&db)?;
+    custom_apps::insert_unique(&mut apps, new_app.clone())?;
+    custom_apps::save(&db, &apps)?;
+
+    Ok(Some(new_app))
+}
+
+#[instrument(skip_all)]
+#[tauri::command]
+pub async fn remove_custom_split_tunnel_app(
+    vpnd: State<'_, VpndClient>,
+    db: State<'_, Db>,
+    path: String,
+) -> Result<(), BackendError> {
+    info!("[command] remove_custom_split_tunnel_app: {path}");
+    let mut apps = custom_apps::load(&db)?;
+    custom_apps::remove(&mut apps, &path);
+    custom_apps::save(&db, &apps)?;
+    // On Windows the daemon owns the live exclude list; clean it up so the
+    // removed app doesn't continue to bypass the VPN silently.
+    #[cfg(windows)]
+    {
+        if let Err(e) = vpnd
+            .remove_app_from_split_tunnel(SplitApp { path: path.clone() })
+            .await
+        {
+            warn!("failed to remove {path} from daemon split tunnel list: {e}");
+        }
+    }
+    Ok(())
 }
 
 #[instrument(skip(vpnd))]

--- a/nym-vpn-app/src-tauri/src/commands/tunnel.rs
+++ b/nym-vpn-app/src-tauri/src/commands/tunnel.rs
@@ -278,30 +278,50 @@ pub async fn get_app_list(
         };
 
         if !daemon_paths.is_empty() {
-            let discovered_set: HashSet<&str> =
-                discovered.iter().map(|a| a.executable_path.as_str()).collect();
+            let discovered_set: HashSet<String> =
+                discovered.iter().map(|a| a.executable_path.to_ascii_lowercase()).collect();
             let custom_set: HashSet<String> =
-                custom.iter().map(|a| a.executable_path.clone()).collect();
+                custom.iter().map(|a| a.executable_path.to_ascii_lowercase()).collect();
 
-            let mut added = 0usize;
-            for path in &daemon_paths {
-                if discovered_set.contains(path.as_str()) || custom_set.contains(path) {
-                    continue;
-                }
-                match custom_apps::build_custom_app(Path::new(path), Some(&app)) {
-                    Ok(new_app) => {
-                        info!("importing daemon split-tunnel app into custom list: {path}");
-                        custom.push(new_app);
-                        added += 1;
-                    }
-                    Err(e) => {
-                        warn!("skipping daemon split-tunnel app '{path}': {e}");
-                    }
-                }
-            }
+            let paths_to_import: Vec<String> = daemon_paths
+                .into_iter()
+                .filter(|p| {
+                    let key = p.to_ascii_lowercase();
+                    !discovered_set.contains(&key) && !custom_set.contains(&key)
+                })
+                .collect();
 
-            if added > 0 {
-                custom_apps::save(&db, &custom)?;
+            if !paths_to_import.is_empty() {
+                let app_clone = app.clone();
+                let new_apps: Vec<App> = tokio::task::spawn_blocking(move || {
+                    paths_to_import
+                        .iter()
+                        .filter_map(|path| {
+                            match custom_apps::build_custom_app(
+                                Path::new(path),
+                                Some(&app_clone),
+                            ) {
+                                Ok(new_app) => {
+                                    info!(
+                                        "importing daemon split-tunnel app into custom list: {path}"
+                                    );
+                                    Some(new_app)
+                                }
+                                Err(e) => {
+                                    warn!("skipping daemon split-tunnel app '{path}': {e}");
+                                    None
+                                }
+                            }
+                        })
+                        .collect()
+                })
+                .await
+                .map_err(|e| BackendError::internal(&e.to_string(), None))?;
+
+                if !new_apps.is_empty() {
+                    custom.extend(new_apps);
+                    custom_apps::save(&db, &custom)?;
+                }
             }
         }
     }
@@ -343,10 +363,16 @@ pub async fn add_custom_split_tunnel_app(
     app: tauri::AppHandle,
     db: State<'_, Db>,
 ) -> Result<Option<App>, BackendError> {
-    let picker = app.dialog().file();
-    #[cfg(windows)]
-    let picker = picker.add_filter("Executable files", &["exe"]);
-    let Some(file_path) = picker.blocking_pick_file() else {
+    let app_clone = app.clone();
+    let file_path = tokio::task::spawn_blocking(move || {
+        let picker = app_clone.dialog().file();
+        #[cfg(windows)]
+        let picker = picker.add_filter("Executable files", &["exe"]);
+        picker.blocking_pick_file()
+    })
+    .await
+    .map_err(|e| BackendError::internal(&e.to_string(), None))?;
+    let Some(file_path) = file_path else {
         info!("user cancelled custom split tunnel app dialog");
         return Ok(None);
     };
@@ -368,25 +394,36 @@ pub async fn add_custom_split_tunnel_app(
 #[instrument(skip_all)]
 #[tauri::command]
 pub async fn remove_custom_split_tunnel_app(
+    app: tauri::AppHandle,
     vpnd: State<'_, VpndClient>,
     db: State<'_, Db>,
     path: String,
 ) -> Result<(), BackendError> {
     info!("[command] remove_custom_split_tunnel_app: {path}");
+    #[cfg(windows)]
+    {
+        let is_in_daemon_list = {
+            let s_state = app.state::<SharedAppState>();
+            let state = s_state.lock().await;
+            state
+                .vpnd_config
+                .as_ref()
+                .map(|c| {
+                    c.split_tunnel
+                        .apps
+                        .iter()
+                        .any(|a| a.path.eq_ignore_ascii_case(&path))
+                })
+                .unwrap_or(false)
+        };
+        if is_in_daemon_list {
+            vpnd.remove_app_from_split_tunnel(SplitApp { path: path.clone() })
+                .await?;
+        }
+    }
     let mut apps = custom_apps::load(&db)?;
     custom_apps::remove(&mut apps, &path);
     custom_apps::save(&db, &apps)?;
-    // On Windows the daemon owns the live exclude list; clean it up so the
-    // removed app doesn't continue to bypass the VPN silently.
-    #[cfg(windows)]
-    {
-        if let Err(e) = vpnd
-            .remove_app_from_split_tunnel(SplitApp { path: path.clone() })
-            .await
-        {
-            warn!("failed to remove {path} from daemon split tunnel list: {e}");
-        }
-    }
     Ok(())
 }
 

--- a/nym-vpn-app/src-tauri/src/commands/tunnel.rs
+++ b/nym-vpn-app/src-tauri/src/commands/tunnel.rs
@@ -288,7 +288,7 @@ pub async fn get_app_list(
                 if discovered_set.contains(path.as_str()) || custom_set.contains(path) {
                     continue;
                 }
-                match custom_apps::build_custom_app(Path::new(path)) {
+                match custom_apps::build_custom_app(Path::new(path), Some(&app)) {
                     Ok(new_app) => {
                         info!("importing daemon split-tunnel app into custom list: {path}");
                         custom.push(new_app);
@@ -357,7 +357,7 @@ pub async fn add_custom_split_tunnel_app(
         .to_path_buf();
     info!("[command] add_custom_split_tunnel_app: {}", path.display());
 
-    let new_app = custom_apps::build_custom_app(&path)?;
+    let new_app = custom_apps::build_custom_app(&path, Some(&app))?;
     let mut apps = custom_apps::load(&db)?;
     custom_apps::insert_unique(&mut apps, new_app.clone())?;
     custom_apps::save(&db, &apps)?;

--- a/nym-vpn-app/src-tauri/src/commands/tunnel.rs
+++ b/nym-vpn-app/src-tauri/src/commands/tunnel.rs
@@ -257,6 +257,7 @@ pub async fn get_app_list(
     let discovered = tokio::task::spawn_blocking(move || get_installed_apps(app_handle))
         .await
         .map_err(|e| BackendError::internal(&e.to_string(), None))??;
+    #[cfg_attr(not(windows), allow(unused_mut))]
     let mut custom = custom_apps::load(&db)?;
 
     #[cfg(windows)]
@@ -394,6 +395,7 @@ pub async fn add_custom_split_tunnel_app(
 
 #[instrument(skip_all)]
 #[tauri::command]
+#[cfg_attr(not(windows), allow(unused_variables))]
 pub async fn remove_custom_split_tunnel_app(
     app: tauri::AppHandle,
     vpnd: State<'_, VpndClient>,

--- a/nym-vpn-app/src-tauri/src/db.rs
+++ b/nym-vpn-app/src-tauri/src/db.rs
@@ -198,6 +198,8 @@ impl Db {
         if key.starts_with("cache-") {
             // some cached data like gateways list are BIG, skip them
             debug!("set key [{key}]");
+        } else if Self::is_sensitive_key(key) {
+            debug!("set key [{key}] value=<redacted_paths>");
         } else {
             debug!("set key [{key}] value={:?}", value);
         }
@@ -249,6 +251,8 @@ impl Db {
             Ok(Some(v)) => {
                 if key.starts_with("cache") {
                     debug!("get key [{key}] SOMEVAL");
+                } else if Self::is_sensitive_key(key) {
+                    debug!("get key [{key}] <redacted_paths>");
                 } else {
                     debug!("get key [{key}] {v:?}");
                 }
@@ -260,5 +264,9 @@ impl Db {
                 error!("failed to get key [{key}]: {e}");
             }
         }
+    }
+
+    fn is_sensitive_key(key: &str) -> bool {
+        key == Key::CustomSplitTunnelApps.as_ref()
     }
 }

--- a/nym-vpn-app/src-tauri/src/db.rs
+++ b/nym-vpn-app/src-tauri/src/db.rs
@@ -33,6 +33,7 @@ pub enum Key {
     DesktopNotifications,
     LastNetworkEnv,
     NetworkStatsEnabled,
+    CustomSplitTunnelApps,
     // some data cache (no semantic difference)
     CacheMxEntryGateways,
     CacheMxExitGateways,

--- a/nym-vpn-app/src-tauri/src/error.rs
+++ b/nym-vpn-app/src-tauri/src/error.rs
@@ -109,7 +109,7 @@ impl From<VpndError> for BackendError {
 
 /// Enum of the possible specialized errors emitted by the daemon
 /// or the app backend side, to be passed to the UI layer
-#[derive(Debug, Serialize, TS, Clone)]
+#[derive(Debug, Serialize, TS, Clone, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 #[ts(export, export_to = "tauri.ts")]
 pub enum ErrorKey {
@@ -143,6 +143,8 @@ pub enum ErrorKey {
     NoSubscription,
     MaxDeviceReached,
     DeviceTimeDesync,
+    SplitTunnelAppInvalid,
+    SplitTunnelAppDuplicate,
     // Failure when querying countries from daemon
     GetMixnetEntryCountriesQuery,
     GetMixnetExitCountriesQuery,

--- a/nym-vpn-app/src-tauri/src/fs/app_discovery/custom_apps.rs
+++ b/nym-vpn-app/src-tauri/src/fs/app_discovery/custom_apps.rs
@@ -1,0 +1,176 @@
+/// Storage and logic for custom (user-added) split-tunnel apps.
+
+use std::path::Path;
+
+use crate::db::{Db, DbError, Key};
+use crate::error::{BackendError, ErrorKey};
+
+use super::App;
+
+pub fn build_custom_app(path: &Path) -> Result<App, BackendError> {
+    let metadata = std::fs::metadata(path).map_err(|e| {
+        BackendError::new(
+            &format!("cannot access selected file '{}': {e}", path.display()),
+            ErrorKey::SplitTunnelAppInvalid,
+        )
+    })?;
+    if !metadata.is_file() {
+        return Err(BackendError::new(
+            &format!("selected path '{}' is not a regular file", path.display()),
+            ErrorKey::SplitTunnelAppInvalid,
+        ));
+    }
+
+    let name = path
+        .file_stem()
+        .or_else(|| path.file_name())
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| path.to_string_lossy().into_owned());
+
+    Ok(App {
+        name,
+        executable_path: path.to_string_lossy().into_owned(),
+        icon: None,
+        is_custom: true,
+    })
+}
+
+pub fn insert_unique(list: &mut Vec<App>, app: App) -> Result<(), BackendError> {
+    if list.iter().any(|a| a.executable_path == app.executable_path) {
+        return Err(BackendError::new(
+            &format!("app '{}' is already in the custom split tunnel list", app.executable_path),
+            ErrorKey::SplitTunnelAppDuplicate,
+        ));
+    }
+    list.push(app);
+    Ok(())
+}
+
+pub fn remove(list: &mut Vec<App>, path: &str) {
+    list.retain(|a| a.executable_path != path);
+}
+
+pub fn merge(mut discovered: Vec<App>, custom: Vec<App>) -> Vec<App> {
+    for app in custom {
+        if !discovered.iter().any(|a| a.executable_path == app.executable_path) {
+            discovered.push(app);
+        }
+    }
+    discovered.sort_by_key(|a| a.name.to_lowercase());
+    discovered
+}
+
+pub fn load(db: &Db) -> Result<Vec<App>, DbError> {
+    let mut apps = db
+        .get_typed::<Vec<App>>(Key::CustomSplitTunnelApps.as_ref())?
+        .unwrap_or_default();
+    for app in &mut apps {
+        app.is_custom = true;
+    }
+    Ok(apps)
+}
+
+pub fn save(db: &Db, apps: &[App]) -> Result<(), DbError> {
+    db.insert(Key::CustomSplitTunnelApps.as_ref(), apps)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn scratch_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("nymvpn-custom-apps-{}-{}", std::process::id(), tag));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn app(name: &str, path: &str) -> App {
+        App {
+            name: name.to_string(),
+            executable_path: path.to_string(),
+            icon: None,
+            is_custom: false,
+        }
+    }
+
+    #[test]
+    fn build_custom_app_from_regular_file() {
+        let dir = scratch_dir("build-ok");
+        let file = dir.join("my-binary");
+        fs::write(&file, b"#!/bin/sh\n").unwrap();
+
+        let result = build_custom_app(&file).unwrap();
+        assert_eq!(result.name, "my-binary");
+        assert_eq!(result.executable_path, file.to_string_lossy().into_owned());
+        assert_eq!(result.icon, None);
+        assert!(result.is_custom);
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn build_custom_app_strips_extension_for_name() {
+        let dir = scratch_dir("build-ext");
+        let file = dir.join("Cursor.AppImage");
+        fs::write(&file, b"x").unwrap();
+
+        let result = build_custom_app(&file).unwrap();
+        assert_eq!(result.name, "Cursor");
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn build_custom_app_rejects_directory() {
+        let dir = scratch_dir("build-dir");
+        let err = build_custom_app(&dir).unwrap_err();
+        assert_eq!(err.key, ErrorKey::SplitTunnelAppInvalid);
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn build_custom_app_rejects_missing_path() {
+        let missing = std::env::temp_dir().join("nymvpn-custom-apps-definitely-missing-xyz");
+        let err = build_custom_app(&missing).unwrap_err();
+        assert_eq!(err.key, ErrorKey::SplitTunnelAppInvalid);
+    }
+
+    #[test]
+    fn insert_unique_adds_then_rejects_duplicate() {
+        let mut list = Vec::new();
+        insert_unique(&mut list, app("foo", "/usr/bin/foo")).unwrap();
+        assert_eq!(list.len(), 1);
+
+        let err = insert_unique(&mut list, app("foo-again", "/usr/bin/foo")).unwrap_err();
+        assert_eq!(err.key, ErrorKey::SplitTunnelAppDuplicate);
+        assert_eq!(list.len(), 1);
+    }
+
+    #[test]
+    fn remove_drops_only_matching_entry() {
+        let mut list = vec![app("foo", "/usr/bin/foo"), app("bar", "/usr/bin/bar")];
+        remove(&mut list, "/usr/bin/foo");
+        assert_eq!(list, vec![app("bar", "/usr/bin/bar")]);
+    }
+
+    #[test]
+    fn merge_dedups_by_path_and_sorts_by_name() {
+        let discovered = vec![app("Zed", "/usr/bin/zed"), app("Firefox", "/usr/bin/firefox")];
+        let custom = vec![
+            app("Firefox copy", "/usr/bin/firefox"), // same path as discovered -> dropped
+            app("Custom", "/opt/custom/app"),
+        ];
+
+        let merged = merge(discovered, custom);
+
+        let names: Vec<&str> = merged.iter().map(|a| a.name.as_str()).collect();
+        assert_eq!(names, vec!["Custom", "Firefox", "Zed"]);
+        assert_eq!(
+            merged.iter().filter(|a| a.executable_path == "/usr/bin/firefox").count(),
+            1
+        );
+    }
+}

--- a/nym-vpn-app/src-tauri/src/fs/app_discovery/custom_apps.rs
+++ b/nym-vpn-app/src-tauri/src/fs/app_discovery/custom_apps.rs
@@ -58,8 +58,16 @@ pub fn build_custom_app(path: &Path, app: Option<&tauri::AppHandle>) -> Result<A
     })
 }
 
+fn paths_equal(a: &str, b: &str) -> bool {
+    if cfg!(windows) {
+        a.eq_ignore_ascii_case(b)
+    } else {
+        a == b
+    }
+}
+
 pub fn insert_unique(list: &mut Vec<App>, app: App) -> Result<(), BackendError> {
-    if list.iter().any(|a| a.executable_path == app.executable_path) {
+    if list.iter().any(|a| paths_equal(&a.executable_path, &app.executable_path)) {
         return Err(BackendError::new(
             &format!("app '{}' is already in the custom split tunnel list", app.executable_path),
             ErrorKey::SplitTunnelAppDuplicate,
@@ -70,16 +78,16 @@ pub fn insert_unique(list: &mut Vec<App>, app: App) -> Result<(), BackendError> 
 }
 
 pub fn remove(list: &mut Vec<App>, path: &str) {
-    list.retain(|a| a.executable_path != path);
+    list.retain(|a| !paths_equal(&a.executable_path, path));
 }
 
 pub fn merge(mut discovered: Vec<App>, custom: Vec<App>) -> Vec<App> {
     for app in custom {
-        if !discovered.iter().any(|a| a.executable_path == app.executable_path) {
+        if !discovered.iter().any(|a| paths_equal(&a.executable_path, &app.executable_path)) {
             discovered.push(app);
         }
     }
-    discovered.sort_by_key(|a| a.name.to_lowercase());
+    discovered.sort_by_cached_key(|a| a.name.to_lowercase());
     discovered
 }
 

--- a/nym-vpn-app/src-tauri/src/fs/app_discovery/custom_apps.rs
+++ b/nym-vpn-app/src-tauri/src/fs/app_discovery/custom_apps.rs
@@ -1,5 +1,4 @@
 /// Storage and logic for custom (user-added) split-tunnel apps.
-
 use std::path::Path;
 
 use crate::db::{Db, DbError, Key};
@@ -67,9 +66,15 @@ fn paths_equal(a: &str, b: &str) -> bool {
 }
 
 pub fn insert_unique(list: &mut Vec<App>, app: App) -> Result<(), BackendError> {
-    if list.iter().any(|a| paths_equal(&a.executable_path, &app.executable_path)) {
+    if list
+        .iter()
+        .any(|a| paths_equal(&a.executable_path, &app.executable_path))
+    {
         return Err(BackendError::new(
-            &format!("app '{}' is already in the custom split tunnel list", app.executable_path),
+            &format!(
+                "app '{}' is already in the custom split tunnel list",
+                app.executable_path
+            ),
             ErrorKey::SplitTunnelAppDuplicate,
         ));
     }
@@ -83,7 +88,10 @@ pub fn remove(list: &mut Vec<App>, path: &str) {
 
 pub fn merge(mut discovered: Vec<App>, custom: Vec<App>) -> Vec<App> {
     for app in custom {
-        if !discovered.iter().any(|a| paths_equal(&a.executable_path, &app.executable_path)) {
+        if !discovered
+            .iter()
+            .any(|a| paths_equal(&a.executable_path, &app.executable_path))
+        {
             discovered.push(app);
         }
     }
@@ -113,7 +121,8 @@ mod tests {
     use std::path::PathBuf;
 
     fn scratch_dir(tag: &str) -> PathBuf {
-        let dir = std::env::temp_dir().join(format!("nymvpn-custom-apps-{}-{}", std::process::id(), tag));
+        let dir =
+            std::env::temp_dir().join(format!("nymvpn-custom-apps-{}-{}", std::process::id(), tag));
         fs::create_dir_all(&dir).unwrap();
         dir
     }
@@ -189,7 +198,10 @@ mod tests {
 
     #[test]
     fn merge_dedups_by_path_and_sorts_by_name() {
-        let discovered = vec![app("Zed", "/usr/bin/zed"), app("Firefox", "/usr/bin/firefox")];
+        let discovered = vec![
+            app("Zed", "/usr/bin/zed"),
+            app("Firefox", "/usr/bin/firefox"),
+        ];
         let custom = vec![
             app("Firefox copy", "/usr/bin/firefox"), // same path as discovered -> dropped
             app("Custom", "/opt/custom/app"),
@@ -200,7 +212,10 @@ mod tests {
         let names: Vec<&str> = merged.iter().map(|a| a.name.as_str()).collect();
         assert_eq!(names, vec!["Custom", "Firefox", "Zed"]);
         assert_eq!(
-            merged.iter().filter(|a| a.executable_path == "/usr/bin/firefox").count(),
+            merged
+                .iter()
+                .filter(|a| a.executable_path == "/usr/bin/firefox")
+                .count(),
             1
         );
     }

--- a/nym-vpn-app/src-tauri/src/fs/app_discovery/custom_apps.rs
+++ b/nym-vpn-app/src-tauri/src/fs/app_discovery/custom_apps.rs
@@ -7,7 +7,7 @@ use crate::error::{BackendError, ErrorKey};
 
 use super::App;
 
-pub fn build_custom_app(path: &Path) -> Result<App, BackendError> {
+pub fn build_custom_app(path: &Path, app: Option<&tauri::AppHandle>) -> Result<App, BackendError> {
     let metadata = std::fs::metadata(path).map_err(|e| {
         BackendError::new(
             &format!("cannot access selected file '{}': {e}", path.display()),
@@ -27,10 +27,33 @@ pub fn build_custom_app(path: &Path) -> Result<App, BackendError> {
         .map(|s| s.to_string_lossy().into_owned())
         .unwrap_or_else(|| path.to_string_lossy().into_owned());
 
+    let executable_path = path.to_string_lossy().into_owned();
+
+    #[cfg(windows)]
+    let icon = app.and_then(|handle| {
+        use tauri::Manager as _;
+        handle
+            .path()
+            .app_cache_dir()
+            .ok()
+            .and_then(|cache_dir| {
+                crate::icon_extractor::extract_icon_to_cache(
+                    &executable_path,
+                    &cache_dir.join("icons"),
+                )
+            })
+            .map(|p| p.to_string_lossy().into_owned())
+    });
+    #[cfg(not(windows))]
+    let icon = {
+        let _ = app;
+        None
+    };
+
     Ok(App {
         name,
-        executable_path: path.to_string_lossy().into_owned(),
-        icon: None,
+        executable_path,
+        icon,
         is_custom: true,
     })
 }
@@ -102,7 +125,7 @@ mod tests {
         let file = dir.join("my-binary");
         fs::write(&file, b"#!/bin/sh\n").unwrap();
 
-        let result = build_custom_app(&file).unwrap();
+        let result = build_custom_app(&file, None).unwrap();
         assert_eq!(result.name, "my-binary");
         assert_eq!(result.executable_path, file.to_string_lossy().into_owned());
         assert_eq!(result.icon, None);
@@ -117,7 +140,7 @@ mod tests {
         let file = dir.join("Cursor.AppImage");
         fs::write(&file, b"x").unwrap();
 
-        let result = build_custom_app(&file).unwrap();
+        let result = build_custom_app(&file, None).unwrap();
         assert_eq!(result.name, "Cursor");
 
         fs::remove_dir_all(&dir).ok();
@@ -126,7 +149,7 @@ mod tests {
     #[test]
     fn build_custom_app_rejects_directory() {
         let dir = scratch_dir("build-dir");
-        let err = build_custom_app(&dir).unwrap_err();
+        let err = build_custom_app(&dir, None).unwrap_err();
         assert_eq!(err.key, ErrorKey::SplitTunnelAppInvalid);
         fs::remove_dir_all(&dir).ok();
     }
@@ -134,7 +157,7 @@ mod tests {
     #[test]
     fn build_custom_app_rejects_missing_path() {
         let missing = std::env::temp_dir().join("nymvpn-custom-apps-definitely-missing-xyz");
-        let err = build_custom_app(&missing).unwrap_err();
+        let err = build_custom_app(&missing, None).unwrap_err();
         assert_eq!(err.key, ErrorKey::SplitTunnelAppInvalid);
     }
 

--- a/nym-vpn-app/src-tauri/src/fs/app_discovery/linux_discovery.rs
+++ b/nym-vpn-app/src-tauri/src/fs/app_discovery/linux_discovery.rs
@@ -57,6 +57,43 @@ fn resolve_icon(icon_name: &str) -> Option<String> {
         .map(|p| p.to_string_lossy().into_owned())
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn scratch_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir()
+            .join(format!("nymvpn-linux-disc-{}-{}", std::process::id(), tag));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn resolve_icon_returns_none_for_missing_absolute_path() {
+        assert!(resolve_icon("/tmp/nymvpn-test-definitely-missing-icon-xyz123.png").is_none());
+    }
+
+    #[test]
+    fn resolve_icon_resolves_existing_absolute_path_to_canonical_form() {
+        let dir = scratch_dir("icon");
+        let file = dir.join("app-icon.png");
+        fs::write(&file, b"fake png data").unwrap();
+
+        let canonical = fs::canonicalize(&file).unwrap().to_string_lossy().into_owned();
+        assert_eq!(resolve_icon(&file.to_string_lossy()), Some(canonical));
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn resolve_icon_returns_none_for_unknown_theme_icon_name() {
+        // A bare name (no leading '/') that is absent from every installed icon theme.
+        assert!(resolve_icon("nymvpn-definitely-nonexistent-icon-xyzzy").is_none());
+    }
+}
+
 /// Cleanup the executable path for Linux
 /// Remove desktop entry placeholder like %U, %u, ...
 /// Remove flatpak unique placeholders

--- a/nym-vpn-app/src-tauri/src/fs/app_discovery/linux_discovery.rs
+++ b/nym-vpn-app/src-tauri/src/fs/app_discovery/linux_discovery.rs
@@ -64,8 +64,8 @@ mod tests {
     use std::path::PathBuf;
 
     fn scratch_dir(tag: &str) -> PathBuf {
-        let dir = std::env::temp_dir()
-            .join(format!("nymvpn-linux-disc-{}-{}", std::process::id(), tag));
+        let dir =
+            std::env::temp_dir().join(format!("nymvpn-linux-disc-{}-{}", std::process::id(), tag));
         fs::create_dir_all(&dir).unwrap();
         dir
     }
@@ -81,7 +81,10 @@ mod tests {
         let file = dir.join("app-icon.png");
         fs::write(&file, b"fake png data").unwrap();
 
-        let canonical = fs::canonicalize(&file).unwrap().to_string_lossy().into_owned();
+        let canonical = fs::canonicalize(&file)
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
         assert_eq!(resolve_icon(&file.to_string_lossy()), Some(canonical));
 
         fs::remove_dir_all(&dir).ok();

--- a/nym-vpn-app/src-tauri/src/fs/app_discovery/linux_discovery.rs
+++ b/nym-vpn-app/src-tauri/src/fs/app_discovery/linux_discovery.rs
@@ -30,6 +30,7 @@ pub fn get_linux_apps() -> Result<Vec<App>, BackendError> {
                 name,
                 executable_path,
                 icon,
+                is_custom: false,
             })
         })
         .collect();

--- a/nym-vpn-app/src-tauri/src/fs/app_discovery/mod.rs
+++ b/nym-vpn-app/src-tauri/src/fs/app_discovery/mod.rs
@@ -1,5 +1,5 @@
 use crate::error::BackendError;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
 #[cfg(any(target_os = "windows", target_os = "linux"))]
@@ -11,7 +11,9 @@ mod windows_discovery;
 #[cfg(target_os = "linux")]
 mod linux_discovery;
 
-#[derive(Debug, Clone, Serialize, TS)]
+pub mod custom_apps;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, TS)]
 #[ts(export, export_to = "tauri.ts")]
 pub struct App {
     pub name: String,
@@ -19,6 +21,9 @@ pub struct App {
     pub executable_path: String,
     /// Absolute path to the cached icon PNG, when available. Stored in tauri app cache directory.
     pub icon: Option<String>,
+    /// Whether this app was added by the user via the file dialog (custom) or discovered.
+    #[serde(default)]
+    pub is_custom: bool,
 }
 
 /// Return all installed applications on the current platform.

--- a/nym-vpn-app/src-tauri/src/fs/app_discovery/utils.rs
+++ b/nym-vpn-app/src-tauri/src/fs/app_discovery/utils.rs
@@ -6,3 +6,38 @@ pub fn is_excluded(name: &str) -> bool {
         .iter()
         .any(|excluded| excluded.eq_ignore_ascii_case(name))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nymvpn_is_excluded_regardless_of_case() {
+        assert!(is_excluded("nymvpn"));
+        assert!(is_excluded("NymVPN"));
+        assert!(is_excluded("NYMVPN"));
+        assert!(is_excluded("Nymvpn"));
+    }
+
+    #[test]
+    fn unrelated_apps_are_not_excluded() {
+        assert!(!is_excluded("Firefox"));
+        assert!(!is_excluded("Chrome"));
+        assert!(!is_excluded("Spotify"));
+        assert!(!is_excluded("Signal"));
+    }
+
+    #[test]
+    fn empty_string_is_not_excluded() {
+        assert!(!is_excluded(""));
+    }
+
+    #[test]
+    fn superstrings_of_excluded_name_are_not_excluded() {
+        // eq_ignore_ascii_case is an exact match, not a substring check
+        assert!(!is_excluded("mynymvpn"));
+        assert!(!is_excluded("nymvpn-old"));
+        assert!(!is_excluded("nymvpn2"));
+        assert!(!is_excluded(" nymvpn")); // leading whitespace is a different string
+    }
+}

--- a/nym-vpn-app/src-tauri/src/fs/app_discovery/windows_discovery.rs
+++ b/nym-vpn-app/src-tauri/src/fs/app_discovery/windows_discovery.rs
@@ -106,6 +106,128 @@ fn parse_lnk(lnk_path: &Path) -> Option<App> {
     })
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn scratch_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir()
+            .join(format!("nymvpn-win-disc-{}-{}", std::process::id(), tag));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    // --- parse_lnk name filtering ---
+    // The "uninstall" / "remove" check fires before any COM call, so these
+    // tests do not need a real .lnk file on disk.
+
+    #[test]
+    fn parse_lnk_rejects_names_containing_uninstall() {
+        for name in &[
+            "Uninstall App.lnk",
+            "uninstall.lnk",
+            "UNINSTALL Me.lnk",
+            "App Uninstaller.lnk",
+        ] {
+            assert!(
+                parse_lnk(Path::new(name)).is_none(),
+                "{name} should be filtered out"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_lnk_rejects_names_containing_remove() {
+        for name in &["Remove App.lnk", "remove.lnk", "REMOVE This.lnk"] {
+            assert!(
+                parse_lnk(Path::new(name)).is_none(),
+                "{name} should be filtered out"
+            );
+        }
+    }
+
+    // For completeness: a non-filtered name also returns None when the file
+    // does not exist (COM resolution fails gracefully).
+    #[test]
+    fn parse_lnk_returns_none_for_nonexistent_lnk() {
+        assert!(parse_lnk(Path::new("ValidApp.lnk")).is_none());
+    }
+
+    // --- scan_lnk_dir directory walking ---
+
+    #[test]
+    fn scan_lnk_dir_empty_directory_yields_no_apps() {
+        let dir = scratch_dir("scan-empty");
+        let mut apps: HashMap<String, App> = HashMap::new();
+        scan_lnk_dir(&dir, &mut apps);
+        assert!(apps.is_empty());
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn scan_lnk_dir_ignores_non_lnk_files() {
+        let dir = scratch_dir("scan-nonlnk");
+        fs::write(dir.join("app.exe"), b"").unwrap();
+        fs::write(dir.join("readme.txt"), b"").unwrap();
+        fs::write(dir.join("config.ini"), b"").unwrap();
+
+        let mut apps: HashMap<String, App> = HashMap::new();
+        scan_lnk_dir(&dir, &mut apps);
+        assert!(apps.is_empty());
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn scan_lnk_dir_skips_malformed_lnk_files() {
+        // Files with a .lnk extension that aren't real shortcuts are silently skipped.
+        let dir = scratch_dir("scan-invalid");
+        fs::write(dir.join("MyApp.lnk"), b"not a real lnk").unwrap();
+
+        let mut apps: HashMap<String, App> = HashMap::new();
+        scan_lnk_dir(&dir, &mut apps);
+        assert!(apps.is_empty());
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn scan_lnk_dir_filters_uninstall_lnk_by_name() {
+        let dir = scratch_dir("scan-filter");
+        fs::write(dir.join("Uninstall App.lnk"), b"dummy").unwrap();
+        fs::write(dir.join("Remove Old Version.lnk"), b"dummy").unwrap();
+
+        let mut apps: HashMap<String, App> = HashMap::new();
+        scan_lnk_dir(&dir, &mut apps);
+        assert!(apps.is_empty(), "uninstall/remove shortcuts must be excluded");
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn scan_lnk_dir_handles_nonexistent_directory_gracefully() {
+        let nonexistent = Path::new(r"C:\NymVPNTest\Definitely\Does\Not\Exist");
+        let mut apps: HashMap<String, App> = HashMap::new();
+        scan_lnk_dir(nonexistent, &mut apps);
+        assert!(apps.is_empty());
+    }
+
+    // --- start_menu_dirs shape ---
+
+    #[test]
+    fn start_menu_dirs_are_nonempty_and_all_reference_start_menu() {
+        let dirs = start_menu_dirs();
+        assert!(!dirs.is_empty());
+        for dir in dirs {
+            let s = dir.to_string_lossy();
+            assert!(
+                s.contains("Start Menu"),
+                "expected 'Start Menu' in path: {s}"
+            );
+        }
+    }
+}
+
 // COM / IShellLink
 
 /// Resolve the target `.exe` path of a `.lnk` file via the Windows Shell COM API.

--- a/nym-vpn-app/src-tauri/src/fs/app_discovery/windows_discovery.rs
+++ b/nym-vpn-app/src-tauri/src/fs/app_discovery/windows_discovery.rs
@@ -102,6 +102,7 @@ fn parse_lnk(lnk_path: &Path) -> Option<App> {
         name,
         icon: Some(target.clone()),
         executable_path: target,
+        is_custom: false,
     })
 }
 

--- a/nym-vpn-app/src-tauri/src/fs/app_discovery/windows_discovery.rs
+++ b/nym-vpn-app/src-tauri/src/fs/app_discovery/windows_discovery.rs
@@ -114,8 +114,8 @@ mod tests {
     use std::path::PathBuf;
 
     fn scratch_dir(tag: &str) -> PathBuf {
-        let dir = std::env::temp_dir()
-            .join(format!("nymvpn-win-disc-{}-{}", std::process::id(), tag));
+        let dir =
+            std::env::temp_dir().join(format!("nymvpn-win-disc-{}-{}", std::process::id(), tag));
         fs::create_dir_all(&dir).unwrap();
         dir
     }
@@ -200,7 +200,10 @@ mod tests {
 
         let mut apps: HashMap<String, App> = HashMap::new();
         scan_lnk_dir(&dir, &mut apps);
-        assert!(apps.is_empty(), "uninstall/remove shortcuts must be excluded");
+        assert!(
+            apps.is_empty(),
+            "uninstall/remove shortcuts must be excluded"
+        );
         fs::remove_dir_all(&dir).ok();
     }
 

--- a/nym-vpn-app/src-tauri/src/main.rs
+++ b/nym-vpn-app/src-tauri/src/main.rs
@@ -322,6 +322,8 @@ async fn main() -> Result<()> {
             tunnel::add_app_to_split_tunnel,
             tunnel::remove_app_from_split_tunnel,
             tunnel::is_split_tunnel_supported,
+            tunnel::add_custom_split_tunnel_app,
+            tunnel::remove_custom_split_tunnel_app,
             tunnel::set_gateway_selection_algorithm,
             tunnel::set_enable_geo_location,
             cmd_db::db_set,

--- a/nym-vpn-app/src/components/toast/ToastList.tsx
+++ b/nym-vpn-app/src/components/toast/ToastList.tsx
@@ -19,9 +19,9 @@ function ToastList() {
             [
               "absolute top-0 right-0 left-0 z-[calc(1000-var(--toast-index))] mx-auto h-(--height) max-w-lg origin-top transform-[translateX(var(--toast-swipe-movement-x))_translateY(calc(var(--toast-swipe-movement-y)+(var(--toast-index)*var(--peek))+(var(--shrink)*var(--height))))_scale(var(--scale))] rounded-lg bg-clip-padding p-4 shadow-lg select-none [--gap:0.75rem] [--height:var(--toast-frontmost-height,var(--toast-height))] [--offset-y:calc(var(--toast-offset-y)+(var(--toast-index)*var(--gap))+var(--toast-swipe-movement-y))] [--peek:0.75rem] [--scale:calc(max(0,1-(var(--toast-index)*0.1)))] [--shrink:calc(1-var(--scale))] [transition:transform_0.5s_cubic-bezier(0.22,1,0.36,1),opacity_0.5s,height_0.15s] after:absolute after:bottom-full after:left-0 after:h-[calc(var(--gap)+1px)] after:w-full after:content-[''] data-ending-style:opacity-0 data-expanded:h-(--toast-height) data-expanded:transform-[translateX(var(--toast-swipe-movement-x))_translateY(calc(var(--offset-y)))] data-limited:opacity-0 data-starting-style:transform-[translateY(-150%)] data-ending-style:data-[swipe-direction=down]:transform-[translateY(calc(var(--toast-swipe-movement-y)+150%))] data-expanded:data-ending-style:data-[swipe-direction=down]:transform-[translateY(calc(var(--toast-swipe-movement-y)+150%))] data-ending-style:data-[swipe-direction=left]:transform-[translateX(calc(var(--toast-swipe-movement-x)-150%))_translateY(var(--offset-y))] data-expanded:data-ending-style:data-[swipe-direction=left]:transform-[translateX(calc(var(--toast-swipe-movement-x)-150%))_translateY(var(--offset-y))] data-ending-style:data-[swipe-direction=right]:transform-[translateX(calc(var(--toast-swipe-movement-x)+150%))_translateY(var(--offset-y))] data-expanded:data-ending-style:data-[swipe-direction=right]:transform-[translateX(calc(var(--toast-swipe-movement-x)+150%))_translateY(var(--offset-y))] data-ending-style:data-[swipe-direction=up]:transform-[translateY(calc(var(--toast-swipe-movement-y)-150%))] data-expanded:data-ending-style:data-[swipe-direction=up]:transform-[translateY(calc(var(--toast-swipe-movement-y)-150%))] [&[data-ending-style]:not([data-limited]):not([data-swipe-direction])]:transform-[translateY(-150%)]",
               toast.updateKey &&
-                (toast.updateKey % 2 === 0
-                  ? 'animate-pulse-scale-even'
-                  : 'animate-pulse-scale-odd'),
+              (toast.updateKey % 2 === 0
+                ? 'animate-pulse-scale-even'
+                : 'animate-pulse-scale-odd'),
             ],
             {
               'bg-status-error text-white': toast.type === 'error',
@@ -34,7 +34,7 @@ function ToastList() {
 
             <div className="flex min-w-0 flex-1 flex-col items-start justify-center gap-1">
               <Toast.Title className="text-sm leading-5 font-medium" />
-              <Toast.Description className="text-xs leading-5 font-normal wrap-break-word break-all text-white dark:text-gray-700" />
+              <Toast.Description className="text-xs leading-5 font-normal wrap-break-word break-all text-text-secondary" />
               <Toast.Action
                 className={clsx([
                   'self-end rounded-2xl border-[1.5px] bg-transparent px-3 py-1.5 text-xs font-bold',

--- a/nym-vpn-app/src/components/toast/ToastList.tsx
+++ b/nym-vpn-app/src/components/toast/ToastList.tsx
@@ -19,9 +19,9 @@ function ToastList() {
             [
               "absolute top-0 right-0 left-0 z-[calc(1000-var(--toast-index))] mx-auto h-(--height) max-w-lg origin-top transform-[translateX(var(--toast-swipe-movement-x))_translateY(calc(var(--toast-swipe-movement-y)+(var(--toast-index)*var(--peek))+(var(--shrink)*var(--height))))_scale(var(--scale))] rounded-lg bg-clip-padding p-4 shadow-lg select-none [--gap:0.75rem] [--height:var(--toast-frontmost-height,var(--toast-height))] [--offset-y:calc(var(--toast-offset-y)+(var(--toast-index)*var(--gap))+var(--toast-swipe-movement-y))] [--peek:0.75rem] [--scale:calc(max(0,1-(var(--toast-index)*0.1)))] [--shrink:calc(1-var(--scale))] [transition:transform_0.5s_cubic-bezier(0.22,1,0.36,1),opacity_0.5s,height_0.15s] after:absolute after:bottom-full after:left-0 after:h-[calc(var(--gap)+1px)] after:w-full after:content-[''] data-ending-style:opacity-0 data-expanded:h-(--toast-height) data-expanded:transform-[translateX(var(--toast-swipe-movement-x))_translateY(calc(var(--offset-y)))] data-limited:opacity-0 data-starting-style:transform-[translateY(-150%)] data-ending-style:data-[swipe-direction=down]:transform-[translateY(calc(var(--toast-swipe-movement-y)+150%))] data-expanded:data-ending-style:data-[swipe-direction=down]:transform-[translateY(calc(var(--toast-swipe-movement-y)+150%))] data-ending-style:data-[swipe-direction=left]:transform-[translateX(calc(var(--toast-swipe-movement-x)-150%))_translateY(var(--offset-y))] data-expanded:data-ending-style:data-[swipe-direction=left]:transform-[translateX(calc(var(--toast-swipe-movement-x)-150%))_translateY(var(--offset-y))] data-ending-style:data-[swipe-direction=right]:transform-[translateX(calc(var(--toast-swipe-movement-x)+150%))_translateY(var(--offset-y))] data-expanded:data-ending-style:data-[swipe-direction=right]:transform-[translateX(calc(var(--toast-swipe-movement-x)+150%))_translateY(var(--offset-y))] data-ending-style:data-[swipe-direction=up]:transform-[translateY(calc(var(--toast-swipe-movement-y)-150%))] data-expanded:data-ending-style:data-[swipe-direction=up]:transform-[translateY(calc(var(--toast-swipe-movement-y)-150%))] [&[data-ending-style]:not([data-limited]):not([data-swipe-direction])]:transform-[translateY(-150%)]",
               toast.updateKey &&
-              (toast.updateKey % 2 === 0
-                ? 'animate-pulse-scale-even'
-                : 'animate-pulse-scale-odd'),
+                (toast.updateKey % 2 === 0
+                  ? 'animate-pulse-scale-even'
+                  : 'animate-pulse-scale-odd'),
             ],
             {
               'bg-status-error text-white': toast.type === 'error',
@@ -34,7 +34,7 @@ function ToastList() {
 
             <div className="flex min-w-0 flex-1 flex-col items-start justify-center gap-1">
               <Toast.Title className="text-sm leading-5 font-medium" />
-              <Toast.Description className="text-xs leading-5 font-normal wrap-break-word break-all text-text-secondary" />
+              <Toast.Description className="text-text-secondary text-xs leading-5 font-normal wrap-break-word break-all" />
               <Toast.Action
                 className={clsx([
                   'self-end rounded-2xl border-[1.5px] bg-transparent px-3 py-1.5 text-xs font-bold',

--- a/nym-vpn-app/src/components/toast/ToastList.tsx
+++ b/nym-vpn-app/src/components/toast/ToastList.tsx
@@ -32,9 +32,9 @@ function ToastList() {
           <Toast.Content className="relative flex flex-row items-start justify-start gap-4 overflow-hidden transition-opacity duration-250 data-behind:pointer-events-none data-behind:opacity-0 data-expanded:pointer-events-auto data-expanded:opacity-100">
             <ToastIcon type={toast.type as ToastAddData['type']} />
 
-            <div className="flex w-full flex-col items-start justify-center gap-1">
+            <div className="flex min-w-0 flex-1 flex-col items-start justify-center gap-1">
               <Toast.Title className="text-sm leading-5 font-medium" />
-              <Toast.Description className="text-xs leading-5 font-normal text-white dark:text-gray-700" />
+              <Toast.Description className="text-xs leading-5 font-normal wrap-break-word break-all text-white dark:text-gray-700" />
               <Toast.Action
                 className={clsx([
                   'self-end rounded-2xl border-[1.5px] bg-transparent px-3 py-1.5 text-xs font-bold',
@@ -44,7 +44,7 @@ function ToastList() {
             </div>
             <Toast.Close
               className={clsx([
-                'relative flex h-6 w-6 items-center justify-center rounded-lg p-0',
+                'relative flex h-6 w-6 shrink-0 items-center justify-center rounded-lg p-0',
                 'bg-transparent',
                 'hover:bg-text-secondary dark:hover:bg-surface-elev',
                 'text-text-primary',

--- a/nym-vpn-app/src/hooks/useI18nError.ts
+++ b/nym-vpn-app/src/hooks/useI18nError.ts
@@ -61,6 +61,11 @@ function useI18nError() {
           return t('account.device-time-out-of-sync');
         case 'bandwidth-exceeded':
           return t('account.bandwidth-exceeded');
+        // split tunnel custom app errors
+        case 'split-tunnel-app-invalid':
+          return t('split-tunnel.app-invalid');
+        case 'split-tunnel-app-duplicate':
+          return t('split-tunnel.app-duplicate');
       }
 
       console.warn('unhandled backend error', error);

--- a/nym-vpn-app/src/i18n/en/errors.json
+++ b/nym-vpn-app/src/i18n/en/errors.json
@@ -70,6 +70,8 @@
     }
   },
   "split-tunnel": {
-    "failed-to-get-app-list": "Failed to get app list"
+    "failed-to-get-app-list": "Failed to get app list",
+    "app-invalid": "The selected file is not a valid application",
+    "app-duplicate": "This app is already in the list"
   }
 }

--- a/nym-vpn-app/src/i18n/en/settings.json
+++ b/nym-vpn-app/src/i18n/en/settings.json
@@ -330,6 +330,7 @@
       },
       "got-it": "Got it!"
     },
+    "remove-app": "Remove {{name}}",
     "remove-confirm-dialog": {
       "title": "Remove {{appName}}?",
       "description": "This removes the app from your custom split tunneling list. It won't uninstall the app, and you can add it again later.",

--- a/nym-vpn-app/src/i18n/en/settings.json
+++ b/nym-vpn-app/src/i18n/en/settings.json
@@ -313,6 +313,8 @@
     "description-linux": "⚡ Launch any app from here to be excluded from the NymVPN funnel and connect directly to the internet!",
     "exclude-warning": "⚠️  Excluding an app will leave it unprotected.",
     "apps": "Apps",
+    "add-custom-app": "Exclude custom app",
+    "custom-app-added": "Added {{name}}",
     "problematic-app": "App isn't available for split tunneling",
     "info-dialog": {
       "title": "Using split tunneling",
@@ -328,6 +330,12 @@
       },
       "got-it": "Got it!"
     },
+    "remove-confirm-dialog": {
+      "title": "Remove {{appName}}?",
+      "description": "This removes the app from your custom split tunneling list. It won't uninstall the app, and you can add it again later.",
+      "remove": "Remove",
+      "cancel": "Cancel"
+    },
     "launch-confirm-dialog": {
       "title": "Launching {{appName}}",
       "description": "The app will be launched outside of the VPN tunnel and will connect directly to the internet (unprotected by NymVPN).\n\nBefore proceeding, please make sure the app is not already running. If it is, close all instances first, then launch the app from here.",
@@ -336,9 +344,12 @@
     },
     "error": {
       "failed-to-open-app": "Failed to open app",
+      "launch-failed": "Couldn't launch {{name}}",
       "failed-to-enable-split-tunneling": "Failed to enable split tunneling",
       "failed-to-add-app-to-split-tunneling": "Failed to add app to split tunneling",
-      "failed-to-remove-app-from-split-tunneling": "Failed to remove app from split tunneling"
+      "failed-to-remove-app-from-split-tunneling": "Failed to remove app from split tunneling",
+      "failed-to-add-custom-app": "Failed to add custom app",
+      "failed-to-remove-custom-app": "Failed to remove custom app"
     }
   }
 }

--- a/nym-vpn-app/src/screens/settings/split-tunneling/AppItem.tsx
+++ b/nym-vpn-app/src/screens/settings/split-tunneling/AppItem.tsx
@@ -92,7 +92,7 @@ function AppItem({
             e.stopPropagation();
             onRemove?.(app);
           }}
-          aria-label={`Remove ${app.name}`}
+          aria-label={t('split-tunneling.remove-app', { name: app.name })}
           className="text-text-tertiary hover:text-status-error transition-noborder flex cursor-default items-center justify-center"
         >
           <MsIcon icon="close" className="text-base" />

--- a/nym-vpn-app/src/screens/settings/split-tunneling/AppItem.tsx
+++ b/nym-vpn-app/src/screens/settings/split-tunneling/AppItem.tsx
@@ -19,9 +19,16 @@ type AppItemProps = {
   ) => Promise<void>;
   isRunning?: boolean;
   onLaunch?: (app: AppEntry) => Promise<void>;
+  onRemove?: (app: AppEntry) => void;
 };
 
-function AppItem({ app, onStateChange, isRunning, onLaunch }: AppItemProps) {
+function AppItem({
+  app,
+  onStateChange,
+  isRunning,
+  onLaunch,
+  onRemove,
+}: AppItemProps) {
   const { t } = useTranslation('settings');
   const os = type();
 
@@ -79,11 +86,22 @@ function AppItem({ app, onStateChange, isRunning, onLaunch }: AppItemProps) {
           </span>
         )}
       </div>
+      {app.is_custom && (
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onRemove?.(app);
+          }}
+          aria-label={`Remove ${app.name}`}
+          className="text-text-tertiary hover:text-status-error transition-noborder flex cursor-default items-center justify-center"
+        >
+          <MsIcon icon="close" className="text-base" />
+        </button>
+      )}
       {os === 'linux' && (
-        <MsIcon
-          icon="open_in_new"
-          className="text-text-tertiary shrink-0 text-base"
-        />
+        <div className="flex shrink-0 items-center gap-2">
+          <MsIcon icon="open_in_new" className="text-text-tertiary text-base" />
+        </div>
       )}
       {/* Only Windows can include/exclude apps from inside the app */}
       {/* Linux uses custom app launcher to launch the app and immediately exclude it from the tunnel */}

--- a/nym-vpn-app/src/screens/settings/split-tunneling/RemoveConfirmDialog.tsx
+++ b/nym-vpn-app/src/screens/settings/split-tunneling/RemoveConfirmDialog.tsx
@@ -1,0 +1,43 @@
+import { DialogTitle } from '@headlessui/react';
+import { useTranslation } from 'react-i18next';
+import { Button, Dialog, MsIcon } from '../../../ui';
+
+export type Props = {
+  isOpen: boolean;
+  appName: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+function RemoveConfirmDialog({ isOpen, appName, onConfirm, onCancel }: Props) {
+  const { t } = useTranslation('settings');
+
+  return (
+    <Dialog open={isOpen} onClose={onCancel} className="flex flex-col gap-6">
+      <div className="flex flex-col items-center gap-4">
+        <MsIcon icon="delete" className="text-text-primary" />
+        <DialogTitle
+          as="h3"
+          className="text-text-primary text-center text-xl font-medium"
+        >
+          {t('split-tunneling.remove-confirm-dialog.title', { appName })}
+        </DialogTitle>
+      </div>
+
+      <div className="text-text-secondary text-sm whitespace-pre-line">
+        <p>{t('split-tunneling.remove-confirm-dialog.description')}</p>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <Button onClick={onConfirm} variant="primary">
+          {t('split-tunneling.remove-confirm-dialog.remove')}
+        </Button>
+        <Button onClick={onCancel} variant="outlined">
+          {t('split-tunneling.remove-confirm-dialog.cancel')}
+        </Button>
+      </div>
+    </Dialog>
+  );
+}
+
+export default RemoveConfirmDialog;

--- a/nym-vpn-app/src/screens/settings/split-tunneling/SplitTunneling.tsx
+++ b/nym-vpn-app/src/screens/settings/split-tunneling/SplitTunneling.tsx
@@ -12,9 +12,12 @@ import { Spinner } from '../../../ui';
 import { useToast } from '../../../hooks/index';
 import InfoDialog from './InfoDialog';
 import LaunchConfirmDialog from './LaunchConfirmDialog';
+import RemoveConfirmDialog from './RemoveConfirmDialog';
 import AppItem, { AppEntry } from './AppItem';
 import { parseExecArgs, useSplitTunnel } from './utils';
 import { PROBLEMATIC_APPS } from './utils/constants';
+
+const LAUNCH_FAILURE_WINDOW_MS = 2500;
 
 function SplitTunneling() {
   const os = type();
@@ -23,24 +26,80 @@ function SplitTunneling() {
   const { isOpen, close } = useDialog();
   const { add: addToast } = useToast();
 
-  const { apps, enabled, loading, setEnabled, add, remove, isSupported } =
-    useSplitTunnel();
+  const {
+    apps,
+    enabled,
+    loading,
+    setEnabled,
+    add,
+    addCustomApp,
+    remove,
+    removeCustomApp,
+    isSupported,
+  } = useSplitTunnel();
 
   const [runningApps, setRunningApps] = useState<Record<string, number[]>>({});
   const [pendingLaunchApp, setPendingLaunchApp] = useState<AppEntry | null>(
     null,
   );
+  const [pendingRemoveApp, setPendingRemoveApp] = useState<AppEntry | null>(
+    null,
+  );
 
   const spawnApp = useCallback(
     async (app: AppEntry) => {
+      // Buffer stderr and remember when we launched, so an early non-zero exit
+      // can be surfaced to the user as a failed launch
+      const stderrLines: string[] = [];
+      const spawnedAt = Date.now();
+
       try {
         const command = Command.create(
           'nym-exclude',
           parseExecArgs(app.executable_path),
+          // nym-vpn-app runs with GDK_BACKEND=wayland (injected by its GTK/WebKit
+          // runtime). nym-exclude passes the environment straight through, and
+          // some apps (e.g. Electron/GTK AppImages) can't open a display under
+          // the forced Wayland backend, failing with "cannot open display: :0".
+          // Override it so the launched app uses X11 (Xwayland), matching a
+          // normal terminal launch.
+          { env: { GDK_BACKEND: 'wayland,x11' } },
         );
 
+        command.stderr.on('data', (line) => {
+          console.error('[nym-exclude][stderr]', line);
+          const trimmed = line.trim();
+          if (trimmed) stderrLines.push(trimmed);
+        });
+
         command.on('close', (data) => {
-          console.info('[nym-exclude] process closed with code', data.code);
+          console.info('[nym-exclude] process closed', {
+            code: data.code,
+            signal: data.signal,
+          });
+
+          // Detect a failed launch: non-zero exit code, or killed by a signal
+          const exitedAbnormally =
+            data.code === null ? data.signal !== null : data.code !== 0;
+          const exitedQuickly =
+            Date.now() - spawnedAt < LAUNCH_FAILURE_WINDOW_MS;
+          if (exitedAbnormally && exitedQuickly) {
+            const maxLen = 300;
+            let detail = stderrLines.join('\n').slice(0, maxLen);
+            if (stderrLines.join('\n').length > maxLen) {
+              detail += '...';
+            }
+
+            addToast({
+              id: `launch-failed-${app.name}`,
+              title: t('split-tunneling.error.launch-failed', {
+                name: app.name,
+              }),
+              description: detail || undefined,
+              type: 'error',
+            });
+          }
+
           setRunningApps((prev) => {
             const pids = prev[app.name];
             if (!pids) return prev;
@@ -108,6 +167,21 @@ function SplitTunneling() {
     setPendingLaunchApp(null);
   }, []);
 
+  const handleRemove = useCallback((app: AppEntry) => {
+    setPendingRemoveApp(app);
+  }, []);
+
+  const handleRemoveConfirm = useCallback(async () => {
+    if (pendingRemoveApp) {
+      await removeCustomApp(pendingRemoveApp);
+    }
+    setPendingRemoveApp(null);
+  }, [pendingRemoveApp, removeCustomApp]);
+
+  const handleRemoveCancel = useCallback(() => {
+    setPendingRemoveApp(null);
+  }, []);
+
   const sectionRefs = useRef<Record<string, HTMLDivElement | null>>({});
 
   const groupedApps = useMemo(() => {
@@ -167,6 +241,13 @@ function SplitTunneling() {
         onCancel={handleLaunchCancel}
       />
 
+      <RemoveConfirmDialog
+        isOpen={pendingRemoveApp !== null}
+        appName={pendingRemoveApp?.name ?? ''}
+        onConfirm={handleRemoveConfirm}
+        onCancel={handleRemoveCancel}
+      />
+
       {/* Enable split tunneling on Windows only*/}
       {os === 'windows' && (
         <SettingsMenuCard
@@ -190,6 +271,15 @@ function SplitTunneling() {
       <p className="text-status-warning bg-surface-elev/40 rounded-lg p-3 text-sm">
         {t('split-tunneling.exclude-warning')}
       </p>
+
+      {/* Exclude a custom app via native file dialog */}
+      {(enabled || os === 'linux') && (
+        <SettingsMenuCard
+          title={t('split-tunneling.add-custom-app')}
+          leadingIcon="add"
+          onClick={addCustomApp}
+        />
+      )}
 
       {/* Apps section */}
       <AnimatePresence initial={false}>
@@ -232,6 +322,7 @@ function SplitTunneling() {
                           onStateChange={handleStateChange}
                           isRunning={(runningApps[app.name]?.length ?? 0) > 0}
                           onLaunch={handleLaunch}
+                          onRemove={handleRemove}
                         />
                         {i < groupedApps[letter].length - 1 && (
                           <div className="bg-surface-hair mx-4 h-px" />

--- a/nym-vpn-app/src/screens/settings/split-tunneling/SplitTunneling.tsx
+++ b/nym-vpn-app/src/screens/settings/split-tunneling/SplitTunneling.tsx
@@ -85,13 +85,12 @@ function SplitTunneling() {
             Date.now() - spawnedAt < LAUNCH_FAILURE_WINDOW_MS;
           if (exitedAbnormally && exitedQuickly) {
             const maxLen = 300;
-            let detail = stderrLines.join('\n').slice(0, maxLen);
-            if (stderrLines.join('\n').length > maxLen) {
-              detail += '...';
-            }
+            const joined = stderrLines.join('\n');
+            const detail =
+              joined.length > maxLen ? joined.slice(0, maxLen) + '...' : joined;
 
             addToast({
-              id: `launch-failed-${app.name}`,
+              id: `launch-failed-${app.executable_path}`,
               title: t('split-tunneling.error.launch-failed', {
                 name: app.name,
               }),

--- a/nym-vpn-app/src/screens/settings/split-tunneling/utils/useSplitTunnel.ts
+++ b/nym-vpn-app/src/screens/settings/split-tunneling/utils/useSplitTunnel.ts
@@ -3,14 +3,16 @@ import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { dispatch, useAppStore } from '../../../../store';
 import { App } from '../../../../types/tauri';
+import { BackendError } from '../../../../types/util';
 import { AppEntry } from '../AppItem';
-import { useToast } from '../../../../hooks/index';
+import { useI18nError, useToast } from '../../../../hooks/index';
 
 export const useSplitTunnel = () => {
   const { t } = useTranslation('settings');
   const splitTunnel = useAppStore((s) => s.splitTunnel);
   const { enabled, apps: splitTunnelApps } = splitTunnel;
   const { add: addToast } = useToast();
+  const { tE } = useI18nError();
 
   const [installedApps, setInstalledApps] = useState<App[]>([]);
   const [loading, setLoading] = useState(false);
@@ -46,9 +48,7 @@ export const useSplitTunnel = () => {
 
   const appList: AppEntry[] = useMemo(() => {
     return installedApps.map<AppEntry>((app) => ({
-      name: app.name,
-      executable_path: app.executable_path,
-      icon: app.icon,
+      ...app,
       state: splitTunnelApps.some(
         (existing) => existing.path === app.executable_path,
       )
@@ -89,6 +89,50 @@ export const useSplitTunnel = () => {
     }
   };
 
+  const addCustomApp = async () => {
+    try {
+      const app = await invoke<App | null>('add_custom_split_tunnel_app');
+      if (!app) return; // user cancelled the dialog
+
+      const appList = await invoke<App[]>('get_app_list');
+      setInstalledApps(appList);
+
+      addToast({
+        title: t('split-tunneling.custom-app-added', { name: app.name }),
+        type: 'info',
+      });
+    } catch (err: unknown) {
+      console.error('Failed to add custom split tunnel app', err);
+      const error = err as BackendError;
+      addToast({
+        title: error?.key
+          ? tE(error.key)
+          : t('split-tunneling.error.failed-to-add-custom-app'),
+        type: 'error',
+      });
+    }
+  };
+
+  const removeCustomApp = async (app: AppEntry) => {
+    try {
+      await invoke('remove_custom_split_tunnel_app', {
+        path: app.executable_path,
+      });
+
+      const appList = await invoke<App[]>('get_app_list');
+      setInstalledApps(appList);
+    } catch (err: unknown) {
+      console.error('Failed to remove custom split tunnel app', err);
+      const error = err as BackendError;
+      addToast({
+        title: error?.key
+          ? tE(error.key)
+          : t('split-tunneling.error.failed-to-remove-custom-app'),
+        type: 'error',
+      });
+    }
+  };
+
   const remove = async (app: AppEntry) => {
     if (app.state === 'excluded') return;
     try {
@@ -117,7 +161,9 @@ export const useSplitTunnel = () => {
     enabled,
     setEnabled,
     add,
+    addCustomApp,
     remove,
+    removeCustomApp,
     loading,
     isSupported,
   };

--- a/nym-vpn-app/src/types/tauri.ts
+++ b/nym-vpn-app/src/types/tauri.ts
@@ -18,6 +18,10 @@ export type App = {
    * Absolute path to the cached icon PNG, when available. Stored in tauri app cache directory.
    */
   icon: string | null;
+  /**
+   * Whether this app was added by the user via the file dialog (custom) or discovered.
+   */
+  is_custom: boolean;
 };
 
 export type Asn = { asn: string; name: string; type: AsnType };
@@ -84,6 +88,7 @@ export type DbKey =
   | 'desktop-notifications'
   | 'last-network-env'
   | 'network-stats-enabled'
+  | 'custom-split-tunnel-apps'
   | 'cache-mx-entry-gateways'
   | 'cache-mx-exit-gateways'
   | 'cache-wg-gateways'
@@ -129,6 +134,8 @@ export type ErrorKey =
   | 'no-subscription'
   | 'max-device-reached'
   | 'device-time-desync'
+  | 'split-tunnel-app-invalid'
+  | 'split-tunnel-app-duplicate'
   | 'get-mixnet-entry-countries-query'
   | 'get-mixnet-exit-countries-query'
   | 'get-wg-countries-query';


### PR DESCRIPTION
## Ticket

[JIRA-NYM-1349](https://nymtech.atlassian.net/browse/NYM-1349)

## Description

Allow adding custom apps to the split tunneling on Windows and Linux


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5488)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Select, persist and remove custom applications for split tunneling on Windows and Linux with a native add/remove UI and confirmation dialog
  * Frontend actions to add/remove custom apps

* **Improvements**
  * Validation plus localized error messages for invalid or duplicate custom app selections
  * Better toast layout and improved app-launch failure reporting with truncated stderr shown

* **Tests**
  * Unit tests covering custom app handling and discovery behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->