### PR TITLE
(tauri) Validate if selected file is executable

### DIFF
--- a/nym-vpn-app/src-tauri/src/fs/app_discovery/custom_apps.rs
+++ b/nym-vpn-app/src-tauri/src/fs/app_discovery/custom_apps.rs
@@ -156,7 +156,7 @@ mod tests {
         let dir = scratch_dir("build-ok");
         let file = dir.join("my-binary");
         fs::write(&file, b"#!/bin/sh\n").unwrap();
-        #[cfg(unix)]
+        #[cfg(target_os = "linux")]
         {
             use std::os::unix::fs::PermissionsExt;
             fs::set_permissions(&file, fs::Permissions::from_mode(0o755)).unwrap();
@@ -176,7 +176,7 @@ mod tests {
         let dir = scratch_dir("build-ext");
         let file = dir.join("Cursor.AppImage");
         fs::write(&file, b"x").unwrap();
-        #[cfg(unix)]
+        #[cfg(target_os = "linux")]
         {
             use std::os::unix::fs::PermissionsExt;
             fs::set_permissions(&file, fs::Permissions::from_mode(0o755)).unwrap();
@@ -196,7 +196,7 @@ mod tests {
         fs::remove_dir_all(&dir).ok();
     }
 
-    #[cfg(unix)]
+    #[cfg(target_os = "linux")]
     #[test]
     fn build_custom_app_rejects_non_executable_file() {
         use std::os::unix::fs::PermissionsExt;

--- a/nym-vpn-app/src-tauri/src/fs/app_discovery/custom_apps.rs
+++ b/nym-vpn-app/src-tauri/src/fs/app_discovery/custom_apps.rs
@@ -20,6 +20,21 @@ pub fn build_custom_app(path: &Path, app: Option<&tauri::AppHandle>) -> Result<A
         ));
     }
 
+    // On Unix there is no canonical executable extension, so we cannot filter the
+    // file picker by name. Instead require the executable permission bit here: the
+    // path is handed to `nym-exclude` which `execvp`s it, so a non-executable file
+    // would only fail later at launch time.
+    #[cfg(target_os = "linux")]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if metadata.permissions().mode() & 0o111 == 0 {
+            return Err(BackendError::new(
+                &format!("selected file '{}' is not executable", path.display()),
+                ErrorKey::SplitTunnelAppInvalid,
+            ));
+        }
+    }
+
     let name = path
         .file_stem()
         .or_else(|| path.file_name())
@@ -141,6 +156,11 @@ mod tests {
         let dir = scratch_dir("build-ok");
         let file = dir.join("my-binary");
         fs::write(&file, b"#!/bin/sh\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&file, fs::Permissions::from_mode(0o755)).unwrap();
+        }
 
         let result = build_custom_app(&file, None).unwrap();
         assert_eq!(result.name, "my-binary");
@@ -156,6 +176,11 @@ mod tests {
         let dir = scratch_dir("build-ext");
         let file = dir.join("Cursor.AppImage");
         fs::write(&file, b"x").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&file, fs::Permissions::from_mode(0o755)).unwrap();
+        }
 
         let result = build_custom_app(&file, None).unwrap();
         assert_eq!(result.name, "Cursor");
@@ -168,6 +193,22 @@ mod tests {
         let dir = scratch_dir("build-dir");
         let err = build_custom_app(&dir, None).unwrap_err();
         assert_eq!(err.key, ErrorKey::SplitTunnelAppInvalid);
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn build_custom_app_rejects_non_executable_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = scratch_dir("build-noexec");
+        let file = dir.join("notes.txt");
+        fs::write(&file, b"just text, not runnable\n").unwrap();
+        fs::set_permissions(&file, fs::Permissions::from_mode(0o644)).unwrap();
+
+        let err = build_custom_app(&file, None).unwrap_err();
+        assert_eq!(err.key, ErrorKey::SplitTunnelAppInvalid);
+
         fs::remove_dir_all(&dir).ok();
     }
 


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

On Unix there is no canonical executable extension, so we cannot filter the file picker by name. Instead require the executable permission bit here: the path is handed to `nym-exclude` which `execvp`s it, so a non-executable file would only fail later at launch time. Hence executable check is added for Linux


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5497)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for custom applications in split tunnel feature. The app now verifies that selected applications have executable permissions on Linux and rejects non-executable files to prevent configuration errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->