### PR TITLE
fix(core): gate ConnectingState behind account-readiness preflight

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,0 +1,57 @@
+# fix/disconnected-state-account-preflight
+
+## Summary
+
+This branch adds an internal account preflight state before entering `ConnectingState`.
+
+The key invariant is: the state machine must not call `ConnectingState::enter()` until the
+account controller is ready to connect (`ReadyToConnect`, `Decentralised`, or `UpgradeMode`).
+`ConnectingState::enter()` raises the VPN API firewall immediately, so inactive/no-plan
+accounts must be rejected or waited on before that point.
+
+Covered callsites:
+
+- `DisconnectedState` user connect command
+- `ErrorState` user connect command
+- `OfflineState` auto-reconnect when connectivity returns
+- reconnect paths through `ConnectedState` tunnel-down recovery and `DisconnectingState`
+
+The preflight state exposes `Connecting/AwaitingAccountReadiness` to the UI while it waits,
+but it first resets to unrestricted networking and does not apply the tunnel firewall. If
+the account becomes ready, it transitions to the normal `ConnectingState`. If the account
+reaches a terminal non-connectable state (`LoggedOut`, `Offline`, or `Error(_)`), it returns
+to `DisconnectedState`; the existing account-state UI then shows the specific account
+message and, for `no-subscription`, routes the main button to pricing.
+
+## Tests run
+
+```text
+cargo fmt --manifest-path nym-vpn-core\Cargo.toml --package nym-vpn-lib
+cargo check --manifest-path nym-vpn-core\Cargo.toml -p nym-vpn-lib
+```
+
+Result: `cargo check` passed.
+
+`cargo fmt` prints the existing rustfmt warning:
+
+```text
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+```
+
+## Manual repro still needed
+
+Use the machine/account state from the original report:
+
+1. Start with an account that has no active subscription.
+2. Click Connect while the account controller is still `Syncing`/settling.
+3. Expected:
+   - UI may show "Setting up your account (2/6)" briefly.
+   - Internet must remain available; no "Allowing endpoints: none" blackout.
+   - Once account state resolves to no subscription, app returns to disconnected/no-plan UI.
+4. Also test reconnect after network offline/online while account is not ready.
+
+## Open questions
+
+- If product wants no visible "2/6" state for no-plan accounts, add a public non-firewall
+  account-preflight state and UI copy. I avoided that broader binding/UI change here.
+- GitHub issue/PR creation is pending repository access from this environment.

--- a/NOTES.md
+++ b/NOTES.md
@@ -26,8 +26,8 @@ message and, for `no-subscription`, routes the main button to pricing.
 ## Tests run
 
 ```text
-cargo fmt --manifest-path nym-vpn-core\Cargo.toml --package nym-vpn-lib
-cargo check --manifest-path nym-vpn-core\Cargo.toml -p nym-vpn-lib
+cargo fmt --manifest-path nym-vpn-core/Cargo.toml --package nym-vpn-lib
+cargo check --manifest-path nym-vpn-core/Cargo.toml -p nym-vpn-lib
 ```
 
 Result: `cargo check` passed.

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/account_preflight_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/account_preflight_state.rs
@@ -99,11 +99,22 @@ impl TunnelStateHandler for AccountPreflightState {
                         NextTunnelState::NewState(DisconnectedState::enter(None, shared_state).await)
                     }
                     TunnelCommand::SetTunnelSettings(tunnel_settings) => {
-                        if DisconnectedState::apply_tunnel_settings(tunnel_settings, shared_state).await {
-                            let new_state = Self::make_preflight_tunnel_state(shared_state);
-                            NextTunnelState::NewState((self, new_state))
-                        } else {
-                            NextTunnelState::SameState(self)
+                        match DisconnectedState::apply_tunnel_settings(tunnel_settings, shared_state).await {
+                            Some(diff) => {
+                                // Invalidate cached gateways if the new settings
+                                // moved entry/exit/quic, mirroring OfflineState.
+                                // Otherwise a reconnect coming out of preflight
+                                // would proceed with stale gateways.
+                                if diff.entry_point_changed()
+                                    || diff.exit_point_changed()
+                                    || diff.quic_changed()
+                                {
+                                    self.selected_gateways = None;
+                                }
+                                let new_state = Self::make_preflight_tunnel_state(shared_state);
+                                NextTunnelState::NewState((self, new_state))
+                            }
+                            None => NextTunnelState::SameState(self),
                         }
                     }
                     TunnelCommand::Block(reason) => {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/account_preflight_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/account_preflight_state.rs
@@ -1,0 +1,141 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use nym_vpn_lib_types::{AccountControllerState, EstablishConnectionState};
+use tokio::sync::{mpsc, watch};
+use tokio_util::sync::CancellationToken;
+
+use crate::tunnel_state_machine::{
+    NextTunnelState, PrivateTunnelState, SharedState, TunnelCommand, TunnelStateHandler,
+    states::{ConnectingState, DisconnectedState, ErrorState, OfflineState},
+    tunnel::SelectedGateways,
+};
+
+enum AccountPreflight {
+    Ready,
+    Wait,
+    Block,
+}
+
+pub struct AccountPreflightState {
+    selected_gateways: Option<SelectedGateways>,
+    account_state_rx: watch::Receiver<AccountControllerState>,
+}
+
+impl AccountPreflightState {
+    fn account_preflight(shared_state: &SharedState) -> AccountPreflight {
+        match shared_state.account_controller_state.get_state() {
+            AccountControllerState::ReadyToConnect
+            | AccountControllerState::Decentralised
+            | AccountControllerState::UpgradeMode => AccountPreflight::Ready,
+            AccountControllerState::Syncing
+            | AccountControllerState::RequestingZkNyms
+            | AccountControllerState::PendingSubscription => AccountPreflight::Wait,
+            AccountControllerState::Offline
+            | AccountControllerState::LoggedOut
+            | AccountControllerState::Error(_) => AccountPreflight::Block,
+        }
+    }
+
+    pub async fn enter(
+        selected_gateways: Option<SelectedGateways>,
+        shared_state: &mut SharedState,
+    ) -> (Box<dyn TunnelStateHandler>, PrivateTunnelState) {
+        match Self::account_preflight(shared_state) {
+            AccountPreflight::Ready => {
+                return ConnectingState::enter(0, selected_gateways, shared_state).await;
+            }
+            AccountPreflight::Block => {
+                return DisconnectedState::enter(None, shared_state).await;
+            }
+            AccountPreflight::Wait => {}
+        }
+
+        DisconnectedState::reset_to_unrestricted_networking(None, shared_state).await;
+        let account_state_rx = shared_state.account_controller_state.subscribe();
+
+        match Self::account_preflight(shared_state) {
+            AccountPreflight::Ready => {
+                ConnectingState::enter(0, selected_gateways, shared_state).await
+            }
+            AccountPreflight::Block => DisconnectedState::enter(None, shared_state).await,
+            AccountPreflight::Wait => {
+                let state = Self::make_preflight_tunnel_state(shared_state);
+                (
+                    Box::new(Self {
+                        selected_gateways,
+                        account_state_rx,
+                    }),
+                    state,
+                )
+            }
+        }
+    }
+
+    fn make_preflight_tunnel_state(shared_state: &SharedState) -> PrivateTunnelState {
+        PrivateTunnelState::Connecting {
+            retry_attempt: 0,
+            state: EstablishConnectionState::AwaitingAccountReadiness,
+            tunnel_type: shared_state.tunnel_settings.tunnel_type_used(),
+            connection_data: None,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl TunnelStateHandler for AccountPreflightState {
+    async fn handle_event(
+        mut self: Box<Self>,
+        shutdown_token: &CancellationToken,
+        command_rx: &'async_trait mut mpsc::UnboundedReceiver<TunnelCommand>,
+        shared_state: &'async_trait mut SharedState,
+    ) -> NextTunnelState {
+        tokio::select! {
+            Some(command) = command_rx.recv() => {
+                tracing::debug!("AccountPreflightState received command: {command:?}");
+                match command {
+                    TunnelCommand::Connect => NextTunnelState::SameState(self),
+                    TunnelCommand::Disconnect => {
+                        NextTunnelState::NewState(DisconnectedState::enter(None, shared_state).await)
+                    }
+                    TunnelCommand::SetTunnelSettings(tunnel_settings) => {
+                        if DisconnectedState::apply_tunnel_settings(tunnel_settings, shared_state).await {
+                            let new_state = Self::make_preflight_tunnel_state(shared_state);
+                            NextTunnelState::NewState((self, new_state))
+                        } else {
+                            NextTunnelState::SameState(self)
+                        }
+                    }
+                    TunnelCommand::Block(reason) => {
+                        NextTunnelState::NewState(ErrorState::enter(reason, shared_state).await)
+                    }
+                }
+            }
+            account_state_changed = self.account_state_rx.changed() => {
+                if account_state_changed.is_err() {
+                    return NextTunnelState::NewState(DisconnectedState::enter(None, shared_state).await);
+                }
+
+                match Self::account_preflight(shared_state) {
+                    AccountPreflight::Ready => {
+                        NextTunnelState::NewState(ConnectingState::enter(0, self.selected_gateways.take(), shared_state).await)
+                    }
+                    AccountPreflight::Block => {
+                        NextTunnelState::NewState(DisconnectedState::enter(None, shared_state).await)
+                    }
+                    AccountPreflight::Wait => NextTunnelState::SameState(self),
+                }
+            }
+            Some(connectivity) = shared_state.connectivity_handle.next() => {
+                if connectivity.is_offline() {
+                    NextTunnelState::NewState(OfflineState::enter(true, self.selected_gateways.take(), shared_state).await)
+                } else {
+                    NextTunnelState::SameState(self)
+                }
+            }
+            _ = shutdown_token.cancelled() => {
+                NextTunnelState::Finished
+            }
+        }
+    }
+}

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
@@ -16,7 +16,7 @@ use crate::tunnel_state_machine::Result;
 use crate::tunnel_state_machine::{
     ConnectionData, NextTunnelState, PrivateActionAfterDisconnect, PrivateTunnelState, SharedState,
     TunnelCommand, TunnelInterface, TunnelStateHandler,
-    states::{ConnectingState, DisconnectingState},
+    states::{AccountPreflightState, DisconnectingState},
     tunnel::SelectedGateways,
     tunnel_monitor::{TunnelMonitorEvent, TunnelMonitorEventReceiver, TunnelMonitorHandle},
 };
@@ -272,7 +272,7 @@ impl ConnectedState {
                 NextTunnelState::NewState(ErrorState::enter(block_reason, shared_state).await)
             }
             None => NextTunnelState::NewState(
-                ConnectingState::enter(0, Some(self.selected_gateways), shared_state).await,
+                AccountPreflightState::enter(Some(self.selected_gateways), shared_state).await,
             ),
         }
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnected_state.rs
@@ -5,8 +5,9 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 use crate::tunnel_state_machine::{
-    NextTunnelState, PrivateTunnelState, SharedState, TunnelCommand, TunnelStateHandler,
-    states::{ConnectingState, OfflineState},
+    NextTunnelState, PrivateTunnelState, SharedState, TunnelCommand, TunnelSettings,
+    TunnelStateHandler,
+    states::{AccountPreflightState, OfflineState},
     tunnel::Tombstone,
 };
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
@@ -20,6 +21,15 @@ impl DisconnectedState {
         tombstone: Option<Tombstone>,
         shared_state: &mut SharedState,
     ) -> (Box<dyn TunnelStateHandler>, PrivateTunnelState) {
+        Self::reset_to_unrestricted_networking(tombstone, shared_state).await;
+
+        (Box::new(Self), PrivateTunnelState::Disconnected)
+    }
+
+    pub(super) async fn reset_to_unrestricted_networking(
+        tombstone: Option<Tombstone>,
+        shared_state: &mut SharedState,
+    ) {
         #[cfg(any(target_os = "macos", target_os = "windows"))]
         if let Err(err) = shared_state.split_tunnel.reset_tunnel().await {
             trace_err_chain!(err, "failed to reset split tunnel");
@@ -48,8 +58,6 @@ impl DisconnectedState {
         {
             shared_state.set_socks5_proxy_tunnel_addrs(None, None);
         }
-
-        (Box::new(Self), PrivateTunnelState::Disconnected)
     }
 
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
@@ -64,6 +72,36 @@ impl DisconnectedState {
         if let Err(error) = shared_state.dns_handler.reset().await {
             trace_err_chain!(error, "Failed to reset DNS");
         }
+    }
+
+    pub(super) async fn apply_tunnel_settings(
+        tunnel_settings: TunnelSettings,
+        shared_state: &mut SharedState,
+    ) -> bool {
+        let diff = shared_state.tunnel_settings.diff(&tunnel_settings);
+        if diff.is_empty() {
+            return false;
+        }
+
+        shared_state.set_tunnel_settings(tunnel_settings).await;
+
+        #[cfg(any(target_os = "macos", target_os = "windows"))]
+        if diff.split_tunnel_changed() || diff.geo_exclusion_enabled_changed() {
+            let _ = shared_state.set_split_tunnel_exclude_paths().await;
+        }
+
+        #[cfg(not(target_os = "ios"))]
+        if diff.geo_exclusion_enabled_changed() {
+            shared_state.start_or_stop_socks5_proxy().await;
+        }
+
+        if diff.enable_ad_blocking_changed() {
+            shared_state
+                .enable_ad_blocking(shared_state.tunnel_settings.enable_ad_blocking)
+                .await;
+        }
+
+        true
     }
 }
 
@@ -80,31 +118,11 @@ impl TunnelStateHandler for DisconnectedState {
                 tracing::debug!("DisconnectedState received command: {command:?}");
                 match command {
                     TunnelCommand::Connect => {
-                        NextTunnelState::NewState(ConnectingState::enter(0, None, shared_state).await)
+                        NextTunnelState::NewState(AccountPreflightState::enter(None, shared_state).await)
                     },
                     TunnelCommand::Disconnect => NextTunnelState::SameState(self),
                     TunnelCommand::SetTunnelSettings(tunnel_settings) => {
-                        let diff = shared_state.tunnel_settings.diff(&tunnel_settings);
-                        if diff.is_empty() {
-                            return NextTunnelState::SameState(self);
-                        }
-
-                        shared_state.set_tunnel_settings(tunnel_settings).await;
-
-                        #[cfg(any(target_os = "macos", target_os = "windows"))]
-                        if diff.split_tunnel_changed() || diff.geo_exclusion_enabled_changed() {
-                            let _ = shared_state.set_split_tunnel_exclude_paths().await;
-                        }
-
-                        #[cfg(not(target_os = "ios"))]
-                        if diff.geo_exclusion_enabled_changed() {
-                            shared_state.start_or_stop_socks5_proxy().await;
-                        }
-
-                        if diff.enable_ad_blocking_changed() {
-                            shared_state.enable_ad_blocking(shared_state.tunnel_settings.enable_ad_blocking).await;
-                        }
-
+                        Self::apply_tunnel_settings(tunnel_settings, shared_state).await;
                         NextTunnelState::SameState(self)
                     }
                     TunnelCommand::Block(_reason) => {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnected_state.rs
@@ -6,7 +6,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::tunnel_state_machine::{
     NextTunnelState, PrivateTunnelState, SharedState, TunnelCommand, TunnelSettings,
-    TunnelStateHandler,
+    TunnelSettingsDiff, TunnelStateHandler,
     states::{AccountPreflightState, OfflineState},
     tunnel::Tombstone,
 };
@@ -74,13 +74,22 @@ impl DisconnectedState {
         }
     }
 
+    /// Apply updated tunnel settings, running the platform-specific side
+    /// effects for whichever fields changed.
+    ///
+    /// Returns `None` when the new settings are identical to the current ones
+    /// (nothing applied), or `Some(diff)` describing the fields that changed.
+    /// Callers that cache selected gateways (e.g. the reconnect paths feeding
+    /// `AccountPreflightState`) must inspect the diff and drop their cache when
+    /// `entry_point`, `exit_point`, or `quic` changed, otherwise a subsequent
+    /// reconnect would use stale gateways.
     pub(super) async fn apply_tunnel_settings(
         tunnel_settings: TunnelSettings,
         shared_state: &mut SharedState,
-    ) -> bool {
+    ) -> Option<TunnelSettingsDiff> {
         let diff = shared_state.tunnel_settings.diff(&tunnel_settings);
         if diff.is_empty() {
-            return false;
+            return None;
         }
 
         shared_state.set_tunnel_settings(tunnel_settings).await;
@@ -101,7 +110,7 @@ impl DisconnectedState {
                 .await;
         }
 
-        true
+        Some(diff)
     }
 }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnecting_state.rs
@@ -8,7 +8,7 @@ use tokio_util::sync::CancellationToken;
 use crate::tunnel_state_machine::{
     NextTunnelState, PrivateActionAfterDisconnect, PrivateTunnelState, SharedState, TunnelCommand,
     TunnelStateHandler,
-    states::{ConnectingState, DisconnectedState, ErrorState, OfflineState},
+    states::{AccountPreflightState, DisconnectedState, ErrorState, OfflineState},
     tunnel::Tombstone,
     tunnel_monitor::TunnelMonitorHandle,
 };
@@ -62,7 +62,7 @@ impl DisconnectingState {
                 ErrorState::enter(reason, shared_state).await
             }
             PrivateActionAfterDisconnect::Reconnect => {
-                ConnectingState::enter(0, None, shared_state).await
+                AccountPreflightState::enter(None, shared_state).await
             }
             PrivateActionAfterDisconnect::Offline {
                 reconnect,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
@@ -33,7 +33,7 @@ use crate::tunnel_state_machine::{Error, Result};
 use crate::tunnel_state_machine::{
     ErrorStateReason, NextTunnelState, PrivateTunnelState, SharedState, TunnelCommand,
     TunnelStateHandler,
-    states::{ConnectingState, DisconnectedState, OfflineState},
+    states::{AccountPreflightState, DisconnectedState, OfflineState},
 };
 
 /// Interface addresses used as placeholders when in error state.
@@ -187,7 +187,7 @@ impl TunnelStateHandler for ErrorState {
                         if shared_state.connectivity_handle.connectivity().await.is_offline() {
                             NextTunnelState::NewState(OfflineState::enter(true, None, shared_state).await)
                         } else {
-                            NextTunnelState::NewState(ConnectingState::enter(0, None, shared_state).await)
+                            NextTunnelState::NewState(AccountPreflightState::enter(None, shared_state).await)
                         }
                     },
                     TunnelCommand::Disconnect => {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+mod account_preflight_state;
 mod connected_state;
 mod connecting_state;
 mod disconnected_state;
@@ -8,6 +9,7 @@ mod disconnecting_state;
 mod error_state;
 mod offline_state;
 
+pub use account_preflight_state::AccountPreflightState;
 pub use connected_state::ConnectedState;
 pub use connecting_state::ConnectingState;
 pub use disconnected_state::DisconnectedState;

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/offline_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/offline_state.rs
@@ -10,7 +10,7 @@ use crate::tunnel_state_machine::ErrorStateReason;
 use crate::tunnel_state_machine::{Error, Result, states::error_state::BlockedPolicyParameters};
 use crate::tunnel_state_machine::{
     NextTunnelState, PrivateTunnelState, SharedState, TunnelCommand, TunnelStateHandler,
-    states::{ConnectingState, DisconnectedState, ErrorState},
+    states::{AccountPreflightState, DisconnectedState, ErrorState},
     tunnel::SelectedGateways,
 };
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
@@ -193,7 +193,7 @@ impl TunnelStateHandler for OfflineState {
                     Self::reset_dns(shared_state).await;
 
                     if self.reconnect {
-                        NextTunnelState::NewState(ConnectingState::enter(0, self.selected_gateways, shared_state).await)
+                        NextTunnelState::NewState(AccountPreflightState::enter(self.selected_gateways, shared_state).await)
                     } else {
                         NextTunnelState::NewState(DisconnectedState::enter(None, shared_state).await)
                     }


### PR DESCRIPTION
## Problem

When the user clicks **Connect**, `DisconnectedState` transitions directly into `ConnectingState::enter()`, which immediately applies a restrictive `FirewallPolicy::Connecting` (killswitch up). Only **after** the firewall is up does `TunnelMonitor` begin checking account readiness.

If the account controller is in `Syncing` / `RequestingZkNyms` / `PendingSubscription`, or has reached a terminal non-connectable state (`Offline`, `LoggedOut`, `Error(_)` including `InactiveSubscription`), the user is left with the killswitch on and an indefinitely-pending tunnel handshake. Empirically this surfaces as the UI being stuck at *"Setting up your account (2/6)"* while the user has lost normal internet access.

Reproduced live against `nym-vpn-lib 1.30.0`: pre-Connect, the account controller already had `InactiveSubscription` responses for an inactive account. On `Connect`, the daemon raised the firewall (`Allowing endpoints: none` for ~1s, then API-only endpoints) and entered `awaiting account readiness, try #0`. The user had to manually `Disconnect` to recover normal internet.

The same direct `ConnectingState::enter()` bypass exists at 4 additional callsites:

- `ErrorState::Connect`
- `OfflineState` auto-reconnect when connectivity returns
- `ConnectedState` tunnel-down recovery (`Reconnect`)
- `DisconnectingState` `PrivateActionAfterDisconnect::Reconnect`

## Fix

Introduce an internal `AccountPreflightState` that gates every transition into `ConnectingState`:

- `ReadyToConnect | Decentralised | UpgradeMode` -> enter `ConnectingState` immediately; behavior unchanged.
- `Syncing | RequestingZkNyms | PendingSubscription` -> reset to unrestricted networking and wait for account state changes. UI still reports `Connecting::AwaitingAccountReadiness` while waiting, but the firewall is **not** raised; the user keeps normal internet.
- `Offline | LoggedOut | Error(_)` -> fall back to `DisconnectedState`. The existing account-state UI already surfaces the specific account message (no plan / logged out / etc.) and routes the call-to-action to pricing or login, so no new public state or binding is required here.

Covered callsites (all switched from `ConnectingState::enter` to `AccountPreflightState::enter`):

- `DisconnectedState` user `Connect` command
- `ErrorState` user `Connect` command
- `OfflineState` auto-reconnect when connectivity returns
- `ConnectedState` tunnel-down recovery reconnect
- `DisconnectingState` `Reconnect` action-after-disconnect

Light refactor in `DisconnectedState`: extract `reset_to_unrestricted_networking()` and `apply_tunnel_settings()` so the preflight state can reuse them without duplicating logic.

The retry/wait logic inside `TunnelMonitor::await_account_readiness_with_retry` is left as-is; it remains useful as a fallback for races during the actual connect and for IAP propagation cases.

## Race-condition handling

`AccountPreflightState::enter` reclassifies the account state **after** subscribing to the `watch::Receiver` to close the window between the initial check and the subscription. Inside the state, `Disconnect` returns to `DisconnectedState`, `Block(reason)` defers to `ErrorState`, connectivity loss defers to `OfflineState`, and channel-drop falls back to `DisconnectedState`.

## Known tradeoff

For the `ConnectedState` tunnel-down -> reconnect path, if the account state has unexpectedly become non-Ready during the session (rare race), the preflight wait briefly leaves networking unrestricted instead of holding the killswitch as `ConnectingState::enter()` would have. This is a minor relaxation of the always-on killswitch guarantee during reconnect for users who explicitly rely on it. We can address this in a follow-up either by keeping the firewall up specifically for the `ConnectedState` reconnect path, or by adding an opt-in "strict killswitch during reconnect" setting.

## UI note

`Connecting::AwaitingAccountReadiness` is reused for the preflight wait, so users may briefly see *"Setting up your account (2/6)"* even when no firewall is applied. A follow-up that introduces an explicit account-preflight tunnel state with dedicated UI copy ("Checking subscription...") would be a small bindings-level change but is intentionally out of scope here.

## Test plan

- [x] `cargo check -p nym-vpn-lib` (clean)
- [x] `cargo fmt` (clean; pre-existing `imports_granularity` nightly-only warning is unrelated)
- [ ] Manual repro: inactive-subscription account, click Connect -> expect immediate fallback to disconnected/no-plan UI with internet intact
- [ ] Manual repro: active-plan account during `Syncing` -> expect UI to show "Setting up your account" briefly without internet drop, then transition to ConnectingState when account becomes Ready
- [ ] Manual repro: reconnect after network drop on an active-plan connection -> expect no behavior change

## Files changed

- `nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/account_preflight_state.rs` *(new)*
- `nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/mod.rs` *(register new module)*
- `nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnected_state.rs` *(extract helpers, route Connect through preflight)*
- `nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs` *(route Connect through preflight)*
- `nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/offline_state.rs` *(route auto-reconnect through preflight)*
- `nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs` *(route tunnel-down reconnect through preflight)*
- `nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnecting_state.rs` *(route Reconnect action through preflight)*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5504)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added account preflight validation state to the tunnel connection flow, integrated across all state transitions to ensure account readiness before establishing connections.

* **Refactor**
  * Refactored networking reset and tunnel settings application logic into dedicated helper methods for improved code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->