### PR TITLE
fix(app): confirm before mode switch interrupts the VPN tunnel

### DIFF
--- a/nym-vpn-app/CHANGELOG.md
+++ b/nym-vpn-app/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Allow adding custom apps (user selected) to split tunneling for Windows & Linux
 
+### Changed
+
+- Mode switch (Fast/Mixnet) now asks for confirmation when the VPN is connected, connecting, or about to auto-reconnect. Previously, simply clicking the other mode tab would trigger an immediate disconnect/reconnect, surprising users who only wanted to view the other mode.
+
 ## [1.30.0] - 2026-05-29
 
 ### Fixed

--- a/nym-vpn-app/src/i18n/en/home.json
+++ b/nym-vpn-app/src/i18n/en/home.json
@@ -20,7 +20,15 @@
   "random-server": "Random server",
   "mode-toggle": {
     "fast": "Fast",
-    "mixnet": "Mixnet"
+    "mixnet": "Mixnet",
+    "switch-confirm": {
+      "title-connected": "Switch to {{mode}} mode?",
+      "title-connecting": "Switch to {{mode}} mode?",
+      "description-connected": "Switching modes will disconnect your VPN. You'll need to reconnect afterwards.",
+      "description-connecting": "Switching modes will cancel the current connection.",
+      "confirm": "Switch and disconnect",
+      "cancel": "Cancel"
+    }
   },
   "snackbar-disabled-message": {
     "connected": "Disabled while connected to VPN",

--- a/nym-vpn-app/src/screens/home/ModeToggle.tsx
+++ b/nym-vpn-app/src/screens/home/ModeToggle.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { motion } from 'motion/react';
 import clsx from 'clsx';
 import { invoke } from '@tauri-apps/api/core';
@@ -10,6 +11,7 @@ import {
 } from '../../assets/icons/gateway-mode';
 import { dispatch, useAppStore, useFetchGateways } from '../../store';
 import { useToast } from '../../hooks';
+import { ConfirmationDialog } from '../../ui';
 import { GatewaySelectionAlgorithm, VpnMode } from '../../types';
 
 const MODES = [
@@ -20,20 +22,41 @@ const MODES = [
 
 type Mode = (typeof MODES)[number]['id'];
 
+// VPN states where switching mode would visibly interrupt the user.
+// For these states we surface a confirmation dialog before proceeding.
+// Other states (disconnected, disconnecting, error, offline, unknown) either
+// have nothing active to interrupt or are already in a transition, so we
+// switch silently as before.
+const INTERRUPTIVE_STATES = new Set<string>([
+  'connected',
+  'connecting',
+  'offline-auto-reconnect',
+]);
+
 export const ModeToggle = () => {
   const { t } = useTranslation('home');
   const { add } = useToast();
   const fetchGateways = useFetchGateways();
 
-  const { algo, vpnMode, gatewaySelectionAlgorithmConfig /*, exitNode */ } =
+  const { algo, vpnMode, gatewaySelectionAlgorithmConfig, state /*, exitNode */ } =
     useAppStore(
       useShallow((s) => ({
         algo: s.gatewaySelectionAlgorithmConfig.gatewaySelectionAlgorithm,
         vpnMode: s.vpnMode,
         gatewaySelectionAlgorithmConfig: s.gatewaySelectionAlgorithmConfig,
+        state: s.state,
         // exitNode: s.exitNode,
       })),
     );
+
+  // Pending mode the user has clicked but not yet confirmed. When non-null,
+  // the confirmation dialog is open. We keep the requested mode here so the
+  // dialog can render the target mode name and the Confirm handler can apply it.
+  const [pendingMode, setPendingMode] = useState<Mode | null>(null);
+  // Set while the confirm handler is awaiting backend acknowledgment of the
+  // mode switch. Drives the loading indicator on the dialog's Confirm button
+  // and blocks double-clicks.
+  const [confirmInFlight, setConfirmInFlight] = useState(false);
 
   const selected: Mode =
     // algo === 'auto' || algo === 'autoEntryExplicitExit'
@@ -92,8 +115,9 @@ export const ModeToggle = () => {
     }
   };
 
-  const handleSelect = async (mode: Mode) => {
-    if (mode === selected) return;
+  // Actually apply the mode change. Extracted out of handleSelect so the
+  // confirmation dialog's "confirm" path can call it directly.
+  const performModeChange = async (mode: Mode) => {
     const vpnModeToSet =
       /* mode === 'auto' || */ mode === 'fast' ? 'wg' : 'mixnet';
     // For Auto, preserve any explicit exit pick: if exitNode is a real
@@ -138,34 +162,92 @@ export const ModeToggle = () => {
     }
   };
 
+  const handleSelect = async (mode: Mode) => {
+    if (mode === selected) return;
+    // If the VPN is currently doing something the user can see (connected,
+    // connecting, or about to auto-reconnect from offline), confirm before
+    // switching, because applying the new mode triggers an immediate
+    // disconnect/reconnect. Without the confirmation users have reported
+    // being kicked off the tunnel just to look at the other mode tab.
+    if (INTERRUPTIVE_STATES.has(state)) {
+      setPendingMode(mode);
+      return;
+    }
+    await performModeChange(mode);
+  };
+
+  const handleConfirmSwitch = async () => {
+    if (!pendingMode || confirmInFlight) return;
+    const mode = pendingMode;
+    setConfirmInFlight(true);
+    try {
+      await performModeChange(mode);
+    } finally {
+      setConfirmInFlight(false);
+      setPendingMode(null);
+    }
+  };
+
+  const handleCancelSwitch = () => {
+    if (confirmInFlight) return;
+    setPendingMode(null);
+  };
+
+  // Choose the title/description copy based on whether the user is mid-connect
+  // or fully connected. Distinguishing these keeps the wording honest about
+  // what gets interrupted (a live session vs an in-flight handshake).
+  const dialogVariant =
+    state === 'connecting' ? 'connecting' : 'connected';
+  const dialogTitle = pendingMode
+    ? t(`mode-toggle.switch-confirm.title-${dialogVariant}`, {
+        mode: t(`mode-toggle.${pendingMode}`),
+      })
+    : '';
+  const dialogDescription = t(
+    `mode-toggle.switch-confirm.description-${dialogVariant}`,
+  );
+
   return (
-    <div className="bg-surface-bg relative flex items-center gap-2 rounded-full p-0.5">
-      {MODES.map((mode) => {
-        const isSelected = selected === mode.id;
-        return (
-          <button
-            key={mode.id}
-            type="button"
-            onClick={() => handleSelect(mode.id)}
-            className={clsx(
-              'relative flex flex-1 cursor-default items-center justify-center gap-1.5 rounded-full px-4.5 py-2.5 text-sm font-bold transition-colors',
-              isSelected
-                ? 'text-primary'
-                : 'text-text-secondary hover:bg-surface-elev',
-            )}
-          >
-            {isSelected && (
-              <motion.div
-                layoutId="mode-toggle-pill"
-                className="bg-surface-elev absolute inset-0 rounded-full"
-                transition={{ duration: 0.3, ease: 'easeOut' }}
-              />
-            )}
-            <mode.Icon className="z-10 h-4 w-auto" />
-            <span className="z-10">{t(`mode-toggle.${mode.id}`)}</span>
-          </button>
-        );
-      })}
-    </div>
+    <>
+      <div className="bg-surface-bg relative flex items-center gap-2 rounded-full p-0.5">
+        {MODES.map((mode) => {
+          const isSelected = selected === mode.id;
+          return (
+            <button
+              key={mode.id}
+              type="button"
+              onClick={() => handleSelect(mode.id)}
+              className={clsx(
+                'relative flex flex-1 cursor-default items-center justify-center gap-1.5 rounded-full px-4.5 py-2.5 text-sm font-bold transition-colors',
+                isSelected
+                  ? 'text-primary'
+                  : 'text-text-secondary hover:bg-surface-elev',
+              )}
+            >
+              {isSelected && (
+                <motion.div
+                  layoutId="mode-toggle-pill"
+                  className="bg-surface-elev absolute inset-0 rounded-full"
+                  transition={{ duration: 0.3, ease: 'easeOut' }}
+                />
+              )}
+              <mode.Icon className="z-10 h-4 w-auto" />
+              <span className="z-10">{t(`mode-toggle.${mode.id}`)}</span>
+            </button>
+          );
+        })}
+      </div>
+      <ConfirmationDialog
+        icon="swap_horiz"
+        title={dialogTitle}
+        description={dialogDescription}
+        confirmButtonText={t('mode-toggle.switch-confirm.confirm')}
+        cancelButtonText={t('mode-toggle.switch-confirm.cancel')}
+        isOpen={pendingMode !== null}
+        isLoading={confirmInFlight}
+        onConfirm={handleConfirmSwitch}
+        onCancel={handleCancelSwitch}
+      />
+    </>
   );
 };

--- a/nym-vpn-app/src/screens/home/ModeToggle.tsx
+++ b/nym-vpn-app/src/screens/home/ModeToggle.tsx
@@ -38,16 +38,20 @@ export const ModeToggle = () => {
   const { add } = useToast();
   const fetchGateways = useFetchGateways();
 
-  const { algo, vpnMode, gatewaySelectionAlgorithmConfig, state /*, exitNode */ } =
-    useAppStore(
-      useShallow((s) => ({
-        algo: s.gatewaySelectionAlgorithmConfig.gatewaySelectionAlgorithm,
-        vpnMode: s.vpnMode,
-        gatewaySelectionAlgorithmConfig: s.gatewaySelectionAlgorithmConfig,
-        state: s.state,
-        // exitNode: s.exitNode,
-      })),
-    );
+  const {
+    algo,
+    vpnMode,
+    gatewaySelectionAlgorithmConfig,
+    state /*, exitNode */,
+  } = useAppStore(
+    useShallow((s) => ({
+      algo: s.gatewaySelectionAlgorithmConfig.gatewaySelectionAlgorithm,
+      vpnMode: s.vpnMode,
+      gatewaySelectionAlgorithmConfig: s.gatewaySelectionAlgorithmConfig,
+      state: s.state,
+      // exitNode: s.exitNode,
+    })),
+  );
 
   // Pending mode the user has clicked but not yet confirmed. When non-null,
   // the confirmation dialog is open. We keep the requested mode here so the
@@ -203,8 +207,7 @@ export const ModeToggle = () => {
   // Choose the title/description copy based on whether the user is mid-connect
   // or fully connected. Distinguishing these keeps the wording honest about
   // what gets interrupted (a live session vs an in-flight handshake).
-  const dialogVariant =
-    state === 'connecting' ? 'connecting' : 'connected';
+  const dialogVariant = state === 'connecting' ? 'connecting' : 'connected';
   const dialogTitle = pendingMode
     ? t(`mode-toggle.switch-confirm.title-${dialogVariant}`, {
         mode: t(`mode-toggle.${pendingMode}`),

--- a/nym-vpn-app/src/screens/home/ModeToggle.tsx
+++ b/nym-vpn-app/src/screens/home/ModeToggle.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { motion } from 'motion/react';
 import clsx from 'clsx';
 import { invoke } from '@tauri-apps/api/core';
@@ -57,6 +57,11 @@ export const ModeToggle = () => {
   // mode switch. Drives the loading indicator on the dialog's Confirm button
   // and blocks double-clicks.
   const [confirmInFlight, setConfirmInFlight] = useState(false);
+  // Synchronous re-entry guard. `confirmInFlight` is React state, so it only
+  // disables the Confirm button on the next render; two very fast clicks can
+  // both pass the `confirmInFlight` check before that render lands and fire
+  // performModeChange twice. The ref flips synchronously, closing that window.
+  const confirmLockRef = useRef(false);
 
   const selected: Mode =
     // algo === 'auto' || algo === 'autoEntryExplicitExit'
@@ -177,12 +182,14 @@ export const ModeToggle = () => {
   };
 
   const handleConfirmSwitch = async () => {
-    if (!pendingMode || confirmInFlight) return;
+    if (!pendingMode || confirmLockRef.current) return;
     const mode = pendingMode;
+    confirmLockRef.current = true;
     setConfirmInFlight(true);
     try {
       await performModeChange(mode);
     } finally {
+      confirmLockRef.current = false;
       setConfirmInFlight(false);
       setPendingMode(null);
     }


### PR DESCRIPTION
## Problem

In `ModeToggle.tsx`, clicking the **Fast** or **Mixnet** pill while a VPN tunnel is active (or mid-connect) immediately fires `invoke('set_vpn_mode', ...)` and `invoke('set_gateway_selection_algorithm', ...)`. The daemon then disconnects the running tunnel and re-establishes it with the new mode. The user is given no chance to back out.

Reproduced live against `nym-vpn-app 1.30.0` while connected through `wg` (Fast) mode: a single tap on the **Mixnet** pill triggers an immediate `Disconnecting to reconnect` in the daemon log, drops the WireGuard tunnel, and starts a Mixnet handshake. Especially painful for users on slow/constrained networks where any reconnect is expensive (visible in logs as multiple WireGuard retry attempts before falling back to the bridge / port 4443).

## Fix

Pure UI change inside `ModeToggle.tsx`. Before applying a mode change, check the current tunnel state:

- If `state` is in `INTERRUPTIVE_STATES = {connected, connecting, offline-auto-reconnect}`, open the existing `ConfirmationDialog` with a mode-aware title and description.
- Otherwise (disconnected / disconnecting / error / offline / unknown), apply the change immediately - matching the previous behavior.

The dialog reuses the existing `ConfirmationDialog` component (Headless UI Dialog under the hood, with focus trapping and backdrop-click dismissal). `confirmInFlight` guards against double-clicks. Cancel keeps the previous mode and leaves the tunnel untouched; Confirm runs the existing `applyAlgorithm` -> `applyVpnMode` flow with the same rollback semantics as before.

i18n strings are added under `home.mode-toggle.switch-confirm.*` with separate descriptions for `connected` (will disconnect your VPN) and `connecting` (will cancel the current connection).

## Test plan

- [x] `cargo check` (workspace, clean)
- [x] No new TypeScript surface for the daemon - frontend-only change
- [ ] Connected in Fast mode, tap Mixnet -> confirmation dialog appears with "Switch to Mixnet mode?"; Cancel keeps tunnel + mode; Confirm disconnects and reconnects on Mixnet
- [ ] Mid-connect, tap the other mode -> confirmation dialog appears with "cancel the current connection" copy; Cancel preserves in-progress connect
- [ ] In `disconnected` state, tap the other mode -> no dialog, mode switches immediately (matches previous behavior)
- [ ] Backdrop click on the dialog -> treated as Cancel
- [ ] Rapid double-tap on Confirm -> only one invocation runs (`confirmInFlight` guard)

## Files changed

- `nym-vpn-app/src/screens/home/ModeToggle.tsx`
- `nym-vpn-app/src/i18n/en/home.json`
- `nym-vpn-app/CHANGELOG.md`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5505)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a confirmation dialog when switching VPN modes (Fast ↔ Mixnet) if the VPN is connected, currently connecting, or about to auto-reconnect.

* **Localization**
  * Added English strings for the confirmation flow: separate titles/descriptions for connected vs connecting, plus confirm and cancel labels.

* **Documentation**
  * Updated changelog entry describing the new confirmation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->