### PR TITLE
NYM-1502: Fix crash in connectivity callback

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [Android] Diagnostic doesn't panic because of uninitialized context (https://github.com/nymtech/nym-vpn-client/pull/5415)
-
+- [Windows] Fix a crash when the network reconnected (https://github.com/nymtech/nym-vpn-client/pull/5508)
 
 ## [1.30] - 2026-05-29
 

--- a/nym-vpn-core/crates/nym-offline-monitor/src/windows.rs
+++ b/nym-vpn-core/crates/nym-offline-monitor/src/windows.rs
@@ -53,6 +53,7 @@ impl BroadcastListener {
             },
             notify_tx,
             pending_online_cancel: None,
+            rt_handle: tokio::runtime::Handle::current(),
         }));
 
         let state = system_state.clone();
@@ -183,8 +184,12 @@ enum StateChange {
 struct SystemState {
     connectivity: ConnectivityInner,
     notify_tx: watch::Sender<Connectivity>,
+
     /// Cancels a pending "Connected" notification during the stabilisation delay.
     pending_online_cancel: Option<CancellationToken>,
+
+    /// Tokio runtime handle to run callbacks in
+    rt_handle: tokio::runtime::Handle,
 }
 
 impl SystemState {
@@ -222,7 +227,7 @@ impl SystemState {
                 self.pending_online_cancel = Some(cancel.clone());
                 let notify_tx = self.notify_tx.clone();
                 let online_connectivity = self.connectivity.into_connectivity();
-                tokio::spawn(async move {
+                self.rt_handle.spawn(async move {
                     tokio::select! {
                         _ = tokio::time::sleep(ONLINE_STABILIZATION_DELAY) => {
                             tracing::info!("Connectivity changed: Connected");


### PR DESCRIPTION
## Ticket

JIRA-NYM-1502

## Description

When the connection is re-established the callback thread was not running in a `tokio`-managed thread which caused a panic.

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5509)
<!-- Reviewable:end -->
