### PR TITLE
LP firewalled by allowed_endpoints

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Android] Diagnostic doesn't panic because of uninitialized context (https://github.com/nymtech/nym-vpn-client/pull/5415)
 - [Windows] Fix a crash when the network reconnected (https://github.com/nymtech/nym-vpn-client/pull/5508)
+- [Linux] LP firewalled by allowed_endpoints (https://github.com/nymtech/nym-vpn-client/pull/5516)
 
 ## [1.30] - 2026-05-29
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -889,22 +889,6 @@ impl ConnectingPolicyParameters {
             })
             .collect::<Vec<_>>();
 
-        // Allow LP control endpoints for LP-based registration.
-        peer_endpoints.extend(
-            self.lp_entry_endpoints
-                .iter()
-                .filter(|addr| addr.is_ipv4() || (self.enable_ipv6 && addr.is_ipv6()))
-                .map(|addr| {
-                    AllowedEndpoint::new(
-                        Endpoint::from_socket_address(*addr, TransportProtocol::Tcp),
-                        #[cfg(any(target_os = "linux", target_os = "macos"))]
-                        AllowedClients::Root,
-                        #[cfg(target_os = "windows")]
-                        AllowedClients::current_exe(),
-                    )
-                }),
-        );
-
         // Allow WireGuard and entry endpoint
         if let Some(addr) = self.wg_entry_endpoint {
             if addr.is_ipv4() || (self.enable_ipv6 && addr.is_ipv6()) {
@@ -938,7 +922,7 @@ impl ConnectingPolicyParameters {
             });
 
         // Allow API endpoints
-        let allowed_endpoints = self
+        let mut allowed_endpoints = self
             .api_endpoints
             .iter()
             .filter(|ip| ip.is_ipv4() || (self.enable_ipv6 && ip.is_ipv6()))
@@ -952,6 +936,23 @@ impl ConnectingPolicyParameters {
                 )
             })
             .collect::<Vec<_>>();
+
+        // Allow LP control endpoints for LP-based registration.
+        allowed_endpoints.extend(
+            self.lp_entry_endpoints
+                .iter()
+                .filter(|addr| addr.is_ipv4() || (self.enable_ipv6 && addr.is_ipv6()))
+                .map(|addr| {
+                    tracing::info!("In policy lp ep: {addr}");
+                    AllowedEndpoint::new(
+                        Endpoint::from_socket_address(*addr, TransportProtocol::Tcp),
+                        #[cfg(any(target_os = "linux", target_os = "macos"))]
+                        AllowedClients::Root,
+                        #[cfg(target_os = "windows")]
+                        AllowedClients::current_exe(),
+                    )
+                }),
+        );
 
         let tunnel = self
             .tunnel_interface


### PR DESCRIPTION
## Ticket

JIRA-NYM-1514

## Description

LP is used only at `Connecting` phase, so its endpoints should be included in the `allowed_endpoints` instead.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5516)
<!-- Reviewable:end -->
