### PR TITLE
Cherry-pick LP firewalled by allowed_endpoints (#5516)

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Android] Diagnostic doesn't panic because of uninitialized context (https://github.com/nymtech/nym-vpn-client/pull/5415)
 - [Windows] Fix a crash when the network reconnected (https://github.com/nymtech/nym-vpn-client/pull/5508)
+- [Linux] LP firewalled by allowed_endpoints (https://github.com/nymtech/nym-vpn-client/pull/5516)
 
 ## [1.30] - 2026-05-29
 

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -5168,7 +5168,7 @@ dependencies = [
 
 [[package]]
 name = "nym-apple-network"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "block2",
  "dispatch2",
@@ -5277,7 +5277,7 @@ dependencies = [
 
 [[package]]
 name = "nym-cgroup"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "anyhow",
  "log",
@@ -5425,7 +5425,7 @@ dependencies = [
 
 [[package]]
 name = "nym-common"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "tracing",
  "tracing-test",
@@ -5471,12 +5471,12 @@ dependencies = [
 
 [[package]]
 name = "nym-connection-monitor"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "async-trait",
  "futures",
  "nix 0.31.3",
- "nym-common 2026.11.0-beta",
+ "nym-common 2026.11.0-beta.1",
  "pretty_assertions",
  "socket2 0.6.3",
  "surge-ping",
@@ -5643,7 +5643,7 @@ dependencies = [
 
 [[package]]
 name = "nym-dbus"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "dbus",
  "libc",
@@ -5654,7 +5654,7 @@ dependencies = [
 
 [[package]]
 name = "nym-diagnostic"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5703,13 +5703,13 @@ dependencies = [
 
 [[package]]
 name = "nym-dns"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "duct",
  "futures",
  "inotify",
  "nix 0.31.3",
- "nym-common 2026.11.0-beta",
+ "nym-common 2026.11.0-beta.1",
  "nym-dbus",
  "nym-routing",
  "nym-windows",
@@ -5766,7 +5766,7 @@ dependencies = [
 
 [[package]]
 name = "nym-exclude"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "nix 0.31.3",
  "nym-cgroup",
@@ -5787,7 +5787,7 @@ dependencies = [
 
 [[package]]
 name = "nym-firewall"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "ipnetwork",
  "libc",
@@ -5796,7 +5796,7 @@ dependencies = [
  "nftnl",
  "nix 0.31.3",
  "nym-cgroup",
- "nym-common 2026.11.0-beta",
+ "nym-common 2026.11.0-beta.1",
  "nym-firewall-config",
  "nym-platform-metadata",
  "pfctl",
@@ -5809,7 +5809,7 @@ dependencies = [
 
 [[package]]
 name = "nym-firewall-config"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "ipnetwork",
 ]
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "nym-gateway-directory"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "anyhow",
  "ipnetwork",
@@ -5992,7 +5992,7 @@ dependencies = [
 
 [[package]]
 name = "nym-ifconfig"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "bitflags 2.11.0",
  "futures",
@@ -6045,7 +6045,7 @@ dependencies = [
 
 [[package]]
 name = "nym-ipc"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6138,7 +6138,7 @@ dependencies = [
 
 [[package]]
 name = "nym-macos"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "nix 0.31.3",
  "tokio",
@@ -6296,14 +6296,14 @@ dependencies = [
 
 [[package]]
 name = "nym-offline-monitor"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "async-trait",
  "debounced",
  "dispatch2",
  "futures",
  "nym-apple-network",
- "nym-common 2026.11.0-beta",
+ "nym-common 2026.11.0-beta.1",
  "nym-routing",
  "nym-windows",
  "thiserror 2.0.18",
@@ -6362,7 +6362,7 @@ dependencies = [
 
 [[package]]
 name = "nym-platform-metadata"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "nym-bin-common",
  "nym-dbus",
@@ -6420,14 +6420,14 @@ dependencies = [
 
 [[package]]
 name = "nym-routing"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "bitflags 2.11.0",
  "futures",
  "ipnetwork",
  "libc",
  "nix 0.31.3",
- "nym-common 2026.11.0-beta",
+ "nym-common 2026.11.0-beta.1",
  "nym-windows",
  "rtnetlink",
  "system-configuration 0.7.0",
@@ -6533,7 +6533,7 @@ dependencies = [
 
 [[package]]
 name = "nym-setup"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -6576,7 +6576,7 @@ dependencies = [
 
 [[package]]
 name = "nym-socks5-proxy"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -6615,7 +6615,7 @@ dependencies = [
 
 [[package]]
 name = "nym-socks5-proxy-ipc"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -6808,7 +6808,7 @@ dependencies = [
 
 [[package]]
 name = "nym-split-tunnel"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "bitflags 2.11.0",
  "bytes",
@@ -6822,7 +6822,7 @@ dependencies = [
  "nftnl",
  "nix 0.31.3",
  "nym-cgroup",
- "nym-common 2026.11.0-beta",
+ "nym-common 2026.11.0-beta.1",
  "nym-dbus",
  "nym-firewall",
  "nym-firewall-config",
@@ -6859,7 +6859,7 @@ dependencies = [
 
 [[package]]
 name = "nym-statistics"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "futures",
  "nym-bin-common",
@@ -6880,7 +6880,7 @@ dependencies = [
 
 [[package]]
 name = "nym-statistics-api-client"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "nym-http-api-client",
  "nym-statistics-common",
@@ -7048,7 +7048,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-account-controller"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -7058,7 +7058,7 @@ dependencies = [
  "bs58",
  "futures",
  "hkdf",
- "nym-common 2026.11.0-beta",
+ "nym-common 2026.11.0-beta.1",
  "nym-compact-ecash",
  "nym-credential-proxy-requests",
  "nym-credential-storage",
@@ -7101,7 +7101,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-api-client"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "async-trait",
  "backon",
@@ -7110,7 +7110,7 @@ dependencies = [
  "bs58",
  "hex",
  "itertools 0.14.0",
- "nym-common 2026.11.0-beta",
+ "nym-common 2026.11.0-beta.1",
  "nym-compact-ecash",
  "nym-config",
  "nym-contracts-common",
@@ -7137,7 +7137,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-lib"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "adblock",
  "anyhow",
@@ -7172,7 +7172,7 @@ dependencies = [
  "nym-bin-common",
  "nym-cgroup",
  "nym-client-core",
- "nym-common 2026.11.0-beta",
+ "nym-common 2026.11.0-beta.1",
  "nym-config",
  "nym-connection-monitor",
  "nym-credentials-interface",
@@ -7253,7 +7253,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-lib-types"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "bip39",
  "ipnetwork",
@@ -7283,7 +7283,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-lib-uniffi"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "async-trait",
  "inventory",
@@ -7294,7 +7294,7 @@ dependencies = [
  "jni 0.22.4",
  "log",
  "ndk-context",
- "nym-common 2026.11.0-beta",
+ "nym-common 2026.11.0-beta.1",
  "nym-firewall-config",
  "nym-gateway-directory",
  "nym-http-api-client",
@@ -7325,10 +7325,10 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-network-config"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "itertools 0.14.0",
- "nym-common 2026.11.0-beta",
+ "nym-common 2026.11.0-beta.1",
  "nym-http-api-client",
  "nym-network-defaults",
  "nym-offline-monitor",
@@ -7349,7 +7349,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-proto"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "hyper 1.9.0",
  "nym-ipc",
@@ -7368,10 +7368,10 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-rpc-uniffi"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "futures",
- "nym-common 2026.11.0-beta",
+ "nym-common 2026.11.0-beta.1",
  "nym-vpn-lib-types",
  "nym-vpn-proto",
  "tokio",
@@ -7382,7 +7382,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-store"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7406,7 +7406,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpnc"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "anyhow",
  "celes",
@@ -7422,7 +7422,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpnd"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -7465,7 +7465,7 @@ dependencies = [
 
 [[package]]
 name = "nym-wg-go"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "hex",
  "ipnetwork",
@@ -7481,7 +7481,7 @@ dependencies = [
 
 [[package]]
 name = "nym-wg-metadata-client"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "nym-credentials-interface",
  "nym-gateway-directory",
@@ -7496,7 +7496,7 @@ dependencies = [
 
 [[package]]
 name = "nym-windows"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "bitflags 2.11.0",
  "futures",
@@ -10825,7 +10825,7 @@ dependencies = [
 
 [[package]]
 name = "test-manager"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "anyhow",
  "async-tempfile",
@@ -10870,7 +10870,7 @@ dependencies = [
 
 [[package]]
 name = "test-rpc"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -10895,7 +10895,7 @@ dependencies = [
 
 [[package]]
 name = "test-runner"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "bytes",
  "dirs",
@@ -10921,7 +10921,7 @@ dependencies = [
 
 [[package]]
 name = "test_macro"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11885,7 +11885,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi-bindgen"
-version = "2026.11.0-beta"
+version = "2026.11.0-beta.1"
 dependencies = [
  "uniffi",
 ]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -889,22 +889,6 @@ impl ConnectingPolicyParameters {
             })
             .collect::<Vec<_>>();
 
-        // Allow LP control endpoints for LP-based registration.
-        peer_endpoints.extend(
-            self.lp_entry_endpoints
-                .iter()
-                .filter(|addr| addr.is_ipv4() || (self.enable_ipv6 && addr.is_ipv6()))
-                .map(|addr| {
-                    AllowedEndpoint::new(
-                        Endpoint::from_socket_address(*addr, TransportProtocol::Tcp),
-                        #[cfg(any(target_os = "linux", target_os = "macos"))]
-                        AllowedClients::Root,
-                        #[cfg(target_os = "windows")]
-                        AllowedClients::current_exe(),
-                    )
-                }),
-        );
-
         // Allow WireGuard and entry endpoint
         if let Some(addr) = self.wg_entry_endpoint {
             if addr.is_ipv4() || (self.enable_ipv6 && addr.is_ipv6()) {
@@ -938,7 +922,7 @@ impl ConnectingPolicyParameters {
             });
 
         // Allow API endpoints
-        let allowed_endpoints = self
+        let mut allowed_endpoints = self
             .api_endpoints
             .iter()
             .filter(|ip| ip.is_ipv4() || (self.enable_ipv6 && ip.is_ipv6()))
@@ -952,6 +936,23 @@ impl ConnectingPolicyParameters {
                 )
             })
             .collect::<Vec<_>>();
+
+        // Allow LP control endpoints for LP-based registration.
+        allowed_endpoints.extend(
+            self.lp_entry_endpoints
+                .iter()
+                .filter(|addr| addr.is_ipv4() || (self.enable_ipv6 && addr.is_ipv6()))
+                .map(|addr| {
+                    tracing::info!("In policy lp ep: {addr}");
+                    AllowedEndpoint::new(
+                        Endpoint::from_socket_address(*addr, TransportProtocol::Tcp),
+                        #[cfg(any(target_os = "linux", target_os = "macos"))]
+                        AllowedClients::Root,
+                        #[cfg(target_os = "windows")]
+                        AllowedClients::current_exe(),
+                    )
+                }),
+        );
 
         let tunnel = self
             .tunnel_interface


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5520)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Resolved an issue on Linux where LP control endpoints were being incorrectly blocked by firewall policies, allowing proper connectivity during VPN connection establishment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->