### PR TITLE
[Feature] Account controller summary cache

### DIFF
--- a/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/api/VpnServiceApiImpl.kt
+++ b/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/api/VpnServiceApiImpl.kt
@@ -75,7 +75,7 @@ internal class VpnServiceApiImpl(private val core: VpnCoreController, override v
 
 	override suspend fun refreshAccount() {
 		Timber.tag(TAG).d("refreshAccount requested")
-		core.requireCoreSender { it.refreshAccount() }
+		core.requireCoreSender { it.refreshAccount(false) }
 	}
 
 	override suspend fun getAccountState(): AccountControllerState = core.requireCoreSender { it.getAccountState() }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/command_sender.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/command_sender.rs
@@ -143,6 +143,17 @@ impl AccountCommandSender {
         rx.await.map_err(AccountCommandError::internal)?
     }
 
+    /// Force a network sync with the VPN API, re-fetching the account summary rather than
+    /// re-evaluating the locally cached one.
+    #[instrument(skip(self))]
+    pub async fn force_refresh_account_state(&self) -> Result<(), AccountCommandError> {
+        let (tx, rx) = ReturnSender::new();
+        self.command_tx
+            .send(AccountCommand::ForceRefreshAccountState(tx))
+            .map_err(AccountCommandError::internal)?;
+        rx.await.map_err(AccountCommandError::internal)?
+    }
+
     #[instrument(skip(self))]
     pub async fn reset_device_identity(
         &self,
@@ -332,9 +343,11 @@ impl AccountCommandSender {
 
     #[instrument(skip(self))]
     pub async fn handle_subscription_payment(&self) -> Result<(), AccountCommandError> {
+        // A payment changes subscription status server-side, so we must re-fetch from the VPN API
+        // rather than re-evaluating the stale cached summary.
         let (tx, rx) = ReturnSender::new();
         self.command_tx
-            .send(AccountCommand::RefreshAccountState(tx))
+            .send(AccountCommand::ForceRefreshAccountState(tx))
             .map_err(AccountCommandError::internal)?;
         rx.await.map_err(AccountCommandError::internal)?
     }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/command_sender.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/command_sender.rs
@@ -135,21 +135,10 @@ impl AccountCommandSender {
     }
 
     #[instrument(skip(self))]
-    pub async fn background_refresh_account_state(&self) -> Result<(), AccountCommandError> {
+    pub async fn refresh_account_state(&self, force: bool) -> Result<(), AccountCommandError> {
         let (tx, rx) = ReturnSender::new();
         self.command_tx
-            .send(AccountCommand::RefreshAccountState(tx))
-            .map_err(AccountCommandError::internal)?;
-        rx.await.map_err(AccountCommandError::internal)?
-    }
-
-    /// Force a network sync with the VPN API, re-fetching the account summary rather than
-    /// re-evaluating the locally cached one.
-    #[instrument(skip(self))]
-    pub async fn force_refresh_account_state(&self) -> Result<(), AccountCommandError> {
-        let (tx, rx) = ReturnSender::new();
-        self.command_tx
-            .send(AccountCommand::ForceRefreshAccountState(tx))
+            .send(AccountCommand::RefreshAccountState(tx, force))
             .map_err(AccountCommandError::internal)?;
         rx.await.map_err(AccountCommandError::internal)?
     }
@@ -347,7 +336,7 @@ impl AccountCommandSender {
         // rather than re-evaluating the stale cached summary.
         let (tx, rx) = ReturnSender::new();
         self.command_tx
-            .send(AccountCommand::ForceRefreshAccountState(tx))
+            .send(AccountCommand::RefreshAccountState(tx, true))
             .map_err(AccountCommandError::internal)?;
         rx.await.map_err(AccountCommandError::internal)?
     }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/dispatch.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/dispatch.rs
@@ -49,8 +49,12 @@ pub enum AccountCommand {
     /// Reset the device identity, optionally take a seed for reproducibility
     ResetDeviceIdentity(ReturnSender<(), AccountCommandError>, Option<[u8; 32]>),
 
-    /// Forces the AC to sync with the VPN API
+    /// Re-evaluates the account state from the locally cached summary, without hitting the VPN API.
+    /// Falls back to a network sync if no summary is cached.
     RefreshAccountState(ReturnSender<(), AccountCommandError>),
+
+    /// Forces the AC to sync with the VPN API, re-fetching the account summary.
+    ForceRefreshAccountState(ReturnSender<(), AccountCommandError>),
 
     /// Tells the AC it's firewalled off the VPN API, so it should stop/pause network communication
     VpnApiFirewallUp(ReturnSender<(), AccountCommandError>),
@@ -78,6 +82,9 @@ impl AccountCommand {
             AccountCommand::ObtainTicketbooks(return_sender, _) => return_sender.send(Err(error)),
             AccountCommand::ResetDeviceIdentity(return_sender, _) => return_sender.send(Err(error)),
             AccountCommand::RefreshAccountState(return_sender) => return_sender.send(Err(error)),
+            AccountCommand::ForceRefreshAccountState(return_sender) => {
+                return_sender.send(Err(error))
+            }
             AccountCommand::VpnApiFirewallUp(return_sender) => return_sender.send(Err(error)),
             AccountCommand::VpnApiFirewallDown(return_sender) => return_sender.send(Err(error)),
             AccountCommand::Common(common_command) => match common_command {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/dispatch.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/dispatch.rs
@@ -49,12 +49,8 @@ pub enum AccountCommand {
     /// Reset the device identity, optionally take a seed for reproducibility
     ResetDeviceIdentity(ReturnSender<(), AccountCommandError>, Option<[u8; 32]>),
 
-    /// Re-evaluates the account state from the locally cached summary, without hitting the VPN API.
-    /// Falls back to a network sync if no summary is cached.
-    RefreshAccountState(ReturnSender<(), AccountCommandError>),
-
-    /// Forces the AC to sync with the VPN API, re-fetching the account summary.
-    ForceRefreshAccountState(ReturnSender<(), AccountCommandError>),
+    /// Re-evaluates the account state
+    RefreshAccountState(ReturnSender<(), AccountCommandError>, bool),
 
     /// Tells the AC it's firewalled off the VPN API, so it should stop/pause network communication
     VpnApiFirewallUp(ReturnSender<(), AccountCommandError>),
@@ -81,10 +77,7 @@ impl AccountCommand {
             AccountCommand::AccountBalance(return_sender) => return_sender.send(Err(error)),
             AccountCommand::ObtainTicketbooks(return_sender, _) => return_sender.send(Err(error)),
             AccountCommand::ResetDeviceIdentity(return_sender, _) => return_sender.send(Err(error)),
-            AccountCommand::RefreshAccountState(return_sender) => return_sender.send(Err(error)),
-            AccountCommand::ForceRefreshAccountState(return_sender) => {
-                return_sender.send(Err(error))
-            }
+            AccountCommand::RefreshAccountState(return_sender, _) => return_sender.send(Err(error)),
             AccountCommand::VpnApiFirewallUp(return_sender) => return_sender.send(Err(error)),
             AccountCommand::VpnApiFirewallDown(return_sender) => return_sender.send(Err(error)),
             AccountCommand::Common(common_command) => match common_command {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/handler.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/handler.rs
@@ -291,10 +291,7 @@ pub(crate) async fn handle_reset_device_identity<C: ConnectivityMonitor>(
         .map_err(AccountCommandError::storage)?; // Storage error
 
     // summary is now stale
-    let _ = shared_state
-        .storage_op_sender
-        .send(AccountStorageOp::RemoveAccountSummary);
-    shared_state.vpn_account_summary = None;
+    shared_state.mark_summary_as_stale();
 
     shared_state.device = Some(device);
 

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/handler.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/handler.rs
@@ -290,6 +290,12 @@ pub(crate) async fn handle_reset_device_identity<C: ConnectivityMonitor>(
         .map_err(AccountCommandError::internal)? // Channel error
         .map_err(AccountCommandError::storage)?; // Storage error
 
+    // summary is now stale
+    let _ = shared_state
+        .storage_op_sender
+        .send(AccountStorageOp::RemoveAccountSummary);
+    shared_state.vpn_account_summary = None;
+
     shared_state.device = Some(device);
 
     Ok(())

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/handler.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/handler.rs
@@ -175,6 +175,12 @@ pub(crate) async fn handle_forget_account<C: ConnectivityMonitor>(
             AccountCommandError::Storage(source.to_string())
         })?; // Handling account removal error
 
+    // Removing account summary
+    shared_state
+        .storage_op_sender
+        .send(AccountStorageOp::RemoveAccountSummary)
+        .map_err(AccountCommandError::internal)?;
+
     // Once we have removed or reset all storage, we need to reset the account state
     shared_state.vpn_api_account = None;
     shared_state.device = None;

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
@@ -110,13 +110,14 @@ where
 
         // Load the cached account summary (if any) so it is available before the first network
         // sync completes. A read failure is non-critical - treat it as no cache.
-        let cached_account_summary = account_storage
-            .load_account_summary()
-            .await
-            .unwrap_or_else(|err| {
-                tracing::warn!("Failed to load cached account summary: {err}");
-                None
-            });
+        let cached_account_summary =
+            account_storage
+                .load_account_summary()
+                .await
+                .unwrap_or_else(|err| {
+                    tracing::warn!("Failed to load cached account summary: {err}");
+                    None
+                });
 
         // Shared_state
         let shared_state = SharedAccountState::new(
@@ -142,7 +143,7 @@ where
         let (current_state_handler, initial_state) = if is_offline {
             OfflineState::enter()
         } else {
-            SyncingNetworkState::enter(&shared_state, 0, SyncMode::Optimistic)
+            SyncingNetworkState::enter(&shared_state, SyncMode::Optimistic)
         };
 
         let public_initial_state = AccountControllerState::from(initial_state);

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
@@ -19,7 +19,8 @@ use crate::{
     event_sender::AccountControllerEventReceiver,
     shared_state::SharedAccountState,
     state_machine::{
-        AccountControllerStateHandler, NextAccountControllerState, OfflineState, SyncingState,
+        AccountControllerStateHandler, NextAccountControllerState, OfflineState, SyncMode,
+        SyncingNetworkState,
     },
     storage::{AccountStorage, AccountStorageOp, VpnCredentialStorage},
 };
@@ -107,6 +108,16 @@ where
             }
         };
 
+        // Load the cached account summary (if any) so it is available before the first network
+        // sync completes. A read failure is non-critical - treat it as no cache.
+        let cached_account_summary = account_storage
+            .load_account_summary()
+            .await
+            .unwrap_or_else(|err| {
+                tracing::warn!("Failed to load cached account summary: {err}");
+                None
+            });
+
         // Shared_state
         let shared_state = SharedAccountState::new(
             connectivity_handle,
@@ -116,6 +127,7 @@ where
             nym_vpn_api_client,
             nyxd_client,
             vpn_api_account,
+            cached_account_summary,
             device_keys,
             storage_op_sender,
             event_channel,
@@ -130,7 +142,7 @@ where
         let (current_state_handler, initial_state) = if is_offline {
             OfflineState::enter()
         } else {
-            SyncingState::enter(&shared_state, 0)
+            SyncingNetworkState::enter(&shared_state, 0, SyncMode::Optimistic)
         };
 
         let public_initial_state = AccountControllerState::from(initial_state);

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/controller.rs
@@ -110,14 +110,19 @@ where
 
         // Load the cached account summary (if any) so it is available before the first network
         // sync completes. A read failure is non-critical - treat it as no cache.
-        let cached_account_summary =
+        let cached_account_summary = if vpn_api_account.is_some() {
             account_storage
                 .load_account_summary()
                 .await
                 .unwrap_or_else(|err| {
                     tracing::warn!("Failed to load cached account summary: {err}");
                     None
-                });
+                })
+        } else {
+            // If we don't have an account stored, make sure we don't have a summary either
+            let _ = account_storage.remove_account_summary().await;
+            None
+        };
 
         // Shared_state
         let shared_state = SharedAccountState::new(

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/error.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/error.rs
@@ -16,6 +16,11 @@ pub enum Error {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 
+    #[error("account summary store error")]
+    AccountSummaryStore {
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
     #[error("failed to setup account storage paths")]
     StoragePaths(#[source] Box<nym_sdk::Error>),
 

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/shared_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/shared_state.rs
@@ -98,4 +98,26 @@ impl<C: ConnectivityMonitor> SharedAccountState<C> {
             event_sender,
         }
     }
+
+    // Mark the summary as stale and best effort to propagate to disk
+    pub(crate) fn mark_summary_as_stale(&mut self) {
+        if let Some(summary) = self.vpn_account_summary.as_mut() {
+            summary.stale = true;
+            let _ = self
+                .storage_op_sender
+                .send(AccountStorageOp::StoreAccountSummary(Box::new(
+                    summary.clone(),
+                )));
+        }
+    }
+
+    // Store the account summary in memory and best effort to propagate to disk
+    pub(crate) fn store_summary(&mut self, summary: VpnAccountSummary) {
+        let _ = self
+            .storage_op_sender
+            .send(AccountStorageOp::StoreAccountSummary(Box::new(
+                summary.clone(),
+            )));
+        self.vpn_account_summary = Some(summary);
+    }
 }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/shared_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/shared_state.rs
@@ -44,7 +44,9 @@ pub(crate) struct SharedAccountState<C: ConnectivityMonitor> {
     /// Stored account
     pub(crate) vpn_api_account: Option<Arc<VpnAccount>>,
 
-    /// Account summary
+    /// Account summary. The persistent copy lives in the platform storage (see
+    /// [`AccountSummaryStorage`](nym_vpn_store::account_summary::AccountSummaryStorage)); this is the
+    /// in-memory working copy, kept in sync via the storage-op channel.
     pub(crate) vpn_account_summary: Option<VpnAccountSummary>,
 
     /// Registered device
@@ -73,6 +75,7 @@ impl<C: ConnectivityMonitor> SharedAccountState<C> {
         vpn_api_client: VpnApiClient,
         nyxd_client: NyxdClient,
         vpn_api_account: Option<VpnAccount>,
+        vpn_account_summary: Option<VpnAccountSummary>,
         device: Option<Device>,
         storage_op_sender: mpsc::UnboundedSender<AccountStorageOp>,
         event_sender: AccountControllerEventSender,
@@ -87,7 +90,7 @@ impl<C: ConnectivityMonitor> SharedAccountState<C> {
             vpn_api_client,
             nyxd_client,
             vpn_api_account: vpn_api_account.map(Arc::new),
-            vpn_account_summary: None,
+            vpn_account_summary,
             device,
             deeplinks,
             firewall_active: false,

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/error_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/error_state.rs
@@ -8,7 +8,8 @@ use crate::{
     commands::{AccountCommand, UpgradeModeCommand, common_handler, handler},
     state_machine::{
         ACCOUNT_UPDATE_INTERVAL, AccountControllerStateHandler, LoggedOutState,
-        NextAccountControllerState, OfflineState, PrivateAccountControllerState, SyncingState,
+        NextAccountControllerState, OfflineState, PrivateAccountControllerState, SyncMode,
+        SyncingNetworkState, syncing_state,
     },
 };
 use nym_offline_monitor::ConnectivityMonitor;
@@ -25,7 +26,8 @@ use tracing::warn;
 /// Crucially, we are online and an account is stored.
 ///
 /// Possible next state :
-/// - SyncingState : We go into that state on a timer, to see if the problem persists. The refresh account commands allows for manually go there
+/// - SyncingNetworkState : On a timer or a refresh command we optimistically re-sync to see if the
+///   problem persists; a force refresh drops the cached summary and re-syncs in mandatory mode
 /// - OfflineState : the connectivity monitor is telling we're not connected
 /// - LoggedOutState : We successfully handled a forget_account command
 pub struct ErrorState {
@@ -66,7 +68,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ErrorState {
                     tracing::debug!("VPN API is firewalled, timed account syncing skipped");
                     return NextAccountControllerState::NewState(ErrorState::enter(self.reason));
                 } else {
-                    return NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0));
+                    return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic));
                 }
             },
             Some(command) = command_rx.recv() => {
@@ -82,7 +84,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ErrorState {
                         let error = res.is_err();
                         return_sender.send(res);
                         if error {
-                            return NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0));
+                            return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic));
                         } else {
                             return NextAccountControllerState::NewState(LoggedOutState::enter());
                         }
@@ -104,7 +106,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ErrorState {
                         if error {
                             return NextAccountControllerState::SameState(self);
                         } else {
-                            return NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0));
+                            return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic));
                         }
                     },
                     AccountCommand::RefreshAccountState(return_sender) => {
@@ -112,7 +114,15 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ErrorState {
                         if shared_state.firewall_active {
                             return NextAccountControllerState::SameState(self);
                         } else {
-                            return NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0));
+                            return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic));
+                        }
+                    },
+                    AccountCommand::ForceRefreshAccountState(return_sender) => {
+                        return_sender.send(Ok(()));
+                        if shared_state.firewall_active {
+                            return NextAccountControllerState::SameState(self);
+                        } else {
+                            return syncing_state::force_refresh(shared_state);
                         }
                     },
 

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/error_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/error_state.rs
@@ -109,20 +109,16 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ErrorState {
                             return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic));
                         }
                     },
-                    AccountCommand::RefreshAccountState(return_sender) => {
+                    AccountCommand::RefreshAccountState(return_sender, force) => {
                         return_sender.send(Ok(()));
                         if shared_state.firewall_active {
                             return NextAccountControllerState::SameState(self);
                         } else {
-                            return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic));
-                        }
-                    },
-                    AccountCommand::ForceRefreshAccountState(return_sender) => {
-                        return_sender.send(Ok(()));
-                        if shared_state.firewall_active {
-                            return NextAccountControllerState::SameState(self);
-                        } else {
-                            return syncing_state::force_refresh(shared_state);
+                            if force {
+                                return syncing_state::force_refresh(shared_state);
+                            } else {
+                                return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic));
+                            }
                         }
                     },
 

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/error_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/error_state.rs
@@ -106,7 +106,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ErrorState {
                         if error {
                             return NextAccountControllerState::SameState(self);
                         } else {
-                            return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Optimistic));
+                            return syncing_state::force_refresh(shared_state); // If we succeed, we need to register the new device, we can't move with a cache we know is now stale
                         }
                     },
                     AccountCommand::RefreshAccountState(return_sender, force) => {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/error_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/error_state.rs
@@ -68,7 +68,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ErrorState {
                     tracing::debug!("VPN API is firewalled, timed account syncing skipped");
                     return NextAccountControllerState::NewState(ErrorState::enter(self.reason));
                 } else {
-                    return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic));
+                    return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Optimistic));
                 }
             },
             Some(command) = command_rx.recv() => {
@@ -84,7 +84,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ErrorState {
                         let error = res.is_err();
                         return_sender.send(res);
                         if error {
-                            return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic));
+                            return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Optimistic));
                         } else {
                             return NextAccountControllerState::NewState(LoggedOutState::enter());
                         }
@@ -106,7 +106,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ErrorState {
                         if error {
                             return NextAccountControllerState::SameState(self);
                         } else {
-                            return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic));
+                            return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Optimistic));
                         }
                     },
                     AccountCommand::RefreshAccountState(return_sender, force) => {
@@ -117,7 +117,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ErrorState {
                             if force {
                                 return syncing_state::force_refresh(shared_state);
                             } else {
-                                return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic));
+                                return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Optimistic));
                             }
                         }
                     },

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/error_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/error_state.rs
@@ -9,7 +9,7 @@ use crate::{
     state_machine::{
         ACCOUNT_UPDATE_INTERVAL, AccountControllerStateHandler, LoggedOutState,
         NextAccountControllerState, OfflineState, PrivateAccountControllerState, SyncMode,
-        SyncingNetworkState, syncing_state,
+        SyncingNetworkState,
     },
 };
 use nym_offline_monitor::ConnectivityMonitor;
@@ -106,7 +106,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ErrorState {
                         if error {
                             return NextAccountControllerState::SameState(self);
                         } else {
-                            return syncing_state::force_refresh(shared_state); // If we succeed, we need to register the new device, we can't move with a cache we know is now stale
+                            return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Mandatory));
                         }
                     },
                     AccountCommand::RefreshAccountState(return_sender, force) => {
@@ -115,7 +115,8 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ErrorState {
                             return NextAccountControllerState::SameState(self);
                         } else {
                             if force {
-                                return syncing_state::force_refresh(shared_state);
+                                shared_state.mark_summary_as_stale();
+                                return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Mandatory));
                             } else {
                                 return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Optimistic));
                             }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/logged_out_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/logged_out_state.rs
@@ -55,7 +55,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for LoggedOutState
                 match command {
                     AccountCommand::CreateAccount(return_sender) => {
                         return_sender.send(handler::handle_create_account(shared_state).await);
-                        return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic));
+                        return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Optimistic));
                     }
                     AccountCommand::StoreAccount(return_sender, storable_account) => {
                         return if let Err(e) = handler::handle_store_account(shared_state, storable_account).await{
@@ -63,7 +63,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for LoggedOutState
                             NextAccountControllerState::SameState(self)
                         } else {
                             return_sender.send(Ok(()));
-                            NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic))
+                            NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Optimistic))
                         }
                     },
                     AccountCommand::ForgetAccount(return_sender) => return_sender.send(Ok(())),

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/logged_out_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/logged_out_state.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     state_machine::{
         AccountControllerStateHandler, NextAccountControllerState, OfflineState,
-        PrivateAccountControllerState, SyncingState,
+        PrivateAccountControllerState, SyncMode, SyncingNetworkState,
     },
 };
 use nym_offline_monitor::ConnectivityMonitor;
@@ -27,7 +27,7 @@ use tracing::warn;
 ///
 ///
 /// Possible next state :
-/// - SyncingState : A successful store_account command handling leads us into SyncingState, to determine where we are at
+/// - SyncingNetworkState : A successful store_account command handling leads us into SyncingNetworkState, to determine where we are at
 /// - OfflineState : the connectivity monitor is telling we're not connected
 ///
 pub struct LoggedOutState;
@@ -55,7 +55,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for LoggedOutState
                 match command {
                     AccountCommand::CreateAccount(return_sender) => {
                         return_sender.send(handler::handle_create_account(shared_state).await);
-                        return NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0));
+                        return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic));
                     }
                     AccountCommand::StoreAccount(return_sender, storable_account) => {
                         return if let Err(e) = handler::handle_store_account(shared_state, storable_account).await{
@@ -63,7 +63,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for LoggedOutState
                             NextAccountControllerState::SameState(self)
                         } else {
                             return_sender.send(Ok(()));
-                            NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0))
+                            NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic))
                         }
                     },
                     AccountCommand::ForgetAccount(return_sender) => return_sender.send(Ok(())),
@@ -76,6 +76,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for LoggedOutState
 
                     AccountCommand::RegisterAccount(return_sender, _, _) => return_no_account(return_sender),
                     AccountCommand::RefreshAccountState(return_sender) => return_no_account(return_sender),
+                    AccountCommand::ForceRefreshAccountState(return_sender) => return_no_account(return_sender),
                     AccountCommand::VpnApiFirewallDown(return_sender) =>  {
                         shared_state.firewall_active = false;
                         return_sender.send(Ok(()));

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/logged_out_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/logged_out_state.rs
@@ -55,7 +55,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for LoggedOutState
                 match command {
                     AccountCommand::CreateAccount(return_sender) => {
                         return_sender.send(handler::handle_create_account(shared_state).await);
-                        return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Optimistic));
+                        return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Mandatory));
                     }
                     AccountCommand::StoreAccount(return_sender, storable_account) => {
                         return if let Err(e) = handler::handle_store_account(shared_state, storable_account).await{
@@ -63,7 +63,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for LoggedOutState
                             NextAccountControllerState::SameState(self)
                         } else {
                             return_sender.send(Ok(()));
-                            NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Optimistic))
+                            NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Mandatory))
                         }
                     },
                     AccountCommand::ForgetAccount(return_sender) => return_sender.send(Ok(())),

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/logged_out_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/logged_out_state.rs
@@ -75,8 +75,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for LoggedOutState
                     AccountCommand::ResetDeviceIdentity(return_sender, _) => return_sender.send(Ok(())),
 
                     AccountCommand::RegisterAccount(return_sender, _, _) => return_no_account(return_sender),
-                    AccountCommand::RefreshAccountState(return_sender) => return_no_account(return_sender),
-                    AccountCommand::ForceRefreshAccountState(return_sender) => return_no_account(return_sender),
+                    AccountCommand::RefreshAccountState(return_sender, _) => return_no_account(return_sender),
                     AccountCommand::VpnApiFirewallDown(return_sender) =>  {
                         shared_state.firewall_active = false;
                         return_sender.send(Ok(()));

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/mod.rs
@@ -35,8 +35,11 @@ pub use offline_state::OfflineState;
 /// Account stored, online, ready to connect
 pub(crate) use ready_state::ReadyState;
 
-/// Account stored, online, determining if we can't connect or not
-pub(crate) use syncing_state::SyncingState;
+/// Account stored, online, fetching the account summary from the VPN API
+pub(crate) use syncing_state::SyncingNetworkState;
+
+/// Whether a network sync is optimistic (short timeout, cache fallback) or mandatory
+pub(crate) use syncing_state::SyncMode;
 
 /// We're in the process of attempting to acquire a zk-nym
 pub(crate) use syncing_state::requesting_zknym_state::RequestingZkNymsState;

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/offline_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/offline_state.rs
@@ -119,7 +119,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for OfflineState {
                 if connectivity.is_offline() {
                     NextAccountControllerState::SameState(self)
                 } else {
-                    NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic))
+                    NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Optimistic))
                 }
             }
             _ = shutdown_token.cancelled() => {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/offline_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/offline_state.rs
@@ -70,8 +70,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for OfflineState {
                     // Same comment as above
                     AccountCommand::ResetDeviceIdentity(return_sender, _) => return_no_connectivity(return_sender),
 
-                    AccountCommand::RefreshAccountState(return_sender) => return_no_connectivity(return_sender),
-                    AccountCommand::ForceRefreshAccountState(return_sender) => return_no_connectivity(return_sender),
+                    AccountCommand::RefreshAccountState(return_sender, _) => return_no_connectivity(return_sender),
 
                     AccountCommand::VpnApiFirewallDown(return_sender) =>  {
                         shared_state.firewall_active = false;

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/offline_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/offline_state.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     state_machine::{
         AccountControllerStateHandler, NextAccountControllerState, PrivateAccountControllerState,
-        SyncingState,
+        SyncMode, SyncingNetworkState,
     },
 };
 use nym_offline_monitor::ConnectivityMonitor;
@@ -23,10 +23,10 @@ use tracing::warn;
 /// There is no assumption wrt to stored account and registered device
 /// Most of the commands can't be handled because of the lack of connectivity
 ///
-/// When the connectivity is restored, we go into SyncingState to get back on our feet
+/// When the connectivity is restored, we go into SyncingNetworkState to get back on our feet
 ///
 /// Possible next state :
-/// - SyncingState : Connectivity is back
+/// - SyncingNetworkState : Connectivity is back
 ///
 pub struct OfflineState;
 
@@ -71,6 +71,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for OfflineState {
                     AccountCommand::ResetDeviceIdentity(return_sender, _) => return_no_connectivity(return_sender),
 
                     AccountCommand::RefreshAccountState(return_sender) => return_no_connectivity(return_sender),
+                    AccountCommand::ForceRefreshAccountState(return_sender) => return_no_connectivity(return_sender),
 
                     AccountCommand::VpnApiFirewallDown(return_sender) =>  {
                         shared_state.firewall_active = false;
@@ -119,7 +120,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for OfflineState {
                 if connectivity.is_offline() {
                     NextAccountControllerState::SameState(self)
                 } else {
-                    NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0))
+                    NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic))
                 }
             }
             _ = shutdown_token.cancelled() => {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/pending_subscription_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/pending_subscription_state.rs
@@ -100,20 +100,16 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for PendingSubscri
                             return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic));
                         }
                     },
-                    AccountCommand::RefreshAccountState(return_sender) => {
+                    AccountCommand::RefreshAccountState(return_sender, force) => {
                         return_sender.send(Ok(()));
                         if shared_state.firewall_active {
                             return NextAccountControllerState::SameState(self);
                         } else {
-                            return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic));
-                        }
-                    },
-                    AccountCommand::ForceRefreshAccountState(return_sender) => {
-                        return_sender.send(Ok(()));
-                        if shared_state.firewall_active {
-                            return NextAccountControllerState::SameState(self);
-                        } else {
-                            return syncing_state::force_refresh(shared_state);
+                            if force {
+                                return syncing_state::force_refresh(shared_state);
+                            } else {
+                                return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic));
+                            }
                         }
                     },
                     AccountCommand::VpnApiFirewallDown(return_sender) => {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/pending_subscription_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/pending_subscription_state.rs
@@ -97,7 +97,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for PendingSubscri
                         if error {
                             return NextAccountControllerState::SameState(self);
                         } else {
-                            return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Optimistic));
+                            return syncing_state::force_refresh(shared_state);
                         }
                     },
                     AccountCommand::RefreshAccountState(return_sender, force) => {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/pending_subscription_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/pending_subscription_state.rs
@@ -59,7 +59,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for PendingSubscri
                     tracing::debug!("VPN API is firewalled, timed account syncing skipped");
                     return NextAccountControllerState::NewState(PendingSubscriptionState::enter());
                 } else {
-                    return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic));
+                    return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Optimistic));
                 }
             },
             Some(command) = command_rx.recv() => {
@@ -75,7 +75,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for PendingSubscri
                         let error = res.is_err();
                         return_sender.send(res);
                         if error {
-                            return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic));
+                            return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Optimistic));
                         } else {
                             return NextAccountControllerState::NewState(LoggedOutState::enter());
                         }
@@ -97,7 +97,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for PendingSubscri
                         if error {
                             return NextAccountControllerState::SameState(self);
                         } else {
-                            return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic));
+                            return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Optimistic));
                         }
                     },
                     AccountCommand::RefreshAccountState(return_sender, force) => {
@@ -108,7 +108,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for PendingSubscri
                             if force {
                                 return syncing_state::force_refresh(shared_state);
                             } else {
-                                return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic));
+                                return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Optimistic));
                             }
                         }
                     },

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/pending_subscription_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/pending_subscription_state.rs
@@ -8,7 +8,8 @@ use crate::{
     commands::{AccountCommand, UpgradeModeCommand, common_handler, handler},
     state_machine::{
         ACCOUNT_UPDATE_INTERVAL, AccountControllerStateHandler, LoggedOutState,
-        NextAccountControllerState, OfflineState, PrivateAccountControllerState, SyncingState,
+        NextAccountControllerState, OfflineState, PrivateAccountControllerState, SyncMode,
+        SyncingNetworkState, syncing_state,
     },
 };
 use nym_offline_monitor::ConnectivityMonitor;
@@ -22,7 +23,8 @@ use tracing::warn;
 /// We wait and then re-enter the syncing state to check if the subscription has become active.
 ///
 /// Possible next state:
-/// - SyncingState: on timer expiry or RefreshAccountState command
+/// - SyncingNetworkState: on timer expiry or a RefreshAccountState command (optimistic re-sync);
+///   a ForceRefreshAccountState command drops the cache and re-syncs in mandatory mode
 /// - OfflineState: connectivity monitor reports offline
 /// - LoggedOutState: successfully handled a forget_account command
 pub struct PendingSubscriptionState {
@@ -57,7 +59,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for PendingSubscri
                     tracing::debug!("VPN API is firewalled, timed account syncing skipped");
                     return NextAccountControllerState::NewState(PendingSubscriptionState::enter());
                 } else {
-                    return NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0));
+                    return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic));
                 }
             },
             Some(command) = command_rx.recv() => {
@@ -73,7 +75,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for PendingSubscri
                         let error = res.is_err();
                         return_sender.send(res);
                         if error {
-                            return NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0));
+                            return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic));
                         } else {
                             return NextAccountControllerState::NewState(LoggedOutState::enter());
                         }
@@ -95,7 +97,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for PendingSubscri
                         if error {
                             return NextAccountControllerState::SameState(self);
                         } else {
-                            return NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0));
+                            return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic));
                         }
                     },
                     AccountCommand::RefreshAccountState(return_sender) => {
@@ -103,7 +105,15 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for PendingSubscri
                         if shared_state.firewall_active {
                             return NextAccountControllerState::SameState(self);
                         } else {
-                            return NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0));
+                            return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic));
+                        }
+                    },
+                    AccountCommand::ForceRefreshAccountState(return_sender) => {
+                        return_sender.send(Ok(()));
+                        if shared_state.firewall_active {
+                            return NextAccountControllerState::SameState(self);
+                        } else {
+                            return syncing_state::force_refresh(shared_state);
                         }
                     },
                     AccountCommand::VpnApiFirewallDown(return_sender) => {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/pending_subscription_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/pending_subscription_state.rs
@@ -9,7 +9,7 @@ use crate::{
     state_machine::{
         ACCOUNT_UPDATE_INTERVAL, AccountControllerStateHandler, LoggedOutState,
         NextAccountControllerState, OfflineState, PrivateAccountControllerState, SyncMode,
-        SyncingNetworkState, syncing_state,
+        SyncingNetworkState,
     },
 };
 use nym_offline_monitor::ConnectivityMonitor;
@@ -97,7 +97,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for PendingSubscri
                         if error {
                             return NextAccountControllerState::SameState(self);
                         } else {
-                            return syncing_state::force_refresh(shared_state);
+                            return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Mandatory));
                         }
                     },
                     AccountCommand::RefreshAccountState(return_sender, force) => {
@@ -106,7 +106,8 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for PendingSubscri
                             return NextAccountControllerState::SameState(self);
                         } else {
                             if force {
-                                return syncing_state::force_refresh(shared_state);
+                                shared_state.mark_summary_as_stale();
+                                return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Mandatory));
                             } else {
                                 return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Optimistic));
                             }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/ready_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/ready_state.rs
@@ -9,7 +9,7 @@ use crate::{
     state_machine::{
         ACCOUNT_UPDATE_INTERVAL, AccountControllerStateHandler, LoggedOutState,
         NextAccountControllerState, OfflineState, PrivateAccountControllerState, SyncMode,
-        SyncingNetworkState, syncing_state,
+        SyncingNetworkState,
     },
 };
 use nym_offline_monitor::ConnectivityMonitor;
@@ -99,7 +99,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ReadyState {
                         if error {
                             return NextAccountControllerState::SameState(self);
                         } else {
-                            return syncing_state::force_refresh(shared_state);
+                            return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Mandatory));
                         }
                     },
                     AccountCommand::RefreshAccountState(return_sender, force) => {
@@ -108,7 +108,8 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ReadyState {
                             return NextAccountControllerState::SameState(self);
                         } else {
                             if force {
-                                return syncing_state::force_refresh(shared_state);
+                                shared_state.mark_summary_as_stale();
+                                return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Mandatory));
                             } else {
                                 return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Optimistic));
                             }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/ready_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/ready_state.rs
@@ -62,7 +62,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ReadyState {
                     tracing::debug!("VPN API is firewalled, timed account syncing skipped");
                     return NextAccountControllerState::NewState(ReadyState::enter());
                 } else {
-                    return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic));
+                    return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Optimistic));
                 }
             },
             Some(command) = command_rx.recv() => {
@@ -99,7 +99,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ReadyState {
                         if error {
                             return NextAccountControllerState::SameState(self);
                         } else {
-                            return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic));
+                            return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Optimistic));
                         }
                     },
                     AccountCommand::RefreshAccountState(return_sender, force) => {
@@ -110,7 +110,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ReadyState {
                             if force {
                                 return syncing_state::force_refresh(shared_state);
                             } else {
-                                return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic));
+                                return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Optimistic));
                             }
                         }
                     },

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/ready_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/ready_state.rs
@@ -102,20 +102,16 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ReadyState {
                             return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic));
                         }
                     },
-                    AccountCommand::RefreshAccountState(return_sender) => {
+                    AccountCommand::RefreshAccountState(return_sender, force) => {
                         return_sender.send(Ok(()));
                         if shared_state.firewall_active {
                             return NextAccountControllerState::SameState(self);
                         } else {
-                            return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic));
-                        }
-                    },
-                    AccountCommand::ForceRefreshAccountState(return_sender) => {
-                        return_sender.send(Ok(()));
-                        if shared_state.firewall_active {
-                            return NextAccountControllerState::SameState(self);
-                        } else {
-                            return syncing_state::force_refresh(shared_state);
+                            if force {
+                                return syncing_state::force_refresh(shared_state);
+                            } else {
+                                return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic));
+                            }
                         }
                     },
 

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/ready_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/ready_state.rs
@@ -99,7 +99,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ReadyState {
                         if error {
                             return NextAccountControllerState::SameState(self);
                         } else {
-                            return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Optimistic));
+                            return syncing_state::force_refresh(shared_state);
                         }
                     },
                     AccountCommand::RefreshAccountState(return_sender, force) => {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/ready_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/ready_state.rs
@@ -8,7 +8,8 @@ use crate::{
     commands::{AccountCommand, ReturnSender, UpgradeModeCommand, common_handler, handler},
     state_machine::{
         ACCOUNT_UPDATE_INTERVAL, AccountControllerStateHandler, LoggedOutState,
-        NextAccountControllerState, OfflineState, PrivateAccountControllerState, SyncingState,
+        NextAccountControllerState, OfflineState, PrivateAccountControllerState, SyncMode,
+        SyncingNetworkState, syncing_state,
     },
 };
 use nym_offline_monitor::ConnectivityMonitor;
@@ -25,7 +26,8 @@ use tracing::warn;
 /// - We have tickets in storage
 ///
 /// Possible next state :
-/// - SyncingState : We go into that state on a timer, to make sure the above still holds. The refresh account commands allows for manually go there
+/// - SyncingNetworkState : On a timer or a refresh command we optimistically re-sync to make sure
+///   the above still holds; a force refresh drops the cached summary and re-syncs in mandatory mode
 /// - OfflineState : the connectivity monitor is telling we're not connected
 /// - LoggedOutState : We successfully handled a forget_account command
 pub struct ReadyState {
@@ -60,7 +62,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ReadyState {
                     tracing::debug!("VPN API is firewalled, timed account syncing skipped");
                     return NextAccountControllerState::NewState(ReadyState::enter());
                 } else {
-                    return NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0));
+                    return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic));
                 }
             },
             Some(command) = command_rx.recv() => {
@@ -97,7 +99,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ReadyState {
                         if error {
                             return NextAccountControllerState::SameState(self);
                         } else {
-                            return NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0));
+                            return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic));
                         }
                     },
                     AccountCommand::RefreshAccountState(return_sender) => {
@@ -105,7 +107,15 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ReadyState {
                         if shared_state.firewall_active {
                             return NextAccountControllerState::SameState(self);
                         } else {
-                            return NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0));
+                            return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic));
+                        }
+                    },
+                    AccountCommand::ForceRefreshAccountState(return_sender) => {
+                        return_sender.send(Ok(()));
+                        if shared_state.firewall_active {
+                            return NextAccountControllerState::SameState(self);
+                        } else {
+                            return syncing_state::force_refresh(shared_state);
                         }
                     },
 

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/local_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/local_state.rs
@@ -56,7 +56,7 @@ const SUMMARY_STALE_AFTER: Duration = Duration::from_secs(24 * 60 * 60);
 /// - OfflineState : the connectivity monitor is telling we're not connected
 /// - DecentralisedState : The loaded account is set to "decentralised" mode
 pub(crate) struct SyncingLocalState {
-    result_rx: oneshot::Receiver<Result<(), SyncError>>,
+    result_rx: oneshot::Receiver<Result<bool, SyncError>>,
     sync_cancel_token: Option<DropGuard>,
 }
 
@@ -117,7 +117,7 @@ impl SyncingLocalState {
     }
 
     async fn check_account(
-        result_tx: oneshot::Sender<Result<(), SyncError>>,
+        result_tx: oneshot::Sender<Result<bool, SyncError>>,
         vpn_api_client: VpnApiClient,
         vpn_api_account: Arc<VpnAccount>,
         device: Device,
@@ -146,7 +146,7 @@ impl SyncingLocalState {
         } else if !summary.time_synced {
             Err(SyncError::DeviceTimeDesynced)
         } else {
-            Ok(())
+            Ok(false)
         };
 
         result_tx.send(result).ok();
@@ -163,14 +163,14 @@ impl SyncingLocalState {
         vpn_api_client: &VpnApiClient,
         vpn_api_account: &VpnAccount,
         device: &Device,
-    ) -> Result<(), SyncError> {
+    ) -> Result<bool, SyncError> {
         vpn_api_client
             .register_device(vpn_api_account, device)
             .await
             .map_err(|err| SyncError::UnregisteredDevice {
                 details: err.to_string(),
             })?;
-        Ok(()) // We can register a device, we have fair usage
+        Ok(true) // We just registered the device, we must update the summary (no need for a full refetch)
     }
 }
 
@@ -198,8 +198,16 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingLocalSt
 
             sync_result = &mut self.result_rx => {
                 match sync_result {
-                    Ok(Ok(())) => {
+                    Ok(Ok(device_registration)) => {
                        // We are all good to proceed
+                       if device_registration {
+                        // We registered our device just now so we need to update the summary
+                        if let Some(summary) = shared_state.vpn_account_summary.as_mut()
+                            && !summary.is_device_active {
+                                summary.is_device_active = true;
+                                summary.remaining_devices += 1;
+                        };
+                       }
                         NextAccountControllerState::NewState(RequestingZkNymsState::enter(shared_state, 0, false))
                     }
                     Ok(Err(err)) => {
@@ -211,9 +219,9 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingLocalSt
                             }
                         }
                     }
-                    Err(_) => {
-                        tracing::error!("No result from local sync, this shouldn't happen");
-                        NextAccountControllerState::NewState(ErrorState::enter(AccountControllerErrorStateReason::Internal { context: SYNCING_LOCAL_STATE_CONTEXT.to_string(), details: "No result sent from syncing task".to_string() }))
+                    Err(e) => {
+                        tracing::error!("No result from local sync, task probably got cancelled : {e}");
+                        NextAccountControllerState::SameState(self)
                     }
                 }
             }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/local_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/local_state.rs
@@ -205,7 +205,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingLocalSt
                     Ok(Err(err)) => {
                         // The account doesn't check out
                         match err {
-                            SyncError::PendingSubscription => NextAccountControllerState::NewState(PendingSubscriptionState::enter()), // Ugh, why is this even a thing? Why isn't it the error state?
+                            SyncError::PendingSubscription => NextAccountControllerState::NewState(PendingSubscriptionState::enter()),
                             err => {
                                 NextAccountControllerState::NewState(ErrorState::enter(err.into_error_reason()))
                             }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/local_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/local_state.rs
@@ -205,7 +205,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingLocalSt
                         if let Some(summary) = shared_state.vpn_account_summary.as_mut()
                             && !summary.is_device_active {
                                 summary.is_device_active = true;
-                                summary.remaining_devices += 1;
+                                summary.remaining_devices -= 1; // We just registered, so it wasn't 0
                         };
                        }
                         NextAccountControllerState::NewState(RequestingZkNymsState::enter(shared_state, 0, false))

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/local_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/local_state.rs
@@ -82,13 +82,13 @@ impl SyncingLocalState {
 
         // Nothing to check locally without a cached summary: go fetch one from the network.
         let Some(summary) = shared_state.vpn_account_summary.clone() else {
-            return SyncingNetworkState::enter(shared_state, 0, SyncMode::Mandatory);
+            return SyncingNetworkState::enter(shared_state, SyncMode::Mandatory);
         };
 
         // A stale cache can't be trusted; force a mandatory re-fetch instead of checking it.
         if Self::is_stale(&summary) {
             tracing::debug!("Cached account summary is stale, forcing a network refresh");
-            return SyncingNetworkState::enter(shared_state, 0, SyncMode::Mandatory);
+            return SyncingNetworkState::enter(shared_state, SyncMode::Mandatory);
         }
 
         let vpn_api_client = shared_state.vpn_api_client.clone();
@@ -253,7 +253,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingLocalSt
                             if force {
                                 return super::force_refresh(shared_state);
                             } else {
-                                return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic));
+                                return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Optimistic));
                             }
                         }
                     },
@@ -267,7 +267,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingLocalSt
                         // No-op if the firewall was already down
                         if shared_state.firewall_active {
                             shared_state.firewall_active = false;
-                            return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic));
+                            return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Optimistic));
                         }
                     },
 

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/local_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/local_state.rs
@@ -21,7 +21,6 @@ use nym_vpn_api_client::{
 use nym_vpn_lib_types::{
     AccountCommandError, AccountControllerErrorStateReason, VpnAccountSummary,
 };
-use time::OffsetDateTime;
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::{CancellationToken, DropGuard};
 use tracing::warn;
@@ -38,6 +37,8 @@ const SUMMARY_STALE_AFTER: Duration = Duration::from_secs(24 * 60 * 60);
 /// - Is the subscription active (or pending) ?
 /// - Is the current device registered ?
 /// - Do we have fair usage left ?
+///
+/// No other state than SyncingNetworkState should lead there
 ///
 /// If no summary is cached (or it is stale), there is nothing to trust locally, so we defer to
 /// [`SyncingNetworkState`] to fetch one first. The only network interaction here is registering the
@@ -86,7 +87,7 @@ impl SyncingLocalState {
         };
 
         // A stale cache can't be trusted; force a mandatory re-fetch instead of checking it.
-        if Self::is_stale(&summary) {
+        if summary.is_stale(SUMMARY_STALE_AFTER) {
             tracing::debug!("Cached account summary is stale, forcing a network refresh");
             return SyncingNetworkState::enter(shared_state, SyncMode::Mandatory);
         }
@@ -152,13 +153,6 @@ impl SyncingLocalState {
         result_tx.send(result).ok();
     }
 
-    /// Whether the cached summary is too old to be trusted and should be force-refreshed.
-    fn is_stale(summary: &VpnAccountSummary) -> bool {
-        let age =
-            OffsetDateTime::now_utc().unix_timestamp() - summary.last_synced_utc.unix_timestamp();
-        age > SUMMARY_STALE_AFTER.as_secs() as i64
-    }
-
     async fn register_device(
         vpn_api_client: &VpnApiClient,
         vpn_api_account: &VpnAccount,
@@ -199,15 +193,18 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingLocalSt
             sync_result = &mut self.result_rx => {
                 match sync_result {
                     Ok(Ok(device_registration)) => {
-                       // We are all good to proceed
-                       if device_registration {
-                        // We registered our device just now so we need to update the summary
-                        if let Some(summary) = shared_state.vpn_account_summary.as_mut()
-                            && !summary.is_device_active {
-                                summary.is_device_active = true;
-                                summary.remaining_devices -= 1; // We just registered, so it wasn't 0
-                        };
-                       }
+                        // If we just registered the device, reflect that in the cached summary
+                        // (memory + disk) so a restart doesn't try to register again, without
+                        // needing a full re-fetch.
+                        if device_registration
+                            && let Some(mut summary) = shared_state.vpn_account_summary.clone()
+                            && !summary.is_device_active
+                        {
+                            summary.is_device_active = true;
+                            // Guarded above: we only register when a slot is free, so this is > 0.
+                            summary.remaining_devices = summary.remaining_devices.saturating_sub(1);
+                            shared_state.store_summary(summary);
+                        }
                         NextAccountControllerState::NewState(RequestingZkNymsState::enter(shared_state, 0, false))
                     }
                     Ok(Err(err)) => {
@@ -259,7 +256,8 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingLocalSt
                             NextAccountControllerState::SameState(self)
                         } else {
                             if force {
-                                return super::force_refresh(shared_state);
+                                shared_state.mark_summary_as_stale();
+                                return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Mandatory));
                             } else {
                                 return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Optimistic));
                             }
@@ -267,7 +265,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingLocalSt
                     },
                     AccountCommand::ResetDeviceIdentity(return_sender, seed) => {
                         return_sender.send(handler::handle_reset_device_identity(shared_state, seed).await);
-                        return super::force_refresh(shared_state)
+                        return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Mandatory));
                     },
 
                     AccountCommand::VpnApiFirewallDown(return_sender) =>  {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/local_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/local_state.rs
@@ -245,20 +245,16 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingLocalSt
                     },
                     AccountCommand::AccountBalance(return_sender) => return_sender.send(Err(AccountCommandError::AccountNotDecentralised)),
                     AccountCommand::ObtainTicketbooks(return_sender, _) => return_sender.send(Err(AccountCommandError::AccountNotDecentralised)),
-                    AccountCommand::RefreshAccountState(return_sender) => {
+                    AccountCommand::RefreshAccountState(return_sender, force) => {
                         return_sender.send(Ok(()));
                         return if shared_state.firewall_active {
                             NextAccountControllerState::SameState(self)
                         } else {
-                            NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic))
-                        }
-                    },
-                    AccountCommand::ForceRefreshAccountState(return_sender) => {
-                        return_sender.send(Ok(()));
-                        return if shared_state.firewall_active {
-                            NextAccountControllerState::SameState(self)
-                        } else {
-                           NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Mandatory))
+                            if force {
+                                return super::force_refresh(shared_state);
+                            } else {
+                                return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic));
+                            }
                         }
                     },
                     AccountCommand::ResetDeviceIdentity(return_sender, seed) => {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/local_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/local_state.rs
@@ -1,0 +1,341 @@
+// Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use std::{sync::Arc, time::Duration};
+
+use crate::{
+    SharedAccountState,
+    commands::{AccountCommand, UpgradeModeCommand, common_handler, handler},
+    state_machine::{
+        AccountControllerStateHandler, DecentralisedState, ErrorState, LoggedOutState,
+        NextAccountControllerState, OfflineState, PendingSubscriptionState,
+        PrivateAccountControllerState, RequestingZkNymsState,
+        syncing_state::{SyncMode, SyncingNetworkState},
+    },
+};
+use nym_offline_monitor::ConnectivityMonitor;
+use nym_vpn_api_client::{
+    VpnApiClient,
+    types::{Device, VpnAccount},
+};
+use nym_vpn_lib_types::{
+    AccountCommandError, AccountControllerErrorStateReason, VpnAccountSummary,
+};
+use time::OffsetDateTime;
+use tokio::sync::{mpsc, oneshot};
+use tokio_util::sync::{CancellationToken, DropGuard};
+use tracing::warn;
+
+const SYNCING_LOCAL_STATE_CONTEXT: &str = "SYNCING_LOCAL_STATE";
+
+/// How old a cached summary may be before it is considered stale and force-refreshed.
+const SUMMARY_STALE_AFTER: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// SyncingLocal State
+/// This is the "local" half of syncing: it runs the account checks against the locally cached
+/// [`VpnAccountSummary`] without hitting the VPN API, answering:
+/// - Is the stored account active ?
+/// - Is the subscription active (or pending) ?
+/// - Is the current device registered ?
+/// - Do we have fair usage left ?
+///
+/// If no summary is cached (or it is stale), there is nothing to trust locally, so we defer to
+/// [`SyncingNetworkState`] to fetch one first. The only network interaction here is registering the
+/// device, which happens as a direct consequence of the checks (a free slot is available).
+///
+/// A failed check goes straight to the error state (or `PendingSubscriptionState` for a pending
+/// subscription); there is no retry, since re-checking the same cached data would not change the
+/// outcome - obtaining fresh data is what `SyncingNetworkState` is for.
+///
+/// Possible next state :
+/// - LoggedOutState : No account is stored
+/// - SyncingNetworkState : No summary is cached, or the cache is stale and must be refreshed
+/// - RequestingZkNymsState : Everything checks out, we just need to top up our zk-nyms
+/// - PendingSubscriptionState : The subscription exists but is not yet active
+/// - ErrorState : One of the checks failed in a non-recoverable way
+/// - OfflineState : the connectivity monitor is telling we're not connected
+/// - DecentralisedState : The loaded account is set to "decentralised" mode
+pub(crate) struct SyncingLocalState {
+    result_rx: oneshot::Receiver<Result<(), SyncError>>,
+    sync_cancel_token: Option<DropGuard>,
+}
+
+impl SyncingLocalState {
+    pub(crate) fn enter<C: ConnectivityMonitor>(
+        shared_state: &SharedAccountState<C>,
+    ) -> (
+        Box<dyn AccountControllerStateHandler<C>>,
+        PrivateAccountControllerState,
+    ) {
+        let Some(vpn_api_account) = shared_state.vpn_api_account.clone() else {
+            return LoggedOutState::enter();
+        };
+        if vpn_api_account.mode().is_decentralised() {
+            return DecentralisedState::enter();
+        }
+        let Some(device) = shared_state.device.clone() else {
+            return ErrorState::enter(AccountControllerErrorStateReason::Internal {
+                context: SYNCING_LOCAL_STATE_CONTEXT.into(),
+                details: "Logged in, but no device keys".into(),
+            });
+        };
+
+        // Nothing to check locally without a cached summary: go fetch one from the network.
+        let Some(summary) = shared_state.vpn_account_summary.clone() else {
+            return SyncingNetworkState::enter(shared_state, 0, SyncMode::Mandatory);
+        };
+
+        // A stale cache can't be trusted; force a mandatory re-fetch instead of checking it.
+        if Self::is_stale(&summary) {
+            tracing::debug!("Cached account summary is stale, forcing a network refresh");
+            return SyncingNetworkState::enter(shared_state, 0, SyncMode::Mandatory);
+        }
+
+        let vpn_api_client = shared_state.vpn_api_client.clone();
+
+        let (result_tx, result_rx) = oneshot::channel();
+        let sync_cancel_token = CancellationToken::new();
+
+        let _syncing_state_handle =
+            tokio::spawn(sync_cancel_token.child_token().run_until_cancelled_owned(
+                SyncingLocalState::check_account(
+                    result_tx,
+                    vpn_api_client,
+                    vpn_api_account,
+                    device,
+                    summary,
+                ),
+            ));
+
+        (
+            Box::new(Self {
+                result_rx,
+                sync_cancel_token: Some(sync_cancel_token.drop_guard()),
+            }),
+            PrivateAccountControllerState::Syncing,
+        )
+    }
+
+    async fn check_account(
+        result_tx: oneshot::Sender<Result<(), SyncError>>,
+        vpn_api_client: VpnApiClient,
+        vpn_api_account: Arc<VpnAccount>,
+        device: Device,
+        summary: VpnAccountSummary,
+    ) {
+        // Checking that the account is active
+        let result = if !summary.is_account_active() {
+            Err(SyncError::InactiveAccount(
+                summary.account_status.to_string(),
+            ))
+        } else if summary.is_subscription_pending() {
+            // subscription exists but is not yet active (e.g. cash payment still processing)
+            Err(SyncError::PendingSubscription)
+        } else if !summary.is_subscription_active() {
+            // that there is an active subscription
+            Err(SyncError::InactiveSubscription)
+        } else if !summary.is_device_active {
+            // that the device is registered or there is a spot left for it with fair usage
+            if summary.remaining_devices == 0 {
+                Err(SyncError::MaxDeviceReached) // Early detection of max device reached
+            } else if !summary.fair_usage_left() {
+                Err(SyncError::FairUsageDepleted)
+            } else {
+                Self::register_device(&vpn_api_client, &vpn_api_account, &device).await
+            }
+        } else if !summary.time_synced {
+            Err(SyncError::DeviceTimeDesynced)
+        } else {
+            Ok(())
+        };
+
+        result_tx.send(result).ok();
+    }
+
+    /// Whether the cached summary is too old to be trusted and should be force-refreshed.
+    fn is_stale(summary: &VpnAccountSummary) -> bool {
+        let age =
+            OffsetDateTime::now_utc().unix_timestamp() - summary.last_synced_utc.unix_timestamp();
+        age > SUMMARY_STALE_AFTER.as_secs() as i64
+    }
+
+    async fn register_device(
+        vpn_api_client: &VpnApiClient,
+        vpn_api_account: &VpnAccount,
+        device: &Device,
+    ) -> Result<(), SyncError> {
+        vpn_api_client
+            .register_device(vpn_api_account, device)
+            .await
+            .map_err(|err| SyncError::UnregisteredDevice {
+                details: err.to_string(),
+            })?;
+        Ok(()) // We can register a device, we have fair usage
+    }
+}
+
+#[async_trait::async_trait]
+impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingLocalState {
+    async fn handle_event(
+        mut self: Box<Self>,
+        shutdown_token: &CancellationToken,
+        command_rx: &'async_trait mut mpsc::UnboundedReceiver<AccountCommand>,
+        shared_state: &'async_trait mut SharedAccountState<C>,
+    ) -> NextAccountControllerState<C> {
+        tokio::select! {
+            biased;
+            _ = shutdown_token.cancelled() => {
+                NextAccountControllerState::Finished
+            }
+
+            Some(connectivity) = shared_state.connectivity_handle.next() => {
+                if connectivity.is_offline() {
+                    NextAccountControllerState::NewState(OfflineState::enter())
+                } else {
+                    NextAccountControllerState::SameState(self)
+                }
+            }
+
+            sync_result = &mut self.result_rx => {
+                match sync_result {
+                    Ok(Ok(())) => {
+                       // We are all good to proceed
+                        NextAccountControllerState::NewState(RequestingZkNymsState::enter(shared_state, 0, false))
+                    }
+                    Ok(Err(err)) => {
+                        // The account doesn't check out
+                        match err {
+                            SyncError::PendingSubscription => NextAccountControllerState::NewState(PendingSubscriptionState::enter()), // Ugh, why is this even a thing? Why isn't it the error state?
+                            err => {
+                                NextAccountControllerState::NewState(ErrorState::enter(err.into_error_reason()))
+                            }
+                        }
+                    }
+                    Err(_) => {
+                        tracing::error!("No result from local sync, this shouldn't happen");
+                        NextAccountControllerState::NewState(ErrorState::enter(AccountControllerErrorStateReason::Internal { context: SYNCING_LOCAL_STATE_CONTEXT.to_string(), details: "No result sent from syncing task".to_string() }))
+                    }
+                }
+            }
+            Some(command) = command_rx.recv() => {
+                match command {
+                    AccountCommand::CreateAccount(return_sender) => return_sender.send(Err(AccountCommandError::ExistingAccount)),
+                    AccountCommand::StoreAccount(return_sender, _) => return_sender.send(Err(AccountCommandError::ExistingAccount)),
+                    AccountCommand::RegisterAccount(return_sender, account, platform) => {
+                        let res = handler::handle_register_account(shared_state, account, platform).await;
+                        return_sender.send(res);
+                    }
+                    AccountCommand::ForgetAccount(return_sender) => {
+                        let res = handler::handle_forget_account(shared_state).await;
+                        let error = res.is_err();
+                        return_sender.send(res);
+                        return if error {
+                            NextAccountControllerState::SameState(self)
+                        } else {
+                            NextAccountControllerState::NewState(LoggedOutState::enter())
+                        }
+                    },
+                    AccountCommand::LinkAccount(return_sender, privy_account) => {
+                        let res = handler::handle_link_account(shared_state, privy_account).await;
+                        return_sender.send(res);
+                    },
+                    AccountCommand::RotateKeys(return_sender) => {
+                        let res = handler::handle_rotate_keys(shared_state).await;
+                        return_sender.send(res);
+                    },
+                    AccountCommand::AccountBalance(return_sender) => return_sender.send(Err(AccountCommandError::AccountNotDecentralised)),
+                    AccountCommand::ObtainTicketbooks(return_sender, _) => return_sender.send(Err(AccountCommandError::AccountNotDecentralised)),
+                    AccountCommand::RefreshAccountState(return_sender) => {
+                        return_sender.send(Ok(()));
+                        return if shared_state.firewall_active {
+                            NextAccountControllerState::SameState(self)
+                        } else {
+                            NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic))
+                        }
+                    },
+                    AccountCommand::ForceRefreshAccountState(return_sender) => {
+                        return_sender.send(Ok(()));
+                        return if shared_state.firewall_active {
+                            NextAccountControllerState::SameState(self)
+                        } else {
+                           NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Mandatory))
+                        }
+                    },
+                    AccountCommand::ResetDeviceIdentity(return_sender, seed) => {
+                        return_sender.send(handler::handle_reset_device_identity(shared_state, seed).await);
+                        return super::force_refresh(shared_state)
+                    },
+
+                    AccountCommand::VpnApiFirewallDown(return_sender) =>  {
+                        return_sender.send(Ok(()));
+                        // No-op if the firewall was already down
+                        if shared_state.firewall_active {
+                            shared_state.firewall_active = false;
+                            return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic));
+                        }
+                    },
+
+                    AccountCommand::VpnApiFirewallUp(return_sender) => {
+                        shared_state.firewall_active = true;
+                        // Explicitly cancel the check task since the same state persists; the only
+                        // network interaction (device registration) must not run while firewalled.
+                        self.sync_cancel_token.take();
+                        return_sender.send(Ok(()));
+                    },
+
+                    AccountCommand::Common(common_command) => {
+                        common_handler::handle_common_command(common_command, shared_state).await
+                    },
+                    AccountCommand::UpgradeMode(upgrade_mode_command) => match upgrade_mode_command {
+                        UpgradeModeCommand::GetUpgradeModeEnabled(return_sender) => {
+                            return_sender.send(Ok(false))
+                        }
+                        UpgradeModeCommand::DisableUpgradeMode(return_sender) => {
+                            warn!(
+                                "received unexpected command to disable upgrade mode while in 'SyncingLocalState' state"
+                            );
+                            return_sender.send(Ok(()))
+                        }
+                    },
+                }
+                NextAccountControllerState::SameState(self)
+            }
+        }
+    }
+}
+
+#[derive(Debug, strum::Display)]
+enum SyncError {
+    InactiveAccount(String),
+    UnregisteredDevice { details: String },
+    InactiveSubscription,
+    PendingSubscription,
+    DeviceTimeDesynced,
+    MaxDeviceReached,
+    FairUsageDepleted,
+}
+
+impl SyncError {
+    /// Returns the corresponding error reason for the error state
+    fn into_error_reason(self) -> AccountControllerErrorStateReason {
+        use SyncError::*;
+        match self {
+            PendingSubscription => AccountControllerErrorStateReason::AccountStatusNotActive {
+                status: "pending".into(),
+            },
+            InactiveAccount(status) => {
+                AccountControllerErrorStateReason::AccountStatusNotActive { status }
+            }
+            InactiveSubscription => AccountControllerErrorStateReason::InactiveSubscription,
+            DeviceTimeDesynced => AccountControllerErrorStateReason::DeviceTimeDesynced,
+            MaxDeviceReached => AccountControllerErrorStateReason::MaxDeviceReached,
+            FairUsageDepleted => AccountControllerErrorStateReason::BandwidthExceeded {
+                context: SYNCING_LOCAL_STATE_CONTEXT.into(),
+            },
+            UnregisteredDevice { details } => AccountControllerErrorStateReason::ApiFailure {
+                context: SYNCING_LOCAL_STATE_CONTEXT.into(),
+                details: format!("Error registering device : {details}"),
+            },
+        }
+    }
+}

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
@@ -1,12 +1,6 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use crate::{
-    SharedAccountState, state_machine::NextAccountControllerState, storage::AccountStorageOp,
-};
-use nym_offline_monitor::ConnectivityMonitor;
-use nym_vpn_lib_types::VpnAccountSummary;
-
 pub(super) mod local_state;
 pub(super) mod network_state;
 pub(super) mod requesting_zknym_state;
@@ -23,40 +17,4 @@ pub(crate) enum SyncMode {
     /// Full fetch with no cache fallback. Used for forced refreshes, stale caches, and retries,
     /// where we must obtain fresh data (or surface an error).
     Mandatory,
-}
-
-/// Build the [`VpnAccountSummary`] from the API response, then store it both in memory and on
-/// disk so it survives restarts and can be re-evaluated locally.
-fn store_summary<C: ConnectivityMonitor>(
-    shared_state: &mut SharedAccountState<C>,
-    summary: VpnAccountSummary,
-) {
-    // Persist the summary alongside the mnemonic/keys (best-effort, via the storage-op
-    // channel) and keep the in-memory working copy in sync.
-    let _ = shared_state
-        .storage_op_sender
-        .send(AccountStorageOp::StoreAccountSummary(Box::new(
-            summary.clone(),
-        )));
-    shared_state.vpn_account_summary = Some(summary);
-}
-
-fn remove_summary<C: ConnectivityMonitor>(shared_state: &mut SharedAccountState<C>) {
-    // best effort
-    let _ = shared_state
-        .storage_op_sender
-        .send(AccountStorageOp::RemoveAccountSummary);
-    shared_state.vpn_account_summary = None;
-}
-
-// This way we can force an account summary cleanup, before actually entering the state
-pub(crate) fn force_refresh<C: ConnectivityMonitor>(
-    shared_state: &mut SharedAccountState<C>,
-) -> NextAccountControllerState<C> {
-    // best effort
-    remove_summary(shared_state);
-    NextAccountControllerState::NewState(SyncingNetworkState::enter(
-        shared_state,
-        SyncMode::Mandatory,
-    ))
 }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
@@ -1,462 +1,63 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{cmp::min, sync::Arc, time::Duration};
-
 use crate::{
-    SharedAccountState,
-    commands::{AccountCommand, UpgradeModeCommand, common_handler, handler},
-    state_machine::{
-        AccountControllerStateHandler, DecentralisedState, ErrorState, LoggedOutState,
-        NextAccountControllerState, OfflineState, PendingSubscriptionState,
-        PrivateAccountControllerState,
-    },
+    SharedAccountState, state_machine::NextAccountControllerState, storage::AccountStorageOp,
 };
 use nym_offline_monitor::ConnectivityMonitor;
-use nym_vpn_api_client::{
-    VpnApiClient,
-    error::VpnApiClientError,
-    response::{NymErrorResponse, NymVpnAccountSummaryWithDeviceResponse},
-    types::{Device, VpnAccount},
-};
-use nym_vpn_lib_types::{
-    AccountCommandError, AccountControllerErrorStateReason, VpnAccountSummary,
-};
-use requesting_zknym_state::RequestingZkNymsState;
-use tokio::sync::mpsc;
-use tokio_util::sync::{CancellationToken, DropGuard};
-use tracing::warn;
+use nym_vpn_lib_types::VpnAccountSummary;
 
+pub(super) mod local_state;
+pub(super) mod network_state;
 pub(super) mod requesting_zknym_state;
 
-const MAX_SYNCING_ATTEMPTS: u32 = 10;
-const SYNCING_STATE_CONTEXT: &str = "SYNCING_STATE";
+pub(crate) use network_state::SyncingNetworkState;
 
-// bounded exponential backoff for retries [0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 8.0, 8.0, 8.0, 8.0, 8.0] = 55.75s max wait
-const RETRY_BACKOFF: Duration = Duration::from_millis(250);
-const MAX_BACKOFF_EXPONENT: u32 = 5;
-const BACKOFF_BASE: u32 = 2;
+/// How aggressively [`SyncingNetworkState`] should try to refresh the account summary.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SyncMode {
+    /// Best-effort refresh on a short timeout. On any failure (timeout, connection error, or an
+    /// error response) we fall back to the cached summary instead of blocking or erroring.
+    Optimistic,
 
-enum SyncEvent {
-    /// Account summary is received
-    AccountSummary(Box<VpnAccountSummary>),
-
-    /// Failure to complete synchronization
-    Failure(SyncError),
-
-    /// Finished synchronization without errors
-    Finished,
+    /// Full fetch with no cache fallback. Used for forced refreshes, stale caches, and retries,
+    /// where we must obtain fresh data (or surface an error).
+    Mandatory,
 }
 
-/// Syncing State
-/// This is the heart of the Account Controller.
-/// That state has to determine where we are at :
-/// - Is an account stored?
-/// - Is the stored account registered ?
-/// - Is the subscription active ?
-/// - Is the current device registered ?
-/// - Do we have fair usage left ?
-///
-/// A retry mechanism is in place, if the error is in the API requests. Other errors lead to the ErrorState since they are not recoverable.
-///
-/// Possible next state :
-/// - LoggedOutState : No account is stored
-/// - RequestingZkNymState : Everything is fine on the account front, we just to check on our ZK-nyms storage before being ready to connect
-/// - SyncingState : We try again if there was an error while making an API request
-/// - ErrorState : An actual error happened, or one of the above questions has a negative answers, preventing us to proceed.
-/// - OfflineState : the connectivity monitor is telling we're not connected
-/// - DecentralisedState : The loaded account is set to "decentralised" mode
-pub struct SyncingState {
-    attempts: u32,
-    event_rx: mpsc::UnboundedReceiver<SyncEvent>,
-    sync_cancel_token: Option<DropGuard>,
-}
-
-impl SyncingState {
-    pub fn enter<C: ConnectivityMonitor>(
-        shared_state: &SharedAccountState<C>,
-        attempts: u32,
-    ) -> (
-        Box<dyn AccountControllerStateHandler<C>>,
-        PrivateAccountControllerState,
-    ) {
-        let Some(vpn_api_account) = shared_state.vpn_api_account.clone() else {
-            return LoggedOutState::enter();
-        };
-        if vpn_api_account.mode().is_decentralised() {
-            return DecentralisedState::enter();
-        }
-        let Some(device) = shared_state.device.clone() else {
-            return ErrorState::enter(AccountControllerErrorStateReason::Internal {
-                context: SYNCING_STATE_CONTEXT.into(),
-                details: "Logged in, but no device keys".into(),
-            });
-        };
-
-        let vpn_api_client = shared_state.vpn_api_client.clone();
-
-        let (event_tx, event_rx) = mpsc::unbounded_channel();
-        let sync_cancel_token = CancellationToken::new();
-
-        // This handle does not need to be awaited since event channel and cancellation token are sufficient.
-        let _syncing_state_handle =
-            tokio::spawn(sync_cancel_token.child_token().run_until_cancelled_owned(
-                SyncingState::sync_account(
-                    event_tx,
-                    vpn_api_client,
-                    vpn_api_account,
-                    device,
-                    attempts,
-                ),
-            ));
-
-        (
-            Box::new(Self {
-                attempts,
-                event_rx,
-                sync_cancel_token: Some(sync_cancel_token.drop_guard()),
-            }),
-            PrivateAccountControllerState::Syncing,
-        )
-    }
-
-    async fn sync_account(
-        event_tx: mpsc::UnboundedSender<SyncEvent>,
-        vpn_api_client: VpnApiClient,
-        vpn_api_account: Arc<VpnAccount>,
-        device: Device,
-        attempts: u32,
-    ) {
-        if attempts > 0 {
-            tokio::time::sleep(Self::get_delay(attempts)).await;
-        }
-
-        let final_event =
-            Self::sync_account_inner(event_tx.clone(), vpn_api_client, vpn_api_account, device)
-                .await
-                .map(|_| SyncEvent::Finished)
-                .unwrap_or_else(SyncEvent::Failure);
-        event_tx.send(final_event).ok();
-    }
-
-    async fn sync_account_inner(
-        event_tx: mpsc::UnboundedSender<SyncEvent>,
-        vpn_api_client: VpnApiClient,
-        vpn_api_account: Arc<VpnAccount>,
-        device: Device,
-    ) -> Result<(), SyncError> {
-        // Make sure time isn't too much desynced, othersiwe Zk-nyms will fail to verify on gateways
-        let remote_time = vpn_api_client
-            .get_remote_time()
-            .await
-            .map_err(Self::map_vpn_api_error)?;
-
-        if remote_time.is_acceptable_synced() {
-            let summary = vpn_api_client
-                .get_account_summary_with_device(&vpn_api_account, &device)
-                .await
-                .map_err(Self::map_vpn_api_error)?;
-
-            tracing::debug!("{summary:#?}");
-
-            Self::handle_received_account_summary(
-                event_tx.clone(),
-                vpn_api_client,
-                &vpn_api_account,
-                &device,
-                summary,
-            )
-            .await
-        } else {
-            Err(SyncError::DeviceTimeDesynced)
-        }
-    }
-
-    async fn handle_received_account_summary(
-        event_tx: mpsc::UnboundedSender<SyncEvent>,
-        vpn_api_client: VpnApiClient,
-        vpn_api_account: &VpnAccount,
-        device: &Device,
-        summary: NymVpnAccountSummaryWithDeviceResponse,
-    ) -> Result<(), SyncError> {
-        let mut vpn_account_summary = VpnAccountSummary::try_from(&summary.account_summary)
-            .map_err(|err| SyncError::ApiResponseError {
-                details: format!("Failed to create account summary from API response: {err}"),
-            })?;
-
-        // todo: refactor, this should not be here.
-        vpn_account_summary.account_mode = Some(vpn_api_account.mode().into());
-
-        // Propagate account summary even if sync eventually fails.
-        let _ = event_tx.send(SyncEvent::AccountSummary(Box::new(
-            vpn_account_summary.clone(),
+/// Build the [`VpnAccountSummary`] from the API response, then store it both in memory and on
+/// disk so it survives restarts and can be re-evaluated locally.
+fn store_summary<C: ConnectivityMonitor>(
+    shared_state: &mut SharedAccountState<C>,
+    summary: VpnAccountSummary,
+) {
+    // Persist the summary alongside the mnemonic/keys (best-effort, via the storage-op
+    // channel) and keep the in-memory working copy in sync.
+    let _ = shared_state
+        .storage_op_sender
+        .send(AccountStorageOp::StoreAccountSummary(Box::new(
+            summary.clone(),
         )));
-
-        // Checking that the account is active
-        if !summary.account_active() {
-            Err(SyncError::InactiveAccount(
-                summary.account_summary.account.status.to_string(),
-            ))
-        } else if summary.subscription_pending() {
-            // subscription exists but is not yet active (e.g. cash payment still processing)
-            Err(SyncError::PendingSubscription)
-        } else if !summary.subscription_active() {
-            // that there is an active subscription
-            Err(SyncError::InactiveSubscription)
-        } else if summary.active_device.is_none() {
-            // that the device is registered or there is a spot left for it with fair usage
-            if summary.remaining_devices() == 0 {
-                Err(SyncError::MaxDeviceReached) // Early detection of max device reached
-            } else if !vpn_account_summary.fair_usage_left() {
-                Err(SyncError::FairUsageDepleted)
-            } else {
-                SyncingState::register_device(&vpn_api_client, vpn_api_account, device).await
-            }
-        } else {
-            Ok(())
-        }
-    }
-
-    fn map_vpn_api_error(err: VpnApiClientError) -> SyncError {
-        match NymErrorResponse::try_from(err) {
-            Ok(error_response) => {
-                // SW Use UUID when it will be available
-                if error_response.status == "access_denied"
-                    && error_response.message == "Account not found"
-                {
-                    // Request was fine, but account is unregistered
-                    // Later down the line we can maybe register it here
-                    SyncError::UnregisteredAccount
-                } else {
-                    SyncError::ApiResponseError {
-                        details: error_response
-                            .code_reference_id
-                            .unwrap_or(error_response.message),
-                    }
-                }
-            }
-            Err(err) => SyncError::from(err),
-        }
-    }
-
-    async fn register_device(
-        vpn_api_client: &VpnApiClient,
-        vpn_api_account: &VpnAccount,
-        device: &Device,
-    ) -> Result<(), SyncError> {
-        vpn_api_client
-            .register_device(vpn_api_account, device)
-            .await?;
-        Ok(()) // We can register a device, we have fair usage
-    }
-
-    /// The attempt retries should  start with attempt 1
-    fn get_delay(attempts: u32) -> Duration {
-        RETRY_BACKOFF * BACKOFF_BASE.pow(min(attempts - 1, MAX_BACKOFF_EXPONENT))
-    }
+    shared_state.vpn_account_summary = Some(summary);
 }
 
-#[async_trait::async_trait]
-impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingState {
-    async fn handle_event(
-        mut self: Box<Self>,
-        shutdown_token: &CancellationToken,
-        command_rx: &'async_trait mut mpsc::UnboundedReceiver<AccountCommand>,
-        shared_state: &'async_trait mut SharedAccountState<C>,
-    ) -> NextAccountControllerState<C> {
-        tokio::select! {
-            biased;
-            _ = shutdown_token.cancelled() => {
-                NextAccountControllerState::Finished
-            }
-            Some(sync_event) = self.event_rx.recv() => {
-                match sync_event {
-                    SyncEvent::AccountSummary(vpn_account_summary) => {
-                        shared_state.vpn_account_summary = Some(*vpn_account_summary);
-                        NextAccountControllerState::SameState(self)
-                    }
-                    SyncEvent::Failure(err) => {
-                        let is_retryable = err.is_retryable();
-                        let err_str = err.to_string();
-                        match err.into_error_reason() {
-                            None => {
-                                tracing::debug!("Subscription is pending, waiting before retrying");
-                                NextAccountControllerState::NewState(PendingSubscriptionState::enter())
-                            }
-                            Some(reason) if is_retryable => {
-                                if self.attempts > MAX_SYNCING_ATTEMPTS {
-                                    tracing::debug!("Error trying to get account summary, exhausted retries : {err_str}");
-                                    NextAccountControllerState::NewState(ErrorState::enter(reason))
-                                } else {
-                                    tracing::debug!(
-                                        "Error trying to get account summary attempt {}, retrying after {:?} : {err_str}",
-                                        self.attempts,
-                                        Self::get_delay(self.attempts + 1),
-                                    );
-                                    NextAccountControllerState::NewState(SyncingState::enter(shared_state, self.attempts + 1))
-                                }
-                            }
-                            Some(reason) => {
-                                tracing::debug!("Error trying to get account summary, not retrying : {err_str}");
-                                NextAccountControllerState::NewState(ErrorState::enter(reason))
-                            }
-                        }
-                    }
-                    SyncEvent::Finished => {
-                        NextAccountControllerState::NewState(RequestingZkNymsState::enter(shared_state, self.attempts, false))
-                    }
-                }
-            }
-            Some(command) = command_rx.recv() => {
-                match command {
-                    AccountCommand::CreateAccount(return_sender) => return_sender.send(Err(AccountCommandError::ExistingAccount)),
-                    AccountCommand::StoreAccount(return_sender, _) => return_sender.send(Err(AccountCommandError::ExistingAccount)),
-                    AccountCommand::RegisterAccount(return_sender, account, platform) => {
-                        let res = handler::handle_register_account(shared_state, account, platform).await;
-                        return_sender.send(res);
-                    }
-                    AccountCommand::ForgetAccount(return_sender) => {
-                        let res = handler::handle_forget_account(shared_state).await;
-                        let error = res.is_err();
-                        return_sender.send(res);
-                        return if error {
-                            NextAccountControllerState::SameState(self)
-                        } else {
-                            NextAccountControllerState::NewState(LoggedOutState::enter())
-                        }
-                    },
-                    AccountCommand::LinkAccount(return_sender, privy_account) => {
-                        let res = handler::handle_link_account(shared_state, privy_account).await;
-                        return_sender.send(res);
-                    },
-                    AccountCommand::RotateKeys(return_sender) => {
-                        let res = handler::handle_rotate_keys(shared_state).await;
-                        return_sender.send(res);
-                    },
-                    AccountCommand::AccountBalance(return_sender) => return_sender.send(Err(AccountCommandError::AccountNotDecentralised)),
-                    AccountCommand::ObtainTicketbooks(return_sender, _) => return_sender.send(Err(AccountCommandError::AccountNotDecentralised)),
-                    AccountCommand::RefreshAccountState(return_sender) => {
-                        return_sender.send(Ok(()));
-                        return if shared_state.firewall_active {
-                            NextAccountControllerState::SameState(self)
-                        } else {
-                            NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0))
-                        }
-                    },
-                    AccountCommand::ResetDeviceIdentity(return_sender, seed) => {
-                        return_sender.send(handler::handle_reset_device_identity(shared_state, seed).await);
-                        return NextAccountControllerState::NewState(SyncingState::enter(shared_state,0));
-                    },
-
-                    AccountCommand::VpnApiFirewallDown(return_sender) =>  {
-                        return_sender.send(Ok(()));
-                        // No-op if the firewall was already down
-                        if shared_state.firewall_active {
-                            shared_state.firewall_active = false;
-                            return NextAccountControllerState::NewState(SyncingState::enter(shared_state, self.attempts));
-                        }
-                    },
-
-                    AccountCommand::VpnApiFirewallUp(return_sender) => {
-                        shared_state.firewall_active = true;
-                        // Explicitly cancel sync task since the same state persists.
-                        // Sync will restart once firewall permits traffic to flow again.
-                        self.sync_cancel_token.take();
-                        return_sender.send(Ok(()));
-                    },
-
-                    AccountCommand::Common(common_command) => {
-                        common_handler::handle_common_command(common_command, shared_state).await
-                    },
-                    AccountCommand::UpgradeMode(upgrade_mode_command) => match upgrade_mode_command {
-                        UpgradeModeCommand::GetUpgradeModeEnabled(return_sender) => {
-                            return_sender.send(Ok(false))
-                        }
-                        UpgradeModeCommand::DisableUpgradeMode(return_sender) => {
-                            warn!(
-                                "received unexpected command to disable upgrade mode while in 'SyncingState' state"
-                            );
-                            return_sender.send(Ok(()))
-                        }
-                    },
-                }
-                NextAccountControllerState::SameState(self)
-            }
-            Some(connectivity) = shared_state.connectivity_handle.next() => {
-                if connectivity.is_offline() {
-                    NextAccountControllerState::NewState(OfflineState::enter())
-                } else {
-                    NextAccountControllerState::SameState(self)
-                }
-            }
-        }
-    }
+fn remove_summary<C: ConnectivityMonitor>(shared_state: &mut SharedAccountState<C>) {
+    // best effort
+    let _ = shared_state
+        .storage_op_sender
+        .send(AccountStorageOp::RemoveAccountSummary);
+    shared_state.vpn_account_summary = None;
 }
 
-#[derive(Debug, strum::Display)]
-enum SyncError {
-    InactiveAccount(String),
-    UnregisteredAccount,
-    InactiveSubscription,
-    PendingSubscription,
-    ApiRequestError(String),
-    ApiResponseError { details: String },
-    DeviceTimeDesynced,
-    MaxDeviceReached,
-    FairUsageDepleted,
-}
-
-impl SyncError {
-    fn is_retryable(&self) -> bool {
-        matches!(
-            self,
-            SyncError::ApiRequestError(_)
-                | SyncError::DeviceTimeDesynced
-                | SyncError::InactiveSubscription // in the case of IAP, it might take a while for the subscription to become active
-        )
-    }
-
-    /// Returns the corresponding error reason for the error state, or `None` if the error
-    /// should not result in an error state (e.g. pending subscription has its own state).
-    fn into_error_reason(self) -> Option<AccountControllerErrorStateReason> {
-        use SyncError::*;
-        match self {
-            PendingSubscription => None,
-            InactiveAccount(status) => {
-                Some(AccountControllerErrorStateReason::AccountStatusNotActive { status })
-            }
-            UnregisteredAccount => {
-                Some(AccountControllerErrorStateReason::AccountStatusNotActive {
-                    status: "unregistered".into(),
-                })
-            }
-            InactiveSubscription => Some(AccountControllerErrorStateReason::InactiveSubscription),
-            ApiRequestError(e) => Some(AccountControllerErrorStateReason::ApiFailure {
-                context: SYNCING_STATE_CONTEXT.into(),
-                details: e,
-            }),
-            ApiResponseError { details } => Some(AccountControllerErrorStateReason::ApiFailure {
-                context: SYNCING_STATE_CONTEXT.into(),
-                details,
-            }),
-            DeviceTimeDesynced => Some(AccountControllerErrorStateReason::DeviceTimeDesynced),
-            MaxDeviceReached => Some(AccountControllerErrorStateReason::MaxDeviceReached),
-            FairUsageDepleted => Some(AccountControllerErrorStateReason::BandwidthExceeded {
-                context: SYNCING_STATE_CONTEXT.into(),
-            }),
-        }
-    }
-}
-
-impl From<VpnApiClientError> for SyncError {
-    fn from(value: VpnApiClientError) -> Self {
-        match NymErrorResponse::try_from(value) {
-            Ok(error_response) => SyncError::ApiResponseError {
-                details: error_response
-                    .code_reference_id
-                    .unwrap_or(error_response.message),
-            },
-            Err(e) => SyncError::ApiRequestError(e.to_string()),
-        }
-    }
+// This way we can force an account summary cleanup, before actually entering the state
+pub(crate) fn force_refresh<C: ConnectivityMonitor>(
+    shared_state: &mut SharedAccountState<C>,
+) -> NextAccountControllerState<C> {
+    // best effort
+    remove_summary(shared_state);
+    NextAccountControllerState::NewState(SyncingNetworkState::enter(
+        shared_state,
+        0,
+        SyncMode::Mandatory,
+    ))
 }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/mod.rs
@@ -57,7 +57,6 @@ pub(crate) fn force_refresh<C: ConnectivityMonitor>(
     remove_summary(shared_state);
     NextAccountControllerState::NewState(SyncingNetworkState::enter(
         shared_state,
-        0,
         SyncMode::Mandatory,
     ))
 }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/network_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/network_state.rs
@@ -131,6 +131,8 @@ impl SyncingNetworkState {
                 match tokio::time::timeout(OPTIMISTIC_SYNC_TIMEOUT, fetch).await {
                     Ok(Ok(summary)) => Ok(Some(summary)),
                     Ok(Err(err)) => {
+                        // We are packing all errors here, but we don't expect a lot of errors that aren't API failure
+                        // Hence it can wait a next forced sync
                         tracing::warn!(
                             "optimistic account summary sync ended with an error : {err}"
                         );

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/network_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/network_state.rs
@@ -100,6 +100,7 @@ impl SyncingNetworkState {
 
         // Use the provided sync mode unless there is no cache
         let sync_mode = if shared_state.vpn_account_summary.is_none() {
+            tracing::debug!("Sync mode overriding because account summary isn't present");
             SyncMode::Mandatory
         } else {
             sync_mode
@@ -277,20 +278,16 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingNetwork
                     },
                     AccountCommand::AccountBalance(return_sender) => return_sender.send(Err(AccountCommandError::AccountNotDecentralised)),
                     AccountCommand::ObtainTicketbooks(return_sender, _) => return_sender.send(Err(AccountCommandError::AccountNotDecentralised)),
-                    AccountCommand::RefreshAccountState(return_sender) => {
+                    AccountCommand::RefreshAccountState(return_sender, force) => {
                         return_sender.send(Ok(()));
                         return if shared_state.firewall_active {
                             NextAccountControllerState::SameState(self)
                         } else {
-                            NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic))
-                        }
-                    },
-                    AccountCommand::ForceRefreshAccountState(return_sender) => {
-                        return_sender.send(Ok(()));
-                        return if shared_state.firewall_active {
-                            NextAccountControllerState::SameState(self)
-                        } else {
-                           super::force_refresh(shared_state)
+                            if force {
+                                return super::force_refresh(shared_state);
+                            } else {
+                                return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic));
+                            }
                         }
                     },
                     AccountCommand::ResetDeviceIdentity(return_sender, seed) => {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/network_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/network_state.rs
@@ -155,15 +155,11 @@ impl SyncingNetworkState {
         // Fetch the remote time so the summary can record whether our clock is acceptably synced
         // (a desync would make zk-nyms fail to verify on gateways). The desync itself is surfaced
         // later, during the local checks, via `VpnAccountSummary::time_synced`.
-        let remote_time = vpn_api_client
-            .get_remote_time()
-            .await
-            .map_err(map_vpn_api_error)?;
+        let remote_time = vpn_api_client.get_remote_time().await?;
 
         let summary = vpn_api_client
             .get_account_summary_with_device(vpn_api_account, device)
-            .await
-            .map_err(map_vpn_api_error)?;
+            .await?;
 
         tracing::debug!("{summary:#?}");
 
@@ -318,11 +314,11 @@ impl SyncError {
         match self {
             ApiRequestError(e) => AccountControllerErrorStateReason::ApiFailure {
                 context: SYNCING_NETWORK_STATE_CONTEXT.into(),
-                details: e,
+                details: format!("Failure to reach the API {}", e),
             },
             ApiResponseError { details } => AccountControllerErrorStateReason::ApiFailure {
                 context: SYNCING_NETWORK_STATE_CONTEXT.into(),
-                details,
+                details: format!("API returned an error:  {}", details),
             },
             UnregisteredAccount => AccountControllerErrorStateReason::AccountStatusNotActive {
                 status: "unregistered".into(),
@@ -334,34 +330,23 @@ impl SyncError {
 impl From<VpnApiClientError> for SyncError {
     fn from(value: VpnApiClientError) -> Self {
         match NymErrorResponse::try_from(value) {
-            Ok(error_response) => SyncError::ApiResponseError {
-                details: error_response
-                    .code_reference_id
-                    .unwrap_or(error_response.message),
-            },
-            Err(e) => SyncError::ApiRequestError(e.to_string()),
-        }
-    }
-}
-
-fn map_vpn_api_error(err: VpnApiClientError) -> SyncError {
-    match NymErrorResponse::try_from(err) {
-        Ok(error_response) => {
-            // SW Use UUID when it will be available
-            if error_response.status == "access_denied"
-                && error_response.message == "Account not found"
-            {
-                // Request was fine, but account is unregistered
-                // Later down the line we can maybe register it here
-                SyncError::UnregisteredAccount
-            } else {
-                SyncError::ApiResponseError {
-                    details: error_response
-                        .code_reference_id
-                        .unwrap_or(error_response.message),
+            Ok(error_response) => {
+                // SW Use UUID when it will be available
+                if error_response.status == "access_denied"
+                    && error_response.message == "Account not found"
+                {
+                    // Request was fine, but account is unregistered
+                    // Later down the line we can maybe register it here
+                    SyncError::UnregisteredAccount
+                } else {
+                    SyncError::ApiResponseError {
+                        details: error_response
+                            .code_reference_id
+                            .unwrap_or(error_response.message),
+                    }
                 }
             }
+            Err(e) => SyncError::ApiRequestError(e.to_string()),
         }
-        Err(err) => SyncError::from(err),
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/network_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/network_state.rs
@@ -318,7 +318,7 @@ impl SyncError {
             },
             ApiResponseError { details } => AccountControllerErrorStateReason::ApiFailure {
                 context: SYNCING_NETWORK_STATE_CONTEXT.into(),
-                details: format!("API returned an error:  {}", details),
+                details: format!("API returned an error: {}", details),
             },
             UnregisteredAccount => AccountControllerErrorStateReason::AccountStatusNotActive {
                 status: "unregistered".into(),

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/network_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/network_state.rs
@@ -212,9 +212,9 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingNetwork
                         tracing::error!("Mandatory sync failed ({err})");
                         NextAccountControllerState::NewState(ErrorState::enter(err.into_error_reason()))
                     }
-                    Err(_) => {
-                        tracing::error!("No result from network sync, this shouldn't happen");
-                        NextAccountControllerState::NewState(ErrorState::enter(AccountControllerErrorStateReason::Internal { context: SYNCING_NETWORK_STATE_CONTEXT.to_string(), details: "No result sent from syncing task".to_string() }))
+                    Err(e) => {
+                        tracing::error!("No result from network sync, task probably got cancelled : {e}");
+                        NextAccountControllerState::SameState(self)
                     }
                 }
             }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/network_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/network_state.rs
@@ -52,7 +52,7 @@ type SyncResult = Result<Option<VpnAccountSummary>, SyncError>;
 /// Possible next state :
 /// - LoggedOutState : No account is stored
 /// - SyncingLocalState : A summary is available (freshly fetched, or the cache after an optimistic
-///   miss) and its checks can run. We always hand off with a summary present.
+///   miss) and its checks can run. We always hand off with an existing non-stale summary.
 /// - SyncingNetworkState : A mandatory fetch failed and we retry (with backoff)
 /// - ErrorState : A mandatory fetch exhausted its retries, preventing us from proceeding
 /// - OfflineState : the connectivity monitor is telling we're not connected
@@ -199,7 +199,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingNetwork
                     Ok(Ok(Some(response))) => {
                         // The summary is stored (and propagated to disk) even if the subsequent
                         // local checks eventually fail.
-                        super::store_summary(shared_state, response);
+                        shared_state.store_summary(response);
                         NextAccountControllerState::NewState(SyncingLocalState::enter(shared_state))
 
                     }
@@ -252,7 +252,8 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingNetwork
                             NextAccountControllerState::SameState(self)
                         } else {
                             if force {
-                                return super::force_refresh(shared_state);
+                                shared_state.mark_summary_as_stale();
+                                return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Mandatory));
                             } else {
                                 return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Optimistic));
                             }
@@ -260,7 +261,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingNetwork
                     },
                     AccountCommand::ResetDeviceIdentity(return_sender, seed) => {
                         return_sender.send(handler::handle_reset_device_identity(shared_state, seed).await);
-                        return super::force_refresh(shared_state);
+                        return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Mandatory));
                     },
 
                     AccountCommand::VpnApiFirewallDown(return_sender) =>  {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/network_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/network_state.rs
@@ -1,0 +1,400 @@
+// Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use std::{cmp::min, sync::Arc, time::Duration};
+
+use crate::{
+    SharedAccountState,
+    commands::{AccountCommand, UpgradeModeCommand, common_handler, handler},
+    state_machine::{
+        AccountControllerStateHandler, DecentralisedState, ErrorState, LoggedOutState,
+        NextAccountControllerState, OfflineState, PrivateAccountControllerState,
+        syncing_state::{SyncMode, local_state::SyncingLocalState},
+    },
+};
+use nym_offline_monitor::ConnectivityMonitor;
+use nym_vpn_api_client::{
+    VpnApiClient,
+    error::VpnApiClientError,
+    response::NymErrorResponse,
+    types::{Device, VpnAccount},
+};
+use nym_vpn_lib_types::{
+    AccountCommandError, AccountControllerErrorStateReason, VpnAccountSummary,
+};
+use tokio::sync::{mpsc, oneshot};
+use tokio_util::sync::{CancellationToken, DropGuard};
+use tracing::warn;
+
+const SYNCING_NETWORK_STATE_CONTEXT: &str = "SYNCING_NETWORK_STATE";
+
+/// In optimistic mode, how long we wait for the summary fetch before falling back to the cached
+/// summary.
+const OPTIMISTIC_SYNC_TIMEOUT: Duration = Duration::from_secs(5);
+
+const MAX_SYNCING_ATTEMPTS: u32 = 5;
+// bounded exponential backoff for retries [0.25, 0.5, 1.0, 2.0, 4.0, 8.0] = 15.75s max wait
+const RETRY_BACKOFF: Duration = Duration::from_millis(250);
+const MAX_BACKOFF_EXPONENT: u32 = 5;
+const BACKOFF_BASE: u32 = 2;
+
+/// The attempt retries should start with attempt 1
+fn get_delay(attempts: u32) -> Duration {
+    RETRY_BACKOFF * BACKOFF_BASE.pow(min(attempts.saturating_sub(1), MAX_BACKOFF_EXPONENT))
+}
+
+type SyncResult = Result<Option<VpnAccountSummary>, SyncError>;
+
+/// SyncingNetwork State
+/// This is the "network" half of syncing: it talks to the VPN API to fetch the account summary
+/// (after making sure the device clock isn't too desynced, otherwise zk-nyms would fail to verify
+/// on gateways) and stores it both in memory and on disk.
+///
+/// Once the summary is stored, control is handed over to [`SyncingLocalState`] which performs the
+/// actual checks on it.
+///
+/// It operates in one of two [`SyncMode`]s:
+/// - [`SyncMode::Optimistic`]: the fetch races a short timeout. If it doesn't complete in time or
+///   fails for any reason, we fall back to the cached summary (one is guaranteed to exist - `enter`
+///   downgrades to `Mandatory` when there is no cache) and run the checks on it.
+/// - [`SyncMode::Mandatory`]: a full fetch with no cache fallback, used for forced/stale/retry
+///   syncs. Failures retry with backoff and eventually land in the error state.
+///
+/// Possible next state :
+/// - LoggedOutState : No account is stored
+/// - SyncingLocalState : A summary is available (freshly fetched, or the cache after an optimistic
+///   miss) and its checks can run. We always hand off with a summary present.
+/// - SyncingNetworkState : A mandatory fetch failed and we retry (with backoff)
+/// - ErrorState : A mandatory fetch exhausted its retries, preventing us from proceeding
+/// - OfflineState : the connectivity monitor is telling we're not connected
+/// - DecentralisedState : The loaded account is set to "decentralised" mode
+pub(crate) struct SyncingNetworkState {
+    attempts: u32,
+    result_rx: oneshot::Receiver<SyncResult>,
+    sync_cancel_token: Option<DropGuard>,
+}
+
+impl SyncingNetworkState {
+    pub(crate) fn enter<C: ConnectivityMonitor>(
+        shared_state: &SharedAccountState<C>,
+        attempts: u32,
+        sync_mode: SyncMode,
+    ) -> (
+        Box<dyn AccountControllerStateHandler<C>>,
+        PrivateAccountControllerState,
+    ) {
+        let Some(vpn_api_account) = shared_state.vpn_api_account.clone() else {
+            return LoggedOutState::enter();
+        };
+        if vpn_api_account.mode().is_decentralised() {
+            return DecentralisedState::enter();
+        }
+        let Some(device) = shared_state.device.clone() else {
+            return ErrorState::enter(AccountControllerErrorStateReason::Internal {
+                context: SYNCING_NETWORK_STATE_CONTEXT.into(),
+                details: "Logged in, but no device keys".into(),
+            });
+        };
+
+        let vpn_api_client = shared_state.vpn_api_client.clone();
+
+        // Use the provided sync mode unless there is no cache
+        let sync_mode = if shared_state.vpn_account_summary.is_none() {
+            SyncMode::Mandatory
+        } else {
+            sync_mode
+        };
+
+        let (result_tx, result_rx) = oneshot::channel();
+        let sync_cancel_token = CancellationToken::new();
+
+        // This handle does not need to be awaited since event channel and cancellation token are sufficient.
+        let _syncing_state_handle =
+            tokio::spawn(sync_cancel_token.child_token().run_until_cancelled_owned(
+                SyncingNetworkState::sync_network(
+                    result_tx,
+                    vpn_api_client,
+                    vpn_api_account,
+                    device,
+                    attempts,
+                    sync_mode,
+                ),
+            ));
+
+        (
+            Box::new(Self {
+                attempts,
+                result_rx,
+                sync_cancel_token: Some(sync_cancel_token.drop_guard()),
+            }),
+            PrivateAccountControllerState::Syncing,
+        )
+    }
+
+    async fn sync_network(
+        result_tx: oneshot::Sender<SyncResult>,
+        vpn_api_client: VpnApiClient,
+        vpn_api_account: Arc<VpnAccount>,
+        device: Device,
+        attempts: u32,
+        sync_mode: SyncMode,
+    ) {
+        if sync_mode == SyncMode::Mandatory && attempts > 0 {
+            tokio::time::sleep(get_delay(attempts)).await;
+        }
+
+        let fetch = Self::fetch_summary(&vpn_api_client, &vpn_api_account, &device);
+
+        let sync_result = match sync_mode {
+            SyncMode::Optimistic => {
+                match tokio::time::timeout(OPTIMISTIC_SYNC_TIMEOUT, fetch).await {
+                    Ok(Ok(summary)) => Ok(Some(summary)),
+                    Ok(Err(err)) => {
+                        tracing::warn!(
+                            "optimistic account summary sync ended with an error : {err}"
+                        );
+                        Ok(None)
+                    }
+                    Err(_elapsed) => {
+                        tracing::warn!("optimistic account summary sync timed out");
+                        Ok(None)
+                    }
+                }
+            }
+            SyncMode::Mandatory => fetch.await.map(Some),
+        };
+        result_tx.send(sync_result).ok();
+    }
+
+    async fn fetch_summary(
+        vpn_api_client: &VpnApiClient,
+        vpn_api_account: &VpnAccount,
+        device: &Device,
+    ) -> Result<VpnAccountSummary, SyncError> {
+        // Fetch the remote time so the summary can record whether our clock is acceptably synced
+        // (a desync would make zk-nyms fail to verify on gateways). The desync itself is surfaced
+        // later, during the local checks, via `VpnAccountSummary::time_synced`.
+        let remote_time = vpn_api_client
+            .get_remote_time()
+            .await
+            .map_err(map_vpn_api_error)?;
+
+        let summary = vpn_api_client
+            .get_account_summary_with_device(vpn_api_account, device)
+            .await
+            .map_err(map_vpn_api_error)?;
+
+        tracing::debug!("{summary:#?}");
+
+        let summary = VpnAccountSummary::from_parts(&summary, vpn_api_account.mode(), remote_time)
+            .map_err(|err| SyncError::ApiResponseError {
+                details: format!("Failed to create account summary from API response: {err}"),
+            })?;
+
+        Ok(summary)
+    }
+}
+
+#[async_trait::async_trait]
+impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingNetworkState {
+    async fn handle_event(
+        mut self: Box<Self>,
+        shutdown_token: &CancellationToken,
+        command_rx: &'async_trait mut mpsc::UnboundedReceiver<AccountCommand>,
+        shared_state: &'async_trait mut SharedAccountState<C>,
+    ) -> NextAccountControllerState<C> {
+        tokio::select! {
+            biased;
+            _ = shutdown_token.cancelled() => {
+                NextAccountControllerState::Finished
+            }
+            Some(connectivity) = shared_state.connectivity_handle.next() => {
+                if connectivity.is_offline() {
+                    NextAccountControllerState::NewState(OfflineState::enter())
+                } else {
+                    NextAccountControllerState::SameState(self)
+                }
+            }
+            sync_result = &mut self.result_rx => {
+                match sync_result {
+                    Ok(Ok(Some(response))) => {
+                        // The summary is stored (and propagated to disk) even if the subsequent
+                        // local checks eventually fail.
+                        super::store_summary(shared_state, response);
+                        NextAccountControllerState::NewState(SyncingLocalState::enter(shared_state))
+
+                    }
+                    Ok(Ok(None)) => {
+                        // An optimistic refresh failed, no big deal
+                        NextAccountControllerState::NewState(SyncingLocalState::enter(shared_state))
+                    }
+                    Ok(Err(err)) => {
+                        // A mandatory sync failed
+                        tracing::error!("Mandatory sync failed ({err})");
+                        if self.attempts > MAX_SYNCING_ATTEMPTS {
+                            tracing::debug!("Error trying to get account summary, exhausted retries : {err}");
+                            NextAccountControllerState::NewState(ErrorState::enter(err.into_error_reason()))
+                        } else {
+                            tracing::debug!(
+                                "Error trying to get account summary attempt {}, retrying after {:?} : {err}",
+                                self.attempts,
+                                get_delay(self.attempts + 1),
+                            );
+                            NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, self.attempts + 1, SyncMode::Mandatory))
+                        }
+                    }
+                    Err(_) => {
+                        tracing::error!("No result from network sync, this shouldn't happen");
+                        NextAccountControllerState::NewState(ErrorState::enter(AccountControllerErrorStateReason::Internal { context: SYNCING_NETWORK_STATE_CONTEXT.to_string(), details: "No result sent from syncing task".to_string() }))
+                    }
+                }
+            }
+            Some(command) = command_rx.recv() => {
+                match command {
+                    AccountCommand::CreateAccount(return_sender) => return_sender.send(Err(AccountCommandError::ExistingAccount)),
+                    AccountCommand::StoreAccount(return_sender, _) => return_sender.send(Err(AccountCommandError::ExistingAccount)),
+                    AccountCommand::RegisterAccount(return_sender, account, platform) => {
+                        let res = handler::handle_register_account(shared_state, account, platform).await;
+                        return_sender.send(res);
+                    }
+                    AccountCommand::ForgetAccount(return_sender) => {
+                        let res = handler::handle_forget_account(shared_state).await;
+                        let error = res.is_err();
+                        return_sender.send(res);
+                        return if error {
+                            NextAccountControllerState::SameState(self)
+                        } else {
+                            NextAccountControllerState::NewState(LoggedOutState::enter())
+                        }
+                    },
+                    AccountCommand::LinkAccount(return_sender, privy_account) => {
+                        let res = handler::handle_link_account(shared_state, privy_account).await;
+                        return_sender.send(res);
+                    },
+                    AccountCommand::RotateKeys(return_sender) => {
+                        let res = handler::handle_rotate_keys(shared_state).await;
+                        return_sender.send(res);
+                    },
+                    AccountCommand::AccountBalance(return_sender) => return_sender.send(Err(AccountCommandError::AccountNotDecentralised)),
+                    AccountCommand::ObtainTicketbooks(return_sender, _) => return_sender.send(Err(AccountCommandError::AccountNotDecentralised)),
+                    AccountCommand::RefreshAccountState(return_sender) => {
+                        return_sender.send(Ok(()));
+                        return if shared_state.firewall_active {
+                            NextAccountControllerState::SameState(self)
+                        } else {
+                            NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic))
+                        }
+                    },
+                    AccountCommand::ForceRefreshAccountState(return_sender) => {
+                        return_sender.send(Ok(()));
+                        return if shared_state.firewall_active {
+                            NextAccountControllerState::SameState(self)
+                        } else {
+                           super::force_refresh(shared_state)
+                        }
+                    },
+                    AccountCommand::ResetDeviceIdentity(return_sender, seed) => {
+                        return_sender.send(handler::handle_reset_device_identity(shared_state, seed).await);
+                        return super::force_refresh(shared_state);
+                    },
+
+                    AccountCommand::VpnApiFirewallDown(return_sender) =>  {
+                        return_sender.send(Ok(()));
+                        // No-op if the firewall was already down
+                        if shared_state.firewall_active {
+                            shared_state.firewall_active = false;
+                            return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, self.attempts, SyncMode::Optimistic));
+                        }
+                    },
+
+                    AccountCommand::VpnApiFirewallUp(return_sender) => {
+                        shared_state.firewall_active = true;
+                        // Explicitly cancel sync task since the same state persists.
+                        // Sync will restart once firewall permits traffic to flow again.
+                        self.sync_cancel_token.take();
+                        return_sender.send(Ok(()));
+                    },
+
+                    AccountCommand::Common(common_command) => {
+                        common_handler::handle_common_command(common_command, shared_state).await
+                    },
+                    AccountCommand::UpgradeMode(upgrade_mode_command) => match upgrade_mode_command {
+                        UpgradeModeCommand::GetUpgradeModeEnabled(return_sender) => {
+                            return_sender.send(Ok(false))
+                        }
+                        UpgradeModeCommand::DisableUpgradeMode(return_sender) => {
+                            warn!(
+                                "received unexpected command to disable upgrade mode while in 'SyncingNetworkState' state"
+                            );
+                            return_sender.send(Ok(()))
+                        }
+                    },
+                }
+                NextAccountControllerState::SameState(self)
+            }
+
+        }
+    }
+}
+
+#[derive(Debug, strum::Display)]
+enum SyncError {
+    ApiRequestError(String),
+    ApiResponseError { details: String },
+    UnregisteredAccount,
+}
+
+impl SyncError {
+    /// Maps a network fetch failure to the reason carried into the error state.
+    fn into_error_reason(self) -> AccountControllerErrorStateReason {
+        use SyncError::*;
+        match self {
+            ApiRequestError(e) => AccountControllerErrorStateReason::ApiFailure {
+                context: SYNCING_NETWORK_STATE_CONTEXT.into(),
+                details: e,
+            },
+            ApiResponseError { details } => AccountControllerErrorStateReason::ApiFailure {
+                context: SYNCING_NETWORK_STATE_CONTEXT.into(),
+                details,
+            },
+            UnregisteredAccount => AccountControllerErrorStateReason::AccountStatusNotActive {
+                status: "unregistered".into(),
+            },
+        }
+    }
+}
+
+impl From<VpnApiClientError> for SyncError {
+    fn from(value: VpnApiClientError) -> Self {
+        match NymErrorResponse::try_from(value) {
+            Ok(error_response) => SyncError::ApiResponseError {
+                details: error_response
+                    .code_reference_id
+                    .unwrap_or(error_response.message),
+            },
+            Err(e) => SyncError::ApiRequestError(e.to_string()),
+        }
+    }
+}
+
+fn map_vpn_api_error(err: VpnApiClientError) -> SyncError {
+    match NymErrorResponse::try_from(err) {
+        Ok(error_response) => {
+            // SW Use UUID when it will be available
+            if error_response.status == "access_denied"
+                && error_response.message == "Account not found"
+            {
+                // Request was fine, but account is unregistered
+                // Later down the line we can maybe register it here
+                SyncError::UnregisteredAccount
+            } else {
+                SyncError::ApiResponseError {
+                    details: error_response
+                        .code_reference_id
+                        .unwrap_or(error_response.message),
+                }
+            }
+        }
+        Err(err) => SyncError::from(err),
+    }
+}

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/network_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/network_state.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{cmp::min, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 use crate::{
     SharedAccountState,
@@ -30,18 +30,7 @@ const SYNCING_NETWORK_STATE_CONTEXT: &str = "SYNCING_NETWORK_STATE";
 
 /// In optimistic mode, how long we wait for the summary fetch before falling back to the cached
 /// summary.
-const OPTIMISTIC_SYNC_TIMEOUT: Duration = Duration::from_secs(5);
-
-const MAX_SYNCING_ATTEMPTS: u32 = 5;
-// bounded exponential backoff for retries [0.25, 0.5, 1.0, 2.0, 4.0, 8.0] = 15.75s max wait
-const RETRY_BACKOFF: Duration = Duration::from_millis(250);
-const MAX_BACKOFF_EXPONENT: u32 = 5;
-const BACKOFF_BASE: u32 = 2;
-
-/// The attempt retries should start with attempt 1
-fn get_delay(attempts: u32) -> Duration {
-    RETRY_BACKOFF * BACKOFF_BASE.pow(min(attempts.saturating_sub(1), MAX_BACKOFF_EXPONENT))
-}
+const OPTIMISTIC_SYNC_TIMEOUT: Duration = Duration::from_secs(3);
 
 type SyncResult = Result<Option<VpnAccountSummary>, SyncError>;
 
@@ -69,7 +58,6 @@ type SyncResult = Result<Option<VpnAccountSummary>, SyncError>;
 /// - OfflineState : the connectivity monitor is telling we're not connected
 /// - DecentralisedState : The loaded account is set to "decentralised" mode
 pub(crate) struct SyncingNetworkState {
-    attempts: u32,
     result_rx: oneshot::Receiver<SyncResult>,
     sync_cancel_token: Option<DropGuard>,
 }
@@ -77,7 +65,6 @@ pub(crate) struct SyncingNetworkState {
 impl SyncingNetworkState {
     pub(crate) fn enter<C: ConnectivityMonitor>(
         shared_state: &SharedAccountState<C>,
-        attempts: u32,
         sync_mode: SyncMode,
     ) -> (
         Box<dyn AccountControllerStateHandler<C>>,
@@ -100,11 +87,11 @@ impl SyncingNetworkState {
 
         // Use the provided sync mode unless there is no cache
         let sync_mode = if shared_state.vpn_account_summary.is_none() {
-            tracing::debug!("Sync mode overriding because account summary isn't present");
             SyncMode::Mandatory
         } else {
             sync_mode
         };
+        tracing::debug!("Optimistic sync? : {}", sync_mode == SyncMode::Optimistic);
 
         let (result_tx, result_rx) = oneshot::channel();
         let sync_cancel_token = CancellationToken::new();
@@ -117,14 +104,12 @@ impl SyncingNetworkState {
                     vpn_api_client,
                     vpn_api_account,
                     device,
-                    attempts,
                     sync_mode,
                 ),
             ));
 
         (
             Box::new(Self {
-                attempts,
                 result_rx,
                 sync_cancel_token: Some(sync_cancel_token.drop_guard()),
             }),
@@ -137,13 +122,8 @@ impl SyncingNetworkState {
         vpn_api_client: VpnApiClient,
         vpn_api_account: Arc<VpnAccount>,
         device: Device,
-        attempts: u32,
         sync_mode: SyncMode,
     ) {
-        if sync_mode == SyncMode::Mandatory && attempts > 0 {
-            tokio::time::sleep(get_delay(attempts)).await;
-        }
-
         let fetch = Self::fetch_summary(&vpn_api_client, &vpn_api_account, &device);
 
         let sync_result = match sync_mode {
@@ -232,17 +212,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingNetwork
                     Ok(Err(err)) => {
                         // A mandatory sync failed
                         tracing::error!("Mandatory sync failed ({err})");
-                        if self.attempts > MAX_SYNCING_ATTEMPTS {
-                            tracing::debug!("Error trying to get account summary, exhausted retries : {err}");
-                            NextAccountControllerState::NewState(ErrorState::enter(err.into_error_reason()))
-                        } else {
-                            tracing::debug!(
-                                "Error trying to get account summary attempt {}, retrying after {:?} : {err}",
-                                self.attempts,
-                                get_delay(self.attempts + 1),
-                            );
-                            NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, self.attempts + 1, SyncMode::Mandatory))
-                        }
+                        NextAccountControllerState::NewState(ErrorState::enter(err.into_error_reason()))
                     }
                     Err(_) => {
                         tracing::error!("No result from network sync, this shouldn't happen");
@@ -286,7 +256,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingNetwork
                             if force {
                                 return super::force_refresh(shared_state);
                             } else {
-                                return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic));
+                                return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Optimistic));
                             }
                         }
                     },
@@ -300,7 +270,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingNetwork
                         // No-op if the firewall was already down
                         if shared_state.firewall_active {
                             shared_state.firewall_active = false;
-                            return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, self.attempts, SyncMode::Optimistic));
+                            return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Optimistic));
                         }
                     },
 

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/requesting_zknym_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/requesting_zknym_state.rs
@@ -348,10 +348,7 @@ impl RequestingZkNymsState {
             AccountCommand::ResetDeviceIdentity(return_sender, seed) => {
                 self.zk_nym_fetching_handle.abort();
                 return_sender.send(handler::handle_reset_device_identity(shared_state, seed).await);
-                return NextAccountControllerState::NewState(SyncingNetworkState::enter(
-                    shared_state,
-                    SyncMode::Optimistic,
-                ));
+                return super::force_refresh(shared_state);
             }
             AccountCommand::RefreshAccountState(return_sender, force) => {
                 return_sender.send(Ok(()));

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/requesting_zknym_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/requesting_zknym_state.rs
@@ -229,7 +229,7 @@ impl RequestingZkNymsState {
         let join_result = match zknym_result {
             Ok(join_result) => join_result,
             Err(err) => {
-                error!("Failed to join on the fetching task, task probably fot cancelled : {err}");
+                error!("Failed to join on the fetching task, task probably got cancelled : {err}");
                 return NextAccountControllerState::SameState(self);
             }
         };

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/requesting_zknym_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/requesting_zknym_state.rs
@@ -222,18 +222,15 @@ impl RequestingZkNymsState {
     }
 
     async fn handle_retrieved_zk_nym<C: ConnectivityMonitor>(
-        &mut self,
+        self: Box<Self>,
         shared_state: &mut SharedAccountState<C>,
         zknym_result: Result<Result<ZkNymFetchResult, ZkNymError>, JoinError>,
     ) -> NextAccountControllerState<C> {
         let join_result = match zknym_result {
             Ok(join_result) => join_result,
             Err(err) => {
-                error!("Failed to join on the fetching task : {err}");
-                return NextAccountControllerState::NewState(SyncingNetworkState::enter(
-                    shared_state,
-                    SyncMode::Optimistic,
-                ));
+                error!("Failed to join on the fetching task, task probably fot cancelled : {err}");
+                return NextAccountControllerState::SameState(self);
             }
         };
 

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/requesting_zknym_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/requesting_zknym_state.rs
@@ -232,7 +232,6 @@ impl RequestingZkNymsState {
                 error!("Failed to join on the fetching task : {err}");
                 return NextAccountControllerState::NewState(SyncingNetworkState::enter(
                     shared_state,
-                    self.attempts + 1,
                     SyncMode::Optimistic,
                 ));
             }
@@ -326,7 +325,6 @@ impl RequestingZkNymsState {
                 return if error {
                     NextAccountControllerState::NewState(SyncingNetworkState::enter(
                         shared_state,
-                        0,
                         SyncMode::Optimistic,
                     ))
                 } else {
@@ -352,7 +350,6 @@ impl RequestingZkNymsState {
                 return_sender.send(handler::handle_reset_device_identity(shared_state, seed).await);
                 return NextAccountControllerState::NewState(SyncingNetworkState::enter(
                     shared_state,
-                    0,
                     SyncMode::Optimistic,
                 ));
             }
@@ -367,7 +364,6 @@ impl RequestingZkNymsState {
                     } else {
                         return NextAccountControllerState::NewState(SyncingNetworkState::enter(
                             shared_state,
-                            0,
                             SyncMode::Optimistic,
                         ));
                     }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/requesting_zknym_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/requesting_zknym_state.rs
@@ -19,7 +19,7 @@ use crate::{
     state_machine::{
         AccountControllerStateHandler, ErrorState, LoggedOutState, NextAccountControllerState,
         OfflineState, PrivateAccountControllerState, ReadyState, SyncMode, SyncingNetworkState,
-        UpgradeModeState, syncing_state,
+        UpgradeModeState,
     },
     storage::VpnCredentialStorage,
 };
@@ -345,7 +345,10 @@ impl RequestingZkNymsState {
             AccountCommand::ResetDeviceIdentity(return_sender, seed) => {
                 self.zk_nym_fetching_handle.abort();
                 return_sender.send(handler::handle_reset_device_identity(shared_state, seed).await);
-                return super::force_refresh(shared_state);
+                return NextAccountControllerState::NewState(SyncingNetworkState::enter(
+                    shared_state,
+                    SyncMode::Mandatory,
+                ));
             }
             AccountCommand::RefreshAccountState(return_sender, force) => {
                 return_sender.send(Ok(()));
@@ -354,7 +357,11 @@ impl RequestingZkNymsState {
                 } else {
                     self.zk_nym_fetching_handle.abort();
                     if force {
-                        return syncing_state::force_refresh(shared_state);
+                        shared_state.mark_summary_as_stale();
+                        return NextAccountControllerState::NewState(SyncingNetworkState::enter(
+                            shared_state,
+                            SyncMode::Mandatory,
+                        ));
                     } else {
                         return NextAccountControllerState::NewState(SyncingNetworkState::enter(
                             shared_state,

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/requesting_zknym_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/requesting_zknym_state.rs
@@ -18,7 +18,8 @@ use crate::{
     },
     state_machine::{
         AccountControllerStateHandler, ErrorState, LoggedOutState, NextAccountControllerState,
-        OfflineState, PrivateAccountControllerState, ReadyState, SyncingState, UpgradeModeState,
+        OfflineState, PrivateAccountControllerState, ReadyState, SyncMode, SyncingNetworkState,
+        UpgradeModeState, syncing_state,
     },
     storage::VpnCredentialStorage,
 };
@@ -47,7 +48,7 @@ const ZK_NYM_STATE_CONTEXT: &str = "ZK_NYM_STATE";
 /// - ReadyState : We have enough tickets already, or we managed to get enough tickets
 /// - ErrorState : An error happened, preventing us to proceed.
 /// - OfflineState : the connectivity monitor is telling we're not connected
-/// - SyncingState : We handled a refresh account command
+/// - SyncingNetworkState : We handled a (force) refresh account command, or a join/retry
 /// - LoggedOutState : A successful forget account command was handled
 /// - UpgradeModeState : Instead of retrieving zk-nyms, we have received information about upgrade mode being activated
 pub(crate) struct RequestingZkNymsState {
@@ -229,9 +230,10 @@ impl RequestingZkNymsState {
             Ok(join_result) => join_result,
             Err(err) => {
                 error!("Failed to join on the fetching task : {err}");
-                return NextAccountControllerState::NewState(SyncingState::enter(
+                return NextAccountControllerState::NewState(SyncingNetworkState::enter(
                     shared_state,
                     self.attempts + 1,
+                    SyncMode::Optimistic,
                 ));
             }
         };
@@ -322,7 +324,11 @@ impl RequestingZkNymsState {
                 let error = res.is_err();
                 return_sender.send(res);
                 return if error {
-                    NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0))
+                    NextAccountControllerState::NewState(SyncingNetworkState::enter(
+                        shared_state,
+                        0,
+                        SyncMode::Optimistic,
+                    ))
                 } else {
                     NextAccountControllerState::NewState(LoggedOutState::enter())
                 };
@@ -344,7 +350,11 @@ impl RequestingZkNymsState {
             AccountCommand::ResetDeviceIdentity(return_sender, seed) => {
                 self.zk_nym_fetching_handle.abort();
                 return_sender.send(handler::handle_reset_device_identity(shared_state, seed).await);
-                return NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0));
+                return NextAccountControllerState::NewState(SyncingNetworkState::enter(
+                    shared_state,
+                    0,
+                    SyncMode::Optimistic,
+                ));
             }
             AccountCommand::RefreshAccountState(return_sender) => {
                 return_sender.send(Ok(()));
@@ -352,7 +362,20 @@ impl RequestingZkNymsState {
                     NextAccountControllerState::SameState(self)
                 } else {
                     self.zk_nym_fetching_handle.abort();
-                    NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0))
+                    NextAccountControllerState::NewState(SyncingNetworkState::enter(
+                        shared_state,
+                        0,
+                        SyncMode::Optimistic,
+                    ))
+                };
+            }
+            AccountCommand::ForceRefreshAccountState(return_sender) => {
+                return_sender.send(Ok(()));
+                return if shared_state.firewall_active {
+                    NextAccountControllerState::SameState(self)
+                } else {
+                    self.zk_nym_fetching_handle.abort();
+                    syncing_state::force_refresh(shared_state)
                 };
             }
             AccountCommand::VpnApiFirewallDown(return_sender) => {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/requesting_zknym_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/requesting_zknym_state.rs
@@ -356,26 +356,21 @@ impl RequestingZkNymsState {
                     SyncMode::Optimistic,
                 ));
             }
-            AccountCommand::RefreshAccountState(return_sender) => {
+            AccountCommand::RefreshAccountState(return_sender, force) => {
                 return_sender.send(Ok(()));
                 return if shared_state.firewall_active {
                     NextAccountControllerState::SameState(self)
                 } else {
                     self.zk_nym_fetching_handle.abort();
-                    NextAccountControllerState::NewState(SyncingNetworkState::enter(
-                        shared_state,
-                        0,
-                        SyncMode::Optimistic,
-                    ))
-                };
-            }
-            AccountCommand::ForceRefreshAccountState(return_sender) => {
-                return_sender.send(Ok(()));
-                return if shared_state.firewall_active {
-                    NextAccountControllerState::SameState(self)
-                } else {
-                    self.zk_nym_fetching_handle.abort();
-                    syncing_state::force_refresh(shared_state)
+                    if force {
+                        return syncing_state::force_refresh(shared_state);
+                    } else {
+                        return NextAccountControllerState::NewState(SyncingNetworkState::enter(
+                            shared_state,
+                            0,
+                            SyncMode::Optimistic,
+                        ));
+                    }
                 };
             }
             AccountCommand::VpnApiFirewallDown(return_sender) => {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/upgrade_mode_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/upgrade_mode_state.rs
@@ -6,8 +6,8 @@ use crate::{
     shared_state::SharedAccountState,
     state_machine::{
         AccountControllerStateHandler, ErrorState, LoggedOutState, NextAccountControllerState,
-        PrivateAccountControllerState, RequestingZkNymsState, SyncingState,
-        UPGRADE_MODE_DEFAULT_REFRESH_INTERVAL,
+        PrivateAccountControllerState, RequestingZkNymsState, SyncMode, SyncingNetworkState,
+        UPGRADE_MODE_DEFAULT_REFRESH_INTERVAL, syncing_state,
     },
 };
 use nym_offline_monitor::ConnectivityMonitor;
@@ -29,7 +29,7 @@ const UM_STATE_CONTEXT: &str = "UPGRADE_MODE_STATE";
 ///   to make sure the above still holds and so that we could refresh our JWT if it's close to expiry.
 /// - ErrorState : An error happened, preventing us to proceed.
 /// - LoggedOutState : A successful forget account command was handled
-/// - SyncingState : A successful disable upgrade mode command was handled
+/// - SyncingNetworkState : A successful disable upgrade mode command was handled
 pub struct UpgradeModeState {
     refresh_timer: Pin<Box<Sleep>>,
 }
@@ -73,7 +73,7 @@ impl UpgradeModeState {
                     // instead of crashing
                     if until_expiration.is_negative() {
                         info!("the retrieved upgrade mode JWT expired immediately");
-                        return SyncingState::enter(shared_state, 0);
+                        return SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic);
                     }
                     until_expiration.unsigned_abs()
                 } else {
@@ -164,7 +164,11 @@ impl UpgradeModeState {
                     if let Err(error_state) = Self::on_exit(shared_state).await {
                         return error_state.into();
                     }
-                    NextAccountControllerState::NewState(SyncingState::enter(shared_state, 0))
+                    NextAccountControllerState::NewState(SyncingNetworkState::enter(
+                        shared_state,
+                        0,
+                        SyncMode::Optimistic,
+                    ))
                 };
             }
             AccountCommand::RefreshAccountState(return_sender) => {
@@ -176,10 +180,23 @@ impl UpgradeModeState {
                     if let Err(error_state) = Self::on_exit(shared_state).await {
                         return error_state.into();
                     }
-                    return NextAccountControllerState::NewState(SyncingState::enter(
+                    return NextAccountControllerState::NewState(SyncingNetworkState::enter(
                         shared_state,
                         0,
+                        SyncMode::Optimistic,
                     ));
+                }
+            }
+            AccountCommand::ForceRefreshAccountState(return_sender) => {
+                return_sender.send(Ok(()));
+                if shared_state.firewall_active {
+                    warn!("firewall is active - unable to refresh account state");
+                    return NextAccountControllerState::SameState(self);
+                } else {
+                    if let Err(error_state) = Self::on_exit(shared_state).await {
+                        return error_state.into();
+                    }
+                    return syncing_state::force_refresh(shared_state);
                 }
             }
             AccountCommand::VpnApiFirewallDown(return_sender) => {
@@ -202,9 +219,10 @@ impl UpgradeModeState {
                     if let Err(error_state) = Self::on_exit(shared_state).await {
                         return error_state.into();
                     }
-                    return NextAccountControllerState::NewState(SyncingState::enter(
+                    return NextAccountControllerState::NewState(SyncingNetworkState::enter(
                         shared_state,
                         0,
+                        SyncMode::Optimistic,
                     ));
                 }
             },

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/upgrade_mode_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/upgrade_mode_state.rs
@@ -7,7 +7,7 @@ use crate::{
     state_machine::{
         AccountControllerStateHandler, ErrorState, LoggedOutState, NextAccountControllerState,
         PrivateAccountControllerState, RequestingZkNymsState, SyncMode, SyncingNetworkState,
-        UPGRADE_MODE_DEFAULT_REFRESH_INTERVAL, syncing_state,
+        UPGRADE_MODE_DEFAULT_REFRESH_INTERVAL,
     },
 };
 use nym_offline_monitor::ConnectivityMonitor;
@@ -164,7 +164,10 @@ impl UpgradeModeState {
                     if let Err(error_state) = Self::on_exit(shared_state).await {
                         return error_state.into();
                     }
-                    syncing_state::force_refresh(shared_state)
+                    return NextAccountControllerState::NewState(SyncingNetworkState::enter(
+                        shared_state,
+                        SyncMode::Mandatory,
+                    ));
                 };
             }
             AccountCommand::RefreshAccountState(return_sender, force) => {
@@ -177,7 +180,11 @@ impl UpgradeModeState {
                         return error_state.into();
                     }
                     if force {
-                        return syncing_state::force_refresh(shared_state);
+                        shared_state.mark_summary_as_stale();
+                        return NextAccountControllerState::NewState(SyncingNetworkState::enter(
+                            shared_state,
+                            SyncMode::Mandatory,
+                        ));
                     } else {
                         return NextAccountControllerState::NewState(SyncingNetworkState::enter(
                             shared_state,

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/upgrade_mode_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/upgrade_mode_state.rs
@@ -171,7 +171,7 @@ impl UpgradeModeState {
                     ))
                 };
             }
-            AccountCommand::RefreshAccountState(return_sender) => {
+            AccountCommand::RefreshAccountState(return_sender, force) => {
                 return_sender.send(Ok(()));
                 if shared_state.firewall_active {
                     warn!("firewall is active - unable to refresh account state");
@@ -180,23 +180,15 @@ impl UpgradeModeState {
                     if let Err(error_state) = Self::on_exit(shared_state).await {
                         return error_state.into();
                     }
-                    return NextAccountControllerState::NewState(SyncingNetworkState::enter(
-                        shared_state,
-                        0,
-                        SyncMode::Optimistic,
-                    ));
-                }
-            }
-            AccountCommand::ForceRefreshAccountState(return_sender) => {
-                return_sender.send(Ok(()));
-                if shared_state.firewall_active {
-                    warn!("firewall is active - unable to refresh account state");
-                    return NextAccountControllerState::SameState(self);
-                } else {
-                    if let Err(error_state) = Self::on_exit(shared_state).await {
-                        return error_state.into();
+                    if force {
+                        return syncing_state::force_refresh(shared_state);
+                    } else {
+                        return NextAccountControllerState::NewState(SyncingNetworkState::enter(
+                            shared_state,
+                            0,
+                            SyncMode::Optimistic,
+                        ));
                     }
-                    return syncing_state::force_refresh(shared_state);
                 }
             }
             AccountCommand::VpnApiFirewallDown(return_sender) => {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/upgrade_mode_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/upgrade_mode_state.rs
@@ -73,7 +73,7 @@ impl UpgradeModeState {
                     // instead of crashing
                     if until_expiration.is_negative() {
                         info!("the retrieved upgrade mode JWT expired immediately");
-                        return SyncingNetworkState::enter(shared_state, 0, SyncMode::Optimistic);
+                        return SyncingNetworkState::enter(shared_state, SyncMode::Optimistic);
                     }
                     until_expiration.unsigned_abs()
                 } else {
@@ -166,7 +166,6 @@ impl UpgradeModeState {
                     }
                     NextAccountControllerState::NewState(SyncingNetworkState::enter(
                         shared_state,
-                        0,
                         SyncMode::Optimistic,
                     ))
                 };
@@ -185,7 +184,6 @@ impl UpgradeModeState {
                     } else {
                         return NextAccountControllerState::NewState(SyncingNetworkState::enter(
                             shared_state,
-                            0,
                             SyncMode::Optimistic,
                         ));
                     }
@@ -213,7 +211,6 @@ impl UpgradeModeState {
                     }
                     return NextAccountControllerState::NewState(SyncingNetworkState::enter(
                         shared_state,
-                        0,
                         SyncMode::Optimistic,
                     ));
                 }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/upgrade_mode_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/upgrade_mode_state.rs
@@ -164,10 +164,7 @@ impl UpgradeModeState {
                     if let Err(error_state) = Self::on_exit(shared_state).await {
                         return error_state.into();
                     }
-                    NextAccountControllerState::NewState(SyncingNetworkState::enter(
-                        shared_state,
-                        SyncMode::Optimistic,
-                    ))
+                    syncing_state::force_refresh(shared_state)
                 };
             }
             AccountCommand::RefreshAccountState(return_sender, force) => {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/account.rs
@@ -3,7 +3,7 @@
 
 use crate::{commands::ReturnSender, error::Error};
 use nym_vpn_api_client::types::{Device, VpnAccount};
-use nym_vpn_lib_types::StorableAccount;
+use nym_vpn_lib_types::{StorableAccount, VpnAccountSummary};
 use nym_vpn_store::VpnStorage;
 
 #[derive(Debug)]
@@ -99,6 +99,33 @@ where
             })
     }
 
+    pub(crate) async fn load_account_summary(&self) -> Result<Option<VpnAccountSummary>, Error> {
+        self.storage
+            .load_summary()
+            .await
+            .map_err(|err| Error::AccountSummaryStore {
+                source: Box::new(err),
+            })
+    }
+
+    async fn store_account_summary(&self, summary: VpnAccountSummary) -> Result<(), Error> {
+        self.storage
+            .store_summary(summary)
+            .await
+            .map_err(|err| Error::AccountSummaryStore {
+                source: Box::new(err),
+            })
+    }
+
+    async fn remove_account_summary(&self) -> Result<(), Error> {
+        self.storage
+            .remove_summary()
+            .await
+            .map_err(|err| Error::AccountSummaryStore {
+                source: Box::new(err),
+            })
+    }
+
     async fn init_account(&self, account: StorableAccount) -> Result<Device, Error> {
         self.init_keys().await?;
         let device = self
@@ -118,7 +145,12 @@ where
 
     async fn forget_account(&self) -> Result<(), Error> {
         self.remove_account().await?;
-        self.remove_device_keys().await
+        self.remove_device_keys().await?;
+        // The cached summary is non-critical; don't fail the whole forget if its removal fails.
+        if let Err(err) = self.remove_account_summary().await {
+            tracing::warn!("Failed to remove cached account summary on forget: {err}");
+        }
+        Ok(())
     }
 
     pub(crate) async fn handle_storage_op(&self, op: AccountStorageOp) {
@@ -135,6 +167,17 @@ where
             AccountStorageOp::ResetKeys(result_tx, seed) => {
                 result_tx.send(self.reset_and_load_keys(seed).await)
             }
+            // Summary persistence is a best-effort cache: log failures rather than surfacing them.
+            AccountStorageOp::StoreAccountSummary(summary) => {
+                if let Err(err) = self.store_account_summary(*summary).await {
+                    tracing::warn!("Failed to persist account summary: {err}");
+                }
+            }
+            AccountStorageOp::RemoveAccountSummary => {
+                if let Err(err) = self.remove_account_summary().await {
+                    tracing::warn!("Failed to remove cached account summary: {err}");
+                }
+            }
         }
     }
 }
@@ -144,4 +187,8 @@ pub(crate) enum AccountStorageOp {
     StoreAccount(ReturnSender<Device, Error>, StorableAccount),
     ForgetAccount(ReturnSender<(), Error>),
     ResetKeys(ReturnSender<Device, Error>, Option<[u8; 32]>),
+    /// Persist the latest account summary to the cache (best-effort, fire-and-forget).
+    StoreAccountSummary(Box<VpnAccountSummary>),
+    /// Drop the cached account summary (best-effort, fire-and-forget).
+    RemoveAccountSummary,
 }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/storage/account.rs
@@ -108,7 +108,10 @@ where
             })
     }
 
-    async fn store_account_summary(&self, summary: VpnAccountSummary) -> Result<(), Error> {
+    pub(crate) async fn store_account_summary(
+        &self,
+        summary: VpnAccountSummary,
+    ) -> Result<(), Error> {
         self.storage
             .store_summary(summary)
             .await
@@ -117,7 +120,7 @@ where
             })
     }
 
-    async fn remove_account_summary(&self) -> Result<(), Error> {
+    pub(crate) async fn remove_account_summary(&self) -> Result<(), Error> {
         self.storage
             .remove_summary()
             .await

--- a/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/commands.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/commands.rs
@@ -252,10 +252,23 @@ async fn ready_state_command() -> anyhow::Result<()> {
         .assert_state(AccountControllerState::ReadyToConnect)
         .await;
 
+    // A local refresh re-evaluates the cached summary and lands back in the ready state.
     assert_eq!(
         test_bench
             .command_sender
             .background_refresh_account_state()
+            .await,
+        Ok(())
+    );
+    test_bench
+        .assert_state(AccountControllerState::ReadyToConnect)
+        .await;
+
+    // A force refresh re-syncs with the VPN API, going through the syncing state.
+    assert_eq!(
+        test_bench
+            .command_sender
+            .force_refresh_account_state()
             .await,
         Ok(())
     );
@@ -360,10 +373,25 @@ async fn error_state_command() -> anyhow::Result<()> {
         ))
         .await;
 
+    // A local refresh re-evaluates the cached summary and lands back in the error state.
     assert_eq!(
         test_bench
             .command_sender
             .background_refresh_account_state()
+            .await,
+        Ok(())
+    );
+    test_bench
+        .assert_state(AccountControllerState::Error(
+            AccountControllerErrorStateReason::MaxDeviceReached,
+        ))
+        .await;
+
+    // A force refresh re-syncs with the VPN API, going through the syncing state.
+    assert_eq!(
+        test_bench
+            .command_sender
+            .force_refresh_account_state()
             .await,
         Ok(())
     );

--- a/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/commands.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/commands.rs
@@ -31,10 +31,7 @@ async fn logged_out_state_command() -> anyhow::Result<()> {
     test_bench.register_vpn_api_mocks(mocks).await;
 
     assert_eq!(
-        test_bench
-            .command_sender
-            .background_refresh_account_state()
-            .await,
+        test_bench.command_sender.refresh_account_state(false).await,
         Err(AccountCommandError::NoAccountStored)
     );
 
@@ -124,10 +121,7 @@ async fn offline_state_command() -> anyhow::Result<()> {
         .await;
 
     assert_eq!(
-        test_bench
-            .command_sender
-            .background_refresh_account_state()
-            .await,
+        test_bench.command_sender.refresh_account_state(false).await,
         Err(AccountCommandError::Offline)
     );
 
@@ -254,10 +248,7 @@ async fn ready_state_command() -> anyhow::Result<()> {
 
     // A local refresh re-evaluates the cached summary and lands back in the ready state.
     assert_eq!(
-        test_bench
-            .command_sender
-            .background_refresh_account_state()
-            .await,
+        test_bench.command_sender.refresh_account_state(false).await,
         Ok(())
     );
     test_bench
@@ -266,10 +257,7 @@ async fn ready_state_command() -> anyhow::Result<()> {
 
     // A force refresh re-syncs with the VPN API, going through the syncing state.
     assert_eq!(
-        test_bench
-            .command_sender
-            .force_refresh_account_state()
-            .await,
+        test_bench.command_sender.refresh_account_state(true).await,
         Ok(())
     );
     test_bench
@@ -375,10 +363,7 @@ async fn error_state_command() -> anyhow::Result<()> {
 
     // A local refresh re-evaluates the cached summary and lands back in the error state.
     assert_eq!(
-        test_bench
-            .command_sender
-            .background_refresh_account_state()
-            .await,
+        test_bench.command_sender.refresh_account_state(false).await,
         Ok(())
     );
     test_bench
@@ -389,10 +374,7 @@ async fn error_state_command() -> anyhow::Result<()> {
 
     // A force refresh re-syncs with the VPN API, going through the syncing state.
     assert_eq!(
-        test_bench
-            .command_sender
-            .force_refresh_account_state()
-            .await,
+        test_bench.command_sender.refresh_account_state(true).await,
         Ok(())
     );
     test_bench

--- a/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/common/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/common/mod.rs
@@ -109,11 +109,12 @@ impl ConnectivityMonitor for MockConnectivityHandle {
     }
 }
 
-/// Mock storage for device keys and mnemonic
+/// Mock storage for device keys, mnemonic and account summary
 #[derive(Default)]
 pub struct MockEphemeralStorage {
     key_store: nym_vpn_store::keys::device::InMemEphemeralKeys,
     mnemonic_storage: nym_vpn_store::account::ephemeral::InMemoryAccountStorage,
+    summary_storage: nym_vpn_store::account_summary::ephemeral::InMemoryAccountSummaryStorage,
 }
 
 impl nym_vpn_store::VpnStorage for MockEphemeralStorage {}
@@ -157,6 +158,28 @@ impl AccountInformationStorage for MockEphemeralStorage {
 
     async fn remove_account(&self) -> Result<(), Self::StorageError> {
         self.mnemonic_storage.remove_account().await
+    }
+}
+
+#[async_trait::async_trait]
+impl nym_vpn_store::account_summary::AccountSummaryStorage for MockEphemeralStorage {
+    type StorageError = std::convert::Infallible;
+
+    async fn load_summary(
+        &self,
+    ) -> Result<Option<nym_vpn_lib_types::VpnAccountSummary>, Self::StorageError> {
+        self.summary_storage.load_summary().await
+    }
+
+    async fn store_summary(
+        &self,
+        account: nym_vpn_lib_types::VpnAccountSummary,
+    ) -> Result<(), Self::StorageError> {
+        self.summary_storage.store_summary(account).await
+    }
+
+    async fn remove_summary(&self) -> Result<(), Self::StorageError> {
+        self.summary_storage.remove_summary().await
     }
 }
 

--- a/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/paths.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/paths.rs
@@ -94,7 +94,7 @@ async fn api_error_reponse_test() -> anyhow::Result<()> {
         .assert_state(AccountControllerState::Error(
             AccountControllerErrorStateReason::ApiFailure {
                 context: "SYNCING_NETWORK_STATE".into(),
-                details: "55cbd0ee-4ff5-4f3d-930e-6f6a95ce849f".into(),
+                details: "API returned an error: 55cbd0ee-4ff5-4f3d-930e-6f6a95ce849f".into(),
             },
         ))
         .await;
@@ -494,7 +494,7 @@ async fn optimistic_refresh_falls_back_but_force_refresh_surfaces_error_test() -
         .assert_state(AccountControllerState::Error(
             AccountControllerErrorStateReason::ApiFailure {
                 context: "SYNCING_NETWORK_STATE".into(),
-                details: "55cbd0ee-4ff5-4f3d-930e-6f6a95ce849f".into(),
+                details: "API returned an error: 55cbd0ee-4ff5-4f3d-930e-6f6a95ce849f".into(),
             },
         ))
         .await;

--- a/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/paths.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/paths.rs
@@ -429,7 +429,7 @@ async fn force_refresh_detects_inactive_account_test() -> anyhow::Result<()> {
         .await;
 
     assert_eq!(
-        test_bench.command_sender.force_refresh_account_state().await,
+        test_bench.command_sender.refresh_account_state(true).await,
         Ok(())
     );
     test_bench
@@ -478,10 +478,7 @@ async fn optimistic_refresh_falls_back_but_force_refresh_surfaces_error_test() -
 
     // Optimistic refresh: the fetch fails, but we fall back to the cached summary and stay ready.
     assert_eq!(
-        test_bench
-            .command_sender
-            .background_refresh_account_state()
-            .await,
+        test_bench.command_sender.refresh_account_state(false).await,
         Ok(())
     );
     test_bench
@@ -490,7 +487,7 @@ async fn optimistic_refresh_falls_back_but_force_refresh_surfaces_error_test() -
 
     // Force refresh: no cache fallback, so the API error is surfaced (after exhausting retries).
     assert_eq!(
-        test_bench.command_sender.force_refresh_account_state().await,
+        test_bench.command_sender.refresh_account_state(true).await,
         Ok(())
     );
     test_bench

--- a/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/paths.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/paths.rs
@@ -93,7 +93,7 @@ async fn api_error_reponse_test() -> anyhow::Result<()> {
     test_bench
         .assert_state(AccountControllerState::Error(
             AccountControllerErrorStateReason::ApiFailure {
-                context: "SYNCING_STATE".into(),
+                context: "SYNCING_NETWORK_STATE".into(),
                 details: "55cbd0ee-4ff5-4f3d-930e-6f6a95ce849f".into(),
             },
         ))
@@ -252,7 +252,7 @@ async fn account_with_no_fair_usage_test() -> anyhow::Result<()> {
     test_bench
         .assert_state(AccountControllerState::Error(
             AccountControllerErrorStateReason::BandwidthExceeded {
-                context: "SYNCING_STATE".into(),
+                context: "SYNCING_LOCAL_STATE".into(),
             },
         ))
         .await;
@@ -391,6 +391,115 @@ async fn decentralised_account_test() -> anyhow::Result<()> {
     test_bench.forget_account().await?;
     test_bench
         .assert_state(AccountControllerState::LoggedOut)
+        .await;
+    Ok(())
+}
+
+/// A force refresh drops the cached summary and does a mandatory re-fetch, so a server-side change
+/// (here: the account going inactive) is picked up and surfaced.
+#[tokio::test]
+async fn force_refresh_detects_inactive_account_test() -> anyhow::Result<()> {
+    let mut test_bench = TestBench::new().await?;
+    let credential_proxy = test_bench.credential_proxy.clone();
+
+    let mocks = vec![
+        endpoints::synced_health(),
+        endpoints::account_summary_with_device_200(account_ready_to_connect()),
+        endpoints::register_account_200(mock_api_device(NymVpnDeviceStatus::Active)),
+        endpoints::zknym_available_200(credential_proxy.clone()),
+        endpoints::zknym_post(credential_proxy.clone()),
+        endpoints::zknym_id(credential_proxy.clone()),
+        endpoints::partial_verification_key_200(credential_proxy.clone()),
+        endpoints::confirm_zk_nym_download_by_id_200(credential_proxy.clone()),
+    ];
+    test_bench.register_vpn_api_mocks(mocks).await;
+
+    test_bench.store_mock_account().await?;
+    test_bench
+        .assert_state(AccountControllerState::ReadyToConnect)
+        .await;
+
+    // The account becomes inactive server-side.
+    test_bench.vpn_api_server.reset().await;
+    test_bench
+        .register_vpn_api_mocks(vec![
+            endpoints::synced_health(),
+            endpoints::account_summary_with_device_200(inactive_account()),
+        ])
+        .await;
+
+    assert_eq!(
+        test_bench.command_sender.force_refresh_account_state().await,
+        Ok(())
+    );
+    test_bench
+        .assert_state(AccountControllerState::Error(
+            AccountControllerErrorStateReason::AccountStatusNotActive {
+                status: "Inactive".into(),
+            },
+        ))
+        .await;
+    Ok(())
+}
+
+/// When the VPN API is unreachable, an (optimistic) refresh falls back to the cached summary and
+/// stays ready, whereas a force refresh - which must obtain fresh data - surfaces the API error.
+#[tokio::test]
+async fn optimistic_refresh_falls_back_but_force_refresh_surfaces_error_test() -> anyhow::Result<()>
+{
+    let mut test_bench = TestBench::new().await?;
+    let credential_proxy = test_bench.credential_proxy.clone();
+
+    let mocks = vec![
+        endpoints::synced_health(),
+        endpoints::account_summary_with_device_200(account_ready_to_connect()),
+        endpoints::register_account_200(mock_api_device(NymVpnDeviceStatus::Active)),
+        endpoints::zknym_available_200(credential_proxy.clone()),
+        endpoints::zknym_post(credential_proxy.clone()),
+        endpoints::zknym_id(credential_proxy.clone()),
+        endpoints::partial_verification_key_200(credential_proxy.clone()),
+        endpoints::confirm_zk_nym_download_by_id_200(credential_proxy.clone()),
+    ];
+    test_bench.register_vpn_api_mocks(mocks).await;
+
+    test_bench.store_mock_account().await?;
+    test_bench
+        .assert_state(AccountControllerState::ReadyToConnect)
+        .await;
+
+    // The account summary endpoint starts failing.
+    test_bench.vpn_api_server.reset().await;
+    test_bench
+        .register_vpn_api_mocks(vec![
+            endpoints::synced_health(),
+            endpoints::account_summary_with_device_403(unrelated_error()),
+        ])
+        .await;
+
+    // Optimistic refresh: the fetch fails, but we fall back to the cached summary and stay ready.
+    assert_eq!(
+        test_bench
+            .command_sender
+            .background_refresh_account_state()
+            .await,
+        Ok(())
+    );
+    test_bench
+        .assert_state(AccountControllerState::ReadyToConnect)
+        .await;
+
+    // Force refresh: no cache fallback, so the API error is surfaced (after exhausting retries).
+    assert_eq!(
+        test_bench.command_sender.force_refresh_account_state().await,
+        Ok(())
+    );
+    test_bench
+        .assert_state(AccountControllerState::Error(
+            AccountControllerErrorStateReason::ApiFailure {
+                context: "SYNCING_NETWORK_STATE".into(),
+                details: "55cbd0ee-4ff5-4f3d-930e-6f6a95ce849f".into(),
+            },
+        ))
         .await;
     Ok(())
 }

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/account/controller_error.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/account/controller_error.rs
@@ -49,7 +49,7 @@ pub enum AccountControllerErrorStateReason {
 
 impl AccountControllerErrorStateReason {
     pub fn is_retryable(&self) -> bool {
-        matches!(self, Self::ApiFailure { .. } | Self::Internal { .. })
+        matches!(self, Self::ApiFailure { .. })
     }
 
     pub fn storage(

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/account/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/account/mod.rs
@@ -279,12 +279,44 @@ pub struct VpnAccountSummary {
     pub account_mode: Option<StoredAccountMode>,
     pub subscription: Option<Subscription>,
     pub is_subscription_stacked: bool,
+
+    /// Status of the account itself (active/inactive/delete-me).
+    pub account_status: VpnAccountStatus,
+
+    /// Number of additional devices that can still be registered to this account.
+    pub remaining_devices: u64,
+
+    /// Whether the current device is registered and active on this account.
+    pub is_device_active: bool,
+
+    /// Wether the time was acceptably synced when the summary was built
+    pub time_synced: bool,
+
+    /// When this summary was last synced from the VPN API. Used to decide when a
+    /// background refresh is due.
+    #[cfg_attr(feature = "typescript-bindings", ts(as = "String"))]
+    #[cfg_attr(feature = "serde", serde(with = "time::serde::iso8601"))]
+    pub last_synced_utc: OffsetDateTime,
 }
 
 // Exported methods
 #[cfg_attr(feature = "uniffi-bindings", uniffi::export)]
 #[allow(unused)]
 impl VpnAccountSummary {
+    /// Returns true if the account itself is active.
+    pub fn is_account_active(&self) -> bool {
+        matches!(self.account_status, VpnAccountStatus::Active)
+    }
+
+    /// Returns true if there is a subscription that exists but is not yet active
+    /// (e.g. a cash payment still processing).
+    pub fn is_subscription_pending(&self) -> bool {
+        matches!(
+            self.subscription.as_ref().map(|sub| &sub.status),
+            Some(NymVpnSubscriptionStatus::Pending)
+        )
+    }
+
     /// Returns true if subscription is active
     pub fn is_subscription_active(&self) -> bool {
         if let Some(subscription) = &self.subscription {
@@ -319,19 +351,20 @@ impl VpnAccountSummary {
 }
 
 #[cfg(feature = "nym-type-conversions")]
-impl TryFrom<&nym_vpn_api_client::response::NymVpnAccountSummaryResponse> for VpnAccountSummary {
-    type Error = nym_vpn_api_client::error::VpnApiClientError;
-
-    fn try_from(
-        value: &nym_vpn_api_client::response::NymVpnAccountSummaryResponse,
-    ) -> Result<Self, Self::Error> {
-        let traffic_reset_time = value
+impl VpnAccountSummary {
+    pub fn from_parts(
+        api_summary: &nym_vpn_api_client::response::NymVpnAccountSummaryWithDeviceResponse,
+        account_mode: nym_vpn_api_client::types::VpnAccountMode,
+        remote_time: nym_vpn_api_client::types::VpnApiTime,
+    ) -> Result<Self, nym_vpn_api_client::error::VpnApiClientError> {
+        let account_summary = &api_summary.account_summary;
+        let traffic_reset_time = account_summary
             .fair_usage
             .resetsOnUtc
             .as_deref()
             .and_then(|t| parse_timestamp(t, "fair_usage.resetsOnUtc"));
 
-        let auth_methods = value
+        let auth_methods = account_summary
             .account
             .auth_methods
             .iter()
@@ -340,12 +373,12 @@ impl TryFrom<&nym_vpn_api_client::response::NymVpnAccountSummaryResponse> for Vp
             .collect::<Result<Vec<_>, _>>()?;
 
         // Active wins over pending; `is_subscription_active()` ignores wire `is_active`.
-        let subscription = if let Some(active) = value.subscription.active.as_ref() {
+        let subscription = if let Some(active) = account_summary.subscription.active.as_ref() {
             Some(Subscription {
                 status: NymVpnSubscriptionStatus::Active,
                 subscription: NymVpnSubscription::try_from(active)?,
             })
-        } else if let Some(pending) = value.subscription.pending.as_ref() {
+        } else if let Some(pending) = account_summary.subscription.pending.as_ref() {
             Some(Subscription {
                 status: NymVpnSubscriptionStatus::Pending,
                 subscription: NymVpnSubscription::try_from(pending)?,
@@ -355,16 +388,21 @@ impl TryFrom<&nym_vpn_api_client::response::NymVpnAccountSummaryResponse> for Vp
         };
 
         Ok(Self {
-            traffic_used_gb: value.fair_usage.usedGB,
-            traffic_limit_gb: value.fair_usage.limitGB,
+            traffic_used_gb: account_summary.fair_usage.usedGB,
+            traffic_limit_gb: account_summary.fair_usage.limitGB,
             traffic_reset_time,
-            fair_usage_data_unavailable: value.fair_usage.data_unavailable,
-            account_addr: value.account.account_addr.clone(),
-            canonical_account_addr: value.account.canonical_account_addr.clone(),
+            fair_usage_data_unavailable: account_summary.fair_usage.data_unavailable,
+            account_addr: account_summary.account.account_addr.clone(),
+            canonical_account_addr: account_summary.account.canonical_account_addr.clone(),
             auth_methods,
-            account_mode: None,
+            account_mode: Some(account_mode.into()),
             subscription,
-            is_subscription_stacked: value.subscription.is_stacked,
+            is_subscription_stacked: account_summary.subscription.is_stacked,
+            account_status: account_summary.account.status.clone().into(),
+            remaining_devices: account_summary.devices.remaining,
+            is_device_active: api_summary.active_device.is_some(),
+            time_synced: remote_time.is_acceptable_synced(),
+            last_synced_utc: OffsetDateTime::now_utc(),
         })
     }
 }
@@ -576,6 +614,19 @@ pub enum VpnAccountStatus {
     DeleteMe,
 }
 
+impl std::fmt::Display for VpnAccountStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Mirror the wire representation (`strum::Display` on the API enum) so error messages
+        // remain stable: "Active" / "Inactive" / "DeleteMe".
+        let s = match self {
+            VpnAccountStatus::Active => "Active",
+            VpnAccountStatus::Inactive => "Inactive",
+            VpnAccountStatus::DeleteMe => "DeleteMe",
+        };
+        f.write_str(s)
+    }
+}
+
 #[cfg(feature = "nym-type-conversions")]
 impl From<nym_vpn_api_client::response::NymVpnAccountStatusResponse> for VpnAccountStatus {
     fn from(value: nym_vpn_api_client::response::NymVpnAccountStatusResponse) -> Self {
@@ -652,13 +703,35 @@ mod tests {
     use nym_vpn_api_client::response::{
         NymVpnAccountResponse, NymVpnAccountStatusResponse, NymVpnAccountSummaryDevices,
         NymVpnAccountSummaryFairUsage, NymVpnAccountSummaryResponse,
-        NymVpnAccountSummarySubscription, NymVpnSubscription as ApiNymVpnSubscription,
+        NymVpnAccountSummarySubscription, NymVpnAccountSummaryWithDeviceResponse,
+        NymVpnSubscription as ApiNymVpnSubscription,
         NymVpnSubscriptionKind as ApiNymVpnSubscriptionKind,
         NymVpnSubscriptionStatus as ApiNymVpnSubscriptionStatus,
     };
+    use nym_vpn_api_client::types::{VpnAccountMode, VpnApiTime};
     use tracing_test::traced_test;
 
     use super::*;
+
+    /// A `VpnApiTime` reporting zero skew, so summaries built in tests count as
+    /// time-synced.
+    fn synced_api_time() -> VpnApiTime {
+        let now = OffsetDateTime::now_utc();
+        VpnApiTime::from_estimated_remote_time(now, now)
+    }
+
+    /// Build a `VpnAccountSummary` the way production code does: wrap the bare
+    /// API summary in a with-device response (no active device) and run it
+    /// through `from_parts` in API mode with a synced clock.
+    fn build(
+        summary: &NymVpnAccountSummaryResponse,
+    ) -> Result<VpnAccountSummary, nym_vpn_api_client::error::VpnApiClientError> {
+        let with_device = NymVpnAccountSummaryWithDeviceResponse {
+            account_summary: summary.clone(),
+            active_device: None,
+        };
+        VpnAccountSummary::from_parts(&with_device, VpnAccountMode::Api, synced_api_time())
+    }
 
     fn far_future_active_subscription() -> ApiNymVpnSubscription {
         ApiNymVpnSubscription {
@@ -726,7 +799,7 @@ mod tests {
         summary.fair_usage.resetsOnUtc = Some("not a date at all".into());
 
         let parsed =
-            VpnAccountSummary::try_from(&summary).expect("must not fail on bad reset timestamp");
+            build(&summary).expect("must not fail on bad reset timestamp");
         assert!(parsed.traffic_reset_time.is_none());
     }
 
@@ -735,7 +808,7 @@ mod tests {
         let mut summary = base_summary();
         summary.fair_usage.resetsOnUtc = Some("2025-08-20 13:46:26.572Z".into());
 
-        let parsed = VpnAccountSummary::try_from(&summary).expect("space-separated must parse");
+        let parsed = build(&summary).expect("space-separated must parse");
         assert!(parsed.traffic_reset_time.is_some());
     }
 
@@ -752,7 +825,7 @@ mod tests {
         };
 
         let parsed =
-            VpnAccountSummary::try_from(&summary).expect("must not fail on bad reset timestamp");
+            build(&summary).expect("must not fail on bad reset timestamp");
         assert!(
             parsed.is_subscription_active(),
             "subscription active in 2099 must still report active"
@@ -771,7 +844,7 @@ mod tests {
             is_stacked: false,
         };
 
-        let err = VpnAccountSummary::try_from(&summary)
+        let err = build(&summary)
             .expect_err("malformed subscription.valid_until_utc must fail the whole summary");
         assert!(
             err.to_string()
@@ -785,7 +858,7 @@ mod tests {
     fn warn_emitted_when_resets_on_utc_malformed() {
         let mut summary = base_summary();
         summary.fair_usage.resetsOnUtc = Some("not a date".into());
-        let _ = VpnAccountSummary::try_from(&summary).unwrap();
+        let _ = build(&summary).unwrap();
         assert!(
             logs_contain("failed to parse fair_usage.resetsOnUtc"),
             "soft-fail of resetsOnUtc must emit a tracing::warn!"
@@ -804,7 +877,7 @@ mod tests {
             pending: None,
             is_stacked: false,
         };
-        let _ = VpnAccountSummary::try_from(&summary).expect_err("malformed valid_until_utc");
+        let _ = build(&summary).expect_err("malformed valid_until_utc");
         assert!(
             logs_contain("failed to parse subscription.valid_until_utc"),
             "parse attempt for subscription.valid_until_utc must emit a tracing::warn!"
@@ -823,7 +896,7 @@ mod tests {
             is_stacked: false,
         };
 
-        let err = VpnAccountSummary::try_from(&summary).expect_err(
+        let err = build(&summary).expect_err(
             "malformed pending subscription.valid_until_utc must fail the whole summary",
         );
         assert!(
@@ -845,7 +918,7 @@ mod tests {
             is_stacked: false,
         };
 
-        let parsed = VpnAccountSummary::try_from(&summary).expect("must parse");
+        let parsed = build(&summary).expect("must parse");
         assert!(
             !parsed.is_subscription_active(),
             "Pending status must not report as active"
@@ -928,6 +1001,11 @@ mod fair_usage_left_semantics_tests {
             account_mode: None,
             subscription,
             is_subscription_stacked: false,
+            account_status: VpnAccountStatus::Active,
+            remaining_devices: 10,
+            is_device_active: false,
+            time_synced: true,
+            last_synced_utc: OffsetDateTime::now_utc(),
         }
     }
 

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/account/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/account/mod.rs
@@ -9,6 +9,8 @@ pub mod request_zknym;
 pub mod storage;
 pub mod ticketbooks;
 
+use std::time::Duration;
+
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
@@ -289,8 +291,11 @@ pub struct VpnAccountSummary {
     /// Whether the current device is registered and active on this account.
     pub is_device_active: bool,
 
-    /// Wether the time was acceptably synced when the summary was built
+    /// Whether the time was acceptably synced when the summary was built
     pub time_synced: bool,
+
+    /// Additional staleness flag
+    pub stale: bool,
 
     /// When this summary was last synced from the VPN API. Used to decide when a
     /// background refresh is due.
@@ -348,6 +353,13 @@ impl VpnAccountSummary {
             .iter()
             .any(|method| method.kind == "privy_secp256k1")
     }
+
+    // Stale if flag is set or age > provided max_age
+    pub fn is_stale(&self, max_age: Duration) -> bool {
+        self.stale
+            || OffsetDateTime::now_utc().unix_timestamp() - self.last_synced_utc.unix_timestamp()
+                > max_age.as_secs() as i64
+    }
 }
 
 #[cfg(feature = "nym-type-conversions")]
@@ -402,6 +414,7 @@ impl VpnAccountSummary {
             remaining_devices: account_summary.devices.remaining,
             is_device_active: api_summary.active_device.is_some(),
             time_synced: remote_time.is_acceptable_synced(),
+            stale: false,
             last_synced_utc: OffsetDateTime::now_utc(),
         })
     }
@@ -1003,6 +1016,7 @@ mod fair_usage_left_semantics_tests {
             remaining_devices: 10,
             is_device_active: false,
             time_synced: true,
+            stale: false,
             last_synced_utc: OffsetDateTime::now_utc(),
         }
     }

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/account/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/account/mod.rs
@@ -798,8 +798,7 @@ mod tests {
         let mut summary = base_summary();
         summary.fair_usage.resetsOnUtc = Some("not a date at all".into());
 
-        let parsed =
-            build(&summary).expect("must not fail on bad reset timestamp");
+        let parsed = build(&summary).expect("must not fail on bad reset timestamp");
         assert!(parsed.traffic_reset_time.is_none());
     }
 
@@ -824,8 +823,7 @@ mod tests {
             is_stacked: false,
         };
 
-        let parsed =
-            build(&summary).expect("must not fail on bad reset timestamp");
+        let parsed = build(&summary).expect("must not fail on bad reset timestamp");
         assert!(
             parsed.is_subscription_active(),
             "subscription active in 2099 must still report active"

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/account.rs
@@ -207,7 +207,7 @@ impl NymAccountController {
     /// this can be used to manually trigger a sync.
     pub async fn update_account_state(&self) -> Result<(), VpnError> {
         self.command_sender
-            .background_refresh_account_state()
+            .refresh_account_state(true)
             .await
             .map_err(VpnError::from)
     }

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_account_storage.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_account_storage.rs
@@ -335,6 +335,7 @@ impl NymVpnAccountStorage {
         let mut vpn_account_summary =
             VpnAccountSummary::try_from(&summary.account_summary).map_err(VpnError::internal)?;
         vpn_account_summary.account_mode = Some(account_mode);
+        vpn_account_summary.is_device_active = summary.active_device.is_some();
 
         Ok(Some(vpn_account_summary))
     }

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_account_storage.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_account_storage.rs
@@ -310,34 +310,14 @@ impl NymVpnAccountStorage {
 
     /// Get a summary of account usage
     pub async fn get_account_summary(&self) -> Result<Option<VpnAccountSummary>, VpnError> {
-        let Some(account) = self
-            .storage
-            .load_account()
-            .await
-            .map_err(|err| VpnError::Storage {
-                details: err.to_string(),
-            })?
-        else {
-            return Ok(None);
-        };
-        let account_mode = account.mode;
-
-        let vpn_account = VpnAccount::try_from(account).map_err(VpnError::internal)?;
-
-        let device = self.load_device().await?;
-
-        let vpn_api_client = self.create_vpn_api_client().await?;
-        let summary = vpn_api_client
-            .get_account_summary_with_device(&vpn_account, &device)
-            .await
-            .map_err(VpnError::internal)?;
-
-        let mut vpn_account_summary =
-            VpnAccountSummary::try_from(&summary.account_summary).map_err(VpnError::internal)?;
-        vpn_account_summary.account_mode = Some(account_mode);
-        vpn_account_summary.is_device_active = summary.active_device.is_some();
-
-        Ok(Some(vpn_account_summary))
+        let maybe_account_summary =
+            self.storage
+                .load_summary()
+                .await
+                .map_err(|err| VpnError::Storage {
+                    details: err.to_string(),
+                })?;
+        Ok(maybe_account_summary)
     }
 
     /// Get the type of account the user is logged in with

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_account_storage.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_account_storage.rs
@@ -20,6 +20,7 @@ use nym_vpn_lib_types::{
 };
 use nym_vpn_store::{
     account::AccountInformationStorage,
+    account_summary::AccountSummaryStorage,
     keys::{device::DeviceKeyStore, wireguard::DB_NAME},
 };
 

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_service_command_sender.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_service_command_sender.rs
@@ -318,8 +318,8 @@ impl NymVpnServiceCommandSender {
             .await
     }
 
-    pub async fn refresh_account(&self) -> Result<()> {
-        self.send_and_wait(VpnServiceCommand::RefreshAccountState, ())
+    pub async fn refresh_account(&self, force: bool) -> Result<()> {
+        self.send_and_wait(VpnServiceCommand::RefreshAccountState, force)
             .await
     }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
@@ -166,7 +166,7 @@ pub enum VpnServiceCommand {
         Locale,
     ),
     GetAccountState(oneshot::Sender<AccountControllerState>, ()),
-    RefreshAccountState(oneshot::Sender<()>, ()),
+    RefreshAccountState(oneshot::Sender<()>, bool),
     GetAccountUsage(
         oneshot::Sender<Result<Vec<NymVpnUsage>, AccountCommandError>>,
         (),
@@ -1103,8 +1103,8 @@ impl NymVpnService {
             VpnServiceCommand::GetAccountState(tx, ()) => {
                 let _ = tx.send(self.handle_get_account_state().await);
             }
-            VpnServiceCommand::RefreshAccountState(tx, ()) => {
-                self.handle_refresh_account_state().await;
+            VpnServiceCommand::RefreshAccountState(tx, force) => {
+                self.handle_refresh_account_state(force).await;
                 let _ = tx.send(());
             }
             VpnServiceCommand::GetAccountUsage(tx, ()) => {
@@ -1958,11 +1958,8 @@ impl NymVpnService {
         self.account_state_rx.get_state()
     }
 
-    async fn handle_refresh_account_state(&self) {
-        let _ = self
-            .account_command_tx
-            .background_refresh_account_state()
-            .await;
+    async fn handle_refresh_account_state(&self, force: bool) {
+        let _ = self.account_command_tx.refresh_account_state(force).await;
     }
 
     async fn handle_get_usage(&self) -> Result<Vec<NymVpnUsage>, AccountCommandError> {
@@ -2033,9 +2030,7 @@ impl NymVpnService {
         if !self.handle_is_account_stored().await {
             return Err(AccountCommandError::NoAccountStored);
         }
-        self.account_command_tx
-            .background_refresh_account_state()
-            .await
+        self.account_command_tx.refresh_account_state(true).await
     }
 
     async fn handle_get_deeplink(

--- a/nym-vpn-core/crates/nym-vpn-lib/src/storage.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/storage.rs
@@ -3,17 +3,20 @@
 
 use std::path::Path;
 
-use nym_vpn_lib_types::StorableAccount;
+use nym_vpn_lib_types::{StorableAccount, VpnAccountSummary};
 use nym_vpn_store::{
     account::{AccountInformationStorage, on_disk::OnDiskMnemonicStorageError},
+    account_summary::{AccountSummaryStorage, on_disk::OnDiskAccountSummaryStorageError},
     keys::device::{DeviceKeyStore, DeviceKeys, DeviceKeysPaths, OnDiskKeysError},
 };
 
 const MNEMONIC_FILE_NAME: &str = "mnemonic.json";
+const ACCOUNT_SUMMARY_FILE_NAME: &str = "account_summary.json";
 
 pub struct VpnClientOnDiskStorage {
     key_store: nym_vpn_store::keys::device::OnDiskKeys,
     account_storage: nym_vpn_store::account::on_disk::OnDiskAccountStorage,
+    summary_storage: nym_vpn_store::account_summary::on_disk::OnDiskAccountSummaryStorage,
 }
 
 impl VpnClientOnDiskStorage {
@@ -25,9 +28,16 @@ impl VpnClientOnDiskStorage {
         let mnemonic_storage =
             nym_vpn_store::account::on_disk::OnDiskAccountStorage::new(mnemonic_storage_path);
 
+        let summary_storage_path = base_data_directory.as_ref().join(ACCOUNT_SUMMARY_FILE_NAME);
+        let summary_storage =
+            nym_vpn_store::account_summary::on_disk::OnDiskAccountSummaryStorage::new(
+                summary_storage_path,
+            );
+
         VpnClientOnDiskStorage {
             key_store,
             account_storage: mnemonic_storage,
+            summary_storage,
         }
     }
 }
@@ -73,5 +83,22 @@ impl AccountInformationStorage for VpnClientOnDiskStorage {
 
     async fn remove_account(&self) -> Result<(), Self::StorageError> {
         self.account_storage.remove_account().await
+    }
+}
+
+#[async_trait::async_trait]
+impl AccountSummaryStorage for VpnClientOnDiskStorage {
+    type StorageError = OnDiskAccountSummaryStorageError;
+
+    async fn load_summary(&self) -> Result<Option<VpnAccountSummary>, Self::StorageError> {
+        self.summary_storage.load_summary().await
+    }
+
+    async fn store_summary(&self, account: VpnAccountSummary) -> Result<(), Self::StorageError> {
+        self.summary_storage.store_summary(account).await
+    }
+
+    async fn remove_summary(&self) -> Result<(), Self::StorageError> {
+        self.summary_storage.remove_summary().await
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -809,7 +809,7 @@ impl TunnelMonitor {
                     "Account controller is in a retryable error state : {reason}. Forcing a refresh"
                 );
                 self.account_command_tx
-                    .background_refresh_account_state()
+                    .refresh_account_state(false)
                     .await
                     .map_err(|e| Error::Account(account::Error::Command(e)))?;
                 self.account_controller_state

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -809,6 +809,10 @@ message DecentralisedObtainTicketbooksRequest {
   uint64 amount = 1;
 }
 
+message RefreshAccountStateRequest {
+  bool force = 1;
+}
+
 message AccountCommandResponse {
   optional AccountCommandError error = 1;
 }
@@ -1230,7 +1234,7 @@ service NymVpnService {
 
   // The vpn client will periodically refresh the account state in the
   // background. This command triggers a manual refresh.
-  rpc RefreshAccountState(google.protobuf.Empty) returns (google.protobuf.Empty) {}
+  rpc RefreshAccountState(RefreshAccountStateRequest) returns (google.protobuf.Empty) {}
 
   // Get the account usage from the nym-vpn-api
   rpc GetAccountUsage(google.protobuf.Empty) returns (GetAccountUsageResponse) {}

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -932,6 +932,11 @@ message VpnAccountSummary {
   optional Subscription subscription = 12;
   bool is_subscription_stacked = 13;
   bool fair_usage_data_unavailable = 14;
+  VpnAccountStatus account_status = 15;
+  uint64 remaining_devices = 16;
+  bool is_device_active = 17;
+  optional google.protobuf.Timestamp last_synced_utc = 18;
+  bool time_synced = 19;
 }
 
 message NymVpnSubscription {

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -941,6 +941,7 @@ message VpnAccountSummary {
   bool is_device_active = 17;
   optional google.protobuf.Timestamp last_synced_utc = 18;
   bool time_synced = 19;
+  bool stale = 20;
 }
 
 message NymVpnSubscription {

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/account.rs
@@ -293,9 +293,10 @@ impl TryFrom<proto::VpnAccountSummary> for VpnAccountSummary {
 
         let subscription = value.subscription.map(Subscription::try_from).transpose()?;
 
-        let account_status: VpnAccountStatus = proto::VpnAccountStatus::try_from(value.account_status)
-            .map(VpnAccountStatus::from)
-            .map_err(|_| ConversionError::NoValueSet("VpnAccountSummary.account_status"))?;
+        let account_status: VpnAccountStatus =
+            proto::VpnAccountStatus::try_from(value.account_status)
+                .map(VpnAccountStatus::from)
+                .map_err(|_| ConversionError::NoValueSet("VpnAccountSummary.account_status"))?;
 
         let last_synced_utc = value
             .last_synced_utc

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/account.rs
@@ -306,7 +306,7 @@ impl TryFrom<proto::VpnAccountSummary> for VpnAccountSummary {
                 })
             })
             .transpose()?
-            .unwrap_or_else(OffsetDateTime::now_utc);
+            .unwrap_or(OffsetDateTime::UNIX_EPOCH);
 
         Ok(Self {
             traffic_used_gb: value.traffic_used_gb,

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/account.rs
@@ -8,6 +8,8 @@ use nym_vpn_lib_types::{
     VpnApiError, VpnApiErrorResponse,
 };
 
+use time::OffsetDateTime;
+
 use crate::{
     conversions::{
         ConversionError,
@@ -291,6 +293,20 @@ impl TryFrom<proto::VpnAccountSummary> for VpnAccountSummary {
 
         let subscription = value.subscription.map(Subscription::try_from).transpose()?;
 
+        let account_status: VpnAccountStatus = proto::VpnAccountStatus::try_from(value.account_status)
+            .map(VpnAccountStatus::from)
+            .map_err(|_| ConversionError::NoValueSet("VpnAccountSummary.account_status"))?;
+
+        let last_synced_utc = value
+            .last_synced_utc
+            .map(|ts| {
+                prost_timestamp_into_offset_datetime(ts).map_err(|e| {
+                    ConversionError::ConvertTime("VpnAccountSummary.last_synced_utc", e)
+                })
+            })
+            .transpose()?
+            .unwrap_or_else(OffsetDateTime::now_utc);
+
         Ok(Self {
             traffic_used_gb: value.traffic_used_gb,
             traffic_limit_gb: value.traffic_limit_gb,
@@ -302,6 +318,11 @@ impl TryFrom<proto::VpnAccountSummary> for VpnAccountSummary {
             account_mode,
             subscription,
             is_subscription_stacked: value.is_subscription_stacked,
+            account_status,
+            remaining_devices: value.remaining_devices,
+            is_device_active: value.is_device_active,
+            last_synced_utc,
+            time_synced: value.time_synced,
         })
     }
 }
@@ -325,6 +346,9 @@ impl From<VpnAccountSummary> for proto::VpnAccountSummary {
 
         let subscription = value.subscription.map(proto::Subscription::from);
 
+        let account_status = proto::VpnAccountStatus::from(value.account_status) as i32;
+        let last_synced_utc = Some(offset_datetime_into_proto_timestamp(value.last_synced_utc));
+
         Self {
             traffic_used_gb: value.traffic_used_gb,
             traffic_limit_gb: value.traffic_limit_gb,
@@ -336,6 +360,11 @@ impl From<VpnAccountSummary> for proto::VpnAccountSummary {
             account_mode,
             subscription,
             is_subscription_stacked: value.is_subscription_stacked,
+            account_status,
+            remaining_devices: value.remaining_devices,
+            is_device_active: value.is_device_active,
+            last_synced_utc,
+            time_synced: value.time_synced,
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/account.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/account.rs
@@ -323,6 +323,7 @@ impl TryFrom<proto::VpnAccountSummary> for VpnAccountSummary {
             remaining_devices: value.remaining_devices,
             is_device_active: value.is_device_active,
             last_synced_utc,
+            stale: value.stale,
             time_synced: value.time_synced,
         })
     }
@@ -365,6 +366,7 @@ impl From<VpnAccountSummary> for proto::VpnAccountSummary {
             remaining_devices: value.remaining_devices,
             is_device_active: value.is_device_active,
             last_synced_utc,
+            stale: value.stale,
             time_synced: value.time_synced,
         }
     }

--- a/nym-vpn-core/crates/nym-vpn-proto/src/rpc_client.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/rpc_client.rs
@@ -525,9 +525,9 @@ impl RpcClient {
         AccountControllerState::try_from(state).map_err(Error::InvalidResponse)
     }
 
-    pub async fn refresh_account_state(&mut self) -> Result<()> {
+    pub async fn refresh_account_state(&mut self, force: bool) -> Result<()> {
         self.0
-            .refresh_account_state(())
+            .refresh_account_state(proto::RefreshAccountStateRequest { force })
             .await
             .map_err(Error::Rpc)?
             .into_inner();

--- a/nym-vpn-core/crates/nym-vpn-rpc-uniffi/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-rpc-uniffi/src/lib.rs
@@ -268,8 +268,8 @@ impl RpcClient {
         Ok(self.inner.clone().get_account_state().await?)
     }
 
-    pub async fn refresh_account_state(&self) -> Result<()> {
-        self.inner.clone().refresh_account_state().await?;
+    pub async fn refresh_account_state(&self, force: bool) -> Result<()> {
+        self.inner.clone().refresh_account_state(force).await?;
         Ok(())
     }
 

--- a/nym-vpn-core/crates/nym-vpn-store/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-store/Cargo.toml
@@ -30,11 +30,11 @@ sqlx = { workspace = true, features = [
 ] }
 thiserror.workspace = true
 time = { workspace = true, features = ["serde"] }
-tokio = { workspace = true, features = ["sync"] }
+tokio = { workspace = true, features = ["sync", "fs"] }
 tracing.workspace = true
 zeroize.workspace = true
 
-nym-vpn-lib-types.workspace = true
+nym-vpn-lib-types = { workspace = true, features = ["serde"] }
 
 [build-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/nym-vpn-core/crates/nym-vpn-store/src/account_summary/ephemeral.rs
+++ b/nym-vpn-core/crates/nym-vpn-store/src/account_summary/ephemeral.rs
@@ -1,0 +1,33 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use std::convert::Infallible;
+
+use nym_vpn_lib_types::VpnAccountSummary;
+use tokio::sync::Mutex;
+
+use super::AccountSummaryStorage;
+
+#[derive(Default)]
+pub struct InMemoryAccountSummaryStorage {
+    summary: Mutex<Option<VpnAccountSummary>>,
+}
+
+#[async_trait::async_trait]
+impl AccountSummaryStorage for InMemoryAccountSummaryStorage {
+    type StorageError = Infallible;
+
+    async fn load_summary(&self) -> Result<Option<VpnAccountSummary>, Self::StorageError> {
+        Ok(self.summary.lock().await.clone())
+    }
+
+    async fn store_summary(&self, account: VpnAccountSummary) -> Result<(), Self::StorageError> {
+        *self.summary.lock().await = Some(account);
+        Ok(())
+    }
+
+    async fn remove_summary(&self) -> Result<(), Self::StorageError> {
+        *self.summary.lock().await = None;
+        Ok(())
+    }
+}

--- a/nym-vpn-core/crates/nym-vpn-store/src/account_summary/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-store/src/account_summary/mod.rs
@@ -1,0 +1,19 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use std::error::Error;
+
+use nym_vpn_lib_types::VpnAccountSummary;
+
+pub mod ephemeral;
+pub mod on_disk;
+
+/// Storage for the account summary cache, kept alongside the mnemonic and device keys.
+#[async_trait::async_trait]
+pub trait AccountSummaryStorage {
+    type StorageError: Error + Send + Sync + 'static;
+
+    async fn load_summary(&self) -> Result<Option<VpnAccountSummary>, Self::StorageError>; // None means no error, but nothing
+    async fn store_summary(&self, account: VpnAccountSummary) -> Result<(), Self::StorageError>;
+    async fn remove_summary(&self) -> Result<(), Self::StorageError>;
+}

--- a/nym-vpn-core/crates/nym-vpn-store/src/account_summary/on_disk.rs
+++ b/nym-vpn-core/crates/nym-vpn-store/src/account_summary/on_disk.rs
@@ -1,0 +1,81 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use std::path::{Path, PathBuf};
+
+use nym_vpn_lib_types::VpnAccountSummary;
+
+use super::AccountSummaryStorage;
+
+#[derive(Debug, thiserror::Error)]
+pub enum OnDiskAccountSummaryStorageError {
+    #[error("failed to read account summary file")]
+    ReadError(#[source] std::io::Error),
+
+    #[error("failed to write account summary file")]
+    WriteError(#[source] std::io::Error),
+
+    #[error("failed to create account summary directory")]
+    CreateDirError(#[source] std::io::Error),
+
+    #[error("failed to remove account summary file")]
+    RemoveError(#[source] std::io::Error),
+
+    #[error("failed to serialize account summary")]
+    SerializeError(#[source] serde_json::Error),
+
+    #[error("failed to deserialize account summary")]
+    DeserializeError(#[source] serde_json::Error),
+}
+
+pub struct OnDiskAccountSummaryStorage {
+    path: PathBuf,
+}
+
+impl OnDiskAccountSummaryStorage {
+    pub fn new<P: AsRef<Path>>(path: P) -> Self {
+        Self {
+            path: path.as_ref().to_path_buf(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl AccountSummaryStorage for OnDiskAccountSummaryStorage {
+    type StorageError = OnDiskAccountSummaryStorageError;
+
+    async fn load_summary(&self) -> Result<Option<VpnAccountSummary>, Self::StorageError> {
+        let bytes = match tokio::fs::read(&self.path).await {
+            Ok(bytes) => bytes,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(err) => return Err(OnDiskAccountSummaryStorageError::ReadError(err)),
+        };
+
+        serde_json::from_slice(&bytes)
+            .map(Some)
+            .map_err(OnDiskAccountSummaryStorageError::DeserializeError)
+    }
+
+    async fn store_summary(&self, account: VpnAccountSummary) -> Result<(), Self::StorageError> {
+        let bytes = serde_json::to_vec(&account)
+            .map_err(OnDiskAccountSummaryStorageError::SerializeError)?;
+
+        if let Some(parent) = self.path.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .map_err(OnDiskAccountSummaryStorageError::CreateDirError)?;
+        }
+
+        tokio::fs::write(&self.path, bytes)
+            .await
+            .map_err(OnDiskAccountSummaryStorageError::WriteError)
+    }
+
+    async fn remove_summary(&self) -> Result<(), Self::StorageError> {
+        match tokio::fs::remove_file(&self.path).await {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(OnDiskAccountSummaryStorageError::RemoveError(err)),
+        }
+    }
+}

--- a/nym-vpn-core/crates/nym-vpn-store/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-store/src/lib.rs
@@ -2,6 +2,12 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 pub mod account;
+pub mod account_summary;
 pub mod keys;
 
-pub trait VpnStorage: account::AccountInformationStorage + keys::device::DeviceKeyStore {}
+pub trait VpnStorage:
+    account::AccountInformationStorage
+    + keys::device::DeviceKeyStore
+    + account_summary::AccountSummaryStorage
+{
+}

--- a/nym-vpn-core/crates/nym-vpnc/src/commands/account.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/commands/account.rs
@@ -45,7 +45,11 @@ pub enum Command {
     },
     /// Refresh account state
     #[clap(hide = true)]
-    Refresh,
+    Refresh {
+        /// Force a fresh fetch from the nym-vpn-api instead of re-evaluating the cached summary
+        #[arg(long, short)]
+        force: bool,
+    },
     /// Get available tickets
     #[clap(hide = true)]
     AvailableTickets,
@@ -175,8 +179,8 @@ impl Command {
 
                 Ok(())
             }
-            Command::Refresh => {
-                rpc_client.refresh_account_state().await?;
+            Command::Refresh { force } => {
+                rpc_client.refresh_account_state(force).await?;
                 Ok(())
             }
             Command::AvailableTickets => {

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface.rs
@@ -743,9 +743,10 @@ impl NymVpnService for CommandInterface {
 
     async fn refresh_account_state(
         &self,
-        _request: tonic::Request<()>,
+        request: tonic::Request<proto::RefreshAccountStateRequest>,
     ) -> Result<tonic::Response<()>> {
-        self.send_and_wait(VpnServiceCommand::RefreshAccountState, ())
+        let force = request.into_inner().force;
+        self.send_and_wait(VpnServiceCommand::RefreshAccountState, force)
             .await?;
 
         Ok(tonic::Response::new(()))


### PR DESCRIPTION
## Ticket

JIRA-NYM-1462

## Split account syncing into network + local, cache the summary

The account controller used to do everything in one `SyncingState`: hit the API, then decide where we're at. I split that in two:

- `SyncingNetworkState` fetches the account summary and stores it (memory + on disk).
- `SyncingLocalState` runs the actual checks (account active, subscription, device registered, fair usage, clock synced) against the stored summary.

The summary is now persisted next to the mnemonic and device keys (`account_summary.json`), so we don't have to call the API every time we want to re-evaluate state. It carries a timestamp (`last_synced_utc`) and a few extra fields needed for the checks (`account_status`, `remaining_devices`, `is_device_active`, `time_synced`).

Syncing has two modes:
- optimistic (normal refresh, timers, coming back online): short timeout, and if the fetch fails or times out we just fall back to the cached summary.
- mandatory (force refresh, stale cache, no cache yet): real fetch, no fallback — if it fails we go to the error state.

A cache older than 24h is considered stale and triggers a mandatory refresh.

On the command side, `RefreshAccountState` now takes a `force` flag (threaded through the gRPC request, daemon, service and uniffi). `nym-vpnc account refresh` is the optimistic path; `nym-vpnc account refresh --force` drops the cache and forces a fresh fetch.

Also in here: moved the shared account types (`StorableAccount`, `Mnemonic`, `StoredAccountMode`) into `lib-types` so `nym-vpn-store` can depend on it (and made `bip39` a normal dep), and wired the new summary fields through the proto conversions.

Tests updated for the renamed error contexts, plus two new ones: force refresh picking up an account going inactive, and optimistic refresh falling back to cache vs force refresh surfacing the API error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5525)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Refresh now accepts a force flag (CLI/API) to choose full re-sync or optimistic local check.
  * Persistent local account-summary cache added for faster startup and fewer network calls.

* **Improvements**
  * New optimistic vs. mandatory sync modes reduce needless API requests while allowing forced re-syncs.
  * Subscription payments now trigger an immediate forced refresh to surface up-to-date account status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->