### PR TITLE
Resolver: fix recursion warning

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix missing "recursion available" flag in DNS responses, passthrough authority and additional records (https://github.com/nymtech/nym-vpn-client/pull/5546)
+
+
+## [2026.10.0] - 2026-06-09
+
 ### Added
 
 - Node family restriction and possibility to check for probable gateway selection before connection (https://github.com/nymtech/nym-vpn-client/pull/5285)
@@ -25,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Android] Diagnostic doesn't panic because of uninitialized context (https://github.com/nymtech/nym-vpn-client/pull/5415)
 - [Windows] Fix a crash when the network reconnected (https://github.com/nymtech/nym-vpn-client/pull/5508)
 - [Linux] LP firewalled by allowed_endpoints (https://github.com/nymtech/nym-vpn-client/pull/5516)
+
 
 ## [1.30] - 2026-05-29
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/resolver/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/resolver/mod.rs
@@ -58,7 +58,9 @@ use hickory_server::{
         net::{DnsError, NetError},
     },
     server::{Request, RequestHandler, ResponseHandler, ResponseInfo, Server},
-    zone_handler::{AuthLookup, MessageRequest, MessageResponse, MessageResponseBuilder},
+    zone_handler::{
+        AuthLookup, LookupRecordsIter, MessageRequest, MessageResponse, MessageResponseBuilder,
+    },
 };
 #[cfg(not(target_os = "ios"))]
 use hickory_server::{net::runtime::TokioRuntimeProvider, resolver::TokioResolver};
@@ -613,8 +615,12 @@ impl ResolverImpl {
         impl Iterator<Item = &'a Record> + Send + 'a,
     > {
         // Sets authoritative to false by default
-        let response_meta = Metadata::response_from_request(&message.metadata);
+        let mut response_meta = Metadata::response_from_request(&message.metadata);
         let builder = MessageResponseBuilder::from_message_request(message);
+
+        if let AuthLookup::Resolved(resolved) = lookup {
+            response_meta.recursion_available = resolved.message().metadata.recursion_available;
+        }
 
         builder.build(
             response_meta,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/resolver/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/resolver/mod.rs
@@ -625,10 +625,9 @@ impl ResolverImpl {
         builder.build(
             response_meta,
             lookup.iter(),
-            // forwarder responses only contain query answers, no ns/soa or additionals
+            lookup.authorities().unwrap_or(LookupRecordsIter::Empty),
             std::iter::empty(),
-            std::iter::empty(),
-            std::iter::empty(),
+            lookup.additionals().unwrap_or(LookupRecordsIter::Empty),
         )
     }
 


### PR DESCRIPTION
## Ticket

JIRA-NYM-1519

## Description

- Fix recursion warning returned by nslookup/dig due to missing `recursion_available` in the response from local resolver
- Passthrough authorities and additionals in DNS responses

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5546)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed DNS response handling to properly set the recursion available flag
  * DNS passthrough now correctly includes authority and additional records in responses

* **Documentation**
  * Updated changelog with new release version information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->