### PR TITLE
ci: cease auto-publish on git tag push

### DIFF
--- a/.github/workflows/publish-nym-vpn-android.yml
+++ b/.github/workflows/publish-nym-vpn-android.yml
@@ -43,10 +43,6 @@ on:
         default: release
         required: true
 
-  push:
-    tags:
-      - "nym-vpn-android-v*.*.*"
-
 env:
   UPLOAD_DIR_ANDROID: android_artifacts
   RELEASE_NOTES: ""
@@ -111,7 +107,9 @@ jobs:
       - if: github.event_name == 'schedule'
         run: echo "TAG_NAME=nym-vpn-android-nightly" >> $GITHUB_ENV
       - if: github.event_name == 'push'
-        run: echo "TAG_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
+        run: |
+          echo "unsupported push action!"
+          exit 1
 
       - name: On nightly release
         if: ${{ contains(env.TAG_NAME, 'nightly') }}

--- a/.github/workflows/publish-nym-vpn-core.yml
+++ b/.github/workflows/publish-nym-vpn-core.yml
@@ -9,9 +9,6 @@ on:
         type: boolean
         default: false
         required: true
-  push:
-    tags:
-      - nym-vpn-core-v[0-9]+.[0-9]+.[0-9]+*
 
 env:
   CARGO_TERM_COLOR: always
@@ -148,7 +145,9 @@ jobs:
       - if: github.event_name == 'schedule'
         run: echo 'TAG_NAME=nym-vpn-core-nightly' >> $GITHUB_ENV
       - if: github.event_name == 'push'
-        run: echo "TAG_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
+        run: |
+          echo "unsupported push action!"
+          exit 1
 
       - name: Set tag
         id: set_tag


### PR DESCRIPTION


## Description

CI used to run publish workflow for core and android on tag push. We should stop doing that as we run workflows explicitly instead.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5555)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Modified release automation to remove automatic triggers for version tag pushes; releases now run only on schedule or manual dispatch.
  * Updated publish checks so tag-based push events are explicitly rejected, preventing automatic derivation of release tags on push.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->