### PR TITLE
ci: fix workflows referencing removed bash scripts

### DIFF
--- a/.github/workflows/build-nym-vpn-core-deb.yml
+++ b/.github/workflows/build-nym-vpn-core-deb.yml
@@ -57,17 +57,11 @@ jobs:
           crate: cargo-deb
           cache-key: ${{ matrix.arch }}
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
+      - name: Install toml-cli
+        uses: baptiste0928/cargo-install@v3
         with:
-          version: "21.12" # 3.21.12: the version on ubuntu 24.04. Don't change this!
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get workspace version
-        id: workspace-version
-        uses: nicolaiunrein/cargo-get@master
-        with:
-          subcommand: workspace.package.version --entry nym-vpn-core
+          crate: toml-cli
+          cache-key: ${{ matrix.arch }}
 
       - name: Install cargo-edit
         uses: baptiste0928/cargo-install@v3
@@ -75,10 +69,33 @@ jobs:
           crate: cargo-edit
           cache-key: ${{ matrix.arch }}
 
-      - name: Append timestamp if it's a dev version
-        run:
-          ./scripts/append-timestamp-to-version.sh nym-vpn-core/Cargo.toml ${{
-          steps.workspace-version.outputs.metadata }}
+      - name: Install cargo-get
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-get
+          cache-key: ${{ matrix.arch }}
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "21.12" # 3.21.12: the version on ubuntu 24.04. Don't change this!
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set version for nightly builds
+        working-directory: nym-vpn-core
+        if: ${{ github.ref_name == 'develop' }}
+        run: |
+          if [ ${{ github.event_name }} = 'schedule' ]; then
+            TAG="nightly"
+          else
+            TAG="dev"
+          fi
+          VERSION=$(cargo-get workspace.package.version --major --minor --patch --delimiter='.')
+          NEW_VERSION="${VERSION}-${TAG}.$(date -u +%Y%m%d%H%M)"
+          echo "::notice:: Update version for nightly build: ${NEW_VERSION}"
+          toml set Cargo.toml workspace.package.version "$NEW_VERSION" > Cargo-patched.toml
+          mv Cargo-patched.toml Cargo.toml
+          cargo update --dry-run
 
       - name: Download wireguard-go artifacts
         uses: actions/download-artifact@v8

--- a/.github/workflows/build-nym-vpn-core-linux.yml
+++ b/.github/workflows/build-nym-vpn-core-linux.yml
@@ -68,16 +68,33 @@ jobs:
           crate: cargo-edit
           cache-key: ${{ matrix.arch }}
 
-      - name: Get workspace version
-        id: workspace-version
-        uses: nicolaiunrein/cargo-get@master
+      - name: Install cargo-get
+        uses: baptiste0928/cargo-install@v3
         with:
-          subcommand: workspace.package.version --entry nym-vpn-core
+          crate: cargo-get
+          cache-key: ${{ matrix.arch }}
 
-      - name: Append timestamp if it's a dev version
-        run:
-          ./scripts/append-timestamp-to-version.sh nym-vpn-core/Cargo.toml ${{
-          steps.workspace-version.outputs.metadata }}
+      - name: Install toml-cli
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: toml-cli
+          cache-key: ${{ matrix.arch }}
+
+      - name: Set version for nightly builds
+        working-directory: nym-vpn-core
+        if: ${{ github.ref_name == 'develop' }}
+        run: |
+          if [ ${{ github.event_name }} = 'schedule' ]; then
+            TAG="nightly"
+          else
+            TAG="dev"
+          fi
+          VERSION=$(cargo-get workspace.package.version --major --minor --patch --delimiter='.')
+          NEW_VERSION="${VERSION}-${TAG}.$(date -u +%Y%m%d%H%M)"
+          echo "::notice:: Update version for nightly build: ${NEW_VERSION}"
+          toml set Cargo.toml workspace.package.version "$NEW_VERSION" > Cargo-patched.toml
+          mv Cargo-patched.toml Cargo.toml
+          cargo update --dry-run
 
       - name: Download wireguard-go artifacts
         uses: actions/download-artifact@v8

--- a/.github/workflows/build-nym-vpn-core-windows.yml
+++ b/.github/workflows/build-nym-vpn-core-windows.yml
@@ -85,12 +85,6 @@ jobs:
           targets: ${{ inputs.cpu_arch == 'ARM64' && 'aarch64-pc-windows-msvc' || 'x86_64-pc-windows-msvc' }}
           components: rustfmt, clippy
 
-      - name: Get workspace version
-        id: workspace-version
-        uses: nicolaiunrein/cargo-get@master
-        with:
-          subcommand: workspace.package.version --entry nym-vpn-core
-
       - name: Install cargo-edit
         uses: baptiste0928/cargo-install@v3
         with:
@@ -101,9 +95,27 @@ jobs:
         with:
           crate: cargo-get
 
-      - name: Append timestamp if it's a dev version
+      - name: Install toml-cli
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: toml-cli
+
+      - name: Set version for nightly builds
         shell: bash
-        run: ./scripts/append-timestamp-to-version.sh nym-vpn-core/Cargo.toml ${{ steps.workspace-version.outputs.metadata }}
+        working-directory: nym-vpn-core
+        if: ${{ github.ref_name == 'develop' }}
+        run: |
+          if [ ${{ github.event_name }} = 'schedule' ]; then
+            TAG="nightly"
+          else
+            TAG="dev"
+          fi
+          VERSION=$(cargo-get workspace.package.version --major --minor --patch --delimiter='.')
+          NEW_VERSION="${VERSION}-${TAG}.$(date -u +%Y%m%d%H%M)"
+          echo "::notice:: Update version for nightly build: ${NEW_VERSION}"
+          toml set Cargo.toml workspace.package.version "$NEW_VERSION" > Cargo-patched.toml
+          mv Cargo-patched.toml Cargo.toml
+          cargo update --dry-run
 
       - name: Download wireguard-go-windows artifacts
         uses: actions/download-artifact@v8

--- a/.github/workflows/build-nym-vpnc-macos.yml
+++ b/.github/workflows/build-nym-vpnc-macos.yml
@@ -51,18 +51,38 @@ jobs:
         with:
           crate: cargo-edit
 
+      - name: Install cargo-get
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-get
+
+      - name: Install toml-cli
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: toml-cli
+
+      - name: Set version for nightly builds
+        shell: bash
+        working-directory: nym-vpn-core
+        if: ${{ github.ref_name == 'develop' }}
+        run: |
+          if [ ${{ github.event_name }} = 'schedule' ]; then
+            TAG="nightly"
+          else
+            TAG="dev"
+          fi
+          VERSION=$(cargo-get workspace.package.version --major --minor --patch --delimiter='.')
+          NEW_VERSION="${VERSION}-${TAG}.$(date -u +%Y%m%d%H%M)"
+          echo "::notice:: Update version for nightly build: ${NEW_VERSION}"
+          toml set Cargo.toml workspace.package.version "$NEW_VERSION" > Cargo-patched.toml
+          mv Cargo-patched.toml Cargo.toml
+          cargo update --dry-run
+
       - name: Get workspace version
         id: workspace-version
         uses: nicolaiunrein/cargo-get@master
         with:
           subcommand: workspace.package.version --entry nym-vpn-core
-
-      - name: Append timestamp if it's a dev version
-        id: version
-        run: |
-          ./scripts/append-timestamp-to-version.sh \
-            nym-vpn-core/Cargo.toml \
-            "${{ steps.workspace-version.outputs.metadata }}"
 
       - name: Add Homebrew to PATH
         run: |

--- a/.github/workflows/generate-build-info-core.yml
+++ b/.github/workflows/generate-build-info-core.yml
@@ -49,6 +49,11 @@ jobs:
         with:
           crate: cargo-get
 
+      - name: Install toml-cli
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: toml-cli
+
       - name: Set version for nightly builds
         shell: bash
         working-directory: nym-vpn-core

--- a/.github/workflows/generate-build-info-core.yml
+++ b/.github/workflows/generate-build-info-core.yml
@@ -39,19 +39,32 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
 
-      - name: Get workspace version
-        id: workspace-version
-        uses: nicolaiunrein/cargo-get@master
-        with:
-          subcommand: workspace.package.version --entry nym-vpn-core
-
       - name: Install cargo-edit
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-edit
 
-      - name: Append timestamp if it's a dev version
-        run: ./scripts/append-timestamp-to-version.sh nym-vpn-core/Cargo.toml ${{ steps.workspace-version.outputs.metadata }}
+      - name: Install cargo-get
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-get
+
+      - name: Set version for nightly builds
+        shell: bash
+        working-directory: nym-vpn-core
+        if: ${{ github.ref_name == 'develop' }}
+        run: |
+          if [ ${{ github.event_name }} = 'schedule' ]; then
+            TAG="nightly"
+          else
+            TAG="dev"
+          fi
+          VERSION=$(cargo-get workspace.package.version --major --minor --patch --delimiter='.')
+          NEW_VERSION="${VERSION}-${TAG}.$(date -u +%Y%m%d%H%M)"
+          echo "::notice:: Update version for nightly build: ${NEW_VERSION}"
+          toml set Cargo.toml workspace.package.version "$NEW_VERSION" > Cargo-patched.toml
+          mv Cargo-patched.toml Cargo.toml
+          cargo update --dry-run
 
       - name: Get package version nym-vpnc
         id: package-version-vpnc
@@ -78,8 +91,8 @@ jobs:
           echo " nym-vpnc: ${{ steps.package-version-vpnc.outputs.metadata }}" >> build-info.txt
           echo " nym-vpnd: ${{ steps.package-version-vpnd.outputs.metadata }}" >> build-info.txt
           echo " nym-vpn-lib: ${{ steps.package-version-lib.outputs.metadata }}" >> build-info.txt
-          echo "Rustc version: ${{ inputs.rust-version}}" >> build-info.txt
-          echo "Build profile: ${{ inputs.build-profile}}" >> build-info.txt
+          echo "Rustc version: ${{ inputs.rust-version }}" >> build-info.txt
+          echo "Build profile: ${{ inputs.build-profile }}" >> build-info.txt
           echo "Date:          ${{ steps.date.outputs.date }}" >> build-info.txt
           cat build-info.txt
 


### PR DESCRIPTION

## Description

What the title says

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5556)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Unified and simplified build versioning for develop/nightly builds, appending deterministic nightly/dev suffixes with timestamps.
  * Replaced scattered timestamping scripts with consolidated inline versioning steps and ensured required tooling is installed in CI.
  * Harmonized workflows across platforms and improved build-info output formatting for clearer build metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->