### PR TITLE
Migrate to using nym-ifconfig

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -7220,6 +7220,7 @@ dependencies = [
  "nym-firewall-config",
  "nym-gateway-directory",
  "nym-http-api-client",
+ "nym-ifconfig",
  "nym-ip-packet-client",
  "nym-ip-packet-requests",
  "nym-lp",

--- a/nym-vpn-core/crates/nym-ifconfig/src/apple/utun.rs
+++ b/nym-vpn-core/crates/nym-ifconfig/src/apple/utun.rs
@@ -51,11 +51,11 @@ impl Utun<'_, OwnedFd> {
 
 impl<'a> Utun<'a, BorrowedFd<'a>> {
     /// Initialize `Utun` using borrowed tunnel file descriptor.
-    pub fn new_from_borrowed_fd(tun_fd: BorrowedFd<'a>) -> Result<Utun<'a, BorrowedFd<'a>>> {
-        Ok(Self {
+    pub fn new_from_borrowed_fd(tun_fd: BorrowedFd<'a>) -> Utun<'a, BorrowedFd<'a>> {
+        Self {
             tun_fd,
             _phantom: std::marker::PhantomData,
-        })
+        }
     }
 }
 

--- a/nym-vpn-core/crates/nym-ifconfig/src/linux/tun.rs
+++ b/nym-vpn-core/crates/nym-ifconfig/src/linux/tun.rs
@@ -82,11 +82,11 @@ impl Tun<'_, OwnedFd> {
 
 impl<'a> Tun<'a, BorrowedFd<'a>> {
     /// Initialize `Utun` using borrowed tunnel file descriptor.
-    pub fn new_from_borrowed_fd(tun_fd: BorrowedFd<'a>) -> Result<Tun<'a, BorrowedFd<'a>>> {
-        Ok(Self {
+    pub fn new_from_borrowed_fd(tun_fd: BorrowedFd<'a>) -> Tun<'a, BorrowedFd<'a>> {
+        Self {
             tun_fd,
             _phantom: std::marker::PhantomData,
-        })
+        }
     }
 }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
@@ -142,6 +142,7 @@ nix = { workspace = true, features = [
     "signal",
     "ioctl",
 ] }
+nym-ifconfig.workspace = true
 
 # Windows-specific dependencies
 [target.'cfg(windows)'.dependencies]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -1272,11 +1272,11 @@ pub enum Error {
 
     #[error("failed to get tunnel device name")]
     #[cfg(any(target_os = "ios", target_os = "android"))]
-    GetTunDeviceName(#[source] tun_name::GetTunNameError),
+    GetTunDeviceName(#[source] nym_ifconfig::Error),
 
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     #[error("failed to set tunnel device ipv6 address")]
-    SetTunDeviceIpv6Addr(#[source] std::io::Error),
+    SetTunDeviceIpv6Addr(#[source] nym_ifconfig::Error),
 
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     #[error("failed to add routes")]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tun_ipv6.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tun_ipv6.rs
@@ -1,27 +1,40 @@
 // Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{io, net::Ipv6Addr, process::Command};
+use std::net::Ipv6Addr;
+
+use ipnetwork::Ipv6Network;
 
 #[cfg(target_os = "linux")]
-pub fn set_ipv6_addr(device_name: &str, ipv6_addr: Ipv6Addr) -> io::Result<()> {
-    Command::new("ip")
-        .args([
-            "-6",
-            "addr",
-            "add",
-            &ipv6_addr.to_string(),
-            "dev",
-            device_name,
-        ])
-        .output()?;
+pub async fn set_ipv6_addr(device_name: &str, ipv6_addr: Ipv6Addr) -> nym_ifconfig::Result<()> {
+    use ipnetwork::IpNetwork;
+    use nym_ifconfig::Session;
+
+    let sess = Session::new()?;
+    sess.add_address(
+        device_name,
+        IpNetwork::V6(Ipv6Network::from(ipv6_addr)),
+        None,
+    )
+    .await?;
+
     Ok(())
 }
 
 #[cfg(target_os = "macos")]
-pub fn set_ipv6_addr(device_name: &str, ipv6_addr: Ipv6Addr) -> io::Result<()> {
-    Command::new("ifconfig")
-        .args([device_name, "inet6", "add", &ipv6_addr.to_string()])
-        .output()?;
+pub async fn set_ipv6_addr(device_name: &str, ipv6_addr: Ipv6Addr) -> nym_ifconfig::Result<()> {
+    use nym_ifconfig::{AddAddressRequestV6, Ipv6AddrFlags, Ipv6AddrLifetime, Session};
+
+    let mut sess = Session::default();
+    sess.add_address(
+        device_name,
+        AddAddressRequestV6 {
+            address: Ipv6Network::from(ipv6_addr),
+            destination: None,
+            lifetime: Ipv6AddrLifetime::default(),
+            flags: Ipv6AddrFlags::IN6_IFF_NODAD,
+        },
+    )?;
+
     Ok(())
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tun_name.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tun_name.rs
@@ -1,60 +1,18 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
 use std::os::fd::BorrowedFd;
-#[cfg(target_os = "android")]
-use std::{ffi::CStr, os::fd::AsRawFd};
-
-#[cfg(target_os = "android")]
-use nix::libc::ifreq;
-#[cfg(target_os = "ios")]
-use nix::sys::socket::{getsockopt, sockopt};
-
-#[cfg(target_os = "android")]
-// This call takes a pointer to ifreq but must be defined as taking integer.
-nix::ioctl_read!(tungetiff, b'T', 210, nix::libc::c_int);
-
-#[derive(thiserror::Error, Debug)]
-pub enum GetTunNameError {
-    #[error("syscall error")]
-    Syscall(#[source] nix::Error),
-
-    #[error("failed to copy interface name")]
-    CopyInterfaceName(#[source] std::ffi::FromBytesUntilNulError),
-
-    #[error("failed to convert interface name to utf-8")]
-    ConvertInterfaceNameToUtf8(#[source] std::str::Utf8Error),
-}
-
-pub type Result<T, E = GetTunNameError> = std::result::Result<T, E>;
 
 /// Returns tunnel interface name for the given tunnel file descriptor.
 #[cfg(target_os = "ios")]
-pub fn get_tun_name(fd: &BorrowedFd) -> Result<String> {
-    getsockopt(fd, sockopt::UtunIfname)
-        .map_err(GetTunNameError::Syscall)?
-        .to_str()
-        .map(|s| s.to_owned())
-        .map_err(GetTunNameError::ConvertInterfaceNameToUtf8)
+pub fn get_tun_name(fd: BorrowedFd) -> nym_ifconfig::Result<String> {
+    let tun = nym_ifconfig::Utun::new_from_borrowed_fd(fd);
+    tun.name()
 }
 
 /// Returns tunnel interface name for the given tunnel file descriptor.
 #[cfg(target_os = "android")]
-pub fn get_tun_name(fd: &BorrowedFd) -> Result<String> {
-    let mut ifr: ifreq = unsafe { std::mem::zeroed() };
-    unsafe { tungetiff(fd.as_raw_fd(), &mut ifr as *mut _ as _) }
-        .map_err(GetTunNameError::Syscall)?;
-
-    #[cfg(not(target_arch = "aarch64"))]
-    let ifr_name_bytes = ifr
-        .ifr_name
-        .into_iter()
-        .map(|c| c as u8)
-        .collect::<Vec<_>>();
-
-    #[cfg(target_arch = "aarch64")]
-    let ifr_name_bytes = ifr.ifr_name;
-
-    CStr::from_bytes_until_nul(&ifr_name_bytes)
-        .map_err(GetTunNameError::CopyInterfaceName)?
-        .to_str()
-        .map(|s| s.to_owned())
-        .map_err(GetTunNameError::ConvertInterfaceNameToUtf8)
+pub fn get_tun_name(fd: BorrowedFd) -> nym_ifconfig::Result<String> {
+    let tun = nym_ifconfig::Tun::new_from_borrowed_fd(fd);
+    tun.name()
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -959,7 +959,7 @@ impl TunnelMonitor {
         #[cfg(any(target_os = "ios", target_os = "android"))]
         let tun_name = {
             let tun_fd = unsafe { BorrowedFd::borrow_raw(tun_device.deref().as_raw_fd()) };
-            tun_name::get_tun_name(&tun_fd).map_err(Error::GetTunDeviceName)?
+            tun_name::get_tun_name(tun_fd).map_err(Error::GetTunDeviceName)?
         };
 
         tracing::info!("Created tun device: {}", tun_name);
@@ -1192,7 +1192,8 @@ impl TunnelMonitor {
             self.enable_ipv6().then_some(conn_data.exit.private_ipv6),
             Some(conn_data.entry.private_ipv4.into()),
             exit_tun_mtu,
-        )?;
+        )
+        .await?;
         let exit_tun_name = exit_tun
             .deref()
             .tun_name()
@@ -1370,7 +1371,8 @@ impl TunnelMonitor {
             self.enable_ipv6().then_some(conn_data.entry.private_ipv6),
             None,
             entry_mtu,
-        )?;
+        )
+        .await?;
         let entry_tun_name = entry_tun
             .deref()
             .tun_name()
@@ -1395,7 +1397,8 @@ impl TunnelMonitor {
             // todo: this needs to be able to set both destinations?
             Some(conn_data.entry.private_ipv4.into()),
             exit_mtu,
-        )?;
+        )
+        .await?;
         let exit_tun_name = exit_tun
             .deref()
             .tun_name()
@@ -1648,7 +1651,7 @@ impl TunnelMonitor {
 
         let tun_device = self.create_tun_device(packet_tunnel_settings).await?;
         let tun_fd = unsafe { BorrowedFd::borrow_raw(tun_device.deref().as_raw_fd()) };
-        let interface = tun_name::get_tun_name(&tun_fd).map_err(Error::GetTunDeviceName)?;
+        let interface = tun_name::get_tun_name(tun_fd).map_err(Error::GetTunDeviceName)?;
         let mut ips = vec![IpAddr::V4(conn_data.exit.private_ipv4)];
         if self.enable_ipv6() {
             ips.push(IpAddr::V6(conn_data.exit.private_ipv6));
@@ -1748,6 +1751,7 @@ impl TunnelMonitor {
                 .tun_name()
                 .map_err(Error::GetTunDeviceName)?;
             tun_ipv6::set_ipv6_addr(&tun_name, interface_ipv6)
+                .await
                 .map_err(Error::SetTunDeviceIpv6Addr)?;
         }
 
@@ -1774,7 +1778,7 @@ impl TunnelMonitor {
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]
-    fn create_wireguard_device(
+    async fn create_wireguard_device(
         interface_ipv4: Ipv4Addr,
         interface_ipv6: Option<Ipv6Addr>,
         destination: Option<IpAddr>,
@@ -1806,6 +1810,7 @@ impl TunnelMonitor {
 
         if let Some(interface_ipv6) = interface_ipv6 {
             tun_ipv6::set_ipv6_addr(&tun_name, interface_ipv6)
+                .await
                 .map_err(Error::SetTunDeviceIpv6Addr)?;
         }
 


### PR DESCRIPTION


## Description

This PR replaces some of `Command` calls with `nym-ifconfig` which performs syscalls to configure IPv6 and/or obtain tunnel device name.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5558)
<!-- Reviewable:end -->
