### PR TITLE
Adapt to new account controller interface

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -427,7 +427,7 @@ impl ConnectingState {
             tracing::info!("Forcing account state refresh due to device time being desynced");
             if let Err(err) = shared_state
                 .account_command_tx
-                .background_refresh_account_state()
+                .refresh_account_state(true)
                 .await
             {
                 trace_err_chain!(


### PR DESCRIPTION
## Description

- `background_refresh_account_state` is no longer available. 
- This PR uses `refresh_account_state(true)` instead to force refresh.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5559)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved VPN connection recovery when device time is out of synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->