### PR TITLE
Recover from bandwidth exceeded when VPN disconnects after daily reset

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/error_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/error_state.rs
@@ -127,9 +127,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ErrorState {
                         return_sender.send(Ok(()));
                         if shared_state.firewall_active {
                             shared_state.firewall_active = false;
-                            if matches!(self.reason, AccountControllerErrorStateReason::BandwidthExceeded { .. }) {
-                                return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Optimistic));
-                            }
+                            return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Optimistic));
                         }
                     },
                     AccountCommand::VpnApiFirewallUp(return_sender) => {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/error_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/error_state.rs
@@ -124,8 +124,13 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ErrorState {
                     },
 
                     AccountCommand::VpnApiFirewallDown(return_sender) =>  {
-                        shared_state.firewall_active = false;
                         return_sender.send(Ok(()));
+                        if shared_state.firewall_active {
+                            shared_state.firewall_active = false;
+                            if matches!(self.reason, AccountControllerErrorStateReason::BandwidthExceeded { .. }) {
+                                return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Mandatory));
+                            }
+                        }
                     },
                     AccountCommand::VpnApiFirewallUp(return_sender) => {
                         shared_state.firewall_active = true;

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/error_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/error_state.rs
@@ -128,7 +128,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ErrorState {
                         if shared_state.firewall_active {
                             shared_state.firewall_active = false;
                             if matches!(self.reason, AccountControllerErrorStateReason::BandwidthExceeded { .. }) {
-                                return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Mandatory));
+                                return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Optimistic));
                             }
                         }
                     },

--- a/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/commands.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/commands.rs
@@ -477,7 +477,10 @@ async fn bandwidth_exceeded_firewall_down_triggers_sync_test() -> anyhow::Result
 
     // Simulate VPN connected (firewall active), then disconnected
     test_bench.command_sender.set_vpn_api_firewall_up().await?;
-    test_bench.command_sender.set_vpn_api_firewall_down().await?;
+    test_bench
+        .command_sender
+        .set_vpn_api_firewall_down()
+        .await?;
 
     // BandwidthExceeded + firewall down must trigger an immediate mandatory sync
     test_bench
@@ -509,7 +512,10 @@ async fn non_bandwidth_error_firewall_down_does_not_sync_test() -> anyhow::Resul
     let mut state_watcher = test_bench.state_receiver.subscribe();
 
     test_bench.command_sender.set_vpn_api_firewall_up().await?;
-    test_bench.command_sender.set_vpn_api_firewall_down().await?;
+    test_bench
+        .command_sender
+        .set_vpn_api_firewall_down()
+        .await?;
 
     // The firewall-down sync transition is scoped to BandwidthExceeded only. A
     // non-bandwidth error must stay in error (the 120s refresh timer will not

--- a/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/commands.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/commands.rs
@@ -482,7 +482,8 @@ async fn bandwidth_exceeded_firewall_down_triggers_sync_test() -> anyhow::Result
         .set_vpn_api_firewall_down()
         .await?;
 
-    // BandwidthExceeded + firewall down must trigger an immediate mandatory sync
+    // BandwidthExceeded + firewall down must trigger an immediate optimistic sync
+    // (SyncingLocalState escalates to mandatory if the cache is stale after reset)
     test_bench
         .assert_state(AccountControllerState::Syncing)
         .await;

--- a/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/commands.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/commands.rs
@@ -455,3 +455,78 @@ async fn error_state_command() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn bandwidth_exceeded_firewall_down_triggers_sync_test() -> anyhow::Result<()> {
+    let mut test_bench = TestBench::new().await?;
+
+    let mocks = vec![
+        endpoints::synced_health(),
+        endpoints::account_summary_with_device_200(account_no_fair_usage()),
+    ];
+    test_bench.register_vpn_api_mocks(mocks).await;
+
+    test_bench.store_mock_account().await?;
+    test_bench
+        .assert_state(AccountControllerState::Error(
+            AccountControllerErrorStateReason::BandwidthExceeded {
+                context: "SYNCING_LOCAL_STATE".into(),
+            },
+        ))
+        .await;
+
+    // Simulate VPN connected (firewall active), then disconnected
+    test_bench.command_sender.set_vpn_api_firewall_up().await?;
+    test_bench.command_sender.set_vpn_api_firewall_down().await?;
+
+    // BandwidthExceeded + firewall down must trigger an immediate mandatory sync
+    test_bench
+        .assert_state(AccountControllerState::Syncing)
+        .await;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn non_bandwidth_error_firewall_down_does_not_sync_test() -> anyhow::Result<()> {
+    let mut test_bench = TestBench::new().await?;
+
+    // MaxDeviceReached is a non-bandwidth error reason
+    let mocks = vec![
+        endpoints::synced_health(),
+        endpoints::account_summary_with_device_200(account_max_devices()),
+    ];
+    test_bench.register_vpn_api_mocks(mocks).await;
+
+    test_bench.store_mock_account().await?;
+    test_bench
+        .assert_state(AccountControllerState::Error(
+            AccountControllerErrorStateReason::MaxDeviceReached,
+        ))
+        .await;
+
+    // Watch for any transition out of the error state before sending the command
+    let mut state_watcher = test_bench.state_receiver.subscribe();
+
+    test_bench.command_sender.set_vpn_api_firewall_up().await?;
+    test_bench.command_sender.set_vpn_api_firewall_down().await?;
+
+    // The firewall-down sync transition is scoped to BandwidthExceeded only. A
+    // non-bandwidth error must stay in error (the 120s refresh timer will not
+    // fire within this window), so waiting for Syncing must time out.
+    let synced = tokio::time::timeout(
+        std::time::Duration::from_secs(3),
+        state_watcher.wait_for(|state| *state == AccountControllerState::Syncing),
+    )
+    .await;
+    assert!(
+        synced.is_err(),
+        "MaxDeviceReached + firewall down must not trigger a sync"
+    );
+    assert_eq!(
+        test_bench.state_receiver.get_state(),
+        AccountControllerState::Error(AccountControllerErrorStateReason::MaxDeviceReached),
+    );
+
+    Ok(())
+}

--- a/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/commands.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/commands.rs
@@ -457,7 +457,7 @@ async fn error_state_command() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-async fn bandwidth_exceeded_firewall_down_triggers_sync_test() -> anyhow::Result<()> {
+async fn error_state_firewall_down_triggers_sync_test() -> anyhow::Result<()> {
     let mut test_bench = TestBench::new().await?;
 
     let mocks = vec![
@@ -475,15 +475,14 @@ async fn bandwidth_exceeded_firewall_down_triggers_sync_test() -> anyhow::Result
         ))
         .await;
 
-    // Simulate VPN connected (firewall active), then disconnected
     test_bench.command_sender.set_vpn_api_firewall_up().await?;
     test_bench
         .command_sender
         .set_vpn_api_firewall_down()
         .await?;
 
-    // BandwidthExceeded + firewall down must trigger an immediate optimistic sync
-    // (SyncingLocalState escalates to mandatory if the cache is stale after reset)
+    // Any error reason + firewall down triggers optimistic sync (parity with local_state.rs).
+    // SyncingLocalState escalates to mandatory if the cache is stale after reset.
     test_bench
         .assert_state(AccountControllerState::Syncing)
         .await;
@@ -492,10 +491,9 @@ async fn bandwidth_exceeded_firewall_down_triggers_sync_test() -> anyhow::Result
 }
 
 #[tokio::test]
-async fn non_bandwidth_error_firewall_down_does_not_sync_test() -> anyhow::Result<()> {
+async fn non_bandwidth_error_state_firewall_down_triggers_sync_test() -> anyhow::Result<()> {
     let mut test_bench = TestBench::new().await?;
 
-    // MaxDeviceReached is a non-bandwidth error reason
     let mocks = vec![
         endpoints::synced_health(),
         endpoints::account_summary_with_device_200(account_max_devices()),
@@ -509,31 +507,15 @@ async fn non_bandwidth_error_firewall_down_does_not_sync_test() -> anyhow::Resul
         ))
         .await;
 
-    // Watch for any transition out of the error state before sending the command
-    let mut state_watcher = test_bench.state_receiver.subscribe();
-
     test_bench.command_sender.set_vpn_api_firewall_up().await?;
     test_bench
         .command_sender
         .set_vpn_api_firewall_down()
         .await?;
 
-    // The firewall-down sync transition is scoped to BandwidthExceeded only. A
-    // non-bandwidth error must stay in error (the 120s refresh timer will not
-    // fire within this window), so waiting for Syncing must time out.
-    let synced = tokio::time::timeout(
-        std::time::Duration::from_secs(3),
-        state_watcher.wait_for(|state| *state == AccountControllerState::Syncing),
-    )
-    .await;
-    assert!(
-        synced.is_err(),
-        "MaxDeviceReached + firewall down must not trigger a sync"
-    );
-    assert_eq!(
-        test_bench.state_receiver.get_state(),
-        AccountControllerState::Error(AccountControllerErrorStateReason::MaxDeviceReached),
-    );
+    test_bench
+        .assert_state(AccountControllerState::Syncing)
+        .await;
 
     Ok(())
 }


### PR DESCRIPTION
- When the account controller is in BandwidthExceeded error state and the VPN disconnects (API firewall down), it now triggers an immediate mandatory account sync.
- Fixes accounts stuck showing yesterday's depleted quota after UTC midnight reset while the VPN was still connected.
- Only applies to BandwidthExceeded - other error reasons are unchanged (flag cleared, no sync).

## Ticket

JIRA-NYM-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5561)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Firewall recovery now acknowledges a firewall-down event immediately and triggers an immediate network resync when appropriate, ensuring faster recovery from connectivity interruptions even while the controller is in an error state.

* **Tests**
  * Added integration tests validating firewall up/down behavior, confirming immediate resync behavior for both bandwidth-related and other error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->