### PR TITLE
NYM-150: Send network stats over the tunnel on iOS

### DIFF
--- a/nym-vpn-apple/Home/Sources/26/Welcome/WelcomeOptInsView.swift
+++ b/nym-vpn-apple/Home/Sources/26/Welcome/WelcomeOptInsView.swift
@@ -6,10 +6,9 @@ import Theme
 import UIComponents
 
 public struct WelcomeOptInsView: View {
-#if os(macOS)
     @AppStorage(AppSettingKey.statistics.rawValue)
     private var isStatisticsEnabled: Bool = true
-#endif
+
     @AppStorage(AppSettingKey.errorReporting.rawValue)
     private var isErrorReportingOn: Bool = false
 
@@ -59,14 +58,12 @@ private extension WelcomeOptInsView {
 
     var cards: some View {
         VStack(spacing: NymSpacing.small) {
-#if os(macOS)
             optInCard(
                 title: "welcomeOptIns.stats.title".localizedString,
                 linkTitle: "welcomeOptIns.stats.link".localizedString,
                 linkURL: URL(string: Constants.anonymousStatsURL.rawValue),
                 isOn: $isStatisticsEnabled
             )
-#endif
             optInCard(
                 title: "welcomeOptIns.error.title".localizedString,
                 linkTitle: "welcomeOptIns.error.link".localizedString,

--- a/nym-vpn-apple/Services/Sources/Services/AppSettings/AppSettings.swift
+++ b/nym-vpn-apple/Services/Sources/Services/AppSettings/AppSettings.swift
@@ -87,12 +87,8 @@ import ConnectionTypes
         didSet { isAdBlockerEnabledPublisher = isAdBlockerEnabled}
     }
 
-#if os(macOS)
     @AppStorage(AppSettingKey.statistics.rawValue)
     public var isStatisticsEnabled = true
-#else
-    public var isStatisticsEnabled = false
-#endif
 
     @AppStorage(AppSettingKey.statisticsConnectionCount.rawValue)
     public var statisticsConnectionCount = 0

--- a/nym-vpn-apple/Settings/Sources/Settings/PrivacyAndData/PrivacyAndDataView.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/PrivacyAndData/PrivacyAndDataView.swift
@@ -31,10 +31,11 @@ public struct PrivacyAndDataView: View {
                 diagnosticToolSection()
                 Spacer()
                     .frame(height: 24)
+#endif
                 statisticsSection()
                 Spacer()
                     .frame(height: 24)
-#endif
+
                 errorReportingSection()
             }
             .frame(maxWidth: MagicNumbers.maxWidth)

--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+### Added
+
+- [iOS] Send network stats over the tunnel interface (https://github.com/nymtech/nym-vpn-client/pull/5564)
+
 ### Fixed
 
 - Fix missing "recursion available" flag in DNS responses, passthrough authority and additional records (https://github.com/nymtech/nym-vpn-client/pull/5546)

--- a/nym-vpn-core/crates/nym-statistics-api-client/src/client.rs
+++ b/nym-vpn-core/crates/nym-statistics-api-client/src/client.rs
@@ -19,30 +19,27 @@ pub(crate) const NYM_STATISTICS_API_TIMEOUT: Duration = Duration::from_secs(30);
 #[derive(Clone, Debug)]
 pub struct StatisticsApiClient {
     inner: nym_http_api_client::Client,
-    /// Kept around to rebuild the client bound to the tunnel interface (iOS).
-    #[cfg_attr(not(target_os = "ios"), allow(dead_code))]
+    #[cfg(target_os = "ios")]
     base_url: Url,
-    #[cfg_attr(not(target_os = "ios"), allow(dead_code))]
+    #[cfg(target_os = "ios")]
     user_agent: UserAgent,
 }
 
 impl StatisticsApiClient {
     pub fn new(base_url: Url, user_agent: UserAgent) -> Result<Self> {
         // What about domain fronting?  The discovery schema makes no provision for it.
-        nym_http_api_client::Client::builder(base_url.clone())
-            .and_then(|builder| {
-                builder
-                    .with_user_agent(user_agent.clone())
-                    .with_timeout(NYM_STATISTICS_API_TIMEOUT)
-                    .build()
-            })
-            .map(|c| Self {
-                inner: c,
+        Ok(Self {
+            #[cfg(target_os = "ios")]
+            base_url: base_url.clone(),
+            #[cfg(target_os = "ios")]
+            user_agent: user_agent.clone(),
+            inner: Self::make_http_client(
                 base_url,
                 user_agent,
-            })
-            .map_err(Box::new)
-            .map_err(StatisticsApiClientError::VpnApiClientCreation)
+                #[cfg(target_os = "ios")]
+                None,
+            )?,
+        })
     }
 
     /// Create a copy of this client with its sockets bound to the given network interface.
@@ -53,23 +50,43 @@ impl StatisticsApiClient {
     /// in-process DNS forwarder bound to the tunnel while it is up; the default DoH/DoT
     /// resolver would create unbound sockets of its own and leak outside of the tunnel.
     #[cfg(target_os = "ios")]
-    pub fn with_bound_interface(&self, interface: &str) -> Result<Self> {
-        let reqwest_builder = nym_http_api_client::registry::default_builder()
-            .interface(interface)
-            .timeout(NYM_STATISTICS_API_TIMEOUT);
-        nym_http_api_client::Client::builder(self.base_url.clone())
+    pub fn with_bound_interface(&self, interface: Option<&str>) -> Result<Self> {
+        let inner =
+            Self::make_http_client(self.base_url.clone(), self.user_agent.clone(), interface)?;
+
+        Ok(Self {
+            base_url: self.base_url.clone(),
+            user_agent: self.user_agent.clone(),
+            inner,
+        })
+    }
+
+    fn make_http_client(
+        base_url: Url,
+        user_agent: UserAgent,
+        #[cfg(target_os = "ios")] bound_interface: Option<&str>,
+    ) -> Result<nym_http_api_client::Client> {
+        nym_http_api_client::Client::builder(base_url)
             .and_then(|builder| {
-                builder
-                    .with_user_agent(self.user_agent.clone())
-                    .with_timeout(NYM_STATISTICS_API_TIMEOUT)
-                    .with_reqwest_builder(reqwest_builder)
-                    .no_hickory_dns()
-                    .build()
-            })
-            .map(|inner| Self {
-                inner,
-                base_url: self.base_url.clone(),
-                user_agent: self.user_agent.clone(),
+                let builder = builder
+                    .with_user_agent(user_agent)
+                    .with_timeout(NYM_STATISTICS_API_TIMEOUT);
+
+                #[cfg(target_os = "ios")]
+                let builder = if let Some(bound_interface) = bound_interface {
+                    let reqwest_builder = nym_http_api_client::registry::default_builder()
+                        .timeout(NYM_STATISTICS_API_TIMEOUT)
+                        .interface(bound_interface);
+
+                    // Enforce the use of system resolver which is set to in-process DNS forwarder that prevents leaks.
+                    let reqwest_builder = reqwest_builder.no_hickory_dns();
+
+                    builder.with_reqwest_builder(reqwest_builder)
+                } else {
+                    builder
+                };
+
+                builder.build()
             })
             .map_err(Box::new)
             .map_err(StatisticsApiClientError::VpnApiClientCreation)

--- a/nym-vpn-core/crates/nym-statistics-api-client/src/client.rs
+++ b/nym-vpn-core/crates/nym-statistics-api-client/src/client.rs
@@ -19,6 +19,11 @@ pub(crate) const NYM_STATISTICS_API_TIMEOUT: Duration = Duration::from_secs(30);
 #[derive(Clone, Debug)]
 pub struct StatisticsApiClient {
     inner: nym_http_api_client::Client,
+    /// Kept around to rebuild the client bound to the tunnel interface (iOS).
+    #[cfg_attr(not(target_os = "ios"), allow(dead_code))]
+    base_url: Url,
+    #[cfg_attr(not(target_os = "ios"), allow(dead_code))]
+    user_agent: UserAgent,
 }
 
 impl StatisticsApiClient {
@@ -27,11 +32,45 @@ impl StatisticsApiClient {
         nym_http_api_client::Client::builder(base_url.clone())
             .and_then(|builder| {
                 builder
-                    .with_user_agent(user_agent)
+                    .with_user_agent(user_agent.clone())
                     .with_timeout(NYM_STATISTICS_API_TIMEOUT)
                     .build()
             })
-            .map(|c| Self { inner: c })
+            .map(|c| Self {
+                inner: c,
+                base_url,
+                user_agent,
+            })
+            .map_err(Box::new)
+            .map_err(StatisticsApiClientError::VpnApiClientCreation)
+    }
+
+    /// Create a copy of this client with its sockets bound to the given network interface.
+    ///
+    /// On iOS, traffic from the packet tunnel provider is excluded from the tunnel, so the
+    /// socket must be explicitly bound to the tun interface for reports to be wrapped in the
+    /// tunnel. Hostnames are resolved through the system resolver, which is served by the
+    /// in-process DNS forwarder bound to the tunnel while it is up; the default DoH/DoT
+    /// resolver would create unbound sockets of its own and leak outside of the tunnel.
+    #[cfg(target_os = "ios")]
+    pub fn with_bound_interface(&self, interface: &str) -> Result<Self> {
+        let reqwest_builder = nym_http_api_client::registry::default_builder()
+            .interface(interface)
+            .timeout(NYM_STATISTICS_API_TIMEOUT);
+        nym_http_api_client::Client::builder(self.base_url.clone())
+            .and_then(|builder| {
+                builder
+                    .with_user_agent(self.user_agent.clone())
+                    .with_timeout(NYM_STATISTICS_API_TIMEOUT)
+                    .with_reqwest_builder(reqwest_builder)
+                    .no_hickory_dns()
+                    .build()
+            })
+            .map(|inner| Self {
+                inner,
+                base_url: self.base_url.clone(),
+                user_agent: self.user_agent.clone(),
+            })
             .map_err(Box::new)
             .map_err(StatisticsApiClientError::VpnApiClientCreation)
     }

--- a/nym-vpn-core/crates/nym-statistics/src/controller.rs
+++ b/nym-vpn-core/crates/nym-statistics/src/controller.rs
@@ -58,15 +58,6 @@ impl StatisticsController {
             );
         }
 
-        // iOS stats are disabled because they currently don't go through the tunnel
-        #[cfg(target_os = "ios")]
-        let mut config = config; // we need the config outside of the scope
-
-        #[cfg(target_os = "ios")]
-        {
-            config.enabled = false;
-        }
-
         let statistics_handler = if let Some(storage) = stats_storage.clone()
             && let Some(api_client) = stats_api_client
         {
@@ -104,12 +95,8 @@ impl StatisticsController {
                 tracing::info!("StatisticsController : Collection disabled");
             }
             ControllerCommand::Config(ConfigCommand::EnableCollection) => {
-                // Impossible to enable stats on ios while the tunnel issue isn't fixed
-                #[cfg(not(target_os = "ios"))]
-                {
-                    self.config.enabled = true;
-                    tracing::info!("StatisticsController : Collection enabled");
-                }
+                self.config.enabled = true;
+                tracing::info!("StatisticsController : Collection enabled");
             }
             ControllerCommand::Config(ConfigCommand::AllowDirectSending(status)) => {
                 self.config.allow_disconnected = status;

--- a/nym-vpn-core/crates/nym-statistics/src/events.rs
+++ b/nym-vpn-core/crates/nym-statistics/src/events.rs
@@ -53,6 +53,7 @@ impl StatisticsSender {
 
     /// Report the name of the tunnel interface that reports must be bound to when sending,
     /// or `None` once that interface is gone.
+    #[cfg(target_os = "ios")]
     pub fn report_tunnel_interface(&self, interface: Option<String>) {
         self.report(StatisticsEvent::ReportSending(
             ReportSendingEvent::TunnelInterface(interface),
@@ -216,5 +217,6 @@ pub enum ReportSendingEvent {
 
     // Name of the tunnel interface to bind to when sending, if any. Used on iOS where the
     // network extension's traffic is excluded from the tunnel unless explicitly bound to it.
+    #[cfg(target_os = "ios")]
     TunnelInterface(Option<String>),
 }

--- a/nym-vpn-core/crates/nym-statistics/src/events.rs
+++ b/nym-vpn-core/crates/nym-statistics/src/events.rs
@@ -50,6 +50,14 @@ impl StatisticsSender {
         self.report(StatisticsEvent::usage_event_from_state(state.clone()));
         self.report(StatisticsEvent::sending_event_from_state(state));
     }
+
+    /// Report the name of the tunnel interface that reports must be bound to when sending,
+    /// or `None` once that interface is gone.
+    pub fn report_tunnel_interface(&self, interface: Option<String>) {
+        self.report(StatisticsEvent::ReportSending(
+            ReportSendingEvent::TunnelInterface(interface),
+        ));
+    }
 }
 
 /// Statistics events
@@ -195,7 +203,7 @@ pub enum UsageEvent {
 }
 
 // Not a stat event per se, but used to instruct the report event to do stuff
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub enum ReportSendingEvent {
     // Tunnel is connected, we're free to send
     Connected,
@@ -205,4 +213,8 @@ pub enum ReportSendingEvent {
     Standby,
 
     AllowDirectSending(bool),
+
+    // Name of the tunnel interface to bind to when sending, if any. Used on iOS where the
+    // network extension's traffic is excluded from the tunnel unless explicitly bound to it.
+    TunnelInterface(Option<String>),
 }

--- a/nym-vpn-core/crates/nym-statistics/src/handler/report_sending.rs
+++ b/nym-vpn-core/crates/nym-statistics/src/handler/report_sending.rs
@@ -70,6 +70,8 @@ impl SendingConfig {
             ReportSendingEvent::Disconnected => self.tunnel_state = TunnelState::Disconnected,
             ReportSendingEvent::Standby => self.tunnel_state = TunnelState::Standby,
             ReportSendingEvent::AllowDirectSending(status) => self.allow_direct_sending = status,
+            // Handled by `InnerHandler` before reaching this point
+            ReportSendingEvent::TunnelInterface(_) => {}
         }
         let new_value = self.allows_sending();
         if old_value == new_value {
@@ -172,6 +174,11 @@ struct InnerHandlerHandle {
 struct InnerHandler {
     storage: StatsStorage,
     api_client: StatisticsApiClient,
+    /// Copy of `api_client` with its sockets bound to the tunnel interface, present while the
+    /// tunnel is up. On iOS the extension's traffic is excluded from the tunnel, so reports
+    /// must only ever be sent through this client to stay wrapped in the tunnel.
+    #[cfg(target_os = "ios")]
+    bound_api_client: Option<StatisticsApiClient>,
     event_rx: Receiver<ReportSendingEvent>,
     sending_config: SendingConfig,
     system_report: StaticInformationReport,
@@ -199,6 +206,8 @@ impl InnerHandler {
         let inner_handler = Self {
             storage,
             api_client,
+            #[cfg(target_os = "ios")]
+            bound_api_client: None,
             event_rx,
             sending_config,
             system_report,
@@ -209,6 +218,44 @@ impl InnerHandler {
             event_tx,
             cancellation_token,
         }
+    }
+
+    /// Rebuild the API client bound to the new tunnel interface, or drop it once the interface
+    /// is gone.
+    #[cfg(target_os = "ios")]
+    fn set_tunnel_interface(&mut self, interface: Option<String>) {
+        self.bound_api_client = interface.and_then(|interface| {
+            self.api_client
+                .with_bound_interface(&interface)
+                .inspect_err(|e| {
+                    tracing::error!(
+                        "Failed to bind statistics client to tunnel interface {interface}: {e}"
+                    )
+                })
+                .ok()
+        });
+    }
+
+    #[cfg(not(target_os = "ios"))]
+    fn set_tunnel_interface(&mut self, _interface: Option<String>) {}
+
+    /// Pick the client to use for the next sending round, or `None` if no client can send
+    /// without leaking reports.
+    ///
+    /// On iOS the network extension's own sockets bypass the tunnel, so reports are only ever
+    /// sent while the tunnel is up, through a client bound to the tunnel interface.
+    #[cfg(target_os = "ios")]
+    fn sending_client(&self) -> Option<StatisticsApiClient> {
+        if self.sending_config.tunnel_state == TunnelState::Connected {
+            self.bound_api_client.clone()
+        } else {
+            None
+        }
+    }
+
+    #[cfg(not(target_os = "ios"))]
+    fn sending_client(&self) -> Option<StatisticsApiClient> {
+        Some(self.api_client.clone())
     }
 
     async fn send_reports(
@@ -288,6 +335,9 @@ impl InnerHandler {
                             // Sending will cancel itself because we're dropping the future
                             return;
                         }
+                        Some(ReportSendingEvent::TunnelInterface(interface)) => {
+                            self.set_tunnel_interface(interface);
+                        }
                         Some(event) => {
                             if let Some(new_allowed) = self.sending_config.update(event) {
                                 // Handle policy changes
@@ -308,7 +358,15 @@ impl InnerHandler {
                     }
                 }
                 _ = &mut timer => {
-                    sending_task.set(Self::send_reports(self.storage.clone(), self.api_client.clone(), self.system_report.clone(), self.sending_config.tunnel_state).fuse());
+                    if !self.sending_config.allows_sending() {
+                        tracing::debug!("Stats report conditions not met, skipping send");
+                        timer.as_mut().set(tokio::time::sleep(SendingConfig::random_big_delay()).fuse());
+                    } else if let Some(api_client) = self.sending_client() {
+                        sending_task.set(Self::send_reports(self.storage.clone(), api_client, self.system_report.clone(), self.sending_config.tunnel_state).fuse());
+                    } else {
+                        tracing::warn!("No statistics client able to send through the tunnel, skipping send");
+                        timer.as_mut().set(tokio::time::sleep(SendingConfig::random_big_delay()).fuse());
+                    }
                 }
                 sending_res = &mut sending_task => {
                     sending_task.as_mut().set(Fuse::terminated());

--- a/nym-vpn-core/crates/nym-statistics/src/handler/report_sending.rs
+++ b/nym-vpn-core/crates/nym-statistics/src/handler/report_sending.rs
@@ -71,6 +71,7 @@ impl SendingConfig {
             ReportSendingEvent::Standby => self.tunnel_state = TunnelState::Standby,
             ReportSendingEvent::AllowDirectSending(status) => self.allow_direct_sending = status,
             // Handled by `InnerHandler` before reaching this point
+            #[cfg(target_os = "ios")]
             ReportSendingEvent::TunnelInterface(_) => {}
         }
         let new_value = self.allows_sending();
@@ -174,11 +175,6 @@ struct InnerHandlerHandle {
 struct InnerHandler {
     storage: StatsStorage,
     api_client: StatisticsApiClient,
-    /// Copy of `api_client` with its sockets bound to the tunnel interface, present while the
-    /// tunnel is up. On iOS the extension's traffic is excluded from the tunnel, so reports
-    /// must only ever be sent through this client to stay wrapped in the tunnel.
-    #[cfg(target_os = "ios")]
-    bound_api_client: Option<StatisticsApiClient>,
     event_rx: Receiver<ReportSendingEvent>,
     sending_config: SendingConfig,
     system_report: StaticInformationReport,
@@ -206,8 +202,6 @@ impl InnerHandler {
         let inner_handler = Self {
             storage,
             api_client,
-            #[cfg(target_os = "ios")]
-            bound_api_client: None,
             event_rx,
             sending_config,
             system_report,
@@ -220,42 +214,15 @@ impl InnerHandler {
         }
     }
 
-    /// Rebuild the API client bound to the new tunnel interface, or drop it once the interface
-    /// is gone.
+    /// Set tunnel interface for the API client.
+    /// Pass `None` to unbind API client from specific interface and rely on system routing instead.
     #[cfg(target_os = "ios")]
-    fn set_tunnel_interface(&mut self, interface: Option<String>) {
-        self.bound_api_client = interface.and_then(|interface| {
-            self.api_client
-                .with_bound_interface(&interface)
-                .inspect_err(|e| {
-                    tracing::error!(
-                        "Failed to bind statistics client to tunnel interface {interface}: {e}"
-                    )
-                })
-                .ok()
-        });
-    }
-
-    #[cfg(not(target_os = "ios"))]
-    fn set_tunnel_interface(&mut self, _interface: Option<String>) {}
-
-    /// Pick the client to use for the next sending round, or `None` if no client can send
-    /// without leaking reports.
-    ///
-    /// On iOS the network extension's own sockets bypass the tunnel, so reports are only ever
-    /// sent while the tunnel is up, through a client bound to the tunnel interface.
-    #[cfg(target_os = "ios")]
-    fn sending_client(&self) -> Option<StatisticsApiClient> {
-        if self.sending_config.tunnel_state == TunnelState::Connected {
-            self.bound_api_client.clone()
-        } else {
-            None
-        }
-    }
-
-    #[cfg(not(target_os = "ios"))]
-    fn sending_client(&self) -> Option<StatisticsApiClient> {
-        Some(self.api_client.clone())
+    fn set_tunnel_interface(&mut self, interface: Option<&str>) -> Result<(), Error> {
+        self.api_client = self
+            .api_client
+            .with_bound_interface(interface)
+            .map_err(Box::new)?;
+        Ok(())
     }
 
     async fn send_reports(
@@ -335,8 +302,17 @@ impl InnerHandler {
                             // Sending will cancel itself because we're dropping the future
                             return;
                         }
+                        #[cfg(target_os = "ios")]
                         Some(ReportSendingEvent::TunnelInterface(interface)) => {
-                            self.set_tunnel_interface(interface);
+                                match self.set_tunnel_interface(interface.as_deref()) {
+                                    Ok(()) => {
+                                        tracing::debug!("Bound statistics client to interface: {interface:?}");
+                                    }
+                                    Err(err) => {
+                                        tracing::error!("Failed to bind statistics client to {interface:?}: {err}");
+                                    }
+                                }
+
                         }
                         Some(event) => {
                             if let Some(new_allowed) = self.sending_config.update(event) {
@@ -358,15 +334,7 @@ impl InnerHandler {
                     }
                 }
                 _ = &mut timer => {
-                    if !self.sending_config.allows_sending() {
-                        tracing::debug!("Stats report conditions not met, skipping send");
-                        timer.as_mut().set(tokio::time::sleep(SendingConfig::random_big_delay()).fuse());
-                    } else if let Some(api_client) = self.sending_client() {
-                        sending_task.set(Self::send_reports(self.storage.clone(), api_client, self.system_report.clone(), self.sending_config.tunnel_state).fuse());
-                    } else {
-                        tracing::warn!("No statistics client able to send through the tunnel, skipping send");
-                        timer.as_mut().set(tokio::time::sleep(SendingConfig::random_big_delay()).fuse());
-                    }
+                    sending_task.set(Self::send_reports(self.storage.clone(), self.api_client.clone(), self.system_report.clone(), self.sending_config.tunnel_state).fuse());
                 }
                 sending_res = &mut sending_task => {
                     sending_task.as_mut().set(Fuse::terminated());

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
@@ -127,8 +127,21 @@ impl ConnectedState {
             .await;
         }
 
-        #[cfg(any(target_os = "android", target_os = "ios"))]
+        #[cfg(target_os = "android")]
         let _ = shared_state; // Avoid unused variable warning
+
+        // Statistics reports must be sent through a socket bound to the tunnel interface,
+        // since the packet tunnel provider's traffic is otherwise excluded from the tunnel.
+        #[cfg(target_os = "ios")]
+        shared_state
+            .statistics_event_sender
+            .report_tunnel_interface(Some(
+                connected_state
+                    .tunnel_interface
+                    .exit_tunnel_metadata()
+                    .interface
+                    .clone(),
+            ));
 
         (
             Box::new(connected_state),
@@ -230,6 +243,10 @@ impl ConnectedState {
         after_disconnect: PrivateActionAfterDisconnect,
         shared_state: &mut SharedState,
     ) -> NextTunnelState {
+        #[cfg(target_os = "ios")]
+        shared_state
+            .statistics_event_sender
+            .report_tunnel_interface(None);
         #[cfg(not(target_os = "android"))]
         {
             Self::reset_dns(shared_state).await;
@@ -258,6 +275,10 @@ impl ConnectedState {
             tracing::info!("Tunnel closed. Reconnecting.");
         }
 
+        #[cfg(target_os = "ios")]
+        shared_state
+            .statistics_event_sender
+            .report_tunnel_interface(None);
         #[cfg(not(target_os = "android"))]
         {
             Self::reset_dns(shared_state).await;

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
@@ -243,18 +243,7 @@ impl ConnectedState {
         after_disconnect: PrivateActionAfterDisconnect,
         shared_state: &mut SharedState,
     ) -> NextTunnelState {
-        #[cfg(target_os = "ios")]
-        shared_state
-            .statistics_event_sender
-            .report_tunnel_interface(None);
-        #[cfg(not(target_os = "android"))]
-        {
-            Self::reset_dns(shared_state).await;
-        }
-        #[cfg(not(any(target_os = "android", target_os = "ios")))]
-        {
-            Self::reset_routes(shared_state).await;
-        }
+        Self::prepare_for_disconnect(shared_state).await;
 
         NextTunnelState::NewState(
             DisconnectingState::enter(
@@ -275,18 +264,7 @@ impl ConnectedState {
             tracing::info!("Tunnel closed. Reconnecting.");
         }
 
-        #[cfg(target_os = "ios")]
-        shared_state
-            .statistics_event_sender
-            .report_tunnel_interface(None);
-        #[cfg(not(target_os = "android"))]
-        {
-            Self::reset_dns(shared_state).await;
-        }
-        #[cfg(not(any(target_os = "android", target_os = "ios")))]
-        {
-            Self::reset_routes(shared_state).await;
-        }
+        Self::prepare_for_disconnect(shared_state).await;
 
         match error_state_reason {
             Some(block_reason) => {
@@ -296,6 +274,22 @@ impl ConnectedState {
                 ConnectingState::enter(0, Some(self.selected_gateways), shared_state).await,
             ),
         }
+    }
+
+    async fn prepare_for_disconnect(shared_state: &mut SharedState) {
+        #[cfg(target_os = "ios")]
+        shared_state
+            .statistics_event_sender
+            .report_tunnel_interface(None);
+
+        #[cfg(not(target_os = "android"))]
+        Self::reset_dns(shared_state).await;
+
+        #[cfg(not(any(target_os = "android", target_os = "ios")))]
+        Self::reset_routes(shared_state).await;
+
+        #[cfg(target_os = "android")]
+        let _ = shared_state; // Avoid unused variable warning
     }
 }
 


### PR DESCRIPTION
## Ticket

JIRA-NYM-150

## Description

Share tunnel state on iOS in order to avoid leaking anonymous statistics.

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5564)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * iOS statistics reporting can include the active tunnel interface and automatically reconfigure the statistics API client when it changes.
  * Statistics UI (including the anonymous stats opt-in) is now available on non-macOS platforms, and the statistics opt-in setting is enabled by default.
* **Bug Fixes**
  * Enabled statistics collection on iOS by removing iOS-specific disabling and allowing collection to be turned on via config.
  * iOS now sends interface information on connect and clears it on disconnect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->