### PR TITLE
APPLE: remove mixnet tuning feature flag

### DIFF
--- a/nym-vpn-apple/Services/Sources/Services/FeatureFlagsManager/FeatureFlagsManager.swift
+++ b/nym-vpn-apple/Services/Sources/Services/FeatureFlagsManager/FeatureFlagsManager.swift
@@ -27,8 +27,6 @@ import GRPCManager
     )
 #endif
 
-    public var isMixnetTuningEnabled = false
-
 #if os(iOS)
     init(configurationManager: ConfigurationManager, appSettings: AppSettings) {
         self.configurationManager = configurationManager
@@ -52,7 +50,6 @@ import GRPCManager
     public func setup() {
         setupPeriodicRefresh()
         setupEnvironmentChangeObserver()
-        setupAppSettingsObservers()
         updateFeatureFlags()
     }
 }
@@ -81,16 +78,6 @@ private extension FeatureFlagsManager {
         }
     }
 
-    func setupAppSettingsObservers() {
-        appSettings.$isMixnetTuningEnabledPublisher
-            .sink { [weak self] newValue in
-                self?.isMixnetTuningEnabled = newValue
-                guard !newValue else { return }
-                self?.updateFeatureFlags()
-            }
-            .store(in: &cancellables)
-    }
-
     func setupPeriodicRefresh() {
         Timer
             .publish(every: 600, on: .main, in: .common)
@@ -112,10 +99,6 @@ private extension FeatureFlagsManager {
 #elseif os(macOS)
             guard let flags = try? await self?.grpcManager.fetchFeatureFlags() else { return }
 #endif
-            Task { @MainActor [weak self] in
-                guard let self else { return }
-                self.isMixnetTuningEnabled = flags.isMixnetTuningEnabled() ?? self.appSettings.isMixnetTuningEnabled
-            }
         }
     }
 }

--- a/nym-vpn-apple/Settings/Sources/Settings/SettingsViewModel.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/SettingsViewModel.swift
@@ -456,19 +456,17 @@ private extension SettingsViewModel {
                 }
             )
         )
-        if featureFlagsManager.isMixnetTuningEnabled {
-            viewModels.append(
-                SettingsListItemViewModel(
-                    accessory: .arrow,
-                    title: "settings.mixnetTuning.title".localizedString,
-                    subtitle: "settings.mixnetTuning.subtitle".localizedString,
-                    systemImageName: "eye.slash",
-                    action: { [weak self] in
-                        self?.navigateToMixnetTuning()
-                    }
-                )
+        viewModels.append(
+            SettingsListItemViewModel(
+                accessory: .arrow,
+                title: "settings.mixnetTuning.title".localizedString,
+                subtitle: "settings.mixnetTuning.subtitle".localizedString,
+                systemImageName: "eye.slash",
+                action: { [weak self] in
+                    self?.navigateToMixnetTuning()
+                }
             )
-        }
+        )
         viewModels.append(
             SettingsListItemViewModel(
                 accessory: .arrow,


### PR DESCRIPTION
## Ticket

JIRA-NYM-1529

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5568)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed availability of the mixnet tuning option in Settings, which is now always visible to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->