### PR TITLE
NYM-1469: Add exit wg handshake check to connection monitor.

### DIFF
--- a/nym-vpn-core/crates/nym-connection-monitor/src/connection_monitor.rs
+++ b/nym-vpn-core/crates/nym-connection-monitor/src/connection_monitor.rs
@@ -55,9 +55,6 @@ pub enum Phase {
 
 #[derive(Debug, Copy, Clone)]
 pub struct TimingConfig {
-    /// Delay before the first probe is sent
-    pub initial_delay: Duration,
-
     /// Probe timeout in the initial phase
     pub initial_probe_timeout: Duration,
 
@@ -78,7 +75,6 @@ impl TimingConfig {
     /// Default timings suitable for mixnet connections
     pub fn mixnet() -> Self {
         TimingConfig {
-            initial_delay: Duration::from_secs(3),
             initial_probe_timeout: Duration::from_secs(10),
             initial_probe_retry_count: 5,
             monitoring_probe_timeout: Duration::from_secs(10),
@@ -90,7 +86,6 @@ impl TimingConfig {
     /// Default timings suitable for two-hop connections
     pub fn two_hop() -> Self {
         TimingConfig {
-            initial_delay: Duration::from_secs(3),
             initial_probe_timeout: Duration::from_secs(3),
             initial_probe_retry_count: 5,
             monitoring_probe_timeout: Duration::from_secs(5),
@@ -210,9 +205,6 @@ where
     }
 
     async fn run(mut self) -> Result<(), Error> {
-        if !self.timing_config.initial_delay.is_zero() {
-            tokio::time::sleep(self.timing_config.initial_delay).await;
-        }
         let timeout = self.state.timeout(&self.timing_config);
         tracing::trace!(
             "Sending initial probe with {} ms timeout",
@@ -535,7 +527,6 @@ mod tests {
     fn test_config() -> TimingConfig {
         // timings are not important since tokio timers are being advanced.
         TimingConfig {
-            initial_delay: Duration::ZERO,
             initial_probe_timeout: INITIAL_PROBE_TIMEOUT,
             initial_probe_retry_count: PROBE_RETRY_COUNT,
             monitoring_probe_timeout: Duration::from_secs(5),

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/account/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/account/mod.rs
@@ -726,15 +726,17 @@ impl From<nym_vpn_api_client::types::VpnAccountMode> for StoredAccountMode {
 // Regression tests for `VpnAccountSummary::try_from` and subscription serde.
 #[cfg(all(test, feature = "nym-type-conversions"))]
 mod tests {
-    use nym_vpn_api_client::response::{
-        NymVpnAccountResponse, NymVpnAccountStatusResponse, NymVpnAccountSummaryDevices,
-        NymVpnAccountSummaryFairUsage, NymVpnAccountSummaryResponse,
-        NymVpnAccountSummarySubscription, NymVpnAccountSummaryWithDeviceResponse,
-        NymVpnSubscription as ApiNymVpnSubscription,
-        NymVpnSubscriptionKind as ApiNymVpnSubscriptionKind,
-        NymVpnSubscriptionStatus as ApiNymVpnSubscriptionStatus,
+    use nym_vpn_api_client::{
+        response::{
+            NymVpnAccountResponse, NymVpnAccountStatusResponse, NymVpnAccountSummaryDevices,
+            NymVpnAccountSummaryFairUsage, NymVpnAccountSummaryResponse,
+            NymVpnAccountSummarySubscription, NymVpnAccountSummaryWithDeviceResponse,
+            NymVpnSubscription as ApiNymVpnSubscription,
+            NymVpnSubscriptionKind as ApiNymVpnSubscriptionKind,
+            NymVpnSubscriptionStatus as ApiNymVpnSubscriptionStatus,
+        },
+        types::{VpnAccountMode, VpnApiTime},
     };
-    use nym_vpn_api_client::types::{VpnAccountMode, VpnApiTime};
     use tracing_test::traced_test;
 
     use super::*;

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
@@ -681,7 +681,7 @@ impl TunnelHandle {
     }
 
     /// Query live stats for the exit WireGuard peer via the UAPI GET interface.
-    pub fn get_exit_stats(&self) -> Option<wireguard_go::TunnelStats> {
+    pub fn get_exit_stats(&self) -> nym_wg_go::Result<wireguard_go::TunnelStats> {
         self.exit_stats_reader.get_stats()
     }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
@@ -215,6 +215,7 @@ impl ConnectedTunnel {
         let wintun_entry_interface = entry_tunnel.wintun_interface().clone();
         #[cfg(windows)]
         let wintun_exit_interface = exit_tunnel.wintun_interface().clone();
+        let exit_stats_reader = exit_tunnel.stats_reader();
 
         let event_handler_task = tokio::spawn(async move {
             #[cfg(windows)]
@@ -264,6 +265,7 @@ impl ConnectedTunnel {
         Ok(TunnelHandle {
             shutdown_token,
             event_handler_task,
+            exit_stats_reader,
             #[cfg(windows)]
             wintun_entry_interface: Some(wintun_entry_interface),
             #[cfg(windows)]
@@ -401,6 +403,7 @@ impl ConnectedTunnel {
 
         #[cfg(windows)]
         let wintun_exit_interface = exit_tunnel.wintun_interface().clone();
+        let exit_stats_reader = exit_tunnel.stats_reader();
 
         let child_shutdown_token = shutdown_token.child_token();
         let event_handler_task = tokio::spawn(async move {
@@ -526,6 +529,7 @@ impl ConnectedTunnel {
         Ok(TunnelHandle {
             shutdown_token,
             event_handler_task,
+            exit_stats_reader,
             #[cfg(windows)]
             wintun_entry_interface: None,
             #[cfg(windows)]
@@ -656,6 +660,7 @@ pub struct NetstackTunnelOptions {
 pub struct TunnelHandle {
     shutdown_token: CancellationToken,
     event_handler_task: JoinHandle<Tombstone>,
+    exit_stats_reader: wireguard_go::TunnelStatsReader,
     #[cfg(windows)]
     wintun_entry_interface: Option<WintunInterface>,
     #[cfg(windows)]
@@ -673,6 +678,11 @@ impl TunnelHandle {
     /// Returns a tombstone containing the no longer used tunnel devices and wireguard tunnels (on Windows).
     pub async fn wait(self) -> Result<Tombstone, JoinError> {
         self.event_handler_task.await
+    }
+
+    /// Query live stats for the exit WireGuard peer via the UAPI GET interface.
+    pub fn get_exit_stats(&self) -> Option<wireguard_go::TunnelStats> {
+        self.exit_stats_reader.get_stats()
     }
 
     /// Returns entry wintun interface descriptor when available.

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -18,11 +18,11 @@ use std::{
 #[cfg(unix)]
 use std::{os::fd::RawFd, sync::Arc};
 
-use futures::{future::Fuse, FutureExt, StreamExt};
+use futures::{FutureExt, StreamExt, future::Fuse};
 #[cfg(any(target_os = "ios", target_os = "android"))]
 use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
 #[cfg(target_os = "linux")]
-use nix::sys::socket::{sockopt::Mark, SetSockOpt};
+use nix::sys::socket::{SetSockOpt, sockopt::Mark};
 use nym_gateway_directory::{
     GatewayCacheHandle, GatewayClient, GatewayMinPerformance, NodeIdentity,
 };
@@ -38,7 +38,7 @@ use tun::AsyncDevice;
 use windows::Win32::NetworkManagement::Ndis::NET_LUID_LH;
 
 use nym_authenticator_client::AuthClientMixnetListenerHandle;
-use nym_common::{trace_err_chain, ErrorExt};
+use nym_common::{ErrorExt, trace_err_chain};
 use nym_connection_monitor::{
     ConnectionEvent, ConnectionMonitor, ConnectionStatusEvent, IcmpProbe, IcmpProbeConfig,
     TcpProbe, TcpProbeConfig, TimingConfig,
@@ -65,35 +65,35 @@ use super::tunnel::wireguard::connected_tunnel::TunTunTunnelOptions;
 #[cfg(windows)]
 use super::wintun::{self, WintunAdapterConfig};
 use super::{
+    Error, NymConfig, Result, TunnelInterface, TunnelMetadata, TunnelSettings,
     tunnel::{
-        self, wireguard::{
+        self, AnyTunnelHandle, SelectedGateways, Tombstone,
+        wireguard::{
             connected_tunnel,
             connected_tunnel::{NetstackTunnelOptions, TunnelOptions},
-        }, AnyTunnelHandle, SelectedGateways,
-        Tombstone,
-    }, Error, NymConfig, Result, TunnelInterface, TunnelMetadata,
-    TunnelSettings,
+        },
+    },
 };
 #[cfg(target_os = "android")]
 use crate::tunnel_provider::AndroidTunProvider;
 #[cfg(target_os = "ios")]
 use crate::tunnel_provider::OSTunProvider;
 use crate::{
-    bandwidth_controller::BandwidthController, mixnet::VpnTopologyServiceHandle, tunnel_state_machine::{
-        account, ipv6_availability, tunnel::{
+    DEFAULT_MIN_GATEWAY_PERFORMANCE, DEFAULT_MIN_MIXNODE_PERFORMANCE, UserAgent,
+    bandwidth_controller::BandwidthController,
+    mixnet::VpnTopologyServiceHandle,
+    tunnel_state_machine::{
+        TunnelConstants, WireguardMultihopMode, account, ipv6_availability,
+        tunnel::{
             gateway_provider::GatewayProvider,
             mixnet,
             transports::{self, TransportError},
             wireguard::{
-                connected_tunnel::ConnectedTunnel, ConnectionData as WgConnectionData, MetadataEvent,
-                MetadataReceiver,
+                ConnectionData as WgConnectionData, MetadataEvent, MetadataReceiver,
+                connected_tunnel::ConnectedTunnel,
             },
-        }, TunnelConstants,
-        WireguardMultihopMode,
+        },
     },
-    UserAgent,
-    DEFAULT_MIN_GATEWAY_PERFORMANCE,
-    DEFAULT_MIN_MIXNODE_PERFORMANCE,
 };
 
 /// Default MTU for mixnet tun device.

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -1914,7 +1914,7 @@ impl TunnelMonitor {
         // Create ICMP probe first, fallback to TCP probe on failure.
         match self.create_icmp_probe(exit_tunnel_metadata) {
             Ok(icmp_probe) => {
-                tracing::info!("Starting ICMP connectivity test");
+                tracing::info!("Initial ICMP connectivity test");
                 Ok(ConnectionMonitor::spawn(
                     icmp_probe,
                     timing_config,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -18,11 +18,11 @@ use std::{
 #[cfg(unix)]
 use std::{os::fd::RawFd, sync::Arc};
 
-use futures::{FutureExt, StreamExt, future::Fuse};
+use futures::{future::Fuse, FutureExt, StreamExt};
 #[cfg(any(target_os = "ios", target_os = "android"))]
 use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
 #[cfg(target_os = "linux")]
-use nix::sys::socket::{SetSockOpt, sockopt::Mark};
+use nix::sys::socket::{sockopt::Mark, SetSockOpt};
 use nym_gateway_directory::{
     GatewayCacheHandle, GatewayClient, GatewayMinPerformance, NodeIdentity,
 };
@@ -38,7 +38,7 @@ use tun::AsyncDevice;
 use windows::Win32::NetworkManagement::Ndis::NET_LUID_LH;
 
 use nym_authenticator_client::AuthClientMixnetListenerHandle;
-use nym_common::{ErrorExt, trace_err_chain};
+use nym_common::{trace_err_chain, ErrorExt};
 use nym_connection_monitor::{
     ConnectionEvent, ConnectionMonitor, ConnectionStatusEvent, IcmpProbe, IcmpProbeConfig,
     TcpProbe, TcpProbeConfig, TimingConfig,
@@ -65,35 +65,35 @@ use super::tunnel::wireguard::connected_tunnel::TunTunTunnelOptions;
 #[cfg(windows)]
 use super::wintun::{self, WintunAdapterConfig};
 use super::{
-    Error, NymConfig, Result, TunnelInterface, TunnelMetadata, TunnelSettings,
     tunnel::{
-        self, AnyTunnelHandle, SelectedGateways, Tombstone,
-        wireguard::{
+        self, wireguard::{
             connected_tunnel,
             connected_tunnel::{NetstackTunnelOptions, TunnelOptions},
-        },
-    },
+        }, AnyTunnelHandle, SelectedGateways,
+        Tombstone,
+    }, Error, NymConfig, Result, TunnelInterface, TunnelMetadata,
+    TunnelSettings,
 };
 #[cfg(target_os = "android")]
 use crate::tunnel_provider::AndroidTunProvider;
 #[cfg(target_os = "ios")]
 use crate::tunnel_provider::OSTunProvider;
 use crate::{
-    DEFAULT_MIN_GATEWAY_PERFORMANCE, DEFAULT_MIN_MIXNODE_PERFORMANCE, UserAgent,
-    bandwidth_controller::BandwidthController,
-    mixnet::VpnTopologyServiceHandle,
-    tunnel_state_machine::{
-        TunnelConstants, WireguardMultihopMode, account, ipv6_availability,
-        tunnel::{
+    bandwidth_controller::BandwidthController, mixnet::VpnTopologyServiceHandle, tunnel_state_machine::{
+        account, ipv6_availability, tunnel::{
             gateway_provider::GatewayProvider,
             mixnet,
             transports::{self, TransportError},
             wireguard::{
-                ConnectionData as WgConnectionData, MetadataEvent, MetadataReceiver,
-                connected_tunnel::ConnectedTunnel,
+                connected_tunnel::ConnectedTunnel, ConnectionData as WgConnectionData, MetadataEvent,
+                MetadataReceiver,
             },
-        },
+        }, TunnelConstants,
+        WireguardMultihopMode,
     },
+    UserAgent,
+    DEFAULT_MIN_GATEWAY_PERFORMANCE,
+    DEFAULT_MIN_MIXNODE_PERFORMANCE,
 };
 
 /// Default MTU for mixnet tun device.
@@ -260,7 +260,7 @@ async fn wait_for_exit_handshake(
     tunnel_handle: &connected_tunnel::TunnelHandle,
     shutdown_token: &CancellationToken,
 ) {
-    const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(6);
+    const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
     const POLL_INTERVAL: Duration = Duration::from_millis(500);
 
     tracing::debug!("Waiting for exit WireGuard handshake to complete");
@@ -269,10 +269,12 @@ async fn wait_for_exit_handshake(
 
     let result = tokio::time::timeout(HANDSHAKE_TIMEOUT, async {
         loop {
-            if let Some(stats) = tunnel_handle.get_exit_stats()
-                && stats.all_peers_connected()
-            {
-                return;
+            match tunnel_handle.get_exit_stats() {
+                Ok(stats) if stats.all_peers_connected() => return,
+                Ok(_) => {}
+                Err(err) => {
+                    tracing::debug!("Failed to get exit tunnel stats: {err}");
+                }
             }
 
             tokio::select! {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -270,8 +270,11 @@ async fn wait_for_exit_handshake(
     let result = tokio::time::timeout(HANDSHAKE_TIMEOUT, async {
         loop {
             match tunnel_handle.get_exit_stats() {
-                Ok(stats) if stats.all_peers_connected() => return,
-                Ok(_) => {}
+                Ok(stats) => {
+                    if stats.all_peers_connected() {
+                        return;
+                    }
+                }
                 Err(err) => {
                     tracing::debug!("Failed to get exit tunnel stats: {err}");
                 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -68,7 +68,10 @@ use super::{
     Error, NymConfig, Result, TunnelInterface, TunnelMetadata, TunnelSettings,
     tunnel::{
         self, AnyTunnelHandle, SelectedGateways, Tombstone,
-        wireguard::connected_tunnel::{NetstackTunnelOptions, TunnelOptions},
+        wireguard::{
+            connected_tunnel,
+            connected_tunnel::{NetstackTunnelOptions, TunnelOptions},
+        },
     },
 };
 #[cfg(target_os = "android")]
@@ -250,6 +253,46 @@ pub struct TunnelMonitor {
     gateway_provider: GatewayProvider<GatewayCacheHandle>,
     custom_topology_provider: VpnTopologyServiceHandle,
     shutdown_token: CancellationToken,
+}
+
+/// Poll the exit WireGuard peer's UAPI stats until the handshake completes or we time out.
+async fn wait_for_exit_handshake(
+    tunnel_handle: &connected_tunnel::TunnelHandle,
+    shutdown_token: &CancellationToken,
+) {
+    const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(6);
+    const POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+    let started = std::time::Instant::now();
+
+    let result = tokio::time::timeout(HANDSHAKE_TIMEOUT, async {
+        loop {
+            if let Some(stats) = tunnel_handle.get_exit_stats()
+                && stats.all_peers_connected()
+            {
+                return;
+            }
+
+            tokio::select! {
+                _ = tokio::time::sleep(POLL_INTERVAL) => {}
+                _ = shutdown_token.cancelled() => return,
+            }
+        }
+    })
+    .await;
+
+    let elapsed = started.elapsed();
+    match result {
+        Ok(()) => {
+            tracing::debug!("Exit WireGuard handshake completed in {elapsed:.2?}");
+        }
+        Err(_) => {
+            tracing::warn!(
+                "Exit WireGuard handshake did not complete within {:.1}s, proceeding",
+                elapsed.as_secs_f32()
+            );
+        }
+    }
 }
 
 impl TunnelMonitor {
@@ -651,6 +694,11 @@ impl TunnelMonitor {
 
         if tokio::time::timeout(REPLY_TIMEOUT, reply_rx).await.is_err() {
             tracing::warn!("Interface up reply timeout");
+        }
+
+        // The firewall now allows traffic through the tunnel. Wait for the exit WG handshake.
+        if let Some(wg_handle) = tunnel_handle.as_wireguard() {
+            wait_for_exit_handshake(wg_handle, &self.shutdown_token).await;
         }
 
         // Send metadata endpoint data to the bandwidth controller

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -263,6 +263,8 @@ async fn wait_for_exit_handshake(
     const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(6);
     const POLL_INTERVAL: Duration = Duration::from_millis(500);
 
+    tracing::debug!("Waiting for exit WireGuard handshake to complete");
+
     let started = std::time::Instant::now();
 
     let result = tokio::time::timeout(HANDSHAKE_TIMEOUT, async {
@@ -1909,12 +1911,15 @@ impl TunnelMonitor {
 
         // Create ICMP probe first, fallback to TCP probe on failure.
         match self.create_icmp_probe(exit_tunnel_metadata) {
-            Ok(icmp_probe) => Ok(ConnectionMonitor::spawn(
-                icmp_probe,
-                timing_config,
-                event_tx,
-                self.shutdown_token.child_token(),
-            )),
+            Ok(icmp_probe) => {
+                tracing::info!("Starting ICMP connectivity test");
+                Ok(ConnectionMonitor::spawn(
+                    icmp_probe,
+                    timing_config,
+                    event_tx,
+                    self.shutdown_token.child_token(),
+                ))
+            }
             Err(err) => {
                 tracing::warn!("{}", err.display_chain());
                 tracing::info!("Fallback to TCP probe");

--- a/nym-vpn-core/crates/nym-wg-go/src/lib.rs
+++ b/nym-vpn-core/crates/nym-wg-go/src/lib.rs
@@ -28,6 +28,12 @@ pub enum Error {
     #[error("failed to set UAPI config (code: {0})")]
     SetUapiConfig(i64),
 
+    #[error("failed to get UAPI config")]
+    GetUapiConfig,
+
+    #[error("tunnel is stopped")]
+    TunnelStopped,
+
     #[cfg(target_os = "android")]
     #[error("failed to obtain tunnel socket fd")]
     ObtainSocketFd,

--- a/nym-vpn-core/crates/nym-wg-go/src/wireguard_go.rs
+++ b/nym-vpn-core/crates/nym-wg-go/src/wireguard_go.rs
@@ -8,7 +8,7 @@ use std::{
     fmt,
     mem::replace,
     net::SocketAddr,
-    sync::{Arc, RwLock},
+    sync::{Arc, PoisonError, RwLock},
     time::{Duration, SystemTime},
 };
 
@@ -312,7 +312,10 @@ impl Tunnel {
     /// Typically used on default route change.
     #[cfg(target_os = "ios")]
     pub fn bump_sockets(&mut self) {
-        let handle = self.tunnel_handle.read().unwrap();
+        let handle = self
+            .tunnel_handle
+            .read()
+            .unwrap_or_else(PoisonError::into_inner);
         if *handle >= 0 {
             unsafe { wgBumpSockets(*handle) }
         }
@@ -333,12 +336,14 @@ impl Tunnel {
         }
         let settings = CString::new(config_builder.into_bytes())
             .map_err(|_| Error::ConvertToCString("peer update config"))?;
-        let handle = self.tunnel_handle.read().unwrap();
-        let ret_code = if *handle >= 0 {
-            unsafe { wgSetConfig(*handle, settings.as_ptr()) }
-        } else {
-            99
-        };
+        let handle = self
+            .tunnel_handle
+            .read()
+            .unwrap_or_else(PoisonError::into_inner);
+        if *handle < 0 {
+            return Err(Error::TunnelStopped);
+        }
+        let ret_code = unsafe { wgSetConfig(*handle, settings.as_ptr()) };
 
         if ret_code == 0 {
             Ok(())
@@ -355,7 +360,13 @@ impl Tunnel {
     }
 
     fn stop_inner(&mut self) {
-        let handle = replace(&mut *self.tunnel_handle.write().unwrap(), -1);
+        let handle = replace(
+            &mut *self
+                .tunnel_handle
+                .write()
+                .unwrap_or_else(PoisonError::into_inner),
+            -1,
+        );
         if handle >= 0 {
             unsafe { wgTurnOff(handle) };
         }
@@ -400,19 +411,22 @@ pub struct TunnelStatsReader {
 }
 
 impl TunnelStatsReader {
-    pub fn get_stats(&self) -> Option<TunnelStats> {
-        let handle = self.tunnel_handle.read().unwrap();
-        if *handle >= 0 {
-            let raw = unsafe { wgGetConfig(*handle) };
-            if !raw.is_null() {
-                let s = unsafe { CStr::from_ptr(raw).to_string_lossy().into_owned() };
-                unsafe { wgFreePtr(raw as *mut c_void) };
-                tracing::trace!("TunnelStats: '{s}'");
-                return Some(Self::parse_tunnel_stats(&s));
-            }
+    pub fn get_stats(&self) -> Result<TunnelStats> {
+        let handle = self
+            .tunnel_handle
+            .read()
+            .unwrap_or_else(PoisonError::into_inner);
+        if *handle < 0 {
+            return Err(Error::TunnelStopped);
         }
-        tracing::error!("Failed to get TunnelStats");
-        None
+        let raw = unsafe { wgGetConfig(*handle) };
+        if raw.is_null() {
+            return Err(Error::GetUapiConfig);
+        }
+        let s = unsafe { CStr::from_ptr(raw).to_string_lossy().into_owned() };
+        unsafe { wgFreePtr(raw as *mut c_void) };
+        tracing::trace!("TunnelStats: '{s}'");
+        Ok(Self::parse_tunnel_stats(&s))
     }
 
     fn parse_tunnel_stats(response: &str) -> TunnelStats {

--- a/nym-vpn-core/crates/nym-wg-go/src/wireguard_go.rs
+++ b/nym-vpn-core/crates/nym-wg-go/src/wireguard_go.rs
@@ -4,7 +4,7 @@
 #[cfg(unix)]
 use std::os::fd::{IntoRawFd, OwnedFd, RawFd};
 use std::{
-    ffi::{CStr, CString, c_char, c_void},
+    ffi::{c_char, c_void, CStr, CString},
     fmt,
     net::SocketAddr,
     sync::{Arc, RwLock},
@@ -19,7 +19,7 @@ use typed_builder::TypedBuilder;
 use windows::Win32::NetworkManagement::Ndis::NET_LUID_LH;
 
 use super::{
-    Error, LoggingCallback, PeerConfig, PeerEndpointUpdate, Result, uapi::UapiConfigBuilder,
+    uapi::UapiConfigBuilder, Error, LoggingCallback, PeerConfig, PeerEndpointUpdate, Result,
 };
 #[cfg(feature = "amnezia")]
 use crate::amnezia::AmneziaConfig;
@@ -354,12 +354,11 @@ impl Tunnel {
     }
 
     fn stop_inner(&mut self) {
-        let handle = self.tunnel_handle.read().unwrap();
-        if *handle >= 0 {
-            unsafe { wgTurnOff(*handle) };
-        }
-        drop(handle);
+        let handle = *self.tunnel_handle.read().unwrap();
         *self.tunnel_handle.write().unwrap() = -1;
+        if handle >= 0 {
+            unsafe { wgTurnOff(handle) };
+        }
     }
 }
 

--- a/nym-vpn-core/crates/nym-wg-go/src/wireguard_go.rs
+++ b/nym-vpn-core/crates/nym-wg-go/src/wireguard_go.rs
@@ -4,8 +4,9 @@
 #[cfg(unix)]
 use std::os::fd::{IntoRawFd, OwnedFd, RawFd};
 use std::{
-    ffi::{c_char, c_void, CStr, CString},
+    ffi::{CStr, CString, c_char, c_void},
     fmt,
+    mem::replace,
     net::SocketAddr,
     sync::{Arc, RwLock},
     time::{Duration, SystemTime},
@@ -19,7 +20,7 @@ use typed_builder::TypedBuilder;
 use windows::Win32::NetworkManagement::Ndis::NET_LUID_LH;
 
 use super::{
-    uapi::UapiConfigBuilder, Error, LoggingCallback, PeerConfig, PeerEndpointUpdate, Result,
+    Error, LoggingCallback, PeerConfig, PeerEndpointUpdate, Result, uapi::UapiConfigBuilder,
 };
 #[cfg(feature = "amnezia")]
 use crate::amnezia::AmneziaConfig;
@@ -354,8 +355,7 @@ impl Tunnel {
     }
 
     fn stop_inner(&mut self) {
-        let handle = *self.tunnel_handle.read().unwrap();
-        *self.tunnel_handle.write().unwrap() = -1;
+        let handle = replace(&mut *self.tunnel_handle.write().unwrap(), -1);
         if handle >= 0 {
             unsafe { wgTurnOff(handle) };
         }

--- a/nym-vpn-core/crates/nym-wg-go/src/wireguard_go.rs
+++ b/nym-vpn-core/crates/nym-wg-go/src/wireguard_go.rs
@@ -6,7 +6,9 @@ use std::os::fd::{IntoRawFd, OwnedFd, RawFd};
 use std::{
     ffi::{CStr, CString, c_char, c_void},
     fmt,
-    sync::Arc,
+    net::SocketAddr,
+    sync::{Arc, RwLock},
+    time::{Duration, SystemTime},
 };
 
 use nym_crypto::asymmetric::x25519;
@@ -142,7 +144,7 @@ pub struct TunnelConfig {
 /// Classic WireGuard tunnel.
 #[derive(Debug)]
 pub struct Tunnel {
-    tunnel_handle: i32,
+    tunnel_handle: Arc<RwLock<i32>>, // Handle is shared between Tunnel and TunnelStatsReader
     #[cfg(windows)]
     wintun_interface: WintunInterface,
 }
@@ -191,7 +193,9 @@ impl Tunnel {
         };
 
         if tunnel_handle >= 0 {
-            Ok(Self { tunnel_handle })
+            Ok(Self {
+                tunnel_handle: Arc::new(RwLock::new(tunnel_handle)),
+            })
         } else {
             Err(Error::StartTunnel(tunnel_handle))
         }
@@ -254,7 +258,7 @@ impl Tunnel {
             };
 
             Ok(Self {
-                tunnel_handle,
+                tunnel_handle: Arc::new(RwLock::new(tunnel_handle)),
                 wintun_interface,
             })
         } else {
@@ -283,7 +287,9 @@ impl Tunnel {
         };
 
         if tunnel_handle >= 0 {
-            Ok(Self { tunnel_handle })
+            Ok(Self {
+                tunnel_handle: Arc::new(RwLock::new(tunnel_handle)),
+            })
         } else {
             Err(Error::StartTunnel(tunnel_handle))
         }
@@ -305,7 +311,10 @@ impl Tunnel {
     /// Typically used on default route change.
     #[cfg(target_os = "ios")]
     pub fn bump_sockets(&mut self) {
-        unsafe { wgBumpSockets(self.tunnel_handle) }
+        let handle = self.tunnel_handle.read().unwrap();
+        if *handle >= 0 {
+            unsafe { wgBumpSockets(*handle) }
+        }
     }
 
     /// Re-bind tunnel socket to the new network interface.
@@ -323,7 +332,12 @@ impl Tunnel {
         }
         let settings = CString::new(config_builder.into_bytes())
             .map_err(|_| Error::ConvertToCString("peer update config"))?;
-        let ret_code = unsafe { wgSetConfig(self.tunnel_handle, settings.as_ptr()) };
+        let handle = self.tunnel_handle.read().unwrap();
+        let ret_code = if *handle >= 0 {
+            unsafe { wgSetConfig(*handle, settings.as_ptr()) }
+        } else {
+            99
+        };
 
         if ret_code == 0 {
             Ok(())
@@ -332,17 +346,167 @@ impl Tunnel {
         }
     }
 
-    fn stop_inner(&mut self) {
-        if self.tunnel_handle >= 0 {
-            unsafe { wgTurnOff(self.tunnel_handle) };
-            self.tunnel_handle = -1;
+    /// Create a stats reader that can query live peer stats without owning the tunnel.
+    pub fn stats_reader(&self) -> TunnelStatsReader {
+        TunnelStatsReader {
+            tunnel_handle: self.tunnel_handle.clone(),
         }
+    }
+
+    fn stop_inner(&mut self) {
+        let handle = self.tunnel_handle.read().unwrap();
+        if *handle >= 0 {
+            unsafe { wgTurnOff(*handle) };
+        }
+        drop(handle);
+        *self.tunnel_handle.write().unwrap() = -1;
     }
 }
 
 impl Drop for Tunnel {
     fn drop(&mut self) {
         self.stop_inner()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PeerStats {
+    pub public_key: [u8; 32],
+    pub endpoint: Option<SocketAddr>,
+    pub last_handshake_time: Option<SystemTime>,
+    pub rx_bytes: u64,
+    pub tx_bytes: u64,
+}
+
+impl PeerStats {
+    pub fn has_completed_handshake(&self) -> bool {
+        self.last_handshake_time.is_some()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TunnelStats {
+    pub listen_port: Option<u16>,
+    pub peers: Vec<PeerStats>,
+}
+
+impl TunnelStats {
+    pub fn all_peers_connected(&self) -> bool {
+        !self.peers.is_empty() && self.peers.iter().all(|p| p.has_completed_handshake())
+    }
+}
+
+pub struct TunnelStatsReader {
+    tunnel_handle: Arc<RwLock<i32>>, // Handle is shared between Tunnel and TunnelStatsReader
+}
+
+impl TunnelStatsReader {
+    pub fn get_stats(&self) -> Option<TunnelStats> {
+        let handle = self.tunnel_handle.read().unwrap();
+        if *handle >= 0 {
+            let raw = unsafe { wgGetConfig(*handle) };
+            if !raw.is_null() {
+                let s = unsafe { CStr::from_ptr(raw).to_string_lossy().into_owned() };
+                unsafe { wgFreePtr(raw as *mut c_void) };
+                tracing::trace!("TunnelStats: '{s}'");
+                return Some(Self::parse_tunnel_stats(&s));
+            }
+        }
+        tracing::error!("Failed to get TunnelStats");
+        None
+    }
+
+    fn parse_tunnel_stats(response: &str) -> TunnelStats {
+        let mut listen_port: Option<u16> = None;
+        let mut peers: Vec<PeerStats> = Vec::new();
+        let mut current: Option<PeerBuilder> = None;
+
+        for line in response.lines() {
+            let Some((key, value)) = line.split_once('=') else {
+                continue;
+            };
+            match key {
+                "listen_port" => listen_port = value.parse().ok(),
+                "public_key" => {
+                    if let Some(builder) = current.take() {
+                        peers.push(builder.build());
+                    }
+                    current = hex::decode(value)
+                        .ok()
+                        .and_then(|b| b.try_into().ok())
+                        .map(PeerBuilder::new);
+                }
+                "endpoint" => {
+                    if let Some(ref mut b) = current {
+                        b.endpoint = value.parse().ok();
+                    }
+                }
+                "last_handshake_time_sec" => {
+                    if let Some(ref mut b) = current {
+                        b.handshake_sec = value.parse().unwrap_or(0);
+                    }
+                }
+                "last_handshake_time_nsec" => {
+                    if let Some(ref mut b) = current {
+                        b.handshake_nsec = value.parse().unwrap_or(0);
+                    }
+                }
+                "rx_bytes" => {
+                    if let Some(ref mut b) = current {
+                        b.rx_bytes = value.parse().unwrap_or(0);
+                    }
+                }
+                "tx_bytes" => {
+                    if let Some(ref mut b) = current {
+                        b.tx_bytes = value.parse().unwrap_or(0);
+                    }
+                }
+                _ => {}
+            }
+        }
+        if let Some(builder) = current {
+            peers.push(builder.build());
+        }
+
+        TunnelStats { listen_port, peers }
+    }
+}
+
+struct PeerBuilder {
+    public_key: [u8; 32],
+    endpoint: Option<SocketAddr>,
+    handshake_sec: u64,
+    handshake_nsec: u32,
+    rx_bytes: u64,
+    tx_bytes: u64,
+}
+
+impl PeerBuilder {
+    fn new(public_key: [u8; 32]) -> Self {
+        Self {
+            public_key,
+            endpoint: None,
+            handshake_sec: 0,
+            handshake_nsec: 0,
+            rx_bytes: 0,
+            tx_bytes: 0,
+        }
+    }
+
+    fn build(self) -> PeerStats {
+        let last_handshake_time = if self.handshake_sec > 0 {
+            SystemTime::UNIX_EPOCH
+                .checked_add(Duration::new(self.handshake_sec, self.handshake_nsec))
+        } else {
+            None
+        };
+        PeerStats {
+            public_key: self.public_key,
+            endpoint: self.endpoint,
+            last_handshake_time,
+            rx_bytes: self.rx_bytes,
+            tx_bytes: self.tx_bytes,
+        }
     }
 }
 


### PR DESCRIPTION
## Ticket

JIRA-NYM-1469

## Description

When testing the connection, check that the exit gateway wireguard handshake has completed before performing ICMP pings.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5571)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time exit peer and tunnel statistics available from WireGuard tunnels.

* **Improvements**
  * Tunnel monitor now waits for the WireGuard exit handshake to complete before proceeding.
  * Connectivity probe startup logs when ICMP testing begins.
  * Improved tunnel error reporting for stopped tunnels and UAPI failures.

* **Changes**
  * Removed the configurable startup delay from the connection monitor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->