### PR TITLE
NYM-257: (tauri) Re-enable mixnet tuning settings

### DIFF
--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/manager/backend/ServiceBackedBackendManager.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/manager/backend/ServiceBackedBackendManager.kt
@@ -134,9 +134,7 @@ class ServiceBackedBackendManager @Inject constructor(
 
 	private suspend fun buildInitRequest(): ConnectInitRequest {
 		val mixnetParamConfig = getFeatureFlags()?.let {
-			it.isMixnetTuningEnabled()?.let {
-				settingsRepository.getMixnetTrafficConfig()
-			}
+			settingsRepository.getMixnetTrafficConfig()
 		}
 
 		return ConnectInitRequest(

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/manager/environment/EnvironmentManager.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/manager/environment/EnvironmentManager.kt
@@ -2,5 +2,4 @@ package net.nymtech.nymvpn.manager.environment
 
 interface EnvironmentManager {
 	suspend fun isDomainFrontingEnabled(): Boolean
-	suspend fun isMixnetTuningEnabled(): Boolean
 }

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/manager/environment/NymEnvironmentManager.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/manager/environment/NymEnvironmentManager.kt
@@ -7,8 +7,6 @@ import javax.inject.Inject
 
 class NymEnvironmentManager @Inject constructor(private val backendManager: BackendManager) : EnvironmentManager {
 
-	override suspend fun isMixnetTuningEnabled(): Boolean = getFeatureFlags()?.isMixnetTuningEnabled() ?: false
-
 	override suspend fun isDomainFrontingEnabled(): Boolean = getFeatureFlags()?.isDomainFrontingEnabled() ?: false
 
 	private suspend fun getFeatureFlags(): FeatureFlags? = try {

--- a/nym-vpn-app/CHANGELOG.md
+++ b/nym-vpn-app/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Allow adding custom apps (user selected) to split tunneling for Windows & Linux
+- Mixnet tuning settings
 
 ## [1.30.0] - 2026-05-29
 

--- a/nym-vpn-app/src-tauri/src/vpnd/feature_flags.rs
+++ b/nym-vpn-app/src-tauri/src/vpnd/feature_flags.rs
@@ -6,7 +6,6 @@ use ts_rs::TS;
 const KEY_QUIC: &str = "quic";
 const KEY_DOMAIN_FRONTING: &str = "domain_fronting";
 const KEY_ZKNYMS: &str = "zkNyms";
-const KEY_MIXNET_TUNING: &str = "mixnet_tuning";
 
 #[derive(Clone, Serialize, TS)]
 #[ts(export, export_to = "tauri.ts")]
@@ -15,7 +14,6 @@ pub struct FeatureFlags {
     pub quic: bool,
     pub domain_fronting: bool,
     pub zknym_credential: bool,
-    pub mixnet_tuning: bool,
 }
 
 impl From<lib::FeatureFlags> for FeatureFlags {
@@ -26,7 +24,6 @@ impl From<lib::FeatureFlags> for FeatureFlags {
                 .unwrap_or(false),
             zknym_credential: get_group_flag(&fflags, KEY_ZKNYMS, "credentialMode")
                 .unwrap_or(false),
-            mixnet_tuning: get_group_flag(&fflags, KEY_MIXNET_TUNING, "enabled").unwrap_or(false),
         }
     }
 }

--- a/nym-vpn-app/src/screens/settings/Settings.tsx
+++ b/nym-vpn-app/src/screens/settings/Settings.tsx
@@ -11,13 +11,8 @@ import { InfoData } from './info-data';
 import SettingsGroup from './SettingsGroup';
 
 function Settings() {
-  const {
-    desktopNotifications,
-    ipv6Support,
-    allowLan,
-    enableAdBlocking,
-    backendFlags,
-  } = useMainState();
+  const { desktopNotifications, ipv6Support, allowLan, enableAdBlocking } =
+    useMainState();
 
   const navigate = useNavigate();
   const { t } = useTranslation('settings');
@@ -126,7 +121,7 @@ function Settings() {
               <MsIcon icon="chevron_right" className="text-text-primary" />
             ),
           },
-          backendFlags.mixnetTuning && {
+          {
             title: t('mixnet-tuning.title'),
             desc: t('mixnet-tuning.desc'),
             leadingIcon: 'visibility_off',

--- a/nym-vpn-app/src/screens/settings/mixnet-tuning/ContinuousTrafficCard.tsx
+++ b/nym-vpn-app/src/screens/settings/mixnet-tuning/ContinuousTrafficCard.tsx
@@ -173,9 +173,9 @@ export function ContinuousTrafficCard() {
   const { state, updateField, continuousItems, backgroundCoverItems } =
     useMixnetTrafficConfig();
 
-  const enabled = !state.disableBackgroundCoverTraffic;
+  const enabled = !state.disablePoissonRate;
   const setEnabled = (enabled: boolean) =>
-    updateField('disableBackgroundCoverTraffic', enabled);
+    updateField('disablePoissonRate', enabled);
 
   const setMessageSendingAverageDelay = (index: number) => {
     const item = continuousItems[index];

--- a/nym-vpn-app/src/screens/settings/mixnet-tuning/MixnetTuning.tsx
+++ b/nym-vpn-app/src/screens/settings/mixnet-tuning/MixnetTuning.tsx
@@ -40,7 +40,7 @@ function MixnetTuning() {
   return (
     <PageAnim className="mt-2 flex h-full flex-col justify-between gap-6 pb-2 select-none">
       <div className="flex flex-col gap-6">
-        <p className="text-text-secondary text-center text-sm whitespace-pre-line">
+        <p className="text-text-secondary text-sm whitespace-pre-line">
           <Trans
             i18nKey="mixnet-tuning.top-description"
             ns="settings"
@@ -72,21 +72,20 @@ function MixnetTuning() {
         >
           {t('mixnet-tuning.save-custom-settings')}
         </Button>
-        {hasSettingsOtherThanDefaults && (
-          <Button variant="outlined" onClick={restoreDefaults}>
-            {t('mixnet-tuning.restore-default-settings')}
-          </Button>
-        )}
+
+        <Button
+          variant="outlined"
+          onClick={restoreDefaults}
+          disabled={!hasSettingsOtherThanDefaults}
+        >
+          {t('mixnet-tuning.restore-default-settings')}
+        </Button>
       </div>
     </PageAnim>
   );
 }
 
 function MixnetTuningWrapper() {
-  // const { mixnetTrafficConfig, mixnetTrafficDefaults } = useMainState();
-
-  // console.log('[MixnetTuningWrapper] mainstate', useMainState());
-
   return (
     <MixnetTrafficConfigProvider>
       <MixnetTuning />

--- a/nym-vpn-app/src/screens/settings/mixnet-tuning/context/provider.tsx
+++ b/nym-vpn-app/src/screens/settings/mixnet-tuning/context/provider.tsx
@@ -74,7 +74,9 @@ function MixnetTrafficConfigProvider({
       state.averagePacketDelay !== defaultState.averagePacketDelay ||
       state.messageSendingAverageDelay !==
         defaultState.messageSendingAverageDelay ||
-      state.disablePoissonRate !== defaultState.disablePoissonRate
+      state.disablePoissonRate !== defaultState.disablePoissonRate ||
+      state.disableBackgroundCoverTraffic !==
+        defaultState.disableBackgroundCoverTraffic
     );
   }, [state, defaultState]);
 

--- a/nym-vpn-app/src/screens/settings/mixnet-tuning/context/provider.tsx
+++ b/nym-vpn-app/src/screens/settings/mixnet-tuning/context/provider.tsx
@@ -43,12 +43,12 @@ function MixnetTrafficConfigProvider({
   const defaultState = useMemo(() => {
     return {
       poissonParameterForLoopCoverStream:
-        mixnetTrafficDefaults.mixingDelay.defaultValue,
+        mixnetTrafficDefaults.defaultBackgroundTraffic.value,
       averagePacketDelay: mixnetTrafficDefaults.mixingDelay.defaultValue,
       messageSendingAverageDelay:
-        mixnetTrafficDefaults.mixingDelay.defaultValue,
+        mixnetTrafficDefaults.defaultContinuousTraffic.value,
       disablePoissonRate: mixnetTrafficDefaults.disablePoissonRate,
-      disableBackgroundCoverTraffic: mixnetTrafficDefaults.disablePoissonRate,
+      disableBackgroundCoverTraffic: false,
       minGatewayMixnetPerformance: 0,
       minMixnodePerformance: 0,
     };
@@ -70,16 +70,13 @@ function MixnetTrafficConfigProvider({
   const hasSettingsOtherThanDefaults = useMemo(() => {
     return (
       state.poissonParameterForLoopCoverStream !==
-        mixnetTrafficDefaults.mixingDelay.defaultValue ||
-      state.averagePacketDelay !==
-        mixnetTrafficDefaults.mixingDelay.defaultValue ||
+        defaultState.poissonParameterForLoopCoverStream ||
+      state.averagePacketDelay !== defaultState.averagePacketDelay ||
       state.messageSendingAverageDelay !==
-        mixnetTrafficDefaults.mixingDelay.defaultValue ||
-      state.disablePoissonRate !== mixnetTrafficDefaults.disablePoissonRate ||
-      state.disableBackgroundCoverTraffic !==
-        mixnetTrafficDefaults.allBackgroundTraffic.length > 0
+        defaultState.messageSendingAverageDelay ||
+      state.disablePoissonRate !== defaultState.disablePoissonRate
     );
-  }, [state, mixnetTrafficDefaults]);
+  }, [state, defaultState]);
 
   const updateField = useCallback(
     (field: keyof MixnetTrafficConfig, value: number | boolean) => {

--- a/nym-vpn-app/src/store/slices/createMainSlice.ts
+++ b/nym-vpn-app/src/store/slices/createMainSlice.ts
@@ -135,7 +135,6 @@ export const initialState: AppState = {
     quic: false,
     domainFronting: false,
     zknymCredential: false,
-    mixnetTuning: false,
   },
   customDnsEnabled: false,
   customDns: [],

--- a/nym-vpn-app/src/types/tauri.ts
+++ b/nym-vpn-app/src/types/tauri.ts
@@ -144,7 +144,6 @@ export type FeatureFlags = {
   quic: boolean;
   domainFronting: boolean;
   zknymCredential: boolean;
-  mixnetTuning: boolean;
 };
 
 export type FrontingMode = 'off' | 'onRetry' | 'always';

--- a/nym-vpn-app/src/ui/CardNew.tsx
+++ b/nym-vpn-app/src/ui/CardNew.tsx
@@ -149,8 +149,7 @@ export function CardHeaderSwitch({
     <div
       className={clsx(
         'flex w-full flex-row items-center justify-between gap-4 select-none',
-        'min-h-16 rounded-t-lg px-4 py-4',
-        'bg-surface-bg',
+        'min-h-14 rounded-t-lg px-4 py-4',
         !noHoverEffect && 'hover:bg-surface-hair',
         'cursor-default',
         disabled && 'pointer-events-none opacity-50',

--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix missing "recursion available" flag in DNS responses, passthrough authority and additional records (https://github.com/nymtech/nym-vpn-client/pull/5546)
 - Provide escape hatch when reconnecting the tunnel in "time desynced" error state (https://github.com/nymtech/nym-vpn-client/pull/5551)
 
+### Removed
+
+- Removed mixnet tuning feature flag
+
 
 ## [2026.10.0] - 2026-06-09
 

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/network.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/network.rs
@@ -182,13 +182,6 @@ impl FeatureFlags {
         self.get_group_flag("privy", "enabled")
     }
 
-    /// If mixnet tuning is enabled or not, if set
-    #[uniffi::method]
-    pub fn is_mixnet_tuning_enabled(&self) -> Option<bool> {
-        // todo: harmonize with nym-vpn-network-config/src/feature_flags.rs
-        self.get_group_flag("mixnet_tuning", "enabled")
-    }
-
     fn get_group_flag(&self, group_name: &str, flag_name: &str) -> Option<bool> {
         if let Some(FlagValue::Group(group)) = self.flags.get(group_name)
             && let Some(value) = group.get(flag_name)

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/feature_flags.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/feature_flags.rs
@@ -62,11 +62,6 @@ impl FeatureFlags {
     pub fn privy_enabled(&self) -> Option<bool> {
         self.get_group_flag("privy", "enabled")
     }
-
-    /// If mixnet tuning is enabled or not, if set
-    pub fn mixnet_tuning_enabled(&self) -> Option<bool> {
-        self.get_group_flag("mixnet_tuning", "enabled")
-    }
 }
 
 impl From<HashMap<String, FlagValue>> for FeatureFlags {

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/lib.rs
@@ -191,12 +191,6 @@ impl Network {
             .and_then(|ff| ff.privy_enabled())
     }
 
-    pub fn mixnet_tuning_enabled(&self) -> Option<bool> {
-        self.feature_flags
-            .as_ref()
-            .and_then(|ff| ff.mixnet_tuning_enabled())
-    }
-
     pub async fn vpn_api_addresses(&self) -> Vec<SocketAddr> {
         let mut unique: HashSet<SocketAddr> = HashSet::with_capacity(16);
 


### PR DESCRIPTION
## Ticket

[JIRA-NYM-257](https://nymtech.atlassian.net/browse/NYM-257)

## Description

- Enable mixnet tuning settings
- Remove mixnet feature flag from core (revert of https://github.com/nymtech/nym-vpn-client/pull/4514)


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5581)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Removed feature-flag gating for mixnet tuning, so the mixnet tuning section is always shown in Settings.
  * Updated continuous traffic controls so the toggle and slider reflect the correct underlying setting.
  * Adjusted the mixnet tuning UI: “Restore defaults” is always visible (disabled when already at defaults) with minor alignment/button styling improvements.
  * Updated exposed feature flags to: QUIC, Domain fronting, and Zk-Nym credential.
  * Minor visual refinements to the card header layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->