### PR TITLE
[iOS] Revert stats disabling on iOS

### DIFF
--- a/nym-vpn-core/crates/nym-statistics/src/controller.rs
+++ b/nym-vpn-core/crates/nym-statistics/src/controller.rs
@@ -58,15 +58,6 @@ impl StatisticsController {
             );
         }
 
-        // iOS stats are disabled because they currently don't go through the tunnel
-        #[cfg(target_os = "ios")]
-        let mut config = config; // we need the config outside of the scope
-
-        #[cfg(target_os = "ios")]
-        {
-            config.enabled = false;
-        }
-
         let statistics_handler = if let Some(storage) = stats_storage.clone()
             && let Some(api_client) = stats_api_client
         {
@@ -104,12 +95,8 @@ impl StatisticsController {
                 tracing::info!("StatisticsController : Collection disabled");
             }
             ControllerCommand::Config(ConfigCommand::EnableCollection) => {
-                // Impossible to enable stats on ios while the tunnel issue isn't fixed
-                #[cfg(not(target_os = "ios"))]
-                {
-                    self.config.enabled = true;
-                    tracing::info!("StatisticsController : Collection enabled");
-                }
+                self.config.enabled = true;
+                tracing::info!("StatisticsController : Collection enabled");
             }
             ControllerCommand::Config(ConfigCommand::AllowDirectSending(status)) => {
                 self.config.allow_disconnected = status;


### PR DESCRIPTION
Revert https://github.com/nymtech/nym-vpn-client/pull/4209 since iOS stats are fixed

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5584)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Statistics collection can now be enabled on iOS. An automatic restriction previously prevented enabling statistics collection on iOS devices. This has been corrected, allowing users to control their statistics collection settings across all platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->