### PR TITLE
Add single click release

### DIFF
--- a/.github/scripts/release/ensure-release.sh
+++ b/.github/scripts/release/ensure-release.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Ensure the unified release object exists in the right state.
+# Inputs (env): MODE (ship|nightly), TAG, TARGET_SHA, NOTES (optional)
+set -euo pipefail
+
+MODE="${MODE:?MODE required}"
+TAG="${TAG:?TAG required}"
+TARGET_SHA="${TARGET_SHA:?TARGET_SHA required}"
+NOTES="${NOTES:-Assembled by release-all-platforms.}"
+
+if [ "$MODE" = "ship" ]; then
+  if gh release view "$TAG" >/dev/null 2>&1; then
+    isDraft="$(gh release view "$TAG" --json isDraft -q .isDraft)"
+    if [ "$isDraft" != "true" ]; then
+      echo "::error:: ${TAG} already published — cannot amend an immutable release"
+      exit 1
+    fi
+    echo "::notice:: reusing existing draft ${TAG}"
+  else
+    gh release create "$TAG" --draft --title "$TAG" --notes "$NOTES" --target "$TARGET_SHA"
+    echo "::notice:: created draft ${TAG}"
+  fi
+else
+  # Nightly: delete every prior nightly release + tag. Native immutable releases
+  # ALLOW deleting a published release and its tag — they only forbid REUSING the
+  # tag name, which we never do (TAG is freshly timestamped each run). Then create
+  # a fresh DRAFT; the orchestrator's finalize-nightly job publishes it once all
+  # assets are attached.
+  while IFS= read -r t; do
+    [ -n "$t" ] || continue
+    echo "::notice:: deleting prior nightly ${t}"
+    gh release delete "$t" --yes --cleanup-tag || true
+  done < <(gh release list --json tagName -q '.[] | select(.tagName | startswith("nym-vpn-nightly")) | .tagName')
+
+  gh release create "$TAG" --draft --prerelease --title "$TAG" --notes "$NOTES" --target "$TARGET_SHA"
+  echo "::notice:: created nightly draft ${TAG}"
+fi

--- a/.github/scripts/release/resolve-version.sh
+++ b/.github/scripts/release/resolve-version.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Resolve the release version + unified tag.
+# Inputs (env): SHIP (true|false), CARGO_ENTRY (default nym-vpn-core/Cargo.toml)
+# Outputs (GITHUB_OUTPUT): core_version, tag
+set -euo pipefail
+
+SHIP="${SHIP:-false}"
+CARGO_ENTRY="${CARGO_ENTRY:-nym-vpn-core/Cargo.toml}"
+
+CORE_VERSION="$(cargo-get workspace.package.version --entry "$CARGO_ENTRY")"
+echo "::notice:: core version: ${CORE_VERSION}"
+
+if [ "$SHIP" = "true" ]; then
+  if [[ "$CORE_VERSION" == *beta* ]]; then
+    echo "::error:: refusing to ship a beta version: ${CORE_VERSION}"
+    exit 1
+  fi
+  TAG="nym-vpn-v${CORE_VERSION}"
+else
+  # Unique-per-run nightly tag. Native immutable releases forbid REUSING a tag
+  # once it was published, so each nightly gets a fresh timestamp; the prior
+  # nightly release + tag are deleted in ensure-release.sh.
+  TAG="nym-vpn-nightly-$(date -u +%Y%m%d%H%M%S)"
+fi
+
+echo "::notice:: unified tag: ${TAG}"
+{
+  echo "core_version=${CORE_VERSION}"
+  echo "tag=${TAG}"
+} >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-nym-vpn-apple.yml
+++ b/.github/workflows/build-nym-vpn-apple.yml
@@ -36,12 +36,19 @@ on:
         description: "Build type: pr | qa | ship (raw or labeled)"
         type: string
         default: "pr"
+      version_tag:
+        description: "Unified release tag (empty = legacy; nym-vpn-nightly = mutable; nym-vpn-v* = immutable ship)"
+        type: string
+        default: ""
+      build_ios:
+        type: boolean
+        default: false
+      build_macos:
+        type: boolean
+        default: false
     outputs:
       RUST_VERSION:
         value: ${{ jobs.build-apple.outputs.RUST_VERSION }}
-  schedule:
-    - cron: "0 1 * * *"
-
 env:
   CARGO_TERM_COLOR: always
   UPLOAD_DIR_IOS: ios_artifacts
@@ -530,13 +537,17 @@ jobs:
           set -euo pipefail
 
           echo "🚀 Uploading to TestFlight..."
+          # Beta groups by release type (--beta-group is repeatable):
+          #   ship (release) → public 'World' + 'Nym Team External'
+          #   qa   (nightly) → 'Nym Team External' only
+          BETA_GROUPS=( --beta-group='Nym Team External' )
+          if [ "${{ env.RELEASE_TYPE }}" = "ship" ]; then
+            BETA_GROUPS+=( --beta-group='World' )
+          fi
           app-store-connect publish \
             --beta-build-localizations=@file:whats_new.json \
-            --beta-group='External QA' \
-            --beta-group='Nym Team External' \
+            "${BETA_GROUPS[@]}" \
             --testflight
-            # --beta-group="World" \
-            # --expire-build-submitted-for-review
 
           echo "✅ Upload completed successfully."
 
@@ -958,6 +969,7 @@ jobs:
         env:
           APPLE_SPARKLE_PRIVATE_KEY: ${{ secrets.APPLE_SPARKLE_PRIVATE_KEY }}
           APP_PATH: ${{ steps.archive-macos.outputs.app_path }}
+          VERSION_TAG: ${{ inputs.version_tag }}
         run: |
           set -euo pipefail
           which jq || brew install jq
@@ -1052,7 +1064,12 @@ jobs:
           echo "✅ sha256-hash.txt:"
           cat sha256-hash.txt
 
-          DOWNLOAD_URL="https://github.com/nymtech/nym-vpn-client/releases/download/nym-vpn-macos-v${MACOS_VERSION}/NymVPN-${MACOS_VERSION}.pkg"
+          if [[ -n "${VERSION_TAG:-}" ]]; then
+            DOWNLOAD_TAG="${VERSION_TAG}"
+          else
+            DOWNLOAD_TAG="nym-vpn-macos-v${MACOS_VERSION}"
+          fi
+          DOWNLOAD_URL="https://github.com/nymtech/nym-vpn-client/releases/download/${DOWNLOAD_TAG}/NymVPN-${MACOS_VERSION}.pkg"
           HOST_LINK="https://nymvpn.com"
           PUB_DATE="$(LC_ALL=C date -u '+%a, %d %b %Y %H:%M:%S %z')"
 
@@ -1177,7 +1194,7 @@ jobs:
           fi
 
       - name: Publish macOS GitHub Release
-        if: ${{ env.RELEASE_TYPE == 'ship' && env.BUILD_MACOS == 'true' && steps.macos_tag.outputs.exists != 'true' }}
+        if: ${{ inputs.version_tag == '' && env.RELEASE_TYPE == 'ship' && env.BUILD_MACOS == 'true' && steps.macos_tag.outputs.exists != 'true' }}
         uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -1195,6 +1212,35 @@ jobs:
             - Branch: ${{ github.ref_name }}
             - Commit: ${{ github.sha }}
             - Built at: ${{ github.run_started_at }}
+
+      - name: Append macOS pkg to unified release
+        if: ${{ inputs.version_tag != '' && env.RELEASE_TYPE == 'ship' && env.BUILD_MACOS == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION_TAG: ${{ inputs.version_tag }}
+        run: |
+          set -euo pipefail
+          # Carry the Sparkle appcast <item> as a release asset so the deferred
+          # nym-websites PR (opened post-publish by on-release-publish.yml) can recover
+          # it. Version is in the asset name → that job needs no unified->macOS mapping.
+          cp "${{ env.APPCAST_ITEM_RELATIVE_PATH }}" "appcast-item-${{ env.MACOS_VERSION }}.xml"
+          files=( \
+            nym-vpn-apple/build/pkg/publish/NymVPN-${{ env.MACOS_VERSION }}.pkg \
+            nym-vpn-apple/build/pkg/publish/sha256-hash.txt \
+            "appcast-item-${{ env.MACOS_VERSION }}.xml" \
+          )
+          # Append to the (ship) draft. No --clobber: gh refuses a duplicate.
+          gh release upload "$VERSION_TAG" "${files[@]}"
+
+      - name: Append macOS pkg to unified nightly release
+        if: ${{ inputs.version_tag != '' && env.RELEASE_TYPE == 'qa' && env.BUILD_MACOS == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION_TAG: ${{ inputs.version_tag }}
+        run: |
+          set -euo pipefail
+          # Append the qa pkg to the fresh nightly draft (finalize-nightly publishes it).
+          gh release upload "$VERSION_TAG" "$renamed_pkg_relative_path"
 
       - name: Upload artifacts (Ship + appcast + hash)
         if: ${{ env.RELEASE_TYPE == 'ship' && env.BUILD_MACOS == 'true' }}
@@ -1237,7 +1283,10 @@ jobs:
           aws_secret_access_key: ${{ secrets.GARAGE_AWS_SECRET_ACCESS_KEY }}
 
       - name: Checkout nym-websites
-        if: ${{ env.RELEASE_TYPE == 'ship' && env.BUILD_MACOS == 'true' }}
+        # Legacy path only. Under orchestration (version_tag set) the appcast <item> is
+        # attached to the unified release and the nym-websites PR is opened post-publish
+        # by on-release-publish.yml — gated behind the human ship/publish action.
+        if: ${{ env.RELEASE_TYPE == 'ship' && env.BUILD_MACOS == 'true' && inputs.version_tag == '' }}
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
@@ -1246,7 +1295,7 @@ jobs:
           path: nym-websites
 
       - name: Insert new Sparkle <item> into nym-websites appcast.xml
-        if: ${{ env.RELEASE_TYPE == 'ship' && env.BUILD_MACOS == 'true' }}
+        if: ${{ env.RELEASE_TYPE == 'ship' && env.BUILD_MACOS == 'true' && inputs.version_tag == '' }}
         working-directory: nym-websites
         env:
           ITEM_FILE: ${{ github.workspace }}/${{ env.APPCAST_ITEM_RELATIVE_PATH }}
@@ -1271,7 +1320,7 @@ jobs:
           sed -n '1,40p' "$TARGET" || true
 
       - name: Create PR in nym-websites
-        if: ${{ env.RELEASE_TYPE == 'ship' && env.BUILD_MACOS == 'true' }}
+        if: ${{ env.RELEASE_TYPE == 'ship' && env.BUILD_MACOS == 'true' && inputs.version_tag == '' }}
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.WEB_REPO_TOKEN_FOR_APPCAST }}

--- a/.github/workflows/on-release-publish.yml
+++ b/.github/workflows/on-release-publish.yml
@@ -1,0 +1,167 @@
+name: on-release-publish
+
+# Auto-runs the post-publish steps that release-all-platforms DEFERS while the
+# unified release is still a draft (they consume PUBLIC release assets that 404
+# on a draft). Fires the moment a human clicks "Publish release" on the ship draft:
+#   aur-vpnd, aur-app        -> publish PKGBUILDs to AUR
+#   post-release             -> changelog/installer/flatpak PR
+#   gen-hashes               -> hashes.json artifact of the published assets
+#   win-sigs + windows-updater -> tauri Windows updater feed PR (skips if no win build)
+#   macos-appcast            -> calls publish-macos-appcast.yml (Sparkle PR; skips if no macOS)
+#
+# Why 'released' (not 'published'):
+#   - 'released'  matches NON-prerelease publishes only  -> ship  (nym-vpn-v*)
+#   - nightlies are created with --prerelease            -> never match here
+# Why this is safe vs. nightlies (belt + braces):
+#   1. nightly drafts are --prerelease, so 'released' never fires for them;
+#   2. nightly drafts are auto-published by finalize-nightly via GITHUB_TOKEN,
+#      and releases published by GITHUB_TOKEN do NOT emit a release event at all.
+#   Nightlies therefore never reach AUR -- which is intended (canonical
+#   nym-vpnd / nym-vpn-app AUR packages stay stable-only).
+#
+# Assumes this workflow + its callees exist on the release commit / default
+# branch (reusable callees resolve at the caller's ref).
+on:
+  release:
+    types: [released]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: on-release-publish-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  setup:
+    # Guard: only act on the unified ship tag (nym-vpn-v*). Ignores legacy
+    # (nym-vpn-core-v*, nym-vpn-app-v*) and nightly (nym-vpn-nightly-*) tags --
+    # none of those share the 'nym-vpn-v' prefix.
+    if: ${{ startsWith(github.event.release.tag_name, 'nym-vpn-v') }}
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.v.outputs.tag }}
+      version: ${{ steps.v.outputs.version }}
+    steps:
+      - name: Resolve tag + version
+        id: v
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          version="${TAG#nym-vpn-v}"
+          {
+            echo "tag=${TAG}"
+            echo "version=${version}"
+          } >> "$GITHUB_OUTPUT"
+          echo "::notice:: post-release fan-out for ${TAG} (version ${version})"
+
+  aur-vpnd:
+    needs: setup
+    uses: ./.github/workflows/publish-aur-nym-vpnd.yml
+    secrets: inherit
+    with:
+      release_tag: ${{ needs.setup.outputs.tag }}
+      pkgrel: 1
+      publish_aur: true
+      commit_msg: "release ${{ needs.setup.outputs.tag }}"
+
+  aur-app:
+    needs: setup
+    uses: ./.github/workflows/publish-aur-nym-vpn-app.yml
+    secrets: inherit
+    with:
+      release_tag: ${{ needs.setup.outputs.tag }}
+      pkgrel: 1
+      publish_aur: true
+      commit_msg: "v${{ needs.setup.outputs.version }}"
+
+  post-release:
+    needs: setup
+    uses: ./.github/workflows/tauri-post-release.yml
+    permissions:
+      contents: write
+      pull-requests: write
+    with:
+      release_tag: ${{ needs.setup.outputs.tag }}
+      version: ${{ needs.setup.outputs.version }}
+      core_release_tag: ${{ needs.setup.outputs.tag }}
+
+  # Hashes JSON of the published assets. The action uploads a workflow ARTIFACT
+  # (not a release asset), so it's safe against immutable-release freezing.
+  gen-hashes:
+    needs: setup
+    uses: ./.github/workflows/gen-hashes-json.yml
+    with:
+      release_tag: ${{ needs.setup.outputs.tag }}
+
+  # Tauri Windows updater feed. tauri-updater.yml wants the bundle signatures as
+  # inputs; under orchestration they came from the build job's outputs, which are
+  # gone by publish time. Recover them from the *setup.exe.sig assets attached to
+  # the release. The app version is embedded in the .sig filename
+  # (NymVPN_<ver>_x64-setup.exe.sig) — parse it rather than assume tag==app version.
+  win-sigs:
+    needs: setup
+    runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.sig.outputs.enabled }}
+      app_version: ${{ steps.sig.outputs.app_version }}
+      sig_x64: ${{ steps.sig.outputs.sig_x64 }}
+      sig_arm64: ${{ steps.sig.outputs.sig_arm64 }}
+    steps:
+      - name: Recover Windows updater signatures from release assets
+        id: sig
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ needs.setup.outputs.tag }}
+        run: |
+          set -euo pipefail
+          mapfile -t sigs < <(gh release view "$TAG" --json assets \
+            -q '.assets[].name | select(endswith("setup.exe.sig"))')
+          if [ "${#sigs[@]}" -eq 0 ]; then
+            echo "::notice:: no Windows updater sigs on ${TAG} — skipping updater feed"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          x64=$(printf '%s\n' "${sigs[@]}" | grep -E 'x64-setup\.exe\.sig$' || true)
+          arm64=$(printf '%s\n' "${sigs[@]}" | grep -E 'arm64-setup\.exe\.sig$' || true)
+          if [ -z "$x64" ] || [ -z "$arm64" ]; then
+            echo "::warning:: incomplete Windows sigs (x64='${x64}' arm64='${arm64}') — skipping updater feed"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          ver=$(printf '%s' "$x64" | sed -E 's/^NymVPN_(.+)_x64-setup\.exe\.sig$/\1/')
+          gh release download "$TAG" --pattern "$x64" --pattern "$arm64" --clobber
+          {
+            echo "enabled=true"
+            echo "app_version=${ver}"
+            echo "sig_x64=$(head -n1 "$x64")"
+            echo "sig_arm64=$(head -n1 "$arm64")"
+          } >> "$GITHUB_OUTPUT"
+
+  windows-updater:
+    needs: [setup, win-sigs]
+    if: ${{ needs.win-sigs.outputs.enabled == 'true' }}
+    uses: ./.github/workflows/tauri-updater.yml
+    permissions:
+      contents: write
+      pull-requests: write
+    with:
+      channel: stable
+      version: ${{ needs.win-sigs.outputs.app_version }}
+      base_url: https://github.com/${{ github.repository }}/releases/download/${{ needs.setup.outputs.tag }}
+      signature_x64: ${{ needs.win-sigs.outputs.sig_x64 }}
+      signature_arm64: ${{ needs.win-sigs.outputs.sig_arm64 }}
+
+  # macOS Sparkle appcast PR into nym-websites — delegated to the apple-owned reusable
+  # workflow so the Sparkle logic lives with the macOS pipeline. The build attached the
+  # appcast <item> to this release as appcast-item-<ver>.xml; publish-macos-appcast
+  # recovers it and opens the PR. Running it here (post-publish) keeps the Sparkle update
+  # behind the human ship gate. secrets: inherit forwards WEB_REPO_TOKEN_FOR_APPCAST.
+  macos-appcast:
+    needs: setup
+    uses: ./.github/workflows/publish-macos-appcast.yml
+    secrets: inherit
+    with:
+      release_tag: ${{ needs.setup.outputs.tag }}

--- a/.github/workflows/publish-aur-nym-vpnd.yml
+++ b/.github/workflows/publish-aur-nym-vpnd.yml
@@ -4,10 +4,14 @@ name: publish-aur-nym-vpnd
 on:
   workflow_dispatch:
     inputs:
+      # NOTE: with unified-only core, this is the unified tag nym-vpn-v<version>,
+      # not the legacy nym-vpn-core-v<version>. The referenced release must be PUBLISHED
+      # (draft URLs 404). on-release-publish.yml calls this AUTOMATICALLY when the unified
+      # ship draft is published; manual dispatch is a fallback / re-run of that step.
       release_tag:
         description: "Tag name of the release"
         required: true
-        default: nym-vpn-core-v0.1.0
+        default: nym-vpn-v0.1.0
       pkgrel:
         description: "PKGBUILD package release number"
         required: false
@@ -24,6 +28,10 @@ on:
         required: false
   workflow_call:
     inputs:
+      # NOTE: with unified-only core, this is the unified tag nym-vpn-v<version>,
+      # not the legacy nym-vpn-core-v<version>. The referenced release must be PUBLISHED
+      # (draft URLs 404). on-release-publish.yml calls this AUTOMATICALLY when the unified
+      # ship draft is published; manual dispatch is a fallback / re-run of that step.
       release_tag:
         required: true
         type: string

--- a/.github/workflows/publish-macos-appcast.yml
+++ b/.github/workflows/publish-macos-appcast.yml
@@ -1,0 +1,99 @@
+name: publish-macos-appcast
+
+# Opens the macOS Sparkle appcast PR into nym-websites for a published release.
+# Apple-owned so the Sparkle/appcast knowledge lives with the rest of the macOS
+# pipeline. build-nym-vpn-apple.yml attaches the appcast <item> to the release as
+# appcast-item-<macosVer>.xml (its enclosure URL already points at that release);
+# this workflow recovers it, splices it into the website's appcast.xml and opens
+# the PR.
+#
+# Invoked post-publish by on-release-publish.yml (so the update isn't announced to
+# end-users before the human ship gate) and dispatchable manually to re-run against
+# an already-published release.
+on:
+  workflow_call:
+    inputs:
+      release_tag:
+        description: "Published release holding the appcast-item-<ver>.xml asset"
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Published release holding the appcast-item-<ver>.xml asset"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  appcast-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Recover macOS appcast item from the release
+        id: item
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          name=$(gh release view "$TAG" --json assets \
+            -q '.assets[].name | select(startswith("appcast-item-") and endswith(".xml"))' | head -n1)
+          if [ -z "${name:-}" ]; then
+            echo "::notice:: no macOS appcast item on ${TAG} — skipping nym-websites PR"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          ver=${name#appcast-item-}; ver=${ver%.xml}
+          gh release download "$TAG" --pattern "$name" --clobber
+          mv "$name" appcast-item.xml
+          {
+            echo "enabled=true"
+            echo "version=${ver}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Checkout nym-websites
+        if: ${{ steps.item.outputs.enabled == 'true' }}
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          repository: nymtech/nym-websites
+          token: ${{ secrets.WEB_REPO_TOKEN_FOR_APPCAST }}
+          path: nym-websites
+
+      - name: Insert new Sparkle <item> into nym-websites appcast.xml
+        if: ${{ steps.item.outputs.enabled == 'true' }}
+        working-directory: nym-websites
+        env:
+          ITEM_FILE: ${{ github.workspace }}/appcast-item.xml
+        run: |
+          set -euo pipefail
+          TARGET="websites/nym/www/public/.wellknown/macos-vpn/appcast.xml"
+          test -f "$ITEM_FILE" || { echo "❌ Missing ITEM_FILE: $ITEM_FILE"; exit 1; }
+          test -f "$TARGET" || { echo "❌ Missing TARGET: $TARGET"; exit 1; }
+          tmp="$(mktemp)"
+          {
+            head -n 4 "$TARGET"
+            cat "$ITEM_FILE"
+            tail -n +5 "$TARGET"
+          } > "$tmp"
+          mv "$tmp" "$TARGET"
+          echo "✅ Updated $TARGET (inserted after line 4)"
+          sed -n '1,40p' "$TARGET" || true
+
+      - name: Create PR in nym-websites
+        if: ${{ steps.item.outputs.enabled == 'true' }}
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.WEB_REPO_TOKEN_FOR_APPCAST }}
+          path: nym-websites
+          commit-message: Update Appcast.xml with v${{ steps.item.outputs.version }}
+          title: Update Appcast.xml with v${{ steps.item.outputs.version }}
+          body: |
+            Automated Sparkle appcast update for macOS v${{ steps.item.outputs.version }}.
+            Source: nym-vpn-client release ${{ inputs.release_tag }}.
+          branch: automation/update-macos-appcast-v${{ steps.item.outputs.version }}
+          base: main
+          delete-branch: true

--- a/.github/workflows/publish-nym-vpn-android.yml
+++ b/.github/workflows/publish-nym-vpn-android.yml
@@ -1,8 +1,6 @@
 name: publish-nym-vpn-android
 
 on:
-  schedule:
-    - cron: "4 3 * * *"
   workflow_dispatch:
     inputs:
       track:
@@ -42,6 +40,23 @@ on:
           - release
         default: release
         required: true
+
+  workflow_call:
+    inputs:
+      version_tag:
+        description: "Unified release tag (empty = legacy; nym-vpn-nightly = mutable; nym-vpn-v* = immutable ship). Play push gated by 'track'."
+        type: string
+        default: ""
+      fdroid:
+        description: "Dispatch the F-Droid repo (ship only)"
+        type: boolean
+        default: false
+      track:
+        type: string
+        default: "none"
+      release_type:
+        type: string
+        default: "release"
 
 env:
   UPLOAD_DIR_ANDROID: android_artifacts
@@ -141,6 +156,7 @@ jobs:
 
       - name: Create release with fastlane changelog notes
         id: create_release
+        if: ${{ inputs.version_tag == '' }}
         uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -158,6 +174,7 @@ jobs:
 
       - name: Append checksum
         id: append_checksum
+        if: ${{ inputs.version_tag == '' }}
         uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -179,6 +196,19 @@ jobs:
           draft: false
           prerelease: ${{ inputs.release_type != 'release' }}
           append_body: true
+
+      - name: Append APK to unified release
+        if: ${{ inputs.version_tag != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION_TAG: ${{ inputs.version_tag }}
+        working-directory: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          mapfile -t apks < <(find "${{ github.workspace }}/temp" -type f -iname '*.apk')
+          # Append to the draft. No --clobber: gh refuses a duplicate so the APK
+          # can't be overwritten. GitHub freezes the release at publish.
+          gh release upload "$VERSION_TAG" "${apks[@]}"
 
       - name: Compose Zulip message (Android)
         if: ${{ inputs.release_type == 'prerelease' || inputs.release_type == 'release' }}
@@ -213,7 +243,7 @@ jobs:
     runs-on: arc-linux-latest
     needs:
       - publish-github
-    if: inputs.release_type == 'release'
+    if: ${{ inputs.release_type == 'release' && (inputs.version_tag == '' || (inputs.fdroid && inputs.version_tag != 'nym-vpn-nightly')) }}
     steps:
       - name: Dispatch update for fdroid repo
         uses: peter-evans/repository-dispatch@v4

--- a/.github/workflows/publish-nym-vpn-app.yml
+++ b/.github/workflows/publish-nym-vpn-app.yml
@@ -1,7 +1,5 @@
 name: publish-nym-vpn-app
 on:
-  schedule:
-    - cron: "4 4 * * *"
   workflow_dispatch:
     inputs:
       release_type:
@@ -29,6 +27,27 @@ on:
         required: true
         type: boolean
         default: false
+  workflow_call:
+    inputs:
+      version_tag:
+        description: "Unified release tag (empty = legacy; nym-vpn-nightly = mutable; nym-vpn-v* = immutable ship)"
+        type: string
+        default: ""
+      linux:
+        type: boolean
+        default: false
+      windows:
+        type: boolean
+        default: false
+      release_type:
+        type: string
+        default: "stable"
+      core_release_tag:
+        type: string
+        default: ""
+      core_artifact_url:
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -87,7 +106,8 @@ jobs:
     with:
       cpu_arch: x64
       dev_mode: ${{ github.event_name == 'schedule' || contains(github.ref_name, 'dev') || contains(github.ref_name, 'nightly') || inputs.dev_mode == true  }}
-      core_build_it: true
+      core_build_it: ${{ inputs.core_release_tag == '' }}
+      core_release_tag: ${{ inputs.core_release_tag }}
       sign: ${{ inputs.release_type == 'stable' || inputs.release_type == 'rc' }}
       updater_bundle: ${{ inputs.updater == true || inputs.release_type == 'stable' }}
       updater_channel: ${{ inputs.release_type == 'stable' && 'stable' || 'dev' }}
@@ -99,7 +119,8 @@ jobs:
     with:
       cpu_arch: ARM64
       dev_mode: ${{ github.event_name == 'schedule' || contains(github.ref_name, 'dev') || contains(github.ref_name, 'nightly') || inputs.dev_mode == true  }}
-      core_build_it: true
+      core_build_it: ${{ inputs.core_release_tag == '' }}
+      core_release_tag: ${{ inputs.core_release_tag }}
       sign: ${{ inputs.release_type == 'stable' || inputs.release_type == 'rc' }}
       updater_bundle: ${{ inputs.updater == true || inputs.release_type == 'stable' }}
       updater_channel: ${{ inputs.release_type == 'stable' && 'stable' || 'dev' }}
@@ -445,7 +466,7 @@ jobs:
 
       - name: Create release
         id: create_release
-        if: ${{ env.RELEASE_TYPE != 'dev' }}
+        if: ${{ inputs.version_tag == '' && env.RELEASE_TYPE != 'dev' }}
         uses: softprops/action-gh-release@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -462,13 +483,57 @@ jobs:
             ${{ env.UPLOAD_DIR_WINDOWS_X64 }}/*
             ${{ env.UPLOAD_DIR_WINDOWS_ARM64 }}/*
 
+      - name: Append linux + windows artifacts to unified release
+        if: ${{ inputs.version_tag != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION_TAG: ${{ inputs.version_tag }}
+        run: |
+          set -euo pipefail
+          files=()
+          # Collect files, dropping byte-identical duplicate basenames (e.g. the
+          # arch-independent `.pkg/linux/install` script copied into every arch dir).
+          # A release can hold only one asset per name, and we upload without
+          # --clobber; FAIL loudly if two same-named files actually differ so a real
+          # collision is renamed rather than silently dropped.
+          # Plain indexed array (no `declare -A`/`mapfile`) so it runs on any bash.
+          collect() {
+            local f b i dup
+            while IFS= read -r f; do
+              b=$(basename "$f")
+              dup=""
+              for i in "${files[@]:-}"; do
+                [ -n "$i" ] || continue
+                if [ "$(basename "$i")" = "$b" ]; then dup="$i"; break; fi
+              done
+              if [ -n "$dup" ]; then
+                cmp -s "$f" "$dup" || { echo "::error:: distinct files share asset name '$b' ('$f' vs '$dup')"; exit 1; }
+                echo "::notice:: skipping duplicate asset '$b' ($f); identical to $dup"
+                continue
+              fi
+              files+=( "$f" )
+            done
+          }
+          if [ "${{ inputs.linux }}" = "true" ]; then
+            collect < <(find "${{ env.UPLOAD_DIR_LINUX_X86_64 }}" "${{ env.UPLOAD_DIR_LINUX_AARCH64 }}" -type f)
+          fi
+          if [ "${{ inputs.windows }}" = "true" ]; then
+            collect < <(find "${{ env.UPLOAD_DIR_WINDOWS_X64 }}" "${{ env.UPLOAD_DIR_WINDOWS_ARM64 }}" -type f)
+          fi
+          [ "${#files[@]}" -gt 0 ] || { echo "::error:: no files selected to append"; exit 1; }
+          # Append to the draft. No --clobber: gh refuses a duplicate so files
+          # can't be overwritten. GitHub freezes the release at publish.
+          gh release upload "$VERSION_TAG" "${files[@]}"
+
   windows-updater:
     uses: ./.github/workflows/tauri-updater.yml
     permissions:
       contents: write
       pull-requests: write
     needs: publish
-    if: ${{ inputs.updater == true || inputs.release_type == 'stable' }}
+    # version_tag set = orchestrated unified run: release is a DRAFT, so defer the
+    # updater feed (references public release-download URLs) until manual publish.
+    if: ${{ (inputs.updater == true || inputs.release_type == 'stable') && inputs.version_tag == '' }}
     with:
       channel: ${{ inputs.release_type == 'stable' && 'stable' || 'dev' }}
       version: ${{ needs.publish.outputs.version }}
@@ -479,7 +544,9 @@ jobs:
   update-aur-app:
     uses: ./.github/workflows/publish-aur-nym-vpn-app.yml
     needs: publish
-    if: ${{ inputs.release_type == 'stable' }}
+    # Deferred under orchestration (version_tag set): AUR pulls public release assets
+    # which 404 while the unified release is a draft. Run after manual publish.
+    if: ${{ inputs.release_type == 'stable' && inputs.version_tag == '' }}
     with:
       release_tag: ${{ needs.publish.outputs.release_tag }}
       pkgrel: 1
@@ -493,7 +560,9 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    if: ${{ inputs.release_type == 'stable' }}
+    # Deferred under orchestration (version_tag set): opens PRs against public release
+    # assets. Run after manual publish.
+    if: ${{ inputs.release_type == 'stable' && inputs.version_tag == '' }}
     with:
       release_tag: ${{ needs.publish.outputs.release_tag }}
       version: ${{ needs.publish.outputs.version }}
@@ -585,7 +654,9 @@ jobs:
   gen-hashes:
     uses: ./.github/workflows/gen-hashes-json.yml
     needs: publish
-    if: ${{ inputs.release_type == 'stable' }}
+    # Deferred under orchestration (version_tag set): hashes the public release assets.
+    # Run after manual publish.
+    if: ${{ inputs.release_type == 'stable' && inputs.version_tag == '' }}
     permissions:
       contents: write
     with:

--- a/.github/workflows/publish-nym-vpn-core.yml
+++ b/.github/workflows/publish-nym-vpn-core.yml
@@ -1,7 +1,5 @@
 name: publish-nym-vpn-core
 on:
-  schedule:
-    - cron: "4 2 * * *"
   workflow_dispatch:
     inputs:
       publish_to_github:
@@ -9,6 +7,12 @@ on:
         type: boolean
         default: false
         required: true
+  workflow_call:
+    inputs:
+      version_tag:
+        description: "Unified release tag (empty = legacy; nym-vpn-nightly = mutable; nym-vpn-v* = immutable ship)"
+        type: string
+        default: ""
 
 env:
   CARGO_TERM_COLOR: always
@@ -238,7 +242,7 @@ jobs:
           echo 'EOF' >> $GITHUB_ENV
 
       - name: Publish release to github
-        if: ${{ steps.determine-ok-to-publish.outputs.ok_to_publish == 'true' }}
+        if: ${{ inputs.version_tag == '' && steps.determine-ok-to-publish.outputs.ok_to_publish == 'true' }}
         run: |
           echo "Setting up the release notes"
           envsubst < "$GITHUB_WORKSPACE/.github/workflows/$NOTES_FILE" > "$RUNNER_TEMP/release-notes.md"
@@ -254,6 +258,28 @@ jobs:
             ${{ env.ARCHIVE_WINDOWS_ARM64 }}.zip ${{ env.ARCHIVE_WINDOWS_ARM64 }}.zip.sha256sum \
             ${{ env.UPLOAD_DIR_DEB_X86_64 }}/*.{deb,sha256sum} \
             ${{ env.UPLOAD_DIR_DEB_AARCH64 }}/*.{deb,sha256sum}
+
+      - name: Append core archives to unified release
+        if: ${{ inputs.version_tag != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION_TAG: ${{ inputs.version_tag }}
+        run: |
+          set -euo pipefail
+          files=( \
+            ${{ env.ARCHIVE_LINUX_X86_64 }}.tar.gz ${{ env.ARCHIVE_LINUX_X86_64 }}.tar.gz.sha256sum \
+            ${{ env.ARCHIVE_LINUX_AARCH64 }}.tar.gz ${{ env.ARCHIVE_LINUX_AARCH64 }}.tar.gz.sha256sum \
+            ${{ env.ARCHIVE_ANDROID }}.tar.gz ${{ env.ARCHIVE_ANDROID }}.tar.gz.sha256sum \
+            ${{ env.ARCHIVE_WINDOWS_X64 }}.zip ${{ env.ARCHIVE_WINDOWS_X64 }}.zip.sha256sum \
+            ${{ env.ARCHIVE_WINDOWS_ARM64 }}.zip ${{ env.ARCHIVE_WINDOWS_ARM64 }}.zip.sha256sum \
+          )
+          for d in ${{ env.UPLOAD_DIR_DEB_X86_64 }} ${{ env.UPLOAD_DIR_DEB_AARCH64 }}; do
+            [ -d "$d" ] && while IFS= read -r f; do files+=( "$f" ); done < <(find "$d" -type f \( -name '*.deb' -o -name '*.sha256sum' \))
+          done
+          # Append to the draft. No --clobber: gh refuses a duplicate asset, so a
+          # platform's files can't be overwritten across runs (ship is additive;
+          # nightly is a fresh draft). GitHub freezes the whole release at publish.
+          gh release upload "$VERSION_TAG" "${files[@]}"
 
       # Upload to CI server
 
@@ -333,7 +359,10 @@ jobs:
 
   gen-hashes:
     needs: publish
-    if: ${{ needs.publish.outputs.ok_to_publish == 'true' }}
+    # Skipped under orchestration (version_tag set): TAG_NAME is only set on the
+    # standalone dispatch/schedule/push paths, so the unified run would pass an empty
+    # release_tag. Hashes are generated post-publish instead.
+    if: ${{ inputs.version_tag == '' && needs.publish.outputs.ok_to_publish == 'true' }}
     uses: ./.github/workflows/gen-hashes-json.yml
     with:
       release_tag: ${{ needs.publish.outputs.tag }}

--- a/.github/workflows/release-all-platforms.yml
+++ b/.github/workflows/release-all-platforms.yml
@@ -35,16 +35,176 @@ on:
         description: "macOS (.pkg + Sparkle)"
         type: boolean
         default: false
+  schedule:
+    - cron: "0 4 * * *"
 
 permissions:
   contents: read
 
+# Ship runs key off the ref so different release branches/versions run in parallel.
+# Nightly runs (cron + manual ship=false) all share ONE group: ensure-release.sh
+# deletes ALL nym-vpn-nightly-* releases, so two concurrent nightlies would clobber
+# each other's release state regardless of ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ (github.event_name == 'schedule' || inputs.ship == false) && 'nightly' || github.ref }}
+  cancel-in-progress: false
+
 jobs:
-  noop:
+  resolve:
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.v.outputs.tag }}
+      core_version: ${{ steps.v.outputs.core_version }}
+      ship: ${{ steps.flags.outputs.ship }}
+      android: ${{ steps.flags.outputs.android }}
+      fdroid: ${{ steps.flags.outputs.fdroid }}
+      linux: ${{ steps.flags.outputs.linux }}
+      windows: ${{ steps.flags.outputs.windows }}
+      ios: ${{ steps.flags.outputs.ios }}
+      macos: ${{ steps.flags.outputs.macos }}
     steps:
-      - name: Stub on default branch
+      - name: Resolve flags (cron OR no platform selected = nightly + all platforms except fdroid)
+        id: flags
+        env:
+          EVENT: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          IN_SHIP: ${{ inputs.ship }}
+          IN_ANDROID: ${{ inputs.android }}
+          IN_FDROID: ${{ inputs.fdroid }}
+          IN_LINUX: ${{ inputs.linux }}
+          IN_WINDOWS: ${{ inputs.windows }}
+          IN_IOS: ${{ inputs.ios }}
+          IN_MACOS: ${{ inputs.macos }}
         run: |
-          echo "::warning:: This is the dispatch-enabler stub on the default branch."
-          echo "Re-run 'Run workflow' and pick the release/PR branch in the ref selector"
-          echo "to execute the real release-all-platforms pipeline at that ref."
+          set -euo pipefail
+          echo "::notice:: releasing from ref $REF_NAME (event $EVENT)"
+          # Nightly when scheduled, OR a manual dispatch with NO platform box ticked
+          # (fdroid counts as a platform). ship is ignored in the nightly fallback.
+          nightly=false
+          if [ "$EVENT" = "schedule" ]; then
+            nightly=true
+          elif [ "$IN_ANDROID" != "true" ] && [ "$IN_FDROID" != "true" ] \
+            && [ "$IN_LINUX" != "true" ] && [ "$IN_WINDOWS" != "true" ] \
+            && [ "$IN_IOS" != "true" ] && [ "$IN_MACOS" != "true" ]; then
+            nightly=true
+          fi
+          if [ "$nightly" = "true" ]; then
+            echo "::notice:: no platform selected (or scheduled) → nightly build of all platforms except fdroid"
+            { echo "ship=false";
+              echo "android=true"; echo "fdroid=false"; echo "linux=true";
+              echo "windows=true"; echo "ios=true"; echo "macos=true"; } >> "$GITHUB_OUTPUT"
+          else
+            { echo "ship=$IN_SHIP";
+              echo "android=$IN_ANDROID"; echo "fdroid=$IN_FDROID";
+              echo "linux=$IN_LINUX"; echo "windows=$IN_WINDOWS";
+              echo "ios=$IN_IOS"; echo "macos=$IN_MACOS"; } >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-get
+
+      - name: Resolve version + tag
+        id: v
+        env:
+          SHIP: ${{ steps.flags.outputs.ship }}
+        run: bash .github/scripts/release/resolve-version.sh
+
+  prepare-release:
+    needs: resolve
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - name: Ensure unified release object
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MODE: ${{ needs.resolve.outputs.ship == 'true' && 'ship' || 'nightly' }}
+          TAG: ${{ needs.resolve.outputs.tag }}
+          TARGET_SHA: ${{ github.sha }}
+          NOTES: "Unified release ${{ needs.resolve.outputs.tag }} assembled by release-all-platforms."
+        run: bash .github/scripts/release/ensure-release.sh
+
+  core:
+    needs: [resolve, prepare-release]
+    permissions:
+      contents: write
+    uses: ./.github/workflows/publish-nym-vpn-core.yml
+    with:
+      version_tag: ${{ needs.resolve.outputs.tag }}
+    secrets: inherit
+
+  apple:
+    needs: [resolve, prepare-release]
+    if: ${{ needs.resolve.outputs.ios == 'true' || needs.resolve.outputs.macos == 'true' }}
+    permissions:
+      contents: write
+    uses: ./.github/workflows/build-nym-vpn-apple.yml
+    with:
+      release_type: ${{ needs.resolve.outputs.ship == 'true' && 'ship' || 'qa' }}
+      version_tag: ${{ needs.resolve.outputs.tag }}
+      build_ios: ${{ needs.resolve.outputs.ios == 'true' }}
+      build_macos: ${{ needs.resolve.outputs.macos == 'true' }}
+    secrets: inherit
+
+  android:
+    needs: [resolve, prepare-release]
+    if: ${{ needs.resolve.outputs.android == 'true' || needs.resolve.outputs.fdroid == 'true' }}
+    permissions:
+      contents: write
+    uses: ./.github/workflows/publish-nym-vpn-android.yml
+    with:
+      version_tag: ${{ needs.resolve.outputs.tag }}
+      fdroid: ${{ needs.resolve.outputs.fdroid == 'true' }}
+      release_type: ${{ needs.resolve.outputs.ship == 'true' && 'release' || 'nightly' }}
+      track: ${{ (needs.resolve.outputs.android == 'true' && needs.resolve.outputs.ship == 'true') && 'production' || 'none' }}
+    secrets: inherit
+
+  # Linux + Windows desktop app. publish-nym-vpn-app.yml builds each OS as its own
+  # internal job (build-linux on ubuntu, build-windows-* on windows) and aggregates in
+  # one Linux publish job, so a single invocation covers both. Core is built INLINE here
+  # (no core_release_tag): consuming core from the unified release can't work because it
+  # is a DRAFT at build time and /releases/tags/<tag> doesn't return drafts. The `linux`/
+  # `windows` flags only gate which built artifacts get appended to the release.
+  app:
+    needs: [resolve, prepare-release]
+    if: ${{ needs.resolve.outputs.linux == 'true' || needs.resolve.outputs.windows == 'true' }}
+    permissions: write-all
+    uses: ./.github/workflows/publish-nym-vpn-app.yml
+    with:
+      version_tag: ${{ needs.resolve.outputs.tag }}
+      linux: ${{ needs.resolve.outputs.linux == 'true' }}
+      windows: ${{ needs.resolve.outputs.windows == 'true' }}
+      release_type: ${{ needs.resolve.outputs.ship == 'true' && 'stable' || 'nightly' }}
+    secrets: inherit
+
+  # Nightly only: assets can't be added after publish, so platforms assemble into a
+  # draft and this job publishes it once they finish. Ship is published manually.
+  finalize-nightly:
+    needs: [resolve, prepare-release, core, apple, android, app]
+    if: ${{ always() && needs.resolve.outputs.ship == 'false' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Publish nightly draft (only if it has assets)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ needs.resolve.outputs.tag }}
+        run: |
+          set -euo pipefail
+          count=$(gh release view "$TAG" --json assets -q '.assets | length' 2>/dev/null || echo 0)
+          if [ "${count:-0}" -gt 0 ]; then
+            gh release edit "$TAG" --draft=false
+            echo "::notice:: published nightly $TAG ($count assets)"
+          else
+            echo "::warning:: nightly $TAG has no assets — leaving as draft"
+          fi

--- a/.pkg/linux/bump.sh
+++ b/.pkg/linux/bump.sh
@@ -4,22 +4,24 @@
 # it updates the install script by bumping app and core versions
 # (stable versions only)
 # it expects the following environment variables to be set:
-# - APP_TAG, eg. nym-vpn-app-v1.2.3
-# - CORE_TAG, eg. nym-vpn-core-v1.2.3
+# - APP_TAG, eg. nym-vpn-app-v1.2.3 (or the unified tag nym-vpn-v1.2.3)
+# - CORE_TAG is the unified release tag (nym-vpn-v<version>) under unified-only core.
 
 set -e
 
-if ! echo "$APP_TAG" | grep -q '^nym-vpn-app-v'; then
-  echo "wrong app tag: $APP_TAG"
-  exit 1
-fi
-if ! echo "$CORE_TAG" | grep -q '^nym-vpn-core-v'; then
+# Accept the legacy app tag (nym-vpn-app-v*) and the unified tag (nym-vpn-v*).
+# Under unified-only releases APP_TAG is the unified tag and app == core version.
+case "$APP_TAG" in
+  nym-vpn-app-v*) app_version=${APP_TAG#nym-vpn-app-v} ;;
+  nym-vpn-v*)     app_version=${APP_TAG#nym-vpn-v} ;;
+  *) echo "wrong app tag: $APP_TAG"; exit 1 ;;
+esac
+if ! echo "$CORE_TAG" | grep -q '^nym-vpn-v'; then
   echo "wrong core tag: $CORE_TAG"
   exit 1
 fi
 
-app_version=${APP_TAG#nym-vpn-app-v}
-core_version=${CORE_TAG#nym-vpn-core-v}
+core_version=${CORE_TAG#nym-vpn-v}
 echo "app version: $app_version"
 echo "core version: $core_version"
 


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

https://github.com/nymtech/nym-vpn-client/pull/5582 <- pre requisite to test from branch

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5585)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated macOS Sparkle appcast updates by pulling the appcast item from a published macOS release and opening a PR with the refreshed entry.
  * Introduced unified, orchestrated release publication across platforms (stable and nightly), including improved draft/publish handling and artifact upload to the unified release.
* **Chores**
  * Added release helper scripts for consistent version/tag resolution and GitHub Release create/reuse/refresh behavior.
  * Updated release/publishing workflows to use reusable, parameterized flows and unified tag semantics; Android/iOS/macOS/core publishing now upload directly to the unified release when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->