### PR TITLE
Prevent configuring geo-exclusions proxy to port 0 or 1080

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/config/config_manager.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/config/config_manager.rs
@@ -323,10 +323,23 @@ impl VpnServiceConfigManager {
         }
     }
 
-    pub async fn set_geo_exclusion_listen_port(&mut self, listen_port: u16) {
-        if self.config.geo_exclusion.listen_port != listen_port {
+    pub async fn set_geo_exclusion_listen_port(
+        &mut self,
+        listen_port: u16,
+    ) -> Result<(), GeoExclusionConfigError> {
+        // Port 1080 is reserved for mixnet socks5 proxy
+        const RESERVED_PORT: u16 = 1080;
+
+        if listen_port == RESERVED_PORT {
+            Err(GeoExclusionConfigError::ReservedPort(listen_port))
+        } else if listen_port == 0 {
+            Err(GeoExclusionConfigError::InvalidPort)
+        } else if self.config.geo_exclusion.listen_port != listen_port {
             self.config.geo_exclusion.listen_port = listen_port;
             self.save_config_and_send_event().await;
+            Ok(())
+        } else {
+            Ok(())
         }
     }
 
@@ -334,12 +347,15 @@ impl VpnServiceConfigManager {
         &mut self,
         excluded_countries: Vec<String>,
     ) -> Result<(), GeoExclusionConfigError> {
-        // Temporary:  At the moment Geo Exclusion is only supported for China
         for country in &excluded_countries {
-            if country != "CN" {
+            if country.len() != 2 || !country.chars().all(|c| c.is_ascii_uppercase()) {
+                return Err(GeoExclusionConfigError::InvalidCountryCode(country.clone()));
+            } else if country != "CN" {
                 return Err(GeoExclusionConfigError::UnsupportedCountry(country.clone()));
             }
         }
+
+        // Temporary:  At the moment Geo Exclusion is only supported for China
         if !excluded_countries.iter().any(|c| c == "CN") {
             return Err(GeoExclusionConfigError::CnRequired);
         }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/error.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/error.rs
@@ -75,6 +75,15 @@ pub enum GlobalConfigError {
 
 #[derive(Debug, thiserror::Error)]
 pub enum GeoExclusionConfigError {
+    #[error("invalid port")]
+    InvalidPort,
+
+    #[error("port '{0}' is reserved and cannot be used")]
+    ReservedPort(u16),
+
+    #[error("invalid country code '{0}': must be a 2-letter uppercase ISO code")]
+    InvalidCountryCode(String),
+
     #[error("unsupported country code '{0}': only 'CN' is currently supported")]
     UnsupportedCountry(String),
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
@@ -120,7 +120,7 @@ pub enum VpnServiceCommand {
         LookupGatewayFilters,
     ),
     SetGeoExclusionEnabled(oneshot::Sender<()>, bool),
-    SetGeoExclusionListenPort(oneshot::Sender<()>, u16),
+    SetGeoExclusionListenPort(oneshot::Sender<Result<(), GeoExclusionConfigError>>, u16),
     SetGeoExclusionExcludedCountries(
         oneshot::Sender<Result<(), GeoExclusionConfigError>>,
         Vec<String>,
@@ -1262,8 +1262,7 @@ impl NymVpnService {
                 let _ = tx.send(());
             }
             VpnServiceCommand::SetGeoExclusionListenPort(tx, listen_port) => {
-                self.handle_set_geo_exclusion_listen_port(listen_port).await;
-                let _ = tx.send(());
+                let _ = tx.send(self.handle_set_geo_exclusion_listen_port(listen_port).await);
             }
             VpnServiceCommand::SetGeoExclusionExcludedCountries(tx, excluded_countries) => {
                 let result = self
@@ -2341,11 +2340,15 @@ impl NymVpnService {
         self.update_tunnel_settings_with_throttle();
     }
 
-    async fn handle_set_geo_exclusion_listen_port(&mut self, listen_port: u16) {
+    async fn handle_set_geo_exclusion_listen_port(
+        &mut self,
+        listen_port: u16,
+    ) -> Result<(), GeoExclusionConfigError> {
         self.config_manager
             .set_geo_exclusion_listen_port(listen_port)
-            .await;
+            .await?;
         self.update_tunnel_settings_with_throttle();
+        Ok(())
     }
 
     async fn handle_set_geo_exclusion_excluded_countries(

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface.rs
@@ -28,9 +28,7 @@ use nym_vpn_proto::proto::{
     nym_vpn_service_server::{NymVpnService, NymVpnServiceServer},
 };
 
-use nym_vpn_lib::service::{
-    GeoExclusionConfigError, SetNetworkError, Socks5Error, VpnServiceCommand,
-};
+use nym_vpn_lib::service::{SetNetworkError, Socks5Error, VpnServiceCommand};
 
 pub type Result<T> = std::result::Result<T, tonic::Status>;
 
@@ -390,7 +388,8 @@ impl NymVpnService for CommandInterface {
             )));
         }
         self.send_and_wait(VpnServiceCommand::SetGeoExclusionListenPort, port as u16)
-            .await?;
+            .await?
+            .map_err(|err| tonic::Status::invalid_argument(err.to_string()))?;
         Ok(tonic::Response::new(()))
     }
 
@@ -399,26 +398,13 @@ impl NymVpnService for CommandInterface {
         request: tonic::Request<proto::StringList>,
     ) -> Result<tonic::Response<()>> {
         let countries = request.into_inner().values;
-        for country in &countries {
-            if country.len() != 2 || !country.chars().all(|c| c.is_ascii_uppercase()) {
-                return Err(tonic::Status::invalid_argument(format!(
-                    "Invalid country code '{country}': must be a 2-letter uppercase ISO code"
-                )));
-            }
-        }
+
         self.send_and_wait(
             VpnServiceCommand::SetGeoExclusionExcludedCountries,
             countries,
         )
         .await?
-        .map_err(|err| match err {
-            GeoExclusionConfigError::UnsupportedCountry(c) => tonic::Status::invalid_argument(
-                format!("unsupported country code '{c}': only 'CN' is currently supported"),
-            ),
-            GeoExclusionConfigError::CnRequired => tonic::Status::invalid_argument(
-                "'CN' must be included in the excluded countries list",
-            ),
-        })?;
+        .map_err(|err| tonic::Status::invalid_argument(err.to_string()))?;
         Ok(tonic::Response::new(()))
     }
 


### PR DESCRIPTION
## Ticket

JIRA-NYM-1543

## Description

- Throw error on attempt to configure port 0 or 1080 for geo-exclusions

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5588)
<!-- Reviewable:end -->
