### PR TITLE
Move `update-aur-vpnd` to `publish-nym-vpn-core` workflow

### DIFF
--- a/.github/workflows/publish-nym-vpn-app.yml
+++ b/.github/workflows/publish-nym-vpn-app.yml
@@ -454,17 +454,6 @@ jobs:
       commit_msg: "v${{ needs.publish.outputs.version }}"
     secrets: inherit
 
-  update-aur-vpnd:
-    uses: ./.github/workflows/publish-aur-nym-vpnd.yml
-    needs: publish
-    if: ${{ inputs.release_type == 'stable' }}
-    with:
-      release_tag: ${{ needs.publish.outputs.core_release_tag }}
-      pkgrel: 1
-      publish_aur: true
-      commit_msg: "release ${{ needs.publish.outputs.core_release_tag }}"
-    secrets: inherit
-
   post-release:
     uses: ./.github/workflows/tauri-post-release.yml
     needs: publish

--- a/.github/workflows/publish-nym-vpn-core.yml
+++ b/.github/workflows/publish-nym-vpn-core.yml
@@ -62,6 +62,7 @@ jobs:
     outputs:
       tag: ${{ steps.set_tag.outputs.tag }}
       ok_to_publish: ${{ steps.determine-ok-to-publish.outputs.ok_to_publish }}
+      is_stable: ${{ steps.determine-ok-to-publish.outputs.is_stable }}
 
     steps:
       - name: Checkout repo
@@ -127,15 +128,18 @@ jobs:
         run: |
           version="${{ steps.workspace-version.outputs.metadata }}"
           should_publish="false"
+          is_stable="false"
           # If version does NOT contain '-' => stable => auto-publish
           if [[ "$version" != *"-"* ]]; then
             should_publish="true"
+            is_stable="true"
           fi
           # Or if the user explicitly sets publish_to_github
           if [[ "${{ inputs.publish_to_github }}" == "true" ]]; then
             should_publish="true"
           fi
           echo "ok_to_publish=$should_publish" >> "$GITHUB_OUTPUT"
+          echo "is_stable=$is_stable" >> "$GITHUB_OUTPUT"
 
       # Setup TAG_NAME, which is used as a general "name"
       - if: github.event_name == 'workflow_dispatch'
@@ -295,4 +299,15 @@ jobs:
     uses: ./.github/workflows/gen-hashes-json.yml
     with:
       release_tag: ${{ needs.publish.outputs.tag }}
+    secrets: inherit
+
+  update-aur-vpnd:
+    uses: ./.github/workflows/publish-aur-nym-vpnd.yml
+    needs: publish
+    if: ${{ needs.publish.outputs.is_stable == 'true' }}
+    with:
+      release_tag: ${{ needs.publish.outputs.tag }}
+      pkgrel: 1
+      publish_aur: true
+      commit_msg: "release ${{ needs.publish.outputs.tag }}"
     secrets: inherit


### PR DESCRIPTION
## Summary

Moves the `update-aur-vpnd` job out of the `publish-nym-vpn-app` (Tauri app) workflow and into the `publish-nym-vpn-core` workflow.

This is for better separation of concerns: the Tauri app workflow shouldn't be responsible for publishing core (`nym-vpnd`) to the AUR. It makes more sense for the core release workflow to handle publishing the core AUR package.

## Changes

- **`publish-nym-vpn-app.yml`**: removed the `update-aur-vpnd` job.
- **`publish-nym-vpn-core.yml`**:
  - Added an `is_stable` output to the `publish` job, derived from the existing `determine-ok-to-publish` step (`true` when the workspace version has no `-` pre-release suffix).
  - Added the `update-aur-vpnd` job, gated on `is_stable == 'true'` and using the publish job's `tag` output (`nym-vpn-core-v<version>`) for both `release_tag` and the commit message.

This preserves the original behavior — the AUR `nym-vpnd` package is only published for stable core releases — while keeping core-related publishing inside the core workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5595)
<!-- Reviewable:end -->
