### PR TITLE
ci: prevent rebuilding release artifacts twice for linux

### DIFF
--- a/.github/workflows/build-nym-vpn-core-linux.yml
+++ b/.github/workflows/build-nym-vpn-core-linux.yml
@@ -136,7 +136,7 @@ jobs:
 
       - name: Move things around to prepare for upload
         env:
-          SRC_BINARY: nym-vpn-core/target/release/
+          SRC_BINARY: nym-vpn-core/target/release
           SRC_DEB: nym-vpn-core/target/debian
         run: |
           mkdir ${{ env.UPLOAD_DIR_LINUX }}

--- a/.github/workflows/build-nym-vpn-core-linux.yml
+++ b/.github/workflows/build-nym-vpn-core-linux.yml
@@ -125,8 +125,8 @@ jobs:
         env:
           SENTRY_DSN: ${{ secrets.VPND_SENTRY_DSN }}
         run: |
-          cargo deb -p nym-vpnd
-          cargo deb -p nym-vpnc
+          cargo deb -p nym-vpnd --no-build
+          cargo deb -p nym-vpnc --no-build
           ls -la target/debian/ || true
 
       - name: Get rust version used for build


### PR DESCRIPTION


## Description

- Use `cargo deb --no-build` to reuse release artifacts build in preceding steps

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5605)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the Debian packaging workflow for Linux by packaging existing build outputs instead of rebuilding during `.deb` creation.  
  * Cleaned up the upload staging path configuration by removing an unnecessary trailing slash.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->