### PR TITLE
ci: ensure that workflows rerun on changes

### DIFF
--- a/.github/workflows/build-nym-vpn-core-linux.yml
+++ b/.github/workflows/build-nym-vpn-core-linux.yml
@@ -1,7 +1,7 @@
 name: build-nym-vpn-core-linux
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize, reopened]
     paths:
       - ".github/workflows/build-nym-vpn-core-linux.yml"
   workflow_dispatch:

--- a/.github/workflows/build-nym-vpn-core-windows.yml
+++ b/.github/workflows/build-nym-vpn-core-windows.yml
@@ -2,7 +2,7 @@ name: build-nym-vpn-core-windows
 run-name: "build-nym-vpn-core-windows (${{ inputs.cpu_arch || 'x64' }})"
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize, reopened]
     paths:
       - ".github/workflows/build-nym-vpn-core-windows.yml"
   workflow_dispatch:


### PR DESCRIPTION

## Description

Having only "open" in pull_requests only runs CI jobs once when PR is opened but not when changes are pushed to branch or PR is re-opened. Let's fix that to make it;s easier to re-test changes to CI workflows

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5606)
<!-- Reviewable:end -->
