### PR TITLE
ci: migrate artifact publishing from SSH/nginx to Garage S3

### DIFF
--- a/.github/actions/push-to-s3/action.yml
+++ b/.github/actions/push-to-s3/action.yml
@@ -25,7 +25,11 @@ inputs:
   args:
     required: false
     default: ""
-    description: "extra `aws s3 sync`/`aws s3 cp` flags, e.g. --delete"
+    description: >
+      Extra flags appended verbatim to the `aws s3 sync`/`aws s3 cp` command,
+      e.g. `--delete` or `--exclude '*.tmp'`. INTERNAL USE ONLY: this is
+      interpolated into the shell as syntax, not data — pass only trusted,
+      workflow-authored literals, never user/PR-controlled input.
 runs:
   using: composite
   steps:

--- a/.github/actions/push-to-s3/action.yml
+++ b/.github/actions/push-to-s3/action.yml
@@ -1,0 +1,58 @@
+name: Push to S3
+description: Sync a local directory (or copy a single file) to an S3-compatible bucket (Garage)
+inputs:
+  source_path:
+    required: true
+    description: "Local file or directory. Trailing slash on a directory uploads its contents under the prefix"
+  destination:
+    required: false
+    default: ""
+    description: "key prefix; empty = bucket root"
+  aws_access_key_id:
+    required: true
+  aws_secret_access_key:
+    required: true
+  bucket:
+    required: false
+    default: builds
+  endpoint:
+    required: false
+    default: https://s3.nymte.ch
+    description: "S3 API endpoint for uploads, NOT the cdn web vhost"
+  region:
+    required: false
+    default: garage
+  args:
+    required: false
+    default: ""
+    description: "extra `aws s3 sync`/`aws s3 cp` flags, e.g. --delete"
+runs:
+  using: composite
+  steps:
+    - name: Ensure AWS CLI is available     # self-hosted arc-* runners may lack it
+      shell: bash
+      run: |
+        if ! command -v aws >/dev/null 2>&1; then
+          curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+          unzip -q /tmp/awscliv2.zip -d /tmp
+          (sudo /tmp/aws/install --update || /tmp/aws/install --update --bin-dir "$HOME/.local/bin" --install-dir "$HOME/.local/aws-cli")
+          export PATH="$HOME/.local/bin:$PATH"
+        fi
+        aws --version
+    - name: Push to S3
+      shell: bash
+      env:
+        AWS_ACCESS_KEY_ID: ${{ inputs.aws_access_key_id }}
+        AWS_SECRET_ACCESS_KEY: ${{ inputs.aws_secret_access_key }}
+        AWS_DEFAULT_REGION: ${{ inputs.region }}
+      run: |
+        export PATH="$HOME/.local/bin:$PATH"
+        src="${{ inputs.source_path }}"
+        dest="s3://${{ inputs.bucket }}/${{ inputs.destination }}"
+        if [ -d "$src" ]; then
+          aws s3 sync "$src" "$dest" \
+            --endpoint-url "${{ inputs.endpoint }}" --no-progress ${{ inputs.args }}
+        else
+          aws s3 cp "$src" "$dest" \
+            --endpoint-url "${{ inputs.endpoint }}" --no-progress ${{ inputs.args }}
+        fi

--- a/.github/actions/push-to-s3/action.yml
+++ b/.github/actions/push-to-s3/action.yml
@@ -22,6 +22,12 @@ inputs:
   region:
     required: false
     default: garage
+  awscli_version:
+    required: false
+    # Pinned for reproducibility: the runtime install fetches this exact version
+    # rather than a moving "latest", so a compromised/changed upstream build cannot
+    # silently swap the binary. Bump deliberately. `aws s3 sync/cp` is API-stable.
+    default: "2.15.30"
   args:
     required: false
     default: ""
@@ -35,9 +41,28 @@ runs:
   steps:
     - name: Ensure AWS CLI is available     # self-hosted arc-* runners may lack it
       shell: bash
+      env:
+        AWSCLI_VERSION: ${{ inputs.awscli_version }}
+        # OpenPGP fingerprint of the AWS CLI team signing key. This is the trust
+        # anchor: we fetch the key by this exact fingerprint and verify the
+        # installer's detached signature before executing it, so neither a changed
+        # upstream binary nor a tampered download is run. Confirm/rotate against
+        # https://docs.aws.amazon.com/cli/latest/userguide/getting-started-version.html
+        AWSCLI_PGP_FPR: "FB5DB77FD5C118B80511ADA8A6310ACC4672475C"
       run: |
+        set -euo pipefail
         if ! command -v aws >/dev/null 2>&1; then
-          curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+          # Versioned URL — pinned, not the moving "latest" zip (supply-chain).
+          base="https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWSCLI_VERSION}.zip"
+          curl -fsSL "$base"      -o /tmp/awscliv2.zip
+          curl -fsSL "${base}.sig" -o /tmp/awscliv2.zip.sig
+          # Verify the signature in a throwaway keyring holding ONLY the pinned
+          # key, so a "good signature" can only mean the AWS CLI key signed it.
+          # Fails closed (no publish) if verification cannot be completed.
+          GNUPGHOME="$(mktemp -d)"; export GNUPGHOME
+          gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$AWSCLI_PGP_FPR" \
+            || gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$AWSCLI_PGP_FPR"
+          gpg --batch --verify /tmp/awscliv2.zip.sig /tmp/awscliv2.zip
           unzip -q /tmp/awscliv2.zip -d /tmp
           (sudo /tmp/aws/install --update || /tmp/aws/install --update --bin-dir "$HOME/.local/bin" --install-dir "$HOME/.local/aws-cli")
           export PATH="$HOME/.local/bin:$PATH"
@@ -49,14 +74,22 @@ runs:
         AWS_ACCESS_KEY_ID: ${{ inputs.aws_access_key_id }}
         AWS_SECRET_ACCESS_KEY: ${{ inputs.aws_secret_access_key }}
         AWS_DEFAULT_REGION: ${{ inputs.region }}
+        # Pass values through env (not ${{ }} into the script body) so they are
+        # treated as data, never interpolated as shell syntax (GHA injection).
+        SRC: ${{ inputs.source_path }}
+        BUCKET: ${{ inputs.bucket }}
+        DESTINATION: ${{ inputs.destination }}
+        ENDPOINT: ${{ inputs.endpoint }}
       run: |
+        set -euo pipefail
         export PATH="$HOME/.local/bin:$PATH"
-        src="${{ inputs.source_path }}"
-        dest="s3://${{ inputs.bucket }}/${{ inputs.destination }}"
-        if [ -d "$src" ]; then
-          aws s3 sync "$src" "$dest" \
-            --endpoint-url "${{ inputs.endpoint }}" --no-progress ${{ inputs.args }}
+        dest="s3://${BUCKET}/${DESTINATION}"
+        # NOTE: ${{ inputs.args }} below is the ONE deliberate verbatim interpolation
+        # (flags must word-split); it is documented INTERNAL-USE-ONLY trusted input.
+        if [ -d "$SRC" ]; then
+          aws s3 sync "$SRC" "$dest" \
+            --endpoint-url "$ENDPOINT" --no-progress ${{ inputs.args }}
         else
-          aws s3 cp "$src" "$dest" \
-            --endpoint-url "${{ inputs.endpoint }}" --no-progress ${{ inputs.args }}
+          aws s3 cp "$SRC" "$dest" \
+            --endpoint-url "$ENDPOINT" --no-progress ${{ inputs.args }}
         fi

--- a/.github/workflows/build-nym-vpn-app-windows.yml
+++ b/.github/workflows/build-nym-vpn-app-windows.yml
@@ -224,48 +224,27 @@ jobs:
           echo "core_release_tag: $release_tag"
           "core_release_tag=$release_tag" >> $env:GITHUB_ENV
 
-      - name: Ensure AWS CLI is available
-        if: ${{ !inputs.core_release_tag && !inputs.core_artifact_url && !inputs.core_build_it && (inputs.dev_mode || github.event_name == 'pull_request') }}
-        run: |
-          if (-not (Get-Command aws -ErrorAction SilentlyContinue)) {
-            Invoke-WebRequest -Uri "https://awscli.amazonaws.com/AWSCLIV2.msi" -OutFile "$env:TEMP\AWSCLIV2.msi"
-            Start-Process msiexec.exe -ArgumentList "/i `"$env:TEMP\AWSCLIV2.msi`" /quiet" -Wait
-            # expose the CLI to subsequent steps
-            "$env:ProgramFiles\Amazon\AWSCLIV2" | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
-            $env:Path = "$env:ProgramFiles\Amazon\AWSCLIV2;$env:Path"
-          }
-          aws --version
-
       - name: Get nym-vpn-core artifact url (latest dev)
         if: ${{ !inputs.core_release_tag && !inputs.core_artifact_url && !inputs.core_build_it && (inputs.dev_mode || github.event_name == 'pull_request') }}
         id: get_dev_url
-        env:
-          # listing uses the S3 API (creds available via secrets: inherit / direct triggers);
-          # the actual download below still goes through the web vhost (VPN_CORE_BUILDS_URL)
-          AWS_ACCESS_KEY_ID: ${{ secrets.GARAGE_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.GARAGE_AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: garage
-          S3_ENDPOINT: https://s3.nymte.ch
-          S3_PREFIX: nym-vpn-client/nym-vpn-core/develop/
         run: |
           $arch = "${{ inputs.cpu_arch == 'ARM64' && 'aarch64' || 'x86_64' }}"
+          $base = "${{ env.VPN_CORE_BUILDS_URL }}/develop"
 
-          # 1) newest build folder (timestamps are zero-padded YYYYMMDDhhmm, so lexical == chronological)
-          $latest = aws s3 ls "s3://builds/$env:S3_PREFIX" --endpoint-url $env:S3_ENDPOINT |
-            Select-String -Pattern 'PRE (\d+)/' | ForEach-Object { $_.Matches.Groups[1].Value } |
-            Sort-Object -Descending | Select-Object -First 1
-          if (-not $latest) { Write-Error "No dev builds found under s3://builds/$env:S3_PREFIX"; exit 1 }
+          # Discover the latest dev build from the published manifest — the same
+          # contract the Linux installer uses (see publish-nym-vpn-core.yml).
+          # Served over the web vhost, so no bucket listing or S3 credentials.
+          $manifest = Invoke-RestMethod -Uri "$base/latest.json"
+          $ts = $manifest.timestamp
+          if (-not $ts) { Write-Error "latest.json has no timestamp at $base/latest.json"; exit 1 }
 
-          # 2) the matching windows artifact inside that folder
-          $artifact = aws s3 ls "s3://builds/$env:S3_PREFIX$latest/" --endpoint-url $env:S3_ENDPOINT |
-            ForEach-Object { ($_ -split '\s+')[-1] } |
-            Where-Object { $_ -match "nym-vpn-core-v.+_windows_$arch\.zip$" } |
+          $artifact = $manifest.files |
+            Where-Object { $_ -match "^nym-vpn-core-v.+_windows_$arch\.zip$" } |
             Select-Object -First 1
-          if (-not $artifact) { Write-Error "Could not find a matching nym-vpn-core artifact in s3://builds/$env:S3_PREFIX$latest/"; exit 1 }
+          if (-not $artifact) { Write-Error "no windows $arch artifact in manifest for build $ts"; exit 1 }
 
-          # 3) download via the web-access vhost (unchanged consumer at the curl step below)
-          "latest_dev_path=/develop/$latest" >> $env:GITHUB_OUTPUT
-          $artifact_url = "${{ env.VPN_CORE_BUILDS_URL }}/develop/$latest/$artifact"
+          "latest_dev_path=/develop/$ts" >> $env:GITHUB_OUTPUT
+          $artifact_url = "$base/$ts/$artifact"
           Write-Output $artifact_url
           "core_asset_url=$artifact_url" >> $env:GITHUB_ENV
 

--- a/.github/workflows/build-nym-vpn-app-windows.yml
+++ b/.github/workflows/build-nym-vpn-app-windows.yml
@@ -133,7 +133,7 @@ jobs:
     needs: [build-core]
     if: ${{ always() && !failure() && !cancelled() }}
     env:
-      VPN_CORE_BUILDS_URL: https://${{ secrets.CI_WWW_REMOTE_HOST }}/nym-vpn-client/nym-vpn-core
+      VPN_CORE_BUILDS_URL: https://builds.cdn.nymte.ch/nym-vpn-client/nym-vpn-core
       UPDATER_URL_STABLE: https://raw.githubusercontent.com/nymtech/nym-vpn-client/refs/heads/develop/.pkg/tauri-updater/stable.json
       UPDATER_URL_DEV: https://raw.githubusercontent.com/nymtech/nym-vpn-client/refs/heads/develop/.pkg/tauri-updater/dev.json
     outputs:
@@ -224,19 +224,49 @@ jobs:
           echo "core_release_tag: $release_tag"
           "core_release_tag=$release_tag" >> $env:GITHUB_ENV
 
+      - name: Ensure AWS CLI is available
+        if: ${{ !inputs.core_release_tag && !inputs.core_artifact_url && !inputs.core_build_it && (inputs.dev_mode || github.event_name == 'pull_request') }}
+        run: |
+          if (-not (Get-Command aws -ErrorAction SilentlyContinue)) {
+            Invoke-WebRequest -Uri "https://awscli.amazonaws.com/AWSCLIV2.msi" -OutFile "$env:TEMP\AWSCLIV2.msi"
+            Start-Process msiexec.exe -ArgumentList "/i `"$env:TEMP\AWSCLIV2.msi`" /quiet" -Wait
+            # expose the CLI to subsequent steps
+            "$env:ProgramFiles\Amazon\AWSCLIV2" | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+            $env:Path = "$env:ProgramFiles\Amazon\AWSCLIV2;$env:Path"
+          }
+          aws --version
+
       - name: Get nym-vpn-core artifact url (latest dev)
         if: ${{ !inputs.core_release_tag && !inputs.core_artifact_url && !inputs.core_build_it && (inputs.dev_mode || github.event_name == 'pull_request') }}
         id: get_dev_url
+        env:
+          # listing uses the S3 API (creds available via secrets: inherit / direct triggers);
+          # the actual download below still goes through the web vhost (VPN_CORE_BUILDS_URL)
+          AWS_ACCESS_KEY_ID: ${{ secrets.GARAGE_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.GARAGE_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: garage
+          S3_ENDPOINT: https://s3.nymte.ch
+          S3_PREFIX: nym-vpn-client/nym-vpn-core/develop/
         run: |
-          $latest = Invoke-WebRequest -Uri "${{ env.VPN_CORE_BUILDS_URL }}/develop" | Select-String -Pattern '<a href="(\d+)/"' -AllMatches | ForEach-Object {$_.Matches} | ForEach-Object {$_.Groups[1].Value} | Sort-Object -Descending | Select-Object -First 1
-          Write-Output "/develop/$latest"
-          "latest_dev_path=/develop/$latest" >> $env:GITHUB_OUTPUT
-          $latest_url = "${{ env.VPN_CORE_BUILDS_URL }}/develop/$latest"
           $arch = "${{ inputs.cpu_arch == 'ARM64' && 'aarch64' || 'x86_64' }}"
-          $artifact = Invoke-WebRequest -Uri "$latest_url" | Select-String -Pattern "<a href=""(nym-vpn-core-v.+_windows_$arch\.zip)""" -AllMatches | ForEach-Object {$_.Matches.Groups[1].Value} | Select-Object -First 1
-          if (-not $artifact) { Write-Error "Could not find a matching nym-vpn-core artifact at $latest_url"; exit 1 }
-          $artifact_url = "$latest_url/$artifact"
-          Write-Output "$artifact_url"
+
+          # 1) newest build folder (timestamps are zero-padded YYYYMMDDhhmm, so lexical == chronological)
+          $latest = aws s3 ls "s3://builds/$env:S3_PREFIX" --endpoint-url $env:S3_ENDPOINT |
+            Select-String -Pattern 'PRE (\d+)/' | ForEach-Object { $_.Matches.Groups[1].Value } |
+            Sort-Object -Descending | Select-Object -First 1
+          if (-not $latest) { Write-Error "No dev builds found under s3://builds/$env:S3_PREFIX"; exit 1 }
+
+          # 2) the matching windows artifact inside that folder
+          $artifact = aws s3 ls "s3://builds/$env:S3_PREFIX$latest/" --endpoint-url $env:S3_ENDPOINT |
+            ForEach-Object { ($_ -split '\s+')[-1] } |
+            Where-Object { $_ -match "nym-vpn-core-v.+_windows_$arch\.zip$" } |
+            Select-Object -First 1
+          if (-not $artifact) { Write-Error "Could not find a matching nym-vpn-core artifact in s3://builds/$env:S3_PREFIX$latest/"; exit 1 }
+
+          # 3) download via the web-access vhost (unchanged consumer at the curl step below)
+          "latest_dev_path=/develop/$latest" >> $env:GITHUB_OUTPUT
+          $artifact_url = "${{ env.VPN_CORE_BUILDS_URL }}/develop/$latest/$artifact"
+          Write-Output $artifact_url
           "core_asset_url=$artifact_url" >> $env:GITHUB_ENV
 
       - name: Get nym-vpn-core artifact url (${{ env.core_release_tag }})

--- a/.github/workflows/build-nym-vpn-apple.yml
+++ b/.github/workflows/build-nym-vpn-apple.yml
@@ -46,6 +46,8 @@ env:
   CARGO_TERM_COLOR: always
   UPLOAD_DIR_IOS: ios_artifacts
   RAW_RELEASE_TYPE: ${{ (github.event_name == 'pull_request' && 'pr') || inputs.release_type || 'pr' }}
+  S3_ENDPOINT: https://s3.nymte.ch     # API endpoint for uploads
+  S3_BUCKET: builds
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -1277,26 +1279,28 @@ jobs:
           if [[ "${RELEASE_TYPE}" == "qa" ]]; then
             UPLOAD_SOURCE="${renamed_pkg_relative_path}"
             echo "UPLOAD_SOURCE=${UPLOAD_SOURCE}" >> "$GITHUB_ENV"
+            # single PKG file -> bucket key nym-vpn-client/macOS/<pkg>
+            echo "UPLOAD_DEST=nym-vpn-client/macOS/" >> "$GITHUB_ENV"
             echo "🌐 QA: will upload PKG only → ${UPLOAD_SOURCE}"
           else
             UPLOAD_SOURCE="${publish_relative_path}"
             echo "UPLOAD_SOURCE=${UPLOAD_SOURCE}" >> "$GITHUB_ENV"
+            # contents of the publish/ dir -> bucket keys under nym-vpn-client/macOS/publish/
+            # (preserves the .../publish/NymVPN-<ver>.pkg download URL used in the appcast)
+            echo "UPLOAD_DEST=nym-vpn-client/macOS/publish/" >> "$GITHUB_ENV"
             echo "🌐 Ship: will upload PKG + appcast.xml + sha256-hash.txt → ${UPLOAD_SOURCE}"
           fi
 
-      - name: Upload to www
+      - name: Publish build to S3
         if: ${{ (env.RELEASE_TYPE == 'qa' || env.RELEASE_TYPE == 'ship') && env.BUILD_MACOS == 'true' }}
-        uses: easingthemes/ssh-deploy@main
+        uses: ./.github/actions/push-to-s3
         with:
-          REMOTE_PORT: 22
-          ARGS: -avzr
-          SSH_CMD_ARGS: -o StrictHostKeyChecking=no
-        env:
-          SSH_PRIVATE_KEY: ${{ secrets.CI_WWW_SSH_PRIVATE_KEY }}
-          REMOTE_HOST: ${{ secrets.CI_WWW_REMOTE_HOST }}
-          REMOTE_USER: ${{ secrets.CI_WWW_REMOTE_USER }}
-          TARGET: ${{ secrets.CI_WWW_REMOTE_TARGET }}/builds/nym-vpn-client/macOS/
-          SOURCE: ${{ env.UPLOAD_SOURCE }}
+          source_path: ${{ env.UPLOAD_SOURCE }}
+          destination: ${{ env.UPLOAD_DEST }}
+          endpoint: ${{ env.S3_ENDPOINT }}
+          bucket: ${{ env.S3_BUCKET }}
+          aws_access_key_id: ${{ secrets.GARAGE_AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.GARAGE_AWS_SECRET_ACCESS_KEY }}
 
       - name: Checkout nym-websites
         if: ${{ env.RELEASE_TYPE == 'ship' && env.BUILD_MACOS == 'true' }}

--- a/.github/workflows/build-nym-vpnc-macos.yml
+++ b/.github/workflows/build-nym-vpnc-macos.yml
@@ -16,6 +16,8 @@ env:
   BINARY_NAME: nym-vpnc
   PKG_IDENTIFIER: net.nymtech.vpnc
   PKG_INSTALL_LOCATION: /usr/local/bin
+  S3_ENDPOINT: https://s3.nymte.ch     # API endpoint for uploads
+  S3_BUCKET: builds
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -346,18 +348,15 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-      - name: Upload to www
-        uses: easingthemes/ssh-deploy@main
+      - name: Publish PKG to S3
+        uses: ./.github/actions/push-to-s3
         with:
-          REMOTE_PORT: 22
-          ARGS: -avzr
-          SSH_CMD_ARGS: -o StrictHostKeyChecking=no
-        env:
-          SSH_PRIVATE_KEY: ${{ secrets.CI_WWW_SSH_PRIVATE_KEY }}
-          REMOTE_HOST: ${{ secrets.CI_WWW_REMOTE_HOST }}
-          REMOTE_USER: ${{ secrets.CI_WWW_REMOTE_USER }}
-          TARGET: ${{ secrets.CI_WWW_REMOTE_TARGET }}/builds/nym-vpn-client/macOS/vpnc/
-          SOURCE: ${{ env.renamed_pkg_relative_path }}
+          source_path: ${{ env.renamed_pkg_relative_path }}
+          destination: nym-vpn-client/macOS/vpnc/
+          endpoint: ${{ env.S3_ENDPOINT }}
+          bucket: ${{ env.S3_BUCKET }}
+          aws_access_key_id: ${{ secrets.GARAGE_AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.GARAGE_AWS_SECRET_ACCESS_KEY }}
 
       - name: Publish GitHub Release
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.release == true }}

--- a/.github/workflows/publish-nym-vpn-app.yml
+++ b/.github/workflows/publish-nym-vpn-app.yml
@@ -221,6 +221,35 @@ jobs:
           cp -v ${{ env.UPLOAD_DIR_DEB_X86_64 }}/*.{deb,sha256sum} ${{ env.OUTPUT_DIR }}
           cp -v ${{ env.UPLOAD_DIR_DEB_AARCH64 }}/*.{deb,sha256sum} ${{ env.OUTPUT_DIR }}
 
+      # Garage's web vhost serves no directory listings, so this producer must
+      # emit the same discovery contract consumers expect (latest.json pointer +
+      # per-build manifest.json). Canonical implementation: publish-nym-vpn-core.yml
+      # "Generate build manifest" — keep these two in sync. This (rc) job ships
+      # only the linux core + debs, so the required-artifact set is smaller (no
+      # windows/android). Shape: { "timestamp": "<YYYYMMDDhhmm>", "files": [...] }.
+      - name: Generate build manifest
+        shell: bash
+        run: |
+          set -euo pipefail
+          TIMESTAMP="$(basename "${{ env.OUTPUT_DIR }}")"
+          BRANCH_DIR="$(dirname "${{ env.OUTPUT_DIR }}")"
+          MANIFEST="${{ env.OUTPUT_DIR }}/manifest.json"
+
+          manifest_json="$(cd "${{ env.OUTPUT_DIR }}" && ls -1 | sort | jq -R . \
+            | jq -s --arg ts "$TIMESTAMP" '{timestamp: $ts, files: .}')"
+          printf '%s\n' "$manifest_json" > "$MANIFEST"
+
+          # validate + sanity-check the consumer-facing artifacts this job publishes
+          jq empty "$MANIFEST"
+          for must in _linux_x86_64.tar.gz _linux_aarch64.tar.gz _amd64.deb _arm64.deb; do
+            jq -e --arg s "$must" '[.files[] | select(endswith($s))] | length > 0' "$MANIFEST" >/dev/null \
+              || { echo "manifest missing expected artifact *$must" >&2; exit 1; }
+          done
+
+          cp "$MANIFEST" "${BRANCH_DIR}/latest.json"
+          echo "---- manifest ----"
+          cat "$MANIFEST"
+
       - name: Publish build to S3
         uses: ./.github/actions/push-to-s3
         with:
@@ -506,7 +535,10 @@ jobs:
               url="${{ env.NYM_BUILDS_URL }}${{ env.core_build_url_path }}/"
             else
               branch="${BRANCH_NAME//[^a-zA-Z0-9._\/-]/}"
-              latest=$(curl -sSL "${{ env.NYM_BUILDS_URL }}/$branch/" | grep -oP '(?<=href=")\d+(?=/)' | sort -rn | head -1)
+              # Garage's web vhost serves no directory listing — resolve the latest
+              # build from the published latest.json pointer (same contract the
+              # Linux installer uses), not by scraping an HTML index.
+              latest=$(curl -sSL "${{ env.NYM_BUILDS_URL }}/$branch/latest.json" | grep -oP '"timestamp"\s*:\s*"\K[0-9]+')
               if [[ -n "$latest" ]]; then
                 url="${{ env.NYM_BUILDS_URL }}/$branch/$latest/"
               else

--- a/.github/workflows/publish-nym-vpn-app.yml
+++ b/.github/workflows/publish-nym-vpn-app.yml
@@ -34,6 +34,10 @@ permissions:
   contents: read
   packages: read
 
+env:
+  S3_ENDPOINT: https://s3.nymte.ch     # API endpoint for uploads
+  S3_BUCKET: builds
+
 jobs:
   download-translations:
     runs-on: arc-linux-latest
@@ -217,15 +221,15 @@ jobs:
           cp -v ${{ env.UPLOAD_DIR_DEB_X86_64 }}/*.{deb,sha256sum} ${{ env.OUTPUT_DIR }}
           cp -v ${{ env.UPLOAD_DIR_DEB_AARCH64 }}/*.{deb,sha256sum} ${{ env.OUTPUT_DIR }}
 
-      - name: Upload to www
-        uses: easingthemes/ssh-deploy@main
-        env:
-          SSH_PRIVATE_KEY: ${{ secrets.CI_WWW_SSH_PRIVATE_KEY }}
-          ARGS: "-avzr"
-          SOURCE: "ci-builds/"
-          REMOTE_HOST: ${{ secrets.CI_WWW_REMOTE_HOST }}
-          REMOTE_USER: ${{ secrets.CI_WWW_REMOTE_USER }}
-          TARGET: ${{ secrets.CI_WWW_REMOTE_TARGET }}/builds/nym-vpn-client/nym-vpn-core
+      - name: Publish build to S3
+        uses: ./.github/actions/push-to-s3
+        with:
+          source_path: ci-builds/
+          destination: nym-vpn-client/nym-vpn-core/
+          endpoint: ${{ env.S3_ENDPOINT }}
+          bucket: ${{ env.S3_BUCKET }}
+          aws_access_key_id: ${{ secrets.GARAGE_AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.GARAGE_AWS_SECRET_ACCESS_KEY }}
 
   generate-build-info-nym-vpn-app:
     uses: ./.github/workflows/generate-build-info-nym-vpn-app.yml
@@ -487,7 +491,7 @@ jobs:
 
       - name: Set vpn-core link
         env:
-          NYM_BUILDS_URL: "https://${{ secrets.CI_WWW_REMOTE_HOST }}/nym-vpn-client/nym-vpn-core"
+          NYM_BUILDS_URL: "https://builds.cdn.nymte.ch/nym-vpn-client/nym-vpn-core"
           core_build_url_path: "${{ needs.publish-core.outputs.core_build_url_path || needs.publish.outputs.core_build_url_path }}"
           BRANCH_NAME: ${{ github.ref_name }}
         run: |

--- a/.github/workflows/publish-nym-vpn-core.yml
+++ b/.github/workflows/publish-nym-vpn-core.yml
@@ -288,25 +288,38 @@ jobs:
       # Garage's web vhost does not generate directory listings, so consumers
       # cannot scrape the bucket to discover the latest build. Publish a manifest
       # instead: manifest.json inside the build dir + a branch-root latest.json
-      # pointer (same content). Both are uploaded by the sync step below.
+      # pointer (same content). Both are uploaded by the sync step below and are
+      # the single discovery contract for all consumers (Linux installer, Windows
+      # CI). Shape: { "timestamp": "<YYYYMMDDhhmm>", "files": ["<name>", ...] }.
       - name: Generate build manifest
         shell: bash
         run: |
+          set -euo pipefail
           TIMESTAMP="$(basename "${{ env.OUTPUT_DIR }}")"
           BRANCH_DIR="$(dirname "${{ env.OUTPUT_DIR }}")"
-          files_json="$(cd "${{ env.OUTPUT_DIR }}" && ls -1 | sort \
-            | awk '{ printf "%s    \"%s\"", (NR==1 ? "" : ",\n"), $0 }')"
-          cat > "${{ env.OUTPUT_DIR }}/manifest.json" <<EOF
-          {
-            "timestamp": "${TIMESTAMP}",
-            "files": [
-          ${files_json}
-            ]
-          }
-          EOF
-          cp "${{ env.OUTPUT_DIR }}/manifest.json" "${BRANCH_DIR}/latest.json"
+          MANIFEST="${{ env.OUTPUT_DIR }}/manifest.json"
+
+          # build valid JSON with jq (no hand-rolled string assembly). Capture via
+          # command substitution first, so the listing runs before MANIFEST is
+          # created and never lists itself.
+          manifest_json="$(cd "${{ env.OUTPUT_DIR }}" && ls -1 | sort | jq -R . \
+            | jq -s --arg ts "$TIMESTAMP" '{timestamp: $ts, files: .}')"
+          printf '%s\n' "$manifest_json" > "$MANIFEST"
+
+          # validate + sanity-check the consumer-facing artifacts before publishing
+          # (Linux installer: *_linux_<arch>.tar.gz + nym-vpnd_*_<deb_arch>.deb;
+          #  Windows CI: *_windows_<arch>.zip)
+          jq empty "$MANIFEST"
+          for must in _linux_x86_64.tar.gz _linux_aarch64.tar.gz \
+                      _windows_x86_64.zip _windows_aarch64.zip \
+                      _amd64.deb _arm64.deb; do
+            jq -e --arg s "$must" '[.files[] | select(endswith($s))] | length > 0' "$MANIFEST" >/dev/null \
+              || { echo "manifest missing expected artifact *$must" >&2; exit 1; }
+          done
+
+          cp "$MANIFEST" "${BRANCH_DIR}/latest.json"
           echo "---- manifest ----"
-          cat "${{ env.OUTPUT_DIR }}/manifest.json"
+          cat "$MANIFEST"
 
       - name: Publish build to S3
         uses: ./.github/actions/push-to-s3

--- a/.github/workflows/publish-nym-vpn-core.yml
+++ b/.github/workflows/publish-nym-vpn-core.yml
@@ -20,6 +20,8 @@ env:
   UPLOAD_DIR_WINDOWS_X64: windows_core_artifacts_x64
   UPLOAD_DIR_WINDOWS_ARM64: windows_core_artifacts_arm64
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  S3_ENDPOINT: https://s3.nymte.ch     # API endpoint for uploads
+  S3_BUCKET: builds
 
 jobs:
   # Builds both the Linux core binaries and the .deb packages in a single job
@@ -283,15 +285,38 @@ jobs:
           cp -v ${{ env.UPLOAD_DIR_DEB_X86_64 }}/*.{deb,sha256sum} ${{ env.OUTPUT_DIR }}
           cp -v ${{ env.UPLOAD_DIR_DEB_AARCH64 }}/*.{deb,sha256sum} ${{ env.OUTPUT_DIR }}
 
-      - name: Upload to www
-        uses: easingthemes/ssh-deploy@main
-        env:
-          SSH_PRIVATE_KEY: ${{ secrets.CI_WWW_SSH_PRIVATE_KEY }}
-          ARGS: "-avzr"
-          SOURCE: "ci-builds/"
-          REMOTE_HOST: ${{ secrets.CI_WWW_REMOTE_HOST }}
-          REMOTE_USER: ${{ secrets.CI_WWW_REMOTE_USER }}
-          TARGET: ${{ secrets.CI_WWW_REMOTE_TARGET }}/builds/nym-vpn-client/nym-vpn-core
+      # Garage's web vhost does not generate directory listings, so consumers
+      # cannot scrape the bucket to discover the latest build. Publish a manifest
+      # instead: manifest.json inside the build dir + a branch-root latest.json
+      # pointer (same content). Both are uploaded by the sync step below.
+      - name: Generate build manifest
+        shell: bash
+        run: |
+          TIMESTAMP="$(basename "${{ env.OUTPUT_DIR }}")"
+          BRANCH_DIR="$(dirname "${{ env.OUTPUT_DIR }}")"
+          files_json="$(cd "${{ env.OUTPUT_DIR }}" && ls -1 | sort \
+            | awk '{ printf "%s    \"%s\"", (NR==1 ? "" : ",\n"), $0 }')"
+          cat > "${{ env.OUTPUT_DIR }}/manifest.json" <<EOF
+          {
+            "timestamp": "${TIMESTAMP}",
+            "files": [
+          ${files_json}
+            ]
+          }
+          EOF
+          cp "${{ env.OUTPUT_DIR }}/manifest.json" "${BRANCH_DIR}/latest.json"
+          echo "---- manifest ----"
+          cat "${{ env.OUTPUT_DIR }}/manifest.json"
+
+      - name: Publish build to S3
+        uses: ./.github/actions/push-to-s3
+        with:
+          source_path: ci-builds/
+          destination: nym-vpn-client/nym-vpn-core/
+          endpoint: ${{ env.S3_ENDPOINT }}
+          bucket: ${{ env.S3_BUCKET }}
+          aws_access_key_id: ${{ secrets.GARAGE_AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.GARAGE_AWS_SECRET_ACCESS_KEY }}
 
   gen-hashes:
     needs: publish

--- a/.pkg/linux/install
+++ b/.pkg/linux/install
@@ -213,35 +213,44 @@ app_dev_setup() {
 }
 
 get_core_dev() {
-  core_archive=$(curl -s "$1" |
-    grep -oP "(?<=^<a href=\")nym-vpn-core-v.+_linux_${arch}\.tar\.gz(?=\">)")
-  vpnd_raw_url="$1$core_archive"
+  # $1 = build manifest (json), $2 = build url
+  core_archive=$(printf '%s' "$1" |
+    grep -oP "nym-vpn-core-v[^\"]+_linux_${arch}\.tar\.gz" |
+    head -n 1)
+  vpnd_raw_url="$2$core_archive"
   ver="${core_archive#nym-vpn-core-v}"
   vpnd_version="${ver%_linux_${arch}.tar.gz}"
 }
 
 get_vpnd_dev_deb() {
-  vpnd_deb=$(curl -s "$1" |
-    grep -oP "(?<=^<a href=\")nym-vpnd_.+_${deb_arch}\.deb(?=\">)")
+  # $1 = build manifest (json), $2 = build url
+  vpnd_deb=$(printf '%s' "$1" |
+    grep -oP "nym-vpnd_[^\"]+_${deb_arch}\.deb" |
+    head -n 1)
   ver="${vpnd_deb#nym-vpnd_}"
   vpnd_deb_ver="${ver%_${deb_arch}.deb}"
-  vpnd_deb_url="$1$vpnd_deb"
+  vpnd_deb_url="$2$vpnd_deb"
 }
 
 vpnd_dev_setup() {
+  # Garage's web vhost serves no directory listing, so we read the published
+  # manifest (see publish-nym-vpn-core.yml) instead of scraping the build dir.
   if [ "$CORE_BUILD" = 0 ]; then
-    core_build_url=https://builds.ci.nymte.ch/nym-vpn-client/nym-vpn-core/develop/
-    latest=$(curl -s $core_build_url |
-      grep -oP '(?<=<a href=")\d+/' |
-      sort -r |
-      head -n 1)
-    build_url="$core_build_url$latest"
+    core_build_base=https://builds.cdn.nymte.ch/nym-vpn-client/nym-vpn-core/develop
+    manifest=$(curl -s "$core_build_base/latest.json")
+    latest=$(printf '%s' "$manifest" | grep -oP '"timestamp"\s*:\s*"\K[0-9]+')
+    if [ -z "$latest" ]; then
+      echo "failed to resolve latest dev build from $core_build_base/latest.json" >&2
+      exit 1
+    fi
+    build_url="$core_build_base/$latest/"
   else
     build_url="$CORE_BUILD/"
+    manifest=$(curl -s "${build_url}manifest.json")
   fi
 
-  get_core_dev "$build_url"
-  get_vpnd_dev_deb "$build_url"
+  get_core_dev "$manifest" "$build_url"
+  get_vpnd_dev_deb "$manifest" "$build_url"
 }
 
 dev_setup() {

--- a/nym-vpn-apple/Scripts/FetchCore.sh
+++ b/nym-vpn-apple/Scripts/FetchCore.sh
@@ -121,16 +121,19 @@ TAG="$(determine_tag)"
 echo "Using build tag: ${TAG}"
 
 TAG_URL="${BASE_URL}/${TAG}"
-echo "Fetching folder listing from: ${TAG_URL}"
 
 # -----------------------------------------------------------------------------
 # 1) Find latest timestamp folder
+#    Garage's web vhost serves no directory listing, so resolve the latest build
+#    from the published latest.json pointer (see publish-nym-vpn-core.yml) instead
+#    of scraping an HTML index.
 # -----------------------------------------------------------------------------
-folder_listing="$(curl -Ls "$TAG_URL")"
-latest_folder="$(echo "$folder_listing" | grep -Eo '[0-9]{12}/' | tr -d '/' | sort | tail -n 1)"
+echo "Resolving latest build from: ${TAG_URL}/latest.json"
+manifest="$(curl -fLs "${TAG_URL}/latest.json")"
+latest_folder="$(echo "$manifest" | grep -oP '"timestamp"\s*:\s*"\K[0-9]+')"
 
 if [[ -z "${latest_folder}" ]]; then
-  echo "❌ Error: Could not determine the latest timestamp folder from ${TAG_URL}"
+  echo "❌ Error: Could not resolve the latest build from ${TAG_URL}/latest.json"
   exit 1
 fi
 
@@ -138,20 +141,15 @@ echo "Latest timestamp folder: ${latest_folder}"
 RELEASE_URL="${TAG_URL}/${latest_folder}"
 
 # -----------------------------------------------------------------------------
-# 2) Extract the shared version slug from the release page (works for iOS/macOS)
+# 2) Extract the shared version slug from the manifest (works for iOS/macOS)
+#    latest.json mirrors the latest build's manifest.json; the version slug is
+#    shared across every platform artifact, so lift it from any nym-vpn-core-v*
+#    entry. Matches both dev/beta (with timestamp) and plain release builds.
 # -----------------------------------------------------------------------------
-echo "Fetching release page content from: ${RELEASE_URL}"
-release_page_content="$(curl -Ls "$RELEASE_URL")"
-if [[ -z "$release_page_content" ]]; then
-  echo "❌ Error: Release page content is empty at ${RELEASE_URL}"
-  exit 1
-fi
-
-# Matches both dev/beta with timestamp and plain release without pre-release suffix
-shared_slug="$(echo "$release_page_content" | grep -Eo 'nym-vpn-core-v[0-9]+\.[0-9]+\.[0-9]+(-(dev|beta)\.[0-9]{12})?' | head -n 1)"
+shared_slug="$(echo "$manifest" | grep -Eo 'nym-vpn-core-v[0-9]+\.[0-9]+\.[0-9]+(-(dev|beta)\.[0-9]{12})?' | head -n 1)"
 
 if [[ -z "$shared_slug" ]]; then
-  echo "❌ Error: Could not extract shared version slug from release page."
+  echo "❌ Error: Could not extract shared version slug from ${TAG_URL}/latest.json"
   exit 1
 fi
 
@@ -184,6 +182,7 @@ fi
 # -----------------------------------------------------------------------------
 export FETCHCORE_TAG="$TAG"
 export FETCHCORE_FOLDER="$latest_folder"
+export FETCHCORE_SLUG="$shared_slug"
 
 # -----------------------------------------------------------------------------
 # 5) Run platform scripts (use bash explicitly)

--- a/nym-vpn-apple/Scripts/FetchCore.sh
+++ b/nym-vpn-apple/Scripts/FetchCore.sh
@@ -20,7 +20,7 @@ error_handler() {
 }
 trap 'error_handler $LINENO' ERR
 
-BASE_URL="https://builds.ci.nymte.ch/nym-vpn-client/nym-vpn-core"
+BASE_URL="https://builds.cdn.nymte.ch/nym-vpn-client/nym-vpn-core"
 MAX_DISTANCE=100
 
 # -----------------------------------------------------------------------------

--- a/nym-vpn-apple/Scripts/FetchIOSCore.sh
+++ b/nym-vpn-apple/Scripts/FetchIOSCore.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Updates the iOS core using nightly/release builds.
-# Source: https://builds.ci.nymte.ch/nym-vpn-client/nym-vpn-core/
+# Source: https://builds.cdn.nymte.ch/nym-vpn-client/nym-vpn-core/
 #
 # Must be run from nym-vpn-apple/Scripts.
 
@@ -14,7 +14,7 @@ error_handler() {
 }
 trap 'error_handler $LINENO' ERR
 
-BASE_URL="https://builds.ci.nymte.ch/nym-vpn-client/nym-vpn-core"
+BASE_URL="https://builds.cdn.nymte.ch/nym-vpn-client/nym-vpn-core"
 
 # -----------------------------------------------------------------------------
 # 0) Determine build tag (default from git branch)

--- a/nym-vpn-apple/Scripts/FetchIOSCore.sh
+++ b/nym-vpn-apple/Scripts/FetchIOSCore.sh
@@ -38,27 +38,19 @@ fi
 
 TAG_URL="${BASE_URL}/${TAG}"
 
-# Choose the iOS asset pattern after TAG is finalized
-if [[ "$TAG" =~ ^release/ ]]; then
-  # release builds may omit -dev/-beta timestamp
-  ios_pattern='nym-vpn-core-v[0-9]+\.[0-9]+\.[0-9]+(-(?:dev|beta)\.[0-9]{12})?_ios_universal\.zip'
-else
-  # nightly/dev builds include -dev/-beta + 12-digit timestamp
-  ios_pattern='nym-vpn-core-v[0-9]+\.[0-9]+\.[0-9]+-(?:dev|beta)\.[0-9]{12}_ios_universal\.zip'
-fi
-
 echo "Using build tag: ${TAG}"
 echo "Base folder: ${TAG_URL}"
 
 # -----------------------------------------------------------------------------
 # 1) Find latest timestamp folder (unless orchestrator provided it)
+#    Garage's web vhost serves no directory listing; resolve via latest.json.
 # -----------------------------------------------------------------------------
 if [[ "$OVERRIDDEN" != "1" ]]; then
-  echo "Fetching folder listing from: ${TAG_URL}"
-  folder_listing="$(curl -Ls "$TAG_URL")"
-  latest_folder="$(echo "$folder_listing" | grep -Eo '[0-9]{12}/' | tr -d '/' | sort | tail -n 1)"
+  echo "Resolving latest build from: ${TAG_URL}/latest.json"
+  manifest="$(curl -fLs "${TAG_URL}/latest.json")"
+  latest_folder="$(echo "$manifest" | grep -oP '"timestamp"\s*:\s*"\K[0-9]+')"
   if [[ -z "${latest_folder}" ]]; then
-    echo "❌ Error: Could not determine the latest timestamp folder from ${TAG_URL}"
+    echo "❌ Error: Could not resolve the latest build from ${TAG_URL}/latest.json"
     exit 1
   fi
 fi
@@ -67,22 +59,22 @@ echo "Latest timestamp folder: ${latest_folder}"
 RELEASE_URL="${TAG_URL}/${latest_folder}"
 
 # -----------------------------------------------------------------------------
-# 2) Discover iOS asset, download, extract
+# 2) Resolve the iOS asset, download, extract
+#    No directory listing on Garage: the iOS asset is co-located in the build
+#    dir and named "<shared_slug>_ios_universal.zip". Use the slug exported by
+#    FetchCore.sh, or lift it from this build's manifest when running standalone.
 # -----------------------------------------------------------------------------
-echo "Fetching release page content from: ${RELEASE_URL}"
-release_page_content="$(curl -Ls "$RELEASE_URL")"
-if [[ -z "$release_page_content" ]]; then
-  echo "❌ Error: Release page content is empty at ${RELEASE_URL}"
+if [[ -n "${FETCHCORE_SLUG:-}" ]]; then
+  shared_slug="${FETCHCORE_SLUG}"
+else
+  shared_slug="$(echo "${manifest:-}" | grep -Eo 'nym-vpn-core-v[0-9]+\.[0-9]+\.[0-9]+(-(?:dev|beta)\.[0-9]{12})?' | head -n 1)"
+fi
+if [[ -z "$shared_slug" ]]; then
+  echo "❌ Error: Could not determine the build version slug (set FETCHCORE_SLUG or ensure ${RELEASE_URL}/manifest.json is reachable)."
   exit 1
 fi
 
-ios_asset="$(echo "$release_page_content" | grep -Eo "$ios_pattern" | head -n 1)"
-if [[ -z "$ios_asset" ]]; then
-  echo "❌ Error: Could not find iOS asset filename in the release page."
-  echo "Pattern used: $ios_pattern"
-  exit 1
-fi
-
+ios_asset="${shared_slug}_ios_universal.zip"
 IOS_ASSET_URL="${RELEASE_URL}/${ios_asset}"
 ios_zip_name="$(basename "$IOS_ASSET_URL")"
 

--- a/nym-vpn-apple/Scripts/TO BE REMOVED/UpdateCoreNightly.sh
+++ b/nym-vpn-apple/Scripts/TO BE REMOVED/UpdateCoreNightly.sh
@@ -2,7 +2,7 @@
 
 # Updates the lib and daemon in the iOS+macOS project using nightly builds.
 # This script now uses the builds available at:
-# https://builds.ci.nymte.ch/nym-vpn-client/nym-vpn-core/
+# https://builds.cdn.nymte.ch/nym-vpn-client/nym-vpn-core/
 #
 # If no tag is provided as an argument, it defaults to using the 'develop' folder.
 # If a tag is provided, it uses the release folder with that tag.
@@ -28,7 +28,7 @@ trap 'error_handler $LINENO' ERR
 # -----------------------------------------------------------------------------
 # 0. Determine the build tag and the latest timestamp folder to use.
 # -----------------------------------------------------------------------------
-BASE_URL="https://builds.ci.nymte.ch/nym-vpn-client/nym-vpn-core"
+BASE_URL="https://builds.cdn.nymte.ch/nym-vpn-client/nym-vpn-core"
 if [[ $# -eq 0 ]]; then
     TAG="develop"
     TAG_URL="${BASE_URL}/${TAG}"


### PR DESCRIPTION
Replace easingthemes/ssh-deploy with a push-to-s3 composite action (aws s3 sync/cp to s3.nymte.ch), and repoint all downloads at the builds.cdn.nymte.ch web vhost.

Since Garage's web vhost serves no directory listing, replace the "latest build" discovery: the Windows workflow lists via the S3 API, and publish-nym-vpn-core now emits latest.json/manifest.json that the Linux installer reads instead of scraping HTML.

## Ticket

JIRA-NYM-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5608)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a composite GitHub action to upload build artifacts to an S3-compatible bucket, supporting sync/copy for files vs folders and a manifest-driven destination path.
* **Chores**
  * Migrated core and client macOS artifact publishing from SSH-based deployment to S3-compatible storage.
  * Updated build artifact retrieval to use CDN JSON manifests (`latest.json` / `manifest.json`) instead of HTML directory scraping.
  * Standardized core artifact URLs on a unified CDN base across workflows and scripts. 
* **Refactor**
  * Updated Linux install tooling to resolve dev artifacts from manifests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->