### PR TITLE
APPLE: node families follow up

### DIFF
--- a/nym-vpn-apple/Home/Sources/26/AppFeature/AppFeatureView.swift
+++ b/nym-vpn-apple/Home/Sources/26/AppFeature/AppFeatureView.swift
@@ -122,6 +122,27 @@ public struct AppFeatureView: View {
 #endif
         }
         .nymSnackbar(manager: viewModel.snackbarManager)
+        .overlay {
+            if viewModel.isFamilyWarningModalDisplayed {
+                ModalOverlayView(
+                    isDisplayed: $viewModel.isFamilyWarningModalDisplayed,
+                    dismissOnOverlayTap: false,
+                    horizontalPadding: NymSpacing.standard,
+                    maxWidth: NymSpacing.drawerMaxWidth
+                ) {
+                    FamilyWarningModalView(
+                        title: "gatewayIndependence.modal.title".localizedString,
+                        reminderText: "gatewayIndependence.modal.disableReminders".localizedString,
+                        reminderLinkText: "gatewayIndependence.modal.notificationSettingsLink".localizedString,
+                        connectAnywayTitle: "gatewayIndependence.warning.connectAnyway".localizedString,
+                        cancelTitle: "cancel".localizedString,
+                        onConnectAnyway: { viewModel.confirmFamilyWarning() },
+                        onCancel: { viewModel.dismissFamilyWarning() },
+                        onOpenNotificationSettings: { viewModel.openNotificationSettingsFromFamilyWarning() }
+                    )
+                }
+            }
+        }
         .preferredColorScheme(appearance.colorScheme)
         .onAppear { wireOneClickNavigation() }
         .onChange(of: isCredentialImported) { _, newValue in

--- a/nym-vpn-apple/Home/Sources/26/AppFeature/AppFeatureViewModel.swift
+++ b/nym-vpn-apple/Home/Sources/26/AppFeature/AppFeatureViewModel.swift
@@ -9,6 +9,8 @@ import CredentialsManager
 import GatewayManager
 import ImpactGenerator
 import NetworkMonitor
+import Routes
+import Settings
 import TunnelStatus
 #if os(macOS)
 import GRPCManager
@@ -23,6 +25,8 @@ import GRPCManager
     public let oneClick: OneClickViewModel
 
     public var path = NavigationPath()
+
+    var isFamilyWarningModalDisplayed = false
 
     var drawerContent: AppDrawerContent?
     var pendingDrawerContent: AppDrawerContent?
@@ -170,6 +174,10 @@ import GRPCManager
     func handleTunnelStatusChange(from oldStatus: TunnelStatus, to newStatus: TunnelStatus) {
         guard oldStatus != newStatus else { return }
 
+        if newStatus == .disconnecting || newStatus == .disconnected || newStatus == .offline {
+            isFamilyWarningModalDisplayed = false
+        }
+
         if newStatus == .connecting || newStatus == .connected {
             pendingPostDisconnectAccountRefresh?.cancel()
             pendingPostDisconnectAccountRefresh = nil
@@ -202,6 +210,24 @@ import GRPCManager
     }
 }
 
+// MARK: - Family warning modal -
+extension AppFeatureViewModel {
+    func confirmFamilyWarning() {
+        isFamilyWarningModalDisplayed = false
+        oneClick.independenceConsentAgreed()
+    }
+
+    func dismissFamilyWarning() {
+        isFamilyWarningModalDisplayed = false
+    }
+
+    func openNotificationSettingsFromFamilyWarning() {
+        isFamilyWarningModalDisplayed = false
+        path.append(HomeLink.settings)
+        path.append(SettingLink.notifications)
+    }
+}
+
 private extension AppFeatureViewModel {
     func wireConnectionStatusDelegates() {
         connectionStatus.onConnectionFailed = { [weak self] errorMessage in
@@ -218,7 +244,7 @@ private extension AppFeatureViewModel {
         let lastError = connectionStatus.connectionManager.lastError
         guard !ConnectionStatusViewModel.isNeedsRelaxedIndependenceCriteria(lastError)
         else {
-            oneClick.requestIndependenceConsent()
+            isFamilyWarningModalDisplayed = true
             return
         }
         snackbarManager.enqueue(

--- a/nym-vpn-apple/Home/Sources/26/OneClick/OneClickViewModel.swift
+++ b/nym-vpn-apple/Home/Sources/26/OneClick/OneClickViewModel.swift
@@ -159,20 +159,6 @@ public final class OneClickViewModel {
         }
     }
 
-    func requestIndependenceConsent() {
-        snackbarManager.enqueue(
-            SnackbarItem(
-                style: .warning,
-                title: "gatewayIndependence.warning.title".localizedString,
-                message: "gatewayIndependence.warning.message".localizedString,
-                actionTitle: "gatewayIndependence.warning.connectAnyway".localizedString,
-                onAction: { [weak self] in self?.independenceConsentAgreed() },
-                secondaryActionTitle: "cancel".localizedString,
-                duration: 15
-            )
-        )
-    }
-
     func independenceConsentAgreed() {
         Task { @MainActor [weak self] in
             guard let self else { return }

--- a/nym-vpn-apple/Home/Sources/Servers/ServerDetailsView.swift
+++ b/nym-vpn-apple/Home/Sources/Servers/ServerDetailsView.swift
@@ -247,6 +247,10 @@ private extension ServerDetailsView {
             separatorLine()
             postQuantumRow()
             separatorLine()
+            if gateway.operatorFamilyName != nil {
+                familyMembershipRow()
+                separatorLine()
+            }
             bridges()
             Spacer()
                 .frame(height: 16)
@@ -267,6 +271,21 @@ private extension ServerDetailsView {
                 .foregroundStyle(Color.Nym.primary)
                 .padding(.trailing, 6)
             rowSubtite(with: "gatewayInfo.lewesProtocol".localizedString)
+        }
+    }
+
+    @ViewBuilder
+    func familyMembershipRow() -> some View {
+        if let family = gateway.operatorFamilyName {
+            HStack(spacing: 0) {
+                rowTitle(with: "gatewayInfo.familyMembership".localizedString)
+                Spacer()
+                GenericImage(systemImageName: "person.3.fill")
+                    .frame(width: 15, height: 15)
+                    .foregroundStyle(Color.Nym.primary)
+                    .padding(.trailing, 6)
+                rowSubtite(with: family)
+            }
         }
     }
 

--- a/nym-vpn-apple/NymMixnetTunnel/PacketTunneProvider+Messaging.swift
+++ b/nym-vpn-apple/NymMixnetTunnel/PacketTunneProvider+Messaging.swift
@@ -78,6 +78,11 @@ extension PacketTunnelProvider {
                 }
             }
             return nil
+        case let .setGatewayIndependenceNotifications(enabled):
+            await runCommand {
+                try await self.commandSender?.setGatewayIndependenceNotifications(enableNotifications: enabled)
+            }
+            return nil
         }
     }
 }

--- a/nym-vpn-apple/NymVPN/Resources/Localizable.xcstrings
+++ b/nym-vpn-apple/NymVPN/Resources/Localizable.xcstrings
@@ -10806,6 +10806,39 @@
         }
       }
     },
+    "gatewayIndependence.modal.disableReminders" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disable reminders in notification settings."
+          }
+        }
+      }
+    },
+    "gatewayIndependence.modal.notificationSettingsLink" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "notification settings"
+          }
+        }
+      }
+    },
+    "gatewayIndependence.modal.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The selected servers are in the same operator family!"
+          }
+        }
+      }
+    },
     "gatewayIndependence.warning.connectAnyway" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -10936,6 +10969,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "高级隐私"
+          }
+        }
+      }
+    },
+    "gatewayInfo.familyMembership" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Family membership"
           }
         }
       }
@@ -28451,6 +28495,39 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mixnet tuning"
+          }
+        }
+      }
+    },
+    "settings.notifications.serverFamilyReminders.subtitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Warn me when the selected entry and exit servers belong to the same operator family."
+          }
+        }
+      }
+    },
+    "settings.notifications.serverFamilyReminders.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Server family reminders"
+          }
+        }
+      }
+    },
+    "settings.notifications.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notifications"
           }
         }
       }

--- a/nym-vpn-apple/Services/Sources/Services/AppSettings/AppSettings.swift
+++ b/nym-vpn-apple/Services/Sources/Services/AppSettings/AppSettings.swift
@@ -87,6 +87,11 @@ import ConnectionTypes
         didSet { isAdBlockerEnabledPublisher = isAdBlockerEnabled}
     }
 
+    @AppStorage(AppSettingKey.serverFamilyReminders.rawValue)
+    public var serverFamilyRemindersEnabled = true {
+        didSet { serverFamilyRemindersEnabledPublisher = serverFamilyRemindersEnabled }
+    }
+
     @AppStorage(AppSettingKey.statistics.rawValue)
     public var isStatisticsEnabled = true
 
@@ -171,6 +176,7 @@ import ConnectionTypes
     @Published public var isMixnetTuningEnabledPublisher: Bool
     @Published public var isAdBlockerEnabledPublisher: Bool
     @Published public var isPassphraseStoredPublisher: Bool
+    @Published public var serverFamilyRemindersEnabledPublisher: Bool
 
     // Init ensures the *Publisher mirrors stored values* on launch.
     private init() {
@@ -185,6 +191,7 @@ import ConnectionTypes
         self.isMixnetTuningEnabledPublisher = false
         isAdBlockerEnabledPublisher = false
         isPassphraseStoredPublisher = false
+        serverFamilyRemindersEnabledPublisher = true
 
         self.isErrorReportingOnPublisher = self.isErrorReportingOn
         self.isCredentialImportedPublisher = self.isCredentialImported
@@ -197,6 +204,7 @@ import ConnectionTypes
         self.isMixnetTuningEnabledPublisher = self.isMixnetTuningEnabled
         self.isAdBlockerEnabledPublisher = self.isAdBlockerEnabled
         self.isPassphraseStoredPublisher = self.isPassphraseStored
+        self.serverFamilyRemindersEnabledPublisher = self.serverFamilyRemindersEnabled
     }
 
     public func resetUserDefaults() {
@@ -251,6 +259,7 @@ public enum AppSettingKey: String {
     case accountSummaryCache
     case accountSummaryLastFetchedAt
     case oneClickDisplayMode
+    case serverFamilyReminders
 }
 
 extension Array: @retroactive RawRepresentable where Element: Codable {

--- a/nym-vpn-apple/Services/Sources/Services/ConnectionManager/ConnectionManager+Settings.swift
+++ b/nym-vpn-apple/Services/Sources/Services/ConnectionManager/ConnectionManager+Settings.swift
@@ -8,6 +8,17 @@ import GRPCManager
 
 @MainActor
 extension ConnectionManager {
+    public func setGatewayIndependenceNotifications(_ enabled: Bool) {
+        appSettings.serverFamilyRemindersEnabled = enabled
+        Task {
+#if os(iOS)
+            await sendAfterPersistingConfig(.setGatewayIndependenceNotifications(enabled))
+#elseif os(macOS)
+            try? await grpcManager.setGatewayIndependenceNotifications(enabled)
+#endif
+        }
+    }
+
     public func setCustomDns(_ dns: [String]) {
         appSettings.customDns = dns
         Task {

--- a/nym-vpn-apple/Services/Sources/Services/ConnectionManager/ConnectionManager+iOS.swift
+++ b/nym-vpn-apple/Services/Sources/Services/ConnectionManager/ConnectionManager+iOS.swift
@@ -112,7 +112,8 @@ extension ConnectionManager {
             isLanBypassEnabled: appSettings.isLanBypassEnabled,
             isAdBlockingEnabled: appSettings.isAdBlockerEnabled,
             isTwoHopEnabled: connectionType == .wireguard,
-            gatewaySelectionAlgorithmConfig: algorithmConfig
+            gatewaySelectionAlgorithmConfig: algorithmConfig,
+            isServerFamilyRemindersEnabled: appSettings.serverFamilyRemindersEnabled
         )
     }
 

--- a/nym-vpn-apple/Services/Sources/Services/TunnelMixnet/Config/MixnetConfig.swift
+++ b/nym-vpn-apple/Services/Sources/Services/TunnelMixnet/Config/MixnetConfig.swift
@@ -28,6 +28,7 @@ public struct MixnetConfig: Codable, Equatable {
     public let mixnetTuning: MixnetTuningConfig
 #if os(iOS)
     public let gatewaySelectionAlgorithmConfig: NymGatewaySelectionAlgorithmConfig
+    public let isServerFamilyRemindersEnabled: Bool
 #endif
 
     public var name = "NymVPN Mixnet"
@@ -47,6 +48,7 @@ public struct MixnetConfig: Codable, Equatable {
         isAdBlockingEnabled: Bool,
         isTwoHopEnabled: Bool = false,
         gatewaySelectionAlgorithmConfig: NymGatewaySelectionAlgorithmConfig = NymGatewaySelectionAlgorithmConfig(),
+        isServerFamilyRemindersEnabled: Bool = true,
         name: String = "NymVPN Mixnet"
     ) {
         self.entryGateway = entryGateway
@@ -63,6 +65,7 @@ public struct MixnetConfig: Codable, Equatable {
         self.isTwoHopEnabled = isTwoHopEnabled
         self.isAdBlockingEnabled = isAdBlockingEnabled
         self.gatewaySelectionAlgorithmConfig = gatewaySelectionAlgorithmConfig
+        self.isServerFamilyRemindersEnabled = isServerFamilyRemindersEnabled
         self.name = name
     }
 #endif
@@ -87,6 +90,7 @@ extension MixnetConfig {
             networkStats: nil,
             gatewaySelectionAlgorithmConfig: gatewaySelectionAlgorithmConfig.sdkValue,
             gatewayIndependence: GatewayIndependence(
+                enableNotifications: isServerFamilyRemindersEnabled,
                 differentNodeFamily: true,
                 differentAsn: true,
                 differentSubnet: true

--- a/nym-vpn-apple/Services/Sources/Services/Tunnels/Messaging/TunnelProviderMessage.swift
+++ b/nym-vpn-apple/Services/Sources/Services/Tunnels/Messaging/TunnelProviderMessage.swift
@@ -15,6 +15,7 @@ public enum TunnelProviderMessage: Codable {
     case setDisableIpv6(Bool)
     case setMixnetTrafficConfig(MixnetTuningConfig)
     case setGatewayIndependence(Bool)
+    case setGatewayIndependenceNotifications(Bool)
 
     public init(messageData: Data) throws {
         self = try JSONDecoder().decode(Self.self, from: messageData)

--- a/nym-vpn-apple/ServicesMacOS/Sources/GRPCManager/GRPCManager+Connection.swift
+++ b/nym-vpn-apple/ServicesMacOS/Sources/GRPCManager/GRPCManager+Connection.swift
@@ -66,6 +66,10 @@ extension GRPCManager {
         try await rpcClient?.setEnableGatewayIndependence(enableGatewayIndependence: isEnabled)
     }
 
+    public func setGatewayIndependenceNotifications(_ enabled: Bool) async throws {
+        try await rpcClient?.setGatewayIndependenceNotifications(enableNotifications: enabled)
+    }
+
     public func setSplitTunnelConfig(_ config: SplitTunnelConfig) async throws {
         let oldConfig = await self.config()?.splitTunnelConfig ?? SplitTunnelConfig()
         if oldConfig.isEnabled != config.isEnabled {

--- a/nym-vpn-apple/ServicesMutual/Sources/ConnectionTypes/Extensions/GatewayNode+Extensions.swift
+++ b/nym-vpn-apple/ServicesMutual/Sources/ConnectionTypes/Extensions/GatewayNode+Extensions.swift
@@ -16,7 +16,8 @@ extension GatewayNode {
             buildVersion: gateway.buildVersion,
             ipv4s: gateway.exitIpv4s,
             ipv6s: gateway.exitIpv6s,
-            bridges: GatewayBridgeInformation(with: gateway.bridgeParams)
+            bridges: GatewayBridgeInformation(with: gateway.bridgeParams),
+            operatorFamilyName: gateway.nodeFamilyName
         )
     }
 }

--- a/nym-vpn-apple/ServicesMutual/Sources/ConnectionTypes/GatewayNode.swift
+++ b/nym-vpn-apple/ServicesMutual/Sources/ConnectionTypes/GatewayNode.swift
@@ -9,6 +9,7 @@ public struct GatewayNode: Codable, Hashable {
     public let ipv4s: [String]
     public let ipv6s: [String]
     public let bridges: GatewayBridgeInformation?
+    public let operatorFamilyName: String?
 
     public var isQuicAvailable: Bool {
         guard let bridges else { return false }
@@ -35,7 +36,8 @@ public struct GatewayNode: Codable, Hashable {
         buildVersion: String?,
         ipv4s: [String],
         ipv6s: [String],
-        bridges: GatewayBridgeInformation?
+        bridges: GatewayBridgeInformation?,
+        operatorFamilyName: String? = nil
     ) {
         self.id = id
         self.location = location
@@ -47,6 +49,7 @@ public struct GatewayNode: Codable, Hashable {
         self.ipv4s = ipv4s
         self.ipv6s = ipv6s
         self.bridges = bridges
+        self.operatorFamilyName = operatorFamilyName
     }
 }
 

--- a/nym-vpn-apple/ServicesMutual/Tests/ConnectionTypesTests/GatewayNodeTests.swift
+++ b/nym-vpn-apple/ServicesMutual/Tests/ConnectionTypesTests/GatewayNodeTests.swift
@@ -1,0 +1,40 @@
+import Testing
+@testable import ConnectionTypes
+
+@Suite("GatewayNode operatorFamilyName")
+struct GatewayNodeTests {
+    @Test("carries operatorFamilyName through init")
+    func carriesFamilyName() {
+        let node = GatewayNode(
+            id: "abc",
+            location: nil,
+            performance: nil,
+            mixnetScore: .noScore,
+            name: "node",
+            description: nil,
+            buildVersion: nil,
+            ipv4s: [],
+            ipv6s: [],
+            bridges: nil,
+            operatorFamilyName: "Savoy Nodes"
+        )
+        #expect(node.operatorFamilyName == "Savoy Nodes")
+    }
+
+    @Test("defaults operatorFamilyName to nil")
+    func defaultsNil() {
+        let node = GatewayNode(
+            id: "abc",
+            location: nil,
+            performance: nil,
+            mixnetScore: .noScore,
+            name: nil,
+            description: nil,
+            buildVersion: nil,
+            ipv4s: [],
+            ipv6s: [],
+            bridges: nil
+        )
+        #expect(node.operatorFamilyName == nil)
+    }
+}

--- a/nym-vpn-apple/Settings/Sources/Settings/AppSettingsSectionKind.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/AppSettingsSectionKind.swift
@@ -6,6 +6,7 @@ public enum AppSettingsSectionKind: SettingsSectionKind {
     case theme
     case logs
     case feedback
+    case notifications
     case killSwitch
     case legal
     case systemStatus

--- a/nym-vpn-apple/Settings/Sources/Settings/Notifications/NotificationsView.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/Notifications/NotificationsView.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+import Theme
+import UIComponents
+
+public struct NotificationsView: View {
+    @StateObject private var viewModel: NotificationsViewModel
+
+    public init(viewModel: NotificationsViewModel) {
+        _viewModel = StateObject(wrappedValue: viewModel)
+    }
+
+    public var body: some View {
+        VStack(spacing: 0) {
+            navbar()
+            Spacer()
+                .frame(height: 24)
+            toggleRow()
+                .padding(.horizontal, 16)
+            Spacer()
+        }
+        .navigationBarBackButtonHidden(true)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background {
+            Color.Nym.background
+                .ignoresSafeArea()
+        }
+    }
+}
+
+private extension NotificationsView {
+    func navbar() -> some View {
+        CustomNavBar(
+            title: "settings.notifications.title".localizedString,
+            leftButton: CustomNavBarButton(type: .back, action: { viewModel.navigateBack() })
+        )
+    }
+
+    func toggleRow() -> some View {
+        HStack(alignment: .center, spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("settings.notifications.serverFamilyReminders.title".localizedString)
+                    .foregroundStyle(Color.Nym.textPrimary)
+                    .nymTextStyle(.bodyDefault)
+                Text("settings.notifications.serverFamilyReminders.subtitle".localizedString)
+                    .foregroundStyle(Color.Nym.textSecondary)
+                    .nymTextStyle(.bodySmall)
+            }
+            Spacer()
+            Toggle("", isOn: Binding(
+                get: { viewModel.isServerFamilyRemindersEnabled },
+                set: { viewModel.setServerFamilyReminders($0) }
+            ))
+            .toggleStyle(.switch)
+            .tint(Color.Nym.primary)
+            .labelsHidden()
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.Nym.surface)
+        .cornerRadius(12)
+    }
+}

--- a/nym-vpn-apple/Settings/Sources/Settings/Notifications/NotificationsViewModel.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/Notifications/NotificationsViewModel.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+import AppSettings
+import ConnectionManager
+
+@MainActor
+public final class NotificationsViewModel: ObservableObject {
+    @Binding private var path: NavigationPath
+    private let appSettings: AppSettings
+    private let connectionManager: ConnectionManager
+
+    @Published var isServerFamilyRemindersEnabled: Bool
+
+    public init(
+        path: Binding<NavigationPath>,
+        appSettings: AppSettings,
+        connectionManager: ConnectionManager
+    ) {
+        _path = path
+        self.appSettings = appSettings
+        self.connectionManager = connectionManager
+        self.isServerFamilyRemindersEnabled = appSettings.serverFamilyRemindersEnabled
+    }
+
+    func navigateBack() {
+        guard !path.isEmpty else { return }
+        path.removeLast()
+    }
+
+    func setServerFamilyReminders(_ enabled: Bool) {
+        isServerFamilyRemindersEnabled = enabled
+        connectionManager.setGatewayIndependenceNotifications(enabled)
+    }
+}

--- a/nym-vpn-apple/Settings/Sources/Settings/SettingLink.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/SettingLink.swift
@@ -25,6 +25,7 @@ public enum SettingLink: Hashable, Identifiable {
     case dns
     case mixnetTuning
     case censorship
+    case notifications
 #if os(macOS)
     case proxy
     case appMode

--- a/nym-vpn-apple/Settings/Sources/Settings/SettingsFlowCoordinator.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/SettingsFlowCoordinator.swift
@@ -96,6 +96,8 @@ struct SettingsFlowCoordinator<Content: View>: View {
             mixnetTuningDestination()
         case .censorship:
             censorshipDestination()
+        case .notifications:
+            notificationsDestination()
         case .accountAndDevices:
             accountAndDevicesDestination()
         case .systemStatus:
@@ -285,6 +287,17 @@ private extension SettingsFlowCoordinator {
     @ViewBuilder
     func censorshipDestination() -> some View {
         CensorshipView(path: $flowState.path)
+    }
+
+    @ViewBuilder
+    func notificationsDestination() -> some View {
+        NotificationsView(
+            viewModel: NotificationsViewModel(
+                path: $flowState.path,
+                appSettings: .shared,
+                connectionManager: .shared
+            )
+        )
     }
 
     func accountAndDevicesDestination() -> some View {

--- a/nym-vpn-apple/Settings/Sources/Settings/SettingsViewModel.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/SettingsViewModel.swift
@@ -186,6 +186,11 @@ private extension SettingsViewModel {
         impactGenerator.softImpact()
         path.append(SettingLink.censorship)
     }
+
+    func navigateToNotifications() {
+        impactGenerator.softImpact()
+        path.append(SettingLink.notifications)
+    }
 }
 
 // MARK: - Setup -
@@ -233,6 +238,7 @@ private extension SettingsViewModel {
             newSections.append(
                 contentsOf: [
                     feedbackSection(),
+                    notificationsSection(),
                     killswitchSection(),
                     appearanceSection(),
                     privacyAndDataSection(),
@@ -328,6 +334,24 @@ private extension SettingsViewModel {
                     action: { [weak self] in
                         Task { @MainActor in
                             self?.navigateToAppearance()
+                        }
+                    }
+                )
+            ]
+        )
+    }
+
+    func notificationsSection() -> AppSettingsSection {
+        AppSettingsSection(
+            kind: .notifications,
+            viewModels: [
+                SettingsListItemViewModel(
+                    accessory: .arrow,
+                    title: "settings.notifications.title".localizedString,
+                    systemImageName: "bell",
+                    action: { [weak self] in
+                        Task { @MainActor in
+                            self?.navigateToNotifications()
                         }
                     }
                 )

--- a/nym-vpn-apple/UIComponents/Sources/UIComponents/26/FamilyWarningModal/FamilyWarningModalView.swift
+++ b/nym-vpn-apple/UIComponents/Sources/UIComponents/26/FamilyWarningModal/FamilyWarningModalView.swift
@@ -1,0 +1,93 @@
+import SwiftUI
+import Theme
+
+public struct FamilyWarningModalView: View {
+    private let title: String
+    private let reminderText: String
+    private let reminderLinkText: String
+    private let connectAnywayTitle: String
+    private let cancelTitle: String
+    private let onConnectAnyway: () -> Void
+    private let onCancel: () -> Void
+    private let onOpenNotificationSettings: () -> Void
+
+    private let notificationsLinkURL = URL(string: "app://open-notifications")
+
+    public init(
+        title: String,
+        reminderText: String,
+        reminderLinkText: String,
+        connectAnywayTitle: String,
+        cancelTitle: String,
+        onConnectAnyway: @escaping () -> Void,
+        onCancel: @escaping () -> Void,
+        onOpenNotificationSettings: @escaping () -> Void
+    ) {
+        self.title = title
+        self.reminderText = reminderText
+        self.reminderLinkText = reminderLinkText
+        self.connectAnywayTitle = connectAnywayTitle
+        self.cancelTitle = cancelTitle
+        self.onConnectAnyway = onConnectAnyway
+        self.onCancel = onCancel
+        self.onOpenNotificationSettings = onOpenNotificationSettings
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 20))
+                    .foregroundStyle(Color.Nym.primary)
+                Text(title)
+                    .foregroundStyle(Color.Nym.textPrimary)
+                    .nymTextStyle(.bodyDefaultBold)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Text(reminderAttributedText())
+                .italic()
+                .nymTextStyle(.bodySmall)
+                .lineLimit(1)
+                .minimumScaleFactor(0.6)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .tint(Color.Nym.primary)
+                .environment(\.openURL, OpenURLAction { url in
+                    guard url == notificationsLinkURL else { return .systemAction }
+                    onOpenNotificationSettings()
+                    return .handled
+                })
+                .padding(.top, 12)
+
+            HStack(spacing: 12) {
+                NymButton(
+                    cancelTitle,
+                    style: .secondary,
+                    cornerRadius: 28,
+                    foregroundColor: .Nym.textSecondary,
+                    borderColor: .Nym.textSecondary,
+                    action: onCancel
+                )
+                NymButton(
+                    connectAnywayTitle,
+                    style: .primary,
+                    cornerRadius: 28,
+                    action: onConnectAnyway
+                )
+            }
+            .padding(.top, 24)
+        }
+        .padding(20)
+    }
+
+    private func reminderAttributedText() -> AttributedString {
+        var attributed = AttributedString(reminderText)
+        attributed.foregroundColor = Color.Nym.textSecondary
+        if let range = attributed.range(of: reminderLinkText) {
+            attributed[range].foregroundColor = Color.Nym.primary
+            attributed[range].underlineStyle = .single
+            attributed[range].link = notificationsLinkURL
+        }
+        return attributed
+    }
+}

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/gateway.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/gateway.rs
@@ -536,6 +536,7 @@ pub struct Gateway {
     pub exit_ipv6s: Vec<Ipv6Addr>,
     pub build_version: Option<String>,
     pub lewes_protocol_details: Option<LewesProtocolDetails>,
+    pub node_family_name: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -933,6 +934,7 @@ impl From<nym_validator_client::models::NymNodeDescriptionV1> for Gateway {
             build_version,
             // v1 has no lp details
             lewes_protocol_details: None,
+            node_family_name: None,
         }
     }
 }
@@ -962,6 +964,7 @@ impl From<nym_validator_client::models::NymNodeDescriptionV2> for Gateway {
             exit_ipv6s,
             build_version,
             lewes_protocol_details: node_description.description.lewes_protocol.map(Into::into),
+            node_family_name: None,
         }
     }
 }
@@ -1124,6 +1127,7 @@ impl From<nym_gateway_directory::Gateway> for Gateway {
             lewes_protocol_details: gateway
                 .lewes_protocol_details
                 .map(LewesProtocolDetails::from),
+            node_family_name: gateway.node_family.map(|family| family.name),
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_service_command_sender.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_service_command_sender.rs
@@ -163,6 +163,17 @@ impl NymVpnServiceCommandSender {
         .await
     }
 
+    pub async fn set_gateway_independence_notifications(
+        &self,
+        enable_notifications: bool,
+    ) -> Result<()> {
+        self.send_and_wait(
+            VpnServiceCommand::SetGatewayIndependenceNotifications,
+            enable_notifications,
+        )
+        .await
+    }
+
     pub async fn set_fronting_mode(&self, fronting_mode: FrontingMode) -> Result<()> {
         self.send_and_wait(VpnServiceCommand::SetFrontingMode, fronting_mode)
             .await

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -393,6 +393,7 @@ message GatewayResponse {
   repeated string exit_ipv6s = 8;
   optional string build_version = 9;
   optional LewesProtocolDetails lp_details = 13;
+  optional string node_family_name = 14;
 }
 
 message KemKeyDigests {

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/vpnd.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/vpnd.rs
@@ -337,6 +337,7 @@ impl TryFrom<proto::GatewayResponse> for nym_vpn_lib_types::Gateway {
             build_version,
             bridge_params,
             lewes_protocol_details: lp_details,
+            node_family_name: gateway.node_family_name,
         })
     }
 }
@@ -364,6 +365,7 @@ impl From<nym_vpn_lib_types::Gateway> for proto::GatewayResponse {
             lp_details: gateway
                 .lewes_protocol_details
                 .map(proto::LewesProtocolDetails::from),
+            node_family_name: gateway.node_family_name,
         }
     }
 }


### PR DESCRIPTION
## Ticket

JIRA-NYM-1059

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)
<img width="645" height="1398" alt="Screenshot 2026-06-17 at 15 29 06" src="https://github.com/user-attachments/assets/5aecad99-c0bb-4ec9-9db7-ba5a65900d41" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5610)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Family warning modal alerts users when selected entry and exit servers belong to the same operator family
  * New Notifications settings screen with "Server family reminders" toggle to control family-related alerts
  * Server details now display operator family membership information

* **Tests**
  * Added tests for operator family name handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->