### PR TITLE
Diagnostic Cleanup

### DIFF
--- a/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/dns.rs
+++ b/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/dns.rs
@@ -5,7 +5,7 @@ use nym_vpn_lib_types::{CompleteDnsReport, DiagnosticResult, DnsResolution};
 use nym_vpn_network_config::Network;
 
 use hickory_resolver::{
-    Resolver, ResolverBuilder, TokioResolver,
+    Resolver, TokioResolver,
     config::{CLOUDFLARE, NameServerConfig, QUAD9, ResolverConfig, ResolverOpts},
     net::runtime::TokioRuntimeProvider,
 };
@@ -27,27 +27,10 @@ pub struct DnsDiagnostic {
 }
 
 impl DnsDiagnostic {
-    fn system() -> Result<TokioResolver, DnsDiagnosticError> {
-        Self::build_resolver(Resolver::builder_tokio()?)
-    }
+    fn create_resolver(&self) -> Result<TokioResolver, DnsDiagnosticError> {
+        let config = ResolverConfig::from_parts(None, Vec::new(), self.nameservers.clone());
+        let base = Resolver::builder_with_config(config, TokioRuntimeProvider::default());
 
-    fn from_nameservers(
-        nameservers: Vec<NameServerConfig>,
-    ) -> Result<TokioResolver, DnsDiagnosticError> {
-        let config = ResolverConfig::from_parts(None, Vec::new(), nameservers);
-        Self::from_config(config)
-    }
-
-    fn from_config(config: ResolverConfig) -> Result<TokioResolver, DnsDiagnosticError> {
-        Self::build_resolver(Resolver::builder_with_config(
-            config,
-            TokioRuntimeProvider::default(),
-        ))
-    }
-
-    fn build_resolver(
-        base: ResolverBuilder<TokioRuntimeProvider>,
-    ) -> Result<TokioResolver, DnsDiagnosticError> {
         let mut options = ResolverOpts::default();
         options.attempts = 0;
         options.cache_size = 0;
@@ -77,18 +60,9 @@ impl DnsDiagnostic {
         );
 
         tracing::debug!("System DNS diagnostic");
-        let system_resolver = DnsDiagnostic::system();
-        let system = match system_resolver {
-            Ok(resolver) => Ok(many_diagnostic.resolve(&resolver).await),
-            Err(e) => Err(e),
-        }
-        .into();
+        let system = DiagnosticResult::from(many_diagnostic.resolve().await);
 
         let single_hostname = many_diagnostic.hostnames[0].clone();
-        let ns_diagnostic = DnsDiagnostic {
-            hostnames: vec![single_hostname],
-            nameservers: system_dns,
-        };
 
         tracing::debug!(
             "Running per ns DNS diagnostic on: {:?}",
@@ -107,12 +81,11 @@ impl DnsDiagnostic {
         let mut results = Vec::new();
         for nameserver in name_servers.into_iter() {
             tracing::debug!("DNS diagnostic - {nameserver:?}");
-            let res = match DnsDiagnostic::from_nameservers(vec![nameserver]) {
-                Ok(resolver) => {
-                    DiagnosticResult::from_value(ns_diagnostic.resolve(&resolver).await)
-                }
-                Err(e) => DiagnosticResult::from_err(e),
+            let diagnostic = DnsDiagnostic {
+                hostnames: vec![single_hostname.clone()],
+                nameservers: vec![nameserver],
             };
+            let res = DiagnosticResult::from(diagnostic.resolve().await);
             results.push(res);
         }
 
@@ -122,13 +95,15 @@ impl DnsDiagnostic {
         }
     }
 
-    async fn resolve(&self, dns_resolver: &impl DnsResolver) -> Vec<DnsResolution> {
-        futures::future::join_all(
+    async fn resolve(&self) -> Result<Vec<DnsResolution>, DnsDiagnosticError> {
+        let resolver = self.create_resolver()?;
+
+        Ok(futures::future::join_all(
             self.hostnames
                 .iter()
-                .map(|h| self.dns_resolution(h, dns_resolver)),
+                .map(|h| self.dns_resolution(h, &resolver)),
         )
-        .await
+        .await)
     }
 
     async fn dns_resolution(

--- a/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/http.rs
+++ b/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/http.rs
@@ -6,6 +6,8 @@ use crate::{
     error::{Error, Result},
 };
 
+use std::fmt;
+
 use nym_http_api_client::{Client, ClientBuilder, FrontPolicy, Url};
 use nym_platform_metadata::new_user_agent;
 use nym_validator_client::nym_api::NymApiClientExt;
@@ -14,6 +16,22 @@ use nym_vpn_lib_types::{
     ApiTimeSkew, ApiUrl, DiagnosticEndpointResponse, DiagnosticResult, HttpReport,
 };
 use nym_vpn_network_config::Network;
+
+#[derive(Debug, Clone)]
+struct HttpDiagnosticError<E> {
+    error: E,
+    url: ApiUrl,
+}
+
+impl<E: fmt::Debug> fmt::Display for HttpDiagnosticError<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "http diagnostic error for {:?}: {:?}",
+            self.url, self.error
+        )
+    }
+}
 
 pub struct HttpDiagnostic;
 
@@ -69,12 +87,17 @@ impl HttpDiagnostic {
 
             for api_client in api_clients {
                 jobs.spawn(async move {
+                    let url = url_from_client(&api_client);
+
                     match api_client.health().await {
                         Ok(res) => DiagnosticResult::from_value(DiagnosticEndpointResponse {
                             status: res.status.is_up().to_string(),
                             url: url_from_client(&api_client),
                         }),
-                        Err(e) => DiagnosticResult::from_err(e),
+                        Err(e) => {
+                            let err = HttpDiagnosticError { url, error: e };
+                            DiagnosticResult::from_err(err)
+                        }
                     }
                 });
             }
@@ -85,14 +108,18 @@ impl HttpDiagnostic {
                 .for_each(|r| results.push(r));
         } else {
             for api_client in api_clients {
+                let url = url_from_client(&api_client);
                 match api_client.health().await {
                     Ok(res) => {
                         results.push(DiagnosticResult::from_value(DiagnosticEndpointResponse {
                             status: res.status.is_up().to_string(),
-                            url: url_from_client(&api_client),
+                            url,
                         }))
                     }
-                    Err(e) => results.push(DiagnosticResult::from_err(e)),
+                    Err(e) => {
+                        let err = HttpDiagnosticError { url, error: e };
+                        results.push(DiagnosticResult::from_err(err))
+                    }
                 }
             }
         }
@@ -114,12 +141,16 @@ impl HttpDiagnostic {
 
             for api_client in api_clients {
                 jobs.spawn(async move {
+                    let url = url_from_client(api_client.as_ref());
                     match api_client.get_health().await {
                         Ok(res) => DiagnosticResult::from_value(DiagnosticEndpointResponse {
                             status: res.status,
                             url: url_from_client(api_client.as_ref()),
                         }),
-                        Err(e) => DiagnosticResult::from_err(e),
+                        Err(e) => {
+                            let err = HttpDiagnosticError { url, error: e };
+                            DiagnosticResult::from_err(err)
+                        }
                     }
                 });
             }
@@ -130,6 +161,7 @@ impl HttpDiagnostic {
                 .for_each(|r| results.push(r));
         } else {
             for api_client in api_clients {
+                let url = url_from_client(api_client.as_ref());
                 match api_client.get_health().await {
                     Ok(res) => {
                         results.push(DiagnosticResult::from_value(DiagnosticEndpointResponse {
@@ -137,7 +169,10 @@ impl HttpDiagnostic {
                             url: url_from_client(api_client.as_ref()),
                         }))
                     }
-                    Err(e) => results.push(DiagnosticResult::from_err(e)),
+                    Err(e) => {
+                        let err = HttpDiagnosticError { url, error: e };
+                        results.push(DiagnosticResult::from_err(err))
+                    }
                 }
             }
         }

--- a/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/hybrid_transport.rs
+++ b/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/hybrid_transport.rs
@@ -71,7 +71,7 @@ async fn probe(tls_config: Arc<ClientConfig>) -> Result<HybridTransportReport, S
 
     let tcp = TcpStream::connect((RELAY_HOST, 443))
         .await
-        .map_err(|e| format!("tcp connect: {e}"))?;
+        .map_err(|e| format!("tcp connect: {e:?}"))?;
 
     let server_name = ServerName::try_from(RELAY_HOST)
         .map_err(|e| format!("invalid server name: {e}"))?
@@ -79,7 +79,7 @@ async fn probe(tls_config: Arc<ClientConfig>) -> Result<HybridTransportReport, S
     let tls = TlsConnector::from(tls_config)
         .connect(server_name, tcp)
         .await
-        .map_err(|e| format!("tls handshake: {e}"))?;
+        .map_err(|e| format!("tls handshake: {e:?}"))?;
 
     let request = Request::builder()
         .uri(format!("wss://{RELAY_HOST}{path}"))
@@ -90,11 +90,11 @@ async fn probe(tls_config: Arc<ClientConfig>) -> Result<HybridTransportReport, S
         .header("Sec-WebSocket-Key", generate_key())
         .header("Sec-WebSocket-Protocol", WS_SUBPROTOCOL)
         .body(())
-        .map_err(|e| format!("build ws request: {e}"))?;
+        .map_err(|e| format!("build ws request: {e:?}"))?;
 
     let (_ws, response) = tokio_tungstenite::client_async(request, tls)
         .await
-        .map_err(|e| format!("ws upgrade: {e}"))?;
+        .map_err(|e| format!("ws upgrade: {e:?}"))?;
 
     let handshake_duration_ms = start.elapsed().as_millis();
     let routing_id = response


### PR DESCRIPTION
## Description

Some changes to the DNS diagnostic missed the understanding of how the diagnostic information is attached to the results. this ended up with the diagnostic sending and logging the correct information, but reporting the system resolver information to the resulting Json output. This is fixed and the correct nameserver information is attached to the appropriate output entry.

The reporting of the HTTP diagnostic also has a shortcoming (fixed in this PR) where errors use only the `ToString` information which misses the `#[source]`  information that is stored with the error. To fix this we make the returned strings include debug information of the errors which includes the full expanded error chain. 


## Checklist:

- [X] Ensure DNS diagnostic reporting attaches the correct nameserver information to result
- [X] Change http test errors to debug log to get full expanded error source log
- [X] Add url information to http diagnostic errors

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5611)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for HTTP diagnostic checks with detailed context about which endpoints failed.
  * Enhanced hybrid transport diagnostics with more descriptive error messages for connection failures, TLS handshakes, and WebSocket operations.

* **Refactor**
  * Streamlined DNS resolution diagnostic flow for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->