### PR TITLE
aur: fix failure to build from source to issues with aws-lc-sys

### DIFF
--- a/nym-vpn-core/crates/nym-vpnc/.pkg/aur/PKGBUILD
+++ b/nym-vpn-core/crates/nym-vpnc/.pkg/aur/PKGBUILD
@@ -31,10 +31,13 @@ build() {
   pushd "$_srcdir"
 
   pushd nym-vpn-core
-  # sqlx does not support LTO build flag, which is enabled by default in Arch
+  # 1. sqlx does not support LTO build flag, which is enabled by default in Arch
   # set the C flag -ffat-lto-objects to solve the issue
   # see https://github.com/launchbadge/sqlx/issues/3149
-  CFLAGS+=" -ffat-lto-objects" cargo build --release --locked -p nym-vpnc
+  #
+  # 2. aws-lc-sys v0.38: build issues related to optimizations (fixed in newer versions)
+  # see: https://github.com/aws/aws-lc-rs/pull/1064
+  CFLAGS+=" -ffat-lto-objects -O0" cargo build --release --locked -p nym-vpnc --verbose
   popd
 
   popd # _srcdir

--- a/nym-vpn-core/crates/nym-vpnd/.pkg/aur/PKGBUILD
+++ b/nym-vpn-core/crates/nym-vpnd/.pkg/aur/PKGBUILD
@@ -38,10 +38,13 @@ build() {
   popd
 
   pushd nym-vpn-core
-  # sqlx does not support LTO build flag, which is enabled by default in Arch
+  # 1. sqlx does not support LTO build flag, which is enabled by default in Arch
   # set the C flag -ffat-lto-objects to solve the issue
   # see https://github.com/launchbadge/sqlx/issues/3149
-  CFLAGS+=" -ffat-lto-objects" cargo build --release --locked
+  #
+  # 2. aws-lc-sys v0.38: build issues related to optimizations (fixed in newer versions)
+  # see: https://github.com/aws/aws-lc-rs/pull/1064
+  CFLAGS+=" -ffat-lto-objects -O0" cargo build --release --locked
   popd
 
   popd # _srcdir


### PR DESCRIPTION


## Description

`aws-lc-sys v0.38` fails to build on ArchLinux due to:

```
#error "The CPU Jitter random number generator must not be compiled with optimizations. See documentation. Use the compiler switch -O0 for compiling jitterentropy.c."
```

As a quick workaround, let's disable C compiler optimizations until `aws-lc-sys` is upgraded to the newer version where this issue is already resolved.

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5616)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Arch Linux package build configuration for nym-vpnc and nym-vpnd to improve compilation reliability and resolve optimization-related build issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->