### PR TITLE
System bandwidth monitor 

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix missing "recursion available" flag in DNS responses, passthrough authority and additional records (https://github.com/nymtech/nym-vpn-client/pull/5546)
 - Provide escape hatch when reconnecting the tunnel in "time desynced" error state (https://github.com/nymtech/nym-vpn-client/pull/5551)
+- Race when network usage spikes happen during longer bandwidth checks, disconnecting the client from the server (https://github.com/nymtech/nym-vpn-client/pull/5618)
 
 ### Removed
 

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -7264,6 +7264,7 @@ dependencies = [
  "socket2 0.6.3",
  "sqlx",
  "strum",
+ "sysinfo 0.39.1",
  "tempfile",
  "thiserror 2.0.18",
  "time",

--- a/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
@@ -108,6 +108,7 @@ sentry = { workspace = true, features = [
 sha2.workspace = true
 strum.workspace = true
 sqlx = { workspace = true, features = ["runtime-tokio-rustls", "sqlite"] }
+sysinfo = { workspace = true, features = ["network"] }
 toml.workspace = true
 thiserror.workspace = true
 time.workspace = true

--- a/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
@@ -6,6 +6,7 @@ use std::{net::IpAddr, time::Duration};
 use nym_authenticator_client::AuthenticatorClient;
 use nym_bandwidth_controller::{BandwidthTicketProvider, DEFAULT_TICKETS_TO_SPEND};
 use nym_registration_common::WireguardConfiguration;
+use sysinfo::Networks;
 use tokio_stream::{StreamExt, wrappers::IntervalStream};
 use tokio_util::sync::CancellationToken;
 
@@ -26,6 +27,11 @@ const UPPER_BOUND_CHECK_DURATION: Duration =
     Duration::from_secs(6 * DEFAULT_PEER_TIMEOUT_CHECK.as_secs());
 const DEFAULT_BANDWIDTH_DEPLETION_RATE: u64 = 1024 * 1024; // 1 MB/s
 const MINIMUM_RAMAINING_BANDWIDTH: u64 = 500 * 1024 * 1024; // 500 MB, the same as a wireguard ticket size (but it doesn't have to be)
+
+// 8 MB/s, in the worse case scenario with 30 seconds until the next check => 240 MB consumed, under the 500 MB bandwidth minimum we have assured with the gateway
+// We consider anything above this threshold to potentially consume bandwidth too fast, so we do a check immediately
+const SYSTEM_BANDWIDTH_THRESHOLD: u64 = 8 * 1024 * 1024; // 8 MB
+const SYSTEM_BANDWIDTH_CHECK_INTERVAL: Duration = Duration::from_secs(1); // 1 second
 
 const DEFAULT_CLIENT_RETRIES: usize = 1;
 
@@ -427,6 +433,15 @@ impl TemporaryBandwidthClient {
         }
     }
 
+    pub(crate) async fn interface_name(&mut self) -> Option<String> {
+        match self {
+            TemporaryBandwidthClient::Deprecated(_) => None,
+            TemporaryBandwidthClient::Latest(metadata_client) => {
+                metadata_client.interface_name().await
+            }
+        }
+    }
+
     pub(crate) async fn topup_bandwidth(
         &mut self,
         credential: nym_credentials_interface::CredentialSpendingData,
@@ -496,6 +511,50 @@ impl TemporaryBandwidthClient {
                 Ok(upgrade_mode_enabled)
             }
         }
+    }
+}
+
+// Structure used to track network usage by looking at the system stats
+// It is not used as a source of truth for topping up bandwidth, but rather as a simpler
+// way to detect potential bandwidth spikes and react to them faster then waiting for the
+// next bandwidth check tick
+struct SystemBandwidthMonitor {
+    networks: Networks,
+    interface_name: Option<String>,
+    threshold: u64,
+}
+
+impl SystemBandwidthMonitor {
+    pub fn new(interface_name: Option<String>, threshold: u64) -> Self {
+        Self {
+            networks: Networks::new_with_refreshed_list(),
+            interface_name,
+            threshold,
+        }
+    }
+
+    pub async fn force_bandwidth_checks(&mut self) -> bool {
+        self.networks.refresh(true);
+        let total_network_usage: u64 = self
+            .networks
+            .list()
+            .iter()
+            .filter_map(
+                |(interface_name, data)| match self.interface_name.as_ref() {
+                    // if interface name is specified, only consider that interface, otherwise consider all interfaces
+                    Some(target_interface_name) => {
+                        if interface_name == target_interface_name {
+                            Some(data.received() + data.transmitted())
+                        } else {
+                            None
+                        }
+                    }
+                    None => Some(data.received() + data.transmitted()),
+                },
+            )
+            .sum();
+        // above the configured threshold, we consider the system to be under heavy load and thus we should attempt to top up bandwidth asap
+        total_network_usage > self.threshold
     }
 }
 
@@ -882,6 +941,13 @@ impl BandwidthController {
     }
 
     pub(crate) async fn run(mut self) {
+        let mut system_bandwidth_monitor = SystemBandwidthMonitor::new(
+            self.wg_exit_gateway_client.interface_name().await,
+            SYSTEM_BANDWIDTH_THRESHOLD,
+        );
+        let mut system_bandwidth_check_interval =
+            IntervalStream::new(tokio::time::interval(SYSTEM_BANDWIDTH_CHECK_INTERVAL));
+
         // Skip the first, immediate tick
         self.timeout_check_interval.next().await;
         while !self.shutdown_token.is_cancelled() {
@@ -889,6 +955,14 @@ impl BandwidthController {
                 _ = self.shutdown_token.cancelled() => {
                     tracing::trace!("BandwidthController: Received shutdown");
                     break;
+                }
+                _ = system_bandwidth_check_interval.next() => {
+                    if system_bandwidth_monitor.force_bandwidth_checks().await {
+                        tracing::debug!("System bandwidth usage is above the configured threshold, forcing bandwidth checks");
+                        // we set the check interval to the lower bound, but we don't do the first tick, which is immediate,
+                        // so we implicitely trigger the check branch bellow
+                        self.timeout_check_interval = IntervalStream::new(tokio::time::interval(LOWER_BOUND_CHECK_DURATION));
+                    }
                 }
                 _ = self.timeout_check_interval.next() => {
                     let current_period = self.timeout_check_interval.as_ref().period();

--- a/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
@@ -551,16 +551,12 @@ struct SystemBandwidthMonitor<N = Networks> {
 }
 
 impl SystemBandwidthMonitor {
-    pub fn new(threshold: u64) -> Self {
+    pub fn new(interface_name: Option<String>, threshold: u64) -> Self {
         Self {
             networks: Networks::new_with_refreshed_list(),
-            interface_name: None,
+            interface_name,
             threshold,
         }
-    }
-
-    pub fn set_interface_name(&mut self, interface_name: Option<String>) {
-        self.interface_name = interface_name;
     }
 }
 
@@ -976,8 +972,13 @@ impl BandwidthController {
     }
 
     pub(crate) async fn run(mut self) {
-        let mut system_bandwidth_monitor = SystemBandwidthMonitor::new(SYSTEM_BANDWIDTH_THRESHOLD);
-        let mut system_bandwidth_monitor_interface_set = false;
+        let exit_interface_name = self
+            .shutdown_token
+            .run_until_cancelled(self.wg_exit_gateway_client.interface_name())
+            .await
+            .flatten();
+        let mut system_bandwidth_monitor =
+            SystemBandwidthMonitor::new(exit_interface_name, SYSTEM_BANDWIDTH_THRESHOLD);
         let mut system_bandwidth_check_interval =
             IntervalStream::new(tokio::time::interval(SYSTEM_BANDWIDTH_CHECK_INTERVAL));
 
@@ -988,10 +989,6 @@ impl BandwidthController {
                 _ = self.shutdown_token.cancelled() => {
                     tracing::trace!("BandwidthController: Received shutdown");
                     break;
-                }
-                exit_interface_name = self.wg_exit_gateway_client.interface_name(), if !system_bandwidth_monitor_interface_set => {
-                    system_bandwidth_monitor_interface_set = true;
-                    system_bandwidth_monitor.set_interface_name(exit_interface_name);
                 }
                 _ = system_bandwidth_check_interval.next() => {
                     if system_bandwidth_monitor.force_bandwidth_checks().await && self.timeout_check_interval.as_ref().period() > LOWER_BOUND_CHECK_DURATION {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
@@ -514,12 +514,30 @@ impl TemporaryBandwidthClient {
     }
 }
 
+trait NetworksSource {
+    fn refresh(&mut self, remove_not_listed_interfaces: bool);
+    fn list(&self) -> Vec<(String, u64, u64)>;
+}
+
+impl NetworksSource for Networks {
+    fn refresh(&mut self, remove_not_listed_interfaces: bool) {
+        Networks::refresh(self, remove_not_listed_interfaces);
+    }
+
+    fn list(&self) -> Vec<(String, u64, u64)> {
+        Networks::list(self)
+            .iter()
+            .map(|(name, data)| (name.clone(), data.received(), data.transmitted()))
+            .collect()
+    }
+}
+
 // Structure used to track network usage by looking at the system stats
 // It is not used as a source of truth for topping up bandwidth, but rather as a simpler
 // way to detect potential bandwidth spikes and react to them faster then waiting for the
 // next bandwidth check tick
-struct SystemBandwidthMonitor {
-    networks: Networks,
+struct SystemBandwidthMonitor<N = Networks> {
+    networks: N,
     interface_name: Option<String>,
     threshold: u64,
 }
@@ -532,24 +550,26 @@ impl SystemBandwidthMonitor {
             threshold,
         }
     }
+}
 
+impl<N: NetworksSource> SystemBandwidthMonitor<N> {
     pub async fn force_bandwidth_checks(&mut self) -> bool {
         self.networks.refresh(true);
         let total_network_usage: u64 = self
             .networks
             .list()
-            .iter()
+            .into_iter()
             .filter_map(
-                |(interface_name, data)| match self.interface_name.as_ref() {
-                    // if interface name is specified, only consider that interface, otherwise consider all interfaces
-                    Some(target_interface_name) => {
-                        if interface_name == target_interface_name {
-                            Some(data.received() + data.transmitted())
+                // if interface name is specified, only consider that interface, otherwise consider all interfaces
+                |(interface_name, received, transmitted)| match self.interface_name.as_ref() {
+                    Some(target) => {
+                        if &interface_name == target {
+                            Some(received + transmitted)
                         } else {
                             None
                         }
                     }
-                    None => Some(data.received() + data.transmitted()),
+                    None => Some(received + transmitted),
                 },
             )
             .sum();
@@ -999,12 +1019,55 @@ impl BandwidthController {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
 
     const BW_1KB: u64 = 1024;
     const BW_1MB: u64 = 1024 * BW_1KB;
     const BW_128MB: u64 = 128 * BW_1MB;
     const BW_512MB: u64 = 512 * BW_1MB;
     const BW_1GB: u64 = 2 * BW_512MB;
+
+    struct MockNetworks {
+        data: HashMap<String, (u64, u64)>,
+        refresh_count: u32,
+    }
+
+    impl MockNetworks {
+        fn new() -> Self {
+            Self {
+                data: HashMap::new(),
+                refresh_count: 0,
+            }
+        }
+
+        fn with_interface(mut self, name: &str, received: u64, transmitted: u64) -> Self {
+            self.data.insert(name.to_string(), (received, transmitted));
+            self
+        }
+    }
+
+    impl NetworksSource for MockNetworks {
+        fn refresh(&mut self, _remove_not_listed_interfaces: bool) {
+            self.refresh_count += 1;
+        }
+
+        fn list(&self) -> Vec<(String, u64, u64)> {
+            self.data
+                .iter()
+                .map(|(name, &(rx, tx))| (name.clone(), rx, tx))
+                .collect()
+        }
+    }
+
+    impl<N: NetworksSource> SystemBandwidthMonitor<N> {
+        fn with_networks(interface_name: Option<String>, threshold: u64, networks: N) -> Self {
+            Self {
+                networks,
+                interface_name,
+                threshold,
+            }
+        }
+    }
 
     #[test]
     fn depletion_rate_slow() {
@@ -1100,5 +1163,107 @@ mod tests {
             ))
             .is_ok()
         );
+    }
+
+    #[tokio::test]
+    async fn system_bandwidth_monitor_no_interfaces_is_below_threshold() {
+        let mock = MockNetworks::new();
+        let mut monitor =
+            SystemBandwidthMonitor::with_networks(None, SYSTEM_BANDWIDTH_THRESHOLD, mock);
+        assert!(!monitor.force_bandwidth_checks().await);
+    }
+
+    #[tokio::test]
+    async fn system_bandwidth_monitor_calls_refresh_on_each_check() {
+        let mock = MockNetworks::new();
+        let mut monitor =
+            SystemBandwidthMonitor::with_networks(None, SYSTEM_BANDWIDTH_THRESHOLD, mock);
+        monitor.force_bandwidth_checks().await;
+        assert_eq!(monitor.networks.refresh_count, 1);
+        monitor.force_bandwidth_checks().await;
+        assert_eq!(monitor.networks.refresh_count, 2);
+    }
+
+    #[tokio::test]
+    async fn system_bandwidth_monitor_below_threshold_returns_false() {
+        // 2 MB combined < 8 MB threshold
+        let mock = MockNetworks::new().with_interface("eth0", BW_1MB, BW_1MB);
+        let mut monitor =
+            SystemBandwidthMonitor::with_networks(None, SYSTEM_BANDWIDTH_THRESHOLD, mock);
+        assert!(!monitor.force_bandwidth_checks().await);
+    }
+
+    #[tokio::test]
+    async fn system_bandwidth_monitor_above_threshold_returns_true() {
+        // 10 MB combined > 8 MB threshold
+        let mock = MockNetworks::new().with_interface("eth0", 5 * BW_1MB, 5 * BW_1MB);
+        let mut monitor =
+            SystemBandwidthMonitor::with_networks(None, SYSTEM_BANDWIDTH_THRESHOLD, mock);
+        assert!(monitor.force_bandwidth_checks().await);
+    }
+
+    #[tokio::test]
+    async fn system_bandwidth_monitor_exactly_at_threshold_returns_false() {
+        // usage must be strictly greater than threshold, not equal
+        let mock = MockNetworks::new().with_interface(
+            "eth0",
+            SYSTEM_BANDWIDTH_THRESHOLD / 2,
+            SYSTEM_BANDWIDTH_THRESHOLD / 2,
+        );
+        let mut monitor =
+            SystemBandwidthMonitor::with_networks(None, SYSTEM_BANDWIDTH_THRESHOLD, mock);
+        assert!(!monitor.force_bandwidth_checks().await);
+    }
+
+    #[tokio::test]
+    async fn system_bandwidth_monitor_sums_all_interfaces_without_filter() {
+        // 3 MB per interface × 3 interfaces = 9 MB total > 8 MB threshold
+        let mock = MockNetworks::new()
+            .with_interface("eth0", 3 * BW_1MB, 0)
+            .with_interface("eth1", 3 * BW_1MB, 0)
+            .with_interface("wlan0", 3 * BW_1MB, 0);
+        let mut monitor =
+            SystemBandwidthMonitor::with_networks(None, SYSTEM_BANDWIDTH_THRESHOLD, mock);
+        assert!(monitor.force_bandwidth_checks().await);
+    }
+
+    #[tokio::test]
+    async fn system_bandwidth_monitor_filters_to_target_interface_below_threshold() {
+        // eth0 has 10 MB (above threshold), but we only watch wg0 which has 2 MB
+        let mock = MockNetworks::new()
+            .with_interface("eth0", 5 * BW_1MB, 5 * BW_1MB)
+            .with_interface("wg0", BW_1MB, BW_1MB);
+        let mut monitor = SystemBandwidthMonitor::with_networks(
+            Some("wg0".to_string()),
+            SYSTEM_BANDWIDTH_THRESHOLD,
+            mock,
+        );
+        assert!(!monitor.force_bandwidth_checks().await);
+    }
+
+    #[tokio::test]
+    async fn system_bandwidth_monitor_filters_to_target_interface_above_threshold() {
+        // eth0 has 2 MB (below threshold), but we only watch wg0 which has 10 MB
+        let mock = MockNetworks::new()
+            .with_interface("eth0", BW_1MB, BW_1MB)
+            .with_interface("wg0", 5 * BW_1MB, 5 * BW_1MB);
+        let mut monitor = SystemBandwidthMonitor::with_networks(
+            Some("wg0".to_string()),
+            SYSTEM_BANDWIDTH_THRESHOLD,
+            mock,
+        );
+        assert!(monitor.force_bandwidth_checks().await);
+    }
+
+    #[tokio::test]
+    async fn system_bandwidth_monitor_nonexistent_target_interface_returns_false() {
+        // eth0 has 10 MB but we watch a non-existent interface, so total is 0
+        let mock = MockNetworks::new().with_interface("eth0", 5 * BW_1MB, 5 * BW_1MB);
+        let mut monitor = SystemBandwidthMonitor::with_networks(
+            Some("nonexistent".to_string()),
+            SYSTEM_BANDWIDTH_THRESHOLD,
+            mock,
+        );
+        assert!(!monitor.force_bandwidth_checks().await);
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
@@ -516,20 +516,30 @@ impl TemporaryBandwidthClient {
     }
 }
 
-trait NetworksSource {
-    fn refresh(&mut self, remove_not_listed_interfaces: bool);
-    fn list(&self) -> Vec<(String, u64, u64)>;
+struct InterfaceStats {
+    interface_name: String,
+    received: u64,
+    transmitted: u64,
 }
 
-impl NetworksSource for Networks {
+trait NetworkInterfaceStats {
+    fn refresh(&mut self, remove_not_listed_interfaces: bool);
+    fn list(&self) -> Vec<InterfaceStats>;
+}
+
+impl NetworkInterfaceStats for Networks {
     fn refresh(&mut self, remove_not_listed_interfaces: bool) {
         Networks::refresh(self, remove_not_listed_interfaces);
     }
 
-    fn list(&self) -> Vec<(String, u64, u64)> {
+    fn list(&self) -> Vec<InterfaceStats> {
         Networks::list(self)
             .iter()
-            .map(|(name, data)| (name.clone(), data.received(), data.transmitted()))
+            .map(|(name, data)| InterfaceStats {
+                interface_name: name.clone(),
+                received: data.received(),
+                transmitted: data.transmitted(),
+            })
             .collect()
     }
 }
@@ -554,7 +564,7 @@ impl SystemBandwidthMonitor {
     }
 }
 
-impl<N: NetworksSource> SystemBandwidthMonitor<N> {
+impl<N: NetworkInterfaceStats> SystemBandwidthMonitor<N> {
     pub async fn force_bandwidth_checks(&mut self) -> bool {
         self.networks.refresh(true);
         let total_network_usage: u64 = self
@@ -563,7 +573,11 @@ impl<N: NetworksSource> SystemBandwidthMonitor<N> {
             .into_iter()
             .filter_map(
                 // if interface name is specified, only consider that interface, otherwise consider all interfaces
-                |(interface_name, received, transmitted)| match self.interface_name.as_ref() {
+                |InterfaceStats {
+                     interface_name,
+                     received,
+                     transmitted,
+                 }| match self.interface_name.as_ref() {
                     Some(target) => {
                         if &interface_name == target {
                             Some(received + transmitted)
@@ -1048,20 +1062,24 @@ mod tests {
         }
     }
 
-    impl NetworksSource for MockNetworks {
+    impl NetworkInterfaceStats for MockNetworks {
         fn refresh(&mut self, _remove_not_listed_interfaces: bool) {
             self.refresh_count += 1;
         }
 
-        fn list(&self) -> Vec<(String, u64, u64)> {
+        fn list(&self) -> Vec<InterfaceStats> {
             self.data
                 .iter()
-                .map(|(name, &(rx, tx))| (name.clone(), rx, tx))
+                .map(|(name, &(received, transmitted))| InterfaceStats {
+                    interface_name: name.clone(),
+                    received,
+                    transmitted,
+                })
                 .collect()
         }
     }
 
-    impl<N: NetworksSource> SystemBandwidthMonitor<N> {
+    impl<N: NetworkInterfaceStats> SystemBandwidthMonitor<N> {
         fn with_networks(interface_name: Option<String>, threshold: u64, networks: N) -> Self {
             Self {
                 networks,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
@@ -523,16 +523,12 @@ struct InterfaceStats {
 }
 
 trait NetworkInterfaceStats {
-    fn refresh(&mut self, remove_not_listed_interfaces: bool);
-    fn list(&self) -> Vec<InterfaceStats>;
+    fn get_interface_stats(&mut self) -> Vec<InterfaceStats>;
 }
 
 impl NetworkInterfaceStats for Networks {
-    fn refresh(&mut self, remove_not_listed_interfaces: bool) {
-        Networks::refresh(self, remove_not_listed_interfaces);
-    }
-
-    fn list(&self) -> Vec<InterfaceStats> {
+    fn get_interface_stats(&mut self) -> Vec<InterfaceStats> {
+        Networks::refresh(self, true);
         Networks::list(self)
             .iter()
             .map(|(name, data)| InterfaceStats {
@@ -570,10 +566,9 @@ impl SystemBandwidthMonitor {
 
 impl<N: NetworkInterfaceStats> SystemBandwidthMonitor<N> {
     pub async fn force_bandwidth_checks(&mut self) -> bool {
-        self.networks.refresh(true);
         let total_network_usage: u64 = self
             .networks
-            .list()
+            .get_interface_stats()
             .into_iter()
             .filter_map(
                 // if interface name is specified, only consider that interface, otherwise consider all interfaces
@@ -1069,11 +1064,8 @@ mod tests {
     }
 
     impl NetworkInterfaceStats for MockNetworks {
-        fn refresh(&mut self, _remove_not_listed_interfaces: bool) {
+        fn get_interface_stats(&mut self) -> Vec<InterfaceStats> {
             self.refresh_count += 1;
-        }
-
-        fn list(&self) -> Vec<InterfaceStats> {
             self.data
                 .iter()
                 .map(|(name, &(received, transmitted))| InterfaceStats {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
@@ -26,9 +26,11 @@ const LOWER_BOUND_CHECK_DURATION: Duration = DEFAULT_PEER_TIMEOUT_CHECK;
 const UPPER_BOUND_CHECK_DURATION: Duration =
     Duration::from_secs(6 * DEFAULT_PEER_TIMEOUT_CHECK.as_secs());
 const DEFAULT_BANDWIDTH_DEPLETION_RATE: u64 = 1024 * 1024; // 1 MB/s
-const MINIMUM_RAMAINING_BANDWIDTH: u64 = 500 * 1024 * 1024; // 500 MB, the same as a wireguard ticket size (but it doesn't have to be)
+// If we consider a maximum supported connection speed of 1 Gbps, then we can consume 125 MB/s, which is 125 * 5 = 625 MB in 5 seconds, which is the minimum time between checks.
+// So we set the minimum remaining bandwidth to 1000 MB > 625 MB, roughly the size of two tickets
+const MINIMUM_RAMAINING_BANDWIDTH: u64 = 1000 * 1024 * 1024; // 1000 MB, the same as two wireguard ticket size
 
-// 8 MB/s, in the worse case scenario with 30 seconds until the next check => 240 MB consumed, under the 500 MB bandwidth minimum we have assured with the gateway
+// 8 MB/s, in the worse case scenario with 30 seconds until the next check => 240 MB consumed, under the 1000 MB bandwidth minimum we have assured with the gateway
 // We consider anything above this threshold to potentially consume bandwidth too fast, so we do a check immediately
 const SYSTEM_BANDWIDTH_THRESHOLD: u64 = 8 * 1024 * 1024; // 8 MB
 const SYSTEM_BANDWIDTH_CHECK_INTERVAL: Duration = Duration::from_secs(1); // 1 second
@@ -977,7 +979,7 @@ impl BandwidthController {
                     break;
                 }
                 _ = system_bandwidth_check_interval.next() => {
-                    if system_bandwidth_monitor.force_bandwidth_checks().await {
+                    if system_bandwidth_monitor.force_bandwidth_checks().await && self.timeout_check_interval.as_ref().period() > LOWER_BOUND_CHECK_DURATION {
                         tracing::debug!("System bandwidth usage is above the configured threshold, forcing bandwidth checks");
                         // we set the check interval to the lower bound, but we don't do the first tick, which is immediate,
                         // so we implicitely trigger the check branch bellow

--- a/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
@@ -555,12 +555,16 @@ struct SystemBandwidthMonitor<N = Networks> {
 }
 
 impl SystemBandwidthMonitor {
-    pub fn new(interface_name: Option<String>, threshold: u64) -> Self {
+    pub fn new(threshold: u64) -> Self {
         Self {
             networks: Networks::new_with_refreshed_list(),
-            interface_name,
+            interface_name: None,
             threshold,
         }
+    }
+
+    pub fn set_interface_name(&mut self, interface_name: Option<String>) {
+        self.interface_name = interface_name;
     }
 }
 
@@ -977,10 +981,8 @@ impl BandwidthController {
     }
 
     pub(crate) async fn run(mut self) {
-        let mut system_bandwidth_monitor = SystemBandwidthMonitor::new(
-            self.wg_exit_gateway_client.interface_name().await,
-            SYSTEM_BANDWIDTH_THRESHOLD,
-        );
+        let mut system_bandwidth_monitor = SystemBandwidthMonitor::new(SYSTEM_BANDWIDTH_THRESHOLD);
+        let mut system_bandwidth_monitor_interface_set = false;
         let mut system_bandwidth_check_interval =
             IntervalStream::new(tokio::time::interval(SYSTEM_BANDWIDTH_CHECK_INTERVAL));
 
@@ -991,6 +993,10 @@ impl BandwidthController {
                 _ = self.shutdown_token.cancelled() => {
                     tracing::trace!("BandwidthController: Received shutdown");
                     break;
+                }
+                exit_interface_name = self.wg_exit_gateway_client.interface_name(), if !system_bandwidth_monitor_interface_set => {
+                    system_bandwidth_monitor_interface_set = true;
+                    system_bandwidth_monitor.set_interface_name(exit_interface_name);
                 }
                 _ = system_bandwidth_check_interval.next() => {
                     if system_bandwidth_monitor.force_bandwidth_checks().await && self.timeout_check_interval.as_ref().period() > LOWER_BOUND_CHECK_DURATION {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
@@ -1078,7 +1078,7 @@ mod tests {
         // the first check would force the placeholder values to be replaced by the actual values
         assert_eq!(
             depletion_rate
-                .update_dynamic_check_interval(current_period, BW_512MB)
+                .update_dynamic_check_interval(current_period, BW_1GB)
                 .unwrap(),
             Some(DEFAULT_BANDWIDTH_CHECK)
         );
@@ -1086,7 +1086,7 @@ mod tests {
         // simulate 1 byte/second depletion rate
         let consumed = current_period.as_secs();
         current_period = depletion_rate
-            .update_dynamic_check_interval(current_period, BW_512MB - consumed)
+            .update_dynamic_check_interval(current_period, BW_1GB - consumed)
             .unwrap()
             .unwrap();
         assert_eq!(current_period, UPPER_BOUND_CHECK_DURATION);
@@ -1118,11 +1118,11 @@ mod tests {
     fn depletion_rate_spike() {
         let mut depletion_rate = DepletionRate::default();
         let mut current_period = DEFAULT_BANDWIDTH_CHECK;
-        let mut current_bandwidth = BW_1GB;
+        let mut current_bandwidth = 2 * BW_1GB;
         // the first check would force the placeholder values to be replaced by the actual values
         assert_eq!(
             depletion_rate
-                .update_dynamic_check_interval(current_period, BW_1GB)
+                .update_dynamic_check_interval(current_period, current_bandwidth)
                 .unwrap(),
             Some(DEFAULT_BANDWIDTH_CHECK)
         );
@@ -1138,14 +1138,14 @@ mod tests {
         }
 
         // spike a 1 MB/s depletion rate
-        for _ in 0..17 {
+        for _ in 0..34 {
             current_bandwidth -= current_period.as_secs() * BW_1MB;
             current_period = depletion_rate
                 .update_dynamic_check_interval(current_period, current_bandwidth)
                 .unwrap()
                 .unwrap();
             assert_eq!(current_period, UPPER_BOUND_CHECK_DURATION);
-            assert!(current_bandwidth > 500 * BW_1MB);
+            assert!(current_bandwidth > 1000 * BW_1MB);
         }
 
         current_bandwidth -= current_period.as_secs() * BW_1MB;
@@ -1153,7 +1153,7 @@ mod tests {
             .update_dynamic_check_interval(current_period, current_bandwidth)
             .unwrap();
         // when we get bellow a convinient dynamic threshold, we start reqwesting more bandwidth (returning None)
-        assert!(current_bandwidth < 500 * BW_1MB);
+        assert!(current_bandwidth < 1000 * BW_1MB);
         assert!(ret.is_none());
     }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/mod.rs
@@ -64,15 +64,7 @@ impl From<MetadataEvent> for nym_wg_metadata_client::TunUpSendData {
                 nym_wg_metadata_client::TunUpSendData::TcpProxy(proxy_addr)
             }
             MetadataEvent::TunnelMetadata(metadata) => {
-                #[cfg(target_os = "linux")]
-                {
-                    nym_wg_metadata_client::TunUpSendData::InterfaceName(metadata.interface)
-                }
-
-                #[cfg(not(target_os = "linux"))]
-                {
-                    nym_wg_metadata_client::TunUpSendData::Signal(metadata.interface)
-                }
+                nym_wg_metadata_client::TunUpSendData::InterfaceName(metadata.interface)
             }
         }
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/mod.rs
@@ -63,15 +63,15 @@ impl From<MetadataEvent> for nym_wg_metadata_client::TunUpSendData {
             MetadataEvent::MetadataProxy(proxy_addr) => {
                 nym_wg_metadata_client::TunUpSendData::TcpProxy(proxy_addr)
             }
-            MetadataEvent::TunnelMetadata(_metadata) => {
+            MetadataEvent::TunnelMetadata(metadata) => {
                 #[cfg(target_os = "linux")]
                 {
-                    nym_wg_metadata_client::TunUpSendData::InterfaceName(_metadata.interface)
+                    nym_wg_metadata_client::TunUpSendData::InterfaceName(metadata.interface)
                 }
 
                 #[cfg(not(target_os = "linux"))]
                 {
-                    nym_wg_metadata_client::TunUpSendData::Signal
+                    nym_wg_metadata_client::TunUpSendData::Signal(metadata.interface)
                 }
             }
         }

--- a/nym-vpn-core/crates/nym-wg-metadata-client/src/lib.rs
+++ b/nym-vpn-core/crates/nym-wg-metadata-client/src/lib.rs
@@ -19,10 +19,8 @@ pub mod error;
 
 #[derive(Clone)]
 pub enum TunUpSendData {
-    #[cfg(not(target_os = "windows"))]
     InterfaceName(String),
     TcpProxy(SocketAddr),
-    Signal(String),
 }
 
 pub type TunUpSender = tokio::sync::oneshot::Sender<TunUpSendData>;
@@ -45,10 +43,12 @@ impl LazyMetadataClient {
         let mut interface_name = None;
         let reqwest_builder = ReqwestClientBuilder::new();
         let reqwest_builder = match sent_data {
-            #[cfg(not(target_os = "windows"))]
             TunUpSendData::InterfaceName(interface) => {
+                #[cfg(target_os = "linux")]
+                let reqwest_builder = reqwest_builder.interface(&interface);
+
                 interface_name = Some(interface.clone());
-                reqwest_builder.interface(&interface).local_address(bind_ip)
+                reqwest_builder.local_address(bind_ip)
             }
             TunUpSendData::TcpProxy(tcp_proxy) => {
                 base_url.set_ip_host(tcp_proxy.ip()).map_err(|_| {
@@ -60,10 +60,6 @@ impl LazyMetadataClient {
                 })?;
 
                 reqwest_builder
-            }
-            TunUpSendData::Signal(interface) => {
-                interface_name = Some(interface.clone());
-                reqwest_builder.local_address(bind_ip)
             }
         };
 

--- a/nym-vpn-core/crates/nym-wg-metadata-client/src/lib.rs
+++ b/nym-vpn-core/crates/nym-wg-metadata-client/src/lib.rs
@@ -22,7 +22,7 @@ pub enum TunUpSendData {
     #[cfg(not(target_os = "windows"))]
     InterfaceName(String),
     TcpProxy(SocketAddr),
-    Signal,
+    Signal(String),
 }
 
 pub type TunUpSender = tokio::sync::oneshot::Sender<TunUpSendData>;
@@ -31,6 +31,7 @@ pub type TunUpReceiver = tokio::sync::oneshot::Receiver<TunUpSendData>;
 #[derive(Debug, Clone)]
 struct LazyMetadataClient {
     inner: nym_http_api_client::Client,
+    interface_name: Option<String>,
     version: Version,
 }
 
@@ -41,10 +42,12 @@ impl LazyMetadataClient {
         retries: usize,
         sent_data: TunUpSendData,
     ) -> Result<Self> {
+        let mut interface_name = None;
         let reqwest_builder = ReqwestClientBuilder::new();
         let reqwest_builder = match sent_data {
             #[cfg(not(target_os = "windows"))]
             TunUpSendData::InterfaceName(interface) => {
+                interface_name = Some(interface.clone());
                 reqwest_builder.interface(&interface).local_address(bind_ip)
             }
             TunUpSendData::TcpProxy(tcp_proxy) => {
@@ -58,7 +61,10 @@ impl LazyMetadataClient {
 
                 reqwest_builder
             }
-            _ => reqwest_builder.local_address(bind_ip),
+            TunUpSendData::Signal(interface) => {
+                interface_name = Some(interface.clone());
+                reqwest_builder.local_address(bind_ip)
+            }
         };
 
         let inner = nym_http_api_client::Client::builder(base_url)
@@ -71,7 +77,11 @@ impl LazyMetadataClient {
             .map_err(Box::new)?;
         let version = inner.version().await.map_err(Box::new)?;
 
-        Ok(Self { inner, version })
+        Ok(Self {
+            inner,
+            interface_name,
+            version,
+        })
     }
 }
 
@@ -128,6 +138,14 @@ impl MetadataClient {
 
     pub fn gateway_id(&self) -> NodeIdentity {
         self.gateway_id
+    }
+
+    pub async fn interface_name(&mut self) -> Option<String> {
+        self.lazy_client()
+            .await
+            .as_ref()
+            .ok()
+            .and_then(|client| client.interface_name.clone())
     }
 
     fn print_remaining_bandwidth(


### PR DESCRIPTION
## Ticket

JIRA-NYM-1553

## Description

Introduce a local system bandwidth monitor that does a more aggressive check of the network usage, every 1 second. It is used to detect spikes in bandwidth consumption and trigger early the checks with each gateway, in case we need to top up sooner.
This should prevent spikes mid-checks causing rapid depletion of bandwidth and being kicked out of the connection by the server.


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5618)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added system-wide RX+TX bandwidth spike detection to monitor overall traffic and automatically increase bandwidth check frequency for more responsive throttling.

* **Bug Fixes**
  * Fixed cross-platform tunnel metadata handling so the correct interface information is used on non-Linux systems.
  * Addressed a race condition where traffic spikes during longer bandwidth checks could disconnect the client.

* **Chores**
  * Updated bandwidth monitoring dependencies to support the new system-wide network statistics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->