### PR TITLE
ci: move aur upload of vpnc into on-release-publish workflow

### DIFF
--- a/.github/workflows/on-release-publish.yml
+++ b/.github/workflows/on-release-publish.yml
@@ -66,6 +66,16 @@ jobs:
       publish_aur: true
       commit_msg: "release ${{ needs.setup.outputs.tag }}"
 
+  aur-vpnc:
+    needs: setup
+    uses: ./.github/workflows/publish-aur-nym-vpnc.yml
+    secrets: inherit
+    with:
+      release_tag: ${{ needs.setup.outputs.tag }}
+      pkgrel: 1
+      publish_aur: true
+      commit_msg: "release ${{ needs.setup.outputs.tag }}"
+
   aur-app:
     needs: setup
     uses: ./.github/workflows/publish-aur-nym-vpn-app.yml

--- a/.github/workflows/publish-aur-nym-vpnc.yml
+++ b/.github/workflows/publish-aur-nym-vpnc.yml
@@ -4,10 +4,14 @@ name: publish-aur-nym-vpnc
 on:
   workflow_dispatch:
     inputs:
+      # NOTE: with unified-only core, this is the unified tag nym-vpn-v<version>,
+      # not the legacy nym-vpn-core-v<version>. The referenced release must be PUBLISHED
+      # (draft URLs 404). on-release-publish.yml calls this AUTOMATICALLY when the unified
+      # ship draft is published; manual dispatch is a fallback / re-run of that step.
       release_tag:
         description: "Tag name of the release"
         required: true
-        default: nym-vpn-core-v0.1.0
+        default: nym-vpn-v0.1.0
       pkgrel:
         description: "PKGBUILD package release number"
         required: false
@@ -24,6 +28,10 @@ on:
         required: false
   workflow_call:
     inputs:
+      # NOTE: with unified-only core, this is the unified tag nym-vpn-v<version>,
+      # not the legacy nym-vpn-core-v<version>. The referenced release must be PUBLISHED
+      # (draft URLs 404). on-release-publish.yml calls this AUTOMATICALLY when the unified
+      # ship draft is published; manual dispatch is a fallback / re-run of that step.
       release_tag:
         required: true
         type: string

--- a/.github/workflows/publish-nym-vpn-core.yml
+++ b/.github/workflows/publish-nym-vpn-core.yml
@@ -68,7 +68,6 @@ jobs:
     outputs:
       tag: ${{ steps.set_tag.outputs.tag }}
       ok_to_publish: ${{ steps.determine-ok-to-publish.outputs.ok_to_publish }}
-      is_stable: ${{ steps.determine-ok-to-publish.outputs.is_stable }}
 
     steps:
       - name: Checkout repo
@@ -134,7 +133,6 @@ jobs:
         run: |
           version="${{ steps.workspace-version.outputs.metadata }}"
           should_publish="false"
-          is_stable="false"
           # If version does NOT contain '-' => stable => auto-publish
           if [[ "$version" != *"-"* ]]; then
             should_publish="true"
@@ -145,7 +143,6 @@ jobs:
             should_publish="true"
           fi
           echo "ok_to_publish=$should_publish" >> "$GITHUB_OUTPUT"
-          echo "is_stable=$is_stable" >> "$GITHUB_OUTPUT"
 
       # Setup TAG_NAME, which is used as a general "name"
       - if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/publish-nym-vpn-core.yml
+++ b/.github/workflows/publish-nym-vpn-core.yml
@@ -367,25 +367,3 @@ jobs:
     with:
       release_tag: ${{ needs.publish.outputs.tag }}
     secrets: inherit
-
-  update-aur-vpnd:
-    uses: ./.github/workflows/publish-aur-nym-vpnd.yml
-    needs: publish
-    if: ${{ needs.publish.outputs.is_stable == 'true' }}
-    with:
-      release_tag: ${{ needs.publish.outputs.tag }}
-      pkgrel: 1
-      publish_aur: true
-      commit_msg: "release ${{ needs.publish.outputs.tag }}"
-    secrets: inherit
-
-  update-aur-vpnc:
-    uses: ./.github/workflows/publish-aur-nym-vpnc.yml
-    needs: publish
-    if: ${{ needs.publish.outputs.is_stable == 'true' }}
-    with:
-      release_tag: ${{ needs.publish.outputs.tag }}
-      pkgrel: 1
-      publish_aur: true
-      commit_msg: "release ${{ needs.publish.outputs.tag }}"
-    secrets: inherit


### PR DESCRIPTION




## Description

- move aur upload of vpnc into on-release-publish workflow
- remove aur flows from `publish-nym-vpn-core` -- this are part of on-release flow

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5622)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores / CI Improvements**
  * Added an additional AUR publication step for vpnc as part of the release publish flow.
  * Standardized AUR release tag naming to the unified `nym-vpn-v<version>` format.
  * Simplified the core publish pipeline by removing stable-only branching; it now proceeds through hash generation and then stops.

* **Documentation**
  * Added clearer inline guidance on the unified tag convention and that referenced releases must be in the published state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->