### PR TITLE
Allow API communication in error state

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [iOS] Send network stats over the tunnel interface (https://github.com/nymtech/nym-vpn-client/pull/5564)
 - Store gateway independence notification toggle (https://github.com/nymtech/nym-vpn-client/pull/5586)
 
+### Changed
+
+- Permit API networking in error state in order to refresh account data (https://github.com/nymtech/nym-vpn-client/pull/5623)
+
 ### Fixed
 
 - Fix missing "recursion available" flag in DNS responses, passthrough authority and additional records (https://github.com/nymtech/nym-vpn-client/pull/5546)

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -63,6 +63,8 @@ use tokio_util::sync::CancellationToken;
 
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use nym_firewall::{Firewall, FirewallArguments, InitialFirewallState};
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+use nym_gateway_directory::ResolvedConfig;
 use nym_gateway_directory::{Config as GatewayDirectoryConfig, GatewayCacheHandle};
 use nym_vpn_lib_types::{
     AccountControllerErrorStateReason, ActionAfterDisconnect, ConnectionData, EntryPoint,
@@ -776,6 +778,9 @@ pub struct SharedState {
     topology_service: VpnTopologyServiceHandle,
     discovery_refresher_command_tx: mpsc::UnboundedSender<DiscoveryRefresherCommand>,
     user_agent: UserAgent,
+    /// API endpoints resolved in connecting state and used for configuring a bypass in error state.
+    #[cfg(not(any(target_os = "android", target_os = "ios")))]
+    resolved_api_endpoints: Option<ResolvedConfig>,
     #[cfg(not(target_os = "ios"))]
     shutdown_token: CancellationToken,
 }
@@ -1116,6 +1121,8 @@ impl TunnelStateMachine {
             topology_service,
             discovery_refresher_command_tx,
             user_agent,
+            #[cfg(not(any(target_os = "android", target_os = "ios")))]
+            resolved_api_endpoints: None,
             #[cfg(not(target_os = "ios"))]
             shutdown_token: shutdown_token.clone(),
         };

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -100,7 +100,7 @@ impl ConnectingState {
 
         #[cfg(target_os = "macos")]
         if let Err(e) = Self::set_local_dns_resolver(shared_state).await {
-            trace_err_chain!(e, "Failed to configure system to use filtering resolver",);
+            trace_err_chain!(e, "Failed to configure system to use filtering resolver");
             return ErrorState::enter(ErrorStateReason::SetDns, shared_state).await;
         }
 
@@ -326,6 +326,10 @@ impl ConnectingState {
         HickoryDnsResolver::shared().set_static_preresolve(resolved_gateway_config.addr_map());
 
         self.firewall_policy_params.api_endpoints = resolved_gateway_config.all_socket_addrs();
+
+        // Store resolved API endpoints for reuse in error state to enable API communication while blocking network.
+        shared_state.resolved_api_endpoints = Some(resolved_gateway_config);
+
         if let Err(err) = Self::set_firewall_policy(shared_state, &self.firewall_policy_params) {
             trace_err_chain!(err, "failed to set firewall policy");
             return NextTunnelState::NewState(

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
@@ -1,6 +1,8 @@
 // Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+use std::net::SocketAddr;
 #[cfg(target_os = "ios")]
 use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
@@ -22,7 +24,9 @@ use tokio_util::sync::CancellationToken;
 ))]
 use nym_common::trace_err_chain;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
-use nym_firewall::FirewallPolicy;
+use nym_firewall::{AllowedClients, AllowedEndpoint, Endpoint, FirewallPolicy, TransportProtocol};
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+use nym_http_api_client::HickoryDnsResolver;
 
 #[cfg(target_os = "ios")]
 use crate::tunnel_provider::{OSTunProvider, TunnelSettings};
@@ -55,9 +59,6 @@ impl ErrorState {
         reason: ErrorStateReason,
         shared_state: &mut SharedState,
     ) -> (Box<dyn TunnelStateHandler>, PrivateTunnelState) {
-        // Disallow networking in error state since there are no configured firewall exceptions
-        shared_state.disallow_networking().await;
-
         #[cfg(target_os = "macos")]
         if !reason.prevents_filtering_resolver() {
             // Set system DNS to our local DNS resolver
@@ -77,15 +78,46 @@ impl ErrorState {
 
         // todo: activate kill switch on Android
 
-        #[cfg(not(any(target_os = "android", target_os = "ios")))]
-        let firewall_policy_params = BlockedPolicyParameters {
-            allow_lan: shared_state.tunnel_settings.allow_lan,
-        };
+        // Android: traffic should flow freely since there should be no tunnel device at this point
+        // iOS: network extensions bypass the tunnel by default
+        #[cfg(any(target_os = "android", target_os = "ios"))]
+        shared_state.allow_networking().await;
 
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
-        if let Err(err) = Self::set_firewall_policy(shared_state, &firewall_policy_params) {
-            trace_err_chain!(err, "failed to set firewall policy");
-        }
+        let firewall_policy_params = {
+            let api_endpoints =
+                if let Some(resolved_config) = shared_state.resolved_api_endpoints.as_ref() {
+                    // Set the resolved addresses as static in the default (shared) DNS resolver. Any http
+                    // client based on `nym-http-api-client::Client` that not modified to be independent will
+                    // use these overrides automatically.
+                    HickoryDnsResolver::shared().set_static_preresolve(resolved_config.addr_map());
+
+                    resolved_config.all_socket_addrs()
+                } else {
+                    vec![]
+                };
+
+            let firewall_policy_params = BlockedPolicyParameters {
+                enable_ipv6: shared_state.tunnel_settings.enable_ipv6,
+                allow_lan: shared_state.tunnel_settings.allow_lan,
+                api_endpoints,
+            };
+
+            if let Err(err) = Self::set_firewall_policy(shared_state, &firewall_policy_params) {
+                trace_err_chain!(err, "failed to set firewall policy");
+            }
+
+            if firewall_policy_params.api_endpoints.is_empty() {
+                tracing::warn!(
+                    "No API endpoints were resolved. API communication will be blocked!"
+                );
+                shared_state.disallow_networking().await;
+            } else {
+                shared_state.allow_networking().await;
+            }
+
+            firewall_policy_params
+        };
 
         let blocked_state = Self {
             #[cfg(not(any(target_os = "android", target_os = "ios")))]
@@ -254,16 +286,38 @@ impl TunnelStateHandler for ErrorState {
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 #[derive(Debug, Clone)]
 pub struct BlockedPolicyParameters {
+    /// Whether IPv6 is enabled
+    pub enable_ipv6: bool,
+
     /// Whether to allow LAN traffic
     pub allow_lan: bool,
+
+    /// API endpoints
+    pub api_endpoints: Vec<SocketAddr>,
 }
 
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 impl BlockedPolicyParameters {
     pub fn as_policy(&self) -> FirewallPolicy {
+        // Allow API endpoints
+        let allowed_endpoints = self
+            .api_endpoints
+            .iter()
+            .filter(|ip| ip.is_ipv4() || (self.enable_ipv6 && ip.is_ipv6()))
+            .map(|addr| {
+                AllowedEndpoint::new(
+                    Endpoint::from_socket_address(*addr, TransportProtocol::Tcp),
+                    #[cfg(any(target_os = "linux", target_os = "macos"))]
+                    AllowedClients::Root,
+                    #[cfg(target_os = "windows")]
+                    AllowedClients::current_exe(),
+                )
+            })
+            .collect::<Vec<_>>();
+
         FirewallPolicy::Blocked {
             allow_lan: self.allow_lan,
-            allowed_endpoints: Vec::new(),
+            allowed_endpoints,
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
@@ -114,6 +114,10 @@ impl ErrorState {
                 shared_state.disallow_networking().await;
             } else {
                 shared_state.allow_networking().await;
+                shared_state
+                    .gateway_provider
+                    .set_active_geo_location(true)
+                    .await;
             }
 
             firewall_policy_params

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/offline_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/offline_state.rs
@@ -44,7 +44,9 @@ impl OfflineState {
 
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         let firewall_policy_params = BlockedPolicyParameters {
+            enable_ipv6: shared_state.tunnel_settings.enable_ipv6,
             allow_lan: shared_state.tunnel_settings.allow_lan,
+            api_endpoints: vec![],
         };
 
         #[cfg(not(any(target_os = "android", target_os = "ios")))]


### PR DESCRIPTION
## Ticket

JIRA-NYM-1379

## Description

- Store resolved API endpoints in the shared state of tunnel state machine
- Allow API communication in error state

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5623)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error-state connectivity by permitting API networking so account data can refresh during connectivity issues.
  * Enhanced firewall policy for API access by reusing resolved API endpoint addresses and applying them to blocked-state rules, with optional IPv6 support where available.
  * Updated offline/blocking behavior to explicitly avoid allowing API endpoints when none are available, falling back to disallowing networking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->