### PR TITLE
(ci) Release all udpates

### DIFF
--- a/.github/scripts/release/resolve-version.sh
+++ b/.github/scripts/release/resolve-version.sh
@@ -1,25 +1,30 @@
 #!/usr/bin/env bash
 # Resolve the release version + unified tag, and (for nightly) the per-platform nightly
-# Cargo versions.
+# versions.
 # Inputs (env): SHIP (true|false), CARGO_ENTRY (default nym-vpn-core/Cargo.toml),
 #               APP_CARGO_ENTRY (default nym-vpn-app/src-tauri/Cargo.toml),
+#               APPLE_PBXPROJ (default nym-vpn-apple/NymVPN.xcodeproj/project.pbxproj),
 #               GITHUB_EVENT_NAME (provided by Actions)
-# Outputs (GITHUB_OUTPUT): core_version, tag, core_nightly_version, app_nightly_version
-#   The two *_nightly_version outputs are empty on ship builds. On nightly builds they
+# Outputs (GITHUB_OUTPUT): core_version, tag, core_nightly_version, app_nightly_version,
+#                          apple_nightly_version
+#   The three *_nightly_version outputs are empty on ship builds. On nightly builds they
 #   share ONE timestamp + label so every platform's build/publish job applies the exact
 #   same string (no per-job drift). Each is based on its own project's X.Y.Z so the
-#   projects keep their independent version numbers.
+#   projects keep their independent version numbers. The apple base comes from the Xcode
+#   project's MARKETING_VERSION (CalVer) since the Apple app has no Cargo manifest.
 set -euo pipefail
 
 SHIP="${SHIP:-false}"
 CARGO_ENTRY="${CARGO_ENTRY:-nym-vpn-core/Cargo.toml}"
 APP_CARGO_ENTRY="${APP_CARGO_ENTRY:-nym-vpn-app/src-tauri/Cargo.toml}"
+APPLE_PBXPROJ="${APPLE_PBXPROJ:-nym-vpn-apple/NymVPN.xcodeproj/project.pbxproj}"
 
 CORE_VERSION="$(cargo-get workspace.package.version --entry "$CARGO_ENTRY")"
 echo "::notice:: core version: ${CORE_VERSION}"
 
 CORE_NIGHTLY_VERSION=""
 APP_NIGHTLY_VERSION=""
+APPLE_NIGHTLY_VERSION=""
 
 if [ "$SHIP" = "true" ]; then
   if [[ "$CORE_VERSION" == *beta* ]]; then
@@ -37,10 +42,18 @@ else
   STAMP="$(date -u +%Y%m%d%H%M)"
   CORE_BASE="$(cargo-get workspace.package.version --major --minor --patch --delimiter='.' --entry "$CARGO_ENTRY")"
   APP_BASE="$(cargo-get package.version --major --minor --patch --delimiter='.' --entry "$APP_CARGO_ENTRY")"
+  APPLE_BASE="$(grep -oE 'MARKETING_VERSION = [^;]+' "$APPLE_PBXPROJ" \
+    | sed -E 's/.*= *//' | sort | uniq -c | sort -rn | head -1 | sed -E 's/^ *[0-9]+ +//')"
+  if [ -z "$APPLE_BASE" ]; then
+    echo "::error:: could not resolve apple MARKETING_VERSION from ${APPLE_PBXPROJ}"
+    exit 1
+  fi
   CORE_NIGHTLY_VERSION="${CORE_BASE}-${NIGHTLY_LABEL}.${STAMP}"
   APP_NIGHTLY_VERSION="${APP_BASE}-${NIGHTLY_LABEL}.${STAMP}"
+  APPLE_NIGHTLY_VERSION="${APPLE_BASE}-${NIGHTLY_LABEL}.${STAMP}"
   echo "::notice:: core nightly version: ${CORE_NIGHTLY_VERSION}"
   echo "::notice:: app nightly version: ${APP_NIGHTLY_VERSION}"
+  echo "::notice:: apple nightly version: ${APPLE_NIGHTLY_VERSION}"
 fi
 
 echo "::notice:: unified tag: ${TAG}"
@@ -49,4 +62,5 @@ echo "::notice:: unified tag: ${TAG}"
   echo "tag=${TAG}"
   echo "core_nightly_version=${CORE_NIGHTLY_VERSION}"
   echo "app_nightly_version=${APP_NIGHTLY_VERSION}"
+  echo "apple_nightly_version=${APPLE_NIGHTLY_VERSION}"
 } >> "$GITHUB_OUTPUT"

--- a/.github/scripts/release/resolve-version.sh
+++ b/.github/scripts/release/resolve-version.sh
@@ -26,9 +26,9 @@ CORE_NIGHTLY_VERSION=""
 APP_NIGHTLY_VERSION=""
 APPLE_NIGHTLY_VERSION=""
 
-if [ "$SHIP" = "true" ]; then
+if [[ "$SHIP" == "true" ]]; then
   if [[ "$CORE_VERSION" == *beta* ]]; then
-    echo "::error:: refusing to ship a beta version: ${CORE_VERSION}"
+    echo "::error:: refusing to ship a beta version: ${CORE_VERSION}" >&2
     exit 1
   fi
   TAG="nym-vpn-v${CORE_VERSION}"
@@ -38,14 +38,14 @@ else
   # nightly release + tag are deleted in ensure-release.sh.
   TAG="nym-vpn-nightly-$(date -u +%Y%m%d%H%M%S)"
 
-  if [ "${GITHUB_EVENT_NAME:-}" = "schedule" ]; then NIGHTLY_LABEL="nightly"; else NIGHTLY_LABEL="dev"; fi
+  if [[ "${GITHUB_EVENT_NAME:-}" == "schedule" ]]; then NIGHTLY_LABEL="nightly"; else NIGHTLY_LABEL="dev"; fi
   STAMP="$(date -u +%Y%m%d%H%M)"
   CORE_BASE="$(cargo-get workspace.package.version --major --minor --patch --delimiter='.' --entry "$CARGO_ENTRY")"
   APP_BASE="$(cargo-get package.version --major --minor --patch --delimiter='.' --entry "$APP_CARGO_ENTRY")"
   APPLE_BASE="$(grep -oE 'MARKETING_VERSION = [^;]+' "$APPLE_PBXPROJ" \
     | sed -E 's/.*= *//' | sort | uniq -c | sort -rn | head -1 | sed -E 's/^ *[0-9]+ +//')"
-  if [ -z "$APPLE_BASE" ]; then
-    echo "::error:: could not resolve apple MARKETING_VERSION from ${APPLE_PBXPROJ}"
+  if [[ -z "$APPLE_BASE" ]]; then
+    echo "::error:: could not resolve apple MARKETING_VERSION from ${APPLE_PBXPROJ}" >&2
     exit 1
   fi
   CORE_NIGHTLY_VERSION="${CORE_BASE}-${NIGHTLY_LABEL}.${STAMP}"

--- a/.github/scripts/release/resolve-version.sh
+++ b/.github/scripts/release/resolve-version.sh
@@ -1,14 +1,25 @@
 #!/usr/bin/env bash
-# Resolve the release version + unified tag.
-# Inputs (env): SHIP (true|false), CARGO_ENTRY (default nym-vpn-core/Cargo.toml)
-# Outputs (GITHUB_OUTPUT): core_version, tag
+# Resolve the release version + unified tag, and (for nightly) the per-platform nightly
+# Cargo versions.
+# Inputs (env): SHIP (true|false), CARGO_ENTRY (default nym-vpn-core/Cargo.toml),
+#               APP_CARGO_ENTRY (default nym-vpn-app/src-tauri/Cargo.toml),
+#               GITHUB_EVENT_NAME (provided by Actions)
+# Outputs (GITHUB_OUTPUT): core_version, tag, core_nightly_version, app_nightly_version
+#   The two *_nightly_version outputs are empty on ship builds. On nightly builds they
+#   share ONE timestamp + label so every platform's build/publish job applies the exact
+#   same string (no per-job drift). Each is based on its own project's X.Y.Z so the
+#   projects keep their independent version numbers.
 set -euo pipefail
 
 SHIP="${SHIP:-false}"
 CARGO_ENTRY="${CARGO_ENTRY:-nym-vpn-core/Cargo.toml}"
+APP_CARGO_ENTRY="${APP_CARGO_ENTRY:-nym-vpn-app/src-tauri/Cargo.toml}"
 
 CORE_VERSION="$(cargo-get workspace.package.version --entry "$CARGO_ENTRY")"
 echo "::notice:: core version: ${CORE_VERSION}"
+
+CORE_NIGHTLY_VERSION=""
+APP_NIGHTLY_VERSION=""
 
 if [ "$SHIP" = "true" ]; then
   if [[ "$CORE_VERSION" == *beta* ]]; then
@@ -21,10 +32,21 @@ else
   # once it was published, so each nightly gets a fresh timestamp; the prior
   # nightly release + tag are deleted in ensure-release.sh.
   TAG="nym-vpn-nightly-$(date -u +%Y%m%d%H%M%S)"
+
+  if [ "${GITHUB_EVENT_NAME:-}" = "schedule" ]; then NIGHTLY_LABEL="nightly"; else NIGHTLY_LABEL="dev"; fi
+  STAMP="$(date -u +%Y%m%d%H%M)"
+  CORE_BASE="$(cargo-get workspace.package.version --major --minor --patch --delimiter='.' --entry "$CARGO_ENTRY")"
+  APP_BASE="$(cargo-get package.version --major --minor --patch --delimiter='.' --entry "$APP_CARGO_ENTRY")"
+  CORE_NIGHTLY_VERSION="${CORE_BASE}-${NIGHTLY_LABEL}.${STAMP}"
+  APP_NIGHTLY_VERSION="${APP_BASE}-${NIGHTLY_LABEL}.${STAMP}"
+  echo "::notice:: core nightly version: ${CORE_NIGHTLY_VERSION}"
+  echo "::notice:: app nightly version: ${APP_NIGHTLY_VERSION}"
 fi
 
 echo "::notice:: unified tag: ${TAG}"
 {
   echo "core_version=${CORE_VERSION}"
   echo "tag=${TAG}"
+  echo "core_nightly_version=${CORE_NIGHTLY_VERSION}"
+  echo "app_nightly_version=${APP_NIGHTLY_VERSION}"
 } >> "$GITHUB_OUTPUT"

--- a/.github/scripts/release/resolve-version.sh
+++ b/.github/scripts/release/resolve-version.sh
@@ -1,30 +1,21 @@
 #!/usr/bin/env bash
-# Resolve the release version + unified tag, and (for nightly) the per-platform nightly
-# versions.
+# Resolve the release version + unified tag, and (for nightly) the shared nightly version.
 # Inputs (env): SHIP (true|false), CARGO_ENTRY (default nym-vpn-core/Cargo.toml),
-#               APP_CARGO_ENTRY (default nym-vpn-app/src-tauri/Cargo.toml),
-#               APPLE_PBXPROJ (default nym-vpn-apple/NymVPN.xcodeproj/project.pbxproj),
 #               GITHUB_EVENT_NAME (provided by Actions)
-# Outputs (GITHUB_OUTPUT): core_version, tag, core_nightly_version, app_nightly_version,
-#                          apple_nightly_version
-#   The three *_nightly_version outputs are empty on ship builds. On nightly builds they
-#   share ONE timestamp + label so every platform's build/publish job applies the exact
-#   same string (no per-job drift). Each is based on its own project's X.Y.Z so the
-#   projects keep their independent version numbers. The apple base comes from the Xcode
-#   project's MARKETING_VERSION (CalVer) since the Apple app has no Cargo manifest.
+# Outputs (GITHUB_OUTPUT): core_version, tag, nightly_version
+#   nightly_version is empty on ship builds. On nightly builds EVERY platform shares this
+#   ONE string (core X.Y.Z + label + timestamp): this pipeline builds nightlies from
+#   develop, so all platforms carry the exact same version derived from core, with no
+#   per-platform version drift.
 set -euo pipefail
 
 SHIP="${SHIP:-false}"
 CARGO_ENTRY="${CARGO_ENTRY:-nym-vpn-core/Cargo.toml}"
-APP_CARGO_ENTRY="${APP_CARGO_ENTRY:-nym-vpn-app/src-tauri/Cargo.toml}"
-APPLE_PBXPROJ="${APPLE_PBXPROJ:-nym-vpn-apple/NymVPN.xcodeproj/project.pbxproj}"
 
 CORE_VERSION="$(cargo-get workspace.package.version --entry "$CARGO_ENTRY")"
 echo "::notice:: core version: ${CORE_VERSION}"
 
-CORE_NIGHTLY_VERSION=""
-APP_NIGHTLY_VERSION=""
-APPLE_NIGHTLY_VERSION=""
+NIGHTLY_VERSION=""
 
 if [[ "$SHIP" == "true" ]]; then
   if [[ "$CORE_VERSION" == *beta* ]]; then
@@ -41,26 +32,13 @@ else
   if [[ "${GITHUB_EVENT_NAME:-}" == "schedule" ]]; then NIGHTLY_LABEL="nightly"; else NIGHTLY_LABEL="dev"; fi
   STAMP="$(date -u +%Y%m%d%H%M)"
   CORE_BASE="$(cargo-get workspace.package.version --major --minor --patch --delimiter='.' --entry "$CARGO_ENTRY")"
-  APP_BASE="$(cargo-get package.version --major --minor --patch --delimiter='.' --entry "$APP_CARGO_ENTRY")"
-  APPLE_BASE="$(grep -oE 'MARKETING_VERSION = [^;]+' "$APPLE_PBXPROJ" \
-    | sed -E 's/.*= *//' | sort | uniq -c | sort -rn | head -1 | sed -E 's/^ *[0-9]+ +//')"
-  if [[ -z "$APPLE_BASE" ]]; then
-    echo "::error:: could not resolve apple MARKETING_VERSION from ${APPLE_PBXPROJ}" >&2
-    exit 1
-  fi
-  CORE_NIGHTLY_VERSION="${CORE_BASE}-${NIGHTLY_LABEL}.${STAMP}"
-  APP_NIGHTLY_VERSION="${APP_BASE}-${NIGHTLY_LABEL}.${STAMP}"
-  APPLE_NIGHTLY_VERSION="${APPLE_BASE}-${NIGHTLY_LABEL}.${STAMP}"
-  echo "::notice:: core nightly version: ${CORE_NIGHTLY_VERSION}"
-  echo "::notice:: app nightly version: ${APP_NIGHTLY_VERSION}"
-  echo "::notice:: apple nightly version: ${APPLE_NIGHTLY_VERSION}"
+  NIGHTLY_VERSION="${CORE_BASE}-${NIGHTLY_LABEL}.${STAMP}"
+  echo "::notice:: nightly version (all platforms): ${NIGHTLY_VERSION}"
 fi
 
 echo "::notice:: unified tag: ${TAG}"
 {
   echo "core_version=${CORE_VERSION}"
   echo "tag=${TAG}"
-  echo "core_nightly_version=${CORE_NIGHTLY_VERSION}"
-  echo "app_nightly_version=${APP_NIGHTLY_VERSION}"
-  echo "apple_nightly_version=${APPLE_NIGHTLY_VERSION}"
+  echo "nightly_version=${NIGHTLY_VERSION}"
 } >> "$GITHUB_OUTPUT"

--- a/.github/scripts/release/set-nightly-version.sh
+++ b/.github/scripts/release/set-nightly-version.sh
@@ -15,7 +15,7 @@
 #   VERSION_KEY      toml key to set (workspace.package.version | package.version)
 set -euo pipefail
 
-if [ -z "${NIGHTLY_VERSION:-}" ]; then
+if [[ -z "${NIGHTLY_VERSION:-}" ]]; then
   echo "::notice:: no nightly version provided; leaving ${CARGO_TOML:-Cargo.toml} unchanged"
   exit 0
 fi

--- a/.github/scripts/release/set-nightly-version.sh
+++ b/.github/scripts/release/set-nightly-version.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Apply a precomputed nightly version to a Cargo.toml.
+#
+# The version is computed ONCE upstream (release-all-platforms.yml -> resolve-version.sh)
+# and passed down to every build/publish job, so the binary's embedded version and the
+# release/artifact names all share the same timestamp (no per-job drift). This script is a
+# dumb applier: it never computes a version itself.
+#
+# No-op when NIGHTLY_VERSION is empty — that is the ship/legacy path, where the real
+# Cargo.toml version is kept as-is.
+#
+# Inputs (env):
+#   NIGHTLY_VERSION  precomputed version string (empty = leave Cargo.toml untouched)
+#   CARGO_TOML       path to the Cargo.toml to patch
+#   VERSION_KEY      toml key to set (workspace.package.version | package.version)
+set -euo pipefail
+
+if [ -z "${NIGHTLY_VERSION:-}" ]; then
+  echo "::notice:: no nightly version provided; leaving ${CARGO_TOML:-Cargo.toml} unchanged"
+  exit 0
+fi
+
+: "${CARGO_TOML:?CARGO_TOML is required when NIGHTLY_VERSION is set}"
+: "${VERSION_KEY:?VERSION_KEY is required when NIGHTLY_VERSION is set}"
+
+echo "::notice:: set ${VERSION_KEY} = ${NIGHTLY_VERSION} in ${CARGO_TOML}"
+toml set "$CARGO_TOML" "$VERSION_KEY" "$NIGHTLY_VERSION" > "${CARGO_TOML}.patched"
+mv "${CARGO_TOML}.patched" "$CARGO_TOML"

--- a/.github/workflows/build-nym-vpn-app-linux.yml
+++ b/.github/workflows/build-nym-vpn-app-linux.yml
@@ -18,6 +18,10 @@ on:
         required: true
         type: boolean
         default: false
+      nightly_version:
+        description: "Precomputed nightly Cargo version (computed once in release-all-platforms.yml; empty = keep real version)"
+        type: string
+        default: ""
     secrets:
       TAURI_PRIVATE_KEY:
         required: true
@@ -84,6 +88,18 @@ jobs:
         with:
           version: "21.12" # version on ubuntu 24.04
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install toml
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: toml-cli
+
+      - name: Set version for nightly builds
+        env:
+          NIGHTLY_VERSION: ${{ inputs.nightly_version }}
+          CARGO_TOML: nym-vpn-app/src-tauri/Cargo.toml
+          VERSION_KEY: package.version
+        run: bash .github/scripts/release/set-nightly-version.sh
 
       - name: Get package version
         id: package-version

--- a/.github/workflows/build-nym-vpn-app-windows.yml
+++ b/.github/workflows/build-nym-vpn-app-windows.yml
@@ -62,6 +62,10 @@ on:
         required: true
         type: boolean
         default: false
+      nightly_version:
+        description: "Precomputed nightly Cargo version (computed once in release-all-platforms.yml; empty = keep real version)"
+        type: string
+        default: ""
       core_release_tag:
         required: false
         type: string
@@ -201,6 +205,19 @@ jobs:
         uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3
         with:
           crate: cargo-get
+
+      - name: Install toml
+        uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3
+        with:
+          crate: toml-cli
+
+      - name: Set version for nightly builds
+        shell: bash
+        env:
+          NIGHTLY_VERSION: ${{ inputs.nightly_version }}
+          CARGO_TOML: nym-vpn-app/src-tauri/Cargo.toml
+          VERSION_KEY: package.version
+        run: bash .github/scripts/release/set-nightly-version.sh
 
       - name: Get package version
         id: package-version

--- a/.github/workflows/build-nym-vpn-apple.yml
+++ b/.github/workflows/build-nym-vpn-apple.yml
@@ -40,12 +40,8 @@ on:
         description: "Unified release tag (empty = legacy; nym-vpn-nightly = mutable; nym-vpn-v* = immutable ship)"
         type: string
         default: ""
-      core_nightly_version:
+      nightly_version:
         description: "Resolved nightly core (Rust) version, e.g. 2.13.0-nightly.<stamp>. Empty on ship/PR → falls back to Cargo.toml. Bundled into the app as libVersion."
-        type: string
-        default: ""
-      apple_nightly_version:
-        description: "Resolved apple nightly version, e.g. 2026.11.0-nightly.<stamp>. Empty on ship/PR. Applied as the macOS MARKETING_VERSION only (iOS keeps numeric CalVer for TestFlight)."
         type: string
         default: ""
       build_ios:
@@ -175,6 +171,8 @@ jobs:
         with:
           go-version: ${{ env.GOLANG_VERSION }}
           cache-dependency-path: wireguard/libwg/go.sum
+
+      # TODO(release-all-platforms): Set version for nightly builds.
 
       - name: Get workspace version
         id: workspace-version
@@ -344,12 +342,12 @@ jobs:
       - name: Update core version in app
         if: ${{ env.RELEASE_TYPE != 'pr' }}
         env:
-          CORE_NIGHTLY_VERSION: ${{ inputs.core_nightly_version }}
+          NIGHTLY_VERSION: ${{ inputs.nightly_version }}
         run: |
           set -euo pipefail
 
-          if [[ -n "${CORE_NIGHTLY_VERSION:-}" ]]; then
-            LIB_VERSION="$CORE_NIGHTLY_VERSION"
+          if [[ -n "${NIGHTLY_VERSION:-}" ]]; then
+            LIB_VERSION="$NIGHTLY_VERSION"
             echo "📦 Core library version (resolved nightly): ${LIB_VERSION}"
           else
             cargo install cargo-get
@@ -587,7 +585,6 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: 14.0
           DEVELOPMENT_TEAM: ${{ secrets.APPLE_TEAM_ID }}
           DEVELOPER_ID_APP_IDENTITY: "Developer ID Application: Nym Technologies SA (${{ secrets.APPLE_TEAM_ID }})"
-          APPLE_NIGHTLY_VERSION: ${{ inputs.apple_nightly_version }}
         run: |
           set -euo pipefail
 
@@ -596,18 +593,6 @@ jobs:
           EXPORT_PLIST="$PWD/export_options.plist"
 
           mkdir -p "$EXPORT_PATH"
-
-          # Nightly: stamp the resolved suffixed version onto the macOS build only (all
-          # Info.plists derive CFBundleShortVersionString from $(MARKETING_VERSION), and the
-          # .pkg/Sparkle path accepts non-numeric versions). Passed as an xcodebuild build
-          # setting so it never touches iOS, which keeps its numeric CalVer for TestFlight.
-          # Empty on ship/PR → no override, MARKETING_VERSION stays as committed. The value
-          # has no whitespace, so the unquoted (possibly empty) expansion below is safe.
-          MV_OVERRIDE=""
-          if [[ -n "${APPLE_NIGHTLY_VERSION:-}" ]]; then
-            MV_OVERRIDE="MARKETING_VERSION=${APPLE_NIGHTLY_VERSION}"
-            echo "🔖 Overriding macOS MARKETING_VERSION → ${APPLE_NIGHTLY_VERSION}"
-          fi
 
           # Create export options plist with explicit profile-to-bundle-ID mapping
           cat > "$EXPORT_PLIST" <<PLIST
@@ -668,9 +653,6 @@ jobs:
           echo "✅ Widget profile: $WIDGET_PROFILE_SPEC"
 
           echo "Archiving macOS app..."
-          # SC2086: $MV_OVERRIDE is deliberately unquoted — empty on ship/PR so it must
-          # expand to zero args, not one empty arg. Its value never contains whitespace.
-          # shellcheck disable=SC2086
           xcodebuild archive \
             -workspace "NymVPN.xcworkspace" \
             -scheme "NymVPNDaemon" \
@@ -684,7 +666,6 @@ jobs:
             MACOS_WIDGET_PROFILE_SPECIFIER="${WIDGET_PROFILE_SPEC}" \
             ENABLE_HARDENED_RUNTIME=YES \
             OTHER_CODE_SIGN_FLAGS="--timestamp" \
-            $MV_OVERRIDE \
             | xcbeautify --renderer github-actions
 
           # Verify archive was created

--- a/.github/workflows/build-nym-vpn-apple.yml
+++ b/.github/workflows/build-nym-vpn-apple.yml
@@ -1243,34 +1243,42 @@ jobs:
             - Commit: ${{ github.sha }}
             - Built at: ${{ github.run_started_at }}
 
-      - name: Append macOS pkg to unified release
+      - name: Stage appcast item asset for unified release
         if: ${{ inputs.version_tag != '' && env.RELEASE_TYPE == 'ship' && env.BUILD_MACOS == 'true' }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION_TAG: ${{ inputs.version_tag }}
         run: |
           set -euo pipefail
           # Carry the Sparkle appcast <item> as a release asset so the deferred
           # nym-websites PR (opened post-publish by on-release-publish.yml) can recover
           # it. Version is in the asset name → that job needs no unified->macOS mapping.
           cp "${{ env.APPCAST_ITEM_RELATIVE_PATH }}" "appcast-item-${{ env.MACOS_VERSION }}.xml"
-          files=( \
-            nym-vpn-apple/build/pkg/publish/NymVPN-${{ env.MACOS_VERSION }}.pkg \
-            nym-vpn-apple/build/pkg/publish/sha256-hash.txt \
-            "appcast-item-${{ env.MACOS_VERSION }}.xml" \
-          )
-          # Append to the (ship) draft. No --clobber: gh refuses a duplicate.
-          gh release upload "$VERSION_TAG" "${files[@]}"
+
+      - name: Append macOS pkg to unified release
+        if: ${{ inputs.version_tag != '' && env.RELEASE_TYPE == 'ship' && env.BUILD_MACOS == 'true' }}
+        uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Append to the (ship) draft; keep it a draft until the release is finalized.
+          tag_name: ${{ inputs.version_tag }}
+          draft: true
+          fail_on_unmatched_files: true
+          files: |
+            nym-vpn-apple/build/pkg/publish/NymVPN-${{ env.MACOS_VERSION }}.pkg
+            nym-vpn-apple/build/pkg/publish/sha256-hash.txt
+            appcast-item-${{ env.MACOS_VERSION }}.xml
 
       - name: Append macOS pkg to unified nightly release
         if: ${{ inputs.version_tag != '' && env.RELEASE_TYPE == 'qa' && env.BUILD_MACOS == 'true' }}
+        uses: softprops/action-gh-release@v2
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION_TAG: ${{ inputs.version_tag }}
-        run: |
-          set -euo pipefail
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
           # Append the qa pkg to the fresh nightly draft (finalize-nightly publishes it).
-          gh release upload "$VERSION_TAG" "$renamed_pkg_relative_path"
+          tag_name: ${{ inputs.version_tag }}
+          draft: true
+          prerelease: true
+          fail_on_unmatched_files: true
+          files: ${{ env.renamed_pkg_relative_path }}
 
       - name: Upload artifacts (Ship + appcast + hash)
         if: ${{ env.RELEASE_TYPE == 'ship' && env.BUILD_MACOS == 'true' }}

--- a/.github/workflows/build-nym-vpn-apple.yml
+++ b/.github/workflows/build-nym-vpn-apple.yml
@@ -40,6 +40,14 @@ on:
         description: "Unified release tag (empty = legacy; nym-vpn-nightly = mutable; nym-vpn-v* = immutable ship)"
         type: string
         default: ""
+      core_nightly_version:
+        description: "Resolved nightly core (Rust) version, e.g. 2.13.0-nightly.<stamp>. Empty on ship/PR → falls back to Cargo.toml. Bundled into the app as libVersion."
+        type: string
+        default: ""
+      apple_nightly_version:
+        description: "Resolved apple nightly version, e.g. 2026.11.0-nightly.<stamp>. Empty on ship/PR. Applied as the macOS MARKETING_VERSION only (iOS keeps numeric CalVer for TestFlight)."
+        type: string
+        default: ""
       build_ios:
         type: boolean
         default: false
@@ -167,8 +175,6 @@ jobs:
         with:
           go-version: ${{ env.GOLANG_VERSION }}
           cache-dependency-path: wireguard/libwg/go.sum
-
-      # TODO(release-all-platforms): Set version for nightly builds.
 
       - name: Get workspace version
         id: workspace-version
@@ -337,14 +343,19 @@ jobs:
 
       - name: Update core version in app
         if: ${{ env.RELEASE_TYPE != 'pr' }}
+        env:
+          CORE_NIGHTLY_VERSION: ${{ inputs.core_nightly_version }}
         run: |
           set -euo pipefail
 
-          cargo install cargo-get
-
-          # Get version from Cargo.toml workspace
-          LIB_VERSION=$(cargo get workspace.package.version --entry nym-vpn-core/Cargo.toml)
-          echo "📦 Core library version: ${LIB_VERSION}"
+          if [[ -n "${CORE_NIGHTLY_VERSION:-}" ]]; then
+            LIB_VERSION="$CORE_NIGHTLY_VERSION"
+            echo "📦 Core library version (resolved nightly): ${LIB_VERSION}"
+          else
+            cargo install cargo-get
+            LIB_VERSION=$(cargo get workspace.package.version --entry nym-vpn-core/Cargo.toml)
+            echo "📦 Core library version (from Cargo.toml): ${LIB_VERSION}"
+          fi
 
           # Path to Swift source file
           app_version_file="nym-vpn-apple/ServicesMutual/Sources/AppVersionProvider/AppVersionProvider.swift"
@@ -576,6 +587,7 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: 14.0
           DEVELOPMENT_TEAM: ${{ secrets.APPLE_TEAM_ID }}
           DEVELOPER_ID_APP_IDENTITY: "Developer ID Application: Nym Technologies SA (${{ secrets.APPLE_TEAM_ID }})"
+          APPLE_NIGHTLY_VERSION: ${{ inputs.apple_nightly_version }}
         run: |
           set -euo pipefail
 
@@ -584,6 +596,18 @@ jobs:
           EXPORT_PLIST="$PWD/export_options.plist"
 
           mkdir -p "$EXPORT_PATH"
+
+          # Nightly: stamp the resolved suffixed version onto the macOS build only (all
+          # Info.plists derive CFBundleShortVersionString from $(MARKETING_VERSION), and the
+          # .pkg/Sparkle path accepts non-numeric versions). Passed as an xcodebuild build
+          # setting so it never touches iOS, which keeps its numeric CalVer for TestFlight.
+          # Empty on ship/PR → no override, MARKETING_VERSION stays as committed. The value
+          # has no whitespace, so the unquoted (possibly empty) expansion below is safe.
+          MV_OVERRIDE=""
+          if [[ -n "${APPLE_NIGHTLY_VERSION:-}" ]]; then
+            MV_OVERRIDE="MARKETING_VERSION=${APPLE_NIGHTLY_VERSION}"
+            echo "🔖 Overriding macOS MARKETING_VERSION → ${APPLE_NIGHTLY_VERSION}"
+          fi
 
           # Create export options plist with explicit profile-to-bundle-ID mapping
           cat > "$EXPORT_PLIST" <<PLIST
@@ -644,6 +668,9 @@ jobs:
           echo "✅ Widget profile: $WIDGET_PROFILE_SPEC"
 
           echo "Archiving macOS app..."
+          # SC2086: $MV_OVERRIDE is deliberately unquoted — empty on ship/PR so it must
+          # expand to zero args, not one empty arg. Its value never contains whitespace.
+          # shellcheck disable=SC2086
           xcodebuild archive \
             -workspace "NymVPN.xcworkspace" \
             -scheme "NymVPNDaemon" \
@@ -657,6 +684,7 @@ jobs:
             MACOS_WIDGET_PROFILE_SPECIFIER="${WIDGET_PROFILE_SPEC}" \
             ENABLE_HARDENED_RUNTIME=YES \
             OTHER_CODE_SIGN_FLAGS="--timestamp" \
+            $MV_OVERRIDE \
             | xcbeautify --renderer github-actions
 
           # Verify archive was created

--- a/.github/workflows/build-nym-vpn-apple.yml
+++ b/.github/workflows/build-nym-vpn-apple.yml
@@ -168,6 +168,8 @@ jobs:
           go-version: ${{ env.GOLANG_VERSION }}
           cache-dependency-path: wireguard/libwg/go.sum
 
+      # TODO(release-all-platforms): Set version for nightly builds.
+
       - name: Get workspace version
         id: workspace-version
         uses: nicolaiunrein/cargo-get@master

--- a/.github/workflows/build-nym-vpn-core-linux.yml
+++ b/.github/workflows/build-nym-vpn-core-linux.yml
@@ -6,6 +6,11 @@ on:
       - ".github/workflows/build-nym-vpn-core-linux.yml"
   workflow_dispatch:
   workflow_call:
+    inputs:
+      nightly_version:
+        description: "Precomputed nightly Cargo version (computed once in release-all-platforms.yml; empty = keep real version)"
+        type: string
+        default: ""
     secrets:
       VPND_SENTRY_DSN:
         required: true
@@ -89,20 +94,11 @@ jobs:
           cache-key: ${{ matrix.arch }}
 
       - name: Set version for nightly builds
-        working-directory: nym-vpn-core
-        if: ${{ github.ref_name == 'develop' }}
-        run: |
-          if [ ${{ github.event_name }} = 'schedule' ]; then
-            TAG="nightly"
-          else
-            TAG="dev"
-          fi
-          VERSION=$(cargo-get workspace.package.version --major --minor --patch --delimiter='.')
-          NEW_VERSION="${VERSION}-${TAG}.$(date -u +%Y%m%d%H%M)"
-          echo "::notice:: Update version for nightly build: ${NEW_VERSION}"
-          toml set Cargo.toml workspace.package.version "$NEW_VERSION" > Cargo-patched.toml
-          mv Cargo-patched.toml Cargo.toml
-          cargo update --dry-run
+        env:
+          NIGHTLY_VERSION: ${{ inputs.nightly_version }}
+          CARGO_TOML: nym-vpn-core/Cargo.toml
+          VERSION_KEY: workspace.package.version
+        run: bash .github/scripts/release/set-nightly-version.sh
 
       - name: Download wireguard-go artifacts
         uses: actions/download-artifact@v8

--- a/.github/workflows/build-nym-vpn-core-windows.yml
+++ b/.github/workflows/build-nym-vpn-core-windows.yml
@@ -22,6 +22,10 @@ on:
         required: false
         default: x64
         type: string
+      nightly_version:
+        description: "Precomputed nightly Cargo version (computed once in release-all-platforms.yml; empty = keep real version)"
+        type: string
+        default: ""
     secrets:
       VPND_SENTRY_DSN:
         required: true
@@ -102,20 +106,11 @@ jobs:
 
       - name: Set version for nightly builds
         shell: bash
-        working-directory: nym-vpn-core
-        if: ${{ github.ref_name == 'develop' }}
-        run: |
-          if [ ${{ github.event_name }} = 'schedule' ]; then
-            TAG="nightly"
-          else
-            TAG="dev"
-          fi
-          VERSION=$(cargo-get workspace.package.version --major --minor --patch --delimiter='.')
-          NEW_VERSION="${VERSION}-${TAG}.$(date -u +%Y%m%d%H%M)"
-          echo "::notice:: Update version for nightly build: ${NEW_VERSION}"
-          toml set Cargo.toml workspace.package.version "$NEW_VERSION" > Cargo-patched.toml
-          mv Cargo-patched.toml Cargo.toml
-          cargo update --dry-run
+        env:
+          NIGHTLY_VERSION: ${{ inputs.nightly_version }}
+          CARGO_TOML: nym-vpn-core/Cargo.toml
+          VERSION_KEY: workspace.package.version
+        run: bash .github/scripts/release/set-nightly-version.sh
 
       - name: Download wireguard-go-windows artifacts
         uses: actions/download-artifact@v8

--- a/.github/workflows/publish-nym-vpn-android.yml
+++ b/.github/workflows/publish-nym-vpn-android.yml
@@ -103,8 +103,6 @@ jobs:
         run: |
           sudo apt update && sudo apt install -y gettext-base gh zip apksigner rsync
 
-      # TODO(release-all-platforms): Set version for nightly builds.
-
       - name: Get version code
         run: |
           version_code=$(grep "VERSION_CODE" ${{ github.workspace }}/nym-vpn-android/buildSrc/src/main/kotlin/Constants.kt | awk '{print $5}' | tr -d '\n')

--- a/.github/workflows/publish-nym-vpn-android.yml
+++ b/.github/workflows/publish-nym-vpn-android.yml
@@ -103,6 +103,8 @@ jobs:
         run: |
           sudo apt update && sudo apt install -y gettext-base gh zip apksigner rsync
 
+      # TODO(release-all-platforms): Set version for nightly builds.
+
       - name: Get version code
         run: |
           version_code=$(grep "VERSION_CODE" ${{ github.workspace }}/nym-vpn-android/buildSrc/src/main/kotlin/Constants.kt | awk '{print $5}' | tr -d '\n')

--- a/.github/workflows/publish-nym-vpn-app.yml
+++ b/.github/workflows/publish-nym-vpn-app.yml
@@ -33,6 +33,10 @@ on:
         description: "Unified release tag (empty = legacy; nym-vpn-nightly = mutable; nym-vpn-v* = immutable ship)"
         type: string
         default: ""
+      nightly_version:
+        description: "Precomputed nightly Cargo version (computed once in release-all-platforms.yml; empty = keep real version)"
+        type: string
+        default: ""
       linux:
         type: boolean
         default: false
@@ -99,6 +103,7 @@ jobs:
     uses: ./.github/workflows/build-nym-vpn-app-linux.yml
     with:
       dev_mode: ${{ github.event_name == 'schedule' || contains(github.ref_name, 'dev') || contains(github.ref_name, 'nightly') || inputs.dev_mode == true }}
+      nightly_version: ${{ inputs.nightly_version }}
     secrets: inherit
   build-windows-x64:
     needs: download-translations
@@ -106,6 +111,7 @@ jobs:
     with:
       cpu_arch: x64
       dev_mode: ${{ github.event_name == 'schedule' || contains(github.ref_name, 'dev') || contains(github.ref_name, 'nightly') || inputs.dev_mode == true  }}
+      nightly_version: ${{ inputs.nightly_version }}
       core_build_it: ${{ inputs.core_release_tag == '' }}
       core_release_tag: ${{ inputs.core_release_tag }}
       sign: ${{ inputs.release_type == 'stable' || inputs.release_type == 'rc' }}
@@ -119,6 +125,7 @@ jobs:
     with:
       cpu_arch: ARM64
       dev_mode: ${{ github.event_name == 'schedule' || contains(github.ref_name, 'dev') || contains(github.ref_name, 'nightly') || inputs.dev_mode == true  }}
+      nightly_version: ${{ inputs.nightly_version }}
       core_build_it: ${{ inputs.core_release_tag == '' }}
       core_release_tag: ${{ inputs.core_release_tag }}
       sign: ${{ inputs.release_type == 'stable' || inputs.release_type == 'rc' }}
@@ -330,6 +337,18 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
           components: rustfmt, clippy
+
+      - name: Install toml
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: toml-cli
+
+      - name: Set version for nightly builds
+        env:
+          NIGHTLY_VERSION: ${{ inputs.nightly_version }}
+          CARGO_TOML: nym-vpn-app/src-tauri/Cargo.toml
+          VERSION_KEY: package.version
+        run: bash .github/scripts/release/set-nightly-version.sh
 
       - name: Get package version
         id: cargo-get

--- a/.github/workflows/publish-nym-vpn-core.yml
+++ b/.github/workflows/publish-nym-vpn-core.yml
@@ -13,6 +13,10 @@ on:
         description: "Unified release tag (empty = legacy; nym-vpn-nightly = mutable; nym-vpn-v* = immutable ship)"
         type: string
         default: ""
+      nightly_version:
+        description: "Precomputed nightly Cargo version (computed once in release-all-platforms.yml; empty = keep real version)"
+        type: string
+        default: ""
 
 env:
   CARGO_TERM_COLOR: always
@@ -32,6 +36,8 @@ jobs:
   # (the .deb step reuses the release build, so there is no second compile).
   build-nym-vpn-core-linux:
     uses: ./.github/workflows/build-nym-vpn-core-linux.yml
+    with:
+      nightly_version: ${{ inputs.nightly_version }}
     secrets:
       VPND_SENTRY_DSN: ${{ secrets.VPND_SENTRY_DSN }}
 
@@ -39,6 +45,7 @@ jobs:
     uses: ./.github/workflows/build-nym-vpn-core-windows.yml
     with:
       cpu_arch: x64
+      nightly_version: ${{ inputs.nightly_version }}
     secrets:
       VPND_SENTRY_DSN: ${{ secrets.VPND_SENTRY_DSN }}
 
@@ -46,6 +53,7 @@ jobs:
     uses: ./.github/workflows/build-nym-vpn-core-windows.yml
     with:
       cpu_arch: ARM64
+      nightly_version: ${{ inputs.nightly_version }}
     secrets:
       VPND_SENTRY_DSN: ${{ secrets.VPND_SENTRY_DSN }}
 
@@ -104,20 +112,11 @@ jobs:
           crate: cargo-edit
 
       - name: Set version for nightly builds
-        working-directory: nym-vpn-core
-        if: ${{ github.ref_name == 'develop' }}
-        run: |
-          if [ ${{ github.event_name }} = 'schedule' ]; then
-            TAG="nightly"
-          else
-            TAG="dev"
-          fi
-          VERSION=$(cargo-get workspace.package.version --major --minor --patch --delimiter='.')
-          NEW_VERSION="${VERSION}-${TAG}.$(date -u +%Y%m%d%H%M)"
-          echo "::notice:: Update version for nightly build: ${NEW_VERSION}"
-          toml set Cargo.toml workspace.package.version "$NEW_VERSION" > Cargo-patched.toml
-          mv Cargo-patched.toml Cargo.toml
-          cargo update --dry-run
+        env:
+          NIGHTLY_VERSION: ${{ inputs.nightly_version }}
+          CARGO_TOML: nym-vpn-core/Cargo.toml
+          VERSION_KEY: workspace.package.version
+        run: bash .github/scripts/release/set-nightly-version.sh
 
       - name: Get nym-vpn-core workspace version (post-append)
         id: workspace-version

--- a/.github/workflows/release-all-platforms.yml
+++ b/.github/workflows/release-all-platforms.yml
@@ -57,6 +57,7 @@ jobs:
       core_version: ${{ steps.v.outputs.core_version }}
       core_nightly_version: ${{ steps.v.outputs.core_nightly_version }}
       app_nightly_version: ${{ steps.v.outputs.app_nightly_version }}
+      apple_nightly_version: ${{ steps.v.outputs.apple_nightly_version }}
       ship: ${{ steps.flags.outputs.ship }}
       android: ${{ steps.flags.outputs.android }}
       fdroid: ${{ steps.flags.outputs.fdroid }}
@@ -153,6 +154,8 @@ jobs:
     with:
       release_type: ${{ needs.resolve.outputs.ship == 'true' && 'ship' || 'qa' }}
       version_tag: ${{ needs.resolve.outputs.tag }}
+      core_nightly_version: ${{ needs.resolve.outputs.core_nightly_version }}
+      apple_nightly_version: ${{ needs.resolve.outputs.apple_nightly_version }}
       build_ios: ${{ needs.resolve.outputs.ios == 'true' }}
       build_macos: ${{ needs.resolve.outputs.macos == 'true' }}
     secrets: inherit

--- a/.github/workflows/release-all-platforms.yml
+++ b/.github/workflows/release-all-platforms.yml
@@ -55,6 +55,8 @@ jobs:
     outputs:
       tag: ${{ steps.v.outputs.tag }}
       core_version: ${{ steps.v.outputs.core_version }}
+      core_nightly_version: ${{ steps.v.outputs.core_nightly_version }}
+      app_nightly_version: ${{ steps.v.outputs.app_nightly_version }}
       ship: ${{ steps.flags.outputs.ship }}
       android: ${{ steps.flags.outputs.android }}
       fdroid: ${{ steps.flags.outputs.fdroid }}
@@ -139,6 +141,7 @@ jobs:
     uses: ./.github/workflows/publish-nym-vpn-core.yml
     with:
       version_tag: ${{ needs.resolve.outputs.tag }}
+      nightly_version: ${{ needs.resolve.outputs.core_nightly_version }}
     secrets: inherit
 
   apple:
@@ -180,6 +183,7 @@ jobs:
     uses: ./.github/workflows/publish-nym-vpn-app.yml
     with:
       version_tag: ${{ needs.resolve.outputs.tag }}
+      nightly_version: ${{ needs.resolve.outputs.app_nightly_version }}
       linux: ${{ needs.resolve.outputs.linux == 'true' }}
       windows: ${{ needs.resolve.outputs.windows == 'true' }}
       release_type: ${{ needs.resolve.outputs.ship == 'true' && 'stable' || 'nightly' }}

--- a/.github/workflows/release-all-platforms.yml
+++ b/.github/workflows/release-all-platforms.yml
@@ -55,9 +55,7 @@ jobs:
     outputs:
       tag: ${{ steps.v.outputs.tag }}
       core_version: ${{ steps.v.outputs.core_version }}
-      core_nightly_version: ${{ steps.v.outputs.core_nightly_version }}
-      app_nightly_version: ${{ steps.v.outputs.app_nightly_version }}
-      apple_nightly_version: ${{ steps.v.outputs.apple_nightly_version }}
+      nightly_version: ${{ steps.v.outputs.nightly_version }}
       ship: ${{ steps.flags.outputs.ship }}
       android: ${{ steps.flags.outputs.android }}
       fdroid: ${{ steps.flags.outputs.fdroid }}
@@ -142,7 +140,7 @@ jobs:
     uses: ./.github/workflows/publish-nym-vpn-core.yml
     with:
       version_tag: ${{ needs.resolve.outputs.tag }}
-      nightly_version: ${{ needs.resolve.outputs.core_nightly_version }}
+      nightly_version: ${{ needs.resolve.outputs.nightly_version }}
     secrets: inherit
 
   apple:
@@ -154,8 +152,6 @@ jobs:
     with:
       release_type: ${{ needs.resolve.outputs.ship == 'true' && 'ship' || 'qa' }}
       version_tag: ${{ needs.resolve.outputs.tag }}
-      core_nightly_version: ${{ needs.resolve.outputs.core_nightly_version }}
-      apple_nightly_version: ${{ needs.resolve.outputs.apple_nightly_version }}
       build_ios: ${{ needs.resolve.outputs.ios == 'true' }}
       build_macos: ${{ needs.resolve.outputs.macos == 'true' }}
     secrets: inherit
@@ -186,7 +182,7 @@ jobs:
     uses: ./.github/workflows/publish-nym-vpn-app.yml
     with:
       version_tag: ${{ needs.resolve.outputs.tag }}
-      nightly_version: ${{ needs.resolve.outputs.app_nightly_version }}
+      nightly_version: ${{ needs.resolve.outputs.nightly_version }}
       linux: ${{ needs.resolve.outputs.linux == 'true' }}
       windows: ${{ needs.resolve.outputs.windows == 'true' }}
       release_type: ${{ needs.resolve.outputs.ship == 'true' && 'stable' || 'nightly' }}


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

- Compute nightly version in one place so the timestamp won't drift
- Build `nym-vpn-app` with nightly version
- Replace direct `gh` cli calls with `softprops/action-gh-release@v2` action due to [failed builds](https://github.com/nymtech/nym-vpn-client/actions/runs/27808000754/job/82354691157)


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5629)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Improved nightly release automation to generate consistent, timestamp-based nightly version strings and expose them as a reusable output across the pipeline.
  * Added a shared `nightly_version` override input for core and app workflows (Linux, Windows, and core/app publishing) so nightly Cargo metadata stays aligned.
  * Updated macOS unified draft upload behavior for nightly/ship builds, including improved appcast asset staging and version-aware artifact handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->