### PR TITLE
fix double poll issue

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/local_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/local_state.rs
@@ -13,6 +13,7 @@ use crate::{
         syncing_state::{SyncMode, SyncingNetworkState},
     },
 };
+use futures::{FutureExt, future::Fuse};
 use nym_offline_monitor::ConnectivityMonitor;
 use nym_vpn_api_client::{
     VpnApiClient,
@@ -57,7 +58,7 @@ const SUMMARY_STALE_AFTER: Duration = Duration::from_secs(24 * 60 * 60);
 /// - OfflineState : the connectivity monitor is telling we're not connected
 /// - DecentralisedState : The loaded account is set to "decentralised" mode
 pub(crate) struct SyncingLocalState {
-    result_rx: oneshot::Receiver<Result<bool, SyncError>>,
+    result_rx: Fuse<oneshot::Receiver<Result<bool, SyncError>>>,
     sync_cancel_token: Option<DropGuard>,
 }
 
@@ -110,7 +111,7 @@ impl SyncingLocalState {
 
         (
             Box::new(Self {
-                result_rx,
+                result_rx: result_rx.fuse(),
                 sync_cancel_token: Some(sync_cancel_token.drop_guard()),
             }),
             PrivateAccountControllerState::Syncing,
@@ -190,8 +191,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingLocalSt
                 }
             }
 
-            sync_result = &mut self.result_rx, if self.sync_cancel_token.is_some() => {
-            // Guard against double poll. If the dropguard is gone, the tx part was dropped and we should not poll again
+            sync_result = &mut self.result_rx => {
                 match sync_result {
                     Ok(Ok(device_registration)) => {
                         // If we just registered the device, reflect that in the cached summary

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/local_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/local_state.rs
@@ -190,7 +190,8 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingLocalSt
                 }
             }
 
-            sync_result = &mut self.result_rx => {
+            sync_result = &mut self.result_rx, if self.sync_cancel_token.is_some() => {
+            // Guard against double poll. If the dropguard is gone, the tx part was dropped and we should not poll again
                 match sync_result {
                     Ok(Ok(device_registration)) => {
                         // If we just registered the device, reflect that in the cached summary

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/network_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/network_state.rs
@@ -194,7 +194,8 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingNetwork
                     NextAccountControllerState::SameState(self)
                 }
             }
-            sync_result = &mut self.result_rx => {
+            sync_result = &mut self.result_rx, if self.sync_cancel_token.is_some() => {
+            // Guard against double poll. If the dropguard is gone, the tx part was dropped and we should not poll again
                 match sync_result {
                     Ok(Ok(Some(response))) => {
                         // The summary is stored (and propagated to disk) even if the subsequent

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/network_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/network_state.rs
@@ -12,6 +12,7 @@ use crate::{
         syncing_state::{SyncMode, local_state::SyncingLocalState},
     },
 };
+use futures::{FutureExt, future::Fuse};
 use nym_offline_monitor::ConnectivityMonitor;
 use nym_vpn_api_client::{
     VpnApiClient,
@@ -58,7 +59,7 @@ type SyncResult = Result<Option<VpnAccountSummary>, SyncError>;
 /// - OfflineState : the connectivity monitor is telling we're not connected
 /// - DecentralisedState : The loaded account is set to "decentralised" mode
 pub(crate) struct SyncingNetworkState {
-    result_rx: oneshot::Receiver<SyncResult>,
+    result_rx: Fuse<oneshot::Receiver<SyncResult>>,
     sync_cancel_token: Option<DropGuard>,
 }
 
@@ -110,7 +111,7 @@ impl SyncingNetworkState {
 
         (
             Box::new(Self {
-                result_rx,
+                result_rx: result_rx.fuse(),
                 sync_cancel_token: Some(sync_cancel_token.drop_guard()),
             }),
             PrivateAccountControllerState::Syncing,
@@ -194,8 +195,7 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingNetwork
                     NextAccountControllerState::SameState(self)
                 }
             }
-            sync_result = &mut self.result_rx, if self.sync_cancel_token.is_some() => {
-            // Guard against double poll. If the dropguard is gone, the tx part was dropped and we should not poll again
+            sync_result = &mut self.result_rx => {
                 match sync_result {
                     Ok(Ok(Some(response))) => {
                         // The summary is stored (and propagated to disk) even if the subsequent


### PR DESCRIPTION
When cancelled by the firewall, some oneshot channels were double polled leading to panic

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5630)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal synchronization state machine logic to prevent redundant polling operations during cancellation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->