### PR TITLE
Set dns to local resolver on tunnel interfaces

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/resolver/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/resolver/mod.rs
@@ -45,7 +45,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use hickory_resolver::config::NameServerConfig;
+use hickory_resolver::config::{LookupIpStrategy, NameServerConfig, ResolverOpts};
 use hickory_server::{
     net::runtime::Time,
     proto::{
@@ -584,7 +584,11 @@ impl LocalResolver {
         #[cfg(not(target_os = "ios"))]
         let connection_provider = TokioRuntimeProvider::default();
 
+        let mut resolver_opts = ResolverOpts::default();
+        resolver_opts.ip_strategy = LookupIpStrategy::Ipv4AndIpv6;
+
         let resolver = TokioResolver::builder_with_config(forward_config, connection_provider)
+            .with_options(resolver_opts)
             .build()
             .map_err(Error::CreateResolver)?;
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -387,7 +387,7 @@ impl ConnectingState {
             tunnel_constants: shared_state.tunnel_constants,
             selected_gateways: self.selected_gateways.clone(),
             user_agent: shared_state.user_agent.clone(),
-            #[cfg(target_os = "ios")]
+            #[cfg(not(target_os = "android"))]
             filtering_resolver_addr: shared_state.filtering_resolver.listen_addr(),
         };
         #[cfg(target_os = "android")]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -233,7 +233,7 @@ pub struct TunnelParameters {
     pub tunnel_constants: TunnelConstants,
     pub selected_gateways: Option<SelectedGateways>,
     pub user_agent: UserAgent,
-    #[cfg(target_os = "ios")]
+    #[cfg(not(target_os = "android"))]
     pub filtering_resolver_addr: SocketAddr,
 }
 
@@ -939,7 +939,7 @@ impl TunnelMonitor {
                 )));
             }
 
-            let dns_servers = self.get_mobile_dns_addresses();
+            let dns_servers = self.get_dns_addresses();
             let packet_tunnel_settings = crate::tunnel_provider::TunnelSettings {
                 dns_servers,
                 interface_addresses,
@@ -1220,7 +1220,7 @@ impl TunnelMonitor {
         let tunnel_options = TunnelOptions::Netstack(NetstackTunnelOptions {
             metadata_proxy_tx: entry_metadata_tx,
             exit_tun,
-            dns: vec![], // we configure system resolver ourselves
+            dns: self.get_dns_addresses(),
         });
 
         let tunnel_metadata = TunnelMetadata {
@@ -1299,7 +1299,7 @@ impl TunnelMonitor {
             exit_tun_name: WG_EXIT_WINTUN_NAME.to_owned(),
             exit_tun_guid: WG_EXIT_WINTUN_GUID.to_owned(),
             wintun_tunnel_type: WINTUN_TUNNEL_TYPE.to_owned(),
-            dns: vec![], // we configure system resolver ourselves
+            dns: self.get_dns_addresses(),
         });
 
         let mut tunnel_handle = connected_tunnel
@@ -1445,7 +1445,7 @@ impl TunnelMonitor {
         let tunnel_options = TunnelOptions::TunTun(TunTunTunnelOptions {
             entry_tun,
             exit_tun,
-            dns: vec![], // we configure system resolver ourselves
+            dns: self.get_dns_addresses(),
         });
 
         let tunnel_handle = connected_tunnel
@@ -1529,7 +1529,7 @@ impl TunnelMonitor {
             exit_tun_name: WG_EXIT_WINTUN_NAME.to_owned(),
             exit_tun_guid: WG_EXIT_WINTUN_GUID.to_owned(),
             wintun_tunnel_type: WINTUN_TUNNEL_TYPE.to_owned(),
-            dns: vec![], // we configure system resolver ourselves
+            dns: self.get_dns_addresses(),
         });
 
         let mut tunnel_handle = connected_tunnel
@@ -1637,10 +1637,10 @@ impl TunnelMonitor {
         }
 
         let entry_endpoint = conn_data.effective_remote_entry_endpoint().ip();
-        let dns_servers = self.get_mobile_dns_addresses();
+        let dns_servers = self.get_dns_addresses();
 
         let packet_tunnel_settings = crate::tunnel_provider::TunnelSettings {
-            dns_servers,
+            dns_servers: dns_servers.clone(),
             interface_addresses,
             remote_addresses: vec![entry_endpoint],
             mtu,
@@ -1668,7 +1668,6 @@ impl TunnelMonitor {
             exit: WireguardNode::from(&conn_data.exit),
         });
 
-        let dns_servers = self.get_mobile_dns_addresses();
         let tunnel_options = TunnelOptions::Netstack(NetstackTunnelOptions {
             metadata_proxy_tx: entry_metadata_tx,
             exit_tun: tun_device,
@@ -1694,13 +1693,13 @@ impl TunnelMonitor {
         })
     }
 
-    #[cfg(target_os = "ios")]
-    fn get_mobile_dns_addresses(&self) -> Vec<IpAddr> {
+    #[cfg(not(target_os = "android"))]
+    fn get_dns_addresses(&self) -> Vec<IpAddr> {
         vec![self.tunnel_parameters.filtering_resolver_addr.ip()]
     }
 
     #[cfg(target_os = "android")]
-    fn get_mobile_dns_addresses(&self) -> Vec<IpAddr> {
+    fn get_dns_addresses(&self) -> Vec<IpAddr> {
         self.tunnel_parameters.tunnel_settings.android_tunnel_dns()
     }
 


### PR DESCRIPTION


## Ticket

JIRA-NYM-XXXX

## Description

- Set dns to local resolver on tunnel interfaces
- Prioritize IPv4 over IPv6 when returning results from resolver

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5632)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * DNS resolver now queries both IPv4 and IPv6 addresses simultaneously, improving compatibility across different network types.

* **Refactor**
  * Unified DNS configuration handling across all tunnel implementations and platforms for consistent behavior and improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->