### PR TITLE
APPLE: allow excluding executables

### DIFF
--- a/.github/workflows/apple/tests/action.yml
+++ b/.github/workflows/apple/tests/action.yml
@@ -30,6 +30,7 @@ runs:
             "ServicesMutual|ServicesMutual-Package|ConnectionTypesTests|ServicesMutual/TestResults.xcresult|ConnectionTypes"
             "Services|Services-Package|ConfigurationManagerTests|Services/TestResults-ConfigurationManagerTests.xcresult|ConfigurationManager"
             "Settings|Settings|SettingsTests|Settings/TestResults-SettingsTests.xcresult|Settings"
+            "ServicesMacOS|ServicesMacOS-Package|AppDiscoveryServiceTests|ServicesMacOS/TestResults-AppDiscoveryServiceTests.xcresult|AppDiscovery"
           )
 
           for suite in "${SUITES[@]}"; do
@@ -108,6 +109,7 @@ runs:
           nym-vpn-apple/ServicesMutual/TestResults.xcresult
           nym-vpn-apple/Services/TestResults-ConfigurationManagerTests.xcresult
           nym-vpn-apple/Settings/TestResults-SettingsTests.xcresult
+          nym-vpn-apple/ServicesMacOS/TestResults-AppDiscoveryServiceTests.xcresult
           account-report.md
         if-no-files-found: warn
         retention-days: 1
@@ -118,4 +120,5 @@ runs:
       run: |
         rm -rf nym-vpn-apple/ServicesMutual/TestResults.xcresult \
                nym-vpn-apple/Services/TestResults-ConfigurationManagerTests.xcresult \
-               nym-vpn-apple/Settings/TestResults-SettingsTests.xcresult
+               nym-vpn-apple/Settings/TestResults-SettingsTests.xcresult \
+               nym-vpn-apple/ServicesMacOS/TestResults-AppDiscoveryServiceTests.xcresult

--- a/nym-vpn-apple/NymVPN/Resources/Localizable.xcstrings
+++ b/nym-vpn-apple/NymVPN/Resources/Localizable.xcstrings
@@ -29418,6 +29418,28 @@
         }
       }
     },
+    "splitTunnel.cannotExcludeNym" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Nym VPN can’t exclude itself."
+          }
+        }
+      }
+    },
+    "splitTunnel.notExecutable" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Not an executable file."
+          }
+        }
+      }
+    },
     "splitTunnel.apps" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/nym-vpn-apple/ServicesMacOS/Package.swift
+++ b/nym-vpn-apple/ServicesMacOS/Package.swift
@@ -42,6 +42,11 @@ let package = Package(
                 .product(name: "TunnelStatus", package: "ServicesMutual")
             ],
             path: "Sources/GRPCManager"
+        ),
+        .testTarget(
+            name: "AppDiscoveryServiceTests",
+            dependencies: ["AppDiscoveryService"],
+            path: "Tests/AppDiscoveryServiceTests"
         )
     ]
 )

--- a/nym-vpn-apple/ServicesMacOS/Sources/AppDiscoveryService/AppDiscoveryService.swift
+++ b/nym-vpn-apple/ServicesMacOS/Sources/AppDiscoveryService/AppDiscoveryService.swift
@@ -18,7 +18,10 @@ public final class AppDiscoveryService {
     }
 
     public func foundApp(at url: URL) -> FoundApp {
-        makeFoundApp(from: url)
+        if url.pathExtension == "app" {
+            return makeFoundApp(from: url)
+        }
+        return makeBareExecutable(from: url)
     }
 }
 
@@ -45,6 +48,23 @@ private extension AppDiscoveryService {
         }
 
         return apps
+    }
+
+    func makeBareExecutable(from url: URL) -> FoundApp {
+        let fileManager = FileManager.default
+        var isDirectory: ObjCBool = false
+        let exists = fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory)
+        // `isExecutableFile` returns true for searchable directories, so the
+        // directory guard is mandatory — we only accept regular executable files.
+        let isExecutable = exists
+            && !isDirectory.boolValue
+            && fileManager.isExecutableFile(atPath: url.path)
+
+        return FoundApp(
+            name: url.lastPathComponent,
+            executablePath: isExecutable ? url.path : nil,
+            icon: nil
+        )
     }
 
     func makeFoundApp(from appURL: URL) -> FoundApp {

--- a/nym-vpn-apple/ServicesMacOS/Tests/AppDiscoveryServiceTests/AppDiscoveryServiceTests.swift
+++ b/nym-vpn-apple/ServicesMacOS/Tests/AppDiscoveryServiceTests/AppDiscoveryServiceTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Testing
+@testable import AppDiscoveryService
+
+@Suite
+struct AppDiscoveryServiceTests {
+    let service = AppDiscoveryService()
+
+    private func makeTempDir() -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("adstest-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    @Test
+    func bareExecutableFileResolvesToItsOwnPath() throws {
+        let bin = makeTempDir().appendingPathComponent("mybin")
+        try Data().write(to: bin)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: bin.path)
+
+        let app = service.foundApp(at: bin)
+
+        #expect(app.executablePath == bin.path)
+        #expect(app.name == "mybin")
+    }
+
+    @Test
+    func nonExecutableFileIsRejected() throws {
+        let file = makeTempDir().appendingPathComponent("notes.txt")
+        try Data().write(to: file)
+        try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: file.path)
+
+        let app = service.foundApp(at: file)
+
+        #expect(app.executablePath == nil)
+    }
+
+    @Test
+    func directoryIsRejected() throws {
+        let sub = makeTempDir().appendingPathComponent("somedir")
+        try FileManager.default.createDirectory(at: sub, withIntermediateDirectories: true)
+
+        let app = service.foundApp(at: sub)
+
+        #expect(app.executablePath == nil)
+    }
+
+    @Test
+    func appBundleStillResolvesViaInfoPlist() throws {
+        let appURL = makeTempDir().appendingPathComponent("Foo.app")
+        let macOS = appURL.appendingPathComponent("Contents/MacOS")
+        try FileManager.default.createDirectory(at: macOS, withIntermediateDirectories: true)
+        let exec = macOS.appendingPathComponent("Foo")
+        try Data().write(to: exec)
+        let plist = appURL.appendingPathComponent("Contents/Info.plist")
+        let data = try PropertyListSerialization.data(
+            fromPropertyList: ["CFBundleExecutable": "Foo"],
+            format: .xml,
+            options: 0
+        )
+        try data.write(to: plist)
+
+        let app = service.foundApp(at: appURL)
+
+        #expect(app.executablePath == exec.path)
+        #expect(app.name == "Foo")
+    }
+}

--- a/nym-vpn-apple/ServicesMutual/Tests/ConnectionTypesTests/WorkflowReportTests.swift
+++ b/nym-vpn-apple/ServicesMutual/Tests/ConnectionTypesTests/WorkflowReportTests.swift
@@ -108,6 +108,7 @@ struct WorkflowReportTests {
     @Test(arguments: [
         (scheme: "Services-Package", target: "ConfigurationManagerTests"),
         (scheme: "Settings", target: "SettingsTests"),
+        (scheme: "ServicesMacOS-Package", target: "AppDiscoveryServiceTests"),
     ])
     func testStepRunsAdditionalSuite(scheme: String, target: String) throws {
         let action = try loadYAML(Self.actionRelativePath)

--- a/nym-vpn-apple/Settings/Sources/Settings/SplitTunneling/SplitTunnelView.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/SplitTunneling/SplitTunnelView.swift
@@ -8,6 +8,7 @@ import ConnectionTypes
 import ExternalLinkManager
 import ImpactGenerator
 import GRPCManager
+import SnackbarManager
 import Theme
 import UIComponents
 
@@ -150,7 +151,7 @@ private extension SplitTunnelView {
         .buttonStyle(.plain)
         .fileImporter(
             isPresented: $isImporterPresented,
-            allowedContentTypes: [.application],
+            allowedContentTypes: [.application, .unixExecutable],
             allowsMultipleSelection: false
         ) { result in
             if case let .success(urls) = result, let url = urls.first {
@@ -497,13 +498,24 @@ private extension SplitTunnelView {
     }
 
     func addCustomApp(at url: URL) {
-        guard url.lastPathComponent != "NymVPN.app" else { return }
+        let name = url.lastPathComponent
+        guard name != "NymVPN.app", name != "nym-vpnd" else {
+            SnackbarManager.shared.enqueue(
+                SnackbarItem(style: .warning, title: "splitTunnel.cannotExcludeNym".localizedString)
+            )
+            return
+        }
 
         let didAccess = url.startAccessingSecurityScopedResource()
         defer { if didAccess { url.stopAccessingSecurityScopedResource() } }
 
         let app = appDiscoveryService.foundApp(at: url)
-        guard let path = app.executablePath else { return }
+        guard let path = app.executablePath else {
+            SnackbarManager.shared.enqueue(
+                SnackbarItem(style: .negative, title: "splitTunnel.notExecutable".localizedString)
+            )
+            return
+        }
 
         var next = splitTunnelConfig
         next.customAppPaths.insert(path)


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5634)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Split tunneling now allows selecting Unix executable files (not just .app bundles).
* **Bug Fixes**
  * Improved validation feedback: users now see notifications when trying to exclude Nym VPN itself or when selecting a non-executable item.
* **Tests**
  * Added App Discovery tests covering executables, directories, and .app bundles.
  * Updated the Apple test workflow to include the new ServicesMacOS test results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->