### PR TITLE
Client auth check flag used on MacOS

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix missing "recursion available" flag in DNS responses, passthrough authority and additional records (https://github.com/nymtech/nym-vpn-client/pull/5546)
 - Provide escape hatch when reconnecting the tunnel in "time desynced" error state (https://github.com/nymtech/nym-vpn-client/pull/5551)
 - Race when network usage spikes happen during longer bandwidth checks, disconnecting the client from the server (https://github.com/nymtech/nym-vpn-client/pull/5618)
+- [macOS] Disable authentication when flag is set (https://github.com/nymtech/nym-vpn-client/pull/5645)
 
 ### Removed
 

--- a/nym-vpn-core/crates/nym-ipc/src/authentication/macos.rs
+++ b/nym-vpn-core/crates/nym-ipc/src/authentication/macos.rs
@@ -59,12 +59,12 @@ fn self_is_signed(signing_requirement: &str) -> bool {
         )
     };
     if status != errSecSuccess {
-        tracing::error!("Could not create a string");
+        tracing::error!("Could not create a SecRequirement");
         return false;
     }
     let ret = unsafe { Retained::from_raw(raw_sec_req) };
     let Some(sec_req) = ret else {
-        tracing::error!("Creating a string returned null on success");
+        tracing::error!("Creating a SecRequirement returned null on success");
         return false;
     };
 

--- a/nym-vpn-core/crates/nym-ipc/src/authentication/macos.rs
+++ b/nym-vpn-core/crates/nym-ipc/src/authentication/macos.rs
@@ -1,6 +1,11 @@
 // Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use std::ptr::NonNull;
+
+use objc2::rc::Retained;
+use objc2_core_foundation::CFString;
+use objc2_security::{SecCSFlags, SecCode, SecRequirement, errSecSuccess};
 use tokio_stream::Stream;
 
 #[cfg(any(not(debug_assertions), feature = "xpc"))]
@@ -28,6 +33,48 @@ pub(crate) async fn is_authenticated(
     _auth_material: AuthenticationMaterial,
 ) -> Result<(), AuthenticationError> {
     Ok(())
+}
+
+fn self_is_signed(signing_requirement: &str) -> bool {
+    let mut raw_sec_code: *mut SecCode = std::ptr::null_mut();
+    let status =
+        unsafe { SecCode::copy_self(SecCSFlags::DefaultFlags, NonNull::from(&mut raw_sec_code)) };
+    if status != errSecSuccess {
+        tracing::error!("Could not obtain self code");
+        return false;
+    }
+    let ret = unsafe { Retained::from_raw(raw_sec_code) };
+    let Some(sec_code) = ret else {
+        tracing::error!("SecCodeCopySelf returned null on success");
+        return false;
+    };
+
+    let mut raw_sec_req: *mut SecRequirement = std::ptr::null_mut();
+    let status = unsafe {
+        SecRequirement::create_with_string(
+            &CFString::from_str(signing_requirement),
+            SecCSFlags::DefaultFlags,
+            NonNull::from(&mut raw_sec_req),
+        )
+    };
+    if status != errSecSuccess {
+        tracing::error!("Could not create a string");
+        return false;
+    }
+    let ret = unsafe { Retained::from_raw(raw_sec_req) };
+    let Some(sec_req) = ret else {
+        tracing::error!("Creating a string returned null on success");
+        return false;
+    };
+
+    let status = unsafe { sec_code.check_validity(SecCSFlags::DefaultFlags, Some(&sec_req)) };
+    tracing::debug!("Daemon signature validation check: {status}");
+    status == errSecSuccess
+}
+
+pub(crate) fn skip_authentication_checks(auth_material: &AuthenticationMaterial) -> bool {
+    auth_material.disable_client_verification
+        || !self_is_signed(&auth_material.signing_requirements.daemon_req)
 }
 
 #[cfg(any(not(debug_assertions), feature = "xpc"))]

--- a/nym-vpn-core/crates/nym-ipc/src/authentication/macos.rs
+++ b/nym-vpn-core/crates/nym-ipc/src/authentication/macos.rs
@@ -35,6 +35,7 @@ pub(crate) async fn is_authenticated(
     Ok(())
 }
 
+#[allow(unused)]
 fn self_is_signed(signing_requirement: &str) -> bool {
     let mut raw_sec_code: *mut SecCode = std::ptr::null_mut();
     let status =
@@ -72,6 +73,7 @@ fn self_is_signed(signing_requirement: &str) -> bool {
     status == errSecSuccess
 }
 
+#[allow(unused)]
 pub(crate) fn skip_authentication_checks(auth_material: &AuthenticationMaterial) -> bool {
     auth_material.disable_client_verification
         || !self_is_signed(&auth_material.signing_requirements.daemon_req)

--- a/nym-vpn-core/crates/nym-ipc/src/authentication/mod.rs
+++ b/nym-vpn-core/crates/nym-ipc/src/authentication/mod.rs
@@ -11,7 +11,7 @@ mod macos;
 #[cfg(target_os = "macos")]
 pub use macos::SigningRequirements;
 #[cfg(target_os = "macos")]
-pub(crate) use macos::{Transport, incoming, is_authenticated};
+pub(crate) use macos::{Transport, incoming, is_authenticated, skip_authentication_checks};
 
 #[cfg(target_os = "windows")]
 mod windows;

--- a/nym-vpn-core/crates/nym-ipc/src/authentication/mod.rs
+++ b/nym-vpn-core/crates/nym-ipc/src/authentication/mod.rs
@@ -10,6 +10,7 @@ pub(crate) use linux::{Transport, incoming, is_authenticated};
 mod macos;
 #[cfg(target_os = "macos")]
 pub use macos::SigningRequirements;
+#[allow(unused)]
 #[cfg(target_os = "macos")]
 pub(crate) use macos::{Transport, incoming, is_authenticated, skip_authentication_checks};
 

--- a/nym-vpn-core/crates/nym-ipc/src/xpc/daemon.rs
+++ b/nym-vpn-core/crates/nym-ipc/src/xpc/daemon.rs
@@ -1,23 +1,22 @@
 // Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{pin::Pin, ptr::NonNull};
+use std::pin::Pin;
 
 use objc2::{
     AnyThread, DefinedClass as _, define_class, msg_send, rc::Retained, runtime::ProtocolObject,
 };
-use objc2_core_foundation::CFString;
 use objc2_foundation::{
     NSObject, NSObjectProtocol, NSString, NSXPCConnection, NSXPCInterface, NSXPCListener,
     NSXPCListenerDelegate,
 };
-use objc2_security::{SecCSFlags, SecCode, SecRequirement, errSecSuccess};
 use tokio::sync::mpsc;
 use tokio_stream::{Stream, wrappers::UnboundedReceiverStream};
 use tokio_util::sync::{CancellationToken, DropGuard};
 
 use crate::{
-    AuthenticationMaterial, authentication,
+    AuthenticationMaterial,
+    authentication::{self, skip_authentication_checks},
     xpc::{
         common::{
             ConnectionInterfaceObj, DAEMON_BUNDLE_IDENTIFIER, NSConnectionInterface, XpcConnection,
@@ -141,43 +140,6 @@ async fn run_task(task: Task, shutdown_token: CancellationToken) {
     }
 }
 
-fn self_is_signed(signing_requirement: &str) -> bool {
-    let mut raw_sec_code: *mut SecCode = std::ptr::null_mut();
-    let status =
-        unsafe { SecCode::copy_self(SecCSFlags::DefaultFlags, NonNull::from(&mut raw_sec_code)) };
-    if status != errSecSuccess {
-        tracing::error!("Could not obtain self code");
-        return false;
-    }
-    let ret = unsafe { Retained::from_raw(raw_sec_code) };
-    let Some(sec_code) = ret else {
-        tracing::error!("SecCodeCopySelf returned null on success");
-        return false;
-    };
-
-    let mut raw_sec_req: *mut SecRequirement = std::ptr::null_mut();
-    let status = unsafe {
-        SecRequirement::create_with_string(
-            &CFString::from_str(signing_requirement),
-            SecCSFlags::DefaultFlags,
-            NonNull::from(&mut raw_sec_req),
-        )
-    };
-    if status != errSecSuccess {
-        tracing::error!("Could not create a string");
-        return false;
-    }
-    let ret = unsafe { Retained::from_raw(raw_sec_req) };
-    let Some(sec_req) = ret else {
-        tracing::error!("Creating a string returned null on success");
-        return false;
-    };
-
-    let status = unsafe { sec_code.check_validity(SecCSFlags::DefaultFlags, Some(&sec_req)) };
-    tracing::debug!("Daemon signature validation check: {status}");
-    status == errSecSuccess
-}
-
 pub(crate) struct XpcService {
     inner: UnboundedReceiverStream<XpcConnection>,
     // needed to keep the XPC listener object alive for the lifetime of this
@@ -189,13 +151,12 @@ impl XpcService {
     pub(crate) fn spawn(auth_material: AuthenticationMaterial) -> std::io::Result<Self> {
         let local_spawner =
             LocalSpawner::new(run_task, auth_material.shutdown_token.child_token())?;
-        let signing_requirement = if self_is_signed(&auth_material.signing_requirements.daemon_req)
-        {
-            tracing::debug!("Daemon will do code signing verification for clients");
-            Some(auth_material.signing_requirements.client_req)
-        } else {
+        let signing_requirement = if skip_authentication_checks(&auth_material) {
             tracing::debug!("Daemon will receive any XPC clients");
             None
+        } else {
+            tracing::debug!("Daemon will do code signing verification for clients");
+            Some(auth_material.signing_requirements.client_req)
         };
 
         let (conn_sender, conn_receiver) = mpsc::unbounded_channel();


### PR DESCRIPTION
## Ticket

JIRA-NYM-1571

## Description

Make use of the `--disable-client-verification` flag inside the MacOS authentication mechanism.


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5645)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated macOS authentication handling to use more reliable code-signing validation and consistent authentication-bypass logic across related components.

* **Bug Fixes**
  * Fixed macOS authentication so verification is correctly skipped when the appropriate client-verification flag is enabled/disabled as intended, and code-signing checks are applied only when required.

* **Documentation**
  * Added a macOS “Fixed” entry to the Unreleased changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->