### PR TITLE
[Android] Timestamp for Constants.kt

### DIFF
--- a/nym-vpn-android/app/build.gradle.kts
+++ b/nym-vpn-android/app/build.gradle.kts
@@ -1,9 +1,6 @@
 import com.android.build.api.variant.BuildConfigField
 import com.android.build.api.variant.ResValue
 import com.android.build.api.variant.impl.VariantOutputImpl
-import java.time.LocalDateTime
-import java.time.ZoneOffset
-import java.time.format.DateTimeFormatter
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -20,10 +17,6 @@ val currentCommitHash: Provider<String> = providers.exec {
 	commandLine("git", "rev-parse", "HEAD")
 	isIgnoreExitValue = true
 }.standardOutput.asText.map { it.trim().ifEmpty { "unknown" } }.orElse("unknown")
-
-val buildTimestamp: String = DateTimeFormatter
-	.ofPattern("yyyyMMddHHmm")
-	.format(LocalDateTime.now(ZoneOffset.UTC))
 
 val languagesArray: Provider<String> = providers.provider {
 	languageList().joinToString(separator = ", ") { "\"$it\"" }
@@ -180,7 +173,7 @@ androidComponents {
 		val flavor = variant.flavorName ?: ""
 		val type = variant.buildType ?: ""
 		val version = if (type == Constants.NIGHTLY) {
-			"${Constants.VERSION_NAME}-nightly.$buildTimestamp"
+			"${Constants.VERSION_NAME}-nightly.${Constants.BUILD_TIMESTAMP}"
 		} else {
 			"${Constants.VERSION_NAME}-$type"
 		}

--- a/nym-vpn-android/buildSrc/src/main/kotlin/Constants.kt
+++ b/nym-vpn-android/buildSrc/src/main/kotlin/Constants.kt
@@ -3,6 +3,7 @@ import org.gradle.api.JavaVersion
 object Constants {
 	const val VERSION_NAME = "v2026.12.0-beta.1"
     const val VERSION_CODE = 20261200
+    const val BUILD_TIMESTAMP = ""
     const val TARGET_SDK = 36
     const val COMPILE_SDK = 37
     const val MIN_SDK = 24


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

Add `BUILD_TIMESTAMP` to `Constants.kt`


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5652)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build system configuration for timestamp handling in nightly builds. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->