### PR TITLE
NYM-1538: (tauri) Add account refresh

### DIFF
--- a/nym-vpn-app/CHANGELOG.md
+++ b/nym-vpn-app/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mixnet tuning settings
 - Node families support
 - Add new "Geo exclusion" settings to allow bypass the VPN tunnel when accessing from certain geographic regions. Currently only China is supported
+- Add account refresh button to account settings page
 
 ### CHANGED
 

--- a/nym-vpn-app/src-tauri/build.rs
+++ b/nym-vpn-app/src-tauri/build.rs
@@ -6,15 +6,15 @@ const VPND_COMPAT_FILE: &str = "vpnd_compat.toml";
 fn set_vpnd_compat() -> Result<(), Box<dyn std::error::Error>> {
     let path = format!("../{VPND_COMPAT_FILE}");
     let content = fs::read_to_string(&path)
-        .inspect_err(|e| println!("cargo::warning=failed to read file `{}`: {e}", &path))?;
+        .inspect_err(|e| println!("cargo::warning=failed to read file `{}`: {e}", path))?;
     let parsed = content
         .parse::<Table>()
-        .inspect_err(|e| println!("cargo::warning=failed to parse `{}`: {e}", &path))?;
+        .inspect_err(|e| println!("cargo::warning=failed to parse `{}`: {e}", path))?;
     let req = parsed.get("version").as_ref().and_then(|v| v.as_str());
     if let Some(v) = req {
         println!("cargo:rustc-env=VPND_COMPAT_REQ={v}");
     } else {
-        println!("cargo::warning=no version req found in `{}`", &path);
+        println!("cargo::warning=no version req found in `{}`", path);
     }
     Ok(())
 }

--- a/nym-vpn-app/src-tauri/src/commands/account.rs
+++ b/nym-vpn-app/src-tauri/src/commands/account.rs
@@ -210,6 +210,18 @@ pub async fn get_account_summary(
     })
 }
 
+#[instrument(skip(vpnd))]
+#[tauri::command]
+pub async fn refresh_account_state(
+    force: bool,
+    vpnd: State<'_, VpndClient>,
+) -> Result<(), BackendError> {
+    vpnd.refresh_account_state(force).await.map_err(|e| {
+        error!("failed to refresh account state: {e}");
+        e.into()
+    })
+}
+
 #[instrument(skip_all)]
 #[tauri::command]
 pub async fn handle_subscription_payment(vpnd: State<'_, VpndClient>) -> Result<(), BackendError> {

--- a/nym-vpn-app/src-tauri/src/main.rs
+++ b/nym-vpn-app/src-tauri/src/main.rs
@@ -354,6 +354,7 @@ async fn main() -> Result<()> {
             account::store_deeplink_account,
             account::get_autologin_deeplink,
             account::get_account_summary,
+            account::refresh_account_state,
             account::handle_subscription_payment,
             cmd_daemon::daemon_status,
             cmd_daemon::set_network,

--- a/nym-vpn-app/src-tauri/src/vpnd/client.rs
+++ b/nym-vpn-app/src-tauri/src/vpnd/client.rs
@@ -988,6 +988,14 @@ impl VpndClient {
         Ok(summary.map(Into::into))
     }
 
+    pub async fn refresh_account_state(&self, force: bool) -> Result<(), VpndError> {
+        let mut vpnd = self.vpnd().await?;
+
+        vpnd.refresh_account_state(force)
+            .or_else(async |e| self.handle_rpc_error("refresh_account_state", e).await)
+            .await
+    }
+
     pub async fn handle_subscription_payment(&self) -> Result<(), VpndError> {
         let mut vpnd = self.vpnd().await?;
 

--- a/nym-vpn-app/src/hooks/index.ts
+++ b/nym-vpn-app/src/hooks/index.ts
@@ -16,5 +16,6 @@ export { default as useToast } from './useToast';
 export { default as useDebounce } from './useDebounce';
 export { default as useConnect } from './useConnect';
 export { default as useGatewayIndependenceWatcher } from './useGatewayIndependenceWatcher';
+export { default as useRefreshAccountSummary } from './useRefreshAccountSummary';
 
 export * from './useToast';

--- a/nym-vpn-app/src/hooks/useRefreshAccountSummary.ts
+++ b/nym-vpn-app/src/hooks/useRefreshAccountSummary.ts
@@ -20,8 +20,6 @@ export default function useRefreshAccountSummary() {
     setRefreshing(true);
     try {
       await invoke<void>('refresh_account_state', { force });
-    } catch (err) {
-      console.error('failed to refresh account state', err);
     } finally {
       inFlight.current = false;
       setRefreshing(false);

--- a/nym-vpn-app/src/hooks/useRefreshAccountSummary.ts
+++ b/nym-vpn-app/src/hooks/useRefreshAccountSummary.ts
@@ -1,0 +1,32 @@
+import { invoke } from '@tauri-apps/api/core';
+import { useCallback, useRef, useState } from 'react';
+
+/**
+ * Triggers a forced refresh of account state/summary on the daemon.
+ *
+ * The daemon responds by emitting AccountStateEvent(s) (`syncing` -> final
+ * state). `useAccountSummaryOnAccountState` already re-fetches the account
+ * summary on those transitions, so this hook only needs to *trigger* the
+ * refresh — it does not fetch the summary itself.
+ */
+export default function useRefreshAccountSummary() {
+  const [refreshing, setRefreshing] = useState(false);
+  // Guard against overlapping invocations (e.g. mount-refresh + fast button clicks).
+  const inFlight = useRef(false);
+
+  const refresh = useCallback(async (force = true) => {
+    if (inFlight.current) return;
+    inFlight.current = true;
+    setRefreshing(true);
+    try {
+      await invoke<void>('refresh_account_state', { force });
+    } catch (err) {
+      console.error('failed to refresh account state', err);
+    } finally {
+      inFlight.current = false;
+      setRefreshing(false);
+    }
+  }, []);
+
+  return { refresh, refreshing };
+}

--- a/nym-vpn-app/src/i18n/en/account.json
+++ b/nym-vpn-app/src/i18n/en/account.json
@@ -17,7 +17,8 @@
     "resets-daily": "Resets daily",
     "reset-unknown": "Unknown",
     "renew-now": "Renew now to stay protected",
-    "failed-to-refresh-account-state": "Failed to refresh account"
+    "failed-to-refresh-account-state": "Failed to refresh account",
+    "refresh": "Refresh account summary"
   },
   "autologin": {
     "title": "Pin code",

--- a/nym-vpn-app/src/i18n/en/account.json
+++ b/nym-vpn-app/src/i18n/en/account.json
@@ -16,7 +16,8 @@
     "data-unavailable": "Usage data temporarily unavailable",
     "resets-daily": "Resets daily",
     "reset-unknown": "Unknown",
-    "renew-now": "Renew now to stay protected"
+    "renew-now": "Renew now to stay protected",
+    "failed-to-refresh-account-state": "Failed to refresh account"
   },
   "autologin": {
     "title": "Pin code",

--- a/nym-vpn-app/src/screens/settings/account/Account.tsx
+++ b/nym-vpn-app/src/screens/settings/account/Account.tsx
@@ -18,7 +18,12 @@ import { CCache } from '../../../cache';
 import { useAutologin } from '../../../contexts';
 import { useMainState } from '../../../store';
 import { routes } from '../../../router';
-import { useDeepLink, useLogout, useToast } from '../../../hooks';
+import {
+  useDeepLink,
+  useLogout,
+  useRefreshAccountSummary,
+  useToast,
+} from '../../../hooks';
 import { DeeplinkTimeout } from '../../../errors';
 import { ContactSupportUrl } from '../../../constants';
 import { AccountStatus } from './account-status';
@@ -48,6 +53,7 @@ function Account() {
 
   const { startListening } = useDeepLink();
   const { add } = useToast();
+  const { refresh } = useRefreshAccountSummary();
 
   const getDeviceId = async () => {
     const deviceId = await CCache.get<string>('cache-device-id');
@@ -83,6 +89,11 @@ function Account() {
     getDeviceId();
     getAccountId();
   }, []);
+
+  // Force-refresh account state/summary each time the account view opens.
+  useEffect(() => {
+    if (account) void refresh();
+  }, [account, refresh]);
 
   // When logged out, navigate to settings
   useEffect(() => {

--- a/nym-vpn-app/src/screens/settings/account/Account.tsx
+++ b/nym-vpn-app/src/screens/settings/account/Account.tsx
@@ -53,7 +53,7 @@ function Account() {
 
   const { startListening } = useDeepLink();
   const { add } = useToast();
-  const { refresh } = useRefreshAccountSummary();
+  const { refresh, refreshing } = useRefreshAccountSummary();
 
   const getDeviceId = async () => {
     const deviceId = await CCache.get<string>('cache-device-id');
@@ -92,7 +92,11 @@ function Account() {
 
   // Force-refresh account state/summary each time the account view opens.
   useEffect(() => {
-    if (account) void refresh();
+    if (account) {
+      refresh().catch((error: unknown) => {
+        console.error('Failed to refresh account state on mount: ', error);
+      });
+    }
   }, [account, refresh]);
 
   // When logged out, navigate to settings
@@ -162,7 +166,7 @@ function Account() {
         </Button>
       )}
 
-      <AccountStatus />
+      <AccountStatus refresh={refresh} refreshing={refreshing} />
 
       <SettingsGroup
         settings={[

--- a/nym-vpn-app/src/screens/settings/account/account-status/AccountStatus.tsx
+++ b/nym-vpn-app/src/screens/settings/account/account-status/AccountStatus.tsx
@@ -2,17 +2,21 @@ import { useTranslation } from 'react-i18next';
 import { useMemo } from 'react';
 import { ButtonIcon, CardNew, CardNewHeader, MsIcon } from '../../../../ui';
 import { useMainState } from '../../../../store';
-import { useRefreshAccountSummary, useToast } from '../../../../hooks';
+import { useToast } from '../../../../hooks';
 import { NoActivePlan } from './NoActivePlan';
 import { ActivePlan } from './ActivePlan';
 
-export function AccountStatus() {
+export type AccountStatusProps = {
+  refresh: () => Promise<void>;
+  refreshing: boolean;
+};
+
+export function AccountStatus({ refresh, refreshing }: AccountStatusProps) {
   const { add } = useToast();
   const { t } = useTranslation('account');
 
   const { accountState, accountSummary, accountSyncing, daemonStatus } =
     useMainState();
-  const { refresh, refreshing } = useRefreshAccountSummary();
 
   const needsSubscription = useMemo(
     () =>
@@ -59,6 +63,7 @@ export function AccountStatus() {
             className="h-8 min-h-8 w-8 min-w-8"
             iconClassName="!text-xl"
             data-testid="refresh-account-summary"
+            aria-label={t('account-status.refresh')}
           />
         </CardNewHeader>
         {needsSubscription ||

--- a/nym-vpn-app/src/screens/settings/account/account-status/AccountStatus.tsx
+++ b/nym-vpn-app/src/screens/settings/account/account-status/AccountStatus.tsx
@@ -1,14 +1,18 @@
 import { useTranslation } from 'react-i18next';
 import { useMemo } from 'react';
-import { CardNew, CardNewHeader, MsIcon } from '../../../../ui';
+import { ButtonIcon, CardNew, CardNewHeader, MsIcon } from '../../../../ui';
 import { useMainState } from '../../../../store';
+import { useRefreshAccountSummary, useToast } from '../../../../hooks';
 import { NoActivePlan } from './NoActivePlan';
 import { ActivePlan } from './ActivePlan';
 
 export function AccountStatus() {
+  const { add } = useToast();
   const { t } = useTranslation('account');
 
-  const { accountState, accountSummary } = useMainState();
+  const { accountState, accountSummary, accountSyncing, daemonStatus } =
+    useMainState();
+  const { refresh, refreshing } = useRefreshAccountSummary();
 
   const needsSubscription = useMemo(
     () =>
@@ -18,6 +22,19 @@ export function AccountStatus() {
     [accountState, accountSummary],
   );
 
+  const handleRefresh = async () => {
+    try {
+      await refresh();
+    } catch (error: unknown) {
+      console.error('Failed to refresh account state: ', error);
+      add({
+        id: 'refresh-account-state-error',
+        title: t('account-status.failed-to-refresh-account-state'),
+        type: 'error',
+      });
+    }
+  };
+
   if (!accountState || accountState === 'error' || accountState === 'offline') {
     return null;
   }
@@ -25,13 +42,24 @@ export function AccountStatus() {
   return (
     <>
       <CardNew>
-        <CardNewHeader className="border-text-tertiary/30 dark:border-surface-bg border-b">
+        <CardNewHeader className="border-text-tertiary/30 dark:border-surface-bg justify-between! border-b">
           <div className="flex flex-row items-center gap-2">
             <MsIcon icon="speed" className="text-text-secondary" />
             <p className="text-text-primary truncate text-left text-base select-none">
               {t('account-status.title')}
             </p>
           </div>
+          <ButtonIcon
+            icon="refresh"
+            color="chalk"
+            onClick={handleRefresh}
+            disabled={daemonStatus === 'down' || accountSyncing || refreshing}
+            clickFeedback
+            noDefaultSize
+            className="h-8 min-h-8 w-8 min-w-8"
+            iconClassName="!text-xl"
+            data-testid="refresh-account-summary"
+          />
         </CardNewHeader>
         {needsSubscription ||
         accountState === 'pending-subscription' ||

--- a/nym-vpn-app/src/ui/ButtonIcon.tsx
+++ b/nym-vpn-app/src/ui/ButtonIcon.tsx
@@ -103,6 +103,7 @@ export type ButtonIconProps = {
   clickDuration?: number;
   noDefaultSize?: boolean;
   'data-testid'?: string;
+  'aria-label'?: string;
 };
 
 function ButtonIcon({
@@ -153,6 +154,7 @@ function ButtonIcon({
         onClick();
       }}
       disabled={disabled}
+      aria-label={rest['aria-label']}
       data-testid={testId}
       data-test-disabled={disabled ? 'true' : 'false'}
       data-test-clicked={isClicked ? 'true' : 'false'}


### PR DESCRIPTION
## Ticket

[JIRA-NYM-1538](https://nymtech.atlassian.net/browse/NYM-1538)

## Description

Add account refresh button


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)
<img width="393" height="759" alt="image" src="https://github.com/user-attachments/assets/59e4996a-681f-4882-b096-dfb2b8828007" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5656)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an account refresh button to the account settings page
  * Account settings now automatically refresh when the page opens
  * Displays an error notification if the refresh operation fails
  * Refresh button is disabled while the account is syncing or when the daemon is offline
<!-- end of auto-generated comment: release notes by coderabbit.ai -->