### PR TITLE
APPLE: node families disconnect on cancel

### DIFF
--- a/nym-vpn-apple/Home/Sources/26/AppFeature/AppFeatureViewModel.swift
+++ b/nym-vpn-apple/Home/Sources/26/AppFeature/AppFeatureViewModel.swift
@@ -218,6 +218,7 @@ extension AppFeatureViewModel {
     }
 
     func dismissFamilyWarning() {
+        oneClick.cancelGatewayIndependenceConsent()
         isFamilyWarningModalDisplayed = false
     }
 

--- a/nym-vpn-apple/Home/Sources/26/OneClick/OneClickViewModel.swift
+++ b/nym-vpn-apple/Home/Sources/26/OneClick/OneClickViewModel.swift
@@ -173,6 +173,33 @@ public final class OneClickViewModel {
         }
     }
 
+    func cancelGatewayIndependenceConsent() {
+        guard !isConnectDisconnectInFlight,
+              connectionManager.currentTunnelStatus == .error
+        else {
+            return
+        }
+
+        impactGenerator.impact()
+        snackbarManager.clear()
+
+        connectDisconnectTask?.cancel()
+        connectDisconnectTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            isConnectDisconnectInFlight = true
+            defer { isConnectDisconnectInFlight = false }
+            do {
+                try await connectionManager.connectDisconnect()
+            } catch {
+                impactGenerator.error()
+                presentConnectionErrorAlert(
+                    message: ConnectionStatusViewModel.userFacingMessage(from: error)
+                )
+            }
+            clearLastErrorIfNeeded()
+        }
+    }
+
     func upCaretTapped() {
         guard displayMode == .powerUser else { return }
         impactGenerator.softImpact()


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5661)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Family warning modal dismissal now properly cancels pending gateway independence consent operations.
  * Enhanced error handling for consent flow cancellation with user feedback and status recovery mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->