### PR TITLE
[Android] Fix gateway independence logic

### DIFF
--- a/.github/workflows/publish-nym-vpn-android.yml
+++ b/.github/workflows/publish-nym-vpn-android.yml
@@ -126,6 +126,8 @@ jobs:
         run: echo "TAG_NAME=${{ github.event.inputs.tag_name }}" >> $GITHUB_ENV
       - if: github.event_name == 'schedule'
         run: echo "TAG_NAME=nym-vpn-android-nightly" >> $GITHUB_ENV
+      - if: github.event_name == 'workflow_call'
+        run: echo "TAG_NAME=${{ inputs.version_tag }}" >> $GITHUB_ENV
       - if: github.event_name == 'push'
         run: |
           echo "unsupported push action!"

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/manager/backend/BackendManager.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/manager/backend/BackendManager.kt
@@ -21,8 +21,8 @@ interface BackendManager {
 	val accountSummaryFlow: StateFlow<VpnAccountSummary?>
 
 	suspend fun stopTunnel()
-	suspend fun startTunnel()
-	suspend fun requestReconnect()
+	suspend fun startTunnel(relaxGatewayIndependence: Boolean = false)
+	suspend fun requestReconnect(relaxGatewayIndependence: Boolean = false)
 	suspend fun storeMnemonic(mnemonic: String)
 	suspend fun isMnemonicStored(): Boolean
 	suspend fun removeMnemonic()

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/manager/backend/ServiceBackedBackendManager.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/manager/backend/ServiceBackedBackendManager.kt
@@ -108,7 +108,7 @@ class ServiceBackedBackendManager @Inject constructor(
 		}
 	}
 
-	override suspend fun startTunnel() {
+	override suspend fun startTunnel(relaxGatewayIndependence: Boolean) {
 		val restrictedApps = getRestrictedAppsPackages()
 		val initReq = buildInitRequest()
 
@@ -121,6 +121,13 @@ class ServiceBackedBackendManager @Inject constructor(
 
 			runCatching { api.init(initReq) }
 				.onFailure { t -> Timber.tag(TAG).w(t, "Auto-init before connect failed") }
+
+			// Must be applied after init(), which force-syncs the persisted config and
+			// would otherwise re-enable gateway independence from nodeFamiliesNotificationsEnabled.
+			if (relaxGatewayIndependence) {
+				runCatching { api.setGatewayIndependenceEnabled(false) }
+					.onFailure { Timber.tag(TAG).w(it, "relax gateway independence failed") }
+			}
 
 			api.connect()
 		}
@@ -150,13 +157,17 @@ class ServiceBackedBackendManager @Inject constructor(
 		}
 	}
 
-	override suspend fun requestReconnect() {
+	override suspend fun requestReconnect(relaxGatewayIndependence: Boolean) {
 		val res = serviceConnectionManager.withApi { api ->
 			runCatching {
 				val restrictedApps = getRestrictedAppsPackages()
 				api.applyUpdates(listOf(CoreVpnConfigUpdate.SetRestrictedApps(restrictedApps)))
 			}.onFailure { t ->
 				Timber.tag(TAG).w(t, "apply restricted apps failed on reconnect")
+			}
+			if (relaxGatewayIndependence) {
+				runCatching { api.setGatewayIndependenceEnabled(false) }
+					.onFailure { Timber.tag(TAG).w(it, "relax gateway independence failed on reconnect") }
 			}
 			api.reconnect()
 		}

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/MainViewModel.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/MainViewModel.kt
@@ -163,8 +163,7 @@ constructor(
 	fun onNodeFamiliesConfirm() = viewModelScope.launch {
 		Timber.tag(TAG).i("NodeFamiliesModalConfirmed")
 		runCatching {
-			backendManager.setGatewayIndependenceEnabled(false)
-			backendManager.startTunnel()
+			backendManager.startTunnel(relaxGatewayIndependence = true)
 		}.onFailure { Timber.tag(TAG).e(it, "NodeFamiliesConnectFailed") }
 	}
 
@@ -175,7 +174,6 @@ constructor(
 		if (notificationsEnabled) {
 			_events.tryEmit(MainUiEvent.ShowNodeFamiliesDialog)
 		} else {
-			backendManager.setGatewayIndependenceEnabled(false)
 			onSilent()
 		}
 	}
@@ -183,7 +181,7 @@ constructor(
 	private suspend fun handleNeedsRelaxedIndependenceCriteria() {
 		Timber.tag(TAG).i("NeedsRelaxedIndependenceCriteria (connected state)")
 		runCatching {
-			resolveNodeFamiliesInteraction { backendManager.requestReconnect() }
+			resolveNodeFamiliesInteraction { backendManager.requestReconnect(relaxGatewayIndependence = true) }
 		}.onFailure { Timber.tag(TAG).e(it, "NeedsRelaxedIndependenceCriteriaFailed") }
 	}
 
@@ -191,7 +189,7 @@ constructor(
 		when (result) {
 			is TentativeGateways.NeedsRelaxedIndependenceCriteria -> {
 				Timber.tag(TAG).i("NeedsRelaxedIndependenceCriteria (pre-connect)")
-				resolveNodeFamiliesInteraction { backendManager.startTunnel() }
+				resolveNodeFamiliesInteraction { backendManager.startTunnel(relaxGatewayIndependence = true) }
 			}
 			else -> backendManager.startTunnel()
 		}

--- a/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/controller/VpnCoreController.kt
+++ b/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/controller/VpnCoreController.kt
@@ -422,9 +422,6 @@ class VpnCoreController(
 		if (force || prev?.adBlockingEnabled != cfg.adBlockingEnabled) {
 			sender.setEnableAdBlocking(cfg.adBlockingEnabled)
 		}
-		if (force || prev?.nodeFamiliesNotificationsEnabled != cfg.nodeFamiliesNotificationsEnabled) {
-			sender.setEnableGatewayIndependence(cfg.nodeFamiliesNotificationsEnabled)
-		}
 
 		applyGeoExclusionToSender(sender, force, prev, cfg)
 	}


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

Fix race condition for `Connect anyway` option when gateway independence error occurs;
Fix notification disabling behavior;


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5666)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added support for a relaxed gateway independence mode, enabling more flexible tunnel startup and reconnection behavior when triggered by the connection flow.
  * Updated server-side configuration handling to apply ad-blocking enablement based on the current settings.
* **Chores**
  * Improved the release publishing workflow to correctly derive the release tag for reusable workflow calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->