### PR TITLE
(core) Tentative gateways timeout fix

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/gateway_cache.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/gateway_cache.rs
@@ -27,7 +27,7 @@ impl GatewayCache for GatewayCacheHandle {
 
 #[cfg(test)]
 pub mod tests {
-    use std::sync::Arc;
+    use std::{sync::Arc, time::Duration};
 
     use nym_gateway_directory::Gateway;
     use tokio::sync::RwLock;
@@ -37,17 +37,36 @@ pub mod tests {
     #[derive(Clone)]
     pub struct MockGatewayCache {
         gateways: Arc<RwLock<Option<Vec<Gateway>>>>,
+        /// Artificial delay applied to every `lookup_gateways` call, used to
+        /// model a fresh selection that hasn't landed a value in the stream yet.
+        lookup_delay: Duration,
     }
 
     impl MockGatewayCache {
         pub fn new(gateways: Arc<RwLock<Option<Vec<Gateway>>>>) -> Self {
-            Self { gateways }
+            Self {
+                gateways,
+                lookup_delay: Duration::ZERO,
+            }
+        }
+
+        pub fn new_with_lookup_delay(
+            gateways: Arc<RwLock<Option<Vec<Gateway>>>>,
+            lookup_delay: Duration,
+        ) -> Self {
+            Self {
+                gateways,
+                lookup_delay,
+            }
         }
     }
 
     #[async_trait::async_trait]
     impl GatewayCache for MockGatewayCache {
         async fn lookup_gateways(&self, gw_type: GatewayType) -> Result<GatewayList, Error> {
+            if !self.lookup_delay.is_zero() {
+                tokio::time::sleep(self.lookup_delay).await;
+            }
             Ok(GatewayList::new(
                 Some(gw_type),
                 self.gateways.read().await.clone().unwrap_or_default(),

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/mod.rs
@@ -135,10 +135,17 @@ impl<C: GatewayCache> GatewayProvider<C> {
     }
 
     pub async fn tentative_gateways(&self) -> TentativeGateways {
-        // use a very small timeout because we actually expect the stream to always have a value ready
-        // if it doesn't, there's probably some error, but we shouldn't block the RPC call anyway
+        // In steady state the stream always has a value buffered, so this peek
+        // returns immediately. However, `set_tunnel_settings` (triggered on every
+        // connect press via `set_gateway_independence`) swaps in a brand-new,
+        // empty stream and asks the algorithm to recompute. When this RPC is
+        // queried in that window we must wait for the first fresh selection to
+        // land rather than reporting `NoGatewaysAvailable` against an empty
+        // stream. The wait is still bounded: a genuinely failing selection (e.g.
+        // an empty gateway pool) yields an `Err` quickly, so this only ever
+        // blocks while a real selection is in flight.
         match tokio::time::timeout(
-            Duration::from_millis(10),
+            Duration::from_millis(100),
             self.selected_gateways_stream.lock().await.peek(),
         )
         .await

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/tests/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/tests/mod.rs
@@ -10,7 +10,9 @@ use nym_gateway_directory::{
 };
 use nym_sdk::UserAgent;
 use nym_vpn_api_client::response::NodeFamily;
-use nym_vpn_lib_types::{EntryPoint, ExitPoint, GatewayIndependence, TunnelType};
+use nym_vpn_lib_types::{
+    EntryPoint, ExitPoint, GatewayIndependence, TentativeGateways, TunnelType,
+};
 use nym_vpn_store::keys::wireguard::WireguardKeysDb;
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
@@ -277,6 +279,54 @@ async fn set_and_stream() {
     for _ in 0..100 {
         gw_provider.next().await.unwrap().unwrap();
     }
+
+    shutdown_token.cancel();
+    handle.await.unwrap();
+}
+
+/// Regression test for the intermittent `NoGatewaysAvailable` race.
+///
+/// `set_tunnel_settings` (triggered on every connect press via
+/// `set_gateway_independence`) swaps in a brand-new, empty selection stream and
+/// asks the algorithm to recompute. If `tentative_gateways` is queried before
+/// the first fresh selection lands in that stream, it must wait for it rather
+/// than immediately reporting `NoGatewaysAvailable`
+#[tokio::test]
+async fn tentative_gateways_waits_for_fresh_selection_after_reset() {
+    let shutdown_token = CancellationToken::new();
+    let possible_gateways = [
+        "2zHiExNRKiCXVKS35SNKtK4apGfZELMpA1jJ2gVevJoz",
+        "38zcSsvjXsAX7C28ko2H3Lt55X4TYxfZYkPADxKXZHUj",
+    ]
+    .map(gateway_id_to_gateway);
+    let gateways = Arc::new(RwLock::new(Some(possible_gateways.to_vec())));
+    let mut tunnel_settings = default_tunnel_settings();
+    tunnel_settings
+        .gateway_selection_algorithm_config
+        .enable_geo_location = false;
+
+    let cache = MockGatewayCache::new_with_lookup_delay(gateways, Duration::from_millis(50));
+    let (gw_provider, handle) = GatewayProvider::new(
+        cache,
+        MockGeoIpClient::new(),
+        tunnel_settings.clone(),
+        WireguardKeysDb::Ephemeral(Default::default()),
+        shutdown_token.child_token(),
+    );
+
+    // Reset the stream (as set_gateway_independence does on every connect press)
+    // and immediately query, before the freshly computed selection is ready.
+    gw_provider
+        .set_tunnel_settings(tunnel_settings)
+        .await
+        .unwrap();
+    let tentative = gw_provider.tentative_gateways().await;
+
+    assert!(
+        matches!(tentative, TentativeGateways::Selected { .. }),
+        "tentative_gateways must wait for the freshly computed selection instead \
+         of returning NoGatewaysAvailable; got {tentative:?}"
+    );
 
     shutdown_token.cancel();
     handle.await.unwrap();


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

- Increate wait for `tentative_gateways` function from `10` to `100`ms
- Add regression tests


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5667)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gateway selection reliability by increasing timeout tolerance when applying tunnel settings changes, reducing premature "no gateways available" errors during configuration updates.

* **Tests**
  * Enhanced test infrastructure to simulate delayed gateway lookups and added regression test for gateway selection behavior during settings resets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->