### PR TITLE
(tauri) Reconnect on node family server change

### DIFF
--- a/nym-vpn-app/src-tauri/src/commands/tunnel.rs
+++ b/nym-vpn-app/src-tauri/src/commands/tunnel.rs
@@ -119,6 +119,13 @@ pub async fn disconnect(
     Ok(TunnelState::Disconnecting(None))
 }
 
+#[instrument(skip_all)]
+#[tauri::command]
+pub async fn reconnect(vpnd: State<'_, VpndClient>) -> Result<(), BackendError> {
+    vpnd.vpn_reconnect().await?;
+    Ok(())
+}
+
 #[instrument(skip(vpnd))]
 #[tauri::command]
 pub async fn set_vpn_mode(vpnd: State<'_, VpndClient>, mode: VpnMode) -> Result<(), BackendError> {

--- a/nym-vpn-app/src-tauri/src/main.rs
+++ b/nym-vpn-app/src-tauri/src/main.rs
@@ -304,6 +304,7 @@ async fn main() -> Result<()> {
             tunnel::get_tunnel_state,
             tunnel::connect,
             tunnel::disconnect,
+            tunnel::reconnect,
             tunnel::set_node,
             tunnel::set_quic,
             tunnel::set_fronting_mode,

--- a/nym-vpn-app/src-tauri/src/vpnd/client.rs
+++ b/nym-vpn-app/src-tauri/src/vpnd/client.rs
@@ -459,6 +459,18 @@ impl VpndClient {
         Ok(())
     }
 
+    /// Reconnect the VPN
+    #[instrument(skip_all)]
+    pub async fn vpn_reconnect(&self) -> Result<(), VpndError> {
+        let mut vpnd = self.vpnd().await?;
+
+        vpnd.reconnect_tunnel()
+            .or_else(async |e| self.handle_rpc_error("reconnect_tunnel", e).await)
+            .await?;
+
+        Ok(())
+    }
+
     /// Disconnect from the VPN
     #[instrument(skip_all)]
     pub async fn vpn_disconnect(&self) -> Result<(), VpndError> {

--- a/nym-vpn-app/src/hooks/useGatewayIndependenceWatcher.ts
+++ b/nym-vpn-app/src/hooks/useGatewayIndependenceWatcher.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { invoke } from '@tauri-apps/api/core';
-import { useAppStore } from '../store';
+import { dispatch, useAppStore } from '../store';
 import { useGwIndependenceWarning } from '../contexts/gatewayIndependence';
 
 // While connected, the daemon may surface
@@ -29,7 +29,13 @@ function useGatewayIndependenceWatcher() {
     const handle = async () => {
       if (notificationsEnabled && !(await requestConfirmation())) return;
 
-      await invoke('set_gateway_independence', { enabled: false });
+      await invoke('set_gateway_independence', {
+        enabled: false,
+      });
+
+      dispatch({ type: 'reset-error' });
+      dispatch({ type: 'connect' });
+      await invoke('reconnect');
     };
 
     handle().catch((e: unknown) => {

--- a/nym-vpn-app/src/hooks/useI18nTunnelError.ts
+++ b/nym-vpn-app/src/hooks/useI18nTunnelError.ts
@@ -59,6 +59,8 @@ function useI18nTunnelError() {
           return t('tunnel.performant-entry-gw-unavailable');
         case 'performant-exit-gw-unavailable':
           return t('tunnel.performant-exit-gw-unavailable');
+        case 'needs-relaxed-independence-criteria':
+          return t('tunnel.needs-relaxed-independence-criteria');
       }
 
       console.warn('unhandled tunnel error', error);

--- a/nym-vpn-app/src/i18n/en/errors.json
+++ b/nym-vpn-app/src/i18n/en/errors.json
@@ -28,7 +28,8 @@
     "tun-device": "TUN device error",
     "tunnel-provider": "Tunnel provider error",
     "inactive-account": "Your account is inactive",
-    "device-logged-out": "This device has been logged out. Please log in to continue using the VPN."
+    "device-logged-out": "This device has been logged out. Please log in to continue using the VPN.",
+    "needs-relaxed-independence-criteria": "Needs relaxed independence criteria"
   },
   "account": {
     "internal": "Internal account error",


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

When changing server to the same family as the other one, manually trigger reconnection in the app


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5673)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added VPN reconnect capability to manually restart active connections.

* **Improvements**
  * Enhanced error detection for gateway independence constraints.
  * System now automatically recovers and reconnects when gateway independence settings require adjustment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->