### PR TITLE
Swap internal resolution to Custom Resolver while in Connected state

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- While in Connected state swap internal resolver to use custom DNS (via system resolver). (https://github.com/nymtech/nym-vpn-client/pull/5674_
+
 ## [2026.11.0] - TBD
 
 ### Added

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
@@ -28,6 +28,7 @@ use nym_common::trace_err_chain;
 use nym_firewall::{
     AllowedClients, AllowedDns, AllowedEndpoint, Endpoint, FirewallPolicy, TransportProtocol,
 };
+use nym_http_api_client::HickoryDnsResolver;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use nym_vpn_lib_types::TunnelConnectionData;
 
@@ -115,6 +116,10 @@ impl ConnectedState {
             )
             .await;
         }
+
+        // point the internal DNS resolver to the system so that it routes over the tunnel
+        // using the custom / commodity DNS flow while in the connected state
+        HickoryDnsResolver::shared().use_system_resolver();
 
         #[cfg(not(any(target_os = "android")))]
         if let Err(e) = connected_state.set_dns(shared_state).await {
@@ -281,6 +286,9 @@ impl ConnectedState {
         shared_state
             .statistics_event_sender
             .report_tunnel_interface(None);
+
+        // Revert the internal resolver to use the configured nameserver group
+        HickoryDnsResolver::shared().use_configured_resolver();
 
         #[cfg(not(target_os = "android"))]
         Self::reset_dns(shared_state).await;


### PR DESCRIPTION
## Ticket

JIRA-NYM-1374

## Description

In general once into the connected state the internal resolver should NOT be going to network for resolutions as it will provide responses from the static-pre-resolve that match the resolved (and firewall excepted) addresses for critical domains. 



However in the connected state if the internal `HickoryDnsResolver` is used for DNS lookups it will: 

* be slower than necessary because it uses DoT / DoH

* might get rate limited by the nameservers because all users per gateway will look like they come from the gateway IP. 

* On iOS the `HickoryDnsResolver` could send outside of the tunnel


#### Solution

On entering the Connected state swap the DNS resolver to system_resolver instead of the configured resolver. 

 On exiting the Connected state revert the internal resolver to use the custom cofigured DNS resolver.

## Checklist:

- [X] Changelog
- [X] Add swap to system resolver for internal DNS

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5674)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved DNS resolver handling during the tunnel connection lifecycle: the app uses system DNS while the tunnel is connected, and automatically reverts to the configured custom nameservers when disconnecting.

* **Documentation**
  * Updated the Unreleased changelog entry to clarify the new DNS resolver behavior during the Connected state and teardown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->