### PR TITLE
Pass monitor shutdown token to bandwidth controller

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -1080,7 +1080,9 @@ impl TunnelMonitor {
             entry_signal_rx,
             exit_signal_rx,
             gw_update_version,
-            self.shutdown_token.child_token(),
+            // BandwidthController fatal paths call `shutdown_token.cancel()`; pass the
+            // monitor parent (not a child) so the tunnel monitor loop exits.
+            self.shutdown_token.clone(),
         );
 
         let authenticator_listener_handle = match authenticator_listener_handle {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -1080,8 +1080,6 @@ impl TunnelMonitor {
             entry_signal_rx,
             exit_signal_rx,
             gw_update_version,
-            // BandwidthController fatal paths call `shutdown_token.cancel()`; pass the
-            // monitor parent (not a child) so the tunnel monitor loop exits.
             self.shutdown_token.clone(),
         );
 


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5685)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tunnel setup reliability by adjusting how shutdown signals are handled for bandwidth control during WireGuard connection startup.
  * This may reduce unexpected interruptions or shutdown-related issues while establishing a VPN tunnel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->