### PR TITLE
(core) Flush pending settings update on `reconnect_tunnel` call

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
@@ -858,6 +858,11 @@ impl NymVpnService {
     async fn reconnect_tunnel(&self) -> bool {
         match self.target_state {
             TargetState::Secured => {
+                // Flush any settings update that is still pending behind the
+                // throttle timer so the upcoming Connect uses the latest config.
+                // Otherwise a reconnect can race ahead of the throttled
+                // SetTunnelSettings and re-run with stale settings
+                self.update_tunnel_settings();
                 self.statistics_event_sender.report_connection_request();
                 let _ = self.command_sender.send(TunnelCommand::Connect);
                 true


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5686)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reconnect behavior so the app now applies the latest tunnel settings before re-establishing a secure connection.
  * This helps ensure connection retries use up-to-date configuration and reduces the chance of reconnecting with stale settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->