### PR TITLE
Fix/macos runner python libexpat (#5688)

### DIFF
--- a/.github/actions/push-to-s3/action.yml
+++ b/.github/actions/push-to-s3/action.yml
@@ -53,12 +53,13 @@ runs:
         set -euo pipefail
         if ! command -v aws >/dev/null 2>&1; then
           if [[ "$(uname -s)" == "Darwin" ]]; then
-            # AppleSilicon self-hosted runners: Homebrew awscli matches host arch.
-            if ! command -v brew >/dev/null 2>&1; then
-              echo "Homebrew is required on macOS to install AWS CLI"
-              exit 1
-            fi
-            brew install awscli || brew upgrade awscli
+            # Official versioned PKG — avoids Homebrew's python@3.14/libexpat
+            # ABI mismatch with macOS system libexpat.1.dylib. Bundles its own
+            # Python so no host library conflicts. Same pinned version as Linux.
+            curl -fsSL "https://awscli.amazonaws.com/AWSCLIV2-${AWSCLI_VERSION}.pkg" \
+              -o /tmp/awscliv2.pkg
+            pkgutil --check-signature /tmp/awscliv2.pkg
+            sudo installer -pkg /tmp/awscliv2.pkg -target /
           else
             # Linux: pinned zip + OpenPGP verify (supply-chain). Ensure gpg exists.
             if ! command -v gpg >/dev/null 2>&1; then

--- a/.github/workflows/build-nym-vpn-apple.yml
+++ b/.github/workflows/build-nym-vpn-apple.yml
@@ -202,6 +202,28 @@ jobs:
           ruby --version
           gem --version
 
+      - name: Ensure codemagic-cli-tools uses compatible Python
+        run: |
+          set -euo pipefail
+          if ! keychain --version >/dev/null 2>&1; then
+            # The runner's system /usr/lib/libexpat.1.dylib is missing
+            # _XML_SetAllocTrackerActivationThreshold. Every Homebrew Python
+            # version (3.12 and 3.14) links pyexpat.so against the system
+            # libexpat, so ALL versions fail — switching Python doesn't help.
+            # Fix: remap each Homebrew Python's pyexpat.so to use Homebrew's
+            # own expat formula (which ships the required symbol), then
+            # ad-hoc re-sign the patched .so so macOS will load it.
+            brew install expat
+            HOMEBREW_EXPAT="$(brew --prefix expat)/lib/libexpat.1.dylib"
+            while IFS= read -r -d '' so; do
+              install_name_tool -change /usr/lib/libexpat.1.dylib \
+                "$HOMEBREW_EXPAT" "$so" \
+                && codesign -f -s - "$so" || true
+            done < <(find /opt/homebrew/Cellar/python@* \
+              -name 'pyexpat*.so' -not -type l -print0 2>/dev/null)
+            keychain --version
+          fi
+
       - name: Apply orchestrated version (apple)
         uses: ./.github/workflows/platform/apply-version
         with:

--- a/.github/workflows/build-nym-vpnc-macos.yml
+++ b/.github/workflows/build-nym-vpnc-macos.yml
@@ -90,6 +90,28 @@ jobs:
         run: |
           echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
 
+      - name: Ensure codemagic-cli-tools uses compatible Python
+        run: |
+          set -euo pipefail
+          if ! keychain --version >/dev/null 2>&1; then
+            # The runner's system /usr/lib/libexpat.1.dylib is missing
+            # _XML_SetAllocTrackerActivationThreshold. Every Homebrew Python
+            # version (3.12 and 3.14) links pyexpat.so against the system
+            # libexpat, so ALL versions fail — switching Python doesn't help.
+            # Fix: remap each Homebrew Python's pyexpat.so to use Homebrew's
+            # own expat formula (which ships the required symbol), then
+            # ad-hoc re-sign the patched .so so macOS will load it.
+            brew install expat
+            HOMEBREW_EXPAT="$(brew --prefix expat)/lib/libexpat.1.dylib"
+            while IFS= read -r -d '' so; do
+              install_name_tool -change /usr/lib/libexpat.1.dylib \
+                "$HOMEBREW_EXPAT" "$so" \
+                && codesign -f -s - "$so" || true
+            done < <(find /opt/homebrew/Cellar/python@* \
+              -name 'pyexpat*.so' -not -type l -print0 2>/dev/null)
+            keychain --version
+          fi
+
       - name: Configure sccache
         run: |
           set -euxo pipefail


### PR DESCRIPTION
* fix(ci): use official AWS CLI PKG on macOS to avoid python@3.14/libexpat ABI mismatch

Homebrew's awscli pulls in python@3.14 whose pyexpat module references _XML_SetAllocTrackerActivationThreshold, a symbol missing from the macOS system libexpat.1.dylib, causing the push-to-s3 action to fail on Apple Silicon self-hosted runners.

Replace brew install with the official versioned AWS CLI PKG installer, which bundles its own Python and has no host library dependencies. Uses the same pinned AWSCLI_VERSION as the Linux path and verifies the Apple code signature via pkgutil before installing.

* fix(ci): reinstall codemagic-cli-tools on python@3.12 if python@3.14 is broken

Homebrew's python@3.14 has a pyexpat/libexpat ABI mismatch on the current macOS release — _XML_SetAllocTrackerActivationThreshold is referenced by the Homebrew bottle but absent in the system libexpat.1.dylib. This breaks the pre-installed codemagic-cli-tools pipx venv on the Apple Silicon runner, causing keychain to fail.

Add an early step to both apple workflows that detects the broken install and reinstalls codemagic-cli-tools via pipx on python@3.12, which is compatible with the system libexpat.

* fix(ci): bypass pipx to reinstall codemagic-cli-tools on python@3.12

pipx itself runs on Homebrew's python@3.14 so pipx reinstall also crashes with the same pyexpat/libexpat ABI error before it can create a new venv. Additionally, pipx install --force silently ignores --python when the venv already exists.

Instead, bypass pipx entirely: remove the broken venv, create a fresh one directly with python@3.12 (which has a working libexpat), install codemagic-cli-tools into it, and add the venv bin to GITHUB_PATH.

* fix(ci): skip ensurepip in venv creation and bootstrap pip via get-pip.py

python3.12 -m venv internally runs ensurepip which can fail on some Homebrew python@3.12 setups (exit status 1 with no output). Use --without-pip to skip ensurepip, then bootstrap pip directly from bootstrap.pypa.io/get-pip.py which runs cleanly under python@3.12 and has no pyexpat/libexpat dependency.

* fix(ci): patch Homebrew Python pyexpat.so to use Homebrew expat

Python 3.12 has the same pyexpat/libexpat ABI mismatch as 3.14 — all Homebrew Python bottles link pyexpat.so against the system /usr/lib/libexpat.1.dylib, which on this runner is missing the _XML_SetAllocTrackerActivationThreshold symbol. Switching Python versions doesn't help.

Instead, install Homebrew's own expat formula (which has the symbol), remap the load path in every Homebrew Python pyexpat.so via install_name_tool, and ad-hoc re-sign the patched .so. This unblocks the existing pipx codemagic-cli-tools install without any venv recreation or pip bootstrapping.

## Ticket

JIRA-NYM-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5691)
<!-- Reviewable:end -->
