### PR TITLE
Pass monitor shutdown token to bandwidth controller

### DIFF
--- a/.github/actions/push-to-s3/action.yml
+++ b/.github/actions/push-to-s3/action.yml
@@ -53,12 +53,13 @@ runs:
         set -euo pipefail
         if ! command -v aws >/dev/null 2>&1; then
           if [[ "$(uname -s)" == "Darwin" ]]; then
-            # AppleSilicon self-hosted runners: Homebrew awscli matches host arch.
-            if ! command -v brew >/dev/null 2>&1; then
-              echo "Homebrew is required on macOS to install AWS CLI"
-              exit 1
-            fi
-            brew install awscli || brew upgrade awscli
+            # Official versioned PKG — avoids Homebrew's python@3.14/libexpat
+            # ABI mismatch with macOS system libexpat.1.dylib. Bundles its own
+            # Python so no host library conflicts. Same pinned version as Linux.
+            curl -fsSL "https://awscli.amazonaws.com/AWSCLIV2-${AWSCLI_VERSION}.pkg" \
+              -o /tmp/awscliv2.pkg
+            pkgutil --check-signature /tmp/awscliv2.pkg
+            sudo installer -pkg /tmp/awscliv2.pkg -target /
           else
             # Linux: pinned zip + OpenPGP verify (supply-chain). Ensure gpg exists.
             if ! command -v gpg >/dev/null 2>&1; then

--- a/.github/workflows/build-nym-vpn-apple.yml
+++ b/.github/workflows/build-nym-vpn-apple.yml
@@ -202,6 +202,28 @@ jobs:
           ruby --version
           gem --version
 
+      - name: Ensure codemagic-cli-tools uses compatible Python
+        run: |
+          set -euo pipefail
+          if ! keychain --version >/dev/null 2>&1; then
+            # The runner's system /usr/lib/libexpat.1.dylib is missing
+            # _XML_SetAllocTrackerActivationThreshold. Every Homebrew Python
+            # version (3.12 and 3.14) links pyexpat.so against the system
+            # libexpat, so ALL versions fail — switching Python doesn't help.
+            # Fix: remap each Homebrew Python's pyexpat.so to use Homebrew's
+            # own expat formula (which ships the required symbol), then
+            # ad-hoc re-sign the patched .so so macOS will load it.
+            brew install expat
+            HOMEBREW_EXPAT="$(brew --prefix expat)/lib/libexpat.1.dylib"
+            while IFS= read -r -d '' so; do
+              install_name_tool -change /usr/lib/libexpat.1.dylib \
+                "$HOMEBREW_EXPAT" "$so" \
+                && codesign -f -s - "$so" || true
+            done < <(find /opt/homebrew/Cellar/python@* \
+              -name 'pyexpat*.so' -not -type l -print0 2>/dev/null)
+            keychain --version
+          fi
+
       - name: Apply orchestrated version (apple)
         uses: ./.github/workflows/platform/apply-version
         with:

--- a/.github/workflows/build-nym-vpnc-macos.yml
+++ b/.github/workflows/build-nym-vpnc-macos.yml
@@ -90,6 +90,28 @@ jobs:
         run: |
           echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
 
+      - name: Ensure codemagic-cli-tools uses compatible Python
+        run: |
+          set -euo pipefail
+          if ! keychain --version >/dev/null 2>&1; then
+            # The runner's system /usr/lib/libexpat.1.dylib is missing
+            # _XML_SetAllocTrackerActivationThreshold. Every Homebrew Python
+            # version (3.12 and 3.14) links pyexpat.so against the system
+            # libexpat, so ALL versions fail — switching Python doesn't help.
+            # Fix: remap each Homebrew Python's pyexpat.so to use Homebrew's
+            # own expat formula (which ships the required symbol), then
+            # ad-hoc re-sign the patched .so so macOS will load it.
+            brew install expat
+            HOMEBREW_EXPAT="$(brew --prefix expat)/lib/libexpat.1.dylib"
+            while IFS= read -r -d '' so; do
+              install_name_tool -change /usr/lib/libexpat.1.dylib \
+                "$HOMEBREW_EXPAT" "$so" \
+                && codesign -f -s - "$so" || true
+            done < <(find /opt/homebrew/Cellar/python@* \
+              -name 'pyexpat*.so' -not -type l -print0 2>/dev/null)
+            keychain --version
+          fi
+
       - name: Configure sccache
         run: |
           set -euxo pipefail

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -5139,7 +5139,7 @@ dependencies = [
 
 [[package]]
 name = "nym-apple-network"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "block2",
  "dispatch2",
@@ -5248,7 +5248,7 @@ dependencies = [
 
 [[package]]
 name = "nym-cgroup"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "anyhow",
  "log",
@@ -5396,7 +5396,7 @@ dependencies = [
 
 [[package]]
 name = "nym-common"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "tracing",
  "tracing-test",
@@ -5442,12 +5442,12 @@ dependencies = [
 
 [[package]]
 name = "nym-connection-monitor"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "async-trait",
  "futures",
  "nix 0.31.3",
- "nym-common 2026.11.0-beta.1",
+ "nym-common 2026.11.0-beta.3",
  "pretty_assertions",
  "socket2 0.6.3",
  "surge-ping",
@@ -5616,7 +5616,7 @@ dependencies = [
 
 [[package]]
 name = "nym-dbus"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "dbus",
  "libc",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "nym-diagnostic"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5677,13 +5677,13 @@ dependencies = [
 
 [[package]]
 name = "nym-dns"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "duct",
  "futures",
  "inotify",
  "nix 0.31.3",
- "nym-common 2026.11.0-beta.1",
+ "nym-common 2026.11.0-beta.3",
  "nym-dbus",
  "nym-routing",
  "nym-windows",
@@ -5740,7 +5740,7 @@ dependencies = [
 
 [[package]]
 name = "nym-exclude"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "nix 0.31.3",
  "nym-cgroup",
@@ -5761,7 +5761,7 @@ dependencies = [
 
 [[package]]
 name = "nym-file-updater"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "futures",
  "reqwest 0.13.3",
@@ -5776,7 +5776,7 @@ dependencies = [
 
 [[package]]
 name = "nym-firewall"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "ipnetwork",
  "libc",
@@ -5785,7 +5785,7 @@ dependencies = [
  "nftnl",
  "nix 0.31.3",
  "nym-cgroup",
- "nym-common 2026.11.0-beta.1",
+ "nym-common 2026.11.0-beta.3",
  "nym-firewall-config",
  "nym-platform-metadata",
  "pfctl",
@@ -5798,7 +5798,7 @@ dependencies = [
 
 [[package]]
 name = "nym-firewall-config"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "ipnetwork",
 ]
@@ -5844,7 +5844,7 @@ dependencies = [
 
 [[package]]
 name = "nym-gateway-directory"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "anyhow",
  "ipnetwork",
@@ -5982,7 +5982,7 @@ dependencies = [
 
 [[package]]
 name = "nym-ifconfig"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "bitflags 2.11.0",
  "futures",
@@ -6034,7 +6034,7 @@ dependencies = [
 
 [[package]]
 name = "nym-ipc"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6140,7 +6140,7 @@ dependencies = [
 
 [[package]]
 name = "nym-macos"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "nix 0.31.3",
  "tokio",
@@ -6326,14 +6326,14 @@ dependencies = [
 
 [[package]]
 name = "nym-offline-monitor"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "async-trait",
  "debounced",
  "dispatch2",
  "futures",
  "nym-apple-network",
- "nym-common 2026.11.0-beta.1",
+ "nym-common 2026.11.0-beta.3",
  "nym-routing",
  "nym-windows",
  "thiserror 2.0.18",
@@ -6392,7 +6392,7 @@ dependencies = [
 
 [[package]]
 name = "nym-platform-metadata"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "nym-bin-common",
  "nym-dbus",
@@ -6451,14 +6451,14 @@ dependencies = [
 
 [[package]]
 name = "nym-routing"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "bitflags 2.11.0",
  "futures",
  "ipnetwork",
  "libc",
  "nix 0.31.3",
- "nym-common 2026.11.0-beta.1",
+ "nym-common 2026.11.0-beta.3",
  "nym-windows",
  "rtnetlink",
  "system-configuration 0.7.0",
@@ -6564,7 +6564,7 @@ dependencies = [
 
 [[package]]
 name = "nym-setup"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -6607,7 +6607,7 @@ dependencies = [
 
 [[package]]
 name = "nym-socks5-proxy"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -6649,7 +6649,7 @@ dependencies = [
 
 [[package]]
 name = "nym-socks5-proxy-ipc"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -6842,7 +6842,7 @@ dependencies = [
 
 [[package]]
 name = "nym-split-tunnel"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "bitflags 2.11.0",
  "bytes",
@@ -6856,7 +6856,7 @@ dependencies = [
  "nftnl",
  "nix 0.31.3",
  "nym-cgroup",
- "nym-common 2026.11.0-beta.1",
+ "nym-common 2026.11.0-beta.3",
  "nym-dbus",
  "nym-firewall",
  "nym-firewall-config",
@@ -6893,7 +6893,7 @@ dependencies = [
 
 [[package]]
 name = "nym-statistics"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "futures",
  "nym-bin-common",
@@ -6914,7 +6914,7 @@ dependencies = [
 
 [[package]]
 name = "nym-statistics-api-client"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "nym-http-api-client",
  "nym-statistics-common",
@@ -7084,7 +7084,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-account-controller"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -7094,7 +7094,7 @@ dependencies = [
  "bs58",
  "futures",
  "hkdf",
- "nym-common 2026.11.0-beta.1",
+ "nym-common 2026.11.0-beta.3",
  "nym-compact-ecash",
  "nym-credential-proxy-requests",
  "nym-credential-storage",
@@ -7137,7 +7137,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-api-client"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "async-trait",
  "backon",
@@ -7146,7 +7146,7 @@ dependencies = [
  "bs58",
  "hex",
  "itertools 0.14.0",
- "nym-common 2026.11.0-beta.1",
+ "nym-common 2026.11.0-beta.3",
  "nym-compact-ecash",
  "nym-config",
  "nym-contracts-common",
@@ -7173,7 +7173,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-lib"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "adblock",
  "anyhow",
@@ -7208,7 +7208,7 @@ dependencies = [
  "nym-bin-common",
  "nym-cgroup",
  "nym-client-core",
- "nym-common 2026.11.0-beta.1",
+ "nym-common 2026.11.0-beta.3",
  "nym-config",
  "nym-connection-monitor",
  "nym-credentials-interface",
@@ -7291,7 +7291,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-lib-types"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "bip39",
  "ipnetwork",
@@ -7321,7 +7321,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-lib-uniffi"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "async-trait",
  "inventory",
@@ -7332,7 +7332,7 @@ dependencies = [
  "jni 0.22.4",
  "log",
  "ndk-context",
- "nym-common 2026.11.0-beta.1",
+ "nym-common 2026.11.0-beta.3",
  "nym-firewall-config",
  "nym-gateway-directory",
  "nym-http-api-client",
@@ -7363,10 +7363,10 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-network-config"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "itertools 0.14.0",
- "nym-common 2026.11.0-beta.1",
+ "nym-common 2026.11.0-beta.3",
  "nym-http-api-client",
  "nym-network-defaults",
  "nym-offline-monitor",
@@ -7387,7 +7387,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-proto"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "hyper 1.9.0",
  "nym-ipc",
@@ -7406,10 +7406,10 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-rpc-uniffi"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "futures",
- "nym-common 2026.11.0-beta.1",
+ "nym-common 2026.11.0-beta.3",
  "nym-vpn-lib-types",
  "nym-vpn-proto",
  "tokio",
@@ -7420,7 +7420,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-store"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7444,7 +7444,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpnc"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "anyhow",
  "celes",
@@ -7461,7 +7461,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpnd"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -7504,7 +7504,7 @@ dependencies = [
 
 [[package]]
 name = "nym-wg-go"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "hex",
  "ipnetwork",
@@ -7520,7 +7520,7 @@ dependencies = [
 
 [[package]]
 name = "nym-wg-metadata-client"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "nym-credentials-interface",
  "nym-gateway-directory",
@@ -7535,7 +7535,7 @@ dependencies = [
 
 [[package]]
 name = "nym-windows"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "bitflags 2.11.0",
  "futures",
@@ -10911,7 +10911,7 @@ dependencies = [
 
 [[package]]
 name = "test-manager"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "anyhow",
  "async-tempfile",
@@ -10956,7 +10956,7 @@ dependencies = [
 
 [[package]]
 name = "test-rpc"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -10981,7 +10981,7 @@ dependencies = [
 
 [[package]]
 name = "test-runner"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "bytes",
  "dirs",
@@ -11007,7 +11007,7 @@ dependencies = [
 
 [[package]]
 name = "test_macro"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11971,7 +11971,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi-bindgen"
-version = "2026.11.0-beta.1"
+version = "2026.11.0-beta.3"
 dependencies = [
  "uniffi",
 ]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -1080,7 +1080,7 @@ impl TunnelMonitor {
             entry_signal_rx,
             exit_signal_rx,
             gw_update_version,
-            self.shutdown_token.child_token(),
+            self.shutdown_token.clone(),
         );
 
         let authenticator_listener_handle = match authenticator_listener_handle {


### PR DESCRIPTION
- Cherry-pick of #5685 from develop: bandwidth controller now shares the monitor shutdown token instead of a child token during WireGuard tunnel setup.
- Single-file change in tunnel monitor shutdown handling.

## Test plan
- [ ] Connect VPN on release branch build and verify tunnel establishes without premature bandwidth-controller shutdown
- [ ] Disconnect and confirm clean shutdown still works

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5693)
<!-- Reviewable:end -->
