### PR TITLE
[Android] Fix mixnet tuning screen issues

### DIFF
--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/data/datastore/DataStoreSettingsRepository.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/data/datastore/DataStoreSettingsRepository.kt
@@ -145,17 +145,18 @@ class DataStoreSettingsRepository(private val dataStoreManager: DataStoreManager
 		val avgDelay = dataStoreManager.getFromStore(mixnetAvgPacketDelay)
 		val disablePoisson = dataStoreManager.getFromStore(mixnetDisablePoisson) ?: MIXNET_CONFIG_DEFAULT.disablePoissonRate
 
-		if (poisson == null && avgDelay == null) return MIXNET_CONFIG_DEFAULT.copy(
-			disablePoissonRate = disablePoisson,
-			disableBackgroundCoverTraffic = disablePoisson,
-		)
+		if (poisson == null && avgDelay == null) {
+			return MIXNET_CONFIG_DEFAULT.copy(
+				disablePoissonRate = disablePoisson,
+				disableBackgroundCoverTraffic = disablePoisson,
+			)
+		}
 
 		return MixnetTrafficConfig(
 			poissonParameterForLoopCoverStream = poisson?.toUInt() ?: MIXNET_CONFIG_DEFAULT.poissonParameterForLoopCoverStream,
 			averagePacketDelay = avgDelay?.toUInt() ?: MIXNET_CONFIG_DEFAULT.averagePacketDelay,
 			messageSendingAverageDelay = dataStoreManager.getFromStore(mixnetMsgSendingDelay)?.toUInt() ?: MIXNET_CONFIG_DEFAULT.messageSendingAverageDelay,
 			disablePoissonRate = disablePoisson,
-			// Keep in sync with disablePoissonRate since both are controlled by the same toggle and only disablePoissonRate is persisted
 			disableBackgroundCoverTraffic = disablePoisson,
 			minMixnodePerformance = null,
 			minGatewayMixnetPerformance = null,

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/data/datastore/DataStoreSettingsRepository.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/data/datastore/DataStoreSettingsRepository.kt
@@ -143,10 +143,13 @@ class DataStoreSettingsRepository(private val dataStoreManager: DataStoreManager
 	override suspend fun getMixnetTrafficConfig(): MixnetTrafficConfig {
 		val poisson = dataStoreManager.getFromStore(mixnetPoissonRate)
 		val avgDelay = dataStoreManager.getFromStore(mixnetAvgPacketDelay)
-
-		if (poisson == null && avgDelay == null) return MIXNET_CONFIG_DEFAULT
-
 		val disablePoisson = dataStoreManager.getFromStore(mixnetDisablePoisson) ?: MIXNET_CONFIG_DEFAULT.disablePoissonRate
+
+		if (poisson == null && avgDelay == null) return MIXNET_CONFIG_DEFAULT.copy(
+			disablePoissonRate = disablePoisson,
+			disableBackgroundCoverTraffic = disablePoisson,
+		)
+
 		return MixnetTrafficConfig(
 			poissonParameterForLoopCoverStream = poisson?.toUInt() ?: MIXNET_CONFIG_DEFAULT.poissonParameterForLoopCoverStream,
 			averagePacketDelay = avgDelay?.toUInt() ?: MIXNET_CONFIG_DEFAULT.averagePacketDelay,

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/data/datastore/DataStoreSettingsRepository.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/data/datastore/DataStoreSettingsRepository.kt
@@ -146,12 +146,14 @@ class DataStoreSettingsRepository(private val dataStoreManager: DataStoreManager
 
 		if (poisson == null && avgDelay == null) return MIXNET_CONFIG_DEFAULT
 
+		val disablePoisson = dataStoreManager.getFromStore(mixnetDisablePoisson) ?: MIXNET_CONFIG_DEFAULT.disablePoissonRate
 		return MixnetTrafficConfig(
 			poissonParameterForLoopCoverStream = poisson?.toUInt() ?: MIXNET_CONFIG_DEFAULT.poissonParameterForLoopCoverStream,
 			averagePacketDelay = avgDelay?.toUInt() ?: MIXNET_CONFIG_DEFAULT.averagePacketDelay,
 			messageSendingAverageDelay = dataStoreManager.getFromStore(mixnetMsgSendingDelay)?.toUInt() ?: MIXNET_CONFIG_DEFAULT.messageSendingAverageDelay,
-			disablePoissonRate = dataStoreManager.getFromStore(mixnetDisablePoisson) ?: MIXNET_CONFIG_DEFAULT.disablePoissonRate,
-			disableBackgroundCoverTraffic = false,
+			disablePoissonRate = disablePoisson,
+			// Keep in sync with disablePoissonRate since both are controlled by the same toggle and only disablePoissonRate is persisted
+			disableBackgroundCoverTraffic = disablePoisson,
 			minMixnodePerformance = null,
 			minGatewayMixnetPerformance = null,
 		)
@@ -168,6 +170,7 @@ class DataStoreSettingsRepository(private val dataStoreManager: DataStoreManager
 		dataStoreManager.preferencesFlow.map { prefs ->
 			prefs?.let { pref ->
 				try {
+					val mixnetDisable = pref[mixnetDisablePoisson] ?: MIXNET_CONFIG_DEFAULT.disablePoissonRate
 					val mixnetConfig = MixnetTrafficConfig(
 						poissonParameterForLoopCoverStream = pref[mixnetPoissonRate]?.toUInt()
 							?: MIXNET_CONFIG_DEFAULT.poissonParameterForLoopCoverStream,
@@ -175,9 +178,8 @@ class DataStoreSettingsRepository(private val dataStoreManager: DataStoreManager
 							?: MIXNET_CONFIG_DEFAULT.averagePacketDelay,
 						messageSendingAverageDelay = pref[mixnetMsgSendingDelay]?.toUInt()
 							?: MIXNET_CONFIG_DEFAULT.messageSendingAverageDelay,
-						disablePoissonRate = pref[mixnetDisablePoisson]
-							?: MIXNET_CONFIG_DEFAULT.disablePoissonRate,
-						disableBackgroundCoverTraffic = false,
+						disablePoissonRate = mixnetDisable,
+						disableBackgroundCoverTraffic = mixnetDisable,
 						minMixnodePerformance = null,
 						minGatewayMixnetPerformance = null,
 					)

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/tuning/components/MixingDelaysSection.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/tuning/components/MixingDelaysSection.kt
@@ -59,7 +59,7 @@ fun MixingDelaysSection(delayValue: Float, onDelayValueChange: (Float) -> Unit) 
 
 			if (delayValue == 0f) {
 				Text(
-					text = stringResource(R.string.mixnet_tuning_traffic_warning),
+					text = stringResource(R.string.mixnet_tuning_delays_warning),
 					style = MaterialTheme.typography.bodySmall,
 					color = LocalNymColors.current.warning,
 					fontFamily = FontFamily(Font(R.font.lab_grotesque_regular)),

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/tuning/components/SendTrafficSection.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/tuning/components/SendTrafficSection.kt
@@ -97,21 +97,24 @@ fun SendTrafficSection(trafficEnabled: Boolean, onTrafficEnable: (enabled: Boole
 					horizontalArrangement = Arrangement.SpaceBetween,
 				) {
 					Text(
-						text = stringResource(R.string.mixnet_tuning_traffic_min),
+						text = stringResource(if (trafficEnabled) R.string.mixnet_tuning_max else R.string.mixnet_tuning_traffic_min),
 						style = MaterialTheme.typography.bodySmall,
 						color = MaterialTheme.colorScheme.onBackground,
 					)
 					Text(
-						text = stringResource(R.string.mixnet_tuning_max),
+						text = stringResource(if (trafficEnabled) R.string.mixnet_tuning_traffic_on_max else R.string.mixnet_tuning_max),
 						style = MaterialTheme.typography.bodySmall,
 						color = MaterialTheme.colorScheme.onBackground,
 					)
 				}
 
+				// Slider is inverted: right = fast (low delay), left = slow (high delay).
+				// trafficValue is the raw delay in ms; displayValue maps high delay to left.
+				val displayValue = (200f - trafficValue.coerceIn(1f, 200f))
 				Slider(
-					value = trafficValue,
-					onValueChange = onTrafficValueChange,
-					valueRange = 0f..200f,
+					value = displayValue,
+					onValueChange = { onTrafficValueChange((200f - it).coerceIn(1f, 200f)) },
+					valueRange = 0f..199f,
 					interactionSource = interactionSource,
 					thumb = {
 						SliderDefaults.Thumb(

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/tuning/components/SendTrafficSection.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/tuning/components/SendTrafficSection.kt
@@ -109,7 +109,6 @@ fun SendTrafficSection(trafficEnabled: Boolean, onTrafficEnable: (enabled: Boole
 				}
 
 				// Slider is inverted: right = fast (low delay), left = slow (high delay).
-				// trafficValue is the raw delay in ms; displayValue maps high delay to left.
 				val displayValue = (200f - trafficValue.coerceIn(1f, 200f))
 				Slider(
 					value = displayValue,

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/util/extensions/UiExtensions.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/util/extensions/UiExtensions.kt
@@ -159,7 +159,7 @@ fun ErrorStateReason.toUserMessage(context: Context): String = when (this) {
 	ErrorStateReason.SplitTunnel -> ""
 
 	is ErrorStateReason.Internal -> context.getString(R.string.unexpected_error, this.v1)
-	ErrorStateReason.NeedsRelaxedIndependenceCriteria -> ""
+	ErrorStateReason.NeedsRelaxedIndependenceCriteria -> context.getString(R.string.node_families_error_message)
 }
 
 fun VpnException.toUserMessage(context: Context): String = when (this) {

--- a/nym-vpn-android/app/src/main/res/values/strings.xml
+++ b/nym-vpn-android/app/src/main/res/values/strings.xml
@@ -553,6 +553,7 @@
 	<string name="node_families_description_text">Disable reminders in </string>
 	<string name="node_families_description_link">notification settings.</string>
 	<string name="node_families_connect_button">Connect anyway</string>
+	<string name="node_families_error_message">Selected servers share a family. Choose a different pair or connect anyway.</string>
 	<!-- Geo Exclusion -->
 	<string name="geo_exclusion_enable_title">Enable Geo Exclusion</string>
 	<string name="geo_exclusion_description">Routes traffic for selected regions outside the VPN tunnel, so domestic apps work at full speed. Everything else stays protected.</string>

--- a/nym-vpn-android/app/src/main/res/values/strings.xml
+++ b/nym-vpn-android/app/src/main/res/values/strings.xml
@@ -509,6 +509,7 @@
 	<string name="mixnet_tuning_traffic_on_description">Cover traffic is always sent to keep the pattern uniform. Adjust the sending rate of your packets.</string>
 	<string name="mixnet_tuning_traffic_off_description">We\'ll still send cover traffic independently of your real traffic.  Choose how much cover you need. </string>
 	<string name="mixnet_tuning_traffic_min">Use less battery &amp; data</string>
+	<string name="mixnet_tuning_traffic_on_max">Fastest</string>
 	<string name="mixnet_tuning_traffic_on_low">Low\n0.7 Mbps</string>
 	<string name="mixnet_tuning_traffic_on_high">High\n2 Mbps</string>
 	<string name="mixnet_tuning_traffic_on_balanced">Balanced\n1 Mbps</string>
@@ -516,6 +517,7 @@
 	<string name="mixnet_tuning_traffic_off_high">High\n20x</string>
 	<string name="mixnet_tuning_traffic_off_balanced">Balanced\n5x</string>
 	<string name="mixnet_tuning_traffic_off_medium">Medium\n10x</string>
+	<string name="mixnet_tuning_delays_warning">⚠️ Setting delay to 0 removes mixing, reducing anonymity</string>
 	<string name="mixnet_tuning_delays_title">Mixing delays</string>
 	<string name="mixnet_tuning_delays_description">Adjust timing delays to change how well your packets are mixed.</string>
 	<string name="mixnet_tuning_delays_min">Faster speed</string>


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

Fix mixnet tuning screen issues  


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5700)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new “Fastest” option for continuous cover traffic.

* **Bug Fixes**
  * Updated traffic tuning so background cover traffic follows the same toggle state as the Poisson-rate setting.

* **UI Improvements**
  * Refreshed the traffic slider behavior with an inverted display model and clearer min/max labels.
  * Updated the zero-mixing warning text to better reflect reduced anonymity.

* **Documentation**
  * Added a dedicated warning string for mixing delay set to 0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->