### PR TITLE
Gate env sync check to iOS-only for macOS CI compile

### DIFF
--- a/nym-vpn-apple/Services/Sources/Services/ConfigurationManager/ConfigurationManager.swift
+++ b/nym-vpn-apple/Services/Sources/Services/ConfigurationManager/ConfigurationManager.swift
@@ -162,12 +162,14 @@ import PathManager
             try await grpcManager.switchEnvironment(to: env.rawValue)
 #endif
             try await self.configure()
+#if os(iOS)
             guard lastConfiguredEnvString == currentEnvString else {
                 self.logger.error(
                     "Network environment did not sync to \(currentEnvString); skipping env-change observers"
                 )
                 return
             }
+#endif
             self.notifyEnvironmentDidChange()
         } catch {
             self.logger.error("Failed to set env to \(env.rawValue): \(error.localizedDescription)")

--- a/nym-vpn-apple/Services/Tests/ConfigurationManagerTests/SantaEnvSwitchPolicyTests.swift
+++ b/nym-vpn-apple/Services/Tests/ConfigurationManagerTests/SantaEnvSwitchPolicyTests.swift
@@ -23,7 +23,7 @@ struct SantaEnvSwitchPolicyTests {
         Case(label: "santaIOSRelease", isSantaBuild: true, isTestFlight: false, isMacOS: false, isRunningOnCI: false, isDebugBuild: false, expected: false),
     ]
 
-    @Test(arguments: cases)
+    @Test(arguments: Self.cases)
     func runtimeAccessGate(_ testCase: Case) {
         #expect(
             SantaEnvSwitchPolicy.canApplyEnvironmentChange(


### PR DESCRIPTION
- Wrap Santa env sync guard in os(iOS) so macOS ConfigurationManager compiles in PR CI.
- Fix Santa policy test Self.cases argument for Swift Testing.

Cherry-pick of 60ca1c1 onto release/2026.11-ulrichshorn (follow-up to #5705).

Test plan
- Confirm macOS ConfigurationManagerTests compile in CI.
- iOS Santa env switch behavior unchanged.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5706)
<!-- Reviewable:end -->
