### PR TITLE
Exit bandwidth metadata uses netstack proxy on single-tun wireguard

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -5139,7 +5139,7 @@ dependencies = [
 
 [[package]]
 name = "nym-apple-network"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "block2",
  "dispatch2",
@@ -5248,7 +5248,7 @@ dependencies = [
 
 [[package]]
 name = "nym-cgroup"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "anyhow",
  "log",
@@ -5396,7 +5396,7 @@ dependencies = [
 
 [[package]]
 name = "nym-common"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "tracing",
  "tracing-test",
@@ -5442,12 +5442,12 @@ dependencies = [
 
 [[package]]
 name = "nym-connection-monitor"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "async-trait",
  "futures",
  "nix 0.31.3",
- "nym-common 2026.11.0-beta.3",
+ "nym-common 2026.11.0-beta.5",
  "pretty_assertions",
  "socket2 0.6.3",
  "surge-ping",
@@ -5616,7 +5616,7 @@ dependencies = [
 
 [[package]]
 name = "nym-dbus"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "dbus",
  "libc",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "nym-diagnostic"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5677,13 +5677,13 @@ dependencies = [
 
 [[package]]
 name = "nym-dns"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "duct",
  "futures",
  "inotify",
  "nix 0.31.3",
- "nym-common 2026.11.0-beta.3",
+ "nym-common 2026.11.0-beta.5",
  "nym-dbus",
  "nym-routing",
  "nym-windows",
@@ -5740,7 +5740,7 @@ dependencies = [
 
 [[package]]
 name = "nym-exclude"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "nix 0.31.3",
  "nym-cgroup",
@@ -5761,7 +5761,7 @@ dependencies = [
 
 [[package]]
 name = "nym-file-updater"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "futures",
  "reqwest 0.13.3",
@@ -5776,7 +5776,7 @@ dependencies = [
 
 [[package]]
 name = "nym-firewall"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "ipnetwork",
  "libc",
@@ -5785,7 +5785,7 @@ dependencies = [
  "nftnl",
  "nix 0.31.3",
  "nym-cgroup",
- "nym-common 2026.11.0-beta.3",
+ "nym-common 2026.11.0-beta.5",
  "nym-firewall-config",
  "nym-platform-metadata",
  "pfctl",
@@ -5798,7 +5798,7 @@ dependencies = [
 
 [[package]]
 name = "nym-firewall-config"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "ipnetwork",
 ]
@@ -5844,7 +5844,7 @@ dependencies = [
 
 [[package]]
 name = "nym-gateway-directory"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "anyhow",
  "ipnetwork",
@@ -5982,7 +5982,7 @@ dependencies = [
 
 [[package]]
 name = "nym-ifconfig"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "bitflags 2.11.0",
  "futures",
@@ -6034,7 +6034,7 @@ dependencies = [
 
 [[package]]
 name = "nym-ipc"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6140,7 +6140,7 @@ dependencies = [
 
 [[package]]
 name = "nym-macos"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "nix 0.31.3",
  "tokio",
@@ -6326,14 +6326,14 @@ dependencies = [
 
 [[package]]
 name = "nym-offline-monitor"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "async-trait",
  "debounced",
  "dispatch2",
  "futures",
  "nym-apple-network",
- "nym-common 2026.11.0-beta.3",
+ "nym-common 2026.11.0-beta.5",
  "nym-routing",
  "nym-windows",
  "thiserror 2.0.18",
@@ -6392,7 +6392,7 @@ dependencies = [
 
 [[package]]
 name = "nym-platform-metadata"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "nym-bin-common",
  "nym-dbus",
@@ -6451,14 +6451,14 @@ dependencies = [
 
 [[package]]
 name = "nym-routing"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "bitflags 2.11.0",
  "futures",
  "ipnetwork",
  "libc",
  "nix 0.31.3",
- "nym-common 2026.11.0-beta.3",
+ "nym-common 2026.11.0-beta.5",
  "nym-windows",
  "rtnetlink",
  "system-configuration 0.7.0",
@@ -6564,7 +6564,7 @@ dependencies = [
 
 [[package]]
 name = "nym-setup"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -6607,7 +6607,7 @@ dependencies = [
 
 [[package]]
 name = "nym-socks5-proxy"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -6649,7 +6649,7 @@ dependencies = [
 
 [[package]]
 name = "nym-socks5-proxy-ipc"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -6842,7 +6842,7 @@ dependencies = [
 
 [[package]]
 name = "nym-split-tunnel"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "bitflags 2.11.0",
  "bytes",
@@ -6856,7 +6856,7 @@ dependencies = [
  "nftnl",
  "nix 0.31.3",
  "nym-cgroup",
- "nym-common 2026.11.0-beta.3",
+ "nym-common 2026.11.0-beta.5",
  "nym-dbus",
  "nym-firewall",
  "nym-firewall-config",
@@ -6893,7 +6893,7 @@ dependencies = [
 
 [[package]]
 name = "nym-statistics"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "futures",
  "nym-bin-common",
@@ -6914,7 +6914,7 @@ dependencies = [
 
 [[package]]
 name = "nym-statistics-api-client"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "nym-http-api-client",
  "nym-statistics-common",
@@ -7084,7 +7084,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-account-controller"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -7094,7 +7094,7 @@ dependencies = [
  "bs58",
  "futures",
  "hkdf",
- "nym-common 2026.11.0-beta.3",
+ "nym-common 2026.11.0-beta.5",
  "nym-compact-ecash",
  "nym-credential-proxy-requests",
  "nym-credential-storage",
@@ -7137,7 +7137,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-api-client"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "async-trait",
  "backon",
@@ -7146,7 +7146,7 @@ dependencies = [
  "bs58",
  "hex",
  "itertools 0.14.0",
- "nym-common 2026.11.0-beta.3",
+ "nym-common 2026.11.0-beta.5",
  "nym-compact-ecash",
  "nym-config",
  "nym-contracts-common",
@@ -7173,7 +7173,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-lib"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "adblock",
  "anyhow",
@@ -7208,7 +7208,7 @@ dependencies = [
  "nym-bin-common",
  "nym-cgroup",
  "nym-client-core",
- "nym-common 2026.11.0-beta.3",
+ "nym-common 2026.11.0-beta.5",
  "nym-config",
  "nym-connection-monitor",
  "nym-credentials-interface",
@@ -7291,7 +7291,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-lib-types"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "bip39",
  "ipnetwork",
@@ -7321,7 +7321,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-lib-uniffi"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "async-trait",
  "inventory",
@@ -7332,7 +7332,7 @@ dependencies = [
  "jni 0.22.4",
  "log",
  "ndk-context",
- "nym-common 2026.11.0-beta.3",
+ "nym-common 2026.11.0-beta.5",
  "nym-firewall-config",
  "nym-gateway-directory",
  "nym-http-api-client",
@@ -7363,10 +7363,10 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-network-config"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "itertools 0.14.0",
- "nym-common 2026.11.0-beta.3",
+ "nym-common 2026.11.0-beta.5",
  "nym-http-api-client",
  "nym-network-defaults",
  "nym-offline-monitor",
@@ -7387,7 +7387,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-proto"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "hyper 1.9.0",
  "nym-ipc",
@@ -7406,10 +7406,10 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-rpc-uniffi"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "futures",
- "nym-common 2026.11.0-beta.3",
+ "nym-common 2026.11.0-beta.5",
  "nym-vpn-lib-types",
  "nym-vpn-proto",
  "tokio",
@@ -7420,7 +7420,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-store"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7444,7 +7444,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpnc"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "anyhow",
  "celes",
@@ -7461,7 +7461,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpnd"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -7504,7 +7504,7 @@ dependencies = [
 
 [[package]]
 name = "nym-wg-go"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "hex",
  "ipnetwork",
@@ -7520,7 +7520,7 @@ dependencies = [
 
 [[package]]
 name = "nym-wg-metadata-client"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "nym-credentials-interface",
  "nym-gateway-directory",
@@ -7535,7 +7535,7 @@ dependencies = [
 
 [[package]]
 name = "nym-windows"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "bitflags 2.11.0",
  "futures",
@@ -10911,7 +10911,7 @@ dependencies = [
 
 [[package]]
 name = "test-manager"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "anyhow",
  "async-tempfile",
@@ -10956,7 +10956,7 @@ dependencies = [
 
 [[package]]
 name = "test-rpc"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -10981,7 +10981,7 @@ dependencies = [
 
 [[package]]
 name = "test-runner"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "bytes",
  "dirs",
@@ -11007,7 +11007,7 @@ dependencies = [
 
 [[package]]
 name = "test_macro"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11971,7 +11971,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi-bindgen"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.5"
 dependencies = [
  "uniffi",
 ]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/mod.rs
@@ -72,3 +72,65 @@ impl From<MetadataEvent> for nym_wg_metadata_client::TunUpSendData {
 
 pub type MetadataSender = tokio::sync::oneshot::Sender<MetadataEvent>;
 pub type MetadataReceiver = tokio::sync::oneshot::Receiver<MetadataEvent>;
+
+pub(crate) fn one_tunnel_bandwidth_metadata_events(
+    proxy_addr: SocketAddr,
+) -> (MetadataEvent, MetadataEvent) {
+    (
+        MetadataEvent::MetadataProxy(proxy_addr),
+        MetadataEvent::MetadataProxy(proxy_addr),
+    )
+}
+
+pub(crate) fn two_tunnel_bandwidth_metadata_events(
+    entry: &TunnelMetadata,
+    exit: &TunnelMetadata,
+) -> (MetadataEvent, MetadataEvent) {
+    (
+        MetadataEvent::TunnelMetadata(entry.clone()),
+        MetadataEvent::TunnelMetadata(exit.clone()),
+    )
+}
+
+#[cfg(test)]
+mod bandwidth_metadata_events_tests {
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+    use super::*;
+
+    fn sample_metadata(interface: &str) -> TunnelMetadata {
+        TunnelMetadata {
+            interface: interface.to_string(),
+            ips: vec![IpAddr::V4(Ipv4Addr::new(10, 1, 0, 2))],
+            ipv4_gateway: None,
+            ipv6_gateway: None,
+        }
+    }
+
+    #[test]
+    fn one_tunnel_uses_metadata_proxy_for_entry_and_exit() {
+        let proxy_addr = SocketAddr::from(([127, 0, 0, 1], 51830));
+
+        let (entry, exit) = one_tunnel_bandwidth_metadata_events(proxy_addr);
+
+        assert!(matches!(entry, MetadataEvent::MetadataProxy(addr) if addr == proxy_addr));
+        assert!(matches!(exit, MetadataEvent::MetadataProxy(addr) if addr == proxy_addr));
+    }
+
+    #[test]
+    fn two_tunnel_uses_tunnel_metadata_for_entry_and_exit() {
+        let entry = sample_metadata("wg0");
+        let exit = sample_metadata("wg1");
+
+        let (entry_event, exit_event) = two_tunnel_bandwidth_metadata_events(&entry, &exit);
+
+        assert!(matches!(
+            entry_event,
+            MetadataEvent::TunnelMetadata(metadata) if metadata.interface == entry.interface
+        ));
+        assert!(matches!(
+            exit_event,
+            MetadataEvent::TunnelMetadata(metadata) if metadata.interface == exit.interface
+        ));
+    }
+}

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -90,7 +90,8 @@ use crate::{
             transports::{self, TransportError},
             wireguard::{
                 ConnectionData as WgConnectionData, MetadataEvent, MetadataReceiver,
-                connected_tunnel::ConnectedTunnel,
+                connected_tunnel::ConnectedTunnel, one_tunnel_bandwidth_metadata_events,
+                two_tunnel_bandwidth_metadata_events,
             },
         },
     },
@@ -710,28 +711,22 @@ impl TunnelMonitor {
 
         // Send metadata endpoint data to the bandwidth controller
         match &tunnel_interface {
-            TunnelInterface::One(exit) => {
+            TunnelInterface::One(_) => {
+                let exit_tx = exit_metadata_tx;
                 let _metadata_event_handler = tokio::spawn(async move {
-                    if let Ok(entry_metadata_endpoint) = entry_metadata_addr_rx.await {
-                        tracing::info!(
-                            "Received entry metadata endpoint: {entry_metadata_endpoint}"
-                        );
-                        entry_metadata_tx
-                            .send(MetadataEvent::MetadataProxy(entry_metadata_endpoint))
-                            .ok();
+                    if let Ok(proxy_addr) = entry_metadata_addr_rx.await {
+                        tracing::info!("Received entry metadata endpoint: {proxy_addr}");
+                        let (entry_event, exit_event) =
+                            one_tunnel_bandwidth_metadata_events(proxy_addr);
+                        entry_metadata_tx.send(entry_event).ok();
+                        exit_tx.send(exit_event).ok();
                     }
                 });
-                exit_metadata_tx
-                    .send(MetadataEvent::TunnelMetadata(exit.clone()))
-                    .ok();
             }
             TunnelInterface::Two { entry, exit } => {
-                entry_metadata_tx
-                    .send(MetadataEvent::TunnelMetadata(entry.clone()))
-                    .ok();
-                exit_metadata_tx
-                    .send(MetadataEvent::TunnelMetadata(exit.clone()))
-                    .ok();
+                let (entry_event, exit_event) = two_tunnel_bandwidth_metadata_events(entry, exit);
+                entry_metadata_tx.send(entry_event).ok();
+                exit_metadata_tx.send(exit_event).ok();
             }
         }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -90,8 +90,8 @@ use crate::{
             transports::{self, TransportError},
             wireguard::{
                 ConnectionData as WgConnectionData, MetadataEvent, MetadataReceiver,
-                connected_tunnel::ConnectedTunnel, one_tunnel_bandwidth_metadata_events,
-                two_tunnel_bandwidth_metadata_events,
+                MetadataSender, connected_tunnel::ConnectedTunnel,
+                one_tunnel_bandwidth_metadata_events, two_tunnel_bandwidth_metadata_events,
             },
         },
     },
@@ -300,6 +300,17 @@ async fn wait_for_exit_handshake(
                 elapsed.as_secs_f32()
             );
         }
+    }
+}
+
+fn send_bandwidth_metadata_event(
+    tx: MetadataSender,
+    event: MetadataEvent,
+    leg: &'static str,
+    tunnel_layout: &'static str,
+) {
+    if tx.send(event).is_err() {
+        tracing::warn!("Bandwidth metadata receiver dropped before {leg} event ({tunnel_layout})");
     }
 }
 
@@ -718,15 +729,20 @@ impl TunnelMonitor {
                         tracing::info!("Received entry metadata endpoint: {proxy_addr}");
                         let (entry_event, exit_event) =
                             one_tunnel_bandwidth_metadata_events(proxy_addr);
-                        entry_metadata_tx.send(entry_event).ok();
-                        exit_tx.send(exit_event).ok();
+                        send_bandwidth_metadata_event(
+                            entry_metadata_tx,
+                            entry_event,
+                            "entry",
+                            "single-tun",
+                        );
+                        send_bandwidth_metadata_event(exit_tx, exit_event, "exit", "single-tun");
                     }
                 });
             }
             TunnelInterface::Two { entry, exit } => {
                 let (entry_event, exit_event) = two_tunnel_bandwidth_metadata_events(entry, exit);
-                entry_metadata_tx.send(entry_event).ok();
-                exit_metadata_tx.send(exit_event).ok();
+                send_bandwidth_metadata_event(entry_metadata_tx, entry_event, "entry", "dual-tun");
+                send_bandwidth_metadata_event(exit_metadata_tx, exit_event, "exit", "dual-tun");
             }
         }
 


### PR DESCRIPTION
- Single-tun wireguard (iOS and Android netstack) routes exit bandwidth metadata through the same local TCP proxy as entry, instead of binding HTTP to the utun interface name.
- Removes the immediate broken exit metadata dispatch that caused bandwidth check failures, tunnel shutdown, and roughly 13-second auto-reconnect loops after connect.

## Ticket

JIRA-NYM-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5707)
<!-- Reviewable:end -->
