### PR TITLE
Automatic beta number

### DIFF
--- a/.github/scripts/release/resolve-version.sh
+++ b/.github/scripts/release/resolve-version.sh
@@ -8,13 +8,17 @@
 #   version   single version stamped into the core lib AND every platform build + the tag
 #   tag       unified GitHub release tag
 #
-#   channel  | guard                | version          | tag
-#   ---------+----------------------+------------------+------------------------------------
-#   nightly  | -                    | <base>-nightly   | nym-vpn-v<base>-nightly.YYYYMMDD
-#   beta     | full MUST have -beta  | <full>           | nym-vpn-v<full>
+#   channel  | guard                 | version          | tag
+#   ---------+-----------------------+------------------+------------------------------------
+#   nightly  | -                     | <base>-nightly   | nym-vpn-v<base>-nightly.YYYYMMDD
+#   beta     | auto +1 from releases | <base>-beta.<N>  | nym-vpn-v<base>-beta.<N>
 #   ship     | full MUST NOT -beta   | <full>           | nym-vpn-v<full>
 #
 # <full> = workspace version verbatim; <base> = major.minor.patch (pre-release stripped).
+#
+# Beta does NOT read its -beta.N from Cargo.toml. The branch pins the BASE
+# (humans bump major.minor.patch manually); the suffix auto-advances here. Needs
+# GH_TOKEN to list releases and the checkout's `origin` remote to read tags.
 set -euo pipefail
 
 CHANNEL="${RELEASE_CHANNEL:?RELEASE_CHANNEL required (nightly|beta|ship)}"
@@ -32,12 +36,34 @@ case "$CHANNEL" in
     TAG="nym-vpn-v${BASE}-nightly.$(date -u +%Y%m%d)"
     ;;
   beta)
-    if [[ "$FULL" != *-beta* ]]; then
-      echo "::error:: beta channel requires a -beta core version, got: ${FULL}"
-      exit 1
-    fi
-    VERSION="${FULL}"
-    TAG="nym-vpn-v${FULL}"
+    # Auto-advance the -beta.N suffix off the BASE pinned by the branch. Find the
+    # highest beta already cut for this base from BOTH sources, then add 1:
+    #   - published beta RELEASES (the canonical "current version from releases")
+    #   - left-behind beta TAGS (ship deletes beta releases but KEEPS their tags;
+    #     those tags are immutable, so we must never recompute onto one)
+    # The bumped version is stamped into the build in-runner by the apply-version
+    # composite and is never committed back to the branch.
+    BASE_RE="${BASE//./[.]}"
+    HIGHEST=0
+
+    while IFS= read -r n; do
+      [ -n "$n" ] || continue
+      [ "$n" -gt "$HIGHEST" ] && HIGHEST="$n"
+    done < <(gh release list --limit 200 --json tagName \
+      -q ".[] | .tagName | select(test(\"^nym-vpn-v${BASE_RE}-beta[.][0-9]+\$\"))" \
+      | sed -E "s/^nym-vpn-v${BASE}-beta[.]//")
+
+    while IFS= read -r n; do
+      [ -n "$n" ] || continue
+      [ "$n" -gt "$HIGHEST" ] && HIGHEST="$n"
+    done < <(git ls-remote --tags origin "refs/tags/nym-vpn-v${BASE}-beta.*" 2>/dev/null \
+      | sed -E "s#.*refs/tags/nym-vpn-v${BASE}-beta[.]([0-9]+)\$#\1#" \
+      | grep -E '^[0-9]+$' || true)
+
+    NEXT=$(( HIGHEST + 1 ))
+    VERSION="${BASE}-beta.${NEXT}"
+    TAG="nym-vpn-v${BASE}-beta.${NEXT}"
+    echo "::notice:: highest existing beta for ${BASE}=${HIGHEST} → next beta.${NEXT}"
     ;;
   ship)
     if [[ "$FULL" == *-beta* ]]; then

--- a/.github/workflows/on-release-publish.yml
+++ b/.github/workflows/on-release-publish.yml
@@ -56,6 +56,38 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           echo "::notice:: post-release fan-out for ${TAG} (version ${version})"
 
+  # Ship is the line's final release: clear the -beta.N releases that led to it so
+  # the Releases page shows only shipped versions. Scoped to the shipped base line
+  # (a ship of 2026.11.0 only clears 2026.11.0-beta.*). Tags are KEPT (no
+  # --cleanup-tag) — they stay the immutable ledger that resolve-version reads to
+  # never recompute onto a used beta number. Only fires on ship: beta releases are
+  # --prerelease, and 'released' never fires for prereleases.
+  delete-betas:
+    needs: setup
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Delete shipped-line beta releases (keep tags)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          VERSION: ${{ needs.setup.outputs.version }}
+        run: |
+          set -euo pipefail
+          BASE="${VERSION%%-*}"          # major.minor.patch of the shipped line
+          BASE_RE="${BASE//./[.]}"       # literal-dot regex for jq test()
+          mapfile -t betas < <(gh release list --limit 200 --json tagName \
+            -q ".[] | .tagName | select(test(\"^nym-vpn-v${BASE_RE}-beta[.][0-9]+\$\"))")
+          if [ "${#betas[@]}" -eq 0 ]; then
+            echo "::notice:: no beta releases for ${BASE} to delete"
+            exit 0
+          fi
+          for t in "${betas[@]}"; do
+            echo "::notice:: deleting beta release ${t} (keeping tag)"
+            gh release delete "$t" --yes   # no --cleanup-tag → tag stays
+          done
+
   aur-vpnd:
     needs: setup
     uses: ./.github/workflows/publish-aur-nym-vpnd.yml

--- a/.github/workflows/release-all-platforms.yml
+++ b/.github/workflows/release-all-platforms.yml
@@ -135,6 +135,8 @@ jobs:
         id: v
         env:
           RELEASE_CHANNEL: ${{ steps.flags.outputs.channel }}
+          # beta auto-advances its -beta.N by reading prior beta releases/tags
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash .github/scripts/release/resolve-version.sh
 
   prepare-release:


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

auto beta number n+1
delete betas on release


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5717)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Beta releases now automatically advance their version number based on the latest previously published beta tag or release.
  * Release publishing now cleans up older beta releases for the same version line after a stable release goes out.

* **Bug Fixes**
  * Improved version/tag resolution so beta builds no longer depend on the version string already containing a beta suffix.
  * Added support for safely reading release information during version resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->