### PR TITLE
Exit bandwidth metadata proxy for single-tun netstack on mobile

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -5139,7 +5139,7 @@ dependencies = [
 
 [[package]]
 name = "nym-apple-network"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "block2",
  "dispatch2",
@@ -5248,7 +5248,7 @@ dependencies = [
 
 [[package]]
 name = "nym-cgroup"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "anyhow",
  "log",
@@ -5396,7 +5396,7 @@ dependencies = [
 
 [[package]]
 name = "nym-common"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "tracing",
  "tracing-test",
@@ -5442,12 +5442,12 @@ dependencies = [
 
 [[package]]
 name = "nym-connection-monitor"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "async-trait",
  "futures",
  "nix 0.31.3",
- "nym-common 2026.11.0-beta.3",
+ "nym-common 2026.11.0-beta.6",
  "pretty_assertions",
  "socket2 0.6.3",
  "surge-ping",
@@ -5616,7 +5616,7 @@ dependencies = [
 
 [[package]]
 name = "nym-dbus"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "dbus",
  "libc",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "nym-diagnostic"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5677,13 +5677,13 @@ dependencies = [
 
 [[package]]
 name = "nym-dns"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "duct",
  "futures",
  "inotify",
  "nix 0.31.3",
- "nym-common 2026.11.0-beta.3",
+ "nym-common 2026.11.0-beta.6",
  "nym-dbus",
  "nym-routing",
  "nym-windows",
@@ -5740,7 +5740,7 @@ dependencies = [
 
 [[package]]
 name = "nym-exclude"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "nix 0.31.3",
  "nym-cgroup",
@@ -5761,7 +5761,7 @@ dependencies = [
 
 [[package]]
 name = "nym-file-updater"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "futures",
  "reqwest 0.13.3",
@@ -5776,7 +5776,7 @@ dependencies = [
 
 [[package]]
 name = "nym-firewall"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "ipnetwork",
  "libc",
@@ -5785,7 +5785,7 @@ dependencies = [
  "nftnl",
  "nix 0.31.3",
  "nym-cgroup",
- "nym-common 2026.11.0-beta.3",
+ "nym-common 2026.11.0-beta.6",
  "nym-firewall-config",
  "nym-platform-metadata",
  "pfctl",
@@ -5798,7 +5798,7 @@ dependencies = [
 
 [[package]]
 name = "nym-firewall-config"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "ipnetwork",
 ]
@@ -5844,7 +5844,7 @@ dependencies = [
 
 [[package]]
 name = "nym-gateway-directory"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "anyhow",
  "ipnetwork",
@@ -5982,7 +5982,7 @@ dependencies = [
 
 [[package]]
 name = "nym-ifconfig"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "bitflags 2.11.0",
  "futures",
@@ -6034,7 +6034,7 @@ dependencies = [
 
 [[package]]
 name = "nym-ipc"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6140,7 +6140,7 @@ dependencies = [
 
 [[package]]
 name = "nym-macos"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "nix 0.31.3",
  "tokio",
@@ -6326,14 +6326,14 @@ dependencies = [
 
 [[package]]
 name = "nym-offline-monitor"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "async-trait",
  "debounced",
  "dispatch2",
  "futures",
  "nym-apple-network",
- "nym-common 2026.11.0-beta.3",
+ "nym-common 2026.11.0-beta.6",
  "nym-routing",
  "nym-windows",
  "thiserror 2.0.18",
@@ -6392,7 +6392,7 @@ dependencies = [
 
 [[package]]
 name = "nym-platform-metadata"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "nym-bin-common",
  "nym-dbus",
@@ -6451,14 +6451,14 @@ dependencies = [
 
 [[package]]
 name = "nym-routing"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "bitflags 2.11.0",
  "futures",
  "ipnetwork",
  "libc",
  "nix 0.31.3",
- "nym-common 2026.11.0-beta.3",
+ "nym-common 2026.11.0-beta.6",
  "nym-windows",
  "rtnetlink",
  "system-configuration 0.7.0",
@@ -6564,7 +6564,7 @@ dependencies = [
 
 [[package]]
 name = "nym-setup"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -6607,7 +6607,7 @@ dependencies = [
 
 [[package]]
 name = "nym-socks5-proxy"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -6649,7 +6649,7 @@ dependencies = [
 
 [[package]]
 name = "nym-socks5-proxy-ipc"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -6842,7 +6842,7 @@ dependencies = [
 
 [[package]]
 name = "nym-split-tunnel"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "bitflags 2.11.0",
  "bytes",
@@ -6856,7 +6856,7 @@ dependencies = [
  "nftnl",
  "nix 0.31.3",
  "nym-cgroup",
- "nym-common 2026.11.0-beta.3",
+ "nym-common 2026.11.0-beta.6",
  "nym-dbus",
  "nym-firewall",
  "nym-firewall-config",
@@ -6893,7 +6893,7 @@ dependencies = [
 
 [[package]]
 name = "nym-statistics"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "futures",
  "nym-bin-common",
@@ -6914,7 +6914,7 @@ dependencies = [
 
 [[package]]
 name = "nym-statistics-api-client"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "nym-http-api-client",
  "nym-statistics-common",
@@ -7084,7 +7084,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-account-controller"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -7094,7 +7094,7 @@ dependencies = [
  "bs58",
  "futures",
  "hkdf",
- "nym-common 2026.11.0-beta.3",
+ "nym-common 2026.11.0-beta.6",
  "nym-compact-ecash",
  "nym-credential-proxy-requests",
  "nym-credential-storage",
@@ -7137,7 +7137,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-api-client"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "async-trait",
  "backon",
@@ -7146,7 +7146,7 @@ dependencies = [
  "bs58",
  "hex",
  "itertools 0.14.0",
- "nym-common 2026.11.0-beta.3",
+ "nym-common 2026.11.0-beta.6",
  "nym-compact-ecash",
  "nym-config",
  "nym-contracts-common",
@@ -7173,7 +7173,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-lib"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "adblock",
  "anyhow",
@@ -7208,7 +7208,7 @@ dependencies = [
  "nym-bin-common",
  "nym-cgroup",
  "nym-client-core",
- "nym-common 2026.11.0-beta.3",
+ "nym-common 2026.11.0-beta.6",
  "nym-config",
  "nym-connection-monitor",
  "nym-credentials-interface",
@@ -7291,7 +7291,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-lib-types"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "bip39",
  "ipnetwork",
@@ -7321,7 +7321,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-lib-uniffi"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "async-trait",
  "inventory",
@@ -7332,7 +7332,7 @@ dependencies = [
  "jni 0.22.4",
  "log",
  "ndk-context",
- "nym-common 2026.11.0-beta.3",
+ "nym-common 2026.11.0-beta.6",
  "nym-firewall-config",
  "nym-gateway-directory",
  "nym-http-api-client",
@@ -7363,10 +7363,10 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-network-config"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "itertools 0.14.0",
- "nym-common 2026.11.0-beta.3",
+ "nym-common 2026.11.0-beta.6",
  "nym-http-api-client",
  "nym-network-defaults",
  "nym-offline-monitor",
@@ -7387,7 +7387,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-proto"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "hyper 1.9.0",
  "nym-ipc",
@@ -7406,10 +7406,10 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-rpc-uniffi"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "futures",
- "nym-common 2026.11.0-beta.3",
+ "nym-common 2026.11.0-beta.6",
  "nym-vpn-lib-types",
  "nym-vpn-proto",
  "tokio",
@@ -7420,7 +7420,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-store"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7444,7 +7444,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpnc"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "anyhow",
  "celes",
@@ -7461,7 +7461,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpnd"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -7504,7 +7504,7 @@ dependencies = [
 
 [[package]]
 name = "nym-wg-go"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "hex",
  "ipnetwork",
@@ -7520,7 +7520,7 @@ dependencies = [
 
 [[package]]
 name = "nym-wg-metadata-client"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "nym-credentials-interface",
  "nym-gateway-directory",
@@ -7535,7 +7535,7 @@ dependencies = [
 
 [[package]]
 name = "nym-windows"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "bitflags 2.11.0",
  "futures",
@@ -10911,7 +10911,7 @@ dependencies = [
 
 [[package]]
 name = "test-manager"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "anyhow",
  "async-tempfile",
@@ -10956,7 +10956,7 @@ dependencies = [
 
 [[package]]
 name = "test-rpc"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -10981,7 +10981,7 @@ dependencies = [
 
 [[package]]
 name = "test-runner"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "bytes",
  "dirs",
@@ -11007,7 +11007,7 @@ dependencies = [
 
 [[package]]
 name = "test_macro"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11971,7 +11971,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi-bindgen"
-version = "2026.11.0-beta.3"
+version = "2026.11.0-beta.6"
 dependencies = [
  "uniffi",
 ]

--- a/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
@@ -184,6 +184,7 @@ hickory-proto.workspace = true
 nym-socks5-proxy.workspace = true
 pnet_packet.workspace = true
 rand.workspace = true
+socket2.workspace = true
 tracing-android.workspace = true
 
 # iOS-specific dependencies

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/metadata_tcp_proxy.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/metadata_tcp_proxy.rs
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use std::io;
-use std::net::{IpAddr, SocketAddr};
+use std::net::{IpAddr, Ipv6Addr, SocketAddr};
 #[cfg(any(target_os = "ios", target_os = "macos"))]
 use std::num::NonZeroU32;
 #[cfg(unix)]
 use std::os::fd::{FromRawFd, IntoRawFd};
+use std::time::Duration;
 
 use socket2::{Domain, Protocol, SockAddr, Socket, Type};
 use tokio::net::TcpListener;
@@ -14,6 +15,15 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
 use crate::tunnel_state_machine::TunnelMetadata;
+
+const METADATA_PROXY_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+fn metadata_listen_addr(destination: SocketAddr) -> SocketAddr {
+    match destination {
+        SocketAddr::V4(_) => SocketAddr::from(([127, 0, 0, 1], 0)),
+        SocketAddr::V6(_) => SocketAddr::from((Ipv6Addr::LOCALHOST, 0)),
+    }
+}
 
 fn metadata_bind_ip(ips: &[IpAddr], destination: SocketAddr) -> Option<IpAddr> {
     match destination {
@@ -36,7 +46,7 @@ impl MetadataTcpProxy {
         let bind_ip = metadata_bind_ip(&tunnel.ips, destination)
             .ok_or_else(|| io::Error::other("tunnel metadata has no bind address"))?;
 
-        let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0))).await?;
+        let listener = TcpListener::bind(metadata_listen_addr(destination)).await?;
         let listen_addr = listener.local_addr()?;
         let interface = tunnel.interface.clone();
 
@@ -79,10 +89,7 @@ impl MetadataTcpProxy {
                                 });
                             }
                             Err(err) => {
-                                tracing::warn!(
-                                    %err,
-                                    "Metadata proxy accept error; retrying"
-                                );
+                                tracing::warn!(%err, "Metadata proxy accept error");
                             }
                         }
                     }
@@ -108,7 +115,13 @@ async fn connect_via_tunnel_interface(
         // SAFETY: `socket` is a valid owned fd from `Socket::new`; nonblocking was set before
         // transfer. Ownership moves to `TcpSocket`, which closes the fd on drop.
         let tcp = unsafe { tokio::net::TcpSocket::from_raw_fd(socket.into_raw_fd()) };
-        tcp.connect(destination).await
+        match tokio::time::timeout(METADATA_PROXY_CONNECT_TIMEOUT, tcp.connect(destination)).await {
+            Ok(connect_result) => connect_result,
+            Err(_) => Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "metadata proxy outbound connect timed out",
+            )),
+        }
     }
     #[cfg(not(unix))]
     {
@@ -150,7 +163,7 @@ fn bind_socket_to_interface(
     #[cfg(any(target_os = "ios", target_os = "macos"))]
     {
         // bind_device_by_index must run before socket.bind on Apple platforms (IP_BOUND_IF /
-        // IPV6_BOUND_IF ordering).
+        // IPV6_BOUND_IF ordering). `nix` is declared under `[target.'cfg(unix)'.dependencies]`.
         let index = nix::net::if_::if_nametoindex(interface)
             .map_err(|err| io::Error::other(format!("if_nametoindex({interface}): {err}")))?;
         let index = NonZeroU32::new(index)
@@ -175,6 +188,20 @@ mod tests {
     use std::net::{Ipv4Addr, Ipv6Addr};
 
     use super::*;
+
+    #[test]
+    fn metadata_listen_addr_matches_destination_address_family() {
+        use std::net::Ipv4Addr;
+
+        assert!(matches!(
+            metadata_listen_addr(SocketAddr::from((Ipv4Addr::LOCALHOST, 51830))),
+            SocketAddr::V4(_)
+        ));
+        assert!(matches!(
+            metadata_listen_addr(SocketAddr::from((Ipv6Addr::LOCALHOST, 51830))),
+            SocketAddr::V6(_)
+        ));
+    }
 
     #[test]
     fn metadata_bind_ip_prefers_ipv4_for_ipv4_destination() {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/metadata_tcp_proxy.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/metadata_tcp_proxy.rs
@@ -1,0 +1,219 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use std::io;
+use std::net::{IpAddr, SocketAddr};
+#[cfg(any(target_os = "ios", target_os = "macos"))]
+use std::num::NonZeroU32;
+#[cfg(unix)]
+use std::os::fd::{FromRawFd, IntoRawFd};
+
+use socket2::{Domain, Protocol, SockAddr, Socket, Type};
+use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use crate::tunnel_state_machine::TunnelMetadata;
+
+fn metadata_bind_ip(ips: &[IpAddr], destination: SocketAddr) -> Option<IpAddr> {
+    match destination {
+        SocketAddr::V4(_) => ips.iter().find(|ip| ip.is_ipv4()).copied(),
+        SocketAddr::V6(_) => ips.iter().find(|ip| ip.is_ipv6()).copied(),
+    }
+}
+
+pub struct MetadataTcpProxy {
+    pub listen_addr: SocketAddr,
+    _task: JoinHandle<()>,
+}
+
+impl MetadataTcpProxy {
+    pub async fn start(
+        tunnel: &TunnelMetadata,
+        destination: SocketAddr,
+        shutdown: CancellationToken,
+    ) -> io::Result<Self> {
+        let bind_ip = metadata_bind_ip(&tunnel.ips, destination)
+            .ok_or_else(|| io::Error::other("tunnel metadata has no bind address"))?;
+
+        let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0))).await?;
+        let listen_addr = listener.local_addr()?;
+        let interface = tunnel.interface.clone();
+
+        let task = tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = shutdown.cancelled() => break,
+                    accept_result = listener.accept() => {
+                        match accept_result {
+                            Ok((mut inbound, _)) => {
+                                let interface = interface.clone();
+                                tokio::spawn(async move {
+                                    match connect_via_tunnel_interface(
+                                        &interface,
+                                        bind_ip,
+                                        destination,
+                                    )
+                                    .await
+                                    {
+                                        Ok(mut outbound) => {
+                                            if let Err(err) = tokio::io::copy_bidirectional(
+                                                &mut inbound,
+                                                &mut outbound,
+                                            )
+                                            .await
+                                            {
+                                                tracing::debug!(
+                                                    %err,
+                                                    "Metadata proxy session ended with error"
+                                                );
+                                            }
+                                        }
+                                        Err(err) => {
+                                            tracing::warn!(
+                                                %err,
+                                                "Metadata proxy failed to connect outbound via tunnel interface"
+                                            );
+                                        }
+                                    }
+                                });
+                            }
+                            Err(err) => {
+                                tracing::warn!(
+                                    %err,
+                                    "Metadata proxy accept error; retrying"
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        Ok(Self {
+            listen_addr,
+            _task: task,
+        })
+    }
+}
+
+async fn connect_via_tunnel_interface(
+    interface: &str,
+    bind_ip: IpAddr,
+    destination: SocketAddr,
+) -> io::Result<tokio::net::TcpStream> {
+    let socket = create_bound_socket(interface, bind_ip, destination)?;
+    #[cfg(unix)]
+    {
+        // SAFETY: `socket` is a valid owned fd from `Socket::new`; nonblocking was set before
+        // transfer. Ownership moves to `TcpSocket`, which closes the fd on drop.
+        let tcp = unsafe { tokio::net::TcpSocket::from_raw_fd(socket.into_raw_fd()) };
+        tcp.connect(destination).await
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (interface, bind_ip, destination, socket);
+        Err(io::Error::other(
+            "tunnel-bound metadata proxy is unsupported on this platform",
+        ))
+    }
+}
+
+fn create_bound_socket(
+    interface: &str,
+    bind_ip: IpAddr,
+    destination: SocketAddr,
+) -> io::Result<Socket> {
+    let domain = match destination {
+        SocketAddr::V4(_) => Domain::IPV4,
+        SocketAddr::V6(_) => Domain::IPV6,
+    };
+
+    let socket = Socket::new(domain, Type::STREAM, Some(Protocol::TCP))?;
+    socket.set_nonblocking(true)?;
+    bind_socket_to_interface(&socket, interface, destination)?;
+    socket.bind(&SockAddr::from(SocketAddr::new(bind_ip, 0)))?;
+    Ok(socket)
+}
+
+fn bind_socket_to_interface(
+    socket: &Socket,
+    interface: &str,
+    destination: SocketAddr,
+) -> io::Result<()> {
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    {
+        let _ = destination;
+        socket.bind_device(Some(interface.as_bytes()))
+    }
+
+    #[cfg(any(target_os = "ios", target_os = "macos"))]
+    {
+        // bind_device_by_index must run before socket.bind on Apple platforms (IP_BOUND_IF /
+        // IPV6_BOUND_IF ordering).
+        let index = nix::net::if_::if_nametoindex(interface)
+            .map_err(|err| io::Error::other(format!("if_nametoindex({interface}): {err}")))?;
+        let index = NonZeroU32::new(index)
+            .ok_or_else(|| io::Error::other(format!("invalid interface index for {interface}")))?;
+        match destination {
+            SocketAddr::V4(_) => socket.bind_device_by_index_v4(Some(index)),
+            SocketAddr::V6(_) => socket.bind_device_by_index_v6(Some(index)),
+        }
+    }
+
+    #[cfg(windows)]
+    {
+        // MetadataTcpProxy is only started on unix; this arm exists so the helper compiles on
+        // Windows where outbound connect returns unsupported before bind is exercised.
+        let _ = (socket, interface, destination);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    use super::*;
+
+    #[test]
+    fn metadata_bind_ip_prefers_ipv4_for_ipv4_destination() {
+        let ips = [
+            IpAddr::V4(Ipv4Addr::new(10, 1, 0, 2)),
+            IpAddr::V6(Ipv6Addr::LOCALHOST),
+        ];
+        let dest = SocketAddr::from((Ipv4Addr::new(10, 1, 0, 1), 51830));
+
+        assert_eq!(
+            metadata_bind_ip(&ips, dest),
+            Some(IpAddr::V4(Ipv4Addr::new(10, 1, 0, 2)))
+        );
+    }
+
+    #[test]
+    fn metadata_bind_ip_empty_returns_none() {
+        assert!(metadata_bind_ip(&[], SocketAddr::from(([127, 0, 0, 1], 1))).is_none());
+    }
+
+    #[test]
+    fn metadata_bind_ip_ipv6_destination_requires_ipv6_address() {
+        let ips = [IpAddr::V4(Ipv4Addr::new(10, 1, 0, 2))];
+        let dest = SocketAddr::from((Ipv6Addr::LOCALHOST, 51830));
+
+        assert!(metadata_bind_ip(&ips, dest).is_none());
+    }
+
+    #[test]
+    fn metadata_bind_ip_ipv6_destination_picks_ipv6_when_present() {
+        let ips = [
+            IpAddr::V4(Ipv4Addr::new(10, 1, 0, 2)),
+            IpAddr::V6(Ipv6Addr::new(0xfd, 0, 0, 0, 0, 0, 0, 2)),
+        ];
+        let dest = SocketAddr::from((Ipv6Addr::new(0xfd, 0, 0, 0, 0, 0, 0, 1), 51830));
+
+        assert_eq!(
+            metadata_bind_ip(&ips, dest),
+            Some(IpAddr::V6(Ipv6Addr::new(0xfd, 0, 0, 0, 0, 0, 0, 2)))
+        );
+    }
+}

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/mod.rs
@@ -15,6 +15,8 @@ pub mod dns64;
 pub mod dns_filter_proxy;
 #[cfg(unix)]
 pub mod fd;
+#[cfg(unix)]
+pub mod metadata_tcp_proxy;
 pub mod two_hop_config;
 
 #[derive(Debug)]
@@ -72,3 +74,89 @@ impl From<MetadataEvent> for nym_wg_metadata_client::TunUpSendData {
 
 pub type MetadataSender = tokio::sync::oneshot::Sender<MetadataEvent>;
 pub type MetadataReceiver = tokio::sync::oneshot::Receiver<MetadataEvent>;
+
+pub(crate) fn single_tun_exit_metadata_event(
+    exit_proxy_addr: Option<SocketAddr>,
+    fallback_tunnel: TunnelMetadata,
+) -> MetadataEvent {
+    match exit_proxy_addr {
+        Some(proxy_addr) => MetadataEvent::MetadataProxy(proxy_addr),
+        None => MetadataEvent::TunnelMetadata(fallback_tunnel),
+    }
+}
+
+pub(crate) fn two_tunnel_bandwidth_metadata_events(
+    entry: &TunnelMetadata,
+    exit: &TunnelMetadata,
+) -> (MetadataEvent, MetadataEvent) {
+    (
+        MetadataEvent::TunnelMetadata(entry.clone()),
+        MetadataEvent::TunnelMetadata(exit.clone()),
+    )
+}
+
+#[cfg(test)]
+mod bandwidth_metadata_events_tests {
+    use std::net::{IpAddr, Ipv4Addr};
+
+    use super::*;
+
+    fn sample_metadata(interface: &str) -> TunnelMetadata {
+        TunnelMetadata {
+            interface: interface.to_string(),
+            ips: vec![IpAddr::V4(Ipv4Addr::new(10, 1, 0, 2))],
+            ipv4_gateway: None,
+            ipv6_gateway: None,
+        }
+    }
+
+    #[test]
+    fn single_tun_exit_uses_metadata_proxy_when_listener_started() {
+        let exit = sample_metadata("utun42");
+        let proxy = SocketAddr::from(([127, 0, 0, 1], 50607));
+
+        assert!(matches!(
+            single_tun_exit_metadata_event(Some(proxy), exit),
+            MetadataEvent::MetadataProxy(addr) if addr == proxy
+        ));
+    }
+
+    #[test]
+    fn single_tun_exit_falls_back_to_tunnel_metadata_when_proxy_unavailable() {
+        let exit = sample_metadata("utun42");
+
+        assert!(matches!(
+            single_tun_exit_metadata_event(None, exit.clone()),
+            MetadataEvent::TunnelMetadata(metadata) if metadata.interface == exit.interface
+        ));
+    }
+
+    #[test]
+    fn single_tun_exit_proxy_maps_to_tcp_proxy_transport() {
+        let exit = sample_metadata("utun42");
+        let proxy = SocketAddr::from(([127, 0, 0, 1], 50607));
+        let event = single_tun_exit_metadata_event(Some(proxy), exit);
+
+        assert!(matches!(
+            nym_wg_metadata_client::TunUpSendData::from(event),
+            nym_wg_metadata_client::TunUpSendData::TcpProxy(addr) if addr == proxy
+        ));
+    }
+
+    #[test]
+    fn two_tunnel_uses_tunnel_metadata_for_entry_and_exit() {
+        let entry = sample_metadata("wg0");
+        let exit = sample_metadata("wg1");
+
+        let (entry_event, exit_event) = two_tunnel_bandwidth_metadata_events(&entry, &exit);
+
+        assert!(matches!(
+            entry_event,
+            MetadataEvent::TunnelMetadata(metadata) if metadata.interface == entry.interface
+        ));
+        assert!(matches!(
+            exit_event,
+            MetadataEvent::TunnelMetadata(metadata) if metadata.interface == exit.interface
+        ));
+    }
+}

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/mod.rs
@@ -6,6 +6,8 @@ use nym_registration_common::WireguardConfiguration;
 use std::net::SocketAddr;
 
 use nym_vpn_lib_types::BridgeAddress;
+#[cfg(unix)]
+use tokio_util::sync::CancellationToken;
 
 pub mod connected_tunnel;
 
@@ -54,6 +56,7 @@ impl ConnectionData {
     }
 }
 
+#[derive(Clone)]
 pub enum MetadataEvent {
     MetadataProxy(SocketAddr),
     TunnelMetadata(TunnelMetadata),
@@ -83,6 +86,64 @@ pub(crate) fn single_tun_exit_metadata_event(
         Some(proxy_addr) => MetadataEvent::MetadataProxy(proxy_addr),
         None => MetadataEvent::TunnelMetadata(fallback_tunnel),
     }
+}
+
+#[cfg(unix)]
+pub(crate) struct SingleTunExitMetadataGuard {
+    pub event: MetadataEvent,
+    proxy: Option<metadata_tcp_proxy::MetadataTcpProxy>,
+}
+
+#[cfg(unix)]
+impl SingleTunExitMetadataGuard {
+    pub async fn start(
+        exit_tunnel: TunnelMetadata,
+        metadata_destination: SocketAddr,
+        metadata_shutdown: CancellationToken,
+    ) -> Self {
+        use metadata_tcp_proxy::MetadataTcpProxy;
+
+        match MetadataTcpProxy::start(
+            &exit_tunnel,
+            metadata_destination,
+            metadata_shutdown.clone(),
+        )
+        .await
+        {
+            Ok(proxy) => {
+                let exit_proxy_addr = proxy.listen_addr;
+                tracing::info!("Exit metadata proxy listening on {exit_proxy_addr}");
+                Self {
+                    event: MetadataEvent::MetadataProxy(exit_proxy_addr),
+                    proxy: Some(proxy),
+                }
+            }
+            Err(err) => {
+                tracing::warn!(
+                    "Failed to start exit metadata proxy: {err}; falling back to tunnel interface"
+                );
+                Self {
+                    event: single_tun_exit_metadata_event(None, exit_tunnel),
+                    proxy: None,
+                }
+            }
+        }
+    }
+
+    pub async fn hold_until_shutdown(self, metadata_shutdown: CancellationToken) {
+        if let Some(proxy) = self.proxy {
+            metadata_shutdown.cancelled().await;
+            drop(proxy);
+        }
+    }
+}
+
+#[cfg(not(unix))]
+pub(crate) fn single_tun_exit_metadata_for_platform(exit_tunnel: TunnelMetadata) -> MetadataEvent {
+    tracing::warn!(
+        "Exit metadata TCP proxy unavailable on this platform; using tunnel interface for exit bandwidth metadata"
+    );
+    single_tun_exit_metadata_event(None, exit_tunnel)
 }
 
 pub(crate) fn two_tunnel_bandwidth_metadata_events(

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -90,7 +90,7 @@ use crate::{
             transports::{self, TransportError},
             wireguard::{
                 ConnectionData as WgConnectionData, MetadataEvent, MetadataReceiver,
-                MetadataSender, connected_tunnel::ConnectedTunnel, single_tun_exit_metadata_event,
+                MetadataSender, connected_tunnel::ConnectedTunnel,
                 two_tunnel_bandwidth_metadata_events,
             },
         },
@@ -98,7 +98,10 @@ use crate::{
 };
 
 #[cfg(unix)]
-use crate::tunnel_state_machine::tunnel::wireguard::metadata_tcp_proxy::MetadataTcpProxy;
+use crate::tunnel_state_machine::tunnel::wireguard::SingleTunExitMetadataGuard;
+
+#[cfg(not(unix))]
+use crate::tunnel_state_machine::tunnel::wireguard::single_tun_exit_metadata_for_platform;
 
 /// Default MTU for mixnet tun device.
 const DEFAULT_TUN_MTU: u16 = if cfg!(any(target_os = "ios", target_os = "android")) {
@@ -745,33 +748,17 @@ impl TunnelMonitor {
                     tracing::info!("Received entry metadata endpoint: {entry_proxy}");
 
                     #[cfg(unix)]
-                    let (exit_event, exit_proxy) = match MetadataTcpProxy::start(
-                        &exit_tunnel,
+                    let exit_guard = SingleTunExitMetadataGuard::start(
+                        exit_tunnel,
                         metadata_destination,
                         metadata_shutdown.clone(),
                     )
-                    .await
-                    {
-                        Ok(proxy) => {
-                            let exit_proxy_addr = proxy.listen_addr;
-                            tracing::info!("Exit metadata proxy listening on {exit_proxy_addr}");
-                            (MetadataEvent::MetadataProxy(exit_proxy_addr), Some(proxy))
-                        }
-                        Err(err) => {
-                            tracing::warn!(
-                                "Failed to start exit metadata proxy: {err}; falling back to tunnel interface"
-                            );
-                            (single_tun_exit_metadata_event(None, exit_tunnel), None)
-                        }
-                    };
+                    .await;
+                    #[cfg(unix)]
+                    let exit_event = exit_guard.event.clone();
 
                     #[cfg(not(unix))]
-                    let exit_event = {
-                        tracing::warn!(
-                            "Exit metadata TCP proxy unavailable on this platform; using tunnel interface for exit bandwidth metadata"
-                        );
-                        single_tun_exit_metadata_event(None, exit_tunnel)
-                    };
+                    let exit_event = single_tun_exit_metadata_for_platform(exit_tunnel);
 
                     send_bandwidth_metadata_event(
                         entry_metadata_tx,
@@ -782,10 +769,7 @@ impl TunnelMonitor {
                     send_bandwidth_metadata_event(exit_tx, exit_event, "exit", "single-tun");
 
                     #[cfg(unix)]
-                    if let Some(keep_exit_proxy_alive) = exit_proxy {
-                        metadata_shutdown.cancelled().await;
-                        drop(keep_exit_proxy_alive);
-                    }
+                    exit_guard.hold_until_shutdown(metadata_shutdown).await;
                 });
             }
             TunnelInterface::Two { entry, exit } => {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -90,11 +90,15 @@ use crate::{
             transports::{self, TransportError},
             wireguard::{
                 ConnectionData as WgConnectionData, MetadataEvent, MetadataReceiver,
-                connected_tunnel::ConnectedTunnel,
+                MetadataSender, connected_tunnel::ConnectedTunnel, single_tun_exit_metadata_event,
+                two_tunnel_bandwidth_metadata_events,
             },
         },
     },
 };
+
+#[cfg(unix)]
+use crate::tunnel_state_machine::tunnel::wireguard::metadata_tcp_proxy::MetadataTcpProxy;
 
 /// Default MTU for mixnet tun device.
 const DEFAULT_TUN_MTU: u16 = if cfg!(any(target_os = "ios", target_os = "android")) {
@@ -299,6 +303,17 @@ async fn wait_for_exit_handshake(
                 elapsed.as_secs_f32()
             );
         }
+    }
+}
+
+fn send_bandwidth_metadata_event(
+    tx: MetadataSender,
+    event: MetadataEvent,
+    leg: &'static str,
+    tunnel_layout: &'static str,
+) {
+    if tx.send(event).is_err() {
+        tracing::warn!("Bandwidth metadata receiver dropped before {leg} event ({tunnel_layout})");
     }
 }
 
@@ -710,28 +725,73 @@ impl TunnelMonitor {
 
         // Send metadata endpoint data to the bandwidth controller
         match &tunnel_interface {
-            TunnelInterface::One(exit) => {
+            TunnelInterface::One(exit_tunnel) => {
+                let exit_tx = exit_metadata_tx;
+                let exit_tunnel = exit_tunnel.clone();
+                #[cfg(unix)]
+                let metadata_destination = self
+                    .tunnel_parameters
+                    .tunnel_constants
+                    .in_tunnel_bandwidth_metadata_endpoint;
+                #[cfg(unix)]
+                let metadata_shutdown = self.shutdown_token.child_token();
                 let _metadata_event_handler = tokio::spawn(async move {
-                    if let Ok(entry_metadata_endpoint) = entry_metadata_addr_rx.await {
-                        tracing::info!(
-                            "Received entry metadata endpoint: {entry_metadata_endpoint}"
+                    let Ok(entry_proxy) = entry_metadata_addr_rx.await else {
+                        tracing::error!(
+                            "Entry metadata proxy address channel dropped before bandwidth setup"
                         );
-                        entry_metadata_tx
-                            .send(MetadataEvent::MetadataProxy(entry_metadata_endpoint))
-                            .ok();
+                        return;
+                    };
+                    tracing::info!("Received entry metadata endpoint: {entry_proxy}");
+
+                    #[cfg(unix)]
+                    let (exit_event, exit_proxy) = match MetadataTcpProxy::start(
+                        &exit_tunnel,
+                        metadata_destination,
+                        metadata_shutdown.clone(),
+                    )
+                    .await
+                    {
+                        Ok(proxy) => {
+                            let exit_proxy_addr = proxy.listen_addr;
+                            tracing::info!("Exit metadata proxy listening on {exit_proxy_addr}");
+                            (MetadataEvent::MetadataProxy(exit_proxy_addr), Some(proxy))
+                        }
+                        Err(err) => {
+                            tracing::warn!(
+                                "Failed to start exit metadata proxy: {err}; falling back to tunnel interface"
+                            );
+                            (single_tun_exit_metadata_event(None, exit_tunnel), None)
+                        }
+                    };
+
+                    #[cfg(not(unix))]
+                    let exit_event = {
+                        tracing::warn!(
+                            "Exit metadata TCP proxy unavailable on this platform; using tunnel interface for exit bandwidth metadata"
+                        );
+                        single_tun_exit_metadata_event(None, exit_tunnel)
+                    };
+
+                    send_bandwidth_metadata_event(
+                        entry_metadata_tx,
+                        MetadataEvent::MetadataProxy(entry_proxy),
+                        "entry",
+                        "single-tun",
+                    );
+                    send_bandwidth_metadata_event(exit_tx, exit_event, "exit", "single-tun");
+
+                    #[cfg(unix)]
+                    if let Some(keep_exit_proxy_alive) = exit_proxy {
+                        metadata_shutdown.cancelled().await;
+                        drop(keep_exit_proxy_alive);
                     }
                 });
-                exit_metadata_tx
-                    .send(MetadataEvent::TunnelMetadata(exit.clone()))
-                    .ok();
             }
             TunnelInterface::Two { entry, exit } => {
-                entry_metadata_tx
-                    .send(MetadataEvent::TunnelMetadata(entry.clone()))
-                    .ok();
-                exit_metadata_tx
-                    .send(MetadataEvent::TunnelMetadata(exit.clone()))
-                    .ok();
+                let (entry_event, exit_event) = two_tunnel_bandwidth_metadata_events(entry, exit);
+                send_bandwidth_metadata_event(entry_metadata_tx, entry_event, "entry", "dual-tun");
+                send_bandwidth_metadata_event(exit_metadata_tx, exit_event, "exit", "dual-tun");
             }
         }
 


### PR DESCRIPTION
- Adds dedicated loopback MetadataTcpProxy for exit bandwidth checks on TunnelInterface::One, routing exit metadata through localhost like the entry netstack proxy to `10.1.0.1:51830`.
- Wires exit proxy startup and lifecycle in `tunnel_monitor.rs`and holds listener until tunnel shutdown.
- Adds single_tun_exit_metadata_event and a helper and unit tests for proxy vs fallback dispatch and TcpProxy transport mapping.
- Adds `socket2` dependency for tunnel-interface-bound outbound dials on unix (iOS, Android, Linux, macOS netstack).

## Ticket

JIRA-NYM-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5725)
<!-- Reviewable:end -->
