### PR TITLE
[Android] Fixes for node family dialog

### DIFF
--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/MainScreen.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/MainScreen.kt
@@ -330,7 +330,10 @@ fun MainScreen(appViewModel: AppViewModel, appUiState: AppUiState, autoStart: Bo
 			showNodeFamiliesDialog = false
 			viewModel.onNodeFamiliesConfirm()
 		},
-		onDismissNodeFamilies = { showNodeFamiliesDialog = false },
+		onDismissNodeFamilies = {
+			showNodeFamiliesDialog = false
+			viewModel.onNodeFamiliesCancel()
+		},
 		onNotificationSettingsClick = { navController.goFromRoot(Route.Notifications) },
 		onDismissAuthSheet = {
 			if (!appUiState.settings.isWelcomeShown) appViewModel.setWelcomeShown()

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/MainViewModel.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/MainViewModel.kt
@@ -68,6 +68,8 @@ constructor(
 
 	private var timerJob: Job? = null
 	private var lastConnectedAt: Long? = null
+	private var pendingNodeFamiliesConfirmAction: (suspend () -> Unit)? = null
+	private var nodeFamiliesEventHandled = false
 
 	init {
 		viewModelScope.launch {
@@ -84,7 +86,12 @@ constructor(
 				handleTunnelStateChange(state.tunnelState, state.connectionData?.connectedAt)
 				val event = state.backendUiEvent
 				if (event is BackendUiEvent.Failure && event.reason is ErrorStateReason.NeedsRelaxedIndependenceCriteria) {
-					handleNeedsRelaxedIndependenceCriteria()
+					if (!nodeFamiliesEventHandled) {
+						nodeFamiliesEventHandled = true
+						handleNeedsRelaxedIndependenceCriteria()
+					}
+				} else {
+					nodeFamiliesEventHandled = false
 				}
 			}
 		}
@@ -162,9 +169,16 @@ constructor(
 
 	fun onNodeFamiliesConfirm() = viewModelScope.launch {
 		Timber.tag(TAG).i("NodeFamiliesModalConfirmed")
+		val action = pendingNodeFamiliesConfirmAction
+		pendingNodeFamiliesConfirmAction = null
 		runCatching {
-			backendManager.startTunnel(relaxGatewayIndependence = true)
+			action?.invoke()
 		}.onFailure { Timber.tag(TAG).e(it, "NodeFamiliesConnectFailed") }
+	}
+
+	fun onNodeFamiliesCancel() {
+		Timber.tag(TAG).i("NodeFamiliesModalCancelled")
+		pendingNodeFamiliesConfirmAction = null
 	}
 
 	private suspend fun resolveNodeFamiliesInteraction(onSilent: suspend () -> Unit) {
@@ -172,6 +186,7 @@ constructor(
 			vpnConfigRepository.getConfig().nodeFamiliesNotificationsEnabled
 		}.getOrDefault(true)
 		if (notificationsEnabled) {
+			pendingNodeFamiliesConfirmAction = onSilent
 			_events.tryEmit(MainUiEvent.ShowNodeFamiliesDialog)
 		} else {
 			onSilent()

--- a/nym-vpn-android/app/src/main/res/values/strings.xml
+++ b/nym-vpn-android/app/src/main/res/values/strings.xml
@@ -499,7 +499,7 @@
 	<!-- Mixnet tuning screen -->
 	<string name="mixnet_tuning_description">Customize your mixnet traffic patterns</string>
 	<string name="mixnet_tuning_current_title">Expected performance of current settings:</string>
-	<string name="mixnet_tuning_current_speed">Speed</string>
+	<string name="mixnet_tuning_current_speed">Packet rate</string>
 	<string name="mixnet_tuning_current_latency">Latency</string>
 	<string name="mixnet_tuning_internet_speed">Up to internet speed</string>
 	<string name="mixnet_tuning_current_description">Expected round-trip latency (RTT) on a standard network</string>


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5726)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of the node-families confirmation flow so the app no longer repeats the same prompt or action unnecessarily.
  - Dismissing the node-families dialog now properly clears any pending selection, reducing unexpected follow-up behavior.
  - Updated the Mixnet tuning screen label from **“Speed”** to **“Packet rate”** for clearer metric wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->