### PR TITLE
Revert "Linux connecting firewall fwmark for WireGuard and bridge peers"

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -917,10 +917,7 @@ impl ConnectingPolicyParameters {
             .map(|addr| {
                 AllowedEndpoint::new(
                     Endpoint::from_socket_address(*addr, TransportProtocol::Tcp),
-                    #[cfg(target_os = "linux")]
-                    // On Linux, All is needed so the mangle chain rule sets fwmark for outbound traffic
-                    AllowedClients::All,
-                    #[cfg(target_os = "macos")]
+                    #[cfg(any(target_os = "linux", target_os = "macos"))]
                     AllowedClients::Root,
                     #[cfg(target_os = "windows")]
                     AllowedClients::current_exe(),
@@ -933,10 +930,7 @@ impl ConnectingPolicyParameters {
             if addr.is_ipv4() || (self.enable_ipv6 && addr.is_ipv6()) {
                 let allow_wg_endpoint = AllowedEndpoint::new(
                     Endpoint::from_socket_address(addr, TransportProtocol::Udp),
-                    #[cfg(target_os = "linux")]
-                    // On Linux, All is needed so the mangle chain rule sets fwmark for outbound traffic
-                    AllowedClients::All,
-                    #[cfg(target_os = "macos")]
+                    #[cfg(any(target_os = "linux", target_os = "macos"))]
                     AllowedClients::Root,
                     #[cfg(target_os = "windows")]
                     AllowedClients::current_exe(),
@@ -955,10 +949,7 @@ impl ConnectingPolicyParameters {
             .for_each(|addr| {
                 let allow_bridge_endpoint = AllowedEndpoint::new(
                     Endpoint::from_socket_address(*addr, TransportProtocol::Udp),
-                    #[cfg(target_os = "linux")]
-                    // On Linux, All is needed so the mangle chain rule sets fwmark for outbound traffic
-                    AllowedClients::All,
-                    #[cfg(target_os = "macos")]
+                    #[cfg(any(target_os = "linux", target_os = "macos"))]
                     AllowedClients::Root,
                     #[cfg(target_os = "windows")]
                     AllowedClients::current_exe(),
@@ -1061,35 +1052,5 @@ mod test {
             .map(|i| wait_delay(*i))
             .collect();
         assert_eq!(delay_values, expected_delays);
-    }
-
-    #[cfg(target_os = "linux")]
-    #[test]
-    fn linux_connecting_peer_endpoints_allow_all_for_fwmark() {
-        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-
-        let params = ConnectingPolicyParameters {
-            enable_ipv6: false,
-            allow_lan: false,
-            wg_entry_endpoint: Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), 51822)),
-            bridge_endpoints: vec![SocketAddr::new(IpAddr::V4(Ipv4Addr::new(5, 6, 7, 8)), 4443)],
-            ws_entry_endpoints: vec![SocketAddr::new(
-                IpAddr::V4(Ipv4Addr::new(9, 10, 11, 12)),
-                9000,
-            )],
-            lp_entry_endpoints: vec![],
-            api_endpoints: vec![],
-            dns_servers: vec![],
-            tunnel_interface: None,
-        };
-
-        let policy = params.as_policy();
-
-        for endpoint in policy.peer_endpoints() {
-            assert!(
-                endpoint.clients.allow_all(),
-                "Linux connecting peer endpoints must use AllowedClients::All so nftables mangle sets fwmark"
-            );
-        }
     }
 }


### PR DESCRIPTION
This reverts commit 0447c37834e55fa5e6ef70a41bab45d48d0eb6e0.

## Ticket

JIRA-NYM-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5738)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tunnel connection authorization for peer endpoints on Linux and macOS, aligning client permissions during connection setup.
  * Adjusted handling of optional UDP and bridge-related endpoints to use a stricter, consistent allowance model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->