### PR TITLE
Bound QUIC bridge connect with timeout

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/transports/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/transports/mod.rs
@@ -31,6 +31,7 @@ use crate::tunnel_state_machine::tunnel::wireguard::two_hop_config::ETHERNET_V2_
 
 const LENGTH_DELIMITER_BYTELEN: usize = 2;
 const INITIAL_CONNECTION_TIMEOUT: Duration = Duration::from_secs(10);
+const QUIC_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(thiserror::Error, Debug)]
 pub enum TransportError {
@@ -48,6 +49,9 @@ pub enum TransportError {
 
     #[error("transport connection was cancelled")]
     Cancelled,
+
+    #[error("quic connection timed out after {0:?}")]
+    TimedOut(Duration),
 
     #[error("transport error: {0}")]
     Other(String),
@@ -430,10 +434,19 @@ pub async fn transport_conn(
     let addr_host = transport_endpoint.ip().to_string();
     let host = options.host.as_deref().unwrap_or(&addr_host);
 
-    endpoint
-        .connect(transport_endpoint, host)?
-        .await
-        .map_err(TransportError::QuicProto)
+    let connecting = endpoint
+        .connect(transport_endpoint, host)
+        .map_err(TransportError::Quic)?;
+
+    match tokio::time::timeout(QUIC_CONNECT_TIMEOUT, connecting).await {
+        Ok(connection) => connection.map_err(TransportError::QuicProto),
+        Err(_) => {
+            tracing::warn!(
+                "QUIC bridge connection to {transport_endpoint} timed out after {QUIC_CONNECT_TIMEOUT:?}"
+            );
+            Err(TransportError::TimedOut(QUIC_CONNECT_TIMEOUT))
+        }
+    }
 }
 
 /// Session Keepalive interval to prevent sessions from closing due to lull in user traffic.
@@ -518,4 +531,23 @@ fn make_socket(addr: Option<SocketAddr>) -> io::Result<std::net::UdpSocket> {
     let socket = std::net::UdpSocket::bind(addr)?;
     socket.set_nonblocking(true)?;
     Ok(socket)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quic_connect_timeout_exceeds_udp_forwarder_handshake_budget() {
+        assert!(
+            QUIC_CONNECT_TIMEOUT > INITIAL_CONNECTION_TIMEOUT,
+            "bridge QUIC connect must outlive the local UDP forwarder initial receive timeout"
+        );
+    }
+
+    #[test]
+    fn timed_out_error_includes_duration() {
+        let err = TransportError::TimedOut(QUIC_CONNECT_TIMEOUT);
+        assert!(err.to_string().contains("30s"));
+    }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/transports/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/transports/mod.rs
@@ -444,6 +444,10 @@ pub async fn transport_conn(
             tracing::warn!(
                 "QUIC bridge connection to {transport_endpoint} timed out after {QUIC_CONNECT_TIMEOUT:?}"
             );
+            endpoint.close(0u32.into(), b"timeout");
+            // TimedOut has no error_state_reason, so tunnel_monitor propagates it as
+            // TunnelMonitorEvent::Down { error_state_reason: None }, which triggers
+            // ConnectingState::reconnect() with a different gateway selection.
             Err(TransportError::TimedOut(QUIC_CONNECT_TIMEOUT))
         }
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/transports/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/transports/mod.rs
@@ -31,7 +31,7 @@ use crate::tunnel_state_machine::tunnel::wireguard::two_hop_config::ETHERNET_V2_
 
 const LENGTH_DELIMITER_BYTELEN: usize = 2;
 const INITIAL_CONNECTION_TIMEOUT: Duration = Duration::from_secs(10);
-const QUIC_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+const QUIC_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[derive(thiserror::Error, Debug)]
 pub enum TransportError {
@@ -535,23 +535,4 @@ fn make_socket(addr: Option<SocketAddr>) -> io::Result<std::net::UdpSocket> {
     let socket = std::net::UdpSocket::bind(addr)?;
     socket.set_nonblocking(true)?;
     Ok(socket)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn quic_connect_timeout_exceeds_udp_forwarder_handshake_budget() {
-        assert!(
-            QUIC_CONNECT_TIMEOUT > INITIAL_CONNECTION_TIMEOUT,
-            "bridge QUIC connect must outlive the local UDP forwarder initial receive timeout"
-        );
-    }
-
-    #[test]
-    fn timed_out_error_includes_duration() {
-        let err = TransportError::TimedOut(QUIC_CONNECT_TIMEOUT);
-        assert!(err.to_string().contains("30s"));
-    }
 }


### PR DESCRIPTION
## Description

The current behavior when a quic transport connection fails is to wait for the full timeout or allow the tunnel conection attempt to timeout which can be a long time (~60s).  

This PR reduces the time taken by a quic transport connection establishment failure. Returns `TransportError::TimedOut` so the tunnel monitor can retry with a different gateway within a more reasonable amount of time (10s).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5740)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a timeout for QUIC connection attempts to prevent them from hanging indefinitely.
  * If the connection takes too long, the app now stops the attempt, closes the connection cleanly, and reports a timeout error with the duration included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->