### PR TITLE
Revert "Gate env sync check to iOS-only for macOS CI compile"

### DIFF
--- a/nym-vpn-apple/Services/Sources/Services/ConfigurationManager/ConfigurationManager.swift
+++ b/nym-vpn-apple/Services/Sources/Services/ConfigurationManager/ConfigurationManager.swift
@@ -162,14 +162,12 @@ import PathManager
             try await grpcManager.switchEnvironment(to: env.rawValue)
 #endif
             try await self.configure()
-#if os(iOS)
             guard lastConfiguredEnvString == currentEnvString else {
                 self.logger.error(
                     "Network environment did not sync to \(currentEnvString); skipping env-change observers"
                 )
                 return
             }
-#endif
             self.notifyEnvironmentDidChange()
         } catch {
             self.logger.error("Failed to set env to \(env.rawValue): \(error.localizedDescription)")

--- a/nym-vpn-apple/Services/Tests/ConfigurationManagerTests/SantaEnvSwitchPolicyTests.swift
+++ b/nym-vpn-apple/Services/Tests/ConfigurationManagerTests/SantaEnvSwitchPolicyTests.swift
@@ -23,7 +23,7 @@ struct SantaEnvSwitchPolicyTests {
         Case(label: "santaIOSRelease", isSantaBuild: true, isTestFlight: false, isMacOS: false, isRunningOnCI: false, isDebugBuild: false, expected: false),
     ]
 
-    @Test(arguments: Self.cases)
+    @Test(arguments: cases)
     func runtimeAccessGate(_ testCase: Case) {
         #expect(
             SantaEnvSwitchPolicy.canApplyEnvironmentChange(


### PR DESCRIPTION
This reverts commit 60ca1c126d812cc89149030616dd98634630fdef.

## Ticket

JIRA-NYM-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5741)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment change handling so updates are only broadcast after the environment is fully in sync, reducing the chance of stale or inconsistent notifications.
  * Added a safety check that logs an error and stops processing when the configured environment does not match the current one.

* **Tests**
  * Updated an existing test to use a simpler case setup without changing test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->