### PR TITLE
APPLE: use world group as default

### DIFF
--- a/.github/workflows/build-nym-vpn-apple.yml
+++ b/.github/workflows/build-nym-vpn-apple.yml
@@ -577,13 +577,8 @@ jobs:
           set -euo pipefail
 
           echo "🚀 Uploading to TestFlight..."
-          # Beta groups by release type (--beta-group is repeatable):
-          #   ship (release) → public 'World' + 'Nym Team External'
-          #   qa   (nightly) → 'Nym Team External' only
-          BETA_GROUPS=( --beta-group='Nym Team External' )
-          if [ "${{ env.RELEASE_TYPE }}" = "ship" ]; then
-            BETA_GROUPS+=( --beta-group='World' )
-          fi
+  
+          BETA_GROUPS=( --beta-group='World' )
           app-store-connect publish \
             --beta-build-localizations=@file:whats_new.json \
             "${BETA_GROUPS[@]}" \


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5746)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the iOS TestFlight upload settings so beta builds are now consistently sent to the **World** beta group.
  * Removed the previous split behavior that used different beta group targeting depending on release type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->