### PR TITLE
APPLE: remove quic reconnect dialog

### DIFF
--- a/nym-vpn-apple/Settings/Sources/Settings/Censorship/CensorshipView.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/Censorship/CensorshipView.swift
@@ -9,7 +9,6 @@ public struct CensorshipView: View {
     @EnvironmentObject private var appSettings: AppSettings
     @EnvironmentObject private var connectionManager: ConnectionManager
     @Binding private var path: NavigationPath
-    @State private var isConfirmationDisplayed = false
 
     public var body: some View {
         VStack(spacing: 0) {
@@ -36,9 +35,6 @@ public struct CensorshipView: View {
         .background {
             Color.Nym.background
                 .ignoresSafeArea()
-        }
-        .overlay {
-            confirmationOnlineOverlay()
         }
     }
 
@@ -68,13 +64,7 @@ private extension CensorshipView {
         let quicBinding = Binding<Bool>(
             get: { appSettings.isQuicEnabled },
             set: { _ in
-                guard connectionManager.currentTunnelStatus == .connected ||
-                        connectionManager.currentTunnelStatus == .connecting
-                else {
-                    connectionManager.setBridges(!appSettings.isQuicEnabled)
-                    return
-                }
-                isConfirmationDisplayed = true
+                connectionManager.setBridges(!appSettings.isQuicEnabled)
             }
         )
 
@@ -153,56 +143,6 @@ private extension CensorshipView {
         return text
     }
 
-    var overlayConfiguration: ActionDialogConfiguration {
-        let alertTitle = appSettings.isQuicEnabled
-        ? "censorship.quic.disable.alert.title".localizedString
-        : "censorship.quic.enable.alert.title".localizedString
-
-        let subtitle = "censorship.quic.disable.alert.subtitle".localizedString
-        + "\n\n"
-        + "censorship.quic.disable.alert.subtitle1".localizedString
-
-        let yesTitle = appSettings.isQuicEnabled
-        ? "censorship.quic.disableAndReconnect".localizedString
-        : "censorship.quic.enableAndReconnect".localizedString
-
-        let noTitle = appSettings.isQuicEnabled
-        ? "censorship.quic.offAndNext".localizedString
-        : "censorship.quic.onAndNext".localizedString
-
-        return ActionDialogConfiguration(
-            systemIconImageName: "shippingbox",
-            titleLocalizedString: alertTitle,
-            subtitleLocalizedString: subtitle,
-            yesLocalizedString: yesTitle,
-            noLocalizedString: noTitle,
-            yesAction: {
-                connectionManager.setBridges(!appSettings.isQuicEnabled)
-                isConfirmationDisplayed = false
-                path = .init()
-            },
-            noAction: {
-                connectionManager.setBridges(!appSettings.isQuicEnabled)
-                isConfirmationDisplayed = false
-            },
-            verticalButtonsLayout: true
-        )
-    }
-
-    @ViewBuilder
-    func confirmationOnlineOverlay() -> some View {
-        if isConfirmationDisplayed {
-            ActionDialogView(
-                viewModel: ActionDialogViewModel(
-                    isDisplayed: $isConfirmationDisplayed,
-                    configuration: overlayConfiguration,
-                    impactGenerator: .shared
-                )
-            )
-            .transition(.opacity)
-            .animation(.easeInOut, value: isConfirmationDisplayed)
-        }
-    }
 }
 
 // MARK: - Actions -


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5748)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified the QUIC toggle flow in censorship settings so changes apply immediately.
  * Removed the extra confirmation dialog that could appear while the connection was active or starting, making the setting feel more responsive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->