### PR TITLE
Wait for metadata endpoint status before declaring connection

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Race when network usage spikes happen during longer bandwidth checks, disconnecting the client from the server (https://github.com/nymtech/nym-vpn-client/pull/5618)
 - [macOS] Disable authentication when flag is set (https://github.com/nymtech/nym-vpn-client/pull/5645)
 - [iOS] Fix metadata endpoint not being reached for exit tunnel (https://github.com/nymtech/nym-vpn-client/pull/5728)
+- Fix going into Connected state when metadata endpoint might not work (https://github.com/nymtech/nym-vpn-client/pull/5750)
 
 ### Removed
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
@@ -36,6 +36,7 @@ const SYSTEM_BANDWIDTH_THRESHOLD: u64 = 8 * 1024 * 1024; // 8 MB
 const SYSTEM_BANDWIDTH_CHECK_INTERVAL: Duration = Duration::from_secs(1); // 1 second
 
 const DEFAULT_CLIENT_RETRIES: usize = 1;
+const DEFAULT_CLIENT_TIMEOUT: Duration = Duration::from_secs(5); // 5 seconds
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -649,6 +650,7 @@ impl BandwidthController {
             bind_ip,
             signal_channel,
             DEFAULT_CLIENT_RETRIES,
+            DEFAULT_CLIENT_TIMEOUT,
         );
         TemporaryBandwidthClient::new(
             gateway,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
@@ -436,6 +436,15 @@ impl TemporaryBandwidthClient {
         }
     }
 
+    pub(crate) async fn lazy_init(&mut self) {
+        match self {
+            TemporaryBandwidthClient::Deprecated(_) => {}
+            TemporaryBandwidthClient::Latest(metadata_client) => {
+                metadata_client.lazy_init().await;
+            }
+        }
+    }
+
     pub(crate) async fn interface_name(&mut self) -> Option<String> {
         match self {
             TemporaryBandwidthClient::Deprecated(_) => None,
@@ -973,12 +982,19 @@ impl BandwidthController {
         None
     }
 
+    async fn init_clients(&self) {
+        tokio::join!(
+            self.wg_entry_gateway_client.lazy_init(),
+            self.wg_exit_gateway_client.lazy_init()
+        );
+    }
+
     pub(crate) async fn run(mut self) {
-        let exit_interface_name = self
-            .shutdown_token
-            .run_until_cancelled(self.wg_exit_gateway_client.interface_name())
-            .await
-            .flatten();
+        // Make sure the clients are up and ready, or notifying early of any problems
+        self.shutdown_token
+            .run_until_cancelled(self.init_clients())
+            .await;
+        let exit_interface_name = self.wg_exit_gateway_client.interface_name().await;
         let mut system_bandwidth_monitor =
             SystemBandwidthMonitor::new(exit_interface_name, SYSTEM_BANDWIDTH_THRESHOLD);
         let mut system_bandwidth_check_interval =

--- a/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
@@ -982,7 +982,7 @@ impl BandwidthController {
         None
     }
 
-    async fn init_clients(&self) {
+    async fn init_clients(&mut self) {
         tokio::join!(
             self.wg_entry_gateway_client.lazy_init(),
             self.wg_exit_gateway_client.lazy_init()
@@ -991,9 +991,21 @@ impl BandwidthController {
 
     pub(crate) async fn run(mut self) {
         // Make sure the clients are up and ready, or notifying early of any problems
-        self.shutdown_token
+        if self
+            .shutdown_token
+            .clone()
             .run_until_cancelled(self.init_clients())
-            .await;
+            .await
+            .is_none()
+        {
+            // Explicitly close the credential storage so that the underlying SQLite pool releases
+            // OS file handles promptly (especially important on Windows).
+            self.ticket_provider.close().await;
+
+            tracing::debug!("BandwidthController: Exiting");
+            return;
+        }
+
         let exit_interface_name = self.wg_exit_gateway_client.interface_name().await;
         let mut system_bandwidth_monitor =
             SystemBandwidthMonitor::new(exit_interface_name, SYSTEM_BANDWIDTH_THRESHOLD);

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/mod.rs
@@ -4,6 +4,7 @@
 use crate::tunnel_state_machine::TunnelMetadata;
 use nym_registration_common::WireguardConfiguration;
 use std::net::SocketAddr;
+use tokio::sync::oneshot;
 
 use nym_vpn_lib_types::BridgeAddress;
 
@@ -52,20 +53,51 @@ impl ConnectionData {
     }
 }
 
-pub enum MetadataEvent {
+pub struct MetadataEvent {
+    metadata_endpoint_reachable_tx: oneshot::Sender<bool>,
+    event_type: MetadataEventType,
+}
+
+impl MetadataEvent {
+    pub fn new_proxy(
+        metadata_endpoint_reachable_tx: oneshot::Sender<bool>,
+        addr: SocketAddr,
+    ) -> Self {
+        Self {
+            metadata_endpoint_reachable_tx,
+            event_type: MetadataEventType::MetadataProxy(addr),
+        }
+    }
+
+    pub fn new_tunnel(
+        metadata_endpoint_reachable_tx: oneshot::Sender<bool>,
+        tunnel_metadata: TunnelMetadata,
+    ) -> Self {
+        Self {
+            metadata_endpoint_reachable_tx,
+            event_type: MetadataEventType::TunnelMetadata(tunnel_metadata),
+        }
+    }
+}
+
+pub enum MetadataEventType {
     MetadataProxy(SocketAddr),
     TunnelMetadata(TunnelMetadata),
 }
 
 impl From<MetadataEvent> for nym_wg_metadata_client::TunUpSendData {
     fn from(event: MetadataEvent) -> Self {
-        match event {
-            MetadataEvent::MetadataProxy(proxy_addr) => {
-                nym_wg_metadata_client::TunUpSendData::TcpProxy(proxy_addr)
-            }
-            MetadataEvent::TunnelMetadata(metadata) => {
-                nym_wg_metadata_client::TunUpSendData::InterfaceName(metadata.interface)
-            }
+        match event.event_type {
+            MetadataEventType::MetadataProxy(proxy_addr) => nym_wg_metadata_client::TunUpSendData {
+                metadata_endpoint_reachable_tx: event.metadata_endpoint_reachable_tx,
+                data_type: nym_wg_metadata_client::TunUpSendDataType::TcpProxy(proxy_addr),
+            },
+            MetadataEventType::TunnelMetadata(metadata) => nym_wg_metadata_client::TunUpSendData {
+                metadata_endpoint_reachable_tx: event.metadata_endpoint_reachable_tx,
+                data_type: nym_wg_metadata_client::TunUpSendDataType::InterfaceName(
+                    metadata.interface,
+                ),
+            },
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -136,6 +136,8 @@ pub type TunnelMonitorEventReceiver = mpsc::UnboundedReceiver<TunnelMonitorEvent
 /// Timeout when waiting for reply from the event handler.
 const REPLY_TIMEOUT: Duration = Duration::from_secs(5);
 
+const METADATA_ENDPOINT_REACHABILITY_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// Timeout for starting the registration client
 const REGISTRATION_CLIENT_STARTUP_TIMEOUT: Duration = Duration::from_secs(8);
 
@@ -708,6 +710,20 @@ impl TunnelMonitor {
             wait_for_exit_handshake(wg_handle, &self.shutdown_token).await;
         }
 
+        let (entry_metadata_endpoint_reachable_tx, entry_metadata_endpoint_reachable_rx) =
+            tokio::sync::oneshot::channel::<bool>();
+        let (exit_metadata_endpoint_reachable_tx, exit_metadata_endpoint_reachable_rx) =
+            tokio::sync::oneshot::channel::<bool>();
+        let metadata_endpoints_reachable =
+            tokio::time::timeout(METADATA_ENDPOINT_REACHABILITY_TIMEOUT, async move {
+                let entry_reachable = entry_metadata_endpoint_reachable_rx.await.unwrap_or(false);
+                let exit_reachable = exit_metadata_endpoint_reachable_rx.await.unwrap_or(false);
+
+                entry_reachable && exit_reachable
+            })
+            .fuse();
+        tokio::pin!(metadata_endpoints_reachable);
+
         // Send metadata endpoint data to the bandwidth controller
         match &tunnel_interface {
             TunnelInterface::One(exit) => {
@@ -717,20 +733,32 @@ impl TunnelMonitor {
                             "Received entry metadata endpoint: {entry_metadata_endpoint}"
                         );
                         entry_metadata_tx
-                            .send(MetadataEvent::MetadataProxy(entry_metadata_endpoint))
+                            .send(MetadataEvent::new_proxy(
+                                entry_metadata_endpoint_reachable_tx,
+                                entry_metadata_endpoint,
+                            ))
                             .ok();
                     }
                 });
                 exit_metadata_tx
-                    .send(MetadataEvent::TunnelMetadata(exit.clone()))
+                    .send(MetadataEvent::new_tunnel(
+                        exit_metadata_endpoint_reachable_tx,
+                        exit.clone(),
+                    ))
                     .ok();
             }
             TunnelInterface::Two { entry, exit } => {
                 entry_metadata_tx
-                    .send(MetadataEvent::TunnelMetadata(entry.clone()))
+                    .send(MetadataEvent::new_tunnel(
+                        entry_metadata_endpoint_reachable_tx,
+                        entry.clone(),
+                    ))
                     .ok();
                 exit_metadata_tx
-                    .send(MetadataEvent::TunnelMetadata(exit.clone()))
+                    .send(MetadataEvent::new_tunnel(
+                        exit_metadata_endpoint_reachable_tx,
+                        exit.clone(),
+                    ))
                     .ok();
             }
         }
@@ -749,6 +777,8 @@ impl TunnelMonitor {
 
         let mut last_connection_status = None;
         let mut has_sent_up_event = false;
+        let mut ping_viable = false;
+        let mut metadata_endpoint_viable = false;
         let connection_data = Box::new(ConnectionData {
             entry_gateway: GatewayLightInfo::from(selected_gateways.entry_gateway().clone()),
             exit_gateway: GatewayLightInfo::from(selected_gateways.exit_gateway().clone()),
@@ -769,10 +799,10 @@ impl TunnelMonitor {
 
                         match event.status {
                             ConnectionStatusEvent::Viable => {
-                                tracing::info!("Tunnel connection is viable");
-                                if !has_sent_up_event {
+                                ping_viable = true;
+                                if !has_sent_up_event && metadata_endpoint_viable {
+                                    tracing::info!("Tunnel connection is viable");
                                     has_sent_up_event = true;
-
                                     self.send_event(TunnelMonitorEvent::Up {
                                         tunnel_interface: tunnel_interface.clone(),
                                         connection_data: connection_data.clone(),
@@ -789,6 +819,26 @@ impl TunnelMonitor {
                                 });
                                 break;
                             }
+                        }
+                    }
+                }
+                reachable = &mut metadata_endpoints_reachable => {
+                    let reachable = reachable.unwrap_or(false);
+                    if !reachable {
+                        tracing::info!("Metadata endpoints not reachable. Exiting");
+                        self.send_event(TunnelMonitorEvent::ConnectionFailed {
+                            exit_gateway_id: selected_gateways.exit_gateway().identity(),
+                        });
+                        break;
+                    } else {
+                        metadata_endpoint_viable = true;
+                        if !has_sent_up_event && ping_viable {
+                            tracing::info!("Tunnel connection is viable");
+                            has_sent_up_event = true;
+                            self.send_event(TunnelMonitorEvent::Up {
+                                tunnel_interface: tunnel_interface.clone(),
+                                connection_data: connection_data.clone(),
+                            });
                         }
                     }
                 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -714,8 +714,13 @@ impl TunnelMonitor {
             tokio::sync::oneshot::channel::<bool>();
         let (exit_metadata_endpoint_reachable_tx, exit_metadata_endpoint_reachable_rx) =
             tokio::sync::oneshot::channel::<bool>();
+        let uses_metadata_endpoint = wg_tunnel_runtime.is_some();
         let metadata_endpoints_reachable =
             tokio::time::timeout(METADATA_ENDPOINT_REACHABILITY_TIMEOUT, async move {
+                // for mixnet tunnel, we don't have metadata endpoints, so we just return true
+                if !uses_metadata_endpoint {
+                    return true;
+                }
                 let entry_reachable = entry_metadata_endpoint_reachable_rx.await.unwrap_or(false);
                 let exit_reachable = exit_metadata_endpoint_reachable_rx.await.unwrap_or(false);
 

--- a/nym-vpn-core/crates/nym-wg-metadata-client/src/lib.rs
+++ b/nym-vpn-core/crates/nym-wg-metadata-client/src/lib.rs
@@ -155,6 +155,11 @@ impl MetadataClient {
         self.gateway_id
     }
 
+    // Make sure the initialization is done, so that we can get the interface name without having to wait for the first query to complete.
+    pub async fn lazy_init(&mut self) {
+        self.lazy_client().await;
+    }
+
     pub async fn interface_name(&mut self) -> Option<String> {
         self.lazy_client()
             .await

--- a/nym-vpn-core/crates/nym-wg-metadata-client/src/lib.rs
+++ b/nym-vpn-core/crates/nym-wg-metadata-client/src/lib.rs
@@ -1,14 +1,17 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::net::{IpAddr, SocketAddr};
+use std::{
+    net::{IpAddr, SocketAddr},
+    time::Duration,
+};
 
 use nym_credentials_interface::CredentialSpendingData;
 use nym_gateway_directory::NodeIdentity;
 use nym_http_api_client::ReqwestClientBuilder;
 use nym_wireguard_private_metadata_client::WireguardMetadataApiClient;
 use nym_wireguard_private_metadata_shared::{AvailableBandwidth, Version, v1, v2};
-use tokio::sync::OnceCell;
+use tokio::sync::{OnceCell, oneshot};
 use url::Url;
 
 use error::Result;
@@ -17,8 +20,13 @@ use crate::error::MetadataClientError;
 
 pub mod error;
 
+pub struct TunUpSendData {
+    pub metadata_endpoint_reachable_tx: oneshot::Sender<bool>,
+    pub data_type: TunUpSendDataType,
+}
+
 #[derive(Clone)]
-pub enum TunUpSendData {
+pub enum TunUpSendDataType {
     InterfaceName(String),
     TcpProxy(SocketAddr),
 }
@@ -38,19 +46,20 @@ impl LazyMetadataClient {
         mut base_url: Url,
         bind_ip: IpAddr,
         retries: usize,
+        timeout: Duration,
         sent_data: TunUpSendData,
     ) -> Result<Self> {
         let mut interface_name = None;
         let reqwest_builder = ReqwestClientBuilder::new();
-        let reqwest_builder = match sent_data {
-            TunUpSendData::InterfaceName(interface) => {
+        let reqwest_builder = match sent_data.data_type {
+            TunUpSendDataType::InterfaceName(interface) => {
                 #[cfg(any(target_os = "linux", target_os = "ios"))]
                 let reqwest_builder = reqwest_builder.interface(&interface);
 
                 interface_name = Some(interface.clone());
                 reqwest_builder.local_address(bind_ip)
             }
-            TunUpSendData::TcpProxy(tcp_proxy) => {
+            TunUpSendDataType::TcpProxy(tcp_proxy) => {
                 base_url.set_ip_host(tcp_proxy.ip()).map_err(|_| {
                     MetadataClientError::Internal("failed to set tcp proxy ip".to_owned())
                 })?;
@@ -68,15 +77,21 @@ impl LazyMetadataClient {
                 builder
                     .with_reqwest_builder(reqwest_builder)
                     .with_retries(retries)
+                    .with_timeout(timeout)
                     .build()
             })
             .map_err(Box::new)?;
-        let version = inner.version().await.map_err(Box::new)?;
+        let response = inner.version().await.map_err(Box::new);
+
+        let endpoint_reachable = response.is_ok();
+        let _ = sent_data
+            .metadata_endpoint_reachable_tx
+            .send(endpoint_reachable);
 
         Ok(Self {
             inner,
             interface_name,
-            version,
+            version: response?,
         })
     }
 }
@@ -84,6 +99,7 @@ impl LazyMetadataClient {
 pub struct MetadataClient {
     lazy_client: OnceCell<Result<LazyMetadataClient>>,
     lazy_client_retries: usize,
+    lazy_client_timeout: Duration,
     gateway_id: NodeIdentity,
     base_url: Url,
     bind_ip: IpAddr,
@@ -108,6 +124,7 @@ impl MetadataClient {
                     self.base_url.clone(),
                     self.bind_ip,
                     self.lazy_client_retries,
+                    self.lazy_client_timeout,
                     data,
                 )
                 .await
@@ -121,10 +138,12 @@ impl MetadataClient {
         bind_ip: IpAddr,
         signal_channel: TunUpReceiver,
         lazy_client_retries: usize,
+        lazy_client_timeout: Duration,
     ) -> Self {
         Self {
             lazy_client: OnceCell::new(),
             lazy_client_retries,
+            lazy_client_timeout,
             gateway_id,
             bind_ip,
             base_url,


### PR DESCRIPTION
## Ticket

JIRA-NYM-1673

## Description

Send back signal that metadata endpoint is reachable for both entry and exit gateways before declaring the client is connected.


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5750)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tunnel startup reliability by confirming metadata endpoint reachability before reporting the VPN/tunnel as connected or “Up.”
  * Added explicit timeout handling for metadata client requests to avoid hangs when metadata services are unavailable.
  * Enhanced startup initialization by eagerly preparing metadata client reachability checks and respecting early shutdown/cancellation paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->