### PR TITLE
NYM-4894: Re-use the firewall API endpoints if we already have them.

### DIFF
--- a/nym-vpn-app/src-tauri/Cargo.lock
+++ b/nym-vpn-app/src-tauri/Cargo.lock
@@ -3715,8 +3715,8 @@ dependencies = [
 
 [[package]]
 name = "nym-crypto"
-version = "1.21.1"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.11-xynomizithra#1bc51696914134766d06872267c6f8d03e7454df"
+version = "1.21.2"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -3732,7 +3732,7 @@ dependencies = [
 
 [[package]]
 name = "nym-dbus"
-version = "2026.11.0-beta.1"
+version = "2026.12.0-beta.1"
 dependencies = [
  "dbus",
  "libc",
@@ -3743,7 +3743,7 @@ dependencies = [
 
 [[package]]
 name = "nym-ipc"
-version = "2026.11.0-beta.1"
+version = "2026.12.0-beta.1"
 dependencies = [
  "block2",
  "cc",
@@ -3762,8 +3762,8 @@ dependencies = [
 
 [[package]]
 name = "nym-pemstore"
-version = "1.21.1"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.11-xynomizithra#1bc51696914134766d06872267c6f8d03e7454df"
+version = "1.21.2"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
 dependencies = [
  "pem",
  "tracing",
@@ -3772,7 +3772,7 @@ dependencies = [
 
 [[package]]
 name = "nym-platform-metadata"
-version = "2026.11.0-beta.1"
+version = "2026.12.0-beta.1"
 dependencies = [
  "nym-dbus",
  "objc2-foundation",
@@ -3784,7 +3784,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-app"
-version = "2026.11.0-beta.1"
+version = "2026.12.0-beta.1"
 dependencies = [
  "anyhow",
  "build-info",
@@ -3845,7 +3845,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-lib-types"
-version = "2026.11.0-beta.1"
+version = "2026.12.0-beta.1"
 dependencies = [
  "bip39",
  "nym-crypto",
@@ -3862,7 +3862,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-proto"
-version = "2026.11.0-beta.1"
+version = "2026.12.0-beta.1"
 dependencies = [
  "hyper",
  "nym-ipc",

--- a/nym-vpn-core/crates/nym-gateway-directory/src/gateway_cache.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/gateway_cache.rs
@@ -297,11 +297,6 @@ impl GatewayCache {
                         Command::Pause(paused) => {
                             tracing::info!("Gateway caching is {}", if paused { "Paused" } else { "Resumed" });
                             self.paused = paused;
-                            if !paused
-                                && self.connectivity_handle.connectivity().await.is_online()
-                            {
-                                self.perform_initial_fetch_once().await;
-                            }
                         }
                     }
                 }

--- a/nym-vpn-core/crates/nym-gateway-directory/src/gateway_cache.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/gateway_cache.rs
@@ -118,6 +118,16 @@ impl GatewayCacheHandle {
             .map_err(|_| Error::Cancelled)
     }
 
+    /// Pause or resume the background gateway cache refresh.
+    ///
+    /// While paused, connectivity-triggered fetches are held until [`set_paused(false)`] is called.
+    /// On resume, if the initial refresh has not yet completed, it fires immediately (if online).
+    pub fn set_paused(&self, paused: bool) -> Result<()> {
+        self.tx
+            .send(Command::Pause(paused))
+            .map_err(|_| Error::Cancelled)
+    }
+
     /// Lookup a NymNode by identity, using cached data if available.
     /// This is specifically for SOCKS5 which needs the nr_address field.
     pub async fn lookup_nymnode_by_identity(&self, identity: NodeIdentity) -> Result<NymNode> {
@@ -196,6 +206,7 @@ enum Command {
     LookupNymNodesForSocks5(tokio::sync::oneshot::Sender<Result<NymNodeList>>),
     ReplaceGatewayClient(Box<GatewayClient>),
     ClearCache,
+    Pause(bool),
 }
 
 pub struct GatewayCache {
@@ -217,6 +228,9 @@ pub struct GatewayCache {
     /// Whether the initial refresh has been performed
     is_performed_initial_refresh: bool,
 
+    /// When true, connectivity-triggered fetches are deferred until unpaused.
+    paused: bool,
+
     // Shutdown token
     shutdown_token: CancellationToken,
 }
@@ -236,6 +250,7 @@ impl GatewayCache {
             cached_gateways: HashMap::default(),
             cached_nymnodes: None,
             is_performed_initial_refresh: false,
+            paused: false,
             shutdown_token,
         };
         let join_handle = tokio::spawn(inner.run());
@@ -243,7 +258,7 @@ impl GatewayCache {
     }
 
     async fn run(mut self) {
-        if self.connectivity_handle.connectivity().await.is_online() {
+        if !self.paused && self.connectivity_handle.connectivity().await.is_online() {
             self.perform_initial_fetch_once().await;
         }
 
@@ -279,10 +294,19 @@ impl GatewayCache {
                         Command::ClearCache => {
                             self.clear_cache();
                         }
+                        Command::Pause(paused) => {
+                            tracing::info!("Gateway caching is {}", if paused { "Paused" } else { "Resumed" });
+                            self.paused = paused;
+                            if !paused
+                                && self.connectivity_handle.connectivity().await.is_online()
+                            {
+                                self.perform_initial_fetch_once().await;
+                            }
+                        }
                     }
                 }
                 Some(status) = self.connectivity_handle.next() => {
-                    if status.is_online() {
+                    if status.is_online() && !self.paused {
                         self.perform_initial_fetch_once().await;
                     }
                 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -786,7 +786,7 @@ pub struct SharedState {
 }
 
 impl SharedState {
-    /// Notify discovery and account controller when network is unrestricted.
+    /// Notify discovery, account controller, and gateway cache when network is unrestricted.
     async fn allow_networking(&self) {
         self.discovery_refresher_command_tx
             .send(DiscoveryRefresherCommand::Pause(false))
@@ -795,15 +795,17 @@ impl SharedState {
             .set_vpn_api_firewall_down()
             .await
             .ok();
+        self.gateway_provider.set_gateway_cache_paused(false);
     }
 
-    /// Notify discovery, account controller and geo-location when network is restricted.
+    /// Notify discovery, account controller, geo-location, and gateway cache when network is restricted.
     async fn disallow_networking(&self) {
         self.discovery_refresher_command_tx
             .send(DiscoveryRefresherCommand::Pause(true))
             .ok();
         self.account_command_tx.set_vpn_api_firewall_up().await.ok();
         self.gateway_provider.set_active_geo_location(false).await;
+        self.gateway_provider.set_gateway_cache_paused(true);
     }
 
     async fn enable_ad_blocking(&self, enable: bool) {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -6,8 +6,8 @@ use std::net::SocketAddr;
 use std::time::Duration;
 
 use futures::{
-    FutureExt,
     future::{BoxFuture, Fuse},
+    FutureExt,
 };
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use nym_firewall::AllowedDns;
@@ -15,18 +15,18 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
-use crate::tunnel_state_machine::Error;
-#[cfg(not(any(target_os = "android", target_os = "ios")))]
 use crate::tunnel_state_machine::gateway_ext::GatewayExt;
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+use crate::tunnel_state_machine::Error;
 use crate::tunnel_state_machine::{
-    ErrorStateReason, NextTunnelState, PrivateActionAfterDisconnect, PrivateTunnelState, Result,
-    SharedState, TunnelCommand, TunnelInterface, TunnelStateHandler,
-    states::{ConnectedState, DisconnectingState, ErrorState, OfflineState},
-    tunnel::{SelectedGateways, Tombstone},
-    tunnel_monitor::{
+    states::{ConnectedState, DisconnectingState, ErrorState, OfflineState}, tunnel::{SelectedGateways, Tombstone}, tunnel_monitor::{
         TunnelMonitor, TunnelMonitorEvent, TunnelMonitorEventReceiver, TunnelMonitorEventSender,
         TunnelMonitorHandle, TunnelParameters,
-    },
+    }, ErrorStateReason, NextTunnelState,
+    PrivateActionAfterDisconnect, PrivateTunnelState, Result, SharedState,
+    TunnelCommand,
+    TunnelInterface,
+    TunnelStateHandler,
 };
 
 use nym_common::trace_err_chain;
@@ -132,6 +132,12 @@ impl ConnectingState {
             #[cfg(target_os = "macos")]
             let redirect_interface = shared_state.split_tunnel.interface().await;
 
+            let api_endpoints = shared_state
+                .resolved_api_endpoints
+                .as_ref()
+                .map(|r| r.all_socket_addrs())
+                .unwrap_or_default();
+
             let firewall_policy_params = ConnectingPolicyParameters {
                 enable_ipv6: shared_state.tunnel_settings.enable_ipv6,
                 allow_lan: shared_state.tunnel_settings.allow_lan,
@@ -145,7 +151,7 @@ impl ConnectingState {
                     .as_ref()
                     .map(|v| v.entry_gateway().lp_endpoints())
                     .unwrap_or_default(),
-                api_endpoints: Vec::new(),
+                api_endpoints,
                 // Allow default DNS servers when connecting since those are used by http/client
                 dns_servers: shared_state.tunnel_settings.allowed_default_dns_endpoints(),
                 tunnel_interface: None,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -132,6 +132,16 @@ impl ConnectingState {
             #[cfg(target_os = "macos")]
             let redirect_interface = shared_state.split_tunnel.interface().await;
 
+            let ws_entry_endpoints = selected_gateways
+                .as_ref()
+                .map(|v| v.entry_gateway().endpoints())
+                .unwrap_or_default();
+
+            let lp_entry_endpoints = selected_gateways
+                .as_ref()
+                .map(|v| v.entry_gateway().lp_endpoints())
+                .unwrap_or_default();
+
             let api_endpoints = shared_state
                 .resolved_api_endpoints
                 .as_ref()
@@ -143,14 +153,8 @@ impl ConnectingState {
                 allow_lan: shared_state.tunnel_settings.allow_lan,
                 wg_entry_endpoint: None,
                 bridge_endpoints,
-                ws_entry_endpoints: selected_gateways
-                    .as_ref()
-                    .map(|v| v.entry_gateway().endpoints())
-                    .unwrap_or_default(),
-                lp_entry_endpoints: selected_gateways
-                    .as_ref()
-                    .map(|v| v.entry_gateway().lp_endpoints())
-                    .unwrap_or_default(),
+                ws_entry_endpoints,
+                lp_entry_endpoints,
                 api_endpoints,
                 // Allow default DNS servers when connecting since those are used by http/client
                 dns_servers: shared_state.tunnel_settings.allowed_default_dns_endpoints(),

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -6,8 +6,8 @@ use std::net::SocketAddr;
 use std::time::Duration;
 
 use futures::{
-    future::{BoxFuture, Fuse},
     FutureExt,
+    future::{BoxFuture, Fuse},
 };
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use nym_firewall::AllowedDns;
@@ -15,18 +15,18 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
-use crate::tunnel_state_machine::gateway_ext::GatewayExt;
-#[cfg(not(any(target_os = "android", target_os = "ios")))]
 use crate::tunnel_state_machine::Error;
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+use crate::tunnel_state_machine::gateway_ext::GatewayExt;
 use crate::tunnel_state_machine::{
-    states::{ConnectedState, DisconnectingState, ErrorState, OfflineState}, tunnel::{SelectedGateways, Tombstone}, tunnel_monitor::{
+    ErrorStateReason, NextTunnelState, PrivateActionAfterDisconnect, PrivateTunnelState, Result,
+    SharedState, TunnelCommand, TunnelInterface, TunnelStateHandler,
+    states::{ConnectedState, DisconnectingState, ErrorState, OfflineState},
+    tunnel::{SelectedGateways, Tombstone},
+    tunnel_monitor::{
         TunnelMonitor, TunnelMonitorEvent, TunnelMonitorEventReceiver, TunnelMonitorEventSender,
         TunnelMonitorHandle, TunnelParameters,
-    }, ErrorStateReason, NextTunnelState,
-    PrivateActionAfterDisconnect, PrivateTunnelState, Result, SharedState,
-    TunnelCommand,
-    TunnelInterface,
-    TunnelStateHandler,
+    },
 };
 
 use nym_common::trace_err_chain;

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/gateway_cache.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/gateway_cache.rs
@@ -8,7 +8,7 @@ pub trait GatewayCache: Clone + Send + Sync + 'static {
     async fn lookup_gateways(&self, gw_type: GatewayType) -> Result<GatewayList, Error>;
     fn replace_gateway_client(&self, gateway_client: GatewayClient) -> Result<(), Error>;
     async fn refresh_all(&self) -> Result<(), Error>;
-    fn set_paused(&self, paused: bool);
+    fn set_paused(&self, paused: bool) -> Result<(), Error>;
 }
 
 #[async_trait::async_trait]
@@ -25,8 +25,8 @@ impl GatewayCache for GatewayCacheHandle {
         self.refresh_all().await
     }
 
-    fn set_paused(&self, paused: bool) {
-        self.set_paused(paused).ok();
+    fn set_paused(&self, paused: bool) -> Result<(), Error> {
+        self.set_paused(paused)
     }
 }
 
@@ -86,6 +86,8 @@ pub mod tests {
             Ok(())
         }
 
-        fn set_paused(&self, _paused: bool) {}
+        fn set_paused(&self, _paused: bool) -> Result<(), Error> {
+            Ok(())
+        }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/gateway_cache.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/gateway_cache.rs
@@ -8,6 +8,7 @@ pub trait GatewayCache: Clone + Send + Sync + 'static {
     async fn lookup_gateways(&self, gw_type: GatewayType) -> Result<GatewayList, Error>;
     fn replace_gateway_client(&self, gateway_client: GatewayClient) -> Result<(), Error>;
     async fn refresh_all(&self) -> Result<(), Error>;
+    fn set_paused(&self, paused: bool);
 }
 
 #[async_trait::async_trait]
@@ -22,6 +23,10 @@ impl GatewayCache for GatewayCacheHandle {
 
     async fn refresh_all(&self) -> Result<(), Error> {
         self.refresh_all().await
+    }
+
+    fn set_paused(&self, paused: bool) {
+        self.set_paused(paused).ok();
     }
 }
 
@@ -80,5 +85,7 @@ pub mod tests {
         async fn refresh_all(&self) -> Result<(), Error> {
             Ok(())
         }
+
+        fn set_paused(&self, _paused: bool) {}
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/mod.rs
@@ -263,6 +263,10 @@ impl<C: GatewayCache> GatewayProvider<C> {
         self.gateway_cache.refresh_all().await.ok();
     }
 
+    pub fn set_gateway_cache_paused(&self, paused: bool) {
+        self.gateway_cache.set_paused(paused);
+    }
+
     pub fn blacklisted_gateways(&self) -> BlacklistedGateways {
         self.blacklisted_gateways.clone()
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/mod.rs
@@ -264,7 +264,12 @@ impl<C: GatewayCache> GatewayProvider<C> {
     }
 
     pub fn set_gateway_cache_paused(&self, paused: bool) {
-        self.gateway_cache.set_paused(paused);
+        if let Err(e) = self.gateway_cache.set_paused(paused) {
+            tracing::warn!(
+                "Failed to {} the gateway cache: {e}",
+                if paused { "pause" } else { "resume" }
+            );
+        }
     }
 
     pub fn blacklisted_gateways(&self) -> BlacklistedGateways {


### PR DESCRIPTION
## Ticket

JIRA-NYM-4894

## Description

When connecting, re-use the firewall API endpoints if we already have them.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5751)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection setup by populating the connecting phase with resolved API socket addresses, ensuring the correct API endpoints are targeted during VPN establishment.
  * Improved resilience when resolved API endpoints are unavailable by using available address resolution results instead of starting empty.
  * Gateway caching now automatically pauses and resumes when networking is restricted or unrestricted, improving consistency and endpoint freshness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->