### PR TITLE
Fix tunnel health dual signal and mobile tcp

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -5118,7 +5118,7 @@ dependencies = [
 
 [[package]]
 name = "nym-apple-network"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "block2",
  "dispatch2",
@@ -5227,7 +5227,7 @@ dependencies = [
 
 [[package]]
 name = "nym-cgroup"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "anyhow",
  "log",
@@ -5375,7 +5375,7 @@ dependencies = [
 
 [[package]]
 name = "nym-common"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "tracing",
  "tracing-test",
@@ -5421,12 +5421,12 @@ dependencies = [
 
 [[package]]
 name = "nym-connection-monitor"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "async-trait",
  "futures",
  "nix 0.31.3",
- "nym-common 2026.11.0-beta.7",
+ "nym-common 2026.11.0-beta.8",
  "pretty_assertions",
  "socket2 0.6.4",
  "surge-ping",
@@ -5595,7 +5595,7 @@ dependencies = [
 
 [[package]]
 name = "nym-dbus"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "dbus",
  "libc",
@@ -5606,7 +5606,7 @@ dependencies = [
 
 [[package]]
 name = "nym-diagnostic"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5656,13 +5656,13 @@ dependencies = [
 
 [[package]]
 name = "nym-dns"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "duct",
  "futures",
  "inotify",
  "nix 0.31.3",
- "nym-common 2026.11.0-beta.7",
+ "nym-common 2026.11.0-beta.8",
  "nym-dbus",
  "nym-routing",
  "nym-windows",
@@ -5719,7 +5719,7 @@ dependencies = [
 
 [[package]]
 name = "nym-exclude"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "nix 0.31.3",
  "nym-cgroup",
@@ -5740,7 +5740,7 @@ dependencies = [
 
 [[package]]
 name = "nym-file-updater"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "futures",
  "reqwest 0.13.4",
@@ -5755,7 +5755,7 @@ dependencies = [
 
 [[package]]
 name = "nym-firewall"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "ipnetwork",
  "libc",
@@ -5764,7 +5764,7 @@ dependencies = [
  "nftnl",
  "nix 0.31.3",
  "nym-cgroup",
- "nym-common 2026.11.0-beta.7",
+ "nym-common 2026.11.0-beta.8",
  "nym-firewall-config",
  "nym-platform-metadata",
  "pfctl",
@@ -5777,7 +5777,7 @@ dependencies = [
 
 [[package]]
 name = "nym-firewall-config"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "ipnetwork",
 ]
@@ -5823,7 +5823,7 @@ dependencies = [
 
 [[package]]
 name = "nym-gateway-directory"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "anyhow",
  "ipnetwork",
@@ -5961,7 +5961,7 @@ dependencies = [
 
 [[package]]
 name = "nym-ifconfig"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "bitflags 2.13.0",
  "futures",
@@ -6013,7 +6013,7 @@ dependencies = [
 
 [[package]]
 name = "nym-ipc"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6119,7 +6119,7 @@ dependencies = [
 
 [[package]]
 name = "nym-macos"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "nix 0.31.3",
  "tokio",
@@ -6305,14 +6305,14 @@ dependencies = [
 
 [[package]]
 name = "nym-offline-monitor"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "async-trait",
  "debounced",
  "dispatch2",
  "futures",
  "nym-apple-network",
- "nym-common 2026.11.0-beta.7",
+ "nym-common 2026.11.0-beta.8",
  "nym-routing",
  "nym-windows",
  "thiserror 2.0.18",
@@ -6371,7 +6371,7 @@ dependencies = [
 
 [[package]]
 name = "nym-platform-metadata"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "nym-bin-common",
  "nym-dbus",
@@ -6430,14 +6430,14 @@ dependencies = [
 
 [[package]]
 name = "nym-routing"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "bitflags 2.13.0",
  "futures",
  "ipnetwork",
  "libc",
  "nix 0.31.3",
- "nym-common 2026.11.0-beta.7",
+ "nym-common 2026.11.0-beta.8",
  "nym-windows",
  "rtnetlink",
  "system-configuration 0.7.0",
@@ -6543,7 +6543,7 @@ dependencies = [
 
 [[package]]
 name = "nym-setup"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -6586,7 +6586,7 @@ dependencies = [
 
 [[package]]
 name = "nym-socks5-proxy"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -6628,7 +6628,7 @@ dependencies = [
 
 [[package]]
 name = "nym-socks5-proxy-ipc"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "serde",
  "serde_json",
@@ -6821,7 +6821,7 @@ dependencies = [
 
 [[package]]
 name = "nym-split-tunnel"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "bitflags 2.13.0",
  "bytes",
@@ -6835,7 +6835,7 @@ dependencies = [
  "nftnl",
  "nix 0.31.3",
  "nym-cgroup",
- "nym-common 2026.11.0-beta.7",
+ "nym-common 2026.11.0-beta.8",
  "nym-dbus",
  "nym-firewall",
  "nym-firewall-config",
@@ -6872,7 +6872,7 @@ dependencies = [
 
 [[package]]
 name = "nym-statistics"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "futures",
  "nym-bin-common",
@@ -6893,7 +6893,7 @@ dependencies = [
 
 [[package]]
 name = "nym-statistics-api-client"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "nym-http-api-client",
  "nym-statistics-common",
@@ -7063,7 +7063,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-account-controller"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -7073,7 +7073,7 @@ dependencies = [
  "bs58",
  "futures",
  "hkdf",
- "nym-common 2026.11.0-beta.7",
+ "nym-common 2026.11.0-beta.8",
  "nym-compact-ecash",
  "nym-credential-proxy-requests",
  "nym-credential-storage",
@@ -7116,7 +7116,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-api-client"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "async-trait",
  "backon",
@@ -7125,7 +7125,7 @@ dependencies = [
  "bs58",
  "hex",
  "itertools 0.14.0",
- "nym-common 2026.11.0-beta.7",
+ "nym-common 2026.11.0-beta.8",
  "nym-compact-ecash",
  "nym-config",
  "nym-contracts-common",
@@ -7152,7 +7152,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-lib"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "adblock",
  "anyhow",
@@ -7187,7 +7187,7 @@ dependencies = [
  "nym-bin-common",
  "nym-cgroup",
  "nym-client-core",
- "nym-common 2026.11.0-beta.7",
+ "nym-common 2026.11.0-beta.8",
  "nym-config",
  "nym-connection-monitor",
  "nym-credentials-interface",
@@ -7270,7 +7270,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-lib-types"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "bip39",
  "ipnetwork",
@@ -7300,7 +7300,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-lib-uniffi"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "async-trait",
  "inventory",
@@ -7311,7 +7311,7 @@ dependencies = [
  "jni",
  "log",
  "ndk-context",
- "nym-common 2026.11.0-beta.7",
+ "nym-common 2026.11.0-beta.8",
  "nym-firewall-config",
  "nym-gateway-directory",
  "nym-http-api-client",
@@ -7342,10 +7342,10 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-network-config"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "itertools 0.14.0",
- "nym-common 2026.11.0-beta.7",
+ "nym-common 2026.11.0-beta.8",
  "nym-http-api-client",
  "nym-network-defaults",
  "nym-offline-monitor",
@@ -7366,7 +7366,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-proto"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "hyper 1.10.1",
  "nym-ipc",
@@ -7385,10 +7385,10 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-rpc-uniffi"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "futures",
- "nym-common 2026.11.0-beta.7",
+ "nym-common 2026.11.0-beta.8",
  "nym-vpn-lib-types",
  "nym-vpn-proto",
  "tokio",
@@ -7399,7 +7399,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpn-store"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7423,7 +7423,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpnc"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "anyhow",
  "celes",
@@ -7440,7 +7440,7 @@ dependencies = [
 
 [[package]]
 name = "nym-vpnd"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -7483,7 +7483,7 @@ dependencies = [
 
 [[package]]
 name = "nym-wg-go"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "hex",
  "ipnetwork",
@@ -7499,7 +7499,7 @@ dependencies = [
 
 [[package]]
 name = "nym-wg-metadata-client"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "nym-credentials-interface",
  "nym-gateway-directory",
@@ -7514,7 +7514,7 @@ dependencies = [
 
 [[package]]
 name = "nym-windows"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "bitflags 2.13.0",
  "futures",
@@ -10869,7 +10869,7 @@ dependencies = [
 
 [[package]]
 name = "test-manager"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "anyhow",
  "async-tempfile",
@@ -10914,7 +10914,7 @@ dependencies = [
 
 [[package]]
 name = "test-rpc"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -10939,7 +10939,7 @@ dependencies = [
 
 [[package]]
 name = "test-runner"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "bytes",
  "dirs",
@@ -10965,7 +10965,7 @@ dependencies = [
 
 [[package]]
 name = "test_macro"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11930,7 +11930,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi-bindgen"
-version = "2026.11.0-beta.7"
+version = "2026.11.0-beta.8"
 dependencies = [
  "uniffi",
 ]

--- a/nym-vpn-core/crates/nym-connection-monitor/src/connection_monitor.rs
+++ b/nym-vpn-core/crates/nym-connection-monitor/src/connection_monitor.rs
@@ -323,11 +323,49 @@ mod tests {
     use tokio_util::sync::DropGuard;
 
     use super::*;
-    use crate::mock_probe::{MockProbe, Outcome};
+    use crate::BoxedProbeError;
+    use crate::mock_probe::{MockProbe, MockProbeError, Outcome};
 
     const PROBE_RETRY_COUNT: u32 = 3;
     const INITIAL_PROBE_TIMEOUT: Duration = Duration::from_secs(3);
     const PROBE_PERIODICITY: Duration = Duration::from_secs(10);
+
+    #[test]
+    fn mock_probe_send_failure_is_not_timeout() {
+        let err = BoxedProbeError::from(MockProbeError::SendFailure);
+        assert!(err.0.is_send_failure());
+        assert!(!err.0.is_timeout());
+    }
+
+    #[test]
+    fn mock_probe_timeout_is_not_send_failure() {
+        let err = BoxedProbeError::from(MockProbeError::Timeout);
+        assert!(!err.0.is_send_failure());
+        assert!(err.0.is_timeout());
+    }
+
+    #[tokio::test(start_paused = true)]
+    #[tracing_test::traced_test]
+    async fn test_send_failures_count_toward_connection_loss() {
+        let probe = MockProbe::repeating(Outcome::SendFailure);
+        let (mut event_rx, _drop_guard) = spawn_monitor(probe);
+
+        let events = collect_events(&mut event_rx, (PROBE_RETRY_COUNT + 1) as usize)
+            .await
+            .into_iter()
+            .map(|event| event.status)
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            events,
+            vec![
+                ConnectionStatusEvent::IntermittentFailure { retry: 1 },
+                ConnectionStatusEvent::IntermittentFailure { retry: 2 },
+                ConnectionStatusEvent::IntermittentFailure { retry: 3 },
+                ConnectionStatusEvent::Failed
+            ]
+        );
+    }
 
     /// Simulated latency of a successful probe.
     const SUCCEEDED_PROBE_LATENCY: Duration = Duration::from_millis(1500);

--- a/nym-vpn-core/crates/nym-connection-monitor/src/connection_probe.rs
+++ b/nym-vpn-core/crates/nym-connection-monitor/src/connection_probe.rs
@@ -16,6 +16,11 @@ pub trait ConnectionProbe {
 pub trait ProbeError: std::error::Error + Send + 'static {
     /// Returns true if the error is a timeout error.
     fn is_timeout(&self) -> bool;
+
+    /// Returns true when the probe could not be sent (e.g. raw socket bind on utun).
+    fn is_send_failure(&self) -> bool {
+        false
+    }
 }
 
 /// Convenience wrapper around a boxed probe error.

--- a/nym-vpn-core/crates/nym-connection-monitor/src/icmp_probe.rs
+++ b/nym-vpn-core/crates/nym-connection-monitor/src/icmp_probe.rs
@@ -165,6 +165,10 @@ impl ProbeError for IcmpProbeError {
             IcmpProbeInnerError::Send(SurgeError::Timeout { .. })
         )
     }
+
+    fn is_send_failure(&self) -> bool {
+        matches!(self.inner, IcmpProbeInnerError::Send(_)) && !self.is_timeout()
+    }
 }
 
 impl From<IcmpProbeError> for BoxedProbeError {

--- a/nym-vpn-core/crates/nym-connection-monitor/src/mock_probe.rs
+++ b/nym-vpn-core/crates/nym-connection-monitor/src/mock_probe.rs
@@ -92,6 +92,10 @@ impl ProbeError for MockProbeError {
     fn is_timeout(&self) -> bool {
         matches!(self, Self::Timeout)
     }
+
+    fn is_send_failure(&self) -> bool {
+        matches!(self, Self::SendFailure)
+    }
 }
 
 impl From<MockProbeError> for BoxedProbeError {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
@@ -969,7 +969,11 @@ impl BandwidthController {
         None
     }
 
-    async fn check_bandwidth(&mut self, entry: bool, current_period: Duration) -> Option<Duration> {
+    async fn check_bandwidth(
+        &mut self,
+        entry: bool,
+        current_period: Duration,
+    ) -> (Option<Duration>, bool) {
         let bw_client = if entry {
             &mut self.wg_entry_gateway_client
         } else {
@@ -980,13 +984,21 @@ impl BandwidthController {
                 tracing::trace!("BandwidthController: Received shutdown");
             }
             ret = bw_client.query_bandwidth_with_retries(DEFAULT_CLIENT_RETRIES) => {
-                match ret {
-                    Ok(query_res) => return self.handle_bandwidth_query(entry, current_period, query_res).await,
-                    Err(err) => self.handle_bandwidth_query_error(entry, err).await,
-                }
+                return match ret {
+                    Ok(query_res) => {
+                        let next_interval = self
+                            .handle_bandwidth_query(entry, current_period, query_res)
+                            .await;
+                        (next_interval, true)
+                    }
+                    Err(err) => {
+                        self.handle_bandwidth_query_error(entry, err).await;
+                        (None, false)
+                    }
+                };
             }
         }
-        None
+        (None, false)
     }
 
     async fn init_clients(&mut self) {
@@ -1037,12 +1049,14 @@ impl BandwidthController {
                 }
                 _ = self.timeout_check_interval.next() => {
                     let current_period = self.timeout_check_interval.as_ref().period();
-                    let entry_duration = self.check_bandwidth(true, current_period).await;
-                    let exit_duration = self.check_bandwidth(false, current_period).await;
+                    let (entry_duration, entry_query_ok) =
+                        self.check_bandwidth(true, current_period).await;
+                    let (exit_duration, exit_query_ok) =
+                        self.check_bandwidth(false, current_period).await;
                     update_metadata_path_health(
                         &self.metadata_path_health,
-                        entry_duration.is_some(),
-                        exit_duration.is_some(),
+                        entry_query_ok,
+                        exit_query_ok,
                     );
                     if let Some(minimal_duration) = match (entry_duration, exit_duration) {
                         (Some(d1), Some(d2)) => {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
@@ -5,6 +5,8 @@ use std::{net::IpAddr, time::Duration};
 
 use nym_authenticator_client::AuthenticatorClient;
 use nym_bandwidth_controller::{BandwidthTicketProvider, DEFAULT_TICKETS_TO_SPEND};
+
+use crate::tunnel_health::{MetadataPathHealth, record_metadata_path_if_both_legs_ok};
 use nym_registration_common::WireguardConfiguration;
 use sysinfo::Networks;
 use tokio_stream::{StreamExt, wrappers::IntervalStream};
@@ -612,6 +614,7 @@ pub(crate) struct BandwidthController {
     shutdown_token: CancellationToken,
     successful_checks: u64,
     upgrade_mode_enabled_on_last_check: bool,
+    metadata_path_health: Option<MetadataPathHealth>,
 }
 
 impl BandwidthController {
@@ -621,6 +624,7 @@ impl BandwidthController {
         wg_exit_gateway_client: TemporaryBandwidthClient,
         account_command_tx: AccountCommandSender,
         shutdown_token: CancellationToken,
+        metadata_path_health: Option<MetadataPathHealth>,
     ) -> Self {
         let timeout_check_interval =
             IntervalStream::new(tokio::time::interval(DEFAULT_BANDWIDTH_CHECK));
@@ -638,6 +642,7 @@ impl BandwidthController {
             shutdown_token,
             successful_checks: 0,
             upgrade_mode_enabled_on_last_check: false,
+            metadata_path_health,
         }
     }
 
@@ -730,6 +735,7 @@ impl BandwidthController {
         exit_signal_channel: TunUpReceiver,
         gateway_metadata_update_version: Option<semver::Version>,
         cancel_token: CancellationToken,
+        metadata_path_health: MetadataPathHealth,
     ) -> BandwidthController {
         let wg_entry_client = Self::construct_bandwidth_client(
             entry_wireguard_config.private_ipv4.into(),
@@ -752,6 +758,7 @@ impl BandwidthController {
             wg_exit_client,
             account_command_tx,
             cancel_token.clone(),
+            Some(metadata_path_health),
         )
     }
 
@@ -1032,6 +1039,11 @@ impl BandwidthController {
                     let current_period = self.timeout_check_interval.as_ref().period();
                     let entry_duration = self.check_bandwidth(true, current_period).await;
                     let exit_duration = self.check_bandwidth(false, current_period).await;
+                    record_metadata_path_if_both_legs_ok(
+                        &self.metadata_path_health,
+                        entry_duration.is_some(),
+                        exit_duration.is_some(),
+                    );
                     if let Some(minimal_duration) = match (entry_duration, exit_duration) {
                         (Some(d1), Some(d2)) => {
                             if d1 < d2 {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
@@ -6,7 +6,7 @@ use std::{net::IpAddr, time::Duration};
 use nym_authenticator_client::AuthenticatorClient;
 use nym_bandwidth_controller::{BandwidthTicketProvider, DEFAULT_TICKETS_TO_SPEND};
 
-use crate::tunnel_health::{MetadataPathHealth, record_metadata_path_if_both_legs_ok};
+use crate::tunnel_health::{MetadataPathHealth, update_metadata_path_health};
 use nym_registration_common::WireguardConfiguration;
 use sysinfo::Networks;
 use tokio_stream::{StreamExt, wrappers::IntervalStream};
@@ -1039,7 +1039,7 @@ impl BandwidthController {
                     let current_period = self.timeout_check_interval.as_ref().period();
                     let entry_duration = self.check_bandwidth(true, current_period).await;
                     let exit_duration = self.check_bandwidth(false, current_period).await;
-                    record_metadata_path_if_both_legs_ok(
+                    update_metadata_path_health(
                         &self.metadata_path_health,
                         entry_duration.is_some(),
                         exit_duration.is_some(),

--- a/nym-vpn-core/crates/nym-vpn-lib/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/lib.rs
@@ -17,6 +17,7 @@ pub mod sentry;
 pub mod service;
 #[cfg(not(target_os = "ios"))]
 pub(crate) mod socks5_proxy;
+mod tunnel_health;
 #[cfg(any(target_os = "ios", target_os = "android"))]
 pub mod tunnel_provider;
 pub mod tunnel_state_machine;

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_health.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_health.rs
@@ -4,19 +4,19 @@
 //! Shared signals used to correlate ICMP health probes with in-tunnel metadata paths.
 
 use std::{
-    sync::{
-        Arc,
-        atomic::{AtomicU64, Ordering},
-    },
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
 };
 
 /// Grace window: bandwidth checks default to ~30s; allow slack for probe failures.
 pub const METADATA_PATH_HEALTH_GRACE: Duration = Duration::from_secs(45);
 
+/// After this many consecutive deferred probe failures, tear down even if metadata was recent.
+pub const MAX_CONSECUTIVE_DEFERRED_PROBE_FAILURES: u32 = 3;
+
 #[derive(Clone, Debug, Default)]
 pub struct MetadataPathHealth {
-    last_success_unix_secs: Arc<AtomicU64>,
+    last_success: Arc<Mutex<Option<Instant>>>,
 }
 
 impl MetadataPathHealth {
@@ -25,23 +25,26 @@ impl MetadataPathHealth {
     }
 
     pub fn record_success(&self) {
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
-        self.last_success_unix_secs.store(now, Ordering::Relaxed);
+        Self::update_last_success(&self.last_success, Instant::now());
     }
 
     pub fn is_recently_healthy(&self, max_age: Duration) -> bool {
-        let last = self.last_success_unix_secs.load(Ordering::Relaxed);
-        if last == 0 {
-            return false;
+        Self::read_last_success(&self.last_success)
+            .is_some_and(|instant| instant.elapsed() <= max_age)
+    }
+
+    fn update_last_success(last_success: &Arc<Mutex<Option<Instant>>>, instant: Instant) {
+        match last_success.lock() {
+            Ok(mut guard) => *guard = Some(instant),
+            Err(poisoned) => *poisoned.into_inner() = Some(instant),
         }
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
-        now.saturating_sub(last) <= max_age.as_secs()
+    }
+
+    fn read_last_success(last_success: &Arc<Mutex<Option<Instant>>>) -> Option<Instant> {
+        match last_success.lock() {
+            Ok(guard) => *guard,
+            Err(poisoned) => *poisoned.into_inner(),
+        }
     }
 }
 
@@ -50,8 +53,11 @@ pub fn should_defer_probe_teardown(
     uses_metadata_endpoint: bool,
     health: Option<&MetadataPathHealth>,
     grace: Duration,
+    consecutive_deferred_failures: u32,
 ) -> bool {
-    uses_metadata_endpoint && health.is_some_and(|h| h.is_recently_healthy(grace))
+    consecutive_deferred_failures < MAX_CONSECUTIVE_DEFERRED_PROBE_FAILURES
+        && uses_metadata_endpoint
+        && health.is_some_and(|h| h.is_recently_healthy(grace))
 }
 
 /// Record metadata-path health only when both entry and exit bandwidth checks succeeded.
@@ -60,10 +66,8 @@ pub fn record_metadata_path_if_both_legs_ok(
     entry_ok: bool,
     exit_ok: bool,
 ) {
-    if entry_ok && exit_ok {
-        if let Some(health) = health {
-            health.record_success();
-        }
+    if entry_ok && exit_ok && let Some(health) = health {
+        health.record_success();
     }
 }
 
@@ -91,7 +95,20 @@ mod tests {
         assert!(should_defer_probe_teardown(
             true,
             Some(&health),
-            METADATA_PATH_HEALTH_GRACE
+            METADATA_PATH_HEALTH_GRACE,
+            0,
+        ));
+    }
+
+    #[test]
+    fn teardown_when_defer_cap_reached() {
+        let health = MetadataPathHealth::new();
+        health.record_success();
+        assert!(!should_defer_probe_teardown(
+            true,
+            Some(&health),
+            METADATA_PATH_HEALTH_GRACE,
+            MAX_CONSECUTIVE_DEFERRED_PROBE_FAILURES,
         ));
     }
 
@@ -101,12 +118,14 @@ mod tests {
         assert!(!should_defer_probe_teardown(
             true,
             Some(&health),
-            METADATA_PATH_HEALTH_GRACE
+            METADATA_PATH_HEALTH_GRACE,
+            0,
         ));
         assert!(!should_defer_probe_teardown(
             false,
             Some(&health),
-            METADATA_PATH_HEALTH_GRACE
+            METADATA_PATH_HEALTH_GRACE,
+            0,
         ));
     }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_health.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_health.rs
@@ -1,0 +1,121 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+//! Shared signals used to correlate ICMP health probes with in-tunnel metadata paths.
+
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+/// Grace window: bandwidth checks default to ~30s; allow slack for probe failures.
+pub const METADATA_PATH_HEALTH_GRACE: Duration = Duration::from_secs(45);
+
+#[derive(Clone, Debug, Default)]
+pub struct MetadataPathHealth {
+    last_success_unix_secs: Arc<AtomicU64>,
+}
+
+impl MetadataPathHealth {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn record_success(&self) {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        self.last_success_unix_secs.store(now, Ordering::Relaxed);
+    }
+
+    pub fn is_recently_healthy(&self, max_age: Duration) -> bool {
+        let last = self.last_success_unix_secs.load(Ordering::Relaxed);
+        if last == 0 {
+            return false;
+        }
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        now.saturating_sub(last) <= max_age.as_secs()
+    }
+}
+
+/// Returns true when an ICMP probe failure should not tear the tunnel down yet.
+pub fn should_defer_probe_teardown(
+    uses_metadata_endpoint: bool,
+    health: Option<&MetadataPathHealth>,
+    grace: Duration,
+) -> bool {
+    uses_metadata_endpoint && health.is_some_and(|h| h.is_recently_healthy(grace))
+}
+
+/// Record metadata-path health only when both entry and exit bandwidth checks succeeded.
+pub fn record_metadata_path_if_both_legs_ok(
+    health: &Option<MetadataPathHealth>,
+    entry_ok: bool,
+    exit_ok: bool,
+) {
+    if entry_ok && exit_ok {
+        if let Some(health) = health {
+            health.record_success();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unhealthy_before_any_success() {
+        let health = MetadataPathHealth::new();
+        assert!(!health.is_recently_healthy(METADATA_PATH_HEALTH_GRACE));
+    }
+
+    #[test]
+    fn healthy_after_success() {
+        let health = MetadataPathHealth::new();
+        health.record_success();
+        assert!(health.is_recently_healthy(METADATA_PATH_HEALTH_GRACE));
+    }
+
+    #[test]
+    fn defer_teardown_when_metadata_recently_healthy() {
+        let health = MetadataPathHealth::new();
+        health.record_success();
+        assert!(should_defer_probe_teardown(
+            true,
+            Some(&health),
+            METADATA_PATH_HEALTH_GRACE
+        ));
+    }
+
+    #[test]
+    fn teardown_when_metadata_stale_or_missing() {
+        let health = MetadataPathHealth::new();
+        assert!(!should_defer_probe_teardown(
+            true,
+            Some(&health),
+            METADATA_PATH_HEALTH_GRACE
+        ));
+        assert!(!should_defer_probe_teardown(
+            false,
+            Some(&health),
+            METADATA_PATH_HEALTH_GRACE
+        ));
+    }
+
+    #[test]
+    fn record_metadata_only_when_both_legs_ok() {
+        let health = MetadataPathHealth::new();
+        record_metadata_path_if_both_legs_ok(&Some(health.clone()), true, false);
+        assert!(!health.is_recently_healthy(METADATA_PATH_HEALTH_GRACE));
+        record_metadata_path_if_both_legs_ok(&Some(health.clone()), true, true);
+        assert!(health.is_recently_healthy(METADATA_PATH_HEALTH_GRACE));
+    }
+}

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_health.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_health.rs
@@ -66,7 +66,10 @@ pub fn record_metadata_path_if_both_legs_ok(
     entry_ok: bool,
     exit_ok: bool,
 ) {
-    if entry_ok && exit_ok && let Some(health) = health {
+    if entry_ok
+        && exit_ok
+        && let Some(health) = health
+    {
         health.record_success();
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_health.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_health.rs
@@ -28,6 +28,10 @@ impl MetadataPathHealth {
         Self::update_last_success(&self.last_success, Instant::now());
     }
 
+    pub fn clear_health(&self) {
+        Self::clear_last_success(&self.last_success);
+    }
+
     pub fn is_recently_healthy(&self, max_age: Duration) -> bool {
         Self::read_last_success(&self.last_success)
             .is_some_and(|instant| instant.elapsed() <= max_age)
@@ -46,6 +50,13 @@ impl MetadataPathHealth {
             Err(poisoned) => *poisoned.into_inner(),
         }
     }
+
+    fn clear_last_success(last_success: &Arc<Mutex<Option<Instant>>>) {
+        match last_success.lock() {
+            Ok(mut guard) => *guard = None,
+            Err(poisoned) => *poisoned.into_inner() = None,
+        }
+    }
 }
 
 /// Returns true when an ICMP probe failure should not tear the tunnel down yet.
@@ -60,17 +71,22 @@ pub fn should_defer_probe_teardown(
         && health.is_some_and(|h| h.is_recently_healthy(grace))
 }
 
-/// Record metadata-path health only when both entry and exit bandwidth checks succeeded.
-pub fn record_metadata_path_if_both_legs_ok(
+/// Update metadata-path health from a bandwidth check interval.
+///
+/// Records success only when both legs succeed; clears any prior success when either leg fails
+/// so probe deferral cannot outlive a real metadata-path outage.
+pub fn update_metadata_path_health(
     health: &Option<MetadataPathHealth>,
     entry_ok: bool,
     exit_ok: bool,
 ) {
-    if entry_ok
-        && exit_ok
-        && let Some(health) = health
-    {
+    let Some(health) = health else {
+        return;
+    };
+    if entry_ok && exit_ok {
         health.record_success();
+    } else if !entry_ok || !exit_ok {
+        health.clear_health();
     }
 }
 
@@ -133,11 +149,40 @@ mod tests {
     }
 
     #[test]
-    fn record_metadata_only_when_both_legs_ok() {
+    fn update_metadata_path_only_when_both_legs_ok() {
         let health = MetadataPathHealth::new();
-        record_metadata_path_if_both_legs_ok(&Some(health.clone()), true, false);
+        update_metadata_path_health(&Some(health.clone()), true, false);
         assert!(!health.is_recently_healthy(METADATA_PATH_HEALTH_GRACE));
-        record_metadata_path_if_both_legs_ok(&Some(health.clone()), true, true);
+        update_metadata_path_health(&Some(health.clone()), true, true);
         assert!(health.is_recently_healthy(METADATA_PATH_HEALTH_GRACE));
+    }
+
+    #[test]
+    fn update_metadata_path_clears_health_on_leg_failure() {
+        let health = MetadataPathHealth::new();
+        update_metadata_path_health(&Some(health.clone()), true, true);
+        assert!(health.is_recently_healthy(METADATA_PATH_HEALTH_GRACE));
+
+        update_metadata_path_health(&Some(health.clone()), true, false);
+        assert!(!health.is_recently_healthy(METADATA_PATH_HEALTH_GRACE));
+        assert!(!should_defer_probe_teardown(
+            true,
+            Some(&health),
+            METADATA_PATH_HEALTH_GRACE,
+            0,
+        ));
+    }
+
+    #[test]
+    fn clear_health_removes_defer_eligibility() {
+        let health = MetadataPathHealth::new();
+        health.record_success();
+        health.clear_health();
+        assert!(!should_defer_probe_teardown(
+            true,
+            Some(&health),
+            METADATA_PATH_HEALTH_GRACE,
+            0,
+        ));
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_health.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_health.rs
@@ -158,6 +158,19 @@ mod tests {
     }
 
     #[test]
+    fn update_metadata_path_success_without_interval_adjustment() {
+        let health = MetadataPathHealth::new();
+        // Successful bandwidth queries usually return no interval change; health must still record.
+        update_metadata_path_health(&Some(health.clone()), true, true);
+        assert!(should_defer_probe_teardown(
+            true,
+            Some(&health),
+            METADATA_PATH_HEALTH_GRACE,
+            0,
+        ));
+    }
+
+    #[test]
     fn update_metadata_path_clears_health_on_leg_failure() {
         let health = MetadataPathHealth::new();
         update_metadata_path_health(&Some(health.clone()), true, true);

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -855,6 +855,9 @@ impl TunnelMonitor {
                 reachable = &mut metadata_endpoints_reachable => {
                     let reachable = reachable.unwrap_or(false);
                     if !reachable {
+                        if let Some(health) = metadata_path_health.as_ref() {
+                            health.clear_health();
+                        }
                         tracing::info!("Metadata endpoints not reachable. Exiting");
                         self.send_event(TunnelMonitorEvent::ConnectionFailed {
                             exit_gateway_id: selected_gateways.exit_gateway().identity(),

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -82,6 +82,7 @@ use crate::{
     DEFAULT_MIN_GATEWAY_PERFORMANCE, DEFAULT_MIN_MIXNODE_PERFORMANCE, UserAgent,
     bandwidth_controller::BandwidthController,
     mixnet::VpnTopologyServiceHandle,
+    tunnel_health::{METADATA_PATH_HEALTH_GRACE, MetadataPathHealth, should_defer_probe_teardown},
     tunnel_state_machine::{
         TunnelConstants, WireguardMultihopMode, account, ipv6_availability,
         tunnel::{
@@ -784,6 +785,9 @@ impl TunnelMonitor {
         let mut has_sent_up_event = false;
         let mut ping_viable = false;
         let mut metadata_endpoint_viable = false;
+        let metadata_path_health = wg_tunnel_runtime
+            .as_ref()
+            .map(|runtime| runtime.metadata_path_health.clone());
         let connection_data = Box::new(ConnectionData {
             entry_gateway: GatewayLightInfo::from(selected_gateways.entry_gateway().clone()),
             exit_gateway: GatewayLightInfo::from(selected_gateways.exit_gateway().clone()),
@@ -818,11 +822,24 @@ impl TunnelMonitor {
                                 tracing::info!("Tunnel connection is failing (retry: {retry})");
                             }
                             ConnectionStatusEvent::Failed => {
-                                tracing::info!("Tunnel connection is down. Exiting");
-                                self.send_event(TunnelMonitorEvent::ConnectionFailed {
-                                    exit_gateway_id: selected_gateways.exit_gateway().identity(),
-                                });
-                                break;
+                                if should_defer_probe_teardown(
+                                    uses_metadata_endpoint,
+                                    metadata_path_health.as_ref(),
+                                    METADATA_PATH_HEALTH_GRACE,
+                                ) {
+                                    tracing::warn!(
+                                        "ICMP probe declared tunnel down but in-tunnel metadata path recently succeeded; deferring teardown"
+                                    );
+                                    last_connection_status = None;
+                                } else {
+                                    tracing::info!("Tunnel connection is down. Exiting");
+                                    self.send_event(TunnelMonitorEvent::ConnectionFailed {
+                                        exit_gateway_id: selected_gateways
+                                            .exit_gateway()
+                                            .identity(),
+                                    });
+                                    break;
+                                }
                             }
                         }
                     }
@@ -1124,6 +1141,8 @@ impl TunnelMonitor {
             .borrow()
             .gw_update_version();
 
+        let metadata_path_health = MetadataPathHealth::new();
+
         let bw = BandwidthController::create(
             bw_controller,
             self.account_command_tx.clone(),
@@ -1136,6 +1155,7 @@ impl TunnelMonitor {
             exit_signal_rx,
             gw_update_version,
             self.shutdown_token.clone(),
+            metadata_path_health.clone(),
         );
 
         let authenticator_listener_handle = match authenticator_listener_handle {
@@ -1156,6 +1176,7 @@ impl TunnelMonitor {
             bandwidth_controller_handle,
             transport_fwd_handle: None,
             authenticator_listener_handle,
+            metadata_path_health,
         };
 
         let connection_data = WgConnectionData {
@@ -1968,6 +1989,27 @@ impl TunnelMonitor {
             TunnelType::Wireguard => TimingConfig::two_hop(),
         };
 
+        #[cfg(any(target_os = "ios", target_os = "android"))]
+        {
+            tracing::info!("Using TCP connectivity test on mobile");
+            match self.create_tcp_probe(exit_tunnel_metadata) {
+                Ok(tcp_probe) => {
+                    return Ok(ConnectionMonitor::spawn(
+                        tcp_probe,
+                        timing_config,
+                        event_tx,
+                        self.shutdown_token.child_token(),
+                    ));
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        "TCP probe setup failed on mobile, falling back to ICMP: {}",
+                        err.display_chain()
+                    );
+                }
+            }
+        }
+
         // Create ICMP probe first, fallback to TCP probe on failure.
         match self.create_icmp_probe(exit_tunnel_metadata) {
             Ok(icmp_probe) => {
@@ -2004,6 +2046,7 @@ struct WgTunnelRuntime {
     bandwidth_controller_handle: JoinHandle<()>,
     transport_fwd_handle: Option<JoinHandle<()>>,
     authenticator_listener_handle: Option<AuthClientMixnetListenerHandle>,
+    metadata_path_health: MetadataPathHealth,
 }
 
 impl WgTunnelRuntime {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -785,6 +785,7 @@ impl TunnelMonitor {
         let mut has_sent_up_event = false;
         let mut ping_viable = false;
         let mut metadata_endpoint_viable = false;
+        let mut consecutive_deferred_probe_failures = 0u32;
         let metadata_path_health = wg_tunnel_runtime
             .as_ref()
             .map(|runtime| runtime.metadata_path_health.clone());
@@ -809,6 +810,7 @@ impl TunnelMonitor {
                         match event.status {
                             ConnectionStatusEvent::Viable => {
                                 ping_viable = true;
+                                consecutive_deferred_probe_failures = 0;
                                 if !has_sent_up_event && metadata_endpoint_viable {
                                     tracing::info!("Tunnel connection is viable");
                                     has_sent_up_event = true;
@@ -826,9 +828,15 @@ impl TunnelMonitor {
                                     uses_metadata_endpoint,
                                     metadata_path_health.as_ref(),
                                     METADATA_PATH_HEALTH_GRACE,
+                                    consecutive_deferred_probe_failures,
                                 ) {
+                                    consecutive_deferred_probe_failures =
+                                        consecutive_deferred_probe_failures.saturating_add(1);
                                     tracing::warn!(
-                                        "ICMP probe declared tunnel down but in-tunnel metadata path recently succeeded; deferring teardown"
+                                        consecutive_deferred_probe_failures,
+                                        max_consecutive_deferred_probe_failures =
+                                            crate::tunnel_health::MAX_CONSECUTIVE_DEFERRED_PROBE_FAILURES,
+                                        "Probe declared tunnel down but in-tunnel metadata path recently succeeded; deferring teardown"
                                     );
                                     last_connection_status = None;
                                 } else {
@@ -854,6 +862,7 @@ impl TunnelMonitor {
                         break;
                     } else {
                         metadata_endpoint_viable = true;
+                        consecutive_deferred_probe_failures = 0;
                         if !has_sent_up_event && ping_viable {
                             tracing::info!("Tunnel connection is viable");
                             has_sent_up_event = true;
@@ -1991,9 +2000,13 @@ impl TunnelMonitor {
 
         #[cfg(any(target_os = "ios", target_os = "android"))]
         {
-            tracing::info!("Using TCP connectivity test on mobile");
             match self.create_tcp_probe(exit_tunnel_metadata) {
                 Ok(tcp_probe) => {
+                    tracing::info!(
+                        probe_type = "tcp",
+                        probe_selection = "mobile_primary",
+                        "Selected TCP connectivity probe on mobile"
+                    );
                     return Ok(ConnectionMonitor::spawn(
                         tcp_probe,
                         timing_config,
@@ -2003,8 +2016,10 @@ impl TunnelMonitor {
                 }
                 Err(err) => {
                     tracing::warn!(
-                        "TCP probe setup failed on mobile, falling back to ICMP: {}",
-                        err.display_chain()
+                        probe_type = "icmp",
+                        probe_selection = "mobile_tcp_setup_failed",
+                        fallback_reason = %err.display_chain(),
+                        "TCP probe setup failed on mobile, falling back to ICMP"
                     );
                 }
             }
@@ -2013,7 +2028,11 @@ impl TunnelMonitor {
         // Create ICMP probe first, fallback to TCP probe on failure.
         match self.create_icmp_probe(exit_tunnel_metadata) {
             Ok(icmp_probe) => {
-                tracing::info!("Initial ICMP connectivity test");
+                tracing::info!(
+                    probe_type = "icmp",
+                    probe_selection = "default_primary",
+                    "Selected ICMP connectivity probe"
+                );
                 Ok(ConnectionMonitor::spawn(
                     icmp_probe,
                     timing_config,
@@ -2022,9 +2041,18 @@ impl TunnelMonitor {
                 ))
             }
             Err(err) => {
-                tracing::warn!("{}", err.display_chain());
-                tracing::info!("Fallback to TCP probe");
+                tracing::warn!(
+                    probe_type = "tcp",
+                    probe_selection = "icmp_setup_failed",
+                    fallback_reason = %err.display_chain(),
+                    "ICMP probe setup failed, falling back to TCP"
+                );
                 let tcp_probe = self.create_tcp_probe(exit_tunnel_metadata)?;
+                tracing::info!(
+                    probe_type = "tcp",
+                    probe_selection = "icmp_setup_failed_fallback",
+                    "Selected TCP connectivity probe after ICMP setup failure"
+                );
                 Ok(ConnectionMonitor::spawn(
                     tcp_probe,
                     timing_config,


### PR DESCRIPTION
Fix iOS false reconnects when ICMP on utun fails but in-tunnel metadata/ bandwidth is healthy. Use TCP probes on mobile and defer teardown when both-leg metadata recently succeeded. 

Disclaimer here as well... We should do a follow  for zombie-connected edge case and ICMP-fallback + real-outage reconnect behavior.

On iOS we saw the tunnel auto-reconnect to the same gateways after ICMP probe failures on utun, while WireGuard and in-tunnel bandwidth/metadata checks were still succeeding seconds earlier. Users get an unnecessary VPN drop (no nym firewall on mobile).

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5762)
<!-- Reviewable:end -->
