### PR TITLE
Fix develop installer

### DIFF
--- a/.pkg/linux/install
+++ b/.pkg/linux/install
@@ -211,8 +211,8 @@ latest_nightly_tag() {
     -H "X-GitHub-Api-Version: 2022-11-28" \
     "https://api.github.com/repos/nymtech/nym-vpn-client/releases?per_page=100" |
     grep -oP '"tag_name":\s*"\Knym-vpn-v[0-9]+\.[0-9]+\.[0-9]+-nightly\.[0-9]+(?=")' |
-    sort -t. -k4 -n -r |
-    head -n1
+    sort -t. -k4 -n |
+    tail -n1
 }
 
 app_dev_setup() {

--- a/.pkg/linux/install
+++ b/.pkg/linux/install
@@ -48,7 +48,9 @@ BI_MGT="$ITL$B_MGT"
 
 BUILD_CHANNEL=${BUILD_CHANNEL:-stable}
 # these are only used when BUILD_CHANNEL=dev
-APP_RELEASE=${APP_RELEASE:-"nym-vpn-app-nightly"}
+# leave empty to auto-resolve the latest nightly release tag
+# (e.g. nym-vpn-v2026.12.0-nightly.20260706)
+APP_RELEASE=${APP_RELEASE:-}
 CORE_BUILD=${CORE_BUILD:-0}
 
 # detect CPU architecture
@@ -199,12 +201,38 @@ _app=1
 sys_pkgs=()
 
 ########################
-app_dev_setup() {
-  app_tag=$APP_RELEASE
-  app_version=$(curl -sSL \
+# resolve the latest nightly release tag from the GitHub releases API.
+# nightly tags look like `nym-vpn-v2026.12.0-nightly.20260706`, i.e.
+# `nym-vpn-vXXXX.YY.ZZ-nightly.TIMESTAMP`; we keep the one with the highest
+# trailing timestamp.
+latest_nightly_tag() {
+  curl -sSL \
     -H "Accept: application/vnd.github+json" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
-    https://api.github.com/repos/nymtech/nym-vpn-client/releases/tags/"$app_tag" |
+    "https://api.github.com/repos/nymtech/nym-vpn-client/releases?per_page=100" |
+    grep -oP '"tag_name":\s*"\Knym-vpn-v[0-9]+\.[0-9]+\.[0-9]+-nightly\.[0-9]+(?=")' |
+    sort -t. -k4 -n -r |
+    head -n1
+}
+
+app_dev_setup() {
+  if [ -z "$APP_RELEASE" ]; then
+    APP_RELEASE=$(latest_nightly_tag)
+    if [ -z "$APP_RELEASE" ]; then
+      echo "failed to resolve latest nightly app release tag from GitHub" >&2
+      exit 1
+    fi
+    log "${I_GRY}resolved latest nightly tag: $APP_RELEASE$RS"
+  fi
+  app_tag=$APP_RELEASE
+  # capture the response first; piping curl straight into `grep -m1` makes grep
+  # close the pipe early on a large release payload, killing curl with SIGPIPE
+  # (exit 23) under pipefail.
+  app_release_json=$(curl -sSL \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    https://api.github.com/repos/nymtech/nym-vpn-client/releases/tags/"$app_tag")
+  app_version=$(printf '%s' "$app_release_json" |
     grep -m1 -oP "(?<=\"name\": \"NymVPN_).+(?=_${app_image_arch}\.AppImage)")
   appimage_url="https://github.com/nymtech/nym-vpn-client/releases/download/$app_tag/NymVPN_${app_version}_${app_image_arch}.AppImage"
   app_deb_url="https://github.com/nymtech/nym-vpn-client/releases/download/$app_tag/nym-vpn-app_${app_version}_${deb_arch}.deb"
@@ -255,7 +283,11 @@ vpnd_dev_setup() {
 
 dev_setup() {
   log "${BI_YLW}⚠ dev channel$RS"
-  log "${I_GRY}fetching app release $APP_RELEASE…$RS"
+  if [ -n "$APP_RELEASE" ]; then
+    log "${I_GRY}fetching app release $APP_RELEASE…$RS"
+  else
+    log "${I_GRY}fetching latest nightly app release…$RS"
+  fi
   app_dev_setup
   if [ "$CORE_BUILD" = 0 ]; then
     log "${I_GRY}fetching latest vpn-core dev build…$RS"


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

Find latest nightly version. Because we switched the nightly tag shape to have timestamp, so this script needs to find latest nightly tag and then use it


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5772)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Linux installer can now automatically select the latest nightly app release when no release is specified.
  * Setup messages now clearly indicate whether a specific release or the latest nightly build is being fetched.

* **Bug Fixes**
  * Improved release detection to avoid failures during download metadata lookup.
  * Added a fallback error if no nightly release tag can be found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->