### PR TITLE
(tauri) Fallback to tauri tray icon when ksni fails

### DIFF
--- a/nym-vpn-app/src-tauri/src/tray/desktop.rs
+++ b/nym-vpn-app/src-tauri/src/tray/desktop.rs
@@ -17,9 +17,8 @@ use tauri::{
 use tokio::{sync::Mutex, task::JoinHandle};
 use tracing::{debug, error, instrument, trace, warn};
 
-use super::{TrayBackend, quit_app, show_window};
+use super::{IconKind, TrayBackend, quit_app, show_window};
 use crate::APP_NAME;
-use crate::vpnd::tunnel::TunnelState;
 
 const TRAY_ICON_ID: &str = "main";
 
@@ -57,12 +56,13 @@ pub(super) struct Backend {
     icon_debounce: Mutex<Option<JoinHandle<()>>>,
 }
 
-fn icon_for_state(state: &TunnelState) -> Image<'static> {
-    match state {
-        TunnelState::Connected(_) => CONNECTED_ICON,
-        TunnelState::Connecting(_) | TunnelState::Disconnecting(_) => CONNECTING_ICON,
-        TunnelState::Disconnected => DISCONNECTED_ICON,
-        TunnelState::Error(_) | TunnelState::Offline { .. } => ERROR_ICON,
+fn image_for_kind(kind: IconKind) -> Image<'static> {
+    match kind {
+        IconKind::Default => APP_ICON,
+        IconKind::Connected => CONNECTED_ICON,
+        IconKind::Connecting => CONNECTING_ICON,
+        IconKind::Disconnected => DISCONNECTED_ICON,
+        IconKind::Error => ERROR_ICON,
     }
 }
 
@@ -199,7 +199,7 @@ impl Backend {
 
 impl TrayBackend for Backend {
     #[instrument(skip_all)]
-    async fn update_tray_icon(&self, state: TunnelState) {
+    async fn update_tray_icon(&self, icon: IconKind) {
         let mut pending = self.icon_debounce.lock().await;
         if let Some(handle) = pending.take() {
             handle.abort();
@@ -209,7 +209,7 @@ impl TrayBackend for Backend {
         let tray = self.tray.clone();
         *pending = Some(tokio::spawn(async move {
             tokio::time::sleep(ICON_DEBOUNCE).await;
-            let _ = tray.set_icon(Some(icon_for_state(&state)));
+            let _ = tray.set_icon(Some(image_for_kind(icon)));
         }));
     }
 

--- a/nym-vpn-app/src-tauri/src/tray/desktop.rs
+++ b/nym-vpn-app/src-tauri/src/tray/desktop.rs
@@ -1,11 +1,14 @@
-//! Windows / macOS: native Tauri tray backend.
+//! Native Tauri tray backend.
+//!
+//! Used on Windows/macOS, and on Linux as the runtime fallback when no
+//! StatusNotifierWatcher is available for the ksni backend (see [`super::linux`]).
 
 use std::time::Duration;
 
 use anyhow::Result;
 use strum::AsRefStr;
 use tauri::{
-    AppHandle, Manager, Wry,
+    AppHandle, Wry,
     image::Image,
     include_image,
     menu::{Menu, MenuEvent, MenuItem, PredefinedMenuItem},
@@ -14,7 +17,7 @@ use tauri::{
 use tokio::{sync::Mutex, task::JoinHandle};
 use tracing::{debug, error, instrument, trace, warn};
 
-use super::{TrayBackend, TrayManager, quit_app, show_window};
+use super::{TrayBackend, quit_app, show_window};
 use crate::APP_NAME;
 use crate::vpnd::tunnel::TunnelState;
 
@@ -42,7 +45,6 @@ enum MenuItemId {
 }
 
 pub(super) struct Backend {
-    app: AppHandle,
     tray: TrayIcon,
     menu: Menu<Wry>,
     show_hide: MenuItem<Wry>,
@@ -55,17 +57,16 @@ pub(super) struct Backend {
     icon_debounce: Mutex<Option<JoinHandle<()>>>,
 }
 
-impl Backend {
-    fn apply_icon(&self, state: &TunnelState) {
-        let icon = match state {
-            TunnelState::Connected(_) => CONNECTED_ICON,
-            TunnelState::Connecting(_) | TunnelState::Disconnecting(_) => CONNECTING_ICON,
-            TunnelState::Disconnected => DISCONNECTED_ICON,
-            TunnelState::Error(_) | TunnelState::Offline { .. } => ERROR_ICON,
-        };
-        let _ = self.tray.set_icon(Some(icon));
+fn icon_for_state(state: &TunnelState) -> Image<'static> {
+    match state {
+        TunnelState::Connected(_) => CONNECTED_ICON,
+        TunnelState::Connecting(_) | TunnelState::Disconnecting(_) => CONNECTING_ICON,
+        TunnelState::Disconnected => DISCONNECTED_ICON,
+        TunnelState::Error(_) | TunnelState::Offline { .. } => ERROR_ICON,
     }
+}
 
+impl Backend {
     #[instrument(skip_all)]
     fn on_tray_event(tray_icon: &TrayIcon, event: TrayIconEvent) {
         if let TrayIconEvent::Click {
@@ -95,10 +96,8 @@ impl Backend {
             _ => warn!("unhandled menu event: {:?}", event.id),
         }
     }
-}
 
-impl TrayBackend for Backend {
-    fn new(app: &AppHandle) -> Result<Self> {
+    pub(super) fn new(app: &AppHandle) -> Result<Self> {
         debug!("building system tray");
 
         // String labels are set in frontend (<TrayProvider>) to support localization
@@ -184,7 +183,6 @@ impl TrayBackend for Backend {
             .inspect_err(|e| error!("failed to set tray tooltip {e}"));
 
         Ok(Self {
-            app: app.clone(),
             tray,
             menu,
             show_hide,
@@ -197,20 +195,21 @@ impl TrayBackend for Backend {
             icon_debounce: Mutex::new(None),
         })
     }
+}
 
+impl TrayBackend for Backend {
     #[instrument(skip_all)]
     async fn update_tray_icon(&self, state: TunnelState) {
         let mut pending = self.icon_debounce.lock().await;
         if let Some(handle) = pending.take() {
             handle.abort();
         }
-        let app = self.app.clone();
+        // `TrayIcon` is reference-counted and `Clone`, so the debounced task can own a
+        // clone and outlive this `&self` borrow without re-fetching from managed state.
+        let tray = self.tray.clone();
         *pending = Some(tokio::spawn(async move {
             tokio::time::sleep(ICON_DEBOUNCE).await;
-            // Re-fetch ourselves from managed state — the debounced task outlives this
-            // `&self` borrow, and the `AppHandle` is the only thing cheap to capture.
-            let manager = app.state::<TrayManager>();
-            manager.inner().0.apply_icon(&state);
+            let _ = tray.set_icon(Some(icon_for_state(&state)));
         }));
     }
 

--- a/nym-vpn-app/src-tauri/src/tray/linux.rs
+++ b/nym-vpn-app/src-tauri/src/tray/linux.rs
@@ -19,8 +19,7 @@ use tauri::AppHandle;
 use tokio::{sync::Mutex, task::JoinHandle};
 use tracing::{debug, instrument, trace};
 
-use super::{TrayBackend, quit_app, show_window};
-use crate::vpnd::tunnel::TunnelState;
+use super::{IconKind, TrayBackend, TrayState, quit_app, show_window};
 
 const APP_ICON: &[u8] = include_bytes!("../../icons/tray_icon.png");
 const CONNECTED_ICON: &[u8] = include_bytes!("../../icons/tray_icon_connected.png");
@@ -28,14 +27,6 @@ const CONNECTING_ICON: &[u8] = include_bytes!("../../icons/tray_icon_connecting.
 const DISCONNECTED_ICON: &[u8] = include_bytes!("../../icons/tray_icon_disconnected.png");
 const ERROR_ICON: &[u8] = include_bytes!("../../icons/tray_icon_error.png");
 const ICON_DEBOUNCE: Duration = Duration::from_millis(300);
-
-// Startup probe for a StatusNotifierWatcher. A watcher provided by a full desktop
-// is already registered before we launch, so the first attempt normally succeeds;
-// the couple of quick retries only absorb a watcher that is still coming up during
-// login. If none appears we return `None` promptly so the caller can fall back to
-// the native XEmbed backend instead of blocking startup.
-const PROBE_ATTEMPTS: u32 = 3;
-const PROBE_INTERVAL: Duration = Duration::from_millis(200);
 
 fn decode_argb(bytes: &[u8]) -> ksni::Icon {
     let img = image::load_from_memory_with_format(bytes, ImageFormat::Png)
@@ -60,40 +51,18 @@ static CONNECTING_ARGB: LazyLock<ksni::Icon> = LazyLock::new(|| decode_argb(CONN
 static DISCONNECTED_ARGB: LazyLock<ksni::Icon> = LazyLock::new(|| decode_argb(DISCONNECTED_ICON));
 static ERROR_ARGB: LazyLock<ksni::Icon> = LazyLock::new(|| decode_argb(ERROR_ICON));
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum IconKind {
-    Default,
-    Connected,
-    Connecting,
-    Disconnected,
-    Error,
-}
-
-impl IconKind {
-    fn pixmap(self) -> ksni::Icon {
-        match self {
-            IconKind::Default => APP_ARGB.clone(),
-            IconKind::Connected => CONNECTED_ARGB.clone(),
-            IconKind::Connecting => CONNECTING_ARGB.clone(),
-            IconKind::Disconnected => DISCONNECTED_ARGB.clone(),
-            IconKind::Error => ERROR_ARGB.clone(),
-        }
-    }
-}
-
-impl From<&TunnelState> for IconKind {
-    fn from(s: &TunnelState) -> Self {
-        match s {
-            TunnelState::Connected(_) => IconKind::Connected,
-            TunnelState::Connecting(_) | TunnelState::Disconnecting(_) => IconKind::Connecting,
-            TunnelState::Disconnected => IconKind::Disconnected,
-            TunnelState::Error(_) | TunnelState::Offline { .. } => IconKind::Error,
-        }
+fn pixmap_for_kind(kind: IconKind) -> ksni::Icon {
+    match kind {
+        IconKind::Default => APP_ARGB.clone(),
+        IconKind::Connected => CONNECTED_ARGB.clone(),
+        IconKind::Connecting => CONNECTING_ARGB.clone(),
+        IconKind::Disconnected => DISCONNECTED_ARGB.clone(),
+        IconKind::Error => ERROR_ARGB.clone(),
     }
 }
 
 #[derive(Clone)]
-struct NymTray {
+pub(super) struct NymTray {
     app: AppHandle,
     icon: IconKind,
     show_hide: String,
@@ -124,7 +93,7 @@ impl ksni::Tray for NymTray {
     }
 
     fn icon_pixmap(&self) -> Vec<ksni::Icon> {
-        vec![self.icon.pixmap()]
+        vec![pixmap_for_kind(self.icon)]
     }
 
     fn activate(&mut self, _x: i32, _y: i32) {
@@ -217,65 +186,58 @@ pub(super) struct Backend {
 }
 
 impl Backend {
-    /// Probe for a StatusNotifierWatcher by attempting to bring up the ksni tray.
-    ///
-    /// Returns `Some` with a live handle when a watcher is available on the session
-    /// bus, or `None` when there is none so the caller can fall back to the
-    /// native XEmbed backend.
-    pub(super) fn try_new(app: &AppHandle) -> Option<Self> {
-        debug!("probing for StatusNotifierWatcher (ksni tray)");
-        let handle = Self::spawn_probe(app.clone())?;
-        Some(Self {
+    /// Build the ksni backend around an already-spawned handle (see
+    /// [`spawn_ksni_once`]). `entry_visible` seeds the mirror used to skip
+    /// redundant menu rebuilds and must match the spawned tray's state.
+    pub(super) fn from_handle(handle: Handle<NymTray>, entry_visible: bool) -> Self {
+        Self {
             handle,
             icon_debounce: Mutex::new(None),
-            entry_visible: Mutex::new(true),
-        })
+            entry_visible: Mutex::new(entry_visible),
+        }
     }
+}
 
-    // Drive the initial ksni connect/register to completion on a short-lived thread.
-    // Once `spawn()` succeeds the ksni service runs on its own async-io executor, so
-    // this thread is only needed to obtain the handle
-    fn spawn_probe(app: AppHandle) -> Option<Handle<NymTray>> {
-        std::thread::Builder::new()
-            .name("ksni-tray-probe".into())
-            .spawn(move || {
-                let tray = NymTray {
-                    app,
-                    icon: IconKind::Default,
-                    show_hide: "Show/Hide".into(),
-                    quit: "Quit (disconnect)".into(),
-                    status: "Status: Initial".into(),
-                    mode: "Mode: Initial".into(),
-                    entry: "Entry: Initial".into(),
-                    exit: "Exit: Initial".into(),
-                    entry_visible: true,
-                };
-                for attempt in 0..PROBE_ATTEMPTS {
-                    match futures::executor::block_on(tray.clone().spawn()) {
-                        Ok(h) => {
-                            debug!("ksni tray spawned (attempt {})", attempt + 1);
-                            return Some(h);
-                        }
-                        Err(e) => {
-                            trace!("ksni tray spawn attempt {} failed: {e:?}", attempt + 1);
-                        }
-                    }
-                    if attempt + 1 < PROBE_ATTEMPTS {
-                        std::thread::sleep(PROBE_INTERVAL);
-                    }
-                }
+/// Attempt to bring up the ksni tray once, seeded from `state`.
+///
+/// Returns `Some(handle)` when a StatusNotifierWatcher is available on the session
+/// bus, `None` otherwise. `ksni::spawn()` must be driven to completion (it then
+/// detaches its service onto its own async-io executor); we do that on a short-lived
+/// thread so this is safe to call from the main thread or a tokio runtime without
+/// risking a nested-runtime panic.
+pub(super) fn spawn_ksni_once(app: &AppHandle, state: &TrayState) -> Option<Handle<NymTray>> {
+    let tray = NymTray {
+        app: app.clone(),
+        icon: state.icon,
+        show_hide: state.show_hide.clone(),
+        quit: state.quit.clone(),
+        status: state.status.clone(),
+        mode: state.mode.clone(),
+        entry: state.entry.clone(),
+        exit: state.exit.clone(),
+        entry_visible: state.entry_visible,
+    };
+    std::thread::Builder::new()
+        .name("ksni-tray-spawn".into())
+        .spawn(move || match futures::executor::block_on(tray.spawn()) {
+            Ok(handle) => {
+                debug!("ksni tray spawned");
+                Some(handle)
+            }
+            Err(e) => {
+                trace!("ksni tray spawn failed: {e:?}");
                 None
-            })
-            .ok()?
-            .join()
-            .ok()
-            .flatten()
-    }
+            }
+        })
+        .ok()?
+        .join()
+        .ok()
+        .flatten()
 }
 
 impl TrayBackend for Backend {
     #[instrument(skip_all)]
-    async fn update_tray_icon(&self, state: TunnelState) {
+    async fn update_tray_icon(&self, icon: IconKind) {
         let mut pending = self.icon_debounce.lock().await;
         if let Some(h) = pending.take() {
             h.abort();
@@ -283,8 +245,7 @@ impl TrayBackend for Backend {
         let handle = self.handle.clone();
         *pending = Some(tokio::spawn(async move {
             tokio::time::sleep(ICON_DEBOUNCE).await;
-            let kind = IconKind::from(&state);
-            handle.update(move |t: &mut NymTray| t.icon = kind).await;
+            handle.update(move |t: &mut NymTray| t.icon = icon).await;
         }));
     }
 

--- a/nym-vpn-app/src-tauri/src/tray/linux.rs
+++ b/nym-vpn-app/src-tauri/src/tray/linux.rs
@@ -1,19 +1,23 @@
 //! Linux: ksni-based `StatusNotifierItem` backend.
 //!
-//! We avoid Tauri's tray-icon backend on Linux because its GTK implementation only calls
-//! `app_indicator_set_menu()`. There's no API to receive left-click separately from the
-//! menu open, so we can't bind left-click to "toggle window". ksni implements SNI
+//! We prefer this over Tauri's tray-icon backend on Linux because that GTK implementation
+//! only calls `app_indicator_set_menu()`. There's no API to receive left-click separately
+//! from the menu open, so we can't bind left-click to "toggle window". ksni implements SNI
 //! directly and exposes `activate` / `secondary_activate` callbacks.
+//!
+//! The catch is that SNI needs a `StatusNotifierWatcher` on the session bus, which minimal
+//! window managers like i3 don't provide. [`Backend::try_new`] probes for one and returns
+//! `None` when it's absent so the caller ([`super::Backend`]) can fall back to the native
+//! XEmbed backend.
 
-use std::sync::{Arc, LazyLock, Mutex as StdMutex};
+use std::sync::LazyLock;
 use std::time::Duration;
 
-use anyhow::Result;
 use image::ImageFormat;
 use ksni::{Handle, TrayMethods, menu::StandardItem};
 use tauri::AppHandle;
 use tokio::{sync::Mutex, task::JoinHandle};
-use tracing::{debug, instrument, trace, warn};
+use tracing::{debug, instrument, trace};
 
 use super::{TrayBackend, quit_app, show_window};
 use crate::vpnd::tunnel::TunnelState;
@@ -25,8 +29,13 @@ const DISCONNECTED_ICON: &[u8] = include_bytes!("../../icons/tray_icon_disconnec
 const ERROR_ICON: &[u8] = include_bytes!("../../icons/tray_icon_error.png");
 const ICON_DEBOUNCE: Duration = Duration::from_millis(300);
 
-const SPAWN_RETRY_INTERVAL: Duration = Duration::from_secs(10);
-const SPAWN_MAX_ATTEMPTS: u32 = 12;
+// Startup probe for a StatusNotifierWatcher. A watcher provided by a full desktop
+// is already registered before we launch, so the first attempt normally succeeds;
+// the couple of quick retries only absorb a watcher that is still coming up during
+// login. If none appears we return `None` promptly so the caller can fall back to
+// the native XEmbed backend instead of blocking startup.
+const PROBE_ATTEMPTS: u32 = 3;
+const PROBE_INTERVAL: Duration = Duration::from_millis(200);
 
 fn decode_argb(bytes: &[u8]) -> ksni::Icon {
     let img = image::load_from_memory_with_format(bytes, ImageFormat::Png)
@@ -197,175 +206,132 @@ impl ksni::Tray for NymTray {
 }
 
 pub(super) struct Backend {
-    // Source of truth for the tray's current contents. Kept in sync by every
-    // `update_tray_*` call regardless of whether the live tray exists yet, so a
-    // tray spawned late (see `spawn_with_retry`) reflects the real state instead
-    // of the initial defaults.
-    state: Arc<StdMutex<NymTray>>,
-    // Live ksni handle. `None` until the tray successfully spawns. SNI requires a
-    // StatusNotifierWatcher on the session bus.
-    // A background task keeps retrying and fills this in if a watcher appears.
-    handle: Arc<StdMutex<Option<Handle<NymTray>>>>,
+    // Live ksni handle. Always present: [`Backend::try_new`] only returns `Some`
+    // once the tray has successfully registered with a StatusNotifierWatcher, so
+    // every `update_*` call has a live tray to drive.
+    handle: Handle<NymTray>,
     icon_debounce: Mutex<Option<JoinHandle<()>>>,
+    // Mirrors the tray's entry visibility so we can skip redundant menu rebuilds
+    // (each `Handle::update` emits a D-Bus layout-changed signal).
+    entry_visible: Mutex<bool>,
 }
 
 impl Backend {
-    // Drives `ksni::spawn()` on a dedicated thread, retrying until it succeeds.
-    // A failed spawn is non-fatal if there is no StatusNotifierWatcher,
-    // so the first `spawn()` errors. Rather than crashing the app out of the setup hook,
-    // we log once and keep retrying in the background — picking up the tray if a watcher
-    // (panel/applet) appears later.
-    fn spawn_with_retry(
-        state: Arc<StdMutex<NymTray>>,
-        handle: Arc<StdMutex<Option<Handle<NymTray>>>>,
-    ) -> Result<()> {
-        std::thread::Builder::new()
-            .name("ksni-tray-init".into())
-            .spawn(move || {
-                for attempt in 0..SPAWN_MAX_ATTEMPTS {
-                    // Spawn from a snapshot of the current state, so a late spawn
-                    // reflects whatever updates landed while we were waiting.
-                    let snapshot = state.lock().unwrap().clone();
-                    match futures::executor::block_on(snapshot.spawn()) {
-                        Ok(h) => {
-                            debug!("ksni tray spawned (attempt {})", attempt + 1);
-                            *handle.lock().unwrap() = Some(h);
-                            return;
-                        }
-                        Err(e) if attempt == 0 => {
-                            warn!(
-                                "system tray unavailable, retrying in background \
-                                 every {}s ({} attempts): {e:?}",
-                                SPAWN_RETRY_INTERVAL.as_secs(),
-                                SPAWN_MAX_ATTEMPTS
-                            );
-                        }
-                        Err(e) => {
-                            trace!("ksni tray spawn retry {} failed: {e:?}", attempt + 1);
-                        }
-                    }
-                    // Don't sleep after the final attempt — give up promptly.
-                    if attempt + 1 < SPAWN_MAX_ATTEMPTS {
-                        std::thread::sleep(SPAWN_RETRY_INTERVAL);
-                    }
-                }
-                warn!(
-                    "no StatusNotifierWatcher appeared after {} attempts; \
-                     giving up, running without a system tray",
-                    SPAWN_MAX_ATTEMPTS
-                );
-            })?;
-        Ok(())
+    /// Probe for a StatusNotifierWatcher by attempting to bring up the ksni tray.
+    ///
+    /// Returns `Some` with a live handle when a watcher is available on the session
+    /// bus, or `None` when there is none so the caller can fall back to the
+    /// native XEmbed backend.
+    pub(super) fn try_new(app: &AppHandle) -> Option<Self> {
+        debug!("probing for StatusNotifierWatcher (ksni tray)");
+        let handle = Self::spawn_probe(app.clone())?;
+        Some(Self {
+            handle,
+            icon_debounce: Mutex::new(None),
+            entry_visible: Mutex::new(true),
+        })
     }
 
-    fn live_handle(&self) -> Option<Handle<NymTray>> {
-        self.handle.lock().unwrap().clone()
+    // Drive the initial ksni connect/register to completion on a short-lived thread.
+    // Once `spawn()` succeeds the ksni service runs on its own async-io executor, so
+    // this thread is only needed to obtain the handle
+    fn spawn_probe(app: AppHandle) -> Option<Handle<NymTray>> {
+        std::thread::Builder::new()
+            .name("ksni-tray-probe".into())
+            .spawn(move || {
+                let tray = NymTray {
+                    app,
+                    icon: IconKind::Default,
+                    show_hide: "Show/Hide".into(),
+                    quit: "Quit (disconnect)".into(),
+                    status: "Status: Initial".into(),
+                    mode: "Mode: Initial".into(),
+                    entry: "Entry: Initial".into(),
+                    exit: "Exit: Initial".into(),
+                    entry_visible: true,
+                };
+                for attempt in 0..PROBE_ATTEMPTS {
+                    match futures::executor::block_on(tray.clone().spawn()) {
+                        Ok(h) => {
+                            debug!("ksni tray spawned (attempt {})", attempt + 1);
+                            return Some(h);
+                        }
+                        Err(e) => {
+                            trace!("ksni tray spawn attempt {} failed: {e:?}", attempt + 1);
+                        }
+                    }
+                    if attempt + 1 < PROBE_ATTEMPTS {
+                        std::thread::sleep(PROBE_INTERVAL);
+                    }
+                }
+                None
+            })
+            .ok()?
+            .join()
+            .ok()
+            .flatten()
     }
 }
 
 impl TrayBackend for Backend {
-    fn new(app: &AppHandle) -> Result<Self> {
-        debug!("building ksni system tray");
-
-        let tray = NymTray {
-            app: app.clone(),
-            icon: IconKind::Default,
-            show_hide: "Show/Hide".into(),
-            quit: "Quit (disconnect)".into(),
-            status: "Status: Initial".into(),
-            mode: "Mode: Initial".into(),
-            entry: "Entry: Initial".into(),
-            exit: "Exit: Initial".into(),
-            entry_visible: true,
-        };
-
-        let state = Arc::new(StdMutex::new(tray));
-        let handle: Arc<StdMutex<Option<Handle<NymTray>>>> = Arc::new(StdMutex::new(None));
-
-        Self::spawn_with_retry(state.clone(), handle.clone())?;
-
-        Ok(Self {
-            state,
-            handle,
-            icon_debounce: Mutex::new(None),
-        })
-    }
-
     #[instrument(skip_all)]
     async fn update_tray_icon(&self, state: TunnelState) {
         let mut pending = self.icon_debounce.lock().await;
         if let Some(h) = pending.take() {
             h.abort();
         }
-        let cache = self.state.clone();
         let handle = self.handle.clone();
         *pending = Some(tokio::spawn(async move {
             tokio::time::sleep(ICON_DEBOUNCE).await;
             let kind = IconKind::from(&state);
-            cache.lock().unwrap().icon = kind;
-            let live = handle.lock().unwrap().clone();
-            if let Some(live) = live {
-                live.update(move |t: &mut NymTray| t.icon = kind).await;
-            }
+            handle.update(move |t: &mut NymTray| t.icon = kind).await;
         }));
     }
 
     async fn update_tray_show_hide(&self, show_hide: String) {
-        self.state.lock().unwrap().show_hide = show_hide.clone();
-        if let Some(handle) = self.live_handle() {
-            handle
-                .update(move |t: &mut NymTray| t.show_hide = show_hide)
-                .await;
-        }
+        self.handle
+            .update(move |t: &mut NymTray| t.show_hide = show_hide)
+            .await;
     }
 
     async fn update_tray_quit(&self, quit: String) {
-        self.state.lock().unwrap().quit = quit.clone();
-        if let Some(handle) = self.live_handle() {
-            handle.update(move |t: &mut NymTray| t.quit = quit).await;
-        }
+        self.handle
+            .update(move |t: &mut NymTray| t.quit = quit)
+            .await;
     }
 
     async fn update_tray_mode(&self, mode: String) {
-        self.state.lock().unwrap().mode = mode.clone();
-        if let Some(handle) = self.live_handle() {
-            handle.update(move |t: &mut NymTray| t.mode = mode).await;
-        }
+        self.handle
+            .update(move |t: &mut NymTray| t.mode = mode)
+            .await;
     }
 
     async fn update_tray_state(&self, state: String) {
-        self.state.lock().unwrap().status = state.clone();
-        if let Some(handle) = self.live_handle() {
-            handle.update(move |t: &mut NymTray| t.status = state).await;
-        }
+        self.handle
+            .update(move |t: &mut NymTray| t.status = state)
+            .await;
     }
 
     async fn update_tray_entry(&self, entry: String) {
-        self.state.lock().unwrap().entry = entry.clone();
-        if let Some(handle) = self.live_handle() {
-            handle.update(move |t: &mut NymTray| t.entry = entry).await;
-        }
+        self.handle
+            .update(move |t: &mut NymTray| t.entry = entry)
+            .await;
     }
 
     async fn update_tray_exit(&self, exit: String) {
-        self.state.lock().unwrap().exit = exit.clone();
-        if let Some(handle) = self.live_handle() {
-            handle.update(move |t: &mut NymTray| t.exit = exit).await;
-        }
+        self.handle
+            .update(move |t: &mut NymTray| t.exit = exit)
+            .await;
     }
 
     async fn update_tray_entry_visible(&self, visible: bool) {
-        {
-            let mut state = self.state.lock().unwrap();
-            if state.entry_visible == visible {
-                return;
-            }
-            state.entry_visible = visible;
+        let mut current = self.entry_visible.lock().await;
+        if *current == visible {
+            return;
         }
-        if let Some(handle) = self.live_handle() {
-            handle
-                .update(move |t: &mut NymTray| t.entry_visible = visible)
-                .await;
-        }
+        *current = visible;
+        self.handle
+            .update(move |t: &mut NymTray| t.entry_visible = visible)
+            .await;
     }
 }

--- a/nym-vpn-app/src-tauri/src/tray/mod.rs
+++ b/nym-vpn-app/src-tauri/src/tray/mod.rs
@@ -20,7 +20,6 @@ mod desktop;
 #[cfg(target_os = "linux")]
 mod linux;
 
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum IconKind {
     Default,
@@ -144,7 +143,6 @@ impl TrayBackend for Backend {
         update_tray_entry_visible(visible: bool),
     }
 }
-
 
 #[cfg(target_os = "linux")]
 #[derive(Clone)]

--- a/nym-vpn-app/src-tauri/src/tray/mod.rs
+++ b/nym-vpn-app/src-tauri/src/tray/mod.rs
@@ -1,5 +1,12 @@
+#[cfg(target_os = "linux")]
+use std::sync::Arc;
+#[cfg(target_os = "linux")]
+use std::time::Duration;
+
 use anyhow::Result;
 use tauri::{AppHandle, Manager};
+#[cfg(target_os = "linux")]
+use tokio::sync::Mutex;
 use tracing::{info, instrument, trace, warn};
 
 use crate::vpnd::tunnel::TunnelState;
@@ -13,8 +20,26 @@ mod desktop;
 #[cfg(target_os = "linux")]
 mod linux;
 
-#[cfg(not(target_os = "linux"))]
-use desktop::Backend;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum IconKind {
+    Default,
+    Connected,
+    Connecting,
+    Disconnected,
+    Error,
+}
+
+impl From<&TunnelState> for IconKind {
+    fn from(state: &TunnelState) -> Self {
+        match state {
+            TunnelState::Connected(_) => IconKind::Connected,
+            TunnelState::Connecting(_) | TunnelState::Disconnecting(_) => IconKind::Connecting,
+            TunnelState::Disconnected => IconKind::Disconnected,
+            TunnelState::Error(_) | TunnelState::Offline { .. } => IconKind::Error,
+        }
+    }
+}
 
 /// Platform-agnostic contract that every tray backend implements.
 ///
@@ -30,7 +55,7 @@ use desktop::Backend;
 /// Note this trait is intentionally private: it is consumed only through the [`TrayManager`]
 /// facade via static dispatch, so the async methods never need `Send` bounds added by callers.
 trait TrayBackend: Send + Sync {
-    async fn update_tray_icon(&self, state: TunnelState);
+    async fn update_tray_icon(&self, icon: IconKind);
     async fn update_tray_show_hide(&self, show_hide: String);
     async fn update_tray_quit(&self, quit: String);
     async fn update_tray_mode(&self, mode: String);
@@ -40,6 +65,52 @@ trait TrayBackend: Send + Sync {
     async fn update_tray_entry_visible(&self, visible: bool);
 }
 
+#[cfg(not(target_os = "linux"))]
+pub struct TrayManager(desktop::Backend);
+
+#[cfg(not(target_os = "linux"))]
+impl TrayManager {
+    pub fn new(app: &AppHandle) -> Result<Self> {
+        Ok(Self(desktop::Backend::new(app)?))
+    }
+
+    pub async fn update_tray_icon(&self, state: TunnelState) {
+        self.0.update_tray_icon(IconKind::from(&state)).await
+    }
+    pub async fn update_tray_show_hide(&self, show_hide: String) {
+        self.0.update_tray_show_hide(show_hide).await
+    }
+    pub async fn update_tray_quit(&self, quit: String) {
+        self.0.update_tray_quit(quit).await
+    }
+    pub async fn update_tray_mode(&self, mode: String) {
+        self.0.update_tray_mode(mode).await
+    }
+    pub async fn update_tray_state(&self, state: String) {
+        self.0.update_tray_state(state).await
+    }
+    pub async fn update_tray_entry(&self, entry: String) {
+        self.0.update_tray_entry(entry).await
+    }
+    pub async fn update_tray_exit(&self, exit: String) {
+        self.0.update_tray_exit(exit).await
+    }
+    pub async fn update_tray_entry_visible(&self, visible: bool) {
+        self.0.update_tray_entry_visible(visible).await
+    }
+}
+
+// ===========================================================================
+// Linux: pick ksni when a StatusNotifierWatcher exists, else the native XEmbed
+// backend; keep probing in the background and upgrade to ksni if a watcher
+// appears within UPGRADE_DEADLINE.
+// ===========================================================================
+
+#[cfg(target_os = "linux")]
+const UPGRADE_INTERVAL: Duration = Duration::from_millis(200);
+#[cfg(target_os = "linux")]
+const UPGRADE_DEADLINE: Duration = Duration::from_secs(120);
+
 #[cfg(target_os = "linux")]
 enum Backend {
     Ksni(linux::Backend),
@@ -47,128 +118,228 @@ enum Backend {
 }
 
 #[cfg(target_os = "linux")]
-impl Backend {
-    fn new(app: &AppHandle) -> Result<Self> {
-        match linux::Backend::try_new(app) {
-            Some(backend) => {
-                info!("system tray: StatusNotifierWatcher found, using ksni (SNI) backend");
-                Ok(Self::Ksni(backend))
+macro_rules! delegate_tray_backend {
+    ($($method:ident($arg:ident: $arg_ty:ty)),+ $(,)?) => {
+        $(
+            async fn $method(&self, $arg: $arg_ty) {
+                match self {
+                    Self::Ksni(b) => b.$method($arg).await,
+                    Self::Native(b) => b.$method($arg).await,
+                }
             }
-            None => {
-                warn!(
-                    "system tray: no StatusNotifierWatcher on the session bus (e.g. i3); \
-                     falling back to the native XEmbed tray — left-click opens the menu \
-                     instead of toggling the window. Run an SNI host such as snixembed \
-                     for the full experience."
-                );
-                Ok(Self::Native(Box::new(desktop::Backend::new(app)?)))
-            }
-        }
-    }
+        )+
+    };
 }
 
 #[cfg(target_os = "linux")]
 impl TrayBackend for Backend {
-    async fn update_tray_icon(&self, state: TunnelState) {
-        match self {
-            Self::Ksni(b) => b.update_tray_icon(state).await,
-            Self::Native(b) => b.update_tray_icon(state).await,
-        }
+    delegate_tray_backend! {
+        update_tray_icon(icon: IconKind),
+        update_tray_show_hide(show_hide: String),
+        update_tray_quit(quit: String),
+        update_tray_mode(mode: String),
+        update_tray_state(state: String),
+        update_tray_entry(entry: String),
+        update_tray_exit(exit: String),
+        update_tray_entry_visible(visible: bool),
     }
+}
 
-    async fn update_tray_show_hide(&self, show_hide: String) {
-        match self {
-            Self::Ksni(b) => b.update_tray_show_hide(show_hide).await,
-            Self::Native(b) => b.update_tray_show_hide(show_hide).await,
-        }
-    }
 
-    async fn update_tray_quit(&self, quit: String) {
-        match self {
-            Self::Ksni(b) => b.update_tray_quit(quit).await,
-            Self::Native(b) => b.update_tray_quit(quit).await,
-        }
-    }
+#[cfg(target_os = "linux")]
+#[derive(Clone)]
+struct TrayState {
+    icon: IconKind,
+    show_hide: String,
+    quit: String,
+    status: String,
+    mode: String,
+    entry: String,
+    exit: String,
+    entry_visible: bool,
+}
 
-    async fn update_tray_mode(&self, mode: String) {
-        match self {
-            Self::Ksni(b) => b.update_tray_mode(mode).await,
-            Self::Native(b) => b.update_tray_mode(mode).await,
-        }
-    }
-
-    async fn update_tray_state(&self, state: String) {
-        match self {
-            Self::Ksni(b) => b.update_tray_state(state).await,
-            Self::Native(b) => b.update_tray_state(state).await,
-        }
-    }
-
-    async fn update_tray_entry(&self, entry: String) {
-        match self {
-            Self::Ksni(b) => b.update_tray_entry(entry).await,
-            Self::Native(b) => b.update_tray_entry(entry).await,
-        }
-    }
-
-    async fn update_tray_exit(&self, exit: String) {
-        match self {
-            Self::Ksni(b) => b.update_tray_exit(exit).await,
-            Self::Native(b) => b.update_tray_exit(exit).await,
-        }
-    }
-
-    async fn update_tray_entry_visible(&self, visible: bool) {
-        match self {
-            Self::Ksni(b) => b.update_tray_entry_visible(visible).await,
-            Self::Native(b) => b.update_tray_entry_visible(visible).await,
+#[cfg(target_os = "linux")]
+impl Default for TrayState {
+    fn default() -> Self {
+        Self {
+            icon: IconKind::Default,
+            show_hide: "Show/Hide".into(),
+            quit: "Quit (disconnect)".into(),
+            status: "Status: Initial".into(),
+            mode: "Mode: Initial".into(),
+            entry: "Entry: Initial".into(),
+            exit: "Exit: Initial".into(),
+            entry_visible: true,
         }
     }
 }
 
 /// The system tray, managed as Tauri state and driven from `commands::tray`.
 ///
-/// Thin facade over the platform-selected [`Backend`]. The delegating bodies need no `cfg`
-/// because every backend exposes the same API through [`TrayBackend`]; the platform-specific
-/// code lives in the [`desktop`] / [`linux`] modules.
-pub struct TrayManager(Backend);
+/// On Linux the backend can be swapped at runtime (native XEmbed -> ksni) by the
+/// background upgrade task, so it lives behind a `Mutex`; `state` is the cache the
+/// upgraded ksni tray is seeded from.
+#[cfg(target_os = "linux")]
+pub struct TrayManager {
+    inner: Arc<Mutex<Backend>>,
+    state: Arc<Mutex<TrayState>>,
+}
 
+#[cfg(target_os = "linux")]
 impl TrayManager {
     pub fn new(app: &AppHandle) -> Result<Self> {
-        Ok(Self(Backend::new(app)?))
+        let state = TrayState::default();
+
+        // One instant ksni attempt, no retry sleeps: on a full desktop the
+        // StatusNotifierWatcher is already up, so this succeeds immediately and we
+        // never build the native tray or the upgrade task.
+        let backend = match linux::spawn_ksni_once(app, &state) {
+            Some(handle) => {
+                info!("system tray: StatusNotifierWatcher found, using ksni (SNI) backend");
+                Backend::Ksni(linux::Backend::from_handle(handle, state.entry_visible))
+            }
+            None => {
+                warn!(
+                    "system tray: no StatusNotifierWatcher on the session bus yet (e.g. i3); \
+                     Will upgrade to ksni if a watcher appears within {}s.",
+                    UPGRADE_DEADLINE.as_secs()
+                );
+                Backend::Native(Box::new(desktop::Backend::new(app)?))
+            }
+        };
+
+        let needs_upgrade = matches!(backend, Backend::Native(_));
+        let manager = Self {
+            inner: Arc::new(Mutex::new(backend)),
+            state: Arc::new(Mutex::new(state)),
+        };
+        if needs_upgrade {
+            Self::spawn_upgrade_task(app.clone(), manager.inner.clone(), manager.state.clone());
+        }
+        Ok(manager)
+    }
+
+    // Retry `ksni::spawn()` (seeded from the live cache) until a watcher appears or
+    // UPGRADE_DEADLINE elapses. On success, swap the native backend out for ksni,
+    // drop the native tray on the main thread (its Drop touches GTK), and re-seed
+    // the new tray from the latest cache.
+    fn spawn_upgrade_task(
+        app: AppHandle,
+        inner: Arc<Mutex<Backend>>,
+        state: Arc<Mutex<TrayState>>,
+    ) {
+        let spawned = std::thread::Builder::new()
+            .name("ksni-tray-upgrade".into())
+            .spawn(move || {
+                let start = std::time::Instant::now();
+                loop {
+                    let snapshot = state.blocking_lock().clone();
+                    if let Some(handle) = linux::spawn_ksni_once(&app, &snapshot) {
+                        info!(
+                            "system tray: StatusNotifierWatcher appeared, upgrading to ksni (SNI) backend"
+                        );
+                        let new_backend = Backend::Ksni(linux::Backend::from_handle(
+                            handle,
+                            snapshot.entry_visible,
+                        ));
+                        let old = {
+                            let mut guard = inner.blocking_lock();
+                            std::mem::replace(&mut *guard, new_backend)
+                        };
+                        let _ = app.run_on_main_thread(move || drop(old));
+                        let inner = inner.clone();
+                        let state = state.clone();
+                        tauri::async_runtime::spawn(async move {
+                            let guard = inner.lock().await;
+                            let snapshot = state.lock().await.clone();
+                            reseed(&guard, &snapshot).await;
+                        });
+                        return;
+                    }
+                    if start.elapsed() >= UPGRADE_DEADLINE {
+                        warn!(
+                            "system tray: no StatusNotifierWatcher appeared within {}s; \
+                             staying on the native XEmbed tray for this session",
+                            UPGRADE_DEADLINE.as_secs()
+                        );
+                        return;
+                    }
+                    std::thread::sleep(UPGRADE_INTERVAL);
+                }
+            });
+        if let Err(e) = spawned {
+            warn!("failed to start ksni upgrade probe thread: {e}");
+        }
     }
 
     pub async fn update_tray_icon(&self, state: TunnelState) {
-        self.0.update_tray_icon(state).await
+        let icon = IconKind::from(&state);
+        self.state.lock().await.icon = icon;
+        self.inner.lock().await.update_tray_icon(icon).await
     }
 
     pub async fn update_tray_show_hide(&self, show_hide: String) {
-        self.0.update_tray_show_hide(show_hide).await
+        self.state.lock().await.show_hide = show_hide.clone();
+        self.inner
+            .lock()
+            .await
+            .update_tray_show_hide(show_hide)
+            .await
     }
 
     pub async fn update_tray_quit(&self, quit: String) {
-        self.0.update_tray_quit(quit).await
+        self.state.lock().await.quit = quit.clone();
+        self.inner.lock().await.update_tray_quit(quit).await
     }
 
     pub async fn update_tray_mode(&self, mode: String) {
-        self.0.update_tray_mode(mode).await
+        self.state.lock().await.mode = mode.clone();
+        self.inner.lock().await.update_tray_mode(mode).await
     }
 
     pub async fn update_tray_state(&self, state: String) {
-        self.0.update_tray_state(state).await
+        self.state.lock().await.status = state.clone();
+        self.inner.lock().await.update_tray_state(state).await
     }
 
     pub async fn update_tray_entry(&self, entry: String) {
-        self.0.update_tray_entry(entry).await
+        self.state.lock().await.entry = entry.clone();
+        self.inner.lock().await.update_tray_entry(entry).await
     }
 
     pub async fn update_tray_exit(&self, exit: String) {
-        self.0.update_tray_exit(exit).await
+        self.state.lock().await.exit = exit.clone();
+        self.inner.lock().await.update_tray_exit(exit).await
     }
 
     pub async fn update_tray_entry_visible(&self, visible: bool) {
-        self.0.update_tray_entry_visible(visible).await
+        {
+            let mut state = self.state.lock().await;
+            if state.entry_visible == visible {
+                return;
+            }
+            state.entry_visible = visible;
+        }
+        self.inner
+            .lock()
+            .await
+            .update_tray_entry_visible(visible)
+            .await
     }
+}
+
+/// Push the full cache onto a backend (used to seed a freshly-upgraded ksni tray).
+#[cfg(target_os = "linux")]
+async fn reseed(backend: &Backend, state: &TrayState) {
+    backend.update_tray_show_hide(state.show_hide.clone()).await;
+    backend.update_tray_quit(state.quit.clone()).await;
+    backend.update_tray_state(state.status.clone()).await;
+    backend.update_tray_mode(state.mode.clone()).await;
+    backend.update_tray_entry(state.entry.clone()).await;
+    backend.update_tray_exit(state.exit.clone()).await;
+    backend.update_tray_entry_visible(state.entry_visible).await;
+    backend.update_tray_icon(state.icon).await;
 }
 
 // ---------------------------------------------------------------------------

--- a/nym-vpn-app/src-tauri/src/tray/mod.rs
+++ b/nym-vpn-app/src-tauri/src/tray/mod.rs
@@ -22,6 +22,7 @@ mod linux;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum IconKind {
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     Default,
     Connected,
     Connecting,

--- a/nym-vpn-app/src-tauri/src/tray/mod.rs
+++ b/nym-vpn-app/src-tauri/src/tray/mod.rs
@@ -7,26 +7,29 @@ use crate::{
     MAIN_WINDOW_LABEL, state::SharedAppState, vpnd::client::VpndClient, window::AppWindow,
 };
 
-#[cfg(not(target_os = "linux"))]
+// The native Tauri backend is compiled on every platform. On Linux it is the
+// runtime fallback used when there is no StatusNotifierWatcher for ksni to talk to.
 mod desktop;
 #[cfg(target_os = "linux")]
 mod linux;
 
 #[cfg(not(target_os = "linux"))]
 use desktop::Backend;
-#[cfg(target_os = "linux")]
-use linux::Backend;
 
 /// Platform-agnostic contract that every tray backend implements.
 ///
-/// Both the native Tauri backend (Windows/macOS, see [`desktop`]) and the ksni
-/// `StatusNotifierItem` backend (Linux, see [`linux`]) implement this, so the compiler
-/// rejects any signature drift between them — even though only one is compiled per target.
+/// The native Tauri backend ([`desktop`]) and the Linux ksni `StatusNotifierItem`
+/// backend ([`linux`]) both implement this, so the compiler rejects any signature
+/// drift between them. On Linux both are compiled and one is picked at runtime (see
+/// the Linux [`Backend`] enum below); on Windows/macOS only [`desktop`] is used.
+///
+/// Construction is intentionally *not* part of this trait: each backend has its own
+/// inherent constructor, because the Linux [`Backend`] enum decides which inner
+/// backend to build only after probing the session bus for a StatusNotifierWatcher.
 ///
 /// Note this trait is intentionally private: it is consumed only through the [`TrayManager`]
 /// facade via static dispatch, so the async methods never need `Send` bounds added by callers.
-trait TrayBackend: Sized + Send + Sync {
-    fn new(app: &AppHandle) -> Result<Self>;
+trait TrayBackend: Send + Sync {
     async fn update_tray_icon(&self, state: TunnelState);
     async fn update_tray_show_hide(&self, show_hide: String);
     async fn update_tray_quit(&self, quit: String);
@@ -35,6 +38,92 @@ trait TrayBackend: Sized + Send + Sync {
     async fn update_tray_entry(&self, entry: String);
     async fn update_tray_exit(&self, exit: String);
     async fn update_tray_entry_visible(&self, visible: bool);
+}
+
+#[cfg(target_os = "linux")]
+enum Backend {
+    Ksni(linux::Backend),
+    Native(Box<desktop::Backend>),
+}
+
+#[cfg(target_os = "linux")]
+impl Backend {
+    fn new(app: &AppHandle) -> Result<Self> {
+        match linux::Backend::try_new(app) {
+            Some(backend) => {
+                info!("system tray: StatusNotifierWatcher found, using ksni (SNI) backend");
+                Ok(Self::Ksni(backend))
+            }
+            None => {
+                warn!(
+                    "system tray: no StatusNotifierWatcher on the session bus (e.g. i3); \
+                     falling back to the native XEmbed tray — left-click opens the menu \
+                     instead of toggling the window. Run an SNI host such as snixembed \
+                     for the full experience."
+                );
+                Ok(Self::Native(Box::new(desktop::Backend::new(app)?)))
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl TrayBackend for Backend {
+    async fn update_tray_icon(&self, state: TunnelState) {
+        match self {
+            Self::Ksni(b) => b.update_tray_icon(state).await,
+            Self::Native(b) => b.update_tray_icon(state).await,
+        }
+    }
+
+    async fn update_tray_show_hide(&self, show_hide: String) {
+        match self {
+            Self::Ksni(b) => b.update_tray_show_hide(show_hide).await,
+            Self::Native(b) => b.update_tray_show_hide(show_hide).await,
+        }
+    }
+
+    async fn update_tray_quit(&self, quit: String) {
+        match self {
+            Self::Ksni(b) => b.update_tray_quit(quit).await,
+            Self::Native(b) => b.update_tray_quit(quit).await,
+        }
+    }
+
+    async fn update_tray_mode(&self, mode: String) {
+        match self {
+            Self::Ksni(b) => b.update_tray_mode(mode).await,
+            Self::Native(b) => b.update_tray_mode(mode).await,
+        }
+    }
+
+    async fn update_tray_state(&self, state: String) {
+        match self {
+            Self::Ksni(b) => b.update_tray_state(state).await,
+            Self::Native(b) => b.update_tray_state(state).await,
+        }
+    }
+
+    async fn update_tray_entry(&self, entry: String) {
+        match self {
+            Self::Ksni(b) => b.update_tray_entry(entry).await,
+            Self::Native(b) => b.update_tray_entry(entry).await,
+        }
+    }
+
+    async fn update_tray_exit(&self, exit: String) {
+        match self {
+            Self::Ksni(b) => b.update_tray_exit(exit).await,
+            Self::Native(b) => b.update_tray_exit(exit).await,
+        }
+    }
+
+    async fn update_tray_entry_visible(&self, visible: bool) {
+        match self {
+            Self::Ksni(b) => b.update_tray_entry_visible(visible).await,
+            Self::Native(b) => b.update_tray_entry_visible(visible).await,
+        }
+    }
 }
 
 /// The system tray, managed as Tauri state and driven from `commands::tray`.

--- a/nym-vpn-core/crates/nym-connection-monitor/src/connection_monitor.rs
+++ b/nym-vpn-core/crates/nym-connection-monitor/src/connection_monitor.rs
@@ -323,8 +323,10 @@ mod tests {
     use tokio_util::sync::DropGuard;
 
     use super::*;
-    use crate::BoxedProbeError;
-    use crate::mock_probe::{MockProbe, MockProbeError, Outcome};
+    use crate::{
+        BoxedProbeError,
+        mock_probe::{MockProbe, MockProbeError, Outcome},
+    };
 
     const PROBE_RETRY_COUNT: u32 = 3;
     const INITIAL_PROBE_TIMEOUT: Duration = Duration::from_secs(3);


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

The Linux tray was migrated to ksni, which speaks only the SNI D-Bus protocol. i3 provides no StatusNotifierWatcher, so the icon never showed. The old default (libayatana) worked because it falls back to XEmbed, which i3bar supports.

On Linux the tray backend is now chosen at runtime — ksni when an SNI watcher exists (KDE/GNOME, keeps left-click toggle), otherwise the native Tauri/libayatana backend (XEmbed, shows on i3; left-click opens the menu).

Changes:
- mod.rs — native desktop backend now compiled on all platforms; new Linux Backend enum (Ksni / boxed Native) probes for a watcher in new() and picks accordingly. TrayBackend trait lost new (per-backend inherent construction) but keeps the 8 update methods for compile-time parity.
- linux.rs — replaced the 2-min background retry with a fast try_new/spawn_probe: attempts ksni::spawn() (errors instantly with no watcher) → returns Some(handle) or None. Simplified state to just the live handle.
- desktop.rs — new made inherent; dropped the app field + TrayManager round-trip (icon task now owns a cloned TrayIcon).


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5773)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved tray handling on Linux by selecting the best available backend and upgrading automatically when it becomes possible.
  * Tray icon updates are now consistently derived from the connection state for clearer, more predictable visuals.

* **Bug Fixes**
  * More reliable tray icon updates during rapid tunnel state changes, with debounced updates applied cleanly.
  * Improved tray startup resilience through bounded probing and graceful fallback.
  * Enhanced responsiveness and deduping for tray menu/visibility updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->