### PR TITLE
Restore Settings killswitch toggle responsiveness on macOS

### DIFF
--- a/nym-vpn-apple/Settings/Sources/Settings/SettingsView.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/SettingsView.swift
@@ -64,7 +64,6 @@ private extension SettingsView {
 #endif
             Task {
                 await credentialsManager.updateAccountSummary()
-                viewModel.reloadSections()
             }
         }
     }

--- a/nym-vpn-apple/Settings/Sources/Settings/SettingsViewModel.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/SettingsViewModel.swift
@@ -215,6 +215,17 @@ private extension SettingsViewModel {
             self?.reloadSections()
         }
         .store(in: &cancellables)
+
+        Publishers.Merge3(
+            appSettings.$isAdBlockerEnabledPublisher,
+            appSettings.$isIPv6TrafficEnabledPublisher,
+            appSettings.$isLanBypassEnabledPublisher
+        )
+        .receive(on: DispatchQueue.main)
+        .sink { [weak self] _ in
+            self?.objectWillChange.send()
+        }
+        .store(in: &cancellables)
     }
 
     func setupCredentialManagerObservers() {
@@ -231,10 +242,23 @@ private extension SettingsViewModel {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 MainActor.assumeIsolated {
-                    self?.reloadSections()
+                    self?.updateAccountSectionOnly()
                 }
             }
             .store(in: &cancellables)
+    }
+
+    func updateAccountSectionOnly() {
+        guard appSettings.isCredentialImported else {
+            sections.removeAll { $0.kind == .account }
+            return
+        }
+        let updated = accountSection()
+        if let index = sections.firstIndex(where: { $0.kind == .account }) {
+            sections[index] = updated
+        } else {
+            sections.insert(updated, at: 0)
+        }
     }
 
     /// Configures sections, to reload all the content - use reloadSections
@@ -408,8 +432,8 @@ private extension SettingsViewModel {
         let adBlockViewModel = SettingsListItemViewModel(
             accessory: .toggle(
                 isOn: Binding(
-                    get: { [weak appSettings] in appSettings?.isAdBlockerEnabled ?? false },
-                    set: { [weak connectionManager] in connectionManager?.setAdBlocking($0) }
+                    get: { [appSettings] in appSettings.isAdBlockerEnabled },
+                    set: { [connectionManager] newValue in connectionManager.setAdBlocking(newValue) }
                 )
             ),
             title: "settings.adblock.title".localizedString,
@@ -434,8 +458,8 @@ private extension SettingsViewModel {
             SettingsListItemViewModel(
                 accessory: .toggle(
                     isOn: Binding(
-                        get: { [weak appSettings] in appSettings?.isIPv6TrafficEnabled ?? true },
-                        set: { [weak connectionManager] in connectionManager?.setIPv6TrafficEnabled($0) }
+                        get: { [appSettings] in appSettings.isIPv6TrafficEnabled },
+                        set: { [connectionManager] newValue in connectionManager.setIPv6TrafficEnabled(newValue) }
                     )
                 ),
                 title: "settings.ipv6.title".localizedString,
@@ -449,8 +473,8 @@ private extension SettingsViewModel {
             SettingsListItemViewModel(
                 accessory: .toggle(
                     isOn: Binding(
-                        get: { [weak appSettings] in appSettings?.isLanBypassEnabled ?? false },
-                        set: { [weak connectionManager] in connectionManager?.setLanBypassEnabled($0) }
+                        get: { [appSettings] in appSettings.isLanBypassEnabled },
+                        set: { [connectionManager] newValue in connectionManager.setLanBypassEnabled(newValue) }
                     )
                 ),
                 title: "settings.lanBypass.title".localizedString,

--- a/nym-vpn-apple/Settings/Tests/SettingsTests/SettingsKillswitchSectionReloadTests.swift
+++ b/nym-vpn-apple/Settings/Tests/SettingsTests/SettingsKillswitchSectionReloadTests.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+import XCTest
+import AppSettings
+import ConfigurationManager
+import ConnectionManager
+import ConnectionTypes
+import CredentialsManager
+import ExternalLinkManager
+import FeatureFlagsManager
+import ImpactGenerator
+#if os(iOS)
+import PurchasesManager
+#endif
+@testable import Settings
+
+@MainActor
+final class SettingsKillswitchSectionReloadTests: XCTestCase {
+    private func makeViewModel() -> SettingsViewModel {
+#if os(macOS)
+        SettingsViewModel(
+            isServing: .constant(true),
+            path: .constant(NavigationPath()),
+            appSettings: .shared,
+            configurationManager: .shared,
+            connectionManager: .shared,
+            credentialsManager: .shared,
+            externalLinkManager: .shared,
+            featureFlagsManager: .shared,
+            impactGenerator: .shared
+        )
+#else
+        SettingsViewModel(
+            path: .constant(NavigationPath()),
+            appSettings: .shared,
+            configurationManager: .shared,
+            connectionManager: .shared,
+            credentialsManager: .shared,
+            externalLinkManager: .shared,
+            featureFlagsManager: .shared,
+            impactGenerator: .shared,
+            purchasesManager: .shared
+        )
+#endif
+    }
+
+    func testAccountSectionUpdatePreservesKillSwitchSection() async {
+        let viewModel = makeViewModel()
+        await waitForSections(viewModel)
+
+        let killSwitchCountBefore = viewModel.sections.first { $0.kind == .killSwitch }?.viewModels.count
+        XCTAssertNotNil(killSwitchCountBefore)
+
+        AppSettings.shared.isCredentialImported = true
+        CredentialsManager.shared.accountSummary = AccountSummary.makeFake(
+            daysRemaining: 30,
+            kind: .oneMonth,
+            isAutoRenew: true,
+            baseAddress: "test"
+        )
+        viewModel.updateAccountSectionOnly()
+
+        let killSwitchCountAfter = viewModel.sections.first { $0.kind == .killSwitch }?.viewModels.count
+        XCTAssertEqual(killSwitchCountBefore, killSwitchCountAfter)
+        XCTAssertNotNil(viewModel.sections.first { $0.kind == .account })
+    }
+
+    private func waitForSections(_ viewModel: SettingsViewModel) async {
+        for _ in 0..<50 where viewModel.sections.isEmpty {
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+        XCTAssertFalse(viewModel.sections.isEmpty)
+    }
+}

--- a/nym-vpn-apple/Settings/Tests/SettingsTests/SettingsToggleBindingTests.swift
+++ b/nym-vpn-apple/Settings/Tests/SettingsTests/SettingsToggleBindingTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+import AppSettings
+import ConnectionManager
+@testable import Settings
+
+@MainActor
+final class SettingsToggleBindingTests: XCTestCase {
+    func testSetAdBlockingUpdatesAppSettings() {
+        let settings = AppSettings.shared
+        let prior = settings.isAdBlockerEnabled
+        defer { settings.isAdBlockerEnabled = prior }
+
+        ConnectionManager.shared.setAdBlocking(true)
+        XCTAssertTrue(settings.isAdBlockerEnabled)
+
+        ConnectionManager.shared.setAdBlocking(false)
+        XCTAssertFalse(settings.isAdBlockerEnabled)
+    }
+
+    func testSetLanBypassUpdatesAppSettings() {
+        let settings = AppSettings.shared
+        let prior = settings.isLanBypassEnabled
+        defer { settings.isLanBypassEnabled = prior }
+
+        ConnectionManager.shared.setLanBypassEnabled(true)
+        XCTAssertTrue(settings.isLanBypassEnabled)
+
+        ConnectionManager.shared.setLanBypassEnabled(false)
+        XCTAssertFalse(settings.isLanBypassEnabled)
+    }
+}


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5780)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Settings now refresh more selectively, improving responsiveness when account status or VPN-related toggles change.
  * Credential status updates no longer trigger a full settings reload, helping preserve the current sections shown on screen.
  * Ad Blocker, IPv6 Traffic, and LAN Bypass toggles now stay in sync more reliably with your settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->