### PR TITLE
Cherry pick macos UI login session

### DIFF
--- a/nym-vpn-apple/Home/Sources/26/PassphraseSignIn/PassphraseSignInCredentialStore.swift
+++ b/nym-vpn-apple/Home/Sources/26/PassphraseSignIn/PassphraseSignInCredentialStore.swift
@@ -1,0 +1,18 @@
+import CredentialsManager
+
+@MainActor
+protocol PassphraseSignInCredentialStore: AnyObject {
+    func storeLoginCredential(_ credential: String) async throws
+    func isAccountActive() -> Bool
+    func updateAccountSummary(force: Bool, untilActive: Bool) async
+}
+
+extension CredentialsManager: PassphraseSignInCredentialStore {
+    func storeLoginCredential(_ credential: String) async throws {
+#if os(iOS)
+        try await performAccountRegistration(loginCredential: credential)
+#else
+        try await add(credential: credential)
+#endif
+    }
+}

--- a/nym-vpn-apple/Home/Sources/26/PassphraseSignIn/PassphraseSignInViewModel.swift
+++ b/nym-vpn-apple/Home/Sources/26/PassphraseSignIn/PassphraseSignInViewModel.swift
@@ -14,7 +14,7 @@ public final class PassphraseSignInViewModel {
         case failed
     }
 
-    private let credentialsManager: CredentialsManager
+    private let credentialStore: PassphraseSignInCredentialStore
     @ObservationIgnored private var loginTask: Task<Void, Never>?
     @ObservationIgnored public weak var sessionCoordinator: AppSessionCoordinating?
 
@@ -29,10 +29,15 @@ public final class PassphraseSignInViewModel {
     var submissionState: SubmissionState = .idle
 
     public init(credentialsManager: CredentialsManager) {
-        self.credentialsManager = credentialsManager
+        self.credentialStore = credentialsManager
+    }
+
+    init(credentialStore: PassphraseSignInCredentialStore) {
+        self.credentialStore = credentialStore
     }
 
     func loginButtonTapped() {
+        guard submissionState != .loading else { return }
         let credential = passphraseText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !credential.isEmpty else { return }
         submissionState = .loading
@@ -43,23 +48,16 @@ public final class PassphraseSignInViewModel {
                 sessionCoordinator?.handle(
                     .session(.authWillBegin(flow: .login, completesOnCredentialImport: false))
                 )
-#if os(iOS)
-                try await credentialsManager.performAccountRegistration(loginCredential: credential)
+                try await credentialStore.storeLoginCredential(credential)
                 let outcome = await AuthCompletionOutcomeResolver.resolveAfterLoginRegistration(
-                    isAccountActive: { self.credentialsManager.isAccountActive() },
+                    isAccountActive: { self.credentialStore.isAccountActive() },
                     updateAccountSummary: {
-                        await self.credentialsManager.updateAccountSummary(force: true, untilActive: false)
+                        await self.credentialStore.updateAccountSummary(force: true, untilActive: false)
                     }
                 )
                 sessionCoordinator?.handle(
                     .session(.authCompleted(outcome: outcome, flow: .login))
                 )
-#else
-                try await credentialsManager.add(credential: credential)
-                try await credentialsManager.registerAccount()
-                passphraseText = ""
-                submissionState = .idle
-#endif
             } catch is CancellationError {
                 sessionCoordinator?.handle(.session(.authHandoffCancelled))
                 submissionState = .idle

--- a/nym-vpn-apple/Home/Sources/26/PassphraseSignIn/PassphraseSignInViewModel.swift
+++ b/nym-vpn-apple/Home/Sources/26/PassphraseSignIn/PassphraseSignInViewModel.swift
@@ -74,4 +74,8 @@ public final class PassphraseSignInViewModel {
             }
         }
     }
+
+    func waitForLoginTask() async {
+        await loginTask?.value
+    }
 }

--- a/nym-vpn-apple/Home/Tests/HomeTests/PassphraseSignInViewModelTests.swift
+++ b/nym-vpn-apple/Home/Tests/HomeTests/PassphraseSignInViewModelTests.swift
@@ -1,0 +1,149 @@
+import Foundation
+import Testing
+import AccountPrefetchGates
+@testable import Home
+
+@MainActor
+private final class FakePassphraseSignInCredentialStore: PassphraseSignInCredentialStore {
+    enum Failure: Error {
+        case storeFailed
+    }
+
+    var storeError: Error?
+    var accountActive = true
+    private(set) var storedCredentials: [String] = []
+    private(set) var summarySyncCount = 0
+
+    func storeLoginCredential(_ credential: String) async throws {
+        if let storeError {
+            throw storeError
+        }
+        storedCredentials.append(credential)
+    }
+
+    func isAccountActive() -> Bool {
+        accountActive
+    }
+
+    func updateAccountSummary(force: Bool, untilActive: Bool) async {
+        summarySyncCount += 1
+    }
+}
+
+@MainActor
+private final class FakePassphraseSignInCoordinator: AppSessionCoordinating {
+    private(set) var actions: [CoordinatorAction] = []
+
+    func handle(_ action: CoordinatorAction) {
+        actions.append(action)
+    }
+}
+
+@MainActor
+private enum PassphraseSignInTestSupport {
+    static func firstAuthWillBegin(
+        from actions: [CoordinatorAction]
+    ) -> (AuthFlowKind, Bool)? {
+        guard case let .session(.authWillBegin(flow, completesOnImport)) = actions.first else {
+            return nil
+        }
+        return (flow, completesOnImport)
+    }
+
+    static func lastAuthCompleted(
+        from actions: [CoordinatorAction]
+    ) -> (AuthCompletionOutcome, AuthFlowKind)? {
+        guard case let .session(.authCompleted(outcome, flow)) = actions.last else {
+            return nil
+        }
+        return (outcome, flow)
+    }
+}
+
+@MainActor
+struct PassphraseSignInViewModelTests {
+    @Test func successfulLoginEmitsAuthCompletedOnce() async {
+        let store = FakePassphraseSignInCredentialStore()
+        store.accountActive = true
+        let coordinator = FakePassphraseSignInCoordinator()
+        let viewModel = PassphraseSignInViewModel(credentialStore: store)
+        viewModel.sessionCoordinator = coordinator
+        viewModel.passphraseText = "alpha beta gamma"
+
+        viewModel.loginButtonTapped()
+        try? await Task.sleep(for: .milliseconds(50))
+
+        #expect(store.storedCredentials == ["alpha beta gamma"])
+        #expect(store.summarySyncCount == 1)
+        #expect(store.storedCredentials.count == 1)
+
+        let begin = PassphraseSignInTestSupport.firstAuthWillBegin(from: coordinator.actions)
+        #expect(begin?.0 == .login)
+        #expect(begin?.1 == false)
+
+        let completed = PassphraseSignInTestSupport.lastAuthCompleted(from: coordinator.actions)
+        #expect(completed?.0 == .loginReady)
+        #expect(completed?.1 == .login)
+        #expect(coordinator.actions.count == 2)
+    }
+
+    @Test func inactiveAccountEmitsRegisteredNeedsPurchase() async {
+        let store = FakePassphraseSignInCredentialStore()
+        store.accountActive = false
+        let coordinator = FakePassphraseSignInCoordinator()
+        let viewModel = PassphraseSignInViewModel(credentialStore: store)
+        viewModel.sessionCoordinator = coordinator
+        viewModel.passphraseText = "alpha beta gamma"
+
+        viewModel.loginButtonTapped()
+        try? await Task.sleep(for: .milliseconds(50))
+
+        let completed = PassphraseSignInTestSupport.lastAuthCompleted(from: coordinator.actions)
+        #expect(completed?.0 == .registeredNeedsPurchase)
+        #expect(completed?.1 == .login)
+    }
+
+    @Test func secondSubmitWhileLoadingIsIgnored() async {
+        let store = FakePassphraseSignInCredentialStore()
+        store.accountActive = true
+        let coordinator = FakePassphraseSignInCoordinator()
+        let viewModel = PassphraseSignInViewModel(credentialStore: store)
+        viewModel.sessionCoordinator = coordinator
+        viewModel.passphraseText = "alpha beta gamma"
+
+        viewModel.loginButtonTapped()
+        #expect(viewModel.submissionState == .loading)
+
+        viewModel.loginButtonTapped()
+        try? await Task.sleep(for: .milliseconds(50))
+
+        #expect(store.storedCredentials == ["alpha beta gamma"])
+        #expect(coordinator.actions.count == 2)
+    }
+
+    @Test func storeFailureCancelsHandoffWithoutSecondStore() async {
+        let store = FakePassphraseSignInCredentialStore()
+        store.storeError = FakePassphraseSignInCredentialStore.Failure.storeFailed
+        let coordinator = FakePassphraseSignInCoordinator()
+        let viewModel = PassphraseSignInViewModel(credentialStore: store)
+        viewModel.sessionCoordinator = coordinator
+        viewModel.passphraseText = "alpha beta gamma"
+
+        viewModel.loginButtonTapped()
+        try? await Task.sleep(for: .milliseconds(50))
+
+        #expect(store.storedCredentials.isEmpty)
+        #expect(viewModel.submissionState == .failed)
+        guard case .session(.authHandoffCancelled) = coordinator.actions.last else {
+            Issue.record("Expected authHandoffCancelled")
+            return
+        }
+        let hasAuthCompleted = coordinator.actions.contains { action in
+            if case .session(.authCompleted) = action {
+                return true
+            }
+            return false
+        }
+        #expect(!hasAuthCompleted)
+    }
+}

--- a/nym-vpn-apple/Home/Tests/HomeTests/PassphraseSignInViewModelTests.swift
+++ b/nym-vpn-apple/Home/Tests/HomeTests/PassphraseSignInViewModelTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 import AccountPrefetchGates
+import CredentialsManager
 @testable import Home
 
 @MainActor
@@ -62,6 +63,11 @@ private enum PassphraseSignInTestSupport {
 
 @MainActor
 struct PassphraseSignInViewModelTests {
+    @Test func credentialsManagerConformsToPassphraseSignInCredentialStore() {
+        let store: PassphraseSignInCredentialStore = CredentialsManager.shared
+        _ = store.isAccountActive()
+    }
+
     @Test func successfulLoginEmitsAuthCompletedOnce() async {
         let store = FakePassphraseSignInCredentialStore()
         store.accountActive = true
@@ -71,7 +77,7 @@ struct PassphraseSignInViewModelTests {
         viewModel.passphraseText = "alpha beta gamma"
 
         viewModel.loginButtonTapped()
-        try? await Task.sleep(for: .milliseconds(50))
+        await viewModel.waitForLoginTask()
 
         #expect(store.storedCredentials == ["alpha beta gamma"])
         #expect(store.summarySyncCount == 1)
@@ -96,7 +102,7 @@ struct PassphraseSignInViewModelTests {
         viewModel.passphraseText = "alpha beta gamma"
 
         viewModel.loginButtonTapped()
-        try? await Task.sleep(for: .milliseconds(50))
+        await viewModel.waitForLoginTask()
 
         let completed = PassphraseSignInTestSupport.lastAuthCompleted(from: coordinator.actions)
         #expect(completed?.0 == .registeredNeedsPurchase)
@@ -115,7 +121,7 @@ struct PassphraseSignInViewModelTests {
         #expect(viewModel.submissionState == .loading)
 
         viewModel.loginButtonTapped()
-        try? await Task.sleep(for: .milliseconds(50))
+        await viewModel.waitForLoginTask()
 
         #expect(store.storedCredentials == ["alpha beta gamma"])
         #expect(coordinator.actions.count == 2)
@@ -130,7 +136,7 @@ struct PassphraseSignInViewModelTests {
         viewModel.passphraseText = "alpha beta gamma"
 
         viewModel.loginButtonTapped()
-        try? await Task.sleep(for: .milliseconds(50))
+        await viewModel.waitForLoginTask()
 
         #expect(store.storedCredentials.isEmpty)
         #expect(viewModel.submissionState == .failed)

--- a/nym-vpn-apple/Services/Tests/CredentialsManagerTests/AppSessionReducerTests.swift
+++ b/nym-vpn-apple/Services/Tests/CredentialsManagerTests/AppSessionReducerTests.swift
@@ -182,6 +182,58 @@ struct AppSessionReducerTests {
         #expect(!finishResult.context.isPurchaseFlowActive)
     }
 
+    // Passphrase login: authWillBegin(completesOnCredentialImport: false) must still
+    // complete via authCompleted and route to login processing (macOS parity).
+    @Test func passphraseLoginHandoff_completesOnAuthCompleted() {
+        var context = AppSessionContext.initial
+        let env = AppSessionEnvironment(
+            isCredentialImported: true,
+            welcomeScreenDidDisplay: true,
+            isAccountActive: true
+        )
+
+        context = AppSessionReducer.reduce(
+            context: context,
+            environment: env,
+            event: .authWillBegin(flow: .login, completesOnCredentialImport: false)
+        ).context
+        #expect(context.pendingAuthFlow == .login)
+        #expect(!context.authHandoffCompleted)
+
+        let result = AppSessionReducer.reduce(
+            context: context,
+            environment: env,
+            event: .authCompleted(outcome: .loginReady, flow: .login)
+        )
+
+        #expect(result.context.authHandoffCompleted)
+        #expect(result.context.pendingAuthFlow == nil)
+        #expect(result.authRoute == .startProcessing(.login))
+    }
+
+    @Test func passphraseLoginHandoff_inactiveAccountStartsLoginProcessing() {
+        var context = AppSessionContext.initial
+        let env = AppSessionEnvironment(
+            isCredentialImported: true,
+            welcomeScreenDidDisplay: true,
+            isAccountActive: false
+        )
+
+        context = AppSessionReducer.reduce(
+            context: context,
+            environment: env,
+            event: .authWillBegin(flow: .login, completesOnCredentialImport: false)
+        ).context
+
+        let result = AppSessionReducer.reduce(
+            context: context,
+            environment: env,
+            event: .authCompleted(outcome: .registeredNeedsPurchase, flow: .login)
+        )
+
+        #expect(result.authRoute == .startProcessing(.login))
+    }
+
     @Test func authCompleted_isIdempotentAfterHandoffCompletes() {
         var context = AppSessionContext.initial
         context.authHandoffCompleted = true

--- a/nym-vpn-apple/Services/Tests/CredentialsManagerTests/CredentialsManagerMacOSRegistrationTests.swift
+++ b/nym-vpn-apple/Services/Tests/CredentialsManagerTests/CredentialsManagerMacOSRegistrationTests.swift
@@ -1,0 +1,12 @@
+#if os(macOS)
+import Foundation
+import Testing
+@testable import CredentialsManager
+
+@MainActor
+struct CredentialsManagerMacOSRegistrationTests {
+    @Test func registerAccountIsNoOpOnMacOS() async throws {
+        try await CredentialsManager.shared.registerAccount()
+    }
+}
+#endif

--- a/nym-vpn-apple/Settings/Sources/Settings/Credenitals/AddCredentials/AddCredentialsViewModel.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/Credenitals/AddCredentials/AddCredentialsViewModel.swift
@@ -102,7 +102,7 @@ import Theme
                 try await credentialsManager.performAccountRegistration(loginCredential: trimmedCredential)
 #elseif os(macOS)
                 try await credentialsManager.add(credential: trimmedCredential)
-                try await credentialsManager.registerAccount()
+                await credentialsManager.updateAccountSummary(force: true, untilActive: false)
 #endif
                 error = CredentialsManagerError.noError
                 credentialsDidAdd()

--- a/nym-vpn-apple/Settings/Sources/Settings/Credenitals/AddCredentials/AddCredentialsViewModel.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/Credenitals/AddCredentials/AddCredentialsViewModel.swift
@@ -101,6 +101,7 @@ import Theme
 #if os(iOS)
                 try await credentialsManager.performAccountRegistration(loginCredential: trimmedCredential)
 #elseif os(macOS)
+                // add → grpc storeAccount persists the mnemonic on the daemon; registerAccount() is iOS-only.
                 try await credentialsManager.add(credential: trimmedCredential)
                 await credentialsManager.updateAccountSummary(force: true, untilActive: false)
 #endif


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5781)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved passphrase sign-in flow to handle credential saving and account status updates more consistently across platforms.
  * Added support for refreshing account summary after importing credentials on macOS.

* **Bug Fixes**
  * Fixed sign-in completion behavior when an account is inactive.
  * Prevented duplicate submit actions while a login is already in progress.
  * Ensured failed credential storage stops the sign-in handoff cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->