### PR TITLE
iOS logout speed and phase feedback after manual VPN disconnect

### DIFF
--- a/nym-vpn-apple/Services/Package.swift
+++ b/nym-vpn-apple/Services/Package.swift
@@ -93,6 +93,7 @@ let package = Package(
             dependencies: [
                 "CredentialsManager",
                 .product(name: "ConnectionTypes", package: "ServicesMutual"),
+                .product(name: "TunnelStatus", package: "ServicesMutual"),
                 "GatewayManager",
                 "NotificationMessages",
                 "Tunnels",

--- a/nym-vpn-apple/Services/Sources/Services/ConnectionManager/ConnectionManager.swift
+++ b/nym-vpn-apple/Services/Sources/Services/ConnectionManager/ConnectionManager.swift
@@ -117,12 +117,32 @@ import GRPCManager
     /// Disconnects tunnel if connected.
     /// iOS removes tunnel profile.
     public func disconnectBeforeLogout() async {
-        await disconnectAndWaitForDisconnected()
+        await disconnectForLogout()
 #if os(iOS)
         resetVpnProfile()
 #endif
         setEntryGateway(.random)
         setExitGateway(.random)
+    }
+
+    /// Logout path: bounded wait when the user already started disconnecting elsewhere.
+    func disconnectForLogout() async {
+        guard LogoutTeardownPolicy.needsDisconnectWait(for: currentTunnelStatus) else { return }
+#if os(iOS)
+        if LogoutTeardownPolicy.shouldInitiateDisconnect(for: currentTunnelStatus) {
+            try? await disconnectActiveTunnel()
+        }
+        await waitForTunnelStatus(
+            with: .disconnected,
+            timeout: LogoutTeardownPolicy.disconnectWaitCapSeconds
+        )
+#elseif os(macOS)
+        try? await grpcManager.disconnect()
+        await waitForTunnelStatus(
+            with: .disconnected,
+            timeout: LogoutTeardownPolicy.disconnectWaitCapSeconds
+        )
+#endif
     }
 
     /// Disconnect and wait for disconnected status
@@ -168,7 +188,32 @@ public extension ConnectionManager {
 // MARK: - Connection -
 
 extension ConnectionManager {
-    func waitForTunnelStatus(with targetStatus: TunnelStatus) async {
+    func waitForTunnelStatus(with targetStatus: TunnelStatus, timeout: TimeInterval? = nil) async {
+        if currentTunnelStatus == targetStatus { return }
+
+        if let timeout {
+            await withTaskGroup(of: Bool.self) { group in
+                group.addTask { @MainActor in
+                    await self.waitForTunnelStatusChange(to: targetStatus)
+                    return true
+                }
+                group.addTask {
+                    try? await Task.sleep(for: .seconds(timeout))
+                    return false
+                }
+                let finishedInTime = await group.next() ?? false
+                group.cancelAll()
+                _ = finishedInTime
+            }
+            return
+        }
+
+        await waitForTunnelStatusChange(to: targetStatus)
+    }
+
+    private func waitForTunnelStatusChange(to targetStatus: TunnelStatus) async {
+        if currentTunnelStatus == targetStatus { return }
+
         await withCheckedContinuation { continuation in
             var cancellable: AnyCancellable?
 

--- a/nym-vpn-apple/Services/Sources/Services/ConnectionManager/ConnectionManager.swift
+++ b/nym-vpn-apple/Services/Sources/Services/ConnectionManager/ConnectionManager.swift
@@ -1,6 +1,7 @@
 import Combine
 import Foundation
 import NetworkExtension
+import os
 import AppSettings
 import ConnectionTypes
 import ConnectionTypes
@@ -13,6 +14,11 @@ import GRPCManager
 #endif
 
 @MainActor public final class ConnectionManager: ObservableObject {
+    private static let logoutLogger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "NymVPN",
+        category: "ConnectionManager.logout"
+    )
+
     private var timerCancellable: AnyCancellable?
 
     let appSettings: AppSettings
@@ -115,30 +121,45 @@ import GRPCManager
 #endif
 
     /// Disconnects tunnel if connected.
-    /// iOS removes tunnel profile.
+    /// iOS removes tunnel profile when disconnect completes within the logout wait cap.
     public func disconnectBeforeLogout() async {
-        await disconnectForLogout()
+        let disconnectedInTime = await disconnectForLogout()
 #if os(iOS)
-        resetVpnProfile()
+        if LogoutTeardownPolicy.shouldResetVpnProfileAfterLogoutDisconnect(
+            disconnectedInTime: disconnectedInTime
+        ) {
+            resetVpnProfile()
+        } else {
+            Self.logoutLogger.warning(
+                "Logout disconnect wait timed out; skipping VPN profile reset"
+            )
+        }
 #endif
         setEntryGateway(.random)
         setExitGateway(.random)
     }
 
     /// Logout path: bounded wait when the user already started disconnecting elsewhere.
-    func disconnectForLogout() async {
-        guard LogoutTeardownPolicy.needsDisconnectWait(for: currentTunnelStatus) else { return }
+    @discardableResult
+    func disconnectForLogout() async -> Bool {
+        guard LogoutTeardownPolicy.needsDisconnectWait(for: currentTunnelStatus) else { return true }
 #if os(iOS)
         if LogoutTeardownPolicy.shouldInitiateDisconnect(for: currentTunnelStatus) {
             try? await disconnectActiveTunnel()
         }
-        await waitForTunnelStatus(
+        let disconnectedInTime = await waitForTunnelStatus(
             with: .disconnected,
             timeout: LogoutTeardownPolicy.disconnectWaitCapSeconds
         )
+        if !disconnectedInTime {
+            Self.logoutLogger.warning(
+                "Logout disconnect wait timed out before tunnel reached disconnected"
+            )
+        }
+        return disconnectedInTime
 #elseif os(macOS)
         try? await grpcManager.disconnect()
-        await waitForTunnelStatus(
+        return await waitForTunnelStatus(
             with: .disconnected,
             timeout: LogoutTeardownPolicy.disconnectWaitCapSeconds
         )
@@ -188,27 +209,22 @@ public extension ConnectionManager {
 // MARK: - Connection -
 
 extension ConnectionManager {
-    func waitForTunnelStatus(with targetStatus: TunnelStatus, timeout: TimeInterval? = nil) async {
-        if currentTunnelStatus == targetStatus { return }
+    @discardableResult
+    func waitForTunnelStatus(with targetStatus: TunnelStatus, timeout: TimeInterval? = nil) async -> Bool {
+        if currentTunnelStatus == targetStatus { return true }
 
         if let timeout {
-            await withTaskGroup(of: Bool.self) { group in
-                group.addTask { @MainActor in
-                    await self.waitForTunnelStatusChange(to: targetStatus)
-                    return true
-                }
-                group.addTask {
-                    try? await Task.sleep(for: .seconds(timeout))
-                    return false
-                }
-                let finishedInTime = await group.next() ?? false
-                group.cancelAll()
-                _ = finishedInTime
+            let pollInterval: Duration = .milliseconds(250)
+            let deadline = ContinuousClock.now + .seconds(timeout)
+            while ContinuousClock.now < deadline {
+                if currentTunnelStatus == targetStatus { return true }
+                try? await Task.sleep(for: pollInterval)
             }
-            return
+            return currentTunnelStatus == targetStatus
         }
 
         await waitForTunnelStatusChange(to: targetStatus)
+        return currentTunnelStatus == targetStatus
     }
 
     private func waitForTunnelStatusChange(to targetStatus: TunnelStatus) async {

--- a/nym-vpn-apple/Services/Sources/Services/CredentialsManager/CredentialsManager+iOSAccountController.swift
+++ b/nym-vpn-apple/Services/Sources/Services/CredentialsManager/CredentialsManager+iOSAccountController.swift
@@ -18,6 +18,21 @@ extension CredentialsManager {
         }
     }
 
+    func shutdownControllersAndWait() async {
+        if let shutdown = accountControllerShutdown {
+            accountControllerShutdown = nil
+            await shutdown()
+        }
+    }
+
+    func prepareForLogoutOnIOS() async {
+        isLoggingOut = true
+        defer { isLoggingOut = false }
+        accountSummaryUpdateTask?.cancel()
+        accountSummaryUpdateTask = nil
+        await shutdownControllersAndWait()
+    }
+
     var isTunnelActive: Bool {
         AccountTunnelPrefetchGate.isTunnelActive(status: TunnelsManager.shared.activeTunnel?.status)
     }

--- a/nym-vpn-apple/Services/Sources/Services/CredentialsManager/CredentialsManager+iOSAccountController.swift
+++ b/nym-vpn-apple/Services/Sources/Services/CredentialsManager/CredentialsManager+iOSAccountController.swift
@@ -25,12 +25,15 @@ extension CredentialsManager {
         }
     }
 
-    func prepareForLogoutOnIOS() async {
+    func beginLogoutOnIOS() async {
         isLoggingOut = true
-        defer { isLoggingOut = false }
         accountSummaryUpdateTask?.cancel()
         accountSummaryUpdateTask = nil
         await shutdownControllersAndWait()
+    }
+
+    func endLogoutOnIOS() {
+        isLoggingOut = false
     }
 
     var isTunnelActive: Bool {

--- a/nym-vpn-apple/Services/Sources/Services/CredentialsManager/CredentialsManager.swift
+++ b/nym-vpn-apple/Services/Sources/Services/CredentialsManager/CredentialsManager.swift
@@ -305,9 +305,15 @@ import PathManager
 #endif
     }
 
-    public func prepareForLogout() async {
+    public func beginLogout() async {
 #if os(iOS)
-        await prepareForLogoutOnIOS()
+        await beginLogoutOnIOS()
+#endif
+    }
+
+    public func endLogout() {
+#if os(iOS)
+        endLogoutOnIOS()
 #endif
     }
 

--- a/nym-vpn-apple/Services/Sources/Services/CredentialsManager/CredentialsManager.swift
+++ b/nym-vpn-apple/Services/Sources/Services/CredentialsManager/CredentialsManager.swift
@@ -39,6 +39,7 @@ import PathManager
     var registrationCapturedEnvString: String?
     private var accountRegistrationTask: Task<Void, Error>?
     var accountControllerShutdown: (() async -> Void)?
+    private(set) var isLoggingOut = false
 #endif
 
     public static let shared = CredentialsManager()
@@ -304,6 +305,12 @@ import PathManager
 #endif
     }
 
+    public func prepareForLogout() async {
+#if os(iOS)
+        await prepareForLogoutOnIOS()
+#endif
+    }
+
     public func removeCredential() async throws {
 #if os(iOS)
         let envOpt = configurationManager.networkEnv
@@ -471,6 +478,9 @@ import PathManager
 extension CredentialsManager {
     public func updateAccountSummary(force: Bool = false, untilActive: Bool = false) async {
         guard !isAccountRegistrationInFlight else { return }
+#if os(iOS)
+        guard !isLoggingOut else { return }
+#endif
 #if SANTA
         guard !isAccountSummaryOverridden else { return }
 #endif

--- a/nym-vpn-apple/Services/Tests/CredentialsManagerTests/CredentialsManagerLogoutTests.swift
+++ b/nym-vpn-apple/Services/Tests/CredentialsManagerTests/CredentialsManagerLogoutTests.swift
@@ -1,0 +1,30 @@
+#if os(iOS)
+import Testing
+@testable import CredentialsManager
+
+@MainActor
+struct CredentialsManagerLogoutTests {
+    @Test func beginLogoutKeepsGuardUntilEndLogout() async {
+        let manager = CredentialsManager.shared
+        manager.endLogout()
+        #expect(manager.isLoggingOut == false)
+
+        await manager.beginLogout()
+        #expect(manager.isLoggingOut == true)
+
+        manager.endLogout()
+        #expect(manager.isLoggingOut == false)
+    }
+
+    @Test func updateAccountSummaryNoOpsWhileLoggingOut() async {
+        let manager = CredentialsManager.shared
+        manager.endLogout()
+        await manager.beginLogout()
+        defer { manager.endLogout() }
+
+        let summaryBefore = manager.accountSummary
+        await manager.updateAccountSummary(force: true)
+        #expect(manager.accountSummary == summaryBefore)
+    }
+}
+#endif

--- a/nym-vpn-apple/ServicesMutual/Sources/TunnelStatus/LogoutTeardownPolicy.swift
+++ b/nym-vpn-apple/ServicesMutual/Sources/TunnelStatus/LogoutTeardownPolicy.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// Pure decisions for iOS logout VPN teardown (bounded wait after manual disconnect).
+public enum LogoutTeardownPolicy: Equatable, Sendable {
+    /// Rust `DISCONNECT_TIMEOUT` (5s) plus Network Extension status slack.
+    public static let disconnectWaitCapSeconds: TimeInterval = 7
+
+    public static func needsDisconnectWait(for status: TunnelStatus) -> Bool {
+        status != .disconnected
+    }
+
+    /// When the tunnel is already tearing down, do not call `stopVPNTunnel` again.
+    public static func shouldInitiateDisconnect(for status: TunnelStatus) -> Bool {
+        switch status {
+        case .connected, .connecting, .reasserting, .restarting, .offlineReconnect, .error:
+            return true
+        case .disconnecting, .disconnected, .offline, .unknown:
+            return false
+        }
+    }
+}

--- a/nym-vpn-apple/ServicesMutual/Sources/TunnelStatus/LogoutTeardownPolicy.swift
+++ b/nym-vpn-apple/ServicesMutual/Sources/TunnelStatus/LogoutTeardownPolicy.swift
@@ -12,10 +12,15 @@ public enum LogoutTeardownPolicy: Equatable, Sendable {
     /// When the tunnel is already tearing down, do not call `stopVPNTunnel` again.
     public static func shouldInitiateDisconnect(for status: TunnelStatus) -> Bool {
         switch status {
-        case .connected, .connecting, .reasserting, .restarting, .offlineReconnect, .error:
+        case .connected, .connecting, .reasserting, .restarting, .offlineReconnect, .offline, .error:
             return true
-        case .disconnecting, .disconnected, .offline, .unknown:
+        case .disconnecting, .disconnected, .unknown:
             return false
         }
+    }
+
+    /// Profile reset assumes the tunnel reached `.disconnected` within the logout wait cap.
+    public static func shouldResetVpnProfileAfterLogoutDisconnect(disconnectedInTime: Bool) -> Bool {
+        disconnectedInTime
     }
 }

--- a/nym-vpn-apple/ServicesMutual/Tests/TunnelStatusTests/LogoutTeardownPolicyTests.swift
+++ b/nym-vpn-apple/ServicesMutual/Tests/TunnelStatusTests/LogoutTeardownPolicyTests.swift
@@ -1,0 +1,24 @@
+import Testing
+import TunnelStatus
+
+struct LogoutTeardownPolicyTests {
+    @Test func disconnectedSkipsDisconnectWait() {
+        #expect(!LogoutTeardownPolicy.needsDisconnectWait(for: .disconnected))
+        #expect(!LogoutTeardownPolicy.shouldInitiateDisconnect(for: .disconnected))
+    }
+
+    @Test func disconnectingWaitsWithoutSecondDisconnect() {
+        #expect(LogoutTeardownPolicy.needsDisconnectWait(for: .disconnecting))
+        #expect(!LogoutTeardownPolicy.shouldInitiateDisconnect(for: .disconnecting))
+    }
+
+    @Test func connectedInitiatesDisconnectAndWaits() {
+        #expect(LogoutTeardownPolicy.needsDisconnectWait(for: .connected))
+        #expect(LogoutTeardownPolicy.shouldInitiateDisconnect(for: .connected))
+    }
+
+    @Test func disconnectWaitCapMatchesRustDisconnectBudget() {
+        #expect(LogoutTeardownPolicy.disconnectWaitCapSeconds >= 5)
+        #expect(LogoutTeardownPolicy.disconnectWaitCapSeconds <= 10)
+    }
+}

--- a/nym-vpn-apple/ServicesMutual/Tests/TunnelStatusTests/LogoutTeardownPolicyTests.swift
+++ b/nym-vpn-apple/ServicesMutual/Tests/TunnelStatusTests/LogoutTeardownPolicyTests.swift
@@ -17,8 +17,17 @@ struct LogoutTeardownPolicyTests {
         #expect(LogoutTeardownPolicy.shouldInitiateDisconnect(for: .connected))
     }
 
+    @Test func offlineInitiatesDisconnectAndWaits() {
+        #expect(LogoutTeardownPolicy.needsDisconnectWait(for: .offline))
+        #expect(LogoutTeardownPolicy.shouldInitiateDisconnect(for: .offline))
+    }
+
     @Test func disconnectWaitCapMatchesRustDisconnectBudget() {
-        #expect(LogoutTeardownPolicy.disconnectWaitCapSeconds >= 5)
-        #expect(LogoutTeardownPolicy.disconnectWaitCapSeconds <= 10)
+        #expect(LogoutTeardownPolicy.disconnectWaitCapSeconds == 7)
+    }
+
+    @Test func profileResetRequiresDisconnectWithinCap() {
+        #expect(LogoutTeardownPolicy.shouldResetVpnProfileAfterLogoutDisconnect(disconnectedInTime: true))
+        #expect(!LogoutTeardownPolicy.shouldResetVpnProfileAfterLogoutDisconnect(disconnectedInTime: false))
     }
 }

--- a/nym-vpn-apple/Settings/Package.swift
+++ b/nym-vpn-apple/Settings/Package.swift
@@ -58,6 +58,7 @@ let package = Package(
                 .product(name: "PurchasesManager", package: "Services"),
                 .product(name: "SentryManager", package: "Services"),
                 .product(name: "SnackbarManager", package: "Services"),
+                .product(name: "TunnelStatus", package: "ServicesMutual"),
                 .product(name: "NymLogger", package: "ServicesMutual"),
                 .product(name: "Routes", package: "Routes"),
                 .product(name: "Theme", package: "Theme"),

--- a/nym-vpn-apple/Settings/Sources/Settings/AccountAndDevices/AccountAndDevicesView+DialogConfigurations.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/AccountAndDevices/AccountAndDevicesView+DialogConfigurations.swift
@@ -14,7 +14,7 @@ extension AccountAndDevicesView {
             isYesDestructive: true,
             yesAction: {
                 isLogoutLoading = true
-                logoutProgressText = "settings.loggingOut".localizedString
+                logoutProgressText = ""
                 Task {
                     await logout()
                     try? await Task.sleep(for: .seconds(0.3))

--- a/nym-vpn-apple/Settings/Sources/Settings/AccountAndDevices/AccountAndDevicesView+DialogConfigurations.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/AccountAndDevices/AccountAndDevicesView+DialogConfigurations.swift
@@ -14,14 +14,14 @@ extension AccountAndDevicesView {
             isYesDestructive: true,
             yesAction: {
                 isLogoutLoading = true
-                logoutProgressText = ""
+                logoutProgressText = nil
                 Task {
                     await logout()
                     try? await Task.sleep(for: .seconds(0.3))
                     Task { @MainActor in
                         isLogoutConfirmationDisplayed = false
                         isLogoutLoading = false
-                        logoutProgressText = ""
+                        logoutProgressText = nil
                         navigateToRoot()
                     }
                 }

--- a/nym-vpn-apple/Settings/Sources/Settings/AccountAndDevices/AccountAndDevicesView+DialogConfigurations.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/AccountAndDevices/AccountAndDevicesView+DialogConfigurations.swift
@@ -14,12 +14,14 @@ extension AccountAndDevicesView {
             isYesDestructive: true,
             yesAction: {
                 isLogoutLoading = true
+                logoutProgressText = "settings.loggingOut".localizedString
                 Task {
                     await logout()
                     try? await Task.sleep(for: .seconds(0.3))
                     Task { @MainActor in
                         isLogoutConfirmationDisplayed = false
                         isLogoutLoading = false
+                        logoutProgressText = ""
                         navigateToRoot()
                     }
                 }

--- a/nym-vpn-apple/Settings/Sources/Settings/AccountAndDevices/AccountAndDevicesView.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/AccountAndDevices/AccountAndDevicesView.swift
@@ -28,7 +28,7 @@ import Theme
     @State private var isPresentedManageSubscription = false
     @State var isLogoutConfirmationDisplayed = false
     @State var isLogoutLoading = false
-    @State var logoutProgressText = ""
+    @State var logoutProgressText: String? = nil
     @State var isRefreshingAccount = false
     @State var autologinState = AutologinState()
 
@@ -330,6 +330,6 @@ extension AccountAndDevicesView {
 
         logoutProgressText = "settings.loggingOut".localizedString
         try? await credentialsManager.removeCredential()
-        logoutProgressText = ""
+        logoutProgressText = nil
     }
 }

--- a/nym-vpn-apple/Settings/Sources/Settings/AccountAndDevices/AccountAndDevicesView.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/AccountAndDevices/AccountAndDevicesView.swift
@@ -318,8 +318,10 @@ extension AccountAndDevicesView {
         }
     }
 
+    @MainActor
     func logout() async {
-        await credentialsManager.prepareForLogout()
+        await credentialsManager.beginLogout()
+        defer { credentialsManager.endLogout() }
 
         if LogoutTeardownPolicy.needsDisconnectWait(for: connectionManager.currentTunnelStatus) {
             logoutProgressText = "disconnecting".localizedString

--- a/nym-vpn-apple/Settings/Sources/Settings/AccountAndDevices/AccountAndDevicesView.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/AccountAndDevices/AccountAndDevicesView.swift
@@ -10,6 +10,7 @@ import CredentialsManager
 import ExternalLinkManager
 import PurchasesManager
 import SnackbarManager
+import TunnelStatus
 import UIComponents
 import Theme
 
@@ -27,6 +28,7 @@ import Theme
     @State private var isPresentedManageSubscription = false
     @State var isLogoutConfirmationDisplayed = false
     @State var isLogoutLoading = false
+    @State var logoutProgressText = ""
     @State var isRefreshingAccount = false
     @State var autologinState = AutologinState()
 
@@ -83,7 +85,8 @@ import Theme
                         isDisplayed: $isLogoutConfirmationDisplayed,
                         configuration: logoutDialogConfiguration,
                         impactGenerator: .shared,
-                        isLoading: $isLogoutLoading
+                        isLoading: $isLogoutLoading,
+                        loadingTextOverride: $logoutProgressText
                     )
                 )
             }
@@ -316,7 +319,15 @@ extension AccountAndDevicesView {
     }
 
     func logout() async {
+        await credentialsManager.prepareForLogout()
+
+        if LogoutTeardownPolicy.needsDisconnectWait(for: connectionManager.currentTunnelStatus) {
+            logoutProgressText = "disconnecting".localizedString
+        }
         await connectionManager.disconnectBeforeLogout()
+
+        logoutProgressText = "settings.loggingOut".localizedString
         try? await credentialsManager.removeCredential()
+        logoutProgressText = ""
     }
 }

--- a/nym-vpn-apple/UIComponents/Sources/UIComponents/25/ActionDialog/ActionDialogView.swift
+++ b/nym-vpn-apple/UIComponents/Sources/UIComponents/25/ActionDialog/ActionDialogView.swift
@@ -132,7 +132,7 @@ private extension ActionDialogView {
 
     @ViewBuilder
     func loadingRow() -> some View {
-        if let loadingText = viewModel.configuration.loadingText {
+        if let loadingText = viewModel.displayedLoadingText {
             HStack(alignment: .center) {
                 Text(loadingText)
                     .textStyle(NymTextStyle.Body.Large.regular)

--- a/nym-vpn-apple/UIComponents/Sources/UIComponents/25/ActionDialog/ActionDialogViewModel.swift
+++ b/nym-vpn-apple/UIComponents/Sources/UIComponents/25/ActionDialog/ActionDialogViewModel.swift
@@ -7,16 +7,26 @@ import ImpactGenerator
 
     @Binding var isDisplayed: Bool
     @Binding var isLoading: Bool
+    @Binding var loadingTextOverride: String?
 
     public init(
         isDisplayed: Binding<Bool>,
         configuration: ActionDialogConfiguration,
         impactGenerator: ImpactGenerator,
-        isLoading: Binding<Bool> = .constant(false)
+        isLoading: Binding<Bool> = .constant(false),
+        loadingTextOverride: Binding<String?> = .constant(nil)
     ) {
         _isDisplayed = isDisplayed
         _isLoading = isLoading
+        _loadingTextOverride = loadingTextOverride
         self.impactGenerator = impactGenerator
         self.configuration = configuration
+    }
+
+    var displayedLoadingText: String? {
+        if let loadingTextOverride, !loadingTextOverride.isEmpty {
+            return loadingTextOverride
+        }
+        return configuration.loadingText
     }
 }


### PR DESCRIPTION
Logout no longer re-waits indefinitely after a manual disconnect; caps tunnel wait at 7s, cancels account refresh, and shows disconnect vs sign-out progress in the dialog.

## Ticket

JIRA-NYM-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5786)
<!-- Reviewable:end -->
