### PR TITLE
Cherry-pick iOS login carousel pacing and step bar sync to develop

### DIFF
--- a/nym-vpn-apple/Home/Sources/26/ProcessingAccount/ProcessingAccountView.swift
+++ b/nym-vpn-apple/Home/Sources/26/ProcessingAccount/ProcessingAccountView.swift
@@ -65,11 +65,18 @@ private extension ProcessingAccountView {
     @ViewBuilder
     var titleBlock: some View {
         Group {
-            if viewModel.usesStaticCopy {
+            switch ProcessingAccountView.titleBlockMode(
+                usesStaticCopy: viewModel.usesStaticCopy,
+                didShowFinalMessage: viewModel.didShowFinalMessage,
+                showsCredentialsCarousel: showsCredentialsCarousel
+            ) {
+            case .staticCopy:
                 staticTitleView
-            } else if viewModel.didShowFinalMessage {
+            case .welcome:
                 welcomeMessage
-            } else {
+            case .credentials:
+                credentialsTitleView
+            case .setupCarousel:
                 switchingTitles
             }
         }
@@ -83,7 +90,10 @@ private extension ProcessingAccountView {
 
     var measurementLayer: some View {
         ZStack(alignment: .top) {
-            ForEach(Array(ProcessingAccountView.pairs(for: viewModel.flow).enumerated()), id: \.offset) { _, pair in
+            ForEach(Array(LoginProcessingUI.setupCarouselPairs().enumerated()), id: \.offset) { _, pair in
+                titlePairMeasurement(title: pair.0, subtitle: pair.1)
+            }
+            ForEach(Array(LoginProcessingUI.credentialsCarouselPairs().enumerated()), id: \.offset) { _, pair in
                 titlePairMeasurement(title: pair.0, subtitle: pair.1)
             }
             welcomeMessage
@@ -116,7 +126,32 @@ private extension ProcessingAccountView {
                     get: { viewModel.currentStep },
                     set: { _ in }
                 ),
-                animateInitialFill: !viewModel.usesStaticCopy
+                animateInitialFill: LoginProcessingUI.stepBarAnimateInitialFill,
+                initialFillLeadIn: LoginProcessingUI.stepBarInitialLeadIn,
+                initialFillStepPause: LoginProcessingUI.stepBarStepPause,
+                forwardFillStepPause: LoginProcessingUI.stepBarStepPause
+            )
+        }
+    }
+
+    @ViewBuilder
+    var credentialsTitleView: some View {
+        if let pair = viewModel.credentialsDisplayPair {
+            VStack(alignment: .center, spacing: AuthLayout.processingCarouselTitleSpacing) {
+                Text(pair.0)
+                    .textStyle(.Headline.Medium.regular)
+                    .foregroundStyle(NymColor.primary)
+                    .multilineTextAlignment(.center)
+                    .contentTransition(.opacity)
+                Text(pair.1)
+                    .textStyle(.Body.Medium.regular)
+                    .foregroundColor(NymColor.gray1)
+                    .multilineTextAlignment(.center)
+                    .contentTransition(.opacity)
+            }
+            .animation(
+                .easeInOut(duration: LoginProcessingUI.setupCarouselTextTransitionDuration),
+                value: pair.0
             )
         }
     }
@@ -139,14 +174,32 @@ private extension ProcessingAccountView {
         SwitchingTitlesView(
             pairs: ProcessingAccountView.pairs(for: viewModel.flow),
             didFinishAnimating: Binding(
-                get: { viewModel.didFinishAnimatingText },
+                get: { viewModel.didFinishSetupCarousel },
                 set: { newValue in
                     if newValue { viewModel.animationDidFinish() }
                 }
             ),
-            timerDidTick: {
-                viewModel.animationDidAdvance()
+            timerDidTick: {},
+            tickInterval: LoginProcessingUI.setupCarouselTickInterval,
+            stepAdvanceDelay: LoginProcessingUI.setupCarouselStepAdvanceDelay,
+            textTransitionDuration: LoginProcessingUI.setupCarouselTextTransitionDuration,
+            initialDwell: LoginProcessingUI.setupCarouselInitialDwell,
+            retainLastPairOnFinish: true,
+            finalPairDwell: LoginProcessingUI.setupCarouselFinalPairDwell,
+            onIndexChanged: { index in
+                viewModel.noteSetupCarouselStepBarTick(atIndex: index)
             }
+        )
+    }
+
+    var showsCredentialsCarousel: Bool {
+        LoginProcessingCarouselVisibilityPolicy.showsCredentialsCopy(
+            usesStaticCopy: viewModel.usesStaticCopy,
+            didShowFinalMessage: viewModel.didShowFinalMessage,
+            isSyncing: viewModel.phase == .syncing,
+            isPrefetching: viewModel.phase == .prefetching,
+            holdsPrefetchCopyThroughAdvance: viewModel.phase == .awaitingAdvance
+                && viewModel.hasReachedPrefetchPhase
         )
     }
 
@@ -179,7 +232,32 @@ private extension ProcessingAccountView {
     }
 
     static func processingCarouselPairs() -> [(String, String)] {
-        let title = LoginProcessingUI.settingUpTitleKey.localizedString
-        return LoginProcessingUI.carouselStepRange.map { _ in (title, "") }
+        LoginProcessingUI.setupCarouselPairs()
+    }
+}
+
+enum ProcessingAccountTitleBlockMode: Equatable {
+    case staticCopy
+    case welcome
+    case credentials
+    case setupCarousel
+}
+
+extension ProcessingAccountView {
+    static func titleBlockMode(
+        usesStaticCopy: Bool,
+        didShowFinalMessage: Bool,
+        showsCredentialsCarousel: Bool
+    ) -> ProcessingAccountTitleBlockMode {
+        if usesStaticCopy {
+            return .staticCopy
+        }
+        if didShowFinalMessage {
+            return .welcome
+        }
+        if showsCredentialsCarousel {
+            return .credentials
+        }
+        return .setupCarousel
     }
 }

--- a/nym-vpn-apple/Home/Sources/26/ProcessingAccount/ProcessingAccountViewModel.swift
+++ b/nym-vpn-apple/Home/Sources/26/ProcessingAccount/ProcessingAccountViewModel.swift
@@ -41,6 +41,10 @@ public final class ProcessingAccountViewModel {
     @ObservationIgnored private let deeplinkLoginCallbackURL: String?
     private(set) var phase: ProcessingPhase = .preparing
     var currentStep: Int = 1
+    private(set) var didFinishSetupCarousel = false
+    private(set) var setupCarouselIndex = 0
+    /// Set when backend prefetch begins; keeps bar segment 4 until navigation advances.
+    private(set) var hasReachedPrefetchPhase = false
 
     var didFinishAnimatingText = false {
         didSet { evaluateAdvance() }
@@ -63,6 +67,19 @@ public final class ProcessingAccountViewModel {
         }
     }
 
+    private var holdsPrefetchCopyThroughAdvance: Bool {
+        phase == .awaitingAdvance && hasReachedPrefetchPhase
+    }
+
+    var credentialsDisplayPair: (String, String)? {
+        guard let keys = LoginProcessingProgressPolicy.credentialsCopyKeys(
+            isSyncing: phase == .syncing,
+            isPrefetching: phase == .prefetching,
+            holdsPrefetchCopyThroughAdvance: holdsPrefetchCopyThroughAdvance
+        ) else { return nil }
+        return (keys.title.localizedString, keys.subtitle.localizedString)
+    }
+
     public init(
         processing: AccountProcessing,
         flow: ProcessingFlow,
@@ -72,13 +89,11 @@ public final class ProcessingAccountViewModel {
         self.flow = flow
         self.deeplinkLoginCallbackURL = deeplinkLoginCallbackURL
         switch flow {
-        case .login:
+        case .login, .createAccount:
             currentStep = LoginProcessingUI.initialProgressStep
         case .postPurchase:
             currentStep = PostPurchaseProcessingUI.progressStep
             didFinishAnimatingText = true
-        case .createAccount:
-            break
         }
     }
 
@@ -95,12 +110,18 @@ public final class ProcessingAccountViewModel {
             switch flow {
             case .login:
                 phase = .preparing
+                syncProgressStep()
                 try await completeDeeplinkLoginIfNeeded()
                 await processing.ensureCredentialImportResolved()
-                try await processing.prepareRegisteredAccount()
+                try await processing.ensureDeviceRegisteredForLogin()
+                try await processing.prepareRegisteredAccount { [weak self] accountPhase in
+                    self?.applyBackendAccountPhase(accountPhase)
+                }
                 try await syncSummaryThenPrefetch()
                 completeWork()
             case .createAccount:
+                phase = .preparing
+                syncProgressStep()
                 await processing.ensureCredentialImportResolved()
                 try await syncSummaryThenPrefetch()
                 completeWork()
@@ -125,16 +146,40 @@ public final class ProcessingAccountViewModel {
     /// Login/create-account: sync the account summary, then prefetch zk-nyms when active.
     private func syncSummaryThenPrefetch() async throws {
         try Task.checkCancellation()
-        phase = .syncing
+        if !hasReachedPrefetchPhase {
+            phase = .syncing
+            syncProgressStep()
+        }
         await processing.updateAccountSummary(force: true, untilActive: true)
         try Task.checkCancellation()
         if AccountZkNymPrefetchGate.shouldPrefetchAfterSummarySync(
             isAccountActive: processing.isAccountActive()
         ) {
-            phase = .prefetching
-            _ = await processing.prefetchZkNyms(timeout: 60)
+            if !hasReachedPrefetchPhase {
+                phase = .prefetching
+                hasReachedPrefetchPhase = true
+                syncProgressStep()
+            }
+            _ = await processing.prefetchZkNyms(timeout: LoginProcessingUI.prefetchTimeoutSeconds)
+            syncProgressStep()
         }
         try Task.checkCancellation()
+    }
+
+    private func applyBackendAccountPhase(
+        _ accountPhase: OnboardingAccountPreparationPolicy.AccountStatePhase
+    ) {
+        guard let displayPhase = LoginProcessingBackendPhasePolicy.displayPhase(for: accountPhase) else {
+            return
+        }
+        switch displayPhase {
+        case .syncing:
+            phase = .syncing
+        case .prefetching:
+            phase = .prefetching
+            hasReachedPrefetchPhase = true
+        }
+        syncProgressStep()
     }
 
     /// Post-IAP: sync the StoreKit receipt, fail if the account isn't active, else prefetch.
@@ -160,7 +205,7 @@ public final class ProcessingAccountViewModel {
         }
 
         phase = .prefetching
-        _ = await processing.prefetchZkNyms(timeout: 60)
+        _ = await processing.prefetchZkNyms(timeout: LoginProcessingUI.prefetchTimeoutSeconds)
         phase = .finished
         sessionCoordinator?.handle(.session(.processingFinished))
     }
@@ -178,12 +223,15 @@ public final class ProcessingAccountViewModel {
         sessionCoordinator?.handle(.dismissPostPurchaseProcessing)
     }
 
-    func animationDidAdvance() {
-        currentStep += 1
+    func noteSetupCarouselStepBarTick(atIndex index: Int) {
+        setupCarouselIndex = index
+        syncProgressStep()
     }
 
     func animationDidFinish() {
-        didFinishAnimatingText = true
+        didFinishSetupCarousel = true
+        syncProgressStep()
+        updateAnimationReady()
     }
 
     /// Awaits the post-advance welcome-message delay. Test hook only.
@@ -198,7 +246,24 @@ public final class ProcessingAccountViewModel {
             return
         }
         phase = .awaitingAdvance
+        syncProgressStep()
         workCompleted = true
+        updateAnimationReady()
+    }
+
+    private func updateAnimationReady() {
+        guard workCompleted, didFinishSetupCarousel else { return }
+        didFinishAnimatingText = true
+    }
+
+    private func syncProgressStep() {
+        currentStep = LoginProcessingProgressPolicy.progressStep(
+            setupCarouselIndex: setupCarouselIndex,
+            didFinishSetupCarousel: didFinishSetupCarousel,
+            isPrefetching: phase == .prefetching,
+            isAwaitingAdvance: phase == .awaitingAdvance,
+            hasReachedPrefetchPhase: hasReachedPrefetchPhase
+        )
     }
 
     private func fail(with error: Error) {

--- a/nym-vpn-apple/Home/Tests/HomeTests/ProcessingAccountTitleBlockTests.swift
+++ b/nym-vpn-apple/Home/Tests/HomeTests/ProcessingAccountTitleBlockTests.swift
@@ -1,0 +1,76 @@
+import Testing
+import AccountPrefetchGates
+@testable import Home
+
+struct ProcessingAccountTitleBlockTests {
+    @Test func titleBlockMode_prefetchBeforeSetupComplete_showsCredentials() {
+        let showsCredentials = LoginProcessingCarouselVisibilityPolicy.showsCredentialsCopy(
+            usesStaticCopy: false,
+            didShowFinalMessage: false,
+            isSyncing: false,
+            isPrefetching: true
+        )
+        #expect(showsCredentials)
+        #expect(
+            ProcessingAccountView.titleBlockMode(
+                usesStaticCopy: false,
+                didShowFinalMessage: false,
+                showsCredentialsCarousel: showsCredentials
+            ) == .credentials
+        )
+    }
+
+    @Test func titleBlockMode_syncing_showsCredentials() {
+        let showsCredentials = LoginProcessingCarouselVisibilityPolicy.showsCredentialsCopy(
+            usesStaticCopy: false,
+            didShowFinalMessage: false,
+            isSyncing: true,
+            isPrefetching: false
+        )
+        #expect(showsCredentials)
+        #expect(
+            ProcessingAccountView.titleBlockMode(
+                usesStaticCopy: false,
+                didShowFinalMessage: false,
+                showsCredentialsCarousel: showsCredentials
+            ) == .credentials
+        )
+    }
+
+    @Test func titleBlockMode_syncingAfterSetup_keepsSetupCarousel() {
+        let showsCredentials = LoginProcessingCarouselVisibilityPolicy.showsCredentialsCopy(
+            usesStaticCopy: false,
+            didShowFinalMessage: false,
+            isSyncing: false,
+            isPrefetching: false
+        )
+        #expect(!showsCredentials)
+        #expect(
+            ProcessingAccountView.titleBlockMode(
+                usesStaticCopy: false,
+                didShowFinalMessage: false,
+                showsCredentialsCarousel: showsCredentials
+            ) == .setupCarousel
+        )
+    }
+
+    @Test func titleBlockMode_setupUntilBackendWait() {
+        #expect(
+            ProcessingAccountView.titleBlockMode(
+                usesStaticCopy: false,
+                didShowFinalMessage: false,
+                showsCredentialsCarousel: false
+            ) == .setupCarousel
+        )
+    }
+
+    @Test func titleBlockMode_welcomeAfterFinalize() {
+        #expect(
+            ProcessingAccountView.titleBlockMode(
+                usesStaticCopy: false,
+                didShowFinalMessage: true,
+                showsCredentialsCarousel: false
+            ) == .welcome
+        )
+    }
+}

--- a/nym-vpn-apple/Home/Tests/HomeTests/ProcessingAccountViewModelTests.swift
+++ b/nym-vpn-apple/Home/Tests/HomeTests/ProcessingAccountViewModelTests.swift
@@ -14,22 +14,40 @@ private final class FakeProcessing: AccountProcessing {
         case syncPayment
         case storeDeeplink(String)
         case register
+        case ensureDeviceRegistered
     }
 
     var prepareError: Error?
+    var preparePhaseScript: [OnboardingAccountPreparationPolicy.AccountStatePhase] = []
+    var holdPrepareUntilReleased = false
+    private var prepareRelease: (() -> Void)?
     var syncPaymentError: Error?
     var storeDeeplinkError: Error?
     var registerError: Error?
     var accountActive = true
+    var prefetchDelay: Duration = .zero
     var prefetchResult: ZkNymPrefetchResult = .fetchedTickets
     private(set) var calls: [Call] = []
+
+    func releasePrepare() {
+        prepareRelease?()
+        prepareRelease = nil
+    }
 
     func ensureCredentialImportResolved() async {
         calls.append(.ensure)
     }
 
-    func prepareRegisteredAccount() async throws {
+    func prepareRegisteredAccount(
+        onAccountPhaseChange: (@MainActor (OnboardingAccountPreparationPolicy.AccountStatePhase) -> Void)?
+    ) async throws {
         calls.append(.prepare)
+        for phase in preparePhaseScript {
+            onAccountPhaseChange?(phase)
+        }
+        if holdPrepareUntilReleased {
+            await withCheckedContinuation { prepareRelease = $0.resume() }
+        }
         if let prepareError {
             throw prepareError
         }
@@ -46,6 +64,9 @@ private final class FakeProcessing: AccountProcessing {
 
     func prefetchZkNyms(timeout: TimeInterval) async -> ZkNymPrefetchResult {
         calls.append(.prefetch)
+        if prefetchDelay > .zero {
+            try? await Task.sleep(for: prefetchDelay)
+        }
         return prefetchResult
     }
 
@@ -65,6 +86,13 @@ private final class FakeProcessing: AccountProcessing {
 
     func registerAccountIfNeeded() async throws {
         calls.append(.register)
+        if let registerError {
+            throw registerError
+        }
+    }
+
+    func ensureDeviceRegisteredForLogin() async throws {
+        calls.append(.ensureDeviceRegistered)
         if let registerError {
             throw registerError
         }
@@ -106,7 +134,7 @@ struct ProcessingAccountViewModelTests {
 
         await viewModel.run()
 
-        #expect(processing.calls == [.ensure, .prepare, .sync, .isActive, .prefetch])
+        #expect(processing.calls == [.ensure, .ensureDeviceRegistered, .prepare, .sync, .isActive, .prefetch])
         #expect(viewModel.phase == .awaitingAdvance)
         #expect(coordinator.actions.isEmpty)
     }
@@ -223,14 +251,42 @@ struct ProcessingAccountViewModelTests {
 
         await viewModel.run()
         #expect(viewModel.phase == .awaitingAdvance)
+        #expect(viewModel.currentStep == 4)
         #expect(coordinator.actions.isEmpty)
 
         viewModel.animationDidFinish()
+        #expect(viewModel.didFinishAnimatingText)
         #expect(viewModel.phase == .finalizing)
 
         await viewModel.awaitFinalMessage()
         #expect(viewModel.phase == .finished)
         #expect(coordinator.actions == [.session(.processingFinished)])
+    }
+
+    @Test func inactiveAccountAdvancesToStepFourWithoutPrefetch() async {
+        let processing = FakeProcessing()
+        processing.accountActive = false
+        let coordinator = FakeCoordinator()
+        let viewModel = makeViewModel(flow: .createAccount, processing: processing, coordinator: coordinator)
+
+        await viewModel.run()
+        viewModel.animationDidFinish()
+
+        #expect(viewModel.phase == .awaitingAdvance)
+        #expect(viewModel.currentStep == 4)
+        #expect(viewModel.credentialsDisplayPair == nil)
+        #expect(viewModel.didFinishAnimatingText)
+    }
+
+    @Test func navigationBlockedUntilSetupCarouselCompletes() async {
+        let processing = FakeProcessing()
+        let coordinator = FakeCoordinator()
+        let viewModel = makeViewModel(flow: .createAccount, processing: processing, coordinator: coordinator)
+
+        await viewModel.run()
+        #expect(viewModel.phase == .awaitingAdvance)
+        #expect(!viewModel.didFinishAnimatingText)
+        #expect(coordinator.actions.isEmpty)
     }
 
     @Test func cancellationDoesNotFailOrNotify() async {
@@ -292,5 +348,134 @@ struct ProcessingAccountViewModelTests {
             return
         }
         #expect(!processing.calls.contains(.prefetch))
+    }
+
+    @Test func prefetchPhaseHoldsStepFourUntilCallbackReturns() async {
+        let processing = FakeProcessing()
+        processing.prefetchDelay = .milliseconds(100)
+        let coordinator = FakeCoordinator()
+        let viewModel = makeViewModel(flow: .createAccount, processing: processing, coordinator: coordinator)
+        viewModel.animationDidFinish()
+
+        await viewModel.run()
+
+        #expect(processing.calls.contains(.prefetch))
+        #expect(viewModel.phase == .awaitingAdvance)
+        #expect(viewModel.currentStep == 4)
+        #expect(viewModel.didFinishAnimatingText)
+        #expect(coordinator.actions.isEmpty)
+    }
+
+    @Test func setupCarouselStepBarTick_updatesIndexAndProgressTogether() {
+        let processing = FakeProcessing()
+        let coordinator = FakeCoordinator()
+        let viewModel = makeViewModel(flow: .login, processing: processing, coordinator: coordinator)
+
+        viewModel.noteSetupCarouselStepBarTick(atIndex: 1)
+
+        #expect(viewModel.setupCarouselIndex == 1)
+        #expect(viewModel.currentStep == 2)
+    }
+
+    @Test func setupCarouselIndexTwoAdvancesBarToStepThree() {
+        let processing = FakeProcessing()
+        let coordinator = FakeCoordinator()
+        let viewModel = makeViewModel(flow: .login, processing: processing, coordinator: coordinator)
+
+        viewModel.noteSetupCarouselStepBarTick(atIndex: 2)
+
+        #expect(viewModel.currentStep == 3)
+    }
+
+    @Test func preparingAfterSetupHoldsThirdSegmentUntilPrefetch() {
+        let processing = FakeProcessing()
+        let coordinator = FakeCoordinator()
+        let viewModel = makeViewModel(flow: .login, processing: processing, coordinator: coordinator)
+
+        viewModel.animationDidFinish()
+
+        #expect(viewModel.currentStep == 3)
+        #expect(viewModel.credentialsDisplayPair == nil)
+    }
+
+    @Test func loginStartsAtFirstProgressSegment() {
+        let processing = FakeProcessing()
+        let coordinator = FakeCoordinator()
+        let viewModel = makeViewModel(flow: .login, processing: processing, coordinator: coordinator)
+
+        #expect(viewModel.currentStep == LoginProcessingUI.initialProgressStep)
+    }
+
+    @Test func loginEnsuresDeviceRegisteredBeforePrepare() async {
+        let processing = FakeProcessing()
+        let coordinator = FakeCoordinator()
+        let viewModel = makeViewModel(flow: .login, processing: processing, coordinator: coordinator)
+
+        await viewModel.run()
+
+        guard
+            let deviceIndex = processing.calls.firstIndex(of: .ensureDeviceRegistered),
+            let prepareIndex = processing.calls.firstIndex(of: .prepare)
+        else {
+            Issue.record("expected device registration before prepare")
+            return
+        }
+        #expect(deviceIndex < prepareIndex)
+    }
+
+    @Test func prefetchCompletingBeforeCarouselDoesNotRegressProgressBar() async {
+        let processing = FakeProcessing()
+        processing.prefetchDelay = .zero
+        let coordinator = FakeCoordinator()
+        let viewModel = makeViewModel(flow: .login, processing: processing, coordinator: coordinator)
+
+        await viewModel.run()
+
+        #expect(viewModel.phase == .awaitingAdvance)
+        #expect(viewModel.hasReachedPrefetchPhase)
+        #expect(viewModel.currentStep == 4)
+        #expect(!viewModel.didFinishSetupCarousel)
+
+        viewModel.noteSetupCarouselStepBarTick(atIndex: 0)
+        #expect(viewModel.currentStep == 4)
+
+        viewModel.noteSetupCarouselStepBarTick(atIndex: 1)
+        #expect(viewModel.currentStep == 4)
+
+        viewModel.animationDidFinish()
+        #expect(viewModel.currentStep == 4)
+    }
+
+    @Test func prepareBackendPhase_showsPrefetchBeforePrepareReturns() async {
+        let processing = FakeProcessing()
+        processing.preparePhaseScript = [.requestingZkNyms]
+        processing.holdPrepareUntilReleased = true
+        let coordinator = FakeCoordinator()
+        let viewModel = makeViewModel(flow: .login, processing: processing, coordinator: coordinator)
+
+        let runTask = Task { await viewModel.run() }
+        await Task.yield()
+        try? await Task.sleep(for: .milliseconds(20))
+
+        #expect(viewModel.phase == .prefetching)
+        #expect(viewModel.hasReachedPrefetchPhase)
+        #expect(viewModel.currentStep == 4)
+        #expect(viewModel.credentialsDisplayPair != nil)
+
+        processing.releasePrepare()
+        await runTask.value
+        #expect(viewModel.phase == .awaitingAdvance)
+    }
+
+    @Test func syncSummaryRefresh_keepsPrefetchPhaseWhenLatchSet() async {
+        let processing = FakeProcessing()
+        processing.preparePhaseScript = [.requestingZkNyms]
+        let coordinator = FakeCoordinator()
+        let viewModel = makeViewModel(flow: .login, processing: processing, coordinator: coordinator)
+
+        await viewModel.run()
+
+        #expect(viewModel.hasReachedPrefetchPhase)
+        #expect(viewModel.currentStep == 4)
     }
 }

--- a/nym-vpn-apple/NymVPN/Resources/Localizable.xcstrings
+++ b/nym-vpn-apple/NymVPN/Resources/Localizable.xcstrings
@@ -23042,6 +23042,83 @@
         }
       }
     },
+    "processingAccount.login.settingUpStep2Subtitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verifying your sign-in"
+          }
+        }
+      }
+    },
+    "processingAccount.login.settingUpStep3Subtitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparing your account for this device"
+          }
+        }
+      }
+    },
+    "processingAccount.login.settingUpStep4Subtitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finishing account setup"
+          }
+        }
+      }
+    },
+    "processingAccount.login.loadingCredentials" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loading your anonymous credentials…"
+          }
+        }
+      }
+    },
+    "processingAccount.login.loadingCredentialsSubtitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This can take a moment on first sign-in"
+          }
+        }
+      }
+    },
+    "processingAccount.login.almostReady" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finishing up…"
+          }
+        }
+      }
+    },
+    "processingAccount.login.almostReadySubtitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Just a few more seconds"
+          }
+        }
+      }
+    },
     "processingAccount.awaitingConfirmation.subtitle" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/nym-vpn-apple/Services/Sources/AccountPrefetchGates/AccountProcessing.swift
+++ b/nym-vpn-apple/Services/Sources/AccountPrefetchGates/AccountProcessing.swift
@@ -6,7 +6,9 @@ import Foundation
 @MainActor
 public protocol AccountProcessing {
     func ensureCredentialImportResolved() async
-    func prepareRegisteredAccount() async throws
+    func prepareRegisteredAccount(
+        onAccountPhaseChange: (@MainActor (OnboardingAccountPreparationPolicy.AccountStatePhase) -> Void)?
+    ) async throws
     func updateAccountSummary(force: Bool, untilActive: Bool) async
     func isAccountActive() -> Bool
     func prefetchZkNyms(timeout: TimeInterval) async -> ZkNymPrefetchResult
@@ -14,6 +16,14 @@ public protocol AccountProcessing {
     func handleSubscriptionPayment() async throws
     func storeDeeplink(callbackURLString: String) async throws
     func registerAccountIfNeeded() async throws
+    /// Re-posts account registration with the VPN API before account prep (includes device registration on OAuth re-login when `registerAccountIfNeeded` no-ops).
+    func ensureDeviceRegisteredForLogin() async throws
+}
+
+extension AccountProcessing {
+    public func prepareRegisteredAccount() async throws {
+        try await prepareRegisteredAccount(onAccountPhaseChange: nil)
+    }
 }
 
 /// Typed, Equatable failure raised by the processing flow so it can be asserted in

--- a/nym-vpn-apple/Services/Sources/AccountPrefetchGates/OnboardingAccountPreparationPolicy.swift
+++ b/nym-vpn-apple/Services/Sources/AccountPrefetchGates/OnboardingAccountPreparationPolicy.swift
@@ -8,6 +8,13 @@ public enum AccountPreparationWaitOutcome: Equatable, Sendable {
 
 /// Pure policy for onboarding account prep: sync may end without an active subscription.
 public enum OnboardingAccountPreparationPolicy {
+    public static let offlineFailDebounceSeconds: TimeInterval = 5
+    public static let waitPollIntervalSeconds: TimeInterval = 0.25
+
+    public static func shouldFailOnOffline(consecutiveOfflineSeconds: TimeInterval) -> Bool {
+        consecutiveOfflineSeconds >= offlineFailDebounceSeconds
+    }
+
     public enum AccountStatePhase: Equatable, Sendable {
         case offline
         case loggedOut

--- a/nym-vpn-apple/Services/Sources/AccountPrefetchGates/ProcessingUIPolicy.swift
+++ b/nym-vpn-apple/Services/Sources/AccountPrefetchGates/ProcessingUIPolicy.swift
@@ -2,15 +2,167 @@ import Foundation
 
 public enum LoginProcessingUI: Sendable {
     public static let progressStep = 4
-    public static let initialProgressStep = 2
+    public static let initialProgressStep = 1
+    /// Setup carousel fills bar segments 1-3; segment 4 is backend prefetch only.
+    public static let setupCarouselMaxProgressStep = 3
     public static let requiresCarousel = true
     public static let carouselStepRange = 2...4
     public static let carouselTitlePrefix = "processingAccount.login"
     public static let settingUpTitleKey = "\(carouselTitlePrefix).settingUp"
-
+    public static let settingUpStep2SubtitleKey = "\(carouselTitlePrefix).settingUpStep2Subtitle"
+    public static let settingUpStep3SubtitleKey = "\(carouselTitlePrefix).settingUpStep3Subtitle"
+    public static let settingUpStep4SubtitleKey = "\(carouselTitlePrefix).settingUpStep4Subtitle"
+    /// Log-calibrated on LTE login (~12:07:57-12:08:11): ~3s per readable beat before prefetch at ~14s.
+    public static let setupCarouselInitialDwell: TimeInterval = 3.0
+    public static let setupCarouselTickInterval: TimeInterval = 3.0
+    /// Extra hold on the last setup subtitle before handoff to backend copy.
+    public static let setupCarouselFinalPairDwell: TimeInterval = 3.5
+    public static let stepBarInitialLeadIn: TimeInterval = 0.8
+    public static let stepBarAnimateInitialFill = true
+    public static let stepBarStepPause: TimeInterval = 1.0
+    /// Text and bar advance on the same carousel tick (no lead/lag).
+    public static let setupCarouselStepAdvanceDelay: TimeInterval = 0
+    public static let setupCarouselTextTransitionDuration: TimeInterval = 0.35
+    public static let loadingCredentialsTitleKey = "\(carouselTitlePrefix).loadingCredentials"
+    public static let loadingCredentialsSubtitleKey = "\(carouselTitlePrefix).loadingCredentialsSubtitle"
+    public static let almostReadyTitleKey = "\(carouselTitlePrefix).almostReady"
+    public static let almostReadySubtitleKey = "\(carouselTitlePrefix).almostReadySubtitle"
+    /// Upper bound for `prefetchZkNyms`; typical device prefetch is 15-30s.
+    public static let prefetchTimeoutSeconds: TimeInterval = 60
     public static var carouselKeys: [String] {
-        [settingUpTitleKey]
+        [
+            settingUpTitleKey,
+            settingUpStep2SubtitleKey,
+            settingUpStep3SubtitleKey,
+            settingUpStep4SubtitleKey,
+        ]
     }
+
+    public static func setupCarouselPairs() -> [(String, String)] {
+        let context = settingUpTitleKey.localizedString
+        return [
+            (settingUpStep2SubtitleKey.localizedString, context),
+            (settingUpStep3SubtitleKey.localizedString, context),
+            (settingUpStep4SubtitleKey.localizedString, context),
+        ]
+    }
+
+    public static var credentialsCarouselKeys: [String] {
+        [
+            loadingCredentialsTitleKey,
+            loadingCredentialsSubtitleKey,
+            almostReadyTitleKey,
+            almostReadySubtitleKey,
+        ]
+    }
+
+    public static func credentialsCarouselPairs() -> [(String, String)] {
+        [
+            (loadingCredentialsTitleKey.localizedString, loadingCredentialsSubtitleKey.localizedString),
+            (almostReadyTitleKey.localizedString, almostReadySubtitleKey.localizedString),
+        ]
+    }
+}
+
+public enum LoginProcessingCarouselTimingPolicy: Sendable {
+    public static func setupCarouselMinimumDurationSeconds() -> TimeInterval {
+        let stepCount = LoginProcessingUI.setupCarouselPairs().count
+        guard stepCount > 0 else { return 0 }
+        return LoginProcessingUI.setupCarouselInitialDwell
+            + TimeInterval(stepCount - 1) * LoginProcessingUI.setupCarouselTickInterval
+            + LoginProcessingUI.setupCarouselFinalPairDwell
+    }
+
+    public static func usesUnifiedSegmentDwell() -> Bool {
+        LoginProcessingUI.setupCarouselStepAdvanceDelay == LoginProcessingUI.stepBarStepPause
+    }
+
+    public static func textAdvanceSyncsWithStepBarTick() -> Bool {
+        LoginProcessingUI.setupCarouselStepAdvanceDelay == 0
+    }
+
+    public static func textAdvancePrecedesStepBarTick() -> Bool {
+        LoginProcessingUI.setupCarouselStepAdvanceDelay > LoginProcessingUI.stepBarStepPause
+    }
+}
+
+public enum LoginProcessingBackendPhasePolicy: Sendable {
+    public enum DisplayPhase: Equatable, Sendable {
+        case syncing
+        case prefetching
+    }
+
+    public static func displayPhase(
+        for accountPhase: OnboardingAccountPreparationPolicy.AccountStatePhase
+    ) -> DisplayPhase? {
+        switch accountPhase {
+        case .syncing:
+            return .syncing
+        case .requestingZkNyms:
+            return .prefetching
+        case .offline, .loggedOut, .readyToConnect, .decentralised, .upgradeMode,
+             .pendingSubscription, .error:
+            return nil
+        }
+    }
+}
+
+public enum LoginProcessingProgressPolicy: Sendable {
+    public static func setupProgressStep(carouselIndex: Int) -> Int {
+        let index = max(0, carouselIndex)
+        return min(index + 1, LoginProcessingUI.setupCarouselMaxProgressStep)
+    }
+
+    public static func credentialsCopyKeys(
+        isSyncing: Bool,
+        isPrefetching: Bool,
+        holdsPrefetchCopyThroughAdvance: Bool = false
+    ) -> (title: String, subtitle: String)? {
+        if isPrefetching || holdsPrefetchCopyThroughAdvance {
+            return (
+                LoginProcessingUI.almostReadyTitleKey,
+                LoginProcessingUI.almostReadySubtitleKey
+            )
+        }
+        guard isSyncing else { return nil }
+        return (
+            LoginProcessingUI.loadingCredentialsTitleKey,
+            LoginProcessingUI.loadingCredentialsSubtitleKey
+        )
+    }
+
+    public static func progressStep(
+        setupCarouselIndex: Int,
+        didFinishSetupCarousel: Bool,
+        isPrefetching: Bool,
+        isAwaitingAdvance: Bool,
+        hasReachedPrefetchPhase: Bool = false
+    ) -> Int {
+        if isPrefetching || isAwaitingAdvance || hasReachedPrefetchPhase {
+            return LoginProcessingUI.progressStep
+        }
+        if didFinishSetupCarousel {
+            return LoginProcessingUI.setupCarouselMaxProgressStep
+        }
+        return setupProgressStep(carouselIndex: setupCarouselIndex)
+    }
+}
+
+public enum LoginProcessingCarouselVisibilityPolicy: Sendable {
+    public static func showsCredentialsCopy(
+        usesStaticCopy: Bool,
+        didShowFinalMessage: Bool,
+        isSyncing: Bool,
+        isPrefetching: Bool,
+        holdsPrefetchCopyThroughAdvance: Bool = false
+    ) -> Bool {
+        guard !usesStaticCopy, !didShowFinalMessage else { return false }
+        return isSyncing || isPrefetching || holdsPrefetchCopyThroughAdvance
+    }
+}
+
+public enum LoginProcessingCopyPolicy: Sendable {
+    public static let credentialsStepTwoForbiddenTerms = ["connect", "ready"]
 }
 
 public enum PostPurchaseProcessingUI: Sendable {

--- a/nym-vpn-apple/Services/Sources/Services/CredentialsManager/CredentialsManager+AccountProcessing.swift
+++ b/nym-vpn-apple/Services/Sources/Services/CredentialsManager/CredentialsManager+AccountProcessing.swift
@@ -12,3 +12,11 @@ extension CredentialsManager: AccountProcessing {
 #endif
     }
 }
+
+#if os(macOS)
+extension CredentialsManager {
+    public func ensureDeviceRegisteredForLogin() async throws {
+        try await registerAccountIfNeeded()
+    }
+}
+#endif

--- a/nym-vpn-apple/Services/Sources/Services/CredentialsManager/CredentialsManager+iOSAccountController.swift
+++ b/nym-vpn-apple/Services/Sources/Services/CredentialsManager/CredentialsManager+iOSAccountController.swift
@@ -55,7 +55,14 @@ extension CredentialsManager {
         return .fetchedTickets
     }
 
-    func prepareRegisteredAccount(environment _: NymEnvironment) async throws {
+    func prepareRegisteredAccount(environment env: NymEnvironment) async throws {
+        try await prepareRegisteredAccount(environment: env, onAccountPhaseChange: nil)
+    }
+
+    func prepareRegisteredAccount(
+        environment _: NymEnvironment,
+        onAccountPhaseChange: (@MainActor (OnboardingAccountPreparationPolicy.AccountStatePhase) -> Void)?
+    ) async throws {
         do {
             try await AccountRegistrationSupport.withAccountStoreRetry(
                 operation: "prepareRegisteredAccount",
@@ -64,7 +71,8 @@ extension CredentialsManager {
                 try await withController { controller in
                     try await waitForOnboardingAccountPrepared(
                         controller: controller,
-                        timeout: 120
+                        timeout: 120,
+                        onAccountPhaseChange: onAccountPhaseChange
                     )
                 }
             }
@@ -75,20 +83,40 @@ extension CredentialsManager {
 
     func waitForOnboardingAccountPrepared(
         controller: NymAccountController,
-        timeout: TimeInterval
+        timeout: TimeInterval,
+        onAccountPhaseChange: (@MainActor (OnboardingAccountPreparationPolicy.AccountStatePhase) -> Void)? = nil
     ) async throws {
         let pollInterval: Duration = .milliseconds(250)
         let deadline = ContinuousClock.now + .seconds(timeout)
+        var consecutiveOfflineSeconds: TimeInterval = 0
+        var lastReportedPhase: OnboardingAccountPreparationPolicy.AccountStatePhase?
 
         while ContinuousClock.now < deadline {
             try Task.checkCancellation()
-            switch Self.accountPreparationWaitOutcome(for: await controller.getAccountState()) {
+            let state = await controller.getAccountState()
+            let accountPhase = Self.accountPreparationPhase(from: state)
+            if accountPhase != lastReportedPhase {
+                lastReportedPhase = accountPhase
+                onAccountPhaseChange?(accountPhase)
+            }
+            switch Self.accountPreparationWaitOutcome(for: state) {
             case .prepared:
                 return
             case .continueWaiting:
+                consecutiveOfflineSeconds = 0
                 try await Task.sleep(for: pollInterval)
             case .fail(let details):
-                throw VpnError.AccountControllerError(details: details)
+                if details == "offline" {
+                    consecutiveOfflineSeconds += OnboardingAccountPreparationPolicy.waitPollIntervalSeconds
+                    if OnboardingAccountPreparationPolicy.shouldFailOnOffline(
+                        consecutiveOfflineSeconds: consecutiveOfflineSeconds
+                    ) {
+                        throw VpnError.AccountControllerError(details: details)
+                    }
+                    try await Task.sleep(for: pollInterval)
+                } else {
+                    throw VpnError.AccountControllerError(details: details)
+                }
             }
         }
         throw VpnError.VpnApiTimeout

--- a/nym-vpn-apple/Services/Sources/Services/CredentialsManager/CredentialsManager.swift
+++ b/nym-vpn-apple/Services/Sources/Services/CredentialsManager/CredentialsManager.swift
@@ -262,12 +262,27 @@ import PathManager
             ).registerAccount()
         }.value
     }
+
+    public func ensureDeviceRegisteredForLogin() async throws {
+        let env = try resolvedRegistrationEnvironment()
+        _ = try await AccountRegistrationSupport.withAccountStoreRetry(
+            operation: "ensureDeviceRegisteredForLogin",
+            logger: logger
+        ) {
+            try await registerAccount(environment: env)
+        }
+    }
 #endif
 
-    public func prepareRegisteredAccount() async throws {
+    public func prepareRegisteredAccount(
+        onAccountPhaseChange: (@MainActor (OnboardingAccountPreparationPolicy.AccountStatePhase) -> Void)?
+    ) async throws {
 #if os(iOS)
         let env = try resolvedNetworkEnvironment()
-        try await prepareRegisteredAccount(environment: env)
+        try await prepareRegisteredAccount(
+            environment: env,
+            onAccountPhaseChange: onAccountPhaseChange
+        )
 #endif
     }
 

--- a/nym-vpn-apple/Services/Tests/CredentialsManagerTests/AccountPrefetchOrchestratorTests.swift
+++ b/nym-vpn-apple/Services/Tests/CredentialsManagerTests/AccountPrefetchOrchestratorTests.swift
@@ -17,7 +17,9 @@ private final class FakeAccountProcessing: AccountProcessing {
 
     func ensureCredentialImportResolved() async {}
 
-    func prepareRegisteredAccount() async throws {}
+    func prepareRegisteredAccount(
+        onAccountPhaseChange: (@MainActor (OnboardingAccountPreparationPolicy.AccountStatePhase) -> Void)?
+    ) async throws {}
 
     func updateAccountSummary(force: Bool, untilActive: Bool) async {
         events.append(.syncSummary)
@@ -38,6 +40,8 @@ private final class FakeAccountProcessing: AccountProcessing {
     func storeDeeplink(callbackURLString: String) async throws {}
 
     func registerAccountIfNeeded() async throws {}
+
+    func ensureDeviceRegisteredForLogin() async throws {}
 }
 
 @MainActor

--- a/nym-vpn-apple/Services/Tests/CredentialsManagerTests/LoginProcessingPolicyTests.swift
+++ b/nym-vpn-apple/Services/Tests/CredentialsManagerTests/LoginProcessingPolicyTests.swift
@@ -5,8 +5,217 @@ import AccountPrefetchGates
 struct LoginProcessingPolicyTests {
     @Test func loginProcessingUsesAnimatedCarousel() {
         #expect(LoginProcessingUI.requiresCarousel)
-        #expect(LoginProcessingUI.carouselKeys.count == 1)
+        #expect(LoginProcessingUI.carouselKeys.count == 4)
+        #expect(LoginProcessingUI.setupCarouselPairs().count == 3)
+        #expect(LoginProcessingUI.credentialsCarouselKeys.count == 4)
+        #expect(LoginProcessingUI.credentialsCarouselPairs().count == 2)
         #expect(ProcessingUIPolicy.showsOnboardingProgressBar(usesStaticCopy: false))
+    }
+
+    @Test func setupCarouselPairs_useDistinctHeadlines() {
+        let pairs = LoginProcessingUI.setupCarouselPairs()
+        let headlines = pairs.map(\.0)
+        #expect(Set(headlines).count == 3)
+        #expect(headlines.allSatisfy { !$0.isEmpty })
+    }
+
+    @Test func setupCarouselPairs_sharesContextSubtitle() {
+        let pairs = LoginProcessingUI.setupCarouselPairs()
+        let subtitles = pairs.map(\.1)
+        #expect(Set(subtitles).count == 1)
+        #expect(!subtitles[0].isEmpty)
+    }
+
+    @Test func setupCarouselTiming_allowsReadableDwellPerStep() {
+        #expect(LoginProcessingUI.setupCarouselInitialDwell >= 3)
+        #expect(LoginProcessingUI.setupCarouselTickInterval >= 3)
+        #expect(LoginProcessingUI.setupCarouselFinalPairDwell >= 3)
+        #expect(LoginProcessingUI.setupCarouselStepAdvanceDelay >= 0)
+        #expect(LoginProcessingCarouselTimingPolicy.setupCarouselMinimumDurationSeconds() >= 12)
+    }
+
+    @Test func setupCarouselTiming_textSyncsWithStepBar() {
+        #expect(LoginProcessingCarouselTimingPolicy.textAdvanceSyncsWithStepBarTick())
+        #expect(!LoginProcessingCarouselTimingPolicy.textAdvancePrecedesStepBarTick())
+        #expect(LoginProcessingUI.setupCarouselStepAdvanceDelay == 0)
+        #expect(LoginProcessingUI.setupCarouselTextTransitionDuration > 0)
+    }
+
+    @Test func setupProgressStep_mapsEachCarouselIndex() {
+        #expect(LoginProcessingProgressPolicy.setupProgressStep(carouselIndex: 0) == 1)
+        #expect(LoginProcessingProgressPolicy.setupProgressStep(carouselIndex: 1) == 2)
+        #expect(LoginProcessingProgressPolicy.setupProgressStep(carouselIndex: 2) == 3)
+    }
+
+    @Test func stepBar_animatesInitialFillToFirstSegment() {
+        #expect(LoginProcessingUI.stepBarAnimateInitialFill)
+        #expect(LoginProcessingUI.initialProgressStep == 1)
+    }
+
+    @Test func progressStep_holdsThirdSegmentAfterSetupUntilBackendPhase() {
+        #expect(
+            LoginProcessingProgressPolicy.progressStep(
+                setupCarouselIndex: 2,
+                didFinishSetupCarousel: true,
+                isPrefetching: false,
+                isAwaitingAdvance: false
+            ) == 3
+        )
+        #expect(
+            LoginProcessingProgressPolicy.credentialsCopyKeys(isSyncing: false, isPrefetching: false) == nil
+        )
+    }
+
+    @Test func credentialsCopyKeys_syncingAndPrefetch() {
+        #expect(LoginProcessingProgressPolicy.credentialsCopyKeys(isSyncing: false, isPrefetching: false) == nil)
+
+        let syncing = LoginProcessingProgressPolicy.credentialsCopyKeys(isSyncing: true, isPrefetching: false)
+        #expect(syncing?.title == LoginProcessingUI.loadingCredentialsTitleKey)
+        #expect(syncing?.subtitle == LoginProcessingUI.loadingCredentialsSubtitleKey)
+
+        let prefetching = LoginProcessingProgressPolicy.credentialsCopyKeys(isSyncing: false, isPrefetching: true)
+        #expect(prefetching?.title == LoginProcessingUI.almostReadyTitleKey)
+        #expect(prefetching?.subtitle == LoginProcessingUI.almostReadySubtitleKey)
+
+        #expect(
+            LoginProcessingProgressPolicy.credentialsCopyKeys(isSyncing: true, isPrefetching: true)?.title
+                == LoginProcessingUI.almostReadyTitleKey
+        )
+        let awaitingAfterPrefetch = LoginProcessingProgressPolicy.credentialsCopyKeys(
+            isSyncing: false,
+            isPrefetching: false,
+            holdsPrefetchCopyThroughAdvance: true
+        )
+        #expect(awaitingAfterPrefetch?.title == LoginProcessingUI.almostReadyTitleKey)
+    }
+
+    @Test func backendPhasePolicy_mapsControllerPhasesToDisplay() {
+        #expect(
+            LoginProcessingBackendPhasePolicy.displayPhase(for: .syncing) == .syncing
+        )
+        #expect(
+            LoginProcessingBackendPhasePolicy.displayPhase(for: .requestingZkNyms) == .prefetching
+        )
+        #expect(LoginProcessingBackendPhasePolicy.displayPhase(for: .readyToConnect) == nil)
+        #expect(LoginProcessingBackendPhasePolicy.displayPhase(for: .offline) == nil)
+    }
+
+    @Test func prefetchTimeout_coversTypicalDeviceWait() {
+        #expect(LoginProcessingUI.prefetchTimeoutSeconds >= 30)
+    }
+
+    @Test func progressStep_capsSetupAtThirdSegmentDuringCarousel() {
+        #expect(
+            LoginProcessingProgressPolicy.progressStep(
+                setupCarouselIndex: 2,
+                didFinishSetupCarousel: false,
+                isPrefetching: false,
+                isAwaitingAdvance: false
+            ) == 3
+        )
+    }
+
+    @Test func progressStep_holdsThirdSegmentDuringSync() {
+        #expect(
+            LoginProcessingProgressPolicy.progressStep(
+                setupCarouselIndex: 2,
+                didFinishSetupCarousel: true,
+                isPrefetching: false,
+                isAwaitingAdvance: false
+            ) == 3
+        )
+    }
+
+    @Test func progressStep_holdsFourthSegmentUntilPrefetchOrCompletion() {
+        #expect(
+            LoginProcessingProgressPolicy.progressStep(
+                setupCarouselIndex: 2,
+                didFinishSetupCarousel: true,
+                isPrefetching: true,
+                isAwaitingAdvance: false
+            ) == 4
+        )
+        #expect(
+            LoginProcessingProgressPolicy.progressStep(
+                setupCarouselIndex: 2,
+                didFinishSetupCarousel: true,
+                isPrefetching: false,
+                isAwaitingAdvance: true
+            ) == 4
+        )
+    }
+
+    @Test func progressStep_latchAfterPrefetchPreventsRegressionDuringCarousel() {
+        #expect(
+            LoginProcessingProgressPolicy.progressStep(
+                setupCarouselIndex: 0,
+                didFinishSetupCarousel: false,
+                isPrefetching: false,
+                isAwaitingAdvance: false,
+                hasReachedPrefetchPhase: true
+            ) == 4
+        )
+        #expect(
+            LoginProcessingProgressPolicy.progressStep(
+                setupCarouselIndex: 1,
+                didFinishSetupCarousel: false,
+                isPrefetching: false,
+                isAwaitingAdvance: false,
+                hasReachedPrefetchPhase: true
+            ) == 4
+        )
+    }
+
+    @Test func credentialsStepTwoCopy_doesNotPromiseConnect() throws {
+        let title = try NymVPNXCStringsReader.englishValue(for: LoginProcessingUI.almostReadyTitleKey)
+        let subtitle = try NymVPNXCStringsReader.englishValue(for: LoginProcessingUI.almostReadySubtitleKey)
+        let combined = (title + " " + subtitle).lowercased()
+        for term in LoginProcessingCopyPolicy.credentialsStepTwoForbiddenTerms {
+            #expect(!combined.contains(term), "Credentials step 2 must not contain \(term)")
+        }
+    }
+
+    @Test func credentialsCarouselVisibility_syncingAndPrefetch() {
+        #expect(
+            !LoginProcessingCarouselVisibilityPolicy.showsCredentialsCopy(
+                usesStaticCopy: false,
+                didShowFinalMessage: false,
+                isSyncing: false,
+                isPrefetching: false
+            )
+        )
+        #expect(
+            LoginProcessingCarouselVisibilityPolicy.showsCredentialsCopy(
+                usesStaticCopy: false,
+                didShowFinalMessage: false,
+                isSyncing: true,
+                isPrefetching: false
+            )
+        )
+        #expect(
+            LoginProcessingCarouselVisibilityPolicy.showsCredentialsCopy(
+                usesStaticCopy: false,
+                didShowFinalMessage: false,
+                isSyncing: false,
+                isPrefetching: true
+            )
+        )
+        #expect(
+            !LoginProcessingCarouselVisibilityPolicy.showsCredentialsCopy(
+                usesStaticCopy: true,
+                didShowFinalMessage: false,
+                isSyncing: true,
+                isPrefetching: true
+            )
+        )
+        #expect(
+            !LoginProcessingCarouselVisibilityPolicy.showsCredentialsCopy(
+                usesStaticCopy: false,
+                didShowFinalMessage: true,
+                isSyncing: true,
+                isPrefetching: true
+            )
+        )
     }
 
     @Test func loginCarouselBlocksNavigationUntilAnimationCompletes() {

--- a/nym-vpn-apple/Services/Tests/CredentialsManagerTests/OnboardingAccountPreparationPolicyTests.swift
+++ b/nym-vpn-apple/Services/Tests/CredentialsManagerTests/OnboardingAccountPreparationPolicyTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 import AccountPrefetchGates
 
@@ -49,5 +50,37 @@ struct OnboardingAccountPreparationPolicyTests {
             for: .error(.maxDeviceReached)
         )
         #expect(outcome == .fail("Max device numbers reached"))
+    }
+
+    @Test func offlineDebounce_transientOfflineDoesNotFailImmediately() {
+        #expect(
+            !OnboardingAccountPreparationPolicy.shouldFailOnOffline(consecutiveOfflineSeconds: 3)
+        )
+        #expect(
+            !OnboardingAccountPreparationPolicy.shouldFailOnOffline(
+                consecutiveOfflineSeconds: OnboardingAccountPreparationPolicy.offlineFailDebounceSeconds - 0.25
+            )
+        )
+    }
+
+    @Test func offlineDebounce_sustainedOfflineFails() {
+        #expect(
+            OnboardingAccountPreparationPolicy.shouldFailOnOffline(
+                consecutiveOfflineSeconds: OnboardingAccountPreparationPolicy.offlineFailDebounceSeconds
+            )
+        )
+        #expect(
+            OnboardingAccountPreparationPolicy.shouldFailOnOffline(consecutiveOfflineSeconds: 6)
+        )
+    }
+
+    @Test func offlineDebounce_resetsAfterNonOfflinePoll() {
+        let interval = OnboardingAccountPreparationPolicy.waitPollIntervalSeconds
+        var streak: TimeInterval = 4.75
+        streak += interval
+        #expect(OnboardingAccountPreparationPolicy.shouldFailOnOffline(consecutiveOfflineSeconds: streak))
+        streak = 0
+        streak += interval
+        #expect(!OnboardingAccountPreparationPolicy.shouldFailOnOffline(consecutiveOfflineSeconds: streak))
     }
 }

--- a/nym-vpn-apple/ServicesMutual/Tests/ConnectionTypesTests/XCStringsResolverTests.swift
+++ b/nym-vpn-apple/ServicesMutual/Tests/ConnectionTypesTests/XCStringsResolverTests.swift
@@ -13,6 +13,13 @@ struct XCStringsResolverTests {
         let resolver = try XCStringsResolver.default()
         let keys = [
             "processingAccount.login.settingUp",
+            "processingAccount.login.settingUpStep2Subtitle",
+            "processingAccount.login.settingUpStep3Subtitle",
+            "processingAccount.login.settingUpStep4Subtitle",
+            "processingAccount.login.loadingCredentials",
+            "processingAccount.login.loadingCredentialsSubtitle",
+            "processingAccount.login.almostReady",
+            "processingAccount.login.almostReadySubtitle",
             "processingAccount.awaitingConfirmation.title",
             "processingAccount.awaitingConfirmation.subtitle"
         ]

--- a/nym-vpn-apple/UIComponents/Sources/UIComponents/26/StepsView/StepView.swift
+++ b/nym-vpn-apple/UIComponents/Sources/UIComponents/26/StepsView/StepView.swift
@@ -7,6 +7,9 @@ public struct StepView: View {
     let stepCount: Int
     @Binding var currentStep: Int
     let animateInitialFill: Bool
+    let initialFillLeadIn: TimeInterval
+    let initialFillStepPause: TimeInterval
+    let forwardFillStepPause: TimeInterval
 
     @State private var displayedStep: Int = 0
     @State private var animationTask: Task<Void, Never>?
@@ -14,11 +17,17 @@ public struct StepView: View {
     public init(
         stepCount: Int,
         currentStep: Binding<Int>,
-        animateInitialFill: Bool = true
+        animateInitialFill: Bool = true,
+        initialFillLeadIn: TimeInterval = 0.3,
+        initialFillStepPause: TimeInterval = 0.3,
+        forwardFillStepPause: TimeInterval? = nil
     ) {
         self.stepCount = stepCount
         _currentStep = currentStep
         self.animateInitialFill = animateInitialFill
+        self.initialFillLeadIn = initialFillLeadIn
+        self.initialFillStepPause = initialFillStepPause
+        self.forwardFillStepPause = forwardFillStepPause ?? 0.3
     }
 
     public var body: some View {
@@ -77,7 +86,7 @@ private extension StepView {
         displayedStep = 0
 
         animationTask = Task { @MainActor in
-            try? await Task.sleep(for: .seconds(0.3))
+            try? await Task.sleep(for: .seconds(initialFillLeadIn))
             guard target > 0 else { return }
             for step in 1...target {
                 guard !Task.isCancelled else { return }
@@ -85,7 +94,7 @@ private extension StepView {
                 withAnimation(.linear(duration: perStepDuration)) {
                     displayedStep = step
                 }
-                try? await Task.sleep(for: .seconds(0.3))
+                try? await Task.sleep(for: .seconds(initialFillStepPause))
             }
         }
     }
@@ -104,7 +113,7 @@ private extension StepView {
                     displayedStep = step
                 }
 
-                try? await Task.sleep(for: .seconds(1))
+                try? await Task.sleep(for: .seconds(forwardFillStepPause))
             }
         }
     }

--- a/nym-vpn-apple/UIComponents/Sources/UIComponents/26/SwitchingTitleSubtitle/SwitchingTitlesView.swift
+++ b/nym-vpn-apple/UIComponents/Sources/UIComponents/26/SwitchingTitleSubtitle/SwitchingTitlesView.swift
@@ -5,16 +5,46 @@ import Theme
 public struct SwitchingTitlesView: View {
     private let pairs: [(title: String, subtitle: String)]
     private let timerDidTick: () -> Void
+    private let tickInterval: TimeInterval
+    private let stepAdvanceDelay: TimeInterval
+    private let textTransitionDuration: TimeInterval
+    private let initialDwell: TimeInterval
+    private let holdOnLastPair: Bool
+    private let retainLastPairOnFinish: Bool
+    private let finalPairDwell: TimeInterval
+    private let onIndexChanged: ((Int) -> Void)?
 
     @State private var currentIndex = 0
     @State private var timerCancellable: AnyCancellable?
+    @State private var stepAdvanceTask: Task<Void, Never>?
+    @State private var initialDwellTask: Task<Void, Never>?
 
     @Binding var didFinishAnimating: Bool
 
-    public init(pairs: [(String, String)], didFinishAnimating: Binding<Bool>, timerDidTick: @escaping () -> Void) {
+    public init(
+        pairs: [(String, String)],
+        didFinishAnimating: Binding<Bool>,
+        timerDidTick: @escaping () -> Void,
+        tickInterval: TimeInterval = 2.0,
+        stepAdvanceDelay: TimeInterval = 0,
+        textTransitionDuration: TimeInterval = 0.35,
+        initialDwell: TimeInterval = 0,
+        holdOnLastPair: Bool = false,
+        retainLastPairOnFinish: Bool = false,
+        finalPairDwell: TimeInterval = 0,
+        onIndexChanged: ((Int) -> Void)? = nil
+    ) {
         self.pairs = pairs.map { (title: $0.0, subtitle: $0.1) }
         _didFinishAnimating = didFinishAnimating
         self.timerDidTick = timerDidTick
+        self.tickInterval = tickInterval
+        self.stepAdvanceDelay = stepAdvanceDelay
+        self.textTransitionDuration = textTransitionDuration
+        self.initialDwell = initialDwell
+        self.holdOnLastPair = holdOnLastPair
+        self.retainLastPairOnFinish = retainLastPairOnFinish
+        self.finalPairDwell = finalPairDwell
+        self.onIndexChanged = onIndexChanged
     }
 
     public var body: some View {
@@ -26,6 +56,8 @@ public struct SwitchingTitlesView: View {
                 .fixedSize(horizontal: false, vertical: true)
                 .lineLimit(2)
                 .minimumScaleFactor(0.9)
+                .contentTransition(.opacity)
+                .animation(textTransition, value: currentIndex)
 
             if !pairs[currentIndex].subtitle.isEmpty {
                 Text(pairs[currentIndex].subtitle)
@@ -35,27 +67,47 @@ public struct SwitchingTitlesView: View {
                     .fixedSize(horizontal: false, vertical: true)
                     .lineLimit(2)
                     .minimumScaleFactor(0.9)
+                    .contentTransition(.opacity)
+                    .animation(textTransition, value: currentIndex)
             }
         }
         .frame(maxWidth: .infinity, alignment: .center)
         .onAppear {
-            startTimer()
+            syncExternalIndex(currentIndex)
+            beginCarousel()
         }
         .onDisappear {
             stopTimer()
+            stepAdvanceTask?.cancel()
+            initialDwellTask?.cancel()
         }
     }
 }
 
 private extension SwitchingTitlesView {
+    var textTransition: Animation {
+        .easeInOut(duration: textTransitionDuration)
+    }
+
+    func beginCarousel() {
+        guard initialDwell > 0 else {
+            startTimer()
+            return
+        }
+        initialDwellTask = Task { @MainActor in
+            try? await Task.sleep(for: .seconds(initialDwell))
+            guard !Task.isCancelled else { return }
+            startTimer()
+        }
+    }
+
     func startTimer() {
         stopTimer()
 
-        timerCancellable = Timer.publish(every: 2.0, on: .main, in: .common)
+        timerCancellable = Timer.publish(every: tickInterval, on: .main, in: .common)
             .autoconnect()
             .sink { _ in
                 advanceIndex()
-                timerDidTick()
             }
     }
 
@@ -65,11 +117,65 @@ private extension SwitchingTitlesView {
     }
 
     func advanceIndex() {
+        stepAdvanceTask?.cancel()
         let nextIndex = currentIndex + 1
         if nextIndex < pairs.count {
-            currentIndex = nextIndex
+            if stepAdvanceDelay > 0 {
+                withAnimation(textTransition) {
+                    currentIndex = nextIndex
+                }
+                syncExternalIndex(nextIndex)
+                scheduleDelayedStepBarTick()
+            } else {
+                commitSyncedAdvance(to: nextIndex)
+            }
+            if retainLastPairOnFinish, nextIndex == pairs.count - 1 {
+                stopTimer()
+                scheduleFinishAfterFinalPairDwell()
+            }
+        } else if holdOnLastPair {
+            return
+        } else if retainLastPairOnFinish {
+            scheduleFinishAfterFinalPairDwell()
         } else {
             currentIndex = 0
+            didFinishAnimating = true
+        }
+    }
+
+    /// Updates copy and notifies the step bar on the same tick.
+    func commitSyncedAdvance(to nextIndex: Int) {
+        withAnimation(textTransition) {
+            currentIndex = nextIndex
+        }
+        syncExternalIndex(nextIndex)
+    }
+
+    func syncExternalIndex(_ index: Int) {
+        if let onIndexChanged {
+            onIndexChanged(index)
+        } else {
+            timerDidTick()
+        }
+    }
+
+    func scheduleDelayedStepBarTick() {
+        stepAdvanceTask = Task { @MainActor in
+            try? await Task.sleep(for: .seconds(stepAdvanceDelay))
+            guard !Task.isCancelled else { return }
+            timerDidTick()
+        }
+    }
+
+    func scheduleFinishAfterFinalPairDwell() {
+        initialDwellTask?.cancel()
+        guard finalPairDwell > 0 else {
+            didFinishAnimating = true
+            return
+        }
+        initialDwellTask = Task { @MainActor in
+            try? await Task.sleep(for: .seconds(finalPairDwell))
+            guard !Task.isCancelled else { return }
             didFinishAnimating = true
         }
     }


### PR DESCRIPTION
- Cherry-picks merged release PR #5776 (commit 0ca42d822) onto develop.
- Slower login setup carousel pacing with distinct copy per beat.
- Login processing text and progress bar stay in sync with account controller phases.
- Prefetch phase latch prevents progress bar regression after zk-nym fetch.
- Offline debounce during account preparation on poor cellular.
- Device registration before prepare on the login path.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5788)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the login/setup experience with a multi-step progress carousel, new credential-loading messages, and smoother title/subtitle transitions.
  * Added clearer step-by-step progress behavior during account setup and device registration.
* **Bug Fixes**
  * Improved handling of offline waiting so brief outages no longer fail the process too early.
  * Prevented progress from jumping backward during setup and prefetch phases.
* **Tests**
  * Added coverage for the new onboarding states, carousel timing, and offline debounce behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->