### PR TITLE
Move logout guard state updates into CredentialsManager

### DIFF
--- a/nym-vpn-apple/Home/Sources/26/AppFeature/AppFeatureViewModel.swift
+++ b/nym-vpn-apple/Home/Sources/26/AppFeature/AppFeatureViewModel.swift
@@ -358,6 +358,10 @@ import GRPCManager
     }
 
     public func reconcilePurchaseFlowAfterAccountRefresh() {
+        guard !pendingPlanPurchaseNavigationAfterDrawerHide,
+              planPurchaseTransitionTask == nil,
+              !isCheckoutNavigationPending
+        else { return }
         guard DrawerSessionPolicy.shouldCompleteCheckoutAfterAccountRefresh(
             isPurchaseFlowActive: sessionContext.isPurchaseFlowActive,
             isAccountActive: credentialsManager.isAccountActive()
@@ -687,20 +691,22 @@ private extension AppFeatureViewModel {
             }
             withAnimation(.easeInOut(duration: Self.paywallTransitionDuration)) {
                 self.drawerContent = nil
-            } completion: {
-                self.completeCheckoutDrawerTransition(hadProcessingDrawer: hadProcessingDrawer)
             }
+            try? await Task.sleep(for: .seconds(Self.paywallTransitionDuration))
+            guard !Task.isCancelled else { return }
+            self.completeCheckoutDrawerTransition(hadProcessingDrawer: hadProcessingDrawer)
         }
     }
 
     func completeCheckoutDrawerTransition(hadProcessingDrawer: Bool = false) {
+        let shouldMarkCheckoutNavigationPending = pendingPlanPurchaseNavigationAfterDrawerHide
         planPurchaseTransitionTask = nil
         if PurchaseTransitionPolicy.shouldCancelProcessingAfterDrawerHidden(
             hadProcessingDrawer: hadProcessingDrawer
         ) {
             cancelProcessingTransition()
         }
-        guard pendingPlanPurchaseNavigationAfterDrawerHide else { return }
+        guard shouldMarkCheckoutNavigationPending else { return }
         isCheckoutNavigationPending = true
         planPurchaseTransitionTask = Task { @MainActor [weak self] in
             try? await Task.sleep(

--- a/nym-vpn-apple/Home/Tests/HomeTests/AppFeatureViewModelCheckoutTransitionTests.swift
+++ b/nym-vpn-apple/Home/Tests/HomeTests/AppFeatureViewModelCheckoutTransitionTests.swift
@@ -10,6 +10,18 @@ import SnackbarManager
 
 @MainActor
 final class AppFeatureViewModelCheckoutTransitionTests: XCTestCase {
+    private func waitForCheckoutNavigationPending(
+        _ viewModel: AppFeatureViewModel,
+        timeoutMs: Int = 2_000
+    ) async throws {
+        let deadline = ContinuousClock.now + .milliseconds(timeoutMs)
+        while ContinuousClock.now < deadline {
+            if viewModel.isCheckoutNavigationPending { return }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        XCTFail("Timed out waiting for checkout navigation pending")
+    }
+
     private func makeViewModel() -> AppFeatureViewModel {
 #if os(iOS)
         AppFeatureViewModel(
@@ -95,7 +107,7 @@ final class AppFeatureViewModelCheckoutTransitionTests: XCTestCase {
         viewModel.handleSessionEvent(.authCompleted(outcome: .registeredActive, flow: .createAccount))
         viewModel.handleSessionEvent(.requestPlanPurchase)
 
-        try await Task.sleep(for: .milliseconds(750))
+        try await waitForCheckoutNavigationPending(viewModel)
 
         XCTAssertTrue(
             viewModel.isCheckoutNavigationPending,

--- a/nym-vpn-apple/Home/Tests/HomeTests/ProcessingAccountViewModelTests.swift
+++ b/nym-vpn-apple/Home/Tests/HomeTests/ProcessingAccountViewModelTests.swift
@@ -46,7 +46,9 @@ private final class FakeProcessing: AccountProcessing {
             onAccountPhaseChange?(phase)
         }
         if holdPrepareUntilReleased {
-            await withCheckedContinuation { prepareRelease = $0.resume() }
+            await withCheckedContinuation { continuation in
+                prepareRelease = { continuation.resume() }
+            }
         }
         if let prepareError {
             throw prepareError

--- a/nym-vpn-apple/Home/Tests/HomeTests/ProcessingAccountViewModelTests.swift
+++ b/nym-vpn-apple/Home/Tests/HomeTests/ProcessingAccountViewModelTests.swift
@@ -157,6 +157,7 @@ struct ProcessingAccountViewModelTests {
             .storeDeeplink("nymvpn://auth/privy/privateKey?x=1"),
             .register,
             .ensure,
+            .ensureDeviceRegistered,
             .prepare,
             .sync,
             .isActive,
@@ -272,12 +273,14 @@ struct ProcessingAccountViewModelTests {
         let viewModel = makeViewModel(flow: .createAccount, processing: processing, coordinator: coordinator)
 
         await viewModel.run()
-        viewModel.animationDidFinish()
-
         #expect(viewModel.phase == .awaitingAdvance)
         #expect(viewModel.currentStep == 4)
         #expect(viewModel.credentialsDisplayPair == nil)
+
+        viewModel.animationDidFinish()
+
         #expect(viewModel.didFinishAnimatingText)
+        #expect(viewModel.phase == .finalizing)
     }
 
     @Test func navigationBlockedUntilSetupCarouselCompletes() async {
@@ -362,9 +365,9 @@ struct ProcessingAccountViewModelTests {
         await viewModel.run()
 
         #expect(processing.calls.contains(.prefetch))
-        #expect(viewModel.phase == .awaitingAdvance)
         #expect(viewModel.currentStep == 4)
         #expect(viewModel.didFinishAnimatingText)
+        #expect(viewModel.phase == .finalizing)
         #expect(coordinator.actions.isEmpty)
     }
 

--- a/nym-vpn-apple/Services/Sources/Services/CredentialsManager/CredentialsManager+iOSAccountController.swift
+++ b/nym-vpn-apple/Services/Sources/Services/CredentialsManager/CredentialsManager+iOSAccountController.swift
@@ -25,17 +25,6 @@ extension CredentialsManager {
         }
     }
 
-    func beginLogoutOnIOS() async {
-        isLoggingOut = true
-        accountSummaryUpdateTask?.cancel()
-        accountSummaryUpdateTask = nil
-        await shutdownControllersAndWait()
-    }
-
-    func endLogoutOnIOS() {
-        isLoggingOut = false
-    }
-
     var isTunnelActive: Bool {
         AccountTunnelPrefetchGate.isTunnelActive(status: TunnelsManager.shared.activeTunnel?.status)
     }

--- a/nym-vpn-apple/Services/Sources/Services/CredentialsManager/CredentialsManager.swift
+++ b/nym-vpn-apple/Services/Sources/Services/CredentialsManager/CredentialsManager.swift
@@ -322,13 +322,16 @@ import PathManager
 
     public func beginLogout() async {
 #if os(iOS)
-        await beginLogoutOnIOS()
+        isLoggingOut = true
+        accountSummaryUpdateTask?.cancel()
+        accountSummaryUpdateTask = nil
+        await shutdownControllersAndWait()
 #endif
     }
 
     public func endLogout() {
 #if os(iOS)
-        endLogoutOnIOS()
+        isLoggingOut = false
 #endif
     }
 

--- a/nym-vpn-apple/Settings/Sources/Settings/SettingsViewModel.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/SettingsViewModel.swift
@@ -200,6 +200,19 @@ private extension SettingsViewModel {
         impactGenerator.softImpact()
         path.append(SettingLink.notifications)
     }
+
+    func updateAccountSectionOnly() {
+        guard appSettings.isCredentialImported else {
+            sections.removeAll { $0.kind == .account }
+            return
+        }
+        let updated = accountSection()
+        if let index = sections.firstIndex(where: { $0.kind == .account }) {
+            sections[index] = updated
+        } else {
+            sections.insert(updated, at: 0)
+        }
+    }
 }
 
 // MARK: - Setup -
@@ -246,19 +259,6 @@ private extension SettingsViewModel {
                 }
             }
             .store(in: &cancellables)
-    }
-
-    func updateAccountSectionOnly() {
-        guard appSettings.isCredentialImported else {
-            sections.removeAll { $0.kind == .account }
-            return
-        }
-        let updated = accountSection()
-        if let index = sections.firstIndex(where: { $0.kind == .account }) {
-            sections[index] = updated
-        } else {
-            sections.insert(updated, at: 0)
-        }
     }
 
     /// Configures sections, to reload all the content - use reloadSections

--- a/nym-vpn-apple/Settings/Sources/Settings/SettingsViewModel.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/SettingsViewModel.swift
@@ -115,6 +115,19 @@ import Theme
     func reloadSections() {
         configureSections()
     }
+
+    func updateAccountSectionOnly() {
+        guard appSettings.isCredentialImported else {
+            sections.removeAll { $0.kind == .account }
+            return
+        }
+        let updated = accountSection()
+        if let index = sections.firstIndex(where: { $0.kind == .account }) {
+            sections[index] = updated
+        } else {
+            sections.insert(updated, at: 0)
+        }
+    }
 }
 
 private extension SettingsViewModel {
@@ -199,19 +212,6 @@ private extension SettingsViewModel {
     func navigateToNotifications() {
         impactGenerator.softImpact()
         path.append(SettingLink.notifications)
-    }
-
-    func updateAccountSectionOnly() {
-        guard appSettings.isCredentialImported else {
-            sections.removeAll { $0.kind == .account }
-            return
-        }
-        let updated = accountSection()
-        if let index = sections.firstIndex(where: { $0.kind == .account }) {
-            sections[index] = updated
-        } else {
-            sections.insert(updated, at: 0)
-        }
     }
 }
 


### PR DESCRIPTION
Swift private members are file-scoped; extension helpers could not set isLoggingOut or cancel accountSummaryUpdateTask during iOS Release CI.

## Ticket

JIRA-NYM-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5791)
<!-- Reviewable:end -->
