### PR TITLE
Fix/nym 1561 reset dns on linux

### DIFF
--- a/nym-vpn-core/crates/nym-dns/src/linux/mod.rs
+++ b/nym-vpn-core/crates/nym-dns/src/linux/mod.rs
@@ -75,7 +75,7 @@ impl super::DnsMonitorT for DnsMonitor {
             inner.reset().await?;
         } else if let Ok(mut inner) = DnsMonitorHolder::new() {
             // This helps reset the DNS configuration when the system is rebooted while the VPN is still connected.
-            inner.reset().await?;
+            let _ = inner.reset().await;
         }
         Ok(())
     }

--- a/nym-vpn-core/crates/nym-dns/src/linux/mod.rs
+++ b/nym-vpn-core/crates/nym-dns/src/linux/mod.rs
@@ -73,6 +73,9 @@ impl super::DnsMonitorT for DnsMonitor {
     async fn reset(&mut self) -> Result<()> {
         if let Some(mut inner) = self.inner.take() {
             inner.reset().await?;
+        } else if let Ok(mut inner) = DnsMonitorHolder::new() {
+            // This helps reset the DNS configuration when the system is rebooted while the VPN is still connected.
+            inner.reset().await?;
         }
         Ok(())
     }

--- a/nym-vpn-core/crates/nym-dns/src/linux/resolvconf.rs
+++ b/nym-vpn-core/crates/nym-dns/src/linux/resolvconf.rs
@@ -25,8 +25,8 @@ pub enum Error {
     #[error("failed to execute 'resolvconf' program")]
     RunResolvconf(#[from] io::Error),
 
-    #[error("using 'resolvconf' to add a record failed: {}", stderr)]
-    AddRecord { stderr: String },
+    #[error("using 'resolvconf' to add record '{record_name}' failed: {stderr}")]
+    AddRecord { record_name: String, stderr: String },
 
     #[error("using 'resolvconf' to delete record '{record_name}' failed: {stderr}")]
     DeleteRecord { record_name: String, stderr: String },
@@ -98,7 +98,10 @@ impl Resolvconf {
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-            return Err(Error::AddRecord { stderr });
+            return Err(Error::AddRecord {
+                record_name,
+                stderr,
+            });
         }
 
         self.record_names.insert(record_name);

--- a/nym-vpn-core/crates/nym-dns/src/linux/resolvconf.rs
+++ b/nym-vpn-core/crates/nym-dns/src/linux/resolvconf.rs
@@ -28,8 +28,8 @@ pub enum Error {
     #[error("using 'resolvconf' to add a record failed: {}", stderr)]
     AddRecord { stderr: String },
 
-    #[error("using 'resolvconf' to delete a record failed")]
-    DeleteRecord,
+    #[error("using 'resolvconf' to delete record '{record_name}' failed: {stderr}")]
+    DeleteRecord { record_name: String, stderr: String },
 
     #[error("detected dnsmasq is running and misconfigured")]
     DnsmasqMisconfiguration,
@@ -116,13 +116,11 @@ impl Resolvconf {
                 .run()
                 .map_err(Error::RunResolvconf)?;
 
-            if !output.status.success() {
-                tracing::error!(
-                    "Failed to delete 'resolvconf' record '{}':\n{}",
+            if !output.status.success() && result.is_ok() {
+                result = Err(Error::DeleteRecord {
                     record_name,
-                    String::from_utf8_lossy(&output.stderr)
-                );
-                result = Err(Error::DeleteRecord);
+                    stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+                });
             }
         }
 

--- a/nym-vpn-core/crates/nym-dns/src/linux/systemd_resolved.rs
+++ b/nym-vpn-core/crates/nym-dns/src/linux/systemd_resolved.rs
@@ -4,7 +4,6 @@
 
 use std::net::IpAddr;
 
-use nym_common::trace_err_chain;
 use nym_dbus::systemd_resolved::{AsyncHandle, SystemdResolved as DbusInterface};
 use nym_routing::RouteManagerHandle;
 

--- a/nym-vpn-core/crates/nym-dns/src/linux/systemd_resolved.rs
+++ b/nym-vpn-core/crates/nym-dns/src/linux/systemd_resolved.rs
@@ -19,6 +19,12 @@ pub enum Error {
 
     #[error("unable to translate network interface name \"{0}\" into index")]
     LookupInterfaceIndex(String, #[source] nix::Error),
+
+    #[error("failed to set search domains")]
+    SetDomainsError(#[source] SystemdDbusError),
+
+    #[error("failed to disable DoT")]
+    DisableDotError(#[source] SystemdDbusError),
 }
 
 pub struct SystemdResolved {
@@ -69,19 +75,22 @@ impl SystemdResolved {
     }
 
     pub async fn reset(&mut self) -> Result<()> {
+        let mut result = Ok(());
+
         if let Err(error) = self
             .dbus_interface
             .set_domains(self.tunnel_index, &[])
             .await
         {
-            trace_err_chain!(error, "Failed to set search domains");
+            result = Err(Error::SetDomainsError(error));
         }
 
-        let _ = self
-            .dbus_interface
-            .set_dns(self.tunnel_index, vec![])
-            .await?;
+        if let Err(error) = self.dbus_interface.set_dns(self.tunnel_index, vec![]).await {
+            if result.is_ok() {
+                result = Err(Error::SystemdResolvedError(error));
+            }
+        }
 
-        Ok(())
+        result
     }
 }

--- a/nym-vpn-core/crates/nym-dns/src/linux/systemd_resolved.rs
+++ b/nym-vpn-core/crates/nym-dns/src/linux/systemd_resolved.rs
@@ -54,17 +54,15 @@ impl SystemdResolved {
             .map_err(|e| Error::LookupInterfaceIndex(interface_name.to_owned(), e))?;
         self.tunnel_index = tunnel_index;
 
-        if let Err(error) = self.dbus_interface.disable_dot(self.tunnel_index).await {
-            trace_err_chain!(error, "Failed to disable DoT");
-        }
+        self.dbus_interface
+            .disable_dot(self.tunnel_index)
+            .await
+            .map_err(Error::DisableDotError)?;
 
-        if let Err(error) = self
-            .dbus_interface
+        self.dbus_interface
             .set_domains(tunnel_index, &[(".", true)])
             .await
-        {
-            trace_err_chain!(error, "Failed to set search domains");
-        }
+            .map_err(Error::SetDomainsError)?;
 
         let _ = self
             .dbus_interface


### PR DESCRIPTION
## Ticket

JIRA-NYM-1561

## Description

Clean-up DNS on Linux when the system was rebooted while the VPN was up.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)
 
This does add a nasty message to the log though:

<img width="623" height="69" alt="image" src="https://github.com/user-attachments/assets/4ecc6677-fc5e-492b-bf3b-5e4f6b38257c" />

Update: Fixed by removing logging from the Linux DNS implementations and instead returning more detailed error enum variants.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5792)
<!-- Reviewable:end -->
