### PR TITLE
Cherry-pick login processing advance fix to develop

### DIFF
--- a/nym-vpn-apple/Home/Sources/26/AppFeature/AppFeatureView.swift
+++ b/nym-vpn-apple/Home/Sources/26/AppFeature/AppFeatureView.swift
@@ -411,9 +411,11 @@ private extension AppFeatureView {
                 imageSize: Constants.NavigationBar.TrailingIcon.size,
                 accessibilityLabel: "home.navigationBar.settings.accessibilityLabel".localizedString
             ) {
+                guard viewModel.drawerContent?.isProcessing != true else { return }
                 impactGenerator.softImpact()
                 viewModel.path.append(HomeLink.settings)
             }
+            .allowsHitTesting(viewModel.drawerContent?.isProcessing != true)
             .padding(.leading, NymSpacing.small)
         }
         .frame(height: Constants.NavigationBar.height)

--- a/nym-vpn-apple/Home/Sources/26/AppFeature/AppFeatureViewModel.swift
+++ b/nym-vpn-apple/Home/Sources/26/AppFeature/AppFeatureViewModel.swift
@@ -490,6 +490,7 @@ private extension AppFeatureViewModel {
         )
         viewModel.sessionCoordinator = self
         processingViewModel = viewModel
+        viewModel.start()
         // Welcome and processing share the same drawer slide identity, so
         // commit directly instead of staging through pendingDrawerContent —
         // that avoids triggering DrawerView.slideOut and lets the inner

--- a/nym-vpn-apple/Home/Sources/26/ProcessingAccount/ProcessingAccountView.swift
+++ b/nym-vpn-apple/Home/Sources/26/ProcessingAccount/ProcessingAccountView.swift
@@ -26,9 +26,6 @@ struct ProcessingAccountView: View {
         .padding(.vertical, AuthLayout.processingCarouselVerticalPadding)
         .frame(maxWidth: .infinity)
         .frame(height: minHeight > 0 ? minHeight : nil, alignment: .top)
-        .task {
-            viewModel.start()
-        }
     }
 }
 

--- a/nym-vpn-apple/Home/Sources/26/ProcessingAccount/ProcessingAccountViewModel.swift
+++ b/nym-vpn-apple/Home/Sources/26/ProcessingAccount/ProcessingAccountViewModel.swift
@@ -98,8 +98,20 @@ public final class ProcessingAccountViewModel {
     }
 
     func start() {
-        processingTask?.cancel()
+        switch phase {
+        case .awaitingAdvance:
+            latchSetupCarouselIfNeeded()
+            updateAnimationReady()
+            evaluateAdvance()
+            return
+        case .finalizing, .finished:
+            return
+        default:
+            break
+        }
+        guard processingTask == nil else { return }
         processingTask = Task { @MainActor [weak self] in
+            defer { self?.processingTask = nil }
             await self?.run()
         }
     }
@@ -247,8 +259,15 @@ public final class ProcessingAccountViewModel {
         }
         phase = .awaitingAdvance
         syncProgressStep()
+        latchSetupCarouselIfNeeded()
         workCompleted = true
         updateAnimationReady()
+    }
+
+    private func latchSetupCarouselIfNeeded() {
+        guard !usesStaticCopy, !didFinishSetupCarousel else { return }
+        didFinishSetupCarousel = true
+        syncProgressStep()
     }
 
     private func updateAnimationReady() {

--- a/nym-vpn-apple/Home/Tests/HomeTests/ProcessingAccountViewModelTests.swift
+++ b/nym-vpn-apple/Home/Tests/HomeTests/ProcessingAccountViewModelTests.swift
@@ -129,7 +129,7 @@ private func makeViewModel(
 
 @MainActor
 struct ProcessingAccountViewModelTests {
-    @Test func loginRunsImportPrepSyncPrefetchThenAwaitsAdvance() async {
+    @Test func loginRunsImportPrepSyncPrefetchThenAdvances() async {
         let processing = FakeProcessing()
         let coordinator = FakeCoordinator()
         let viewModel = makeViewModel(flow: .login, processing: processing, coordinator: coordinator)
@@ -137,8 +137,9 @@ struct ProcessingAccountViewModelTests {
         await viewModel.run()
 
         #expect(processing.calls == [.ensure, .ensureDeviceRegistered, .prepare, .sync, .isActive, .prefetch])
-        #expect(viewModel.phase == .awaitingAdvance)
-        #expect(coordinator.actions.isEmpty)
+        await viewModel.awaitFinalMessage()
+        #expect(viewModel.phase == .finished)
+        #expect(coordinator.actions == [.session(.processingFinished)])
     }
 
     @Test func deeplinkLoginStoresAndRegistersBeforePrepare() async {
@@ -163,8 +164,10 @@ struct ProcessingAccountViewModelTests {
             .isActive,
             .prefetch
         ])
-        #expect(viewModel.phase == .awaitingAdvance)
-        #expect(coordinator.actions.isEmpty)
+        #expect(viewModel.phase == .finished || viewModel.phase == .finalizing)
+        await viewModel.awaitFinalMessage()
+        #expect(viewModel.phase == .finished)
+        #expect(coordinator.actions == [.session(.processingFinished)])
     }
 
     @Test func deeplinkLoginStoreFailureFailsBeforePrepare() async {
@@ -200,7 +203,8 @@ struct ProcessingAccountViewModelTests {
         await viewModel.run()
 
         #expect(processing.calls == [.ensure, .sync, .isActive, .prefetch])
-        #expect(viewModel.phase == .awaitingAdvance)
+        await viewModel.awaitFinalMessage()
+        #expect(viewModel.phase == .finished)
     }
 
     @Test func postPurchaseStaticFinishesWithoutAnimation() async {
@@ -224,7 +228,8 @@ struct ProcessingAccountViewModelTests {
 
         #expect(processing.calls == [.ensure, .sync, .isActive])
         #expect(!processing.calls.contains(.prefetch))
-        #expect(viewModel.phase == .awaitingAdvance)
+        await viewModel.awaitFinalMessage()
+        #expect(viewModel.phase == .finished)
     }
 
     @Test func prepareFailurePublishesFailedAndNotifiesCoordinator() async {
@@ -247,19 +252,16 @@ struct ProcessingAccountViewModelTests {
         }
     }
 
-    @Test func advanceWaitsForBothWorkAndAnimation() async {
+    @Test func advanceWhenWorkCompletesWithoutWaitingForCarousel() async {
         let processing = FakeProcessing()
         let coordinator = FakeCoordinator()
         let viewModel = makeViewModel(flow: .createAccount, processing: processing, coordinator: coordinator)
 
         await viewModel.run()
-        #expect(viewModel.phase == .awaitingAdvance)
-        #expect(viewModel.currentStep == 4)
-        #expect(coordinator.actions.isEmpty)
 
-        viewModel.animationDidFinish()
+        #expect(viewModel.didFinishSetupCarousel)
         #expect(viewModel.didFinishAnimatingText)
-        #expect(viewModel.phase == .finalizing)
+        #expect(viewModel.currentStep == 4)
 
         await viewModel.awaitFinalMessage()
         #expect(viewModel.phase == .finished)
@@ -273,25 +275,27 @@ struct ProcessingAccountViewModelTests {
         let viewModel = makeViewModel(flow: .createAccount, processing: processing, coordinator: coordinator)
 
         await viewModel.run()
-        #expect(viewModel.phase == .awaitingAdvance)
         #expect(viewModel.currentStep == 4)
         #expect(viewModel.credentialsDisplayPair == nil)
+        #expect(viewModel.didFinishSetupCarousel)
 
-        viewModel.animationDidFinish()
-
-        #expect(viewModel.didFinishAnimatingText)
-        #expect(viewModel.phase == .finalizing)
+        await viewModel.awaitFinalMessage()
+        #expect(viewModel.phase == .finished)
     }
 
-    @Test func navigationBlockedUntilSetupCarouselCompletes() async {
+    @Test func navigationAdvancesWhenWorkCompletesBeforeCarousel() async {
         let processing = FakeProcessing()
         let coordinator = FakeCoordinator()
         let viewModel = makeViewModel(flow: .createAccount, processing: processing, coordinator: coordinator)
 
         await viewModel.run()
-        #expect(viewModel.phase == .awaitingAdvance)
-        #expect(!viewModel.didFinishAnimatingText)
-        #expect(coordinator.actions.isEmpty)
+
+        #expect(viewModel.didFinishSetupCarousel)
+        #expect(viewModel.didFinishAnimatingText)
+
+        await viewModel.awaitFinalMessage()
+        #expect(viewModel.phase == .finished)
+        #expect(coordinator.actions == [.session(.processingFinished)])
     }
 
     @Test func cancellationDoesNotFailOrNotify() async {
@@ -436,10 +440,9 @@ struct ProcessingAccountViewModelTests {
 
         await viewModel.run()
 
-        #expect(viewModel.phase == .awaitingAdvance)
         #expect(viewModel.hasReachedPrefetchPhase)
         #expect(viewModel.currentStep == 4)
-        #expect(!viewModel.didFinishSetupCarousel)
+        #expect(viewModel.didFinishSetupCarousel)
 
         viewModel.noteSetupCarouselStepBarTick(atIndex: 0)
         #expect(viewModel.currentStep == 4)
@@ -447,8 +450,23 @@ struct ProcessingAccountViewModelTests {
         viewModel.noteSetupCarouselStepBarTick(atIndex: 1)
         #expect(viewModel.currentStep == 4)
 
-        viewModel.animationDidFinish()
-        #expect(viewModel.currentStep == 4)
+        await viewModel.awaitFinalMessage()
+        #expect(viewModel.phase == .finished)
+        #expect(coordinator.actions == [.session(.processingFinished)])
+    }
+
+    @Test func startDoesNotRestartWhenWorkAlreadyCompleted() async {
+        let processing = FakeProcessing()
+        processing.prefetchDelay = .zero
+        let coordinator = FakeCoordinator()
+        let viewModel = makeViewModel(flow: .login, processing: processing, coordinator: coordinator)
+
+        await viewModel.run()
+        let callsAfterRun = processing.calls
+
+        viewModel.start()
+
+        #expect(processing.calls == callsAfterRun)
     }
 
     @Test func prepareBackendPhase_showsPrefetchBeforePrepareReturns() async {
@@ -465,11 +483,14 @@ struct ProcessingAccountViewModelTests {
         #expect(viewModel.phase == .prefetching)
         #expect(viewModel.hasReachedPrefetchPhase)
         #expect(viewModel.currentStep == 4)
+        #expect(viewModel.setupCarouselIndex == 0)
+        #expect(!viewModel.didFinishSetupCarousel)
         #expect(viewModel.credentialsDisplayPair != nil)
 
         processing.releasePrepare()
         await runTask.value
-        #expect(viewModel.phase == .awaitingAdvance)
+        await viewModel.awaitFinalMessage()
+        #expect(viewModel.phase == .finished)
     }
 
     @Test func syncSummaryRefresh_keepsPrefetchPhaseWhenLatchSet() async {


### PR DESCRIPTION
- Cherry-pick of #5794 from release/2026.11-ulrichshorn (117a75a).
- Latch setup carousel completion when account prep finishes so the drawer does not stick on Finishing up.
- Start processing once from the drawer transition and block settings navigation during sign-in.

### Test plan
- Merge after CI green.
- Manual: TestFlight re-login after overlay reinstall; confirm drawer leaves Finishing up within seconds.
- Manual: macOS passphrase login through the same processing drawer.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5795)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the account setup flow so it now finishes more reliably after processing completes.
  * Prevented the settings button from being used while processing is underway, avoiding accidental navigation at the wrong time.
  * Updated processing behavior to avoid restarting work once it has already completed.
  * Refined completion handling so the app moves through the final steps more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->