### PR TITLE
BandwidthController step 1 and Ziller update

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -5099,7 +5099,7 @@ dependencies = [
 [[package]]
 name = "nym-api-requests"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "bs58",
  "celes",
@@ -5152,7 +5152,7 @@ dependencies = [
 [[package]]
 name = "nym-authenticator-client"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "bincode",
  "futures",
@@ -5167,6 +5167,7 @@ dependencies = [
  "nym-wireguard-types",
  "semver",
  "thiserror 2.0.18",
+ "time",
  "tokio",
  "tokio-util",
  "tracing",
@@ -5175,7 +5176,7 @@ dependencies = [
 [[package]]
 name = "nym-authenticator-requests"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -5199,8 +5200,9 @@ dependencies = [
 [[package]]
 name = "nym-bandwidth-controller"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
+ "arc-swap",
  "async-trait",
  "log",
  "nym-credential-storage",
@@ -5211,13 +5213,16 @@ dependencies = [
  "nym-task",
  "nym-validator-client",
  "rand 0.8.6",
+ "strum",
  "thiserror 2.0.18",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "nym-bin-common"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "const-str",
  "log",
@@ -5259,7 +5264,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5319,7 +5324,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-config-types"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "humantime-serde",
  "nym-config",
@@ -5335,7 +5340,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-gateways-storage"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5355,7 +5360,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-surb-storage"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5374,7 +5379,7 @@ dependencies = [
 [[package]]
 name = "nym-coconut-dkg-common"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -5388,7 +5393,7 @@ dependencies = [
 [[package]]
 name = "nym-common"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "tracing",
  "tracing-test",
@@ -5405,7 +5410,7 @@ dependencies = [
 [[package]]
 name = "nym-compact-ecash"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "bincode",
  "bs58",
@@ -5428,7 +5433,7 @@ dependencies = [
 [[package]]
 name = "nym-config"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "dirs",
  "handlebars",
@@ -5461,7 +5466,7 @@ dependencies = [
 [[package]]
 name = "nym-contracts-common"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -5476,7 +5481,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-proxy-requests"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "async-trait",
  "nym-credentials",
@@ -5497,7 +5502,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-storage"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5518,7 +5523,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-utils"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "log",
  "nym-bandwidth-controller",
@@ -5537,7 +5542,7 @@ dependencies = [
 [[package]]
 name = "nym-credentials"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "bincode",
  "cosmrs",
@@ -5563,7 +5568,7 @@ dependencies = [
 [[package]]
 name = "nym-credentials-interface"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "nym-bls12_381-fork",
  "nym-compact-ecash",
@@ -5582,7 +5587,7 @@ dependencies = [
 [[package]]
 name = "nym-crypto"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "aead",
  "aes 0.8.4",
@@ -5702,7 +5707,7 @@ dependencies = [
 [[package]]
 name = "nym-ecash-contract-common"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -5716,7 +5721,7 @@ dependencies = [
 [[package]]
 name = "nym-ecash-signer-check-types"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "nym-coconut-dkg-common",
  "nym-crypto",
@@ -5732,7 +5737,7 @@ dependencies = [
 [[package]]
 name = "nym-ecash-time"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "nym-compact-ecash",
  "time",
@@ -5750,7 +5755,7 @@ dependencies = [
 [[package]]
 name = "nym-exit-policy"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "serde",
  "serde_json",
@@ -5806,7 +5811,7 @@ dependencies = [
 [[package]]
 name = "nym-gateway-client"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "futures",
  "getrandom 0.2.17",
@@ -5871,7 +5876,7 @@ dependencies = [
 [[package]]
 name = "nym-gateway-requests"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "bs58",
  "futures",
@@ -5901,7 +5906,7 @@ dependencies = [
 [[package]]
 name = "nym-group-contract-common"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "cosmwasm-schema",
  "cw-controllers",
@@ -5913,7 +5918,7 @@ dependencies = [
 [[package]]
 name = "nym-http-api-client"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5947,7 +5952,7 @@ dependencies = [
 [[package]]
 name = "nym-http-api-client-macro"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5959,7 +5964,7 @@ dependencies = [
 [[package]]
 name = "nym-http-api-common"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "bincode",
  "serde",
@@ -5970,7 +5975,7 @@ dependencies = [
 [[package]]
 name = "nym-id"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "nym-credential-storage",
  "nym-credentials",
@@ -5998,7 +6003,7 @@ dependencies = [
 [[package]]
 name = "nym-ip-packet-client"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "bincode",
  "bytes",
@@ -6015,7 +6020,7 @@ dependencies = [
 [[package]]
 name = "nym-ip-packet-requests"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "bincode",
  "bytes",
@@ -6063,7 +6068,7 @@ dependencies = [
 [[package]]
 name = "nym-kkt"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "libcrux-chacha20poly1305",
  "libcrux-ecdh",
@@ -6084,7 +6089,7 @@ dependencies = [
 [[package]]
 name = "nym-kkt-ciphersuite"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "blake3",
  "libcrux-sha3",
@@ -6098,7 +6103,7 @@ dependencies = [
 [[package]]
 name = "nym-kkt-context"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "num_enum",
  "nym-kkt-ciphersuite",
@@ -6108,7 +6113,7 @@ dependencies = [
 [[package]]
 name = "nym-lp"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "bs58",
  "bytes",
@@ -6129,7 +6134,7 @@ dependencies = [
 [[package]]
 name = "nym-lp-data"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "bytes",
  "num_enum",
@@ -6150,7 +6155,7 @@ dependencies = [
 [[package]]
 name = "nym-metrics"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "dashmap",
  "lazy_static",
@@ -6161,7 +6166,7 @@ dependencies = [
 [[package]]
 name = "nym-mixnet-client"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "dashmap",
  "futures",
@@ -6179,7 +6184,7 @@ dependencies = [
 [[package]]
 name = "nym-mixnet-contract-common"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -6200,7 +6205,7 @@ dependencies = [
 [[package]]
 name = "nym-multisig-contract-common"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -6216,7 +6221,7 @@ dependencies = [
 [[package]]
 name = "nym-network-defaults"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "cargo_metadata 0.19.2",
  "dotenvy",
@@ -6232,7 +6237,7 @@ dependencies = [
 [[package]]
 name = "nym-network-monitors-contract-common"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -6245,7 +6250,7 @@ dependencies = [
 [[package]]
 name = "nym-node-families-contract-common"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -6261,7 +6266,7 @@ dependencies = [
 [[package]]
 name = "nym-node-requests"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "celes",
  "humantime-serde",
@@ -6286,7 +6291,7 @@ dependencies = [
 [[package]]
 name = "nym-noise"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -6307,7 +6312,7 @@ dependencies = [
 [[package]]
 name = "nym-noise-keys"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "nym-crypto",
  "schemars 0.8.22",
@@ -6318,7 +6323,7 @@ dependencies = [
 [[package]]
 name = "nym-nonexhaustive-delayqueue"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -6348,7 +6353,7 @@ dependencies = [
 [[package]]
 name = "nym-ordered-buffer"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "log",
  "thiserror 2.0.18",
@@ -6357,7 +6362,7 @@ dependencies = [
 [[package]]
 name = "nym-outfox"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "blake3",
  "chacha20 0.9.1",
@@ -6371,7 +6376,7 @@ dependencies = [
 [[package]]
 name = "nym-pemstore"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "pem",
  "tracing",
@@ -6381,7 +6386,7 @@ dependencies = [
 [[package]]
 name = "nym-performance-contract-common"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -6409,7 +6414,7 @@ dependencies = [
 [[package]]
 name = "nym-registration-client"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "bincode",
  "bytes",
@@ -6424,10 +6429,10 @@ dependencies = [
  "nym-lp-data",
  "nym-registration-common",
  "nym-sdk",
- "nym-validator-client",
  "nym-wireguard-types",
  "rand 0.9.2",
  "thiserror 2.0.18",
+ "time",
  "tokio",
  "tokio-util",
  "tracing",
@@ -6437,7 +6442,7 @@ dependencies = [
 [[package]]
 name = "nym-registration-common"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "bincode",
  "nym-authenticator-requests",
@@ -6474,7 +6479,7 @@ dependencies = [
 [[package]]
 name = "nym-sdk"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6532,7 +6537,7 @@ dependencies = [
 [[package]]
 name = "nym-serde-helpers"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -6544,7 +6549,7 @@ dependencies = [
 [[package]]
 name = "nym-service-provider-requests-common"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -6553,7 +6558,7 @@ dependencies = [
 [[package]]
 name = "nym-service-providers-common"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "async-trait",
  "log",
@@ -6577,7 +6582,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-client-core"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "anyhow",
  "dirs",
@@ -6637,7 +6642,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-proxy-helpers"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "bytes",
  "futures",
@@ -6660,7 +6665,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-requests"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "bincode",
  "log",
@@ -6676,7 +6681,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "nym-crypto",
  "nym-metrics",
@@ -6702,7 +6707,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-acknowledgements"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "nym-crypto",
  "nym-pemstore",
@@ -6719,7 +6724,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-addressing"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-types",
@@ -6730,7 +6735,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-anonymous-replies"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "bs58",
  "nym-crypto",
@@ -6748,7 +6753,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-chunking"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "dashmap",
  "log",
@@ -6767,7 +6772,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-cover"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-acknowledgements",
@@ -6785,7 +6790,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-forwarding"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "nym-sphinx-addressing",
  "nym-sphinx-anonymous-replies",
@@ -6797,7 +6802,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-framing"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -6814,7 +6819,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-params"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-types",
@@ -6825,7 +6830,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-routing"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "nym-sphinx-addressing",
  "nym-sphinx-types",
@@ -6835,7 +6840,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-types"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "nym-outfox",
  "sphinx-packet",
@@ -6884,7 +6889,7 @@ dependencies = [
 [[package]]
 name = "nym-sqlx-pool-guard"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "proc_pidinfo",
  "sqlx",
@@ -6928,7 +6933,7 @@ dependencies = [
 [[package]]
 name = "nym-statistics-common"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "futures",
  "log",
@@ -6953,7 +6958,7 @@ dependencies = [
 [[package]]
 name = "nym-task"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "cfg-if",
  "futures",
@@ -6970,7 +6975,7 @@ dependencies = [
 [[package]]
 name = "nym-ticketbooks-merkle"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "nym-credentials-interface",
  "nym-serde-helpers",
@@ -6985,7 +6990,7 @@ dependencies = [
 [[package]]
 name = "nym-topology"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "async-trait",
  "nym-api-requests",
@@ -7005,7 +7010,7 @@ dependencies = [
 [[package]]
 name = "nym-upgrade-mode-check"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "jwt-simple",
  "nym-crypto",
@@ -7022,7 +7027,7 @@ dependencies = [
 [[package]]
 name = "nym-validator-client"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7074,7 +7079,7 @@ dependencies = [
 [[package]]
 name = "nym-vesting-contract-common"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -7493,7 +7498,7 @@ dependencies = [
 [[package]]
 name = "nym-wasm-utils"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "futures",
  "getrandom 0.2.17",
@@ -7555,7 +7560,7 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-private-metadata-client"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "async-trait",
  "nym-http-api-client",
@@ -7566,7 +7571,7 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-private-metadata-shared"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "axum",
  "bincode",
@@ -7580,7 +7585,7 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-types"
 version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.12-yaroslavsky#821381fb1baac73fe85fecca550246db6ec30296"
+source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
 dependencies = [
  "base64 0.22.1",
  "nym-crypto",

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -5099,7 +5099,7 @@ dependencies = [
 [[package]]
 name = "nym-api-requests"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "bs58",
  "celes",
@@ -5152,7 +5152,7 @@ dependencies = [
 [[package]]
 name = "nym-authenticator-client"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "bincode",
  "futures",
@@ -5176,7 +5176,7 @@ dependencies = [
 [[package]]
 name = "nym-authenticator-requests"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -5200,7 +5200,7 @@ dependencies = [
 [[package]]
 name = "nym-bandwidth-controller"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -5222,7 +5222,7 @@ dependencies = [
 [[package]]
 name = "nym-bin-common"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "const-str",
  "log",
@@ -5264,7 +5264,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5324,7 +5324,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-config-types"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "humantime-serde",
  "nym-config",
@@ -5340,7 +5340,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-gateways-storage"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5360,7 +5360,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-surb-storage"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5379,7 +5379,7 @@ dependencies = [
 [[package]]
 name = "nym-coconut-dkg-common"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -5393,7 +5393,7 @@ dependencies = [
 [[package]]
 name = "nym-common"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "tracing",
  "tracing-test",
@@ -5410,7 +5410,7 @@ dependencies = [
 [[package]]
 name = "nym-compact-ecash"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "bincode",
  "bs58",
@@ -5433,7 +5433,7 @@ dependencies = [
 [[package]]
 name = "nym-config"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "dirs",
  "handlebars",
@@ -5466,7 +5466,7 @@ dependencies = [
 [[package]]
 name = "nym-contracts-common"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -5481,7 +5481,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-proxy-requests"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "async-trait",
  "nym-credentials",
@@ -5502,7 +5502,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-storage"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5523,7 +5523,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-utils"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "log",
  "nym-bandwidth-controller",
@@ -5542,7 +5542,7 @@ dependencies = [
 [[package]]
 name = "nym-credentials"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "bincode",
  "cosmrs",
@@ -5568,7 +5568,7 @@ dependencies = [
 [[package]]
 name = "nym-credentials-interface"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "nym-bls12_381-fork",
  "nym-compact-ecash",
@@ -5587,7 +5587,7 @@ dependencies = [
 [[package]]
 name = "nym-crypto"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "aead",
  "aes 0.8.4",
@@ -5707,7 +5707,7 @@ dependencies = [
 [[package]]
 name = "nym-ecash-contract-common"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -5721,7 +5721,7 @@ dependencies = [
 [[package]]
 name = "nym-ecash-signer-check-types"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "nym-coconut-dkg-common",
  "nym-crypto",
@@ -5737,7 +5737,7 @@ dependencies = [
 [[package]]
 name = "nym-ecash-time"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "nym-compact-ecash",
  "time",
@@ -5755,7 +5755,7 @@ dependencies = [
 [[package]]
 name = "nym-exit-policy"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "serde",
  "serde_json",
@@ -5811,7 +5811,7 @@ dependencies = [
 [[package]]
 name = "nym-gateway-client"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "futures",
  "getrandom 0.2.17",
@@ -5876,7 +5876,7 @@ dependencies = [
 [[package]]
 name = "nym-gateway-requests"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "bs58",
  "futures",
@@ -5906,7 +5906,7 @@ dependencies = [
 [[package]]
 name = "nym-group-contract-common"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "cosmwasm-schema",
  "cw-controllers",
@@ -5918,7 +5918,7 @@ dependencies = [
 [[package]]
 name = "nym-http-api-client"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5952,7 +5952,7 @@ dependencies = [
 [[package]]
 name = "nym-http-api-client-macro"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5964,7 +5964,7 @@ dependencies = [
 [[package]]
 name = "nym-http-api-common"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "bincode",
  "serde",
@@ -5975,7 +5975,7 @@ dependencies = [
 [[package]]
 name = "nym-id"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "nym-credential-storage",
  "nym-credentials",
@@ -6003,7 +6003,7 @@ dependencies = [
 [[package]]
 name = "nym-ip-packet-client"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "bincode",
  "bytes",
@@ -6020,7 +6020,7 @@ dependencies = [
 [[package]]
 name = "nym-ip-packet-requests"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "bincode",
  "bytes",
@@ -6068,7 +6068,7 @@ dependencies = [
 [[package]]
 name = "nym-kkt"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "libcrux-chacha20poly1305",
  "libcrux-ecdh",
@@ -6089,7 +6089,7 @@ dependencies = [
 [[package]]
 name = "nym-kkt-ciphersuite"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "blake3",
  "libcrux-sha3",
@@ -6103,7 +6103,7 @@ dependencies = [
 [[package]]
 name = "nym-kkt-context"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "num_enum",
  "nym-kkt-ciphersuite",
@@ -6113,7 +6113,7 @@ dependencies = [
 [[package]]
 name = "nym-lp"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "bs58",
  "bytes",
@@ -6134,7 +6134,7 @@ dependencies = [
 [[package]]
 name = "nym-lp-data"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "bytes",
  "num_enum",
@@ -6155,7 +6155,7 @@ dependencies = [
 [[package]]
 name = "nym-metrics"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "dashmap",
  "lazy_static",
@@ -6166,7 +6166,7 @@ dependencies = [
 [[package]]
 name = "nym-mixnet-client"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "dashmap",
  "futures",
@@ -6184,7 +6184,7 @@ dependencies = [
 [[package]]
 name = "nym-mixnet-contract-common"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -6205,7 +6205,7 @@ dependencies = [
 [[package]]
 name = "nym-multisig-contract-common"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -6221,7 +6221,7 @@ dependencies = [
 [[package]]
 name = "nym-network-defaults"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "cargo_metadata 0.19.2",
  "dotenvy",
@@ -6237,7 +6237,7 @@ dependencies = [
 [[package]]
 name = "nym-network-monitors-contract-common"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -6250,7 +6250,7 @@ dependencies = [
 [[package]]
 name = "nym-node-families-contract-common"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -6266,7 +6266,7 @@ dependencies = [
 [[package]]
 name = "nym-node-requests"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "celes",
  "humantime-serde",
@@ -6291,7 +6291,7 @@ dependencies = [
 [[package]]
 name = "nym-noise"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -6312,7 +6312,7 @@ dependencies = [
 [[package]]
 name = "nym-noise-keys"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "nym-crypto",
  "schemars 0.8.22",
@@ -6323,7 +6323,7 @@ dependencies = [
 [[package]]
 name = "nym-nonexhaustive-delayqueue"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -6353,7 +6353,7 @@ dependencies = [
 [[package]]
 name = "nym-ordered-buffer"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "log",
  "thiserror 2.0.18",
@@ -6362,7 +6362,7 @@ dependencies = [
 [[package]]
 name = "nym-outfox"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "blake3",
  "chacha20 0.9.1",
@@ -6376,7 +6376,7 @@ dependencies = [
 [[package]]
 name = "nym-pemstore"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "pem",
  "tracing",
@@ -6386,7 +6386,7 @@ dependencies = [
 [[package]]
 name = "nym-performance-contract-common"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -6414,7 +6414,7 @@ dependencies = [
 [[package]]
 name = "nym-registration-client"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "bincode",
  "bytes",
@@ -6442,7 +6442,7 @@ dependencies = [
 [[package]]
 name = "nym-registration-common"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "bincode",
  "nym-authenticator-requests",
@@ -6479,7 +6479,7 @@ dependencies = [
 [[package]]
 name = "nym-sdk"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6537,7 +6537,7 @@ dependencies = [
 [[package]]
 name = "nym-serde-helpers"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -6549,7 +6549,7 @@ dependencies = [
 [[package]]
 name = "nym-service-provider-requests-common"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -6558,7 +6558,7 @@ dependencies = [
 [[package]]
 name = "nym-service-providers-common"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "async-trait",
  "log",
@@ -6582,7 +6582,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-client-core"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "anyhow",
  "dirs",
@@ -6642,7 +6642,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-proxy-helpers"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "bytes",
  "futures",
@@ -6665,7 +6665,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-requests"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "bincode",
  "log",
@@ -6681,7 +6681,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "nym-crypto",
  "nym-metrics",
@@ -6707,7 +6707,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-acknowledgements"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "nym-crypto",
  "nym-pemstore",
@@ -6724,7 +6724,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-addressing"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-types",
@@ -6735,7 +6735,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-anonymous-replies"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "bs58",
  "nym-crypto",
@@ -6753,7 +6753,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-chunking"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "dashmap",
  "log",
@@ -6772,7 +6772,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-cover"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-acknowledgements",
@@ -6790,7 +6790,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-forwarding"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "nym-sphinx-addressing",
  "nym-sphinx-anonymous-replies",
@@ -6802,7 +6802,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-framing"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -6819,7 +6819,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-params"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-types",
@@ -6830,7 +6830,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-routing"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "nym-sphinx-addressing",
  "nym-sphinx-types",
@@ -6840,7 +6840,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-types"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "nym-outfox",
  "sphinx-packet",
@@ -6889,7 +6889,7 @@ dependencies = [
 [[package]]
 name = "nym-sqlx-pool-guard"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "proc_pidinfo",
  "sqlx",
@@ -6933,7 +6933,7 @@ dependencies = [
 [[package]]
 name = "nym-statistics-common"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "futures",
  "log",
@@ -6958,7 +6958,7 @@ dependencies = [
 [[package]]
 name = "nym-task"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "cfg-if",
  "futures",
@@ -6975,7 +6975,7 @@ dependencies = [
 [[package]]
 name = "nym-ticketbooks-merkle"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "nym-credentials-interface",
  "nym-serde-helpers",
@@ -6990,7 +6990,7 @@ dependencies = [
 [[package]]
 name = "nym-topology"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "async-trait",
  "nym-api-requests",
@@ -7010,7 +7010,7 @@ dependencies = [
 [[package]]
 name = "nym-upgrade-mode-check"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "jwt-simple",
  "nym-crypto",
@@ -7027,7 +7027,7 @@ dependencies = [
 [[package]]
 name = "nym-validator-client"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7079,7 +7079,7 @@ dependencies = [
 [[package]]
 name = "nym-vesting-contract-common"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -7498,7 +7498,7 @@ dependencies = [
 [[package]]
 name = "nym-wasm-utils"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "futures",
  "getrandom 0.2.17",
@@ -7560,7 +7560,7 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-private-metadata-client"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "async-trait",
  "nym-http-api-client",
@@ -7571,7 +7571,7 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-private-metadata-shared"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "axum",
  "bincode",
@@ -7585,7 +7585,7 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-types"
 version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.13-ziller#34f587edcba4263d40a26ad988335480639499da"
 dependencies = [
  "base64 0.22.1",
  "nym-crypto",

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -5098,8 +5098,8 @@ dependencies = [
 
 [[package]]
 name = "nym-api-requests"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "bs58",
  "celes",
@@ -5151,8 +5151,8 @@ dependencies = [
 
 [[package]]
 name = "nym-authenticator-client"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "bincode",
  "futures",
@@ -5175,8 +5175,8 @@ dependencies = [
 
 [[package]]
 name = "nym-authenticator-requests"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -5199,8 +5199,8 @@ dependencies = [
 
 [[package]]
 name = "nym-bandwidth-controller"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -5221,8 +5221,8 @@ dependencies = [
 
 [[package]]
 name = "nym-bin-common"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "const-str",
  "log",
@@ -5263,8 +5263,8 @@ dependencies = [
 
 [[package]]
 name = "nym-client-core"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5323,8 +5323,8 @@ dependencies = [
 
 [[package]]
 name = "nym-client-core-config-types"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "humantime-serde",
  "nym-config",
@@ -5339,8 +5339,8 @@ dependencies = [
 
 [[package]]
 name = "nym-client-core-gateways-storage"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5359,8 +5359,8 @@ dependencies = [
 
 [[package]]
 name = "nym-client-core-surb-storage"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5378,8 +5378,8 @@ dependencies = [
 
 [[package]]
 name = "nym-coconut-dkg-common"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -5392,8 +5392,8 @@ dependencies = [
 
 [[package]]
 name = "nym-common"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "tracing",
  "tracing-test",
@@ -5409,8 +5409,8 @@ dependencies = [
 
 [[package]]
 name = "nym-compact-ecash"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "bincode",
  "bs58",
@@ -5432,8 +5432,8 @@ dependencies = [
 
 [[package]]
 name = "nym-config"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "dirs",
  "handlebars",
@@ -5465,8 +5465,8 @@ dependencies = [
 
 [[package]]
 name = "nym-contracts-common"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -5480,8 +5480,8 @@ dependencies = [
 
 [[package]]
 name = "nym-credential-proxy-requests"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "async-trait",
  "nym-credentials",
@@ -5501,8 +5501,8 @@ dependencies = [
 
 [[package]]
 name = "nym-credential-storage"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5522,8 +5522,8 @@ dependencies = [
 
 [[package]]
 name = "nym-credential-utils"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "log",
  "nym-bandwidth-controller",
@@ -5541,8 +5541,8 @@ dependencies = [
 
 [[package]]
 name = "nym-credentials"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "bincode",
  "cosmrs",
@@ -5567,8 +5567,8 @@ dependencies = [
 
 [[package]]
 name = "nym-credentials-interface"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "nym-bls12_381-fork",
  "nym-compact-ecash",
@@ -5586,8 +5586,8 @@ dependencies = [
 
 [[package]]
 name = "nym-crypto"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "aead",
  "aes 0.8.4",
@@ -5706,8 +5706,8 @@ dependencies = [
 
 [[package]]
 name = "nym-ecash-contract-common"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -5720,8 +5720,8 @@ dependencies = [
 
 [[package]]
 name = "nym-ecash-signer-check-types"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "nym-coconut-dkg-common",
  "nym-crypto",
@@ -5736,8 +5736,8 @@ dependencies = [
 
 [[package]]
 name = "nym-ecash-time"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "nym-compact-ecash",
  "time",
@@ -5754,8 +5754,8 @@ dependencies = [
 
 [[package]]
 name = "nym-exit-policy"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "serde",
  "serde_json",
@@ -5810,8 +5810,8 @@ dependencies = [
 
 [[package]]
 name = "nym-gateway-client"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "futures",
  "getrandom 0.2.17",
@@ -5875,8 +5875,8 @@ dependencies = [
 
 [[package]]
 name = "nym-gateway-requests"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "bs58",
  "futures",
@@ -5905,8 +5905,8 @@ dependencies = [
 
 [[package]]
 name = "nym-group-contract-common"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "cosmwasm-schema",
  "cw-controllers",
@@ -5917,8 +5917,8 @@ dependencies = [
 
 [[package]]
 name = "nym-http-api-client"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5951,8 +5951,8 @@ dependencies = [
 
 [[package]]
 name = "nym-http-api-client-macro"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5963,8 +5963,8 @@ dependencies = [
 
 [[package]]
 name = "nym-http-api-common"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "bincode",
  "serde",
@@ -5974,8 +5974,8 @@ dependencies = [
 
 [[package]]
 name = "nym-id"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "nym-credential-storage",
  "nym-credentials",
@@ -6002,8 +6002,8 @@ dependencies = [
 
 [[package]]
 name = "nym-ip-packet-client"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "bincode",
  "bytes",
@@ -6019,8 +6019,8 @@ dependencies = [
 
 [[package]]
 name = "nym-ip-packet-requests"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "bincode",
  "bytes",
@@ -6067,8 +6067,8 @@ dependencies = [
 
 [[package]]
 name = "nym-kkt"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "libcrux-chacha20poly1305",
  "libcrux-ecdh",
@@ -6088,8 +6088,8 @@ dependencies = [
 
 [[package]]
 name = "nym-kkt-ciphersuite"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "blake3",
  "libcrux-sha3",
@@ -6102,8 +6102,8 @@ dependencies = [
 
 [[package]]
 name = "nym-kkt-context"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "num_enum",
  "nym-kkt-ciphersuite",
@@ -6112,13 +6112,13 @@ dependencies = [
 
 [[package]]
 name = "nym-lp"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "bs58",
  "bytes",
  "libcrux-psq",
- "nym-common 1.21.2",
+ "nym-common 1.21.3",
  "nym-crypto",
  "nym-kkt",
  "nym-kkt-ciphersuite",
@@ -6133,12 +6133,12 @@ dependencies = [
 
 [[package]]
 name = "nym-lp-data"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "bytes",
  "num_enum",
- "nym-common 1.21.2",
+ "nym-common 1.21.3",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -6154,8 +6154,8 @@ dependencies = [
 
 [[package]]
 name = "nym-metrics"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "dashmap",
  "lazy_static",
@@ -6165,8 +6165,8 @@ dependencies = [
 
 [[package]]
 name = "nym-mixnet-client"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "dashmap",
  "futures",
@@ -6183,8 +6183,8 @@ dependencies = [
 
 [[package]]
 name = "nym-mixnet-contract-common"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -6204,8 +6204,8 @@ dependencies = [
 
 [[package]]
 name = "nym-multisig-contract-common"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -6220,8 +6220,8 @@ dependencies = [
 
 [[package]]
 name = "nym-network-defaults"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "cargo_metadata 0.19.2",
  "dotenvy",
@@ -6236,8 +6236,8 @@ dependencies = [
 
 [[package]]
 name = "nym-network-monitors-contract-common"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -6249,8 +6249,8 @@ dependencies = [
 
 [[package]]
 name = "nym-node-families-contract-common"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -6265,8 +6265,8 @@ dependencies = [
 
 [[package]]
 name = "nym-node-requests"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "celes",
  "humantime-serde",
@@ -6290,8 +6290,8 @@ dependencies = [
 
 [[package]]
 name = "nym-noise"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -6311,8 +6311,8 @@ dependencies = [
 
 [[package]]
 name = "nym-noise-keys"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "nym-crypto",
  "schemars 0.8.22",
@@ -6322,8 +6322,8 @@ dependencies = [
 
 [[package]]
 name = "nym-nonexhaustive-delayqueue"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -6352,8 +6352,8 @@ dependencies = [
 
 [[package]]
 name = "nym-ordered-buffer"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "log",
  "thiserror 2.0.18",
@@ -6361,8 +6361,8 @@ dependencies = [
 
 [[package]]
 name = "nym-outfox"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "blake3",
  "chacha20 0.9.1",
@@ -6375,8 +6375,8 @@ dependencies = [
 
 [[package]]
 name = "nym-pemstore"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "pem",
  "tracing",
@@ -6385,8 +6385,8 @@ dependencies = [
 
 [[package]]
 name = "nym-performance-contract-common"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -6413,8 +6413,8 @@ dependencies = [
 
 [[package]]
 name = "nym-registration-client"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "bincode",
  "bytes",
@@ -6441,8 +6441,8 @@ dependencies = [
 
 [[package]]
 name = "nym-registration-common"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "bincode",
  "nym-authenticator-requests",
@@ -6478,8 +6478,8 @@ dependencies = [
 
 [[package]]
 name = "nym-sdk"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6536,8 +6536,8 @@ dependencies = [
 
 [[package]]
 name = "nym-serde-helpers"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -6548,8 +6548,8 @@ dependencies = [
 
 [[package]]
 name = "nym-service-provider-requests-common"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -6557,8 +6557,8 @@ dependencies = [
 
 [[package]]
 name = "nym-service-providers-common"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "async-trait",
  "log",
@@ -6581,8 +6581,8 @@ dependencies = [
 
 [[package]]
 name = "nym-socks5-client-core"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "anyhow",
  "dirs",
@@ -6641,8 +6641,8 @@ dependencies = [
 
 [[package]]
 name = "nym-socks5-proxy-helpers"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "bytes",
  "futures",
@@ -6664,8 +6664,8 @@ dependencies = [
 
 [[package]]
 name = "nym-socks5-requests"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "bincode",
  "log",
@@ -6680,8 +6680,8 @@ dependencies = [
 
 [[package]]
 name = "nym-sphinx"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "nym-crypto",
  "nym-metrics",
@@ -6706,8 +6706,8 @@ dependencies = [
 
 [[package]]
 name = "nym-sphinx-acknowledgements"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "nym-crypto",
  "nym-pemstore",
@@ -6723,8 +6723,8 @@ dependencies = [
 
 [[package]]
 name = "nym-sphinx-addressing"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-types",
@@ -6734,8 +6734,8 @@ dependencies = [
 
 [[package]]
 name = "nym-sphinx-anonymous-replies"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "bs58",
  "nym-crypto",
@@ -6752,8 +6752,8 @@ dependencies = [
 
 [[package]]
 name = "nym-sphinx-chunking"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "dashmap",
  "log",
@@ -6771,8 +6771,8 @@ dependencies = [
 
 [[package]]
 name = "nym-sphinx-cover"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-acknowledgements",
@@ -6789,8 +6789,8 @@ dependencies = [
 
 [[package]]
 name = "nym-sphinx-forwarding"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "nym-sphinx-addressing",
  "nym-sphinx-anonymous-replies",
@@ -6801,8 +6801,8 @@ dependencies = [
 
 [[package]]
 name = "nym-sphinx-framing"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -6818,8 +6818,8 @@ dependencies = [
 
 [[package]]
 name = "nym-sphinx-params"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-types",
@@ -6829,8 +6829,8 @@ dependencies = [
 
 [[package]]
 name = "nym-sphinx-routing"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "nym-sphinx-addressing",
  "nym-sphinx-types",
@@ -6839,8 +6839,8 @@ dependencies = [
 
 [[package]]
 name = "nym-sphinx-types"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "nym-outfox",
  "sphinx-packet",
@@ -6888,8 +6888,8 @@ dependencies = [
 
 [[package]]
 name = "nym-sqlx-pool-guard"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "proc_pidinfo",
  "sqlx",
@@ -6932,8 +6932,8 @@ dependencies = [
 
 [[package]]
 name = "nym-statistics-common"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "futures",
  "log",
@@ -6957,8 +6957,8 @@ dependencies = [
 
 [[package]]
 name = "nym-task"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "cfg-if",
  "futures",
@@ -6974,8 +6974,8 @@ dependencies = [
 
 [[package]]
 name = "nym-ticketbooks-merkle"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "nym-credentials-interface",
  "nym-serde-helpers",
@@ -6989,8 +6989,8 @@ dependencies = [
 
 [[package]]
 name = "nym-topology"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "async-trait",
  "nym-api-requests",
@@ -7009,8 +7009,8 @@ dependencies = [
 
 [[package]]
 name = "nym-upgrade-mode-check"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "jwt-simple",
  "nym-crypto",
@@ -7026,8 +7026,8 @@ dependencies = [
 
 [[package]]
 name = "nym-validator-client"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7078,8 +7078,8 @@ dependencies = [
 
 [[package]]
 name = "nym-vesting-contract-common"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -7497,8 +7497,8 @@ dependencies = [
 
 [[package]]
 name = "nym-wasm-utils"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "futures",
  "getrandom 0.2.17",
@@ -7559,8 +7559,8 @@ dependencies = [
 
 [[package]]
 name = "nym-wireguard-private-metadata-client"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "async-trait",
  "nym-http-api-client",
@@ -7570,8 +7570,8 @@ dependencies = [
 
 [[package]]
 name = "nym-wireguard-private-metadata-shared"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "axum",
  "bincode",
@@ -7584,8 +7584,8 @@ dependencies = [
 
 [[package]]
 name = "nym-wireguard-types"
-version = "1.21.2"
-source = "git+https://github.com/nymtech/nym?branch=develop#ae8af31e82e68c8ad30b5adcf2e72ca05bad243c"
+version = "1.21.3"
+source = "git+https://github.com/nymtech/nym?branch=release%2F2026.13-ziller#674fa7b80ab394a0d7262843cc0ad6ef2fb3417c"
 dependencies = [
  "base64 0.22.1",
  "nym-crypto",

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -274,42 +274,42 @@ nym-windows = { path = "crates/nym-windows" }
 test-rpc = { path = "crates/test/test-rpc" }
 
 
-nym-authenticator-client = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
-nym-authenticator-requests = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
-nym-api-requests = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
-nym-bandwidth-controller = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
-nym-bin-common = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
-nym-client-core = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
-nym-compact-ecash = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
-nym-config = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
-nym-contracts-common = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
-nym-credential-proxy-requests = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller", default-features = false }
-nym-credential-storage = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
-nym-credential-utils = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
-nym-credentials = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
-nym-credentials-interface = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
-nym-crypto = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
-nym-ecash-time = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
-nym-gateway-requests = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
-nym-http-api-client = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
-nym-http-api-client-macro = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
-nym-lp = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
-nym-lp-data = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
-nym-network-defaults = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
-nym-ip-packet-requests = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
-nym-ip-packet-client = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
-nym-pemstore = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
-nym-registration-client = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
-nym-registration-common = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
-nym-sdk = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
-nym-statistics-common = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
-nym-topology = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
-nym-upgrade-mode-check = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
-nym-validator-client = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
-nym-wireguard-private-metadata-client = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
-nym-wireguard-private-metadata-shared = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
-nym-wireguard-types = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
-nym-sqlx-pool-guard = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
+nym-authenticator-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.13-ziller" }
+nym-authenticator-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.13-ziller" }
+nym-api-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.13-ziller" }
+nym-bandwidth-controller = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.13-ziller" }
+nym-bin-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.13-ziller" }
+nym-client-core = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.13-ziller" }
+nym-compact-ecash = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.13-ziller" }
+nym-config = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.13-ziller" }
+nym-contracts-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.13-ziller" }
+nym-credential-proxy-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.13-ziller", default-features = false }
+nym-credential-storage = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.13-ziller" }
+nym-credential-utils = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.13-ziller" }
+nym-credentials = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.13-ziller" }
+nym-credentials-interface = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.13-ziller" }
+nym-crypto = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.13-ziller" }
+nym-ecash-time = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.13-ziller" }
+nym-gateway-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.13-ziller" }
+nym-http-api-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.13-ziller" }
+nym-http-api-client-macro = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.13-ziller" }
+nym-lp = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.13-ziller" }
+nym-lp-data = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.13-ziller" }
+nym-network-defaults = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.13-ziller" }
+nym-ip-packet-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.13-ziller" }
+nym-ip-packet-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.13-ziller" }
+nym-pemstore = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.13-ziller" }
+nym-registration-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.13-ziller" }
+nym-registration-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.13-ziller" }
+nym-sdk = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.13-ziller" }
+nym-statistics-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.13-ziller" }
+nym-topology = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.13-ziller" }
+nym-upgrade-mode-check = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.13-ziller" }
+nym-validator-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.13-ziller" }
+nym-wireguard-private-metadata-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.13-ziller" }
+nym-wireguard-private-metadata-shared = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.13-ziller" }
+nym-wireguard-types = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.13-ziller" }
+nym-sqlx-pool-guard = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.13-ziller" }
 # For local development
 # [patch."https://github.com/nymtech/nym"]
 # nym-authenticator-client = { path = "../../nym/nym-authenticator-client" }

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -274,42 +274,42 @@ nym-windows = { path = "crates/nym-windows" }
 test-rpc = { path = "crates/test/test-rpc" }
 
 
-nym-authenticator-client = { git = "https://github.com/nymtech/nym", branch = "develop" }
-nym-authenticator-requests = { git = "https://github.com/nymtech/nym", branch = "develop" }
-nym-api-requests = { git = "https://github.com/nymtech/nym", branch = "develop" }
-nym-bandwidth-controller = { git = "https://github.com/nymtech/nym", branch = "develop" }
-nym-bin-common = { git = "https://github.com/nymtech/nym", branch = "develop" }
-nym-client-core = { git = "https://github.com/nymtech/nym", branch = "develop" }
-nym-compact-ecash = { git = "https://github.com/nymtech/nym", branch = "develop" }
-nym-config = { git = "https://github.com/nymtech/nym", branch = "develop" }
-nym-contracts-common = { git = "https://github.com/nymtech/nym", branch = "develop" }
-nym-credential-proxy-requests = { git = "https://github.com/nymtech/nym", branch = "develop", default-features = false }
-nym-credential-storage = { git = "https://github.com/nymtech/nym", branch = "develop" }
-nym-credential-utils = { git = "https://github.com/nymtech/nym", branch = "develop" }
-nym-credentials = { git = "https://github.com/nymtech/nym", branch = "develop" }
-nym-credentials-interface = { git = "https://github.com/nymtech/nym", branch = "develop" }
-nym-crypto = { git = "https://github.com/nymtech/nym", branch = "develop" }
-nym-ecash-time = { git = "https://github.com/nymtech/nym", branch = "develop" }
-nym-gateway-requests = { git = "https://github.com/nymtech/nym", branch = "develop" }
-nym-http-api-client = { git = "https://github.com/nymtech/nym", branch = "develop" }
-nym-http-api-client-macro = { git = "https://github.com/nymtech/nym", branch = "develop" }
-nym-lp = { git = "https://github.com/nymtech/nym", branch = "develop" }
-nym-lp-data = { git = "https://github.com/nymtech/nym", branch = "develop" }
-nym-network-defaults = { git = "https://github.com/nymtech/nym", branch = "develop" }
-nym-ip-packet-requests = { git = "https://github.com/nymtech/nym", branch = "develop" }
-nym-ip-packet-client = { git = "https://github.com/nymtech/nym", branch = "develop" }
-nym-pemstore = { git = "https://github.com/nymtech/nym", branch = "develop" }
-nym-registration-client = { git = "https://github.com/nymtech/nym", branch = "develop" }
-nym-registration-common = { git = "https://github.com/nymtech/nym", branch = "develop" }
-nym-sdk = { git = "https://github.com/nymtech/nym", branch = "develop" }
-nym-statistics-common = { git = "https://github.com/nymtech/nym", branch = "develop" }
-nym-topology = { git = "https://github.com/nymtech/nym", branch = "develop" }
-nym-upgrade-mode-check = { git = "https://github.com/nymtech/nym", branch = "develop" }
-nym-validator-client = { git = "https://github.com/nymtech/nym", branch = "develop" }
-nym-wireguard-private-metadata-client = { git = "https://github.com/nymtech/nym", branch = "develop" }
-nym-wireguard-private-metadata-shared = { git = "https://github.com/nymtech/nym", branch = "develop" }
-nym-wireguard-types = { git = "https://github.com/nymtech/nym", branch = "develop" }
-nym-sqlx-pool-guard = { git = "https://github.com/nymtech/nym", branch = "develop" }
+nym-authenticator-client = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
+nym-authenticator-requests = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
+nym-api-requests = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
+nym-bandwidth-controller = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
+nym-bin-common = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
+nym-client-core = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
+nym-compact-ecash = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
+nym-config = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
+nym-contracts-common = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
+nym-credential-proxy-requests = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller", default-features = false }
+nym-credential-storage = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
+nym-credential-utils = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
+nym-credentials = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
+nym-credentials-interface = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
+nym-crypto = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
+nym-ecash-time = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
+nym-gateway-requests = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
+nym-http-api-client = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
+nym-http-api-client-macro = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
+nym-lp = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
+nym-lp-data = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
+nym-network-defaults = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
+nym-ip-packet-requests = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
+nym-ip-packet-client = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
+nym-pemstore = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
+nym-registration-client = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
+nym-registration-common = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
+nym-sdk = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
+nym-statistics-common = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
+nym-topology = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
+nym-upgrade-mode-check = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
+nym-validator-client = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
+nym-wireguard-private-metadata-client = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
+nym-wireguard-private-metadata-shared = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
+nym-wireguard-types = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
+nym-sqlx-pool-guard = { git = "https://github.com/nymtech/nym", branch = "release/2026.13-ziller" }
 # For local development
 # [patch."https://github.com/nymtech/nym"]
 # nym-authenticator-client = { path = "../../nym/nym-authenticator-client" }

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -273,78 +273,77 @@ nym-wg-metadata-client = { path = "crates/nym-wg-metadata-client" }
 nym-windows = { path = "crates/nym-windows" }
 test-rpc = { path = "crates/test/test-rpc" }
 
-# For normal development
-nym-authenticator-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.12-yaroslavsky" }
-nym-authenticator-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.12-yaroslavsky" }
-nym-api-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.12-yaroslavsky" }
-nym-bandwidth-controller = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.12-yaroslavsky" }
-nym-bin-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.12-yaroslavsky" }
-nym-client-core = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.12-yaroslavsky" }
-nym-compact-ecash = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.12-yaroslavsky" }
-nym-config = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.12-yaroslavsky" }
-nym-contracts-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.12-yaroslavsky" }
-nym-credential-proxy-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.12-yaroslavsky", default-features = false }
-nym-credential-storage = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.12-yaroslavsky" }
-nym-credential-utils = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.12-yaroslavsky" }
-nym-credentials = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.12-yaroslavsky" }
-nym-credentials-interface = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.12-yaroslavsky" }
-nym-crypto = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.12-yaroslavsky" }
-nym-ecash-time = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.12-yaroslavsky" }
-nym-gateway-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.12-yaroslavsky" }
-nym-http-api-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.12-yaroslavsky" }
-nym-http-api-client-macro = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.12-yaroslavsky" }
-nym-lp = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.12-yaroslavsky" }
-nym-lp-data = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.12-yaroslavsky" }
-nym-network-defaults = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.12-yaroslavsky" }
-nym-ip-packet-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.12-yaroslavsky" }
-nym-ip-packet-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.12-yaroslavsky" }
-nym-pemstore = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.12-yaroslavsky" }
-nym-registration-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.12-yaroslavsky" }
-nym-registration-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.12-yaroslavsky" }
-nym-sdk = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.12-yaroslavsky" }
-nym-statistics-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.12-yaroslavsky" }
-nym-topology = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.12-yaroslavsky" }
-nym-upgrade-mode-check = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.12-yaroslavsky" }
-nym-validator-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.12-yaroslavsky" }
-nym-wireguard-private-metadata-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.12-yaroslavsky" }
-nym-wireguard-private-metadata-shared = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.12-yaroslavsky" }
-nym-wireguard-types = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.12-yaroslavsky" }
-nym-sqlx-pool-guard = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.12-yaroslavsky" }
 
+nym-authenticator-client = { git = "https://github.com/nymtech/nym", branch = "develop" }
+nym-authenticator-requests = { git = "https://github.com/nymtech/nym", branch = "develop" }
+nym-api-requests = { git = "https://github.com/nymtech/nym", branch = "develop" }
+nym-bandwidth-controller = { git = "https://github.com/nymtech/nym", branch = "develop" }
+nym-bin-common = { git = "https://github.com/nymtech/nym", branch = "develop" }
+nym-client-core = { git = "https://github.com/nymtech/nym", branch = "develop" }
+nym-compact-ecash = { git = "https://github.com/nymtech/nym", branch = "develop" }
+nym-config = { git = "https://github.com/nymtech/nym", branch = "develop" }
+nym-contracts-common = { git = "https://github.com/nymtech/nym", branch = "develop" }
+nym-credential-proxy-requests = { git = "https://github.com/nymtech/nym", branch = "develop", default-features = false }
+nym-credential-storage = { git = "https://github.com/nymtech/nym", branch = "develop" }
+nym-credential-utils = { git = "https://github.com/nymtech/nym", branch = "develop" }
+nym-credentials = { git = "https://github.com/nymtech/nym", branch = "develop" }
+nym-credentials-interface = { git = "https://github.com/nymtech/nym", branch = "develop" }
+nym-crypto = { git = "https://github.com/nymtech/nym", branch = "develop" }
+nym-ecash-time = { git = "https://github.com/nymtech/nym", branch = "develop" }
+nym-gateway-requests = { git = "https://github.com/nymtech/nym", branch = "develop" }
+nym-http-api-client = { git = "https://github.com/nymtech/nym", branch = "develop" }
+nym-http-api-client-macro = { git = "https://github.com/nymtech/nym", branch = "develop" }
+nym-lp = { git = "https://github.com/nymtech/nym", branch = "develop" }
+nym-lp-data = { git = "https://github.com/nymtech/nym", branch = "develop" }
+nym-network-defaults = { git = "https://github.com/nymtech/nym", branch = "develop" }
+nym-ip-packet-requests = { git = "https://github.com/nymtech/nym", branch = "develop" }
+nym-ip-packet-client = { git = "https://github.com/nymtech/nym", branch = "develop" }
+nym-pemstore = { git = "https://github.com/nymtech/nym", branch = "develop" }
+nym-registration-client = { git = "https://github.com/nymtech/nym", branch = "develop" }
+nym-registration-common = { git = "https://github.com/nymtech/nym", branch = "develop" }
+nym-sdk = { git = "https://github.com/nymtech/nym", branch = "develop" }
+nym-statistics-common = { git = "https://github.com/nymtech/nym", branch = "develop" }
+nym-topology = { git = "https://github.com/nymtech/nym", branch = "develop" }
+nym-upgrade-mode-check = { git = "https://github.com/nymtech/nym", branch = "develop" }
+nym-validator-client = { git = "https://github.com/nymtech/nym", branch = "develop" }
+nym-wireguard-private-metadata-client = { git = "https://github.com/nymtech/nym", branch = "develop" }
+nym-wireguard-private-metadata-shared = { git = "https://github.com/nymtech/nym", branch = "develop" }
+nym-wireguard-types = { git = "https://github.com/nymtech/nym", branch = "develop" }
+nym-sqlx-pool-guard = { git = "https://github.com/nymtech/nym", branch = "develop" }
 # For local development
-#[patch."https://github.com/nymtech/nym"]
-#nym-authenticator-client = { path = "../../nym/nym-authenticator-client" }
-#nym-authenticator-requests = { path = "../../nym/common/authenticator-requests" }
-#nym-api-requests = { path = "../../nym/nym-api/nym-api-requests" }
-#nym-bandwidth-controller = { path = "../../nym/common/bandwidth-controller" }
-#nym-bin-common = { path = "../../nym/common/bin-common" }
-#nym-client-core = { path = "../../nym/common/client-core" }
-#nym-compact-ecash = { path = "../../nym/common/nym_offline_compact_ecash" }
-#nym-config = { path = "../../nym/common/config" }
-#nym-contracts-common = { path = "../../nym/common/cosmwasm-smart-contracts/contracts-common" }
-#nym-credential-proxy-requests = { path = "../../nym/nym-credential-proxy/nym-credential-proxy-requests", default-features = false }
-#nym-credential-storage = { path = "../../nym/common/credential-storage" }
-#nym-credential-utils = { path = "../../nym/common/credential-utils" }
-#nym-credentials = { path = "../../nym/common/credentials" }
-#nym-credentials-interface = { path = "../../nym/common/credentials-interface" }
-#nym-crypto = { path = "../../nym/common/crypto" }
-#nym-ecash-time = { path = "../../nym/common/ecash-time" }
-#nym-gateway-requests = { path = "../../nym/common/gateway-requests"}
-#nym-http-api-client = { path = "../../nym/common/http-api-client" }
-#nym-http-api-client-macro = { path = "../../nym/common/http-api-client-macro" }
-#nym-lp = { path = "../../nym/common/nym-lp" }
-#nym-network-defaults = { path = "../../nym/common/network-defaults" }
-#nym-ip-packet-requests = { path = "../../nym/common/ip-packet-requests" }
-#nym-ip-packet-client = { path = "../../nym/nym-ip-packet-client" }
-#nym-pemstore = { path = "../../nym/common/pemstore" }
-#nym-registration-client = { path = "../../nym/nym-registration-client" }
-#nym-registration-common = { path = "../../nym/common/registration" }
-#nym-sdk = { path = "../../nym/sdk/rust/nym-sdk" }
-#nym-statistics-common = { path = "../../nym/common/statistics" }
-#nym-topology = { path = "../../nym/common/topology" }
-#nym-upgrade-mode-check = { path = "../../nym/common/upgrade-mode-check" }
-#nym-validator-client = { path = "../../nym/common/client-libs/validator-client" }
-#nym-wireguard-private-metadata-client = { path = "../../nym/common/wireguard-private-metadata/client" }
-#nym-wireguard-private-metadata-shared = { path = "../../nym/common/wireguard-private-metadata/shared" }
-#nym-wireguard-types = { path = "../../nym/common/wireguard-types" }
-#nym-sqlx-pool-guard = { path = "../../nym/nym-sqlx-pool-guard" }
+# [patch."https://github.com/nymtech/nym"]
+# nym-authenticator-client = { path = "../../nym/nym-authenticator-client" }
+# nym-authenticator-requests = { path = "../../nym/common/authenticator-requests" }
+# nym-api-requests = { path = "../../nym/nym-api/nym-api-requests" }
+# nym-bandwidth-controller = { path = "../../nym/common/bandwidth-controller" }
+# nym-bin-common = { path = "../../nym/common/bin-common" }
+# nym-client-core = { path = "../../nym/common/client-core" }
+# nym-compact-ecash = { path = "../../nym/common/nym_offline_compact_ecash" }
+# nym-config = { path = "../../nym/common/config" }
+# nym-contracts-common = { path = "../../nym/common/cosmwasm-smart-contracts/contracts-common" }
+# nym-credential-proxy-requests = { path = "../../nym/nym-credential-proxy/nym-credential-proxy-requests", default-features = false }
+# nym-credential-storage = { path = "../../nym/common/credential-storage" }
+# nym-credential-utils = { path = "../../nym/common/credential-utils" }
+# nym-credentials = { path = "../../nym/common/credentials" }
+# nym-credentials-interface = { path = "../../nym/common/credentials-interface" }
+# nym-crypto = { path = "../../nym/common/crypto" }
+# nym-ecash-time = { path = "../../nym/common/ecash-time" }
+# nym-gateway-requests = { path = "../../nym/common/gateway-requests" }
+# nym-http-api-client = { path = "../../nym/common/http-api-client" }
+# nym-http-api-client-macro = { path = "../../nym/common/http-api-client-macro" }
+# nym-lp = { path = "../../nym/common/nym-lp" }
+# nym-network-defaults = { path = "../../nym/common/network-defaults" }
+# nym-ip-packet-requests = { path = "../../nym/common/ip-packet-requests" }
+# nym-ip-packet-client = { path = "../../nym/nym-ip-packet-client" }
+# nym-pemstore = { path = "../../nym/common/pemstore" }
+# nym-registration-client = { path = "../../nym/nym-registration-client" }
+# nym-registration-common = { path = "../../nym/common/registration" }
+# nym-sdk = { path = "../../nym/sdk/rust/nym-sdk" }
+# nym-statistics-common = { path = "../../nym/common/statistics" }
+# nym-topology = { path = "../../nym/common/topology" }
+# nym-upgrade-mode-check = { path = "../../nym/common/upgrade-mode-check" }
+# nym-validator-client = { path = "../../nym/common/client-libs/validator-client" }
+# nym-wireguard-private-metadata-client = { path = "../../nym/common/wireguard-private-metadata/client" }
+# nym-wireguard-private-metadata-shared = { path = "../../nym/common/wireguard-private-metadata/shared" }
+# nym-wireguard-types = { path = "../../nym/common/wireguard-types" }
+# nym-sqlx-pool-guard = { path = "../../nym/nym-sqlx-pool-guard" }

--- a/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/registration/lp_client.rs
+++ b/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/registration/lp_client.rs
@@ -150,7 +150,7 @@ async fn setup_registration(
             .map_err(|e| anyhow::anyhow!("Incorrect kem key digests : {e}"))?,
     );
 
-    let bandwidth_provider = setup_bandwidth_provider(network, storage_path)
+    let bandwidth_provider = setup_bandwidth_provider(storage_path)
         .await
         .map_err(|e| anyhow::anyhow!("Failed to setup bandwidth provider : {e}"))?;
 

--- a/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/registration/mixnet_client.rs
+++ b/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/registration/mixnet_client.rs
@@ -16,7 +16,7 @@ use nym_sdk::{
     },
 };
 use nym_topology::HardcodedTopologyProvider;
-use nym_validator_client::{client::NymApiClientExt, models::NymNodeDescriptionV2};
+use nym_validator_client::{client::NymApiClientExt, models::described::v2::NymNodeDescriptionV2};
 use nym_vpn_lib_types::{DiagnosticRegisterParams, DiagnosticResult, RegistrationReport};
 use nym_vpn_network_config::Network;
 

--- a/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/registration/mixnet_client.rs
+++ b/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/registration/mixnet_client.rs
@@ -125,22 +125,17 @@ impl MixnetClientRegistration {
             }
         };
 
-        let registration_config = match setup_wg_registration(
-            network,
-            &gateway,
-            parameters.storage_path.as_ref(),
-        )
-        .await
-        {
-            Ok(config) => config,
-            Err(e) => {
-                registration_report.mixnet_based_dvpn_registration = Some(
-                    DiagnosticResult::from_err(format!("Registration not possible: {e}")),
-                );
-                mixnet_client.disconnect().await;
-                return None;
-            }
-        };
+        let registration_config =
+            match setup_wg_registration(&gateway, parameters.storage_path.as_ref()).await {
+                Ok(config) => config,
+                Err(e) => {
+                    registration_report.mixnet_based_dvpn_registration = Some(
+                        DiagnosticResult::from_err(format!("Registration not possible: {e}")),
+                    );
+                    mixnet_client.disconnect().await;
+                    return None;
+                }
+            };
 
         tracing::info!("Registering...");
 
@@ -295,7 +290,6 @@ fn lookup_ipr_address(gateway: &NymNodeDescriptionV2) -> anyhow::Result<Recipien
 }
 
 async fn setup_wg_registration(
-    network: &Network,
     gateway: &NymNodeDescriptionV2,
     storage_path: Option<&PathBuf>,
 ) -> anyhow::Result<WgRegistrationConfig> {
@@ -321,7 +315,7 @@ async fn setup_wg_registration(
             "Chosen gateway does not have announced IP addresses",
         ))?;
 
-    let bandwidth_provider = setup_bandwidth_provider(network, storage_path)
+    let bandwidth_provider = setup_bandwidth_provider(storage_path)
         .await
         .map_err(|e| anyhow::anyhow!("Failed to setup bandwidth provider : {e}"))?;
 

--- a/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/registration/mod.rs
+++ b/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/registration/mod.rs
@@ -5,7 +5,6 @@ use crate::diagnostic::registration::{
 };
 use nym_bandwidth_controller::{BandwidthController, BandwidthTicketProvider};
 use nym_sdk::mixnet::StoragePaths;
-use nym_validator_client::nyxd::{Config as NyxdClientConfig, NyxdClient};
 use nym_vpn_lib_types::{
     DiagnosticRegisterParams, DiagnosticResult, RegistrationMode, RegistrationReport,
 };
@@ -72,19 +71,8 @@ impl RegistrationDiagnostic {
 }
 
 async fn setup_bandwidth_provider(
-    network: &Network,
     storage_path: &PathBuf,
 ) -> anyhow::Result<Box<dyn BandwidthTicketProvider>> {
-    let config = NyxdClientConfig::try_from_nym_network_details(network.nym_network_details())
-        .map_err(|e| anyhow::anyhow!("Nyx config error : {e}"))?;
-
-    let nyxd_url = network
-        .nym_network_details()
-        .endpoints
-        .first()
-        .map(|ep| ep.nyxd_url())
-        .ok_or(anyhow::anyhow!("Invalid Nyxd URl"))?;
-
     let storage_paths = StoragePaths::new_from_dir(storage_path)
         .map_err(|e| anyhow::anyhow!("Storage setup error : {e}"))?;
     if !storage_paths.credential_database_path.exists() {
@@ -97,11 +85,6 @@ async fn setup_bandwidth_provider(
         .await
         .map_err(|e| anyhow::anyhow!("Credential database : {e}"))?;
 
-    let nyxd_client = NyxdClient::connect(config, nyxd_url.as_str())
-        .map_err(|e| anyhow::anyhow!("NyxdClient connection : {e}"))?;
-
-    Ok(Box::new(BandwidthController::new(
-        credential_storage,
-        nyxd_client,
-    )))
+    // No need for a public data fetcher. Vpn credentials are imported with the global data
+    Ok(Box::new(BandwidthController::new(credential_storage)))
 }

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/mod.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/mod.rs
@@ -8,7 +8,10 @@ use ipnetwork::IpNetwork;
 use itertools::Itertools;
 use nym_sdk::mixnet::NodeIdentity;
 use nym_topology::{NodeId, RoutingNode};
-use nym_validator_client::models::{KeyRotationId, LewesProtocolDetailsV1, NymNodeDescriptionV2};
+use nym_validator_client::models::{
+    KeyRotationId,
+    described::{type_translation::LewesProtocolDetailsV1, v2::NymNodeDescriptionV2},
+};
 use nym_vpn_api_client::{
     response::{BridgeInformation, BridgeParameters, NodeFamily, NodeStaking},
     types::Percent,

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/ipr_addresses.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/ipr_addresses.rs
@@ -3,7 +3,7 @@
 
 use crate::{Error, error::Result};
 use nym_sdk::mixnet::{NodeIdentity, Recipient};
-use nym_validator_client::models::NymNodeDataV1;
+use nym_validator_client::models::described::v1::NymNodeDataV1;
 
 #[derive(Debug, Copy, Clone)]
 pub struct IpPacketRouterAddress(Recipient);

--- a/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
@@ -10,7 +10,8 @@ use std::{
 use nym_network_defaults::ApiUrl;
 use nym_sdk::UserAgent;
 use nym_validator_client::{
-    models::NymNodeDescriptionV2, nym_api::NymApiClientExt, nym_nodes::SkimmedNodesWithMetadata,
+    models::described::v2::NymNodeDescriptionV2, nym_api::NymApiClientExt,
+    nym_nodes::SkimmedNodesWithMetadata,
 };
 use nym_vpn_api_client::{
     ResolverOverrides, api_urls_to_urls, fronted_http_client,

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
@@ -12,7 +12,7 @@ use itertools::Itertools;
 use nym_contracts_common::Percent;
 use nym_credential_proxy_requests::api::v1::ticketbook::models::TicketbookWalletSharesResponse;
 pub use nym_credential_proxy_requests::api::v1::ticketbook::models::UpgradeModeAttestation;
-use nym_validator_client::models::LewesProtocolDetailsV1;
+use nym_validator_client::models::described::type_translation::LewesProtocolDetailsV1;
 use serde::{Deserialize, Serialize};
 use time::{OffsetDateTime, UtcDateTime, format_description::well_known::Iso8601};
 

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/gateway.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/gateway.rs
@@ -909,8 +909,10 @@ impl From<nym_gateway_directory::Country> for Country {
 }
 
 #[cfg(feature = "nym-type-conversions")]
-impl From<nym_validator_client::models::NymNodeDescriptionV1> for Gateway {
-    fn from(node_description: nym_validator_client::models::NymNodeDescriptionV1) -> Self {
+impl From<nym_validator_client::models::described::v1::NymNodeDescriptionV1> for Gateway {
+    fn from(
+        node_description: nym_validator_client::models::described::v1::NymNodeDescriptionV1,
+    ) -> Self {
         let build_version = Some(node_description.version().to_owned());
         let (exit_ipv4s, exit_ipv6s) = nym_gateway_directory::split_ips(
             node_description.description.host_information.ip_address,
@@ -940,8 +942,10 @@ impl From<nym_validator_client::models::NymNodeDescriptionV1> for Gateway {
 }
 
 #[cfg(feature = "nym-type-conversions")]
-impl From<nym_validator_client::models::NymNodeDescriptionV2> for Gateway {
-    fn from(node_description: nym_validator_client::models::NymNodeDescriptionV2) -> Self {
+impl From<nym_validator_client::models::described::v2::NymNodeDescriptionV2> for Gateway {
+    fn from(
+        node_description: nym_validator_client::models::described::v2::NymNodeDescriptionV2,
+    ) -> Self {
         let build_version = Some(node_description.version().to_owned());
         let (exit_ipv4s, exit_ipv6s) = nym_gateway_directory::split_ips(
             node_description.description.host_information.ip_address,
@@ -1038,8 +1042,12 @@ impl From<nym_gateway_directory::Lp> for Lp {
 }
 
 #[cfg(feature = "nym-type-conversions")]
-impl From<nym_validator_client::models::LewesProtocolDetailsV1> for LewesProtocolDetails {
-    fn from(value: nym_validator_client::models::LewesProtocolDetailsV1) -> Self {
+impl From<nym_validator_client::models::described::type_translation::LewesProtocolDetailsV1>
+    for LewesProtocolDetails
+{
+    fn from(
+        value: nym_validator_client::models::described::type_translation::LewesProtocolDetailsV1,
+    ) -> Self {
         Self {
             content: value.content.into(),
             signature: value.signature.to_base58_string(),
@@ -1048,8 +1056,12 @@ impl From<nym_validator_client::models::LewesProtocolDetailsV1> for LewesProtoco
 }
 
 #[cfg(feature = "nym-type-conversions")]
-impl From<nym_validator_client::models::LewesProtocolDetailsDataV1> for LewesProtocolDetailsData {
-    fn from(value: nym_validator_client::models::LewesProtocolDetailsDataV1) -> Self {
+impl From<nym_validator_client::models::described::type_translation::LewesProtocolDetailsDataV1>
+    for LewesProtocolDetailsData
+{
+    fn from(
+        value: nym_validator_client::models::described::type_translation::LewesProtocolDetailsDataV1,
+    ) -> Self {
         let kem_keys = value
             .kem_keys
             .into_iter()

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_event.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_event.rs
@@ -12,8 +12,6 @@ use ts_rs::TS;
 use crate::{AccountControllerState, service::VpnServiceConfig};
 
 #[cfg(feature = "nym-type-conversions")]
-use nym_bandwidth_controller::BandwidthStatusMessage;
-#[cfg(feature = "nym-type-conversions")]
 use nym_statistics_common::clients::packet_statistics::{
     MixnetBandwidthStatisticsEvent, PacketRates,
 };
@@ -235,16 +233,6 @@ impl SphinxPacketRates {
 
     pub fn cover_sent(&self) -> String {
         bibytes2(self.cover_packets_sent_size)
-    }
-}
-
-#[cfg(feature = "nym-type-conversions")]
-impl From<&BandwidthStatusMessage> for BandwidthEvent {
-    fn from(value: &BandwidthStatusMessage) -> Self {
-        match value {
-            BandwidthStatusMessage::NoBandwidth => Self::NoBandwidth,
-            BandwidthStatusMessage::RemainingBandwidth(value) => Self::RemainingBandwidth(*value),
-        }
     }
 }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_controller.rs
@@ -9,6 +9,7 @@ use nym_bandwidth_controller::{BandwidthTicketProvider, DEFAULT_TICKETS_TO_SPEND
 use crate::tunnel_health::{MetadataPathHealth, update_metadata_path_health};
 use nym_registration_common::WireguardConfiguration;
 use sysinfo::Networks;
+use time::OffsetDateTime;
 use tokio_stream::{StreamExt, wrappers::IntervalStream};
 use tokio_util::sync::CancellationToken;
 
@@ -88,6 +89,12 @@ pub enum SpecificGatewayError {
         ticketbook_type: TicketType,
         #[source]
         source: Box<MetadataClientError>,
+    },
+
+    #[error("No credential of type {ticketbook_type} available to send to gateway: {gateway_id}")]
+    NoCredentialAvailable {
+        ticketbook_type: TicketType,
+        gateway_id: String,
     },
 
     #[error("failed to query bandwidth from gateway: {gateway_id}")]
@@ -781,12 +788,17 @@ impl BandwidthController {
                 ticketbook_type,
                 bw_client.gateway_id(),
                 DEFAULT_TICKETS_TO_SPEND,
+                OffsetDateTime::now_utc(), // Skew input can be fed here
             )
             .await
             .map_err(|source| SpecificGatewayError::RequestCredential {
                 gateway_id: bw_client.gateway_id().to_string(),
                 ticketbook_type,
                 source: Box::new(source),
+            })?
+            .ok_or(SpecificGatewayError::NoCredentialAvailable {
+                ticketbook_type,
+                gateway_id: bw_client.gateway_id().to_string(),
             })?
             .data;
         let remaining_bandwidth = bw_client

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/error.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/error.rs
@@ -37,6 +37,9 @@ pub enum Error {
     #[error("failed to create account controller")]
     CreateAccountController(#[source] nym_vpn_account_controller::Error),
 
+    #[error("failed to setup bandwidth controller storage paths")]
+    BandwidthControllerStorage(#[source] Box<nym_sdk::Error>),
+
     #[error("failed to create gateway client")]
     CreateGatewayClient(#[source] crate::gateway_directory::Error),
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
@@ -10,7 +10,9 @@ use std::{
 };
 
 use futures::{FutureExt, StreamExt, future::Fuse};
+use nym_bandwidth_controller::BandwidthController;
 use nym_diagnostic::DiagnosticHandler;
+use nym_sdk::mixnet::StoragePaths;
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 use tokio::{
     sync::{RwLock, broadcast, mpsc, oneshot, watch},
@@ -330,6 +332,9 @@ pub struct NymVpnService {
     // Statistics controller handle
     statistics_controller_handle: JoinHandle<()>,
 
+    // Bandwidth controller handle
+    bandwidth_controller_handle: JoinHandle<()>,
+
     // Topology service join handle
     topology_service_join_handle: JoinHandle<()>,
 
@@ -511,6 +516,17 @@ impl NymVpnService {
         let wireguard_keys_db = account_controller.get_wireguard_keys_storage();
         let account_controller_handle = tokio::task::spawn(account_controller.run());
 
+        let credential_storage = StoragePaths::new_from_dir(network_data_dir.clone())
+            .map_err(|e| Error::BandwidthControllerStorage(Box::new(e)))?
+            .persistent_credential_storage()
+            .await
+            .map_err(|e| Error::BandwidthControllerStorage(Box::new(e)))?;
+        let bandwidth_controller = BandwidthController::new(credential_storage);
+        let bandwidth_command_tx = bandwidth_controller.get_request_sender();
+        let bandwidth_controller_handle = tokio::task::spawn(
+            bandwidth_controller.run(services_shutdown_token.child_token().into()),
+        );
+
         let config_manager = match parameters.service_storage_type {
             ServiceConfigStorageType::Persistent => {
                 VpnServiceConfigManager::new(&config_dir, Some(tunnel_event_tx.clone())).await?
@@ -672,6 +688,7 @@ impl NymVpnService {
             tunnel_constants,
             account_command_tx.clone(),
             account_state_rx.clone(),
+            bandwidth_command_tx.clone(),
             statistics_event_sender.clone(),
             topology_service.clone(),
             connectivity_handle,
@@ -709,6 +726,7 @@ impl NymVpnService {
             state_machine_handle: Some(state_machine_handle),
             account_controller_handle,
             statistics_controller_handle,
+            bandwidth_controller_handle,
             topology_service_join_handle,
             topology_service_handle: topology_service,
             config_manager,
@@ -799,6 +817,10 @@ impl NymVpnService {
 
         if let Err(e) = self.account_controller_handle.await {
             tracing::error!("Failed to join on account controller handle: {e}");
+        }
+
+        if let Err(e) = self.bandwidth_controller_handle.await {
+            tracing::error!("Failed to join on bandwidth controller handle: {e}");
         }
 
         if let Err(e) = self.statistics_controller_handle.await {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -49,6 +49,7 @@ use crate::{
 use hickory_resolver::config::NameServerConfig;
 #[cfg(not(target_os = "ios"))]
 use hickory_resolver::config::ProtocolConfig;
+use nym_bandwidth_controller::requests::BandwidthControllerRequestSender;
 use nym_config::defaults::{WG_METADATA_PORT, WG_TUN_DEVICE_IP_ADDRESS_V4};
 use nym_offline_monitor::ConnectivityHandle;
 use nym_registration_client::MixnetClientConfig;
@@ -773,6 +774,7 @@ pub struct SharedState {
     tun_provider: Arc<dyn AndroidTunProvider>,
     account_command_tx: AccountCommandSender,
     account_controller_state: AccountStateReceiver,
+    bandwidth_command_tx: BandwidthControllerRequestSender,
     statistics_event_sender: StatisticsSender,
     gateway_provider: GatewayProvider<GatewayCacheHandle>,
     topology_service: VpnTopologyServiceHandle,
@@ -1034,6 +1036,7 @@ impl TunnelStateMachine {
         tunnel_constants: TunnelConstants,
         account_command_tx: AccountCommandSender,
         account_controller_state: AccountStateReceiver,
+        bandwidth_command_tx: BandwidthControllerRequestSender,
         statistics_event_sender: StatisticsSender,
         topology_service: VpnTopologyServiceHandle,
         connectivity_handle: ConnectivityHandle,
@@ -1118,6 +1121,7 @@ impl TunnelStateMachine {
             tun_provider,
             account_command_tx,
             account_controller_state,
+            bandwidth_command_tx,
             statistics_event_sender,
             gateway_provider,
             topology_service,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -411,6 +411,7 @@ impl ConnectingState {
             tunnel_parameters,
             shared_state.account_controller_state.clone(),
             shared_state.account_command_tx.clone(),
+            shared_state.bandwidth_command_tx.clone(),
             shared_state.gateway_provider.clone(),
             shared_state.topology_service.clone(),
             tunnel_monitor_event_sender,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -23,6 +23,7 @@ use futures::{FutureExt, StreamExt, future::Fuse};
 use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
 #[cfg(target_os = "linux")]
 use nix::sys::socket::{SetSockOpt, sockopt::Mark};
+use nym_bandwidth_controller::requests::BandwidthControllerRequestSender;
 use nym_gateway_directory::{
     GatewayCacheHandle, GatewayClient, GatewayMinPerformance, NodeIdentity,
 };
@@ -253,6 +254,7 @@ pub struct TunnelMonitor {
     dns_filter: Option<crate::dns_filter::DnsFilter>,
     account_controller_state: AccountStateReceiver,
     account_command_tx: AccountCommandSender,
+    bandwidth_command_tx: BandwidthControllerRequestSender,
     gateway_provider: GatewayProvider<GatewayCacheHandle>,
     custom_topology_provider: VpnTopologyServiceHandle,
     shutdown_token: CancellationToken,
@@ -311,6 +313,7 @@ impl TunnelMonitor {
         tunnel_parameters: TunnelParameters,
         account_controller_state: AccountStateReceiver,
         account_command_tx: AccountCommandSender,
+        bandwidth_command_tx: BandwidthControllerRequestSender,
         gateway_provider: GatewayProvider<GatewayCacheHandle>,
         custom_topology_provider: VpnTopologyServiceHandle,
         monitor_event_sender: mpsc::UnboundedSender<TunnelMonitorEvent>,
@@ -331,6 +334,7 @@ impl TunnelMonitor {
             dns_filter,
             account_controller_state,
             account_command_tx,
+            bandwidth_command_tx,
             gateway_provider,
             custom_topology_provider,
             shutdown_token: shutdown_token.clone(),
@@ -528,10 +532,11 @@ impl TunnelMonitor {
         let rcb_config_builder = RegistrationClientBuilderConfig::builder()
             .entry_node(entry_node)
             .exit_node(exit_node)
-            .data_path(Some(self.tunnel_parameters.nym_config.data_path.clone()))
+            .data_path(self.tunnel_parameters.nym_config.data_path.clone())
             .mixnet_client_config(mixnet_client_config)
             .mixnet_client_startup_timeout(REGISTRATION_CLIENT_STARTUP_TIMEOUT)
             .mode(mode)
+            .bandwidth_request_sender(self.bandwidth_command_tx.clone())
             .enable_lp_registration(true)
             .user_agent(user_agent)
             .custom_topology_provider(Box::new(
@@ -1126,7 +1131,6 @@ impl TunnelMonitor {
             entry_gateway_data,
             exit_gateway_data,
             authenticator_listener_handle,
-            bw_controller,
         ) = match registration_result {
             WireguardRegistrationResult::Legacy(res) => (
                 Some(res.entry_gateway_client),
@@ -1134,7 +1138,6 @@ impl TunnelMonitor {
                 res.entry_gateway_data,
                 res.exit_gateway_data,
                 Some(res.authenticator_listener_handle),
-                res.bw_controller,
             ),
             WireguardRegistrationResult::LewesProtocol(res) => (
                 None,
@@ -1142,7 +1145,6 @@ impl TunnelMonitor {
                 res.entry_gateway_data,
                 res.exit_gateway_data,
                 None,
-                res.bw_controller,
             ),
         };
 
@@ -1156,7 +1158,7 @@ impl TunnelMonitor {
         let metadata_path_health = MetadataPathHealth::new();
 
         let bw = BandwidthController::create(
-            bw_controller,
+            Box::new(self.bandwidth_command_tx.clone()),
             self.account_command_tx.clone(),
             selected_gateways,
             entry_gateway_client,


### PR DESCRIPTION
## Bandwidth controller step 1: single shared `BandwidthController` owned by the VPN service

### Summary

First step of the bandwidth-controller migration. Adopts the reworked `nym-bandwidth-controller` API from upstream `nym` and moves to a **single, long-lived `BandwidthController`** owned by `NymVpnService`, instead of constructing an ad-hoc controller per WireGuard registration.

The controller now owns the persistent credential (ticketbook) storage and exposes a request channel. A `BandwidthControllerRequestSender` is threaded down through the tunnel state machine so registration and top-ups talk to the shared instance. This is the plumbing step — behavior is unchanged; later steps move credential/zk-nym acquisition off the `AccountController` and onto pluggable fetchers.

---

### Bandwidth controller work

- **`vpn_service.rs`** — build persistent credential storage via `StoragePaths::persistent_credential_storage()`, construct one `BandwidthController`, spawn it as its own task (`bandwidth_controller_handle`), and keep its `get_request_sender()` handle. The handle is awaited on shutdown, and a new `Error::BandwidthControllerStorage` covers storage-path setup failures.
- **`tunnel_monitor.rs`** — registration is fed the shared sender via `RegistrationClientBuilderConfig::bandwidth_request_sender(...)`; the per-registration `bw_controller` field is dropped from both `WireguardRegistrationResult::Legacy` and `::LewesProtocol`, and `BandwidthController::create` receives the shared sender instead.
- **`bandwidth_controller.rs`** — `get_ticketbook` now takes an `OffsetDateTime` (skew input, currently `now_utc()`) and returns an `Option`; added `SpecificGatewayError::NoCredentialAvailable { ticketbook_type, gateway_id }` for the `None` case.
- **`nym-diagnostic` registration** — `BandwidthController::new` no longer needs a `NyxdClient` (VPN credentials are imported with the global data), so `setup_bandwidth_provider` drops the nyxd client/config setup.

---

### Import / plumbing changes

- **Dependency bump** — `nym` git dependencies moved from branch `vpn/release/2026.12-yaroslavsky` → `vpn/release/2026.13-ziller`, which carries the new `BandwidthController` API. (`Cargo.toml`, `Cargo.lock`)
- **State machine wiring** — `bandwidth_command_tx: BandwidthControllerRequestSender` added to `SharedState` and `TunnelStateMachine::new`, cloned into `ConnectingState`, and passed into `TunnelMonitor`. (`tunnel_state_machine/mod.rs`, `states/connecting_state.rs`, `tunnel_monitor.rs`)
- **`tunnel_monitor.rs`** — `data_path` is now non-optional in the registration client builder config.
- **`nym-vpn-lib-types`** — removed the `BandwidthStatusMessage → BandwidthEvent` conversion (type gone upstream); updated `validator_client::models` import paths for `NymNodeDescriptionV1/V2` and `LewesProtocolDetails*` to their new `models::described::…` locations.

---

### Notes

- Pure plumbing / dependency-adoption step — no user-facing behavior change intended.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5799)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved bandwidth top-up handling during VPN connection setup.
  * Bandwidth control is now integrated more directly into tunnel startup and runtime.

* **Bug Fixes**
  * Connection setup now reports a clearer error when no credential/ticket is available for a gateway.
  * Registration and tunnel startup flows were streamlined to reduce failures caused by unnecessary setup steps.

* **Chores**
  * Updated internal crate references and dependency sources to the latest release branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->