### PR TITLE
Connect on healthy metadata when mobile TCP probe fails

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_health.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_health.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-//! Shared signals used to correlate ICMP health probes with in-tunnel metadata paths.
+//! Shared signals used to correlate connectivity health probes with in-tunnel metadata paths.
 
 use std::{
     sync::{Arc, Mutex},
@@ -59,7 +59,17 @@ impl MetadataPathHealth {
     }
 }
 
-/// Returns true when an ICMP probe failure should not tear the tunnel down yet.
+/// Returns true when dual-leg metadata recently succeeded on a mobile netstack path
+/// and the tunnel should be treated as connect-viable despite probe failure.
+pub fn should_treat_metadata_as_connect_viable(
+    uses_metadata_endpoint: bool,
+    health: Option<&MetadataPathHealth>,
+    grace: Duration,
+) -> bool {
+    uses_metadata_endpoint && health.is_some_and(|h| h.is_recently_healthy(grace))
+}
+
+/// Returns true when a connectivity probe failure should not tear the tunnel down yet.
 pub fn should_defer_probe_teardown(
     uses_metadata_endpoint: bool,
     health: Option<&MetadataPathHealth>,
@@ -196,6 +206,23 @@ mod tests {
             Some(&health),
             METADATA_PATH_HEALTH_GRACE,
             0,
+        ));
+    }
+
+    #[test]
+    fn connect_viable_after_defer_cap_when_metadata_healthy() {
+        let health = MetadataPathHealth::new();
+        health.record_success();
+        assert!(!should_defer_probe_teardown(
+            true,
+            Some(&health),
+            METADATA_PATH_HEALTH_GRACE,
+            MAX_CONSECUTIVE_DEFERRED_PROBE_FAILURES,
+        ));
+        assert!(should_treat_metadata_as_connect_viable(
+            true,
+            Some(&health),
+            METADATA_PATH_HEALTH_GRACE,
         ));
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_health.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_health.rs
@@ -59,8 +59,9 @@ impl MetadataPathHealth {
     }
 }
 
-/// Returns true when dual-leg metadata recently succeeded on a mobile netstack path
-/// and the tunnel should be treated as connect-viable despite probe failure.
+/// Returns true when dual-leg metadata recently succeeded on a wireguard netstack path
+/// (`uses_metadata_endpoint`) and the tunnel should be treated as connect-viable despite
+/// connectivity probe failure.
 pub fn should_treat_metadata_as_connect_viable(
     uses_metadata_endpoint: bool,
     health: Option<&MetadataPathHealth>,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
@@ -28,6 +28,7 @@ use nym_common::trace_err_chain;
 use nym_firewall::{
     AllowedClients, AllowedDns, AllowedEndpoint, Endpoint, FirewallPolicy, TransportProtocol,
 };
+use nym_http_api_client::HickoryDnsResolver;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use nym_vpn_lib_types::TunnelConnectionData;
 
@@ -115,6 +116,10 @@ impl ConnectedState {
             )
             .await;
         }
+
+        // point the internal DNS resolver to the system so that it routes over the tunnel
+        // using the custom / commodity DNS flow while in the connected state
+        HickoryDnsResolver::shared().use_system_resolver();
 
         #[cfg(not(any(target_os = "android")))]
         if let Err(e) = connected_state.set_dns(shared_state).await {
@@ -281,6 +286,9 @@ impl ConnectedState {
         shared_state
             .statistics_event_sender
             .report_tunnel_interface(None);
+
+        // Revert the internal resolver to use the configured nameserver group
+        HickoryDnsResolver::shared().use_configured_resolver();
 
         #[cfg(not(target_os = "android"))]
         Self::reset_dns(shared_state).await;

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -739,8 +739,8 @@ impl TunnelStateHandler for ConnectingState {
                         }
                     }
                     TunnelMonitorEvent::ConnectionFailed { exit_gateway_id } => {
-                        // WG handshake timed out or ICMP connectivity check failed; blacklist
-                        // the gateway so a different one is selected on the next attempt.
+                        // WG handshake timed out or connectivity probe failed without a healthy
+                        // metadata path; blacklist the exit so a different one is selected.
                         shared_state.gateway_provider.add_blacklisted_gateway(exit_gateway_id).await;
                         self.selected_gateways = None;
                         NextTunnelState::SameState(self)

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -847,13 +847,15 @@ impl TunnelMonitor {
                                     metadata_path_health.as_ref(),
                                     METADATA_PATH_HEALTH_GRACE,
                                 ) {
-                                    tracing::info!(
-                                        "Probe failed but dual-leg metadata recently healthy; treating tunnel as viable"
-                                    );
-                                    self.send_event(TunnelMonitorEvent::Up {
-                                        tunnel_interface: tunnel_interface.clone(),
-                                        connection_data: connection_data.clone(),
-                                    });
+                                    if !has_sent_up_event {
+                                        tracing::info!(
+                                            "Probe failed but dual-leg metadata recently healthy; treating tunnel as viable"
+                                        );
+                                        self.send_event(TunnelMonitorEvent::Up {
+                                            tunnel_interface: tunnel_interface.clone(),
+                                            connection_data: connection_data.clone(),
+                                        });
+                                    }
                                     break;
                                 } else {
                                     tracing::info!("Tunnel connection is down. Exiting");

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -82,7 +82,10 @@ use crate::{
     DEFAULT_MIN_GATEWAY_PERFORMANCE, DEFAULT_MIN_MIXNODE_PERFORMANCE, UserAgent,
     bandwidth_controller::BandwidthController,
     mixnet::VpnTopologyServiceHandle,
-    tunnel_health::{METADATA_PATH_HEALTH_GRACE, MetadataPathHealth, should_defer_probe_teardown},
+    tunnel_health::{
+        METADATA_PATH_HEALTH_GRACE, MetadataPathHealth, should_defer_probe_teardown,
+        should_treat_metadata_as_connect_viable,
+    },
     tunnel_state_machine::{
         TunnelConstants, WireguardMultihopMode, account, ipv6_availability,
         tunnel::{
@@ -839,6 +842,19 @@ impl TunnelMonitor {
                                         "Probe declared tunnel down but in-tunnel metadata path recently succeeded; deferring teardown"
                                     );
                                     last_connection_status = None;
+                                } else if should_treat_metadata_as_connect_viable(
+                                    uses_metadata_endpoint,
+                                    metadata_path_health.as_ref(),
+                                    METADATA_PATH_HEALTH_GRACE,
+                                ) {
+                                    tracing::info!(
+                                        "Probe failed but dual-leg metadata recently healthy; treating tunnel as viable"
+                                    );
+                                    self.send_event(TunnelMonitorEvent::Up {
+                                        tunnel_interface: tunnel_interface.clone(),
+                                        connection_data: connection_data.clone(),
+                                    });
+                                    break;
                                 } else {
                                     tracing::info!("Tunnel connection is down. Exiting");
                                     self.send_event(TunnelMonitorEvent::ConnectionFailed {
@@ -866,7 +882,12 @@ impl TunnelMonitor {
                     } else {
                         metadata_endpoint_viable = true;
                         consecutive_deferred_probe_failures = 0;
-                        if !has_sent_up_event && ping_viable {
+                        let metadata_connect_viable = should_treat_metadata_as_connect_viable(
+                            uses_metadata_endpoint,
+                            metadata_path_health.as_ref(),
+                            METADATA_PATH_HEALTH_GRACE,
+                        );
+                        if !has_sent_up_event && (ping_viable || metadata_connect_viable) {
                             tracing::info!("Tunnel connection is viable");
                             has_sent_up_event = true;
                             self.send_event(TunnelMonitorEvent::Up {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -851,12 +851,12 @@ impl TunnelMonitor {
                                         tracing::info!(
                                             "Probe failed but dual-leg metadata recently healthy; treating tunnel as viable"
                                         );
+                                        has_sent_up_event = true;
                                         self.send_event(TunnelMonitorEvent::Up {
                                             tunnel_interface: tunnel_interface.clone(),
                                             connection_data: connection_data.clone(),
                                         });
                                     }
-                                    break;
                                 } else {
                                     tracing::info!("Tunnel connection is down. Exiting");
                                     self.send_event(TunnelMonitorEvent::ConnectionFailed {


### PR DESCRIPTION
Emit Up instead of ConnectionFailed when dual-leg bandwidth metadata recently succeeded on the netstack path, avoiding false exit blacklists and multi-minute establish stalls on iOS.

## Ticket

JIRA-NYM-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5800)
<!-- Reviewable:end -->
