### PR TITLE
NYM-1561: Avoid deadlock with NetworkManager on Linux.

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [macOS] Disable authentication when flag is set (https://github.com/nymtech/nym-vpn-client/pull/5645)
 - [iOS] Fix metadata endpoint not being reached for exit tunnel (https://github.com/nymtech/nym-vpn-client/pull/5728)
 - Fix going into Connected state when metadata endpoint might not work (https://github.com/nymtech/nym-vpn-client/pull/5750)
+- [Linux] Fix a deadlock with NetworkManager when the daemon starts after a reboot (https://github.com/nymtech/nym-vpn-client/pull/5801) 
 
 ### Removed
 

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -7215,6 +7215,7 @@ dependencies = [
  "nym-connection-monitor",
  "nym-credentials-interface",
  "nym-crypto",
+ "nym-dbus",
  "nym-diagnostic",
  "nym-dns",
  "nym-file-updater",

--- a/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
@@ -144,6 +144,10 @@ nix = { workspace = true, features = [
     "ioctl",
 ] }
 
+# Linux-specific dependencies
+[target.'cfg(target_os = "linux")'.dependencies]
+nym-dbus.workspace = true
+
 # Windows-specific dependencies
 [target.'cfg(windows)'.dependencies]
 nym-windows.workspace = true

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -774,6 +774,8 @@ pub struct SharedState {
     account_command_tx: AccountCommandSender,
     account_controller_state: AccountStateReceiver,
     statistics_event_sender: StatisticsSender,
+    #[cfg(target_os = "linux")]
+    nm_connectivity_check_enabled: Option<bool>,
     gateway_provider: GatewayProvider<GatewayCacheHandle>,
     topology_service: VpnTopologyServiceHandle,
     discovery_refresher_command_tx: mpsc::UnboundedSender<DiscoveryRefresherCommand>,
@@ -806,6 +808,24 @@ impl SharedState {
         self.account_command_tx.set_vpn_api_firewall_up().await.ok();
         self.gateway_provider.set_active_geo_location(false).await;
         self.gateway_provider.set_gateway_cache_paused(true);
+    }
+
+    #[cfg(target_os = "linux")]
+    pub fn disable_nm_connectivity_check(&mut self) {
+        if self.nm_connectivity_check_enabled.is_none()
+            && let Ok(nm) = nym_dbus::network_manager::NetworkManager::new()
+        {
+            self.nm_connectivity_check_enabled = nm.disable_connectivity_check();
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    pub fn restore_nm_connectivity_check(&mut self) {
+        if let Some(true) = self.nm_connectivity_check_enabled.take()
+            && let Ok(nm) = nym_dbus::network_manager::NetworkManager::new()
+        {
+            nm.enable_connectivity_check();
+        }
     }
 
     async fn enable_ad_blocking(&self, enable: bool) {
@@ -1119,6 +1139,8 @@ impl TunnelStateMachine {
             account_command_tx,
             account_controller_state,
             statistics_event_sender,
+            #[cfg(target_os = "linux")]
+            nm_connectivity_check_enabled: None,
             gateway_provider,
             topology_service,
             discovery_refresher_command_tx,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -217,6 +217,9 @@ impl ConnectingState {
     ) -> Result<()> {
         let policy = params.as_policy();
 
+        #[cfg(target_os = "linux")]
+        shared_state.disable_nm_connectivity_check();
+
         shared_state
             .firewall
             .apply_policy(policy)

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnected_state.rs
@@ -57,6 +57,9 @@ impl DisconnectedState {
         if let Err(e) = shared_state.firewall.reset_policy() {
             trace_err_chain!(e, "Failed to reset firewall policy");
         }
+
+        #[cfg(target_os = "linux")]
+        shared_state.restore_nm_connectivity_check();
     }
 
     #[cfg(not(any(target_os = "android", target_os = "ios")))]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
@@ -152,6 +152,9 @@ impl ErrorState {
 
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     fn reset_firewall_policy(shared_state: &mut SharedState) {
+        #[cfg(target_os = "linux")]
+        shared_state.restore_nm_connectivity_check();
+
         if let Err(e) = shared_state.firewall.reset_policy() {
             trace_err_chain!(e, "Failed to reset firewall policy");
         }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/offline_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/offline_state.rs
@@ -80,6 +80,9 @@ impl OfflineState {
 
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     fn reset_firewall_policy(shared_state: &mut SharedState) {
+        #[cfg(target_os = "linux")]
+        shared_state.restore_nm_connectivity_check();
+
         if let Err(e) = shared_state.firewall.reset_policy() {
             trace_err_chain!(e, "Failed to reset firewall policy");
         }


### PR DESCRIPTION
## Ticket

JIRA-NYM-1561

## Description

NYM-1561: Avoid deadlock with NetworkManager on Linux.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5802)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux VPN startup and recovery behavior to avoid NetworkManager-related deadlocks after reboot.
  * Restores normal connectivity checking when disconnecting, entering error handling, or going offline.
  * Adjusts connection setup on Linux to temporarily disable connectivity checks while applying network changes.
* **Chores**
  * Updated the changelog with the latest Linux fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->