### PR TITLE
Restore icmp probe, tweak timings

### DIFF
--- a/nym-vpn-core/crates/nym-connection-monitor/src/connection_monitor.rs
+++ b/nym-vpn-core/crates/nym-connection-monitor/src/connection_monitor.rs
@@ -83,14 +83,25 @@ impl TimingConfig {
         }
     }
 
-    /// Default timings suitable for two-hop connections
-    pub fn two_hop() -> Self {
+    /// Default timings suitable for two-hop connections using ICMP probe
+    pub fn two_hop_icmp() -> Self {
         TimingConfig {
             initial_probe_timeout: Duration::from_secs(3),
             initial_probe_retry_count: 5,
             monitoring_probe_timeout: Duration::from_secs(5),
             monitoring_probe_retry_count: 3,
             probe_periodicity: Duration::from_secs(10),
+        }
+    }
+
+    /// Default timings suitable for two-hop connections using TCP probe
+    pub fn two_hop_tcp() -> Self {
+        TimingConfig {
+            initial_probe_timeout: Duration::from_secs(10),
+            initial_probe_retry_count: 5,
+            monitoring_probe_timeout: Duration::from_secs(10),
+            monitoring_probe_retry_count: 3,
+            probe_periodicity: Duration::from_secs(20),
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -1996,11 +1996,6 @@ impl TunnelMonitor {
         exit_tunnel_metadata: &TunnelMetadata,
         event_tx: mpsc::UnboundedSender<ConnectionEvent>,
     ) -> Result<JoinHandle<Result<(), nym_connection_monitor::Error>>> {
-        let timing_config = match self.tunnel_parameters.tunnel_settings.tunnel_type_used() {
-            TunnelType::Mixnet => TimingConfig::mixnet(),
-            TunnelType::Wireguard => TimingConfig::two_hop(),
-        };
-
         // Create ICMP probe first, fallback to TCP probe on failure.
         match self.create_icmp_probe(exit_tunnel_metadata) {
             Ok(icmp_probe) => {
@@ -2009,6 +2004,13 @@ impl TunnelMonitor {
                     probe_selection = "default_primary",
                     "Selected ICMP connectivity probe"
                 );
+
+                let timing_config = match self.tunnel_parameters.tunnel_settings.tunnel_type_used()
+                {
+                    TunnelType::Mixnet => TimingConfig::mixnet(),
+                    TunnelType::Wireguard => TimingConfig::two_hop_icmp(),
+                };
+
                 Ok(ConnectionMonitor::spawn(
                     icmp_probe,
                     timing_config,
@@ -2023,6 +2025,13 @@ impl TunnelMonitor {
                     fallback_reason = %err.display_chain(),
                     "ICMP probe setup failed, falling back to TCP"
                 );
+
+                let timing_config = match self.tunnel_parameters.tunnel_settings.tunnel_type_used()
+                {
+                    TunnelType::Mixnet => TimingConfig::mixnet(),
+                    TunnelType::Wireguard => TimingConfig::two_hop_tcp(),
+                };
+
                 let tcp_probe = self.create_tcp_probe(exit_tunnel_metadata)?;
                 tracing::info!(
                     probe_type = "tcp",

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -2001,33 +2001,6 @@ impl TunnelMonitor {
             TunnelType::Wireguard => TimingConfig::two_hop(),
         };
 
-        #[cfg(any(target_os = "ios", target_os = "android"))]
-        {
-            match self.create_tcp_probe(exit_tunnel_metadata) {
-                Ok(tcp_probe) => {
-                    tracing::info!(
-                        probe_type = "tcp",
-                        probe_selection = "mobile_primary",
-                        "Selected TCP connectivity probe on mobile"
-                    );
-                    return Ok(ConnectionMonitor::spawn(
-                        tcp_probe,
-                        timing_config,
-                        event_tx,
-                        self.shutdown_token.child_token(),
-                    ));
-                }
-                Err(err) => {
-                    tracing::warn!(
-                        probe_type = "icmp",
-                        probe_selection = "mobile_tcp_setup_failed",
-                        fallback_reason = %err.display_chain(),
-                        "TCP probe setup failed on mobile, falling back to ICMP"
-                    );
-                }
-            }
-        }
-
         // Create ICMP probe first, fallback to TCP probe on failure.
         match self.create_icmp_probe(exit_tunnel_metadata) {
             Ok(icmp_probe) => {


### PR DESCRIPTION


## Description

- Restore ICMP probe and try using it first when possible on both Android and iOS
- Introduce different timings for two-hop TCP/ICMP probes

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5803)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate connection-monitor timing options for ICMP and TCP two-hop checks.
  * Connection monitoring now uses probe-specific settings, improving consistency between probe type and retry behavior.

* **Bug Fixes**
  * Updated tunnel monitoring to try ICMP first and fall back to TCP across all platforms.
  * Improved how connection checks are timed for different tunnel types, which may make connectivity detection more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->