### PR TITLE
(tauri) Remove unused cli args from Windows installer

### DIFF
--- a/nym-vpn-app/src-tauri/bundle/windows/installer.nsi
+++ b/nym-vpn-app/src-tauri/bundle/windows/installer.nsi
@@ -473,7 +473,7 @@ Var AppStartMenuFolder
 !insertmacro MUI_PAGE_FINISH
 
 Function RunMainBinary
-  nsis_tauri_utils::RunAsUser "$INSTDIR\${MAINBINARYNAME}.exe" "-l -Ldebug"
+  nsis_tauri_utils::RunAsUser "$INSTDIR\${MAINBINARYNAME}.exe" ""
 FunctionEnd
 
 ; Uninstaller Pages
@@ -1047,14 +1047,14 @@ Function CreateOrUpdateStartMenuShortcut
   !insertmacro IsShortcutTarget "$SMPROGRAMS\$AppStartMenuFolder\${PRODUCTNAME}.lnk" "$INSTDIR\$OldMainBinaryName"
   Pop $0
   ${If} $0 = 1
-    !insertmacro SetShortcutTarget "$SMPROGRAMS\$AppStartMenuFolder\${PRODUCTNAME}.lnk" '"$INSTDIR\${MAINBINARYNAME}.exe" -l -Ldebug'
+    !insertmacro SetShortcutTarget "$SMPROGRAMS\$AppStartMenuFolder\${PRODUCTNAME}.lnk" '"$INSTDIR\${MAINBINARYNAME}.exe"'
     StrCpy $R0 1
   ${EndIf}
 
   !insertmacro IsShortcutTarget "$SMPROGRAMS\${PRODUCTNAME}.lnk" "$INSTDIR\$OldMainBinaryName"
   Pop $0
   ${If} $0 = 1
-    !insertmacro SetShortcutTarget "$SMPROGRAMS\${PRODUCTNAME}.lnk" '"$INSTDIR\${MAINBINARYNAME}.exe" -l -Ldebug'
+    !insertmacro SetShortcutTarget "$SMPROGRAMS\${PRODUCTNAME}.lnk" '"$INSTDIR\${MAINBINARYNAME}.exe"'
     StrCpy $R0 1
   ${EndIf}
 
@@ -1073,10 +1073,10 @@ Function CreateOrUpdateStartMenuShortcut
 
   !if "${STARTMENUFOLDER}" != ""
     CreateDirectory "$SMPROGRAMS\$AppStartMenuFolder"
-    CreateShortcut "$SMPROGRAMS\$AppStartMenuFolder\${PRODUCTNAME}.lnk" "$INSTDIR\${MAINBINARYNAME}.exe" "-l -Ldebug"
+    CreateShortcut "$SMPROGRAMS\$AppStartMenuFolder\${PRODUCTNAME}.lnk" "$INSTDIR\${MAINBINARYNAME}.exe"
     !insertmacro SetLnkAppUserModelId "$SMPROGRAMS\$AppStartMenuFolder\${PRODUCTNAME}.lnk"
   !else
-    CreateShortcut "$SMPROGRAMS\${PRODUCTNAME}.lnk" "$INSTDIR\${MAINBINARYNAME}.exe" "-l -Ldebug"
+    CreateShortcut "$SMPROGRAMS\${PRODUCTNAME}.lnk" "$INSTDIR\${MAINBINARYNAME}.exe"
     !insertmacro SetLnkAppUserModelId "$SMPROGRAMS\${PRODUCTNAME}.lnk"
   !endif
 FunctionEnd
@@ -1087,7 +1087,7 @@ Function CreateOrUpdateDesktopShortcut
   !insertmacro IsShortcutTarget "$DESKTOP\${PRODUCTNAME}.lnk" "$INSTDIR\$OldMainBinaryName"
   Pop $0
   ${If} $0 = 1
-    !insertmacro SetShortcutTarget "$DESKTOP\${PRODUCTNAME}.lnk" '"$INSTDIR\${MAINBINARYNAME}.exe" -l -Ldebug'
+    !insertmacro SetShortcutTarget "$DESKTOP\${PRODUCTNAME}.lnk" '"$INSTDIR\${MAINBINARYNAME}.exe"'
     Return
   ${EndIf}
 
@@ -1100,6 +1100,6 @@ Function CreateOrUpdateDesktopShortcut
     ${EndIf}
   ${EndIf}
 
-  CreateShortcut "$DESKTOP\${PRODUCTNAME}.lnk" "$INSTDIR\${MAINBINARYNAME}.exe" "-l -Ldebug"
+  CreateShortcut "$DESKTOP\${PRODUCTNAME}.lnk" "$INSTDIR\${MAINBINARYNAME}.exe"
   !insertmacro SetLnkAppUserModelId "$DESKTOP\${PRODUCTNAME}.lnk"
 FunctionEnd

--- a/nym-vpn-app/src-tauri/src/log.rs
+++ b/nym-vpn-app/src-tauri/src/log.rs
@@ -80,20 +80,15 @@ fn rotate_log_file(log_dir: &Path) -> Result<Option<PathBuf>> {
 }
 
 pub async fn setup_tracing(
-    cli: &Cli,
+    #[cfg_attr(not(windows), allow(unused_variables))] cli: &Cli,
     sentry_enabled: bool,
     debug_logging: bool,
 ) -> Result<DebugLogging> {
-    let mut filter = EnvFilter::builder()
-        .with_default_directive(LevelFilter::INFO.into())
+    let filter = EnvFilter::builder()
+        .with_default_directive(LevelFilter::DEBUG.into())
         .from_env()?
         .add_directive("hyper::proto=info".parse()?)
         .add_directive("netlink_proto=info".parse()?);
-
-    if let Some(log_level) = cli.log_level.as_ref() {
-        filter =
-            filter.add_directive(format!("{}={}", env!("CARGO_CRATE_NAME"), log_level).parse()?);
-    }
 
     #[cfg(windows)]
     let enable_ansi = !cli.console;


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

- Remove unused cli args from windows installer
- Set default logging level to debug


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5805)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows installer shortcuts so the app starts normally without extra debug/logging flags.
  * Preserved existing shortcut links and app association behavior during shortcut creation and migration.
  * Improved logging setup so debug-level tracing is applied more consistently, while keeping non-Windows builds warning-free.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->