### PR TITLE
[iOS] adblock: block subdomains

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [iOS] Skip ad-blocking rules that do not block by domain (https://github.com/nymtech/nym-vpn-client/pull/5658)
+- [iOS] Handle sub-domain blocking (https://github.com/nymtech/nym-vpn-client/pull/5810)
 
 
 ## [2026.11.0] - TBD

--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Permit API networking in error state in order to refresh account data (https://github.com/nymtech/nym-vpn-client/pull/5623)
+- Increase timeout for TCP-based probe for connection monitoring in two-hop mode (https://github.com/nymtech/nym-vpn-client/pull/5803)
 
 ### Fixed
 
@@ -39,7 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- Removed mixnet tuning feature flag
+- Removed mixnet tuning feature flag (https://github.com/nymtech/nym-vpn-client/pull/5581)
 
 
 ## [2026.10.0] - 2026-06-09

--- a/nym-vpn-core/crates/nym-vpn-lib/src/adblocker/engines/simple.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/adblocker/engines/simple.rs
@@ -11,6 +11,7 @@ use adblock::{
     lists::{ParseOptions, ParsedFilter, RuleTypes, parse_filter},
 };
 use futures::{StreamExt, TryFutureExt, TryStreamExt, pin_mut};
+use itertools::Itertools;
 use nym_common::trace_err_chain;
 use nym_sqlx_pool_guard::SqlitePoolGuard;
 use sqlx::{
@@ -233,13 +234,26 @@ where
 
     /// Returns true if the given domain is blocked.
     pub async fn has_domain(&mut self, domain: &str) -> sqlx::Result<bool> {
-        sqlx::query_scalar!(
-            r#"SELECT EXISTS(SELECT 1 FROM blocked_domains WHERE domain_name = $1 LIMIT 1)"#,
-            domain
-        )
-        .fetch_one(self.executor.as_mut())
-        .map_ok(|res| res == 1)
-        .await
+        let domains: Vec<String> = get_all_subdomains(domain);
+        if domains.is_empty() {
+            return Ok(false);
+        }
+
+        let placeholders = vec!["?"; domains.len()].join(", ");
+        let sql = format!(
+            "SELECT EXISTS(SELECT 1 FROM blocked_domains WHERE domain_name IN ({}) LIMIT 1)",
+            placeholders
+        );
+
+        let mut query = sqlx::query_scalar(&sql);
+        for d in domains {
+            query = query.bind(d);
+        }
+
+        query
+            .fetch_one(self.executor.as_mut())
+            .map_ok(|res: i32| res == 1)
+            .await
     }
 }
 
@@ -396,6 +410,25 @@ fn add_path_suffix(path: &Path, suffix: &str) -> PathBuf {
     new_path
 }
 
+fn get_all_subdomains(domain: &str) -> Vec<String> {
+    let components = domain
+        .split('.')
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<&str>>();
+
+    if components.len() > 1 {
+        let mut matches = Vec::with_capacity(8);
+        // skip top-level domain
+        for skip in 0..components.len() - 1 {
+            let subdomain = components.iter().skip(skip).join(".");
+            matches.push(subdomain);
+        }
+        matches
+    } else {
+        Vec::from_iter(components.first().map(|v| (*v).to_owned()).into_iter())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use tempfile::TempDir;
@@ -404,6 +437,21 @@ mod tests {
     use crate::adblocker::file_manager::tests::init_tests;
 
     const SHOULD_BE_BLOCKED_DOMAIN: &str = "ad.doubleclick.net";
+
+    #[test]
+    fn test_get_all_subdomains() {
+        assert_eq!(
+            get_all_subdomains("ad.doubleclick.net"),
+            vec!["ad.doubleclick.net", "doubleclick.net"]
+        );
+        assert_eq!(
+            get_all_subdomains(".ad..doubleclick.net."),
+            vec!["ad.doubleclick.net", "doubleclick.net"]
+        );
+        assert_eq!(get_all_subdomains("localhost"), vec!["localhost"]);
+        assert_eq!(get_all_subdomains("nym.com"), vec!["nym.com"]);
+        assert_eq!(get_all_subdomains(""), Vec::<&str>::new());
+    }
 
     #[tokio::test]
     #[tracing_test::traced_test]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/adblocker/engines/simple.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/adblocker/engines/simple.rs
@@ -15,7 +15,7 @@ use itertools::Itertools;
 use nym_common::trace_err_chain;
 use nym_sqlx_pool_guard::SqlitePoolGuard;
 use sqlx::{
-    Connection, QueryBuilder, Sqlite, SqliteConnection,
+    ConnectOptions, Connection, QueryBuilder, Sqlite, SqliteConnection,
     pool::PoolConnection,
     sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions},
 };
@@ -263,6 +263,7 @@ async fn open_db(db_path: &Path) -> Result<SqlitePoolGuard> {
         .filename(db_path)
         .create_if_missing(true)
         .journal_mode(SqliteJournalMode::Wal)
+        .disable_statement_logging()
         .pragma("soft_heap_limit", SQL_SOFT_HEAP_LIMIT.to_string())
         .pragma("hard_heap_limit", SQL_HARD_HEAP_LIMIT.to_string());
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/adblocker/engines/simple.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/adblocker/engines/simple.rs
@@ -426,7 +426,7 @@ fn get_all_subdomains(domain: &str) -> Vec<String> {
         }
         matches
     } else {
-        Vec::from_iter(components.first().map(|v| (*v).to_owned()).into_iter())
+        Vec::from_iter(components.first().map(|v| (*v).to_owned()))
     }
 }
 


### PR DESCRIPTION
## Ticket

JIRA-NYM-1547

## Description

This PR implements support for blocking subdomains. 

As explained in [filter cheatsheet](https://adblockplus.org/filter-cheatsheet#blocking2), rules that start with double pipe match sub-domains too. Previously we only matched directly which caused many sub-domains to remain unfiltered. With this change we should block even more ads on iOS.

So for example, the rule that looks as `||ads.example.com^` should block:

- ads.example.com
- subdomain.ads.example.com
- etc..

Since only `ads.example.com` is registered in the blocked domains database, I think the simplest solution is to query database against each parent domain. For example, if `subdomain.ads.example.com` is being resolved, the database is queried against the following domains to find a match:

- subdomain.ads.example.com
- ads.example.com
- example.com

The implementation relies on SQL `WHERE .. IN` clause to check if domain is blocked.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5810)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DNS blocking now applies to a domain’s subdomains for broader protection.
* **Bug Fixes**
  * Improved handling of edge cases in domain parsing (e.g., leading/trailing dots, empty labels, and `localhost`) to improve blocked-domain detection.
* **Changed**
  * Increased the timeout for the two-hop TCP connection-monitoring probe.
* **Tests**
  * Added unit tests for subdomain generation and related edge cases.
* **Documentation**
  * Updated the changelog for the upcoming release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->