### PR TITLE
[Android] Update slider values for Mixnet Tuning screen

### DIFF
--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/tuning/MixnetTuningScreen.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/tuning/MixnetTuningScreen.kt
@@ -217,7 +217,7 @@ internal fun PreviewMixnetTuningScreen() {
 			latency = "At least 690 ms",
 			trafficEnabled = true,
 			onTrafficEnable = {},
-			trafficValue = 20f,
+			trafficValue = 1f,
 			onTrafficValueChange = {},
 			delayValue = 15f,
 			onDelayValueChange = {},

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/tuning/MixnetTuningUiState.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/tuning/MixnetTuningUiState.kt
@@ -2,6 +2,9 @@ package net.nymtech.nymvpn.ui.screens.settings.tuning
 
 import net.nymtech.nymvpn.data.domain.Settings
 import nym_vpn_lib_types.MixnetTrafficConfig
+import kotlin.math.roundToInt
+
+internal const val MBPS_TO_DELAY_CONSTANT = 20f
 
 data class MixnetTuningUiState(
 	val trafficEnabled: Boolean = false,
@@ -18,7 +21,8 @@ data class MixnetTuningUiState(
 	fun fromConfig(config: MixnetTrafficConfig): MixnetTuningUiState {
 		val trafficEnabled = !config.disableBackgroundCoverTraffic
 		val trafficValue = if (trafficEnabled) {
-			config.messageSendingAverageDelay?.toFloat() ?: 0f
+			val delayMs = config.messageSendingAverageDelay?.toFloat() ?: MBPS_TO_DELAY_CONSTANT
+			MBPS_TO_DELAY_CONSTANT / delayMs
 		} else {
 			config.poissonParameterForLoopCoverStream?.toFloat() ?: 0f
 		}
@@ -34,7 +38,7 @@ data class MixnetTuningUiState(
 		disableBackgroundCoverTraffic = !trafficEnabled,
 		disablePoissonRate = !trafficEnabled,
 		averagePacketDelay = averagePacketDelay.toUInt(),
-		messageSendingAverageDelay = if (trafficEnabled) currentTrafficValue.toUInt() else original.messageSendingAverageDelay,
+		messageSendingAverageDelay = if (trafficEnabled) (MBPS_TO_DELAY_CONSTANT / currentTrafficValue).roundToInt().toUInt() else original.messageSendingAverageDelay,
 		poissonParameterForLoopCoverStream = if (!trafficEnabled) currentTrafficValue.toUInt() else original.poissonParameterForLoopCoverStream,
 	)
 

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/tuning/MixnetTuningViewModel.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/tuning/MixnetTuningViewModel.kt
@@ -13,7 +13,6 @@ import net.nymtech.nymvpn.data.domain.Settings
 import nym_vpn_lib_types.MixnetTrafficConfig
 import timber.log.Timber
 import javax.inject.Inject
-import kotlin.math.roundToInt
 
 @HiltViewModel
 class MixnetTuningViewModel @Inject constructor(private val settingsRepository: SettingsRepository) : ViewModel() {
@@ -35,8 +34,13 @@ class MixnetTuningViewModel @Inject constructor(private val settingsRepository: 
 	}
 
 	fun onTrafficEnable(enabled: Boolean) {
-		_uiState.update {
-			it.copy(trafficEnabled = enabled)
+		_uiState.update { currentState ->
+			val newTrafficValue = if (enabled) {
+				DEFAULT_MESSAGE_STREAM_MBPS
+			} else {
+				Settings.MIXNET_CONFIG_DEFAULT.poissonParameterForLoopCoverStream!!.toFloat()
+			}
+			currentState.copy(trafficEnabled = enabled, currentTrafficValue = newTrafficValue)
 				.recalculateMetrics()
 				.checkState(savedConfig)
 		}
@@ -97,27 +101,16 @@ class MixnetTuningViewModel @Inject constructor(private val settingsRepository: 
 	}
 
 	private fun MixnetTuningUiState.recalculateMetrics(): MixnetTuningUiState {
-		val tempDelay = this.averagePacketDelay.roundToInt().toUInt()
-		val tempTraffic = this.currentTrafficValue.roundToInt().toUInt()
-
-		val tempConfig = Settings.MIXNET_CONFIG_DEFAULT.copy(
-			disableBackgroundCoverTraffic = !this.trafficEnabled,
-			averagePacketDelay = tempDelay,
-			messageSendingAverageDelay = if (this.trafficEnabled) tempTraffic else Settings.MIXNET_CONFIG_DEFAULT.messageSendingAverageDelay,
-			poissonParameterForLoopCoverStream = if (!this.trafficEnabled) tempTraffic else Settings.MIXNET_CONFIG_DEFAULT.poissonParameterForLoopCoverStream,
-		)
-
-		val latencyResult = tempConfig.calculateTrafficLatency()
-
-		val mbps = if (this.trafficEnabled && this.currentTrafficValue > 0) {
-			20f / this.currentTrafficValue
-		} else {
-			0f
-		}
+		val latencyResult = this.toConfig(original = Settings.MIXNET_CONFIG_DEFAULT).calculateTrafficLatency()
+		val mbps = if (this.trafficEnabled) this.currentTrafficValue else 0f
 
 		return this.copy(
 			calculatedLatencyMs = latencyResult,
 			calculatedSpeedMbps = mbps,
 		)
+	}
+
+	companion object {
+		private const val DEFAULT_MESSAGE_STREAM_MBPS = 1f
 	}
 }

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/tuning/components/MixingDelaysSection.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/tuning/components/MixingDelaysSection.kt
@@ -5,15 +5,11 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Slider
-import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -23,14 +19,12 @@ import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import net.nymtech.nymvpn.R
 import net.nymtech.nymvpn.data.domain.Settings
 import net.nymtech.nymvpn.ui.theme.LocalNymColors
 import kotlin.math.roundToInt
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MixingDelaysSection(delayValue: Float, onDelayValueChange: (Float) -> Unit) {
 	val interactionSource = remember { MutableInteractionSource() }
@@ -89,33 +83,13 @@ fun MixingDelaysSection(delayValue: Float, onDelayValueChange: (Float) -> Unit) 
 				)
 			}
 
-			Slider(
+			TuningSlider(
 				value = delayValue,
 				onValueChange = { newValue ->
 					onDelayValueChange(newValue.roundToInt().toFloat())
 				},
 				valueRange = 0f..200f,
 				interactionSource = interactionSource,
-				modifier = Modifier.fillMaxWidth(),
-				thumb = {
-					SliderDefaults.Thumb(
-						interactionSource = interactionSource,
-						colors = SliderDefaults.colors(thumbColor = MaterialTheme.colorScheme.onBackground),
-						thumbSize = DpSize(20.dp, 20.dp),
-					)
-				},
-				track = { sliderState ->
-					SliderDefaults.Track(
-						sliderState = sliderState,
-						modifier = Modifier.height(4.dp),
-						colors = SliderDefaults.colors(
-							activeTrackColor = MaterialTheme.colorScheme.primary,
-							inactiveTrackColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.2f),
-						),
-						thumbTrackGapSize = 0.dp,
-						drawStopIndicator = null,
-					)
-				},
 			)
 
 			Row(

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/tuning/components/SendTrafficSection.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/tuning/components/SendTrafficSection.kt
@@ -6,16 +6,12 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Slider
-import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -25,7 +21,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import net.nymtech.nymvpn.R
 import net.nymtech.nymvpn.ui.common.buttons.ScaledSwitch
@@ -33,7 +28,6 @@ import net.nymtech.nymvpn.ui.theme.LocalNymColors
 import net.nymtech.nymvpn.ui.theme.NymVPNTheme
 import net.nymtech.nymvpn.ui.theme.Theme
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SendTrafficSection(trafficEnabled: Boolean, onTrafficEnable: (enabled: Boolean) -> Unit, trafficValue: Float, onTrafficValueChange: (Float) -> Unit) {
 	val interactionSource = remember { MutableInteractionSource() }
@@ -165,36 +159,6 @@ fun SendTrafficSection(trafficEnabled: Boolean, onTrafficEnable: (enabled: Boole
 			}
 		}
 	}
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun TuningSlider(value: Float, onValueChange: (Float) -> Unit, valueRange: ClosedFloatingPointRange<Float>, interactionSource: MutableInteractionSource) {
-	Slider(
-		value = value,
-		onValueChange = onValueChange,
-		valueRange = valueRange,
-		interactionSource = interactionSource,
-		thumb = {
-			SliderDefaults.Thumb(
-				interactionSource = interactionSource,
-				colors = SliderDefaults.colors(thumbColor = MaterialTheme.colorScheme.onBackground),
-				thumbSize = DpSize(20.dp, 20.dp),
-			)
-		},
-		track = { sliderState ->
-			SliderDefaults.Track(
-				sliderState = sliderState,
-				modifier = Modifier.height(4.dp),
-				colors = SliderDefaults.colors(
-					activeTrackColor = MaterialTheme.colorScheme.primary,
-					inactiveTrackColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.2f),
-				),
-				thumbTrackGapSize = 0.dp,
-				drawStopIndicator = null,
-			)
-		},
-	)
 }
 
 @Composable

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/tuning/components/SendTrafficSection.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/tuning/components/SendTrafficSection.kt
@@ -108,33 +108,22 @@ fun SendTrafficSection(trafficEnabled: Boolean, onTrafficEnable: (enabled: Boole
 					)
 				}
 
-				// Slider is inverted: right = fast (low delay), left = slow (high delay).
-				val displayValue = (200f - trafficValue.coerceIn(1f, 200f))
-				Slider(
-					value = displayValue,
-					onValueChange = { onTrafficValueChange((200f - it).coerceIn(1f, 200f)) },
-					valueRange = 0f..199f,
-					interactionSource = interactionSource,
-					thumb = {
-						SliderDefaults.Thumb(
-							interactionSource = interactionSource,
-							colors = SliderDefaults.colors(thumbColor = MaterialTheme.colorScheme.onBackground),
-							thumbSize = DpSize(20.dp, 20.dp),
-						)
-					},
-					track = { sliderState ->
-						SliderDefaults.Track(
-							sliderState = sliderState,
-							modifier = Modifier.height(4.dp),
-							colors = SliderDefaults.colors(
-								activeTrackColor = MaterialTheme.colorScheme.primary,
-								inactiveTrackColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.2f),
-							),
-							thumbTrackGapSize = 0.dp,
-							drawStopIndicator = null,
-						)
-					},
-				)
+				if (trafficEnabled) {
+					TuningSlider(
+						value = trafficValue.coerceIn(0.7f, 2f),
+						onValueChange = { onTrafficValueChange(it.coerceIn(0.7f, 2f)) },
+						valueRange = 0.7f..2f,
+						interactionSource = interactionSource,
+					)
+				} else {
+					val displayValue = 200f - trafficValue.coerceIn(1f, 200f)
+					TuningSlider(
+						value = displayValue,
+						onValueChange = { onTrafficValueChange((200f - it).coerceIn(1f, 200f)) },
+						valueRange = 0f..199f,
+						interactionSource = interactionSource,
+					)
+				}
 			}
 
 			Row(
@@ -176,6 +165,36 @@ fun SendTrafficSection(trafficEnabled: Boolean, onTrafficEnable: (enabled: Boole
 			}
 		}
 	}
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun TuningSlider(value: Float, onValueChange: (Float) -> Unit, valueRange: ClosedFloatingPointRange<Float>, interactionSource: MutableInteractionSource) {
+	Slider(
+		value = value,
+		onValueChange = onValueChange,
+		valueRange = valueRange,
+		interactionSource = interactionSource,
+		thumb = {
+			SliderDefaults.Thumb(
+				interactionSource = interactionSource,
+				colors = SliderDefaults.colors(thumbColor = MaterialTheme.colorScheme.onBackground),
+				thumbSize = DpSize(20.dp, 20.dp),
+			)
+		},
+		track = { sliderState ->
+			SliderDefaults.Track(
+				sliderState = sliderState,
+				modifier = Modifier.height(4.dp),
+				colors = SliderDefaults.colors(
+					activeTrackColor = MaterialTheme.colorScheme.primary,
+					inactiveTrackColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.2f),
+				),
+				thumbTrackGapSize = 0.dp,
+				drawStopIndicator = null,
+			)
+		},
+	)
 }
 
 @Composable

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/tuning/components/TuningSlider.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/tuning/components/TuningSlider.kt
@@ -1,0 +1,44 @@
+package net.nymtech.nymvpn.ui.screens.settings.tuning.components
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TuningSlider(value: Float, onValueChange: (Float) -> Unit, valueRange: ClosedFloatingPointRange<Float>, interactionSource: MutableInteractionSource, modifier: Modifier = Modifier) {
+	Slider(
+		value = value,
+		onValueChange = onValueChange,
+		valueRange = valueRange,
+		interactionSource = interactionSource,
+		modifier = modifier.fillMaxWidth(),
+		thumb = {
+			SliderDefaults.Thumb(
+				interactionSource = interactionSource,
+				colors = SliderDefaults.colors(thumbColor = MaterialTheme.colorScheme.onBackground),
+				thumbSize = DpSize(20.dp, 20.dp),
+			)
+		},
+		track = { sliderState ->
+			SliderDefaults.Track(
+				sliderState = sliderState,
+				modifier = Modifier.height(4.dp),
+				colors = SliderDefaults.colors(
+					activeTrackColor = MaterialTheme.colorScheme.primary,
+					inactiveTrackColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.2f),
+				),
+				thumbTrackGapSize = 0.dp,
+				drawStopIndicator = null,
+			)
+		},
+	)
+}


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

Update slider values for `MixnetTuningScreen.kt`.
UI fixes and updates.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5813)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a reusable tuning slider component, now used across the mixnet tuning UI (traffic and mixing delays).

* **Bug Fixes**
  * Improved the traffic slider’s enabled/disabled behavior, including more consistent value mapping and display.
  * Updated how traffic settings are translated between the UI and saved configuration for better consistency.
  * Refreshed tuning previews and recalculated latency/speed to match the updated logic.

* **Refactor**
  * Streamlined tuning metric updates to provide smoother, more reliable feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->