### PR TITLE
Only flush settings if timer is active

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
@@ -9,7 +9,10 @@ use std::{
     sync::Arc,
 };
 
-use futures::{FutureExt, StreamExt, future::Fuse};
+use futures::{
+    FutureExt, StreamExt,
+    future::{Fuse, FusedFuture},
+};
 use nym_diagnostic::DiagnosticHandler;
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 use tokio::{
@@ -855,14 +858,17 @@ impl NymVpnService {
         }
     }
 
-    async fn reconnect_tunnel(&self) -> bool {
+    async fn reconnect_tunnel(&mut self) -> bool {
         match self.target_state {
             TargetState::Secured => {
                 // Flush any settings update that is still pending behind the
                 // throttle timer so the upcoming Connect uses the latest config.
                 // Otherwise a reconnect can race ahead of the throttled
                 // SetTunnelSettings and re-run with stale settings
-                self.update_tunnel_settings();
+                if !self.tunnel_settings_update_timer.is_terminated() {
+                    self.tunnel_settings_update_timer.set(Fuse::terminated());
+                    self.update_tunnel_settings();
+                }
                 self.statistics_event_sender.report_connection_request();
                 let _ = self.command_sender.send(TunnelCommand::Connect);
                 true


### PR DESCRIPTION
## Description

This PR eliminates extra calls to `update_tunnel_settings()` if there is no active timer scheduled to apply new settings to TSM

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5817)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VPN reconnect behavior to be more reliable when transitioning back to a secured state.
  * Avoided applying outdated tunnel settings during reconnect by only updating when the pending throttled update is ready to be flushed.
  * Reduced unnecessary reconnect-side tunnel-settings updates, improving responsiveness during changing network conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->