### PR TITLE
Avoid adding superficial "no-nat" rules

### DIFF
--- a/nym-vpn-core/crates/nym-firewall/src/macos.rs
+++ b/nym-vpn-core/crates/nym-firewall/src/macos.rs
@@ -332,6 +332,11 @@ impl Firewall {
             return Ok(vec![]);
         };
 
+        if policy.redirect_interface().is_some() {
+            tracing::debug!("Skipping NAT masquerade because split tunneling is active");
+            return Ok(vec![]);
+        }
+
         let allowed_endpoints = policy.allowed_endpoints();
 
         let mut rules = vec![];
@@ -385,11 +390,6 @@ impl Firewall {
                 .interface(tunnel_interface)
                 .build()?;
             rules.push(no_nat_on_tun);
-        }
-
-        if policy.redirect_interface().is_some() {
-            tracing::debug!("Skipping NAT masquerade because split tunneling is active");
-            return Ok(rules);
         }
 
         // Masquerade other traffic via VPN utun


### PR DESCRIPTION


## Description

Since actual "nat" rule is not being added when using split-tunneling on macOS 14.6 .. 15.1, there is no reason to add "no-nat" rules which are exceptions to the main "nat" rule.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5818)
<!-- Reviewable:end -->
