### PR TITLE
Chore: add skip metadata toggle to release-all-platforms

### DIFF
--- a/.github/workflows/publish-nym-vpn-android.yml
+++ b/.github/workflows/publish-nym-vpn-android.yml
@@ -61,6 +61,10 @@ on:
         description: "Orchestrated app version to embed (empty = use Constants.kt as before)"
         type: string
         default: ""
+      publish-metadata:
+        description: "Skip app metadata"
+        type: boolean
+        default: true
 
 env:
   UPLOAD_DIR_ANDROID: android_artifacts
@@ -426,6 +430,6 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: |
           bundle install
-          bundle exec fastlane ${{ inputs.track }} skip_bundle:${{ github.event.inputs.publish-bundle == 'true' }} skip_metadata:${{ github.event.inputs.publish-metadata == 'true' }}
+          bundle exec fastlane ${{ inputs.track }} skip_bundle:${{ github.event.inputs.publish-bundle == 'true' }} skip_metadata:${{ inputs.publish-metadata }}
         env:
           ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}

--- a/.github/workflows/release-all-platforms.yml
+++ b/.github/workflows/release-all-platforms.yml
@@ -39,6 +39,10 @@ on:
         description: "macOS (.pkg + Sparkle)"
         type: boolean
         default: false
+      publish-metadata:
+        description: "Skip Google Play metadata"
+        type: boolean
+        default: true
   schedule:
     - cron: "0 4 * * *"
 
@@ -66,6 +70,7 @@ jobs:
       windows: ${{ steps.flags.outputs.windows }}
       ios: ${{ steps.flags.outputs.ios }}
       macos: ${{ steps.flags.outputs.macos }}
+      publish_metadata: ${{ steps.flags.outputs.publish_metadata }}
     steps:
       - name: Resolve channel + platform flags
         id: flags
@@ -79,6 +84,7 @@ jobs:
           IN_WINDOWS: ${{ inputs.windows }}
           IN_IOS: ${{ inputs.ios }}
           IN_MACOS: ${{ inputs.macos }}
+          IN_PUBLISH_METADATA: ${{ inputs.publish-metadata }}
         run: |
           set -euo pipefail
           echo "::notice:: releasing from ref $REF_NAME (event $EVENT)"
@@ -117,10 +123,14 @@ jobs:
             echo "::notice:: $CHANNEL → selected platforms"
           fi
 
+          # Google Play metadata skip toggle (schedule/cron defaults to true = skip).
+          PUBLISH_METADATA="${IN_PUBLISH_METADATA:-true}"
+
           {
             echo "channel=$CHANNEL"
             echo "android=$ANDROID"; echo "fdroid=$FDROID"; echo "linux=$LINUX"
             echo "windows=$WINDOWS"; echo "ios=$IOS"; echo "macos=$MACOS"
+            echo "publish_metadata=$PUBLISH_METADATA"
           } >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@v7
@@ -196,6 +206,7 @@ jobs:
       # Play push is ship-only (beta builds the same as nightly = no store). Requires the
       # Android platform actually selected, not just an F-Droid-only dispatch.
       track: ${{ (needs.resolve.outputs.android == 'true' && needs.resolve.outputs.channel == 'ship') && 'production' || 'none' }}
+      publish-metadata: ${{ needs.resolve.outputs.publish_metadata == 'true' }}
     secrets: inherit
 
   # Linux + Windows desktop app. publish-nym-vpn-app.yml builds each OS as its own


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5820)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new release option to control whether app metadata is published during Android/Play Store releases.
  - Updated the release flow to pass this choice through automatically to Android publishing steps.

- **Bug Fixes**
  - Made metadata publishing behavior consistent across reusable and manual release workflows.
  - Default behavior now clearly skips metadata unless explicitly changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->