### PR TITLE
ci: clean up working directory before checkout

### DIFF
--- a/.github/workflows/build-wireguard-go-windows.yml
+++ b/.github/workflows/build-wireguard-go-windows.yml
@@ -32,6 +32,14 @@ jobs:
     runs-on: "custom-windows-11"
 
     steps:
+      - name: Cleanup working directory
+        shell: bash
+        run: |
+          ls -la ./
+          rm -rf ./* || true
+          rm -rf ./.??* || true
+          ls -la ./
+
       - name: Checkout repo
         uses: actions/checkout@v7
         with:


### PR DESCRIPTION


## Description

Our custom runners don't seem to wipe working directory!


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5831)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the build workflow with an automatic cleanup step to start from a fresh working directory before running the remaining actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->