### PR TITLE
Avoid sending empty response when hostname resolution fails

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - While in Connected state swap internal resolver to use custom DNS (via system resolver). (https://github.com/nymtech/nym-vpn-client/pull/5674)
 
+### Fixed
+
+- Improve behavior of forwarding resolver by not sending empty response when hostname resolution fails. Instead simulate timeout to let clients retry more aggressively. (https://github.com/nymtech/nym-vpn-client/pull/5832)
+
 
 ## [2026.11.0] - TBD
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/resolver/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/resolver/mod.rs
@@ -691,6 +691,7 @@ impl ResolverImpl {
                         .error_msg(&message.metadata, response_code);
                     response_handler.send_response(response).await
                 } else {
+                    // todo: passthrough network error!
                     let response = Self::build_response(message, &AuthLookup::Empty);
                     response_handler.send_response(response).await
                 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/resolver/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/resolver/mod.rs
@@ -15,6 +15,7 @@
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 mod unix;
 
+use nym_common::trace_err_chain;
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 pub(crate) use unix::flush_system_cache;
 
@@ -501,7 +502,7 @@ impl LocalResolver {
                 request = self.rx.recv() => {
                     match request {
                         Some(ResolverMessage::SetConfig { new_config, response_tx }) => {
-                            let res = self.update_config(new_config) ;
+                            let res = self.update_config(new_config);
                             #[cfg(not(target_os = "ios"))]
                             if res.is_ok() {
                                 flush_system_cache().await;
@@ -677,32 +678,34 @@ impl ResolverImpl {
             return Ok(make_response_info(message, ResponseCode::ServFail));
         };
 
-        let lookup_result = response_rx.await;
-        let response_result = match lookup_result {
+        match response_rx.await {
             Ok(Ok(ref lookup)) => {
                 let response = Self::build_response(message, lookup);
-                response_handler.send_response(response).await
+                response_handler
+                    .send_response(response)
+                    .await
+                    .inspect_err(|err| {
+                        trace_err_chain!(err, "failed to send response");
+                    })
             }
-            Err(_error) => Ok(make_response_info(message, ResponseCode::ServFail)),
             Ok(Err(resolve_err)) => {
                 if let NetError::Dns(DnsError::NoRecordsFound(no_records)) = resolve_err {
                     let response_code = no_records.response_code;
                     let response = MessageResponseBuilder::from_message_request(message)
                         .error_msg(&message.metadata, response_code);
-                    response_handler.send_response(response).await
+                    response_handler
+                        .send_response(response)
+                        .await
+                        .inspect_err(|err| {
+                            trace_err_chain!(err, "failed to send response");
+                        })
                 } else {
-                    // todo: passthrough network error!
-                    let response = Self::build_response(message, &AuthLookup::Empty);
-                    response_handler.send_response(response).await
+                    trace_err_chain!(resolve_err, "failed to resolve hostname");
+                    Err(resolve_err)
                 }
             }
-        };
-
-        if let Err(err) = &response_result {
-            tracing::error!("Failed to send response: {err}");
+            Err(_error) => Err(NetError::Message("channel is closed")),
         }
-
-        response_result
     }
 }
 


### PR DESCRIPTION
## Ticket

JIRA-NYM-1155

## Description

Previously, we used to send empty DNS response with no TTL on failure to resolve hostname. This would force clients to wait for a certain amount of time before re-querying the same hostname. 

Since clients cache dns responses, this would result into apps not being able to resolve DNS for a certain period of time with no attempts to retry until a later time. 

This change simulates timeout which forces the client to retry more aggressively and prevents clients from caching empty DNS responses.

Running a simple test I can see that nslookup performs three attempts when connection to DoH and DoT servers breaks down, which seems like expected behavior:

```
nslookup google.com
;; communications error to 127.216.215.166#53: timed out
;; communications error to 127.216.215.166#53: timed out
;; communications error to 127.216.215.166#53: timed out
;; no servers could be reached
```

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5832)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hostname resolution behavior when lookups fail: failures no longer produce an empty DNS response, allowing clients to retry more effectively.
  * Made DNS error responses more consistent, especially for “no records found” cases, reducing unexpected lookup outcomes.
  * Enhanced diagnostic logging for DNS resolution and response sending failures to help identify problematic resolution paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->