### PR TITLE
Fix logging of cache deserialization errors

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-network-config/src/persistent_discovery.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/persistent_discovery.rs
@@ -45,7 +45,7 @@ impl PersistentDiscovery {
                 }
             }
             Err(err) if err.should_overwrite_file() => {
-                if err.is_file_not_found() {
+                if !err.is_file_not_found() {
                     trace_err_chain!(err, "failed to deserialize cache");
                 }
 

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/persistent_envs.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/persistent_envs.rs
@@ -36,7 +36,7 @@ impl PersistentEnvs {
                 cached_envs,
             }),
             Err(err) if err.should_overwrite_file() => {
-                if err.is_file_not_found() {
+                if !err.is_file_not_found() {
                     trace_err_chain!(err, "failed to deserialize cache");
                 }
                 let default_persistent_envs = Self::new(cache_dir, RegisteredNetworks::default());

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/persistent_network_details.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/persistent_network_details.rs
@@ -62,7 +62,7 @@ impl PersistentNetworkDetails {
                 }
             }
             Err(err) if err.should_overwrite_file() => {
-                if err.is_file_not_found() {
+                if !err.is_file_not_found() {
                     trace_err_chain!(err, "failed to deserialize cache");
                 }
                 if network_name == "mainnet" {


### PR DESCRIPTION


## Description

Deserialization errors were only output when cache file was not found.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5835)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of missing or unreadable local configuration cache files.
  - Missing cache files now follow the normal default-initialization and persistence flow instead of being incorrectly treated as deserialization failures.
  - Applied consistent recovery behavior across network discovery, environment, and network details configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->