### PR TITLE
cli: add short -l for listen

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- [CLI] Add short option `-l` for `nym-vpnc status --listen` (https://github.com/nymtech/nym-vpn-client/pull/5839)
+
 ### Changed
 
 - While in Connected state swap internal resolver to use custom DNS (via system resolver). (https://github.com/nymtech/nym-vpn-client/pull/5674)
@@ -16,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve behavior of forwarding resolver by not sending empty response when hostname resolution fails. Instead simulate timeout to let clients retry more aggressively. (https://github.com/nymtech/nym-vpn-client/pull/5832)
 
 
-## [2026.11.0] - TBD
+## [2026.11.0] - 2026-07-10
 
 ### Added
 

--- a/nym-vpn-core/crates/nym-vpnc/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/main.rs
@@ -68,7 +68,7 @@ pub enum Command {
     /// Get the current connection status
     Status {
         /// Monitor tunnel state continuously until ctrl+c.
-        #[arg(long, default_value = "false", action = ArgAction::SetTrue)]
+        #[arg(short, long, default_value = "false", action = ArgAction::SetTrue)]
         listen: bool,
     },
 


### PR DESCRIPTION


## Description

- Add short option `-l` for `nym-vpnc status --listen`
- Mark release of 2026.11 in the changelog

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5839)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `-l` shorthand option for `nym-vpnc status --listen`, alongside the existing long-form option.

* **Documentation**
  * Updated the unreleased changelog with the new CLI option.
  * Set the 2026.11.0 release date to July 10, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->