### PR TITLE
Add android to the same cfg that already binds on linux/ios (#5840)

### DIFF
--- a/nym-vpn-core/crates/nym-wg-metadata-client/src/lib.rs
+++ b/nym-vpn-core/crates/nym-wg-metadata-client/src/lib.rs
@@ -53,7 +53,7 @@ impl LazyMetadataClient {
         let reqwest_builder = ReqwestClientBuilder::new();
         let reqwest_builder = match sent_data.data_type {
             TunUpSendDataType::InterfaceName(interface) => {
-                #[cfg(any(target_os = "linux", target_os = "ios"))]
+                #[cfg(any(target_os = "linux", target_os = "ios", target_os = "android"))]
                 let reqwest_builder = reqwest_builder.interface(&interface);
 
                 interface_name = Some(interface.clone());


### PR DESCRIPTION
* Add android to the same cfg that already binds on linux/ios

- Android InterfaceName metadata clients now call reqwest .interface(&interface) before bind IP

* PR comment fixes

* KISS

## Ticket

JIRA-NYM-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5842)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VPN metadata client compatibility on Android by enabling interface-specific network configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->