### PR TITLE
Use correct name for family and staking data

### DIFF
--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/mod.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/mod.rs
@@ -72,9 +72,9 @@ pub struct Gateway {
     #[builder(default)]
     pub lewes_protocol_details: Option<LewesProtocolDetailsV1>,
     #[builder(default)]
-    pub node_staking: Option<NodeStaking>,
+    pub staking_data: Option<NodeStaking>,
     #[builder(default)]
-    pub node_family: Option<NodeFamily>,
+    pub family_data: Option<NodeFamily>,
 }
 
 impl Gateway {
@@ -160,8 +160,8 @@ impl Gateway {
             performance: None,
             version,
             lewes_protocol_details,
-            node_staking: None,
-            node_family: None,
+            staking_data: None,
+            family_data: None,
         })
     }
 
@@ -688,8 +688,8 @@ impl TryFrom<nym_vpn_api_client::response::NymDirectoryGateway> for Gateway {
             performance,
             version: gateway.build_information.map(|info| info.build_version),
             lewes_protocol_details: gateway.lewes_protocol_details,
-            node_staking: gateway.node_staking,
-            node_family: gateway.node_family,
+            staking_data: gateway.staking_data,
+            family_data: gateway.family_data,
         })
     }
 }

--- a/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/tests.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/entries/gateway/tests.rs
@@ -486,8 +486,8 @@ fn sample_gateway_list(gw_type: GatewayType) -> GatewayList {
                 }),
                 version: None,
                 lewes_protocol_details: None,
-                node_staking: None,
-                node_family: None,
+                staking_data: None,
+                family_data: None,
             }
         })
         .collect();
@@ -522,8 +522,8 @@ fn create_test_gateway(identity: &str, country: &str, score: ScoreValue) -> Gate
         }),
         version: None,
         lewes_protocol_details: None,
-        node_staking: None,
-        node_family: None,
+        staking_data: None,
+        family_data: None,
     }
 }
 
@@ -584,7 +584,7 @@ fn create_response_nym_gateway(
         }),
         build_information: None,
         lewes_protocol_details: None,
-        node_staking: None,
-        node_family: None,
+        staking_data: None,
+        family_data: None,
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
@@ -425,8 +425,8 @@ pub struct NymDirectoryGateway {
     pub performance_v2: Option<DVpnGatewayPerformance>,
     pub build_information: Option<BuildInformation>,
     pub lewes_protocol_details: Option<LewesProtocolDetailsV1>,
-    pub node_staking: Option<NodeStaking>,
-    pub node_family: Option<NodeFamily>,
+    pub staking_data: Option<NodeStaking>,
+    pub family_data: Option<NodeFamily>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/gateway.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/gateway.rs
@@ -1139,7 +1139,7 @@ impl From<nym_gateway_directory::Gateway> for Gateway {
             lewes_protocol_details: gateway
                 .lewes_protocol_details
                 .map(LewesProtocolDetails::from),
-            node_family_name: gateway.node_family.map(|family| family.name),
+            node_family_name: gateway.family_data.map(|family| family.name),
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/independence.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/independence.rs
@@ -26,7 +26,7 @@ pub(crate) fn gateways_are_independent(
     }
     // node family not present is assumed that they are independent, as no node family is the default node configuration
     if criteria.different_node_family
-        && let (Some(nf1), Some(nf2)) = (&gw1.node_family, &gw2.node_family)
+        && let (Some(nf1), Some(nf2)) = (&gw1.family_data, &gw2.family_data)
         && nf1.id == nf2.id
     {
         return false;
@@ -94,7 +94,7 @@ mod tests {
     fn make_gateway_with_family(id: &str, family_id: u32) -> Gateway {
         Gateway::builder()
             .identity(id.parse().unwrap())
-            .node_family(Some(NodeFamily {
+            .family_data(Some(NodeFamily {
                 id: family_id,
                 name: "Test Family".to_string(),
                 description: String::new(),
@@ -275,7 +275,7 @@ mod tests {
                 }),
                 ..Default::default()
             })
-            .node_family(Some(NodeFamily {
+            .family_data(Some(NodeFamily {
                 id: 1,
                 name: String::new(),
                 description: String::new(),
@@ -294,7 +294,7 @@ mod tests {
                 }),
                 ..Default::default()
             })
-            .node_family(Some(NodeFamily {
+            .family_data(Some(NodeFamily {
                 id: 2,
                 name: String::new(),
                 description: String::new(),
@@ -322,7 +322,7 @@ mod tests {
                 }),
                 ..Default::default()
             })
-            .node_family(Some(NodeFamily {
+            .family_data(Some(NodeFamily {
                 id: 1,
                 name: String::new(),
                 description: String::new(),
@@ -341,7 +341,7 @@ mod tests {
                 }),
                 ..Default::default()
             })
-            .node_family(Some(NodeFamily {
+            .family_data(Some(NodeFamily {
                 id: 2,
                 name: String::new(),
                 description: String::new(),
@@ -369,7 +369,7 @@ mod tests {
                 }),
                 ..Default::default()
             })
-            .node_family(Some(NodeFamily {
+            .family_data(Some(NodeFamily {
                 id: 1,
                 name: String::new(),
                 description: String::new(),
@@ -388,7 +388,7 @@ mod tests {
                 }),
                 ..Default::default()
             })
-            .node_family(Some(NodeFamily {
+            .family_data(Some(NodeFamily {
                 id: 2,
                 name: String::new(),
                 description: String::new(),

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/tests/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/tests/mod.rs
@@ -123,7 +123,7 @@ fn gw_full(id: &str, family_id: u32, asn: &str, route: &str) -> Gateway {
             load: ScoreValue::Low,
             uptime_percentage_last_24_hours: Default::default(),
         })
-        .node_family(Some(NodeFamily {
+        .family_data(Some(NodeFamily {
             id: family_id,
             name: format!("Family {family_id}"),
             description: String::new(),
@@ -450,7 +450,7 @@ async fn mainnet_syntethic_node_families() {
     for gw in &mut gateways {
         let name = gw.name.trim().to_string();
         if let Some((id, label, size)) = name_to_family.get(&name) {
-            gw.node_family = Some(NodeFamily {
+            gw.family_data = Some(NodeFamily {
                 id: *id,
                 name: label.clone(),
                 description: String::new(),
@@ -496,7 +496,7 @@ async fn mainnet_syntethic_node_families() {
     // ── Index structures shared by all scenarios ──────────────────────────
     let mut by_family_id: HashMap<u32, Vec<Gateway>> = HashMap::new();
     for gw in &gateways {
-        if let Some(nf) = &gw.node_family {
+        if let Some(nf) = &gw.family_data {
             by_family_id.entry(nf.id).or_default().push(gw.clone());
         }
     }
@@ -559,7 +559,7 @@ async fn mainnet_syntethic_node_families() {
     // The default independence settings (different_node_family: true) make this
     // an impossible pair, even though the full gateway pool is available.
     let same_family_pair = by_family_id.values().find(|v| v.len() >= 2).map(|v| {
-        let label = v[0].node_family.as_ref().unwrap().name.clone();
+        let label = v[0].family_data.as_ref().unwrap().name.clone();
         (v[0].clone(), v[1].clone(), label)
     });
     if let Some((gw_a, gw_b, family_name)) = same_family_pair {
@@ -664,8 +664,8 @@ async fn mainnet_syntethic_node_families() {
         "random selection on full pool under default criteria should succeed; got {result:?}"
     );
     let selected = result.unwrap();
-    let entry_family = selected.entry_gateway().node_family.as_ref().map(|f| f.id);
-    let exit_family = selected.exit_gateway().node_family.as_ref().map(|f| f.id);
+    let entry_family = selected.entry_gateway().family_data.as_ref().map(|f| f.id);
+    let exit_family = selected.exit_gateway().family_data.as_ref().map(|f| f.id);
     if let (Some(ef), Some(xf)) = (entry_family, exit_family) {
         assert_ne!(
             ef, xf,
@@ -763,10 +763,10 @@ async fn mainnet_syntethic_node_families() {
     let single_family_countries: Vec<(String, Vec<Gateway>)> = by_country
         .iter()
         .filter(|(_, gws)| {
-            gws.len() >= 2 && gws.iter().all(|gw| gw.node_family.is_some()) && {
-                let first_family = gws[0].node_family.as_ref().map(|f| f.id);
+            gws.len() >= 2 && gws.iter().all(|gw| gw.family_data.is_some()) && {
+                let first_family = gws[0].family_data.as_ref().map(|f| f.id);
                 gws.iter()
-                    .all(|gw| gw.node_family.as_ref().map(|f| f.id) == first_family)
+                    .all(|gw| gw.family_data.as_ref().map(|f| f.id) == first_family)
             }
         })
         .map(|(cc, gws)| (cc.clone(), gws.clone()))
@@ -778,7 +778,7 @@ async fn mainnet_syntethic_node_families() {
     }
     for (cc, country_gws) in single_family_countries {
         let family_label = country_gws[0]
-            .node_family
+            .family_data
             .as_ref()
             .map(|f| f.name.as_str())
             .unwrap_or("?");


### PR DESCRIPTION
## Ticket

JIRA-NYM-1679

## Description

Fix deserialisation naming for family and staking data


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5859)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Renamed gateway staking and family metadata fields for clearer, more consistent terminology.
  * Updated gateway data handling and serialization to use the new field names, including population of family labels.
  * Adjusted gateway independence checks and family-based selection to align with the updated metadata.
* **Tests**
  * Updated gateway fixtures and scenario logic to use the renamed fields, ensuring family-based selection continues to behave correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->