### PR TITLE
Reduce WG socket churn on iOS 

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
@@ -471,7 +471,7 @@ impl ConnectedTunnel {
                                             tracing::error!("Failed to update peers on network change: {}", e);
                                         }
 
-                                        // update the peer if it has changed 
+                                        // update the peer if it has changed
                                         old_resolved_peer = resolved_peer;
                                     } else {
                                         tracing::debug!("Skipping peer update: resolved address unchanged: {}", resolved_peer.endpoint);

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
@@ -467,13 +467,11 @@ impl ConnectedTunnel {
                                     Ok(resolved_peer) => {
                                         // check if peer has changed
                                         if resolved_peer != old_resolved_peer {
+                                            old_resolved_peer = resolved_peer.clone();
                                             // Update wireguard-go configuration with re-resolved peer endpoints.
                                             if let Err(e) = entry_tunnel.update_peers(&[resolved_peer]) {
                                                 tracing::error!("Failed to update peers on network change: {}", e);
                                             }
-
-                                            // update the peer if it has changed
-                                            old_resolved_peer = resolved_peer;
                                         } else {
                                             tracing::debug!("Skipping peer update: resolved address unchanged: {}", resolved_peer.endpoint);
                                         }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
@@ -451,7 +451,7 @@ impl ConnectedTunnel {
                 });
                 path_monitor.start();
 
-                let mut old_resolved_peer = entry_peer_update;
+                let mut old_resolved_peer = entry_peer_update.clone();
 
                 loop {
                     tokio::select! {
@@ -462,7 +462,7 @@ impl ConnectedTunnel {
                             // For instance when device connects to IPv4-only server from IPv6-only network,
                             // it needs to use an IPv4-mapped address, which can be received by re-resolving
                             // the original peer IP.
-                            match old_resolved_peer.clone().resolved() {
+                            match entry_peer_update.clone().resolved() {
                                 Ok(resolved_peer) => {
                                     // check if peer has changed
                                     if resolved_peer != old_resolved_peer {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
@@ -451,40 +451,30 @@ impl ConnectedTunnel {
                 });
                 path_monitor.start();
 
-                let mut last_material_path: Option<(String, bool, bool)> = None;
+                let mut old_resolved_peer = entry_peer_update;
 
                 loop {
                     tokio::select! {
                         Some(new_path) = default_path_rx.next() => {
                             tracing::debug!("New default path: {}", new_path.description());
 
-                            let current_material_path = (
-                                new_path.interface_name(),
-                                new_path.supports_ipv4(),
-                                new_path.supports_ipv6(),
-                            );
-
-                            if last_material_path
-                                .as_ref()
-                                .is_some_and(|prev| prev == &current_material_path)
-                            {
-                                tracing::debug!(
-                                    "Skipping peer update and socket bump: default path material identity unchanged"
-                                );
-                                continue;
-                            }
-                            last_material_path = Some(current_material_path);
-
                             // Depending on the network device is connected to, we may need to re-resolve the IP addresses.
                             // For instance when device connects to IPv4-only server from IPv6-only network,
                             // it needs to use an IPv4-mapped address, which can be received by re-resolving
                             // the original peer IP.
-                            match entry_peer_update.clone().resolved() {
+                            match old_resolved_peer.clone().resolved() {
                                 Ok(resolved_peer) => {
+                                    // check if peer has changed
+                                    if resolved_peer != old_resolved_peer {
+                                        // Update wireguard-go configuration with re-resolved peer endpoints.
+                                        if let Err(e) = entry_tunnel.update_peers(&[resolved_peer]) {
+                                            tracing::error!("Failed to update peers on network change: {}", e);
+                                        }
 
-                                    // Update wireguard-go configuration with re-resolved peer endpoints.
-                                    if let Err(e) = entry_tunnel.update_peers(&[resolved_peer]) {
-                                       tracing::error!("Failed to update peers on network change: {}", e);
+                                        // update the peer if it has changed 
+                                        old_resolved_peer = resolved_peer;
+                                    } else {
+                                        tracing::debug!("Skipping peer update: resolved address unchanged: {}", resolved_peer.endpoint);
                                     }
                                 }
                                 Err(e) => {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
@@ -451,10 +451,29 @@ impl ConnectedTunnel {
                 });
                 path_monitor.start();
 
+                let mut last_material_path: Option<(String, bool, bool)> = None;
+
                 loop {
                     tokio::select! {
                         Some(new_path) = default_path_rx.next() => {
                             tracing::debug!("New default path: {}", new_path.description());
+
+                            let current_material_path = (
+                                new_path.interface_name(),
+                                new_path.supports_ipv4(),
+                                new_path.supports_ipv6(),
+                            );
+
+                            if last_material_path
+                                .as_ref()
+                                .is_some_and(|prev| prev == &current_material_path)
+                            {
+                                tracing::debug!(
+                                    "Skipping peer update and socket bump: default path material identity unchanged"
+                                );
+                                continue;
+                            }
+                            last_material_path = Some(current_material_path);
 
                             // Depending on the network device is connected to, we may need to re-resolve the IP addresses.
                             // For instance when device connects to IPv4-only server from IPv6-only network,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
@@ -462,23 +462,25 @@ impl ConnectedTunnel {
                             // For instance when device connects to IPv4-only server from IPv6-only network,
                             // it needs to use an IPv4-mapped address, which can be received by re-resolving
                             // the original peer IP.
-                            match entry_peer_update.clone().resolved() {
-                                Ok(resolved_peer) => {
-                                    // check if peer has changed
-                                    if resolved_peer != old_resolved_peer {
-                                        // Update wireguard-go configuration with re-resolved peer endpoints.
-                                        if let Err(e) = entry_tunnel.update_peers(&[resolved_peer]) {
-                                            tracing::error!("Failed to update peers on network change: {}", e);
-                                        }
+                            if !entry_peer_update.is_loopback() {
+                                match entry_peer_update.clone().resolved() {
+                                    Ok(resolved_peer) => {
+                                        // check if peer has changed
+                                        if resolved_peer != old_resolved_peer {
+                                            // Update wireguard-go configuration with re-resolved peer endpoints.
+                                            if let Err(e) = entry_tunnel.update_peers(&[resolved_peer]) {
+                                                tracing::error!("Failed to update peers on network change: {}", e);
+                                            }
 
-                                        // update the peer if it has changed
-                                        old_resolved_peer = resolved_peer;
-                                    } else {
-                                        tracing::debug!("Skipping peer update: resolved address unchanged: {}", resolved_peer.endpoint);
+                                            // update the peer if it has changed
+                                            old_resolved_peer = resolved_peer;
+                                        } else {
+                                            tracing::debug!("Skipping peer update: resolved address unchanged: {}", resolved_peer.endpoint);
+                                        }
                                     }
-                                }
-                                Err(e) => {
-                                    tracing::error!("Failed to re-resolve peer on default path update: {}", e);
+                                    Err(e) => {
+                                        tracing::error!("Failed to re-resolve peer on default path update: {}", e);
+                                    }
                                 }
                             }
 

--- a/nym-vpn-core/crates/nym-wg-go/src/lib.rs
+++ b/nym-vpn-core/crates/nym-wg-go/src/lib.rs
@@ -98,7 +98,7 @@ impl fmt::Debug for PeerConfig {
 }
 
 /// Holds new endpoint for the peer matching by public key.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct PeerEndpointUpdate {
     pub public_key: x25519::PublicKey,
     pub endpoint: SocketAddr,
@@ -108,5 +108,9 @@ impl PeerEndpointUpdate {
     fn append_to(&self, config_builder: &mut UapiConfigBuilder) {
         config_builder.add("public_key", self.public_key.as_bytes().as_ref());
         config_builder.add("endpoint", self.endpoint.to_string().as_str());
+    }
+
+    pub fn is_loopback(&self) -> bool {
+        self.endpoint.ip().is_loopback()
     }
 }


### PR DESCRIPTION

## Description

On iOS the DNS64 re-resolves and restarts the wireguard socket on every path change from the network module. Many of these changes result in no functional change to the socket and only cause churn in the setup.

This PR adds a check so  that path updates that don't materially change the socket don't kick-off a (64) resolution and a socket bump. If there is a change then the current process for handling path updates will take effect. 


This should reduce unnecessary wg socket churn.

example logs:

```
2026-07-10T12:56:07.354589Z DEBUG nym_vpn_lib::tunnel_state_machine::tunnel::wireguard::connected_tunnel: New default path: satisfied (Path is satisfied), interface: pdp_ip0[lte], scoped, ipv4, ipv6, dns, expensive, uses cell, estimated upload: 65536Bps, LQM: moderate
2026-07-10T12:56:07.354668Z  INFO nym_vpn_lib::tunnel_state_machine::tunnel::wireguard::dns64: Resolved 127.0.0.1:51230 to self
2026-07-10T12:56:07.354955Z DEBUG nym_wg_go::netstack: peer(F6Bs…hDEE) - UAPI: Updating endpoint
2026-07-10T12:56:07.355157Z DEBUG nym_wg_go::netstack: Routine: receive incoming v4 - stopped
2026-07-10T12:56:07.355200Z DEBUG nym_wg_go::netstack: Routine: receive incoming v6 - stopped
2026-07-10T12:56:07.355642Z DEBUG nym_wg_go::netstack: UDP bind has been updated
2026-07-10T12:56:07.355671Z DEBUG nym_wg_go::netstack: Routine: receive incoming v6 - started
2026-07-10T12:56:07.355696Z DEBUG nym_wg_go::netstack: Routine: receive incoming v4 - started
2026-07-10T12:56:08.043418Z  INFO nym_offline_monitor::imp::path_monitor: Path update: satisfied (Path is satisfied), interface: pdp_ip0[lte], scoped, ipv4, ipv6, dns, expensive, uses cell, estimated upload: 65536Bps, LQM: moderate
2026-07-10T12:56:08.476728Z DEBUG nym_vpn_lib::tunnel_state_machine::tunnel::wireguard::connected_tunnel: New default path: satisfied (Path is satisfied), interface: pdp_ip0[lte], scoped, ipv4, ipv6, dns, expensive, uses cell, LQM: moderate
2026-07-10T12:56:08.476818Z  INFO nym_vpn_lib::tunnel_state_machine::tunnel::wireguard::dns64: Resolved 127.0.0.1:51230 to self
2026-07-10T12:56:08.476963Z DEBUG nym_wg_go::netstack: peer(F6Bs…hDEE) - UAPI: Updating endpoint
2026-07-10T12:56:08.477267Z DEBUG nym_wg_go::netstack: Routine: receive incoming v4 - stopped
2026-07-10T12:56:08.477342Z DEBUG nym_wg_go::netstack: Routine: receive incoming v6 - stopped
2026-07-10T12:56:08.477685Z DEBUG nym_wg_go::netstack: UDP bind has been updated
2026-07-10T12:56:08.477712Z DEBUG nym_wg_go::netstack: Routine: receive incoming v6 - started
2026-07-10T12:56:08.477730Z DEBUG nym_wg_go::netstack: Routine: receive incoming v4 - started
2026-07-10T12:56:09.223415Z  INFO nym_offline_monitor::imp::path_monitor: Path update: satisfied (Path is satisfied), interface: pdp_ip0[lte], scoped, ipv4, ipv6, dns, expensive, uses cell, LQM: moderate
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5868)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced unnecessary WireGuard peer updates during iOS default-path changes by only applying updates when the resolved peer endpoint actually changes.
  * Added loopback-aware handling to avoid triggering peer resolution and updates when the entry peer is a loopback address.
  * Improves connection stability and efficiency by skipping redundant re-resolution and peer update work when nothing meaningful changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->