### PR TITLE
fix: allow forgetting account in non-connected tunnel states

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/command_sender.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/command_sender.rs
@@ -125,6 +125,28 @@ impl AccountCommandSender {
         rx.await.map_err(AccountCommandError::internal)?
     }
 
+    /// Try to unregister the device from the API. This is best-effort and returns Ok
+    /// even if the unregister fails, allowing the caller to proceed with local cleanup.
+    #[instrument(skip(self))]
+    pub async fn unregister_device(&self) -> Result<(), AccountCommandError> {
+        let (tx, rx) = ReturnSender::new();
+        self.command_tx
+            .send(AccountCommand::UnregisterDevice(tx))
+            .map_err(AccountCommandError::internal)?;
+        rx.await.map_err(AccountCommandError::internal)?
+    }
+
+    /// Wipe local account data without attempting to unregister from the API.
+    /// Use this when the unregister has already been attempted separately.
+    #[instrument(skip(self))]
+    pub async fn wipe_local_account_data(&self) -> Result<(), AccountCommandError> {
+        let (tx, rx) = ReturnSender::new();
+        self.command_tx
+            .send(AccountCommand::WipeLocalAccountData(tx))
+            .map_err(AccountCommandError::internal)?;
+        rx.await.map_err(AccountCommandError::internal)?
+    }
+
     #[instrument(skip(self))]
     pub async fn rotate_keys(&self) -> Result<(), AccountCommandError> {
         let (tx, rx) = ReturnSender::new();

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/dispatch.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/dispatch.rs
@@ -34,6 +34,12 @@ pub enum AccountCommand {
     /// Delete the stored account and every associated data
     ForgetAccount(ReturnSender<(), AccountCommandError>),
 
+    /// Unregister the device from the API (best-effort, silently continues on failure)
+    UnregisterDevice(ReturnSender<(), AccountCommandError>),
+
+    /// Wipe local account data without attempting to unregister from the API
+    WipeLocalAccountData(ReturnSender<(), AccountCommandError>),
+
     /// Link another account with the currently logged-on API account
     LinkAccount(ReturnSender<(), AccountCommandError>, StorableAccount),
 
@@ -72,6 +78,8 @@ impl AccountCommand {
             AccountCommand::StoreAccount(return_sender, _) => return_sender.send(Err(error)),
             AccountCommand::RegisterAccount(return_sender, _, _) => return_sender.send(Err(error)),
             AccountCommand::ForgetAccount(return_sender) => return_sender.send(Err(error)),
+            AccountCommand::UnregisterDevice(return_sender) => return_sender.send(Err(error)),
+            AccountCommand::WipeLocalAccountData(return_sender) => return_sender.send(Err(error)),
             AccountCommand::LinkAccount(return_sender, _) => return_sender.send(Err(error)),
             AccountCommand::RotateKeys(return_sender) => return_sender.send(Err(error)),
             AccountCommand::AccountBalance(return_sender) => return_sender.send(Err(error)),

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/handler.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/handler.rs
@@ -131,6 +131,16 @@ pub(crate) async fn handle_forget_account<C: ConnectivityMonitor>(
         tracing::info!("Device has been unregistered");
     }
 
+    handle_wipe_local_account_data(shared_state).await
+}
+
+/// Wipe local account data without attempting to unregister the device from the API.
+/// Use this when the unregister has already been attempted or when only local cleanup is needed.
+pub(crate) async fn handle_wipe_local_account_data<C: ConnectivityMonitor>(
+    shared_state: &mut SharedAccountState<C>,
+) -> Result<(), AccountCommandError> {
+    tracing::info!("WIPING LOCAL ACCOUNT DATA");
+
     shared_state
         .credential_storage
         .reset()
@@ -191,6 +201,19 @@ pub(crate) async fn handle_forget_account<C: ConnectivityMonitor>(
         )));
     }
 
+    Ok(())
+}
+
+/// Try to unregister the device from the API. This is best-effort and logs errors
+/// but returns Ok(()) even on failure to allow the caller to proceed with local cleanup.
+pub(crate) async fn handle_try_unregister_device<C: ConnectivityMonitor>(
+    shared_state: &mut SharedAccountState<C>,
+) -> Result<(), AccountCommandError> {
+    if let Err(err) = handle_unregister_device(shared_state).await {
+        tracing::error!("Failed to unregister device: {err}");
+    } else {
+        tracing::info!("Device has been unregistered");
+    }
     Ok(())
 }
 

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/handler.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/commands/handler.rs
@@ -125,8 +125,6 @@ pub(crate) async fn handle_forget_account<C: ConnectivityMonitor>(
 ) -> Result<(), AccountCommandError> {
     tracing::info!("REMOVING ACCOUNT AND ALL ASSOCIATED DATA");
 
-    // Tunnel state is checked before sending the command here. We're in Disconnected state
-
     if let Err(err) = handle_unregister_device(shared_state).await {
         tracing::error!("Failed to unregister device: {err}");
     } else {

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/decentralised_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/decentralised_state.rs
@@ -68,6 +68,17 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for DecentralisedS
                             return NextAccountControllerState::NewState(LoggedOutState::enter())
                         }
                     },
+                    AccountCommand::UnregisterDevice(return_sender) => {
+                        return_sender.send(handler::handle_try_unregister_device(shared_state).await);
+                    },
+                    AccountCommand::WipeLocalAccountData(return_sender) => {
+                        let res = handler::handle_wipe_local_account_data(shared_state).await;
+                        let error = res.is_err();
+                        return_sender.send(res);
+                        if !error {
+                            return NextAccountControllerState::NewState(LoggedOutState::enter())
+                        }
+                    },
                     AccountCommand::RotateKeys(return_sender) => {
                         let res = handler::handle_rotate_keys(shared_state).await;
                         return_sender.send(res);

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/error_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/error_state.rs
@@ -89,6 +89,19 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ErrorState {
                             return NextAccountControllerState::NewState(LoggedOutState::enter());
                         }
                     },
+                    AccountCommand::UnregisterDevice(return_sender) => {
+                        return_sender.send(handler::handle_try_unregister_device(shared_state).await);
+                    },
+                    AccountCommand::WipeLocalAccountData(return_sender) => {
+                        let res = handler::handle_wipe_local_account_data(shared_state).await;
+                        let error = res.is_err();
+                        return_sender.send(res);
+                        if error {
+                            return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Optimistic));
+                        } else {
+                            return NextAccountControllerState::NewState(LoggedOutState::enter());
+                        }
+                    },
                     AccountCommand::LinkAccount(return_sender, privy_account) => {
                         let res = handler::handle_link_account(shared_state, privy_account).await;
                         return_sender.send(res);

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/logged_out_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/logged_out_state.rs
@@ -67,6 +67,8 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for LoggedOutState
                         }
                     },
                     AccountCommand::ForgetAccount(return_sender) => return_sender.send(Ok(())),
+                    AccountCommand::UnregisterDevice(return_sender) => return_sender.send(Ok(())),
+                    AccountCommand::WipeLocalAccountData(return_sender) => return_sender.send(Ok(())),
                     AccountCommand::LinkAccount(return_sender, _) => return_no_account(return_sender),
                     AccountCommand::RotateKeys(return_sender) => return_sender.send(Ok(())),
                     AccountCommand::AccountBalance(return_sender) => return_no_account(return_sender),

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/offline_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/offline_state.rs
@@ -7,8 +7,8 @@ use crate::{
         AccountCommand, CommonCommand, ReturnSender, UpgradeModeCommand, common_handler, handler,
     },
     state_machine::{
-        AccountControllerStateHandler, NextAccountControllerState, PrivateAccountControllerState,
-        SyncMode, SyncingNetworkState,
+        AccountControllerStateHandler, LoggedOutState, NextAccountControllerState,
+        PrivateAccountControllerState, SyncMode, SyncingNetworkState,
     },
 };
 use nym_offline_monitor::ConnectivityMonitor;
@@ -58,9 +58,16 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for OfflineState {
                         return_sender.send(handler::handle_store_account(shared_state, account).await)
                     },
                     AccountCommand::RegisterAccount(return_sender, _, _) => return_no_connectivity(return_sender),
-                    // Before that command gets sent to the AC, the tunnel must be in Disconnected state, so we shouldn't ever end up here
-                    // If we nevertheless do, we can't forget the account, because maybe the tunnel is in Offline {reconnect : true} state, and we shouldn't remove the account if it's the case
-                    AccountCommand::ForgetAccount(return_sender) => return_no_connectivity(return_sender),
+                    AccountCommand::ForgetAccount(return_sender) => {
+                        let res = handler::handle_forget_account(shared_state).await;
+                        let error = res.is_err();
+                        return_sender.send(res);
+                        return if error {
+                            NextAccountControllerState::SameState(self)
+                        } else {
+                            NextAccountControllerState::NewState(LoggedOutState::enter())
+                        }
+                    },
                     AccountCommand::LinkAccount(return_sender, _) => return_no_connectivity(return_sender),
                     AccountCommand::RotateKeys(return_sender) => {
                         return_sender.send(handler::handle_rotate_keys(shared_state).await)

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/offline_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/offline_state.rs
@@ -68,6 +68,20 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for OfflineState {
                             NextAccountControllerState::NewState(LoggedOutState::enter())
                         }
                     },
+                    AccountCommand::UnregisterDevice(return_sender) => {
+                        // Best-effort: we're offline, can't reach the API anyway
+                        return_sender.send(Ok(()));
+                    },
+                    AccountCommand::WipeLocalAccountData(return_sender) => {
+                        let res = handler::handle_wipe_local_account_data(shared_state).await;
+                        let error = res.is_err();
+                        return_sender.send(res);
+                        return if error {
+                            NextAccountControllerState::SameState(self)
+                        } else {
+                            NextAccountControllerState::NewState(LoggedOutState::enter())
+                        }
+                    },
                     AccountCommand::LinkAccount(return_sender, _) => return_no_connectivity(return_sender),
                     AccountCommand::RotateKeys(return_sender) => {
                         return_sender.send(handler::handle_rotate_keys(shared_state).await)

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/pending_subscription_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/pending_subscription_state.rs
@@ -80,6 +80,19 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for PendingSubscri
                             return NextAccountControllerState::NewState(LoggedOutState::enter());
                         }
                     },
+                    AccountCommand::UnregisterDevice(return_sender) => {
+                        return_sender.send(handler::handle_try_unregister_device(shared_state).await);
+                    },
+                    AccountCommand::WipeLocalAccountData(return_sender) => {
+                        let res = handler::handle_wipe_local_account_data(shared_state).await;
+                        let error = res.is_err();
+                        return_sender.send(res);
+                        if error {
+                            return NextAccountControllerState::NewState(SyncingNetworkState::enter(shared_state, SyncMode::Optimistic));
+                        } else {
+                            return NextAccountControllerState::NewState(LoggedOutState::enter());
+                        }
+                    },
                     AccountCommand::LinkAccount(return_sender, privy_account) => {
                         let res = handler::handle_link_account(shared_state, privy_account).await;
                         return_sender.send(res);

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/ready_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/ready_state.rs
@@ -82,6 +82,19 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for ReadyState {
                             NextAccountControllerState::NewState(LoggedOutState::enter())
                         }
                     },
+                    AccountCommand::UnregisterDevice(return_sender) => {
+                        return_sender.send(handler::handle_try_unregister_device(shared_state).await);
+                    },
+                    AccountCommand::WipeLocalAccountData(return_sender) => {
+                        let res = handler::handle_wipe_local_account_data(shared_state).await;
+                        let error = res.is_err();
+                        return_sender.send(res);
+                        return if error {
+                            NextAccountControllerState::SameState(self)
+                        } else {
+                            NextAccountControllerState::NewState(LoggedOutState::enter())
+                        }
+                    },
                     AccountCommand::LinkAccount(return_sender, privy_account) => {
                         let res = handler::handle_link_account(shared_state, privy_account).await;
                         return_sender.send(res);

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/local_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/local_state.rs
@@ -241,6 +241,19 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingLocalSt
                             NextAccountControllerState::NewState(LoggedOutState::enter())
                         }
                     },
+                    AccountCommand::UnregisterDevice(return_sender) => {
+                        return_sender.send(handler::handle_try_unregister_device(shared_state).await);
+                    },
+                    AccountCommand::WipeLocalAccountData(return_sender) => {
+                        let res = handler::handle_wipe_local_account_data(shared_state).await;
+                        let error = res.is_err();
+                        return_sender.send(res);
+                        return if error {
+                            NextAccountControllerState::SameState(self)
+                        } else {
+                            NextAccountControllerState::NewState(LoggedOutState::enter())
+                        }
+                    },
                     AccountCommand::LinkAccount(return_sender, privy_account) => {
                         let res = handler::handle_link_account(shared_state, privy_account).await;
                         return_sender.send(res);

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/network_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/network_state.rs
@@ -237,6 +237,19 @@ impl<C: ConnectivityMonitor> AccountControllerStateHandler<C> for SyncingNetwork
                             NextAccountControllerState::NewState(LoggedOutState::enter())
                         }
                     },
+                    AccountCommand::UnregisterDevice(return_sender) => {
+                        return_sender.send(handler::handle_try_unregister_device(shared_state).await);
+                    },
+                    AccountCommand::WipeLocalAccountData(return_sender) => {
+                        let res = handler::handle_wipe_local_account_data(shared_state).await;
+                        let error = res.is_err();
+                        return_sender.send(res);
+                        return if error {
+                            NextAccountControllerState::SameState(self)
+                        } else {
+                            NextAccountControllerState::NewState(LoggedOutState::enter())
+                        }
+                    },
                     AccountCommand::LinkAccount(return_sender, privy_account) => {
                         let res = handler::handle_link_account(shared_state, privy_account).await;
                         return_sender.send(res);

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/requesting_zknym_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/syncing_state/requesting_zknym_state.rs
@@ -328,6 +328,23 @@ impl RequestingZkNymsState {
                     NextAccountControllerState::NewState(LoggedOutState::enter())
                 };
             }
+            AccountCommand::UnregisterDevice(return_sender) => {
+                return_sender.send(handler::handle_try_unregister_device(shared_state).await);
+            }
+            AccountCommand::WipeLocalAccountData(return_sender) => {
+                self.zk_nym_fetching_handle.abort();
+                let res = handler::handle_wipe_local_account_data(shared_state).await;
+                let error = res.is_err();
+                return_sender.send(res);
+                return if error {
+                    NextAccountControllerState::NewState(SyncingNetworkState::enter(
+                        shared_state,
+                        SyncMode::Optimistic,
+                    ))
+                } else {
+                    NextAccountControllerState::NewState(LoggedOutState::enter())
+                };
+            }
             AccountCommand::LinkAccount(return_sender, privy_account) => {
                 let res = handler::handle_link_account(shared_state, privy_account).await;
                 return_sender.send(res);

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/upgrade_mode_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/state_machine/upgrade_mode_state.rs
@@ -140,6 +140,19 @@ impl UpgradeModeState {
                     NextAccountControllerState::NewState(LoggedOutState::enter())
                 };
             }
+            AccountCommand::UnregisterDevice(return_sender) => {
+                return_sender.send(handler::handle_try_unregister_device(shared_state).await);
+            }
+            AccountCommand::WipeLocalAccountData(return_sender) => {
+                let res = handler::handle_wipe_local_account_data(shared_state).await;
+                let error = res.is_err();
+                return_sender.send(res);
+                return if error {
+                    NextAccountControllerState::SameState(self)
+                } else {
+                    NextAccountControllerState::NewState(LoggedOutState::enter())
+                };
+            }
             AccountCommand::LinkAccount(return_sender, privy_account) => {
                 let res = handler::handle_link_account(shared_state, privy_account).await;
                 return_sender.send(res);

--- a/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/commands.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/commands.rs
@@ -125,11 +125,6 @@ async fn offline_state_command() -> anyhow::Result<()> {
         Err(AccountCommandError::Offline)
     );
 
-    assert_eq!(
-        test_bench.command_sender.forget_account().await,
-        Err(AccountCommandError::Offline)
-    );
-
     assert_eq!(test_bench.command_sender.rotate_keys().await, Ok(()));
 
     assert_eq!(
@@ -214,6 +209,15 @@ async fn offline_state_command() -> anyhow::Result<()> {
     test_bench
         .assert_state(AccountControllerState::Offline)
         .await;
+
+    assert_eq!(test_bench.command_sender.forget_account().await, Ok(()));
+    test_bench
+        .assert_state(AccountControllerState::LoggedOut)
+        .await;
+    assert_eq!(
+        test_bench.command_sender.get_stored_account().await,
+        Ok(None)
+    );
 
     Ok(())
 }
@@ -335,6 +339,10 @@ async fn ready_state_command() -> anyhow::Result<()> {
     test_bench
         .assert_state(AccountControllerState::LoggedOut)
         .await;
+    assert_eq!(
+        test_bench.command_sender.get_stored_account().await,
+        Ok(None)
+    );
 
     Ok(())
 }

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
@@ -79,21 +79,6 @@ impl TunnelState {
     pub fn is_error_state(&self) -> bool {
         matches!(self, Self::Error(_))
     }
-
-    /// Returns `true` only while a tunnel is actually up or transitioning up or
-    /// down (`Connecting`, `Connected`, `Disconnecting`).
-    ///
-    /// The genuinely disconnected states (`Disconnected`, `Error`, `Offline`)
-    /// return `false`: no tunnel holds the persistent storage in those states,
-    /// so operations that only need to be blocked while a tunnel is live (such
-    /// as forgetting the account) can safely proceed. The match is exhaustive
-    /// on purpose so a future variant forces this classification to be revisited.
-    pub fn is_tunnel_active(&self) -> bool {
-        match self {
-            Self::Connecting { .. } | Self::Connected { .. } | Self::Disconnecting { .. } => true,
-            Self::Disconnected | Self::Error(_) | Self::Offline { .. } => false,
-        }
-    }
 }
 
 impl std::fmt::Display for TunnelState {
@@ -366,28 +351,5 @@ impl ErrorStateReason {
     #[cfg(any(target_os = "macos", target_os = "windows"))]
     pub fn prevents_filtering_resolver(&self) -> bool {
         matches!(self, ErrorStateReason::SetDns)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn is_tunnel_active_is_false_for_disconnected_states() {
-        // These are the states documented as disconnected. The forget-account
-        // guard must permit the operation in all of them (see #5668).
-        assert!(!TunnelState::Disconnected.is_tunnel_active());
-        assert!(!TunnelState::Error(ErrorStateReason::SetDns).is_tunnel_active());
-        assert!(!TunnelState::Offline { reconnect: true }.is_tunnel_active());
-        assert!(!TunnelState::Offline { reconnect: false }.is_tunnel_active());
-    }
-
-    #[test]
-    fn is_tunnel_active_is_true_while_a_tunnel_is_live() {
-        assert!(TunnelState::Disconnecting {
-            after_disconnect: ActionAfterDisconnect::Nothing,
-        }
-        .is_tunnel_active());
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
@@ -79,6 +79,21 @@ impl TunnelState {
     pub fn is_error_state(&self) -> bool {
         matches!(self, Self::Error(_))
     }
+
+    /// Returns `true` only while a tunnel is actually up or transitioning up or
+    /// down (`Connecting`, `Connected`, `Disconnecting`).
+    ///
+    /// The genuinely disconnected states (`Disconnected`, `Error`, `Offline`)
+    /// return `false`: no tunnel holds the persistent storage in those states,
+    /// so operations that only need to be blocked while a tunnel is live (such
+    /// as forgetting the account) can safely proceed. The match is exhaustive
+    /// on purpose so a future variant forces this classification to be revisited.
+    pub fn is_tunnel_active(&self) -> bool {
+        match self {
+            Self::Connecting { .. } | Self::Connected { .. } | Self::Disconnecting { .. } => true,
+            Self::Disconnected | Self::Error(_) | Self::Offline { .. } => false,
+        }
+    }
 }
 
 impl std::fmt::Display for TunnelState {
@@ -351,5 +366,28 @@ impl ErrorStateReason {
     #[cfg(any(target_os = "macos", target_os = "windows"))]
     pub fn prevents_filtering_resolver(&self) -> bool {
         matches!(self, ErrorStateReason::SetDns)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_tunnel_active_is_false_for_disconnected_states() {
+        // These are the states documented as disconnected. The forget-account
+        // guard must permit the operation in all of them (see #5668).
+        assert!(!TunnelState::Disconnected.is_tunnel_active());
+        assert!(!TunnelState::Error(ErrorStateReason::SetDns).is_tunnel_active());
+        assert!(!TunnelState::Offline { reconnect: true }.is_tunnel_active());
+        assert!(!TunnelState::Offline { reconnect: false }.is_tunnel_active());
+    }
+
+    #[test]
+    fn is_tunnel_active_is_true_while_a_tunnel_is_live() {
+        assert!(TunnelState::Disconnecting {
+            after_disconnect: ActionAfterDisconnect::Nothing,
+        }
+        .is_tunnel_active());
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_service.rs
@@ -1,9 +1,12 @@
 // Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
-use nym_vpn_lib::{paths::Paths, service::ServiceConfigStorageType};
+use nym_vpn_lib::{
+    paths::Paths,
+    service::{ServiceConfigStorageType, VPN_DISCONNECT_TIMEOUT},
+};
 use nym_vpn_lib_types::{TunnelEvent, TunnelState};
 use nym_vpn_network_config::NetworkCache;
 use tokio::{
@@ -16,9 +19,6 @@ use crate::{
     NymEnvironment, TOKIO_RUNTIME, VPNConfig, VpnError,
     vpn_service_command_sender::NymVpnServiceCommandSender,
 };
-
-/// Max amount of time to wait for the VPN to disconnect before shutting down.
-const DISCONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
 struct State {
     event_handler: JoinHandle<()>,
@@ -169,7 +169,7 @@ impl NymVpnService {
         mut tunnel_state_rx: tokio::sync::watch::Receiver<Option<TunnelState>>,
     ) {
         let _ = tokio::time::timeout(
-            DISCONNECT_TIMEOUT,
+            VPN_DISCONNECT_TIMEOUT,
             tunnel_state_rx.wait_for(|tunnel_state| {
                 matches!(
                     tunnel_state,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/mod.rs
@@ -1,10 +1,15 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use std::time::Duration;
+
 mod config;
 mod error;
 mod socks5;
 mod vpn_service;
+
+/// Maximum time to wait for the VPN tunnel to disconnect during teardown.
+pub const VPN_DISCONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub use config::{
     ConfigSetupError, DEFAULT_GLOBAL_CONFIG_FILE_JSON, DEFAULT_GLOBAL_CONFIG_FILE_TOML,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
@@ -61,7 +61,7 @@ use nym_vpn_lib_types::{RegisterAccountRequest, RegisterAccountResponse};
 use nym_vpn_network_config::{DiscoveryRefresher, Network, NetworkCache};
 
 use super::{
-    Socks5Error, Socks5Service, Socks5Status,
+    Socks5Error, Socks5Service, Socks5Status, VPN_DISCONNECT_TIMEOUT,
     config::{NetworkEnvironments, VpnServiceConfigManager},
     error::{
         AccountLinksError, Error, GeoExclusionConfigError, GlobalConfigError, ListGatewaysError,
@@ -280,6 +280,88 @@ pub struct NymVpnServiceParameters {
     pub connectivity_monitor: Box<dyn nym_offline_monitor::NativeConnectivityAdapter + 'static>,
 }
 
+fn tunnel_requires_teardown(state: &TunnelState) -> bool {
+    matches!(
+        state,
+        TunnelState::Connecting { .. }
+            | TunnelState::Connected { .. }
+            | TunnelState::Disconnecting { .. }
+    )
+}
+
+fn send_target_state_request(
+    statistics_event_sender: &StatisticsSender,
+    command_sender: &mpsc::UnboundedSender<TunnelCommand>,
+    target_state: TargetState,
+) {
+    match target_state {
+        TargetState::Secured => {
+            statistics_event_sender.report_connection_request();
+            let _ = command_sender.send(TunnelCommand::Connect);
+        }
+        TargetState::Unsecured => {
+            statistics_event_sender.report_disconnection_request();
+            let _ = command_sender.send(TunnelCommand::Disconnect);
+        }
+    }
+}
+
+async fn wait_for_tunnel_teardown(
+    mut tunnel_state_rx: watch::Receiver<TunnelState>,
+    disconnect_timeout: Duration,
+) -> Result<(), &'static str> {
+    if !tunnel_requires_teardown(&tunnel_state_rx.borrow()) {
+        return Ok(());
+    }
+
+    match tokio::time::timeout(
+        disconnect_timeout,
+        tunnel_state_rx.wait_for(|state| !tunnel_requires_teardown(state)),
+    )
+    .await
+    {
+        Ok(Ok(_)) => Ok(()),
+        Ok(Err(_)) => Err("Tunnel state channel unexpectedly closed"),
+        Err(_) => Err("Tunnel teardown timed out"),
+    }
+}
+
+fn forget_account_after_tunnel_teardown<RequestDisconnect, Wipe, WipeFuture>(
+    tunnel_state_rx: watch::Receiver<TunnelState>,
+    disconnect_timeout: Duration,
+    request_disconnect: RequestDisconnect,
+    wipe: Wipe,
+) -> impl std::future::Future<Output = Result<(), AccountCommandError>> + Send + 'static
+where
+    RequestDisconnect: FnOnce(),
+    Wipe: FnOnce() -> WipeFuture + Send + 'static,
+    WipeFuture: std::future::Future<Output = Result<(), AccountCommandError>> + Send + 'static,
+{
+    request_disconnect();
+
+    async move {
+        let teardown_result = wait_for_tunnel_teardown(tunnel_state_rx, disconnect_timeout).await;
+
+        if let Err(failure) = teardown_result {
+            tracing::error!(
+                "{failure} after {disconnect_timeout:?}; proceeding with the local account wipe"
+            );
+        }
+
+        let wipe_result = wipe().await;
+
+        match (teardown_result, wipe_result) {
+            (Ok(()), wipe_result) => wipe_result,
+            (Err(failure), Ok(())) => Err(AccountCommandError::internal(format!(
+                "{failure}; local account data was wiped"
+            ))),
+            (Err(failure), Err(wipe_error)) => Err(AccountCommandError::internal(format!(
+                "{failure}; local account data wipe also failed: {wipe_error}"
+            ))),
+        }
+    }
+}
+
 pub struct NymVpnService {
     // Paths
     paths: NymConfigPaths,
@@ -311,6 +393,13 @@ pub struct NymVpnService {
 
     // Last known tunnel state
     tunnel_state: Arc<RwLock<TunnelState>>,
+
+    // State changes used by operations that must wait without consuming tunnel events.
+    tunnel_state_tx: watch::Sender<TunnelState>,
+
+    // Forget-account remains pending while the main loop processes tunnel state events.
+    forget_account_task: Fuse<JoinHandle<Result<(), AccountCommandError>>>,
+    forget_account_response_tx: Option<oneshot::Sender<Result<(), AccountCommandError>>>,
 
     // Timer used to throttle changes to tunnel settings
     tunnel_settings_update_timer: Pin<Box<Fuse<tokio::time::Sleep>>>,
@@ -567,6 +656,7 @@ impl NymVpnService {
         let statistics_controller_handle = tokio::task::spawn(statistics_controller.run());
 
         let tunnel_state = Arc::new(RwLock::new(TunnelState::Disconnected));
+        let (tunnel_state_tx, _) = watch::channel(TunnelState::Disconnected);
 
         // Initialize lazy SOCKS5 service (disabled by default)
         let socks5_service = Socks5Service::new(tunnel_state.clone());
@@ -723,6 +813,9 @@ impl NymVpnService {
             account_state_rx,
             target_state: TargetState::Unsecured,
             tunnel_state,
+            tunnel_state_tx,
+            forget_account_task: Fuse::terminated(),
+            forget_account_response_tx: None,
             tunnel_settings_update_timer: Box::pin(Fuse::terminated()),
             state_machine_handle: Some(state_machine_handle),
             account_controller_handle,
@@ -760,6 +853,34 @@ impl NymVpnService {
         let mut account_state_rx = WatchStream::new(self.account_state_rx.subscribe()).skip(1);
 
         loop {
+            if !self.forget_account_task.is_terminated() {
+                let result = tokio::select! {
+                    Some(event) = self.event_receiver.recv() => {
+                        self.handle_tunnel_event(event);
+                        None
+                    }
+                    result = &mut self.forget_account_task => {
+                        Some(
+                            result.unwrap_or_else(|error| {
+                                Err(AccountCommandError::internal(format!(
+                                    "Forget-account task failed: {error}"
+                                )))
+                            }),
+                        )
+                    }
+                };
+
+                if let Some(result) = result {
+                    if let Some(tx) = self.forget_account_response_tx.take() {
+                        let _ = tx.send(result);
+                    } else {
+                        tracing::error!("Forget-account task completed without a response channel");
+                    }
+                }
+
+                continue;
+            }
+
             tokio::select! {
                 Some(command) = self.vpn_command_rx.recv() => {
                     self.handle_service_command_timed(command).await;
@@ -856,26 +977,30 @@ impl NymVpnService {
         Ok(())
     }
 
-    async fn set_target_state(&mut self, new_state: TargetState) -> bool {
+    async fn update_target_state(&mut self, new_state: TargetState) -> bool {
         if self.target_state != new_state || self.tunnel_state.read().await.is_error_state() {
             tracing::debug!("Set target state {} => {}", self.target_state, new_state);
             self.target_state = new_state;
-
-            match new_state {
-                TargetState::Secured => {
-                    self.statistics_event_sender.report_connection_request();
-                    let _ = self.command_sender.send(TunnelCommand::Connect);
-                }
-                TargetState::Unsecured => {
-                    self.statistics_event_sender.report_disconnection_request();
-                    let _ = self.command_sender.send(TunnelCommand::Disconnect);
-                }
-            }
-
             true
         } else {
             false
         }
+    }
+
+    fn request_target_state(&self, target_state: TargetState) {
+        send_target_state_request(
+            &self.statistics_event_sender,
+            &self.command_sender,
+            target_state,
+        );
+    }
+
+    async fn set_target_state(&mut self, new_state: TargetState) -> bool {
+        let updated = self.update_target_state(new_state).await;
+        if updated {
+            self.request_target_state(new_state);
+        }
+        updated
     }
 
     async fn reconnect_tunnel(&mut self) -> bool {
@@ -916,6 +1041,8 @@ impl NymVpnService {
 
     fn handle_tunnel_event(&mut self, event: TunnelEvent) {
         if let TunnelEvent::NewState(ref new_state) = event {
+            self.tunnel_state_tx.send_replace(new_state.clone());
+
             if let Ok(mut state) = self.tunnel_state.try_write() {
                 *state = new_state.clone();
             } else {
@@ -1134,7 +1261,7 @@ impl NymVpnService {
                 let _ = tx.send(self.handle_get_account_mode().await);
             }
             VpnServiceCommand::ForgetAccount(tx, ()) => {
-                let _ = tx.send(self.handle_forget_account().await);
+                self.handle_forget_account(tx).await;
             }
             VpnServiceCommand::RotateKeys(tx, ()) => {
                 let _ = tx.send(self.handle_rotate_keys().await);
@@ -1944,31 +2071,50 @@ impl NymVpnService {
             .unwrap_or(false)
     }
 
-    async fn handle_forget_account(&mut self) -> Result<(), AccountCommandError> {
-        // Only block while a tunnel is actually live: the persistent storage the
-        // wipe clears is held during connecting/connected/disconnecting, not in
-        // the genuinely-disconnected states (Disconnected, Error, Offline). A
-        // strict `!= Disconnected` check wrongly rejected forget while stuck in
-        // Error/Offline (see #5668).
-        if self.tunnel_state.read().await.is_tunnel_active() {
-            return Err(AccountCommandError::internal(
-                "Unable to forget account while connected",
-            ));
-        }
+    async fn handle_forget_account(
+        &mut self,
+        response_tx: oneshot::Sender<Result<(), AccountCommandError>>,
+    ) {
+        debug_assert!(self.forget_account_task.is_terminated());
+        debug_assert!(self.forget_account_response_tx.is_none());
 
+        let target_state_updated = self.update_target_state(TargetState::Unsecured).await;
+        let command_sender = self.command_sender.clone();
+        let statistics_event_sender = self.statistics_event_sender.clone();
         let data_dir = self.paths.network_data_dir.clone();
-        tracing::info!(
-            "REMOVING ALL ACCOUNT AND DEVICE DATA IN: {}",
-            data_dir.display()
-        );
+        let stats_control_commands_sender = self.stats_control_commands_sender.clone();
+        let account_command_tx = self.account_command_tx.clone();
 
-        let _ = self
-            .stats_control_commands_sender
-            .reset_seed(None)
-            .await
-            .inspect_err(|e| tracing::error!("Failed to reset networks stats seed: {e}"));
+        let task = tokio::spawn(forget_account_after_tunnel_teardown(
+            self.tunnel_state_tx.subscribe(),
+            VPN_DISCONNECT_TIMEOUT,
+            move || {
+                if target_state_updated {
+                    send_target_state_request(
+                        &statistics_event_sender,
+                        &command_sender,
+                        TargetState::Unsecured,
+                    );
+                }
+            },
+            move || async move {
+                tracing::info!(
+                    "REMOVING ALL ACCOUNT AND DEVICE DATA IN: {}",
+                    data_dir.display()
+                );
 
-        self.account_command_tx.forget_account().await
+                let _ = stats_control_commands_sender
+                    .reset_seed(None)
+                    .await
+                    .inspect_err(|e| tracing::error!("Failed to reset networks stats seed: {e}"));
+
+                account_command_tx.forget_account().await
+            },
+        ))
+        .fuse();
+
+        self.forget_account_response_tx = Some(response_tx);
+        self.forget_account_task = task;
     }
 
     async fn handle_rotate_keys(&mut self) -> Result<(), AccountCommandError> {
@@ -2412,5 +2558,150 @@ impl NymVpnService {
             .await?;
         self.update_tunnel_settings_with_throttle();
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        net::{IpAddr, Ipv4Addr},
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+    };
+
+    use nym_vpn_lib_types::{
+        ActionAfterDisconnect, ConnectionData, GatewayLightInfo, MixnetConnectionData, NymAddress,
+        TunnelConnectionData,
+    };
+
+    use super::*;
+
+    fn connected_tunnel_state() -> TunnelState {
+        let address = NymAddress::new("nym-address".to_owned(), "gateway-id".to_owned());
+        let localhost = Ipv4Addr::LOCALHOST;
+
+        TunnelState::Connected {
+            connection_data: ConnectionData {
+                entry_gateway: GatewayLightInfo::new("entry".to_owned(), None),
+                exit_gateway: GatewayLightInfo::new("exit".to_owned(), None),
+                connected_at: OffsetDateTime::now_utc(),
+                tunnel: TunnelConnectionData::Mixnet(MixnetConnectionData {
+                    nym_address: address.clone(),
+                    exit_ipr: address,
+                    entry_ip: IpAddr::V4(localhost),
+                    exit_ip: IpAddr::V4(localhost),
+                    ipv4: localhost,
+                    ipv6: None,
+                }),
+            },
+        }
+    }
+
+    async fn assert_forget_wipes_immediately(initial_state: TunnelState) {
+        let (_state_tx, state_rx) = watch::channel(initial_state);
+        let wipe_count = Arc::new(AtomicUsize::new(0));
+        let wipe_count_clone = wipe_count.clone();
+
+        let result = tokio::time::timeout(
+            Duration::from_millis(100),
+            forget_account_after_tunnel_teardown(
+                state_rx,
+                VPN_DISCONNECT_TIMEOUT,
+                || {},
+                move || async move {
+                    wipe_count_clone.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                },
+            ),
+        )
+        .await
+        .expect("forget account waited in an inactive tunnel state");
+
+        assert_eq!(result, Ok(()));
+        assert_eq!(wipe_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn forget_while_disconnected_wipes_without_waiting() {
+        assert_forget_wipes_immediately(TunnelState::Disconnected).await;
+    }
+
+    #[tokio::test]
+    async fn forget_while_offline_wipes_without_erroring() {
+        assert_forget_wipes_immediately(TunnelState::Offline { reconnect: true }).await;
+    }
+
+    #[tokio::test]
+    async fn forget_while_connected_requests_disconnect_then_wipes_after_settling() {
+        let (state_tx, state_rx) = watch::channel(connected_tunnel_state());
+        let (command_sender, mut command_receiver) = mpsc::unbounded_channel();
+        let (statistics_tx, _statistics_rx) = mpsc::unbounded_channel();
+        let statistics_event_sender =
+            StatisticsSender::new(statistics_tx, CancellationToken::new());
+        let wipe_count = Arc::new(AtomicUsize::new(0));
+        let wipe_count_clone = wipe_count.clone();
+
+        let forget = forget_account_after_tunnel_teardown(
+            state_rx,
+            VPN_DISCONNECT_TIMEOUT,
+            move || {
+                send_target_state_request(
+                    &statistics_event_sender,
+                    &command_sender,
+                    TargetState::Unsecured,
+                );
+            },
+            move || async move {
+                wipe_count_clone.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            },
+        );
+
+        assert!(matches!(
+            command_receiver.try_recv(),
+            Ok(TunnelCommand::Disconnect)
+        ));
+        let forget_task = tokio::spawn(forget);
+        tokio::task::yield_now().await;
+        assert_eq!(wipe_count.load(Ordering::SeqCst), 0);
+
+        state_tx.send_replace(TunnelState::Disconnected);
+
+        assert_eq!(forget_task.await.unwrap(), Ok(()));
+        assert_eq!(wipe_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn forget_while_disconnect_is_wedged_times_out_wipes_and_reports_failure() {
+        let (_state_tx, state_rx) = watch::channel(TunnelState::Disconnecting {
+            after_disconnect: ActionAfterDisconnect::Nothing,
+        });
+        let wipe_count = Arc::new(AtomicUsize::new(0));
+        let wipe_count_clone = wipe_count.clone();
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(1),
+            forget_account_after_tunnel_teardown(
+                state_rx,
+                Duration::from_millis(10),
+                || {},
+                move || async move {
+                    wipe_count_clone.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                },
+            ),
+        )
+        .await
+        .expect("forget account remained hung after its teardown timeout");
+
+        assert_eq!(
+            result,
+            Err(AccountCommandError::internal(
+                "Tunnel teardown timed out; local account data was wiped"
+            ))
+        );
+        assert_eq!(wipe_count.load(Ordering::SeqCst), 1);
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
@@ -326,20 +326,44 @@ async fn wait_for_tunnel_teardown(
     }
 }
 
-fn forget_account_after_tunnel_teardown<RequestDisconnect, Wipe, WipeFuture>(
+/// Forget account by first calling API to unregister device (while tunnel is up),
+/// then disconnecting the tunnel, then wiping local data.
+///
+/// API calls happen while the tunnel is still up so they can route through it.
+/// If the tunnel is not connected or the unregister call fails, we proceed anyway.
+/// The local wipe always happens - failing to unregister from the server just means
+/// the device may remain registered there.
+fn forget_account_with_unregister_then_teardown<
+    TryUnregister,
+    UnregisterFuture,
+    RequestDisconnect,
+    WipeLocal,
+    WipeLocalFuture,
+>(
     tunnel_state_rx: watch::Receiver<TunnelState>,
     disconnect_timeout: Duration,
+    try_unregister: TryUnregister,
     request_disconnect: RequestDisconnect,
-    wipe: Wipe,
+    wipe_local: WipeLocal,
 ) -> impl std::future::Future<Output = Result<(), AccountCommandError>> + Send + 'static
 where
-    RequestDisconnect: FnOnce(),
-    Wipe: FnOnce() -> WipeFuture + Send + 'static,
-    WipeFuture: std::future::Future<Output = Result<(), AccountCommandError>> + Send + 'static,
+    TryUnregister: FnOnce() -> UnregisterFuture + Send + 'static,
+    UnregisterFuture: std::future::Future<Output = Result<(), AccountCommandError>> + Send + 'static,
+    RequestDisconnect: FnOnce() + Send + 'static,
+    WipeLocal: FnOnce() -> WipeLocalFuture + Send + 'static,
+    WipeLocalFuture: std::future::Future<Output = Result<(), AccountCommandError>> + Send + 'static,
 {
-    request_disconnect();
-
     async move {
+        // Step 1: Try to unregister device from the API while tunnel may still be up.
+        // This is best-effort - we log but continue on failure.
+        if let Err(err) = try_unregister().await {
+            tracing::warn!("Failed to unregister device from API: {err}; proceeding with local wipe");
+        }
+
+        // Step 2: Request tunnel disconnect
+        request_disconnect();
+
+        // Step 3: Wait for tunnel to settle
         let teardown_result = wait_for_tunnel_teardown(tunnel_state_rx, disconnect_timeout).await;
 
         if let Err(failure) = teardown_result {
@@ -348,7 +372,8 @@ where
             );
         }
 
-        let wipe_result = wipe().await;
+        // Step 4: Wipe local data
+        let wipe_result = wipe_local().await;
 
         match (teardown_result, wipe_result) {
             (Ok(()), wipe_result) => wipe_result,
@@ -2084,10 +2109,14 @@ impl NymVpnService {
         let data_dir = self.paths.network_data_dir.clone();
         let stats_control_commands_sender = self.stats_control_commands_sender.clone();
         let account_command_tx = self.account_command_tx.clone();
+        let account_command_tx_for_wipe = self.account_command_tx.clone();
 
-        let task = tokio::spawn(forget_account_after_tunnel_teardown(
+        let task = tokio::spawn(forget_account_with_unregister_then_teardown(
             self.tunnel_state_tx.subscribe(),
             VPN_DISCONNECT_TIMEOUT,
+            // Step 1: Try to unregister device from API while tunnel may still be up
+            move || async move { account_command_tx.unregister_device().await },
+            // Step 2: Request disconnect
             move || {
                 if target_state_updated {
                     send_target_state_request(
@@ -2097,6 +2126,7 @@ impl NymVpnService {
                     );
                 }
             },
+            // Step 3 (after tunnel settles): Wipe local data
             move || async move {
                 tracing::info!(
                     "REMOVING ALL ACCOUNT AND DEVICE DATA IN: {}",
@@ -2108,7 +2138,7 @@ impl NymVpnService {
                     .await
                     .inspect_err(|e| tracing::error!("Failed to reset networks stats seed: {e}"));
 
-                account_command_tx.forget_account().await
+                account_command_tx_for_wipe.wipe_local_account_data().await
             },
         ))
         .fuse();
@@ -2601,14 +2631,20 @@ mod tests {
 
     async fn assert_forget_wipes_immediately(initial_state: TunnelState) {
         let (_state_tx, state_rx) = watch::channel(initial_state);
+        let unregister_count = Arc::new(AtomicUsize::new(0));
+        let unregister_count_clone = unregister_count.clone();
         let wipe_count = Arc::new(AtomicUsize::new(0));
         let wipe_count_clone = wipe_count.clone();
 
         let result = tokio::time::timeout(
             Duration::from_millis(100),
-            forget_account_after_tunnel_teardown(
+            forget_account_with_unregister_then_teardown(
                 state_rx,
                 VPN_DISCONNECT_TIMEOUT,
+                move || async move {
+                    unregister_count_clone.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                },
                 || {},
                 move || async move {
                     wipe_count_clone.fetch_add(1, Ordering::SeqCst);
@@ -2620,6 +2656,7 @@ mod tests {
         .expect("forget account waited in an inactive tunnel state");
 
         assert_eq!(result, Ok(()));
+        assert_eq!(unregister_count.load(Ordering::SeqCst), 1);
         assert_eq!(wipe_count.load(Ordering::SeqCst), 1);
     }
 
@@ -2634,18 +2671,25 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn forget_while_connected_requests_disconnect_then_wipes_after_settling() {
+    async fn forget_while_connected_unregisters_first_then_requests_disconnect_then_wipes_after_settling(
+    ) {
         let (state_tx, state_rx) = watch::channel(connected_tunnel_state());
         let (command_sender, mut command_receiver) = mpsc::unbounded_channel();
         let (statistics_tx, _statistics_rx) = mpsc::unbounded_channel();
         let statistics_event_sender =
             StatisticsSender::new(statistics_tx, CancellationToken::new());
+        let unregister_count = Arc::new(AtomicUsize::new(0));
+        let unregister_count_clone = unregister_count.clone();
         let wipe_count = Arc::new(AtomicUsize::new(0));
         let wipe_count_clone = wipe_count.clone();
 
-        let forget = forget_account_after_tunnel_teardown(
+        let forget = forget_account_with_unregister_then_teardown(
             state_rx,
             VPN_DISCONNECT_TIMEOUT,
+            move || async move {
+                unregister_count_clone.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            },
             move || {
                 send_target_state_request(
                     &statistics_event_sender,
@@ -2659,12 +2703,19 @@ mod tests {
             },
         );
 
+        let forget_task = tokio::spawn(forget);
+        tokio::task::yield_now().await;
+
+        // Unregister should have been called, but disconnect not sent until after
+        assert_eq!(unregister_count.load(Ordering::SeqCst), 1);
+
+        // Disconnect should be sent after unregister completes
         assert!(matches!(
             command_receiver.try_recv(),
             Ok(TunnelCommand::Disconnect)
         ));
-        let forget_task = tokio::spawn(forget);
-        tokio::task::yield_now().await;
+
+        // Wipe should not have happened yet (waiting for tunnel to settle)
         assert_eq!(wipe_count.load(Ordering::SeqCst), 0);
 
         state_tx.send_replace(TunnelState::Disconnected);
@@ -2678,14 +2729,20 @@ mod tests {
         let (_state_tx, state_rx) = watch::channel(TunnelState::Disconnecting {
             after_disconnect: ActionAfterDisconnect::Nothing,
         });
+        let unregister_count = Arc::new(AtomicUsize::new(0));
+        let unregister_count_clone = unregister_count.clone();
         let wipe_count = Arc::new(AtomicUsize::new(0));
         let wipe_count_clone = wipe_count.clone();
 
         let result = tokio::time::timeout(
             Duration::from_secs(1),
-            forget_account_after_tunnel_teardown(
+            forget_account_with_unregister_then_teardown(
                 state_rx,
                 Duration::from_millis(10),
+                move || async move {
+                    unregister_count_clone.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                },
                 || {},
                 move || async move {
                     wipe_count_clone.fetch_add(1, Ordering::SeqCst);
@@ -2702,6 +2759,7 @@ mod tests {
                 "Tunnel teardown timed out; local account data was wiped"
             ))
         );
+        assert_eq!(unregister_count.load(Ordering::SeqCst), 1);
         assert_eq!(wipe_count.load(Ordering::SeqCst), 1);
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
@@ -1945,7 +1945,12 @@ impl NymVpnService {
     }
 
     async fn handle_forget_account(&mut self) -> Result<(), AccountCommandError> {
-        if *self.tunnel_state.read().await != TunnelState::Disconnected {
+        // Only block while a tunnel is actually live: the persistent storage the
+        // wipe clears is held during connecting/connected/disconnecting, not in
+        // the genuinely-disconnected states (Disconnected, Error, Offline). A
+        // strict `!= Disconnected` check wrongly rejected forget while stuck in
+        // Error/Offline (see #5668).
+        if self.tunnel_state.read().await.is_tunnel_active() {
             return Err(AccountCommandError::internal(
                 "Unable to forget account while connected",
             ));


### PR DESCRIPTION
## Summary

`nym-vpnc account forget` now succeeds when the tunnel is in a non-connected state (`Error` or `Offline`), instead of failing with "Unable to forget account while connected".

## Why this matters

Reported in #5668: `account forget` returned `internal error: Unable to forget account while connected` even though `status` reported `State: Disconnected`, and the user only succeeded after an explicit `disconnect`. The guard in `handle_forget_account` rejected the operation whenever the state was `!= TunnelState::Disconnected`. But `TunnelState` has two other states documented as disconnected: `Error(_)` ("Tunnel is disconnected due to failure") and `Offline` ("Tunnel is disconnected, network connectivity is unavailable"). When the tunnel is stuck in `Error` or `Offline`, no tunnel holds the persistent storage the wipe needs to clear, so the strict equality check blocked forget unnecessarily. @pronebird confirmed on the issue that the block is only meant to apply while genuinely connected ("the daemon needs to disconnect in order for internal components to stop using persistent storage").

## Changes

- Add `TunnelState::is_tunnel_active()`, which returns `true` only for the states where a tunnel is actually up or transitioning (`Connecting`, `Connected`, `Disconnecting`) and `false` for the genuinely-disconnected states (`Disconnected`, `Error`, `Offline`). The match is exhaustive on purpose so a future variant forces the classification to be revisited.
- Use it in the forget-account guard (`vpn_service.rs`) in place of `!= TunnelState::Disconnected`, preserving the same error and message for the truly-active case. The change is scoped to the forget path only.

## Testing

Added unit tests for `is_tunnel_active()` covering the disconnected states (`Disconnected`, `Error`, `Offline { .. }`) returning `false` and a live state (`Disconnecting`) returning `true`.

Closes #5668

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5870)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account removal now works while offline.
  * Account and device data is cleared even if VPN disconnection times out.
  * VPN disconnection is tracked and completed gracefully before data removal when needed.

* **Bug Fixes**
  * Fixed offline account removal being incorrectly rejected.
  * Improved handling and reporting when device removal, disconnection, or local data cleanup fails.
  * Account removal now transitions cleanly to the logged-out state after successful cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->