### PR TITLE
VPN-4907: Reject SOCKS5 proxy non-excluded traffic if no VPN.

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ad-blocker and nym-socks5-proxy files are no longer stored in the network directory. (https://github.com/nymtech/nym-vpn-client/pull/5826)
 - Improve behavior of forwarding resolver by not sending empty response when hostname resolution fails. Instead simulate timeout to let clients retry more aggressively. (https://github.com/nymtech/nym-vpn-client/pull/5832)
+- When no VPN tunnel is active the geo-exclusion feature rejects non-excluded traffic. (https://github.com/nymtech/nym-vpn-client/pull/5872)
 
 
 ## [2026.11.0] - 2026-07-10

--- a/nym-vpn-core/crates/nym-socks5-proxy/src/proxy.rs
+++ b/nym-vpn-core/crates/nym-socks5-proxy/src/proxy.rs
@@ -304,6 +304,13 @@ async fn serve_socks5(
          default_interface={default_interface:?} tunnel_addrs={tunnel_addrs:?}"
     );
 
+    if routing_decision == RoutingDecision::Reject {
+        let _ = proto.reply_error(&ReplyError::NetworkUnreachable).await;
+        bail!(
+            "Refusing non-excluded {target_addr} (from {peer_addr}): no active VPN tunnel to carry it"
+        );
+    }
+
     let outbound = match connect_to_target(
         if routing_decision == RoutingDecision::DefaultInterface {
             Some(default_interface)

--- a/nym-vpn-core/crates/nym-socks5-proxy/src/routing/mod.rs
+++ b/nym-vpn-core/crates/nym-socks5-proxy/src/routing/mod.rs
@@ -25,6 +25,7 @@ use tokio::io::AsyncReadExt;
 pub enum RoutingDecision {
     VpnTunnelInterface,
     DefaultInterface,
+    Reject,
 }
 
 pub struct RoutingDatabase {
@@ -63,7 +64,7 @@ pub fn decide_route_for_addrs(
     if tunnel_can_reach_any {
         RoutingDecision::VpnTunnelInterface
     } else {
-        RoutingDecision::DefaultInterface
+        RoutingDecision::Reject
     }
 }
 

--- a/nym-vpn-core/crates/nym-socks5-proxy/src/routing/tests.rs
+++ b/nym-vpn-core/crates/nym-socks5-proxy/src/routing/tests.rs
@@ -193,8 +193,29 @@ fn ipv6_empty_set() {
 
 #[test]
 fn decide_route_no_tunnel() {
+    // With no tunnel active, non-excluded traffic must be rejected rather than
+    // leaked over the default interface (kill-switch behaviour).
     let db = GeoIpDatabase {
         excluded_countries: HashMap::new(),
+    };
+    assert_eq!(
+        decide_route_for_addrs(&sa("1.0.1.1"), &InterfaceAddresses::default(), &db),
+        RoutingDecision::Reject,
+    );
+}
+
+#[test]
+fn decide_route_no_tunnel_excluded_still_direct() {
+    // Excluded destinations continue to route directly even when no tunnel is
+    // active: they were always meant to bypass the VPN, so this leaks nothing new.
+    let mut countries = HashMap::new();
+    let set = CountryIpSet {
+        v4: make_v4_set(&["1.0.1.0/24"]),
+        v6: IpRange::new(),
+    };
+    countries.insert("CN".to_string(), set);
+    let db = GeoIpDatabase {
+        excluded_countries: countries,
     };
     assert_eq!(
         decide_route_for_addrs(&sa("1.0.1.1"), &InterfaceAddresses::default(), &db),
@@ -234,19 +255,21 @@ fn decide_route_excluded_country() {
 
 #[test]
 fn decide_route_no_tunnel_ipv6() {
-    // With no tunnel addresses at all, all traffic must use the default interface.
+    // With no tunnel addresses at all, non-excluded traffic must be rejected.
     let db = GeoIpDatabase {
         excluded_countries: HashMap::new(),
     };
     assert_eq!(
         decide_route_for_addrs(&sa("2001:db8::1"), &InterfaceAddresses::default(), &db),
-        RoutingDecision::DefaultInterface,
+        RoutingDecision::Reject,
     );
 }
 
 #[test]
 fn decide_route_ipv6_no_v6_tunnel() {
-    // Tunnel has only an IPv4 address — IPv6 destinations must use default interface.
+    // Tunnel has only an IPv4 address — non-excluded IPv6 destinations cannot be
+    // carried by the tunnel and must be rejected, not leaked over the default
+    // interface.
     let db = GeoIpDatabase {
         excluded_countries: HashMap::new(),
     };
@@ -256,7 +279,7 @@ fn decide_route_ipv6_no_v6_tunnel() {
     };
     assert_eq!(
         decide_route_for_addrs(&sa("2606:4700::1"), &tunnel_addrs, &db),
-        RoutingDecision::DefaultInterface,
+        RoutingDecision::Reject,
     );
     // IPv4 destinations can still use the tunnel.
     assert_eq!(


### PR DESCRIPTION

## Ticket

JIRA-VPN-4907

## Description

If there is no tunnel then the `nym-socks5-proxy` should reject non-excluded traffic instead of routing it through the default interface.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5872)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced kill-switch behavior: when no VPN tunnel is active, traffic to non-excluded destinations is now blocked instead of using the default direct route.
  * Requests are explicitly refused with a “network unreachable” style response, avoiding any attempt to connect outbound.
  * Corrected IPv4/IPv6 handling when no suitable tunnel addresses are available.

* **Tests**
  * Updated routing tests to validate the new reject/geo-exclusion behavior across IPv4 and IPv6.

* **Documentation**
  * Added an Unreleased changelog entry describing the geo-exclusion behavior when no tunnel is active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->