### PR TITLE
Cherry pick: Check kernel version for older android configuration

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [iOS] Skip ad-blocking rules that do not block by domain (https://github.com/nymtech/nym-vpn-client/pull/5658)
 - [iOS] Handle sub-domain blocking (https://github.com/nymtech/nym-vpn-client/pull/5810)
 - [macOS] Skip catch-all NAT masquerade when split tunneling is active (macOS >=14.6, <15.1 only). (https://github.com/nymtech/nym-vpn-client/pull/5569)
+- [Android] Fix old Android devices failing to bind for metadata endpoint (https://github.com/nymtech/nym-vpn-client/pull/5878)
 
 ### Removed
 

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -7531,11 +7531,13 @@ dependencies = [
 name = "nym-wg-metadata-client"
 version = "2026.12.0-beta.1"
 dependencies = [
+ "nix 0.31.3",
  "nym-credentials-interface",
  "nym-gateway-directory",
  "nym-http-api-client",
  "nym-wireguard-private-metadata-client",
  "nym-wireguard-private-metadata-shared",
+ "semver",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/nym-vpn-core/crates/nym-wg-metadata-client/Cargo.toml
+++ b/nym-vpn-core/crates/nym-wg-metadata-client/Cargo.toml
@@ -12,11 +12,13 @@ license.workspace = true
 workspace = true
 
 [dependencies]
+nix.workspace = true
 nym-credentials-interface.workspace = true
 nym-gateway-directory.workspace = true
 nym-http-api-client.workspace = true
 nym-wireguard-private-metadata-client = { workspace = true }
 nym-wireguard-private-metadata-shared = { workspace = true }
+semver.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/nym-vpn-core/crates/nym-wg-metadata-client/src/lib.rs
+++ b/nym-vpn-core/crates/nym-wg-metadata-client/src/lib.rs
@@ -41,6 +41,23 @@ struct LazyMetadataClient {
     version: Version,
 }
 
+#[cfg(target_os = "android")]
+// Kernel after version 5.7 supports binding without root or `CAP_NET_RAW` capability
+// Linux is already ran as root so the version only needs to be > 2.0.30 (released in 1997)
+// so we don't check for that
+fn kernel_supports_interface_binding() -> bool {
+    let Ok(uts_name) = nix::sys::utsname::uname() else {
+        return false;
+    };
+    let Some(release_str) = uts_name.release().to_str() else {
+        return false;
+    };
+    let Ok(version) = semver::Version::parse(release_str) else {
+        return false;
+    };
+    version >= semver::Version::new(5, 7, 0)
+}
+
 impl LazyMetadataClient {
     async fn new(
         mut base_url: Url,
@@ -53,8 +70,14 @@ impl LazyMetadataClient {
         let reqwest_builder = ReqwestClientBuilder::new();
         let reqwest_builder = match sent_data.data_type {
             TunUpSendDataType::InterfaceName(interface) => {
-                #[cfg(any(target_os = "linux", target_os = "ios", target_os = "android"))]
+                #[cfg(any(target_os = "linux", target_os = "ios"))]
                 let reqwest_builder = reqwest_builder.interface(&interface);
+                #[cfg(target_os = "android")]
+                let reqwest_builder = if kernel_supports_interface_binding() {
+                    reqwest_builder.interface(&interface)
+                } else {
+                    reqwest_builder
+                };
 
                 interface_name = Some(interface.clone());
                 reqwest_builder.local_address(bind_ip)


### PR DESCRIPTION
## Ticket

JIRA-NYM-1702

## Description


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5878)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an Android issue where older devices could fail to connect to the metadata endpoint.
  * Improved compatibility by adapting network interface binding to the device’s kernel capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->