### PR TITLE
NYM-1703: Infer device time from VPN API Date header.

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
@@ -44,6 +44,17 @@ pub(crate) const DEVICE_AUTHORIZATION_HEADER: &str = "x-device-authorization";
 // GET requests can unfortunately take a long time over the mixnet
 pub(crate) const NYM_VPN_API_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Whether a request that failed with a JWT error should be retried after
+/// synchronizing with the remote time.
+#[derive(Clone, Copy, Debug)]
+enum RemoteTimeRetry {
+    /// Synchronization succeeded: retry the request, using the remote time
+    /// override, or the local time when `None` (clocks are aligned).
+    Retry(Option<VpnApiTime>),
+    /// The remote time could not be determined: keep the original error.
+    GiveUp,
+}
+
 #[derive(Clone, Debug)]
 pub struct VpnApiClient {
     inner: Client,
@@ -122,7 +133,7 @@ impl VpnApiClient {
         headers: &HeaderMap,
         time_before: OffsetDateTime,
         time_after: OffsetDateTime,
-    ) -> Option<VpnApiTime> {
+    ) -> RemoteTimeRetry {
         if let Some(remote_timestamp) = parse_date_header(headers) {
             match self
                 .skew_manager
@@ -130,7 +141,7 @@ impl VpnApiClient {
                 .await
                 .sync_with_response_timestamp(time_before, remote_timestamp, time_after)
             {
-                Ok(jwt) => return jwt,
+                Ok(jwt) => return RemoteTimeRetry::Retry(jwt),
                 Err(err) => {
                     tracing::warn!(
                         "Failed to derive remote time from Date header: {err}. Falling back to fetching remote time"
@@ -143,16 +154,19 @@ impl VpnApiClient {
             );
         }
 
-        self.skew_manager
+        match self
+            .skew_manager
             .write()
             .await
             .sync_with_remote_time()
             .await
-            .inspect_err(|err| {
-                tracing::error!("Failed to get remote time: {err}. Not retrying anymore")
-            })
-            .ok()
-            .flatten()
+        {
+            Ok(jwt) => RemoteTimeRetry::Retry(jwt),
+            Err(err) => {
+                tracing::error!("Failed to get remote time: {err}. Not retrying anymore");
+                RemoteTimeRetry::GiveUp
+            }
+        }
     }
 
     async fn get_query<T>(
@@ -215,13 +229,14 @@ impl VpnApiClient {
                     tracing::warn!(
                         "Encountered possible JWT error: {error}. Retrying query with remote time"
                     );
-                    if let Some(jwt) = self
+                    if let RemoteTimeRetry::Retry(jwt) = self
                         .remote_time_for_retry(headers, time_before, time_after)
                         .await
                     {
-                        // retry with remote vpn api time, and return that only if it succeeds,
-                        // otherwise return the initial error
-                        let res = self.get_query(path, account, device, Some(jwt)).await;
+                        // retry with the freshly synchronized time (remote override, or local
+                        // time when the clocks are aligned), and return the result only if it
+                        // succeeds, otherwise return the initial error
+                        let res = self.get_query(path, account, device, jwt).await;
                         if res.is_ok() {
                             return res;
                         }
@@ -401,15 +416,14 @@ impl VpnApiClient {
                     tracing::warn!(
                         "Encountered possible JWT error: {error}. Retrying query with remote time"
                     );
-                    if let Some(jwt) = self
+                    if let RemoteTimeRetry::Retry(jwt) = self
                         .remote_time_for_retry(headers, time_before, time_after)
                         .await
                     {
-                        // retry with remote vpn api time, and return that only if it succeeds,
-                        // otherwise return the initial error
-                        let res = self
-                            .post_query(path, json_body, account, device, Some(jwt))
-                            .await;
+                        // retry with the freshly synchronized time (remote override, or local
+                        // time when the clocks are aligned), and return the result only if it
+                        // succeeds, otherwise return the initial error
+                        let res = self.post_query(path, json_body, account, device, jwt).await;
                         if res.is_ok() {
                             return res;
                         }
@@ -455,8 +469,22 @@ impl VpnApiClient {
     where
         T: DeserializeOwned,
     {
+        let jwt = self
+            .skew_manager
+            .write()
+            .await
+            .current_remote_time()
+            .await
+            .unwrap_or_else(|err| {
+                tracing::debug!(
+                    error = %err,
+                    "Failed to determine cached remote time"
+                );
+                None
+            });
+
         let time_before = self.device_time().await;
-        match self.delete_query::<T>(path, account, device, None).await {
+        match self.delete_query::<T>(path, account, device, jwt).await {
             Ok(response) => Ok(response),
             Err(err) => {
                 let time_after = self.device_time().await;
@@ -466,13 +494,14 @@ impl VpnApiClient {
                     tracing::warn!(
                         "Encountered possible JWT error: {error}. Retrying query with remote time"
                     );
-                    if let Some(jwt) = self
+                    if let RemoteTimeRetry::Retry(jwt) = self
                         .remote_time_for_retry(headers, time_before, time_after)
                         .await
                     {
-                        // retry with remote vpn api time, and return that only if it succeeds,
-                        // otherwise return the initial error
-                        let res = self.delete_query(path, account, device, Some(jwt)).await;
+                        // retry with the freshly synchronized time (remote override, or local
+                        // time when the clocks are aligned), and return the result only if it
+                        // succeeds, otherwise return the initial error
+                        let res = self.delete_query(path, account, device, jwt).await;
                         if res.is_ok() {
                             return res;
                         }
@@ -522,9 +551,23 @@ impl VpnApiClient {
         T: DeserializeOwned,
         B: Serialize,
     {
+        let jwt = self
+            .skew_manager
+            .write()
+            .await
+            .current_remote_time()
+            .await
+            .unwrap_or_else(|err| {
+                tracing::debug!(
+                    error = %err,
+                    "Failed to determine cached remote time"
+                );
+                None
+            });
+
         let time_before = self.device_time().await;
         match self
-            .patch_query::<T, B>(path, json_body, account, device, None)
+            .patch_query::<T, B>(path, json_body, account, device, jwt)
             .await
         {
             Ok(response) => Ok(response),
@@ -536,14 +579,15 @@ impl VpnApiClient {
                     tracing::warn!(
                         "Encountered possible JWT error: {error}. Retrying query with remote time"
                     );
-                    if let Some(jwt) = self
+                    if let RemoteTimeRetry::Retry(jwt) = self
                         .remote_time_for_retry(headers, time_before, time_after)
                         .await
                     {
-                        // retry with remote vpn api time, and return that only if it succeeds,
-                        // otherwise return the initial error
+                        // retry with the freshly synchronized time (remote override, or local
+                        // time when the clocks are aligned), and return the result only if it
+                        // succeeds, otherwise return the initial error
                         let res = self
-                            .patch_query(path, json_body, account, device, Some(jwt))
+                            .patch_query(path, json_body, account, device, jwt)
                             .await;
                         if res.is_ok() {
                             return res;
@@ -1524,10 +1568,12 @@ mod tests {
         // Remote time is 2 hours behind the device time
         let headers = headers_with_date("Thu, 16 Jul 2026 10:00:00 GMT");
 
-        let jwt = client
+        let RemoteTimeRetry::Retry(Some(jwt)) = client
             .remote_time_for_retry(&headers, device_time(), device_time())
             .await
-            .expect("skew is significant, expected remote time override");
+        else {
+            panic!("skew is significant, expected retry with remote time override");
+        };
 
         assert_eq!(remote_calls.load(Ordering::SeqCst), 0);
         assert_eq!(jwt.local_time_ahead_skew().whole_hours(), 2);
@@ -1546,16 +1592,56 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn date_header_negligible_skew_returns_no_override() {
+    async fn date_header_negligible_skew_retries_with_local_time() {
         let (client, remote_calls) = test_client(device_time());
         // Remote time is only 30 seconds ahead of the device time: below the threshold
         let headers = headers_with_date("Thu, 16 Jul 2026 12:00:30 GMT");
 
-        let jwt = client
+        let retry = client
             .remote_time_for_retry(&headers, device_time(), device_time())
             .await;
 
-        assert!(jwt.is_none());
+        assert!(matches!(retry, RemoteTimeRetry::Retry(None)));
+        assert_eq!(remote_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn aligned_date_header_corrects_stale_cached_skew_and_retries() {
+        let (client, remote_calls) = test_client(device_time());
+
+        // Seed the cache with a stale skew: the device clock used to be 2 hours ahead
+        client
+            .skew_manager
+            .write()
+            .await
+            .sync_with_response_timestamp(
+                device_time(),
+                device_time() - Duration::from_hours(2),
+                device_time(),
+            )
+            .unwrap()
+            .expect("seeded skew is significant");
+
+        // The failing request's Date header shows the clocks are now aligned
+        let headers = headers_with_date("Thu, 16 Jul 2026 12:00:00 GMT");
+        let retry = client
+            .remote_time_for_retry(&headers, device_time(), device_time())
+            .await;
+
+        // Synchronization succeeded, so the request must still be retried, now
+        // with local time since the clocks are aligned
+        assert!(matches!(retry, RemoteTimeRetry::Retry(None)));
+        assert_eq!(remote_calls.load(Ordering::SeqCst), 0);
+
+        // The stale cached skew was replaced: no override and no network request
+        let cached = client
+            .skew_manager
+            .write()
+            .await
+            .current_remote_time()
+            .await
+            .unwrap();
+        assert!(cached.is_none());
         assert_eq!(remote_calls.load(Ordering::SeqCst), 0);
     }
 
@@ -1563,10 +1649,12 @@ mod tests {
     async fn missing_date_header_falls_back_to_remote_time_request() {
         let (client, remote_calls) = test_client(device_time() - Duration::from_hours(2));
 
-        let jwt = client
+        let RemoteTimeRetry::Retry(Some(jwt)) = client
             .remote_time_for_retry(&HeaderMap::new(), device_time(), device_time())
             .await
-            .expect("skew is significant, expected remote time override");
+        else {
+            panic!("skew is significant, expected retry with remote time override");
+        };
 
         assert_eq!(remote_calls.load(Ordering::SeqCst), 1);
         assert_eq!(jwt.local_time_ahead_skew().whole_hours(), 2);
@@ -1577,10 +1665,12 @@ mod tests {
         let (client, remote_calls) = test_client(device_time() - Duration::from_hours(2));
         let headers = headers_with_date("not a date");
 
-        let jwt = client
+        let RemoteTimeRetry::Retry(Some(jwt)) = client
             .remote_time_for_retry(&headers, device_time(), device_time())
             .await
-            .expect("skew is significant, expected remote time override");
+        else {
+            panic!("skew is significant, expected retry with remote time override");
+        };
 
         assert_eq!(remote_calls.load(Ordering::SeqCst), 1);
         assert_eq!(jwt.local_time_ahead_skew().whole_hours(), 2);
@@ -1593,14 +1683,16 @@ mod tests {
 
         // The request appears to have finished before it started, so the Date header
         // cannot be trusted
-        let jwt = client
+        let RemoteTimeRetry::Retry(Some(jwt)) = client
             .remote_time_for_retry(
                 &headers,
                 device_time(),
                 device_time() - Duration::from_secs(1),
             )
             .await
-            .expect("skew is significant, expected remote time override");
+        else {
+            panic!("skew is significant, expected retry with remote time override");
+        };
 
         assert_eq!(remote_calls.load(Ordering::SeqCst), 1);
         assert_eq!(jwt.local_time_ahead_skew().whole_hours(), 2);

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
@@ -7,9 +7,10 @@ use backon::Retryable;
 use nym_credential_proxy_requests::api::v1::ticketbook::models::PartialVerificationKeysResponse;
 use nym_http_api_client::{
     ApiClient, Client, HttpClientError, NO_PARAMS, Params, PathSegments, Url, UserAgent,
+    reqwest::header::{DATE, HeaderMap},
 };
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
-use time::OffsetDateTime;
+use time::{OffsetDateTime, format_description::well_known::Rfc2822};
 use tokio::sync::RwLock;
 
 use crate::{
@@ -112,6 +113,48 @@ impl VpnApiClient {
         self.skew_manager.write().await.get_remote_time().await
     }
 
+    async fn device_time(&self) -> OffsetDateTime {
+        self.skew_manager.read().await.device_time()
+    }
+
+    async fn remote_time_for_retry(
+        &self,
+        headers: &HeaderMap,
+        time_before: OffsetDateTime,
+        time_after: OffsetDateTime,
+    ) -> Option<VpnApiTime> {
+        if let Some(remote_timestamp) = parse_date_header(headers) {
+            match self
+                .skew_manager
+                .write()
+                .await
+                .sync_with_response_timestamp(time_before, remote_timestamp, time_after)
+            {
+                Ok(jwt) => return jwt,
+                Err(err) => {
+                    tracing::warn!(
+                        "Failed to derive remote time from Date header: {err}. Falling back to fetching remote time"
+                    );
+                }
+            }
+        } else {
+            tracing::debug!(
+                "Response has no usable Date header, falling back to fetching remote time"
+            );
+        }
+
+        self.skew_manager
+            .write()
+            .await
+            .sync_with_remote_time()
+            .await
+            .inspect_err(|err| {
+                tracing::error!("Failed to get remote time: {err}. Not retrying anymore")
+            })
+            .ok()
+            .flatten()
+    }
+
     async fn get_query<T>(
         &self,
         path: PathSegments<'_>,
@@ -161,24 +204,20 @@ impl VpnApiClient {
                 None
             });
 
+        let time_before = self.device_time().await;
         match self.get_query::<T>(path, account, device, jwt).await {
             Ok(response) => Ok(response),
             Err(err) => {
-                if let HttpClientError::EndpointFailure { error, .. } = &err
+                let time_after = self.device_time().await;
+                if let HttpClientError::EndpointFailure { error, headers, .. } = &err
                     && jwt_error(&error.to_string())
                 {
                     tracing::warn!(
                         "Encountered possible JWT error: {error}. Retrying query with remote time"
                     );
-                    if let Ok(Some(jwt)) = self
-                        .skew_manager
-                        .write()
+                    if let Some(jwt) = self
+                        .remote_time_for_retry(headers, time_before, time_after)
                         .await
-                        .sync_with_remote_time()
-                        .await
-                        .inspect_err(|err| {
-                            tracing::error!("Failed to get remote time: {err}. Not retring anymore")
-                        })
                     {
                         // retry with remote vpn api time, and return that only if it succeeds,
                         // otherwise return the initial error
@@ -348,29 +387,23 @@ impl VpnApiClient {
                 None
             });
 
+        let time_before = self.device_time().await;
         match self
             .post_query::<T, B>(path, json_body, account, device, jwt)
             .await
         {
             Ok(response) => Ok(response),
             Err(err) => {
-                if let HttpClientError::EndpointFailure { error, .. } = &err
+                let time_after = self.device_time().await;
+                if let HttpClientError::EndpointFailure { error, headers, .. } = &err
                     && jwt_error(&error.to_string())
                 {
                     tracing::warn!(
                         "Encountered possible JWT error: {error}. Retrying query with remote time"
                     );
-                    if let Ok(Some(jwt)) = self
-                        .skew_manager
-                        .write()
+                    if let Some(jwt) = self
+                        .remote_time_for_retry(headers, time_before, time_after)
                         .await
-                        .sync_with_remote_time()
-                        .await
-                        .inspect_err(|err| {
-                            tracing::error!(
-                                "Failed to get remote time: {err}. Not retrying anymore"
-                            )
-                        })
                     {
                         // retry with remote vpn api time, and return that only if it succeeds,
                         // otherwise return the initial error
@@ -422,24 +455,20 @@ impl VpnApiClient {
     where
         T: DeserializeOwned,
     {
+        let time_before = self.device_time().await;
         match self.delete_query::<T>(path, account, device, None).await {
             Ok(response) => Ok(response),
             Err(err) => {
-                if let HttpClientError::EndpointFailure { error, .. } = &err
+                let time_after = self.device_time().await;
+                if let HttpClientError::EndpointFailure { error, headers, .. } = &err
                     && jwt_error(&error.to_string())
                 {
                     tracing::warn!(
                         "Encountered possible JWT error: {error}. Retrying query with remote time"
                     );
-                    if let Ok(Some(jwt)) = self
-                        .skew_manager
-                        .write()
+                    if let Some(jwt) = self
+                        .remote_time_for_retry(headers, time_before, time_after)
                         .await
-                        .sync_with_remote_time()
-                        .await
-                        .inspect_err(|err| {
-                            tracing::error!("Failed to get remote time: {err}. Not retring anymore")
-                        })
                     {
                         // retry with remote vpn api time, and return that only if it succeeds,
                         // otherwise return the initial error
@@ -493,27 +522,23 @@ impl VpnApiClient {
         T: DeserializeOwned,
         B: Serialize,
     {
+        let time_before = self.device_time().await;
         match self
             .patch_query::<T, B>(path, json_body, account, device, None)
             .await
         {
             Ok(response) => Ok(response),
             Err(err) => {
-                if let HttpClientError::EndpointFailure { error, .. } = &err
+                let time_after = self.device_time().await;
+                if let HttpClientError::EndpointFailure { error, headers, .. } = &err
                     && jwt_error(&error.to_string())
                 {
                     tracing::warn!(
                         "Encountered possible JWT error: {error}. Retrying query with remote time"
                     );
-                    if let Ok(Some(jwt)) = self
-                        .skew_manager
-                        .write()
+                    if let Some(jwt) = self
+                        .remote_time_for_retry(headers, time_before, time_after)
                         .await
-                        .sync_with_remote_time()
-                        .await
-                        .inspect_err(|err| {
-                            tracing::error!("Failed to get remote time: {err}. Not retring anymore")
-                        })
                     {
                         // retry with remote vpn api time, and return that only if it succeeds,
                         // otherwise return the initial error
@@ -1377,6 +1402,16 @@ fn jwt_error(error: &str) -> bool {
     error.to_lowercase().contains("jwt")
 }
 
+// Extracts the remote timestamp from the `Date` header of a response. The header is formatted
+// as an RFC 7231 IMF-fixdate (e.g. "Sun, 06 Nov 1994 08:49:37 GMT"), which is a valid RFC 2822
+// date.
+fn parse_date_header(headers: &HeaderMap) -> Option<OffsetDateTime> {
+    let date = headers.get(DATE)?.to_str().ok()?;
+    OffsetDateTime::parse(date, &Rfc2822)
+        .inspect_err(|err| tracing::debug!("Failed to parse Date header '{date}': {err}"))
+        .ok()
+}
+
 #[derive(Debug)]
 struct VpnApiRemoteTimeProvider {
     inner: Client,
@@ -1399,5 +1434,175 @@ impl RemoteTimeProvider for VpnApiRemoteTimeProvider {
             .map_err(VpnApiClientError::GetHealth)?;
 
         Ok(res.timestamp_utc)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use nym_http_api_client::reqwest::header::HeaderValue;
+
+    use super::*;
+    use crate::skew_manager::DeviceTimeProvider;
+
+    // Thu, 16 Jul 2026 12:00:00 UTC
+    fn device_time() -> OffsetDateTime {
+        OffsetDateTime::from_unix_timestamp(1_784_203_200).unwrap()
+    }
+
+    #[derive(Debug)]
+    struct FixedDeviceTimeProvider;
+
+    impl DeviceTimeProvider for FixedDeviceTimeProvider {
+        fn device_time(&self) -> OffsetDateTime {
+            device_time()
+        }
+    }
+
+    #[derive(Debug)]
+    struct CountingRemoteTimeProvider {
+        calls: Arc<AtomicUsize>,
+        remote_time: OffsetDateTime,
+    }
+
+    #[async_trait::async_trait]
+    impl RemoteTimeProvider for CountingRemoteTimeProvider {
+        async fn request_remote_time(&self) -> Result<OffsetDateTime> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(self.remote_time)
+        }
+    }
+
+    // Returns a client that never makes real network requests: the device clock is fixed and
+    // remote time requests are counted and answered with `remote_time`.
+    fn test_client(remote_time: OffsetDateTime) -> (VpnApiClient, Arc<AtomicUsize>) {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let remote_time_provider = CountingRemoteTimeProvider {
+            calls: calls.clone(),
+            remote_time,
+        };
+        let skew_manager =
+            SkewManager::new_for_testing(FixedDeviceTimeProvider, remote_time_provider);
+        let inner = fronted_http_client(
+            vec![Url::new("https://nymvpn.test/api/", None).unwrap()],
+            None,
+            Some(NYM_VPN_API_TIMEOUT),
+        )
+        .unwrap();
+        (
+            VpnApiClient {
+                inner,
+                skew_manager: Arc::new(RwLock::new(skew_manager)),
+            },
+            calls,
+        )
+    }
+
+    fn headers_with_date(date: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(DATE, HeaderValue::from_str(date).unwrap());
+        headers
+    }
+
+    #[test]
+    fn parse_date_header_accepts_imf_fixdate() {
+        let headers = headers_with_date("Sun, 06 Nov 1994 08:49:37 GMT");
+        let parsed = parse_date_header(&headers).expect("valid IMF-fixdate");
+        assert_eq!(parsed.unix_timestamp(), 784_111_777);
+    }
+
+    #[test]
+    fn parse_date_header_rejects_garbage() {
+        assert!(parse_date_header(&headers_with_date("not a date")).is_none());
+        assert!(parse_date_header(&HeaderMap::new()).is_none());
+    }
+
+    #[tokio::test]
+    async fn date_header_skew_avoids_remote_time_request() {
+        let (client, remote_calls) = test_client(device_time());
+        // Remote time is 2 hours behind the device time
+        let headers = headers_with_date("Thu, 16 Jul 2026 10:00:00 GMT");
+
+        let jwt = client
+            .remote_time_for_retry(&headers, device_time(), device_time())
+            .await
+            .expect("skew is significant, expected remote time override");
+
+        assert_eq!(remote_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(jwt.local_time_ahead_skew().whole_hours(), 2);
+
+        // The derived skew is cached and reused without any network request
+        let cached = client
+            .skew_manager
+            .write()
+            .await
+            .current_remote_time()
+            .await
+            .unwrap()
+            .expect("cached skew is significant");
+        assert_eq!(remote_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(cached.local_time_ahead_skew().whole_hours(), 2);
+    }
+
+    #[tokio::test]
+    async fn date_header_negligible_skew_returns_no_override() {
+        let (client, remote_calls) = test_client(device_time());
+        // Remote time is only 30 seconds ahead of the device time: below the threshold
+        let headers = headers_with_date("Thu, 16 Jul 2026 12:00:30 GMT");
+
+        let jwt = client
+            .remote_time_for_retry(&headers, device_time(), device_time())
+            .await;
+
+        assert!(jwt.is_none());
+        assert_eq!(remote_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn missing_date_header_falls_back_to_remote_time_request() {
+        let (client, remote_calls) = test_client(device_time() - Duration::from_hours(2));
+
+        let jwt = client
+            .remote_time_for_retry(&HeaderMap::new(), device_time(), device_time())
+            .await
+            .expect("skew is significant, expected remote time override");
+
+        assert_eq!(remote_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(jwt.local_time_ahead_skew().whole_hours(), 2);
+    }
+
+    #[tokio::test]
+    async fn malformed_date_header_falls_back_to_remote_time_request() {
+        let (client, remote_calls) = test_client(device_time() - Duration::from_hours(2));
+        let headers = headers_with_date("not a date");
+
+        let jwt = client
+            .remote_time_for_retry(&headers, device_time(), device_time())
+            .await
+            .expect("skew is significant, expected remote time override");
+
+        assert_eq!(remote_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(jwt.local_time_ahead_skew().whole_hours(), 2);
+    }
+
+    #[tokio::test]
+    async fn untrustworthy_request_time_falls_back_to_remote_time_request() {
+        let (client, remote_calls) = test_client(device_time() - Duration::from_hours(2));
+        let headers = headers_with_date("Thu, 16 Jul 2026 10:00:00 GMT");
+
+        // The request appears to have finished before it started, so the Date header
+        // cannot be trusted
+        let jwt = client
+            .remote_time_for_retry(
+                &headers,
+                device_time(),
+                device_time() - Duration::from_secs(1),
+            )
+            .await
+            .expect("skew is significant, expected remote time override");
+
+        assert_eq!(remote_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(jwt.local_time_ahead_skew().whole_hours(), 2);
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/skew_manager.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/skew_manager.rs
@@ -81,7 +81,7 @@ impl SkewManager {
         let cached_remote_time = match status {
             Some(SkewStatus::Valid(skew)) => {
                 tracing::debug!("Valid VPN API time skew");
-                let local_time = self.now();
+                let local_time = self.device_time();
                 let estimated_remote_time = local_time - skew;
 
                 VpnApiTime::from_estimated_remote_time(local_time, estimated_remote_time)
@@ -110,14 +110,43 @@ impl SkewManager {
         }
     }
 
+    pub fn sync_with_response_timestamp(
+        &mut self,
+        time_before: OffsetDateTime,
+        remote_timestamp: OffsetDateTime,
+        time_after: OffsetDateTime,
+    ) -> Result<Option<VpnApiTime>> {
+        let request_time = time_after - time_before;
+
+        // Detect sleep or time travel, in which case the timestamp cannot be trusted
+        if request_time.is_negative() {
+            tracing::warn!("Request time is negative. Time traveling?");
+            return Err(VpnApiClientError::TimeTravelTooMuch);
+        }
+        if request_time > NYM_VPN_API_TIMEOUT {
+            tracing::warn!("Request time exceeds the timeout. Device fell asleep?");
+            return Err(VpnApiClientError::TimeTravelTooMuch);
+        }
+
+        let remote_time =
+            VpnApiTime::from_remote_timestamp(time_before, remote_timestamp, time_after);
+        self.store_skew(remote_time);
+
+        if Self::use_remote_time(remote_time) {
+            Ok(Some(remote_time))
+        } else {
+            Ok(None)
+        }
+    }
+
     pub async fn get_remote_time(&mut self) -> Result<VpnApiTime> {
         let mut last_error: Option<VpnApiClientError> = None;
 
         for retry in 0..=REMOTE_TIME_MAX_RETRIES {
-            let time_before = self.now();
+            let time_before = self.device_time();
             match self.remote_time_provider.request_remote_time().await {
                 Ok(remote_timestamp) => {
-                    let time_after = self.now();
+                    let time_after = self.device_time();
                     let request_time = time_after - time_before;
 
                     // Detect sleep or time travel and retry the request
@@ -170,16 +199,21 @@ impl SkewManager {
 
     async fn refresh_skew(&mut self) -> Result<VpnApiTime> {
         let remote_time = self.get_remote_time().await?;
+        self.store_skew(remote_time);
+
+        Ok(remote_time)
+    }
+
+    fn store_skew(&mut self, remote_time: VpnApiTime) {
         let skew = remote_time.local_time_ahead_skew();
         let now = Instant::now();
 
         self.skew_state.replace(SkewState::new(skew, now));
         tracing::debug!(skew = ?skew, "Refreshed VPN API time skew");
-
-        Ok(remote_time)
     }
 
-    fn now(&self) -> OffsetDateTime {
+    /// Returns the current device time.
+    pub fn device_time(&self) -> OffsetDateTime {
         self.device_time_provider.device_time()
     }
 }
@@ -253,6 +287,72 @@ mod tests {
         ));
     }
 
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn test_sync_with_response_timestamp_updates_cache() {
+        let mut skew_manager = SkewManager::new_for_testing(
+            MockDeviceTimeProvider::new(vec![]),
+            PanickingTimeProvider,
+        );
+
+        let time_before = OffsetDateTime::now_utc();
+        let remote_timestamp = time_before - Duration::from_hours(2);
+        let time_after = time_before + Duration::from_secs(1);
+
+        let remote_time = skew_manager
+            .sync_with_response_timestamp(time_before, remote_timestamp, time_after)
+            .unwrap()
+            .expect("skew is significant");
+        assert_eq!(remote_time.local_time_ahead_skew().whole_hours(), 2);
+
+        // The derived skew is cached and reused without a remote time request
+        // (which would panic)
+        let cached = skew_manager
+            .current_remote_time()
+            .await
+            .unwrap()
+            .expect("cached skew is significant");
+        assert_eq!(cached.local_time_ahead_skew().whole_hours(), 2);
+    }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn test_sync_with_response_timestamp_negligible_skew() {
+        let mut skew_manager = SkewManager::new_for_testing(
+            MockDeviceTimeProvider::new(vec![]),
+            PanickingTimeProvider,
+        );
+
+        let time_before = OffsetDateTime::now_utc();
+        let remote_timestamp = time_before + Duration::from_secs(30);
+
+        let remote_time = skew_manager
+            .sync_with_response_timestamp(time_before, remote_timestamp, time_before)
+            .unwrap();
+        assert!(remote_time.is_none());
+
+        // The negligible skew is still cached: no remote time request is made
+        // (which would panic) and no override is returned
+        let cached = skew_manager.current_remote_time().await.unwrap();
+        assert!(cached.is_none());
+    }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn test_sync_with_response_timestamp_time_travel() {
+        let mut skew_manager = SkewManager::new_for_testing(
+            MockDeviceTimeProvider::new(vec![]),
+            PanickingTimeProvider,
+        );
+
+        let time_before = OffsetDateTime::now_utc();
+        let time_after = time_before - Duration::from_secs(1);
+
+        let result =
+            skew_manager.sync_with_response_timestamp(time_before, time_before, time_after);
+        assert!(matches!(result, Err(VpnApiClientError::TimeTravelTooMuch)));
+    }
+
     #[derive(Debug)]
     struct MockTimeProvider;
 
@@ -260,6 +360,16 @@ mod tests {
     impl RemoteTimeProvider for MockTimeProvider {
         async fn request_remote_time(&self) -> Result<OffsetDateTime> {
             Ok(OffsetDateTime::now_utc())
+        }
+    }
+
+    #[derive(Debug)]
+    struct PanickingTimeProvider;
+
+    #[async_trait::async_trait]
+    impl RemoteTimeProvider for PanickingTimeProvider {
+        async fn request_remote_time(&self) -> Result<OffsetDateTime> {
+            panic!("remote time must not be requested");
         }
     }
 


### PR DESCRIPTION
## Ticket

JIRA-NYM-1703

## Description

Use the Date header from the VPN API HTTP Response to keep local device time.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5880)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of authentication request retries when device and server clocks are out of sync.
  * Derives retry timing from server `Date` response headers when available, and synchronizes skew accordingly.
  * Added safer parsing and fallback behavior for missing, malformed, or untrustworthy timestamps.
  * Improved reliability of authorized GET, POST, PATCH, and DELETE requests during JWT-related failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->