### PR TITLE
[BandwidthController] Rename vpn bandwidth controller into bandwidth monitor

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_monitor.rs
@@ -359,20 +359,20 @@ impl TemporaryBandwidthClient {
                     .unwrap_or(false)
             {
                 tracing::debug!(
-                    "Using latest metadata client for {}'s bandwidth controller",
+                    "Using latest metadata client for {}'s bandwidth monitor",
                     gateway.identity()
                 );
                 TemporaryBandwidthClient::Latest(Box::new(metadata_client))
             } else {
                 tracing::debug!(
-                    "Using deprecated mixnet client for {}'s bandwidth controller",
+                    "Using deprecated mixnet client for {}'s bandwidth monitor",
                     gateway.identity()
                 );
                 TemporaryBandwidthClient::Deprecated(Box::new(auth_client))
             }
         } else {
             tracing::debug!(
-                "No authenticator client provided, using latest metadata client for {}'s bandwidth controller",
+                "No authenticator client provided, using latest metadata client for {}'s bandwidth monitor",
                 gateway.identity()
             );
             TemporaryBandwidthClient::Latest(Box::new(metadata_client))

--- a/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_monitor.rs
@@ -608,7 +608,7 @@ impl<N: NetworkInterfaceStats> SystemBandwidthMonitor<N> {
     }
 }
 
-pub(crate) struct BandwidthController {
+pub(crate) struct BandwidthMonitor {
     ticket_provider: Box<dyn BandwidthTicketProvider>,
     wg_entry_gateway_client: TemporaryBandwidthClient,
     wg_exit_gateway_client: TemporaryBandwidthClient,
@@ -624,7 +624,7 @@ pub(crate) struct BandwidthController {
     metadata_path_health: Option<MetadataPathHealth>,
 }
 
-impl BandwidthController {
+impl BandwidthMonitor {
     pub fn new(
         ticket_provider: Box<dyn BandwidthTicketProvider>,
         wg_entry_gateway_client: TemporaryBandwidthClient,
@@ -636,7 +636,7 @@ impl BandwidthController {
         let timeout_check_interval =
             IntervalStream::new(tokio::time::interval(DEFAULT_BANDWIDTH_CHECK));
 
-        BandwidthController {
+        BandwidthMonitor {
             ticket_provider,
             wg_entry_gateway_client,
             wg_exit_gateway_client,
@@ -743,7 +743,7 @@ impl BandwidthController {
         gateway_metadata_update_version: Option<semver::Version>,
         cancel_token: CancellationToken,
         metadata_path_health: MetadataPathHealth,
-    ) -> BandwidthController {
+    ) -> BandwidthMonitor {
         let wg_entry_client = Self::construct_bandwidth_client(
             entry_wireguard_config.private_ipv4.into(),
             entry_signal_channel,
@@ -993,7 +993,7 @@ impl BandwidthController {
         };
         tokio::select! {
             _ = self.shutdown_token.cancelled() => {
-                tracing::trace!("BandwidthController: Received shutdown");
+                tracing::trace!("BandwidthMonitor: Received shutdown");
             }
             ret = bw_client.query_bandwidth_with_retries(DEFAULT_CLIENT_RETRIES) => {
                 return match ret {
@@ -1033,7 +1033,7 @@ impl BandwidthController {
             // OS file handles promptly (especially important on Windows).
             self.ticket_provider.close().await;
 
-            tracing::debug!("BandwidthController: Exiting");
+            tracing::debug!("BandwidthMonitor: Exiting");
             return;
         }
 
@@ -1048,7 +1048,7 @@ impl BandwidthController {
         while !self.shutdown_token.is_cancelled() {
             tokio::select! {
                 _ = self.shutdown_token.cancelled() => {
-                    tracing::trace!("BandwidthController: Received shutdown");
+                    tracing::trace!("BandwidthMonitor: Received shutdown");
                     break;
                 }
                 _ = system_bandwidth_check_interval.next() => {
@@ -1094,7 +1094,7 @@ impl BandwidthController {
         // OS file handles promptly (especially important on Windows).
         self.ticket_provider.close().await;
 
-        tracing::debug!("BandwidthController: Exiting");
+        tracing::debug!("BandwidthMonitor: Exiting");
     }
 }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/lib.rs
@@ -5,7 +5,7 @@ pub mod paths;
 pub mod storage;
 
 mod adblocker;
-mod bandwidth_controller;
+mod bandwidth_monitor;
 pub mod cache_refresh;
 pub mod config;
 mod dns_filter;

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -41,7 +41,7 @@ use crate::socks5_proxy::Socks5ProxyManager;
 use crate::socks5_proxy::find_proxy_binary;
 
 use crate::{
-    GatewayProviderError, UserAgent, bandwidth_controller::Error as BandwidthControllerError,
+    GatewayProviderError, UserAgent, bandwidth_monitor::Error as BandwidthMonitorError,
     mixnet::VpnTopologyServiceHandle,
     tunnel_state_machine::tunnel::gateway_provider::GatewayProvider,
 };
@@ -1496,14 +1496,14 @@ impl tunnel::Error {
                 }
                 _ => None,
             },
-            Self::BandwidthController(BandwidthControllerError::EntryGateway(error)) => {
+            Self::BandwidthMonitor(BandwidthMonitorError::EntryGateway(error)) => {
                 if error.is_no_retry() {
                     Some(ErrorStateReason::CredentialWastedOnEntryGateway)
                 } else {
                     None
                 }
             }
-            Self::BandwidthController(BandwidthControllerError::ExitGateway(error)) => {
+            Self::BandwidthMonitor(BandwidthMonitorError::ExitGateway(error)) => {
                 if error.is_no_retry() {
                     Some(ErrorStateReason::CredentialWastedOnExitGateway)
                 } else {
@@ -1524,7 +1524,7 @@ impl tunnel::Error {
             )),
             Self::NoIpAddressAnnounced { .. }
             | Self::MixnetClient(_)
-            | Self::BandwidthController(_)
+            | Self::BandwidthMonitor(_)
             | Self::Wireguard(_)
             | Self::Cancelled
             | Self::Transport(_) => None,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
@@ -29,7 +29,7 @@ pub enum Error {
     NoIpAddressAnnounced { gateway_id: String },
 
     #[error("bandwidth controller error")]
-    BandwidthController(#[from] crate::bandwidth_controller::Error),
+    BandwidthMonitor(#[from] crate::bandwidth_monitor::Error),
 
     #[error("registration client error")]
     RegistrationClient(#[source] Box<nym_registration_client::RegistrationClientError>),

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/mod.rs
@@ -28,7 +28,7 @@ pub enum Error {
     #[error("{} has no ip addresses announced", gateway_id)]
     NoIpAddressAnnounced { gateway_id: String },
 
-    #[error("bandwidth controller error")]
+    #[error("bandwidth monitor error")]
     BandwidthMonitor(#[from] crate::bandwidth_monitor::Error),
 
     #[error("registration client error")]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -741,7 +741,7 @@ impl TunnelMonitor {
             .fuse();
         tokio::pin!(metadata_endpoints_reachable);
 
-        // Send metadata endpoint data to the bandwidth controller
+        // Send metadata endpoint data to the bandwidth monitor
         match &tunnel_interface {
             TunnelInterface::One(exit) => {
                 let _metadata_event_handler = tokio::spawn(async move {
@@ -911,7 +911,7 @@ impl TunnelMonitor {
         // Shutdown WireGuard tunnel runtime
         if let Some(wg_tunnel_runtime) = wg_tunnel_runtime {
             if let Err(err) = wg_tunnel_runtime.bandwidth_monitor_handle.await {
-                tracing::error!("Failed to await bandwidth controller handle: {}", err);
+                tracing::error!("Failed to await bandwidth monitor handle: {}", err);
             }
 
             if let Some(transport_fwd_handle) = wg_tunnel_runtime.transport_fwd_handle
@@ -1182,7 +1182,7 @@ impl TunnelMonitor {
             Some(handle) if bw.is_using_latest_client() => {
                 // We don't need the mixnet client anymore
                 tracing::info!(
-                    "Disconnecting mixnet client as we are using the latest bandwidth controller"
+                    "Disconnecting mixnet client as we are using the latest bandwidth monitor"
                 );
                 handle.stop().await;
                 None

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -81,7 +81,7 @@ use crate::tunnel_provider::AndroidTunProvider;
 use crate::tunnel_provider::OSTunProvider;
 use crate::{
     DEFAULT_MIN_GATEWAY_PERFORMANCE, DEFAULT_MIN_MIXNODE_PERFORMANCE, UserAgent,
-    bandwidth_controller::BandwidthController,
+    bandwidth_monitor::BandwidthMonitor,
     mixnet::VpnTopologyServiceHandle,
     tunnel_health::{METADATA_PATH_HEALTH_GRACE, MetadataPathHealth, should_defer_probe_teardown},
     tunnel_state_machine::{
@@ -910,7 +910,7 @@ impl TunnelMonitor {
 
         // Shutdown WireGuard tunnel runtime
         if let Some(wg_tunnel_runtime) = wg_tunnel_runtime {
-            if let Err(err) = wg_tunnel_runtime.bandwidth_controller_handle.await {
+            if let Err(err) = wg_tunnel_runtime.bandwidth_monitor_handle.await {
                 tracing::error!("Failed to await bandwidth controller handle: {}", err);
             }
 
@@ -1163,7 +1163,7 @@ impl TunnelMonitor {
 
         let metadata_path_health = MetadataPathHealth::new();
 
-        let bw = BandwidthController::create(
+        let bw = BandwidthMonitor::create(
             Box::new(self.bandwidth_command_tx.clone()),
             self.account_command_tx.clone(),
             selected_gateways,
@@ -1190,10 +1190,10 @@ impl TunnelMonitor {
             Some(handle) => Some(handle),
             None => None,
         };
-        let bandwidth_controller_handle = tokio::spawn(bw.run());
+        let bandwidth_monitor_handle = tokio::spawn(bw.run());
 
         let rt = WgTunnelRuntime {
-            bandwidth_controller_handle,
+            bandwidth_monitor_handle,
             transport_fwd_handle: None,
             authenticator_listener_handle,
             metadata_path_health,
@@ -2064,7 +2064,7 @@ struct StartTunnelResult {
 }
 
 struct WgTunnelRuntime {
-    bandwidth_controller_handle: JoinHandle<()>,
+    bandwidth_monitor_handle: JoinHandle<()>,
     transport_fwd_handle: Option<JoinHandle<()>>,
     authenticator_listener_handle: Option<AuthClientMixnetListenerHandle>,
     metadata_path_health: MetadataPathHealth,


### PR DESCRIPTION
## Ticket
To avoid confusion with ongoing BC work, and make the future PR easier to review, rename the VPN BandwidthController into BandwidthMonitor

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5887)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Renamed the VPN tunnel bandwidth component from “Bandwidth Controller” to “Bandwidth Monitor” across the tunnel system.
  - Updated tunnel error handling to recognize the new bandwidth monitor error variants and reasons.
  - Adjusted tunnel shutdown coordination to await the bandwidth monitor task using consistent monitoring terminology.
  - Refreshed related debug/log messages to reference “bandwidth monitoring.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->