### PR TITLE
NYM-1704: Integrate BC with improved skew manager.

### DIFF
--- a/nym-vpn-app/src-tauri/Cargo.lock
+++ b/nym-vpn-app/src-tauri/Cargo.lock
@@ -3715,8 +3715,8 @@ dependencies = [
 
 [[package]]
 name = "nym-crypto"
-version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.14-amsterdam#a68b8eab116df7f9a431cda0c52cd20fd9313b04"
+version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -3762,8 +3762,8 @@ dependencies = [
 
 [[package]]
 name = "nym-pemstore"
-version = "1.21.3"
-source = "git+https://github.com/nymtech/nym?branch=release%2F2026.14-amsterdam#a68b8eab116df7f9a431cda0c52cd20fd9313b04"
+version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "pem",
  "tracing",

--- a/nym-vpn-core/crates/nym-gateway-directory/src/gateway_cache.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/gateway_cache.rs
@@ -463,7 +463,7 @@ impl GatewayCache {
     async fn lookup_gateway_ip(&mut self, gateway_identity: &str) -> Result<IpAddr> {
         // If we have a populated list of gateways, we should always be able to find the IP there.
         if let Ok(identity) = NodeIdentity::from_base58_string(gateway_identity) {
-            for (_, (gateways, _)) in self.cached_gateways.iter() {
+            for (gateways, _) in self.cached_gateways.values() {
                 if let Some(ip) = gateways
                     .node_with_identity(&identity)
                     .and_then(Gateway::lookup_ip)

--- a/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
@@ -104,7 +104,7 @@ impl fmt::Display for Config {
                 .map(|url| url.url.clone())
                 .collect::<Vec<_>>()
                 .join(", "),
-            &self.min_gateway_performance,
+            self.min_gateway_performance,
         )
     }
 }

--- a/nym-vpn-core/crates/nym-statistics/build.rs
+++ b/nym-vpn-core/crates/nym-statistics/build.rs
@@ -21,5 +21,5 @@ async fn main() {
         .await
         .expect("Failed to perform SQLx migrations");
 
-    println!("cargo:rustc-env=DATABASE_URL=sqlite://{}", &database_path);
+    println!("cargo:rustc-env=DATABASE_URL=sqlite://{}", database_path);
 }

--- a/nym-vpn-core/crates/nym-vpn-api-client/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-api-client/Cargo.toml
@@ -51,7 +51,7 @@ bip39 = { workspace = true, features = ["zeroize"] }
 nym-crypto = { workspace = true, features = ["asymmetric", "stream_cipher"] }
 nym-http-api-client.workspace = true
 serde_json.workspace = true
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
 tracing-test.workspace = true
 wiremock.workspace = true
 

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{sync::Arc, time::Duration};
+use std::time::Duration;
 
 use backon::Retryable;
 use nym_credential_proxy_requests::api::v1::ticketbook::models::{
@@ -17,7 +17,6 @@ use time::{
     Date, OffsetDateTime,
     format_description::{BorrowedFormatItem, well_known::Rfc2822},
 };
-use tokio::sync::RwLock;
 
 use crate::{
     api_urls_to_urls,
@@ -67,7 +66,7 @@ enum RemoteTimeRetry {
 #[derive(Clone, Debug)]
 pub struct VpnApiClient {
     inner: Client,
-    skew_manager: Arc<RwLock<SkewManager>>,
+    skew_manager: SkewManager,
 }
 
 impl AsRef<Client> for VpnApiClient {
@@ -83,15 +82,27 @@ impl AsMut<Client> for VpnApiClient {
 }
 
 impl VpnApiClient {
+    /// Builds a `RemoteTimeProvider` that queries this VPN API's health endpoint, over its own
+    /// dedicated HTTP client. Useful for constructing a `SkewManager` before any `VpnApiClient`
+    /// exists, so it can be shared (injected via `new`/`from_network`) rather than owned solely
+    /// by the client.
+    pub fn health_endpoint_time_provider(
+        urls: Vec<Url>,
+        user_agent: Option<UserAgent>,
+    ) -> Result<impl RemoteTimeProvider + Send + Sync + 'static> {
+        let inner = fronted_http_client(urls, user_agent, Some(NYM_VPN_API_TIMEOUT))?;
+        Ok(VpnApiRemoteTimeProvider::new(inner))
+    }
+
     pub fn new(urls: Vec<Url>, user_agent: Option<UserAgent>) -> Result<Self> {
         let inner =
             fronted_http_client(urls.clone(), user_agent.clone(), Some(NYM_VPN_API_TIMEOUT))?;
 
-        let time_provider = VpnApiRemoteTimeProvider::new(inner.clone());
+        let skew_manager = SkewManager::new(VpnApiRemoteTimeProvider::new(inner.clone()));
 
         Ok(Self {
             inner,
-            skew_manager: Arc::new(RwLock::new(SkewManager::new(time_provider))),
+            skew_manager,
         })
     }
 
@@ -113,12 +124,20 @@ impl VpnApiClient {
         let inner =
             fronted_http_client(urls.clone(), user_agent.clone(), Some(NYM_VPN_API_TIMEOUT))?;
 
-        let time_provider = VpnApiRemoteTimeProvider::new(inner.clone());
+        let skew_manager = SkewManager::new(VpnApiRemoteTimeProvider::new(inner.clone()));
 
         Ok(Self {
             inner,
-            skew_manager: Arc::new(RwLock::new(SkewManager::new(time_provider))),
+            skew_manager,
         })
+    }
+
+    /// Replaces this client's skew manager with an externally-shared one (e.g. built via
+    /// [`Self::health_endpoint_time_provider`]), so both observe and update the same cache
+    /// instead of the client tracking its own, unshared skew state.
+    pub fn with_skew_manager(mut self, skew_manager: SkewManager) -> Self {
+        self.skew_manager = skew_manager;
+        self
     }
 
     pub fn api_client(&self) -> &impl ApiClient {
@@ -130,11 +149,11 @@ impl VpnApiClient {
     }
 
     pub async fn get_remote_time(&self) -> Result<VpnApiTime> {
-        self.skew_manager.write().await.get_remote_time().await
+        self.skew_manager.get_remote_time().await
     }
 
     async fn device_time(&self) -> OffsetDateTime {
-        self.skew_manager.read().await.device_time()
+        self.skew_manager.device_time()
     }
 
     async fn remote_time_for_retry(
@@ -146,9 +165,8 @@ impl VpnApiClient {
         if let Some(remote_timestamp) = parse_date_header(headers) {
             match self
                 .skew_manager
-                .write()
-                .await
                 .sync_with_response_timestamp(time_before, remote_timestamp, time_after)
+                .await
             {
                 Ok(jwt) => return RemoteTimeRetry::Retry(jwt),
                 Err(err) => {
@@ -163,13 +181,7 @@ impl VpnApiClient {
             );
         }
 
-        match self
-            .skew_manager
-            .write()
-            .await
-            .sync_with_remote_time()
-            .await
-        {
+        match self.skew_manager.sync_with_remote_time().await {
             Ok(jwt) => RemoteTimeRetry::Retry(jwt),
             Err(err) => {
                 tracing::error!("Failed to get remote time: {err}. Not retrying anymore");
@@ -215,8 +227,6 @@ impl VpnApiClient {
     {
         let jwt = self
             .skew_manager
-            .write()
-            .await
             .current_remote_time()
             .await
             .unwrap_or_else(|err| {
@@ -399,8 +409,6 @@ impl VpnApiClient {
     {
         let jwt = self
             .skew_manager
-            .write()
-            .await
             .current_remote_time()
             .await
             .unwrap_or_else(|err| {
@@ -480,8 +488,6 @@ impl VpnApiClient {
     {
         let jwt = self
             .skew_manager
-            .write()
-            .await
             .current_remote_time()
             .await
             .unwrap_or_else(|err| {
@@ -562,8 +568,6 @@ impl VpnApiClient {
     {
         let jwt = self
             .skew_manager
-            .write()
-            .await
             .current_remote_time()
             .await
             .unwrap_or_else(|err| {
@@ -1559,7 +1563,10 @@ impl RemoteTimeProvider for VpnApiRemoteTimeProvider {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
 
     use nym_http_api_client::reqwest::header::HeaderValue;
 
@@ -1613,7 +1620,7 @@ mod tests {
         (
             VpnApiClient {
                 inner,
-                skew_manager: Arc::new(RwLock::new(skew_manager)),
+                skew_manager,
             },
             calls,
         )
@@ -1657,8 +1664,6 @@ mod tests {
         // The derived skew is cached and reused without any network request
         let cached = client
             .skew_manager
-            .write()
-            .await
             .current_remote_time()
             .await
             .unwrap()
@@ -1688,13 +1693,12 @@ mod tests {
         // Seed the cache with a stale skew: the device clock used to be 2 hours ahead
         client
             .skew_manager
-            .write()
-            .await
             .sync_with_response_timestamp(
                 device_time(),
                 device_time() - Duration::from_hours(2),
                 device_time(),
             )
+            .await
             .unwrap()
             .expect("seeded skew is significant");
 
@@ -1710,13 +1714,7 @@ mod tests {
         assert_eq!(remote_calls.load(Ordering::SeqCst), 0);
 
         // The stale cached skew was replaced: no override and no network request
-        let cached = client
-            .skew_manager
-            .write()
-            .await
-            .current_remote_time()
-            .await
-            .unwrap();
+        let cached = client.skew_manager.current_remote_time().await.unwrap();
         assert!(cached.is_none());
         assert_eq!(remote_calls.load(Ordering::SeqCst), 0);
     }

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/lib.rs
@@ -22,4 +22,5 @@ pub use fronted_http_client::{
 };
 pub use network_compatibility::NetworkCompatibility;
 pub use resolve_host::{str_to_socket_addr, url_to_socket_addr};
+pub use skew_manager::{DeviceTimeProvider, RemoteTimeProvider, SkewManager};
 pub use types::ResolverOverrides;

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/skew_manager.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/skew_manager.rs
@@ -1,10 +1,13 @@
 // Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use time::{Duration as TimeDuration, OffsetDateTime};
-use tokio::time::Instant;
+use tokio::{
+    sync::{Mutex, RwLock},
+    time::Instant,
+};
 
 use crate::{
     client::NYM_VPN_API_TIMEOUT,
@@ -45,46 +48,57 @@ impl DeviceTimeProvider for DefaultDeviceTimeProvider {
     }
 }
 
-/// Type managing skew between device time and API server time.
-#[derive(Debug)]
+/// Shared component tracking the clock skew between the local device and the VPN API server.
+///
+/// Cheaply `Clone`-able: every clone shares the same underlying cache (via an internal `Arc`),
+/// so multiple owners can hold a handle to the same skew state without needing an actor/task of
+/// its own. `VpnApiClient` holds one and opportunistically refreshes it from response headers,
+/// but it can just as well refresh itself on demand via the remote time provider (e.g. the
+/// health endpoint) when nobody has updated it recently.
+#[derive(Clone, Debug)]
 pub struct SkewManager {
-    skew_state: Option<SkewState>,
+    inner: Arc<SkewManagerInner>,
+}
+
+#[derive(Debug)]
+struct SkewManagerInner {
+    skew_state: RwLock<Option<SkewState>>,
+    refresh_lock: Mutex<()>,
     device_time_provider: Box<dyn DeviceTimeProvider + Send + Sync>,
     remote_time_provider: Box<dyn RemoteTimeProvider + Send + Sync>,
 }
 
 impl SkewManager {
     pub fn new(remote_time_provider: impl RemoteTimeProvider + Send + Sync + 'static) -> Self {
-        Self {
-            skew_state: None,
-            device_time_provider: Box::new(DefaultDeviceTimeProvider),
-            remote_time_provider: Box::new(remote_time_provider),
-        }
+        Self::with_device_time_provider(DefaultDeviceTimeProvider, remote_time_provider)
     }
 
-    #[cfg(test)]
     pub fn new_for_testing(
         device_time_provider: impl DeviceTimeProvider + Send + Sync + 'static,
         remote_time_provider: impl RemoteTimeProvider + Send + Sync + 'static,
     ) -> Self {
+        Self::with_device_time_provider(device_time_provider, remote_time_provider)
+    }
+
+    fn with_device_time_provider(
+        device_time_provider: impl DeviceTimeProvider + Send + Sync + 'static,
+        remote_time_provider: impl RemoteTimeProvider + Send + Sync + 'static,
+    ) -> Self {
         Self {
-            skew_state: None,
-            device_time_provider: Box::new(device_time_provider),
-            remote_time_provider: Box::new(remote_time_provider),
+            inner: Arc::new(SkewManagerInner {
+                skew_state: RwLock::new(None),
+                refresh_lock: Mutex::new(()),
+                device_time_provider: Box::new(device_time_provider),
+                remote_time_provider: Box::new(remote_time_provider),
+            }),
         }
     }
 
-    pub async fn current_remote_time(&mut self) -> Result<Option<VpnApiTime>> {
-        let now = Instant::now();
-        let status = self.skew_state.as_ref().map(|state| state.status(now));
-
-        let cached_remote_time = match status {
+    pub async fn current_remote_time(&self) -> Result<Option<VpnApiTime>> {
+        let cached_remote_time = match self.skew_status(Instant::now()).await {
             Some(SkewStatus::Valid(skew)) => {
                 tracing::debug!("Valid VPN API time skew");
-                let local_time = self.device_time();
-                let estimated_remote_time = local_time - skew;
-
-                VpnApiTime::from_estimated_remote_time(local_time, estimated_remote_time)
+                self.estimate_remote_time(skew)
             }
             Some(SkewStatus::Expired) | None => {
                 tracing::debug!("VPN API time skew expired or not present, refreshing");
@@ -100,7 +114,7 @@ impl SkewManager {
         })
     }
 
-    pub async fn sync_with_remote_time(&mut self) -> Result<Option<VpnApiTime>> {
+    pub async fn sync_with_remote_time(&self) -> Result<Option<VpnApiTime>> {
         let remote_time = self.refresh_skew().await?;
 
         if Self::use_remote_time(remote_time) {
@@ -110,8 +124,8 @@ impl SkewManager {
         }
     }
 
-    pub fn sync_with_response_timestamp(
-        &mut self,
+    pub async fn sync_with_response_timestamp(
+        &self,
         time_before: OffsetDateTime,
         remote_timestamp: OffsetDateTime,
         time_after: OffsetDateTime,
@@ -130,7 +144,7 @@ impl SkewManager {
 
         let remote_time =
             VpnApiTime::from_remote_timestamp(time_before, remote_timestamp, time_after);
-        self.store_skew(remote_time);
+        self.store_skew(remote_time).await;
 
         if Self::use_remote_time(remote_time) {
             Ok(Some(remote_time))
@@ -139,12 +153,12 @@ impl SkewManager {
         }
     }
 
-    pub async fn get_remote_time(&mut self) -> Result<VpnApiTime> {
+    pub async fn get_remote_time(&self) -> Result<VpnApiTime> {
         let mut last_error: Option<VpnApiClientError> = None;
 
         for retry in 0..=REMOTE_TIME_MAX_RETRIES {
             let time_before = self.device_time();
-            match self.remote_time_provider.request_remote_time().await {
+            match self.inner.remote_time_provider.request_remote_time().await {
                 Ok(remote_timestamp) => {
                     let time_after = self.device_time();
                     let request_time = time_after - time_before;
@@ -197,24 +211,77 @@ impl SkewManager {
         }
     }
 
-    async fn refresh_skew(&mut self) -> Result<VpnApiTime> {
+    async fn refresh_skew(&self) -> Result<VpnApiTime> {
+        // Serialize concurrent refreshes: only the first caller to acquire this lock actually
+        // hits the remote time endpoint. Everyone else re-checks the cache once they get in and
+        // reuses whatever was just stored (refreshed moments ago, so just as trustworthy),
+        // instead of each issuing their own redundant network request.
+        let _refresh_guard = self.inner.refresh_lock.lock().await;
+
+        if let Some(SkewStatus::Valid(skew)) = self.skew_status(Instant::now()).await {
+            return Ok(self.estimate_remote_time(skew));
+        }
+
         let remote_time = self.get_remote_time().await?;
-        self.store_skew(remote_time);
+        self.store_skew(remote_time).await;
 
         Ok(remote_time)
     }
 
-    fn store_skew(&mut self, remote_time: VpnApiTime) {
+    async fn skew_status(&self, now: Instant) -> Option<SkewStatus> {
+        self.inner
+            .skew_state
+            .read()
+            .await
+            .as_ref()
+            .map(|state| state.status(now))
+    }
+
+    fn estimate_remote_time(&self, skew: TimeDuration) -> VpnApiTime {
+        let local_time = self.device_time();
+        let estimated_remote_time = local_time - skew;
+        VpnApiTime::from_estimated_remote_time(local_time, estimated_remote_time)
+    }
+
+    async fn store_skew(&self, remote_time: VpnApiTime) {
         let skew = remote_time.local_time_ahead_skew();
         let now = Instant::now();
 
-        self.skew_state.replace(SkewState::new(skew, now));
+        self.inner
+            .skew_state
+            .write()
+            .await
+            .replace(SkewState::new(skew, now));
         tracing::debug!(skew = ?skew, "Refreshed VPN API time skew");
     }
 
     /// Returns the current device time.
     pub fn device_time(&self) -> OffsetDateTime {
-        self.device_time_provider.device_time()
+        self.inner.device_time_provider.device_time()
+    }
+
+    /// Returns a timestamp corrected for the skew between the local device clock and the VPN API
+    /// server clock, if a valid cached skew is available right now - or `None` otherwise (skew
+    /// not yet known, expired, not significant, or the cache is momentarily locked for writing).
+    ///
+    /// Synchronous and non-blocking: this never performs network I/O and never waits on a lock
+    /// (a locked cache is simply treated as "not available"), so it's safe to call from
+    /// time-sensitive paths that must not be delayed. Callers decide what "not available" means
+    /// for them - typically, falling back to `device_time()`.
+    pub fn cached_skew_corrected_time(&self) -> Option<OffsetDateTime> {
+        let skew = match self
+            .inner
+            .skew_state
+            .try_read()
+            .ok()?
+            .as_ref()?
+            .status(Instant::now())
+        {
+            SkewStatus::Valid(skew) => skew,
+            SkewStatus::Expired => return None,
+        };
+
+        Self::use_remote_time(self.estimate_remote_time(skew)).then(|| self.device_time() - skew)
     }
 }
 
@@ -249,7 +316,81 @@ impl SkewState {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
     use super::*;
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn test_concurrent_refreshes_on_cold_cache_share_one_remote_time_request() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let remote_time_provider = CountingDelayedTimeProvider {
+            calls: calls.clone(),
+            delay: Duration::from_millis(20),
+        };
+        let skew_manager =
+            SkewManager::new_for_testing(MockDeviceTimeProvider::new(vec![]), remote_time_provider);
+
+        // Several concurrent lookups race against a cold (empty) cache; they must share one
+        // refresh instead of each hitting the remote time endpoint.
+        let (a, b, c) = tokio::join!(
+            skew_manager.current_remote_time(),
+            skew_manager.current_remote_time(),
+            skew_manager.current_remote_time(),
+        );
+        a.unwrap();
+        b.unwrap();
+        c.unwrap();
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn test_cached_skew_corrected_time_uses_significant_cached_skew() {
+        // Fixed so the later `device_time()` reads inside `cached_skew_corrected_time` (there
+        // are two) return exactly this instant rather than drifting a few microseconds past it.
+        let time_before = OffsetDateTime::now_utc();
+        let remote_timestamp = time_before - Duration::from_hours(2);
+        let skew_manager = SkewManager::new_for_testing(
+            MockDeviceTimeProvider::new(vec![time_before; 4]),
+            PanickingTimeProvider,
+        );
+
+        skew_manager
+            .sync_with_response_timestamp(time_before, remote_timestamp, time_before)
+            .await
+            .unwrap()
+            .expect("skew is significant");
+
+        // Reads the cache synchronously: no network request (which would panic)
+        let corrected = skew_manager
+            .cached_skew_corrected_time()
+            .expect("cached skew is significant");
+        assert_eq!((time_before - corrected).whole_hours(), 2);
+    }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn test_cached_skew_corrected_time_none_when_skew_negligible_or_missing() {
+        let skew_manager = SkewManager::new_for_testing(
+            MockDeviceTimeProvider::new(vec![]),
+            PanickingTimeProvider,
+        );
+
+        // No skew has been recorded yet
+        assert!(skew_manager.cached_skew_corrected_time().is_none());
+
+        let time_before = OffsetDateTime::now_utc();
+        let remote_timestamp = time_before + Duration::from_secs(30);
+        skew_manager
+            .sync_with_response_timestamp(time_before, remote_timestamp, time_before)
+            .await
+            .unwrap();
+
+        // A negligible skew is cached, but not significant enough to correct for
+        assert!(skew_manager.cached_skew_corrected_time().is_none());
+    }
 
     #[tokio::test]
     #[tracing_test::traced_test]
@@ -261,7 +402,7 @@ mod tests {
             ]
             .repeat(3),
         );
-        let mut skew_manager = SkewManager::new_for_testing(device_time_provider, MockTimeProvider);
+        let skew_manager = SkewManager::new_for_testing(device_time_provider, MockTimeProvider);
         let time_result = skew_manager.current_remote_time().await;
         assert!(matches!(
             time_result,
@@ -279,7 +420,7 @@ mod tests {
             ]
             .repeat(3),
         );
-        let mut skew_manager = SkewManager::new_for_testing(device_time_provider, MockTimeProvider);
+        let skew_manager = SkewManager::new_for_testing(device_time_provider, MockTimeProvider);
         let time_result = skew_manager.current_remote_time().await;
         assert!(matches!(
             time_result,
@@ -290,7 +431,7 @@ mod tests {
     #[tokio::test]
     #[tracing_test::traced_test]
     async fn test_sync_with_response_timestamp_updates_cache() {
-        let mut skew_manager = SkewManager::new_for_testing(
+        let skew_manager = SkewManager::new_for_testing(
             MockDeviceTimeProvider::new(vec![]),
             PanickingTimeProvider,
         );
@@ -301,6 +442,7 @@ mod tests {
 
         let remote_time = skew_manager
             .sync_with_response_timestamp(time_before, remote_timestamp, time_after)
+            .await
             .unwrap()
             .expect("skew is significant");
         assert_eq!(remote_time.local_time_ahead_skew().whole_hours(), 2);
@@ -318,7 +460,7 @@ mod tests {
     #[tokio::test]
     #[tracing_test::traced_test]
     async fn test_sync_with_response_timestamp_negligible_skew() {
-        let mut skew_manager = SkewManager::new_for_testing(
+        let skew_manager = SkewManager::new_for_testing(
             MockDeviceTimeProvider::new(vec![]),
             PanickingTimeProvider,
         );
@@ -328,6 +470,7 @@ mod tests {
 
         let remote_time = skew_manager
             .sync_with_response_timestamp(time_before, remote_timestamp, time_before)
+            .await
             .unwrap();
         assert!(remote_time.is_none());
 
@@ -340,7 +483,7 @@ mod tests {
     #[tokio::test]
     #[tracing_test::traced_test]
     async fn test_sync_with_response_timestamp_time_travel() {
-        let mut skew_manager = SkewManager::new_for_testing(
+        let skew_manager = SkewManager::new_for_testing(
             MockDeviceTimeProvider::new(vec![]),
             PanickingTimeProvider,
         );
@@ -348,8 +491,9 @@ mod tests {
         let time_before = OffsetDateTime::now_utc();
         let time_after = time_before - Duration::from_secs(1);
 
-        let result =
-            skew_manager.sync_with_response_timestamp(time_before, time_before, time_after);
+        let result = skew_manager
+            .sync_with_response_timestamp(time_before, time_before, time_after)
+            .await;
         assert!(matches!(result, Err(VpnApiClientError::TimeTravelTooMuch)));
     }
 
@@ -359,6 +503,21 @@ mod tests {
     #[async_trait::async_trait]
     impl RemoteTimeProvider for MockTimeProvider {
         async fn request_remote_time(&self) -> Result<OffsetDateTime> {
+            Ok(OffsetDateTime::now_utc())
+        }
+    }
+
+    #[derive(Debug)]
+    struct CountingDelayedTimeProvider {
+        calls: Arc<AtomicUsize>,
+        delay: Duration,
+    }
+
+    #[async_trait::async_trait]
+    impl RemoteTimeProvider for CountingDelayedTimeProvider {
+        async fn request_remote_time(&self) -> Result<OffsetDateTime> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            tokio::time::sleep(self.delay).await;
             Ok(OffsetDateTime::now_utc())
         }
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/build.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/build.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await
         .expect("Failed to perform SQLx migrations");
 
-    println!("cargo:rustc-env=DATABASE_URL=sqlite://{}", &database_path);
+    println!("cargo:rustc-env=DATABASE_URL=sqlite://{}", database_path);
 
     Emitter::default()
         .add_instructions(&BuildBuilder::all_build()?)?

--- a/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_monitor.rs
@@ -10,8 +10,8 @@ use nym_bandwidth_controller::{
     DEFAULT_TICKETS_TO_SPEND, requests::BandwidthControllerRequestSender,
 };
 use nym_registration_common::WireguardConfiguration;
+use nym_vpn_api_client::SkewManager;
 use sysinfo::Networks;
-use time::OffsetDateTime;
 use tokio_stream::{StreamExt, wrappers::IntervalStream};
 use tokio_util::sync::CancellationToken;
 
@@ -611,6 +611,7 @@ impl<N: NetworkInterfaceStats> SystemBandwidthMonitor<N> {
 
 pub(crate) struct BandwidthMonitor {
     bc_command_tx: BandwidthControllerRequestSender,
+    skew_manager: SkewManager,
     wg_entry_gateway_client: TemporaryBandwidthClient,
     wg_exit_gateway_client: TemporaryBandwidthClient,
     timeout_check_interval: IntervalStream,
@@ -625,8 +626,10 @@ pub(crate) struct BandwidthMonitor {
 }
 
 impl BandwidthMonitor {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         bc_command_tx: BandwidthControllerRequestSender,
+        skew_manager: SkewManager,
         wg_entry_gateway_client: TemporaryBandwidthClient,
         wg_exit_gateway_client: TemporaryBandwidthClient,
         shutdown_token: CancellationToken,
@@ -637,6 +640,7 @@ impl BandwidthMonitor {
 
         BandwidthMonitor {
             bc_command_tx,
+            skew_manager,
             wg_entry_gateway_client,
             wg_exit_gateway_client,
             timeout_check_interval,
@@ -730,6 +734,7 @@ impl BandwidthMonitor {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn create(
         bc_command_tx: BandwidthControllerRequestSender,
+        skew_manager: SkewManager,
         selected_gateways: &SelectedGateways,
         entry_auth_client: Option<AuthenticatorClient>,
         exit_auth_client: Option<AuthenticatorClient>,
@@ -758,6 +763,7 @@ impl BandwidthMonitor {
 
         Self::new(
             bc_command_tx,
+            skew_manager,
             wg_entry_client,
             wg_exit_client,
             cancel_token.clone(),
@@ -778,13 +784,18 @@ impl BandwidthMonitor {
             &mut self.wg_exit_gateway_client
         };
 
+        let spend_time = self
+            .skew_manager
+            .cached_skew_corrected_time()
+            .unwrap_or_else(|| self.skew_manager.device_time());
+
         let credential = self
             .bc_command_tx
             .get_ecash_ticket(
                 ticketbook_type,
                 bw_client.gateway_id(),
                 DEFAULT_TICKETS_TO_SPEND,
-                OffsetDateTime::now_utc(), // Skew input can be fed here
+                spend_time,
             )
             .await
             .map_err(|source| SpecificGatewayError::RequestCredential {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
@@ -521,12 +521,26 @@ impl NymVpnService {
         };
 
         let network_details = network_env.nym_network_details();
+
+        // Built here (rather than owned solely by `VpnApiClient`) so it can be shared with the
+        // tunnel state machine's bandwidth monitor further down.
+        let skew_time_provider_urls = network_env
+            .nym_vpn_api_urls()
+            .ok_or(Error::InvalidEnvironment("empty nym_vpn_api_urls"))?;
+        let skew_time_provider = nym_vpn_api_client::VpnApiClient::health_endpoint_time_provider(
+            api_urls_to_urls(&skew_time_provider_urls).map_err(Error::ConvertApiUrls)?,
+            Some(parameters.user_agent.clone()),
+        )
+        .map_err(Error::CreateApiClient)?;
+        let skew_manager = nym_vpn_api_client::SkewManager::new(skew_time_provider);
+
         let nym_vpn_api_client = nym_vpn_api_client::VpnApiClient::from_network(
             network_details,
             Some(parameters.user_agent.clone()),
         )
         .await
-        .map_err(Error::CreateApiClient)?;
+        .map_err(Error::CreateApiClient)?
+        .with_skew_manager(skew_manager.clone());
 
         let nyxd_client = NyxdClient::new(&network_env);
 
@@ -716,6 +730,7 @@ impl NymVpnService {
             account_command_tx.clone(),
             account_state_rx.clone(),
             bandwidth_command_tx.clone(),
+            skew_manager,
             statistics_event_sender.clone(),
             topology_service.clone(),
             connectivity_handle,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -58,6 +58,7 @@ use nym_offline_monitor::ConnectivityHandle;
 use nym_registration_client::MixnetClientConfig;
 use nym_statistics::StatisticsSender;
 use nym_vpn_account_controller::{AccountCommandSender, AccountStateReceiver};
+use nym_vpn_api_client::SkewManager;
 use nym_vpn_network_config::{DiscoveryRefresherCommand, Network};
 use tokio::{
     sync::{mpsc, watch},
@@ -794,6 +795,7 @@ pub struct SharedState {
     account_command_tx: AccountCommandSender,
     account_controller_state: AccountStateReceiver,
     bandwidth_command_tx: BandwidthControllerRequestSender,
+    skew_manager: SkewManager,
     statistics_event_sender: StatisticsSender,
     #[cfg(target_os = "linux")]
     nm_connectivity_check_enabled: Option<bool>,
@@ -1125,6 +1127,7 @@ impl TunnelStateMachine {
         account_command_tx: AccountCommandSender,
         account_controller_state: AccountStateReceiver,
         bandwidth_command_tx: BandwidthControllerRequestSender,
+        skew_manager: SkewManager,
         statistics_event_sender: StatisticsSender,
         topology_service: VpnTopologyServiceHandle,
         connectivity_handle: ConnectivityHandle,
@@ -1208,6 +1211,7 @@ impl TunnelStateMachine {
             account_command_tx,
             account_controller_state,
             bandwidth_command_tx,
+            skew_manager,
             statistics_event_sender,
             #[cfg(target_os = "linux")]
             nm_connectivity_check_enabled: None,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -415,6 +415,7 @@ impl ConnectingState {
             shared_state.account_controller_state.clone(),
             shared_state.account_command_tx.clone(),
             shared_state.bandwidth_command_tx.clone(),
+            shared_state.skew_manager.clone(),
             shared_state.gateway_provider.clone(),
             shared_state.topology_service.clone(),
             tunnel_monitor_event_sender,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -49,6 +49,7 @@ use nym_registration_client::{
     RegistrationMode, RegistrationNymNode, RegistrationResult, WireguardRegistrationResult,
 };
 use nym_vpn_account_controller::{AccountCommandSender, AccountStateReceiver};
+use nym_vpn_api_client::SkewManager;
 use nym_vpn_lib_types::{
     AccountControllerError, BridgeAddress, ConnectionData, ErrorStateReason,
     EstablishConnectionData, GatewayLightInfo, MixnetConnectionData, NymAddress,
@@ -264,6 +265,7 @@ pub struct TunnelMonitor {
     account_controller_state: AccountStateReceiver,
     account_command_tx: AccountCommandSender,
     bandwidth_command_tx: BandwidthControllerRequestSender,
+    skew_manager: SkewManager,
     gateway_provider: GatewayProvider<GatewayCacheHandle>,
     custom_topology_provider: VpnTopologyServiceHandle,
     shutdown_token: CancellationToken,
@@ -323,6 +325,7 @@ impl TunnelMonitor {
         account_controller_state: AccountStateReceiver,
         account_command_tx: AccountCommandSender,
         bandwidth_command_tx: BandwidthControllerRequestSender,
+        skew_manager: SkewManager,
         gateway_provider: GatewayProvider<GatewayCacheHandle>,
         custom_topology_provider: VpnTopologyServiceHandle,
         monitor_event_sender: mpsc::UnboundedSender<TunnelMonitorEvent>,
@@ -344,6 +347,7 @@ impl TunnelMonitor {
             account_controller_state,
             account_command_tx,
             bandwidth_command_tx,
+            skew_manager,
             gateway_provider,
             custom_topology_provider,
             shutdown_token: shutdown_token.clone(),
@@ -1206,6 +1210,7 @@ impl TunnelMonitor {
 
         let bw = BandwidthMonitor::create(
             self.bandwidth_command_tx.clone(),
+            self.skew_manager.clone(),
             selected_gateways,
             entry_gateway_client,
             exit_gateway_client,

--- a/nym-vpn-core/crates/nym-vpn-store/build.rs
+++ b/nym-vpn-core/crates/nym-vpn-store/build.rs
@@ -21,11 +21,5 @@ async fn main() {
         .await
         .expect("Failed to perform SQLx migrations");
 
-    #[cfg(target_family = "unix")]
-    println!("cargo:rustc-env=DATABASE_URL=sqlite://{}", &database_path);
-
-    #[cfg(target_family = "windows")]
-    // for some strange reason we need to add a leading `/` to the windows path even though it's
-    // not a valid windows path... but hey, it works...
-    println!("cargo:rustc-env=DATABASE_URL=sqlite:///{}", &database_path);
+    println!("cargo:rustc-env=DATABASE_URL=sqlite://{}", database_path);
 }

--- a/nym-vpn-core/crates/test/test-manager/src/config/manifest/test_locations.rs
+++ b/nym-vpn-core/crates/test/test-manager/src/config/manifest/test_locations.rs
@@ -14,7 +14,7 @@ pub struct TestLocation(glob::Pattern, Vec<String>);
 
 impl fmt::Debug for TestLocation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}: {:?}", self.0, &self.1)
+        write!(f, "{}: {:?}", self.0, self.1)
     }
 }
 

--- a/nym-vpn-core/crates/test/test-manager/src/main.rs
+++ b/nym-vpn-core/crates/test/test-manager/src/main.rs
@@ -231,7 +231,7 @@ async fn main() -> Result<()> {
             } else {
                 config::Display::Local
             };
-            log::info!("🖥️ Display mode: {:?}", &config.runtime_opts.display);
+            log::info!("🖥️ Display mode: {:?}", config.runtime_opts.display);
 
             let mut instance = vm::run(&config, &vm).await.context("Failed to start VM")?;
 
@@ -264,7 +264,7 @@ async fn main() -> Result<()> {
                 (false, true) => config::Display::Vnc,
                 (true, true) => unreachable!("invalid combination"),
             };
-            log::info!("🖥️ Display mode: {:?}", &config.runtime_opts.display);
+            log::info!("🖥️ Display mode: {:?}", config.runtime_opts.display);
 
             let vm_config = vm::get_vm_config(&config, &vm).context("Cannot get VM config")?;
 
@@ -273,7 +273,7 @@ async fn main() -> Result<()> {
                 log::debug!("Using default runner dir");
                 vm_config.get_default_runner_dir()
             });
-            log::debug!("Runner dir: {}", &runner_dir.display());
+            log::debug!("Runner dir: {}", runner_dir.display());
             let artifacts_dir = provision::provision(vm_config, &*instance, runner_dir)
                 .await
                 .context("Failed to run provisioning for VM")?;
@@ -297,7 +297,7 @@ async fn main() -> Result<()> {
             ));
 
             let mut tests = get_filtered_tests(&test_filters, &skip)?;
-            log::info!("{} filtered tests:\n{:#?}", tests.len(), &tests);
+            log::info!("{} filtered tests:\n{:#?}", tests.len(), tests);
 
             for test in tests.iter_mut() {
                 test.location = config.test_locations.lookup(test.name).cloned();
@@ -346,7 +346,7 @@ async fn main() -> Result<()> {
             let update_output = vm::update_packages(vm_config.clone(), &*instance)
                 .await
                 .context("Failed to update packages to the VM image")?;
-            log::info!("Update command finished with output: {}", &update_output);
+            log::info!("Update command finished with output: {}", update_output);
             // TODO: If the update was successful, commit the changes to the VM image.
             log::info!("Note: updates have not been persisted to the image");
             Ok(())


### PR DESCRIPTION

## Ticket

JIRA-NYM-1704

## Description

Integrate BC with improved skew manager.

Also fixed many clippy warnings, which appear to relate to a newer version of Rust.

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5899)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bandwidth top-ups now use skew-corrected remote time when available, with device-time fallback when it isn’t.
  * Added API client support for skew-corrected timestamps and cached skew reuse.
* **Bug Fixes**
  * Improved tunnel and bandwidth monitoring initialization to consistently use a shared skew manager handle.
  * Standardized emitted database URL formatting across build targets.
* **Tests**
  * Added/updated async coverage for skew-significant, negligible, unavailable, and cached remote-time scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->