### PR TITLE
Fix anonymous Mixnet MTU and retransmissions on desktop

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/processor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/processor.rs
@@ -356,10 +356,13 @@ impl MixnetMessageSinkTranslator for ToIprDataRequest {
         // sphinx packets that carry the actual data, since we try to keep the payload for IP
         // traffic contained within a single sphinx packet.
         let surbs = 0;
-        Ok(
-            InputMessage::new_anonymous(self.recipient, packet, surbs, lane, packet_type)
-                .with_max_retransmissions(0),
-        )
+        Ok(InputMessage::new_anonymous(
+            self.recipient,
+            packet,
+            surbs,
+            lane,
+            packet_type,
+        ))
     }
 }
 
@@ -378,4 +381,45 @@ pub async fn start_processor(
         cancel_token,
         event_rx,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_IPR_ADDRESS: &str = "MNrmKzuKjNdbEhfPUzVNfjw63oBQNSayqoQKGL4JjAV.6fDcSN6faGpvA3pd3riCwjpzXc7RQfWmGMa82UVoEwKE@d5adfJNtcdZW2XwK85JAAU8nXAs9JCPYn2RNvDLZn4e";
+
+    #[test]
+    fn data_request_keeps_public_ipr_wire_format_with_normal_retransmissions() {
+        let ipr_address = IpPacketRouterAddress::try_from_base58_string(TEST_IPR_ADDRESS).unwrap();
+        let message_creator = ToIprDataRequest::new(ipr_address);
+        let bundled_ip_packets = [0x45, 0, 0, 20, 0, 0, 0, 0];
+
+        let expected_data = IpPacketRequest::new_data_request(
+            BytesMut::from(bundled_ip_packets.as_slice()).freeze(),
+        )
+        .to_bytes()
+        .unwrap();
+
+        let message = message_creator
+            .to_input_message(&bundled_ip_packets)
+            .unwrap();
+
+        let InputMessage::Anonymous {
+            recipient,
+            data,
+            reply_surbs,
+            lane,
+            max_retransmissions,
+        } = message
+        else {
+            panic!("IPR data requests must remain anonymous Mixnet messages");
+        };
+
+        assert_eq!(recipient, Recipient::from(ipr_address));
+        assert_eq!(data, expected_data);
+        assert_eq!(reply_surbs, 0);
+        assert_eq!(lane, TransmissionLane::General);
+        assert_eq!(max_retransmissions, None);
+    }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -99,11 +99,7 @@ use crate::{
 };
 
 /// Default MTU for mixnet tun device.
-const DEFAULT_TUN_MTU: u16 = if cfg!(any(target_os = "ios", target_os = "android")) {
-    1280
-} else {
-    1500
-};
+const DEFAULT_TUN_MTU: u16 = 1280;
 
 /// User-facing tunnel type identifier.
 #[cfg(windows)]
@@ -1004,6 +1000,7 @@ impl TunnelMonitor {
                             e.display_chain_with_msg("Failed to detect mtu for route")
                         );
                     })
+                    .map(|mtu| mtu.min(DEFAULT_TUN_MTU))
                     .unwrap_or(DEFAULT_TUN_MTU)
             }
 


### PR DESCRIPTION
## Ticket

N/A (external reproduction)

## Description

Fix anonymous Mixnet website stalls on desktop by aligning the client TUN MTU
with the existing mobile behavior and restoring the SDK's normal retransmission
policy for client-to-IPR data messages.

Desktop clients currently default the Mixnet TUN to 1500 bytes, while iOS and
Android use 1280. The IPR Linux TUN defaults to 1420, and its connect response
does not negotiate an effective MTU. In a controlled IPR test, a 1500-byte
client completed TCP and TLS but then stalled receiving HTTP data; the exit
kernel emitted ICMP Fragmentation Needed and incremented `IpFragFails`.

The client-to-IPR v8 path also explicitly sets `max_retransmissions` to zero.
That makes the first ACK timeout discard the Mixnet message instead of applying
the SDK's normal retry policy, which can leave the encapsulated TCP flow stalled.

This PR:

- uses a 1280-byte default for anonymous Mixnet TUN devices on desktop, matching
  the existing iOS/Android value;
- caps Linux/Windows entry-route MTU detection at 1280 while preserving any
  lower detected value;
- continues to honor an explicitly configured Mixnet MTU;
- removes the request-side `with_max_retransmissions(0)` override so normal SDK
  retransmission behavior applies; and
- adds a regression test proving the retransmission fix does not change the
  public IPR payload, recipient, anonymous-message mode, reply SURB count, or
  transmission lane.

The change is limited to anonymous Mixnet IP routing. It does not modify the IPR
wire protocol, IPR server implementation, or WireGuard/two-hop behavior.

A locally built macOS client containing these two changes successfully loaded
sites that had previously stalled after the TLS ClientHello or during HTTP body
transfer.

## Validation

```text
cargo test -p nym-vpn-lib data_request_keeps_public_ipr_wire_format_with_normal_retransmissions --lib
cargo fmt -p nym-vpn-lib --check
git diff --check
```

The focused Rust test passes (`1 passed, 0 failed`). The macOS app and modern
installer package also built successfully with the embedded daemon.

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

Not applicable.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5900)
<!-- Reviewable:end -->
