### PR TITLE
Recents manager

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - [CLI] Add short option `-l` for `nym-vpnc status --listen` (https://github.com/nymtech/nym-vpn-client/pull/5839)
+- Recents manager for storing successful gateway connections (https://github.com/nymtech/nym-vpn-client/pull/5903)
 
 ### Changed
 

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/gateway.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/gateway.rs
@@ -19,6 +19,8 @@ use nym_crypto::asymmetric::{
     x25519,
 };
 
+use crate::TunnelType;
+
 // Types that duplicate what nym-sdk already offers without pulling the whole nym-sdk into types crate
 pub type ClientEncryptionKey = x25519::PublicKey;
 pub type ClientIdentity = ed25519::PublicKey;
@@ -556,6 +558,35 @@ pub enum TentativeGateways {
     },
     NeedsRelaxedIndependenceCriteria,
     NoGatewaysAvailable,
+}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "uniffi-bindings", derive(uniffi::Record))]
+#[cfg_attr(
+    feature = "typescript-bindings",
+    derive(TS),
+    ts(export),
+    ts(export_to = "bindings.ts")
+)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "typescript-bindings", serde(rename_all = "camelCase"))]
+pub struct GetRecentGatewaysParams {
+    pub tunnel_type: TunnelType,
+}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "uniffi-bindings", derive(uniffi::Record))]
+#[cfg_attr(
+    feature = "typescript-bindings",
+    derive(TS),
+    ts(export),
+    ts(export_to = "bindings.ts")
+)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "typescript-bindings", serde(rename_all = "camelCase"))]
+pub struct RecentGateways {
+    pub entry: Vec<Gateway>,
+    pub exit: Vec<Gateway>,
 }
 
 #[derive(Debug, Clone)]

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
@@ -80,9 +80,10 @@ pub use diagnostic::{
 };
 pub use gateway::{
     Asn, AsnKind, BridgeInformation, BridgeParameters, Country, Entry, EntryPoint, Exit, ExitPoint,
-    Gateway, GatewayFilter, GatewayType, LewesProtocolDetails, LewesProtocolDetailsData, Location,
-    LookupGatewayFilters, Lp, NodeIdentity, ParseRecipientError, Performance, Probe, ProbeOutcome,
-    QuicClientOptions, Recipient, Score, Socks5, TentativeGateways,
+    Gateway, GatewayFilter, GatewayType, GetRecentGatewaysParams, LewesProtocolDetails,
+    LewesProtocolDetailsData, Location, LookupGatewayFilters, Lp, NodeIdentity,
+    ParseRecipientError, Performance, Probe, ProbeOutcome, QuicClientOptions, RecentGateways,
+    Recipient, Score, Socks5, TentativeGateways,
 };
 pub use gateway_independence::GatewayIndependence;
 pub use gateway_selection_algorithm::{GatewaySelectionAlgorithm, GatewaySelectionAlgorithmConfig};

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/gateway_cache.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/gateway_cache.rs
@@ -3,10 +3,13 @@
 
 use std::sync::Arc;
 
+use nym_vpn_lib::RecentGatewayCache;
 use tokio::{sync::Mutex, task::JoinHandle};
 use tokio_util::sync::{CancellationToken, DropGuard};
 
-use nym_gateway_directory::{GatewayCache, GatewayCacheHandle, GatewayClient};
+use nym_gateway_directory::{
+    Error as GatewayDirectoryError, GatewayCache, GatewayCacheHandle, GatewayClient, GatewayList,
+};
 use nym_vpn_lib_types::{Gateway, GatewayType, UserAgent};
 
 use crate::{environment::NymEnvironment, error::VpnError, offline_monitor::NymOfflineMonitor};
@@ -16,6 +19,16 @@ pub struct NymGatewayCache {
     gateway_cache_handle: GatewayCacheHandle,
     join_handle: Arc<Mutex<Option<JoinHandle<()>>>>,
     shutdown_drop_guard: Arc<Mutex<Option<DropGuard>>>,
+}
+
+#[async_trait::async_trait]
+impl RecentGatewayCache for &NymGatewayCache {
+    async fn lookup_gateways(
+        &self,
+        gw_type: nym_gateway_directory::GatewayType,
+    ) -> Result<GatewayList, GatewayDirectoryError> {
+        self.inner_get_gateways(gw_type).await
+    }
 }
 
 #[uniffi::export(async_runtime = "tokio")]
@@ -71,8 +84,7 @@ impl NymGatewayCache {
     }
 
     pub async fn get_gateways(&self, gw_type: GatewayType) -> Result<Vec<Gateway>, VpnError> {
-        self.inner()
-            .lookup_gateways(gw_type.into())
+        self.inner_get_gateways(gw_type.into())
             .await
             .map(|gateways| {
                 gateways
@@ -90,5 +102,12 @@ impl NymGatewayCache {
 impl NymGatewayCache {
     pub fn inner(&self) -> GatewayCacheHandle {
         self.gateway_cache_handle.clone()
+    }
+
+    async fn inner_get_gateways(
+        &self,
+        gw_type: nym_gateway_directory::GatewayType,
+    ) -> Result<GatewayList, GatewayDirectoryError> {
+        self.inner().lookup_gateways(gw_type).await
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_service_command_sender.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_service_command_sender.rs
@@ -1,11 +1,12 @@
 // Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{net::IpAddr, sync::Arc};
+use std::{net::IpAddr, path::PathBuf, sync::Arc};
 
 use nym_common::ErrorExt;
-use nym_vpn_lib::service::{
-    AccountLinksError, GeoExclusionConfigError, ListGatewaysError, VpnServiceCommand,
+use nym_vpn_lib::{
+    RecentsManager,
+    service::{AccountLinksError, GeoExclusionConfigError, ListGatewaysError, VpnServiceCommand},
 };
 use tokio::sync::{mpsc, oneshot};
 
@@ -13,10 +14,12 @@ use nym_vpn_lib_types::{
     AccountCommandError, AccountControllerState, AutologinResponse, DiagnosticRunParams,
     EntryPoint, ExitPoint, FeatureFlags, FrontingMode, Gateway, GatewaySelectionAlgorithm,
     GetDeeplinkParams, ListGatewaysOptions, MixnetTrafficConfig, NetworkCompatibility,
-    ParsedAccountLinks, RegisterAccountRequest, RegisterAccountResponse, StoreAccountRequest,
-    StoredAccountMode, SystemMessage, TargetState, TentativeGateways, TunnelState,
-    VpnAccountSummary, VpnServiceConfig, VpnServiceInfo,
+    ParsedAccountLinks, RecentGateways, RegisterAccountRequest, RegisterAccountResponse,
+    StoreAccountRequest, StoredAccountMode, SystemMessage, TargetState, TentativeGateways,
+    TunnelState, TunnelType, VpnAccountSummary, VpnServiceConfig, VpnServiceInfo,
 };
+
+use crate::gateway_cache::NymGatewayCache;
 
 #[derive(Debug, thiserror::Error)]
 enum NymVpnServiceCommandInnerError {
@@ -449,5 +452,29 @@ impl NymVpnServiceCommandSender {
     pub async fn get_tentative_gateways(&self) -> Result<TentativeGateways> {
         self.send_and_wait(VpnServiceCommand::GetTentativeGateways, ())
             .await
+    }
+
+    pub async fn get_recent_gateways(&self, tunnel_type: TunnelType) -> Result<RecentGateways> {
+        Ok(self
+            .send_and_wait(VpnServiceCommand::GetRecentGateways, tunnel_type)
+            .await?
+            .map_err(NymVpnServiceCommandInnerError::ListGateway)?)
+    }
+
+    pub async fn get_recent_gateways_no_service(
+        &self,
+        data_dir: PathBuf,
+        gateway_cache: &NymGatewayCache,
+        tunnel_type: TunnelType,
+    ) -> Result<RecentGateways> {
+        let recent_gateway_cache = RecentsManager::new(data_dir, gateway_cache).await;
+        Ok(recent_gateway_cache
+            .get_recent(tunnel_type)
+            .await
+            .map_err(|source| ListGatewaysError::GetRecentGateways {
+                tunnel_type,
+                source,
+            })
+            .map_err(NymVpnServiceCommandInnerError::ListGateway)?)
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/lib.rs
@@ -12,6 +12,7 @@ mod dns_filter;
 pub mod logging;
 mod mixnet;
 pub mod privy;
+mod recents;
 #[cfg(not(target_os = "android"))]
 mod resolver;
 pub mod sentry;
@@ -46,6 +47,7 @@ pub use crate::{
         DEFAULT_MIN_GATEWAY_PERFORMANCE, DEFAULT_MIN_MIXNODE_PERFORMANCE, MixnetError,
         VpnTopologyProvider, VpnTopologyService, VpnTopologyServiceError, VpnTopologyServiceHandle,
     },
+    recents::{RecentGatewayCache, RecentsManager},
     tunnel_state_machine::tunnel::gateway_provider::GatewayProviderError,
 };
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/recents/error.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/recents/error.rs
@@ -1,0 +1,10 @@
+// Copyright 2026 Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+#[derive(thiserror::Error, Debug)]
+pub enum RecentsError {
+    #[error("failed to lookup gateway cache")]
+    GetGateways {
+        source: crate::gateway_directory::Error,
+    },
+}

--- a/nym-vpn-core/crates/nym-vpn-lib/src/recents/gateway_cache.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/recents/gateway_cache.rs
@@ -1,0 +1,16 @@
+// Copyright 2026 Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use nym_gateway_directory::{Error, GatewayCacheHandle, GatewayList, GatewayType};
+
+#[async_trait::async_trait]
+pub trait RecentGatewayCache: Send + Sync {
+    async fn lookup_gateways(&self, gw_type: GatewayType) -> Result<GatewayList, Error>;
+}
+
+#[async_trait::async_trait]
+impl RecentGatewayCache for GatewayCacheHandle {
+    async fn lookup_gateways(&self, gw_type: GatewayType) -> Result<GatewayList, Error> {
+        self.lookup_gateways(gw_type).await
+    }
+}

--- a/nym-vpn-core/crates/nym-vpn-lib/src/recents/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/recents/mod.rs
@@ -1,0 +1,184 @@
+// Copyright 2026 Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use std::{collections::VecDeque, path::PathBuf, str::FromStr, sync::Arc};
+
+use itertools::Itertools;
+use nym_gateway_directory::{GatewayList, GatewayType, NodeIdentity};
+use nym_vpn_lib_types::{Gateway, RecentGateways, TunnelType};
+use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
+
+pub use crate::recents::gateway_cache::RecentGatewayCache;
+
+mod gateway_cache;
+
+const MAX_RECENTS: usize = 20;
+const RECENTS_FILE_NAME: &str = "recents.json";
+
+#[derive(Clone, Serialize, Deserialize)]
+struct InnerRecents {
+    entry: VecDeque<String>,
+    exit: VecDeque<String>,
+}
+
+impl InnerRecents {
+    fn truncate(&mut self) {
+        if self.entry.len() > MAX_RECENTS {
+            let _ = self.entry.split_off(MAX_RECENTS);
+        }
+        if self.exit.len() > MAX_RECENTS {
+            let _ = self.exit.split_off(MAX_RECENTS);
+        }
+    }
+}
+
+impl Default for InnerRecents {
+    fn default() -> Self {
+        Self {
+            entry: VecDeque::with_capacity(MAX_RECENTS),
+            exit: VecDeque::with_capacity(MAX_RECENTS),
+        }
+    }
+}
+
+#[derive(Clone, Default, Serialize, Deserialize)]
+struct Recents {
+    mixnet_recents: InnerRecents,
+    wireguard_recents: InnerRecents,
+}
+
+impl Recents {
+    fn to_bytes(&self) -> Result<Vec<u8>, serde_json::Error> {
+        serde_json::to_vec(self)
+    }
+
+    fn truncate(&mut self) {
+        self.mixnet_recents.truncate();
+        self.wireguard_recents.truncate();
+    }
+}
+
+/// Manager for storing the recent successful gateway connections to disk and in a memory cache
+#[derive(Clone)]
+pub struct RecentsManager<C: RecentGatewayCache> {
+    file_path: PathBuf,
+    gateway_cache: C,
+    cache: Arc<RwLock<Recents>>,
+}
+
+async fn persisted_recents(file_path: &PathBuf) -> Option<Recents> {
+    let bytes = tokio::fs::read(file_path)
+        .await
+        .inspect_err(|err| tracing::warn!("Could not load disk recents, clearing it out: {err:?}"))
+        .ok()?;
+    serde_json::from_slice(&bytes)
+        .inspect_err(|err| tracing::warn!("Could not decode recents, clearing it out: {err:?}"))
+        .ok()
+}
+
+async fn flush(file_path: PathBuf, contents: Vec<u8>) {
+    if let Err(err) = tokio::fs::write(file_path, contents).await {
+        tracing::warn!("Could not flush recents file: {err:?}");
+    } else {
+        tracing::debug!("Recents file written to disk");
+    }
+}
+
+impl<C: RecentGatewayCache> RecentsManager<C> {
+    pub async fn new(dir_path: PathBuf, gateway_cache: C) -> Self {
+        let file_path = dir_path.join(RECENTS_FILE_NAME);
+        match persisted_recents(&file_path).await {
+            Some(mut cache) => {
+                // in case disk got more entries than current maximum, we truncate that to the current max value
+                cache.truncate();
+                Self {
+                    file_path,
+                    gateway_cache,
+                    cache: Arc::new(RwLock::new(cache)),
+                }
+            }
+            None => {
+                let cache = Recents::default();
+                if let Ok(contents) = cache.to_bytes() {
+                    // write the first empty recents, to have the file created on disk
+                    flush(file_path.clone(), contents).await;
+                } else {
+                    tracing::warn!("Could not serialize empty recents cache");
+                };
+                Self {
+                    file_path,
+                    gateway_cache,
+                    cache: Arc::new(RwLock::new(cache)),
+                }
+            }
+        }
+    }
+
+    fn add_recent_to_queue(queue: &mut VecDeque<String>, recent: String) {
+        if let Some((idx, _)) = queue.iter().find_position(|v| **v == recent) {
+            if idx == 0 {
+                // already the most recent, nothing to do
+                return;
+            }
+            queue.remove(idx);
+        } else if queue.len() >= MAX_RECENTS {
+            queue.pop_back();
+        }
+        queue.push_front(recent);
+    }
+
+    pub async fn add_recent(&mut self, tunnel_type: TunnelType, entry: String, exit: String) {
+        let mut cache: tokio::sync::RwLockWriteGuard<'_, Recents> = self.cache.write().await;
+        let inner = match tunnel_type {
+            TunnelType::Mixnet => &mut cache.mixnet_recents,
+            TunnelType::Wireguard => &mut cache.wireguard_recents,
+        };
+        Self::add_recent_to_queue(&mut inner.entry, entry);
+        Self::add_recent_to_queue(&mut inner.exit, exit);
+
+        let Ok(contents) = cache.to_bytes() else {
+            tracing::warn!("Could not serialize recents cache");
+            return;
+        };
+        let file_path = self.file_path.clone();
+        // put IO disk operation on a new thread, as it's a best effort sync to disk that's not needed
+        // for the hot path of going into connected state
+        tokio::spawn(flush(file_path, contents));
+    }
+
+    fn get_recent_queue(queue: &VecDeque<String>, gateways: &GatewayList) -> Vec<Gateway> {
+        queue
+            .iter()
+            .filter_map(|gw_str| NodeIdentity::from_str(gw_str).ok())
+            .filter_map(|id| gateways.gateway_with_identity(&id))
+            .cloned()
+            .map(Into::into)
+            .collect()
+    }
+
+    pub async fn get_recent(
+        &self,
+        tunnel_type: TunnelType,
+    ) -> Result<RecentGateways, crate::gateway_directory::Error> {
+        let cache = self.cache.read().await.clone();
+        let (inner, entry_gateways, exit_gateways) = match tunnel_type {
+            TunnelType::Mixnet => (
+                cache.mixnet_recents,
+                self.gateway_cache
+                    .lookup_gateways(GatewayType::MixnetEntry)
+                    .await?,
+                self.gateway_cache
+                    .lookup_gateways(GatewayType::MixnetExit)
+                    .await?,
+            ),
+            TunnelType::Wireguard => {
+                let wg_gateways = self.gateway_cache.lookup_gateways(GatewayType::Wg).await?;
+                (cache.wireguard_recents, wg_gateways.clone(), wg_gateways)
+            }
+        };
+        let entry = Self::get_recent_queue(&inner.entry, &entry_gateways);
+        let exit = Self::get_recent_queue(&inner.exit, &exit_gateways);
+        Ok(RecentGateways { entry, exit })
+    }
+}

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/error.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/error.rs
@@ -3,7 +3,7 @@
 
 use crate::{MixnetError, tunnel_state_machine::Error as TunnelStateMachineError};
 use nym_vpn_api_client::error::VpnApiClientError;
-use nym_vpn_lib_types::GatewayType;
+use nym_vpn_lib_types::{GatewayType, TunnelType};
 
 use super::config::ConfigSetupError;
 
@@ -108,6 +108,12 @@ pub enum ListGatewaysError {
     #[error("failed to get filtered gateways ({gw_type:?})")]
     GetFilteredGateways {
         gw_type: GatewayType,
+        source: crate::gateway_directory::Error,
+    },
+
+    #[error("failed to get recent gateways ({tunnel_type:?})")]
+    GetRecentGateways {
+        tunnel_type: TunnelType,
         source: crate::gateway_directory::Error,
     },
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
@@ -52,9 +52,9 @@ use nym_vpn_lib_types::{
     FeatureFlags, Gateway, GatewaySelectionAlgorithm, GetDeeplinkParams, ListGatewaysOptions,
     LogPath, LookupGatewayFilters, MixnetTrafficConfig, NetworkCompatibility,
     NetworkStatisticsIdentity, NymNetworkDetails, NymVpnDevice, NymVpnNetwork, NymVpnUsage,
-    ParsedAccountLinks, RegistrationReport, StorableAccount, StoreAccountRequest,
+    ParsedAccountLinks, RecentGateways, RegistrationReport, StorableAccount, StoreAccountRequest,
     StoredAccountMode, SystemMessage, TargetState, TentativeGateways, TunnelEvent, TunnelState,
-    VpnAccountSummary, VpnServiceConfig, VpnServiceInfo,
+    TunnelType, VpnAccountSummary, VpnServiceConfig, VpnServiceInfo,
 };
 #[cfg(any(target_os = "android", target_os = "ios"))]
 use nym_vpn_lib_types::{RegisterAccountRequest, RegisterAccountResponse};
@@ -82,6 +82,7 @@ use crate::{
     gateway_directory::{self, GatewayCache, GatewayCacheHandle, GatewayClient},
     logging::LogFileRemoverHandle,
     paths::{NymConfigPaths, Paths},
+    recents::RecentsManager,
     tunnel_state_machine::{
         NymConfig, TunnelCommand, TunnelConstants, TunnelStateMachine,
         tunnel::gateway_provider::GatewayProvider,
@@ -235,6 +236,10 @@ pub enum VpnServiceCommand {
         DiagnosticRegisterParams,
     ),
     GetTentativeGateways(oneshot::Sender<TentativeGateways>, ()),
+    GetRecentGateways(
+        oneshot::Sender<Result<RecentGateways, ListGatewaysError>>,
+        TunnelType,
+    ),
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     IsSplitTunnelSupported(oneshot::Sender<bool>, ()),
     #[cfg(any(target_os = "macos", target_os = "windows"))]
@@ -389,6 +394,9 @@ pub struct NymVpnService {
 
     // Gateway provider join handle
     gateway_provider_handle: JoinHandle<()>,
+
+    // Manager of recent gateways
+    recents_manager: RecentsManager<GatewayCacheHandle>,
 
     #[cfg(target_os = "linux")]
     split_tunnel_pid_manager: nym_split_tunnel::PidManager,
@@ -679,6 +687,12 @@ impl NymVpnService {
             state_machine_shutdown_token.child_token(),
         );
 
+        let recents_manager = RecentsManager::new(
+            nym_config.paths.network_data_dir.clone(),
+            gateway_cache_handle.clone(),
+        )
+        .await;
+
         let (file_updater, file_updater_handle) =
             nym_file_updater::FileUpdater::new().map_err(Error::CreateFileUpdater)?;
         tokio::spawn(file_updater.run(services_shutdown_token.child_token()));
@@ -699,6 +713,7 @@ impl NymVpnService {
             #[cfg(any(target_os = "macos", target_os = "windows"))]
             split_tunnel.clone(),
             gateway_provider.clone(),
+            recents_manager.clone(),
             #[cfg(target_os = "linux")]
             split_tunnel_config,
             #[cfg(not(any(target_os = "android", target_os = "ios")))]
@@ -750,6 +765,7 @@ impl NymVpnService {
             split_tunnel_join_handle,
             gateway_provider,
             gateway_provider_handle,
+            recents_manager,
             #[cfg(target_os = "linux")]
             split_tunnel_pid_manager,
         })
@@ -1306,6 +1322,9 @@ impl NymVpnService {
                     .handle_set_geo_exclusion_excluded_countries(excluded_countries)
                     .await;
                 let _ = tx.send(result);
+            }
+            VpnServiceCommand::GetRecentGateways(tx, gateway_type) => {
+                let _ = tx.send(self.handle_get_recent_gateways(gateway_type).await);
             }
         }
     }
@@ -2407,5 +2426,18 @@ impl NymVpnService {
             .await?;
         self.update_tunnel_settings_with_throttle();
         Ok(())
+    }
+
+    async fn handle_get_recent_gateways(
+        &mut self,
+        tunnel_type: TunnelType,
+    ) -> Result<RecentGateways, ListGatewaysError> {
+        self.recents_manager
+            .get_recent(tunnel_type)
+            .await
+            .map_err(|source| ListGatewaysError::GetRecentGateways {
+                tunnel_type,
+                source,
+            })
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -32,13 +32,13 @@ use crate::tunnel_provider::AndroidTunProvider;
 #[cfg(target_os = "ios")]
 use crate::tunnel_provider::OSTunProvider;
 
-use crate::adblocker;
 #[cfg(not(target_os = "android"))]
 use crate::resolver;
 #[cfg(not(target_os = "ios"))]
 use crate::socks5_proxy::Socks5ProxyManager;
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 use crate::socks5_proxy::find_proxy_binary;
+use crate::{adblocker, recents::RecentsManager};
 
 use crate::{
     GatewayProviderError, UserAgent, bandwidth_monitor::Error as BandwidthMonitorError,
@@ -780,6 +780,7 @@ pub struct SharedState {
     nm_connectivity_check_enabled: Option<bool>,
     gateway_provider: GatewayProvider<GatewayCacheHandle>,
     topology_service: VpnTopologyServiceHandle,
+    recents_manager: RecentsManager<GatewayCacheHandle>,
     discovery_refresher_command_tx: mpsc::UnboundedSender<DiscoveryRefresherCommand>,
     user_agent: UserAgent,
     /// API endpoints resolved in connecting state and used for configuring a bypass in error state.
@@ -1112,6 +1113,7 @@ impl TunnelStateMachine {
         #[cfg(any(target_os = "macos", target_os = "windows"))]
         split_tunnel: nym_split_tunnel::SplitTunnelHandle,
         gateway_provider: GatewayProvider<GatewayCacheHandle>,
+        recents_manager: RecentsManager<GatewayCacheHandle>,
         #[cfg(target_os = "linux")] split_tunnel_config: LinuxSplitTunnelConfiguration,
         #[cfg(not(any(target_os = "android", target_os = "ios")))] route_handler: RouteHandler,
         #[cfg(target_os = "ios")] tun_provider: Arc<dyn OSTunProvider>,
@@ -1192,6 +1194,7 @@ impl TunnelStateMachine {
             nm_connectivity_check_enabled: None,
             gateway_provider,
             topology_service,
+            recents_manager,
             discovery_refresher_command_tx,
             user_agent,
             #[cfg(not(any(target_os = "android", target_os = "ios")))]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
@@ -132,8 +132,14 @@ impl ConnectedState {
             .await;
         }
 
-        #[cfg(target_os = "android")]
-        let _ = shared_state; // Avoid unused variable warning
+        shared_state
+            .recents_manager
+            .add_recent(
+                connection_data.tunnel.tunnel_type(),
+                connection_data.entry_gateway.id.clone(),
+                connection_data.exit_gateway.id.clone(),
+            )
+            .await;
 
         // Statistics reports must be sent through a socket bound to the tunnel interface,
         // since the packet tunnel provider's traffic is otherwise excluded from the tunnel.

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -396,6 +396,11 @@ message GatewayResponse {
   optional string node_family_name = 14;
 }
 
+message RecentGateways {
+  repeated GatewayResponse entry = 1;
+  repeated GatewayResponse exit = 2;
+}
+
 message KemKeyDigests {
   map<string, string> digests = 1;
 }
@@ -1137,6 +1142,10 @@ message SplitTunnelExcludedProcessList {
   repeated SplitTunnelExcludedProcess processes = 1;
 }
 
+message GetRecentGatewaysParams {
+  TunnelType tunnel_type = 1;
+}
+
 service NymVpnService {
   // Get info regarding the nym-vpnd in general, like version etc.
   rpc Info(google.protobuf.Empty) returns (InfoResponse) {}
@@ -1341,4 +1350,7 @@ service NymVpnService {
   // Split-tunnel (macOS only)
   // Check whether the app needs TCC approval for split tunneling (macOS)
   rpc NeedFullDiskPermissions(google.protobuf.Empty) returns (google.protobuf.BoolValue) {}
+
+  // Get recent gateways
+  rpc GetRecentGateways(GetRecentGatewaysParams) returns (RecentGateways) {}
 }

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/mod.rs
@@ -11,6 +11,7 @@ pub mod gateway_selection_algorithm;
 pub mod network_config;
 pub mod network_stats;
 pub mod prost;
+pub mod recents;
 pub mod service;
 pub mod socket_addr;
 pub mod socks5;

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/recents.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/recents.rs
@@ -1,0 +1,24 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use crate::{conversions::ConversionError, proto};
+
+impl From<nym_vpn_lib_types::GetRecentGatewaysParams> for proto::GetRecentGatewaysParams {
+    fn from(value: nym_vpn_lib_types::GetRecentGatewaysParams) -> Self {
+        Self {
+            tunnel_type: proto::TunnelType::from(value.tunnel_type) as i32,
+        }
+    }
+}
+
+impl TryFrom<proto::GetRecentGatewaysParams> for nym_vpn_lib_types::GetRecentGatewaysParams {
+    type Error = ConversionError;
+
+    fn try_from(value: proto::GetRecentGatewaysParams) -> Result<Self, Self::Error> {
+        let tunnel_type = proto::TunnelType::try_from(value.tunnel_type)
+            .map_err(|e| ConversionError::Decode("TunnelType", e))
+            .map(nym_vpn_lib_types::TunnelType::from)?;
+
+        Ok(Self { tunnel_type })
+    }
+}

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/vpnd.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/vpnd.rs
@@ -433,6 +433,34 @@ impl From<nym_vpn_lib_types::TentativeGateways> for proto::TentativeGateways {
     }
 }
 
+impl From<nym_vpn_lib_types::RecentGateways> for proto::RecentGateways {
+    fn from(value: nym_vpn_lib_types::RecentGateways) -> Self {
+        Self {
+            entry: value.entry.into_iter().map(Into::into).collect(),
+            exit: value.exit.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl TryFrom<proto::RecentGateways> for nym_vpn_lib_types::RecentGateways {
+    type Error = ConversionError;
+
+    fn try_from(value: proto::RecentGateways) -> Result<Self, Self::Error> {
+        Ok(Self {
+            entry: value
+                .entry
+                .into_iter()
+                .map(TryInto::try_into)
+                .collect::<Result<Vec<_>, Self::Error>>()?,
+            exit: value
+                .exit
+                .into_iter()
+                .map(TryInto::try_into)
+                .collect::<Result<Vec<_>, Self::Error>>()?,
+        })
+    }
+}
+
 impl From<BridgeInformation> for proto::BridgeInformation {
     fn from(value: BridgeInformation) -> Self {
         let transports = value

--- a/nym-vpn-core/crates/nym-vpn-proto/src/rpc_client.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/rpc_client.rs
@@ -16,9 +16,9 @@ use nym_vpn_lib_types::{
     AvailableTickets, DiagnosticReport, EntryPoint, ExitPoint, FeatureFlags, FrontingMode, Gateway,
     GetDeeplinkParams, HttpRpcSettings, ListGatewaysOptions, LogPath, LookupGatewayFilters,
     NetworkCompatibility, NetworkStatisticsIdentity, NymVpnDevice, NymVpnUsage, ParsedAccountLinks,
-    PrivyDerivationMessage, RegistrationReport, Socks5Settings, Socks5Status, StoreAccountRequest,
-    StoredAccountMode, SystemMessage, TentativeGateways, TunnelEvent, TunnelState,
-    VpnAccountSummary, VpnServiceConfig, VpnServiceInfo,
+    PrivyDerivationMessage, RecentGateways, RegistrationReport, Socks5Settings, Socks5Status,
+    StoreAccountRequest, StoredAccountMode, SystemMessage, TentativeGateways, TunnelEvent,
+    TunnelState, VpnAccountSummary, VpnServiceConfig, VpnServiceInfo,
 };
 
 use crate::proto::{self, nym_vpn_service_client::NymVpnServiceClient};
@@ -932,6 +932,20 @@ impl RpcClient {
             .map(|v| v.into_inner())
             .map_err(Error::Rpc)?;
         TentativeGateways::try_from(response).map_err(Error::InvalidResponse)
+    }
+
+    pub async fn get_recent_gateways(
+        &mut self,
+        params: nym_vpn_lib_types::GetRecentGatewaysParams,
+    ) -> Result<RecentGateways> {
+        let request = proto::GetRecentGatewaysParams::from(params);
+        let response = self
+            .0
+            .get_recent_gateways(request)
+            .await
+            .map(|v| v.into_inner())
+            .map_err(Error::Rpc)?;
+        RecentGateways::try_from(response).map_err(Error::InvalidResponse)
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]

--- a/nym-vpn-core/crates/nym-vpnc/src/commands/gateway.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/commands/gateway.rs
@@ -5,8 +5,8 @@ use anyhow::{Result, anyhow};
 use tabled::Table;
 
 use nym_vpn_lib_types::{
-    EntryPoint, ExitPoint, GatewayFilter, ListGatewaysOptions, LookupGatewayFilters, NodeIdentity,
-    Recipient,
+    EntryPoint, ExitPoint, GatewayFilter, GetRecentGatewaysParams, ListGatewaysOptions,
+    LookupGatewayFilters, NodeIdentity, Recipient,
 };
 use nym_vpn_proto::rpc_client::RpcClient;
 
@@ -57,6 +57,12 @@ pub enum Command {
 
         #[command(flatten)]
         filters: FilterArgs,
+    },
+
+    /// List recently connected gateways
+    Recents {
+        /// Tunnel type of the recent connection to the gateways
+        tunnel_type: TunnelType,
     },
 }
 
@@ -187,6 +193,10 @@ impl Args {
                     .await?;
                 Ok(())
             }
+            Command::Recents { tunnel_type } => {
+                self.recent_gateways(rpc_client, tunnel_type).await?;
+                Ok(())
+            }
         }
     }
 
@@ -225,6 +235,54 @@ impl Args {
             gateways.len()
         );
         let models = gateways
+            .into_iter()
+            .map(|gateway| GatewayModel::new(gateway, gw_type))
+            .collect::<Vec<_>>();
+        let mut table = Table::new(models);
+        self.table_style.apply_style(&mut table);
+        println!("{table}");
+
+        Ok(())
+    }
+
+    async fn recent_gateways(
+        &self,
+        mut rpc_client: RpcClient,
+        tunnel_type: TunnelType,
+    ) -> Result<()> {
+        let recent_gateways = rpc_client
+            .get_recent_gateways(GetRecentGatewaysParams {
+                tunnel_type: tunnel_type.into(),
+            })
+            .await?;
+
+        println!(
+            "Recent entry gateways for:  {tunnel_type:?} ({})",
+            recent_gateways.entry.len(),
+        );
+        let gw_type = match tunnel_type {
+            TunnelType::Mixnet => GatewayType::MixnetEntry,
+            TunnelType::Wg => GatewayType::Wg,
+        };
+        let models = recent_gateways
+            .entry
+            .into_iter()
+            .map(|gateway| GatewayModel::new(gateway, gw_type))
+            .collect::<Vec<_>>();
+        let mut table = Table::new(models);
+        self.table_style.apply_style(&mut table);
+        println!("{table}");
+
+        println!(
+            "Recent exit gateways for:  {tunnel_type:?} ({})",
+            recent_gateways.exit.len(),
+        );
+        let gw_type = match tunnel_type {
+            TunnelType::Mixnet => GatewayType::MixnetExit,
+            TunnelType::Wg => GatewayType::Wg,
+        };
+        let models = recent_gateways
+            .exit
             .into_iter()
             .map(|gateway| GatewayModel::new(gateway, gw_type))
             .collect::<Vec<_>>();
@@ -332,6 +390,23 @@ impl From<GatewayType> for nym_vpn_lib_types::GatewayType {
             GatewayType::MixnetEntry => Self::MixnetEntry,
             GatewayType::MixnetExit => Self::MixnetExit,
             GatewayType::Wg => Self::Wg,
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, clap::ValueEnum)]
+pub enum TunnelType {
+    /// Mixnet tunnel
+    Mixnet,
+    /// Wireguard tunnel
+    Wg,
+}
+
+impl From<TunnelType> for nym_vpn_lib_types::TunnelType {
+    fn from(value: TunnelType) -> Self {
+        match value {
+            TunnelType::Mixnet => nym_vpn_lib_types::TunnelType::Mixnet,
+            TunnelType::Wg => nym_vpn_lib_types::TunnelType::Wireguard,
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface.rs
@@ -428,6 +428,26 @@ impl NymVpnService for CommandInterface {
         Ok(tonic::Response::new(()))
     }
 
+    async fn get_recent_gateways(
+        &self,
+        request: tonic::Request<proto::GetRecentGatewaysParams>,
+    ) -> Result<tonic::Response<proto::RecentGateways>> {
+        let tunnel_type =
+            nym_vpn_lib_types::GetRecentGatewaysParams::try_from(request.into_inner())
+                .map_err(|e| {
+                    tonic::Status::invalid_argument(format!("Invalid recent gateway params: {e}"))
+                })?
+                .tunnel_type;
+        let response = self
+            .send_and_wait(VpnServiceCommand::GetRecentGateways, tunnel_type)
+            .await?
+            .map_err(|err| {
+                tonic::Status::internal(format!("Failed to get recent gateways: {err}"))
+            })?;
+
+        Ok(tonic::Response::new(response.into()))
+    }
+
     async fn set_network(&self, request: tonic::Request<String>) -> Result<tonic::Response<()>> {
         let network = request.into_inner();
         let status = self


### PR DESCRIPTION
## Ticket

JIRA-NYM-1655

## Description

Add recents data, to be used by UIs.
Store it in memory for ease of use, and on disk for persistence, in a new JSON file.


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5903)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added recently used gateway tracking with persistence across sessions, separated into entry and exit lists and filtered by tunnel type (most-recent-first).
  * Added a `gateway recents` command to view recent entry/exit gateways for the selected tunnel type.
  * Added a new API endpoint to fetch recent gateways, with UniFFI and gRPC support.
* **Bug Fixes**
  * Recent gateways are now recorded when a tunnel connects (removing prior no-op behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->