### PR TITLE
Bound proxy startup so it cannot wedge the tunnel state machine

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/socks5_proxy/process.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/socks5_proxy/process.rs
@@ -20,9 +20,31 @@ const PROXY_BINARY_NAME: &str = if cfg!(windows) {
     "nym-socks5-proxy"
 };
 
-/// Maximum time to wait for nym-socks5-proxy to report readiness before giving up
-/// on it.
+/// Default maximum time to wait for nym-socks5-proxy to report readiness before
+/// giving up on it. Overridable at runtime via `READY_TIMEOUT_ENV` for slow CI or
+/// constrained environments.
 const READY_TIMEOUT: Duration = Duration::from_secs(30);
+
+const READY_TIMEOUT_ENV: &str = "NYM_SOCKS5_PROXY_READY_TIMEOUT_SECS";
+
+fn ready_timeout() -> Duration {
+    resolve_ready_timeout(env::var(READY_TIMEOUT_ENV).ok())
+}
+
+fn resolve_ready_timeout(raw: Option<String>) -> Duration {
+    match raw {
+        Some(val) => match val.parse::<u64>() {
+            Ok(secs) => Duration::from_secs(secs),
+            Err(_) => {
+                tracing::warn!(
+                    "invalid {READY_TIMEOUT_ENV}={val:?}; using default {READY_TIMEOUT:?}"
+                );
+                READY_TIMEOUT
+            }
+        },
+        None => READY_TIMEOUT,
+    }
+}
 
 pub struct RunningProcess {
     msg_tx: mpsc::UnboundedSender<DaemonMessage>,
@@ -107,8 +129,17 @@ pub async fn spawn(
 
     // Wait for the proxy to become ready, but never block forever: a proxy that
     // starts yet never reports ready would otherwise wedge the tunnel state
-    // machine
-    await_ready(ready_rx, READY_TIMEOUT, &supervisor_token).await?;
+    // machine.
+    let ready_timeout = ready_timeout();
+    if let Err(err) = await_ready(ready_rx, ready_timeout).await {
+        if matches!(err, SpawnError::ReadyTimeout(_)) {
+            tracing::warn!(
+                "nym-socks5-proxy did not report ready within {ready_timeout:?}; tearing it down and continuing without it"
+            );
+        }
+        teardown_after_failed_start(&supervisor_token, join_handle).await;
+        return Err(err);
+    }
 
     tracing::info!("nym-socks5-proxy is ready");
 
@@ -119,23 +150,26 @@ pub async fn spawn(
     })
 }
 
-/// Await the proxy readiness signal
+/// Classify the proxy readiness outcome, bounded by `timeout`.
 async fn await_ready(
     ready_rx: oneshot::Receiver<Result<(), String>>,
     timeout: Duration,
-    supervisor_token: &CancellationToken,
 ) -> Result<(), SpawnError> {
     match tokio::time::timeout(timeout, ready_rx).await {
         Ok(Ok(Ok(()))) => Ok(()),
         Ok(Ok(Err(msg))) => Err(SpawnError::ProxyError(msg)),
         Ok(Err(_)) => Err(SpawnError::ExitedBeforeReady),
-        Err(_) => {
-            tracing::warn!(
-                "nym-socks5-proxy did not report ready within {timeout:?}; tearing it down and continuing without it"
-            );
-            supervisor_token.cancel();
-            Err(SpawnError::ReadyTimeout(timeout))
-        }
+        Err(_) => Err(SpawnError::ReadyTimeout(timeout)),
+    }
+}
+
+async fn teardown_after_failed_start(
+    supervisor_token: &CancellationToken,
+    join_handle: JoinHandle<()>,
+) {
+    supervisor_token.cancel();
+    if let Err(join_err) = join_handle.await {
+        tracing::error!("nym-socks5-proxy supervisor task panicked during teardown: {join_err}");
     }
 }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/socks5_proxy/process.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/socks5_proxy/process.rs
@@ -137,6 +137,9 @@ pub async fn spawn(
                 "nym-socks5-proxy did not report ready within {ready_timeout:?}; tearing it down and continuing without it"
             );
         }
+        // Safe for all three error variants: cancellation is idempotent and
+        // joining a supervisor that has already exited (ProxyError,
+        // ExitedBeforeReady) or is mid-exit returns immediately without racing.
         teardown_after_failed_start(&supervisor_token, join_handle).await;
         return Err(err);
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/socks5_proxy/process.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/socks5_proxy/process.rs
@@ -20,6 +20,10 @@ const PROXY_BINARY_NAME: &str = if cfg!(windows) {
     "nym-socks5-proxy"
 };
 
+/// Maximum time to wait for nym-socks5-proxy to report readiness before giving up
+/// on it.
+const READY_TIMEOUT: Duration = Duration::from_secs(30);
+
 pub struct RunningProcess {
     msg_tx: mpsc::UnboundedSender<DaemonMessage>,
     shutdown_token: CancellationToken,
@@ -101,12 +105,10 @@ pub async fn spawn(
         supervisor_token.clone(),
     ));
 
-    // Wait for the proxy to become ready.
-    match ready_rx.await {
-        Ok(Ok(())) => {}
-        Ok(Err(msg)) => return Err(SpawnError::ProxyError(msg)),
-        Err(_) => return Err(SpawnError::ExitedBeforeReady),
-    }
+    // Wait for the proxy to become ready, but never block forever: a proxy that
+    // starts yet never reports ready would otherwise wedge the tunnel state
+    // machine
+    await_ready(ready_rx, READY_TIMEOUT, &supervisor_token).await?;
 
     tracing::info!("nym-socks5-proxy is ready");
 
@@ -115,6 +117,26 @@ pub async fn spawn(
         shutdown_token: supervisor_token,
         join_handle,
     })
+}
+
+/// Await the proxy readiness signal
+async fn await_ready(
+    ready_rx: oneshot::Receiver<Result<(), String>>,
+    timeout: Duration,
+    supervisor_token: &CancellationToken,
+) -> Result<(), SpawnError> {
+    match tokio::time::timeout(timeout, ready_rx).await {
+        Ok(Ok(Ok(()))) => Ok(()),
+        Ok(Ok(Err(msg))) => Err(SpawnError::ProxyError(msg)),
+        Ok(Err(_)) => Err(SpawnError::ExitedBeforeReady),
+        Err(_) => {
+            tracing::warn!(
+                "nym-socks5-proxy did not report ready within {timeout:?}; tearing it down and continuing without it"
+            );
+            supervisor_token.cancel();
+            Err(SpawnError::ReadyTimeout(timeout))
+        }
+    }
 }
 
 async fn supervisor(
@@ -295,6 +317,9 @@ pub enum SpawnError {
 
     #[error("Proxy process exited before reporting ready")]
     ExitedBeforeReady,
+
+    #[error("Proxy did not report ready within {0:?}")]
+    ReadyTimeout(Duration),
 
     #[error("Proxy reported an error: {0}")]
     ProxyError(String),

--- a/nym-vpn-core/crates/nym-vpn-lib/src/socks5_proxy/process.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/socks5_proxy/process.rs
@@ -6,7 +6,7 @@ use std::{env, path::PathBuf, process::Stdio, result::Result, time::Duration};
 use nym_socks5_proxy_ipc::{DaemonMessage, InterfaceAddresses, ProxyConfig, ProxyMessage};
 use tokio::{
     io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
-    process::{Child, ChildStdin, ChildStdout, Command},
+    process::{Child, ChildStderr, ChildStdin, ChildStdout, Command},
     sync::{mpsc, oneshot},
     task::JoinHandle,
 };
@@ -88,8 +88,8 @@ pub async fn spawn(
     command
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        // Proxy logs go to its own log file; discard stderr.
-        .stderr(Stdio::null());
+        // Capture stderr and forward it into the daemon log (backup for proxy logs)
+        .stderr(Stdio::piped());
     // Run in own process group on Unix so it doesn't inherit a terminal.
     #[cfg(unix)]
     command.process_group(0);
@@ -104,6 +104,12 @@ pub async fn spawn(
         .stdout
         .take()
         .expect("stdout was piped but is unavailable");
+    let stderr = child
+        .stderr
+        .take()
+        .expect("stderr was piped but is unavailable");
+
+    tokio::spawn(stderr_forwarder(stderr));
 
     // Channel for sending DaemonMessages from handle → writer task → child stdin.
     let (msg_tx, msg_rx) = mpsc::unbounded_channel::<DaemonMessage>();
@@ -176,6 +182,20 @@ async fn teardown_after_failed_start(
     }
 }
 
+async fn stderr_forwarder(stderr: ChildStderr) {
+    let mut lines = BufReader::new(stderr).lines();
+    loop {
+        match lines.next_line().await {
+            Ok(Some(line)) => tracing::warn!("nym-socks5-proxy stderr: {line}"),
+            Ok(None) => break,
+            Err(err) => {
+                tracing::debug!("error reading nym-socks5-proxy stderr: {err}");
+                break;
+            }
+        }
+    }
+}
+
 async fn supervisor(
     mut child: Child,
     stdin: ChildStdin,
@@ -195,6 +215,7 @@ async fn supervisor(
             result = lines.next_line() => {
                 match result {
                     Ok(Some(line)) => {
+                        tracing::debug!("nym-socks5-proxy stdout: {line}");
                         handle_proxy_line(&line, &mut ready_tx, &event_tx);
                     }
                     Ok(None) => {


### PR DESCRIPTION
## Description

The tunnel state machine awaits Socks5ProxyManager::start() inline, which awaits process::spawn()'s ready signal. That await had no timeout: a proxy that starts but never reports ready blocks the state machine forever, making nym-vpnd stop servicing management RPCs (every e2e daemon call then hits DeadlineExceeded).

The proxy is already treated as optional (start() logs and continues on any spawn error). 


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5904)
<!-- Reviewable:end -->
