### PR TITLE
Move no_service function outside of service

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/favorites.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/favorites.rs
@@ -1,0 +1,70 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use std::path::PathBuf;
+
+use nym_vpn_lib::{RecentsError, RecentsManager};
+use nym_vpn_lib_types::{RecentGateways, TunnelType};
+
+use crate::gateway_cache::NymGatewayCache;
+
+#[derive(Debug, thiserror::Error)]
+enum FavoritesInnerError {
+    #[error("failed to get recent gateways ({0})")]
+    Recents(RecentsError),
+}
+
+impl FavoritesInnerError {
+    pub fn error_chain(&self) -> String {
+        match self {
+            Self::Recents(err) => err.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, uniffi::Object)]
+#[uniffi::export(Display)]
+pub struct FavoritesError {
+    inner: FavoritesInnerError,
+}
+
+impl FavoritesError {
+    fn new(inner: FavoritesInnerError) -> Self {
+        Self { inner }
+    }
+}
+
+#[uniffi::export]
+impl FavoritesError {
+    /// Returns formatted error chain
+    pub fn error_chain(&self) -> String {
+        self.inner.error_chain()
+    }
+}
+
+impl std::fmt::Display for FavoritesError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.inner.to_string())
+    }
+}
+
+impl From<FavoritesInnerError> for FavoritesError {
+    fn from(value: FavoritesInnerError) -> Self {
+        Self::new(value)
+    }
+}
+
+type Result<T, E = FavoritesError> = std::result::Result<T, E>;
+
+#[uniffi::export]
+pub async fn get_recent_gateways_no_service(
+    data_dir: PathBuf,
+    gateway_cache: &NymGatewayCache,
+    tunnel_type: TunnelType,
+) -> Result<RecentGateways> {
+    let recent_gateway_cache = RecentsManager::new(data_dir, gateway_cache).await;
+    Ok(recent_gateway_cache
+        .get_recent(tunnel_type)
+        .await
+        .map_err(FavoritesInnerError::Recents)?)
+}

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/lib.rs
@@ -182,6 +182,7 @@ mod android_connectivity_monitor;
 #[cfg(target_os = "ios")]
 mod deeplink;
 mod environment;
+mod favorites;
 mod gateway_cache;
 mod logging;
 mod offline_monitor;

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_service_command_sender.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_service_command_sender.rs
@@ -1,12 +1,11 @@
 // Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{net::IpAddr, path::PathBuf, sync::Arc};
+use std::{net::IpAddr, sync::Arc};
 
 use nym_common::ErrorExt;
-use nym_vpn_lib::{
-    RecentsManager,
-    service::{AccountLinksError, GeoExclusionConfigError, ListGatewaysError, VpnServiceCommand},
+use nym_vpn_lib::service::{
+    AccountLinksError, GeoExclusionConfigError, ListGatewaysError, VpnServiceCommand,
 };
 use tokio::sync::{mpsc, oneshot};
 
@@ -18,8 +17,6 @@ use nym_vpn_lib_types::{
     StoreAccountRequest, StoredAccountMode, SystemMessage, TargetState, TentativeGateways,
     TunnelState, TunnelType, VpnAccountSummary, VpnServiceConfig, VpnServiceInfo,
 };
-
-use crate::gateway_cache::NymGatewayCache;
 
 #[derive(Debug, thiserror::Error)]
 enum NymVpnServiceCommandInnerError {
@@ -458,23 +455,6 @@ impl NymVpnServiceCommandSender {
         Ok(self
             .send_and_wait(VpnServiceCommand::GetRecentGateways, tunnel_type)
             .await?
-            .map_err(NymVpnServiceCommandInnerError::ListGateway)?)
-    }
-
-    pub async fn get_recent_gateways_no_service(
-        &self,
-        data_dir: PathBuf,
-        gateway_cache: &NymGatewayCache,
-        tunnel_type: TunnelType,
-    ) -> Result<RecentGateways> {
-        let recent_gateway_cache = RecentsManager::new(data_dir, gateway_cache).await;
-        Ok(recent_gateway_cache
-            .get_recent(tunnel_type)
-            .await
-            .map_err(|source| ListGatewaysError::GetRecentGateways {
-                tunnel_type,
-                source,
-            })
             .map_err(NymVpnServiceCommandInnerError::ListGateway)?)
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/lib.rs
@@ -47,7 +47,7 @@ pub use crate::{
         DEFAULT_MIN_GATEWAY_PERFORMANCE, DEFAULT_MIN_MIXNODE_PERFORMANCE, MixnetError,
         VpnTopologyProvider, VpnTopologyService, VpnTopologyServiceError, VpnTopologyServiceHandle,
     },
-    recents::{RecentGatewayCache, RecentsManager},
+    recents::{RecentGatewayCache, RecentsError, RecentsManager},
     tunnel_state_machine::tunnel::gateway_provider::GatewayProviderError,
 };
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/recents/error.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/recents/error.rs
@@ -1,10 +1,13 @@
 // Copyright 2026 Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use nym_vpn_lib_types::TunnelType;
+
 #[derive(thiserror::Error, Debug)]
 pub enum RecentsError {
     #[error("failed to lookup gateway cache")]
     GetGateways {
+        tunnel_type: TunnelType,
         source: crate::gateway_directory::Error,
     },
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/recents/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/recents/mod.rs
@@ -9,8 +9,9 @@ use nym_vpn_lib_types::{Gateway, RecentGateways, TunnelType};
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 
-pub use crate::recents::gateway_cache::RecentGatewayCache;
+pub use crate::recents::{error::RecentsError, gateway_cache::RecentGatewayCache};
 
+mod error;
 mod gateway_cache;
 
 const MAX_RECENTS: usize = 20;
@@ -157,7 +158,7 @@ impl<C: RecentGatewayCache> RecentsManager<C> {
             .collect()
     }
 
-    pub async fn get_recent(
+    async fn inner_get_recent(
         &self,
         tunnel_type: TunnelType,
     ) -> Result<RecentGateways, crate::gateway_directory::Error> {
@@ -180,5 +181,16 @@ impl<C: RecentGatewayCache> RecentsManager<C> {
         let entry = Self::get_recent_queue(&inner.entry, &entry_gateways);
         let exit = Self::get_recent_queue(&inner.exit, &exit_gateways);
         Ok(RecentGateways { entry, exit })
+    }
+    pub async fn get_recent(
+        &self,
+        tunnel_type: TunnelType,
+    ) -> Result<RecentGateways, RecentsError> {
+        self.inner_get_recent(tunnel_type)
+            .await
+            .map_err(|source| RecentsError::GetGateways {
+                tunnel_type,
+                source,
+            })
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/error.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/error.rs
@@ -1,9 +1,9 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use crate::{MixnetError, tunnel_state_machine::Error as TunnelStateMachineError};
+use crate::{MixnetError, RecentsError, tunnel_state_machine::Error as TunnelStateMachineError};
 use nym_vpn_api_client::error::VpnApiClientError;
-use nym_vpn_lib_types::{GatewayType, TunnelType};
+use nym_vpn_lib_types::GatewayType;
 
 use super::config::ConfigSetupError;
 
@@ -111,11 +111,8 @@ pub enum ListGatewaysError {
         source: crate::gateway_directory::Error,
     },
 
-    #[error("failed to get recent gateways ({tunnel_type:?})")]
-    GetRecentGateways {
-        tunnel_type: TunnelType,
-        source: crate::gateway_directory::Error,
-    },
+    #[error("failed to get recent gateways ({0})")]
+    GetRecentGateways(RecentsError),
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
@@ -2435,9 +2435,6 @@ impl NymVpnService {
         self.recents_manager
             .get_recent(tunnel_type)
             .await
-            .map_err(|source| ListGatewaysError::GetRecentGateways {
-                tunnel_type,
-                source,
-            })
+            .map_err(ListGatewaysError::GetRecentGateways)
     }
 }


### PR DESCRIPTION
## Ticket

JIRA-NYM-1655

## Description

Make the `get_recent_gateways_no_service` uniffi function be stand-alone.
Refactor the errors so that they accommodate both in and out of service usage.


## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5906)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving recently used gateways without requiring the VPN service.
  * Improved error reporting for recent gateway retrieval, including tunnel type context.

* **Improvements**
  * Recent gateway requests now use consistent error handling across service and direct-access paths.
  * Recent gateway functionality is available through the public library interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->