### PR TITLE
Capture nym-vpnd log over SSH on test failure

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -304,6 +304,25 @@ jobs:
             ${{ env.VM_USER }}@${VM_IP}:/tmp/test-report.txt /tmp/test-report.txt 2>/dev/null || \
             echo "No test report found"
 
+      - name: Retrieve daemon logs
+        if: always()
+        env:
+          VM_IP: ${{ steps.vm-ip.outputs.ip }}
+        run: |
+          mkdir -p /tmp/daemon-logs
+          scp ${{ env.SSH_OPTS }} -i ${{ env.SSH_KEY_PATH }} \
+            ${{ env.VM_USER }}@${VM_IP}:'/tmp/daemon-log-*.log' /tmp/daemon-logs/ 2>/dev/null || \
+            echo "No daemon logs found"
+
+      - name: Upload daemon logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: daemon-logs
+          path: /tmp/daemon-logs/
+          if-no-files-found: ignore
+          retention-days: 20
+
       - name: Format test report
         if: always()
         run: |

--- a/nym-vpn-core/crates/test/scripts/ssh-setup.sh
+++ b/nym-vpn-core/crates/test/scripts/ssh-setup.sh
@@ -63,6 +63,11 @@ Environment="RUST_LOG=debug"
 WantedBy=multi-user.target
 EOF
 
+    # The base VM image may ship a pre-baked, logged-in account under
+    # /var/lib/nym-vpnd. 
+    echo "Clearing any pre-baked nym-vpnd account state"
+    rm -rf /var/lib/nym-vpnd/mainnet
+
     echo "Starting Nym VPNd service"
 
     semanage fcontext -a -t bin_t "$RUNNER_DIR/.*" &> /dev/null || true

--- a/nym-vpn-core/crates/test/test-manager/src/main.rs
+++ b/nym-vpn-core/crates/test/test-manager/src/main.rs
@@ -325,9 +325,20 @@ async fn main() -> Result<()> {
                 None => None,
             };
 
-            let result = run_tests::run(&*instance, tests, skip_wait, !verbose, summary_logger)
-                .await
-                .context("Tests failed");
+            // SSH creds for out-of-band daemon log capture on test failure.
+            let ssh_options = vm_config
+                .get_ssh_options()
+                .map(|(user, password)| (user.to_string(), password.to_string()));
+            let result = run_tests::run(
+                &*instance,
+                tests,
+                skip_wait,
+                !verbose,
+                summary_logger,
+                ssh_options,
+            )
+            .await
+            .context("Tests failed");
 
             if display {
                 instance.wait().await;

--- a/nym-vpn-core/crates/test/test-manager/src/run_tests.rs
+++ b/nym-vpn-core/crates/test/test-manager/src/run_tests.rs
@@ -2,6 +2,7 @@
 // Copyright 2025 Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use crate::vm::ssh::SSHSession;
 use crate::{
     logging::{Logger, Panic, TestOutput, TestResult},
     nym_daemon::{self, RpcClientProvider},
@@ -12,8 +13,76 @@ use crate::{
 use anyhow::{Context, Result};
 use futures::FutureExt;
 use nym_vpn_proto::rpc_client::RpcClient as NymProxyClient;
-use std::{panic, time::Duration};
+use std::{io::Write, net::IpAddr, panic, time::Duration};
 use test_rpc::{client_nym::NymServiceClient, logging::Output};
+
+const GUEST_DAEMON_LOG_PATH: &str = "/var/log/nym-vpnd/nym-vpnd.log";
+
+const DAEMON_LOG_TAIL_LINES: usize = 4000;
+
+#[derive(Clone)]
+struct GuestSshAccess {
+    user: String,
+    password: String,
+    ip: IpAddr,
+}
+
+/// Fetch the daemon log over SSH, retrying briefly since the guest may be
+/// firewalled off by the kill-switch during a connect attempt.
+async fn fetch_guest_daemon_log(access: GuestSshAccess) -> Result<String> {
+    tokio::task::spawn_blocking(move || {
+        let mut last_err = None;
+        for attempt in 1..=5 {
+            match SSHSession::connect(access.user.clone(), access.password.clone(), access.ip)
+                .and_then(|session| {
+                    session.exec_blocking(&format!("sudo cat {GUEST_DAEMON_LOG_PATH}"))
+                }) {
+                Ok(contents) => return Ok(contents),
+                Err(err) => {
+                    log::debug!("daemon log capture attempt {attempt}/5 failed: {err:#}");
+                    last_err = Some(err);
+                    std::thread::sleep(Duration::from_secs(3));
+                }
+            }
+        }
+        Err(last_err.unwrap_or_else(|| anyhow::anyhow!("no attempts made")))
+    })
+    .await
+    .context("daemon log capture task panicked")?
+}
+
+/// Best-effort: write the full daemon log to a host file and echo the tail into
+/// the CI output. Never fails the run.
+async fn capture_daemon_log_on_failure(access: &GuestSshAccess, test_name: &str) {
+    let contents = match fetch_guest_daemon_log(access.clone()).await {
+        Ok(contents) => contents,
+        Err(err) => {
+            log::warn!("Could not capture daemon log for '{test_name}' over SSH: {err:#}");
+            return;
+        }
+    };
+
+    // Write to /tmp so CI can collect it (same place as the test report), rather
+    // than the ephemeral working dir.
+    let file_name = format!("/tmp/daemon-log-{test_name}.log");
+    match std::fs::File::create(&file_name).and_then(|mut f| f.write_all(contents.as_bytes())) {
+        Ok(()) => log::info!("Wrote full daemon log for '{test_name}' to {file_name}"),
+        Err(err) => log::warn!("Failed to write daemon log file {file_name}: {err}"),
+    }
+
+    let lines: Vec<&str> = contents.lines().collect();
+    let tail = lines
+        .iter()
+        .skip(lines.len().saturating_sub(DAEMON_LOG_TAIL_LINES))
+        .copied()
+        .collect::<Vec<_>>()
+        .join("\n");
+    log::info!(
+        "===== nym-vpnd log tail ({} of {} lines) for {test_name} =====\n{tail}\n===== end nym-vpnd log for {test_name} =====",
+        DAEMON_LOG_TAIL_LINES.min(lines.len()),
+        lines.len(),
+    );
+}
 
 /// The baud rate of the serial connection between the test manager and the test runner.
 /// There is a known issue with setting a baud rate at all or macOS, and the workaround
@@ -30,6 +99,8 @@ struct TestHandler<'a> {
     summary_logger: Option<SummaryLogger>,
     print_failed_tests_only: bool,
     logger: Logger,
+    /// SSH access for out-of-band daemon log capture on failure.
+    guest_ssh_access: Option<GuestSshAccess>,
 }
 
 impl TestHandler<'_> {
@@ -65,6 +136,12 @@ impl TestHandler<'_> {
                 self.logger.flush_records();
             }
             self.logger.store_records(false);
+        }
+
+        if test_output.result.failure()
+            && let Some(access) = &self.guest_ssh_access
+        {
+            capture_daemon_log_on_failure(access, test_name).await;
         }
 
         test_output.print();
@@ -106,7 +183,13 @@ pub async fn run(
     skip_wait: bool,
     print_failed_tests_only: bool,
     summary_logger: Option<SummaryLogger>,
+    ssh_options: Option<(String, String)>,
 ) -> Result<TestResult> {
+    let guest_ssh_access = ssh_options.map(|(user, password)| GuestSshAccess {
+        user,
+        password,
+        ip: *instance.get_ip(),
+    });
     log::trace!("Setting test constants");
 
     let pty_path = instance.get_pty();
@@ -155,6 +238,7 @@ pub async fn run(
         summary_logger,
         print_failed_tests_only,
         logger: Logger::get_or_init(),
+        guest_ssh_access,
     };
 
     for test in tests {

--- a/nym-vpn-core/crates/test/test-manager/src/run_tests.rs
+++ b/nym-vpn-core/crates/test/test-manager/src/run_tests.rs
@@ -37,7 +37,14 @@ async fn fetch_guest_daemon_log(access: GuestSshAccess) -> Result<String> {
                 .and_then(|session| {
                     session.exec_blocking(&format!("sudo cat {GUEST_DAEMON_LOG_PATH}"))
                 }) {
-                Ok(contents) => return Ok(contents),
+                Ok(contents) if !contents.trim().is_empty() => return Ok(contents),
+                Ok(_) => {
+                    log::debug!(
+                        "daemon log capture attempt {attempt}/5: empty output (missing/unreadable file?)"
+                    );
+                    last_err = Some(anyhow::anyhow!("empty daemon log output"));
+                    std::thread::sleep(Duration::from_secs(3));
+                }
                 Err(err) => {
                     log::debug!("daemon log capture attempt {attempt}/5 failed: {err:#}");
                     last_err = Some(err);

--- a/nym-vpn-core/crates/test/test-manager/src/tests/nym_test.rs
+++ b/nym-vpn-core/crates/test/test-manager/src/tests/nym_test.rs
@@ -121,6 +121,10 @@ pub async fn dc_and_ensure_logged_in(
         .await
         .context("Failed to ensure logged in")?;
 
+    if let Err(err) = nym_proxy_client.set_allow_lan(true).await {
+        log::warn!("Failed to enable allow_lan for diagnostics: {err}");
+    }
+
     log::debug!("🔄 Daemon successfully prepared 🔄");
 
     Ok(())

--- a/nym-vpn-core/crates/test/test-manager/src/vm/mod.rs
+++ b/nym-vpn-core/crates/test/test-manager/src/vm/mod.rs
@@ -11,7 +11,7 @@ mod logging;
 pub mod network;
 pub mod provision;
 mod qemu;
-mod ssh;
+pub(crate) mod ssh;
 #[cfg(target_os = "macos")]
 mod tart;
 mod update;

--- a/nym-vpn-core/crates/test/test-manager/src/vm/ssh.rs
+++ b/nym-vpn-core/crates/test/test-manager/src/vm/ssh.rs
@@ -8,10 +8,13 @@ use ssh2::Session;
 use std::{
     io::Read,
     net::{IpAddr, SocketAddr, TcpStream},
+    time::Duration,
 };
 
 /// Default `ssh` port.
 const PORT: u16 = 22;
+
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Handle to an `ssh` session.
 pub struct SSHSession {
@@ -26,7 +29,8 @@ impl SSHSession {
     pub fn connect(username: String, password: String, ip: IpAddr) -> Result<Self> {
         // Set up the SSH connection
         log::info!("initializing a new SSH session ..");
-        let stream = TcpStream::connect(SocketAddr::new(ip, PORT)).context("TCP connect failed")?;
+        let stream = TcpStream::connect_timeout(&SocketAddr::new(ip, PORT), CONNECT_TIMEOUT)
+            .context("TCP connect failed")?;
         let mut session = Session::new().context("Failed to connect to SSH server")?;
         session.set_tcp_stream(stream);
         session.handshake()?;


### PR DESCRIPTION
## Description

- The runner RPC log fetch (get_nym_app_logs) rides the same transport that wedges on a bad connect, so it returns nothing exactly when the daemon log is needed.

- Pull /var/log/nym-vpnd/nym-vpnd.log off the guest over SSH on failure, write it to /tmp, echo the tail to stdout, and collect it as a CI artifact.

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5908)
<!-- Reviewable:end -->
