### PR TITLE
NYM-1408: Use `SkewManager` with registration clients.

### DIFF
--- a/nym-vpn-app/src-tauri/Cargo.lock
+++ b/nym-vpn-app/src-tauri/Cargo.lock
@@ -3716,7 +3716,7 @@ dependencies = [
 [[package]]
 name = "nym-crypto"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -3763,7 +3763,7 @@ dependencies = [
 [[package]]
 name = "nym-pemstore"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "pem",
  "tracing",

--- a/nym-vpn-app/src-tauri/Cargo.lock
+++ b/nym-vpn-app/src-tauri/Cargo.lock
@@ -3716,6 +3716,7 @@ dependencies = [
 [[package]]
 name = "nym-crypto"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -3762,6 +3763,7 @@ dependencies = [
 [[package]]
 name = "nym-pemstore"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "pem",
  "tracing",

--- a/nym-vpn-app/src-tauri/Cargo.lock
+++ b/nym-vpn-app/src-tauri/Cargo.lock
@@ -3716,7 +3716,6 @@ dependencies = [
 [[package]]
 name = "nym-crypto"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -3763,7 +3762,6 @@ dependencies = [
 [[package]]
 name = "nym-pemstore"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "pem",
  "tracing",

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -5099,7 +5099,6 @@ dependencies = [
 [[package]]
 name = "nym-api-requests"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "bs58",
  "celes",
@@ -5152,7 +5151,6 @@ dependencies = [
 [[package]]
 name = "nym-authenticator-client"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "bincode",
  "futures",
@@ -5176,7 +5174,6 @@ dependencies = [
 [[package]]
 name = "nym-authenticator-requests"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -5200,7 +5197,6 @@ dependencies = [
 [[package]]
 name = "nym-bandwidth-controller"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "async-trait",
  "log",
@@ -5222,7 +5218,6 @@ dependencies = [
 [[package]]
 name = "nym-bandwidth-fetcher"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5244,7 +5239,6 @@ dependencies = [
 [[package]]
 name = "nym-bin-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "const-str",
  "log",
@@ -5286,7 +5280,6 @@ dependencies = [
 [[package]]
 name = "nym-client-core"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5347,7 +5340,6 @@ dependencies = [
 [[package]]
 name = "nym-client-core-config-types"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "humantime-serde",
  "nym-config",
@@ -5363,7 +5355,6 @@ dependencies = [
 [[package]]
 name = "nym-client-core-gateways-storage"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5383,7 +5374,6 @@ dependencies = [
 [[package]]
 name = "nym-client-core-surb-storage"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5402,7 +5392,6 @@ dependencies = [
 [[package]]
 name = "nym-coconut-dkg-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -5416,7 +5405,6 @@ dependencies = [
 [[package]]
 name = "nym-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "tracing",
  "tracing-test",
@@ -5433,7 +5421,6 @@ dependencies = [
 [[package]]
 name = "nym-compact-ecash"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "bincode",
  "bs58",
@@ -5456,7 +5443,6 @@ dependencies = [
 [[package]]
 name = "nym-config"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "dirs",
  "handlebars",
@@ -5489,7 +5475,6 @@ dependencies = [
 [[package]]
 name = "nym-contracts-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -5504,7 +5489,6 @@ dependencies = [
 [[package]]
 name = "nym-credential-proxy-requests"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "async-trait",
  "nym-credentials",
@@ -5525,7 +5509,6 @@ dependencies = [
 [[package]]
 name = "nym-credential-storage"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5546,7 +5529,6 @@ dependencies = [
 [[package]]
 name = "nym-credentials"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "bincode",
  "cosmrs",
@@ -5572,7 +5554,6 @@ dependencies = [
 [[package]]
 name = "nym-credentials-interface"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "nym-bls12_381-fork",
  "nym-compact-ecash",
@@ -5591,7 +5572,6 @@ dependencies = [
 [[package]]
 name = "nym-crypto"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "aead",
  "aes 0.8.4",
@@ -5711,7 +5691,6 @@ dependencies = [
 [[package]]
 name = "nym-ecash-contract-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -5725,7 +5704,6 @@ dependencies = [
 [[package]]
 name = "nym-ecash-signer-check-types"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "nym-coconut-dkg-common",
  "nym-crypto",
@@ -5741,7 +5719,6 @@ dependencies = [
 [[package]]
 name = "nym-ecash-time"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "nym-compact-ecash",
  "time",
@@ -5759,7 +5736,6 @@ dependencies = [
 [[package]]
 name = "nym-exit-policy"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "serde",
  "serde_json",
@@ -5815,7 +5791,6 @@ dependencies = [
 [[package]]
 name = "nym-gateway-client"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "futures",
  "getrandom 0.2.17",
@@ -5880,7 +5855,6 @@ dependencies = [
 [[package]]
 name = "nym-gateway-requests"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "bs58",
  "futures",
@@ -5910,7 +5884,6 @@ dependencies = [
 [[package]]
 name = "nym-group-contract-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "cosmwasm-schema",
  "cw-controllers",
@@ -5922,7 +5895,6 @@ dependencies = [
 [[package]]
 name = "nym-http-api-client"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5956,7 +5928,6 @@ dependencies = [
 [[package]]
 name = "nym-http-api-client-macro"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5968,7 +5939,6 @@ dependencies = [
 [[package]]
 name = "nym-http-api-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "bincode",
  "serde",
@@ -5979,7 +5949,6 @@ dependencies = [
 [[package]]
 name = "nym-id"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "nym-credential-storage",
  "nym-credentials",
@@ -6007,7 +5976,6 @@ dependencies = [
 [[package]]
 name = "nym-ip-packet-client"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "bincode",
  "bytes",
@@ -6024,7 +5992,6 @@ dependencies = [
 [[package]]
 name = "nym-ip-packet-requests"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "bincode",
  "bytes",
@@ -6072,7 +6039,6 @@ dependencies = [
 [[package]]
 name = "nym-kkt"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "libcrux-chacha20poly1305",
  "libcrux-ecdh",
@@ -6093,7 +6059,6 @@ dependencies = [
 [[package]]
 name = "nym-kkt-ciphersuite"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "blake3",
  "libcrux-sha3",
@@ -6107,7 +6072,6 @@ dependencies = [
 [[package]]
 name = "nym-kkt-context"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "num_enum",
  "nym-kkt-ciphersuite",
@@ -6117,7 +6081,6 @@ dependencies = [
 [[package]]
 name = "nym-lp"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "bs58",
  "bytes",
@@ -6138,7 +6101,6 @@ dependencies = [
 [[package]]
 name = "nym-lp-data"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "bytes",
  "num_enum",
@@ -6159,7 +6121,6 @@ dependencies = [
 [[package]]
 name = "nym-metrics"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "dashmap",
  "lazy_static",
@@ -6170,7 +6131,6 @@ dependencies = [
 [[package]]
 name = "nym-mixnet-client"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "dashmap",
  "futures",
@@ -6188,7 +6148,6 @@ dependencies = [
 [[package]]
 name = "nym-mixnet-contract-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -6209,7 +6168,6 @@ dependencies = [
 [[package]]
 name = "nym-multisig-contract-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -6225,7 +6183,6 @@ dependencies = [
 [[package]]
 name = "nym-network-defaults"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "cargo_metadata 0.19.2",
  "dotenvy",
@@ -6241,7 +6198,6 @@ dependencies = [
 [[package]]
 name = "nym-network-monitors-contract-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -6254,7 +6210,6 @@ dependencies = [
 [[package]]
 name = "nym-node-families-contract-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -6270,7 +6225,6 @@ dependencies = [
 [[package]]
 name = "nym-node-requests"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "celes",
  "humantime-serde",
@@ -6295,7 +6249,6 @@ dependencies = [
 [[package]]
 name = "nym-noise"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -6316,7 +6269,6 @@ dependencies = [
 [[package]]
 name = "nym-noise-keys"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "nym-crypto",
  "schemars 0.8.22",
@@ -6327,7 +6279,6 @@ dependencies = [
 [[package]]
 name = "nym-nonexhaustive-delayqueue"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -6357,7 +6308,6 @@ dependencies = [
 [[package]]
 name = "nym-ordered-buffer"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "log",
  "thiserror 2.0.18",
@@ -6366,7 +6316,6 @@ dependencies = [
 [[package]]
 name = "nym-outfox"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "blake3",
  "chacha20 0.9.1",
@@ -6380,7 +6329,6 @@ dependencies = [
 [[package]]
 name = "nym-pemstore"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "pem",
  "tracing",
@@ -6390,7 +6338,6 @@ dependencies = [
 [[package]]
 name = "nym-performance-contract-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -6418,7 +6365,6 @@ dependencies = [
 [[package]]
 name = "nym-registration-client"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "bincode",
  "bytes",
@@ -6446,7 +6392,6 @@ dependencies = [
 [[package]]
 name = "nym-registration-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "bincode",
  "nym-authenticator-requests",
@@ -6483,7 +6428,6 @@ dependencies = [
 [[package]]
 name = "nym-sdk"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6542,7 +6486,6 @@ dependencies = [
 [[package]]
 name = "nym-serde-helpers"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -6554,7 +6497,6 @@ dependencies = [
 [[package]]
 name = "nym-service-provider-requests-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -6563,11 +6505,12 @@ dependencies = [
 [[package]]
 name = "nym-service-providers-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "async-trait",
  "log",
  "nym-bin-common",
+ "nym-client-core",
+ "nym-credential-storage",
  "nym-sphinx-anonymous-replies",
  "serde",
  "serde_json",
@@ -6587,7 +6530,6 @@ dependencies = [
 [[package]]
 name = "nym-socks5-client-core"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "anyhow",
  "dirs",
@@ -6647,7 +6589,6 @@ dependencies = [
 [[package]]
 name = "nym-socks5-proxy-helpers"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "bytes",
  "futures",
@@ -6670,7 +6611,6 @@ dependencies = [
 [[package]]
 name = "nym-socks5-requests"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "bincode",
  "log",
@@ -6686,7 +6626,6 @@ dependencies = [
 [[package]]
 name = "nym-sphinx"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "nym-crypto",
  "nym-metrics",
@@ -6712,7 +6651,6 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-acknowledgements"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "nym-crypto",
  "nym-pemstore",
@@ -6729,7 +6667,6 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-addressing"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-types",
@@ -6740,7 +6677,6 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-anonymous-replies"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "bs58",
  "nym-crypto",
@@ -6758,7 +6694,6 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-chunking"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "dashmap",
  "log",
@@ -6777,7 +6712,6 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-cover"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-acknowledgements",
@@ -6795,7 +6729,6 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-forwarding"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "nym-sphinx-addressing",
  "nym-sphinx-anonymous-replies",
@@ -6807,7 +6740,6 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-framing"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -6824,7 +6756,6 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-params"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-types",
@@ -6835,7 +6766,6 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-routing"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "nym-sphinx-addressing",
  "nym-sphinx-types",
@@ -6845,7 +6775,6 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-types"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "nym-outfox",
  "sphinx-packet",
@@ -6894,7 +6823,6 @@ dependencies = [
 [[package]]
 name = "nym-sqlx-pool-guard"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "proc_pidinfo",
  "sqlx",
@@ -6938,7 +6866,6 @@ dependencies = [
 [[package]]
 name = "nym-statistics-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "futures",
  "log",
@@ -6963,7 +6890,6 @@ dependencies = [
 [[package]]
 name = "nym-task"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "cfg-if",
  "futures",
@@ -6980,7 +6906,6 @@ dependencies = [
 [[package]]
 name = "nym-ticketbooks-merkle"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "nym-credentials-interface",
  "nym-serde-helpers",
@@ -6995,7 +6920,6 @@ dependencies = [
 [[package]]
 name = "nym-topology"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "async-trait",
  "nym-api-requests",
@@ -7015,7 +6939,6 @@ dependencies = [
 [[package]]
 name = "nym-upgrade-mode-check"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "jwt-simple",
  "nym-crypto",
@@ -7032,7 +6955,6 @@ dependencies = [
 [[package]]
 name = "nym-validator-client"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7084,7 +7006,6 @@ dependencies = [
 [[package]]
 name = "nym-vesting-contract-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -7533,7 +7454,6 @@ dependencies = [
 [[package]]
 name = "nym-wasm-utils"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "futures",
  "getrandom 0.2.17",
@@ -7597,7 +7517,6 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-private-metadata-client"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "async-trait",
  "nym-http-api-client",
@@ -7608,7 +7527,6 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-private-metadata-shared"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "axum",
  "bincode",
@@ -7622,7 +7540,6 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-types"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "base64 0.22.1",
  "nym-crypto",

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -5099,6 +5099,7 @@ dependencies = [
 [[package]]
 name = "nym-api-requests"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "bs58",
  "celes",
@@ -5151,6 +5152,7 @@ dependencies = [
 [[package]]
 name = "nym-authenticator-client"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "bincode",
  "futures",
@@ -5174,6 +5176,7 @@ dependencies = [
 [[package]]
 name = "nym-authenticator-requests"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -5197,6 +5200,7 @@ dependencies = [
 [[package]]
 name = "nym-bandwidth-controller"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "async-trait",
  "log",
@@ -5218,6 +5222,7 @@ dependencies = [
 [[package]]
 name = "nym-bandwidth-fetcher"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5239,6 +5244,7 @@ dependencies = [
 [[package]]
 name = "nym-bin-common"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "const-str",
  "log",
@@ -5280,6 +5286,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5340,6 +5347,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-config-types"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "humantime-serde",
  "nym-config",
@@ -5355,6 +5363,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-gateways-storage"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5374,6 +5383,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-surb-storage"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5392,6 +5402,7 @@ dependencies = [
 [[package]]
 name = "nym-coconut-dkg-common"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -5405,6 +5416,7 @@ dependencies = [
 [[package]]
 name = "nym-common"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "tracing",
  "tracing-test",
@@ -5421,6 +5433,7 @@ dependencies = [
 [[package]]
 name = "nym-compact-ecash"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "bincode",
  "bs58",
@@ -5443,6 +5456,7 @@ dependencies = [
 [[package]]
 name = "nym-config"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "dirs",
  "handlebars",
@@ -5475,6 +5489,7 @@ dependencies = [
 [[package]]
 name = "nym-contracts-common"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -5489,6 +5504,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-proxy-requests"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "async-trait",
  "nym-credentials",
@@ -5509,6 +5525,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-storage"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5529,6 +5546,7 @@ dependencies = [
 [[package]]
 name = "nym-credentials"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "bincode",
  "cosmrs",
@@ -5554,6 +5572,7 @@ dependencies = [
 [[package]]
 name = "nym-credentials-interface"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "nym-bls12_381-fork",
  "nym-compact-ecash",
@@ -5572,6 +5591,7 @@ dependencies = [
 [[package]]
 name = "nym-crypto"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "aead",
  "aes 0.8.4",
@@ -5691,6 +5711,7 @@ dependencies = [
 [[package]]
 name = "nym-ecash-contract-common"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -5704,6 +5725,7 @@ dependencies = [
 [[package]]
 name = "nym-ecash-signer-check-types"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "nym-coconut-dkg-common",
  "nym-crypto",
@@ -5719,6 +5741,7 @@ dependencies = [
 [[package]]
 name = "nym-ecash-time"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "nym-compact-ecash",
  "time",
@@ -5736,6 +5759,7 @@ dependencies = [
 [[package]]
 name = "nym-exit-policy"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "serde",
  "serde_json",
@@ -5791,6 +5815,7 @@ dependencies = [
 [[package]]
 name = "nym-gateway-client"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "futures",
  "getrandom 0.2.17",
@@ -5855,6 +5880,7 @@ dependencies = [
 [[package]]
 name = "nym-gateway-requests"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "bs58",
  "futures",
@@ -5884,6 +5910,7 @@ dependencies = [
 [[package]]
 name = "nym-group-contract-common"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "cosmwasm-schema",
  "cw-controllers",
@@ -5895,6 +5922,7 @@ dependencies = [
 [[package]]
 name = "nym-http-api-client"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5928,6 +5956,7 @@ dependencies = [
 [[package]]
 name = "nym-http-api-client-macro"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5939,6 +5968,7 @@ dependencies = [
 [[package]]
 name = "nym-http-api-common"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "bincode",
  "serde",
@@ -5949,6 +5979,7 @@ dependencies = [
 [[package]]
 name = "nym-id"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "nym-credential-storage",
  "nym-credentials",
@@ -5976,6 +6007,7 @@ dependencies = [
 [[package]]
 name = "nym-ip-packet-client"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "bincode",
  "bytes",
@@ -5992,6 +6024,7 @@ dependencies = [
 [[package]]
 name = "nym-ip-packet-requests"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "bincode",
  "bytes",
@@ -6039,6 +6072,7 @@ dependencies = [
 [[package]]
 name = "nym-kkt"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "libcrux-chacha20poly1305",
  "libcrux-ecdh",
@@ -6059,6 +6093,7 @@ dependencies = [
 [[package]]
 name = "nym-kkt-ciphersuite"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "blake3",
  "libcrux-sha3",
@@ -6072,6 +6107,7 @@ dependencies = [
 [[package]]
 name = "nym-kkt-context"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "num_enum",
  "nym-kkt-ciphersuite",
@@ -6081,6 +6117,7 @@ dependencies = [
 [[package]]
 name = "nym-lp"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "bs58",
  "bytes",
@@ -6101,6 +6138,7 @@ dependencies = [
 [[package]]
 name = "nym-lp-data"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "bytes",
  "num_enum",
@@ -6121,6 +6159,7 @@ dependencies = [
 [[package]]
 name = "nym-metrics"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "dashmap",
  "lazy_static",
@@ -6131,6 +6170,7 @@ dependencies = [
 [[package]]
 name = "nym-mixnet-client"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "dashmap",
  "futures",
@@ -6148,6 +6188,7 @@ dependencies = [
 [[package]]
 name = "nym-mixnet-contract-common"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -6168,6 +6209,7 @@ dependencies = [
 [[package]]
 name = "nym-multisig-contract-common"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -6183,6 +6225,7 @@ dependencies = [
 [[package]]
 name = "nym-network-defaults"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "cargo_metadata 0.19.2",
  "dotenvy",
@@ -6198,6 +6241,7 @@ dependencies = [
 [[package]]
 name = "nym-network-monitors-contract-common"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -6210,6 +6254,7 @@ dependencies = [
 [[package]]
 name = "nym-node-families-contract-common"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -6225,6 +6270,7 @@ dependencies = [
 [[package]]
 name = "nym-node-requests"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "celes",
  "humantime-serde",
@@ -6249,6 +6295,7 @@ dependencies = [
 [[package]]
 name = "nym-noise"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -6269,6 +6316,7 @@ dependencies = [
 [[package]]
 name = "nym-noise-keys"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "nym-crypto",
  "schemars 0.8.22",
@@ -6279,6 +6327,7 @@ dependencies = [
 [[package]]
 name = "nym-nonexhaustive-delayqueue"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -6308,6 +6357,7 @@ dependencies = [
 [[package]]
 name = "nym-ordered-buffer"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "log",
  "thiserror 2.0.18",
@@ -6316,6 +6366,7 @@ dependencies = [
 [[package]]
 name = "nym-outfox"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "blake3",
  "chacha20 0.9.1",
@@ -6329,6 +6380,7 @@ dependencies = [
 [[package]]
 name = "nym-pemstore"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "pem",
  "tracing",
@@ -6338,6 +6390,7 @@ dependencies = [
 [[package]]
 name = "nym-performance-contract-common"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -6365,6 +6418,7 @@ dependencies = [
 [[package]]
 name = "nym-registration-client"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "bincode",
  "bytes",
@@ -6392,6 +6446,7 @@ dependencies = [
 [[package]]
 name = "nym-registration-common"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "bincode",
  "nym-authenticator-requests",
@@ -6428,6 +6483,7 @@ dependencies = [
 [[package]]
 name = "nym-sdk"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6486,6 +6542,7 @@ dependencies = [
 [[package]]
 name = "nym-serde-helpers"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -6497,6 +6554,7 @@ dependencies = [
 [[package]]
 name = "nym-service-provider-requests-common"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -6505,12 +6563,11 @@ dependencies = [
 [[package]]
 name = "nym-service-providers-common"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "async-trait",
  "log",
  "nym-bin-common",
- "nym-client-core",
- "nym-credential-storage",
  "nym-sphinx-anonymous-replies",
  "serde",
  "serde_json",
@@ -6530,6 +6587,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-client-core"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "anyhow",
  "dirs",
@@ -6589,6 +6647,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-proxy-helpers"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "bytes",
  "futures",
@@ -6611,6 +6670,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-requests"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "bincode",
  "log",
@@ -6626,6 +6686,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "nym-crypto",
  "nym-metrics",
@@ -6651,6 +6712,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-acknowledgements"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "nym-crypto",
  "nym-pemstore",
@@ -6667,6 +6729,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-addressing"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-types",
@@ -6677,6 +6740,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-anonymous-replies"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "bs58",
  "nym-crypto",
@@ -6694,6 +6758,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-chunking"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "dashmap",
  "log",
@@ -6712,6 +6777,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-cover"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-acknowledgements",
@@ -6729,6 +6795,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-forwarding"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "nym-sphinx-addressing",
  "nym-sphinx-anonymous-replies",
@@ -6740,6 +6807,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-framing"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -6756,6 +6824,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-params"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-types",
@@ -6766,6 +6835,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-routing"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "nym-sphinx-addressing",
  "nym-sphinx-types",
@@ -6775,6 +6845,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-types"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "nym-outfox",
  "sphinx-packet",
@@ -6823,6 +6894,7 @@ dependencies = [
 [[package]]
 name = "nym-sqlx-pool-guard"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "proc_pidinfo",
  "sqlx",
@@ -6866,6 +6938,7 @@ dependencies = [
 [[package]]
 name = "nym-statistics-common"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "futures",
  "log",
@@ -6890,6 +6963,7 @@ dependencies = [
 [[package]]
 name = "nym-task"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "cfg-if",
  "futures",
@@ -6906,6 +6980,7 @@ dependencies = [
 [[package]]
 name = "nym-ticketbooks-merkle"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "nym-credentials-interface",
  "nym-serde-helpers",
@@ -6920,6 +6995,7 @@ dependencies = [
 [[package]]
 name = "nym-topology"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "async-trait",
  "nym-api-requests",
@@ -6939,6 +7015,7 @@ dependencies = [
 [[package]]
 name = "nym-upgrade-mode-check"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "jwt-simple",
  "nym-crypto",
@@ -6955,6 +7032,7 @@ dependencies = [
 [[package]]
 name = "nym-validator-client"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7006,6 +7084,7 @@ dependencies = [
 [[package]]
 name = "nym-vesting-contract-common"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -7454,6 +7533,7 @@ dependencies = [
 [[package]]
 name = "nym-wasm-utils"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "futures",
  "getrandom 0.2.17",
@@ -7517,6 +7597,7 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-private-metadata-client"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "async-trait",
  "nym-http-api-client",
@@ -7527,6 +7608,7 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-private-metadata-shared"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "axum",
  "bincode",
@@ -7540,6 +7622,7 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-types"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#1bff1b388b3a2d5fb2dc299c5e9462d44893a5bd"
 dependencies = [
  "base64 0.22.1",
  "nym-crypto",

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -5099,7 +5099,7 @@ dependencies = [
 [[package]]
 name = "nym-api-requests"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "bs58",
  "celes",
@@ -5152,7 +5152,7 @@ dependencies = [
 [[package]]
 name = "nym-authenticator-client"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "bincode",
  "futures",
@@ -5176,7 +5176,7 @@ dependencies = [
 [[package]]
 name = "nym-authenticator-requests"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -5200,7 +5200,7 @@ dependencies = [
 [[package]]
 name = "nym-bandwidth-controller"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "async-trait",
  "log",
@@ -5222,7 +5222,7 @@ dependencies = [
 [[package]]
 name = "nym-bandwidth-fetcher"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5244,7 +5244,7 @@ dependencies = [
 [[package]]
 name = "nym-bin-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "const-str",
  "log",
@@ -5286,7 +5286,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5347,7 +5347,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-config-types"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "humantime-serde",
  "nym-config",
@@ -5363,7 +5363,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-gateways-storage"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5383,7 +5383,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-surb-storage"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5402,7 +5402,7 @@ dependencies = [
 [[package]]
 name = "nym-coconut-dkg-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -5416,7 +5416,7 @@ dependencies = [
 [[package]]
 name = "nym-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "tracing",
  "tracing-test",
@@ -5433,7 +5433,7 @@ dependencies = [
 [[package]]
 name = "nym-compact-ecash"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "bincode",
  "bs58",
@@ -5456,7 +5456,7 @@ dependencies = [
 [[package]]
 name = "nym-config"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "dirs",
  "handlebars",
@@ -5489,7 +5489,7 @@ dependencies = [
 [[package]]
 name = "nym-contracts-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -5504,7 +5504,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-proxy-requests"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "async-trait",
  "nym-credentials",
@@ -5525,7 +5525,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-storage"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5546,7 +5546,7 @@ dependencies = [
 [[package]]
 name = "nym-credentials"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "bincode",
  "cosmrs",
@@ -5572,7 +5572,7 @@ dependencies = [
 [[package]]
 name = "nym-credentials-interface"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "nym-bls12_381-fork",
  "nym-compact-ecash",
@@ -5591,7 +5591,7 @@ dependencies = [
 [[package]]
 name = "nym-crypto"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "aead",
  "aes 0.8.4",
@@ -5711,7 +5711,7 @@ dependencies = [
 [[package]]
 name = "nym-ecash-contract-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -5725,7 +5725,7 @@ dependencies = [
 [[package]]
 name = "nym-ecash-signer-check-types"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "nym-coconut-dkg-common",
  "nym-crypto",
@@ -5741,7 +5741,7 @@ dependencies = [
 [[package]]
 name = "nym-ecash-time"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "nym-compact-ecash",
  "time",
@@ -5759,7 +5759,7 @@ dependencies = [
 [[package]]
 name = "nym-exit-policy"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "serde",
  "serde_json",
@@ -5815,7 +5815,7 @@ dependencies = [
 [[package]]
 name = "nym-gateway-client"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "futures",
  "getrandom 0.2.17",
@@ -5880,7 +5880,7 @@ dependencies = [
 [[package]]
 name = "nym-gateway-requests"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "bs58",
  "futures",
@@ -5910,7 +5910,7 @@ dependencies = [
 [[package]]
 name = "nym-group-contract-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "cosmwasm-schema",
  "cw-controllers",
@@ -5922,7 +5922,7 @@ dependencies = [
 [[package]]
 name = "nym-http-api-client"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5956,7 +5956,7 @@ dependencies = [
 [[package]]
 name = "nym-http-api-client-macro"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5968,7 +5968,7 @@ dependencies = [
 [[package]]
 name = "nym-http-api-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "bincode",
  "serde",
@@ -5979,7 +5979,7 @@ dependencies = [
 [[package]]
 name = "nym-id"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "nym-credential-storage",
  "nym-credentials",
@@ -6007,7 +6007,7 @@ dependencies = [
 [[package]]
 name = "nym-ip-packet-client"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "bincode",
  "bytes",
@@ -6024,7 +6024,7 @@ dependencies = [
 [[package]]
 name = "nym-ip-packet-requests"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "bincode",
  "bytes",
@@ -6072,7 +6072,7 @@ dependencies = [
 [[package]]
 name = "nym-kkt"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "libcrux-chacha20poly1305",
  "libcrux-ecdh",
@@ -6093,7 +6093,7 @@ dependencies = [
 [[package]]
 name = "nym-kkt-ciphersuite"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "blake3",
  "libcrux-sha3",
@@ -6107,7 +6107,7 @@ dependencies = [
 [[package]]
 name = "nym-kkt-context"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "num_enum",
  "nym-kkt-ciphersuite",
@@ -6117,7 +6117,7 @@ dependencies = [
 [[package]]
 name = "nym-lp"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "bs58",
  "bytes",
@@ -6138,7 +6138,7 @@ dependencies = [
 [[package]]
 name = "nym-lp-data"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "bytes",
  "num_enum",
@@ -6159,7 +6159,7 @@ dependencies = [
 [[package]]
 name = "nym-metrics"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "dashmap",
  "lazy_static",
@@ -6170,7 +6170,7 @@ dependencies = [
 [[package]]
 name = "nym-mixnet-client"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "dashmap",
  "futures",
@@ -6188,7 +6188,7 @@ dependencies = [
 [[package]]
 name = "nym-mixnet-contract-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -6209,7 +6209,7 @@ dependencies = [
 [[package]]
 name = "nym-multisig-contract-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -6225,7 +6225,7 @@ dependencies = [
 [[package]]
 name = "nym-network-defaults"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "cargo_metadata 0.19.2",
  "dotenvy",
@@ -6241,7 +6241,7 @@ dependencies = [
 [[package]]
 name = "nym-network-monitors-contract-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -6254,7 +6254,7 @@ dependencies = [
 [[package]]
 name = "nym-node-families-contract-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -6270,7 +6270,7 @@ dependencies = [
 [[package]]
 name = "nym-node-requests"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "celes",
  "humantime-serde",
@@ -6295,7 +6295,7 @@ dependencies = [
 [[package]]
 name = "nym-noise"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -6316,7 +6316,7 @@ dependencies = [
 [[package]]
 name = "nym-noise-keys"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "nym-crypto",
  "schemars 0.8.22",
@@ -6327,7 +6327,7 @@ dependencies = [
 [[package]]
 name = "nym-nonexhaustive-delayqueue"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -6357,7 +6357,7 @@ dependencies = [
 [[package]]
 name = "nym-ordered-buffer"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "log",
  "thiserror 2.0.18",
@@ -6366,7 +6366,7 @@ dependencies = [
 [[package]]
 name = "nym-outfox"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "blake3",
  "chacha20 0.9.1",
@@ -6380,7 +6380,7 @@ dependencies = [
 [[package]]
 name = "nym-pemstore"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "pem",
  "tracing",
@@ -6390,7 +6390,7 @@ dependencies = [
 [[package]]
 name = "nym-performance-contract-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -6418,7 +6418,7 @@ dependencies = [
 [[package]]
 name = "nym-registration-client"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "bincode",
  "bytes",
@@ -6446,7 +6446,7 @@ dependencies = [
 [[package]]
 name = "nym-registration-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "bincode",
  "nym-authenticator-requests",
@@ -6483,7 +6483,7 @@ dependencies = [
 [[package]]
 name = "nym-sdk"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6542,7 +6542,7 @@ dependencies = [
 [[package]]
 name = "nym-serde-helpers"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -6554,7 +6554,7 @@ dependencies = [
 [[package]]
 name = "nym-service-provider-requests-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -6563,13 +6563,11 @@ dependencies = [
 [[package]]
 name = "nym-service-providers-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "async-trait",
  "log",
  "nym-bin-common",
- "nym-client-core",
- "nym-credential-storage",
  "nym-sphinx-anonymous-replies",
  "serde",
  "serde_json",
@@ -6589,7 +6587,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-client-core"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "anyhow",
  "dirs",
@@ -6649,7 +6647,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-proxy-helpers"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "bytes",
  "futures",
@@ -6672,7 +6670,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-requests"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "bincode",
  "log",
@@ -6688,7 +6686,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "nym-crypto",
  "nym-metrics",
@@ -6714,7 +6712,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-acknowledgements"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "nym-crypto",
  "nym-pemstore",
@@ -6731,7 +6729,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-addressing"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-types",
@@ -6742,7 +6740,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-anonymous-replies"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "bs58",
  "nym-crypto",
@@ -6760,7 +6758,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-chunking"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "dashmap",
  "log",
@@ -6779,7 +6777,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-cover"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-acknowledgements",
@@ -6797,7 +6795,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-forwarding"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "nym-sphinx-addressing",
  "nym-sphinx-anonymous-replies",
@@ -6809,7 +6807,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-framing"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -6826,7 +6824,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-params"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-types",
@@ -6837,7 +6835,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-routing"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "nym-sphinx-addressing",
  "nym-sphinx-types",
@@ -6847,7 +6845,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-types"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "nym-outfox",
  "sphinx-packet",
@@ -6896,7 +6894,7 @@ dependencies = [
 [[package]]
 name = "nym-sqlx-pool-guard"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "proc_pidinfo",
  "sqlx",
@@ -6940,7 +6938,7 @@ dependencies = [
 [[package]]
 name = "nym-statistics-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "futures",
  "log",
@@ -6965,7 +6963,7 @@ dependencies = [
 [[package]]
 name = "nym-task"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "cfg-if",
  "futures",
@@ -6982,7 +6980,7 @@ dependencies = [
 [[package]]
 name = "nym-ticketbooks-merkle"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "nym-credentials-interface",
  "nym-serde-helpers",
@@ -6997,7 +6995,7 @@ dependencies = [
 [[package]]
 name = "nym-topology"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "async-trait",
  "nym-api-requests",
@@ -7017,7 +7015,7 @@ dependencies = [
 [[package]]
 name = "nym-upgrade-mode-check"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "jwt-simple",
  "nym-crypto",
@@ -7034,7 +7032,7 @@ dependencies = [
 [[package]]
 name = "nym-validator-client"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7086,7 +7084,7 @@ dependencies = [
 [[package]]
 name = "nym-vesting-contract-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -7535,7 +7533,7 @@ dependencies = [
 [[package]]
 name = "nym-wasm-utils"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "futures",
  "getrandom 0.2.17",
@@ -7599,7 +7597,7 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-private-metadata-client"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "async-trait",
  "nym-http-api-client",
@@ -7610,7 +7608,7 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-private-metadata-shared"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "axum",
  "bincode",
@@ -7624,7 +7622,7 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-types"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
 dependencies = [
  "base64 0.22.1",
  "nym-crypto",

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -5099,6 +5099,7 @@ dependencies = [
 [[package]]
 name = "nym-api-requests"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "bs58",
  "celes",
@@ -5151,6 +5152,7 @@ dependencies = [
 [[package]]
 name = "nym-authenticator-client"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "bincode",
  "futures",
@@ -5174,6 +5176,7 @@ dependencies = [
 [[package]]
 name = "nym-authenticator-requests"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -5197,6 +5200,7 @@ dependencies = [
 [[package]]
 name = "nym-bandwidth-controller"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "async-trait",
  "log",
@@ -5218,6 +5222,7 @@ dependencies = [
 [[package]]
 name = "nym-bandwidth-fetcher"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5239,6 +5244,7 @@ dependencies = [
 [[package]]
 name = "nym-bin-common"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "const-str",
  "log",
@@ -5280,6 +5286,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5340,6 +5347,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-config-types"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "humantime-serde",
  "nym-config",
@@ -5355,6 +5363,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-gateways-storage"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5374,6 +5383,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-surb-storage"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5392,6 +5402,7 @@ dependencies = [
 [[package]]
 name = "nym-coconut-dkg-common"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -5405,6 +5416,7 @@ dependencies = [
 [[package]]
 name = "nym-common"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "tracing",
  "tracing-test",
@@ -5421,6 +5433,7 @@ dependencies = [
 [[package]]
 name = "nym-compact-ecash"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "bincode",
  "bs58",
@@ -5443,6 +5456,7 @@ dependencies = [
 [[package]]
 name = "nym-config"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "dirs",
  "handlebars",
@@ -5475,6 +5489,7 @@ dependencies = [
 [[package]]
 name = "nym-contracts-common"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -5489,6 +5504,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-proxy-requests"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "async-trait",
  "nym-credentials",
@@ -5509,6 +5525,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-storage"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5529,6 +5546,7 @@ dependencies = [
 [[package]]
 name = "nym-credentials"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "bincode",
  "cosmrs",
@@ -5554,6 +5572,7 @@ dependencies = [
 [[package]]
 name = "nym-credentials-interface"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "nym-bls12_381-fork",
  "nym-compact-ecash",
@@ -5572,6 +5591,7 @@ dependencies = [
 [[package]]
 name = "nym-crypto"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "aead",
  "aes 0.8.4",
@@ -5691,6 +5711,7 @@ dependencies = [
 [[package]]
 name = "nym-ecash-contract-common"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -5704,6 +5725,7 @@ dependencies = [
 [[package]]
 name = "nym-ecash-signer-check-types"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "nym-coconut-dkg-common",
  "nym-crypto",
@@ -5719,6 +5741,7 @@ dependencies = [
 [[package]]
 name = "nym-ecash-time"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "nym-compact-ecash",
  "time",
@@ -5736,6 +5759,7 @@ dependencies = [
 [[package]]
 name = "nym-exit-policy"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "serde",
  "serde_json",
@@ -5791,6 +5815,7 @@ dependencies = [
 [[package]]
 name = "nym-gateway-client"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "futures",
  "getrandom 0.2.17",
@@ -5855,6 +5880,7 @@ dependencies = [
 [[package]]
 name = "nym-gateway-requests"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "bs58",
  "futures",
@@ -5884,6 +5910,7 @@ dependencies = [
 [[package]]
 name = "nym-group-contract-common"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "cosmwasm-schema",
  "cw-controllers",
@@ -5895,6 +5922,7 @@ dependencies = [
 [[package]]
 name = "nym-http-api-client"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5928,6 +5956,7 @@ dependencies = [
 [[package]]
 name = "nym-http-api-client-macro"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5939,6 +5968,7 @@ dependencies = [
 [[package]]
 name = "nym-http-api-common"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "bincode",
  "serde",
@@ -5949,6 +5979,7 @@ dependencies = [
 [[package]]
 name = "nym-id"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "nym-credential-storage",
  "nym-credentials",
@@ -5976,6 +6007,7 @@ dependencies = [
 [[package]]
 name = "nym-ip-packet-client"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "bincode",
  "bytes",
@@ -5992,6 +6024,7 @@ dependencies = [
 [[package]]
 name = "nym-ip-packet-requests"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "bincode",
  "bytes",
@@ -6039,6 +6072,7 @@ dependencies = [
 [[package]]
 name = "nym-kkt"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "libcrux-chacha20poly1305",
  "libcrux-ecdh",
@@ -6059,6 +6093,7 @@ dependencies = [
 [[package]]
 name = "nym-kkt-ciphersuite"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "blake3",
  "libcrux-sha3",
@@ -6072,6 +6107,7 @@ dependencies = [
 [[package]]
 name = "nym-kkt-context"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "num_enum",
  "nym-kkt-ciphersuite",
@@ -6081,6 +6117,7 @@ dependencies = [
 [[package]]
 name = "nym-lp"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "bs58",
  "bytes",
@@ -6101,6 +6138,7 @@ dependencies = [
 [[package]]
 name = "nym-lp-data"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "bytes",
  "num_enum",
@@ -6121,6 +6159,7 @@ dependencies = [
 [[package]]
 name = "nym-metrics"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "dashmap",
  "lazy_static",
@@ -6131,6 +6170,7 @@ dependencies = [
 [[package]]
 name = "nym-mixnet-client"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "dashmap",
  "futures",
@@ -6148,6 +6188,7 @@ dependencies = [
 [[package]]
 name = "nym-mixnet-contract-common"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -6168,6 +6209,7 @@ dependencies = [
 [[package]]
 name = "nym-multisig-contract-common"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -6183,6 +6225,7 @@ dependencies = [
 [[package]]
 name = "nym-network-defaults"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "cargo_metadata 0.19.2",
  "dotenvy",
@@ -6198,6 +6241,7 @@ dependencies = [
 [[package]]
 name = "nym-network-monitors-contract-common"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -6210,6 +6254,7 @@ dependencies = [
 [[package]]
 name = "nym-node-families-contract-common"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -6225,6 +6270,7 @@ dependencies = [
 [[package]]
 name = "nym-node-requests"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "celes",
  "humantime-serde",
@@ -6249,6 +6295,7 @@ dependencies = [
 [[package]]
 name = "nym-noise"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -6269,6 +6316,7 @@ dependencies = [
 [[package]]
 name = "nym-noise-keys"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "nym-crypto",
  "schemars 0.8.22",
@@ -6279,6 +6327,7 @@ dependencies = [
 [[package]]
 name = "nym-nonexhaustive-delayqueue"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -6308,6 +6357,7 @@ dependencies = [
 [[package]]
 name = "nym-ordered-buffer"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "log",
  "thiserror 2.0.18",
@@ -6316,6 +6366,7 @@ dependencies = [
 [[package]]
 name = "nym-outfox"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "blake3",
  "chacha20 0.9.1",
@@ -6329,6 +6380,7 @@ dependencies = [
 [[package]]
 name = "nym-pemstore"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "pem",
  "tracing",
@@ -6338,6 +6390,7 @@ dependencies = [
 [[package]]
 name = "nym-performance-contract-common"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -6365,6 +6418,7 @@ dependencies = [
 [[package]]
 name = "nym-registration-client"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "bincode",
  "bytes",
@@ -6392,6 +6446,7 @@ dependencies = [
 [[package]]
 name = "nym-registration-common"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "bincode",
  "nym-authenticator-requests",
@@ -6428,6 +6483,7 @@ dependencies = [
 [[package]]
 name = "nym-sdk"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6486,6 +6542,7 @@ dependencies = [
 [[package]]
 name = "nym-serde-helpers"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -6497,6 +6554,7 @@ dependencies = [
 [[package]]
 name = "nym-service-provider-requests-common"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -6505,6 +6563,7 @@ dependencies = [
 [[package]]
 name = "nym-service-providers-common"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "async-trait",
  "log",
@@ -6530,6 +6589,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-client-core"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "anyhow",
  "dirs",
@@ -6589,6 +6649,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-proxy-helpers"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "bytes",
  "futures",
@@ -6611,6 +6672,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-requests"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "bincode",
  "log",
@@ -6626,6 +6688,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "nym-crypto",
  "nym-metrics",
@@ -6651,6 +6714,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-acknowledgements"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "nym-crypto",
  "nym-pemstore",
@@ -6667,6 +6731,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-addressing"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-types",
@@ -6677,6 +6742,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-anonymous-replies"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "bs58",
  "nym-crypto",
@@ -6694,6 +6760,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-chunking"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "dashmap",
  "log",
@@ -6712,6 +6779,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-cover"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-acknowledgements",
@@ -6729,6 +6797,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-forwarding"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "nym-sphinx-addressing",
  "nym-sphinx-anonymous-replies",
@@ -6740,6 +6809,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-framing"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -6756,6 +6826,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-params"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-types",
@@ -6766,6 +6837,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-routing"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "nym-sphinx-addressing",
  "nym-sphinx-types",
@@ -6775,6 +6847,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-types"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "nym-outfox",
  "sphinx-packet",
@@ -6823,6 +6896,7 @@ dependencies = [
 [[package]]
 name = "nym-sqlx-pool-guard"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "proc_pidinfo",
  "sqlx",
@@ -6866,6 +6940,7 @@ dependencies = [
 [[package]]
 name = "nym-statistics-common"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "futures",
  "log",
@@ -6890,6 +6965,7 @@ dependencies = [
 [[package]]
 name = "nym-task"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "cfg-if",
  "futures",
@@ -6906,6 +6982,7 @@ dependencies = [
 [[package]]
 name = "nym-ticketbooks-merkle"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "nym-credentials-interface",
  "nym-serde-helpers",
@@ -6920,6 +6997,7 @@ dependencies = [
 [[package]]
 name = "nym-topology"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "async-trait",
  "nym-api-requests",
@@ -6939,6 +7017,7 @@ dependencies = [
 [[package]]
 name = "nym-upgrade-mode-check"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "jwt-simple",
  "nym-crypto",
@@ -6955,6 +7034,7 @@ dependencies = [
 [[package]]
 name = "nym-validator-client"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7006,6 +7086,7 @@ dependencies = [
 [[package]]
 name = "nym-vesting-contract-common"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -7454,6 +7535,7 @@ dependencies = [
 [[package]]
 name = "nym-wasm-utils"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "futures",
  "getrandom 0.2.17",
@@ -7517,6 +7599,7 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-private-metadata-client"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "async-trait",
  "nym-http-api-client",
@@ -7527,6 +7610,7 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-private-metadata-shared"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "axum",
  "bincode",
@@ -7540,6 +7624,7 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-types"
 version = "1.21.4"
+source = "git+https://github.com/nymtech/nym?branch=feature%2Fnym-1408-registration-client-skew-manager#60a4abaf2d9c9e50c423781ecdb876ef649e6ab6"
 dependencies = [
  "base64 0.22.1",
  "nym-crypto",

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -276,78 +276,78 @@ nym-windows = { path = "crates/nym-windows" }
 test-rpc = { path = "crates/test/test-rpc" }
 
 # For normal development
-nym-authenticator-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-authenticator-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-api-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-bandwidth-controller = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-bandwidth-fetcher = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-bin-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-client-core = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-compact-ecash = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-config = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-contracts-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-credential-proxy-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam", default-features = false }
-nym-credential-storage = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-credentials = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-credentials-interface = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-crypto = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-ecash-time = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-gateway-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-http-api-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-http-api-client-macro = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-lp = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-lp-data = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-network-defaults = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-ip-packet-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-ip-packet-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-pemstore = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-registration-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-registration-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-sdk = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-statistics-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-topology = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-upgrade-mode-check = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-validator-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-wireguard-private-metadata-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-wireguard-private-metadata-shared = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-wireguard-types = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-sqlx-pool-guard = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-authenticator-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-authenticator-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-api-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-bandwidth-controller = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-bandwidth-fetcher = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-bin-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-client-core = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-compact-ecash = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-config = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-contracts-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-credential-proxy-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam", default-features = false }
+#nym-credential-storage = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-credentials = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-credentials-interface = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-crypto = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-ecash-time = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-gateway-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-http-api-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-http-api-client-macro = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-lp = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-lp-data = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-network-defaults = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-ip-packet-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-ip-packet-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-pemstore = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-registration-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-registration-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-sdk = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-statistics-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-topology = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-upgrade-mode-check = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-validator-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-wireguard-private-metadata-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-wireguard-private-metadata-shared = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-wireguard-types = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-sqlx-pool-guard = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
 
 # For local development
 # [patch."https://github.com/nymtech/nym"]
-#nym-authenticator-client = { path = "../../nym/nym-authenticator-client" }
-#nym-authenticator-requests = { path = "../../nym/common/authenticator-requests" }
-#nym-api-requests = { path = "../../nym/nym-api/nym-api-requests" }
-#nym-bandwidth-controller = { path = "../../nym/common/bandwidth-controller" }
-#nym-bandwidth-fetcher = { path = "../../nym/common/bandwidth-fetcher" }
-#nym-bin-common = { path = "../../nym/common/bin-common" }
-#nym-client-core = { path = "../../nym/common/client-core" }
-#nym-compact-ecash = { path = "../../nym/common/nym_offline_compact_ecash" }
-#nym-config = { path = "../../nym/common/config" }
-#nym-contracts-common = { path = "../../nym/common/cosmwasm-smart-contracts/contracts-common" }
-#nym-credential-proxy-requests = { path = "../../nym/nym-credential-proxy/nym-credential-proxy-requests", default-features = false }
-#nym-credential-storage = { path = "../../nym/common/credential-storage" }
-#nym-credentials = { path = "../../nym/common/credentials" }
-#nym-credentials-interface = { path = "../../nym/common/credentials-interface" }
-#nym-crypto = { path = "../../nym/common/crypto" }
-#nym-ecash-time = { path = "../../nym/common/ecash-time" }
-#nym-gateway-requests = { path = "../../nym/common/gateway-requests" }
-#nym-http-api-client = { path = "../../nym/common/http-api-client" }
-#nym-http-api-client-macro = { path = "../../nym/common/http-api-client-macro" }
-#nym-lp = { path = "../../nym/common/nym-lp" }
-#nym-lp-data = { path = "../../nym/common/nym-lp-data" }
-#nym-network-defaults = { path = "../../nym/common/network-defaults" }
-#nym-ip-packet-requests = { path = "../../nym/common/ip-packet-requests" }
-#nym-ip-packet-client = { path = "../../nym/nym-ip-packet-client" }
-#nym-pemstore = { path = "../../nym/common/pemstore" }
-#nym-registration-client = { path = "../../nym/nym-registration-client" }
-#nym-registration-common = { path = "../../nym/common/registration" }
-#nym-sdk = { path = "../../nym/sdk/rust/nym-sdk" }
-#nym-statistics-common = { path = "../../nym/common/statistics" }
-#nym-topology = { path = "../../nym/common/topology" }
-#nym-upgrade-mode-check = { path = "../../nym/common/upgrade-mode-check" }
-#nym-validator-client = { path = "../../nym/common/client-libs/validator-client" }
-#nym-wireguard-private-metadata-client = { path = "../../nym/common/wireguard-private-metadata/client" }
-#nym-wireguard-private-metadata-shared = { path = "../../nym/common/wireguard-private-metadata/shared" }
-#nym-wireguard-types = { path = "../../nym/common/wireguard-types" }
-#nym-sqlx-pool-guard = { path = "../../nym/nym-sqlx-pool-guard" }
+nym-authenticator-client = { path = "../../nym/nym-authenticator-client" }
+nym-authenticator-requests = { path = "../../nym/common/authenticator-requests" }
+nym-api-requests = { path = "../../nym/nym-api/nym-api-requests" }
+nym-bandwidth-controller = { path = "../../nym/common/bandwidth-controller" }
+nym-bandwidth-fetcher = { path = "../../nym/common/bandwidth-fetcher" }
+nym-bin-common = { path = "../../nym/common/bin-common" }
+nym-client-core = { path = "../../nym/common/client-core" }
+nym-compact-ecash = { path = "../../nym/common/nym_offline_compact_ecash" }
+nym-config = { path = "../../nym/common/config" }
+nym-contracts-common = { path = "../../nym/common/cosmwasm-smart-contracts/contracts-common" }
+nym-credential-proxy-requests = { path = "../../nym/nym-credential-proxy/nym-credential-proxy-requests", default-features = false }
+nym-credential-storage = { path = "../../nym/common/credential-storage" }
+nym-credentials = { path = "../../nym/common/credentials" }
+nym-credentials-interface = { path = "../../nym/common/credentials-interface" }
+nym-crypto = { path = "../../nym/common/crypto" }
+nym-ecash-time = { path = "../../nym/common/ecash-time" }
+nym-gateway-requests = { path = "../../nym/common/gateway-requests" }
+nym-http-api-client = { path = "../../nym/common/http-api-client" }
+nym-http-api-client-macro = { path = "../../nym/common/http-api-client-macro" }
+nym-lp = { path = "../../nym/common/nym-lp" }
+nym-lp-data = { path = "../../nym/common/nym-lp-data" }
+nym-network-defaults = { path = "../../nym/common/network-defaults" }
+nym-ip-packet-requests = { path = "../../nym/common/ip-packet-requests" }
+nym-ip-packet-client = { path = "../../nym/nym-ip-packet-client" }
+nym-pemstore = { path = "../../nym/common/pemstore" }
+nym-registration-client = { path = "../../nym/nym-registration-client" }
+nym-registration-common = { path = "../../nym/common/registration" }
+nym-sdk = { path = "../../nym/sdk/rust/nym-sdk" }
+nym-statistics-common = { path = "../../nym/common/statistics" }
+nym-topology = { path = "../../nym/common/topology" }
+nym-upgrade-mode-check = { path = "../../nym/common/upgrade-mode-check" }
+nym-validator-client = { path = "../../nym/common/client-libs/validator-client" }
+nym-wireguard-private-metadata-client = { path = "../../nym/common/wireguard-private-metadata/client" }
+nym-wireguard-private-metadata-shared = { path = "../../nym/common/wireguard-private-metadata/shared" }
+nym-wireguard-types = { path = "../../nym/common/wireguard-types" }
+nym-sqlx-pool-guard = { path = "../../nym/nym-sqlx-pool-guard" }

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -276,77 +276,78 @@ nym-windows = { path = "crates/nym-windows" }
 test-rpc = { path = "crates/test/test-rpc" }
 
 # For normal development
-nym-authenticator-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-authenticator-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-api-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-bandwidth-controller = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-bandwidth-fetcher = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-bin-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-client-core = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-compact-ecash = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-config = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-contracts-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-credential-proxy-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam", default-features = false }
-nym-credential-storage = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-credentials = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-credentials-interface = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-crypto = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-ecash-time = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-gateway-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-http-api-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-http-api-client-macro = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-lp = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-lp-data = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-network-defaults = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-ip-packet-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-ip-packet-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-pemstore = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-registration-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-registration-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-sdk = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-statistics-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-topology = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-upgrade-mode-check = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-validator-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-wireguard-private-metadata-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-wireguard-private-metadata-shared = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-wireguard-types = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-nym-sqlx-pool-guard = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-authenticator-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-authenticator-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-api-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-bandwidth-controller = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-bandwidth-fetcher = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-bin-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-client-core = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-compact-ecash = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-config = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-contracts-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-credential-proxy-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam", default-features = false }
+#nym-credential-storage = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-credentials = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-credentials-interface = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-crypto = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-ecash-time = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-gateway-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-http-api-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-http-api-client-macro = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-lp = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-lp-data = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-network-defaults = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-ip-packet-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-ip-packet-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-pemstore = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-registration-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-registration-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-sdk = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-statistics-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-topology = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-upgrade-mode-check = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-validator-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-wireguard-private-metadata-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-wireguard-private-metadata-shared = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-wireguard-types = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+#nym-sqlx-pool-guard = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
 
 # For local development
 # [patch."https://github.com/nymtech/nym"]
-# nym-authenticator-client = { path = "../../nym/nym-authenticator-client" }
-# nym-authenticator-requests = { path = "../../nym/common/authenticator-requests" }
-# nym-api-requests = { path = "../../nym/nym-api/nym-api-requests" }
-# nym-bandwidth-controller = { path = "../../nym/common/bandwidth-controller" }
-# nym-bandwidth-fetcher = { path = "../../nym/common/bandwidth-fetcher" }
-# nym-bin-common = { path = "../../nym/common/bin-common" }
-# nym-client-core = { path = "../../nym/common/client-core" }
-# nym-compact-ecash = { path = "../../nym/common/nym_offline_compact_ecash" }
-# nym-config = { path = "../../nym/common/config" }
-# nym-contracts-common = { path = "../../nym/common/cosmwasm-smart-contracts/contracts-common" }
-# nym-credential-proxy-requests = { path = "../../nym/nym-credential-proxy/nym-credential-proxy-requests", default-features = false }
-# nym-credential-storage = { path = "../../nym/common/credential-storage" }
-# nym-credentials = { path = "../../nym/common/credentials" }
-# nym-credentials-interface = { path = "../../nym/common/credentials-interface" }
-# nym-crypto = { path = "../../nym/common/crypto" }
-# nym-ecash-time = { path = "../../nym/common/ecash-time" }
-# nym-gateway-requests = { path = "../../nym/common/gateway-requests" }
-# nym-http-api-client = { path = "../../nym/common/http-api-client" }
-# nym-http-api-client-macro = { path = "../../nym/common/http-api-client-macro" }
-# nym-lp = { path = "../../nym/common/nym-lp" }
-# nym-network-defaults = { path = "../../nym/common/network-defaults" }
-# nym-ip-packet-requests = { path = "../../nym/common/ip-packet-requests" }
-# nym-ip-packet-client = { path = "../../nym/nym-ip-packet-client" }
-# nym-pemstore = { path = "../../nym/common/pemstore" }
-# nym-registration-client = { path = "../../nym/nym-registration-client" }
-# nym-registration-common = { path = "../../nym/common/registration" }
-# nym-sdk = { path = "../../nym/sdk/rust/nym-sdk" }
-# nym-statistics-common = { path = "../../nym/common/statistics" }
-# nym-topology = { path = "../../nym/common/topology" }
-# nym-upgrade-mode-check = { path = "../../nym/common/upgrade-mode-check" }
-# nym-validator-client = { path = "../../nym/common/client-libs/validator-client" }
-# nym-wireguard-private-metadata-client = { path = "../../nym/common/wireguard-private-metadata/client" }
-# nym-wireguard-private-metadata-shared = { path = "../../nym/common/wireguard-private-metadata/shared" }
-# nym-wireguard-types = { path = "../../nym/common/wireguard-types" }
-# nym-sqlx-pool-guard = { path = "../../nym/nym-sqlx-pool-guard" }
+nym-authenticator-client = { path = "../../nym/nym-authenticator-client" }
+nym-authenticator-requests = { path = "../../nym/common/authenticator-requests" }
+nym-api-requests = { path = "../../nym/nym-api/nym-api-requests" }
+nym-bandwidth-controller = { path = "../../nym/common/bandwidth-controller" }
+nym-bandwidth-fetcher = { path = "../../nym/common/bandwidth-fetcher" }
+nym-bin-common = { path = "../../nym/common/bin-common" }
+nym-client-core = { path = "../../nym/common/client-core" }
+nym-compact-ecash = { path = "../../nym/common/nym_offline_compact_ecash" }
+nym-config = { path = "../../nym/common/config" }
+nym-contracts-common = { path = "../../nym/common/cosmwasm-smart-contracts/contracts-common" }
+nym-credential-proxy-requests = { path = "../../nym/nym-credential-proxy/nym-credential-proxy-requests", default-features = false }
+nym-credential-storage = { path = "../../nym/common/credential-storage" }
+nym-credentials = { path = "../../nym/common/credentials" }
+nym-credentials-interface = { path = "../../nym/common/credentials-interface" }
+nym-crypto = { path = "../../nym/common/crypto" }
+nym-ecash-time = { path = "../../nym/common/ecash-time" }
+nym-gateway-requests = { path = "../../nym/common/gateway-requests" }
+nym-http-api-client = { path = "../../nym/common/http-api-client" }
+nym-http-api-client-macro = { path = "../../nym/common/http-api-client-macro" }
+nym-lp = { path = "../../nym/common/nym-lp" }
+nym-lp-data = { path = "../../nym/common/nym-lp-data" }
+nym-network-defaults = { path = "../../nym/common/network-defaults" }
+nym-ip-packet-requests = { path = "../../nym/common/ip-packet-requests" }
+nym-ip-packet-client = { path = "../../nym/nym-ip-packet-client" }
+nym-pemstore = { path = "../../nym/common/pemstore" }
+nym-registration-client = { path = "../../nym/nym-registration-client" }
+nym-registration-common = { path = "../../nym/common/registration" }
+nym-sdk = { path = "../../nym/sdk/rust/nym-sdk" }
+nym-statistics-common = { path = "../../nym/common/statistics" }
+nym-topology = { path = "../../nym/common/topology" }
+nym-upgrade-mode-check = { path = "../../nym/common/upgrade-mode-check" }
+nym-validator-client = { path = "../../nym/common/client-libs/validator-client" }
+nym-wireguard-private-metadata-client = { path = "../../nym/common/wireguard-private-metadata/client" }
+nym-wireguard-private-metadata-shared = { path = "../../nym/common/wireguard-private-metadata/shared" }
+nym-wireguard-types = { path = "../../nym/common/wireguard-types" }
+nym-sqlx-pool-guard = { path = "../../nym/nym-sqlx-pool-guard" }

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -276,78 +276,78 @@ nym-windows = { path = "crates/nym-windows" }
 test-rpc = { path = "crates/test/test-rpc" }
 
 # For normal development
-#nym-authenticator-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-authenticator-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-api-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-bandwidth-controller = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-bandwidth-fetcher = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-bin-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-client-core = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-compact-ecash = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-config = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-contracts-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-credential-proxy-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam", default-features = false }
-#nym-credential-storage = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-credentials = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-credentials-interface = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-crypto = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-ecash-time = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-gateway-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-http-api-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-http-api-client-macro = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-lp = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-lp-data = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-network-defaults = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-ip-packet-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-ip-packet-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-pemstore = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-registration-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-registration-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-sdk = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-statistics-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-topology = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-upgrade-mode-check = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-validator-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-wireguard-private-metadata-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-wireguard-private-metadata-shared = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-wireguard-types = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-sqlx-pool-guard = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-authenticator-client = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
+nym-authenticator-requests = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
+nym-api-requests = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
+nym-bandwidth-controller = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
+nym-bandwidth-fetcher = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
+nym-bin-common = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
+nym-client-core = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
+nym-compact-ecash = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
+nym-config = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
+nym-contracts-common = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
+nym-credential-proxy-requests = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager", default-features = false }
+nym-credential-storage = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
+nym-credentials = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
+nym-credentials-interface = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
+nym-crypto = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
+nym-ecash-time = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
+nym-gateway-requests = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
+nym-http-api-client = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
+nym-http-api-client-macro = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
+nym-lp = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
+nym-lp-data = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
+nym-network-defaults = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
+nym-ip-packet-requests = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
+nym-ip-packet-client = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
+nym-pemstore = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
+nym-registration-client = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
+nym-registration-common = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
+nym-sdk = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
+nym-statistics-common = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
+nym-topology = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
+nym-upgrade-mode-check = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
+nym-validator-client = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
+nym-wireguard-private-metadata-client = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
+nym-wireguard-private-metadata-shared = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
+nym-wireguard-types = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
+nym-sqlx-pool-guard = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
 
 # For local development
 # [patch."https://github.com/nymtech/nym"]
-nym-authenticator-client = { path = "../../nym/nym-authenticator-client" }
-nym-authenticator-requests = { path = "../../nym/common/authenticator-requests" }
-nym-api-requests = { path = "../../nym/nym-api/nym-api-requests" }
-nym-bandwidth-controller = { path = "../../nym/common/bandwidth-controller" }
-nym-bandwidth-fetcher = { path = "../../nym/common/bandwidth-fetcher" }
-nym-bin-common = { path = "../../nym/common/bin-common" }
-nym-client-core = { path = "../../nym/common/client-core" }
-nym-compact-ecash = { path = "../../nym/common/nym_offline_compact_ecash" }
-nym-config = { path = "../../nym/common/config" }
-nym-contracts-common = { path = "../../nym/common/cosmwasm-smart-contracts/contracts-common" }
-nym-credential-proxy-requests = { path = "../../nym/nym-credential-proxy/nym-credential-proxy-requests", default-features = false }
-nym-credential-storage = { path = "../../nym/common/credential-storage" }
-nym-credentials = { path = "../../nym/common/credentials" }
-nym-credentials-interface = { path = "../../nym/common/credentials-interface" }
-nym-crypto = { path = "../../nym/common/crypto" }
-nym-ecash-time = { path = "../../nym/common/ecash-time" }
-nym-gateway-requests = { path = "../../nym/common/gateway-requests" }
-nym-http-api-client = { path = "../../nym/common/http-api-client" }
-nym-http-api-client-macro = { path = "../../nym/common/http-api-client-macro" }
-nym-lp = { path = "../../nym/common/nym-lp" }
-nym-lp-data = { path = "../../nym/common/nym-lp-data" }
-nym-network-defaults = { path = "../../nym/common/network-defaults" }
-nym-ip-packet-requests = { path = "../../nym/common/ip-packet-requests" }
-nym-ip-packet-client = { path = "../../nym/nym-ip-packet-client" }
-nym-pemstore = { path = "../../nym/common/pemstore" }
-nym-registration-client = { path = "../../nym/nym-registration-client" }
-nym-registration-common = { path = "../../nym/common/registration" }
-nym-sdk = { path = "../../nym/sdk/rust/nym-sdk" }
-nym-statistics-common = { path = "../../nym/common/statistics" }
-nym-topology = { path = "../../nym/common/topology" }
-nym-upgrade-mode-check = { path = "../../nym/common/upgrade-mode-check" }
-nym-validator-client = { path = "../../nym/common/client-libs/validator-client" }
-nym-wireguard-private-metadata-client = { path = "../../nym/common/wireguard-private-metadata/client" }
-nym-wireguard-private-metadata-shared = { path = "../../nym/common/wireguard-private-metadata/shared" }
-nym-wireguard-types = { path = "../../nym/common/wireguard-types" }
-nym-sqlx-pool-guard = { path = "../../nym/nym-sqlx-pool-guard" }
+#nym-authenticator-client = { path = "../../nym/nym-authenticator-client" }
+#nym-authenticator-requests = { path = "../../nym/common/authenticator-requests" }
+#nym-api-requests = { path = "../../nym/nym-api/nym-api-requests" }
+#nym-bandwidth-controller = { path = "../../nym/common/bandwidth-controller" }
+#nym-bandwidth-fetcher = { path = "../../nym/common/bandwidth-fetcher" }
+#nym-bin-common = { path = "../../nym/common/bin-common" }
+#nym-client-core = { path = "../../nym/common/client-core" }
+#nym-compact-ecash = { path = "../../nym/common/nym_offline_compact_ecash" }
+#nym-config = { path = "../../nym/common/config" }
+#nym-contracts-common = { path = "../../nym/common/cosmwasm-smart-contracts/contracts-common" }
+#nym-credential-proxy-requests = { path = "../../nym/nym-credential-proxy/nym-credential-proxy-requests", default-features = false }
+#nym-credential-storage = { path = "../../nym/common/credential-storage" }
+#nym-credentials = { path = "../../nym/common/credentials" }
+#nym-credentials-interface = { path = "../../nym/common/credentials-interface" }
+#nym-crypto = { path = "../../nym/common/crypto" }
+#nym-ecash-time = { path = "../../nym/common/ecash-time" }
+#nym-gateway-requests = { path = "../../nym/common/gateway-requests" }
+#nym-http-api-client = { path = "../../nym/common/http-api-client" }
+#nym-http-api-client-macro = { path = "../../nym/common/http-api-client-macro" }
+#nym-lp = { path = "../../nym/common/nym-lp" }
+#nym-lp-data = { path = "../../nym/common/nym-lp-data" }
+#nym-network-defaults = { path = "../../nym/common/network-defaults" }
+#nym-ip-packet-requests = { path = "../../nym/common/ip-packet-requests" }
+#nym-ip-packet-client = { path = "../../nym/nym-ip-packet-client" }
+#nym-pemstore = { path = "../../nym/common/pemstore" }
+#nym-registration-client = { path = "../../nym/nym-registration-client" }
+#nym-registration-common = { path = "../../nym/common/registration" }
+#nym-sdk = { path = "../../nym/sdk/rust/nym-sdk" }
+#nym-statistics-common = { path = "../../nym/common/statistics" }
+#nym-topology = { path = "../../nym/common/topology" }
+#nym-upgrade-mode-check = { path = "../../nym/common/upgrade-mode-check" }
+#nym-validator-client = { path = "../../nym/common/client-libs/validator-client" }
+#nym-wireguard-private-metadata-client = { path = "../../nym/common/wireguard-private-metadata/client" }
+#nym-wireguard-private-metadata-shared = { path = "../../nym/common/wireguard-private-metadata/shared" }
+#nym-wireguard-types = { path = "../../nym/common/wireguard-types" }
+#nym-sqlx-pool-guard = { path = "../../nym/nym-sqlx-pool-guard" }

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -276,78 +276,78 @@ nym-windows = { path = "crates/nym-windows" }
 test-rpc = { path = "crates/test/test-rpc" }
 
 # For normal development
-#nym-authenticator-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-authenticator-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-api-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-bandwidth-controller = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-bandwidth-fetcher = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-bin-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-client-core = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-compact-ecash = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-config = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-contracts-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-credential-proxy-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam", default-features = false }
-#nym-credential-storage = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-credentials = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-credentials-interface = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-crypto = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-ecash-time = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-gateway-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-http-api-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-http-api-client-macro = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-lp = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-lp-data = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-network-defaults = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-ip-packet-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-ip-packet-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-pemstore = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-registration-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-registration-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-sdk = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-statistics-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-topology = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-upgrade-mode-check = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-validator-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-wireguard-private-metadata-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-wireguard-private-metadata-shared = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-wireguard-types = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
-#nym-sqlx-pool-guard = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-authenticator-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-authenticator-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-api-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-bandwidth-controller = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-bandwidth-fetcher = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-bin-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-client-core = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-compact-ecash = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-config = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-contracts-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-credential-proxy-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam", default-features = false }
+nym-credential-storage = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-credentials = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-credentials-interface = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-crypto = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-ecash-time = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-gateway-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-http-api-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-http-api-client-macro = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-lp = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-lp-data = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-network-defaults = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-ip-packet-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-ip-packet-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-pemstore = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-registration-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-registration-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-sdk = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-statistics-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-topology = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-upgrade-mode-check = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-validator-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-wireguard-private-metadata-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-wireguard-private-metadata-shared = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-wireguard-types = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-sqlx-pool-guard = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
 
 # For local development
 # [patch."https://github.com/nymtech/nym"]
-nym-authenticator-client = { path = "../../nym/nym-authenticator-client" }
-nym-authenticator-requests = { path = "../../nym/common/authenticator-requests" }
-nym-api-requests = { path = "../../nym/nym-api/nym-api-requests" }
-nym-bandwidth-controller = { path = "../../nym/common/bandwidth-controller" }
-nym-bandwidth-fetcher = { path = "../../nym/common/bandwidth-fetcher" }
-nym-bin-common = { path = "../../nym/common/bin-common" }
-nym-client-core = { path = "../../nym/common/client-core" }
-nym-compact-ecash = { path = "../../nym/common/nym_offline_compact_ecash" }
-nym-config = { path = "../../nym/common/config" }
-nym-contracts-common = { path = "../../nym/common/cosmwasm-smart-contracts/contracts-common" }
-nym-credential-proxy-requests = { path = "../../nym/nym-credential-proxy/nym-credential-proxy-requests", default-features = false }
-nym-credential-storage = { path = "../../nym/common/credential-storage" }
-nym-credentials = { path = "../../nym/common/credentials" }
-nym-credentials-interface = { path = "../../nym/common/credentials-interface" }
-nym-crypto = { path = "../../nym/common/crypto" }
-nym-ecash-time = { path = "../../nym/common/ecash-time" }
-nym-gateway-requests = { path = "../../nym/common/gateway-requests" }
-nym-http-api-client = { path = "../../nym/common/http-api-client" }
-nym-http-api-client-macro = { path = "../../nym/common/http-api-client-macro" }
-nym-lp = { path = "../../nym/common/nym-lp" }
-nym-lp-data = { path = "../../nym/common/nym-lp-data" }
-nym-network-defaults = { path = "../../nym/common/network-defaults" }
-nym-ip-packet-requests = { path = "../../nym/common/ip-packet-requests" }
-nym-ip-packet-client = { path = "../../nym/nym-ip-packet-client" }
-nym-pemstore = { path = "../../nym/common/pemstore" }
-nym-registration-client = { path = "../../nym/nym-registration-client" }
-nym-registration-common = { path = "../../nym/common/registration" }
-nym-sdk = { path = "../../nym/sdk/rust/nym-sdk" }
-nym-statistics-common = { path = "../../nym/common/statistics" }
-nym-topology = { path = "../../nym/common/topology" }
-nym-upgrade-mode-check = { path = "../../nym/common/upgrade-mode-check" }
-nym-validator-client = { path = "../../nym/common/client-libs/validator-client" }
-nym-wireguard-private-metadata-client = { path = "../../nym/common/wireguard-private-metadata/client" }
-nym-wireguard-private-metadata-shared = { path = "../../nym/common/wireguard-private-metadata/shared" }
-nym-wireguard-types = { path = "../../nym/common/wireguard-types" }
-nym-sqlx-pool-guard = { path = "../../nym/nym-sqlx-pool-guard" }
+#nym-authenticator-client = { path = "../../nym/nym-authenticator-client" }
+#nym-authenticator-requests = { path = "../../nym/common/authenticator-requests" }
+#nym-api-requests = { path = "../../nym/nym-api/nym-api-requests" }
+#nym-bandwidth-controller = { path = "../../nym/common/bandwidth-controller" }
+#nym-bandwidth-fetcher = { path = "../../nym/common/bandwidth-fetcher" }
+#nym-bin-common = { path = "../../nym/common/bin-common" }
+#nym-client-core = { path = "../../nym/common/client-core" }
+#nym-compact-ecash = { path = "../../nym/common/nym_offline_compact_ecash" }
+#nym-config = { path = "../../nym/common/config" }
+#nym-contracts-common = { path = "../../nym/common/cosmwasm-smart-contracts/contracts-common" }
+#nym-credential-proxy-requests = { path = "../../nym/nym-credential-proxy/nym-credential-proxy-requests", default-features = false }
+#nym-credential-storage = { path = "../../nym/common/credential-storage" }
+#nym-credentials = { path = "../../nym/common/credentials" }
+#nym-credentials-interface = { path = "../../nym/common/credentials-interface" }
+#nym-crypto = { path = "../../nym/common/crypto" }
+#nym-ecash-time = { path = "../../nym/common/ecash-time" }
+#nym-gateway-requests = { path = "../../nym/common/gateway-requests" }
+#nym-http-api-client = { path = "../../nym/common/http-api-client" }
+#nym-http-api-client-macro = { path = "../../nym/common/http-api-client-macro" }
+#nym-lp = { path = "../../nym/common/nym-lp" }
+#nym-lp-data = { path = "../../nym/common/nym-lp-data" }
+#nym-network-defaults = { path = "../../nym/common/network-defaults" }
+#nym-ip-packet-requests = { path = "../../nym/common/ip-packet-requests" }
+#nym-ip-packet-client = { path = "../../nym/nym-ip-packet-client" }
+#nym-pemstore = { path = "../../nym/common/pemstore" }
+#nym-registration-client = { path = "../../nym/nym-registration-client" }
+#nym-registration-common = { path = "../../nym/common/registration" }
+#nym-sdk = { path = "../../nym/sdk/rust/nym-sdk" }
+#nym-statistics-common = { path = "../../nym/common/statistics" }
+#nym-topology = { path = "../../nym/common/topology" }
+#nym-upgrade-mode-check = { path = "../../nym/common/upgrade-mode-check" }
+#nym-validator-client = { path = "../../nym/common/client-libs/validator-client" }
+#nym-wireguard-private-metadata-client = { path = "../../nym/common/wireguard-private-metadata/client" }
+#nym-wireguard-private-metadata-shared = { path = "../../nym/common/wireguard-private-metadata/shared" }
+#nym-wireguard-types = { path = "../../nym/common/wireguard-types" }
+#nym-sqlx-pool-guard = { path = "../../nym/nym-sqlx-pool-guard" }

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -276,42 +276,42 @@ nym-windows = { path = "crates/nym-windows" }
 test-rpc = { path = "crates/test/test-rpc" }
 
 # For normal development
-nym-authenticator-client = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
-nym-authenticator-requests = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
-nym-api-requests = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
-nym-bandwidth-controller = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
-nym-bandwidth-fetcher = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
-nym-bin-common = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
-nym-client-core = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
-nym-compact-ecash = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
-nym-config = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
-nym-contracts-common = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
-nym-credential-proxy-requests = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager", default-features = false }
-nym-credential-storage = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
-nym-credentials = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
-nym-credentials-interface = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
-nym-crypto = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
-nym-ecash-time = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
-nym-gateway-requests = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
-nym-http-api-client = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
-nym-http-api-client-macro = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
-nym-lp = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
-nym-lp-data = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
-nym-network-defaults = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
-nym-ip-packet-requests = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
-nym-ip-packet-client = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
-nym-pemstore = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
-nym-registration-client = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
-nym-registration-common = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
-nym-sdk = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
-nym-statistics-common = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
-nym-topology = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
-nym-upgrade-mode-check = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
-nym-validator-client = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
-nym-wireguard-private-metadata-client = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
-nym-wireguard-private-metadata-shared = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
-nym-wireguard-types = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
-nym-sqlx-pool-guard = { git = "https://github.com/nymtech/nym", branch = "feature/nym-1408-registration-client-skew-manager" }
+nym-authenticator-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-authenticator-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-api-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-bandwidth-controller = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-bandwidth-fetcher = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-bin-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-client-core = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-compact-ecash = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-config = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-contracts-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-credential-proxy-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam", default-features = false }
+nym-credential-storage = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-credentials = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-credentials-interface = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-crypto = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-ecash-time = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-gateway-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-http-api-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-http-api-client-macro = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-lp = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-lp-data = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-network-defaults = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-ip-packet-requests = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-ip-packet-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-pemstore = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-registration-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-registration-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-sdk = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-statistics-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-topology = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-upgrade-mode-check = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-validator-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-wireguard-private-metadata-client = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-wireguard-private-metadata-shared = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-wireguard-types = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
+nym-sqlx-pool-guard = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.14-amsterdam" }
 
 # For local development
 # [patch."https://github.com/nymtech/nym"]

--- a/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/registration/lp_client.rs
+++ b/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/registration/lp_client.rs
@@ -4,7 +4,7 @@
 use crate::diagnostic::{build_api_client, registration::setup_bandwidth_provider};
 
 use anyhow::Context;
-use nym_bandwidth_controller::{BandwidthTicketProvider, SystemSpendTimeProvider};
+use nym_bandwidth_controller::BandwidthTicketProvider;
 use nym_credentials_interface::TicketType;
 use nym_lp::{Ciphersuite, peer::LpRemotePeer};
 use nym_lp_data::packet::version;
@@ -68,7 +68,7 @@ impl LpClientRegistration {
                 &registration_config.local_wg_keypair,
                 &registration_config.gateway_id_key,
                 &registration_config.bandwidth_provider,
-                &SystemSpendTimeProvider,
+                None,
                 TicketType::V1WireguardEntry,
             )
             .await;

--- a/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/registration/lp_client.rs
+++ b/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/registration/lp_client.rs
@@ -4,7 +4,7 @@
 use crate::diagnostic::{build_api_client, registration::setup_bandwidth_provider};
 
 use anyhow::Context;
-use nym_bandwidth_controller::BandwidthTicketProvider;
+use nym_bandwidth_controller::{BandwidthTicketProvider, SystemSpendTimeProvider};
 use nym_credentials_interface::TicketType;
 use nym_lp::{Ciphersuite, peer::LpRemotePeer};
 use nym_lp_data::packet::version;
@@ -68,6 +68,7 @@ impl LpClientRegistration {
                 &registration_config.local_wg_keypair,
                 &registration_config.gateway_id_key,
                 &registration_config.bandwidth_provider,
+                &SystemSpendTimeProvider,
                 TicketType::V1WireguardEntry,
             )
             .await;

--- a/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/registration/mixnet_client.rs
+++ b/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/registration/mixnet_client.rs
@@ -3,7 +3,7 @@
 use crate::diagnostic::{build_api_client, registration::setup_bandwidth_provider};
 
 use nym_authenticator_client::{AuthClientMixnetListener, AuthenticatorClient, RegistrationError};
-use nym_bandwidth_controller::BandwidthTicketProvider;
+use nym_bandwidth_controller::{BandwidthTicketProvider, SystemSpendTimeProvider};
 use nym_client_core::client::topology_control::nym_api_provider::Config;
 use nym_credentials_interface::TicketType;
 use nym_ip_packet_client::IprClientConnect;
@@ -199,6 +199,7 @@ impl MixnetClientRegistration {
         let auth_res = auth_client
             .register_wireguard(
                 &*wg_registration_config.bandwidth_provider,
+                &SystemSpendTimeProvider,
                 TicketType::V1WireguardEntry,
             )
             .await;

--- a/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/registration/mixnet_client.rs
+++ b/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/registration/mixnet_client.rs
@@ -3,7 +3,7 @@
 use crate::diagnostic::{build_api_client, registration::setup_bandwidth_provider};
 
 use nym_authenticator_client::{AuthClientMixnetListener, AuthenticatorClient, RegistrationError};
-use nym_bandwidth_controller::{BandwidthTicketProvider, SystemSpendTimeProvider};
+use nym_bandwidth_controller::BandwidthTicketProvider;
 use nym_client_core::client::topology_control::nym_api_provider::Config;
 use nym_credentials_interface::TicketType;
 use nym_ip_packet_client::IprClientConnect;
@@ -199,7 +199,7 @@ impl MixnetClientRegistration {
         let auth_res = auth_client
             .register_wireguard(
                 &*wg_registration_config.bandwidth_provider,
-                &SystemSpendTimeProvider,
+                None,
                 TicketType::V1WireguardEntry,
             )
             .await;

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/skew_manager.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/skew_manager.rs
@@ -261,25 +261,26 @@ impl SkewManager {
     }
 
     /// Returns a timestamp corrected for the skew between the local device clock and the VPN API
-    /// server clock, if a valid cached skew is available right now - or `None` otherwise (skew
-    /// not yet known, expired, not significant, or the cache is momentarily locked for writing).
+    /// server clock, falling back to the device clock as-is if no valid skew is cached right now
+    /// (not yet known, expired, or the cache is momentarily locked for writing).
     ///
     /// Synchronous and non-blocking: this never performs network I/O and never waits on a lock
     /// (a locked cache is simply treated as "not available"), so it's safe to call from
-    /// time-sensitive paths that must not be delayed. Callers decide what "not available" means
-    /// for them - typically, falling back to `device_time()`.
+    /// time-sensitive paths that must not be delayed.
     ///
     /// Note this samples the device clock *now* - if the result is going to be used significantly
     /// later (e.g. after a slow async operation), prefer [`Self::cached_skew`] instead and apply
     /// it to a clock reading taken at the point of actual use, or this correction will itself
     /// become stale by the time it's used.
-    pub fn cached_skew_corrected_time(&self) -> Option<OffsetDateTime> {
-        self.cached_skew().map(|skew| self.device_time() - skew)
+    pub fn cached_skew_corrected_time(&self) -> OffsetDateTime {
+        let device_time = self.device_time();
+        self.cached_skew()
+            .map_or(device_time, |skew| device_time - skew)
     }
 
     /// Returns the currently cached clock skew (how far ahead of the VPN API server's clock the
-    /// local device clock is) - or `None` otherwise (skew not yet known, expired, not
-    /// significant, or the cache is momentarily locked for writing).
+    /// local device clock is) - or `None` if none is cached yet, it's expired, or the cache is
+    /// momentarily locked for writing.
     ///
     /// Unlike [`Self::cached_skew_corrected_time`], this doesn't sample the device clock itself:
     /// it returns just the offset, so callers can apply it to a clock reading taken right before
@@ -287,7 +288,7 @@ impl SkewManager {
     /// before, which would let unrelated async work (network round-trips, retries, ...) make the
     /// correction stale before it's used.
     pub fn cached_skew(&self) -> Option<TimeDuration> {
-        let skew = match self
+        match self
             .inner
             .skew_state
             .try_read()
@@ -295,11 +296,9 @@ impl SkewManager {
             .as_ref()?
             .status(Instant::now())
         {
-            SkewStatus::Valid(skew) => skew,
-            SkewStatus::Expired => return None,
-        };
-
-        Self::use_remote_time(self.estimate_remote_time(skew)).then_some(skew)
+            SkewStatus::Valid(skew) => Some(skew),
+            SkewStatus::Expired => None,
+        }
     }
 }
 
@@ -365,13 +364,13 @@ mod tests {
 
     #[tokio::test]
     #[tracing_test::traced_test]
-    async fn test_cached_skew_corrected_time_uses_significant_cached_skew() {
-        // Fixed so the later `device_time()` reads inside `cached_skew_corrected_time` (there
-        // are two) return exactly this instant rather than drifting a few microseconds past it.
+    async fn test_cached_skew_corrected_time_applies_large_cached_skew() {
+        // Fixed so the `device_time()` read inside `cached_skew_corrected_time` returns exactly
+        // this instant rather than drifting a few microseconds past it.
         let time_before = OffsetDateTime::now_utc();
         let remote_timestamp = time_before - Duration::from_hours(2);
         let skew_manager = SkewManager::new_for_testing(
-            MockDeviceTimeProvider::new(vec![time_before; 4]),
+            MockDeviceTimeProvider::new(vec![time_before]),
             PanickingTimeProvider,
         );
 
@@ -382,32 +381,41 @@ mod tests {
             .expect("skew is significant");
 
         // Reads the cache synchronously: no network request (which would panic)
-        let corrected = skew_manager
-            .cached_skew_corrected_time()
-            .expect("cached skew is significant");
+        let corrected = skew_manager.cached_skew_corrected_time();
         assert_eq!((time_before - corrected).whole_hours(), 2);
     }
 
     #[tokio::test]
     #[tracing_test::traced_test]
-    async fn test_cached_skew_corrected_time_none_when_skew_negligible_or_missing() {
+    async fn test_cached_skew_corrected_time_falls_back_to_device_time_when_none_cached() {
+        let time_before = OffsetDateTime::now_utc();
         let skew_manager = SkewManager::new_for_testing(
-            MockDeviceTimeProvider::new(vec![]),
+            MockDeviceTimeProvider::new(vec![time_before]),
             PanickingTimeProvider,
         );
 
-        // No skew has been recorded yet
-        assert!(skew_manager.cached_skew_corrected_time().is_none());
+        // No skew has been recorded yet: falls back to the device clock as-is
+        assert_eq!(skew_manager.cached_skew_corrected_time(), time_before);
+    }
 
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn test_cached_skew_corrected_time_applies_small_cached_skew() {
         let time_before = OffsetDateTime::now_utc();
         let remote_timestamp = time_before + Duration::from_secs(30);
+        let skew_manager = SkewManager::new_for_testing(
+            MockDeviceTimeProvider::new(vec![time_before]),
+            PanickingTimeProvider,
+        );
+
         skew_manager
             .sync_with_response_timestamp(time_before, remote_timestamp, time_before)
             .await
             .unwrap();
 
-        // A negligible skew is cached, but not significant enough to correct for
-        assert!(skew_manager.cached_skew_corrected_time().is_none());
+        // Even a skew as small as 30s is applied - no "is it significant enough" filtering
+        let corrected = skew_manager.cached_skew_corrected_time();
+        assert_eq!((corrected - time_before).whole_seconds(), 30);
     }
 
     #[tokio::test]

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/skew_manager.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/skew_manager.rs
@@ -268,7 +268,25 @@ impl SkewManager {
     /// (a locked cache is simply treated as "not available"), so it's safe to call from
     /// time-sensitive paths that must not be delayed. Callers decide what "not available" means
     /// for them - typically, falling back to `device_time()`.
+    ///
+    /// Note this samples the device clock *now* - if the result is going to be used significantly
+    /// later (e.g. after a slow async operation), prefer [`Self::cached_skew`] instead and apply
+    /// it to a clock reading taken at the point of actual use, or this correction will itself
+    /// become stale by the time it's used.
     pub fn cached_skew_corrected_time(&self) -> Option<OffsetDateTime> {
+        self.cached_skew().map(|skew| self.device_time() - skew)
+    }
+
+    /// Returns the currently cached clock skew (how far ahead of the VPN API server's clock the
+    /// local device clock is) - or `None` otherwise (skew not yet known, expired, not
+    /// significant, or the cache is momentarily locked for writing).
+    ///
+    /// Unlike [`Self::cached_skew_corrected_time`], this doesn't sample the device clock itself:
+    /// it returns just the offset, so callers can apply it to a clock reading taken right before
+    /// it's actually needed (e.g. `OffsetDateTime::now_utc() - skew`) instead of one taken well
+    /// before, which would let unrelated async work (network round-trips, retries, ...) make the
+    /// correction stale before it's used.
+    pub fn cached_skew(&self) -> Option<TimeDuration> {
         let skew = match self
             .inner
             .skew_state
@@ -281,7 +299,7 @@ impl SkewManager {
             SkewStatus::Expired => return None,
         };
 
-        Self::use_remote_time(self.estimate_remote_time(skew)).then(|| self.device_time() - skew)
+        Self::use_remote_time(self.estimate_remote_time(skew)).then_some(skew)
     }
 }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/bandwidth_monitor.rs
@@ -784,10 +784,7 @@ impl BandwidthMonitor {
             &mut self.wg_exit_gateway_client
         };
 
-        let spend_time = self
-            .skew_manager
-            .cached_skew_corrected_time()
-            .unwrap_or_else(|| self.skew_manager.device_time());
+        let spend_time = self.skew_manager.cached_skew_corrected_time();
 
         let credential = self
             .bc_command_tx

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -5,6 +5,8 @@
 use std::net::{Ipv4Addr, Ipv6Addr};
 #[cfg(any(target_os = "linux", target_os = "ios", target_os = "android"))]
 use std::os::fd::BorrowedFd;
+#[cfg(unix)]
+use std::os::fd::RawFd;
 #[cfg(any(target_os = "android", target_os = "ios"))]
 use std::os::fd::{AsRawFd, IntoRawFd};
 #[cfg(target_os = "android")]
@@ -13,17 +15,16 @@ use std::{
     net::{IpAddr, SocketAddr},
     ops::Deref,
     pin::pin,
+    sync::Arc,
     time::Duration,
 };
-#[cfg(unix)]
-use std::{os::fd::RawFd, sync::Arc};
 
 use futures::{FutureExt, StreamExt, future::Fuse};
 #[cfg(any(target_os = "ios", target_os = "android"))]
 use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
 #[cfg(target_os = "linux")]
 use nix::sys::socket::{SetSockOpt, sockopt::Mark};
-use nym_bandwidth_controller::requests::BandwidthControllerRequestSender;
+use nym_bandwidth_controller::{SpendTimeProvider, requests::BandwidthControllerRequestSender};
 use nym_gateway_directory::{
     GatewayCacheHandle, GatewayClient, GatewayMinPerformance, NodeIdentity,
 };
@@ -149,6 +150,20 @@ const TICKETBOOK_READINESS_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// Whether LP registration is enabled
 const ENABLE_LP_REGISTRATION: bool = true;
+
+/// Adapts [`SkewManager`] to the registration client's [`SpendTimeProvider`], so that ecash
+/// tickets spent during registration are timestamped with the VPN API's clock rather than the
+/// potentially skewed local one, same as [`BandwidthMonitor`] already does for topups.
+#[derive(Debug, Clone)]
+struct RegistrationSpendTimeProvider(SkewManager);
+
+impl SpendTimeProvider for RegistrationSpendTimeProvider {
+    fn spend_time(&self) -> OffsetDateTime {
+        self.0
+            .cached_skew_corrected_time()
+            .unwrap_or_else(|| self.0.device_time())
+    }
+}
 
 #[derive(Debug)]
 pub enum TunnelMonitorEvent {
@@ -564,6 +579,9 @@ impl TunnelMonitor {
             .mixnet_client_startup_timeout(REGISTRATION_CLIENT_STARTUP_TIMEOUT)
             .mode(mode)
             .bandwidth_request_sender(self.bandwidth_command_tx.clone())
+            .spend_time_provider(Arc::new(RegistrationSpendTimeProvider(
+                self.skew_manager.clone(),
+            )))
             .enable_lp_registration(ENABLE_LP_REGISTRATION)
             .user_agent(user_agent)
             .custom_topology_provider(Box::new(

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -5,8 +5,6 @@
 use std::net::{Ipv4Addr, Ipv6Addr};
 #[cfg(any(target_os = "linux", target_os = "ios", target_os = "android"))]
 use std::os::fd::BorrowedFd;
-#[cfg(unix)]
-use std::os::fd::RawFd;
 #[cfg(any(target_os = "android", target_os = "ios"))]
 use std::os::fd::{AsRawFd, IntoRawFd};
 #[cfg(target_os = "android")]
@@ -15,16 +13,17 @@ use std::{
     net::{IpAddr, SocketAddr},
     ops::Deref,
     pin::pin,
-    sync::Arc,
     time::Duration,
 };
+#[cfg(unix)]
+use std::{os::fd::RawFd, sync::Arc};
 
 use futures::{FutureExt, StreamExt, future::Fuse};
 #[cfg(any(target_os = "ios", target_os = "android"))]
 use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
 #[cfg(target_os = "linux")]
 use nix::sys::socket::{SetSockOpt, sockopt::Mark};
-use nym_bandwidth_controller::{SpendTimeProvider, requests::BandwidthControllerRequestSender};
+use nym_bandwidth_controller::requests::BandwidthControllerRequestSender;
 use nym_gateway_directory::{
     GatewayCacheHandle, GatewayClient, GatewayMinPerformance, NodeIdentity,
 };
@@ -150,20 +149,6 @@ const TICKETBOOK_READINESS_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// Whether LP registration is enabled
 const ENABLE_LP_REGISTRATION: bool = true;
-
-/// Adapts [`SkewManager`] to the registration client's [`SpendTimeProvider`], so that ecash
-/// tickets spent during registration are timestamped with the VPN API's clock rather than the
-/// potentially skewed local one, same as [`BandwidthMonitor`] already does for topups.
-#[derive(Debug, Clone)]
-struct RegistrationSpendTimeProvider(SkewManager);
-
-impl SpendTimeProvider for RegistrationSpendTimeProvider {
-    fn spend_time(&self) -> OffsetDateTime {
-        self.0
-            .cached_skew_corrected_time()
-            .unwrap_or_else(|| self.0.device_time())
-    }
-}
 
 #[derive(Debug)]
 pub enum TunnelMonitorEvent {
@@ -579,9 +564,7 @@ impl TunnelMonitor {
             .mixnet_client_startup_timeout(REGISTRATION_CLIENT_STARTUP_TIMEOUT)
             .mode(mode)
             .bandwidth_request_sender(self.bandwidth_command_tx.clone())
-            .spend_time_provider(Arc::new(RegistrationSpendTimeProvider(
-                self.skew_manager.clone(),
-            )))
+            .spend_time(self.skew_manager.cached_skew_corrected_time())
             .enable_lp_registration(ENABLE_LP_REGISTRATION)
             .user_agent(user_agent)
             .custom_topology_provider(Box::new(

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -564,7 +564,7 @@ impl TunnelMonitor {
             .mixnet_client_startup_timeout(REGISTRATION_CLIENT_STARTUP_TIMEOUT)
             .mode(mode)
             .bandwidth_request_sender(self.bandwidth_command_tx.clone())
-            .spend_time(self.skew_manager.cached_skew_corrected_time())
+            .spend_time_skew(self.skew_manager.cached_skew())
             .enable_lp_registration(ENABLE_LP_REGISTRATION)
             .user_agent(user_agent)
             .custom_topology_provider(Box::new(


### PR DESCRIPTION
## Ticket

JIRA-NYM-1408

## Description

Use `SkewManager` with registration clients.

`nym` PR: https://github.com/nymtech/nym/pull/6973


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5912)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VPN registration reliability by applying skew-derived spend-time when building the registration client.
  * Made LP and WireGuard registration flows use consistent parameter handling.
* **Documentation**
  * Clarified skew computation timing, including when device clock sampling occurs versus when cached skew is used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->