### PR TITLE
[Android] Update changelog. Cherry-pick changes from release

### DIFF
--- a/.github/workflows/bump-all-platforms.yml
+++ b/.github/workflows/bump-all-platforms.yml
@@ -189,11 +189,11 @@ jobs:
           if [[ -n "$PRE_RELEASE_SUFFIX" ]]; then
             CORE_VERSION="${SEMVER}-${PRE_RELEASE_SUFFIX}"
             DEB_VERSION="${SEMVER}~${PRE_RELEASE_SUFFIX}"
-            ANDROID_VERSION_NAME="v${SEMVER}-${PRE_RELEASE_SUFFIX}"
+            ANDROID_VERSION_NAME="${SEMVER}-${PRE_RELEASE_SUFFIX}"
           else
             CORE_VERSION="$SEMVER"
             DEB_VERSION="$SEMVER"
-            ANDROID_VERSION_NAME="v${SEMVER}"
+            ANDROID_VERSION_NAME="${SEMVER}"
           fi
 
           # Formula supports MINOR 0-99 and PATCH 0-99; e.g. 2026.12.0 → 20261200, 2026.99.99 → 20269999

--- a/.github/workflows/platform/apply-version/action.yml
+++ b/.github/workflows/platform/apply-version/action.yml
@@ -64,7 +64,7 @@ runs:
             # carries it. VERSION_CODE is an integer and is left untouched.
             VN="${VERSION%-nightly}"
             f="nym-vpn-android/buildSrc/src/main/kotlin/Constants.kt"
-            VN="$VN" perl -0777 -pi -e 's/(VERSION_NAME\s*=\s*")[^"]*(")/$1 . "v" . $ENV{VN} . $2/e' "$f"
+            VN="$VN" perl -0777 -pi -e 's/(VERSION_NAME\s*=\s*")[^"]*(")/$1 . $ENV{VN} . $2/e' "$f"
             ;;
           apple)
             # fastlane lane sets MARKETING_VERSION (CFBundleShortVersionString) on the 6

--- a/fastlane/metadata/android/en-US/changelogs/20261102.txt
+++ b/fastlane/metadata/android/en-US/changelogs/20261102.txt
@@ -1,0 +1,13 @@
+New beta feature: MIXNET TUNING allows for customizing traffic patterns over the mixnet to increase anonymity or performance.
+
+Introducing SERVER FAMILIES: NymVPN now alerts you to when the servers you’ve chosen may belong to the same operator family to ensure decentralization in your use of the network.
+
+Better access in restricted regions and improved connectivity on heavily filtered networks.
+
+New daily data allowance: fair-usage limits are now a daily allowance instead of a monthly one.
+
+Android Auto fix: Android Auto is no longer routed through the VPN, so in-car connections work normally.
+
+Connection reliability and performance improvements.
+
+Disguise the app: switch to an alternate app icon to keep NymVPN discreet.

--- a/fastlane/metadata/android/en-US/changelogs/20261103.txt
+++ b/fastlane/metadata/android/en-US/changelogs/20261103.txt
@@ -1,13 +1,14 @@
-New beta feature: MIXNET TUNING allows for customizing traffic patterns over the mixnet to increase anonymity or performance.
+2026.11.3: Fixes to kernel and added 32-bit arch support to address reported connection problems with exit servers on Android 7-14 devices.
 
-Introducing SERVER FAMILIES: NymVPN now alerts you to when the servers you’ve chosen may belong to the same operator family to ensure decentralization in your use of the network.
+2026.11:
+- New beta feature: MIXNET TUNING allows for customizing traffic patterns over the mixnet to increase anonymity or performance.
 
-Better access in restricted regions and improved connectivity on heavily filtered networks.
+- Introducing SERVER FAMILIES: NymVPN now alerts you to when the servers you’ve chosen may belong to the same operator family to ensure decentralization in your use of the network.
 
-New daily data allowance: fair-usage limits are now a daily allowance instead of a monthly one.
+- Better access in restricted regions and improved connectivity on heavily filtered networks.
 
-Android Auto fix: Android Auto is no longer routed through the VPN, so in-car connections work normally.
+- New daily data allowance: fair-usage limits are now a daily allowance instead of a monthly one.
 
-Connection reliability and performance improvements.
+- Android Auto fix: Android Auto is no longer routed through the VPN, so in-car connections work normally.
 
-Disguise the app: switch to an alternate app icon to keep NymVPN discreet.
+- Connection reliability and performance improvements.

--- a/fastlane/metadata/android/en-US/changelogs/20261103.txt
+++ b/fastlane/metadata/android/en-US/changelogs/20261103.txt
@@ -1,0 +1,13 @@
+New beta feature: MIXNET TUNING allows for customizing traffic patterns over the mixnet to increase anonymity or performance.
+
+Introducing SERVER FAMILIES: NymVPN now alerts you to when the servers you’ve chosen may belong to the same operator family to ensure decentralization in your use of the network.
+
+Better access in restricted regions and improved connectivity on heavily filtered networks.
+
+New daily data allowance: fair-usage limits are now a daily allowance instead of a monthly one.
+
+Android Auto fix: Android Auto is no longer routed through the VPN, so in-car connections work normally.
+
+Connection reliability and performance improvements.
+
+Disguise the app: switch to an alternate app icon to keep NymVPN discreet.

--- a/nym-vpn-android/CHANGELOG.md
+++ b/nym-vpn-android/CHANGELOG.md
@@ -7,10 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [v2026.12.0]
+### Added
+- Recents support (https://github.com/nymtech/nym-vpn-client/pull/5922)
+- Favorites support (https://github.com/nymtech/nym-vpn-client/pull/5922)
+
+### Changed
+- Changed UI for Server Details screen (https://github.com/nymtech/nym-vpn-client/pull/5922)
+- Changed UI for Server List screen (https://github.com/nymtech/nym-vpn-client/pull/5922)
+
+## [v2026.11.3]
+
+### Added
+- Add 32-bit arch support (https://github.com/nymtech/nym-vpn-client/pull/5881)
+
+### Fixed
+- Fixes for old Android versions (https://github.com/nymtech/nym-vpn-client/pull/5884)
+
+## [v2026.11.1]
 
 ### Added
 - Add Icon Switcher to Appearance settings. With camouflage options (https://github.com/nymtech/nym-vpn-client/pull/5837)
+
+### Changed
+- Update Colors for light theme (https://github.com/nymtech/nym-vpn-client/pull/5843)
+
+### Fixed
+- Fix for the issue with bottom sheet dialogs overlapping (https://github.com/nymtech/nym-vpn-client/pull/5843)
 
 ## [v2026.11.0] - 10.07.2026
 

--- a/nym-vpn-android/app/build.gradle.kts
+++ b/nym-vpn-android/app/build.gradle.kts
@@ -193,7 +193,7 @@ androidComponents {
 
 		variant.outputs.forEach { output ->
 			(output as? VariantOutputImpl)?.outputFileName?.set("$fullName.apk")
-			(output as? VariantOutputImpl)?.versionName?.set(fullName)
+			(output as? VariantOutputImpl)?.versionName?.set(version)
 		}
 
 		variant.buildConfigFields?.put("APP_NAME", BuildConfigField("String", "\"$fullName\"", "App Name"))

--- a/nym-vpn-android/buildSrc/src/main/kotlin/Constants.kt
+++ b/nym-vpn-android/buildSrc/src/main/kotlin/Constants.kt
@@ -1,7 +1,7 @@
 import org.gradle.api.JavaVersion
 
 object Constants {
-	const val VERSION_NAME = "v2026.12.0-beta.1"
+	const val VERSION_NAME = "2026.12.0-beta.1"
     const val VERSION_CODE = 20261200
     const val TARGET_SDK = 36
     const val COMPILE_SDK = 37

--- a/nym-vpn-android/docs/release.md
+++ b/nym-vpn-android/docs/release.md
@@ -24,7 +24,7 @@ Release tags must follow the following patterns:
 1. Navigate to the file `buildSrc/src/main/kotlin/Constants.kt` \
    and update the version name and version code.
    ```kotlin
-   const val VERSION_NAME = "v1.2.3"
+   const val VERSION_NAME = "1.2.3"
    const val VERSION_CODE = 12300
 	```
 	* first three digits of version code should match the version name


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

- Drop `v` for `.apk` name;
- Cherry-pick changelogs and updates from `2026.11` release branch;
-  Keep `CHANGELOG.md` up to date;

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5923)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **Recents** and **Favorites** for quicker server selection.
  * Updated **Server Details** and **Server List** screens.
  * Introduced **mixnet tuning (beta)**, **server family warnings**, and an **alternate app icon** option.
  * Improved access/connectivity in restricted areas and switched fair-usage to a **daily allowance**.
  * Added **32-bit device support** and improved **Android Auto** routing.

* **Bug Fixes**
  * Improved connection reliability and performance.
  * Fixed issues on older Android versions, and addressed UI overlap in bottom sheets.
  * Updated the app’s displayed version name to remove the leading “v”.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->