### PR TITLE
NYM-262: (tauri) Add favorites

### DIFF
--- a/nym-vpn-app/CHANGELOG.md
+++ b/nym-vpn-app/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Allow marking specific server, country or region as favorite
+
 ## [2026.11.0] - 2026-07-10
 
 ### Added

--- a/nym-vpn-app/src-tauri/src/commands/favorites.rs
+++ b/nym-vpn-app/src-tauri/src/commands/favorites.rs
@@ -1,0 +1,73 @@
+use nym_vpn_lib_types as lib;
+use tauri::State;
+use tracing::{debug, info, instrument};
+
+use crate::commands::gateway::Hop;
+use crate::error::BackendError;
+use crate::favorites::{Favorite, Favorites, FavoritesState};
+
+fn to_selector(favorite: Favorite) -> Result<lib::FavoriteSelector, BackendError> {
+    lib::FavoriteSelector::try_from(favorite)
+        .map_err(|e| BackendError::internal_with_detail("invalid favorite selector", e.to_string()))
+}
+
+fn unavailable() -> BackendError {
+    BackendError::internal("favorites store is unavailable", None)
+}
+
+#[instrument(skip(favorites))]
+#[tauri::command]
+pub async fn get_favorites(
+    favorites: State<'_, FavoritesState>,
+) -> Result<Favorites, BackendError> {
+    let guard = favorites.0.lock().await;
+    let Some(manager) = guard.as_ref() else {
+        info!("favorites store unavailable");
+        return Ok(Favorites::default());
+    };
+    let favorites = Favorites::from(manager.get_favorites());
+    debug!(
+        "favorites: entry #{} exit #{}",
+        favorites.entry.len(),
+        favorites.exit.len()
+    );
+    Ok(favorites)
+}
+
+#[instrument(skip(favorites))]
+#[tauri::command]
+pub async fn add_favorite(
+    hop: Hop,
+    favorite: Favorite,
+    favorites: State<'_, FavoritesState>,
+) -> Result<(), BackendError> {
+    info!("adding favorite {favorite} for {hop:?}");
+    let selector = to_selector(favorite)?;
+    let mut guard = favorites.0.lock().await;
+    let manager = guard.as_mut().ok_or_else(unavailable)?;
+
+    match hop {
+        Hop::Entry => manager.add_favorite_entry(selector).await,
+        Hop::Exit => manager.add_favorite_exit(selector).await,
+    }
+    .map_err(|e| BackendError::internal_with_detail("failed to add favorite", e.to_string()))
+}
+
+#[instrument(skip(favorites))]
+#[tauri::command]
+pub async fn remove_favorite(
+    hop: Hop,
+    favorite: Favorite,
+    favorites: State<'_, FavoritesState>,
+) -> Result<(), BackendError> {
+    info!("removing favorite {favorite} for {hop:?}");
+    let selector = to_selector(favorite)?;
+    let mut guard = favorites.0.lock().await;
+    let manager = guard.as_mut().ok_or_else(unavailable)?;
+
+    match hop {
+        Hop::Entry => manager.remove_favorite_entry(selector).await,
+        Hop::Exit => manager.remove_favorite_exit(selector).await,
+    }
+    .map_err(|e| BackendError::internal_with_detail("failed to remove favorite", e.to_string()))
+}

--- a/nym-vpn-app/src-tauri/src/commands/gateway.rs
+++ b/nym-vpn-app/src-tauri/src/commands/gateway.rs
@@ -11,7 +11,6 @@ use crate::error::{BackendError, ErrorKey};
 use crate::vpnd::client::VpndClient;
 use crate::vpnd::gateway::{Gateway, GatewayType};
 
-#[allow(dead_code)]
 #[derive(Debug, Serialize, Deserialize, TS, Clone)]
 #[ts(export, export_to = "tauri.ts")]
 #[serde(rename_all = "kebab-case")]

--- a/nym-vpn-app/src-tauri/src/commands/mod.rs
+++ b/nym-vpn-app/src-tauri/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod cli;
 pub mod daemon;
 pub mod db;
 pub mod diagnostic;
+pub mod favorites;
 pub mod fs;
 pub mod gateway;
 pub mod gateway_independence;

--- a/nym-vpn-app/src-tauri/src/favorites.rs
+++ b/nym-vpn-app/src-tauri/src/favorites.rs
@@ -1,0 +1,81 @@
+use std::fmt;
+use std::str::FromStr;
+
+use nym_favorites::FavoritesManager;
+use nym_vpn_lib_types as lib;
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+use ts_rs::TS;
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, TS)]
+#[serde(rename_all = "lowercase")]
+#[ts(export, export_to = "tauri.ts")]
+pub enum Favorite {
+    Country { code: String },
+    Gateway { id: String },
+    Region(String),
+}
+
+impl TryFrom<Favorite> for lib::FavoriteSelector {
+    type Error = anyhow::Error;
+
+    fn try_from(favorite: Favorite) -> Result<Self, Self::Error> {
+        Ok(match favorite {
+            Favorite::Country { code } => lib::FavoriteSelector::Country {
+                two_letter_iso_country_code: code,
+            },
+            Favorite::Region(region) => lib::FavoriteSelector::Region { region },
+            Favorite::Gateway { id } => lib::FavoriteSelector::Gateway {
+                identity: lib::NodeIdentity::from_str(&id)?,
+            },
+        })
+    }
+}
+
+impl From<lib::FavoriteSelector> for Favorite {
+    fn from(selector: lib::FavoriteSelector) -> Self {
+        match selector {
+            lib::FavoriteSelector::Country {
+                two_letter_iso_country_code: code,
+            } => Favorite::Country { code },
+            lib::FavoriteSelector::Region { region } => Favorite::Region(region),
+            lib::FavoriteSelector::Gateway { identity } => Favorite::Gateway {
+                id: identity.to_base58_string(),
+            },
+        }
+    }
+}
+
+impl fmt::Display for Favorite {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Favorite::Country { code } => write!(f, "country [{}]", code.to_uppercase()),
+            Favorite::Region(region) => write!(f, "region {region}"),
+            Favorite::Gateway { id } => write!(f, "gateway [{id}]"),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default, TS)]
+#[ts(export, export_to = "tauri.ts")]
+pub struct Favorites {
+    pub entry: Vec<Favorite>,
+    pub exit: Vec<Favorite>,
+}
+
+impl From<lib::FavoriteSelectors> for Favorites {
+    fn from(selectors: lib::FavoriteSelectors) -> Self {
+        Favorites {
+            entry: selectors.entry.into_iter().map(Favorite::from).collect(),
+            exit: selectors.exit.into_iter().map(Favorite::from).collect(),
+        }
+    }
+}
+
+pub struct FavoritesState(pub Mutex<Option<FavoritesManager>>);
+
+impl FavoritesState {
+    pub fn new(manager: Option<FavoritesManager>) -> Self {
+        Self(Mutex::new(manager))
+    }
+}

--- a/nym-vpn-app/src-tauri/src/main.rs
+++ b/nym-vpn-app/src-tauri/src/main.rs
@@ -4,7 +4,8 @@
 use std::time::Duration;
 
 use crate::cli::{Commands, db_command};
-use crate::fs::path::APP_CONFIG_DIR;
+use crate::favorites::FavoritesState;
+use crate::fs::path::{APP_CONFIG_DIR, APP_DATA_DIR};
 use crate::startup_error::{ErrorKey, StartupError};
 use crate::tray::TrayManager;
 #[cfg(windows)]
@@ -23,6 +24,7 @@ use clap::Parser;
 use commands::daemon as cmd_daemon;
 use commands::db as cmd_db;
 use commands::diagnostic as cmd_diag;
+use commands::favorites as cmd_favorites;
 use commands::fs as cmd_fs;
 use commands::gateway as cmd_gw;
 use commands::log as cmd_log;
@@ -34,6 +36,7 @@ use commands::tray as cmd_tray;
 use commands::updater as cmd_updater;
 use commands::window as cmd_window;
 use commands::*;
+use nym_favorites::FavoritesManager;
 use state::app::AppState;
 use tauri::Manager;
 use tauri_plugin_window_state::StateFlags;
@@ -48,6 +51,7 @@ mod db;
 mod env;
 mod error;
 mod events;
+mod favorites;
 mod fs;
 #[cfg(windows)]
 mod icon_extractor;
@@ -137,6 +141,21 @@ async fn main() -> Result<()> {
         None
     };
 
+    // Built here rather than in `setup`: `FavoritesManager::new` is async while the
+    // setup hook is synchronous, so awaiting it on main avoids blocking on the
+    // async runtime from inside the hook, and guarantees the store is loaded
+    // before any command can read it.
+    let favorites_manager = match APP_DATA_DIR.clone() {
+        Some(dir) => {
+            info!("favorites store dir: {}", dir.display());
+            Some(FavoritesManager::new(dir).await)
+        }
+        None => {
+            error!("failed to get app data dir, favorites will be unavailable");
+            None
+        }
+    };
+
     let c_os = os.clone();
     info!("app version: {}", pkg_info.version);
     info!("Starting tauri app");
@@ -199,6 +218,7 @@ async fn main() -> Result<()> {
 
             app.manage(cli.clone());
             app.manage(Mutex::new(debug_logging_control));
+            app.manage(FavoritesState::new(favorites_manager));
 
             info!("Creating k/v embedded db");
             let db = match Db::new() {
@@ -345,6 +365,9 @@ async fn main() -> Result<()> {
             cmd_db::db_del,
             cmd_db::db_flush,
             cmd_gw::get_gateways,
+            cmd_favorites::get_favorites,
+            cmd_favorites::add_favorite,
+            cmd_favorites::remove_favorite,
             cmd_window::show_main_window,
             cmd_window::set_background_color,
             commands::cli::cli_args,

--- a/nym-vpn-app/src/hooks/index.ts
+++ b/nym-vpn-app/src/hooks/index.ts
@@ -13,6 +13,7 @@ export { default as useScore } from './useScore';
 export { default as useDeepLink } from './useDeepLink';
 export { default as useLogout } from './useLogout';
 export { default as useToast } from './useToast';
+export { default as useToggleFavorite } from './useToggleFavorite';
 export { default as useDebounce } from './useDebounce';
 export { default as useConnect } from './useConnect';
 export { default as useGatewayIndependenceWatcher } from './useGatewayIndependenceWatcher';

--- a/nym-vpn-app/src/hooks/useNodeListData.ts
+++ b/nym-vpn-app/src/hooks/useNodeListData.ts
@@ -16,18 +16,25 @@ import {
   UiRegion,
   isSelectedNodeType,
 } from '../types/node';
+import { favoriteKey, isNodeFavorite } from '../types/favorites';
 import { useAppStore } from '../store';
+import { useFavorites } from '../store/favoritesState';
 import useLang from './useLang';
 
 function countryToUi(
   country: Country,
   selectedEntry: SelectedNode,
   selectedExit: SelectedNode,
+  favoriteKeys: ReadonlySet<string>,
 ): UiCountry {
   return {
     ...country,
     nodeType: 'country',
     isSelected: isSelectedNodeType(country, selectedEntry, selectedExit),
+    isFavorite: isNodeFavorite(
+      { nodeType: 'country', code: country.code },
+      favoriteKeys,
+    ),
   };
 }
 
@@ -36,6 +43,7 @@ function gatewaysToUi(
   selectedEntry: SelectedNode,
   selectedExit: SelectedNode,
   quicFilter: boolean,
+  favoriteKeys: ReadonlySet<string>,
 ): UiGateway[] {
   return gateways.reduce<UiGateway[]>((acc, gw) => {
     if (quicFilter && !gw.quic) return acc;
@@ -47,6 +55,10 @@ function gatewaysToUi(
         selectedEntry,
         selectedExit,
       ) as GwSelectedKind,
+      isFavorite: isNodeFavorite(
+        { nodeType: 'gateway', id: gw.id },
+        favoriteKeys,
+      ),
     });
     return acc;
   }, []);
@@ -57,6 +69,7 @@ function regionsToUi(
   selectedEntry: SelectedNode,
   selectedExit: SelectedNode,
   quicFilter: boolean,
+  favoriteKeys: ReadonlySet<string>,
 ): UiRegion[] {
   return regions.reduce<UiRegion[]>((acc, region) => {
     const gateways = gatewaysToUi(
@@ -64,6 +77,7 @@ function regionsToUi(
       selectedEntry,
       selectedExit,
       quicFilter,
+      favoriteKeys,
     );
     if (gateways.length === 0) return acc;
     acc.push({
@@ -71,6 +85,10 @@ function regionsToUi(
       nodeType: 'region',
       gateways,
       isSelected: isSelectedNodeType(region, selectedEntry, selectedExit),
+      isFavorite: isNodeFavorite(
+        { nodeType: 'region', name: region.name },
+        favoriteKeys,
+      ),
     });
     return acc;
   }, []);
@@ -83,6 +101,7 @@ function buildNodeList(
   quicFilter: boolean,
   getCountryName: (code: string) => string | null | undefined,
   compare: (a: string, b: string) => number,
+  favoriteKeys: ReadonlySet<string>,
 ): UiGatewaysByCountry[] {
   return list
     .reduce<UiGatewaysByCountry[]>((acc, gwByCountry) => {
@@ -93,6 +112,7 @@ function buildNodeList(
         selectedEntry,
         selectedExit,
         quicFilter,
+        favoriteKeys,
       );
       if (gateways.length === 0) return acc;
 
@@ -100,6 +120,7 @@ function buildNodeList(
         gwByCountry.country,
         selectedEntry,
         selectedExit,
+        favoriteKeys,
       );
 
       // Defensive check: regions structure changed in 1.18.0; cached data
@@ -110,6 +131,7 @@ function buildNodeList(
             selectedEntry,
             selectedExit,
             quicFilter,
+            favoriteKeys,
           )
         : [];
 
@@ -129,6 +151,11 @@ function buildNodeList(
 
 export function useNodeListData(hop: NodeHop) {
   const { compare, getCountryName } = useLang();
+  const favorites = useFavorites(hop);
+  const favoriteKeys = useMemo(
+    () => new Set(favorites.map(favoriteKey)),
+    [favorites],
+  );
 
   const {
     vpnMode,
@@ -185,6 +212,7 @@ export function useNodeListData(hop: NodeHop) {
       quicFilter,
       getCountryName,
       compare,
+      favoriteKeys,
     );
   }, [
     vpnMode,
@@ -197,6 +225,7 @@ export function useNodeListData(hop: NodeHop) {
     quicFilter,
     getCountryName,
     compare,
+    favoriteKeys,
   ]);
 
   const gateways = useMemo(() => {

--- a/nym-vpn-app/src/hooks/useToggleFavorite.ts
+++ b/nym-vpn-app/src/hooks/useToggleFavorite.ts
@@ -1,0 +1,45 @@
+import { useCallback } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { useTranslation } from 'react-i18next';
+import { Favorite, NodeHop } from '../types';
+import { useFavoritesStore } from '../store/favoritesState';
+import useToast from './useToast';
+
+function useToggleFavorite(hop: NodeHop) {
+  const addFavorite = useFavoritesStore((s) => s.add);
+  const removeFavorite = useFavoritesStore((s) => s.remove);
+  const { add: addToast } = useToast();
+  const { t } = useTranslation('node-location');
+
+  return useCallback(
+    async (favorite: Favorite, isFavorite: boolean) => {
+      if (isFavorite) {
+        removeFavorite(hop, favorite);
+      } else {
+        addFavorite(hop, favorite);
+      }
+
+      try {
+        await invoke(isFavorite ? 'remove_favorite' : 'add_favorite', {
+          hop,
+          favorite,
+        });
+      } catch (error: unknown) {
+        console.error('failed to update favorite', error);
+        if (isFavorite) {
+          addFavorite(hop, favorite);
+        } else {
+          removeFavorite(hop, favorite);
+        }
+        addToast({
+          id: 'favorite-error',
+          title: t('favorites.error'),
+          type: 'error',
+        });
+      }
+    },
+    [hop, addFavorite, removeFavorite, addToast, t],
+  );
+}
+
+export default useToggleFavorite;

--- a/nym-vpn-app/src/i18n/en/node-location.json
+++ b/nym-vpn-app/src/i18n/en/node-location.json
@@ -79,7 +79,20 @@
       "description": "Something went wrong. Please try different server."
     }
   },
-  "search-other-nodes": "Other search results",
+  "favorites": {
+    "tab-favorites": "Favorites",
+    "tab-all": "All servers",
+    "add": "Add to favorites",
+    "remove": "Remove from favorites",
+    "error": "Failed to update favorites",
+    "empty": {
+      "none": "No favorites yet.",
+      "none-description": "Tap the star next to a location or server to add it here.",
+      "unavailable": "None of your favorites are available here.",
+      "unavailable-description": "Your favorites aren't in this mode's server list. Switch mode or pick another server."
+    }
+  },
+  "search-other-nodes": "Servers",
   "no-results-found": {
     "title": "No results found.",
     "description": "Try another location or check the server name.\n<1>Contact us for help</1> or learn <2>how to run a server</2>."

--- a/nym-vpn-app/src/screens/node/FavoriteStar.tsx
+++ b/nym-vpn-app/src/screens/node/FavoriteStar.tsx
@@ -33,7 +33,7 @@ function FavoriteStar({ favorite, isFavorite, hop, className }: Props) {
         icon="star"
         filled={isFavorite}
         className={clsx(
-          'text-xl! transition-colors',
+          'text-2xl! transition-colors',
           isFavorite
             ? 'text-status-warning hover:text-status-warning/80'
             : 'text-text-secondary hover:text-text-primary',

--- a/nym-vpn-app/src/screens/node/FavoriteStar.tsx
+++ b/nym-vpn-app/src/screens/node/FavoriteStar.tsx
@@ -1,0 +1,46 @@
+import clsx from 'clsx';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@headlessui/react';
+import { MsIcon } from '../../ui';
+import { Favorite, NodeHop } from '../../types';
+import { useToggleFavorite } from '../../hooks';
+
+type Props = {
+  favorite: Favorite;
+  isFavorite: boolean;
+  hop: NodeHop;
+  className?: string;
+};
+
+function FavoriteStar({ favorite, isFavorite, hop, className }: Props) {
+  const toggleFavorite = useToggleFavorite(hop);
+  const { t } = useTranslation('node-location');
+
+  return (
+    <Button
+      onClick={() => toggleFavorite(favorite, isFavorite)}
+      aria-pressed={isFavorite}
+      aria-label={t(isFavorite ? 'favorites.remove' : 'favorites.add')}
+      title={t(isFavorite ? 'favorites.remove' : 'favorites.add')}
+      data-testid="favorite-star"
+      data-favorite={isFavorite}
+      className={clsx(
+        'flex shrink-0 cursor-default items-center justify-center rounded-full p-1 focus:outline-none',
+        className,
+      )}
+    >
+      <MsIcon
+        icon="star"
+        filled={isFavorite}
+        className={clsx(
+          'text-xl! transition-colors',
+          isFavorite
+            ? 'text-status-warning hover:text-status-warning/80'
+            : 'text-text-secondary hover:text-text-primary',
+        )}
+      />
+    </Button>
+  );
+}
+
+export default FavoriteStar;

--- a/nym-vpn-app/src/screens/node/FavoriteStar.tsx
+++ b/nym-vpn-app/src/screens/node/FavoriteStar.tsx
@@ -25,7 +25,7 @@ function FavoriteStar({ favorite, isFavorite, hop, className }: Props) {
       data-testid="favorite-star"
       data-favorite={isFavorite}
       className={clsx(
-        'flex shrink-0 cursor-default items-center justify-center rounded-full p-1 focus:outline-none',
+        'flex shrink-0 cursor-default items-center justify-center rounded-full p-1 focus:outline-none focus-visible:outline-2 focus-visible:outline-brand-primary',
         className,
       )}
     >

--- a/nym-vpn-app/src/screens/node/FavoriteStar.tsx
+++ b/nym-vpn-app/src/screens/node/FavoriteStar.tsx
@@ -25,7 +25,7 @@ function FavoriteStar({ favorite, isFavorite, hop, className }: Props) {
       data-testid="favorite-star"
       data-favorite={isFavorite}
       className={clsx(
-        'flex shrink-0 cursor-default items-center justify-center rounded-full p-1 focus:outline-none focus-visible:outline-2 focus-visible:outline-brand-primary',
+        'focus-visible:outline-brand-primary flex shrink-0 cursor-default items-center justify-center rounded-full p-1 focus:outline-none focus-visible:outline-2',
         className,
       )}
     >

--- a/nym-vpn-app/src/screens/node/Node.tsx
+++ b/nym-vpn-app/src/screens/node/Node.tsx
@@ -18,8 +18,15 @@ import { useNodeListData } from '../../hooks/useNodeListData';
 import { routes } from '../../router';
 import { dispatch, useAppStore, useFetchGateways } from '../../store';
 import { useNodeListState } from '../../store/nodeListState';
+import { useFavorites } from '../../store/favoritesState';
 import { LocationDetailsDialog } from './location-details-dialog';
-import { NodeList, useFilterList } from './list';
+import {
+  FavoritesEmpty,
+  NodeList,
+  ViewToggle,
+  filterToFavorites,
+  useFilterList,
+} from './list';
 
 const QUICK_PICK_CLASSES =
   'bg-surface-bg hover:bg-surface-hair flex cursor-default flex-row items-center gap-3 rounded-2xl p-4 transition-all duration-100';
@@ -49,6 +56,7 @@ function Node({ node }: { node: NodeHop }) {
     reset: resetSaved,
     addToExpanded,
     setSearch,
+    setView,
   } = useNodeListState();
 
   const expanded =
@@ -56,16 +64,32 @@ function Node({ node }: { node: NodeHop }) {
   const focused =
     node === 'entry' ? entryNodeList.focused : exitNodeList.focused;
   const search = node === 'entry' ? entryNodeList.search : exitNodeList.search;
+  const view = node === 'entry' ? entryNodeList.view : exitNodeList.view;
+  const favorites = useFavorites(node);
 
   const { tE } = useI18nError();
   const navigate = useNavigate();
   const { add } = useToast();
   const { t } = useTranslation('node-location');
 
+  const viewNodes = useMemo(
+    () => (view === 'favorites' ? filterToFavorites(rawNodes) : rawNodes),
+    [view, rawNodes],
+  );
+  const viewGateways = useMemo(() => {
+    if (view !== 'favorites') return rawGateways;
+    const flat: UiGateway[] = [];
+    for (const country of viewNodes) flat.push(...country.gateways);
+    const visible = new Set(flat.map((gw) => gw.id));
+    return rawGateways.filter((gw) => visible.has(gw.id));
+  }, [view, rawGateways, viewNodes]);
+
+  const favoritesEmpty = viewNodes.length === 0 && viewGateways.length === 0;
+
   const { filter, nodes, gateways } = useFilterList(
     node,
-    rawNodes,
-    rawGateways,
+    viewNodes,
+    viewGateways,
     vpnMode,
   );
   const deferredNodes = useDeferredValue(nodes);
@@ -334,6 +358,9 @@ function Node({ node }: { node: NodeHop }) {
               nodesCount,
             })}
           </p>
+          <div className="mt-3">
+            <ViewToggle view={view} onChange={(v) => setView(node, v)} />
+          </div>
         </div>
         <div className="min-h-0 flex-1 overflow-y-auto">
           {loading && (
@@ -347,34 +374,39 @@ function Node({ node }: { node: NodeHop }) {
               {t('loading')}
             </motion.div>
           )}
-          {!loading && (
+          {!loading && view === 'favorites' && favoritesEmpty && (
+            <FavoritesEmpty hasFavorites={favorites.length > 0} />
+          )}
+          {!loading && !(view === 'favorites' && favoritesEmpty) && (
             <>
-              <div className="flex w-full flex-col gap-3 px-3 pt-3">
-                <Button
-                  onClick={handleRandom}
-                  className={clsx(QUICK_PICK_CLASSES, {
-                    'border-brand-primary-active border-2': randomActive,
-                  })}
-                >
-                  <MsIcon icon="shuffle" className="text-text-primary" />
-                  <span className="text-text-primary text-base">
-                    {t('quick-pick.random')}
-                  </span>
-                </Button>
-                {/* {showBestServer && (
+              {view === 'all' && (
+                <div className="flex w-full flex-col gap-3 px-3 pt-3">
                   <Button
-                    onClick={handleBestServer}
+                    onClick={handleRandom}
                     className={clsx(QUICK_PICK_CLASSES, {
-                      'border-brand-primary-active border-2': bestServerActive,
+                      'border-brand-primary-active border-2': randomActive,
                     })}
                   >
-                    <SmileyIcon className="h-6 w-6" />
+                    <MsIcon icon="shuffle" className="text-text-primary" />
                     <span className="text-text-primary text-base">
-                      {t('quick-pick.best-server')}
+                      {t('quick-pick.random')}
                     </span>
                   </Button>
-                )} */}
-              </div>
+                  {/* {showBestServer && (
+                    <Button
+                      onClick={handleBestServer}
+                      className={clsx(QUICK_PICK_CLASSES, {
+                        'border-brand-primary-active border-2': bestServerActive,
+                      })}
+                    >
+                      <SmileyIcon className="h-6 w-6" />
+                      <span className="text-text-primary text-base">
+                        {t('quick-pick.best-server')}
+                      </span>
+                    </Button>
+                  )} */}
+                </div>
+              )}
               <NodeList
                 nodes={deferredNodes}
                 gateways={deferredGateways}

--- a/nym-vpn-app/src/screens/node/details/NodeDetails.tsx
+++ b/nym-vpn-app/src/screens/node/details/NodeDetails.tsx
@@ -7,7 +7,10 @@ import { invoke } from '@tauri-apps/api/core';
 import { useLocation, useNavigate } from 'react-router';
 import { useShallow } from 'zustand/react/shallow';
 import { UiGateway, isSelectedNodeType } from '../../../types/node';
+import { favoriteKey, nodeToFavorite } from '../../../types/favorites';
 import { useNodeListState } from '../../../store/nodeListState';
+import { useFavorites } from '../../../store/favoritesState';
+import FavoriteStar from '../FavoriteStar';
 import {
   Button,
   ButtonIconNew,
@@ -82,6 +85,13 @@ function NodeDetails() {
   const asnValue = asn?.asn;
   const asnName = asn?.name;
   const showCard3 = exitIpv4 || exitIpv6 || asnValue || asnName;
+
+  const favorites = useFavorites(hop);
+  const favorite = useMemo(() => nodeToFavorite(gateway), [gateway]);
+  const isFavorite = useMemo(() => {
+    const key = favoriteKey(favorite);
+    return favorites.some((f) => favoriteKey(f) === key);
+  }, [favorites, favorite]);
   const selectedNode = isSelectedNodeType(gateway, entryNode, exitNode);
   const isSelected = selectedNode === 'exit' || selectedNode === 'entry';
   const quic = backendFlags.quic && gateway.quic;
@@ -194,7 +204,15 @@ function NodeDetails() {
                 alt={country.code}
                 className="h-6 w-6 shrink-0 rounded-full"
               />
-              <p className="text-text-primary ml-4 text-base">{gateway.name}</p>
+              <p className="text-text-primary ml-4 truncate text-base">
+                {gateway.name}
+              </p>
+              <FavoriteStar
+                favorite={favorite}
+                isFavorite={isFavorite}
+                hop={hop}
+                className="ml-auto"
+              />
             </CardNewHeader>
             <CardDivider />
             <CardNewBody className="flex-col gap-3 py-4">

--- a/nym-vpn-app/src/screens/node/list/FavoritesEmpty.tsx
+++ b/nym-vpn-app/src/screens/node/list/FavoritesEmpty.tsx
@@ -1,0 +1,24 @@
+import { useTranslation } from 'react-i18next';
+
+function FavoritesEmpty({ hasFavorites }: { hasFavorites: boolean }) {
+  const { t } = useTranslation('node-location');
+
+  return (
+    <div className="space-y-4 px-6 py-4" data-testid="favorites-empty">
+      <p className="text-text-primary truncate">
+        {t(
+          hasFavorites ? 'favorites.empty.unavailable' : 'favorites.empty.none',
+        )}
+      </p>
+      <p className="text-text-secondary whitespace-pre-line">
+        {t(
+          hasFavorites
+            ? 'favorites.empty.unavailable-description'
+            : 'favorites.empty.none-description',
+        )}
+      </p>
+    </div>
+  );
+}
+
+export default FavoritesEmpty;

--- a/nym-vpn-app/src/screens/node/list/GatewayItem.tsx
+++ b/nym-vpn-app/src/screens/node/list/GatewayItem.tsx
@@ -2,8 +2,10 @@ import { useCallback } from 'react';
 import { Button } from '@headlessui/react';
 import clsx from 'clsx';
 import { UiGateway } from '../../../types/node';
+import { nodeToFavorite } from '../../../types/favorites';
 import { useNodeListState } from '../../../store/nodeListState';
 import { ButtonIcon, MsIcon } from '../../../ui';
+import FavoriteStar from '../FavoriteStar';
 import { NodeHop, VpnMode } from '../../../types';
 import { useLang } from '../../../hooks';
 import { countriesWithRegions } from '../../../constants';
@@ -107,6 +109,11 @@ const GatewayItem = ({
       {streamOptimized && (
         <MsIcon icon="smart_display" className="text-status-info" />
       )}
+      <FavoriteStar
+        favorite={nodeToFavorite(gateway)}
+        isFavorite={gateway.isFavorite}
+        hop={node}
+      />
       <div className="flex items-center self-stretch p-2">
         <ButtonIcon
           color="chalk"

--- a/nym-vpn-app/src/screens/node/list/RowHeader.tsx
+++ b/nym-vpn-app/src/screens/node/list/RowHeader.tsx
@@ -2,7 +2,9 @@ import { useCallback } from 'react';
 import clsx from 'clsx';
 import { Collapsible } from '@base-ui-components/react';
 import { SelectedKind, UiCountry, UiRegion } from '../../../types/node';
+import { nodeToFavorite } from '../../../types/favorites';
 import { useNodeListState } from '../../../store/nodeListState';
+import FavoriteStar from '../FavoriteStar';
 import LocationInfo from './LocationInfo';
 import FoldButton from './FoldButton';
 
@@ -75,6 +77,11 @@ function RowHeader({
           hideFlag={node.nodeType === 'region'}
         />
       </div>
+      <FavoriteStar
+        favorite={nodeToFavorite(node)}
+        isFavorite={node.isFavorite}
+        hop={hop}
+      />
       <Collapsible.Trigger
         render={(props, state) => <FoldButton html={props} state={state} />}
       />

--- a/nym-vpn-app/src/screens/node/list/ViewToggle.tsx
+++ b/nym-vpn-app/src/screens/node/list/ViewToggle.tsx
@@ -1,0 +1,60 @@
+import clsx from 'clsx';
+import { useTranslation } from 'react-i18next';
+import { MsIcon } from '../../../ui';
+import { ListView } from '../../../store/nodeListState';
+
+const VIEWS = [
+  { id: 'favorites', icon: 'star', label: 'favorites.tab-favorites' },
+  { id: 'all', icon: 'format_list_bulleted', label: 'favorites.tab-all' },
+] as const;
+
+function ViewToggle({
+  view,
+  onChange,
+}: {
+  view: ListView;
+  onChange: (view: ListView) => void;
+}) {
+  const { t } = useTranslation('node-location');
+
+  return (
+    <div
+      className="bg-surface-bg relative flex items-center gap-2 rounded-full p-0.5"
+      data-testid="node-list-view-toggle"
+    >
+      <div
+        className="bg-surface-elev absolute inset-y-0.5 w-[calc(50%-0.375rem)] rounded-full transition-[left] duration-300 ease-out"
+        style={{
+          left: view === 'favorites' ? '0.125rem' : 'calc(50% + 0.25rem)',
+        }}
+      />
+      {VIEWS.map((item) => {
+        const isSelected = view === item.id;
+        return (
+          <button
+            key={item.id}
+            type="button"
+            onClick={() => onChange(item.id)}
+            aria-pressed={isSelected}
+            data-testid={`node-list-view-${item.id}`}
+            className={clsx(
+              'relative z-10 flex flex-1 cursor-default items-center justify-center gap-1.5 rounded-full px-4.5 py-2.5 text-sm font-bold transition-colors',
+              isSelected
+                ? 'text-primary'
+                : 'text-text-secondary hover:bg-surface-elev',
+            )}
+          >
+            <MsIcon
+              icon={item.icon}
+              filled={item.id === 'favorites' && isSelected}
+              className="h-4 w-auto text-base! leading-none"
+            />
+            <span>{t(item.label)}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export default ViewToggle;

--- a/nym-vpn-app/src/screens/node/list/index.ts
+++ b/nym-vpn-app/src/screens/node/list/index.ts
@@ -1,2 +1,5 @@
 export { default as NodeList } from './NodeList';
+export { default as ViewToggle } from './ViewToggle';
+export { default as FavoritesEmpty } from './FavoritesEmpty';
 export { useFilterList } from './useFilterList';
+export { filterToFavorites } from './util';

--- a/nym-vpn-app/src/screens/node/list/util.ts
+++ b/nym-vpn-app/src/screens/node/list/util.ts
@@ -1,4 +1,5 @@
 import { Score } from '../../../types';
+import { UiGatewaysByCountry, UiRegion } from '../../../types/node';
 
 const scoreOrder: Record<Score, number> = {
   offline: 0,
@@ -12,4 +13,64 @@ export function sortByScore(a: Score, b: Score): number {
     return 0;
   }
   return scoreOrder[b] - scoreOrder[a];
+}
+
+function regionToFavorites(
+  region: UiRegion,
+  countryIsFavorite: boolean,
+): UiRegion | null {
+  // A favorited country carries its whole subtree, so nothing below it is
+  // filtered.
+  if (countryIsFavorite || region.isFavorite) return region;
+
+  const gateways = region.gateways.filter((gw) => gw.isFavorite);
+  return gateways.length > 0 ? { ...region, gateways } : null;
+}
+
+/**
+ * Narrows the node tree to favorited entities, preserving structure and order.
+ *
+ * A country is kept when it is itself favorited, or when it contains a favorited
+ * region or gateway. A favorited country contributes its full subtree; otherwise
+ * only its favorited regions (with their full gateway sets) and its favorited
+ * gateways are kept. Countries left with no gateways are dropped, mirroring how
+ * `buildNodeList` discards empty countries.
+ *
+ * Favorited gateways stay nested under their country rather than being lifted
+ * out, so nothing is rendered twice when a country and one of its gateways are
+ * both favorited.
+ */
+export function filterToFavorites(
+  nodes: UiGatewaysByCountry[],
+): UiGatewaysByCountry[] {
+  return nodes.reduce<UiGatewaysByCountry[]>((acc, node) => {
+    if (node.country.isFavorite) {
+      acc.push(node);
+      return acc;
+    }
+
+    const regions = node.regions.reduce<UiRegion[]>((regionAcc, region) => {
+      const filtered = regionToFavorites(region, false);
+      if (filtered) regionAcc.push(filtered);
+      return regionAcc;
+    }, []);
+
+    // The country's flat gateway list must cover everything reachable below it:
+    // its own favorited gateways plus every gateway carried in by a favorited
+    // region. `NodeItem` renders the flat list for non-US countries and the
+    // regions for the US, while the header count reads the flat list for both —
+    // so a favorited region has to contribute here or its nodes go uncounted.
+    const keep = new Set<string>();
+    for (const gw of node.gateways) if (gw.isFavorite) keep.add(gw.id);
+    for (const region of regions)
+      for (const gw of region.gateways) keep.add(gw.id);
+
+    // Filtering the original array rather than concatenating preserves the
+    // performance ordering the backend applied.
+    const gateways = node.gateways.filter((gw) => keep.has(gw.id));
+    if (gateways.length === 0) return acc;
+
+    acc.push({ ...node, gateways, regions });
+    return acc;
+  }, []);
 }

--- a/nym-vpn-app/src/state/init.ts
+++ b/nym-vpn-app/src/state/init.ts
@@ -9,6 +9,7 @@ import { kvGet } from '../kvStore';
 import {
   AccountLinks,
   CodeDependency,
+  Favorites,
   FeatureFlags,
   NetworkCompat,
   TAccountMode,
@@ -19,6 +20,7 @@ import {
   UiTheme,
 } from '../types';
 import { dispatch } from '../store';
+import { useFavoritesStore } from '../store/favoritesState';
 import { updateAccountState, updateTunnel } from './update';
 import { TauriReq, fireRequests } from './helper';
 
@@ -250,10 +252,19 @@ export async function initSecondBatch() {
     },
   };
 
+  const getFavoritesRq: TauriReq<() => Promise<Favorites>> = {
+    name: 'getFavoritesRq',
+    request: () => invoke<Favorites>('get_favorites'),
+    onFulfilled: (favorites) => {
+      useFavoritesStore.getState().hydrate(favorites);
+    },
+  };
+
   await fireRequests([
     getAutostart,
     getDefaultDnsRq,
     getAccountLinksRq,
     getNetworkCompatRq,
+    getFavoritesRq,
   ]);
 }

--- a/nym-vpn-app/src/store/favoritesState.ts
+++ b/nym-vpn-app/src/store/favoritesState.ts
@@ -1,0 +1,32 @@
+import { create } from 'zustand';
+import { Favorite, Favorites } from '../types/tauri';
+import { NodeHop } from '../types/util';
+import { favoriteKey } from '../types/favorites';
+
+type FavoritesStore = {
+  entry: Favorite[];
+  exit: Favorite[];
+  hydrate: (favorites: Favorites) => void;
+  add: (hop: NodeHop, favorite: Favorite) => void;
+  remove: (hop: NodeHop, favorite: Favorite) => void;
+};
+
+export const useFavoritesStore = create<FavoritesStore>((set, get) => ({
+  entry: [],
+  exit: [],
+
+  hydrate: ({ entry, exit }) => set({ entry, exit }),
+
+  add: (hop, favorite) => {
+    const key = favoriteKey(favorite);
+    if (get()[hop].some((f) => favoriteKey(f) === key)) return;
+    set((s) => ({ [hop]: [...s[hop], favorite] }));
+  },
+
+  remove: (hop, favorite) => {
+    const key = favoriteKey(favorite);
+    set((s) => ({ [hop]: s[hop].filter((f) => favoriteKey(f) !== key) }));
+  },
+}));
+
+export const useFavorites = (hop: NodeHop) => useFavoritesStore((s) => s[hop]);

--- a/nym-vpn-app/src/store/nodeListState.ts
+++ b/nym-vpn-app/src/store/nodeListState.ts
@@ -9,10 +9,14 @@ export type Focused = {
   key: string;
 };
 
+/** Which subset of the node list is shown. */
+export type ListView = 'all' | 'favorites';
+
 type HopState = {
   expanded: string[];
   focused: Focused | null;
   search: string | null;
+  view: ListView;
 };
 
 type NodeListStore = {
@@ -22,10 +26,16 @@ type NodeListStore = {
   addToExpanded: (hop: Hop, value: string) => void;
   setFocused: (hop: Hop, focused: Focused | null) => void;
   setSearch: (hop: Hop, search: string | null) => void;
+  setView: (hop: Hop, view: ListView) => void;
   reset: (hop: Hop | 'all') => void;
 };
 
-const emptyHop: HopState = { expanded: [], focused: null, search: null };
+const emptyHop: HopState = {
+  expanded: [],
+  focused: null,
+  search: null,
+  view: 'all',
+};
 
 export const useNodeListStateStore = create<NodeListStore>((set, get) => ({
   entry: { ...emptyHop },
@@ -45,11 +55,19 @@ export const useNodeListStateStore = create<NodeListStore>((set, get) => ({
 
   setSearch: (hop, search) => set((s) => ({ [hop]: { ...s[hop], search } })),
 
+  setView: (hop, view) => set((s) => ({ [hop]: { ...s[hop], view } })),
+
+  // `view` deliberately survives a reset: expanded/focused/search are list
+  // positioning that should be cleared on navigation, whereas the active view is
+  // a choice the user made for the session.
   reset: (hop) => {
     if (hop === 'all') {
-      set({ entry: { ...emptyHop }, exit: { ...emptyHop } });
+      set((s) => ({
+        entry: { ...emptyHop, view: s.entry.view },
+        exit: { ...emptyHop, view: s.exit.view },
+      }));
     } else {
-      set({ [hop]: { ...emptyHop } });
+      set((s) => ({ [hop]: { ...emptyHop, view: s[hop].view } }));
     }
   },
 }));

--- a/nym-vpn-app/src/types/favorites.ts
+++ b/nym-vpn-app/src/types/favorites.ts
@@ -1,0 +1,30 @@
+import { Favorite } from './tauri';
+
+export type FavoritableNode =
+  | { nodeType: 'country'; code: string }
+  | { nodeType: 'region'; name: string }
+  | { nodeType: 'gateway'; id: string };
+
+export function favoriteKey(favorite: Favorite): string {
+  if ('country' in favorite) return `country:${favorite.country.code}`;
+  if ('gateway' in favorite) return `gateway:${favorite.gateway.id}`;
+  return `region:${favorite.region}`;
+}
+
+export function nodeToFavorite(node: FavoritableNode): Favorite {
+  switch (node.nodeType) {
+    case 'country':
+      return { country: { code: node.code } };
+    case 'region':
+      return { region: node.name };
+    case 'gateway':
+      return { gateway: { id: node.id } };
+  }
+}
+
+export function isNodeFavorite(
+  node: FavoritableNode,
+  favoriteKeys: ReadonlySet<string>,
+): boolean {
+  return favoriteKeys.has(favoriteKey(nodeToFavorite(node)));
+}

--- a/nym-vpn-app/src/types/index.ts
+++ b/nym-vpn-app/src/types/index.ts
@@ -4,3 +4,4 @@ export * from './routes';
 export * from './licenses';
 export * from './util';
 export * from './node';
+export * from './favorites';

--- a/nym-vpn-app/src/types/node.ts
+++ b/nym-vpn-app/src/types/node.ts
@@ -25,17 +25,20 @@ export type SelectedUiNode =
 export type UiCountry = Country & {
   nodeType: 'country';
   isSelected: SelectedKind;
+  isFavorite: boolean;
 };
 
 export type UiGateway = Gateway & {
   nodeType: 'gateway';
   isSelected: GwSelectedKind;
+  isFavorite: boolean;
 };
 
 export type UiRegion = Omit<Region, 'gateways'> & {
   nodeType: 'region';
   gateways: UiGateway[];
   isSelected: SelectedKind;
+  isFavorite: boolean;
 };
 
 export type UiGatewaysByCountry = Omit<

--- a/nym-vpn-app/src/types/tauri.ts
+++ b/nym-vpn-app/src/types/tauri.ts
@@ -133,9 +133,17 @@ export type ErrorKey =
   | 'device-time-desync'
   | 'split-tunnel-app-invalid'
   | 'split-tunnel-app-duplicate'
+  | 'insufficient-funds'
   | 'get-mixnet-entry-countries-query'
   | 'get-mixnet-exit-countries-query'
   | 'get-wg-countries-query';
+
+export type Favorite =
+  | { country: { code: string } }
+  | { gateway: { id: string } }
+  | { region: string };
+
+export type Favorites = { entry: Array<Favorite>; exit: Array<Favorite> };
 
 export type FeatureFlags = {
   quic: boolean;


### PR DESCRIPTION
## Ticket

[JIRA-NYM-262](https://nymtech.atlassian.net/browse/NYM-262)

## Description

- Add favorites button to server lists and server details pages


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)
<img width="470" height="846" alt="image" src="https://github.com/user-attachments/assets/20246ebb-41dd-4a80-88ac-86856e29788e" />
<img width="470" height="850" alt="image" src="https://github.com/user-attachments/assets/f6edcced-1666-41fa-bfcd-0cc4f89ebd32" />
![Uploading image.png…]()


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5925)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added persistent favorites for servers (gateways), countries, and regions, with backend-backed add/remove and favorites retrieval.
  * Introduced a Favorites vs. All toggle for the node list, including favorites-only filtering.
* **UI Enhancements**
  * Added star controls to mark/unmark favorites in node lists and node details.
  * Added an empty state when no favorites are available.
* **Localization**
  * Added new i18n strings for favorite states (add/remove, error, none, unavailable).
  * Updated the node search label to “Servers”.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->