### PR TITLE
CI improvements

### DIFF
--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -14,7 +14,7 @@ runs:
       run: |
         echo "RUSTC_WRAPPER=$SCCACHE_PATH" >> "$GITHUB_ENV"
         echo "SCCACHE_DIR=$HOME/.cache/sccache" >> "$GITHUB_ENV"
-        echo "SCCACHE_CACHE_SIZE=15G" >> "$GITHUB_ENV"
+        echo "SCCACHE_CACHE_SIZE=10G" >> "$GITHUB_ENV" # keep it lower for unix runners (macos is a bottleneck!)
         echo "SCCACHE_IDLE_TIMEOUT=0" >> "$GITHUB_ENV"
         echo "CARGO_INCREMENTAL=0" >> "$GITHUB_ENV"
 

--- a/.github/workflows/build-nym-vpn-app-ios.yml
+++ b/.github/workflows/build-nym-vpn-app-ios.yml
@@ -137,6 +137,16 @@ jobs:
         with:
           crate: cargo-license
 
+      - name: Install cargo-edit
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-edit
+
+      - name: Install cargo-get
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-get
+
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
         with:
@@ -147,11 +157,6 @@ jobs:
         with:
           go-version: ${{ env.GOLANG_VERSION }}
           cache-dependency-path: wireguard/libwg/go.sum
-
-      - name: Install cargo-edit
-        uses: baptiste0928/cargo-install@v3
-        with:
-          crate: cargo-edit
 
       - name: Add Homebrew, Ruby to PATH
         run: |
@@ -307,8 +312,6 @@ jobs:
         if: ${{ env.RELEASE_TYPE != 'pr' }}
         run: |
           set -euo pipefail
-
-          cargo install cargo-get
 
           # Get version from Cargo.toml workspace
           LIB_VERSION=$(cargo get workspace.package.version --entry nym-vpn-core/Cargo.toml)

--- a/.github/workflows/build-nym-vpn-app-ios.yml
+++ b/.github/workflows/build-nym-vpn-app-ios.yml
@@ -176,6 +176,7 @@ jobs:
           brew install xmlstarlet
           brew install jq
           brew install brotli
+          brew uninstall homebrew/core/sentry-cli || true # Tim apple had a different tap with the same name
           brew install getsentry/tools/sentry-cli
 
       - name: Set locale (for Fastlane)

--- a/.github/workflows/build-nym-vpn-app-ios.yml
+++ b/.github/workflows/build-nym-vpn-app-ios.yml
@@ -164,13 +164,19 @@ jobs:
           echo "${RUBY_PREFIX}/bin" >> "$GITHUB_PATH"
           export PATH="${RUBY_PREFIX}/bin:$PATH"
 
-          # Ensure xcbeautify is available for xcodebuild output formatting
-          which xcbeautify || brew install xcbeautify
-
           # Show versions for debugging
           brew --version
           ruby --version
           gem --version
+
+      - name: Install system dependencies
+        run: |
+          brew install xcbeautify
+          brew install crowdin
+          brew install xmlstarlet
+          brew install jq
+          brew install brotli
+          brew install getsentry/tools/sentry-cli
 
       - name: Set locale (for Fastlane)
         run: |
@@ -327,7 +333,6 @@ jobs:
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
         run: |
-          brew install crowdin
           crowdin_prefix="$(brew --prefix crowdin)"
           export PATH="$crowdin_prefix/bin:$PATH"
 
@@ -465,12 +470,6 @@ jobs:
           path: ${{ env.UPLOAD_DIR_IOS }}
           if-no-files-found: error
           retention-days: 1
-
-      - name: Install Sentry (nightly)
-        if: ${{ env.RELEASE_TYPE == 'qa' }}
-        run: |
-          brew install sentry-cli || brew upgrade sentry-cli || true
-          sentry-cli --version
 
       - name: Upload iOS dSYMs to Sentry (nightly)
         if: ${{ env.RELEASE_TYPE == 'qa' }}

--- a/.github/workflows/build-nym-vpn-app-macos.yml
+++ b/.github/workflows/build-nym-vpn-app-macos.yml
@@ -176,6 +176,7 @@ jobs:
           brew install xmlstarlet
           brew install jq
           brew install brotli
+          brew uninstall homebrew/core/sentry-cli || true # Tim apple had a different tap with the same name
           brew install getsentry/tools/sentry-cli
 
       - name: Set locale (for Fastlane)

--- a/.github/workflows/build-nym-vpn-app-macos.yml
+++ b/.github/workflows/build-nym-vpn-app-macos.yml
@@ -87,14 +87,6 @@ jobs:
       - name: Setup sccache
         uses: ./.github/actions/setup-sccache
 
-      - name: Install system dependencies
-        run: |
-          brew install xcbeautify
-          brew install crowdin
-          brew install xmlstarlet
-          brew install jq
-          brew install getsentry/tools/sentry-cli
-
       - name: Normalize release_type
         run: |
           set -euo pipefail
@@ -176,6 +168,15 @@ jobs:
           brew --version
           ruby --version
           gem --version
+
+      - name: Install system dependencies
+        run: |
+          brew install xcbeautify
+          brew install crowdin
+          brew install xmlstarlet
+          brew install jq
+          brew install brotli
+          brew install getsentry/tools/sentry-cli
 
       - name: Set locale (for Fastlane)
         run: |

--- a/.github/workflows/build-nym-vpn-app-macos.yml
+++ b/.github/workflows/build-nym-vpn-app-macos.yml
@@ -137,6 +137,16 @@ jobs:
         with:
           crate: cargo-license
 
+      - name: Install cargo-edit
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-edit
+
+      - name: Install cargo-get
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-get
+
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
         with:
@@ -147,11 +157,6 @@ jobs:
         with:
           go-version: ${{ env.GOLANG_VERSION }}
           cache-dependency-path: wireguard/libwg/go.sum
-
-      - name: Install cargo-edit
-        uses: baptiste0928/cargo-install@v3
-        with:
-          crate: cargo-edit
 
       - name: Add Homebrew, Ruby to PATH
         run: |
@@ -340,8 +345,6 @@ jobs:
         if: ${{ env.RELEASE_TYPE != 'pr' }}
         run: |
           set -euo pipefail
-
-          cargo install cargo-get
 
           # Get version from Cargo.toml workspace
           LIB_VERSION=$(cargo get workspace.package.version --entry nym-vpn-core/Cargo.toml)

--- a/.github/workflows/bump-all-platforms.yml
+++ b/.github/workflows/bump-all-platforms.yml
@@ -231,7 +231,7 @@ jobs:
           toml set Cargo.toml workspace.package.version "${{ steps.version.outputs.core_version }}" > Cargo-patched.toml
           mv Cargo-patched.toml Cargo.toml
           # update Cargo.lock with new workspace version (no other changes)
-          cargo fetch --offline
+          cargo fetch
 
       # --- tauri app (Linux + Windows) ---
       - name: Update nym-vpn-app/src-tauri/Cargo.toml
@@ -239,7 +239,7 @@ jobs:
         run: |
           toml set Cargo.toml package.version "${{ steps.version.outputs.core_version }}" > Cargo-patched.toml
           mv Cargo-patched.toml Cargo.toml
-          cargo fetch --offline
+          cargo fetch
 
       - name: Update nym-vpn-app/vpnd_compat.toml
         working-directory: nym-vpn-app

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -26,7 +26,6 @@ jobs:
         uses: ./.github/workflows/release-all-platforms.yml
         with:
           gh_release: auto
-          notify_zulip: true
           release_channel: nightly
           android: false
           fdroid: true

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -17,10 +17,16 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Checkout repo
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
       - name: Publish nightly release
         uses: ./.github/workflows/release-all-platforms.yml
         with:
-          publish_github_release: true
+          gh_release: auto
+          notify_zulip: true
           release_channel: nightly
           android: false
           fdroid: true

--- a/.github/workflows/platform/apply-version/action.yml
+++ b/.github/workflows/platform/apply-version/action.yml
@@ -48,13 +48,13 @@ runs:
             ( cd nym-vpn-core
               toml set Cargo.toml workspace.package.version "$VERSION" > Cargo-patched.toml
               mv Cargo-patched.toml Cargo.toml
-              cargo fetch --offline )
+              cargo fetch )
             ;;
           tauri)
             ( cd nym-vpn-app/src-tauri
               toml set Cargo.toml package.version "$VERSION" > Cargo-patched.toml
               mv Cargo-patched.toml Cargo.toml
-              cargo fetch --offline )
+              cargo fetch )
             ;;
           android)
             # No set-version tool: gradle builds the final apk name from

--- a/.github/workflows/prepare-release-notes.yml
+++ b/.github/workflows/prepare-release-notes.yml
@@ -14,6 +14,9 @@ on:
       version:
         type: string
         required: true
+      android:
+        type: boolean
+        required: true
       fdroid:
         type: boolean
         required: true
@@ -75,6 +78,9 @@ on:
         required: true
       version:
         type: string
+        required: true
+      android:
+        type: boolean
         required: true
       fdroid:
         type: boolean
@@ -146,6 +152,7 @@ jobs:
     outputs:
       github_release_type: ${{ steps.set-params.outputs.github_release_type }}
       version: ${{ steps.set-params.outputs.version }}
+      android: ${{ steps.set-params.outputs.android }}
       fdroid: ${{ steps.set-params.outputs.fdroid }}
       linux: ${{ steps.set-params.outputs.linux }}
       windows: ${{ steps.set-params.outputs.windows }}
@@ -174,6 +181,7 @@ jobs:
             # --- PULL REQUEST TEST VALUES ---
             echo "github_release_type=draft" >> $GITHUB_OUTPUT
             echo "version=0.0.0-pr-test" >> $GITHUB_OUTPUT
+            echo "android=true" >> $GITHUB_OUTPUT
             echo "fdroid=true" >> $GITHUB_OUTPUT
             echo "linux=true" >> $GITHUB_OUTPUT
             echo "windows=true" >> $GITHUB_OUTPUT
@@ -196,6 +204,7 @@ jobs:
           else
             echo "github_release_type=${{ inputs.github_release_type }}" >> $GITHUB_OUTPUT
             echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
+            echo "android=${{ inputs.android }}" >> $GITHUB_OUTPUT
             echo "fdroid=${{ inputs.fdroid }}" >> $GITHUB_OUTPUT
             echo "linux=${{ inputs.linux }}" >> $GITHUB_OUTPUT
             echo "windows=${{ inputs.windows }}" >> $GITHUB_OUTPUT
@@ -238,18 +247,18 @@ jobs:
 
       - name: Extract android changelog
         id: android-changelog
+        if: ${{ needs.resolve.outputs.android == 'true' || needs.resolve.outputs.fdroid == 'true' }}
         uses: ffurrer2/extract-release-notes@v2
         with:
           changelog_file: nym-vpn-android/CHANGELOG.md
           # for prereleases, extract the changelog from the [unreleased] section
           prerelease: ${{ needs.resolve.outputs.github_release_type != 'release' }}
 
-      - name: Add release notes (General)
+      - name: Add release notes (General + Core changes)
         env:
           RELEASE_NOTES: ${{ env.RELEASE_NOTES }}
           VERSION: ${{ needs.resolve.outputs.version }}
           CORE_CHANGES: ${{ steps.core-changelog.outputs.release_notes }}
-          ANDROID_CHANGES: ${{ steps.android-changelog.outputs.release_notes }}
         run: |
           cat << 'EOF' > "$RELEASE_NOTES"
           Nym VPN v${{ env.VERSION }} application and core binaries.
@@ -269,6 +278,13 @@ jobs:
           EOF
           fi
 
+      - name: Add release notes (Android changes)
+        if: ${{ needs.resolve.outputs.android == 'true' || needs.resolve.outputs.fdroid == 'true' }}
+        env:
+          RELEASE_NOTES: ${{ env.RELEASE_NOTES }}
+          VERSION: ${{ needs.resolve.outputs.version }}
+          ANDROID_CHANGES: ${{ steps.android-changelog.outputs.release_notes || '' }}
+        run: |
           if [ -n "$ANDROID_CHANGES" ]; then
             # Increase indentation from h3 to h4 to better fit the release notes
             export UPDATED_ANDROID_CHANGES=$(sed 's/^### /#### /' <<< "$ANDROID_CHANGES")
@@ -281,6 +297,10 @@ jobs:
           EOF
           fi
 
+      - name: Add release notes (Core overview)
+        env:
+          RELEASE_NOTES: ${{ env.RELEASE_NOTES }}
+        run: |
           cat << 'EOF' >> "$RELEASE_NOTES"
           ## 📦 Core Components Overview
 
@@ -290,14 +310,11 @@ jobs:
           - `nym-diagnostic`: System information and network troubleshooting tool.
           - `nym-setup`: macOS helper tool for system service configuration.
 
-          EOF
-
-          cat << 'EOF' >> "$RELEASE_NOTES"
           ## 💾 Downloads & Assets
 
           EOF
 
-      - name: Add release notes (Android)
+      - name: Add release notes (F-Droid)
         if: ${{ needs.resolve.outputs.fdroid == 'true' }}
         env:
           RELEASE_NOTES: ${{ env.RELEASE_NOTES }}

--- a/.github/workflows/prepare-release-notes.yml
+++ b/.github/workflows/prepare-release-notes.yml
@@ -1,5 +1,8 @@
 name: prepare-release-notes
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]

--- a/.github/workflows/prepare-release-notes.yml
+++ b/.github/workflows/prepare-release-notes.yml
@@ -144,7 +144,6 @@ jobs:
   resolve:
     runs-on: arc-linux-latest
     outputs:
-      # Required Variables
       github_release_type: ${{ steps.set-params.outputs.github_release_type }}
       version: ${{ steps.set-params.outputs.version }}
       fdroid: ${{ steps.set-params.outputs.fdroid }}

--- a/.github/workflows/prepare-release-notes.yml
+++ b/.github/workflows/prepare-release-notes.yml
@@ -1,0 +1,312 @@
+name: prepare-release-notes
+
+on:
+  workflow_dispatch:
+    inputs:
+      github_release_type:
+        type: string
+        required: true
+      version:
+        type: string
+        required: true
+      fdroid:
+        type: boolean
+        required: true
+      linux:
+        type: boolean
+        required: true
+      windows:
+        type: boolean
+        required: true
+      macos:
+        type: boolean
+        required: true
+      ios:
+        type: boolean
+        required: true
+      android_apk:
+        type: string
+        required: false
+      vpnd_deb_x86_64:
+        type: string
+        required: false
+      vpnd_deb_aarch64:
+        type: string
+        required: false
+      vpnc_deb_x86_64:
+        type: string
+        required: false
+      vpnc_deb_aarch64:
+        type: string
+        required: false
+      linux_app_deb_x64:
+        type: string
+        required: false
+      linux_app_deb_arm64:
+        type: string
+        required: false
+      linux_app_appimage_x64:
+        type: string
+        required: false
+      linux_app_appimage_arm64:
+        type: string
+        required: false
+      macos_installer_name:
+        type: string
+        required: false
+      vpnc_macos_installer_name:
+        type: string
+        required: false
+      windows_app_installer_x64:
+        type: string
+        required: false
+      windows_app_installer_arm64:
+        type: string
+        required: false
+  workflow_call:
+    inputs:
+      github_release_type:
+        type: string
+        required: true
+      version:
+        type: string
+        required: true
+      fdroid:
+        type: boolean
+        required: true
+      linux:
+        type: boolean
+        required: true
+      windows:
+        type: boolean
+        required: true
+      macos:
+        type: boolean
+        required: true
+      ios:
+        type: boolean
+        required: true
+      android_apk:
+        type: string
+        required: false
+      vpnd_deb_x86_64:
+        type: string
+        required: false
+      vpnd_deb_aarch64:
+        type: string
+        required: false
+      vpnc_deb_x86_64:
+        type: string
+        required: false
+      vpnc_deb_aarch64:
+        type: string
+        required: false
+      linux_app_deb_x64:
+        type: string
+        required: false
+      linux_app_deb_arm64:
+        type: string
+        required: false
+      linux_app_appimage_x64:
+        type: string
+        required: false
+      linux_app_appimage_arm64:
+        type: string
+        required: false
+      macos_installer_name:
+        type: string
+        required: false
+      vpnc_macos_installer_name:
+        type: string
+        required: false
+      windows_app_installer_x64:
+        type: string
+        required: false
+      windows_app_installer_arm64:
+        type: string
+        required: false
+    outputs:
+      release_notes_artifact:
+        value: ${{ jobs.prepare-release-notes.outputs.release_notes_artifact }}
+      release_notes_file:
+        value: ${{ jobs.prepare-release-notes.outputs.release_notes_file }}
+
+env:
+  RELEASE_NOTES_ARTIFACT: release-notes
+  RELEASE_NOTES: release-notes.md
+
+jobs:
+  prepare-release-notes:
+    runs-on: arc-linux-latest
+    outputs:
+      release_notes_artifact: ${{ env.RELEASE_NOTES_ARTIFACT }}
+      release_notes_file: ${{ env.RELEASE_NOTES }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Extract core changelog
+        id: core-changelog
+        uses: ffurrer2/extract-release-notes@v2
+        with:
+          changelog_file: nym-vpn-core/CHANGELOG.md
+          # for prereleases, extract the changelog from the [unreleased] section
+          prerelease: ${{ inputs.github_release_type != 'release' }}
+
+      - name: Extract android changelog
+        id: android-changelog
+        uses: ffurrer2/extract-release-notes@v2
+        with:
+          changelog_file: nym-vpn-android/CHANGELOG.md
+          # for prereleases, extract the changelog from the [unreleased] section
+          prerelease: ${{ inputs.github_release_type != 'release' }}
+
+      - name: Add release notes (General)
+        env:
+          RELEASE_NOTES: ${{ env.RELEASE_NOTES }}
+          VERSION: ${{ inputs.version }}
+          CORE_CHANGES: ${{ steps.core-changelog.outputs.release_notes }}
+          ANDROID_CHANGES: ${{ steps.android-changelog.outputs.release_notes }}
+        run: |
+          cat << 'EOF' > "$RELEASE_NOTES"
+          Nym VPN v${{ env.VERSION }} application and core binaries.
+
+          EOF
+
+          if [ -n "$CORE_CHANGES" ]; then
+            # Increase indentation from h3 to h4 to better fit the release notes
+            export UPDATED_CORE_CHANGES=$(sed 's/^### /#### /' <<< "$CORE_CHANGES")
+
+            envsubst '$UPDATED_CORE_CHANGES' << 'EOF' >> "$RELEASE_NOTES"
+          ## 🚀 What's New
+          ### 🛠️ Core Changes
+
+          $UPDATED_CORE_CHANGES
+
+          EOF
+          fi
+
+          if [ -n "$ANDROID_CHANGES" ]; then
+            # Increase indentation from h3 to h4 to better fit the release notes
+            export UPDATED_ANDROID_CHANGES=$(sed 's/^### /#### /' <<< "$ANDROID_CHANGES")
+
+            envsubst '$UPDATED_ANDROID_CHANGES' << 'EOF' >> "$RELEASE_NOTES"
+          ### 🤖 Android Changes
+
+          $UPDATED_ANDROID_CHANGES
+
+          EOF
+          fi
+
+          cat << 'EOF' >> "$RELEASE_NOTES"
+          ## 📦 Core Components Overview
+
+          - `nym-vpnd`: Background daemon service managed via the UI app or CLI.
+          - `nym-vpnc`:  Command-line interface (CLI) to control the daemon (`nym-vpnd`).
+          - `nym-socks5-proxy`: SOCKS5 proxy handling geo-exclusion routing.
+          - `nym-diagnostic`: System information and network troubleshooting tool.
+          - `nym-setup`: macOS helper tool for system service configuration.
+
+          EOF
+
+          cat << 'EOF' >> "$RELEASE_NOTES"
+          ## 💾 Downloads & Assets
+
+          EOF
+
+      - name: Add release notes (Android)
+        if: ${{ inputs.fdroid == true }}
+        env:
+          RELEASE_NOTES: ${{ env.RELEASE_NOTES }}
+          ANDROID_APK: ${{ inputs.android_apk }}
+        run: |
+          cat << 'EOF' >> "$RELEASE_NOTES"
+          ### 🤖 Android
+
+          - `${{ env.ANDROID_APK }}`: Android App (F-Droid Build)
+
+          <details>
+          <summary>How to verify the build fingerprint?</summary>
+
+          #### Signing Certificate SHA-256 Fingerprint (4096-bit):
+
+          ```text
+          3c98a016aa4f14a3ba185c764ed363415cf7ff3c3d328a87ffff2ff1b140ff06
+          ```
+
+          #### Verification Steps:
+
+          To verify the build fingerprint on your system, run:
+          ```sh
+          apksigner verify --print-certs "${{ env.ANDROID_APK }}" | grep SHA-256
+          ```
+
+          </details>
+
+          EOF
+
+      - name: Add release notes (Linux)
+        if: ${{ inputs.linux == true }}
+        env:
+          RELEASE_NOTES: ${{ env.RELEASE_NOTES }}
+          VPND_DEB_X86_64: ${{ inputs.vpnd_deb_x86_64 }}
+          VPND_DEB_ARM64: ${{ inputs.vpnd_deb_aarch64 }}
+          VPNC_DEB_X86_64: ${{ inputs.vpnc_deb_x86_64 }}
+          VPNC_DEB_ARM64: ${{ inputs.vpnc_deb_aarch64 }}
+          LINUX_APP_DEB_X64: ${{ inputs.linux_app_deb_x64 }}
+          LINUX_APP_DEB_ARM64: ${{ inputs.linux_app_deb_arm64 }}
+          LINUX_APP_APPIMAGE_X64: ${{ inputs.linux_app_appimage_x64 }}
+          LINUX_APP_APPIMAGE_ARM64: ${{ inputs.linux_app_appimage_arm64 }}
+        run: |
+          cat << 'EOF' >> "$RELEASE_NOTES"
+          ### 🐧 Linux
+
+          - **Desktop App**
+            - `${{ env.LINUX_APP_DEB_X64 }}`: Nym VPN app, debian package (x86_64)
+            - `${{ env.LINUX_APP_DEB_ARM64 }}`: Nym VPN app, debian package (arm64)
+            - `${{ env.LINUX_APP_APPIMAGE_X64 }}`: Nym VPN app, AppImage (x86_64)
+            - `${{ env.LINUX_APP_APPIMAGE_ARM64 }}`: Nym VPN app, AppImage (arm64)
+          - **CLI & Daemon**
+            - `${{ env.VPND_DEB_X86_64 }}`: Nym VPN daemon, debian package (x86_64)
+            - `${{ env.VPND_DEB_ARM64 }}`: Nym VPN daemon, debian package (arm64)
+            - `${{ env.VPNC_DEB_X86_64 }}`: Nym VPN command-line tool, debian package (x86_64)
+            - `${{ env.VPNC_DEB_ARM64 }}`: Nym VPN command-line tool, debian package (arm64)
+
+          EOF
+
+      - name: Add release notes (macOS)
+        if: ${{ inputs.macos == true }}
+        env:
+          RELEASE_NOTES: ${{ env.RELEASE_NOTES }}
+          MACOS_INSTALLER_NAME: ${{ inputs.macos_installer_name }}
+          VPNC_MACOS_INSTALLER_NAME: ${{ inputs.vpnc_macos_installer_name }}
+        run: |
+          cat << 'EOF' >> "$RELEASE_NOTES"
+          ### 🍎 macOS
+
+          - `${{ env.MACOS_INSTALLER_NAME }}`: Desktop App Installer
+          - `${{ env.VPNC_MACOS_INSTALLER_NAME }}`: Command-Line Tool Installer
+
+          EOF
+
+      - name: Add release notes (Windows)
+        if: ${{ inputs.windows == true }}
+        env:
+          RELEASE_NOTES: ${{ env.RELEASE_NOTES }}
+          WINDOWS_APP_INSTALLER_X64: ${{ inputs.windows_app_installer_x64 }}
+          WINDOWS_APP_INSTALLER_ARM64: ${{ inputs.windows_app_installer_arm64 }}
+        run: |
+          cat << 'EOF' >> "$RELEASE_NOTES"
+          ### 🪟 Windows
+
+          - `${{ env.WINDOWS_APP_INSTALLER_X64 }}`: Desktop App Installer (x64)
+          - `${{ env.WINDOWS_APP_INSTALLER_ARM64 }}`: Desktop App Installer (arm64)
+
+          EOF
+
+      - name: Upload release notes
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ env.RELEASE_NOTES_ARTIFACT }}
+          path: ${{ env.RELEASE_NOTES }}

--- a/.github/workflows/prepare-release-notes.yml
+++ b/.github/workflows/prepare-release-notes.yml
@@ -1,6 +1,8 @@
 name: prepare-release-notes
 
 on:
+  pull_request:
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
     inputs:
       github_release_type:
@@ -136,8 +138,86 @@ env:
   RELEASE_NOTES: release-notes.md
 
 jobs:
+  resolve:
+    runs-on: arc-linux-latest
+    outputs:
+      # Required Variables
+      github_release_type: ${{ steps.set-params.outputs.github_release_type }}
+      version: ${{ steps.set-params.outputs.version }}
+      fdroid: ${{ steps.set-params.outputs.fdroid }}
+      linux: ${{ steps.set-params.outputs.linux }}
+      windows: ${{ steps.set-params.outputs.windows }}
+      macos: ${{ steps.set-params.outputs.macos }}
+      ios: ${{ steps.set-params.outputs.ios }}
+      android_apk: ${{ steps.set-params.outputs.android_apk }}
+      vpnd_deb_x86_64: ${{ steps.set-params.outputs.vpnd_deb_x86_64 }}
+      vpnd_deb_aarch64: ${{ steps.set-params.outputs.vpnd_deb_aarch64 }}
+      vpnc_deb_x86_64: ${{ steps.set-params.outputs.vpnc_deb_x86_64 }}
+      vpnc_deb_aarch64: ${{ steps.set-params.outputs.vpnc_deb_aarch64 }}
+      linux_app_deb_x64: ${{ steps.set-params.outputs.linux_app_deb_x64 }}
+      linux_app_deb_arm64: ${{ steps.set-params.outputs.linux_app_deb_arm64 }}
+      linux_app_appimage_x64: ${{ steps.set-params.outputs.linux_app_appimage_x64 }}
+      linux_app_appimage_arm64: ${{ steps.set-params.outputs.linux_app_appimage_arm64 }}
+      macos_installer_name: ${{ steps.set-params.outputs.macos_installer_name }}
+      vpnc_macos_installer_name: ${{ steps.set-params.outputs.vpnc_macos_installer_name }}
+      windows_app_installer_x64: ${{ steps.set-params.outputs.windows_app_installer_x64 }}
+      windows_app_installer_arm64: ${{ steps.set-params.outputs.windows_app_installer_arm64 }}
+    steps:
+      - name: Resolve runtime parameters
+        id: set-params
+        run: |
+          IS_PR="${{ github.event_name == 'pull_request' }}"
+
+          if [ "$IS_PR" = "true" ]; then
+            # --- PULL REQUEST TEST VALUES ---
+            echo "github_release_type=draft" >> $GITHUB_OUTPUT
+            echo "version=0.0.0-pr-test" >> $GITHUB_OUTPUT
+            echo "fdroid=true" >> $GITHUB_OUTPUT
+            echo "linux=true" >> $GITHUB_OUTPUT
+            echo "windows=true" >> $GITHUB_OUTPUT
+            echo "macos=true" >> $GITHUB_OUTPUT
+            echo "ios=true" >> $GITHUB_OUTPUT
+
+            echo "android_apk=app-release.apk" >> $GITHUB_OUTPUT
+            echo "vpnd_deb_x86_64=vpnd_amd64.deb" >> $GITHUB_OUTPUT
+            echo "vpnd_deb_aarch64=vpnd_arm64.deb" >> $GITHUB_OUTPUT
+            echo "vpnc_deb_x86_64=vpnc_amd64.deb" >> $GITHUB_OUTPUT
+            echo "vpnc_deb_aarch64=vpnc_arm64.deb" >> $GITHUB_OUTPUT
+            echo "linux_app_deb_x64=app_amd64.deb" >> $GITHUB_OUTPUT
+            echo "linux_app_deb_arm64=app_arm64.deb" >> $GITHUB_OUTPUT
+            echo "linux_app_appimage_x64=app_x64.AppImage" >> $GITHUB_OUTPUT
+            echo "linux_app_appimage_arm64=app_arm64.AppImage" >> $GITHUB_OUTPUT
+            echo "macos_installer_name=app_installer.pkg" >> $GITHUB_OUTPUT
+            echo "vpnc_macos_installer_name=vpnc_installer.pkg" >> $GITHUB_OUTPUT
+            echo "windows_app_installer_x64=app_x64.exe" >> $GITHUB_OUTPUT
+            echo "windows_app_installer_arm64=app_arm64.exe" >> $GITHUB_OUTPUT
+          else
+            echo "github_release_type=${{ inputs.github_release_type }}" >> $GITHUB_OUTPUT
+            echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
+            echo "fdroid=${{ inputs.fdroid }}" >> $GITHUB_OUTPUT
+            echo "linux=${{ inputs.linux }}" >> $GITHUB_OUTPUT
+            echo "windows=${{ inputs.windows }}" >> $GITHUB_OUTPUT
+            echo "macos=${{ inputs.macos }}" >> $GITHUB_OUTPUT
+            echo "ios=${{ inputs.ios }}" >> $GITHUB_OUTPUT
+
+            echo "android_apk=${{ inputs.android_apk || '' }}" >> $GITHUB_OUTPUT
+            echo "vpnd_deb_x86_64=${{ inputs.vpnd_deb_x86_64 || '' }}" >> $GITHUB_OUTPUT
+            echo "vpnd_deb_aarch64=${{ inputs.vpnd_deb_aarch64 || '' }}" >> $GITHUB_OUTPUT
+            echo "vpnc_deb_x86_64=${{ inputs.vpnc_deb_x86_64 || '' }}" >> $GITHUB_OUTPUT
+            echo "vpnc_deb_aarch64=${{ inputs.vpnc_deb_aarch64 || '' }}" >> $GITHUB_OUTPUT
+            echo "linux_app_deb_x64=${{ inputs.linux_app_deb_x64 || '' }}" >> $GITHUB_OUTPUT
+            echo "linux_app_deb_arm64=${{ inputs.linux_app_deb_arm64 || '' }}" >> $GITHUB_OUTPUT
+            echo "linux_app_appimage_x64=${{ inputs.linux_app_appimage_x64 || '' }}" >> $GITHUB_OUTPUT
+            echo "linux_app_appimage_arm64=${{ inputs.linux_app_appimage_arm64 || '' }}" >> $GITHUB_OUTPUT
+            echo "macos_installer_name=${{ inputs.macos_installer_name || '' }}" >> $GITHUB_OUTPUT
+            echo "vpnc_macos_installer_name=${{ inputs.vpnc_macos_installer_name || '' }}" >> $GITHUB_OUTPUT
+            echo "windows_app_installer_x64=${{ inputs.windows_app_installer_x64 || '' }}" >> $GITHUB_OUTPUT
+            echo "windows_app_installer_arm64=${{ inputs.windows_app_installer_arm64 || '' }}" >> $GITHUB_OUTPUT
+          fi
+
   prepare-release-notes:
     runs-on: arc-linux-latest
+    needs: [resolve]
     outputs:
       release_notes_artifact: ${{ env.RELEASE_NOTES_ARTIFACT }}
       release_notes_file: ${{ env.RELEASE_NOTES }}
@@ -152,7 +232,7 @@ jobs:
         with:
           changelog_file: nym-vpn-core/CHANGELOG.md
           # for prereleases, extract the changelog from the [unreleased] section
-          prerelease: ${{ inputs.github_release_type != 'release' }}
+          prerelease: ${{ needs.resolve.outputs.github_release_type != 'release' }}
 
       - name: Extract android changelog
         id: android-changelog
@@ -160,12 +240,12 @@ jobs:
         with:
           changelog_file: nym-vpn-android/CHANGELOG.md
           # for prereleases, extract the changelog from the [unreleased] section
-          prerelease: ${{ inputs.github_release_type != 'release' }}
+          prerelease: ${{ needs.resolve.outputs.github_release_type != 'release' }}
 
       - name: Add release notes (General)
         env:
           RELEASE_NOTES: ${{ env.RELEASE_NOTES }}
-          VERSION: ${{ inputs.version }}
+          VERSION: ${{ needs.resolve.outputs.version }}
           CORE_CHANGES: ${{ steps.core-changelog.outputs.release_notes }}
           ANDROID_CHANGES: ${{ steps.android-changelog.outputs.release_notes }}
         run: |
@@ -216,10 +296,10 @@ jobs:
           EOF
 
       - name: Add release notes (Android)
-        if: ${{ inputs.fdroid == true }}
+        if: ${{ needs.resolve.outputs.fdroid == 'true' }}
         env:
           RELEASE_NOTES: ${{ env.RELEASE_NOTES }}
-          ANDROID_APK: ${{ inputs.android_apk }}
+          ANDROID_APK: ${{ needs.resolve.outputs.android_apk }}
         run: |
           cat << 'EOF' >> "$RELEASE_NOTES"
           ### 🤖 Android
@@ -247,17 +327,17 @@ jobs:
           EOF
 
       - name: Add release notes (Linux)
-        if: ${{ inputs.linux == true }}
+        if: ${{ needs.resolve.outputs.linux == 'true' }}
         env:
           RELEASE_NOTES: ${{ env.RELEASE_NOTES }}
-          VPND_DEB_X86_64: ${{ inputs.vpnd_deb_x86_64 }}
-          VPND_DEB_ARM64: ${{ inputs.vpnd_deb_aarch64 }}
-          VPNC_DEB_X86_64: ${{ inputs.vpnc_deb_x86_64 }}
-          VPNC_DEB_ARM64: ${{ inputs.vpnc_deb_aarch64 }}
-          LINUX_APP_DEB_X64: ${{ inputs.linux_app_deb_x64 }}
-          LINUX_APP_DEB_ARM64: ${{ inputs.linux_app_deb_arm64 }}
-          LINUX_APP_APPIMAGE_X64: ${{ inputs.linux_app_appimage_x64 }}
-          LINUX_APP_APPIMAGE_ARM64: ${{ inputs.linux_app_appimage_arm64 }}
+          VPND_DEB_X86_64: ${{ needs.resolve.outputs.vpnd_deb_x86_64 }}
+          VPND_DEB_ARM64: ${{ needs.resolve.outputs.vpnd_deb_aarch64 }}
+          VPNC_DEB_X86_64: ${{ needs.resolve.outputs.vpnc_deb_x86_64 }}
+          VPNC_DEB_ARM64: ${{ needs.resolve.outputs.vpnc_deb_aarch64 }}
+          LINUX_APP_DEB_X64: ${{ needs.resolve.outputs.linux_app_deb_x64 }}
+          LINUX_APP_DEB_ARM64: ${{ needs.resolve.outputs.linux_app_deb_arm64 }}
+          LINUX_APP_APPIMAGE_X64: ${{ needs.resolve.outputs.linux_app_appimage_x64 }}
+          LINUX_APP_APPIMAGE_ARM64: ${{ needs.resolve.outputs.linux_app_appimage_arm64 }}
         run: |
           cat << 'EOF' >> "$RELEASE_NOTES"
           ### 🐧 Linux
@@ -276,11 +356,11 @@ jobs:
           EOF
 
       - name: Add release notes (macOS)
-        if: ${{ inputs.macos == true }}
+        if: ${{ needs.resolve.outputs.macos == 'true' }}
         env:
           RELEASE_NOTES: ${{ env.RELEASE_NOTES }}
-          MACOS_INSTALLER_NAME: ${{ inputs.macos_installer_name }}
-          VPNC_MACOS_INSTALLER_NAME: ${{ inputs.vpnc_macos_installer_name }}
+          MACOS_INSTALLER_NAME: ${{ needs.resolve.outputs.macos_installer_name }}
+          VPNC_MACOS_INSTALLER_NAME: ${{ needs.resolve.outputs.vpnc_macos_installer_name }}
         run: |
           cat << 'EOF' >> "$RELEASE_NOTES"
           ### 🍎 macOS
@@ -291,11 +371,11 @@ jobs:
           EOF
 
       - name: Add release notes (Windows)
-        if: ${{ inputs.windows == true }}
+        if: ${{ needs.resolve.outputs.windows == 'true' }}
         env:
           RELEASE_NOTES: ${{ env.RELEASE_NOTES }}
-          WINDOWS_APP_INSTALLER_X64: ${{ inputs.windows_app_installer_x64 }}
-          WINDOWS_APP_INSTALLER_ARM64: ${{ inputs.windows_app_installer_arm64 }}
+          WINDOWS_APP_INSTALLER_X64: ${{ needs.resolve.outputs.windows_app_installer_x64 }}
+          WINDOWS_APP_INSTALLER_ARM64: ${{ needs.resolve.outputs.windows_app_installer_arm64 }}
         run: |
           cat << 'EOF' >> "$RELEASE_NOTES"
           ### 🪟 Windows

--- a/.github/workflows/release-all-platforms.yml
+++ b/.github/workflows/release-all-platforms.yml
@@ -9,10 +9,10 @@ on:
           Github release mode:
             - none = no release
             - draft = draft release
-            - auto = based on branch and release channel
-              release/*, ship -> release
-              release/*, beta -> prerelease,
-              develop, nightly -> prerelease
+            - auto = based on branch and release channel;
+              release/*, ship -> release;
+              release/*, beta -> prerelease;
+              develop, nightly -> prerelease;
               rest: draft
         type: choice
         default: 'none'

--- a/.github/workflows/release-all-platforms.yml
+++ b/.github/workflows/release-all-platforms.yml
@@ -203,7 +203,7 @@ jobs:
           PUBLISH_METADATA="${IN_PUBLISH_METADATA:-true}"
           GH_RELEASE="${IN_GH_RELEASE:-none}"
 
-          if [[ "$GH_RELEASE" != "none" || "$GH_RELEASE" != "draft" || "$GH_RELEASE" != "auto"  ]]; then
+          if [[ "$GH_RELEASE" != "none" && "$GH_RELEASE" != "draft" && "$GH_RELEASE" != "auto"  ]]; then
             echo "::error:: Unknown GitHub release mode: $GH_RELEASE"
             exit 1
           fi

--- a/.github/workflows/release-all-platforms.yml
+++ b/.github/workflows/release-all-platforms.yml
@@ -510,7 +510,8 @@ jobs:
         ${{
           case(
             startsWith(github.ref_name, 'release/') && needs.resolve.outputs.channel == 'ship', 'release',
-            startsWith(github.ref_name, 'release/') && (needs.resolve.outputs.channel == 'beta' || needs.resolve.outputs.channel == 'nightly'), 'prerelease',
+            startsWith(github.ref_name, 'release/') && needs.resolve.outputs.channel == 'beta', 'prerelease',
+            github.ref_name == 'develop' && needs.resolve.outputs.channel == 'nightly', 'prerelease',
             'draft'
           )
         }}

--- a/.github/workflows/release-all-platforms.yml
+++ b/.github/workflows/release-all-platforms.yml
@@ -185,17 +185,11 @@ jobs:
           fi
 
           if [ "$ALL" = "true" ]; then
-            ANDROID=true; LINUX=true; WINDOWS=true; IOS=true; MACOS=true
-            # The F-Droid APK is built + attached by the Android job regardless of this
-            # flag; `fdroid` only DISPATCHES the F-Droid repo (a store) = ship-only.
-            if [ "$CHANNEL" = "ship" ]; then FDROID=true; else FDROID=false; fi
-            echo "::notice:: $CHANNEL → all platforms (F-Droid submission: $FDROID)"
+            ANDROID=true; FDROID=true; LINUX=true; WINDOWS=true; IOS=true; MACOS=true
+            echo "::notice:: $CHANNEL → all platforms"
           else
-            ANDROID="${IN_ANDROID:-false}"; LINUX="${IN_LINUX:-false}"
+            ANDROID="${IN_ANDROID:-false}"; FDROID="${IN_FDROID:-false}"; LINUX="${IN_LINUX:-false}"
             WINDOWS="${IN_WINDOWS:-false}"; IOS="${IN_IOS:-false}"; MACOS="${IN_MACOS:-false}"
-            # F-Droid repo dispatch is ship-only; on nightly/beta the box is a no-op
-            # (the F-Droid APK still builds + attaches via the Android job).
-            if [ "$CHANNEL" = "ship" ] && [ "$IN_FDROID" = "true" ]; then FDROID=true; else FDROID=false; fi
             echo "::notice:: $CHANNEL → selected platforms"
           fi
 

--- a/.github/workflows/release-all-platforms.yml
+++ b/.github/workflows/release-all-platforms.yml
@@ -4,10 +4,22 @@ on:
   # NOTE: pick the release branch in the "Run workflow" ref selector.
   workflow_dispatch:
     inputs:
-      publish_github_release:
-        description: "Publish on GitHub (leave unchecked for dry-run)"
-        type: boolean
-        default: false
+      gh_release:
+        description: |
+          Github release mode:
+            - none = no release
+            - draft = draft release
+            - auto = based on branch and release channel
+              release/*, ship -> release
+              release/*, beta -> prerelease,
+              develop, nightly -> prerelease
+              rest: draft
+        type: choice
+        default: 'none'
+        options:
+          - none
+          - draft
+          - auto
       release_channel:
         description: "Release channel"
         type: choice
@@ -46,10 +58,10 @@ on:
         default: false
   workflow_call:
     inputs:
-      publish_github_release:
-        description: "Release on GitHub? (leave unchecked for dry-run)"
-        type: boolean
-        default: false
+      gh_release:
+        description: "Github release mode (none, draft, auto)"
+        type: string
+        default: 'draft' # none, draft, public
       release_channel:
         description: "Release channel"
         type: string # nightly, beta, ship
@@ -115,7 +127,8 @@ jobs:
   resolve:
     runs-on: arc-linux-latest
     outputs:
-      publish_github_release: ${{ steps.flags.outputs.publish_github_release }}
+      gh_release: ${{ steps.flags.outputs.gh_release }}
+      gh_release_type: ${{ steps.flags.outputs.gh_release_type }}
       tag: ${{ steps.v.outputs.tag }}
       version: ${{ steps.v.outputs.version }}
       nightly_timestamp: ${{ steps.v.outputs.nightly_timestamp || '' }}
@@ -153,23 +166,9 @@ jobs:
           IN_IOS: ${{ inputs.ios }}
           IN_MACOS: ${{ inputs.macos }}
           IN_PUBLISH_METADATA: ${{ inputs.publish-metadata }}
-          IN_PUBLISH_GITHUB_RELEASE: ${{ inputs.publish_github_release }}
+          IN_GH_RELEASE: ${{ inputs.gh_release }}
         run: |
           set -euo pipefail
-
-          # Used for testing purposes when running this workflow from PR
-          if ${{ github.event_name == 'push' || github.event_name == 'pull_request' }}; then
-            echo "::notice:: dry-run release from ref $REF_NAME (event $EVENT)"
-            echo "::notice:: nightly → all platforms (dry run)"
-            {
-              echo "publish_github_release=false"
-              echo "channel=nightly"
-              echo "android=true"; echo "fdroid=true"; echo "linux=true"
-              echo "windows=true"; echo "ios=true"; echo "macos=true"
-              echo "publish_metadata=false"
-            } >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
 
           echo "::notice:: releasing from ref $REF_NAME (event $EVENT)"
 
@@ -202,14 +201,38 @@ jobs:
 
           # Google Play metadata skip toggle
           PUBLISH_METADATA="${IN_PUBLISH_METADATA:-true}"
-          PUBLISH_GITHUB_RELEASE="${IN_PUBLISH_GITHUB_RELEASE:-true}"
+          GH_RELEASE="${IN_GH_RELEASE:-none}"
+
+          if [[ "$GH_RELEASE" != "none" || "$GH_RELEASE" != "draft" || "$GH_RELEASE" != "auto"  ]]; then
+            echo "::error:: Unknown GitHub release mode: $GH_RELEASE"
+            exit 1
+          fi
+
+          if [[ "$GH_RELEASE" = "none" || "$GH_RELEASE" = "draft" ]]; then
+            GH_RELEASE_TYPE="draft"
+
+          elif [[ "$REF_NAME" == release/* ]] && [ "$CHANNEL" = "ship" ]; then
+            GH_RELEASE_TYPE="release"
+
+          elif [[ "$REF_NAME" == release/* ]] && [ "$CHANNEL" = "beta" ]; then
+            GH_RELEASE_TYPE="prerelease"
+
+          elif [ "$REF_NAME" = "develop" ] && [ "$CHANNEL" = "nightly" ]; then
+            GH_RELEASE_TYPE="prerelease"
+
+          else
+            GH_RELEASE_TYPE="draft"
+          fi
+
+          echo "::notice:: Github release type: $GH_RELEASE_TYPE"
 
           {
-            echo "publish_github_release=$PUBLISH_GITHUB_RELEASE"
             echo "channel=$CHANNEL"
             echo "android=$ANDROID"; echo "fdroid=$FDROID"; echo "linux=$LINUX"
             echo "windows=$WINDOWS"; echo "ios=$IOS"; echo "macos=$MACOS"
             echo "publish_metadata=$PUBLISH_METADATA"
+            echo "gh_release=$GH_RELEASE"
+            echo "gh_release_type=$GH_RELEASE_TYPE"
           } >> "$GITHUB_OUTPUT"
 
       - uses: baptiste0928/cargo-install@v3
@@ -233,8 +256,14 @@ jobs:
         id: check_release
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_RELEASE_TYPE: ${{ needs.resolve.outputs.gh_release_type }}
         run: |
           TAG="${{ needs.resolve.outputs.tag }}"
+          if [ "$GH_RELEASE_TYPE" = "draft" ] ; then
+            echo "::warning:: Skip tag check for draft release"
+            exit 0
+          fi
+
           if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" ; then
             echo "::error:: Release $TAG already exists. Aborting"
             exit 1
@@ -493,21 +522,13 @@ jobs:
   release:
     needs: [resolve, build-outputs]
     if: |
-      !cancelled() && needs.build-outputs.result == 'success' && needs.resolve.outputs.publish_github_release == 'true'
+      !cancelled() && needs.build-outputs.result == 'success' && needs.resolve.outputs.gh_release != 'none'
     uses: ./.github/workflows/release-release-artifacts.yml
     permissions:
       contents: write
     with:
       tag: ${{ needs.resolve.outputs.tag }}
-      github_release_type: |-
-        ${{
-          case(
-            startsWith(github.ref_name, 'release/') && needs.resolve.outputs.channel == 'ship', 'release',
-            startsWith(github.ref_name, 'release/') && needs.resolve.outputs.channel == 'beta', 'prerelease',
-            github.ref_name == 'develop' && needs.resolve.outputs.channel == 'nightly', 'prerelease',
-            'draft'
-          )
-        }}
+      github_release_type: ${{ needs.resolve.outputs.gh_release_type }}
       version: ${{ needs.resolve.outputs.version }}
       android: ${{ needs.resolve.outputs.android == 'true' }}
       fdroid: ${{ needs.resolve.outputs.fdroid == 'true' }}
@@ -524,7 +545,7 @@ jobs:
     needs: [resolve, build-outputs, release]
     # condition is needed because 'release' may be skipped due to dependence on cache actions
     if: |
-      !cancelled() && needs.release.result == 'success' && needs.build-outputs.result == 'success'
+      !cancelled() && needs.release.result == 'success' && needs.build-outputs.result == 'success' && needs.resolve.outputs.gh_release_type != 'draft'
     uses: ./.github/workflows/distribute-release.yml
     permissions:
       contents: read
@@ -541,7 +562,8 @@ jobs:
   zulip:
     needs: [resolve, release, build-outputs, distribute]
     if: |
-      !cancelled() && needs.release.result == 'success' && needs.build-outputs.result == 'success'
+      !cancelled() && needs.release.result == 'success' && needs.build-outputs.result == 'success' &&
+      needs.resolve.outputs.gh_release_type != 'draft'
     uses: ./.github/workflows/zulip-notify-release.yml
     with:
       version: ${{ needs.resolve.outputs.version }}

--- a/.github/workflows/release-all-platforms.yml
+++ b/.github/workflows/release-all-platforms.yml
@@ -173,20 +173,13 @@ jobs:
 
           echo "::notice:: releasing from ref $REF_NAME (event $EVENT)"
 
-          # Channel: scheduled runs are always nightly; a manual dispatch honours the
-          # chosen release_channel (the platform selection no longer overrides it).
-          if [ "$EVENT" = "schedule" ]; then
-            CHANNEL=nightly
-          else
-            CHANNEL="${IN_CHANNEL:-nightly}"
-          fi
+          CHANNEL="${IN_CHANNEL:-nightly}"
 
           # Platform set: a cron run, OR a dispatch with NO platform box ticked, builds
           # EVERY platform for that channel. Any box ticked builds only the ticked ones.
-          if [ "$EVENT" = "schedule" ] \
-            || { [ "$IN_ANDROID" != "true" ] && [ "$IN_FDROID" != "true" ] \
-              && [ "$IN_LINUX" != "true" ] && [ "$IN_WINDOWS" != "true" ] \
-              && [ "$IN_IOS" != "true" ] && [ "$IN_MACOS" != "true" ]; }; then
+          if [ "$IN_ANDROID" != "true" ] && [ "$IN_FDROID" != "true" ] \
+            && [ "$IN_LINUX" != "true" ] && [ "$IN_WINDOWS" != "true" ] \
+            && [ "$IN_IOS" != "true" ] && [ "$IN_MACOS" != "true" ]; then
             ALL=true
           else
             ALL=false

--- a/.github/workflows/release-all-platforms.yml
+++ b/.github/workflows/release-all-platforms.yml
@@ -550,7 +550,7 @@ jobs:
     permissions:
       contents: read
     with:
-      publish_play: ${{ needs.resolve.outputs.android == 'true' }}
+      publish_play: ${{ needs.resolve.outputs.android == 'true' && needs.resolve.outputs.channel == 'ship' }}
       publish_play_metadata: ${{ needs.resolve.outputs.publish_metadata == 'true' }}
       # only publish nightly builds to avoid downgrades
       publish_testflight: ${{ needs.resolve.outputs.ios == 'true' && needs.resolve.outputs.channel == 'nightly' }}

--- a/.github/workflows/release-release-artifacts.yml
+++ b/.github/workflows/release-release-artifacts.yml
@@ -300,177 +300,29 @@ jobs:
           echo "android_apk=${ANDROID_APK}" >> $GITHUB_OUTPUT
 
   prepare-release-notes:
-    runs-on: arc-linux-latest
     needs: [resolve, resolve-artifacts]
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 1
-
-      - name: Extract core changelog
-        id: core-changelog
-        uses: ffurrer2/extract-release-notes@v2
-        with:
-          changelog_file: nym-vpn-core/CHANGELOG.md
-          # for prereleases, extract the changelog from the [unreleased] section
-          prerelease: ${{ inputs.github_release_type != 'release' }}
-
-      - name: Extract android changelog
-        id: android-changelog
-        uses: ffurrer2/extract-release-notes@v2
-        with:
-          changelog_file: nym-vpn-android/CHANGELOG.md
-          # for prereleases, extract the changelog from the [unreleased] section
-          prerelease: ${{ inputs.github_release_type != 'release' }}
-
-      - name: Add release notes (General)
-        env:
-          RELEASE_NOTES: ${{ env.RELEASE_NOTES }}
-          VERSION: ${{ needs.resolve.outputs.version }}
-          CORE_CHANGES: ${{ steps.core-changelog.outputs.release_notes }}
-          ANDROID_CHANGES: ${{ steps.android-changelog.outputs.release_notes }}
-        run: |
-          cat << 'EOF' > "$RELEASE_NOTES"
-          Nym VPN v${{ env.VERSION }} application and core binaries.
-
-          EOF
-
-          if [ -n "$CORE_CHANGES" ]; then
-            # Increase indentation from h3 to h4 to better fit the release notes
-            export UPDATED_CORE_CHANGES=$(sed 's/^### /#### /' <<< "$CORE_CHANGES")
-
-            envsubst '$UPDATED_CORE_CHANGES' << 'EOF' >> "$RELEASE_NOTES"
-          ## 🚀 What's New
-          ### 🛠️ Core Changes
-
-          $UPDATED_CORE_CHANGES
-
-          EOF
-          fi
-
-          if [ -n "$ANDROID_CHANGES" ]; then
-            # Increase indentation from h3 to h4 to better fit the release notes
-            export UPDATED_ANDROID_CHANGES=$(sed 's/^### /#### /' <<< "$ANDROID_CHANGES")
-
-            envsubst '$UPDATED_ANDROID_CHANGES' << 'EOF' >> "$RELEASE_NOTES"
-          ### 🤖 Android Changes
-
-          $UPDATED_ANDROID_CHANGES
-
-          EOF
-          fi
-
-          cat << 'EOF' >> "$RELEASE_NOTES"
-          ## 📦 Core Components Overview
-
-          - `nym-vpnd`: Background daemon service managed via the UI app or CLI.
-          - `nym-vpnc`:  Command-line interface (CLI) to control the daemon (`nym-vpnd`).
-          - `nym-socks5-proxy`: SOCKS5 proxy handling geo-exclusion routing.
-          - `nym-diagnostic`: System information and network troubleshooting tool.
-          - `nym-setup`: macOS helper tool for system service configuration.
-
-          EOF
-
-          cat << 'EOF' >> "$RELEASE_NOTES"
-          ## 💾 Downloads & Assets
-
-          EOF
-
-      - name: Add release notes (Android)
-        if: ${{ needs.resolve.outputs.fdroid == 'true' }}
-        env:
-          RELEASE_NOTES: ${{ env.RELEASE_NOTES }}
-          ANDROID_APK: ${{ needs.resolve-artifacts.outputs.android_apk }}
-        run: |
-          cat << 'EOF' >> "$RELEASE_NOTES"
-          ### 🤖 Android
-
-          - `${{ env.ANDROID_APK }}`: Android App (F-Droid Build)
-
-          <details>
-          <summary>How to verify the build fingerprint?</summary>
-
-          #### Signing Certificate SHA-256 Fingerprint (4096-bit):
-
-          ```text
-          3c98a016aa4f14a3ba185c764ed363415cf7ff3c3d328a87ffff2ff1b140ff06
-          ```
-
-          #### Verification Steps:
-
-          To verify the build fingerprint on your system, run:
-          ```sh
-          apksigner verify --print-certs "${{ env.ANDROID_APK }}" | grep SHA-256
-          ```
-
-          </details>
-
-          EOF
-
-      - name: Add release notes (Linux)
-        if: ${{ needs.resolve.outputs.linux == 'true' }}
-        env:
-          RELEASE_NOTES: ${{ env.RELEASE_NOTES }}
-          VPND_DEB_X86_64: ${{ needs.resolve-artifacts.outputs.vpnd_deb_x86_64 }}
-          VPND_DEB_ARM64: ${{ needs.resolve-artifacts.outputs.vpnd_deb_aarch64 }}
-          VPNC_DEB_X86_64: ${{ needs.resolve-artifacts.outputs.vpnc_deb_x86_64 }}
-          VPNC_DEB_ARM64: ${{ needs.resolve-artifacts.outputs.vpnc_deb_aarch64 }}
-          LINUX_APP_DEB_X64: ${{ needs.resolve-artifacts.outputs.linux_app_deb_x64 }}
-          LINUX_APP_DEB_ARM64: ${{ needs.resolve-artifacts.outputs.linux_app_deb_arm64 }}
-          LINUX_APP_APPIMAGE_X64: ${{ needs.resolve-artifacts.outputs.linux_app_appimage_x64 }}
-          LINUX_APP_APPIMAGE_ARM64: ${{ needs.resolve-artifacts.outputs.linux_app_appimage_arm64 }}
-        run: |
-          cat << 'EOF' >> "$RELEASE_NOTES"
-          ### 🐧 Linux
-
-          - **Desktop App**
-            - `${{ env.LINUX_APP_DEB_X64 }}`: Nym VPN app, debian package (x86_64)
-            - `${{ env.LINUX_APP_DEB_ARM64 }}`: Nym VPN app, debian package (arm64)
-            - `${{ env.LINUX_APP_APPIMAGE_X64 }}`: Nym VPN app, AppImage (x86_64)
-            - `${{ env.LINUX_APP_APPIMAGE_ARM64 }}`: Nym VPN app, AppImage (arm64)
-          - **CLI & Daemon**
-            - `${{ env.VPND_DEB_X86_64 }}`: Nym VPN daemon, debian package (x86_64)
-            - `${{ env.VPND_DEB_ARM64 }}`: Nym VPN daemon, debian package (arm64)
-            - `${{ env.VPNC_DEB_X86_64 }}`: Nym VPN command-line tool, debian package (x86_64)
-            - `${{ env.VPNC_DEB_ARM64 }}`: Nym VPN command-line tool, debian package (arm64)
-
-          EOF
-
-      - name: Add release notes (macOS)
-        if: ${{ needs.resolve.outputs.macos == 'true' }}
-        env:
-          RELEASE_NOTES: ${{ env.RELEASE_NOTES }}
-          MACOS_INSTALLER_NAME: ${{ needs.resolve-artifacts.outputs.macos_installer_name }}
-          VPNC_MACOS_INSTALLER_NAME: ${{ needs.resolve-artifacts.outputs.vpnc_macos_installer_name }}
-        run: |
-          cat << 'EOF' >> "$RELEASE_NOTES"
-          ### 🍎 macOS
-
-          - `${{ env.MACOS_INSTALLER_NAME }}`: Desktop App Installer
-          - `${{ env.VPNC_MACOS_INSTALLER_NAME }}`: Command-Line Tool Installer
-
-          EOF
-
-      - name: Add release notes (Windows)
-        if: ${{ needs.resolve.outputs.windows == 'true' }}
-        env:
-          RELEASE_NOTES: ${{ env.RELEASE_NOTES }}
-          WINDOWS_APP_INSTALLER_X64: ${{ needs.resolve-artifacts.outputs.windows_app_installer_x64 }}
-          WINDOWS_APP_INSTALLER_ARM64: ${{ needs.resolve-artifacts.outputs.windows_app_installer_arm64 }}
-        run: |
-          cat << 'EOF' >> "$RELEASE_NOTES"
-          ### 🪟 Windows
-
-          - `${{ env.WINDOWS_APP_INSTALLER_X64 }}`: Desktop App Installer (x64)
-          - `${{ env.WINDOWS_APP_INSTALLER_ARM64 }}`: Desktop App Installer (arm64)
-
-          EOF
-
-      - name: Upload release notes
-        uses: actions/upload-artifact@v7
-        with:
-          name: ${{ env.RELEASE_NOTES_ARTIFACT }}
-          path: ${{ env.RELEASE_NOTES }}
+    uses: ./.github/workflows/prepare-release-notes.yml
+    with:
+      github_release_type: ${{ needs.resolve.outputs.github_release_type }}
+      version: ${{ needs.resolve.outputs.version }}
+      fdroid: ${{ needs.resolve.outputs.fdroid == 'true' }}
+      linux: ${{ needs.resolve.outputs.linux == 'true' }}
+      windows: ${{ needs.resolve.outputs.windows == 'true' }}
+      macos: ${{ needs.resolve.outputs.macos == 'true' }}
+      ios: ${{ needs.resolve.outputs.ios == 'true' }}
+      android_apk: ${{ needs.resolve-artifacts.outputs.android_apk }}
+      vpnd_deb_x86_64: ${{ needs.resolve-artifacts.outputs.vpnd_deb_x86_64 }}
+      vpnd_deb_aarch64: ${{ needs.resolve-artifacts.outputs.vpnd_deb_aarch64 }}
+      vpnc_deb_x86_64: ${{ needs.resolve-artifacts.outputs.vpnc_deb_x86_64 }}
+      vpnc_deb_aarch64: ${{ needs.resolve-artifacts.outputs.vpnc_deb_aarch64 }}
+      linux_app_deb_x64: ${{ needs.resolve-artifacts.outputs.linux_app_deb_x64 }}
+      linux_app_deb_aarch64: ${{ needs.resolve-artifacts.outputs.linux_app_deb_arm64 }}
+      linux_app_appimage_x64: ${{ needs.resolve-artifacts.outputs.linux_app_appimage_x64 }}
+      linux_app_appimage_aarch64: ${{ needs.resolve-artifacts.outputs.linux_app_appimage_arm64 }}
+      macos_installer_name: ${{ needs.resolve-artifacts.outputs.macos_installer_name }}
+      vpnc_macos_installer_name: ${{ needs.resolve-artifacts.outputs.vpnc_macos_installer_name }}
+      windows_app_installer_x64: ${{ needs.resolve-artifacts.outputs.windows_app_installer_x64 }}
+      windows_app_installer_arm64: ${{ needs.resolve-artifacts.outputs.windows_app_installer_arm64 }}
 
   create-release:
     runs-on: arc-linux-latest
@@ -712,7 +564,7 @@ jobs:
           RELEASE_TYPE: ${{ needs.resolve.outputs.github_release_type }}
           TAG_NAME: ${{ needs.resolve.outputs.tag }}
           VERSION_NAME: "v${{ needs.resolve.outputs.version }}"
-          RELEASE_NOTES: ${{ github.workspace }}/${{ env.RELEASE_NOTES_ARTIFACT }}/${{ env.RELEASE_NOTES }}
+          RELEASE_NOTES: ${{ github.workspace }}/${{ needs.prepare-release-notes.outputs.release_notes_artifact }}/${{ needs.prepare-release-notes.outputs.release_notes_file }}
           ASSETS_FILE: "${{ github.workspace }}/${{ env.RELEASE_ASSETS }}"
         run: |
           set -euo pipefail

--- a/.github/workflows/release-release-artifacts.yml
+++ b/.github/workflows/release-release-artifacts.yml
@@ -316,9 +316,9 @@ jobs:
       vpnc_deb_x86_64: ${{ needs.resolve-artifacts.outputs.vpnc_deb_x86_64 }}
       vpnc_deb_aarch64: ${{ needs.resolve-artifacts.outputs.vpnc_deb_aarch64 }}
       linux_app_deb_x64: ${{ needs.resolve-artifacts.outputs.linux_app_deb_x64 }}
-      linux_app_deb_aarch64: ${{ needs.resolve-artifacts.outputs.linux_app_deb_arm64 }}
+      linux_app_deb_arm64: ${{ needs.resolve-artifacts.outputs.linux_app_deb_arm64 }}
       linux_app_appimage_x64: ${{ needs.resolve-artifacts.outputs.linux_app_appimage_x64 }}
-      linux_app_appimage_aarch64: ${{ needs.resolve-artifacts.outputs.linux_app_appimage_arm64 }}
+      linux_app_appimage_arm64: ${{ needs.resolve-artifacts.outputs.linux_app_appimage_arm64 }}
       macos_installer_name: ${{ needs.resolve-artifacts.outputs.macos_installer_name }}
       vpnc_macos_installer_name: ${{ needs.resolve-artifacts.outputs.vpnc_macos_installer_name }}
       windows_app_installer_x64: ${{ needs.resolve-artifacts.outputs.windows_app_installer_x64 }}

--- a/.github/workflows/release-release-artifacts.yml
+++ b/.github/workflows/release-release-artifacts.yml
@@ -105,7 +105,7 @@ jobs:
       github_release_type: ${{ steps.resolve.outputs.github_release_type }}
       version: ${{ steps.resolve.outputs.version }}
       channel: ${{ steps.resolve.outputs.channel }}
-      android: ${{ steps.resolve.outputs.android }} # unused
+      android: ${{ steps.resolve.outputs.android }}
       fdroid: ${{ steps.resolve.outputs.fdroid }}
       linux: ${{ steps.resolve.outputs.linux }}
       windows: ${{ steps.resolve.outputs.windows }}
@@ -305,6 +305,7 @@ jobs:
     with:
       github_release_type: ${{ needs.resolve.outputs.github_release_type }}
       version: ${{ needs.resolve.outputs.version }}
+      android: ${{ needs.resolve.outputs.android == 'true' }}
       fdroid: ${{ needs.resolve.outputs.fdroid == 'true' }}
       linux: ${{ needs.resolve.outputs.linux == 'true' }}
       windows: ${{ needs.resolve.outputs.windows == 'true' }}


### PR DESCRIPTION


## Description

- Nightly builds off `develop` branch should be automatically promoted to prerelease
- Only publish Google Play (aab) when shipping release
- Move release notes generator into separate workflow. Make it testable via pull-request event
- Introduce additional "github release" selector that can be used to test builds and/or create a draft release but without sending anything on Zulip or uploading to app stores
- Fix missing checkout action in the nightly workflow
- Fix fdroid builds from being skipped when all platform flags are unchecked
- Add brotli on macos CIs, which is used by `UpdatePrebundledServers.sh`
- Fix sentry-cli installation issues
- Remove use of `cargo install ..` in favor of gh action to avoid erroring when the crate is already installed

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5927)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Management**
  * Release channel calculation now consistently follows the selected input (defaulting to Nightly when not specified).
  * Scheduled runs no longer auto-trigger an “all platforms” build; platform selection only falls back to all when no platforms are chosen.
  * Release classification was refined: `release/*` on beta is marked as a prerelease, and nightly handling is now determined separately.
* **CI / Build Automation**
  * Version bump workflows now fetch Rust dependencies using non-offline mode.
* **Release Notes Automation**
  * Release-notes generation and GitHub Release wiring were updated to include the correct platform-specific installers/packages and to use the prepared release-notes artifact output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->