### PR TITLE
APPLE: fix tests and favorites on macOS

### DIFF
--- a/nym-vpn-apple/Services/Package.swift
+++ b/nym-vpn-apple/Services/Package.swift
@@ -182,7 +182,12 @@ let package = Package(
                 .product(name: "GRPCManager", package: "ServicesMacOS", condition: .when(platforms: [.macOS]))
             ],
             path: "Sources/Services/GatewayManager",
-            swiftSettings: santaSwiftSettings
+            swiftSettings: santaSwiftSettings,
+            linkerSettings: [
+                // NymVPNRpcUniffi static lib references SystemConfiguration/Network symbols
+                .linkedFramework("SystemConfiguration", .when(platforms: [.macOS])),
+                .linkedFramework("Network", .when(platforms: [.macOS]))
+            ]
         ),
         .target(
             name: "ImpactGenerator",

--- a/nym-vpn-apple/Services/Sources/Services/GatewayManager/GatewayWorker+Favorites.swift
+++ b/nym-vpn-apple/Services/Sources/Services/GatewayManager/GatewayWorker+Favorites.swift
@@ -40,8 +40,8 @@ extension GatewayWorker {
     /// Data dir is the group data folder, matching `nym-vpnc`'s `app_data_dir()` — favorites
     /// are not network-scoped.
     private func controller() async throws -> FavoritesController {
-        let dataDir = try PathManager.dataFolderURL().path()
-        return await FavoritesController(dataDir: dataDir)
+        let dataDir = try PathManager.dataFolderURL().path(percentEncoded: false)
+        return await FavoritesController.open(dataDir: dataDir)
     }
 }
 

--- a/nym-vpn-apple/ServicesMacOS/Package.swift
+++ b/nym-vpn-apple/ServicesMacOS/Package.swift
@@ -41,7 +41,12 @@ let package = Package(
                 .product(name: "NymLogger", package: "ServicesMutual"),
                 .product(name: "TunnelStatus", package: "ServicesMutual")
             ],
-            path: "Sources/GRPCManager"
+            path: "Sources/GRPCManager",
+            linkerSettings: [
+                // NymVPNRpcUniffi static lib references SystemConfiguration/Network symbols
+                .linkedFramework("SystemConfiguration"),
+                .linkedFramework("Network")
+            ]
         ),
         .testTarget(
             name: "AppDiscoveryServiceTests",

--- a/nym-vpn-apple/ServicesMutual/Package.swift
+++ b/nym-vpn-apple/ServicesMutual/Package.swift
@@ -50,7 +50,12 @@ let package = Package(
                 "Theme"
             ],
             path: "Sources/ConnectionTypes",
-            swiftSettings: santaSwiftSettings
+            swiftSettings: santaSwiftSettings,
+            linkerSettings: [
+                // NymVPNRpcUniffi static lib references SystemConfiguration/Network symbols
+                .linkedFramework("SystemConfiguration", .when(platforms: [.macOS])),
+                .linkedFramework("Network", .when(platforms: [.macOS]))
+            ]
         ),
         .target(
             name: "Constants",

--- a/nym-vpn-apple/ServicesMutual/Tests/ConnectionTypesTests/WorkflowReportTests.swift
+++ b/nym-vpn-apple/ServicesMutual/Tests/ConnectionTypesTests/WorkflowReportTests.swift
@@ -25,7 +25,7 @@ import Testing
 /// `AccountReportTests.viewButtonTitleKeys`; Foundation ships no YAML parser and the
 /// assertions don't need full structure.)
 struct WorkflowReportTests {
-    private static let workflowRelativePath = ".github/workflows/build-nym-vpn-apple.yml"
+    private static let workflowRelativePath = ".github/workflows/ci-nym-vpn-app-macos.yml"
     private static let actionRelativePath = ".github/workflows/apple/tests/action.yml"
     /// The composite action's input the workflow passes the report path through.
     private static let reportInputKey = "account-report-path"

--- a/nym-vpn-core/crates/nym-vpn-rpc-uniffi/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-rpc-uniffi/src/lib.rs
@@ -531,7 +531,7 @@ pub struct FavoritesController {
 #[uniffi::export(async_runtime = "tokio")]
 impl FavoritesController {
     #[uniffi::constructor]
-    pub async fn new(data_dir: PathBuf) -> Self {
+    pub async fn open(data_dir: PathBuf) -> Self {
         Self {
             manager: Arc::new(RwLock::new(FavoritesManager::new(data_dir).await)),
         }


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5929)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS networking support by explicitly linking required system frameworks for VPN/connection components.
  * Fixed favorites persistence by using the correct data-directory path and initializing favorites storage more consistently.

* **Tests**
  * Updated workflow YAML path used by workflow report tests.

* **Chores**
  * Applied consistent macOS framework-linking settings across relevant service targets to improve build reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->