### PR TITLE
VPN-4903: Add support for Russia in Geo-Exclusion.

### DIFF
--- a/nym-vpn-app/src/i18n/en/settings.json
+++ b/nym-vpn-app/src/i18n/en/settings.json
@@ -344,7 +344,7 @@
     "beta": "Beta",
     "enable": "Enable Geo Exclusion",
     "description": "Routes traffic for selected regions outside the VPN tunnel, so domestic apps work at full speed. Everything else stays protected.",
-    "beta-note": "Beta version: China only for now. More regions coming.",
+    "beta-note": "Beta version: China and Russia only for now. More regions coming.",
     "warning": "Traffic to excluded regions bypasses the VPN.",
     "port": {
       "socks5-port": "SOCKS5 port",
@@ -354,7 +354,11 @@
     },
     "excluded-regions": {
       "title": "Excluded regions",
-      "add-region": "Add region"
+      "select-region": "Select region"
+    },
+    "select-region": {
+      "title": "Select region",
+      "beta-note": "Beta version: only one region can be excluded at a time."
     },
     "setup-instructions": {
       "title": "Setup instructions",
@@ -428,7 +432,8 @@
     },
     "errors": {
       "failed-to-start": "Geo Exclusion couldn't start. Reconnect and try again.",
-      "failed-to-set-port": "Couldn't update the SOCKS5 port. Please try again."
+      "failed-to-set-port": "Couldn't update the SOCKS5 port. Please try again.",
+      "failed-to-set-region": "Couldn't update the excluded region. Please try again."
     }
   }
 }

--- a/nym-vpn-app/src/router.tsx
+++ b/nym-vpn-app/src/router.tsx
@@ -12,6 +12,7 @@ import {
   Display,
   Error,
   GeoExclusion,
+  GeoExclusionSelectRegion,
   GeoExclusionSetup,
   Lang,
   Legal,
@@ -55,6 +56,7 @@ export const routes = {
   splitTunneling: '/settings/split-tunneling',
   geoExclusion: '/settings/geo-exclusion',
   geoExclusionSetup: '/settings/geo-exclusion/setup-instructions',
+  geoExclusionSelectRegion: '/settings/geo-exclusion/select-region',
   notifications: '/settings/notifications',
   support: '/settings/support',
   legal: '/settings/legal',
@@ -198,6 +200,11 @@ const router = createBrowserRouter([
           {
             path: routes.geoExclusionSetup,
             Component: GeoExclusionSetup,
+            errorElement: <Error />,
+          },
+          {
+            path: routes.geoExclusionSelectRegion,
+            Component: GeoExclusionSelectRegion,
             errorElement: <Error />,
           },
           {

--- a/nym-vpn-app/src/screens/settings/geo-exclusion/SelectRegion.tsx
+++ b/nym-vpn-app/src/screens/settings/geo-exclusion/SelectRegion.tsx
@@ -30,8 +30,10 @@ function SelectRegion() {
   }, [getCountryName]);
 
   const handleChange = async (region: SupportedExcludedRegion) => {
-    await setExcludedCountry(region);
-    navigate(-1);
+    const success = await setExcludedCountry(region);
+    if (success) {
+      navigate(-1);
+    }
   };
 
   return (

--- a/nym-vpn-app/src/screens/settings/geo-exclusion/SelectRegion.tsx
+++ b/nym-vpn-app/src/screens/settings/geo-exclusion/SelectRegion.tsx
@@ -1,0 +1,55 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router';
+import {
+  FlagIcon,
+  PageAnim,
+  RadioGroup,
+  RadioGroupOption,
+  countryCode,
+} from '../../../ui';
+import { useLang } from '../../../hooks';
+import { useGeoExclusion } from './utils/useGeoExclusion';
+import {
+  SupportedExcludedRegion,
+  SupportedExcludedRegions,
+} from './utils/regions';
+
+function SelectRegion() {
+  const { t } = useTranslation('settings');
+  const navigate = useNavigate();
+  const { getCountryName } = useLang();
+  const { excludedCountries, setExcludedCountry } = useGeoExclusion();
+
+  const options = useMemo<RadioGroupOption<SupportedExcludedRegion>[]>(() => {
+    return SupportedExcludedRegions.map((code) => ({
+      key: code,
+      label: getCountryName(code) ?? code,
+      icon: <FlagIcon code={code.toLowerCase() as countryCode} alt={code} />,
+    }));
+  }, [getCountryName]);
+
+  const handleChange = async (region: SupportedExcludedRegion) => {
+    await setExcludedCountry(region);
+    navigate(-1);
+  };
+
+  return (
+    <PageAnim
+      className="flex h-full flex-col gap-6 py-6"
+      data-testid="geo-exclusion-select-region-page"
+    >
+      <RadioGroup
+        defaultValue={excludedCountries[0] as SupportedExcludedRegion}
+        options={options}
+        onChange={handleChange}
+        data-testid="geo-exclusion-region-radio-group"
+      />
+      <p className="text-text-tertiary px-1 text-xs">
+        {t('geo-exclusion.select-region.beta-note')}
+      </p>
+    </PageAnim>
+  );
+}
+
+export default SelectRegion;

--- a/nym-vpn-app/src/screens/settings/geo-exclusion/components/ExcludedRegions.tsx
+++ b/nym-vpn-app/src/screens/settings/geo-exclusion/components/ExcludedRegions.tsx
@@ -1,8 +1,16 @@
 import { Fragment } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@base-ui/react';
-import { CardDivider, CardNew, MsIcon } from '../../../../ui';
+import { useNavigate } from 'react-router';
+import {
+  CardDivider,
+  CardNew,
+  FlagIcon,
+  MsIcon,
+  countryCode,
+} from '../../../../ui';
 import { useLang } from '../../../../hooks';
+import { routes } from '../../../../router';
 
 type ExcludedRegionsProps = {
   countries: string[];
@@ -10,6 +18,7 @@ type ExcludedRegionsProps = {
 
 function ExcludedRegions({ countries }: ExcludedRegionsProps) {
   const { t } = useTranslation('settings');
+  const navigate = useNavigate();
   const { getCountryName } = useLang();
 
   return (
@@ -21,7 +30,8 @@ function ExcludedRegions({ countries }: ExcludedRegionsProps) {
         {countries.map((code, index) => (
           <Fragment key={code}>
             {index > 0 && <CardDivider />}
-            <div className="flex min-h-16 items-center px-4 py-3">
+            <div className="flex min-h-16 items-center gap-3 px-4 py-3">
+              <FlagIcon code={code.toLowerCase() as countryCode} alt={code} />
               <p className="text-text-primary">
                 {getCountryName(code) ?? code}
               </p>
@@ -29,14 +39,13 @@ function ExcludedRegions({ countries }: ExcludedRegionsProps) {
           </Fragment>
         ))}
         <CardDivider />
-        {/* "Add region" is intentionally disabled for the MVP (China only). */}
         <Button
-          disabled
-          className="flex min-h-12 w-full items-center gap-2 px-4 py-3 text-left opacity-50"
+          onClick={() => navigate(routes.geoExclusionSelectRegion)}
+          className="flex min-h-12 w-full items-center gap-2 px-4 py-3 text-left"
         >
-          <MsIcon icon="add" className="text-text-secondary" />
+          <MsIcon icon="edit" className="text-text-secondary" />
           <span className="text-text-secondary">
-            {t('geo-exclusion.excluded-regions.add-region')}
+            {t('geo-exclusion.excluded-regions.select-region')}
           </span>
         </Button>
       </CardNew>

--- a/nym-vpn-app/src/screens/settings/geo-exclusion/index.ts
+++ b/nym-vpn-app/src/screens/settings/geo-exclusion/index.ts
@@ -1,2 +1,3 @@
 export { default as GeoExclusion } from './GeoExclusion';
 export { default as GeoExclusionSetup } from './SetupInstructions';
+export { default as GeoExclusionSelectRegion } from './SelectRegion';

--- a/nym-vpn-app/src/screens/settings/geo-exclusion/utils/regions.ts
+++ b/nym-vpn-app/src/screens/settings/geo-exclusion/utils/regions.ts
@@ -1,0 +1,5 @@
+// TODO: fetch the supported excluded regions from the daemon via gRPC instead
+// of hardcoding them here.
+export const SupportedExcludedRegions = ['CN', 'RU'] as const;
+
+export type SupportedExcludedRegion = (typeof SupportedExcludedRegions)[number];

--- a/nym-vpn-app/src/screens/settings/geo-exclusion/utils/useGeoExclusion.ts
+++ b/nym-vpn-app/src/screens/settings/geo-exclusion/utils/useGeoExclusion.ts
@@ -37,5 +37,26 @@ export const useGeoExclusion = () => {
     }
   };
 
-  return { enabled, listenPort, excludedCountries, setEnabled, setPort };
+  const setExcludedCountry = async (country: string) => {
+    try {
+      const countries = [country];
+      await invoke('set_geo_exclusion_excluded_countries', { countries });
+      dispatch({ type: 'set-geo-exclusion-excluded-countries', countries });
+    } catch (error) {
+      console.error('Failed to set geo exclusion excluded countries', error);
+      addToast({
+        title: t('geo-exclusion.errors.failed-to-set-region'),
+        type: 'error',
+      });
+    }
+  };
+
+  return {
+    enabled,
+    listenPort,
+    excludedCountries,
+    setEnabled,
+    setPort,
+    setExcludedCountry,
+  };
 };

--- a/nym-vpn-app/src/screens/settings/geo-exclusion/utils/useGeoExclusion.ts
+++ b/nym-vpn-app/src/screens/settings/geo-exclusion/utils/useGeoExclusion.ts
@@ -42,12 +42,14 @@ export const useGeoExclusion = () => {
       const countries = [country];
       await invoke('set_geo_exclusion_excluded_countries', { countries });
       dispatch({ type: 'set-geo-exclusion-excluded-countries', countries });
+      return true;
     } catch (error) {
       console.error('Failed to set geo exclusion excluded countries', error);
       addToast({
         title: t('geo-exclusion.errors.failed-to-set-region'),
         type: 'error',
       });
+      return false;
     }
   };
 

--- a/nym-vpn-app/src/ui/FlagIcon.tsx
+++ b/nym-vpn-app/src/ui/FlagIcon.tsx
@@ -290,7 +290,7 @@ function FlagIcon({ code, alt, className, ...rest }: FlagIconProps) {
       data-testid={`${testId}-container`}
     >
       <img
-        src={`./flags/${code}.svg`}
+        src={`/flags/${code}.svg`}
         className={clsx([
           'pointer-events-none h-6 fill-current',
           className && className,

--- a/nym-vpn-app/src/ui/TopBar.tsx
+++ b/nym-vpn-app/src/ui/TopBar.tsx
@@ -58,6 +58,14 @@ export default function TopBar() {
   });
 
   const navBarData = useMemo<NavBarData>(() => {
+    const backNav = (title: NavLocation['title']): NavLocation => ({
+      title,
+      leftIcon: 'keyboard_arrow_left',
+      handleLeftNav: () => {
+        navigate(-1);
+      },
+    });
+
     return {
       '/technical-optin': {
         leftIcon: uiTheme === 'dark' ? 'dark_mode' : 'light_mode',
@@ -198,13 +206,9 @@ export default function TopBar() {
           navigate(-1);
         },
       },
-      '/settings/geo-exclusion/select-region': {
-        title: t('geo-exclusion.select-region.title', { ns: 'settings' }),
-        leftIcon: 'keyboard_arrow_left',
-        handleLeftNav: () => {
-          navigate(-1);
-        },
-      },
+      '/settings/geo-exclusion/select-region': backNav(
+        t('geo-exclusion.select-region.title', { ns: 'settings' }),
+      ),
       '/settings/anti-censorship': {
         title: t('anti-censorship.title', { ns: 'settings' }),
         leftIcon: 'keyboard_arrow_left',

--- a/nym-vpn-app/src/ui/TopBar.tsx
+++ b/nym-vpn-app/src/ui/TopBar.tsx
@@ -198,6 +198,13 @@ export default function TopBar() {
           navigate(-1);
         },
       },
+      '/settings/geo-exclusion/select-region': {
+        title: t('geo-exclusion.select-region.title', { ns: 'settings' }),
+        leftIcon: 'keyboard_arrow_left',
+        handleLeftNav: () => {
+          navigate(-1);
+        },
+      },
       '/settings/anti-censorship': {
         title: t('anti-censorship.title', { ns: 'settings' }),
         leftIcon: 'keyboard_arrow_left',

--- a/nym-vpn-core/crates/nym-socks5-proxy-ipc/src/lib.rs
+++ b/nym-vpn-core/crates/nym-socks5-proxy-ipc/src/lib.rs
@@ -14,6 +14,7 @@ use std::{
 pub enum DaemonMessage {
     Configure(ProxyConfig),
     SetTunnelAddresses(InterfaceAddresses),
+    SetExcludedCountries(Vec<String>),
     Terminate,
 }
 
@@ -61,24 +62,28 @@ impl ProxyConfig {
             return Err("log_level cannot be empty".into());
         }
 
-        for country in &self.excluded_countries {
-            if country.len() != 2 || !country.chars().all(|c| c.is_ascii_uppercase()) {
-                return Err(format!(
-                    "Invalid excluded country code '{}': must be a 2-letter uppercase string",
-                    country
-                ));
-            }
-        }
-
-        let mut seen = std::collections::HashSet::new();
-        for country in &self.excluded_countries {
-            if !seen.insert(country) {
-                return Err(format!("Duplicate excluded country code: '{}'", country));
-            }
-        }
-
-        Ok(())
+        validate_country_codes(&self.excluded_countries)
     }
+}
+
+pub fn validate_country_codes(countries: &[String]) -> Result<(), String> {
+    for country in countries {
+        if country.len() != 2 || !country.chars().all(|c| c.is_ascii_uppercase()) {
+            return Err(format!(
+                "Invalid excluded country code '{}': must be a 2-letter uppercase string",
+                country
+            ));
+        }
+    }
+
+    let mut seen = std::collections::HashSet::new();
+    for country in countries {
+        if !seen.insert(country) {
+            return Err(format!("Duplicate excluded country code: '{}'", country));
+        }
+    }
+
+    Ok(())
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/nym-vpn-core/crates/nym-socks5-proxy/src/file_manager.rs
+++ b/nym-vpn-core/crates/nym-socks5-proxy/src/file_manager.rs
@@ -58,7 +58,10 @@ pub(crate) fn selected_sources<'a>(
 
 /// Seed builtin files and their ETag sidecars into `data_dir` if not already present, for the
 /// given selected countries only.
-pub(crate) async fn init_files(data_dir: &Path, excluded_countries: &[String]) -> anyhow::Result<()> {
+pub(crate) async fn init_files(
+    data_dir: &Path,
+    excluded_countries: &[String],
+) -> anyhow::Result<()> {
     fs::create_dir_all(data_dir)
         .await
         .with_context(|| format!("Failed to create directory '{}'", data_dir.display()))?;

--- a/nym-vpn-core/crates/nym-socks5-proxy/src/file_manager.rs
+++ b/nym-vpn-core/crates/nym-socks5-proxy/src/file_manager.rs
@@ -7,6 +7,7 @@ use anyhow::Context;
 use tokio::fs::{self, try_exists};
 
 pub(crate) struct Source {
+    pub country: &'static str,
     pub file_name: &'static str,
     pub builtin: &'static [u8],
     pub builtin_etag: &'static str,
@@ -15,24 +16,28 @@ pub(crate) struct Source {
 
 pub(crate) static SOURCES: &[Source] = &[
     Source {
+        country: "CN",
         file_name: "CN-ip.json.gz",
         builtin: include_bytes!("../builtin/CN-ip.json.gz"),
         builtin_etag: include_str!("../builtin/CN-ip.json.etag"),
         url: "https://geo-exclusion.sos-ch-gva-2.exoscale-cdn.com/CN-ip.json.gz",
     },
     Source {
+        country: "CN",
         file_name: "CN-domain.txt.gz",
         builtin: include_bytes!("../builtin/CN-domain.txt.gz"),
         builtin_etag: include_str!("../builtin/CN-domain.txt.etag"),
         url: "https://geo-exclusion.sos-ch-gva-2.exoscale-cdn.com/CN-domain.txt.gz",
     },
     Source {
+        country: "RU",
         file_name: "RU-ip.json.gz",
         builtin: include_bytes!("../builtin/RU-ip.json.gz"),
         builtin_etag: include_str!("../builtin/RU-ip.json.etag"),
         url: "https://geo-exclusion.sos-ch-gva-2.exoscale-cdn.com/RU-ip.json.gz",
     },
     Source {
+        country: "RU",
         file_name: "RU-domain.txt.gz",
         builtin: include_bytes!("../builtin/RU-domain.txt.gz"),
         builtin_etag: include_str!("../builtin/RU-domain.txt.etag"),
@@ -40,13 +45,25 @@ pub(crate) static SOURCES: &[Source] = &[
     },
 ];
 
-/// Seed builtin files and their ETag sidecars into `data_dir` if not already present.
-pub(crate) async fn init_files(data_dir: &Path) -> anyhow::Result<()> {
+/// Returns the sources for countries the user has actually selected for geo-exclusion.
+pub(crate) fn selected_sources<'a>(
+    excluded_countries: &'a [String],
+) -> impl Iterator<Item = &'static Source> + 'a {
+    SOURCES.iter().filter(move |source| {
+        excluded_countries
+            .iter()
+            .any(|code| code.eq_ignore_ascii_case(source.country))
+    })
+}
+
+/// Seed builtin files and their ETag sidecars into `data_dir` if not already present, for the
+/// given selected countries only.
+pub(crate) async fn init_files(data_dir: &Path, excluded_countries: &[String]) -> anyhow::Result<()> {
     fs::create_dir_all(data_dir)
         .await
         .with_context(|| format!("Failed to create directory '{}'", data_dir.display()))?;
 
-    for source in SOURCES.iter() {
+    for source in selected_sources(excluded_countries) {
         let dest = data_dir.join(source.file_name);
         if !try_exists(&dest).await.unwrap_or(false) {
             fs::write(&dest, source.builtin)

--- a/nym-vpn-core/crates/nym-socks5-proxy/src/main.rs
+++ b/nym-vpn-core/crates/nym-socks5-proxy/src/main.rs
@@ -13,7 +13,7 @@ use std::{
 
 use anyhow::{Context, Result, bail};
 use nym_socks5_proxy_ipc::{
-    DaemonMessage, ErrorData, InterfaceAddresses, ProxyConfig, ProxyMessage,
+    DaemonMessage, ErrorData, InterfaceAddresses, ProxyConfig, ProxyMessage, validate_country_codes,
 };
 use tokio::{
     io::{AsyncBufReadExt, BufReader, stdin},
@@ -51,6 +51,10 @@ async fn main() -> Result<()> {
     // Shared VPN tunnel addressese
     let (tunnel_addrs_tx, tunnel_addrs_rx) = watch::channel(InterfaceAddresses::default());
 
+    // Shared geo-exclusion excluded countries list, updatable at runtime without a restart.
+    let (excluded_countries_tx, excluded_countries_rx) =
+        watch::channel(config.excluded_countries.clone());
+
     if let Err(err) = init_tracing(&config.log_dir, &config.log_level) {
         send_error_message(&format!("{err:#}"));
         return Err(err);
@@ -74,6 +78,7 @@ async fn main() -> Result<()> {
         config,
         default_interface_rx,
         tunnel_addrs_rx,
+        excluded_countries_rx,
         shutdown_token.clone(),
         file_updater_handle,
         #[cfg(target_os = "android")]
@@ -97,7 +102,7 @@ async fn main() -> Result<()> {
             result = lines.next_line() => {
                 match result {
                     Ok(Some(line)) if !line.trim().is_empty() => {
-                        handle_daemon_message(&line, &tunnel_addrs_tx, &shutdown_token);
+                        handle_daemon_message(&line, &tunnel_addrs_tx, &excluded_countries_tx, &shutdown_token);
                     }
                     Ok(Some(_)) => {} // blank line — ignore
                     Ok(None) => {
@@ -154,6 +159,7 @@ async fn read_initial_config(
 fn handle_daemon_message(
     line: &str,
     tunnel_addrs_tx: &watch::Sender<InterfaceAddresses>,
+    excluded_countries_tx: &watch::Sender<Vec<String>>,
     shutdown_token: &CancellationToken,
 ) {
     match line.parse::<DaemonMessage>() {
@@ -164,6 +170,16 @@ fn handle_daemon_message(
         Ok(DaemonMessage::SetTunnelAddresses(tunnel_addrs)) => {
             tracing::info!("VPN tunnel addresses changed: {tunnel_addrs:?}");
             let _ = tunnel_addrs_tx.send(tunnel_addrs);
+            send_message(&ProxyMessage::Ack);
+        }
+        Ok(DaemonMessage::SetExcludedCountries(countries)) => {
+            if let Err(err) = validate_country_codes(&countries) {
+                tracing::warn!("Rejected SetExcludedCountries: {err}");
+                send_error_message(&format!("Invalid excluded countries: {err}"));
+                return;
+            }
+            tracing::info!("Geo-exclusion excluded countries changed: {countries:?}");
+            let _ = excluded_countries_tx.send(countries);
             send_message(&ProxyMessage::Ack);
         }
         Ok(DaemonMessage::Terminate) => {

--- a/nym-vpn-core/crates/nym-socks5-proxy/src/proxy.rs
+++ b/nym-vpn-core/crates/nym-socks5-proxy/src/proxy.rs
@@ -45,6 +45,7 @@ pub async fn run(
     config: ProxyConfig,
     default_interface_rx: watch::Receiver<DefaultInterface>,
     tunnel_addrs_rx: watch::Receiver<InterfaceAddresses>,
+    excluded_countries_rx: watch::Receiver<Vec<String>>,
     shutdown_token: CancellationToken,
     file_updater_handle: FileUpdaterHandle,
     #[cfg(target_os = "android")] socket_protector: crate::SocketProtector,
@@ -63,41 +64,17 @@ pub async fn run(
 
     // Register each selected country's source file with the updater for periodic refresh.
     let excluded_countries = config.excluded_countries.clone();
-    let mut receivers: Vec<mpsc::UnboundedReceiver<Result<UpdateOutcome, FileUpdaterError>>> =
-        Vec::new();
-
-    for source in file_manager::selected_sources(&excluded_countries) {
-        let url = source
-            .url
-            .parse::<Url>()
-            .with_context(|| format!("Invalid SOCKS5 source URL: {}", source.url))?;
-        let dest = config.data_dir.join(source.file_name);
-        match file_updater_handle
-            .register(
-                url,
-                dest,
-                SOCKS5_INITIAL_UPDATE_DELAY,
-                SOCKS5_UPDATE_INTERVAL,
-            )
-            .await
-        {
-            Ok(rx) => receivers.push(rx),
-            Err(err) => {
-                tracing::error!(
-                    "Failed to register SOCKS5 source {} with updater: {err}",
-                    source.file_name
-                );
-            }
-        }
-    }
+    let receivers =
+        register_country_sources(&config.data_dir, &excluded_countries, &file_updater_handle).await;
 
     // Load the initial routing database.
-    let db = RoutingDatabase::load(&config.excluded_countries, &config.data_dir)
+    let db = RoutingDatabase::load(&excluded_countries, &config.data_dir)
         .await
         .context("Failed to build routing database")?;
     let (db_tx, db_rx) = watch::channel(Arc::new(db));
 
-    // Background task: reload the routing database whenever a source file is updated.
+    // Background task: reload the routing database whenever a source file is updated, or
+    // whenever the daemon reports a change to the excluded countries list.
     // The file_updater_handle is moved here to keep the updater loop alive for the lifetime
     // of this task — dropping it earlier would cause the updater to exit.
     tokio::spawn(handle_db_updates(
@@ -105,6 +82,7 @@ pub async fn run(
         config.data_dir.clone(),
         db_tx,
         receivers,
+        excluded_countries_rx,
         file_updater_handle,
         shutdown_token.child_token(),
     ));
@@ -122,54 +100,164 @@ pub async fn run(
     Ok(())
 }
 
-/// Listen for update notifications and reload the routing database when files change.
+/// Register each of the given countries' source files with the updater for periodic refresh.
+/// Failures to register an individual source are logged and otherwise ignored.
+async fn register_country_sources(
+    data_dir: &std::path::Path,
+    countries: &[String],
+    file_updater_handle: &FileUpdaterHandle,
+) -> Vec<(
+    String,
+    mpsc::UnboundedReceiver<Result<UpdateOutcome, FileUpdaterError>>,
+)> {
+    let mut receivers = Vec::new();
+
+    for source in file_manager::selected_sources(countries) {
+        let url = match source.url.parse::<Url>() {
+            Ok(url) => url,
+            Err(err) => {
+                tracing::error!("Invalid SOCKS5 source URL {}: {err}", source.url);
+                continue;
+            }
+        };
+        let dest = data_dir.join(source.file_name);
+        match file_updater_handle
+            .register(
+                url,
+                dest,
+                SOCKS5_INITIAL_UPDATE_DELAY,
+                SOCKS5_UPDATE_INTERVAL,
+            )
+            .await
+        {
+            Ok(rx) => receivers.push((source.country.to_string(), rx)),
+            Err(err) => {
+                tracing::error!(
+                    "Failed to register SOCKS5 source {} with updater: {err}",
+                    source.file_name
+                );
+            }
+        }
+    }
+
+    receivers
+}
+
+/// Listen for update notifications and reload the routing database when files change, and
+/// react to the daemon changing the excluded countries list at runtime.
 async fn handle_db_updates(
-    excluded_countries: Vec<String>,
+    mut excluded_countries: Vec<String>,
     data_dir: PathBuf,
     db_tx: watch::Sender<Arc<RoutingDatabase>>,
-    mut receivers: Vec<mpsc::UnboundedReceiver<Result<UpdateOutcome, FileUpdaterError>>>,
-    _file_updater_handle: FileUpdaterHandle,
+    mut receivers: Vec<(
+        String,
+        mpsc::UnboundedReceiver<Result<UpdateOutcome, FileUpdaterError>>,
+    )>,
+    mut excluded_countries_rx: watch::Receiver<Vec<String>>,
+    file_updater_handle: FileUpdaterHandle,
     cancel_token: CancellationToken,
 ) {
     loop {
-        match recv_any_update(&mut receivers, &cancel_token).await {
-            Some(Ok(UpdateOutcome::Updated)) => {
-                // Drain any other notifications from the same update cycle.
-                for rx in &mut receivers {
-                    while rx.try_recv().is_ok() {}
-                }
-                match RoutingDatabase::load(&excluded_countries, &data_dir).await {
-                    Ok(db) => {
-                        tracing::info!("SOCKS5 routing database reloaded");
-                        let _ = db_tx.send(Arc::new(db));
+        tokio::select! {
+            update = recv_any_update(&mut receivers, &cancel_token) => {
+                match update {
+                    Some(Ok(UpdateOutcome::Updated)) => {
+                        // Drain any other notifications from the same update cycle.
+                        for (_, rx) in &mut receivers {
+                            while rx.try_recv().is_ok() {}
+                        }
+                        reload_routing_database(&excluded_countries, &data_dir, &db_tx, "after file update").await;
                     }
-                    Err(err) => {
-                        tracing::error!("Failed to reload SOCKS5 routing database: {err:#}");
+                    Some(Ok(UpdateOutcome::NotModified)) => {}
+                    Some(Err(err)) => {
+                        tracing::error!("SOCKS5 updater error: {err}");
+                    }
+                    None => {
+                        tracing::debug!("SOCKS5 updater shutting down");
+                        return;
                     }
                 }
             }
-            Some(Ok(UpdateOutcome::NotModified)) => {}
-            Some(Err(err)) => {
-                tracing::error!("SOCKS5 updater error: {err}");
-            }
-            None => {
-                tracing::debug!("SOCKS5 updater receivers closed");
-                return;
+            changed = excluded_countries_rx.changed() => {
+                if changed.is_err() {
+                    tracing::debug!("Excluded countries channel closed");
+                    return;
+                }
+                let new_countries = excluded_countries_rx.borrow_and_update().clone();
+                if new_countries == excluded_countries {
+                    continue;
+                }
+                tracing::info!(countries = ?new_countries, "Geo-exclusion excluded countries changed");
+
+                let newly_selected: Vec<String> = new_countries
+                    .iter()
+                    .filter(|c| !excluded_countries.iter().any(|e| e.eq_ignore_ascii_case(c)))
+                    .cloned()
+                    .collect();
+
+                if !newly_selected.is_empty() {
+                    if let Err(err) = file_manager::init_files(&data_dir, &newly_selected).await {
+                        tracing::error!(
+                            "Failed to seed data files for newly selected countries {newly_selected:?}: {err:#}"
+                        );
+                    }
+                    receivers.extend(
+                        register_country_sources(&data_dir, &newly_selected, &file_updater_handle).await,
+                    );
+                }
+
+                // Countries no longer selected: dropping their receivers automatically
+                // unregisters them from periodic refresh.
+                receivers.retain(|(country, _)| {
+                    new_countries.iter().any(|c| c.eq_ignore_ascii_case(country))
+                });
+
+                excluded_countries = new_countries;
+                reload_routing_database(&excluded_countries, &data_dir, &db_tx, "after country list change").await;
             }
         }
     }
 }
 
-/// Poll all receivers concurrently; return the first message that arrives or None on cancellation.
+async fn reload_routing_database(
+    excluded_countries: &[String],
+    data_dir: &std::path::Path,
+    db_tx: &watch::Sender<Arc<RoutingDatabase>>,
+    reason: &str,
+) {
+    match RoutingDatabase::load(excluded_countries, data_dir).await {
+        Ok(db) => {
+            tracing::info!("SOCKS5 routing database reloaded {reason}");
+            let _ = db_tx.send(Arc::new(db));
+        }
+        Err(err) => {
+            tracing::error!("Failed to reload SOCKS5 routing database {reason}: {err:#}");
+        }
+    }
+}
+
+/// Poll all receivers concurrently; return the first message that arrives, or None on
+/// cancellation. Blocks indefinitely (without returning `None`) while `receivers` is empty,
+/// so the caller's other event sources keep being serviced.
 async fn recv_any_update(
-    receivers: &mut Vec<mpsc::UnboundedReceiver<Result<UpdateOutcome, FileUpdaterError>>>,
+    receivers: &mut Vec<(
+        String,
+        mpsc::UnboundedReceiver<Result<UpdateOutcome, FileUpdaterError>>,
+    )>,
     cancel_token: &CancellationToken,
 ) -> Option<Result<UpdateOutcome, FileUpdaterError>> {
     loop {
         if receivers.is_empty() {
+            // No sources registered (yet). Wait for cancellation rather than returning
+            // None, so the caller's other event sources (e.g. excluded-countries changes)
+            // keep being serviced instead of the whole task exiting.
+            cancel_token.cancelled().await;
             return None;
         }
-        let futs: Vec<_> = receivers.iter_mut().map(|rx| Box::pin(rx.recv())).collect();
+        let futs: Vec<_> = receivers
+            .iter_mut()
+            .map(|(_, rx)| Box::pin(rx.recv()))
+            .collect();
         // Destructure inside select! so _rest is dropped before the match below.
         let result = tokio::select! {
             _ = cancel_token.cancelled() => return None,
@@ -178,7 +266,7 @@ async fn recv_any_update(
         match result {
             Some(msg) => return Some(msg),
             None => {
-                receivers.retain_mut(|rx| !rx.is_closed());
+                receivers.retain_mut(|(_, rx)| !rx.is_closed());
             }
         }
     }

--- a/nym-vpn-core/crates/nym-socks5-proxy/src/proxy.rs
+++ b/nym-vpn-core/crates/nym-socks5-proxy/src/proxy.rs
@@ -10,7 +10,7 @@ use std::{
 
 use crate::{
     default_interface::DefaultInterface,
-    file_manager::{self, SOURCES},
+    file_manager,
     routing::{RoutingDatabase, RoutingDecision, decide_route_for_addrs, is_excluded_domain},
 };
 
@@ -56,17 +56,17 @@ pub async fn run(
 
     tracing::info!("SOCKS5 proxy listener bound: {listen_addr}");
 
-    // Seed builtin files to disk on first run.
-    file_manager::init_files(&config.data_dir)
+    // Seed builtin files to disk on first run, for selected countries only.
+    file_manager::init_files(&config.data_dir, &config.excluded_countries)
         .await
         .context("Failed to initialise SOCKS5 routing data files")?;
 
-    // Register each source file with the updater for periodic refresh.
+    // Register each selected country's source file with the updater for periodic refresh.
     let excluded_countries = config.excluded_countries.clone();
     let mut receivers: Vec<mpsc::UnboundedReceiver<Result<UpdateOutcome, FileUpdaterError>>> =
         Vec::new();
 
-    for source in SOURCES.iter() {
+    for source in file_manager::selected_sources(&excluded_countries) {
         let url = source
             .url
             .parse::<Url>()

--- a/nym-vpn-core/crates/nym-vpn-lib/src/socks5_proxy/manager.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/socks5_proxy/manager.rs
@@ -138,6 +138,27 @@ impl Socks5ProxyManager {
         }
     }
 
+    /// Notify the running proxy of an updated excluded-countries list. A no-op if the proxy
+    /// isn't currently running — a fresh start already picks up the latest list via
+    /// `ProxyConfig`.
+    pub fn set_excluded_countries(&self, excluded_countries: Vec<String>) {
+        #[cfg(not(target_os = "android"))]
+        if let Socks5ProxyState::RunningProcess(running) = &self.state {
+            tracing::debug!(
+                "Notifying nym-socks5-proxy of updated excluded countries: {excluded_countries:?}",
+            );
+            running.set_excluded_countries(excluded_countries);
+        }
+
+        #[cfg(target_os = "android")]
+        if let Socks5ProxyState::RunningTask(running) = &self.state {
+            tracing::debug!(
+                "Notifying nym-socks5-proxy of updated excluded countries: {excluded_countries:?}",
+            );
+            running.set_excluded_countries(excluded_countries);
+        }
+    }
+
     pub fn set_tunnel_addrs(&mut self, v4_addr: Option<Ipv4Addr>, v6_addr: Option<Ipv6Addr>) {
         self.tunnel_addrs.v4_addr = v4_addr;
         self.tunnel_addrs.v6_addr = v6_addr;

--- a/nym-vpn-core/crates/nym-vpn-lib/src/socks5_proxy/process.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/socks5_proxy/process.rs
@@ -34,6 +34,13 @@ impl RunningProcess {
         }
     }
 
+    pub fn set_excluded_countries(&self, excluded_countries: Vec<String>) {
+        let msg = DaemonMessage::SetExcludedCountries(excluded_countries);
+        if self.msg_tx.send(msg).is_err() {
+            tracing::warn!("could not send SetExcludedCountries to proxy: channel closed");
+        }
+    }
+
     pub fn shutdown(&self) {
         self.shutdown_token.cancel();
     }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/socks5_proxy/task.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/socks5_proxy/task.rs
@@ -29,6 +29,13 @@ impl RunningTask {
         }
     }
 
+    pub fn set_excluded_countries(&self, excluded_countries: Vec<String>) {
+        let msg = DaemonMessage::SetExcludedCountries(excluded_countries);
+        if self.msg_tx.send(msg).is_err() {
+            tracing::warn!("could not send SetExcludedCountries to proxy task: channel closed");
+        }
+    }
+
     pub fn shutdown(&self) {
         self.shutdown_token.cancel();
     }
@@ -93,6 +100,8 @@ async fn supervisor(
     }
 
     let (tunnel_addrs_tx, tunnel_addrs_rx) = watch::channel(InterfaceAddresses::default());
+    let (excluded_countries_tx, excluded_countries_rx) =
+        watch::channel(config.excluded_countries.clone());
     let default_interface_rx = default_interface::start_monitor(shutdown_token.child_token()).await;
 
     let file_updater_handle = match FileUpdater::new() {
@@ -112,6 +121,7 @@ async fn supervisor(
         config,
         default_interface_rx,
         tunnel_addrs_rx,
+        excluded_countries_rx,
         shutdown_token.clone(),
         file_updater_handle,
         #[cfg(target_os = "android")]
@@ -140,6 +150,10 @@ async fn supervisor(
                     Some(DaemonMessage::SetTunnelAddresses(addrs)) => {
                         tracing::debug!("SOCKS5 proxy task: updating tunnel addresses");
                         let _ = tunnel_addrs_tx.send(addrs);
+                    }
+                    Some(DaemonMessage::SetExcludedCountries(countries)) => {
+                        tracing::debug!("SOCKS5 proxy task: updating excluded countries");
+                        let _ = excluded_countries_tx.send(countries);
                     }
                     Some(DaemonMessage::Terminate) | None => {
                         tracing::debug!("SOCKS5 proxy task: shutting down");

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -1006,6 +1006,16 @@ impl SharedState {
     }
 
     #[cfg(not(target_os = "ios"))]
+    fn set_socks5_proxy_excluded_countries(&self) {
+        self.socks5_proxy_manager.set_excluded_countries(
+            self.tunnel_settings
+                .geo_exclusion_settings
+                .excluded_countries
+                .clone(),
+        );
+    }
+
+    #[cfg(not(target_os = "ios"))]
     fn build_proxy_config(&self) -> Result<ProxyConfig, String> {
         let listen_port = self.tunnel_settings.geo_exclusion_settings.listen_port;
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
@@ -381,6 +381,8 @@ impl TunnelStateHandler for ConnectedState {
                             shared_state
                                 .start_or_stop_socks5_proxy()
                                 .await;
+                        } else if diff.geo_exclusion_excluded_countries_changed() {
+                            shared_state.set_socks5_proxy_excluded_countries();
                         }
 
                         if diff.enable_ad_blocking_changed() {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -832,6 +832,8 @@ impl TunnelStateHandler for ConnectingState {
                             shared_state
                                 .start_or_stop_socks5_proxy()
                                 .await;
+                        } else if diff.geo_exclusion_excluded_countries_changed() {
+                            shared_state.set_socks5_proxy_excluded_countries();
                         }
 
                         if diff.enable_ad_blocking_changed() {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnected_state.rs
@@ -104,6 +104,8 @@ impl TunnelStateHandler for DisconnectedState {
                         #[cfg(not(target_os = "ios"))]
                         if diff.geo_exclusion_enabled_changed() {
                             shared_state.start_or_stop_socks5_proxy().await;
+                        } else if diff.geo_exclusion_excluded_countries_changed() {
+                            shared_state.set_socks5_proxy_excluded_countries();
                         }
 
                         if diff.enable_ad_blocking_changed() {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnecting_state.rs
@@ -126,6 +126,8 @@ impl TunnelStateHandler for DisconnectingState {
                         #[cfg(not(target_os = "ios"))]
                         if diff.geo_exclusion_enabled_changed() {
                             shared_state.start_or_stop_socks5_proxy().await;
+                        } else if diff.geo_exclusion_excluded_countries_changed() {
+                            shared_state.set_socks5_proxy_excluded_countries();
                         }
 
                         if diff.enable_ad_blocking_changed() {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
@@ -257,6 +257,8 @@ impl TunnelStateHandler for ErrorState {
                         #[cfg(not(target_os = "ios"))]
                         if diff.geo_exclusion_enabled_changed() {
                             shared_state.start_or_stop_socks5_proxy().await;
+                        } else if diff.geo_exclusion_excluded_countries_changed() {
+                            shared_state.set_socks5_proxy_excluded_countries();
                         }
 
                         if diff.enable_ad_blocking_changed() {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/offline_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/offline_state.rs
@@ -164,6 +164,8 @@ impl TunnelStateHandler for OfflineState {
                             shared_state
                                 .start_or_stop_socks5_proxy()
                                 .await;
+                        } else if diff.geo_exclusion_excluded_countries_changed() {
+                            shared_state.set_socks5_proxy_excluded_countries();
                         }
 
                         if diff.enable_ad_blocking_changed() {


### PR DESCRIPTION
## Ticket

JIRA-NYM-4903

## Description

Add support for Russia in Geo-Exclusion in the Tauri app.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

https://github.com/user-attachments/assets/00c6d7a8-df1f-40cd-a7ff-60434f374c0b

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5931)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added a Geo-exclusion “select region” screen to choose China or Russia, with flag icons, beta guidance, and back navigation.

- **Updates**
  - Updated Geo-exclusion settings to use a “select region” flow and limit exclusions to one region at a time.
  - Improved Geo-exclusion error messaging when saving changes.

- **Improvements**
  - Geo-exclusion changes now update the proxy’s routing for the newly selected country without requiring a full restart.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->