### PR TITLE
ci: only build google play artifact in release builds

### DIFF
--- a/.github/workflows/release-all-platforms.yml
+++ b/.github/workflows/release-all-platforms.yml
@@ -413,7 +413,7 @@ jobs:
       release_channel: ${{ needs.resolve.outputs.channel }}
       version: ${{ needs.resolve.outputs.version }}
       nightly_timestamp: ${{ needs.resolve.outputs.nightly_timestamp }}
-      android: ${{ needs.resolve.outputs.android == 'true' }}
+      android: ${{ needs.resolve.outputs.android == 'true' && needs.resolve.outputs.channel == 'ship' }}
       fdroid: ${{ needs.resolve.outputs.fdroid == 'true' }}
       linux: ${{ needs.resolve.outputs.linux == 'true' }}
       windows: ${{ needs.resolve.outputs.windows == 'true' }}
@@ -524,7 +524,7 @@ jobs:
       tag: ${{ needs.resolve.outputs.tag }}
       github_release_type: ${{ needs.resolve.outputs.gh_release_type }}
       version: ${{ needs.resolve.outputs.version }}
-      android: ${{ needs.resolve.outputs.android == 'true' }}
+      android: ${{ needs.resolve.outputs.android == 'true' && needs.resolve.outputs.channel == 'ship' }}
       fdroid: ${{ needs.resolve.outputs.fdroid == 'true' }}
       linux: ${{ needs.resolve.outputs.linux == 'true' }}
       windows: ${{ needs.resolve.outputs.windows == 'true' }}


### PR DESCRIPTION


## Description

Currently google play artifacts are only distributed in release runs (release channel: `ship`) therefore there is no need to build Google Play app if we don't ship it.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5934)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Android releases are now enabled only for the Ship channel.
  - Nightly and Beta releases will no longer include Android handling, even when Android is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->