### PR TITLE
macos: clean build cache before archiving

### DIFF
--- a/.github/workflows/build-nym-vpn-app-macos.yml
+++ b/.github/workflows/build-nym-vpn-app-macos.yml
@@ -426,6 +426,13 @@ jobs:
 
           mv core_artifacts_macos/NymVPNRpc nym-vpn-apple/NymVPNRpc
 
+      - name: Purge caches
+        working-directory: nym-vpn-apple
+        run: |
+          # purge cache to rebuild with new NYM_SANTA env variable.
+          rm -rf "$HOME/Library/Caches/org.swift.swiftpm/" || true
+          rm -rf "$HOME/Library/Developer/Xcode/DerivedData/" || true
+
       - name: Archive macOS
         id: archive-macos
         working-directory: nym-vpn-apple

--- a/.github/workflows/release-all-platforms.yml
+++ b/.github/workflows/release-all-platforms.yml
@@ -547,7 +547,7 @@ jobs:
       publish_play: ${{ needs.resolve.outputs.android == 'true' && needs.resolve.outputs.channel == 'ship' }}
       publish_play_metadata: ${{ needs.resolve.outputs.publish_metadata == 'true' }}
       # only publish nightly builds to avoid downgrades
-      publish_testflight: ${{ needs.resolve.outputs.ios == 'true' && needs.resolve.outputs.channel == 'nightly' }}
+      publish_testflight: ${{ needs.resolve.outputs.ios == 'true' }}
       ios_ipa_name: ${{ needs.build-outputs.outputs.ios_ipa_name }}
       publish_to_public_testflight: true
       play_artifact_name: ${{ needs.build-outputs.outputs.play_artifact_name }}

--- a/.github/workflows/release-release-artifacts.yml
+++ b/.github/workflows/release-release-artifacts.yml
@@ -595,7 +595,7 @@ jobs:
             ARGS+=(--latest)
           fi
 
-          RELEASE_URL=$(gh release create "$TAG_NAME" --repo "$GITHUB_REPOSITORY" "${ARGS[@]}" "${ASSET_FILES[@]}")
+          RELEASE_URL=$(gh release create "$TAG_NAME" --target "$GITHUB_SHA" --repo "$GITHUB_REPOSITORY" "${ARGS[@]}" "${ASSET_FILES[@]}")
           RELEASE_TAG="${RELEASE_URL##*/}"
 
           echo "::notice:: Release URL: $RELEASE_URL"


### PR DESCRIPTION


## Description

- Flush build caches before archiving mac app to avoid caching issues due to use of `NYM_SANTA` environment variable
- Point tag release to `$GITHUB_SHA` (default points at `develop` 😨 )
- Always upload TF builds

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5935)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores / Build & Release**
  * Adjusted the macOS build workflow to run only for specific pull request events and only when the workflow file itself changes.
  * Improved artifact downloading by using a fixed workflow run source and authenticated access.
  * Added a cache purge before archiving to ensure a clean rebuild.
  * Updated TestFlight publishing so iOS builds can publish regardless of release channel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->