### PR TITLE
Run Debian12 E2E against published core betas and Zulip the result

### DIFF
--- a/.github/scripts/e2e/.shellcheckrc
+++ b/.github/scripts/e2e/.shellcheckrc
@@ -1,0 +1,2 @@
+# Keep CI + local lint aligned with resolve job: shellcheck -S warning
+severity=warning

--- a/.github/scripts/e2e/release-core.sh
+++ b/.github/scripts/e2e/release-core.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# E2E helpers for published nym-vpn-v* linux_x86_64 core archives.
+#   release-core.sh archive-name <tag>
+#   release-core.sh latest-beta
+#   release-core.sh pick-beta   # stdin: gh release list JSON
+#   release-core.sh fetch <tag> <dest_dir>
+set -euo pipefail
+
+BETA_TAG_RE='^nym-vpn-v[0-9]+[.][0-9]+[.][0-9]+-beta[.][0-9]+$'
+
+usage() {
+  echo "usage: $0 archive-name <tag> | latest-beta | pick-beta | fetch <tag> <dest_dir>" >&2
+  exit 2
+}
+
+archive_name() {
+  local tag="${1:-}"
+  [[ -n "$tag" ]] || usage
+  [[ "$tag" == nym-vpn-v* ]] || {
+    echo "error: tag must start with nym-vpn-v (got: ${tag})" >&2
+    exit 1
+  }
+  local version="${tag#nym-vpn-v}"
+  [[ -n "$version" && "$version" != "$tag" ]] || {
+    echo "error: could not strip nym-vpn-v prefix from tag: ${tag}" >&2
+    exit 1
+  }
+  local dir="nym-vpn-core-v${version}_linux_x86_64"
+  echo "version=${version}"
+  echo "archive=${dir}.tar.gz"
+  echo "archive_dir=${dir}"
+}
+
+pick_beta() {
+  jq -r --arg re "$BETA_TAG_RE" '
+    [
+      .[]
+      | select(.tagName | test($re))
+    ]
+    | sort_by(.publishedAt)
+    | reverse
+    | .[0].tagName // empty
+  '
+}
+
+latest_beta() {
+  local tag
+  tag="$(gh release list --limit 200 --json tagName,publishedAt | pick_beta)"
+  [[ -n "$tag" ]] || {
+    echo "error: no published nym-vpn-v*-beta.* release found" >&2
+    exit 1
+  }
+  echo "$tag"
+}
+
+load_archive_vars() {
+  local tag="$1" line key value
+  version="" archive="" archive_dir=""
+  while IFS= read -r line; do
+    key="${line%%=*}"
+    value="${line#*=}"
+    case "$key" in
+      version) version="$value" ;;
+      archive) archive="$value" ;;
+      archive_dir) archive_dir="$value" ;;
+    esac
+  done < <(archive_name "$tag")
+  [[ -n "$archive" && -n "$archive_dir" ]] || {
+    echo "error: failed to resolve archive names for ${tag}" >&2
+    exit 1
+  }
+}
+
+fetch() {
+  local tag="${1:-}" dest="${2:-}"
+  [[ -n "$tag" && -n "$dest" ]] || usage
+
+  local version archive archive_dir work src bin
+  load_archive_vars "$tag"
+
+  mkdir -p "$dest"
+  work="$(mktemp -d)"
+
+  echo "Downloading ${archive} from release ${tag}"
+  gh release download "$tag" --pattern "$archive" --dir "$work" --clobber
+  tar -xzf "${work}/${archive}" -C "$work"
+
+  src="${work}/${archive_dir}"
+  for bin in nym-vpnd nym-vpnc nym-socks5-proxy; do
+    [[ -f "${src}/${bin}" ]] || {
+      rm -rf "$work"
+      echo "error: ${bin} missing from ${archive}" >&2
+      exit 1
+    }
+    cp -f "${src}/${bin}" "${dest}/${bin}"
+    chmod +x "${dest}/${bin}"
+  done
+  rm -rf "$work"
+  echo "Installed release core binaries into ${dest}"
+}
+
+cmd="${1:-}"
+shift || true
+case "$cmd" in
+  archive-name) archive_name "${1:-}" ;;
+  pick-beta) pick_beta ;;
+  latest-beta) latest_beta ;;
+  fetch) fetch "${1:-}" "${2:-}" ;;
+  *) usage ;;
+esac

--- a/.github/scripts/e2e/release-core.sh
+++ b/.github/scripts/e2e/release-core.sh
@@ -1,25 +1,37 @@
 #!/usr/bin/env bash
 # E2E helpers for published nym-vpn-v* linux_x86_64 core archives.
 #   release-core.sh archive-name <tag>
+#   release-core.sh validate-tag <tag>
 #   release-core.sh latest-beta
 #   release-core.sh pick-beta   # stdin: gh release list JSON
 #   release-core.sh fetch <tag> <dest_dir>
 set -euo pipefail
 
+# Ship: nym-vpn-vMAJOR.MINOR.PATCH
+# Pre:  ...-beta.N | ...-nightly.YYYYMMDD (or similar alnum suffix)
+RELEASE_TAG_RE='^nym-vpn-v[0-9]+[.][0-9]+[.][0-9]+(-(beta|nightly)[.][0-9A-Za-z._-]+)?$'
 BETA_TAG_RE='^nym-vpn-v[0-9]+[.][0-9]+[.][0-9]+-beta[.][0-9]+$'
 
 usage() {
-  echo "usage: $0 archive-name <tag> | latest-beta | pick-beta | fetch <tag> <dest_dir>" >&2
+  echo "usage: $0 archive-name <tag> | validate-tag <tag> | latest-beta | pick-beta | fetch <tag> <dest_dir>" >&2
   exit 2
+}
+
+validate_tag() {
+  local tag="${1:-}"
+  [[ -n "$tag" ]] || {
+    echo "error: empty tag" >&2
+    exit 1
+  }
+  if [[ ! "$tag" =~ $RELEASE_TAG_RE ]]; then
+    echo "error: tag must match nym-vpn-vMAJOR.MINOR.PATCH[-beta.N|-nightly.DATE] (got: ${tag})" >&2
+    exit 1
+  fi
 }
 
 archive_name() {
   local tag="${1:-}"
-  [[ -n "$tag" ]] || usage
-  [[ "$tag" == nym-vpn-v* ]] || {
-    echo "error: tag must start with nym-vpn-v (got: ${tag})" >&2
-    exit 1
-  }
+  validate_tag "$tag"
   local version="${tag#nym-vpn-v}"
   [[ -n "$version" && "$version" != "$tag" ]] || {
     echo "error: could not strip nym-vpn-v prefix from tag: ${tag}" >&2
@@ -35,7 +47,10 @@ pick_beta() {
   jq -r --arg re "$BETA_TAG_RE" '
     [
       .[]
-      | select(.tagName | test($re))
+      | select(
+          (.tagName | type == "string")
+          and (.tagName | test($re))
+        )
     ]
     | sort_by(.publishedAt)
     | reverse
@@ -75,14 +90,25 @@ fetch() {
   local tag="${1:-}" dest="${2:-}"
   [[ -n "$tag" && -n "$dest" ]] || usage
 
-  local version archive archive_dir work src bin
+  local version archive archive_dir work src bin checksum
   load_archive_vars "$tag"
+  checksum="${archive}.sha256sum"
 
   mkdir -p "$dest"
   work="$(mktemp -d)"
 
-  echo "Downloading ${archive} from release ${tag}"
-  gh release download "$tag" --pattern "$archive" --dir "$work" --clobber
+  echo "Downloading ${archive} and ${checksum} from release ${tag}"
+  gh release download "$tag" --pattern "$archive" --pattern "$checksum" --dir "$work" --clobber
+  [[ -f "${work}/${checksum}" ]] || {
+    rm -rf "$work"
+    echo "error: missing ${checksum} for ${tag}" >&2
+    exit 1
+  }
+  (
+    cd "$work"
+    sha256sum -c "$checksum"
+  )
+
   tar -xzf "${work}/${archive}" -C "$work"
 
   src="${work}/${archive_dir}"
@@ -103,6 +129,7 @@ cmd="${1:-}"
 shift || true
 case "$cmd" in
   archive-name) archive_name "${1:-}" ;;
+  validate-tag) validate_tag "${1:-}" ;;
   pick-beta) pick_beta ;;
   latest-beta) latest_beta ;;
   fetch) fetch "${1:-}" "${2:-}" ;;

--- a/.github/scripts/e2e/test_release_core.sh
+++ b/.github/scripts/e2e/test_release_core.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RC="${SCRIPT_DIR}/release-core.sh"
+failures=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" != "$actual" ]]; then
+    echo "FAIL ${label}: expected '${expected}', got '${actual}'"
+    failures=$((failures + 1))
+  else
+    echo "ok   ${label}"
+  fi
+}
+
+assert_fails() {
+  local label="$1"
+  shift
+  if "$@" >/dev/null 2>&1; then
+    echo "FAIL ${label}: expected non-zero exit"
+    failures=$((failures + 1))
+  else
+    echo "ok   ${label}"
+  fi
+}
+
+assert_ok() {
+  local label="$1"
+  shift
+  if "$@" >/dev/null 2>&1; then
+    echo "ok   ${label}"
+  else
+    echo "FAIL ${label}: expected zero exit"
+    failures=$((failures + 1))
+  fi
+}
+
+out="$("$RC" archive-name "nym-vpn-v2026.12.0-beta.1")"
+assert_eq "beta version" "version=2026.12.0-beta.1" "$(echo "$out" | sed -n '1p')"
+assert_eq "beta archive" \
+  "archive=nym-vpn-core-v2026.12.0-beta.1_linux_x86_64.tar.gz" \
+  "$(echo "$out" | sed -n '2p')"
+assert_eq "beta archive_dir" \
+  "archive_dir=nym-vpn-core-v2026.12.0-beta.1_linux_x86_64" \
+  "$(echo "$out" | sed -n '3p')"
+
+out="$("$RC" archive-name "nym-vpn-v2026.12.0")"
+assert_eq "ship archive" \
+  "archive=nym-vpn-core-v2026.12.0_linux_x86_64.tar.gz" \
+  "$(echo "$out" | sed -n '2p')"
+
+out="$("$RC" archive-name "nym-vpn-v2026.12.0-nightly.20260729")"
+assert_eq "nightly archive" \
+  "archive=nym-vpn-core-v2026.12.0-nightly.20260729_linux_x86_64.tar.gz" \
+  "$(echo "$out" | sed -n '2p')"
+
+assert_fails "rejects empty tag" "$RC" archive-name
+assert_fails "rejects empty version after prefix" "$RC" archive-name "nym-vpn-v"
+assert_fails "rejects non-unified tag" "$RC" archive-name "v2026.12.0-beta.1"
+assert_fails "rejects bare version" "$RC" archive-name "2026.12.0-beta.1"
+assert_fails "rejects path traversal tag" "$RC" archive-name "nym-vpn-v../../etc/passwd"
+# Intentional single quotes: assert the tag is rejected, not expanded by the shell.
+# shellcheck disable=SC2016
+assert_fails "rejects shell metacharacters in tag" \
+  "$RC" archive-name 'nym-vpn-v1.0.0-beta.1$(touch /tmp/x)'
+
+assert_ok "validate-tag accepts ship" "$RC" validate-tag "nym-vpn-v2026.12.0"
+assert_ok "validate-tag accepts beta" "$RC" validate-tag "nym-vpn-v2026.12.0-beta.1"
+assert_fails "validate-tag rejects prefix-only glob abuse" \
+  "$RC" validate-tag "nym-vpn-v../../something"
+
+fixture='[
+  {"tagName":"nym-vpn-v2026.11.3-beta.3","publishedAt":"2026-07-20T10:00:00Z"},
+  {"tagName":"nym-vpn-v2026.12.0-beta.1","publishedAt":"2026-07-28T12:00:00Z"},
+  {"tagName":"nym-vpn-v2026.12.0-nightly.20260729","publishedAt":"2026-07-29T04:00:00Z"},
+  {"tagName":"nym-vpn-v2026.12.0","publishedAt":"2026-07-30T08:00:00Z"},
+  {"tagName":"nym-vpn-v2026.11.3-beta.2","publishedAt":"2026-07-18T10:00:00Z"}
+]'
+assert_eq "picks newest beta by publishedAt" \
+  "nym-vpn-v2026.12.0-beta.1" \
+  "$("$RC" pick-beta <<<"$fixture")"
+assert_eq "empty when no betas" \
+  "" \
+  "$("$RC" pick-beta <<<'[{"tagName":"nym-vpn-v2026.12.0","publishedAt":"2026-07-30T08:00:00Z"}]')"
+assert_eq "ignores null tagName" \
+  "nym-vpn-v2026.12.0-beta.1" \
+  "$("$RC" pick-beta <<<'[{"tagName":null,"publishedAt":"2026-07-31T00:00:00Z"},{"tagName":"nym-vpn-v2026.12.0-beta.1","publishedAt":"2026-07-28T12:00:00Z"}]')"
+assert_eq "empty when only null tagName" \
+  "" \
+  "$("$RC" pick-beta <<<'[{"tagName":null,"publishedAt":"2026-07-31T00:00:00Z"}]')"
+
+if [[ "$failures" -ne 0 ]]; then
+  echo "${failures} failure(s)"
+  exit 1
+fi
+echo "all tests passed"

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,11 +1,22 @@
+# Debian12 E2E:
+#   - nightly cron: zigbuild HEAD
+#   - weekday cron: latest published nym-vpn-v*-beta.N core tarball
+#   - release.published (nym-vpn-v*): that release's core tarball
+#   - dispatch: release_tag set → that tarball; empty → zigbuild HEAD
 name: e2e-test
 
 on:
   schedule:
-    # Every weekday (Mon–Fri) at 02:00 UTC
-    - cron: "0 2 * * 1-5"
+    # Nightly zigbuild of the default branch (HEAD).
+    - cron: "0 2 * * *"
+    # Weekday smoke against the newest published beta core archive.
+    - cron: "0 4 * * 1-5"
   workflow_dispatch:
     inputs:
+      release_tag:
+        description: "Optional nym-vpn-v* tag (core tarball). Empty = zigbuild HEAD."
+        required: false
+        type: string
       test_filters:
         description: "Only execute these (space-separated) tests. Can be used in
           conjunction with skip_tests"
@@ -25,6 +36,8 @@ on:
         options:
           - standard.medium
           - standard.large
+  release:
+    types: [published]
 
 permissions:
   contents: read
@@ -37,16 +50,93 @@ env:
   CARGO_TERM_COLOR: always
   TEST_CRATE_DIR: nym-vpn-core/crates/test
   DEFAULT_INSTANCE_TYPE: standard.medium
+  E2E_SCRIPTS_DIR: .github/scripts/e2e
+  # Must match the schedule: entries above (github.event.schedule).
+  CRON_NIGHTLY_ZIGBUILD: "0 2 * * *"
+  CRON_WEEKDAY_LATEST_BETA: "0 4 * * 1-5"
 
 jobs:
+  resolve:
+    name: Resolve binary source
+    if: >-
+      github.event_name != 'release' ||
+      startsWith(github.event.release.tag_name, 'nym-vpn-v')
+    runs-on: arc-linux-latest
+    outputs:
+      release_tag: ${{ steps.pick.outputs.release_tag }}
+      binary_source: ${{ steps.pick.outputs.binary_source }}
+      checkout_ref: ${{ steps.pick.outputs.checkout_ref }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Script unit tests
+        run: |
+          chmod +x "${{ env.E2E_SCRIPTS_DIR }}/release-core.sh" \
+            "${{ env.E2E_SCRIPTS_DIR }}/test_release_core.sh"
+          if ! command -v jq >/dev/null; then
+            sudo apt-get update && sudo apt-get install -y jq
+          fi
+          "${{ env.E2E_SCRIPTS_DIR }}/test_release_core.sh"
+
+      - name: Pick release tag / zigbuild mode
+        id: pick
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          SCHEDULE_CRON: ${{ github.event.schedule }}
+          RELEASE_EVENT_TAG: ${{ github.event.release.tag_name }}
+          INPUT_RELEASE_TAG: ${{ inputs.release_tag }}
+          WORKFLOW_SHA: ${{ github.sha }}
+          CRON_WEEKDAY_LATEST_BETA: ${{ env.CRON_WEEKDAY_LATEST_BETA }}
+        run: |
+          TAG=""
+          if [ "$EVENT_NAME" = "release" ]; then
+            TAG="$RELEASE_EVENT_TAG"
+          elif [ -n "$INPUT_RELEASE_TAG" ]; then
+            TAG="$INPUT_RELEASE_TAG"
+          elif [ "$EVENT_NAME" = "schedule" ] && [ "$SCHEDULE_CRON" = "$CRON_WEEKDAY_LATEST_BETA" ]; then
+            TAG="$("${{ env.E2E_SCRIPTS_DIR }}/release-core.sh" latest-beta)"
+            echo "schedule: latest beta is ${TAG}"
+          elif [ "$EVENT_NAME" = "schedule" ]; then
+            echo "schedule: nightly zigbuild HEAD"
+          fi
+
+          if [ -n "$TAG" ]; then
+            case "$TAG" in
+              nym-vpn-v*) ;;
+              *)
+                echo "::error::release_tag must start with nym-vpn-v (got: ${TAG})"
+                exit 1
+                ;;
+            esac
+            {
+              echo "release_tag=${TAG}"
+              echo "binary_source=release"
+              echo "checkout_ref=${TAG}"
+            } >> "$GITHUB_OUTPUT"
+            echo "mode=release tag=${TAG}"
+          else
+            {
+              echo "release_tag="
+              echo "binary_source=zigbuild"
+              echo "checkout_ref=${WORKFLOW_SHA}"
+            } >> "$GITHUB_OUTPUT"
+            echo "mode=zigbuild ref=${WORKFLOW_SHA}"
+          fi
+
   build:
     name: Build test binaries
+    needs: resolve
     runs-on: arc-linux-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v7
         with:
           fetch-depth: 1
+          ref: ${{ needs.resolve.outputs.checkout_ref }}
 
       - name: Dotenv Action
         uses: xom9ikk/dotenv@v2.4.0
@@ -100,15 +190,18 @@ jobs:
             ${{ runner.os }}-cargo-build-${{ env.RUST_VERSION }}-
 
       - name: Install Go
+        if: needs.resolve.outputs.binary_source == 'zigbuild'
         uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GOLANG_VERSION}}
           cache-dependency-path: wireguard/libwg/go.sum
 
       - name: Build wireguard-go
+        if: needs.resolve.outputs.binary_source == 'zigbuild'
         run: ./wireguard/build-wireguard-go.sh
 
       - name: Build nym-vpnc, nym-vpnd and nym-socks5-proxy
+        if: needs.resolve.outputs.binary_source == 'zigbuild'
         env:
           CFLAGS_x86_64_unknown_linux_gnu: -I/usr/include/x86_64-linux-gnu
           BINDGEN_EXTRA_CLANG_ARGS_x86_64_unknown_linux_gnu: -I/usr/include/x86_64-linux-gnu
@@ -145,7 +238,7 @@ jobs:
           key: ${{ runner.os }}-cargo-build-${{ env.RUST_VERSION }}-${{ hashFiles('nym-vpn-core/Cargo.lock') }}-${{ hashFiles('nym-vpn-core/**/*.rs') }}
 
       - name: Save Go modules cache
-        if: always()
+        if: always() && needs.resolve.outputs.binary_source == 'zigbuild'
         uses: actions/cache/save@v6
         with:
           path: |
@@ -153,12 +246,36 @@ jobs:
             ~/.cache/go-build
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
-      - name: Collect binaries
+      - name: Collect zigbuild binaries
+        if: needs.resolve.outputs.binary_source == 'zigbuild'
         run: |
           mkdir -p /tmp/dist
           cp nym-vpn-core/target/x86_64-unknown-linux-gnu/release/nym-vpnc /tmp/dist/
           cp nym-vpn-core/target/x86_64-unknown-linux-gnu/release/nym-vpnd /tmp/dist/
           cp nym-vpn-core/target/x86_64-unknown-linux-gnu/release/nym-socks5-proxy /tmp/dist/
+          cp nym-vpn-core/target/x86_64-unknown-linux-gnu/release/test-manager /tmp/dist/
+          cp nym-vpn-core/target/x86_64-unknown-linux-gnu/release/test-runner /tmp/dist/
+
+      - name: Checkout workflow scripts
+        if: needs.resolve.outputs.binary_source == 'release'
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+          ref: ${{ github.sha }}
+          sparse-checkout: |
+            .github/scripts/e2e
+          path: workflow-scripts
+
+      - name: Fetch release core binaries
+        if: needs.resolve.outputs.binary_source == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
+        run: |
+          mkdir -p /tmp/dist
+          SCRIPT="workflow-scripts/${{ env.E2E_SCRIPTS_DIR }}/release-core.sh"
+          chmod +x "$SCRIPT"
+          "$SCRIPT" fetch "$RELEASE_TAG" /tmp/dist
           cp nym-vpn-core/target/x86_64-unknown-linux-gnu/release/test-manager /tmp/dist/
           cp nym-vpn-core/target/x86_64-unknown-linux-gnu/release/test-runner /tmp/dist/
 
@@ -171,7 +288,7 @@ jobs:
 
   e2e-test:
     name: Run E2E tests
-    needs: build
+    needs: [resolve, build]
     runs-on: arc-linux-latest
     env:
       SSH_KEY_PATH: /tmp/exoscale_key
@@ -191,6 +308,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 1
+          ref: ${{ needs.resolve.outputs.checkout_ref }}
 
       - name: Download binaries
         uses: actions/download-artifact@v8
@@ -243,7 +361,7 @@ jobs:
               echo "SSH is ready"
               exit 0
             fi
-            echo "Attempt $i/30 — waiting 10s..."
+            echo "Attempt $i/30 - waiting 10s..."
             sleep 10
           done
           echo "ERROR: SSH never became available after 30 attempts"
@@ -388,3 +506,62 @@ jobs:
       - name: Cleanup SSH key
         if: always()
         run: rm -f ${{ env.SSH_KEY_PATH }}
+
+  notify-zulip:
+    name: Zulip E2E status
+    needs: [resolve, build, e2e-test]
+    if: always() && needs.resolve.result == 'success'
+    runs-on: arc-linux-latest
+    steps:
+      - name: Compose message
+        id: msg
+        env:
+          BINARY_SOURCE: ${{ needs.resolve.outputs.binary_source }}
+          RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
+          CHECKOUT_REF: ${{ needs.resolve.outputs.checkout_ref }}
+          BUILD_RESULT: ${{ needs.build.result }}
+          E2E_RESULT: ${{ needs.e2e-test.result }}
+          EVENT_NAME: ${{ github.event_name }}
+          SCHEDULE_CRON: ${{ github.event.schedule }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ "$BUILD_RESULT" != "success" ]; then
+            STATUS="build ${BUILD_RESULT}"
+          elif [ "$E2E_RESULT" = "success" ]; then
+            STATUS="passed"
+          elif [ "$E2E_RESULT" = "skipped" ]; then
+            STATUS="e2e skipped"
+          else
+            STATUS="e2e ${E2E_RESULT}"
+          fi
+
+          if [ "$BINARY_SOURCE" = "release" ] && [ -n "$RELEASE_TAG" ]; then
+            SOURCE_LINE="release tag \`${RELEASE_TAG}\` (published core tarball)"
+          else
+            SOURCE_LINE="zigbuild from \`${CHECKOUT_REF}\`"
+          fi
+
+          {
+            echo "content<<MSG_EOF"
+            echo "**E2E** ${STATUS}"
+            echo ""
+            echo "- source: ${SOURCE_LINE}"
+            echo "- event: \`${EVENT_NAME}\`"
+            if [ "$EVENT_NAME" = "schedule" ] && [ -n "$SCHEDULE_CRON" ]; then
+              echo "- cron: \`${SCHEDULE_CRON}\`"
+            fi
+            echo "- run: ${RUN_URL}"
+            echo "MSG_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Send Zulip notification
+        continue-on-error: true
+        uses: zulip/github-actions-zulip/send-message@v2
+        with:
+          api-key: ${{ secrets.TEST_HARNESS_ZULIP_BOT_API_KEY }}
+          email: ${{ secrets.TEST_HARNESS_ZULIP_BOT_EMAIL }}
+          organization-url: ${{ secrets.ZULIP_ORG_URL }}
+          to: ${{ secrets.TEST_HARNESS_ZULIP_CHANNEL }}
+          type: "stream"
+          topic: ${{ secrets.TEST_HARNESS_ZULIP_TOPIC }}
+          content: ${{ steps.msg.outputs.content }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -39,9 +39,6 @@ on:
   release:
     types: [published]
 
-permissions:
-  contents: read
-
 concurrency:
   group: e2e-mainnet-test-account
   cancel-in-progress: false
@@ -62,6 +59,8 @@ jobs:
       github.event_name != 'release' ||
       startsWith(github.event.release.tag_name, 'nym-vpn-v')
     runs-on: arc-linux-latest
+    permissions:
+      contents: read
     outputs:
       release_tag: ${{ steps.pick.outputs.release_tag }}
       binary_source: ${{ steps.pick.outputs.binary_source }}
@@ -134,6 +133,8 @@ jobs:
     name: Build test binaries
     needs: resolve
     runs-on: arc-linux-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repo
         uses: actions/checkout@v7
@@ -293,6 +294,8 @@ jobs:
     name: Run E2E tests
     needs: [resolve, build]
     runs-on: arc-linux-latest
+    permissions:
+      contents: read
     env:
       SSH_KEY_PATH: /tmp/exoscale_key
       SSH_OPTS: "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o
@@ -515,6 +518,7 @@ jobs:
     needs: [resolve, build, e2e-test]
     if: always()
     runs-on: arc-linux-latest
+    permissions: {}
     steps:
       - name: Compose message
         id: msg

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -76,9 +76,15 @@ jobs:
         run: |
           chmod +x "${{ env.E2E_SCRIPTS_DIR }}/release-core.sh" \
             "${{ env.E2E_SCRIPTS_DIR }}/test_release_core.sh"
-          if ! command -v jq >/dev/null; then
-            sudo apt-get update && sudo apt-get install -y jq
+          pkgs=()
+          command -v jq >/dev/null || pkgs+=(jq)
+          command -v shellcheck >/dev/null || pkgs+=(shellcheck)
+          if [ "${#pkgs[@]}" -gt 0 ]; then
+            sudo apt-get update && sudo apt-get install -y "${pkgs[@]}"
           fi
+          shellcheck -S warning \
+            "${{ env.E2E_SCRIPTS_DIR }}/release-core.sh" \
+            "${{ env.E2E_SCRIPTS_DIR }}/test_release_core.sh"
           "${{ env.E2E_SCRIPTS_DIR }}/test_release_core.sh"
 
       - name: Pick release tag / zigbuild mode
@@ -105,13 +111,10 @@ jobs:
           fi
 
           if [ -n "$TAG" ]; then
-            case "$TAG" in
-              nym-vpn-v*) ;;
-              *)
-                echo "::error::release_tag must start with nym-vpn-v (got: ${TAG})"
-                exit 1
-                ;;
-            esac
+            if ! "${{ env.E2E_SCRIPTS_DIR }}/release-core.sh" validate-tag "$TAG"; then
+              echo "::error::release_tag must match nym-vpn-vMAJOR.MINOR.PATCH[-beta.N|-nightly.DATE] (got: ${TAG})"
+              exit 1
+            fi
             {
               echo "release_tag=${TAG}"
               echo "binary_source=release"
@@ -510,12 +513,13 @@ jobs:
   notify-zulip:
     name: Zulip E2E status
     needs: [resolve, build, e2e-test]
-    if: always() && needs.resolve.result == 'success'
+    if: always()
     runs-on: arc-linux-latest
     steps:
       - name: Compose message
         id: msg
         env:
+          RESOLVE_RESULT: ${{ needs.resolve.result }}
           BINARY_SOURCE: ${{ needs.resolve.outputs.binary_source }}
           RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
           CHECKOUT_REF: ${{ needs.resolve.outputs.checkout_ref }}
@@ -525,7 +529,10 @@ jobs:
           SCHEDULE_CRON: ${{ github.event.schedule }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          if [ "$BUILD_RESULT" != "success" ]; then
+          if [ "$RESOLVE_RESULT" != "success" ]; then
+            STATUS="resolve ${RESOLVE_RESULT}"
+            SOURCE_LINE="(resolve did not complete)"
+          elif [ "$BUILD_RESULT" != "success" ]; then
             STATUS="build ${BUILD_RESULT}"
           elif [ "$E2E_RESULT" = "success" ]; then
             STATUS="passed"
@@ -535,10 +542,12 @@ jobs:
             STATUS="e2e ${E2E_RESULT}"
           fi
 
-          if [ "$BINARY_SOURCE" = "release" ] && [ -n "$RELEASE_TAG" ]; then
-            SOURCE_LINE="release tag \`${RELEASE_TAG}\` (published core tarball)"
-          else
-            SOURCE_LINE="zigbuild from \`${CHECKOUT_REF}\`"
+          if [ "$RESOLVE_RESULT" = "success" ]; then
+            if [ "$BINARY_SOURCE" = "release" ] && [ -n "$RELEASE_TAG" ]; then
+              SOURCE_LINE="release tag \`${RELEASE_TAG}\` (published core tarball)"
+            else
+              SOURCE_LINE="zigbuild from \`${CHECKOUT_REF}\`"
+            fi
           fi
 
           {


### PR DESCRIPTION
- Weekday schedule now exercises the newest published `nym-vpn-v*-beta.N` linux x86_64 core tarball instead of only zigbuilding HEAD.
- Publishing a `nym-vpn-v*` GitHub Release (including prereleases) triggers the same release-artifact path; dispatch can pass an explicit tag or omit it to zigbuild HEAD.
- Harness binaries still zigbuild from the chosen ref; daemon/CLI/socks5 come from the release core archive when in release mode.

## Ticket

JIRA-NYM-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5950)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded end-to-end testing to support nightly builds, weekday beta smoke tests, published release triggers, and manual release selection.
  * Added automated retrieval and integrity verification of published core binaries for release-based tests.
  * Added consolidated status notifications for end-to-end test runs.

* **Bug Fixes**
  * Improved release tag validation and handling of invalid or unexpected release metadata.

* **Tests**
  * Added coverage for archive naming, tag validation, beta selection, and invalid input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->