### PR TITLE
Fix concurrency deadlock

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -5,10 +5,6 @@ on:
     - cron: "0 4 * * *"
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: false
-
 jobs:
   release-nightly:
     name: Publish nightly release

--- a/.github/workflows/zulip-notify-release.yml
+++ b/.github/workflows/zulip-notify-release.yml
@@ -63,10 +63,6 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: false
-
 jobs:
   zulip-notify-release-android:
     runs-on: arc-linux-latest


### PR DESCRIPTION


## Ticket

JIRA-NYM-XXXX

## Description

Both`release-nightly.yml` and `zulip-notify-release.yml` share the same concurrency lock: `${{ github.workflow }}`. This creates a deadlock. Github detects it and kills zulip. Let's remove concurrency setting since `release-all-platforms.yml` already declares a separate concurrency key.

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5954)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation workflows to allow concurrent runs without workflow-level concurrency restrictions.
  * Existing release jobs and permissions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->