### PR TITLE
E2E reliability cases for LAN policy, offline detection, and daemon restart

### DIFF
--- a/.github/scripts/e2e/compose_zulip_e2e_message.sh
+++ b/.github/scripts/e2e/compose_zulip_e2e_message.sh
@@ -110,21 +110,21 @@ emit_body() {
 
   echo "**E2E** ${E2E_STATUS}"
   echo ""
-  echo "- branch: \`${E2E_BRANCH}\` @ \`${E2E_SHA}\`"
-  echo "- source: ${E2E_SOURCE_LINE}"
-  echo "- event: \`${E2E_EVENT_NAME}\`"
+  echo "- Branch: \`${E2E_BRANCH}\` @ \`${E2E_SHA}\`"
+  echo "- Source: ${E2E_SOURCE_LINE}"
+  echo "- Event: \`${E2E_EVENT_NAME}\`"
   if [[ "${E2E_EVENT_NAME}" == "schedule" && -n "${E2E_SCHEDULE_CRON:-}" ]]; then
     echo "- cron: \`${E2E_SCHEDULE_CRON}\`"
   fi
 
   if [[ "$has_report" == "true" ]]; then
     platform="${config_name:-unknown}"
-    echo "- results: ${passed} passed, ${failed} failed, ${skipped} skipped (\`${platform}\`)"
+    echo "- Results: ${passed} passed, ${failed} failed, ${skipped} skipped (\`${platform}\`)"
     if [[ "$unknown" -gt 0 ]]; then
       echo "- unknown results: ${unknown}"
     fi
     if [[ "${#failed_names[@]}" -gt 0 ]]; then
-      echo "- failed:"
+      echo "- Failed:"
       for name in "${failed_names[@]}"; do
         if [[ "$max_failed" -ge 0 && "$shown" -ge "$max_failed" ]]; then
           omitted=$((omitted + 1))
@@ -139,7 +139,7 @@ emit_body() {
       fi
     fi
     if [[ "$include_skips" == "true" && "${#skipped_names[@]}" -gt 0 ]]; then
-      echo "- skipped:"
+      echo "- Skipped:"
       for name in "${skipped_names[@]}"; do
         echo "  - \`${name}\`"
       done

--- a/.github/scripts/e2e/compose_zulip_e2e_message.sh
+++ b/.github/scripts/e2e/compose_zulip_e2e_message.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# Compose Zulip markdown for the e2e-test notify-zulip job.
+# Verbosity: counts + failed/skipped names (no pass name list).
+# Artifacts: GitHub artifact-url links only (auth-gated).
+#
+# Usage:
+#   compose_zulip_e2e_message.sh [--report PATH]
+#
+# Required env:
+#   E2E_STATUS E2E_BRANCH E2E_SHA E2E_SOURCE_LINE E2E_EVENT_NAME E2E_RUN_URL
+# Optional env:
+#   E2E_SCHEDULE_CRON E2E_TEST_REPORT_URL E2E_DAEMON_LOGS_URL
+set -euo pipefail
+
+# Stay under Zulip send-message 10000-byte content limit.
+MAX_BYTES=9000
+
+PASS_MARK=$'\xe2\x9c\x85'   # ✅
+FAIL_MARK=$'\xe2\x9d\x8c'   # ❌
+SKIP_MARK=$'\xe2\x86\xa9\xef\xb8\x8f' # ↪️
+
+REPORT=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --report)
+      REPORT="${2:-}"
+      shift 2
+      ;;
+    -h | --help)
+      echo "usage: $0 [--report PATH]" >&2
+      exit 2
+      ;;
+    *)
+      echo "usage: $0 [--report PATH]" >&2
+      exit 2
+      ;;
+  esac
+done
+
+: "${E2E_STATUS:?E2E_STATUS is required}"
+: "${E2E_BRANCH:?E2E_BRANCH is required}"
+: "${E2E_SHA:?E2E_SHA is required}"
+: "${E2E_SOURCE_LINE:?E2E_SOURCE_LINE is required}"
+: "${E2E_EVENT_NAME:?E2E_EVENT_NAME is required}"
+: "${E2E_RUN_URL:?E2E_RUN_URL is required}"
+
+passed=0
+failed=0
+skipped=0
+unknown=0
+config_name=""
+failed_names=()
+skipped_names=()
+
+parse_report() {
+  local path="$1"
+  if [[ ! -f "$path" ]]; then
+    return 1
+  fi
+
+  local line test_name result line_no=0
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line_no=$((line_no + 1))
+    if [[ "$line_no" -eq 1 ]]; then
+      config_name="$line"
+      continue
+    fi
+    if [[ "$line_no" -eq 2 ]]; then
+      continue
+    fi
+    [[ -z "$line" ]] && continue
+
+    test_name="${line%% *}"
+    result="${line#"${test_name}"}"
+    result="${result#"${result%%[![:space:]]*}"}"
+
+    case "$result" in
+      "$PASS_MARK")
+        passed=$((passed + 1))
+        ;;
+      "$FAIL_MARK")
+        failed=$((failed + 1))
+        failed_names+=("$test_name")
+        ;;
+      "$SKIP_MARK")
+        skipped=$((skipped + 1))
+        skipped_names+=("$test_name")
+        ;;
+      *)
+        unknown=$((unknown + 1))
+        ;;
+    esac
+  done <"$path"
+  return 0
+}
+
+has_report=false
+if [[ -n "$REPORT" ]]; then
+  if parse_report "$REPORT"; then
+    has_report=true
+  fi
+fi
+
+# Args: include_skips (true|false), max_failed_names (int, -1 = all)
+emit_body() {
+  local include_skips="$1"
+  local max_failed="$2"
+  local platform truncated_fails=false
+  local name shown=0 omitted=0
+
+  echo "**E2E** ${E2E_STATUS}"
+  echo ""
+  echo "- branch: \`${E2E_BRANCH}\` @ \`${E2E_SHA}\`"
+  echo "- source: ${E2E_SOURCE_LINE}"
+  echo "- event: \`${E2E_EVENT_NAME}\`"
+  if [[ "${E2E_EVENT_NAME}" == "schedule" && -n "${E2E_SCHEDULE_CRON:-}" ]]; then
+    echo "- cron: \`${E2E_SCHEDULE_CRON}\`"
+  fi
+
+  if [[ "$has_report" == "true" ]]; then
+    platform="${config_name:-unknown}"
+    echo "- results: ${passed} passed, ${failed} failed, ${skipped} skipped (\`${platform}\`)"
+    if [[ "$unknown" -gt 0 ]]; then
+      echo "- unknown results: ${unknown}"
+    fi
+    if [[ "${#failed_names[@]}" -gt 0 ]]; then
+      echo "- failed:"
+      for name in "${failed_names[@]}"; do
+        if [[ "$max_failed" -ge 0 && "$shown" -ge "$max_failed" ]]; then
+          omitted=$((omitted + 1))
+          continue
+        fi
+        echo "  - \`${name}\`"
+        shown=$((shown + 1))
+      done
+      if [[ "$omitted" -gt 0 ]]; then
+        echo "  - _…and ${omitted} more (truncated)_"
+        truncated_fails=true
+      fi
+    fi
+    if [[ "$include_skips" == "true" && "${#skipped_names[@]}" -gt 0 ]]; then
+      echo "- skipped:"
+      for name in "${skipped_names[@]}"; do
+        echo "  - \`${name}\`"
+      done
+    fi
+  else
+    echo "- results: (no test report)"
+  fi
+
+  if [[ -n "${E2E_TEST_REPORT_URL:-}" || -n "${E2E_DAEMON_LOGS_URL:-}" ]]; then
+    echo "- artifacts:"
+    if [[ -n "${E2E_TEST_REPORT_URL:-}" ]]; then
+      echo "  - [test-report](${E2E_TEST_REPORT_URL})"
+    fi
+    if [[ -n "${E2E_DAEMON_LOGS_URL:-}" ]]; then
+      echo "  - [daemon-logs](${E2E_DAEMON_LOGS_URL})"
+    fi
+  fi
+
+  echo "- run: ${E2E_RUN_URL}"
+
+  if [[ "$include_skips" != "true" || "$truncated_fails" == "true" ]]; then
+    echo ""
+    echo "_(message truncated to stay under Zulip size limit)_"
+  fi
+}
+
+msg_file="$(mktemp "${TMPDIR:-/tmp}/zulip-e2e-msg.XXXXXX")"
+trap 'rm -f "$msg_file"' EXIT
+
+emit_body true -1 >"$msg_file"
+byte_len=$(wc -c <"$msg_file" | tr -d ' ')
+
+if [[ "$byte_len" -gt "$MAX_BYTES" ]]; then
+  # Drop skipped names first.
+  emit_body false -1 >"$msg_file"
+  byte_len=$(wc -c <"$msg_file" | tr -d ' ')
+fi
+
+if [[ "$byte_len" -gt "$MAX_BYTES" && "${#failed_names[@]}" -gt 0 ]]; then
+  # Binary-search how many failed names fit under MAX_BYTES.
+  local_lo=0
+  local_hi=${#failed_names[@]}
+  local_best=0
+  while [[ "$local_lo" -le "$local_hi" ]]; do
+    local_mid=$(((local_lo + local_hi) / 2))
+    emit_body false "$local_mid" >"$msg_file"
+    byte_len=$(wc -c <"$msg_file" | tr -d ' ')
+    if [[ "$byte_len" -le "$MAX_BYTES" ]]; then
+      local_best=$local_mid
+      local_lo=$((local_mid + 1))
+    else
+      local_hi=$((local_mid - 1))
+    fi
+  done
+  emit_body false "$local_best" >"$msg_file"
+  byte_len=$(wc -c <"$msg_file" | tr -d ' ')
+fi
+
+if [[ "$byte_len" -gt "$MAX_BYTES" ]]; then
+  # Last resort: keep a minimal header + URLs (always under cap for normal inputs).
+  {
+    echo "**E2E** ${E2E_STATUS}"
+    echo ""
+    echo "- branch: \`${E2E_BRANCH}\` @ \`${E2E_SHA}\`"
+    echo "- source: ${E2E_SOURCE_LINE}"
+    echo "- event: \`${E2E_EVENT_NAME}\`"
+    if [[ "$has_report" == "true" ]]; then
+      echo "- results: ${passed} passed, ${failed} failed, ${skipped} skipped (truncated)"
+    else
+      echo "- results: (no test report)"
+    fi
+    if [[ -n "${E2E_TEST_REPORT_URL:-}" || -n "${E2E_DAEMON_LOGS_URL:-}" ]]; then
+      echo "- artifacts:"
+      if [[ -n "${E2E_TEST_REPORT_URL:-}" ]]; then
+        echo "  - [test-report](${E2E_TEST_REPORT_URL})"
+      fi
+      if [[ -n "${E2E_DAEMON_LOGS_URL:-}" ]]; then
+        echo "  - [daemon-logs](${E2E_DAEMON_LOGS_URL})"
+      fi
+    fi
+    echo "- run: ${E2E_RUN_URL}"
+    echo ""
+    echo "_(message truncated to stay under Zulip size limit)_"
+  } >"$msg_file"
+fi
+
+cat "$msg_file"

--- a/.github/scripts/e2e/test_compose_zulip_e2e_message.sh
+++ b/.github/scripts/e2e/test_compose_zulip_e2e_message.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPOSE="${SCRIPT_DIR}/compose_zulip_e2e_message.sh"
+failures=0
+
+assert_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "FAIL ${label}: missing '${needle}'"
+    echo "----- output -----"
+    echo "$haystack"
+    echo "------------------"
+    failures=$((failures + 1))
+  else
+    echo "ok   ${label}"
+  fi
+}
+
+assert_not_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo "FAIL ${label}: unexpectedly found '${needle}'"
+    failures=$((failures + 1))
+  else
+    echo "ok   ${label}"
+  fi
+}
+
+assert_fails() {
+  local label="$1"
+  shift
+  if "$@" >/dev/null 2>&1; then
+    echo "FAIL ${label}: expected non-zero exit"
+    failures=$((failures + 1))
+  else
+    echo "ok   ${label}"
+  fi
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=$'\xe2\x9c\x85'
+FAIL=$'\xe2\x9d\x8c'
+SKIP=$'\xe2\x86\xa9\xef\xb8\x8f'
+
+# Matches SummaryLogger layout: config name, JSON Os, then "name emoji" lines.
+cat >"${TMP}/report.txt" <<EOF
+debian12_cli
+"linux"
+test_daemon_info ${PASS}
+test_dns_leak ${PASS}
+test_allow_lan_off_blocks_prior_resolver_tcp ${FAIL}
+test_optional_skip ${SKIP}
+EOF
+
+export E2E_STATUS="e2e failure"
+export E2E_BRANCH="feat/e2e-notify"
+export E2E_SHA="217912acd44d7a6a7f1089695a9e5cc837db87f4"
+export E2E_SOURCE_LINE='zigbuild from `217912acd44d7a6a7f1089695a9e5cc837db87f4`'
+export E2E_EVENT_NAME="workflow_dispatch"
+export E2E_RUN_URL="https://github.com/nymtech/nym-vpn-client/actions/runs/30627386088"
+export E2E_TEST_REPORT_URL="https://github.com/nymtech/nym-vpn-client/actions/runs/30627386088/artifacts/8793208152"
+export E2E_DAEMON_LOGS_URL="https://github.com/nymtech/nym-vpn-client/actions/runs/30627386088/artifacts/8793207461"
+
+out="$("$COMPOSE" --report "${TMP}/report.txt")"
+
+assert_contains "status line" "**E2E** e2e failure" "$out"
+assert_contains "branch" "branch: \`feat/e2e-notify\`" "$out"
+assert_contains "sha" "217912acd44d7a6a7f1089695a9e5cc837db87f4" "$out"
+assert_contains "counts" "2 passed, 1 failed, 1 skipped (\`debian12_cli\`)" "$out"
+assert_contains "failed name" "test_allow_lan_off_blocks_prior_resolver_tcp" "$out"
+assert_contains "skipped name" "test_optional_skip" "$out"
+assert_not_contains "no pass name list" "test_daemon_info" "$out"
+assert_contains "test-report link" "[test-report](${E2E_TEST_REPORT_URL})" "$out"
+assert_contains "daemon-logs link" "[daemon-logs](${E2E_DAEMON_LOGS_URL})" "$out"
+assert_contains "run url" "$E2E_RUN_URL" "$out"
+
+# Missing report file → explicit no-report line; still includes branch/run.
+unset E2E_TEST_REPORT_URL E2E_DAEMON_LOGS_URL
+out_missing="$("$COMPOSE" --report "${TMP}/does-not-exist.txt")"
+assert_contains "missing report" "results: (no test report)" "$out_missing"
+assert_contains "missing still has branch" "feat/e2e-notify" "$out_missing"
+assert_contains "missing still has run" "$E2E_RUN_URL" "$out_missing"
+assert_not_contains "no artifacts section when empty" "artifacts:" "$out_missing"
+
+# Required env missing → non-zero.
+assert_fails "requires E2E_STATUS" \
+  env -u E2E_STATUS "$COMPOSE" --report "${TMP}/report.txt"
+
+# Truncation keeps failure names and URLs.
+export E2E_TEST_REPORT_URL="https://example.test/report"
+export E2E_DAEMON_LOGS_URL="https://example.test/logs"
+{
+  echo "debian12_cli"
+  echo '"linux"'
+  echo "test_the_only_failure ${FAIL}"
+  i=0
+  while [[ "$i" -lt 600 ]]; do
+    printf 'test_pad_%03d %s\n' "$i" "$SKIP"
+    i=$((i + 1))
+  done
+} >"${TMP}/huge.txt"
+
+out_huge="$("$COMPOSE" --report "${TMP}/huge.txt")"
+byte_len=$(printf '%s' "$out_huge" | wc -c | tr -d ' ')
+if [[ "$byte_len" -gt 10000 ]]; then
+  echo "FAIL truncation: output is ${byte_len} bytes (>10000)"
+  failures=$((failures + 1))
+else
+  echo "ok   truncation under 10000 bytes (${byte_len})"
+fi
+assert_contains "truncation keeps failure" "test_the_only_failure" "$out_huge"
+assert_contains "truncation keeps report url" "https://example.test/report" "$out_huge"
+assert_contains "truncation marker" "truncated" "$out_huge"
+
+# Many failures must also stay under Zulip's 10KB content cap.
+{
+  echo "debian12_cli"
+  echo '"linux"'
+  i=0
+  while [[ "$i" -lt 500 ]]; do
+    printf 'test_fail_with_a_longer_name_%03d %s\n' "$i" "$FAIL"
+    i=$((i + 1))
+  done
+} >"${TMP}/many-fail.txt"
+
+out_many="$("$COMPOSE" --report "${TMP}/many-fail.txt")"
+many_len=$(printf '%s' "$out_many" | wc -c | tr -d ' ')
+if [[ "$many_len" -gt 10000 ]]; then
+  echo "FAIL many-failure truncation: output is ${many_len} bytes (>10000)"
+  failures=$((failures + 1))
+else
+  echo "ok   many-failure under 10000 bytes (${many_len})"
+fi
+assert_contains "many-failure keeps a fail name" "test_fail_with_a_longer_name_" "$out_many"
+assert_contains "many-failure keeps run url" "$E2E_RUN_URL" "$out_many"
+assert_contains "many-failure keeps report url" "https://example.test/report" "$out_many"
+
+if [[ "$failures" -ne 0 ]]; then
+  echo "${failures} failure(s)"
+  exit 1
+fi
+echo "all tests passed"

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -206,11 +206,15 @@ jobs:
 
       - name: Build nym-vpnc, nym-vpnd and nym-socks5-proxy
         if: needs.resolve.outputs.binary_source == 'zigbuild'
+        timeout-minutes: 25
         env:
           CFLAGS_x86_64_unknown_linux_gnu: -I/usr/include/x86_64-linux-gnu
           BINDGEN_EXTRA_CLANG_ARGS_x86_64_unknown_linux_gnu: -I/usr/include/x86_64-linux-gnu
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -L /usr/lib/x86_64-linux-gnu
-        run: cargo zigbuild --release --target x86_64-unknown-linux-gnu.2.36 -p nym-vpnc -p nym-vpnd -p nym-socks5-proxy
+          CARGO_BUILD_JOBS: "4"
+        run: |
+          cargo zigbuild --release --target x86_64-unknown-linux-gnu.2.36 -p nym-vpnc -p nym-socks5-proxy
+          cargo zigbuild --release --target x86_64-unknown-linux-gnu.2.36 -p nym-vpnd
         working-directory: nym-vpn-core
 
       - name: Build test-manager, test-runner

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -74,7 +74,9 @@ jobs:
       - name: Script unit tests
         run: |
           chmod +x "${{ env.E2E_SCRIPTS_DIR }}/release-core.sh" \
-            "${{ env.E2E_SCRIPTS_DIR }}/test_release_core.sh"
+            "${{ env.E2E_SCRIPTS_DIR }}/test_release_core.sh" \
+            "${{ env.E2E_SCRIPTS_DIR }}/compose_zulip_e2e_message.sh" \
+            "${{ env.E2E_SCRIPTS_DIR }}/test_compose_zulip_e2e_message.sh"
           pkgs=()
           command -v jq >/dev/null || pkgs+=(jq)
           command -v shellcheck >/dev/null || pkgs+=(shellcheck)
@@ -83,8 +85,11 @@ jobs:
           fi
           shellcheck -S warning \
             "${{ env.E2E_SCRIPTS_DIR }}/release-core.sh" \
-            "${{ env.E2E_SCRIPTS_DIR }}/test_release_core.sh"
+            "${{ env.E2E_SCRIPTS_DIR }}/test_release_core.sh" \
+            "${{ env.E2E_SCRIPTS_DIR }}/compose_zulip_e2e_message.sh" \
+            "${{ env.E2E_SCRIPTS_DIR }}/test_compose_zulip_e2e_message.sh"
           "${{ env.E2E_SCRIPTS_DIR }}/test_release_core.sh"
+          "${{ env.E2E_SCRIPTS_DIR }}/test_compose_zulip_e2e_message.sh"
 
       - name: Pick release tag / zigbuild mode
         id: pick
@@ -300,6 +305,11 @@ jobs:
     runs-on: arc-linux-latest
     permissions:
       contents: read
+    outputs:
+      has_report: ${{ steps.export-report.outputs.has_report }}
+      report: ${{ steps.export-report.outputs.report }}
+      test_report_url: ${{ steps.upload-report.outputs.artifact-url }}
+      daemon_logs_url: ${{ steps.upload-logs.outputs.artifact-url }}
     env:
       SSH_KEY_PATH: /tmp/exoscale_key
       SSH_OPTS: "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o
@@ -448,6 +458,21 @@ jobs:
             ${{ env.VM_USER }}@${VM_IP}:/tmp/test-report.txt /tmp/test-report.txt 2>/dev/null || \
             echo "No test report found"
 
+      - name: Export test report for Zulip
+        if: always()
+        id: export-report
+        run: |
+          if [ -f /tmp/test-report.txt ]; then
+            {
+              echo "has_report=true"
+              echo "report<<REPORT_EOF"
+              cat /tmp/test-report.txt
+              echo "REPORT_EOF"
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "has_report=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Retrieve daemon logs
         if: always()
         env:
@@ -460,6 +485,7 @@ jobs:
 
       - name: Upload daemon logs
         if: always()
+        id: upload-logs
         uses: actions/upload-artifact@v7
         with:
           name: daemon-logs
@@ -479,6 +505,7 @@ jobs:
 
       - name: Upload test report
         if: always()
+        id: upload-report
         uses: actions/upload-artifact@v7
         with:
           name: test-report
@@ -522,8 +549,16 @@ jobs:
     needs: [resolve, build, e2e-test]
     if: always()
     runs-on: arc-linux-latest
-    permissions: {}
+    permissions:
+      contents: read
     steps:
+      - name: Checkout notify scripts
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+          sparse-checkout: |
+            .github/scripts/e2e
+
       - name: Compose message
         id: msg
         env:
@@ -536,6 +571,13 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           SCHEDULE_CRON: ${{ github.event.schedule }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          BRANCH: ${{ github.ref_name }}
+          SHA: ${{ github.sha }}
+          HAS_REPORT: ${{ needs.e2e-test.outputs.has_report }}
+          REPORT: ${{ needs.e2e-test.outputs.report }}
+          TEST_REPORT_URL: ${{ needs.e2e-test.outputs.test_report_url }}
+          DAEMON_LOGS_URL: ${{ needs.e2e-test.outputs.daemon_logs_url }}
+          E2E_SCRIPTS_DIR: ${{ env.E2E_SCRIPTS_DIR }}
         run: |
           if [ "$RESOLVE_RESULT" != "success" ]; then
             STATUS="resolve ${RESOLVE_RESULT}"
@@ -558,16 +600,25 @@ jobs:
             fi
           fi
 
+          REPORT_ARGS=()
+          if [ "$HAS_REPORT" = "true" ] && [ -n "$REPORT" ]; then
+            printf '%s\n' "$REPORT" > /tmp/test-report.txt
+            REPORT_ARGS=(--report /tmp/test-report.txt)
+          fi
+
+          chmod +x "${E2E_SCRIPTS_DIR}/compose_zulip_e2e_message.sh"
           {
             echo "content<<MSG_EOF"
-            echo "**E2E** ${STATUS}"
-            echo ""
-            echo "- source: ${SOURCE_LINE}"
-            echo "- event: \`${EVENT_NAME}\`"
-            if [ "$EVENT_NAME" = "schedule" ] && [ -n "$SCHEDULE_CRON" ]; then
-              echo "- cron: \`${SCHEDULE_CRON}\`"
-            fi
-            echo "- run: ${RUN_URL}"
+            E2E_STATUS="$STATUS" \
+              E2E_BRANCH="$BRANCH" \
+              E2E_SHA="$SHA" \
+              E2E_SOURCE_LINE="$SOURCE_LINE" \
+              E2E_EVENT_NAME="$EVENT_NAME" \
+              E2E_SCHEDULE_CRON="$SCHEDULE_CRON" \
+              E2E_RUN_URL="$RUN_URL" \
+              E2E_TEST_REPORT_URL="$TEST_REPORT_URL" \
+              E2E_DAEMON_LOGS_URL="$DAEMON_LOGS_URL" \
+              "${E2E_SCRIPTS_DIR}/compose_zulip_e2e_message.sh" "${REPORT_ARGS[@]}"
             echo "MSG_EOF"
           } >> "$GITHUB_OUTPUT"
 

--- a/nym-vpn-core/crates/test/test-manager/src/logging.rs
+++ b/nym-vpn-core/crates/test/test-manager/src/logging.rs
@@ -152,12 +152,14 @@ pub struct TestOutput {
     pub log_output: Option<LogOutput>,
 }
 
-/// Inventory / environment gaps should use `bail!("SKIP: …")` so CI stays green
-/// without a silent pass.
+/// Prefix for inventory / environment gaps. Prefer `bail!("{SKIP_PREFIX} …")` so CI
+/// stays green without a silent pass; mapped to [`TestResult::Skip`].
+pub const SKIP_PREFIX: &str = "SKIP:";
+
 pub fn is_skip_error(error: &Error) -> bool {
     error
         .chain()
-        .any(|cause| cause.to_string().starts_with("SKIP:"))
+        .any(|cause| cause.to_string().starts_with(SKIP_PREFIX))
 }
 
 // Convert this unwieldy return type to a workable `TestResult`.
@@ -321,7 +323,7 @@ mod tests {
 
     #[test]
     fn skip_prefix_maps_to_skip_not_failure() {
-        let err = anyhow::anyhow!("SKIP: no inventory");
+        let err = anyhow::anyhow!("{} no inventory", super::SKIP_PREFIX);
         assert!(is_skip_error(&err));
         let result = TestResult::from(Ok::<Result<(), anyhow::Error>, Panic>(Err(err)));
         assert!(matches!(result, TestResult::Skip(_)));
@@ -333,7 +335,7 @@ mod tests {
     #[test]
     fn nested_skip_via_context_still_maps() {
         // Inherent Error::context (not the Result Context trait).
-        let err = anyhow::anyhow!("SKIP: gap").context("outer wrapper");
+        let err = anyhow::anyhow!("{} gap", super::SKIP_PREFIX).context("outer wrapper");
         assert!(is_skip_error(&err));
         let result = TestResult::from(Ok::<Result<(), anyhow::Error>, Panic>(Err(err)));
         assert!(matches!(result, TestResult::Skip(_)));

--- a/nym-vpn-core/crates/test/test-manager/src/logging.rs
+++ b/nym-vpn-core/crates/test/test-manager/src/logging.rs
@@ -152,12 +152,21 @@ pub struct TestOutput {
     pub log_output: Option<LogOutput>,
 }
 
+/// Inventory / environment gaps should use `bail!("SKIP: …")` so CI stays green
+/// without a silent pass.
+pub fn is_skip_error(error: &Error) -> bool {
+    error
+        .chain()
+        .any(|cause| cause.to_string().starts_with("SKIP:"))
+}
+
 // Convert this unwieldy return type to a workable `TestResult`.
 // What we are converting from is the acutal return type of the test execution.
 impl From<Result<Result<(), Error>, Panic>> for TestResult {
     fn from(value: Result<Result<(), Error>, Panic>) -> Self {
         match value {
             Ok(Ok(())) => TestResult::Pass,
+            Ok(Err(e)) if is_skip_error(&e) => TestResult::Skip(e),
             Ok(Err(e)) => TestResult::Fail(e),
             Err(e) => TestResult::Panic(e),
         }
@@ -169,6 +178,8 @@ impl From<Result<Result<(), Error>, Panic>> for TestResult {
 pub enum TestResult {
     /// Test passed.
     Pass,
+    /// Environment/inventory unavailable; treated as non-failure for suite pass/fail.
+    Skip(Error),
     /// Test failed during execution. Contains the source error which caused the test to fail.
     Fail(Error),
     /// Test panicked during execution. Contains the caught unwound panic.
@@ -186,15 +197,16 @@ impl TestResult {
     pub const fn summary(&self) -> summary::TestResult {
         match self {
             TestResult::Pass => summary::TestResult::Pass,
+            TestResult::Skip(_) => summary::TestResult::Skip,
             TestResult::Fail(_) | TestResult::Panic(_) => summary::TestResult::Fail,
         }
     }
 
-    /// Consume `self` and convert into a [`Result`] where [`TestResult::Pass`] is mapped to [`Ok`]
-    /// while [`TestResult::Fail`] & [`TestResult::Panic`] is mapped to [`Err`].
+    /// Consume `self` and convert into a [`Result`] where [`TestResult::Pass`] / [`Skip`] map to
+    /// [`Ok`] while [`TestResult::Fail`] & [`TestResult::Panic`] map to [`Err`].
     pub fn anyhow(self) -> anyhow::Result<()> {
         match self {
-            TestResult::Pass => Ok(()),
+            TestResult::Pass | TestResult::Skip(_) => Ok(()),
             TestResult::Fail(error) => anyhow::bail!(error),
             TestResult::Panic(error) => anyhow::bail!(error.to_string()),
         }
@@ -218,6 +230,18 @@ impl TestOutput {
                 println_with_time!(
                     "{}",
                     format!("[TEST] {} SUCCEEDED! ✅", self.test_name).green()
+                );
+                return;
+            }
+            TestResult::Skip(e) => {
+                println_with_time!(
+                    "{}",
+                    format!(
+                        "[TEST] {} SKIPPED ↪️: {}",
+                        self.test_name,
+                        format!("{e:#}").bold()
+                    )
+                    .yellow()
                 );
                 return;
             }
@@ -287,5 +311,40 @@ impl TestOutput {
         }
 
         println_with_time!("{}", format!("TEST {} END OF OUTPUT", self.test_name).red());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Panic, TestResult, is_skip_error};
+    use crate::summary;
+
+    #[test]
+    fn skip_prefix_maps_to_skip_not_failure() {
+        let err = anyhow::anyhow!("SKIP: no inventory");
+        assert!(is_skip_error(&err));
+        let result = TestResult::from(Ok::<Result<(), anyhow::Error>, Panic>(Err(err)));
+        assert!(matches!(result, TestResult::Skip(_)));
+        assert!(!result.failure());
+        assert!(matches!(result.summary(), summary::TestResult::Skip));
+        assert!(result.anyhow().is_ok());
+    }
+
+    #[test]
+    fn nested_skip_via_context_still_maps() {
+        // Inherent Error::context (not the Result Context trait).
+        let err = anyhow::anyhow!("SKIP: gap").context("outer wrapper");
+        assert!(is_skip_error(&err));
+        let result = TestResult::from(Ok::<Result<(), anyhow::Error>, Panic>(Err(err)));
+        assert!(matches!(result, TestResult::Skip(_)));
+    }
+
+    #[test]
+    fn non_skip_error_is_fail() {
+        let err = anyhow::anyhow!("real failure");
+        assert!(!is_skip_error(&err));
+        let result = TestResult::from(Ok::<Result<(), anyhow::Error>, Panic>(Err(err)));
+        assert!(matches!(result, TestResult::Fail(_)));
+        assert!(result.failure());
     }
 }

--- a/nym-vpn-core/crates/test/test-manager/src/tests/blocking_tests.rs
+++ b/nym-vpn-core/crates/test/test-manager/src/tests/blocking_tests.rs
@@ -5,7 +5,7 @@
 
 use crate::tests::{
     TestContext,
-    helpers_nym::{self, ROUNDTRIP_DNS_TIMEOUT, resolve_hostname_with_retry},
+    helpers_nym::{self},
     nym_test::dc_and_ensure_logged_in,
 };
 use anyhow::Context;
@@ -106,44 +106,61 @@ fn verification_for_blocked_addrs(blocked_socket_addrs: &[String]) -> TunnelVeri
     }
 }
 
-/// Verify that the VPN tunnel carries traffic, by hostname or by IP depending on
-/// whether the test blocked the resolvers the tunnel itself depends on.
-async fn verify_tunnel_connectivity(
-    rpc: &NymServiceClient,
-    verification: TunnelVerification,
-) -> anyhow::Result<()> {
-    match verification {
-        TunnelVerification::ResolveHostnames => {
-            for host in ["nym.com", "google.com"] {
-                log::info!("Resolving {} inside VM via VPN tunnel...", host);
-                let addrs = resolve_hostname_with_retry(rpc, host, ROUNDTRIP_DNS_TIMEOUT)
-                    .await
-                    .context(format!("DNS resolution failed for {host} inside VM"))?;
-                log::info!("Resolved {} to {:?}", host, addrs);
+/// Verify IP-only tunnel reachability (used when DNS resolvers themselves are blocked).
+async fn verify_tunnel_ip_connectivity(rpc: &NymServiceClient) -> anyhow::Result<()> {
+    let mut last_error = None;
+    for dest in IP_PROBE_SOCKET_ADDRS {
+        log::info!("Connecting to {} inside VM via VPN tunnel...", dest);
+        match rpc.send_tcp(None, IP_PROBE_BIND_ADDR, dest).await {
+            Ok(()) => {
+                log::info!("TCP connectivity to {} verified inside VM", dest);
+                return Ok(());
             }
-            Ok(())
+            Err(error) => {
+                log::warn!("TCP connectivity to {dest} failed inside VM: {error}");
+                last_error = Some(anyhow::Error::new(error).context(format!("probe {dest}")));
+            }
         }
-        TunnelVerification::ReachIpOnly => {
-            let mut last_error = None;
-            for dest in IP_PROBE_SOCKET_ADDRS {
-                log::info!("Connecting to {} inside VM via VPN tunnel...", dest);
-                match rpc.send_tcp(None, IP_PROBE_BIND_ADDR, dest).await {
-                    Ok(()) => {
-                        log::info!("TCP connectivity to {} verified inside VM", dest);
-                        return Ok(());
-                    }
-                    Err(error) => {
-                        log::warn!("TCP connectivity to {dest} failed inside VM: {error}");
-                        last_error =
-                            Some(anyhow::Error::new(error).context(format!("probe {dest}")));
+    }
+    Err(last_error
+        .unwrap_or_else(|| anyhow::anyhow!("no probe addresses configured"))
+        .context("TCP connectivity failed inside VM for every probe address"))
+}
+
+/// Resolve hostnames in-tunnel with one exit retry on dead/partial DoT upstream TCP.
+async fn verify_tunnel_dns_with_exit_retry(
+    rpc: &NymServiceClient,
+    provider: &crate::nym_daemon::RpcClientProvider,
+    mut nym_client: NymProxyClient,
+) -> (anyhow::Result<()>, Option<NymProxyClient>) {
+    for host in ["nym.com", "google.com"] {
+        log::info!("Resolving {} inside VM via VPN tunnel...", host);
+        let outcome =
+            helpers_nym::ensure_in_tunnel_hostname_resolves(rpc, provider, nym_client, host).await;
+        match outcome.resolve {
+            Ok(addrs) => {
+                log::info!("Resolved {} to {:?}", host, addrs);
+                match outcome.client {
+                    Some(client) => nym_client = client,
+                    None => {
+                        return (
+                            Err(anyhow::anyhow!(
+                                "DNS ok for {host} but cleanup client was lost"
+                            )),
+                            None,
+                        );
                     }
                 }
             }
-            Err(last_error
-                .unwrap_or_else(|| anyhow::anyhow!("no probe addresses configured"))
-                .context("TCP connectivity failed inside VM for every probe address"))
+            Err(error) => {
+                return (
+                    Err(error.context(format!("DNS resolution failed for {host} inside VM"))),
+                    outcome.client,
+                );
+            }
         }
     }
+    (Ok(()), Some(nym_client))
 }
 
 async fn with_socket_blocks<F, Fut>(
@@ -242,12 +259,20 @@ async fn connect_verify_disconnect(
     )
     .await?;
 
-    verify_tunnel_connectivity(rpc, verification).await?;
+    let (body, nym_client) = match verification {
+        TunnelVerification::ResolveHostnames => {
+            verify_tunnel_dns_with_exit_retry(rpc, &test_context.rpc_provider, nym_client).await
+        }
+        TunnelVerification::ReachIpOnly => {
+            (verify_tunnel_ip_connectivity(rpc).await, Some(nym_client))
+        }
+    };
 
     log::info!("Disconnecting tunnel...");
-    helpers_nym::disconnect_and_wait(rpc, nym_client, &test_context.rpc_provider).await?;
-
-    Ok(())
+    let cleanup =
+        helpers_nym::disconnect_after_in_tunnel_dns(rpc, &test_context.rpc_provider, nym_client)
+            .await;
+    merge_body_and_cleanup(body, cleanup)
 }
 
 /// Ensure connection with default DNS Nameservers blocklisted

--- a/nym-vpn-core/crates/test/test-manager/src/tests/helpers_nym.rs
+++ b/nym-vpn-core/crates/test/test-manager/src/tests/helpers_nym.rs
@@ -882,6 +882,7 @@ pub fn classify_upstream_probes(
     }
 }
 
+#[cfg(test)]
 fn summarize_upstream_probes(probes: &[(SocketAddr, Option<String>)]) -> String {
     classify_upstream_probes(probes).summary()
 }

--- a/nym-vpn-core/crates/test/test-manager/src/tests/helpers_nym.rs
+++ b/nym-vpn-core/crates/test/test-manager/src/tests/helpers_nym.rs
@@ -373,6 +373,20 @@ pub async fn set_enable_two_hop_with_recovery(
     Ok(client)
 }
 
+pub async fn set_allow_lan_with_recovery(
+    provider: &RpcClientProvider,
+    client: NymProxyClient,
+    allow_lan: bool,
+) -> Result<NymProxyClient, Error> {
+    let (_, client) =
+        call_nym_with_transport_recovery(provider, client, move |mut client| async move {
+            let result = client.set_allow_lan(allow_lan).await;
+            (client, result)
+        })
+        .await?;
+    Ok(client)
+}
+
 pub async fn connect_tunnel_with_recovery(
     provider: &RpcClientProvider,
     client: NymProxyClient,

--- a/nym-vpn-core/crates/test/test-manager/src/tests/helpers_nym.rs
+++ b/nym-vpn-core/crates/test/test-manager/src/tests/helpers_nym.rs
@@ -809,7 +809,7 @@ const DNS_PROBE_BIND_ADDR: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNS
 /// Classification of raw TCP reachability to public DoT upstreams through the tunnel.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DnsUpstreamReachability {
-    /// DoT TCP to every probe succeeded - daemon local forwarder is the likely failure point.
+    /// DoT TCP to every probe succeeded - DoT/query or local forwarder may still be failing.
     AllReachable { reached: String },
     /// No DoT TCP probe succeeded - exit-hop public egress is likely dead.
     NoneReachable { reasons: String },
@@ -821,8 +821,8 @@ impl DnsUpstreamReachability {
     pub fn summary(&self) -> String {
         match self {
             Self::AllReachable { reached } => format!(
-                "tunnel reaches every DNS upstream ({reached}), so the daemon's local forwarder \
-                 is the likely failure point"
+                "tunnel TCP-reaches every DNS upstream ({reached}); DoT/query may still fail \
+                 (exit DoT path or daemon local forwarder)"
             ),
             Self::NoneReachable { reasons } => {
                 format!("tunnel reaches no DNS upstream at all ({reasons})")
@@ -833,9 +833,13 @@ impl DnsUpstreamReachability {
         }
     }
 
-    /// Dead or degraded exit egress - one reconnect with a fresh exit is warranted.
+    /// One reconnect is always warranted after in-tunnel DNS failure.
+    ///
+    /// TCP reachability to :853 is only a coarse oracle: exits can accept the handshake while
+    /// DoT/TLS queries still time out. Retrying once may select a healthier exit without hiding a
+    /// persistent forwarder bug (second failure still embeds this summary).
     pub const fn should_retry_with_new_exit(&self) -> bool {
-        matches!(self, Self::NoneReachable { .. } | Self::Partial { .. })
+        true
     }
 }
 
@@ -978,17 +982,14 @@ pub async fn ensure_in_tunnel_hostname_resolves(
         Err(error) => error,
     };
 
+    // Probe for diagnostics + retry decision. Always retry once: TCP :853 success does not prove
+    // DoT works (CI: metadata OK + DNS request timed out with AllReachable classification).
     let reachability = probe_dns_upstreams(rpc).await;
-    if !reachability.should_retry_with_new_exit() {
-        return InTunnelDnsOutcome {
-            resolve: Err(first_error),
-            client: Some(nym_client),
-        };
-    }
+    debug_assert!(reachability.should_retry_with_new_exit());
 
     log::warn!(
-        "in-tunnel DNS for {hostname} failed with likely dead exit egress ({}); \
-         disconnecting and reconnecting once",
+        "in-tunnel DNS for {hostname} failed ({}); disconnecting and reconnecting once \
+         (TCP :853 probe is coarse - may be dead exit DoT or local forwarder flake)",
         reachability.summary()
     );
 
@@ -1169,7 +1170,10 @@ mod tests {
     fn upstream_probe_summary_separates_a_dead_tunnel_from_a_dead_forwarder() {
         let all_reachable =
             summarize_upstream_probes(&[probe("9.9.9.9:853", None), probe("1.1.1.1:853", None)]);
-        assert!(all_reachable.contains("local forwarder"), "{all_reachable}");
+        assert!(
+            all_reachable.contains("DoT/query may still fail"),
+            "{all_reachable}"
+        );
 
         let none_reachable = summarize_upstream_probes(&[
             probe("9.9.9.9:853", Some("connection refused")),
@@ -1194,11 +1198,16 @@ mod tests {
     }
 
     #[test]
-    fn exit_retry_only_when_upstream_tcp_is_dead_or_partial() {
+    fn exit_retry_on_any_upstream_classification_after_dns_failure() {
         let all =
             classify_upstream_probes(&[probe("9.9.9.9:853", None), probe("1.1.1.1:853", None)]);
         assert!(matches!(all, DnsUpstreamReachability::AllReachable { .. }));
-        assert!(!all.should_retry_with_new_exit());
+        assert!(all.should_retry_with_new_exit());
+        assert!(
+            all.summary().contains("DoT/query may still fail"),
+            "{}",
+            all.summary()
+        );
 
         let none = classify_upstream_probes(&[
             probe("9.9.9.9:853", Some("timed out")),

--- a/nym-vpn-core/crates/test/test-manager/src/tests/helpers_nym.rs
+++ b/nym-vpn-core/crates/test/test-manager/src/tests/helpers_nym.rs
@@ -789,10 +789,14 @@ pub async fn resolve_hostname_with_retry(
     })
     .await;
 
-    if result.is_err() {
-        log_dns_failure_diagnostics(rpc, hostname).await;
+    match result {
+        Ok(addrs) => Ok(addrs),
+        Err(error) => {
+            let reachability = probe_dns_upstreams(rpc).await;
+            log_dns_failure_diagnostics(rpc, hostname, &reachability).await;
+            Err(error.context(reachability.summary()))
+        }
     }
-    result
 }
 
 const DOT_UPSTREAM_PROBES: [SocketAddr; 2] = [
@@ -802,33 +806,42 @@ const DOT_UPSTREAM_PROBES: [SocketAddr; 2] = [
 
 const DNS_PROBE_BIND_ADDR: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0);
 
-/// Best effort: a diagnostic that fails must not replace the resolution error.
-async fn log_dns_failure_diagnostics(rpc: &NymServiceClient, hostname: &str) {
-    for args in [["status", "tun1"], ["query", hostname]] {
-        match rpc.exec("resolvectl", args).await {
-            Ok(output) => log::error!(
-                "resolvectl {}: {}{}",
-                args.join(" "),
-                String::from_utf8_lossy(&output.stdout),
-                String::from_utf8_lossy(&output.stderr)
+/// Classification of raw TCP reachability to public DoT upstreams through the tunnel.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DnsUpstreamReachability {
+    /// DoT TCP to every probe succeeded - daemon local forwarder is the likely failure point.
+    AllReachable { reached: String },
+    /// No DoT TCP probe succeeded - exit-hop public egress is likely dead.
+    NoneReachable { reasons: String },
+    /// Mixed - treat like a degraded exit for retry purposes.
+    Partial { reached: String, missed: String },
+}
+
+impl DnsUpstreamReachability {
+    pub fn summary(&self) -> String {
+        match self {
+            Self::AllReachable { reached } => format!(
+                "tunnel reaches every DNS upstream ({reached}), so the daemon's local forwarder \
+                 is the likely failure point"
             ),
-            Err(error) => log::warn!("resolvectl {} failed in VM: {error}", args.join(" ")),
+            Self::NoneReachable { reasons } => {
+                format!("tunnel reaches no DNS upstream at all ({reasons})")
+            }
+            Self::Partial { reached, missed } => {
+                format!("tunnel reaches {reached} but not {missed}")
+            }
         }
     }
 
-    let mut probes = Vec::with_capacity(DOT_UPSTREAM_PROBES.len());
-    for dest in DOT_UPSTREAM_PROBES {
-        let failure = rpc
-            .send_tcp(None, DNS_PROBE_BIND_ADDR, dest)
-            .await
-            .err()
-            .map(|error| error.to_string());
-        probes.push((dest, failure));
+    /// Dead or degraded exit egress - one reconnect with a fresh exit is warranted.
+    pub const fn should_retry_with_new_exit(&self) -> bool {
+        matches!(self, Self::NoneReachable { .. } | Self::Partial { .. })
     }
-    log::error!("{}", summarize_upstream_probes(&probes));
 }
 
-fn summarize_upstream_probes(probes: &[(SocketAddr, Option<String>)]) -> String {
+pub fn classify_upstream_probes(
+    probes: &[(SocketAddr, Option<String>)],
+) -> DnsUpstreamReachability {
     let (unreachable, reachable): (Vec<_>, Vec<_>) =
         probes.iter().partition(|(_, failure)| failure.is_some());
 
@@ -841,10 +854,9 @@ fn summarize_upstream_probes(probes: &[(SocketAddr, Option<String>)]) -> String 
     };
 
     if unreachable.is_empty() {
-        return format!(
-            "tunnel reaches every DNS upstream ({}), so the daemon's local forwarder is the likely failure point",
-            reached(&reachable)
-        );
+        return DnsUpstreamReachability::AllReachable {
+            reached: reached(&reachable),
+        };
     }
 
     let reasons = unreachable
@@ -857,9 +869,191 @@ fn summarize_upstream_probes(probes: &[(SocketAddr, Option<String>)]) -> String 
         .join("; ");
 
     if reachable.is_empty() {
-        format!("tunnel reaches no DNS upstream at all ({reasons})")
+        DnsUpstreamReachability::NoneReachable { reasons }
     } else {
-        format!("tunnel reaches {} but not {reasons}", reached(&reachable))
+        DnsUpstreamReachability::Partial {
+            reached: reached(&reachable),
+            missed: reasons,
+        }
+    }
+}
+
+fn summarize_upstream_probes(probes: &[(SocketAddr, Option<String>)]) -> String {
+    classify_upstream_probes(probes).summary()
+}
+
+pub async fn probe_dns_upstreams(rpc: &NymServiceClient) -> DnsUpstreamReachability {
+    let mut probes = Vec::with_capacity(DOT_UPSTREAM_PROBES.len());
+    for dest in DOT_UPSTREAM_PROBES {
+        let failure = rpc
+            .send_tcp(None, DNS_PROBE_BIND_ADDR, dest)
+            .await
+            .err()
+            .map(|error| error.to_string());
+        probes.push((dest, failure));
+    }
+    classify_upstream_probes(&probes)
+}
+
+/// Best effort: a diagnostic that fails must not replace the resolution error.
+async fn log_dns_failure_diagnostics(
+    rpc: &NymServiceClient,
+    hostname: &str,
+    reachability: &DnsUpstreamReachability,
+) {
+    for args in [["status", "tun1"], ["query", hostname]] {
+        match rpc.exec("resolvectl", args).await {
+            Ok(output) => log::error!(
+                "resolvectl {}: {}{}",
+                args.join(" "),
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            ),
+            Err(error) => log::warn!("resolvectl {} failed in VM: {error}", args.join(" ")),
+        }
+    }
+    log::error!("{}", reachability.summary());
+}
+
+async fn recover_client_for_cleanup(provider: &RpcClientProvider) -> Option<NymProxyClient> {
+    match provider.recover_client_nym().await {
+        Ok(client) => Some(client),
+        Err(_) => provider.new_client_nym().await.ok(),
+    }
+}
+
+/// Prefer the live client; if missing, use a recovered one. Err when both are absent.
+pub fn resolve_dns_cleanup_client<T>(
+    existing: Option<T>,
+    recovered: Option<T>,
+) -> anyhow::Result<T> {
+    match existing {
+        Some(client) => Ok(client),
+        None => recovered.ok_or_else(|| {
+            anyhow::anyhow!(
+                "lost nym client after in-tunnel DNS exit retry; tunnel may remain connected"
+            )
+        }),
+    }
+}
+
+/// Disconnect after in-tunnel DNS work. Recovers a client when the ensure path lost it.
+pub async fn disconnect_after_in_tunnel_dns(
+    rpc: &NymServiceClient,
+    provider: &RpcClientProvider,
+    client: Option<NymProxyClient>,
+) -> anyhow::Result<()> {
+    let recovered = if client.is_none() {
+        recover_client_for_cleanup(provider).await
+    } else {
+        None
+    };
+    let client = resolve_dns_cleanup_client(client, recovered)?;
+    disconnect_and_wait(rpc, client, provider)
+        .await
+        .map(|_| ())
+        .map_err(|error| anyhow::anyhow!(error))
+}
+
+/// Result of [`ensure_in_tunnel_hostname_resolves`]: DNS outcome plus optional cleanup client.
+pub struct InTunnelDnsOutcome {
+    pub resolve: anyhow::Result<Vec<SocketAddr>>,
+    pub client: Option<NymProxyClient>,
+}
+
+pub async fn ensure_in_tunnel_hostname_resolves(
+    rpc: &NymServiceClient,
+    provider: &RpcClientProvider,
+    mut nym_client: NymProxyClient,
+    hostname: &str,
+) -> InTunnelDnsOutcome {
+    let first_error = match resolve_hostname_with_retry(rpc, hostname, ROUNDTRIP_DNS_TIMEOUT).await
+    {
+        Ok(addrs) => {
+            return InTunnelDnsOutcome {
+                resolve: Ok(addrs),
+                client: Some(nym_client),
+            };
+        }
+        Err(error) => error,
+    };
+
+    let reachability = probe_dns_upstreams(rpc).await;
+    if !reachability.should_retry_with_new_exit() {
+        return InTunnelDnsOutcome {
+            resolve: Err(first_error),
+            client: Some(nym_client),
+        };
+    }
+
+    log::warn!(
+        "in-tunnel DNS for {hostname} failed with likely dead exit egress ({}); \
+         disconnecting and reconnecting once",
+        reachability.summary()
+    );
+
+    nym_client = match disconnect_and_wait(rpc, nym_client, provider).await {
+        Ok(client) => client,
+        Err(error) => {
+            return InTunnelDnsOutcome {
+                resolve: Err(first_error.context(format!(
+                    "exit retry aborted: disconnect failed ({error:#}); {}",
+                    reachability.summary()
+                ))),
+                client: recover_client_for_cleanup(provider).await,
+            };
+        }
+    };
+
+    nym_client = match connect_tunnel_with_recovery(provider, nym_client).await {
+        Ok(client) => client,
+        Err(error) => {
+            return InTunnelDnsOutcome {
+                resolve: Err(anyhow::anyhow!(
+                    "exit retry aborted: reconnect failed ({error:#}); first DNS failure: \
+                     {first_error:#}; {}",
+                    reachability.summary()
+                )),
+                client: recover_client_for_cleanup(provider).await,
+            };
+        }
+    };
+
+    nym_client = match wait_for_tunnel_state(
+        rpc,
+        nym_client,
+        provider,
+        ExpectedTunnelState::Connected,
+    )
+    .await
+    {
+        Ok((_, client)) => client,
+        Err(error) => {
+            return InTunnelDnsOutcome {
+                resolve: Err(anyhow::anyhow!(
+                    "exit retry aborted: wait Connected failed ({error:#}); first DNS failure: \
+                     {first_error:#}; {}",
+                    reachability.summary()
+                )),
+                client: recover_client_for_cleanup(provider).await,
+            };
+        }
+    };
+
+    match resolve_hostname_with_retry(rpc, hostname, ROUNDTRIP_DNS_TIMEOUT).await {
+        Ok(addrs) => {
+            log::info!("in-tunnel DNS for {hostname} succeeded after one exit retry");
+            InTunnelDnsOutcome {
+                resolve: Ok(addrs),
+                client: Some(nym_client),
+            }
+        }
+        Err(second_error) => InTunnelDnsOutcome {
+            resolve: Err(second_error.context(format!(
+                "in-tunnel DNS still failing after one exit retry; first failure was: {first_error:#}"
+            ))),
+            client: Some(nym_client),
+        },
     }
 }
 
@@ -911,12 +1105,13 @@ where
 mod tests {
     use super::{
         AccountWaiter, AllowLanPrepClass, DisconnectClient, DisconnectRpcClass,
-        ExpectedTunnelState, TunnelObserver, account_target, classify_allow_lan_prep,
-        classify_disconnect_nym_error, classify_disconnect_rpc, enforce_tunnel_wait_deadline,
-        is_daemon_rpc_transport_error, is_daemon_rpc_transport_message,
-        is_nym_client_transport_error, merge_wait_and_client, resolve_with_retry, run_account_wait,
-        run_tunnel_wait, settle_daemon_rpc_quiesce, summarize_upstream_probes, tunnel_target,
-        tunnel_wait_budget, tunnel_wait_params,
+        DnsUpstreamReachability, ExpectedTunnelState, TunnelObserver, account_target,
+        classify_allow_lan_prep, classify_disconnect_nym_error, classify_disconnect_rpc,
+        classify_upstream_probes, enforce_tunnel_wait_deadline, is_daemon_rpc_transport_error,
+        is_daemon_rpc_transport_message, is_nym_client_transport_error, merge_wait_and_client,
+        resolve_dns_cleanup_client, resolve_with_retry, run_account_wait, run_tunnel_wait,
+        settle_daemon_rpc_quiesce, summarize_upstream_probes, tunnel_target, tunnel_wait_budget,
+        tunnel_wait_params,
     };
     use crate::tests::{Error, WAIT_FOR_TUNNEL_CONNECTED_TIMEOUT, WAIT_FOR_TUNNEL_STATE_TIMEOUT};
     use futures::StreamExt;
@@ -996,6 +1191,62 @@ mod tests {
         ]);
         assert!(mixed.contains("9.9.9.9:853"), "{mixed}");
         assert!(mixed.contains("1.1.1.1:853: timed out"), "{mixed}");
+    }
+
+    #[test]
+    fn exit_retry_only_when_upstream_tcp_is_dead_or_partial() {
+        let all =
+            classify_upstream_probes(&[probe("9.9.9.9:853", None), probe("1.1.1.1:853", None)]);
+        assert!(matches!(all, DnsUpstreamReachability::AllReachable { .. }));
+        assert!(!all.should_retry_with_new_exit());
+
+        let none = classify_upstream_probes(&[
+            probe("9.9.9.9:853", Some("timed out")),
+            probe("1.1.1.1:853", Some("timed out")),
+        ]);
+        assert!(matches!(
+            none,
+            DnsUpstreamReachability::NoneReachable { .. }
+        ));
+        assert!(none.should_retry_with_new_exit());
+
+        let partial = classify_upstream_probes(&[
+            probe("9.9.9.9:853", None),
+            probe("1.1.1.1:853", Some("timed out")),
+        ]);
+        assert!(matches!(partial, DnsUpstreamReachability::Partial { .. }));
+        assert!(partial.should_retry_with_new_exit());
+    }
+
+    #[test]
+    fn dns_failure_context_embeds_upstream_probe_summary() {
+        let summary = classify_upstream_probes(&[
+            probe("9.9.9.9:853", Some("timed out")),
+            probe("1.1.1.1:853", Some("connection refused")),
+        ])
+        .summary();
+        let err = anyhow::anyhow!("resolve timed out").context(summary);
+        let rendered = format!("{err:#}");
+        assert!(rendered.contains("no DNS upstream at all"), "{rendered}");
+        assert!(rendered.contains("timed out"), "{rendered}");
+    }
+
+    #[test]
+    fn dns_cleanup_recovers_missing_client_or_errors_explicitly() {
+        assert_eq!(
+            resolve_dns_cleanup_client(Some(7), None).expect("existing client"),
+            7
+        );
+        assert_eq!(
+            resolve_dns_cleanup_client(None, Some(9)).expect("recovered client"),
+            9
+        );
+        let err = resolve_dns_cleanup_client::<i32>(None, None).expect_err("both missing");
+        let rendered = format!("{err}");
+        assert!(
+            rendered.contains("tunnel may remain connected"),
+            "{rendered}"
+        );
     }
 
     #[tokio::test(start_paused = true)]

--- a/nym-vpn-core/crates/test/test-manager/src/tests/mod.rs
+++ b/nym-vpn-core/crates/test/test-manager/src/tests/mod.rs
@@ -7,6 +7,7 @@ pub mod config_nym;
 mod envs;
 pub(crate) mod helpers_nym;
 pub mod nym_test;
+mod reliability_tests;
 mod test_metadata;
 mod tunnel_tests;
 

--- a/nym-vpn-core/crates/test/test-manager/src/tests/reliability_tests.rs
+++ b/nym-vpn-core/crates/test/test-manager/src/tests/reliability_tests.rs
@@ -63,14 +63,9 @@ async fn connect_and_wait_connected(
     nym_client: NymProxyClient,
 ) -> anyhow::Result<(ObservedTunnelState, NymProxyClient)> {
     let nym_client = helpers_nym::connect_tunnel_with_recovery(provider, nym_client).await?;
-    wait_for_tunnel_state(
-        rpc,
-        nym_client,
-        provider,
-        ExpectedTunnelState::Connected,
-    )
-    .await
-    .map_err(Into::into)
+    wait_for_tunnel_state(rpc, nym_client, provider, ExpectedTunnelState::Connected)
+        .await
+        .map_err(Into::into)
 }
 
 /// LAN / link-local ranges that `allow_lan=false` is expected to fence off.

--- a/nym-vpn-core/crates/test/test-manager/src/tests/reliability_tests.rs
+++ b/nym-vpn-core/crates/test/test-manager/src/tests/reliability_tests.rs
@@ -110,14 +110,21 @@ async fn tcp_reachable(rpc: &NymServiceClient, dest: SocketAddr) -> bool {
     rpc.send_tcp(None, PROBE_BIND, dest).await.is_ok()
 }
 
-async fn assert_tunnel_dns_and_tcp(rpc: &NymServiceClient) -> anyhow::Result<()> {
-    let addrs = resolve_hostname_with_retry(rpc, "nym.com", ROUNDTRIP_DNS_TIMEOUT)
-        .await
-        .context("in-tunnel DNS failed")?;
-    let dest = SocketAddr::new(addrs[0].ip(), 443);
-    rpc.send_tcp(None, PROBE_BIND, dest)
-        .await
-        .context("in-tunnel TCP failed")?;
+async fn assert_lan_resolvers_blocked(
+    rpc: &NymServiceClient,
+    lan_nameservers: &[IpAddr],
+) -> anyhow::Result<()> {
+    let mut still_open = Vec::new();
+    for ip in lan_nameservers {
+        let dest = SocketAddr::new(*ip, 53);
+        if tcp_reachable(rpc, dest).await {
+            still_open.push(dest);
+        }
+    }
+    ensure!(
+        still_open.is_empty(),
+        "allow_lan=false but LAN resolvers still reachable on TCP/53: {still_open:?}"
+    );
     Ok(())
 }
 
@@ -237,24 +244,49 @@ pub async fn test_allow_lan_off_blocks_prior_resolver_tcp(
     let (_, nym_client) =
         connect_and_wait_connected(&rpc, &test_context.rpc_provider, nym_client).await?;
 
-    let body = async {
-        let mut still_open = Vec::new();
-        for ip in &lan_nameservers {
-            let dest = SocketAddr::new(*ip, 53);
-            if tcp_reachable(&rpc, dest).await {
-                still_open.push(dest);
+    let body_lan = assert_lan_resolvers_blocked(&rpc, &lan_nameservers).await;
+    let (body, nym_client) = match body_lan {
+        Err(error) => (Err(error), Some(nym_client)),
+        Ok(()) => {
+            let outcome = helpers_nym::ensure_in_tunnel_hostname_resolves(
+                &rpc,
+                &test_context.rpc_provider,
+                nym_client,
+                "nym.com",
+            )
+            .await;
+            match outcome.resolve {
+                Ok(addrs) => match addrs.first() {
+                    None => (
+                        Err(anyhow::anyhow!("in-tunnel DNS returned no addresses")),
+                        outcome.client,
+                    ),
+                    Some(first) => {
+                        let dest = SocketAddr::new(first.ip(), 443);
+                        let tcp = rpc
+                            .send_tcp(None, PROBE_BIND, dest)
+                            .await
+                            .context("in-tunnel TCP failed");
+                        // Re-check LAN after a possible exit reconnect (allow_lan must persist).
+                        let lan = assert_lan_resolvers_blocked(&rpc, &lan_nameservers).await;
+                        let combined = match (tcp, lan) {
+                            (Ok(()), Ok(())) => Ok(()),
+                            (Err(e), Ok(())) | (Ok(()), Err(e)) => Err(e),
+                            (Err(e), Err(lan_err)) => Err(e.context(format!(
+                                "LAN re-check also failed after DNS retry: {lan_err:#}"
+                            ))),
+                        };
+                        (combined, outcome.client)
+                    }
+                },
+                Err(error) => (Err(error.context("in-tunnel DNS failed")), outcome.client),
             }
         }
-        ensure!(
-            still_open.is_empty(),
-            "allow_lan=false but LAN resolvers still reachable on TCP/53: {still_open:?}"
-        );
-        assert_tunnel_dns_and_tcp(&rpc).await?;
-        Ok(())
-    }
-    .await;
+    };
 
-    let cleanup = disconnect_cleanup(&rpc, nym_client, &test_context.rpc_provider).await;
+    let cleanup =
+        helpers_nym::disconnect_after_in_tunnel_dns(&rpc, &test_context.rpc_provider, nym_client)
+            .await;
     merge_body_and_cleanup(body, cleanup)
 }
 
@@ -335,8 +367,29 @@ pub async fn test_daemon_restart_then_reconnect(
     let (_, nym_client) =
         connect_and_wait_connected(&rpc, &test_context.rpc_provider, nym_client).await?;
 
-    let body = assert_tunnel_dns_and_tcp(&rpc).await;
-    let cleanup = disconnect_cleanup(&rpc, nym_client, &test_context.rpc_provider).await;
+    let outcome = helpers_nym::ensure_in_tunnel_hostname_resolves(
+        &rpc,
+        &test_context.rpc_provider,
+        nym_client,
+        "nym.com",
+    )
+    .await;
+    let body = match outcome.resolve {
+        Ok(addrs) => match addrs.first() {
+            Some(first) => rpc
+                .send_tcp(None, PROBE_BIND, SocketAddr::new(first.ip(), 443))
+                .await
+                .context("in-tunnel TCP failed"),
+            None => Err(anyhow::anyhow!("in-tunnel DNS returned no addresses")),
+        },
+        Err(error) => Err(error.context("in-tunnel DNS failed")),
+    };
+    let cleanup = helpers_nym::disconnect_after_in_tunnel_dns(
+        &rpc,
+        &test_context.rpc_provider,
+        outcome.client,
+    )
+    .await;
     merge_body_and_cleanup(body, cleanup)
 }
 

--- a/nym-vpn-core/crates/test/test-manager/src/tests/reliability_tests.rs
+++ b/nym-vpn-core/crates/test/test-manager/src/tests/reliability_tests.rs
@@ -2,13 +2,17 @@
 //!
 //! Priorities sit after core tunnel tests and before censorship blocklist cases.
 
-use crate::tests::{
-    TestContext,
-    helpers_nym::{
-        self, ExpectedTunnelState, ROUNDTRIP_DNS_TIMEOUT, resolve_hostname_with_retry,
-        wait_for_tunnel_state,
+use crate::{
+    logging::SKIP_PREFIX,
+    nym_daemon::RpcClientProvider,
+    tests::{
+        TestContext,
+        helpers_nym::{
+            self, ExpectedTunnelState, ROUNDTRIP_DNS_TIMEOUT, resolve_hostname_with_retry,
+            wait_for_tunnel_state,
+        },
+        nym_test::dc_and_ensure_logged_in,
     },
-    nym_test::dc_and_ensure_logged_in,
 };
 use anyhow::{Context, bail, ensure};
 use nym_vpn_lib_types::ExitPoint;
@@ -40,6 +44,33 @@ fn merge_body_and_cleanup(
             "cleanup also failed (guest may be left degraded): {cleanup_err:#}"
         ))),
     }
+}
+
+async fn disconnect_cleanup(
+    rpc: &NymServiceClient,
+    nym_client: NymProxyClient,
+    provider: &RpcClientProvider,
+) -> Result<(), anyhow::Error> {
+    helpers_nym::disconnect_and_wait(rpc, nym_client, provider)
+        .await
+        .map(|_| ())
+        .map_err(|e| anyhow::anyhow!(e))
+}
+
+async fn connect_and_wait_connected(
+    rpc: &NymServiceClient,
+    provider: &RpcClientProvider,
+    nym_client: NymProxyClient,
+) -> anyhow::Result<(ObservedTunnelState, NymProxyClient)> {
+    let nym_client = helpers_nym::connect_tunnel_with_recovery(provider, nym_client).await?;
+    wait_for_tunnel_state(
+        rpc,
+        nym_client,
+        provider,
+        ExpectedTunnelState::Connected,
+    )
+    .await
+    .map_err(Into::into)
 }
 
 /// LAN / link-local ranges that `allow_lan=false` is expected to fence off.
@@ -197,8 +228,8 @@ pub async fn test_allow_lan_off_blocks_prior_resolver_tcp(
     let lan_nameservers = get_vm_lan_nameservers(&rpc).await?;
     if lan_nameservers.is_empty() {
         bail!(
-            "SKIP: VM has no LAN/private resolvectl nameservers to probe under allow_lan=false \
-             (public resolvers are not a LAN-policy oracle)"
+            "{SKIP_PREFIX} VM has no LAN/private resolvectl nameservers to probe under \
+             allow_lan=false (public resolvers are not a LAN-policy oracle)"
         );
     }
 
@@ -208,33 +239,28 @@ pub async fn test_allow_lan_off_blocks_prior_resolver_tcp(
     let nym_client =
         helpers_nym::set_enable_two_hop_with_recovery(&test_context.rpc_provider, nym_client, true)
             .await?;
+    let (_, nym_client) =
+        connect_and_wait_connected(&rpc, &test_context.rpc_provider, nym_client).await?;
 
-    let nym_client =
-        helpers_nym::connect_tunnel_with_recovery(&test_context.rpc_provider, nym_client).await?;
-    let (_, nym_client) = wait_for_tunnel_state(
-        &rpc,
-        nym_client,
-        &test_context.rpc_provider,
-        ExpectedTunnelState::Connected,
-    )
-    .await?;
-
-    let mut still_open = Vec::new();
-    for ip in &lan_nameservers {
-        let dest = SocketAddr::new(*ip, 53);
-        if tcp_reachable(&rpc, dest).await {
-            still_open.push(dest);
+    let body = async {
+        let mut still_open = Vec::new();
+        for ip in &lan_nameservers {
+            let dest = SocketAddr::new(*ip, 53);
+            if tcp_reachable(&rpc, dest).await {
+                still_open.push(dest);
+            }
         }
+        ensure!(
+            still_open.is_empty(),
+            "allow_lan=false but LAN resolvers still reachable on TCP/53: {still_open:?}"
+        );
+        assert_tunnel_dns_and_tcp(&rpc).await?;
+        Ok(())
     }
-    ensure!(
-        still_open.is_empty(),
-        "allow_lan=false but LAN resolvers still reachable on TCP/53: {still_open:?}"
-    );
+    .await;
 
-    assert_tunnel_dns_and_tcp(&rpc).await?;
-
-    helpers_nym::disconnect_and_wait(&rpc, nym_client, &test_context.rpc_provider).await?;
-    Ok(())
+    let cleanup = disconnect_cleanup(&rpc, nym_client, &test_context.rpc_provider).await;
+    merge_body_and_cleanup(body, cleanup)
 }
 
 /// Taking the default uplink down must surface ObservedTunnelState::Offline (daemon detection).
@@ -290,16 +316,8 @@ pub async fn test_daemon_restart_then_reconnect(
     let nym_client =
         helpers_nym::set_enable_two_hop_with_recovery(&test_context.rpc_provider, nym_client, true)
             .await?;
-
-    let nym_client =
-        helpers_nym::connect_tunnel_with_recovery(&test_context.rpc_provider, nym_client).await?;
-    let (_, nym_client) = wait_for_tunnel_state(
-        &rpc,
-        nym_client,
-        &test_context.rpc_provider,
-        ExpectedTunnelState::Connected,
-    )
-    .await?;
+    let (_, nym_client) =
+        connect_and_wait_connected(&rpc, &test_context.rpc_provider, nym_client).await?;
 
     drop(nym_client);
     log::info!("Restarting nym-vpnd via systemd...");
@@ -319,20 +337,12 @@ pub async fn test_daemon_restart_then_reconnect(
     nym_client =
         helpers_nym::set_enable_two_hop_with_recovery(&test_context.rpc_provider, nym_client, true)
             .await?;
+    let (_, nym_client) =
+        connect_and_wait_connected(&rpc, &test_context.rpc_provider, nym_client).await?;
 
-    nym_client =
-        helpers_nym::connect_tunnel_with_recovery(&test_context.rpc_provider, nym_client).await?;
-    let (_, nym_client) = wait_for_tunnel_state(
-        &rpc,
-        nym_client,
-        &test_context.rpc_provider,
-        ExpectedTunnelState::Connected,
-    )
-    .await?;
-    assert_tunnel_dns_and_tcp(&rpc).await?;
-
-    helpers_nym::disconnect_and_wait(&rpc, nym_client, &test_context.rpc_provider).await?;
-    Ok(())
+    let body = assert_tunnel_dns_and_tcp(&rpc).await;
+    let cleanup = disconnect_cleanup(&rpc, nym_client, &test_context.rpc_provider).await;
+    merge_body_and_cleanup(body, cleanup)
 }
 
 /// Fast ↔ Mixnet toggle must select the matching observed tunnel type across reconnects.
@@ -356,16 +366,8 @@ pub async fn test_two_hop_toggle_survives_reconnect(
             two_hop,
         )
         .await?;
-        nym_client =
-            helpers_nym::connect_tunnel_with_recovery(&test_context.rpc_provider, nym_client)
-                .await?;
-        let (state, client) = wait_for_tunnel_state(
-            &rpc,
-            nym_client,
-            &test_context.rpc_provider,
-            ExpectedTunnelState::Connected,
-        )
-        .await?;
+        let (state, client) =
+            connect_and_wait_connected(&rpc, &test_context.rpc_provider, nym_client).await?;
         nym_client = client;
         match state {
             ObservedTunnelState::Connected { tunnel_type } if tunnel_type == expected => {
@@ -409,15 +411,8 @@ pub async fn test_exit_country_persists_across_reconnect(
     .await
     .context("set_exit_point failed")?;
 
-    let nym_client =
-        helpers_nym::connect_tunnel_with_recovery(&test_context.rpc_provider, nym_client).await?;
-    let (_, nym_client) = wait_for_tunnel_state(
-        &rpc,
-        nym_client,
-        &test_context.rpc_provider,
-        ExpectedTunnelState::Connected,
-    )
-    .await?;
+    let (_, nym_client) =
+        connect_and_wait_connected(&rpc, &test_context.rpc_provider, nym_client).await?;
 
     let (_, nym_client) = helpers_nym::call_nym_with_transport_recovery(
         &test_context.rpc_provider,
@@ -429,32 +424,39 @@ pub async fn test_exit_country_persists_across_reconnect(
     )
     .await
     .context("reconnect_tunnel failed")?;
-    let (_, nym_client) = wait_for_tunnel_state(
-        &rpc,
-        nym_client,
-        &test_context.rpc_provider,
-        ExpectedTunnelState::Connected,
-    )
-    .await?;
+    let nym_client = {
+        let (_, client) = wait_for_tunnel_state(
+            &rpc,
+            nym_client,
+            &test_context.rpc_provider,
+            ExpectedTunnelState::Connected,
+        )
+        .await?;
+        client
+    };
 
-    let _ = resolve_hostname_with_retry(&rpc, "ipinfo.io", ROUNDTRIP_DNS_TIMEOUT).await?;
-    let ip_output = rpc
-        .exec("curl", ["-s", "--max-time", "15", "https://ipinfo.io/json"])
-        .await
-        .context("curl ipinfo.io failed")?;
-    let ip_info: serde_json::Value =
-        serde_json::from_slice(&ip_output.stdout).context("parse ipinfo.io JSON")?;
-    let country = ip_info
-        .get("country")
-        .and_then(|v| v.as_str())
-        .context("ipinfo.io missing country")?;
-    ensure!(
-        country == TARGET_COUNTRY,
-        "after reconnect expected country {TARGET_COUNTRY}, got {country}"
-    );
+    let body = async {
+        let _ = resolve_hostname_with_retry(&rpc, "ipinfo.io", ROUNDTRIP_DNS_TIMEOUT).await?;
+        let ip_output = rpc
+            .exec("curl", ["-s", "--max-time", "15", "https://ipinfo.io/json"])
+            .await
+            .context("curl ipinfo.io failed")?;
+        let ip_info: serde_json::Value =
+            serde_json::from_slice(&ip_output.stdout).context("parse ipinfo.io JSON")?;
+        let country = ip_info
+            .get("country")
+            .and_then(|v| v.as_str())
+            .context("ipinfo.io missing country")?;
+        ensure!(
+            country == TARGET_COUNTRY,
+            "after reconnect expected country {TARGET_COUNTRY}, got {country}"
+        );
+        Ok(())
+    }
+    .await;
 
-    helpers_nym::disconnect_and_wait(&rpc, nym_client, &test_context.rpc_provider).await?;
-    Ok(())
+    let cleanup = disconnect_cleanup(&rpc, nym_client, &test_context.rpc_provider).await;
+    merge_body_and_cleanup(body, cleanup)
 }
 
 #[cfg(test)]

--- a/nym-vpn-core/crates/test/test-manager/src/tests/reliability_tests.rs
+++ b/nym-vpn-core/crates/test/test-manager/src/tests/reliability_tests.rs
@@ -23,8 +23,7 @@ use test_rpc::{
     nym_daemon::{ObservedTunnelState, ObservedTunnelType},
 };
 
-const PUBLIC_TCP_PROBE: SocketAddr =
-    SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)), 443);
+const PUBLIC_TCP_PROBE: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)), 443);
 const PROBE_BIND: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0);
 const OFFLINE_WAIT: Duration = Duration::from_secs(45);
 const DAEMON_READY_WAIT: Duration = Duration::from_secs(60);

--- a/nym-vpn-core/crates/test/test-manager/src/tests/reliability_tests.rs
+++ b/nym-vpn-core/crates/test/test-manager/src/tests/reliability_tests.rs
@@ -1,0 +1,499 @@
+//! User reliability journeys: LAN policy, offline detection, daemon restart, sticky settings.
+//!
+//! Priorities sit after core tunnel tests and before censorship blocklist cases.
+
+use crate::tests::{
+    TestContext,
+    helpers_nym::{
+        self, ExpectedTunnelState, ROUNDTRIP_DNS_TIMEOUT, resolve_hostname_with_retry,
+        wait_for_tunnel_state,
+    },
+    nym_test::dc_and_ensure_logged_in,
+};
+use anyhow::{Context, bail, ensure};
+use nym_vpn_lib_types::ExitPoint;
+use nym_vpn_proto::rpc_client::RpcClient as NymProxyClient;
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    time::Duration,
+};
+use test_macro::test_function_nym;
+use test_rpc::{
+    NymServiceClient,
+    nym_daemon::{ObservedTunnelState, ObservedTunnelType},
+};
+
+const PUBLIC_TCP_PROBE: SocketAddr =
+    SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)), 443);
+const PROBE_BIND: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0);
+const OFFLINE_WAIT: Duration = Duration::from_secs(45);
+const DAEMON_READY_WAIT: Duration = Duration::from_secs(60);
+
+fn merge_body_and_cleanup(
+    body: Result<(), anyhow::Error>,
+    cleanup: Result<(), anyhow::Error>,
+) -> Result<(), anyhow::Error> {
+    match (body, cleanup) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Ok(()), Err(cleanup_err)) => Err(cleanup_err),
+        (Err(body_err), Ok(())) => Err(body_err),
+        (Err(body_err), Err(cleanup_err)) => Err(body_err.context(format!(
+            "cleanup also failed (guest may be left degraded): {cleanup_err:#}"
+        ))),
+    }
+}
+
+/// LAN / link-local ranges that `allow_lan=false` is expected to fence off.
+fn is_lan_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => v4.is_private() || v4.is_link_local(),
+        IpAddr::V6(v6) => {
+            let segments = v6.segments();
+            // Unique local fc00::/7 and link-local fe80::/10
+            (segments[0] & 0xfe00) == 0xfc00 || (segments[0] & 0xffc0) == 0xfe80
+        }
+    }
+}
+
+async fn get_vm_lan_nameservers(rpc: &NymServiceClient) -> anyhow::Result<Vec<IpAddr>> {
+    let output = rpc
+        .exec("resolvectl", ["dns"])
+        .await
+        .context("resolvectl dns failed")?;
+    let text = String::from_utf8_lossy(&output.stdout);
+    let mut nameservers = Vec::new();
+    for line in text.lines() {
+        let line = line.trim();
+        // Prefer non-tun links for "prior LAN resolvers".
+        if line.contains("(tun") {
+            continue;
+        }
+        if let Some((_, servers)) = line.split_once(':') {
+            for server in servers.split_whitespace() {
+                if let Ok(ip) = server.parse::<IpAddr>()
+                    && is_lan_ip(ip)
+                {
+                    nameservers.push(ip);
+                }
+            }
+        }
+    }
+    Ok(nameservers)
+}
+
+async fn tcp_reachable(rpc: &NymServiceClient, dest: SocketAddr) -> bool {
+    rpc.send_tcp(None, PROBE_BIND, dest).await.is_ok()
+}
+
+async fn assert_tunnel_dns_and_tcp(rpc: &NymServiceClient) -> anyhow::Result<()> {
+    let addrs = resolve_hostname_with_retry(rpc, "nym.com", ROUNDTRIP_DNS_TIMEOUT)
+        .await
+        .context("in-tunnel DNS failed")?;
+    let dest = SocketAddr::new(addrs[0].ip(), 443);
+    rpc.send_tcp(None, PROBE_BIND, dest)
+        .await
+        .context("in-tunnel TCP failed")?;
+    Ok(())
+}
+
+async fn detect_default_iface(rpc: &NymServiceClient) -> anyhow::Result<String> {
+    let output = rpc
+        .exec("ip", ["-o", "route", "show", "default"])
+        .await
+        .context("ip route show default")?;
+    ensure!(
+        output.success(),
+        "ip route show default failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let line = String::from_utf8_lossy(&output.stdout);
+    let iface = line
+        .split_whitespace()
+        .skip_while(|tok| *tok != "dev")
+        .nth(1)
+        .context("could not parse default route interface")?;
+    Ok(iface.to_string())
+}
+
+async fn wait_for_observed_offline(
+    rpc: &NymServiceClient,
+    timeout: Duration,
+) -> anyhow::Result<()> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    let mut last = None;
+    loop {
+        if tokio::time::Instant::now() >= deadline {
+            bail!("timed out waiting for Offline tunnel state; last={last:?}");
+        }
+        match rpc.get_observed_tunnel_state().await {
+            Ok(ObservedTunnelState::Offline) => return Ok(()),
+            Ok(state) => last = Some(format!("{state:?}")),
+            Err(err) => last = Some(format!("observe error: {err}")),
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+
+async fn bring_iface_down(rpc: &NymServiceClient, iface: &str) -> anyhow::Result<()> {
+    let output = rpc
+        .exec("ip", ["link", "set", "dev", iface, "down"])
+        .await
+        .context("ip link set down")?;
+    ensure!(
+        output.success(),
+        "failed to bring {iface} down: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    Ok(())
+}
+
+async fn bring_iface_up(rpc: &NymServiceClient, iface: &str) -> anyhow::Result<()> {
+    let up = rpc
+        .exec("ip", ["link", "set", "dev", iface, "up"])
+        .await
+        .context("ip link set up")?;
+    ensure!(
+        up.success(),
+        "failed to bring {iface} up: {}",
+        String::from_utf8_lossy(&up.stderr)
+    );
+    let _ = rpc.exec("dhclient", ["-1", "-v", iface]).await;
+    let _ = rpc.exec("networkctl", ["renew", iface]).await;
+    Ok(())
+}
+
+async fn wait_daemon_rpc_ready(
+    provider: &crate::nym_daemon::RpcClientProvider,
+    timeout: Duration,
+) -> anyhow::Result<NymProxyClient> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    let mut last_err = None;
+    while tokio::time::Instant::now() < deadline {
+        match provider.recover_client_nym().await {
+            Ok(client) => match helpers_nym::ensure_daemon_rpc_responsive(provider, client).await {
+                Ok(client) => return Ok(client),
+                Err(err) => last_err = Some(err.to_string()),
+            },
+            Err(err) => last_err = Some(err.to_string()),
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+    bail!(
+        "daemon RPC not ready after {}s; last={:?}",
+        timeout.as_secs(),
+        last_err
+    )
+}
+
+/// User disables Local network access: prior *LAN* resolvers must not answer on TCP while connected.
+#[test_function_nym(priority = 30)]
+pub async fn test_allow_lan_off_blocks_prior_resolver_tcp(
+    test_context: TestContext,
+    rpc: NymServiceClient,
+    nym_client: NymProxyClient,
+) -> Result<(), anyhow::Error> {
+    let nym_client =
+        dc_and_ensure_logged_in(&rpc, nym_client, &test_context.rpc_provider, false).await?;
+
+    let lan_nameservers = get_vm_lan_nameservers(&rpc).await?;
+    if lan_nameservers.is_empty() {
+        bail!(
+            "SKIP: VM has no LAN/private resolvectl nameservers to probe under allow_lan=false \
+             (public resolvers are not a LAN-policy oracle)"
+        );
+    }
+
+    let nym_client =
+        helpers_nym::set_allow_lan_with_recovery(&test_context.rpc_provider, nym_client, false)
+            .await?;
+    let nym_client =
+        helpers_nym::set_enable_two_hop_with_recovery(&test_context.rpc_provider, nym_client, true)
+            .await?;
+
+    let nym_client =
+        helpers_nym::connect_tunnel_with_recovery(&test_context.rpc_provider, nym_client).await?;
+    let (_, nym_client) = wait_for_tunnel_state(
+        &rpc,
+        nym_client,
+        &test_context.rpc_provider,
+        ExpectedTunnelState::Connected,
+    )
+    .await?;
+
+    let mut still_open = Vec::new();
+    for ip in &lan_nameservers {
+        let dest = SocketAddr::new(*ip, 53);
+        if tcp_reachable(&rpc, dest).await {
+            still_open.push(dest);
+        }
+    }
+    ensure!(
+        still_open.is_empty(),
+        "allow_lan=false but LAN resolvers still reachable on TCP/53: {still_open:?}"
+    );
+
+    assert_tunnel_dns_and_tcp(&rpc).await?;
+
+    helpers_nym::disconnect_and_wait(&rpc, nym_client, &test_context.rpc_provider).await?;
+    Ok(())
+}
+
+/// Taking the default uplink down must surface ObservedTunnelState::Offline (daemon detection).
+/// Does not assert clearnet TCP failure — that is "no route", not FirewallPolicy::Blocked.
+#[test_function_nym(priority = 31)]
+pub async fn test_uplink_down_reports_offline(
+    test_context: TestContext,
+    rpc: NymServiceClient,
+    nym_client: NymProxyClient,
+) -> Result<(), anyhow::Error> {
+    let nym_client =
+        dc_and_ensure_logged_in(&rpc, nym_client, &test_context.rpc_provider, false).await?;
+    let _ = helpers_nym::set_allow_lan_with_recovery(&test_context.rpc_provider, nym_client, false)
+        .await?;
+
+    ensure!(
+        tcp_reachable(&rpc, PUBLIC_TCP_PROBE).await,
+        "precondition: public TCP to {PUBLIC_TCP_PROBE} should work while online"
+    );
+
+    let iface = detect_default_iface(&rpc).await?;
+    log::info!("Bringing uplink {iface} down to force Offline");
+    bring_iface_down(&rpc, &iface).await?;
+    let body = async {
+        wait_for_observed_offline(&rpc, OFFLINE_WAIT).await?;
+        Ok(())
+    }
+    .await;
+    let cleanup = bring_iface_up(&rpc, &iface).await;
+    merge_body_and_cleanup(body, cleanup)?;
+
+    wait_daemon_rpc_ready(&test_context.rpc_provider, Duration::from_secs(30))
+        .await
+        .context("daemon RPC not ready after uplink restore")?;
+
+    ensure!(
+        tcp_reachable(&rpc, PUBLIC_TCP_PROBE).await,
+        "public TCP should work again after uplink restore"
+    );
+
+    Ok(())
+}
+
+/// Daemon crash/restart: recover RPC, reconnect, DNS/TCP still works.
+#[test_function_nym(priority = 32)]
+pub async fn test_daemon_restart_then_reconnect(
+    test_context: TestContext,
+    rpc: NymServiceClient,
+    nym_client: NymProxyClient,
+) -> Result<(), anyhow::Error> {
+    let nym_client =
+        dc_and_ensure_logged_in(&rpc, nym_client, &test_context.rpc_provider, false).await?;
+    let nym_client =
+        helpers_nym::set_enable_two_hop_with_recovery(&test_context.rpc_provider, nym_client, true)
+            .await?;
+
+    let nym_client =
+        helpers_nym::connect_tunnel_with_recovery(&test_context.rpc_provider, nym_client).await?;
+    let (_, nym_client) = wait_for_tunnel_state(
+        &rpc,
+        nym_client,
+        &test_context.rpc_provider,
+        ExpectedTunnelState::Connected,
+    )
+    .await?;
+
+    drop(nym_client);
+    log::info!("Restarting nym-vpnd via systemd...");
+    rpc.restart_nymvpn_daemon()
+        .await
+        .context("restart_nymvpn_daemon failed")?;
+
+    let mut nym_client = wait_daemon_rpc_ready(&test_context.rpc_provider, DAEMON_READY_WAIT)
+        .await
+        .context("daemon did not become ready after restart")?;
+
+    nym_client = helpers_nym::login_idempotent(&rpc, nym_client, &test_context.rpc_provider)
+        .await
+        .context("re-login after daemon restart failed")?;
+    nym_client =
+        helpers_nym::finish_prep_with_allow_lan(&test_context.rpc_provider, nym_client).await?;
+    nym_client =
+        helpers_nym::set_enable_two_hop_with_recovery(&test_context.rpc_provider, nym_client, true)
+            .await?;
+
+    nym_client =
+        helpers_nym::connect_tunnel_with_recovery(&test_context.rpc_provider, nym_client).await?;
+    let (_, nym_client) = wait_for_tunnel_state(
+        &rpc,
+        nym_client,
+        &test_context.rpc_provider,
+        ExpectedTunnelState::Connected,
+    )
+    .await?;
+    assert_tunnel_dns_and_tcp(&rpc).await?;
+
+    helpers_nym::disconnect_and_wait(&rpc, nym_client, &test_context.rpc_provider).await?;
+    Ok(())
+}
+
+/// Fast ↔ Mixnet toggle must select the matching observed tunnel type across reconnects.
+#[test_function_nym(priority = 33)]
+pub async fn test_two_hop_toggle_survives_reconnect(
+    test_context: TestContext,
+    rpc: NymServiceClient,
+    nym_client: NymProxyClient,
+) -> Result<(), anyhow::Error> {
+    let mut nym_client =
+        dc_and_ensure_logged_in(&rpc, nym_client, &test_context.rpc_provider, false).await?;
+
+    for (two_hop, expected) in [
+        (true, ObservedTunnelType::Wireguard),
+        (false, ObservedTunnelType::Mixnet),
+        (true, ObservedTunnelType::Wireguard),
+    ] {
+        nym_client = helpers_nym::set_enable_two_hop_with_recovery(
+            &test_context.rpc_provider,
+            nym_client,
+            two_hop,
+        )
+        .await?;
+        nym_client =
+            helpers_nym::connect_tunnel_with_recovery(&test_context.rpc_provider, nym_client)
+                .await?;
+        let (state, client) = wait_for_tunnel_state(
+            &rpc,
+            nym_client,
+            &test_context.rpc_provider,
+            ExpectedTunnelState::Connected,
+        )
+        .await?;
+        nym_client = client;
+        match state {
+            ObservedTunnelState::Connected { tunnel_type } if tunnel_type == expected => {
+                log::info!("Got expected tunnel type {expected:?} (two_hop={two_hop})");
+            }
+            other => bail!("two_hop={two_hop}: expected Connected {expected:?}, got {other:?}"),
+        }
+        nym_client =
+            helpers_nym::disconnect_and_wait(&rpc, nym_client, &test_context.rpc_provider).await?;
+    }
+
+    Ok(())
+}
+
+/// Country exit selection must stick across reconnect_tunnel.
+#[test_function_nym(priority = 34)]
+pub async fn test_exit_country_persists_across_reconnect(
+    test_context: TestContext,
+    rpc: NymServiceClient,
+    nym_client: NymProxyClient,
+) -> Result<(), anyhow::Error> {
+    const TARGET_COUNTRY: &str = "CH";
+
+    let nym_client =
+        dc_and_ensure_logged_in(&rpc, nym_client, &test_context.rpc_provider, false).await?;
+    let nym_client =
+        helpers_nym::set_enable_two_hop_with_recovery(&test_context.rpc_provider, nym_client, true)
+            .await?;
+    let (_, nym_client) = helpers_nym::call_nym_with_transport_recovery(
+        &test_context.rpc_provider,
+        nym_client,
+        |mut client| async move {
+            let result = client
+                .set_exit_point(ExitPoint::Country {
+                    two_letter_iso_country_code: TARGET_COUNTRY.to_string(),
+                })
+                .await;
+            (client, result)
+        },
+    )
+    .await
+    .context("set_exit_point failed")?;
+
+    let nym_client =
+        helpers_nym::connect_tunnel_with_recovery(&test_context.rpc_provider, nym_client).await?;
+    let (_, nym_client) = wait_for_tunnel_state(
+        &rpc,
+        nym_client,
+        &test_context.rpc_provider,
+        ExpectedTunnelState::Connected,
+    )
+    .await?;
+
+    let (_, nym_client) = helpers_nym::call_nym_with_transport_recovery(
+        &test_context.rpc_provider,
+        nym_client,
+        |mut client| async move {
+            let result = client.reconnect_tunnel().await;
+            (client, result)
+        },
+    )
+    .await
+    .context("reconnect_tunnel failed")?;
+    let (_, nym_client) = wait_for_tunnel_state(
+        &rpc,
+        nym_client,
+        &test_context.rpc_provider,
+        ExpectedTunnelState::Connected,
+    )
+    .await?;
+
+    let _ = resolve_hostname_with_retry(&rpc, "ipinfo.io", ROUNDTRIP_DNS_TIMEOUT).await?;
+    let ip_output = rpc
+        .exec("curl", ["-s", "--max-time", "15", "https://ipinfo.io/json"])
+        .await
+        .context("curl ipinfo.io failed")?;
+    let ip_info: serde_json::Value =
+        serde_json::from_slice(&ip_output.stdout).context("parse ipinfo.io JSON")?;
+    let country = ip_info
+        .get("country")
+        .and_then(|v| v.as_str())
+        .context("ipinfo.io missing country")?;
+    ensure!(
+        country == TARGET_COUNTRY,
+        "after reconnect expected country {TARGET_COUNTRY}, got {country}"
+    );
+
+    helpers_nym::disconnect_and_wait(&rpc, nym_client, &test_context.rpc_provider).await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::{is_lan_ip, merge_body_and_cleanup};
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+    #[test]
+    fn merge_prefers_body_error_but_surfaces_cleanup() {
+        let err = merge_body_and_cleanup(
+            Err(anyhow::anyhow!("body failed")),
+            Err(anyhow::anyhow!("cleanup failed")),
+        )
+        .expect_err("combined failure");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("body failed"), "{msg}");
+        assert!(msg.contains("cleanup failed"), "{msg}");
+    }
+
+    #[test]
+    fn merge_cleanup_only_surfaces() {
+        let err = merge_body_and_cleanup(Ok(()), Err(anyhow::anyhow!("cleanup failed")))
+            .expect_err("cleanup-only");
+        assert!(err.to_string().contains("cleanup failed"));
+    }
+
+    #[test]
+    fn lan_ip_classifier_accepts_private_rejects_public() {
+        assert!(is_lan_ip(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1))));
+        assert!(is_lan_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))));
+        assert!(is_lan_ip(IpAddr::V4(Ipv4Addr::new(172, 29, 1, 1))));
+        assert!(!is_lan_ip(IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1))));
+        assert!(!is_lan_ip(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))));
+        assert!(is_lan_ip(IpAddr::V6(Ipv6Addr::new(
+            0xfd00, 0, 0, 0, 0, 0, 0, 1
+        ))));
+        assert!(!is_lan_ip(IpAddr::V6(Ipv6Addr::new(
+            0x2606, 0x4700, 0x4700, 0, 0, 0, 0, 0x1111
+        ))));
+    }
+}

--- a/nym-vpn-core/crates/test/test-manager/src/tests/reliability_tests.rs
+++ b/nym-vpn-core/crates/test/test-manager/src/tests/reliability_tests.rs
@@ -7,10 +7,7 @@ use crate::{
     nym_daemon::RpcClientProvider,
     tests::{
         TestContext,
-        helpers_nym::{
-            self, ExpectedTunnelState, ROUNDTRIP_DNS_TIMEOUT, resolve_hostname_with_retry,
-            wait_for_tunnel_state,
-        },
+        helpers_nym::{self, ExpectedTunnelState, wait_for_tunnel_state},
         nym_test::dc_and_ensure_logged_in,
     },
 };
@@ -44,17 +41,6 @@ fn merge_body_and_cleanup(
             "cleanup also failed (guest may be left degraded): {cleanup_err:#}"
         ))),
     }
-}
-
-async fn disconnect_cleanup(
-    rpc: &NymServiceClient,
-    nym_client: NymProxyClient,
-    provider: &RpcClientProvider,
-) -> Result<(), anyhow::Error> {
-    helpers_nym::disconnect_and_wait(rpc, nym_client, provider)
-        .await
-        .map(|_| ())
-        .map_err(|e| anyhow::anyhow!(e))
 }
 
 async fn connect_and_wait_connected(
@@ -483,8 +469,19 @@ pub async fn test_exit_country_persists_across_reconnect(
         client
     };
 
+    let helpers_nym::InTunnelDnsOutcome {
+        resolve,
+        client: nym_client,
+    } = helpers_nym::ensure_in_tunnel_hostname_resolves(
+        &rpc,
+        &test_context.rpc_provider,
+        nym_client,
+        "ipinfo.io",
+    )
+    .await;
+
     let body = async {
-        let _ = resolve_hostname_with_retry(&rpc, "ipinfo.io", ROUNDTRIP_DNS_TIMEOUT).await?;
+        let _ = resolve.context("in-tunnel DNS for ipinfo.io failed after reconnect")?;
         let ip_output = rpc
             .exec("curl", ["-s", "--max-time", "15", "https://ipinfo.io/json"])
             .await
@@ -503,7 +500,9 @@ pub async fn test_exit_country_persists_across_reconnect(
     }
     .await;
 
-    let cleanup = disconnect_cleanup(&rpc, nym_client, &test_context.rpc_provider).await;
+    let cleanup =
+        helpers_nym::disconnect_after_in_tunnel_dns(&rpc, &test_context.rpc_provider, nym_client)
+            .await;
     merge_body_and_cleanup(body, cleanup)
 }
 

--- a/nym-vpn-core/crates/test/test-manager/src/tests/tunnel_tests.rs
+++ b/nym-vpn-core/crates/test/test-manager/src/tests/tunnel_tests.rs
@@ -10,6 +10,7 @@ use crate::tests::{
     nym_test::dc_and_ensure_logged_in,
 };
 use anyhow::{Context, bail, ensure};
+use helpers_nym::disconnect_after_in_tunnel_dns;
 use nym_vpn_lib_types::{ExitPoint, GatewayType, ListGatewaysOptions};
 use nym_vpn_proto::rpc_client::RpcClient as NymProxyClient;
 use std::{
@@ -643,36 +644,56 @@ pub async fn test_country_exit_node(
     )
     .await?;
 
-    let addrs = resolve_hostname_with_retry(&rpc, "ipinfo.io", ROUNDTRIP_DNS_TIMEOUT)
-        .await
-        .context("DNS resolution of ipinfo.io failed inside VM")?;
-    log::info!("Resolved ipinfo.io inside VM: {:?}", addrs);
+    let helpers_nym::InTunnelDnsOutcome {
+        resolve,
+        client: nym_client,
+    } = helpers_nym::ensure_in_tunnel_hostname_resolves(
+        &rpc,
+        &test_context.rpc_provider,
+        nym_client,
+        "ipinfo.io",
+    )
+    .await;
 
-    let ip_output = rpc
-        .exec("curl", ["-s", "--max-time", "15", "https://ipinfo.io/json"])
-        .await
-        .context("Failed to curl ipinfo.io from VM")?;
-    let ip_str = String::from_utf8_lossy(&ip_output.stdout);
-    log::info!("ipinfo.io response: {}", ip_str);
+    let body = async {
+        let addrs = resolve.context("DNS resolution of ipinfo.io failed inside VM")?;
+        log::info!("Resolved ipinfo.io inside VM: {:?}", addrs);
 
-    let ip_info: serde_json::Value =
-        serde_json::from_str(&ip_str).context("Failed to parse ipinfo.io response as JSON")?;
-    let country = ip_info
-        .get("country")
-        .and_then(|v| v.as_str())
-        .context("ipinfo.io response missing 'country' field")?;
-    log::info!("Detected exit country: {}", country);
-    ensure!(
-        country == TARGET_COUNTRY,
-        "Expected exit country {}, got {}",
-        TARGET_COUNTRY,
-        country,
-    );
+        let ip_output = rpc
+            .exec("curl", ["-s", "--max-time", "15", "https://ipinfo.io/json"])
+            .await
+            .context("Failed to curl ipinfo.io from VM")?;
+        let ip_str = String::from_utf8_lossy(&ip_output.stdout);
+        log::info!("ipinfo.io response: {}", ip_str);
+
+        let ip_info: serde_json::Value =
+            serde_json::from_str(&ip_str).context("Failed to parse ipinfo.io response as JSON")?;
+        let country = ip_info
+            .get("country")
+            .and_then(|v| v.as_str())
+            .context("ipinfo.io response missing 'country' field")?;
+        log::info!("Detected exit country: {}", country);
+        ensure!(
+            country == TARGET_COUNTRY,
+            "Expected exit country {}, got {}",
+            TARGET_COUNTRY,
+            country,
+        );
+        Ok(())
+    }
+    .await;
 
     log::info!("Disconnecting...");
-    helpers_nym::disconnect_and_wait(&rpc, nym_client, &test_context.rpc_provider).await?;
-
-    Ok(())
+    let cleanup =
+        disconnect_after_in_tunnel_dns(&rpc, &test_context.rpc_provider, nym_client).await;
+    match (body, cleanup) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Ok(()), Err(cleanup_err)) => Err(cleanup_err),
+        (Err(body_err), Ok(())) => Err(body_err),
+        (Err(body_err), Err(cleanup_err)) => Err(body_err.context(format!(
+            "cleanup also failed (guest may be left degraded): {cleanup_err:#}"
+        ))),
+    }
 }
 
 #[test_function_nym(priority = 25)]

--- a/nym-vpn-core/crates/test/test-manager/src/tests/tunnel_tests.rs
+++ b/nym-vpn-core/crates/test/test-manager/src/tests/tunnel_tests.rs
@@ -738,11 +738,33 @@ pub async fn test_reconnect_tunnel(
     )
     .await?;
 
-    let addrs = resolve_hostname_with_retry(&rpc, "nym.com", ROUNDTRIP_DNS_TIMEOUT).await?;
-    log::info!("DNS resolution after reconnect (in VM): {:?}", addrs);
+    let helpers_nym::InTunnelDnsOutcome {
+        resolve,
+        client: nym_client,
+    } = helpers_nym::ensure_in_tunnel_hostname_resolves(
+        &rpc,
+        &test_context.rpc_provider,
+        nym_client,
+        "nym.com",
+    )
+    .await;
+
+    let body = async {
+        let addrs = resolve.context("DNS resolution after reconnect failed inside VM")?;
+        log::info!("DNS resolution after reconnect (in VM): {:?}", addrs);
+        Ok(())
+    }
+    .await;
 
     log::info!("Disconnecting...");
-    helpers_nym::disconnect_and_wait(&rpc, nym_client, &test_context.rpc_provider).await?;
-
-    Ok(())
+    let cleanup =
+        disconnect_after_in_tunnel_dns(&rpc, &test_context.rpc_provider, nym_client).await;
+    match (body, cleanup) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Ok(()), Err(cleanup_err)) => Err(cleanup_err),
+        (Err(body_err), Ok(())) => Err(body_err),
+        (Err(body_err), Err(cleanup_err)) => Err(body_err.context(format!(
+            "cleanup also failed (guest may be left degraded): {cleanup_err:#}"
+        ))),
+    }
 }


### PR DESCRIPTION
## Description

- Adds reliability harness cases for allow_lan-off LAN resolver probes, uplink-down Offline detection, daemon restart reconnect, and sticky two-hop/country settings.
- Treats inventory gaps as explicit SKIP rather than suite failure via harness Skip mapping.
- Classifies LAN leak probes with private/link-local addresses only; does not treat public DoH success as a leak.

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5959)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer end-to-end test notifications with pass, fail, skipped, and unknown test counts.
  * Notifications now include relevant failed-test details, test reports, artifact links, and run links while respecting message-size limits.
  * Tests marked as skipped are no longer reported as failures.

* **Bug Fixes**
  * Improved recovery and cleanup during network, DNS, daemon restart, reconnect, and tunnel verification scenarios.

* **Tests**
  * Added reliability coverage for LAN blocking, offline detection, reconnect persistence, and multi-hop settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->