### PR TITLE
[Android] Onboarding updates

### DIFF
--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/onboarding/OnboardingScreen.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/onboarding/OnboardingScreen.kt
@@ -60,17 +60,13 @@ import net.nymtech.nymvpn.util.extensions.navigateAndForget
 import net.nymtech.nymvpn.util.extensions.scaledHeight
 import net.nymtech.nymvpn.util.extensions.scaledWidth
 
-private val DEFAULT_PAGES = OnboardingPage.entries.filterNot { it == OnboardingPage.PLAN }
-
 @Composable
 fun OnboardingScreen(viewModel: OnboardingViewModel = hiltViewModel()) {
 	val navigator = LocalNavController.current
 	val scope = rememberCoroutineScope()
 	val planPricing by viewModel.planPricing.collectAsStateWithLifecycle()
-	val pages = if (viewModel.isPlanPageEnabled) OnboardingPage.entries else DEFAULT_PAGES
 
 	OnboardingScreen(
-		pages = pages,
 		planPricing = planPricing,
 		onFinish = {
 			scope.launch {
@@ -82,7 +78,7 @@ fun OnboardingScreen(viewModel: OnboardingViewModel = hiltViewModel()) {
 }
 
 @Composable
-fun OnboardingScreen(pages: List<OnboardingPage> = DEFAULT_PAGES, planPricing: OnboardingPlanPricing? = null, onFinish: () -> Unit) {
+fun OnboardingScreen(pages: List<OnboardingPage> = OnboardingPage.entries, planPricing: OnboardingPlanPricing? = null, onFinish: () -> Unit) {
 	val scope = rememberCoroutineScope()
 	var selectedMode by remember { mutableStateOf(ConnectMode.FAST) }
 
@@ -136,7 +132,7 @@ fun OnboardingScreen(pages: List<OnboardingPage> = DEFAULT_PAGES, planPricing: O
 
 			OnboardingBottomCard(
 				onGetStartedClick = onFinish,
-				modifier = Modifier.padding(bottom = 24.dp.scaledHeight()),
+				modifier = Modifier.padding(bottom = 20.dp.scaledHeight()),
 				tagline = tagline,
 			)
 		}

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/onboarding/OnboardingViewModel.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/onboarding/OnboardingViewModel.kt
@@ -23,14 +23,14 @@ class OnboardingViewModel
 @Inject
 constructor(private val settingsRepository: SettingsRepository, private val billingManager: BillingManager) : ViewModel() {
 
-	val isPlanPageEnabled: Boolean = billingManager.isAvailable() && BuildConfig.APPLICATION_ID == Constants.APP_ID
+	val isBillingAvailable: Boolean = billingManager.isAvailable() && BuildConfig.APPLICATION_ID == Constants.APP_ID
 
 	val planPricing: StateFlow<OnboardingPlanPricing?> = billingManager.products
 		.map { OnboardingPlanPricing.from(it) }
 		.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
 
 	init {
-		if (isPlanPageEnabled) {
+		if (isBillingAvailable) {
 			billingManager.initialize()
 			viewModelScope.launch {
 				billingManager.uiState

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/onboarding/components/OnboardingBottomCard.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/onboarding/components/OnboardingBottomCard.kt
@@ -38,7 +38,7 @@ fun OnboardingBottomCard(onGetStartedClick: () -> Unit, modifier: Modifier = Mod
 		Icon(
 			imageVector = ImageVector.vectorResource(R.drawable.app_label),
 			contentDescription = stringResource(R.string.app_name),
-			tint = MaterialTheme.colorScheme.onSurface,
+			tint = MaterialTheme.colorScheme.onPrimaryContainer,
 		)
 		Text(
 			text = tagline ?: " ",

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/onboarding/components/OnboardingPageContent.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/onboarding/components/OnboardingPageContent.kt
@@ -160,7 +160,7 @@ private fun PlanPage(pricing: OnboardingPlanPricing?, modifier: Modifier = Modif
 					.fillMaxWidth(0.5f),
 			)
 		}
-		Spacer(modifier = Modifier.height(40.dp))
+		Spacer(modifier = Modifier.height(16.dp))
 		OnboardingTitle(stringResource(R.string.onboarding_plan_title))
 		OnboardingDescription(planSubtitle(pricing))
 	}

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/onboarding/components/OnboardingPageContent.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/onboarding/components/OnboardingPageContent.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -148,7 +149,6 @@ private fun PlanPage(pricing: OnboardingPlanPricing?, modifier: Modifier = Modif
 		Box(
 			contentAlignment = Alignment.Center,
 			modifier = Modifier
-				.height(200.dp.scaledHeight())
 				.fillMaxWidth(),
 		) {
 			Icon(
@@ -160,6 +160,7 @@ private fun PlanPage(pricing: OnboardingPlanPricing?, modifier: Modifier = Modif
 					.fillMaxWidth(0.5f),
 			)
 		}
+		Spacer(modifier = Modifier.height(40.dp))
 		OnboardingTitle(stringResource(R.string.onboarding_plan_title))
 		OnboardingDescription(planSubtitle(pricing))
 	}
@@ -169,6 +170,7 @@ private fun PlanPage(pricing: OnboardingPlanPricing?, modifier: Modifier = Modif
 private fun planSubtitle(pricing: OnboardingPlanPricing?): AnnotatedString {
 	val baseColor = MaterialTheme.colorScheme.onPrimaryContainer
 	val highlightColor = MaterialTheme.colorScheme.primary
+	val p = pricing ?: OnboardingPlanPricing.FALLBACK
 
 	return buildAnnotatedString {
 		fun base(text: String) = withStyle(SpanStyle(fontWeight = FontWeight.Bold, color = baseColor)) { append(text) }
@@ -176,20 +178,20 @@ private fun planSubtitle(pricing: OnboardingPlanPricing?): AnnotatedString {
 
 		base(stringResource(R.string.onboarding_plan_community_favorite))
 		append("\n\n")
-		pricing?.let { p ->
-			p.savingsPercent?.let { savings ->
-				base(stringResource(R.string.onboarding_plan_year_plan_prefix))
-				highlight(stringResource(R.string.onboarding_plan_save_percent, savings))
-				append("\n")
-			}
-			p.freeTrialDays?.let { days ->
-				base(stringResource(R.string.onboarding_plan_free_trial, days))
-				append("\n")
-			}
-			base(stringResource(R.string.onboarding_plan_starting_at_prefix))
-			highlight(stringResource(R.string.onboarding_plan_price_per_month, p.monthlyEquivalentPrice))
-			append("\n\n")
+		p.savingsPercent?.let { savings ->
+			base(stringResource(R.string.onboarding_plan_year_plan_prefix))
+			append(" ")
+			highlight(stringResource(R.string.onboarding_plan_save_percent, savings))
+			append("\n")
 		}
+		p.freeTrialDays?.let { days ->
+			base(stringResource(R.string.onboarding_plan_free_trial, days))
+			append("\n")
+		}
+		base(stringResource(R.string.onboarding_plan_starting_at_prefix))
+		append(" ")
+		highlight(stringResource(R.string.onboarding_plan_price_per_month, p.monthlyEquivalentPrice))
+		append("\n\n")
 		base(stringResource(R.string.onboarding_plan_try_prefix))
 		base(stringResource(R.string.onboarding_plan_one_month))
 		base(stringResource(R.string.onboarding_plan_try_suffix))

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/onboarding/components/OnboardingPlanPricing.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/onboarding/components/OnboardingPlanPricing.kt
@@ -9,6 +9,8 @@ import java.util.Currency
 
 data class OnboardingPlanPricing(val monthlyEquivalentPrice: String, val savingsPercent: String?, val freeTrialDays: Int?) {
 	companion object {
+		val FALLBACK = OnboardingPlanPricing(monthlyEquivalentPrice = "$8.26", savingsPercent = "65%", freeTrialDays = 7)
+
 		fun from(products: List<ProductData>): OnboardingPlanPricing? {
 			val yearly = products.firstOrNull { it.id == ProductId.Yearly.value } ?: return null
 			val yearlyMicros = yearly.priceAmountMicros ?: return null

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/splash/SplashScreen.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/splash/SplashScreen.kt
@@ -39,7 +39,8 @@ fun SplashScreen(appViewModel: AppViewModel, appUiState: AppUiState, topOffset: 
 
 	LaunchedEffect(appUiState.managerState.isInitialized, isAppReady) {
 		if (appUiState.managerState.isInitialized && isAppReady) {
-			val destination = if (appUiState.settings.isOnboardingCompleted) Route.Main() else Route.Onboarding
+			val shouldShowOnboarding = !appUiState.settings.isOnboardingCompleted && !appUiState.managerState.isMnemonicStored
+			val destination = if (shouldShowOnboarding) Route.Onboarding else Route.Main()
 			navController.navigateAndForget(destination)
 		}
 	}


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

- Update colors and spacing;
- Change Onboarding display logic;
- Show Plan page with default values when billing is not available;


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5972)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Onboarding now includes the plan page by default.
  * Plan details display starting price, savings, and free-trial information when available.
  * Added fallback pricing details for cases where plan data is unavailable.

* **Bug Fixes**
  * Improved splash-screen navigation for returning users and users with stored credentials.

* **Style**
  * Refined onboarding spacing, card padding, icon tint, and plan illustration layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->