### PR TITLE
VPN-4908: Avoid DNS on macOS from setting DNS on invalid interfaces.

### DIFF
--- a/nym-vpn-core/crates/nym-dns/src/macos.rs
+++ b/nym-vpn-core/crates/nym-dns/src/macos.rs
@@ -514,6 +514,9 @@ fn read_all_dns(store: &SCDynamicStore) -> HashMap<ServicePath, Option<DnsSettin
         for state_path in paths.iter() {
             let state_path_str = state_path.to_string();
             let setup_path_str = state_to_setup_path(&state_path_str).unwrap();
+            if !has_backing_interface(store, &state_path_str) {
+                continue;
+            }
             settings.insert(
                 state_path_str,
                 DnsSettings::load(store, state_path.clone()).ok(),
@@ -528,12 +531,21 @@ fn read_all_dns(store: &SCDynamicStore) -> HashMap<ServicePath, Option<DnsSettin
     if let Some(paths) = store.get_keys(SETUP_PATH_PATTERN) {
         for setup_path in paths.iter() {
             let setup_path_str = setup_path.to_string();
+            if !has_backing_interface(store, &setup_path_str) {
+                continue;
+            }
             settings
                 .entry(setup_path_str)
                 .or_insert_with(|| DnsSettings::load(store, setup_path.clone()).ok());
         }
     }
     settings
+}
+
+fn has_backing_interface(store: &SCDynamicStore, dns_path: &str) -> bool {
+    InterfaceSettings::load_from_dns_key(store, dns_path.to_string())
+        .and_then(|settings| settings.interface_name())
+        .is_ok()
 }
 
 fn state_to_setup_path(state_path: &str) -> Option<String> {


### PR DESCRIPTION

## Ticket

JIRA-VPN-4908

## Description

Some network services can have a leftover `.../DNS` key in the dynamic store with no corresponding `.../Interface` entry (e.g. disabled or orphaned services). Writing DNS to those never sticks, and the write itself re-triggers our own change notification, so treating them as manageable causes a self-sustaining save/notify loop. Skip them entirely.

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5973)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNS state handling on macOS by ignoring entries that are not associated with a valid network interface.
  * Prevents invalid or incomplete network configuration data from affecting DNS behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->