### PR TITLE
Enable TRACE DNS diagnostics with Nym systemd log-level override

### DIFF
--- a/nym-vpn-core/crates/test/test-manager/src/tests/helpers_nym.rs
+++ b/nym-vpn-core/crates/test/test-manager/src/tests/helpers_nym.rs
@@ -920,6 +920,59 @@ async fn log_dns_failure_diagnostics(
     log::error!("{}", reachability.summary());
 }
 
+const GUEST_DAEMON_LOG_PATH: &str = "/var/log/nym-vpnd/nym-vpnd.log";
+
+const IN_TUNNEL_DNS_LOG_GREP: &str = "Running DNS resolver on|failed to resolve hostname|hickory_|timed out|ConnectError|connecting to";
+
+const IN_TUNNEL_DNS_LOG_TAIL_LINES: usize = 80;
+
+/// Best-effort scrape of guest DNS / daemon log context for CI. Never fails the test.
+pub async fn log_in_tunnel_dns_diagnostics(rpc: &NymServiceClient) {
+    match rpc.exec("resolvectl", ["dns"]).await {
+        Ok(output) => log::info!(
+            "in-tunnel DNS diag resolvectl dns: {}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        ),
+        Err(error) => log::warn!("in-tunnel DNS diag: resolvectl dns failed: {error}"),
+    }
+
+    match rpc
+        .exec(
+            "sudo",
+            ["grep", "-E", IN_TUNNEL_DNS_LOG_GREP, GUEST_DAEMON_LOG_PATH],
+        )
+        .await
+    {
+        Ok(output) => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let lines: Vec<_> = stdout.lines().collect();
+            let tail = if lines.len() > IN_TUNNEL_DNS_LOG_TAIL_LINES {
+                &lines[lines.len() - IN_TUNNEL_DNS_LOG_TAIL_LINES..]
+            } else {
+                &lines[..]
+            };
+            if tail.is_empty() {
+                log::info!(
+                    "in-tunnel DNS diag: no matching lines in {GUEST_DAEMON_LOG_PATH} \
+                     (grep exit {:?})",
+                    output.code
+                );
+            } else {
+                log::info!(
+                    "in-tunnel DNS diag daemon log matches (last {} of {}):\n{}",
+                    tail.len(),
+                    lines.len(),
+                    tail.join("\n")
+                );
+            }
+        }
+        Err(error) => {
+            log::warn!("in-tunnel DNS diag: grep {GUEST_DAEMON_LOG_PATH} failed: {error}")
+        }
+    }
+}
+
 async fn recover_client_for_cleanup(provider: &RpcClientProvider) -> Option<NymProxyClient> {
     match provider.recover_client_nym().await {
         Ok(client) => Some(client),
@@ -1107,13 +1160,13 @@ where
 mod tests {
     use super::{
         AccountWaiter, AllowLanPrepClass, DisconnectClient, DisconnectRpcClass,
-        DnsUpstreamReachability, ExpectedTunnelState, TunnelObserver, account_target,
-        classify_allow_lan_prep, classify_disconnect_nym_error, classify_disconnect_rpc,
-        classify_upstream_probes, enforce_tunnel_wait_deadline, is_daemon_rpc_transport_error,
-        is_daemon_rpc_transport_message, is_nym_client_transport_error, merge_wait_and_client,
-        resolve_dns_cleanup_client, resolve_with_retry, run_account_wait, run_tunnel_wait,
-        settle_daemon_rpc_quiesce, summarize_upstream_probes, tunnel_target, tunnel_wait_budget,
-        tunnel_wait_params,
+        DnsUpstreamReachability, ExpectedTunnelState, IN_TUNNEL_DNS_LOG_GREP, TunnelObserver,
+        account_target, classify_allow_lan_prep, classify_disconnect_nym_error,
+        classify_disconnect_rpc, classify_upstream_probes, enforce_tunnel_wait_deadline,
+        is_daemon_rpc_transport_error, is_daemon_rpc_transport_message,
+        is_nym_client_transport_error, merge_wait_and_client, resolve_dns_cleanup_client,
+        resolve_with_retry, run_account_wait, run_tunnel_wait, settle_daemon_rpc_quiesce,
+        summarize_upstream_probes, tunnel_target, tunnel_wait_budget, tunnel_wait_params,
     };
     use crate::tests::{Error, WAIT_FOR_TUNNEL_CONNECTED_TIMEOUT, WAIT_FOR_TUNNEL_STATE_TIMEOUT};
     use futures::StreamExt;
@@ -1126,6 +1179,28 @@ mod tests {
         "93.184.216.34:443"
             .parse()
             .expect("literal is a socket addr")
+    }
+
+    #[test]
+    fn in_tunnel_dns_log_grep_avoids_bare_timeout_token() {
+        assert!(
+            !IN_TUNNEL_DNS_LOG_GREP
+                .split('|')
+                .any(|part| part == "timeout"),
+            "bare 'timeout' matches too many daemon log lines; use 'timed out' instead: {IN_TUNNEL_DNS_LOG_GREP}"
+        );
+        assert!(
+            IN_TUNNEL_DNS_LOG_GREP
+                .split('|')
+                .any(|part| part == "timed out"),
+            "expected 'timed out' DNS failure token in grep: {IN_TUNNEL_DNS_LOG_GREP}"
+        );
+        assert!(
+            IN_TUNNEL_DNS_LOG_GREP
+                .split('|')
+                .any(|part| part == "hickory_"),
+            "expected hickory_ token for TRACE upstream visibility: {IN_TUNNEL_DNS_LOG_GREP}"
+        );
     }
 
     /// The tunnel reports Connected before the exit gateway resolver answers, so the first

--- a/nym-vpn-core/crates/test/test-manager/src/tests/tunnel_tests.rs
+++ b/nym-vpn-core/crates/test/test-manager/src/tests/tunnel_tests.rs
@@ -20,7 +20,7 @@ use std::{
 use test_macro::test_function_nym;
 use test_rpc::{
     NymServiceClient,
-    nym_daemon::{ObservedTunnelState, ObservedTunnelType},
+    nym_daemon::{ObservedTunnelState, ObservedTunnelType, Verbosity},
 };
 
 /// Parse `resolvectl dns` link lines, e.g. `Link 5 (tun1): 127.111.152.46`.
@@ -130,6 +130,28 @@ mod resolvectl_tests {
     fn returns_nothing_for_output_without_link_lines() {
         assert!(parse_resolvectl_dns("Global: 1.1.1.1\n").is_empty());
         assert!(parse_resolvectl_dns("").is_empty());
+    }
+}
+
+#[cfg(test)]
+mod bash_ws_conclusion_tests {
+    use super::bash_ws_conclusion_mentions_leak;
+
+    #[test]
+    fn detects_leak_word_case_insensitively() {
+        assert!(bash_ws_conclusion_mentions_leak("DNS may be leaking"));
+        assert!(bash_ws_conclusion_mentions_leak("LEAK DETECTED"));
+        assert!(bash_ws_conclusion_mentions_leak("possible Leak via ISP"));
+        // Substring match: "not leaking" still contains "leak".
+        assert!(bash_ws_conclusion_mentions_leak("DNS is not leaking"));
+    }
+
+    #[test]
+    fn ignores_conclusions_without_leak_substring() {
+        assert!(!bash_ws_conclusion_mentions_leak("Looks good"));
+        assert!(!bash_ws_conclusion_mentions_leak(""));
+        assert!(!bash_ws_conclusion_mentions_leak("OK"));
+        assert!(!bash_ws_conclusion_mentions_leak("No issues found"));
     }
 }
 
@@ -394,116 +416,161 @@ pub async fn test_dns_leak(
     rpc: NymServiceClient,
     nym_client: NymProxyClient,
 ) -> Result<(), anyhow::Error> {
-    let nym_client =
-        dc_and_ensure_logged_in(&rpc, nym_client, &test_context.rpc_provider, false).await?;
-
-    let pre_vpn_nameservers = get_vm_nameservers(&rpc).await?;
-    log::info!("Pre-VPN nameservers (in VM): {:?}", pre_vpn_nameservers);
-    ensure!(
-        !pre_vpn_nameservers.is_empty(),
-        "VM should have at least one nameserver"
+    // TRACE (-vv) unmasks hickory_* crates so CI daemon logs show remote DoT connect/timeout.
+    log::info!(
+        "Setting daemon log level to TRACE (-vv) for hickory upstream visibility in guest nym-vpnd.log"
     );
+    rpc.set_daemon_log_level(Verbosity::Trace).await?;
 
-    let reachable_before = reachable_resolvers(&rpc, &pre_vpn_nameservers).await;
-    log::info!("Pre-VPN resolvers reachable on TCP: {:?}", reachable_before);
+    let body = async {
+        let nym_client =
+            dc_and_ensure_logged_in(&rpc, nym_client, &test_context.rpc_provider, false).await?;
 
-    let nym_client =
-        helpers_nym::set_enable_two_hop_with_recovery(&test_context.rpc_provider, nym_client, true)
-            .await?;
-    log::info!("Connecting tunnel for DNS leak test...");
-    let nym_client =
-        helpers_nym::connect_tunnel_with_recovery(&test_context.rpc_provider, nym_client).await?;
-    let (_, nym_client) = wait_for_tunnel_state(
-        &rpc,
-        nym_client,
-        &test_context.rpc_provider,
-        ExpectedTunnelState::Connected,
-    )
-    .await?;
-
-    // Under systemd-resolved the daemon sets DNS per link and never rewrites
-    // /etc/resolv.conf, so that file still lists the DHCP nameserver by design.
-    match get_tunnel_link_nameservers(&rpc).await? {
-        Some(tunnel_nameservers) => {
-            log::info!("Tunnel link nameservers (in VM): {:?}", tunnel_nameservers);
-            ensure!(
-                !tunnel_nameservers.is_empty(),
-                "tunnel interface has no nameservers configured while connected"
-            );
-            let leaked: Vec<_> = tunnel_nameservers
-                .iter()
-                .filter(|ns| pre_vpn_nameservers.contains(ns))
-                .collect();
-            ensure!(
-                leaked.is_empty(),
-                "DNS LEAK: tunnel interface still resolves via pre-VPN nameservers: {:?}",
-                leaked,
-            );
-        }
-        None => {
-            let post_vpn_nameservers = get_vm_nameservers(&rpc).await?;
-            log::info!("Post-VPN nameservers (in VM): {:?}", post_vpn_nameservers);
-            let leaked: Vec<_> = post_vpn_nameservers
-                .iter()
-                .filter(|ns| pre_vpn_nameservers.contains(ns))
-                .collect();
-            ensure!(
-                leaked.is_empty(),
-                "DNS LEAK: post-VPN resolv.conf still contains pre-VPN nameservers: {:?}",
-                leaked,
-            );
-        }
-    }
-
-    if reachable_before.is_empty() {
-        log::warn!(
-            "No pre-VPN resolver answered on TCP/53, so reachability while connected proves nothing"
-        );
-    } else {
-        let still_reachable = reachable_resolvers(
-            &rpc,
-            &reachable_before
-                .iter()
-                .map(|addr| addr.ip().to_string())
-                .collect::<Vec<_>>(),
-        )
-        .await;
+        let pre_vpn_nameservers = get_vm_nameservers(&rpc).await?;
+        log::info!("Pre-VPN nameservers (in VM): {:?}", pre_vpn_nameservers);
         ensure!(
-            still_reachable.is_empty(),
-            "DNS LEAK: pre-VPN resolvers still reachable while connected: {:?}. \
-             The harness enables allow_lan, which may be exposing the LAN resolver",
-            still_reachable,
+            !pre_vpn_nameservers.is_empty(),
+            "VM should have at least one nameserver"
         );
-        log::info!("Pre-VPN resolvers are unreachable while connected");
-    }
 
-    let addrs = resolve_hostname_with_retry(&rpc, "nym.com", ROUNDTRIP_DNS_TIMEOUT)
-        .await
-        .context("DNS resolution failed inside VM while VPN is connected")?;
-    log::info!("Resolved nym.com inside VM: {:?}", addrs);
+        let reachable_before = reachable_resolvers(&rpc, &pre_vpn_nameservers).await;
+        log::info!("Pre-VPN resolvers reachable on TCP: {:?}", reachable_before);
 
-    let dest = SocketAddr::new(addrs[0].ip(), 443);
-    rpc.send_tcp(None, "0.0.0.0:0".parse().unwrap(), dest)
-        .await
-        .context("TCP connectivity check failed inside VM while VPN is connected")?;
-    log::info!("TCP connectivity to {} verified inside VM", dest);
+        let nym_client = helpers_nym::set_enable_two_hop_with_recovery(
+            &test_context.rpc_provider,
+            nym_client,
+            true,
+        )
+        .await?;
+        log::info!("Connecting tunnel for DNS leak test...");
+        let nym_client =
+            helpers_nym::connect_tunnel_with_recovery(&test_context.rpc_provider, nym_client)
+                .await?;
+        let (_, nym_client) = wait_for_tunnel_state(
+            &rpc,
+            nym_client,
+            &test_context.rpc_provider,
+            ExpectedTunnelState::Connected,
+        )
+        .await?;
 
-    let bash_ws_result = check_dns_leak_bash_ws(&rpc, &pre_vpn_nameservers).await;
-    match bash_ws_result {
-        Ok(()) => log::info!("bash.ws DNS leak check passed"),
-        Err(e) => {
-            let msg = format!("{e:#}");
-            if msg.contains("DNS LEAK") {
-                bail!("{e}");
+        helpers_nym::log_in_tunnel_dns_diagnostics(&rpc).await;
+
+        // Under systemd-resolved the daemon sets DNS per link and never rewrites
+        // /etc/resolv.conf, so that file still lists the DHCP nameserver by design.
+        match get_tunnel_link_nameservers(&rpc).await? {
+            Some(tunnel_nameservers) => {
+                log::info!("Tunnel link nameservers (in VM): {:?}", tunnel_nameservers);
+                ensure!(
+                    !tunnel_nameservers.is_empty(),
+                    "tunnel interface has no nameservers configured while connected"
+                );
+                let leaked: Vec<_> = tunnel_nameservers
+                    .iter()
+                    .filter(|ns| pre_vpn_nameservers.contains(ns))
+                    .collect();
+                ensure!(
+                    leaked.is_empty(),
+                    "DNS LEAK: tunnel interface still resolves via pre-VPN nameservers: {:?}",
+                    leaked,
+                );
             }
-            log::warn!("bash.ws check could not complete (service may be down): {e}");
+            None => {
+                let post_vpn_nameservers = get_vm_nameservers(&rpc).await?;
+                log::info!("Post-VPN nameservers (in VM): {:?}", post_vpn_nameservers);
+                let leaked: Vec<_> = post_vpn_nameservers
+                    .iter()
+                    .filter(|ns| pre_vpn_nameservers.contains(ns))
+                    .collect();
+                ensure!(
+                    leaked.is_empty(),
+                    "DNS LEAK: post-VPN resolv.conf still contains pre-VPN nameservers: {:?}",
+                    leaked,
+                );
+            }
         }
+
+        if reachable_before.is_empty() {
+            log::warn!(
+                "No pre-VPN resolver answered on TCP/53, so reachability while connected proves nothing"
+            );
+        } else {
+            let still_reachable = reachable_resolvers(
+                &rpc,
+                &reachable_before
+                    .iter()
+                    .map(|addr| addr.ip().to_string())
+                    .collect::<Vec<_>>(),
+            )
+            .await;
+            ensure!(
+                still_reachable.is_empty(),
+                "DNS LEAK: pre-VPN resolvers still reachable while connected: {:?}. \
+                 The harness enables allow_lan, which may be exposing the LAN resolver",
+                still_reachable,
+            );
+            log::info!("Pre-VPN resolvers are unreachable while connected");
+        }
+
+        let addrs = match resolve_hostname_with_retry(&rpc, "nym.com", ROUNDTRIP_DNS_TIMEOUT).await
+        {
+            Ok(addrs) => addrs,
+            Err(error) => {
+                helpers_nym::log_in_tunnel_dns_diagnostics(&rpc).await;
+                return Err(error)
+                    .context("DNS resolution failed inside VM while VPN is connected");
+            }
+        };
+        log::info!("Resolved nym.com inside VM: {:?}", addrs);
+
+        let dest = SocketAddr::new(addrs[0].ip(), 443);
+        rpc.send_tcp(None, "0.0.0.0:0".parse().unwrap(), dest)
+            .await
+            .context("TCP connectivity check failed inside VM while VPN is connected")?;
+        log::info!("TCP connectivity to {} verified inside VM", dest);
+
+        let bash_ws_result = check_dns_leak_bash_ws(&rpc, &pre_vpn_nameservers).await;
+        match bash_ws_result {
+            Ok(()) => log::info!("bash.ws DNS leak check passed"),
+            Err(e) => {
+                let msg = format!("{e:#}");
+                if msg.contains("DNS LEAK") {
+                    bail!("{e}");
+                }
+                log::warn!("bash.ws check could not complete (service may be down): {e}");
+            }
+        }
+
+        log::info!("Disconnecting...");
+        helpers_nym::disconnect_and_wait(&rpc, nym_client, &test_context.rpc_provider).await?;
+
+        Ok(())
+    }
+    .await;
+
+    // Restore Info (no -v) to match ssh-setup.sh baseline ExecStart.
+    let restore = rpc
+        .set_daemon_log_level(Verbosity::Info)
+        .await
+        .context("failed to restore daemon log level to Info");
+    if restore.is_ok() {
+        log::info!("Restored daemon log level to Info");
     }
 
-    log::info!("Disconnecting...");
-    helpers_nym::disconnect_and_wait(&rpc, nym_client, &test_context.rpc_provider).await?;
+    match (body, restore) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Ok(()), Err(restore_err)) => Err(restore_err),
+        (Err(body_err), Ok(())) => Err(body_err),
+        (Err(body_err), Err(restore_err)) => Err(body_err.context(format!(
+            "also failed to restore daemon log level to Info: {restore_err:#}"
+        ))),
+    }
+}
 
-    Ok(())
+/// Whether bash.ws conclusion text mentions a leak (case-insensitive).
+/// Informational only - harness pass/fail does not use this.
+fn bash_ws_conclusion_mentions_leak(conclusion: &str) -> bool {
+    conclusion.to_ascii_lowercase().contains("leak")
 }
 
 /// end to end DNS leak check using bash.ws
@@ -571,7 +638,14 @@ async fn check_dns_leak_bash_ws(
                     _ => String::new(),
                 }
             ),
-            "conclusion" => log::info!("bash.ws conclusion: {ip}"),
+            "conclusion" => {
+                log::info!("bash.ws conclusion: {ip}");
+                if bash_ws_conclusion_mentions_leak(ip) {
+                    log::warn!(
+                        "bash.ws conclusion is informational; harness only fails on pre-VPN nameserver IPs"
+                    );
+                }
+            }
             other => log::debug!("bash.ws: unknown entry type '{other}': {ip}"),
         }
     }
@@ -598,7 +672,7 @@ async fn check_dns_leak_bash_ws(
         }
     }
     log::info!(
-        "No DNS leak detected via bash.ws ({} DNS resolvers checked)",
+        "Harness oracle: no pre-VPN nameserver observed by bash.ws ({} resolvers checked)",
         dns_entries.len()
     );
     Ok(())

--- a/nym-vpn-core/crates/test/test-runner/src/sys.rs
+++ b/nym-vpn-core/crates/test/test-runner/src/sys.rs
@@ -4,12 +4,33 @@
 
 #[cfg(target_os = "linux")]
 use std::collections::HashMap;
-#[cfg(target_os = "linux")]
 use test_rpc::nym_daemon::Verbosity;
 
-#[cfg(target_os = "linux")]
+/// Drop-in path must match the unit name (`nymvpnd.service`), not a Mullvad leftover.
 pub(crate) const NYM_VPN_SYSTEMD_OVERRIDE_FILE: &str =
-    "/etc/systemd/system/nymvpn.service.d/override.conf";
+    "/etc/systemd/system/nymvpnd.service.d/override.conf";
+
+/// Systemd override body for guest `nym-vpnd` log verbosity (`-v` / `-vv`).
+///
+/// Matches `ssh-setup.sh` ExecStart shape: `run-as-service --disable-client-verification`.
+pub(crate) fn daemon_log_level_override_content(
+    daemon_bin: &str,
+    verbosity_level: Verbosity,
+) -> String {
+    let verbosity = match verbosity_level {
+        Verbosity::Info => "",
+        Verbosity::Debug => "-v",
+        Verbosity::Trace => "-vv",
+    };
+    let verbosity_arg = if verbosity.is_empty() {
+        String::new()
+    } else {
+        format!(" {verbosity}")
+    };
+    format!(
+        "[Service]\nExecStart=\nExecStart={daemon_bin} run-as-service --disable-client-verification{verbosity_arg}\n"
+    )
+}
 
 #[cfg(unix)]
 pub fn reboot() -> Result<(), test_rpc::Error> {
@@ -42,16 +63,8 @@ pub async fn set_daemon_log_level(
     use tokio::io::AsyncWriteExt;
     log::debug!("Setting log level");
 
-    let verbosity = match verbosity_level {
-        Verbosity::Info => "",
-        Verbosity::Debug => "-v",
-        Verbosity::Trace => "-vv",
-    };
-    let systemd_service_file_content = format!(
-        r#"[Service]
-ExecStart=
-ExecStart=/usr/bin/{service_name} --disable-stdout-timestamps {verbosity}"#
-    );
+    let systemd_service_file_content =
+        daemon_log_level_override_content(crate::app_nymvpn::NYMVPND_CLI_BIN, verbosity_level);
 
     let override_path = std::path::Path::new(systemd_override_file);
     if let Some(parent) = override_path.parent() {
@@ -373,6 +386,8 @@ pub fn get_os_version() -> Result<test_rpc::meta::OsVersion, test_rpc::Error> {
 
 #[cfg(test)]
 mod test {
+    use super::{NYM_VPN_SYSTEMD_OVERRIDE_FILE, daemon_log_level_override_content};
+    use test_rpc::nym_daemon::Verbosity;
 
     #[cfg(target_os = "linux")]
     #[test]
@@ -396,5 +411,39 @@ mod test {
         let second = env_vars.get(1).unwrap();
         assert_eq!(second.var, "var2");
         assert_eq!(second.value, "value2");
+    }
+
+    #[test]
+    fn systemd_override_path_matches_nymvpnd_unit() {
+        assert!(
+            NYM_VPN_SYSTEMD_OVERRIDE_FILE.contains("nymvpnd.service.d"),
+            "drop-in dir must match unit nymvpnd.service, got {NYM_VPN_SYSTEMD_OVERRIDE_FILE}"
+        );
+        assert!(
+            !NYM_VPN_SYSTEMD_OVERRIDE_FILE.contains("nymvpn.service.d"),
+            "Mullvad leftover nymvpn.service.d would never apply"
+        );
+    }
+
+    #[test]
+    fn daemon_log_level_override_is_nym_shaped() {
+        let bin = "/opt/testing/nym-vpnd";
+        let trace = daemon_log_level_override_content(bin, Verbosity::Trace);
+        assert!(trace.contains(
+            "ExecStart=/opt/testing/nym-vpnd run-as-service --disable-client-verification -vv"
+        ));
+        assert!(!trace.contains("disable-stdout-timestamps"));
+        assert!(!trace.contains("/usr/bin/nymvpnd.service"));
+
+        let info = daemon_log_level_override_content(bin, Verbosity::Info);
+        assert!(info.contains(
+            "ExecStart=/opt/testing/nym-vpnd run-as-service --disable-client-verification\n"
+        ));
+        assert!(!info.contains(" -v"));
+
+        let debug = daemon_log_level_override_content(bin, Verbosity::Debug);
+        assert!(debug.contains(
+            "ExecStart=/opt/testing/nym-vpnd run-as-service --disable-client-verification -v\n"
+        ));
     }
 }


### PR DESCRIPTION
- Unmask hickory in test_dns_leak via a correct nymvpnd drop-in ExecStart, restore Info after the test, and scrape resolvectl/daemon-log context on failure.

## Ticket

JIRA-NYM-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5984)
<!-- Reviewable:end -->
