### PR TITLE
Custom bind ip for local resolver

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `NYM_LOCAL_RESOLVER_IP` environment variable for local DNS resolver bind IP customization (https://github.com/nymtech/nym-vpn-client/pull/5989)
+
+
 ## [2026.12.0] - TBD
 
 ### Added

--- a/nym-vpn-core/README.md
+++ b/nym-vpn-core/README.md
@@ -315,6 +315,9 @@ make -C nym-vpn-core -f Android.mk
         - `netsh`: use the `netsh` program
         - `tcpip`: set TCP/IP parameters in the registry
 
+- `NYM_LOCAL_RESOLVER_IP` - Set to IPv4 address to override local DNS resolver IP. If not set, the
+  default behavior is to bind to random alias to loopback interface (`127.x.x.x`).
+
 - `NYM_DISABLE_OFFLINE_MONITOR` - Set to `1` to forces the daemon to always assume the host is online.
 
 - `NYM_USE_PATH_MONITOR` - Set to `1` to use Apple Network framework for offline monitoring. (macOS only)

--- a/nym-vpn-core/crates/nym-vpn-lib/src/resolver/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/resolver/mod.rs
@@ -32,7 +32,7 @@ mod tcp;
 use tcp::new_tcp_listener;
 
 mod udp;
-use udp::new_random_socket;
+use udp::{new_random_socket, new_udp_socket};
 
 #[cfg(target_os = "ios")]
 mod apple_connection_provider;
@@ -144,6 +144,23 @@ pub struct LocalResolver {
     inner_resolver: Resolver,
     dns_filter: DnsFilter,
     shutdown_token: CancellationToken,
+}
+
+/// Interface to listen on for DNS queries
+pub enum ListenInterface {
+    /// Listen on the loopback interface
+    Loopback {
+        /// Whether to add random IP alias to the loopback interface
+        random_loopback: bool,
+    },
+    /// Listen on user-specified IP
+    Custom { bind_to: Ipv4Addr },
+}
+
+impl ListenInterface {
+    fn is_loopback(&self) -> bool {
+        matches!(self, ListenInterface::Loopback { .. })
+    }
 }
 
 /// A message to [LocalResolver]
@@ -383,17 +400,27 @@ impl ResolverHandle {
 impl LocalResolver {
     /// Spawn new filtering resolver and its handle.
     pub async fn spawn(
-        use_random_loopback: bool,
+        listen_interface: ListenInterface,
         shutdown_token: CancellationToken,
     ) -> Result<(ResolverHandle, tokio::task::JoinHandle<()>), Error> {
         let (tx, rx) = mpsc::unbounded_channel();
 
-        let (udp_socket, loopback_alias) =
-            new_random_socket(DNS_LISTEN_PORT, use_random_loopback).await?;
+        let (udp_socket, loopback_alias) = match listen_interface {
+            ListenInterface::Loopback { random_loopback } => {
+                new_random_socket(DNS_LISTEN_PORT, random_loopback).await?
+            }
+            ListenInterface::Custom { bind_to } => {
+                let addr = SocketAddr::new(IpAddr::V4(bind_to), DNS_LISTEN_PORT);
+                let udp_socket = new_udp_socket(addr, false)
+                    .await
+                    .map_err(|_| Error::UdpBind)?;
+                (udp_socket, None)
+            }
+        };
         let resolver_addr = udp_socket.local_addr().map_err(Error::GetSocketAddr)?;
 
         // Attempt to bind TCP listener to the same port as UDP, but don't fail if it's not possible.
-        let tcp_listener = new_tcp_listener(resolver_addr)
+        let tcp_listener = new_tcp_listener(resolver_addr, listen_interface.is_loopback())
             .inspect_err(|_err| {
                 tracing::warn!("Failed to bind TCP socket to {resolver_addr}");
             })
@@ -726,10 +753,7 @@ impl RequestHandler for ResolverImpl {
         request: &Request,
         response_handle: R,
     ) -> ResponseInfo {
-        if !request.src().ip().is_loopback() {
-            tracing::error!("Dropping a stray request from outside: {}", request.src());
-            make_response_info(request, ResponseCode::Refused)
-        } else if request.metadata.message_type == MessageType::Query
+        if request.metadata.message_type == MessageType::Query
             && request.metadata.op_code == OpCode::Query
         {
             self.lookup(request, response_handle)

--- a/nym-vpn-core/crates/nym-vpn-lib/src/resolver/tcp.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/resolver/tcp.rs
@@ -8,7 +8,7 @@ use tokio::net::TcpListener;
 
 const DEFAULT_BACKLOG: i32 = 128;
 
-pub fn new_tcp_listener(socket_addr: SocketAddr) -> std::io::Result<TcpListener> {
+pub fn new_tcp_listener(socket_addr: SocketAddr, reuse_addr: bool) -> std::io::Result<TcpListener> {
     let domain = Domain::for_address(socket_addr);
     let socket = Socket::new(domain, Type::STREAM, Some(Protocol::TCP)).inspect_err(|err| {
         tracing::warn!("Failed to open TCP socket: {err}");
@@ -22,9 +22,11 @@ pub fn new_tcp_listener(socket_addr: SocketAddr) -> std::io::Result<TcpListener>
     // SO_REUSEADDR allows us to bind to `127.x.y.z` even if another socket is bound to `0.0.0.0`.
     // Best-effort: allow binding even if wildcard is in use. Windows semantics differ but
     // this is harmless.
-    socket.set_reuse_address(true).inspect_err(|err| {
-        tracing::warn!("Failed to set SO_REUSEADDR on TCP socket: {err}");
-    })?;
+    if reuse_addr {
+        socket.set_reuse_address(true).inspect_err(|err| {
+            tracing::warn!("Failed to set SO_REUSEADDR on TCP socket: {err}");
+        })?;
+    }
 
     let sa = SockAddr::from(socket_addr);
     socket.bind(&sa).inspect_err(|err| {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/resolver/tests.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/resolver/tests.rs
@@ -21,9 +21,14 @@ async fn test_bind() {
         .expect("failed to bind wildcard port");
 
     let shutdown_token = CancellationToken::new();
-    let (handle, join_handle) = LocalResolver::spawn(false, shutdown_token.child_token())
-        .await
-        .unwrap();
+    let (handle, join_handle) = LocalResolver::spawn(
+        ListenInterface::Loopback {
+            random_loopback: false,
+        },
+        shutdown_token.child_token(),
+    )
+    .await
+    .unwrap();
 
     let test_resolver = get_test_resolver(handle.listen_addr()).expect("failed to create resolver");
     test_resolver
@@ -46,9 +51,14 @@ async fn test_bind() {
 #[ignore] // Won't work unless we are root
 async fn test_random_loopback_bind() {
     let shutdown_token = CancellationToken::new();
-    let (handle, join_handle) = LocalResolver::spawn(true, shutdown_token.child_token())
-        .await
-        .unwrap();
+    let (handle, join_handle) = LocalResolver::spawn(
+        ListenInterface::Loopback {
+            random_loopback: true,
+        },
+        shutdown_token.child_token(),
+    )
+    .await
+    .unwrap();
 
     let ip = handle.listen_addr().ip();
     assert!(ip.is_ipv4(), "expected IPv4 loopback resolver address");
@@ -66,9 +76,14 @@ async fn test_random_loopback_bind() {
 #[serial_test::serial]
 async fn test_successful_lookup() {
     let shutdown_token = CancellationToken::new();
-    let (handle, join_handle) = LocalResolver::spawn(false, shutdown_token.child_token())
-        .await
-        .unwrap();
+    let (handle, join_handle) = LocalResolver::spawn(
+        ListenInterface::Loopback {
+            random_loopback: false,
+        },
+        shutdown_token.child_token(),
+    )
+    .await
+    .unwrap();
     let test_resolver = get_test_resolver(handle.listen_addr()).expect("failed to create resolver");
 
     for domain in &*ALLOWED_DOMAINS {
@@ -86,9 +101,14 @@ async fn test_successful_lookup() {
 #[serial_test::serial]
 async fn test_failed_lookup() {
     let shutdown_token = CancellationToken::new();
-    let (handle, join_handle) = LocalResolver::spawn(false, shutdown_token.child_token())
-        .await
-        .unwrap();
+    let (handle, join_handle) = LocalResolver::spawn(
+        ListenInterface::Loopback {
+            random_loopback: false,
+        },
+        shutdown_token.child_token(),
+    )
+    .await
+    .unwrap();
     let test_resolver = get_test_resolver(handle.listen_addr()).expect("failed to create resolver");
 
     let captive_portal_domain = LowerName::from(Name::from_str("apple.com").unwrap());
@@ -109,9 +129,14 @@ async fn test_failed_lookup() {
 async fn test_unbind_socket_on_stop() {
     // Bind resolver to 127.0.0.1 so we can easily bind to the same address here.
     let shutdown_token = CancellationToken::new();
-    let (handle, join_handle) = LocalResolver::spawn(false, shutdown_token.child_token())
-        .await
-        .unwrap();
+    let (handle, join_handle) = LocalResolver::spawn(
+        ListenInterface::Loopback {
+            random_loopback: false,
+        },
+        shutdown_token.child_token(),
+    )
+    .await
+    .unwrap();
     let addr = handle.listen_addr();
     assert_eq!(
         addr,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/resolver/udp.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/resolver/udp.rs
@@ -39,7 +39,7 @@ pub async fn new_random_socket(
             4.. => break,
         };
 
-        match bind_socket(SocketAddr::new(ip, port)).await {
+        match new_udp_socket(SocketAddr::new(ip, port), true).await {
             Ok(socket) => {
                 return Ok((socket, alias));
             }
@@ -55,7 +55,7 @@ pub async fn new_random_socket(
     Err(Error::UdpBind)
 }
 
-async fn bind_socket(addr: SocketAddr) -> std::io::Result<UdpSocket> {
+pub async fn new_udp_socket(addr: SocketAddr, reuse_addr: bool) -> std::io::Result<UdpSocket> {
     let sock = Socket::new(Domain::IPV4, Type::DGRAM, Some(Protocol::UDP)).inspect_err(|err| {
         tracing::error!("Failed to open IPv4/UDP socket: {err}");
     })?;
@@ -68,7 +68,7 @@ async fn bind_socket(addr: SocketAddr) -> std::io::Result<UdpSocket> {
     // SO_REUSEADDR enables us to bind to `127.x.y.z` even if another socket is bound to `0.0.0.0`.
     // Best-effort: allow binding even if wildcard is in use. Windows semantics differ but
     // this is harmless.
-    if let Err(err) = sock.set_reuse_address(true) {
+    if reuse_addr && let Err(err) = sock.set_reuse_address(true) {
         tracing::warn!("Failed to set SO_REUSEADDR on UDP socket: {err}");
     }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -19,6 +19,8 @@ mod tunnel_monitor;
 #[cfg(windows)]
 mod wintun;
 
+#[cfg(not(target_os = "android"))]
+use std::str::FromStr;
 #[cfg(any(target_os = "ios", target_os = "android"))]
 use std::sync::Arc;
 
@@ -1143,10 +1145,12 @@ impl TunnelStateMachine {
         let dns_handler_shutdown_token = CancellationToken::new();
 
         #[cfg(not(target_os = "android"))]
-        let (filtering_resolver, filtering_resolver_handle) =
-            resolver::LocalResolver::spawn(true, dns_handler_shutdown_token.child_token())
-                .await
-                .map_err(Error::StartLocalDnsResolver)?;
+        let (filtering_resolver, filtering_resolver_handle) = resolver::LocalResolver::spawn(
+            resolver_listen_addr(),
+            dns_handler_shutdown_token.child_token(),
+        )
+        .await
+        .map_err(Error::StartLocalDnsResolver)?;
 
         let adblocker = create_adblocker(&nym_config, file_updater_handle);
         if tunnel_settings.enable_ad_blocking {
@@ -1630,5 +1634,26 @@ impl From<tunnel::transports::TransportError> for Error {
 impl From<nym_registration_client::RegistrationClientError> for Error {
     fn from(value: nym_registration_client::RegistrationClientError) -> Self {
         Self::Tunnel(Box::new(tunnel::Error::RegistrationClient(Box::new(value))))
+    }
+}
+
+#[cfg(not(target_os = "android"))]
+fn resolver_listen_addr() -> resolver::ListenInterface {
+    if let Some(bind_to) = std::env::var("NYM_LOCAL_RESOLVER_IP")
+        .inspect_err(|err| tracing::warn!("Failed to parse NYM_LOCAL_RESOLVER_IP: {err}"))
+        .ok()
+        .and_then(|v| {
+            Ipv4Addr::from_str(&v)
+                .inspect_err(|err| {
+                    tracing::warn!("Couldn't parse IPv4 address from NYM_LOCAL_RESOLVER_IP: {err}")
+                })
+                .ok()
+        })
+    {
+        resolver::ListenInterface::Custom { bind_to }
+    } else {
+        resolver::ListenInterface::Loopback {
+            random_loopback: true,
+        }
     }
 }


### PR DESCRIPTION


## Description

This PR adds a way to customize bind IP for local resolver. This could be useful in restricted environments where local resolver needs to be available outside of loopback, perhaps in Qubes?

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5989)
<!-- Reviewable:end -->
