### PR TITLE
NYM-1726: Suggest running diagnostics when errors occur.

### DIFF
--- a/nym-vpn-app/e2e/tests/main.screen.spec.ts
+++ b/nym-vpn-app/e2e/tests/main.screen.spec.ts
@@ -36,7 +36,9 @@ test.describe('MainScreen', () => {
   test('renders entry and exit server rows', async () => {
     await expect(mainPage.serverRow('Entry')).toBeVisible();
     await expect(mainPage.serverRow('Exit')).toBeVisible();
-    await expect(mainPage.serverRow('Entry')).toContainText('Random');
+    await expect(mainPage.serverRow('Entry')).toContainText(
+      'Safest server selection',
+    );
   });
 
   test('navigates to settings screen correctly', async ({ page }) => {

--- a/nym-vpn-app/src-tauri/src/events.rs
+++ b/nym-vpn-app/src-tauri/src/events.rs
@@ -7,13 +7,18 @@ use crate::error::{BackendError, ErrorKey};
 use crate::vpnd::account::AccountState;
 use crate::vpnd::config::VpndConfig;
 use crate::vpnd::tunnel::ConnectingState;
-use crate::vpnd::{client::VpndStatus, events::MixnetEvent, tunnel::TunnelState};
+use crate::vpnd::{
+    client::VpndStatus,
+    events::{DiagnosticsSuggestedReason, MixnetEvent},
+    tunnel::TunnelState,
+};
 
 pub const EVENT_VPND_STATUS: &str = "vpnd-status";
 pub const EVENT_TUNNEL_STATE: &str = "tunnel-state";
 pub const EVENT_ACCOUNT_STATE: &str = "account-state";
 pub const EVENT_VPN_CONFIG: &str = "vpn-config";
 pub const EVENT_MIXNET: &str = "mixnet-event";
+pub const EVENT_DIAGNOSTICS_SUGGESTED: &str = "diagnostics-suggested";
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 pub const EVENT_UPDATE_PENDING: &str = "update-pending";
 
@@ -67,6 +72,7 @@ pub trait AppHandleEventEmitter {
     fn emit_disconnected(&self, error: Option<BackendError>);
     fn emit_mixnet_event(&self, event: MixnetEvent);
     fn emit_account_state_update(&self, state: &AccountState);
+    fn emit_diagnostics_suggested(&self, reason: DiagnosticsSuggestedReason);
 }
 
 impl AppHandleEventEmitter for tauri::AppHandle {
@@ -122,5 +128,13 @@ impl AppHandleEventEmitter for tauri::AppHandle {
             state.as_ref()
         );
         self.emit(EVENT_ACCOUNT_STATE, state).ok();
+    }
+
+    fn emit_diagnostics_suggested(&self, reason: DiagnosticsSuggestedReason) {
+        debug!(
+            "sending event [{}]: {:?}",
+            EVENT_DIAGNOSTICS_SUGGESTED, reason
+        );
+        self.emit(EVENT_DIAGNOSTICS_SUGGESTED, reason).ok();
     }
 }

--- a/nym-vpn-app/src-tauri/src/vpnd/client.rs
+++ b/nym-vpn-app/src-tauri/src/vpnd/client.rs
@@ -11,7 +11,7 @@ pub use super::{
 };
 use super::{
     config::{MixnetTrafficConfig, VpndConfig},
-    events::MixnetEvent,
+    events::{DiagnosticsSuggestedReason, MixnetEvent},
     gateway::{Gateway, GatewayType},
     tentative_gateways::TentativeGateways,
     tunnel::{FrontingMode, SplitApp, TunnelState},
@@ -305,6 +305,7 @@ impl VpndClient {
             }
             lib::TunnelEvent::DiagnosticsSuggested(reason) => {
                 debug!("diagnostics suggested: {reason}");
+                app.emit_diagnostics_suggested(DiagnosticsSuggestedReason::from_lib(reason));
             }
         }
         Ok(())

--- a/nym-vpn-app/src-tauri/src/vpnd/client.rs
+++ b/nym-vpn-app/src-tauri/src/vpnd/client.rs
@@ -303,6 +303,9 @@ impl VpndClient {
                 debug!("config event {e}");
                 VpndClient::handle_config_update(app, *e).await.ok();
             }
+            lib::TunnelEvent::DiagnosticsSuggested(reason) => {
+                debug!("diagnostics suggested: {reason}");
+            }
         }
         Ok(())
     }

--- a/nym-vpn-app/src-tauri/src/vpnd/events.rs
+++ b/nym-vpn-app/src-tauri/src/vpnd/events.rs
@@ -3,6 +3,30 @@ use serde::Serialize;
 use tracing::instrument;
 use ts_rs::TS;
 
+use super::tunnel_error::TunnelError;
+
+#[derive(Serialize, Clone, Debug, PartialEq, TS)]
+#[ts(export, export_to = "tauri.ts")]
+#[serde(rename_all = "kebab-case")]
+pub enum DiagnosticsSuggestedReason {
+    RepeatedConnectionRetries { attempts: u32 },
+    AmbiguousError(TunnelError),
+}
+
+impl DiagnosticsSuggestedReason {
+    #[instrument(skip(reason))]
+    pub fn from_lib(reason: lib::DiagnosticsSuggestionReason) -> Self {
+        match reason {
+            lib::DiagnosticsSuggestionReason::RepeatedConnectionRetries { attempts } => {
+                Self::RepeatedConnectionRetries { attempts }
+            }
+            lib::DiagnosticsSuggestionReason::AmbiguousError(reason) => {
+                Self::AmbiguousError(TunnelError::from(reason))
+            }
+        }
+    }
+}
+
 #[derive(Serialize, Clone, Debug, PartialEq, TS, strum::AsRefStr)]
 #[ts(export, export_to = "tauri.ts")]
 #[serde(rename_all = "kebab-case")]
@@ -51,5 +75,34 @@ impl From<lib::ConnectionEvent> for MixnetEvent {
             lib::ConnectionEvent::ConnectedIpv4 => Self::ConnectedIpv4,
             lib::ConnectionEvent::ConnectedIpv6 => Self::ConnectedIpv6,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn diagnostics_suggested_reason_from_lib_repeated_connection_retries() {
+        let reason = DiagnosticsSuggestedReason::from_lib(
+            lib::DiagnosticsSuggestionReason::RepeatedConnectionRetries { attempts: 3 },
+        );
+
+        assert_eq!(
+            reason,
+            DiagnosticsSuggestedReason::RepeatedConnectionRetries { attempts: 3 }
+        );
+    }
+
+    #[test]
+    fn diagnostics_suggested_reason_from_lib_ambiguous_error() {
+        let reason = DiagnosticsSuggestedReason::from_lib(
+            lib::DiagnosticsSuggestionReason::AmbiguousError(lib::ErrorStateReason::SetDns),
+        );
+
+        assert_eq!(
+            reason,
+            DiagnosticsSuggestedReason::AmbiguousError(TunnelError::SetDns)
+        );
     }
 }

--- a/nym-vpn-app/src/types/tauri.ts
+++ b/nym-vpn-app/src/types/tauri.ts
@@ -93,7 +93,15 @@ export type DbKey =
   | 'cache-device-id';
 
 export type DeeplinkKind =
-  'privy' | 'privyLink' | 'autologinRenew' | 'autologinView' | 'createAccount';
+  | 'privy'
+  | 'privyLink'
+  | 'autologinRenew'
+  | 'autologinView'
+  | 'createAccount';
+
+export type DiagnosticsSuggestedReason =
+  | { 'repeated-connection-retries': { attempts: number } }
+  | { 'ambiguous-error': TunnelError };
 
 export type DisplayServer = 'x11' | 'wayland' | { unknown: string | null };
 
@@ -498,14 +506,20 @@ export type TTunnelState =
 export type TVpnAccountStatus = 'active' | 'inactive' | 'delete-me';
 
 export type TVpnSubscriptionKind =
-  'one-month' | 'one-year' | 'two-years' | 'freepass' | { other: string };
+  | 'one-month'
+  | 'one-year'
+  | 'two-years'
+  | 'freepass'
+  | { other: string };
 
 /**
  * Only the discriminant is needed by the UI to decide the connect flow, so the
  * `Selected` entry/exit payload is intentionally dropped.
  */
 export type TentativeGateways =
-  'selected' | 'needs-relaxed-independence-criteria' | 'no-gateways-available';
+  | 'selected'
+  | 'needs-relaxed-independence-criteria'
+  | 'no-gateways-available';
 
 export type ThemeMode = 'system' | 'light' | 'dark';
 

--- a/nym-vpn-app/src/types/tauri.ts
+++ b/nym-vpn-app/src/types/tauri.ts
@@ -93,11 +93,7 @@ export type DbKey =
   | 'cache-device-id';
 
 export type DeeplinkKind =
-  | 'privy'
-  | 'privyLink'
-  | 'autologinRenew'
-  | 'autologinView'
-  | 'createAccount';
+  'privy' | 'privyLink' | 'autologinRenew' | 'autologinView' | 'createAccount';
 
 export type DiagnosticsSuggestedReason =
   | { 'repeated-connection-retries': { attempts: number } }
@@ -506,20 +502,14 @@ export type TTunnelState =
 export type TVpnAccountStatus = 'active' | 'inactive' | 'delete-me';
 
 export type TVpnSubscriptionKind =
-  | 'one-month'
-  | 'one-year'
-  | 'two-years'
-  | 'freepass'
-  | { other: string };
+  'one-month' | 'one-year' | 'two-years' | 'freepass' | { other: string };
 
 /**
  * Only the discriminant is needed by the UI to decide the connect flow, so the
  * `Selected` entry/exit payload is intentionally dropped.
  */
 export type TentativeGateways =
-  | 'selected'
-  | 'needs-relaxed-independence-criteria'
-  | 'no-gateways-available';
+  'selected' | 'needs-relaxed-independence-criteria' | 'no-gateways-available';
 
 export type ThemeMode = 'system' | 'light' | 'dark';
 

--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Detect when the diagnostics check should be run (https://github.com/nymtech/nym-vpn-client/pull/5993)
+
+
 ## [2026.12.0] - TBD
 
 ### Added

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
@@ -107,8 +107,8 @@ pub use service::{
 pub use socks5::{EnableSocks5Request, HttpRpcSettings, Socks5Settings, Socks5State, Socks5Status};
 pub use split_tunnel::{SplitTunnelExcludedProcess, SplitTunnelExcludedProcessList};
 pub use tunnel_event::{
-    BandwidthEvent, ConnectionEvent, ConnectionStatisticsEvent, MixnetEvent, SphinxPacketRates,
-    TunnelEvent,
+    BandwidthEvent, ConnectionEvent, ConnectionStatisticsEvent, DiagnosticsSuggestionReason,
+    MixnetEvent, SphinxPacketRates, TunnelEvent,
 };
 pub use tunnel_state::{ActionAfterDisconnect, ErrorStateReason, TunnelState, TunnelType};
 pub use user_agent::UserAgent;

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_event.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_event.rs
@@ -9,7 +9,7 @@ use si_scale::helpers::bibytes2;
 #[cfg(feature = "typescript-bindings")]
 use ts_rs::TS;
 
-use crate::{AccountControllerState, service::VpnServiceConfig};
+use crate::{AccountControllerState, ErrorStateReason, service::VpnServiceConfig};
 
 #[cfg(feature = "nym-type-conversions")]
 use nym_statistics_common::clients::packet_statistics::{
@@ -33,6 +33,7 @@ pub enum TunnelEvent {
     MixnetState(MixnetEvent),
     ConfigChanged(Box<VpnServiceConfig>),
     AccountState(AccountControllerState),
+    DiagnosticsSuggested(DiagnosticsSuggestionReason),
 }
 
 impl fmt::Display for TunnelEvent {
@@ -42,6 +43,40 @@ impl fmt::Display for TunnelEvent {
             Self::MixnetState(event) => event.fmt(f),
             Self::ConfigChanged(config) => config.fmt(f),
             Self::AccountState(account_state) => account_state.fmt(f),
+            Self::DiagnosticsSuggested(reason) => {
+                write!(f, "Diagnostics suggested: {reason}")
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "uniffi-bindings", derive(uniffi::Enum))]
+#[cfg_attr(
+    feature = "typescript-bindings",
+    derive(TS),
+    ts(export),
+    ts(export_to = "bindings.ts")
+)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "typescript-bindings", serde(rename_all = "camelCase"))]
+pub enum DiagnosticsSuggestionReason {
+    /// Stuck retrying to connect without ever reaching `Connected`.
+    RepeatedConnectionRetries { attempts: u32 },
+
+    /// Landed in an error state whose cause is ambiguous or network/reachability shaped,
+    /// as opposed to account/billing/permission states that already carry their own
+    /// obvious remediation.
+    AmbiguousError(ErrorStateReason),
+}
+
+impl fmt::Display for DiagnosticsSuggestionReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::RepeatedConnectionRetries { attempts } => {
+                write!(f, "repeated connection retries ({attempts})")
+            }
+            Self::AmbiguousError(reason) => write!(f, "ambiguous error ({reason})"),
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/tunnel_state.rs
@@ -360,4 +360,19 @@ impl ErrorStateReason {
     pub fn prevents_filtering_resolver(&self) -> bool {
         matches!(self, ErrorStateReason::SetDns)
     }
+
+    pub fn suggests_running_diagnostics(&self) -> bool {
+        matches!(
+            self,
+            Self::SetDns
+                | Self::SetRouting
+                | Self::TunDevice
+                | Self::TunnelProvider
+                | Self::PerformantEntryGatewayUnavailable
+                | Self::PerformantExitGatewayUnavailable
+                | Self::CredentialWastedOnEntryGateway
+                | Self::CredentialWastedOnExitGateway
+                | Self::Internal(_)
+        )
+    }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -73,10 +73,10 @@ use nym_firewall::{Firewall, FirewallArguments, InitialFirewallState};
 use nym_gateway_directory::ResolvedConfig;
 use nym_gateway_directory::{Config as GatewayDirectoryConfig, GatewayCacheHandle};
 use nym_vpn_lib_types::{
-    AccountControllerErrorStateReason, ActionAfterDisconnect, ConnectionData, EntryPoint,
-    ErrorStateReason, EstablishConnectionData, EstablishConnectionState, ExitPoint,
-    GatewayIndependence, GatewaySelectionAlgorithmConfig, GeoExclusionSettings,
-    SplitTunnelSettings, TunnelEvent, TunnelState, TunnelType,
+    AccountControllerErrorStateReason, ActionAfterDisconnect, ConnectionData,
+    DiagnosticsSuggestionReason, EntryPoint, ErrorStateReason, EstablishConnectionData,
+    EstablishConnectionState, ExitPoint, GatewayIndependence, GatewaySelectionAlgorithmConfig,
+    GeoExclusionSettings, SplitTunnelSettings, TunnelEvent, TunnelState, TunnelType,
 };
 
 use tunnel::SelectedGateways;
@@ -1097,11 +1097,53 @@ pub struct NymConfig {
     pub network_rx: watch::Receiver<Box<Network>>,
 }
 
+const DIAGNOSTICS_SUGGESTION_RETRY_THRESHOLD: u32 = 3;
+
+#[derive(Default)]
+struct DiagnosticsSuggestionTracker {
+    already_suggested: bool,
+}
+
+impl DiagnosticsSuggestionTracker {
+    fn observe(&mut self, state: &TunnelState) -> Option<DiagnosticsSuggestionReason> {
+        match state {
+            TunnelState::Connected { .. } | TunnelState::Disconnected => {
+                self.already_suggested = false;
+                None
+            }
+            TunnelState::Connecting { retry_attempt, .. }
+                if *retry_attempt >= DIAGNOSTICS_SUGGESTION_RETRY_THRESHOLD =>
+            {
+                self.suggest_once(DiagnosticsSuggestionReason::RepeatedConnectionRetries {
+                    attempts: *retry_attempt,
+                })
+            }
+            TunnelState::Error(reason) if reason.suggests_running_diagnostics() => {
+                self.suggest_once(DiagnosticsSuggestionReason::AmbiguousError(reason.clone()))
+            }
+            _ => None,
+        }
+    }
+
+    fn suggest_once(
+        &mut self,
+        reason: DiagnosticsSuggestionReason,
+    ) -> Option<DiagnosticsSuggestionReason> {
+        if self.already_suggested {
+            None
+        } else {
+            self.already_suggested = true;
+            Some(reason)
+        }
+    }
+}
+
 pub struct TunnelStateMachine {
     current_state_handler: Box<dyn TunnelStateHandler>,
     shared_state: SharedState,
     command_receiver: mpsc::UnboundedReceiver<TunnelCommand>,
     event_sender: mpsc::UnboundedSender<TunnelEvent>,
+    diagnostics_suggestion_tracker: DiagnosticsSuggestionTracker,
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     dns_handler_task: JoinHandle<()>,
     #[cfg(not(target_os = "android"))]
@@ -1247,6 +1289,7 @@ impl TunnelStateMachine {
             shared_state,
             command_receiver,
             event_sender,
+            diagnostics_suggestion_tracker: DiagnosticsSuggestionTracker::default(),
             #[cfg(not(any(target_os = "android", target_os = "ios")))]
             dns_handler_task,
             #[cfg(not(target_os = "android"))]
@@ -1279,7 +1322,15 @@ impl TunnelStateMachine {
                     self.shared_state
                         .statistics_event_sender
                         .report_tunnel_state(state.clone());
+                    let diagnostics_suggestion =
+                        self.diagnostics_suggestion_tracker.observe(&state);
                     let _ = self.event_sender.send(TunnelEvent::NewState(state));
+                    if let Some(reason) = diagnostics_suggestion {
+                        tracing::info!("Suggesting diagnostics: {reason}");
+                        let _ = self
+                            .event_sender
+                            .send(TunnelEvent::DiagnosticsSuggested(reason));
+                    }
                 }
                 NextTunnelState::SameState(same_state) => {
                     self.current_state_handler = same_state;

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -612,6 +612,18 @@ message TunnelEvent {
     MixnetEvent mixnet_event = 2;
     ConfigChangedEvent config_changed_event = 3;
     AccountControllerState account_state = 4;
+    DiagnosticsSuggestedEvent diagnostics_suggested_event = 5;
+  }
+}
+
+// Advisory hint that running the diagnostic tool might help. Does not change TunnelState.
+message DiagnosticsSuggestedEvent {
+  message RepeatedConnectionRetries {
+    uint32 attempts = 1;
+  }
+  oneof reason {
+    RepeatedConnectionRetries repeated_connection_retries = 1;
+    TunnelState.Error ambiguous_error = 2;
   }
 }
 

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/tunnel_event.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/tunnel_event.rs
@@ -3,7 +3,8 @@
 
 use nym_vpn_lib_types::{
     AccountControllerState, BandwidthEvent, ConnectionEvent, ConnectionStatisticsEvent,
-    MixnetEvent, SphinxPacketRates, TunnelEvent, TunnelState,
+    DiagnosticsSuggestionReason, ErrorStateReason, MixnetEvent, SphinxPacketRates, TunnelEvent,
+    TunnelState,
 };
 
 use crate::{conversions::ConversionError, proto};
@@ -32,6 +33,9 @@ impl TryFrom<proto::TunnelEvent> for TunnelEvent {
             proto::tunnel_event::Event::AccountState(account_state) => {
                 TunnelEvent::AccountState(AccountControllerState::try_from(account_state)?)
             }
+            proto::tunnel_event::Event::DiagnosticsSuggestedEvent(event) => {
+                TunnelEvent::DiagnosticsSuggested(DiagnosticsSuggestionReason::try_from(event)?)
+            }
         })
     }
 }
@@ -53,8 +57,54 @@ impl From<TunnelEvent> for proto::TunnelEvent {
             TunnelEvent::AccountState(account_state) => proto::tunnel_event::Event::AccountState(
                 proto::AccountControllerState::from(account_state),
             ),
+            TunnelEvent::DiagnosticsSuggested(reason) => {
+                proto::tunnel_event::Event::DiagnosticsSuggestedEvent(
+                    proto::DiagnosticsSuggestedEvent::from(reason),
+                )
+            }
         };
         Self { event: Some(event) }
+    }
+}
+
+impl TryFrom<proto::DiagnosticsSuggestedEvent> for DiagnosticsSuggestionReason {
+    type Error = ConversionError;
+
+    fn try_from(value: proto::DiagnosticsSuggestedEvent) -> Result<Self, Self::Error> {
+        let reason = value.reason.ok_or(ConversionError::NoValueSet(
+            "DiagnosticsSuggestedEvent.reason",
+        ))?;
+
+        Ok(match reason {
+            proto::diagnostics_suggested_event::Reason::RepeatedConnectionRetries(retries) => {
+                Self::RepeatedConnectionRetries {
+                    attempts: retries.attempts,
+                }
+            }
+            proto::diagnostics_suggested_event::Reason::AmbiguousError(error) => {
+                Self::AmbiguousError(ErrorStateReason::try_from(error)?)
+            }
+        })
+    }
+}
+
+impl From<DiagnosticsSuggestionReason> for proto::DiagnosticsSuggestedEvent {
+    fn from(value: DiagnosticsSuggestionReason) -> Self {
+        let reason = match value {
+            DiagnosticsSuggestionReason::RepeatedConnectionRetries { attempts } => {
+                proto::diagnostics_suggested_event::Reason::RepeatedConnectionRetries(
+                    proto::diagnostics_suggested_event::RepeatedConnectionRetries { attempts },
+                )
+            }
+            DiagnosticsSuggestionReason::AmbiguousError(reason) => {
+                proto::diagnostics_suggested_event::Reason::AmbiguousError(
+                    proto::tunnel_state::Error::from(reason),
+                )
+            }
+        };
+        Self {
+            reason: Some(reason),
+        }
     }
 }
 

--- a/nym-vpn-core/crates/test/test-manager/src/run_tests.rs
+++ b/nym-vpn-core/crates/test/test-manager/src/run_tests.rs
@@ -2,13 +2,13 @@
 // Copyright 2025 Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use crate::vm::ssh::SSHSession;
 use crate::{
     logging::{Logger, Panic, TestOutput, TestResult},
     nym_daemon::{self, RpcClientProvider},
     summary::SummaryLogger,
     tests::{TestContext, TestMetadata, TestWrapperFunctionNym},
     vm,
+    vm::ssh::SSHSession,
 };
 use anyhow::{Context, Result};
 use futures::FutureExt;

--- a/nym-vpn-core/crates/test/test-manager/src/tests/helpers_nym.rs
+++ b/nym-vpn-core/crates/test/test-manager/src/tests/helpers_nym.rs
@@ -1118,9 +1118,7 @@ mod tests {
     use crate::tests::{Error, WAIT_FOR_TUNNEL_CONNECTED_TIMEOUT, WAIT_FOR_TUNNEL_STATE_TIMEOUT};
     use futures::StreamExt;
     use nym_vpn_proto::rpc_client::Error as NymClientError;
-    use std::cell::Cell;
-    use std::collections::VecDeque;
-    use std::sync::Mutex;
+    use std::{cell::Cell, collections::VecDeque, sync::Mutex};
 
     fn sample_addr() -> std::net::SocketAddr {
         "93.184.216.34:443"


### PR DESCRIPTION
## Ticket

JIRA-NYM-1726

## Description

When certain error conditions are met, we send an additonal tunnel event to the UI to suggest that it runs the diagnostics tool to give us more to work with.


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5993)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added diagnostic suggestions when VPN connections repeatedly fail or encounter ambiguous errors.
  * Suggestions identify repeated connection attempts or specific error conditions that may benefit from running diagnostics.
  * Diagnostic suggestion events are now available through the service interface.
  * Duplicate suggestions are suppressed until the connection state resets.

* **Documentation**
  * Added an unreleased changelog entry describing diagnostics-check detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->