### PR TITLE
Fix latest location awaiting

### DIFF
--- a/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/controller/VpnCoreController.kt
+++ b/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/controller/VpnCoreController.kt
@@ -362,7 +362,7 @@ class VpnCoreController(
 			userAgent = userAgent,
 			tunProvider = service,
 			connectivityMonitor = service,
-			gatewaySelectionAlgorithmConfig = GatewaySelectionAlgorithmConfig(false),
+			gatewaySelectionAlgorithmConfig = GatewaySelectionAlgorithmConfig(true),
 			gatewayIndependence = GatewayIndependence(enableNotifications = nodeFamiliesNotificationsEnabled, differentNodeFamily = true, differentAsn = true, differentSubnet = true),
 		)
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/algorithm.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/algorithm.rs
@@ -73,12 +73,11 @@ impl<C: GatewayCache> SelectionAlgorithm<C> {
         }
     }
 
-    pub async fn run(mut self, mut latest_tunnel_settings: SelectAndSend) {
-        let mut latest_location = self
-            .shutdown_token
-            .run_until_cancelled(self.geo_ip_provider.new_location())
-            .await
-            .flatten();
+    pub async fn run(
+        mut self,
+        mut latest_tunnel_settings: SelectAndSend,
+        mut latest_location: Option<Location>,
+    ) {
         loop {
             tokio::select! {
                 _ = self.shutdown_token.cancelled() => {
@@ -153,11 +152,13 @@ mod tests {
             WireguardKeysDb::Ephemeral(Default::default()),
             shutdown_token.clone(),
         );
-        let handle = tokio::spawn(algo.run(SelectAndSend {
-            tunnel_settings: default_tunnel_settings(),
-            selection_tx,
-        }));
-        let _ = update_location_tx.send(Location::default());
+        let handle = tokio::spawn(algo.run(
+            SelectAndSend {
+                tunnel_settings: default_tunnel_settings(),
+                selection_tx,
+            },
+            None,
+        ));
 
         // set some default settings
         let mut selection_rx = reset_default_settings(&tunnel_settings_tx).await;

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/algorithm.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/algorithm.rs
@@ -134,7 +134,7 @@ mod tests {
     #[tokio::test]
     async fn run_algo() {
         let (tunnel_settings_tx, tunnel_settings_rx) = mpsc::channel(1);
-        let (update_location_tx, update_location_rx) = mpsc::unbounded_channel();
+        let (_update_location_tx, update_location_rx) = mpsc::unbounded_channel();
         let (selection_tx, _selection_rx) = mpsc::channel(10);
         let shutdown_token = CancellationToken::new();
         let possible_gateways_ids = [

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/mod.rs
@@ -81,7 +81,7 @@ impl<C: GatewayCache> GatewayProvider<C> {
         let (query_control_tx, query_control_rx) = mpsc::unbounded_channel();
         let (update_location_tx, update_location_rx) = mpsc::unbounded_channel();
 
-        let geo_ip_provider = GeoIpProvider::new(update_location_rx);
+        let mut geo_ip_provider = GeoIpProvider::new(update_location_rx);
         let geo_ip_fetcher = GeoIpFetcher::new(
             tunnel_settings
                 .gateway_selection_algorithm_config
@@ -96,20 +96,37 @@ impl<C: GatewayCache> GatewayProvider<C> {
 
         // Pre-compute at most 10 different possibilities of selected gateways
         let (selection_tx, selection_rx) = mpsc::channel(10);
-        let selection_algorithm_handle = tokio::spawn(
+        let gateway_cache_clone = gateway_cache.clone();
+        let blacklisted_gateways_clone = blacklisted_gateways.clone();
+        let selection_algorithm_handle = tokio::spawn(async move {
+            let latest_location = if tunnel_settings
+                .gateway_selection_algorithm_config
+                .enable_geo_location
+            {
+                shutdown_token
+                    .run_until_cancelled(geo_ip_provider.new_location())
+                    .await
+                    .flatten()
+            } else {
+                None
+            };
             SelectionAlgorithm::new(
                 tunnel_settings_rx,
-                gateway_cache.clone(),
+                gateway_cache_clone,
                 geo_ip_provider,
-                blacklisted_gateways.clone(),
+                blacklisted_gateways_clone,
                 wg_keys_db,
                 shutdown_token,
             )
-            .run(SelectAndSend {
-                tunnel_settings,
-                selection_tx,
-            }),
-        );
+            .run(
+                SelectAndSend {
+                    tunnel_settings,
+                    selection_tx,
+                },
+                latest_location,
+            )
+            .await
+        });
         let selected_gateways_stream = Arc::new(Mutex::new(tokio_stream::StreamExt::peekable(
             ReceiverStream::new(selection_rx),
         )));

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/tests/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/tests/mod.rs
@@ -252,6 +252,33 @@ async fn error_stream() {
 }
 
 #[tokio::test]
+async fn geo_location_disabled() {
+    let shutdown_token = CancellationToken::new();
+    let gateways = Arc::new(RwLock::new(None));
+    let mut tunnel_settings = default_tunnel_settings();
+    tunnel_settings
+        .gateway_selection_algorithm_config
+        .enable_geo_location = false;
+    let (mut gw_provider, handle) = GatewayProvider::new(
+        MockGatewayCache::new(gateways),
+        MockGeoIpClient::new(),
+        tunnel_settings,
+        WireguardKeysDb::Ephemeral(Default::default()),
+        shutdown_token.child_token(),
+    );
+    // No gateways come out of the stream when there are no gateways to select from
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), gw_provider.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .is_err()
+    );
+    shutdown_token.cancel();
+    handle.await.unwrap();
+}
+
+#[tokio::test]
 async fn set_and_stream() {
     let shutdown_token = CancellationToken::new();
     let possible_gateways = [


### PR DESCRIPTION
## Ticket

JIRA-NYM-1731

## Description

Fix possibility of stalling when connecting with `enable_geo_location` set to `false` on Android (where there is no pre-running daemon)


## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5994)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized gateway selection algorithm during VPN initialization for faster connection establishment
  * Enhanced device location handling to support geo-aware gateway routing when available
  * Improved stability and error handling when geolocation-based selection is unavailable
  * Refined startup process for more reliable VPN connections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->