### PR TITLE
sign cli with bundle id, update macos signing requirement

### DIFF
--- a/.github/workflows/build-nym-vpnc-macos.yml
+++ b/.github/workflows/build-nym-vpnc-macos.yml
@@ -161,7 +161,7 @@ jobs:
             --timestamp \
             --options runtime \
             --force \
-            -i "net.nymtech.vpn.cli"
+            -i "net.nymtech.vpn.cli" \
             "$BINARY"
 
           echo "Verifying codesign..."

--- a/.github/workflows/build-nym-vpnc-macos.yml
+++ b/.github/workflows/build-nym-vpnc-macos.yml
@@ -161,6 +161,7 @@ jobs:
             --timestamp \
             --options runtime \
             --force \
+            -i "net.nymtech.vpn.cli"
             "$BINARY"
 
           echo "Verifying codesign..."

--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Detect when the diagnostics check should be run (https://github.com/nymtech/nym-vpn-client/pull/5993)
 
+### Changed
+
+- [macOS] Sign cli with net.nymtech.vpn.cli bundle identifier. Add it to client signing requirement. (https://github.com/nymtech/nym-vpn-client/pull/5998)
+
 
 ## [2026.12.0] - TBD
 

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface.rs
@@ -39,7 +39,7 @@ const NYM_CERTIFICATE_SERIAL_NUMBER: &str = "4ec9356d8c87f9cf3ccf60e7bdad022f";
 // The MacOS signing requirement signifying that the binary was signed by apple
 // certificate with Nym's identifiers
 #[cfg(target_os = "macos")]
-const CLIENT_SIGNING_REQUIREMENT: &str = r#"anchor apple generic and certificate leaf[subject.OU] = "VW5DZLFHM5" and identifier "net.nymtech.vpn""#;
+const CLIENT_SIGNING_REQUIREMENT: &str = r#"anchor apple generic and certificate leaf[subject.OU] = "VW5DZLFHM5" and (identifier "net.nymtech.vpn" or identifier "net.nymtech.vpn.cli")"#;
 #[cfg(target_os = "macos")]
 const DAEMON_SIGNING_REQUIREMENT: &str = r#"anchor apple generic and certificate leaf[subject.OU] = "VW5DZLFHM5" and identifier "net.nymtech.vpn.daemon""#;
 


### PR DESCRIPTION


## Description

- Sign nym-vpnc with `net.nymtech.vpn.cli` identifier
- XPC: add `net.nymtech.vpn.cli` to signature verification

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5998)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved macOS command-line client signing by including its bundle identifier.
  - macOS now recognizes both the standard VPN client and command-line client identifiers, helping signed CLI builds launch and operate correctly.

- **Documentation**
  - Updated the changelog with details about macOS CLI signing and the supported client identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->