### PR TITLE
ci: build with nym-ipc/xpc feat

### DIFF
--- a/.github/workflows/ci-nym-vpn-core-macos.yml
+++ b/.github/workflows/ci-nym-vpn-core-macos.yml
@@ -81,5 +81,5 @@ jobs:
       - name: Build and test
         working-directory: nym-vpn-core
         run: |
-          cargo build --profile ci --workspace --locked
-          cargo test --profile ci --workspace --locked --exclude nym-ifconfig
+          cargo build --profile ci --workspace --locked -F nym-ipc/xpc
+          cargo test --profile ci --workspace --locked --exclude nym-ifconfig -F nym-ipc/xpc


### PR DESCRIPTION
## Description

Since apps are shipped with `nym-ipc/xpc` in release builds, let's make sure that CI debug runs cover it too. 

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/5999)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS build and test configuration to support XPC-enabled components.
  * Improved validation of macOS-specific functionality in continuous integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->