### PR TITLE
[Android] Update Generating screen and SelectPlan screen

### DIFF
--- a/nym-vpn-android/CHANGELOG.md
+++ b/nym-vpn-android/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Improved account signup and subscription flow (https://github.com/nymtech/nym-vpn-client/pull/6014)
+
 ## [2026.12.0] - TBD
 
 ### Added

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/AppUiState.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/AppUiState.kt
@@ -20,6 +20,7 @@ data class AppUiState(
 	val managerState: TunnelManagerState = TunnelManagerState(),
 	val networkStatus: NetworkStatus = NetworkStatus.Unknown,
 	val subscription: SubscriptionUiState? = null,
+	val hasSubscriptionHistory: Boolean = false,
 ) {
 
 	private val effectiveEntryPoint: EntryPoint

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/AppViewModel.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/AppViewModel.kt
@@ -34,6 +34,8 @@ import net.nymtech.nymvpn.util.StringValue
 import net.nymtech.nymvpn.util.extensions.toSubscriptionUiState
 import net.nymtech.vpn.backend.Tunnel
 import net.nymtech.vpn.config.CoreVpnConfigUpdate
+import nym_vpn_lib_types.AccountControllerErrorStateReason
+import nym_vpn_lib_types.AccountControllerState
 import nym_vpn_lib_types.DeeplinkKind
 import nym_vpn_lib_types.SystemMessage
 import timber.log.Timber
@@ -94,6 +96,7 @@ constructor(
 		) { base, accountSummary ->
 			base.copy(
 				subscription = accountSummary?.toSubscriptionUiState(),
+				hasSubscriptionHistory = accountSummary?.subscription != null,
 			)
 		}.stateIn(
 			viewModelScope,
@@ -115,6 +118,16 @@ constructor(
 		autologinJob?.cancel()
 		autologinJob = viewModelScope.launch {
 			_autologinState.value = AutologinState.Loading
+
+			val accountState = backendManager.stateFlow.value.accountState
+			val needsRegistration = accountState is AccountControllerState.Error &&
+				accountState.v1 is AccountControllerErrorStateReason.AccountStatusNotActive
+			if (needsRegistration) {
+				runCatching { backendManager.registerAccount(null) }
+					.onSuccess { Timber.tag(TAG).i("RegisterAccountSuccess") }
+					.onFailure { t -> Timber.tag(TAG).w(t, "RegisterAccountFailed") }
+			}
+
 			runCatching { backendManager.getAutologinDeeplink(kind) }
 				.onSuccess { response ->
 					if (response != null) {

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/common/snackbar/AlertController.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/common/snackbar/AlertController.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.flow.asStateFlow
 
 enum class AlertType { Confirmation, Neutral, Negative, Warning, Error }
 
-enum class AlertId { InactiveAccount, ExpiryWarning, Expired, ConnectionError }
+enum class AlertId { PendingSubscription, ExpiryWarning, Expired, ConnectionError }
 
 data class AlertMessage(
 	val type: AlertType = AlertType.Neutral,

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/account/generating/GeneratingScreen.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/account/generating/GeneratingScreen.kt
@@ -28,12 +28,11 @@ import net.nymtech.nymvpn.ui.common.snackbar.AlertMessage
 import net.nymtech.nymvpn.ui.common.snackbar.AlertType
 import net.nymtech.nymvpn.ui.theme.*
 import net.nymtech.nymvpn.util.extensions.navigateAndForget
-import net.nymtech.nymvpn.util.extensions.replaceCurrentWith
 import kotlin.time.Duration.Companion.milliseconds
 
 @Composable
 fun GeneratingScreen(viewModel: GeneratingViewModel = hiltViewModel()) {
-	val pendingNavigation by viewModel.pendingNavigation.collectAsStateWithLifecycle()
+	val readyForSelectPlan by viewModel.readyForSelectPlan.collectAsStateWithLifecycle()
 	val navController = LocalNavController.current
 	val mode = viewModel.mode
 	val errorText = stringResource(R.string.account_generating_error)
@@ -46,13 +45,9 @@ fun GeneratingScreen(viewModel: GeneratingViewModel = hiltViewModel()) {
 		}
 	}
 
-	LaunchedEffect(animationEnded, pendingNavigation) {
-		val nav = pendingNavigation ?: return@LaunchedEffect
-		if (!animationEnded) return@LaunchedEffect
-		when (nav) {
-			Route.SelectPlan -> navController.replaceCurrentWith(Route.SelectPlan)
-			else -> navController.navigateAndForget(nav)
-		}
+	LaunchedEffect(animationEnded, readyForSelectPlan) {
+		if (!readyForSelectPlan || !animationEnded) return@LaunchedEffect
+		navController.navigateAndForget(Route.SelectPlan)
 	}
 
 	GeneratingContent(

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/account/generating/GeneratingViewModel.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/account/generating/GeneratingViewModel.kt
@@ -11,29 +11,16 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import net.nymtech.nymvpn.BuildConfig
 import net.nymtech.nymvpn.R
-import net.nymtech.nymvpn.data.SettingsRepository
 import net.nymtech.nymvpn.manager.backend.BackendManager
-import net.nymtech.nymvpn.manager.billing.BillingManager
 import net.nymtech.nymvpn.ui.Route
 import net.nymtech.nymvpn.ui.common.snackbar.SnackbarController
-import net.nymtech.nymvpn.ui.AuthRoute
-import net.nymtech.nymvpn.ui.routeName
-import net.nymtech.nymvpn.util.Constants
 import net.nymtech.nymvpn.util.StringValue
 import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
-class GeneratingViewModel
-@Inject
-constructor(
-	private val backendManager: BackendManager,
-	savedStateHandle: SavedStateHandle,
-	private val billingManager: BillingManager,
-	private val settingsRepository: SettingsRepository,
-) : ViewModel() {
+class GeneratingViewModel @Inject constructor(private val backendManager: BackendManager, savedStateHandle: SavedStateHandle) : ViewModel() {
 
 	companion object {
 		private const val TAG = "ui-generate-account-vm"
@@ -44,25 +31,19 @@ constructor(
 	private val _error = MutableSharedFlow<Unit>(extraBufferCapacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
 	val error = _error.asSharedFlow()
 
-	private val _pendingNavigation = MutableStateFlow<Route?>(null)
-	val pendingNavigation = _pendingNavigation.asStateFlow()
+	private val _readyForSelectPlan = MutableStateFlow(false)
+	val readyForSelectPlan = _readyForSelectPlan.asStateFlow()
 
 	init {
 		if (mode == GeneratingMode.CreateAccount) {
 			viewModelScope.launch {
-				val billingAvailable = checkBillingAvailable()
-				Timber.tag(TAG).i("CreateAccountRequested billingAvailable=$billingAvailable")
+				Timber.tag(TAG).i("CreateAccountRequested")
 
 				runCatching {
 					backendManager.createAccount()
 					Timber.tag(TAG).i("CreateAccountSuccess")
 
-					if (billingAvailable) {
-						_pendingNavigation.value = Route.SelectPlan
-					} else {
-						val shouldShowTechnical = !settingsRepository.isTechnicalOptScreenCompleted()
-						_pendingNavigation.value = if (shouldShowTechnical) Route.Main(authRoute = AuthRoute.TechOpt.routeName) else Route.Main()
-					}
+					_readyForSelectPlan.value = true
 				}.onFailure { t ->
 					Timber.tag(TAG).e(t, "AccountSetupFailed")
 					_error.emit(Unit)
@@ -72,10 +53,5 @@ constructor(
 		} else {
 			Timber.tag(TAG).i("GeneratingScreen started in Login mode. Waiting for external logic.")
 		}
-	}
-
-	private fun checkBillingAvailable(): Boolean {
-		val billingAllowed = BuildConfig.APPLICATION_ID == Constants.APP_ID
-		return billingAllowed && billingManager.isAvailable()
 	}
 }

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/MainAlerts.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/MainAlerts.kt
@@ -18,7 +18,6 @@ import net.nymtech.nymvpn.ui.model.ConnectionState
 import net.nymtech.nymvpn.ui.screens.account.info.AutologinState
 import net.nymtech.nymvpn.ui.screens.settings.components.ExpiryState
 import net.nymtech.nymvpn.util.extensions.toUserMessage
-import nym_vpn_lib_types.AccountControllerErrorStateReason
 import nym_vpn_lib_types.AccountControllerState
 
 @Composable
@@ -29,6 +28,7 @@ fun MainAlerts(
 	expiryState: ExpiryState?,
 	validUntilDate: String,
 	expiryBannerDismissed: Boolean,
+	hasSubscriptionHistory: Boolean,
 	onRetryConnect: () -> Unit,
 	onDismissExpiryBanner: () -> Unit,
 	onRenewSubscription: () -> Unit,
@@ -49,7 +49,10 @@ fun MainAlerts(
 	val expiredTitle = stringResource(R.string.error_expired_subscription_title)
 	val expiredBody = stringResource(R.string.error_expired_subscription_description)
 	val expiredAction = stringResource(R.string.error_expired_subscription_button)
-	LaunchedEffect(expiryState, expiryBannerDismissed) {
+	val noSubscriptionTitle = stringResource(R.string.error_no_subscription_title)
+	val noSubscriptionBody = stringResource(R.string.error_no_subscription_description)
+	val noSubscriptionAction = stringResource(R.string.error_no_subscription_button)
+	LaunchedEffect(expiryState, expiryBannerDismissed, hasSubscriptionHistory) {
 		when {
 			!expiryBannerDismissed && expiryState == ExpiryState.WARNING -> AlertController.show(
 				AlertMessage(
@@ -69,9 +72,9 @@ fun MainAlerts(
 				AlertController.show(
 					AlertMessage(
 						type = AlertType.Error,
-						title = expiredTitle,
-						body = expiredBody,
-						action = AlertAction(expiredAction) { onNavigateToSelectPlan() },
+						title = if (hasSubscriptionHistory) expiredTitle else noSubscriptionTitle,
+						body = if (hasSubscriptionHistory) expiredBody else noSubscriptionBody,
+						action = AlertAction(if (hasSubscriptionHistory) expiredAction else noSubscriptionAction) { onNavigateToSelectPlan() },
 						duration = Long.MAX_VALUE,
 						id = AlertId.Expired,
 					),
@@ -84,23 +87,21 @@ fun MainAlerts(
 		}
 	}
 
-	val inactiveAccountTitle = stringResource(R.string.error_inactive_account)
-	val inactiveAccountBody = stringResource(R.string.error_inactive_account_subtitle)
+	val pendingSubscriptionTitle = stringResource(R.string.account_subscription_pending_title)
+	val pendingSubscriptionBody = stringResource(R.string.account_subscription_pending_description)
 	LaunchedEffect(accountState) {
-		val isInactive = accountState is AccountControllerState.Error &&
-			accountState.v1 is AccountControllerErrorStateReason.AccountStatusNotActive
-		if (isInactive) {
+		if (accountState is AccountControllerState.PendingSubscription) {
 			AlertController.show(
 				AlertMessage(
-					type = AlertType.Error,
-					title = inactiveAccountTitle,
-					body = inactiveAccountBody,
+					type = AlertType.Neutral,
+					title = pendingSubscriptionTitle,
+					body = pendingSubscriptionBody,
 					duration = Long.MAX_VALUE,
-					id = AlertId.InactiveAccount,
+					id = AlertId.PendingSubscription,
 				),
 			)
 		} else {
-			AlertController.dismiss(id = AlertId.InactiveAccount)
+			AlertController.dismiss(id = AlertId.PendingSubscription)
 		}
 	}
 

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/MainScreen.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/MainScreen.kt
@@ -195,8 +195,11 @@ fun MainScreen(appViewModel: AppViewModel, appUiState: AppUiState, autoStart: Bo
 	LaunchedEffect(appUiState.managerState.isInitialized) {
 		if (appUiState.managerState.isInitialized && !authSheetChecked) {
 			authSheetChecked = true
-			if (!appUiState.managerState.isMnemonicStored && !appUiState.settings.isWelcomeShown) {
-				bottomSheetContent = MainBottomSheetContent.Auth(AuthRoute.Welcome)
+			when {
+				!appUiState.managerState.isMnemonicStored && !appUiState.settings.isWelcomeShown ->
+					bottomSheetContent = MainBottomSheetContent.Auth(AuthRoute.Welcome)
+				appUiState.managerState.isMnemonicStored && !appUiState.settings.technicalOptCompleted ->
+					bottomSheetContent = MainBottomSheetContent.Auth(AuthRoute.TechOpt)
 			}
 		}
 	}
@@ -245,6 +248,7 @@ fun MainScreen(appViewModel: AppViewModel, appUiState: AppUiState, autoStart: Bo
 		expiryState = appUiState.subscription?.expiryState,
 		validUntilDate = appUiState.subscription?.validUntilDate ?: "",
 		expiryBannerDismissed = expiryBannerDismissed,
+		hasSubscriptionHistory = appUiState.hasSubscriptionHistory,
 		onRetryConnect = ::onConnectPressed,
 		onDismissExpiryBanner = viewModel::dismissExpiryBanner,
 		onRenewSubscription = { appViewModel.fetchAutologin(DeeplinkKind.AUTOLOGIN_RENEW) },
@@ -268,6 +272,7 @@ fun MainScreen(appViewModel: AppViewModel, appUiState: AppUiState, autoStart: Bo
 				}
 				ConnectAction.STOP_KILL_SWITCH -> navController.goFromRoot(Route.Settings(true))
 				ConnectAction.GET_STARTED -> onGetStartedPressed()
+				ConnectAction.REFRESH_ACCOUNT -> viewModel.refreshAccount()
 			}
 		},
 		onModeChange = { mode ->
@@ -402,6 +407,7 @@ private fun MainScreenContent(
 		),
 		initialPanelState = initialPanelState,
 		isSubscriptionExpired = appUiState.subscription?.expiryState == ExpiryState.EXPIRED,
+		hasSubscriptionHistory = appUiState.hasSubscriptionHistory,
 	)
 
 	Box(

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/MainViewModel.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/MainViewModel.kt
@@ -100,6 +100,12 @@ constructor(
 		_expiryBannerDismissed.value = true
 	}
 
+	fun refreshAccount() = viewModelScope.launch {
+		Timber.tag(TAG).i("RefreshAccountRequested")
+		runCatching { backendManager.refreshAccount() }
+			.onFailure { t -> Timber.tag(TAG).e(t, "RefreshAccountFailed") }
+	}
+
 	fun registerAccount() = viewModelScope.launch {
 		Timber.tag(TAG).i("RegisterAccountRequested")
 		_events.tryEmit(MainUiEvent.NavigateToSelectPlan)

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/panel/ConnectPanel.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/panel/ConnectPanel.kt
@@ -131,6 +131,7 @@ fun ConnectPanel(
 				accountState = state.accountState,
 				isMnemonicStored = state.isMnemonicStored,
 				isSubscriptionExpired = state.isSubscriptionExpired,
+				hasSubscriptionHistory = state.hasSubscriptionHistory,
 				onAction = onAction,
 			)
 		}

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/panel/ConnectPanelModels.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/panel/ConnectPanelModels.kt
@@ -8,7 +8,7 @@ enum class PanelState { COLLAPSED, FULL }
 
 enum class ConnectMode { FAST, MIXNET }
 
-enum class ConnectAction { CONNECT, DISCONNECT, STOP_KILL_SWITCH, GET_STARTED }
+enum class ConnectAction { CONNECT, DISCONNECT, STOP_KILL_SWITCH, GET_STARTED, REFRESH_ACCOUNT }
 
 enum class NodeSelectionType { NODE, RANDOM, AUTO }
 
@@ -23,4 +23,5 @@ data class ConnectPanelState(
 	val entryNode: ServerNode,
 	val initialPanelState: PanelState,
 	val isSubscriptionExpired: Boolean = false,
+	val hasSubscriptionHistory: Boolean = false,
 )

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/panel/components/ActionButton.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/panel/components/ActionButton.kt
@@ -29,6 +29,7 @@ internal fun ActionButton(
 	accountState: AccountControllerState,
 	isMnemonicStored: Boolean,
 	isSubscriptionExpired: Boolean,
+	hasSubscriptionHistory: Boolean,
 	onAction: (ConnectAction) -> Unit,
 	modifier: Modifier = Modifier,
 ) {
@@ -43,15 +44,25 @@ internal fun ActionButton(
 		-> {
 			val isAccountNotActive = accountState is AccountControllerState.Error &&
 				accountState.v1 is AccountControllerErrorStateReason.AccountStatusNotActive
+			val isPendingSubscription = accountState is AccountControllerState.PendingSubscription
 			val label = when {
-				isAccountNotActive -> R.string.get_started
-				isSubscriptionExpired -> R.string.error_expired_subscription_button
+				isAccountNotActive -> R.string.connect
+				isSubscriptionExpired -> if (hasSubscriptionHistory) R.string.error_expired_subscription_button else R.string.error_no_subscription_button
 				isMnemonicStored -> R.string.connect
 				else -> R.string.get_started
 			}
 			MainStyledButton(
-				onClick = { onAction(if (!isAccountNotActive && isMnemonicStored && !isSubscriptionExpired) ConnectAction.CONNECT else ConnectAction.GET_STARTED) },
+				onClick = {
+					onAction(
+						when {
+							isPendingSubscription -> ConnectAction.REFRESH_ACCOUNT
+							!isAccountNotActive && isMnemonicStored && !isSubscriptionExpired -> ConnectAction.CONNECT
+							else -> ConnectAction.GET_STARTED
+						},
+					)
+				},
 				content = { Text(stringResource(label), style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.onPrimary) },
+				color = if (isPendingSubscription) MaterialTheme.colorScheme.secondary else MaterialTheme.colorScheme.primary,
 				modifier = buttonModifier,
 				shape = buttonShape,
 			)

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/panel/components/ActionButton.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/panel/components/ActionButton.kt
@@ -97,10 +97,16 @@ internal fun ActionButton(
 		is ConnectionState.Error -> {
 			val isSubscriptionError = connectionState.reason is ErrorStateReason.InactiveSubscription ||
 				connectionState.reason is ErrorStateReason.InactiveAccount
-			val isAccountActionPending = accountState == AccountControllerState.Syncing ||
-				accountState == AccountControllerState.PendingSubscription
+			val isPendingSubscription = accountState is AccountControllerState.PendingSubscription
+			val isAccountActionPending = accountState == AccountControllerState.Syncing || isPendingSubscription
 
 			when {
+				isSubscriptionError && isPendingSubscription -> MainStyledButton(
+					onClick = { onAction(ConnectAction.REFRESH_ACCOUNT) },
+					content = { Text(stringResource(R.string.refresh), style = CustomTypography.buttonMain) },
+					modifier = buttonModifier,
+					shape = buttonShape,
+				)
 				isSubscriptionError && !isAccountActionPending && isVpnAlwaysOn(context) -> MainStyledButton(
 					onClick = { onAction(ConnectAction.STOP_KILL_SWITCH) },
 					textColor = MaterialTheme.colorScheme.onError,

--- a/nym-vpn-android/app/src/main/res/values/strings.xml
+++ b/nym-vpn-android/app/src/main/res/values/strings.xml
@@ -189,6 +189,11 @@
 	<string name="error_expired_subscription_title">Your subscription has expired</string>
 	<string name="error_expired_subscription_description">Recurring payment method has been refused</string>
 	<string name="error_expired_subscription_button">Renew Now</string>
+	<string name="error_no_subscription_title">No active subscription</string>
+	<string name="error_no_subscription_description">Choose a plan to start using NymVPN</string>
+	<string name="error_no_subscription_button">Select Plan</string>
+	<string name="account_subscription_pending_title">Subscription pending</string>
+	<string name="account_subscription_pending_description">We\'re waiting for your payment to be confirmed. This can take a little while for some payment methods.</string>
 	<!-- Main Screen -->
 	<string name="connection_state_resolving_addresses">Initializing NymVPN (1/7)</string>
 	<string name="connection_state_awaiting_readiness">Setting up your account (2/7)</string>


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

Rework the anonymous-account signup and subscription flow so users are guided into plan selection at the right moments, and show accurate, history-aware messaging (select vs. renew) for pending, expired, and never-subscribed states.  


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6014)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved messaging for pending, expired, and unavailable subscriptions.
  * Added account refresh actions for pending subscriptions.
  * Added tailored options for renewing or selecting a subscription plan.
  * Automatically opens technical opt-in when required during account setup.
  * Streamlined account creation by continuing directly to plan selection.
  * Improved automatic sign-in by registering inactive accounts when needed.
  * Added clearer subscription-state actions and styling throughout the connection experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->