### PR TITLE
Keep an Android VPN interface up while switching servers so it cannot leak

### DIFF
--- a/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/controller/VpnTunController.kt
+++ b/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/controller/VpnTunController.kt
@@ -13,9 +13,6 @@ import timber.log.Timber
 class VpnTunController(private val service: VpnService) {
 	companion object {
 		private const val TAG = "core-vpn"
-
-		// Must match nym_vpn_lib blocking_tun::BLOCKING_INTERFACE_ADDRS[0] / android_blocking_dns().
-		private const val BLOCKING_INTERFACE_V4 = "169.254.0.10"
 	}
 
 	@Volatile private var disallowedApps: List<String> = emptyList()
@@ -41,11 +38,11 @@ class VpnTunController(private val service: VpnService) {
 				runCatching { builder.addDisallowedApplication(pkg) }
 			}
 
-			// Blocking placeholder blackholes all routes. Exclude this app so control-plane
-			// (LP registration, API) can use the physical interface; other apps stay covered.
-			if (isBlockingPlaceholder(config)) {
+			// Blocking placeholder: exclude this app so control-plane can use the physical
+			// interface while other apps stay covered. Flag comes from Rust TunnelSettings.
+			if (config.excludeVpnApp) {
 				runCatching { builder.addDisallowedApplication(service.packageName) }
-					.onFailure { Timber.tag(TAG).w(it, "Failed to exclude VPN app from blocking TUN") }
+					.onFailure { Timber.tag(TAG).w(it, "Failed to exclude VPN app from tunnel") }
 			}
 
 			config.ipv4Settings?.addresses.orEmpty().forEach { cidr ->
@@ -95,15 +92,5 @@ class VpnTunController(private val service: VpnService) {
 
 	fun closeInterfaceSafely() {
 		// Rust will close the FD when the tunnel is stopped or reconfigured.
-	}
-
-	private fun isBlockingPlaceholder(config: TunnelNetworkSettings): Boolean {
-		val hasBlockingDns = config.dnsSettings?.servers.orEmpty().any { server ->
-			server.toString() == BLOCKING_INTERFACE_V4
-		}
-		val hasBlockingAddr = config.ipv4Settings?.addresses.orEmpty().any { cidr ->
-			cidr.trim().startsWith("$BLOCKING_INTERFACE_V4/")
-		}
-		return hasBlockingDns || hasBlockingAddr
 	}
 }

--- a/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/controller/VpnTunController.kt
+++ b/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/controller/VpnTunController.kt
@@ -13,6 +13,9 @@ import timber.log.Timber
 class VpnTunController(private val service: VpnService) {
 	companion object {
 		private const val TAG = "core-vpn"
+
+		// Must match nym_vpn_lib blocking_tun::BLOCKING_INTERFACE_ADDRS[0] / android_blocking_dns().
+		private const val BLOCKING_INTERFACE_V4 = "169.254.0.10"
 	}
 
 	@Volatile private var disallowedApps: List<String> = emptyList()
@@ -36,6 +39,13 @@ class VpnTunController(private val service: VpnService) {
 
 			disallowedApps.forEach { pkg ->
 				runCatching { builder.addDisallowedApplication(pkg) }
+			}
+
+			// Blocking placeholder blackholes all routes. Exclude this app so control-plane
+			// (LP registration, API) can use the physical interface; other apps stay covered.
+			if (isBlockingPlaceholder(config)) {
+				runCatching { builder.addDisallowedApplication(service.packageName) }
+					.onFailure { Timber.tag(TAG).w(it, "Failed to exclude VPN app from blocking TUN") }
 			}
 
 			config.ipv4Settings?.addresses.orEmpty().forEach { cidr ->
@@ -85,5 +95,15 @@ class VpnTunController(private val service: VpnService) {
 
 	fun closeInterfaceSafely() {
 		// Rust will close the FD when the tunnel is stopped or reconfigured.
+	}
+
+	private fun isBlockingPlaceholder(config: TunnelNetworkSettings): Boolean {
+		val hasBlockingDns = config.dnsSettings?.servers.orEmpty().any { server ->
+			server.toString() == BLOCKING_INTERFACE_V4
+		}
+		val hasBlockingAddr = config.ipv4Settings?.addresses.orEmpty().any { cidr ->
+			cidr.trim().startsWith("$BLOCKING_INTERFACE_V4/")
+		}
+		return hasBlockingDns || hasBlockingAddr
 	}
 }

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/tunnel_provider/tunnel_settings.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/tunnel_provider/tunnel_settings.rs
@@ -234,6 +234,9 @@ pub struct TunnelNetworkSettings {
 
     /// Tunnel device MTU.
     pub mtu: u16,
+
+    /// When true on Android, exclude the VPN app from the tunnel (blocking placeholder).
+    pub exclude_vpn_app: bool,
 }
 
 #[cfg(target_os = "android")]
@@ -338,6 +341,7 @@ impl From<nym_vpn_lib::tunnel_provider::TunnelSettings> for TunnelNetworkSetting
                 match_domains: Some(vec!["".to_owned()]),
             }),
             mtu: settings.mtu,
+            exclude_vpn_app: settings.exclude_vpn_app,
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/lib.rs
@@ -19,7 +19,6 @@ pub mod service;
 #[cfg(not(target_os = "ios"))]
 pub(crate) mod socks5_proxy;
 mod tunnel_health;
-#[cfg(any(target_os = "ios", target_os = "android"))]
 pub mod tunnel_provider;
 pub mod tunnel_state_machine;
 mod wg_config;

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_provider/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_provider/mod.rs
@@ -38,4 +38,8 @@ pub struct TunnelSettings {
 
     /// Tunnel device MTU.
     pub mtu: u16,
+
+    /// When true on Android, exclude the VPN app from the tunnel so control-plane traffic can
+    /// use the physical interface (used by the blocking placeholder during reconnect/error).
+    pub exclude_vpn_app: bool,
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/blocking_tun.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/blocking_tun.rs
@@ -27,6 +27,7 @@ pub fn blocking_tunnel_settings(dns_server: IpAddr) -> TunnelSettings {
         interface_addresses: BLOCKING_INTERFACE_ADDRS.map(IpNetwork::from).to_vec(),
         dns_servers: vec![dns_server],
         mtu: BLOCKING_TUN_MTU,
+        exclude_vpn_app: true,
     }
 }
 
@@ -60,6 +61,7 @@ mod tests {
         assert_eq!(settings.mtu, BLOCKING_TUN_MTU);
         assert_eq!(settings.dns_servers, vec![dns]);
         assert!(settings.remote_addresses.is_empty());
+        assert!(settings.exclude_vpn_app);
         assert_eq!(
             settings.interface_addresses,
             BLOCKING_INTERFACE_ADDRS.map(IpNetwork::from).to_vec()

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/blocking_tun.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/blocking_tun.rs
@@ -103,4 +103,23 @@ mod tests {
         assert_eq!(err, Err("fail"));
         assert_eq!(steps.into_inner(), ["install"]);
     }
+
+    /// Connecting/Connected unexpected Down must use this ordering (not cold Connecting::enter).
+    #[test]
+    fn reconnect_down_cover_ordering_is_install_then_release() {
+        let steps = RefCell::new(Vec::new());
+        with_blocking_before_tun_release::<()>(
+            || {
+                steps.borrow_mut().push("blocking_cover");
+                Ok(())
+            },
+            || steps.borrow_mut().push("release_tombstone"),
+        )
+        .expect("cover ok");
+        assert_eq!(
+            steps.into_inner(),
+            ["blocking_cover", "release_tombstone"],
+            "ISP window if tombstone is released before blocking establish"
+        );
+    }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/blocking_tun.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/blocking_tun.rs
@@ -1,0 +1,104 @@
+// Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+//! Shared blocking / placeholder TUN settings used on iOS and Android while the real tunnel is down.
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+use ipnetwork::IpNetwork;
+
+use crate::tunnel_provider::TunnelSettings;
+
+/// Placeholder interface addresses used while the real tunnel is down (Error / reconnect gap).
+pub const BLOCKING_INTERFACE_ADDRS: [IpAddr; 2] = [
+    IpAddr::V4(Ipv4Addr::new(169, 254, 0, 10)),
+    IpAddr::V6(Ipv6Addr::new(
+        0xfdcc, 0x9fc0, 0xe75a, 0x53c3, 0xfa25, 0x241f, 0x21c0, 0x70d0,
+    )),
+];
+
+/// Minimum IPv6 MTU; used for the blocking placeholder interface.
+pub const BLOCKING_TUN_MTU: u16 = 1280;
+
+/// Tunnel settings that keep a VPN interface up without forwarding traffic (blackhole).
+pub fn blocking_tunnel_settings(dns_server: IpAddr) -> TunnelSettings {
+    TunnelSettings {
+        remote_addresses: vec![],
+        interface_addresses: BLOCKING_INTERFACE_ADDRS.map(IpNetwork::from).to_vec(),
+        dns_servers: vec![dns_server],
+        mtu: BLOCKING_TUN_MTU,
+    }
+}
+
+/// Default DNS for Android blocking TUN (no local filtering resolver on Android).
+#[cfg(any(target_os = "android", test))]
+pub fn android_blocking_dns() -> IpAddr {
+    BLOCKING_INTERFACE_ADDRS[0]
+}
+
+/// Install blocking cover before releasing the previous TUN so reconnect cannot open an ISP window.
+#[cfg(any(target_os = "android", test))]
+pub fn with_blocking_before_tun_release<E>(
+    install_blocking: impl FnOnce() -> Result<(), E>,
+    release_previous_tun: impl FnOnce(),
+) -> Result<(), E> {
+    install_blocking()?;
+    release_previous_tun();
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+
+    use super::*;
+
+    #[test]
+    fn blocking_tunnel_settings_uses_shared_addrs_and_mtu() {
+        let dns = IpAddr::V4(Ipv4Addr::new(169, 254, 0, 10));
+        let settings = blocking_tunnel_settings(dns);
+        assert_eq!(settings.mtu, BLOCKING_TUN_MTU);
+        assert_eq!(settings.dns_servers, vec![dns]);
+        assert!(settings.remote_addresses.is_empty());
+        assert_eq!(
+            settings.interface_addresses,
+            BLOCKING_INTERFACE_ADDRS.map(IpNetwork::from).to_vec()
+        );
+    }
+
+    #[test]
+    fn android_blocking_dns_is_link_local_v4() {
+        assert_eq!(
+            android_blocking_dns(),
+            IpAddr::V4(Ipv4Addr::new(169, 254, 0, 10))
+        );
+    }
+
+    #[test]
+    fn with_blocking_before_tun_release_installs_before_drop() {
+        let steps = RefCell::new(Vec::new());
+        with_blocking_before_tun_release::<()>(
+            || {
+                steps.borrow_mut().push("install");
+                Ok(())
+            },
+            || steps.borrow_mut().push("drop"),
+        )
+        .expect("install ok");
+        assert_eq!(steps.into_inner(), ["install", "drop"]);
+    }
+
+    #[test]
+    fn with_blocking_before_tun_release_skips_drop_on_install_error() {
+        let steps = RefCell::new(Vec::new());
+        let err = with_blocking_before_tun_release(
+            || {
+                steps.borrow_mut().push("install");
+                Err("fail")
+            },
+            || steps.borrow_mut().push("drop"),
+        );
+        assert_eq!(err, Err("fail"));
+        assert_eq!(steps.into_inner(), ["install"]);
+    }
+}

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 mod account;
+#[cfg(any(target_os = "android", target_os = "ios", test))]
+mod blocking_tun;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 mod dns_handler;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
@@ -28,9 +30,14 @@ use std::{
 };
 
 #[cfg(target_os = "android")]
+use std::os::fd::{FromRawFd, OwnedFd};
+
+#[cfg(target_os = "android")]
 use crate::tunnel_provider::AndroidTunProvider;
 #[cfg(target_os = "ios")]
 use crate::tunnel_provider::OSTunProvider;
+#[cfg(target_os = "android")]
+use crate::tunnel_state_machine::blocking_tun::{android_blocking_dns, blocking_tunnel_settings};
 
 use crate::adblocker;
 #[cfg(not(target_os = "android"))]
@@ -777,6 +784,12 @@ pub struct SharedState {
     tun_provider: Arc<dyn OSTunProvider>,
     #[cfg(target_os = "android")]
     tun_provider: Arc<dyn AndroidTunProvider>,
+    /// Held FD for the Android blocking / placeholder VPN interface during Connecting / Error.
+    #[cfg(target_os = "android")]
+    android_blocking_tun: Option<OwnedFd>,
+    /// Previous live TUN kept when blocking install fails mid-reconnect (avoids ISP window).
+    #[cfg(target_os = "android")]
+    android_tun_hold: Option<tunnel::Tombstone>,
     account_command_tx: AccountCommandSender,
     account_controller_state: AccountStateReceiver,
     bandwidth_command_tx: BandwidthControllerRequestSender,
@@ -817,6 +830,35 @@ impl SharedState {
         self.account_command_tx.set_vpn_api_firewall_up().await.ok();
         self.gateway_provider.set_active_geo_location(false).await;
         self.gateway_provider.set_gateway_cache_paused(true);
+    }
+
+    /// Establish (or replace) the Android blocking VPN interface and retain its FD.
+    #[cfg(target_os = "android")]
+    fn install_android_blocking_tun(&mut self) -> std::io::Result<()> {
+        let settings = blocking_tunnel_settings(android_blocking_dns());
+        let raw_fd = self.tun_provider.configure_tunnel(settings)?;
+        // Safety: configure_tunnel returns a freshly owned FD from VpnService.Builder.establish().
+        let owned = unsafe { OwnedFd::from_raw_fd(raw_fd) };
+        self.android_blocking_tun = Some(owned);
+        // Blocking interface replaced any prior live TUN; drop retained tombstone if present.
+        self.android_tun_hold = None;
+        Ok(())
+    }
+
+    /// Install blocking TUN when none is held yet.
+    #[cfg(target_os = "android")]
+    fn ensure_android_blocking_tun(&mut self) -> std::io::Result<()> {
+        if self.android_blocking_tun.is_some() {
+            return Ok(());
+        }
+        self.install_android_blocking_tun()
+    }
+
+    /// Drop blocking TUN and any retained previous TUN (intentional Disconnect / real tunnel up).
+    #[cfg(target_os = "android")]
+    fn clear_android_blocking_tun(&mut self) {
+        self.android_blocking_tun = None;
+        self.android_tun_hold = None;
     }
 
     #[cfg(target_os = "linux")]
@@ -1203,6 +1245,10 @@ impl TunnelStateMachine {
             status_listener_handle: None,
             #[cfg(any(target_os = "ios", target_os = "android"))]
             tun_provider,
+            #[cfg(target_os = "android")]
+            android_blocking_tun: None,
+            #[cfg(target_os = "android")]
+            android_tun_hold: None,
             account_command_tx,
             account_controller_state,
             bandwidth_command_tx,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -861,6 +861,27 @@ impl SharedState {
         self.android_tun_hold = None;
     }
 
+    /// Install blocking cover, then release the previous TUN. On install failure, keep the previous
+    /// TUN in `android_tun_hold` so reconnect/error cannot open an ISP window.
+    #[cfg(target_os = "android")]
+    fn prepare_blocking_cover_before_release(
+        &mut self,
+        mut tombstone: Option<tunnel::Tombstone>,
+    ) -> std::io::Result<()> {
+        use crate::tunnel_state_machine::blocking_tun::with_blocking_before_tun_release;
+
+        let result = with_blocking_before_tun_release(
+            || self.install_android_blocking_tun(),
+            || {
+                drop(tombstone.take());
+            },
+        );
+        if result.is_err() {
+            self.android_tun_hold = tombstone;
+        }
+        result
+    }
+
     #[cfg(target_os = "linux")]
     pub fn disable_nm_connectivity_check(&mut self) {
         if self.nm_connectivity_check_enabled.is_none()

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
@@ -56,6 +56,10 @@ impl ConnectedState {
         tunnel_monitor_event_receiver: TunnelMonitorEventReceiver,
         shared_state: &mut SharedState,
     ) -> (Box<dyn TunnelStateHandler>, PrivateTunnelState) {
+        // Real tunnel replaced the blocking placeholder via configure_tunnel; drop the stale FD.
+        #[cfg(target_os = "android")]
+        shared_state.clear_android_blocking_tun();
+
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         let wg_entry_endpoint =
             if let TunnelConnectionData::Wireguard(ref wg) = connection_data.tunnel {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
@@ -13,6 +13,8 @@ use tokio_util::sync::CancellationToken;
 
 #[cfg(target_os = "ios")]
 use crate::tunnel_state_machine::Result;
+#[cfg(target_os = "android")]
+use crate::tunnel_state_machine::tunnel::Tombstone;
 use crate::tunnel_state_machine::{
     ConnectionData, NextTunnelState, PrivateActionAfterDisconnect, PrivateTunnelState, SharedState,
     TunnelCommand, TunnelInterface, TunnelStateHandler,
@@ -32,6 +34,7 @@ use nym_http_api_client::HickoryDnsResolver;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use nym_vpn_lib_types::TunnelConnectionData;
 
+#[cfg(target_os = "android")]
 use super::ErrorState;
 
 pub struct ConnectedState {
@@ -283,12 +286,43 @@ impl ConnectedState {
         Self::prepare_for_disconnect(shared_state).await;
 
         match error_state_reason {
-            Some(block_reason) => {
-                NextTunnelState::NewState(ErrorState::enter(block_reason, shared_state).await)
-            }
-            None => NextTunnelState::NewState(
-                ConnectingState::enter(0, Some(self.selected_gateways), shared_state).await,
+            // Ordered cover via Disconnecting (same as Connecting Down → Error).
+            Some(block_reason) => NextTunnelState::NewState(
+                DisconnectingState::enter(
+                    PrivateActionAfterDisconnect::Error(block_reason),
+                    Some(self.tunnel_monitor_handle),
+                    shared_state,
+                )
+                .await,
             ),
+            None => {
+                // Preserve selected gateways (Disconnecting(Reconnect) would clear them).
+                // Install Android blocking cover before releasing the TUN, then re-enter Connecting.
+                self.tunnel_monitor_handle.cancel();
+                let tombstone = self.tunnel_monitor_handle.wait().await;
+
+                #[cfg(target_os = "android")]
+                {
+                    if let Err(err) =
+                        shared_state.prepare_blocking_cover_before_release(Some(tombstone))
+                    {
+                        tracing::error!(
+                            "Failed to install Android blocking TUN before Connected reconnect: {err}"
+                        );
+                        return NextTunnelState::NewState(
+                            ErrorState::enter(ErrorStateReason::TunnelProvider, shared_state).await,
+                        );
+                    }
+                    // Cover already released the live TUN; still clear socks5 / side-effects.
+                    ConnectingState::handle_tunnel_close(Tombstone::default(), shared_state).await;
+                }
+                #[cfg(not(target_os = "android"))]
+                ConnectingState::handle_tunnel_close(tombstone, shared_state).await;
+
+                NextTunnelState::NewState(
+                    ConnectingState::enter(0, Some(self.selected_gateways), shared_state).await,
+                )
+            }
         }
     }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -275,7 +275,7 @@ impl ConnectingState {
         )
     }
 
-    async fn handle_tunnel_close(tombstone: Tombstone, shared_state: &mut SharedState) {
+    pub(super) async fn handle_tunnel_close(tombstone: Tombstone, shared_state: &mut SharedState) {
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         shared_state.route_handler.remove_routes().await;
 
@@ -740,6 +740,28 @@ impl TunnelStateHandler for ConnectingState {
                         } else {
                             if let Some(tunnel_monitor_handle) = self.tunnel_monitor_handle.take() {
                                 let tombstone = tunnel_monitor_handle.wait().await;
+                                #[cfg(target_os = "android")]
+                                {
+                                    // Install blocking cover before releasing the live TUN (same
+                                    // ordering as Disconnecting(Reconnect)).
+                                    if let Err(err) = shared_state
+                                        .prepare_blocking_cover_before_release(Some(tombstone))
+                                    {
+                                        tracing::error!(
+                                            "Failed to install Android blocking TUN before Connecting reconnect: {err}"
+                                        );
+                                        return NextTunnelState::NewState(
+                                            ErrorState::enter(
+                                                ErrorStateReason::TunnelProvider,
+                                                shared_state,
+                                            )
+                                            .await,
+                                        );
+                                    }
+                                    Self::handle_tunnel_close(Tombstone::default(), shared_state)
+                                        .await;
+                                }
+                                #[cfg(not(target_os = "android"))]
                                 Self::handle_tunnel_close(tombstone, shared_state).await;
                             }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnected_state.rs
@@ -34,6 +34,11 @@ impl DisconnectedState {
         // Drop tombstone to close tunnel devices.
         drop(tombstone);
 
+        // Intentional disconnect: release Android blocking / held TUN so ISP path is available again
+        // (OS Always-On / block-without-VPN remain a user choice).
+        #[cfg(target_os = "android")]
+        shared_state.clear_android_blocking_tun();
+
         // Clear addresses from the pre-resolve table in the (shared) DNS resolver.
         HickoryDnsResolver::shared().clear_preresolve();
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnecting_state.rs
@@ -5,6 +5,11 @@ use futures::future::{BoxFuture, Fuse, FusedFuture, FutureExt};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
+#[cfg(target_os = "android")]
+use nym_vpn_lib_types::ErrorStateReason;
+
+#[cfg(target_os = "android")]
+use crate::tunnel_state_machine::blocking_tun::with_blocking_before_tun_release;
 use crate::tunnel_state_machine::{
     NextTunnelState, PrivateActionAfterDisconnect, PrivateTunnelState, SharedState, TunnelCommand,
     TunnelStateHandler,
@@ -59,9 +64,51 @@ impl DisconnectingState {
                 DisconnectedState::enter(tombstone, shared_state).await
             }
             PrivateActionAfterDisconnect::Error(reason) => {
+                #[cfg(target_os = "android")]
+                {
+                    let mut tombstone = tombstone;
+                    if let Err(err) = with_blocking_before_tun_release(
+                        || shared_state.install_android_blocking_tun(),
+                        || {
+                            drop(tombstone.take());
+                        },
+                    ) {
+                        tracing::error!(
+                            "Failed to install Android blocking TUN before error state: {err}"
+                        );
+                        shared_state.android_tun_hold = tombstone;
+                    }
+                }
+                #[cfg(not(target_os = "android"))]
+                {
+                    let _ = tombstone;
+                }
                 ErrorState::enter(reason, shared_state).await
             }
             PrivateActionAfterDisconnect::Reconnect => {
+                #[cfg(target_os = "android")]
+                {
+                    let mut tombstone = tombstone;
+                    let install_result = with_blocking_before_tun_release(
+                        || shared_state.install_android_blocking_tun(),
+                        || {
+                            drop(tombstone.take());
+                        },
+                    );
+                    if let Err(err) = install_result {
+                        tracing::error!(
+                            "Failed to install Android blocking TUN before reconnect: {err}"
+                        );
+                        // Keep previous TUN alive — do not open an ISP window.
+                        shared_state.android_tun_hold = tombstone;
+                        return ErrorState::enter(ErrorStateReason::TunnelProvider, shared_state)
+                            .await;
+                    }
+                }
+                #[cfg(not(target_os = "android"))]
+                {
+                    let _ = tombstone;
+                }
                 ConnectingState::enter(0, None, shared_state).await
             }
             PrivateActionAfterDisconnect::Offline {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnecting_state.rs
@@ -8,8 +8,6 @@ use tokio_util::sync::CancellationToken;
 #[cfg(target_os = "android")]
 use nym_vpn_lib_types::ErrorStateReason;
 
-#[cfg(target_os = "android")]
-use crate::tunnel_state_machine::blocking_tun::with_blocking_before_tun_release;
 use crate::tunnel_state_machine::{
     NextTunnelState, PrivateActionAfterDisconnect, PrivateTunnelState, SharedState, TunnelCommand,
     TunnelStateHandler,
@@ -65,19 +63,10 @@ impl DisconnectingState {
             }
             PrivateActionAfterDisconnect::Error(reason) => {
                 #[cfg(target_os = "android")]
-                {
-                    let mut tombstone = tombstone;
-                    if let Err(err) = with_blocking_before_tun_release(
-                        || shared_state.install_android_blocking_tun(),
-                        || {
-                            drop(tombstone.take());
-                        },
-                    ) {
-                        tracing::error!(
-                            "Failed to install Android blocking TUN before error state: {err}"
-                        );
-                        shared_state.android_tun_hold = tombstone;
-                    }
+                if let Err(err) = shared_state.prepare_blocking_cover_before_release(tombstone) {
+                    tracing::error!(
+                        "Failed to install Android blocking TUN before error state: {err}"
+                    );
                 }
                 #[cfg(not(target_os = "android"))]
                 {
@@ -87,23 +76,11 @@ impl DisconnectingState {
             }
             PrivateActionAfterDisconnect::Reconnect => {
                 #[cfg(target_os = "android")]
-                {
-                    let mut tombstone = tombstone;
-                    let install_result = with_blocking_before_tun_release(
-                        || shared_state.install_android_blocking_tun(),
-                        || {
-                            drop(tombstone.take());
-                        },
+                if let Err(err) = shared_state.prepare_blocking_cover_before_release(tombstone) {
+                    tracing::error!(
+                        "Failed to install Android blocking TUN before reconnect: {err}"
                     );
-                    if let Err(err) = install_result {
-                        tracing::error!(
-                            "Failed to install Android blocking TUN before reconnect: {err}"
-                        );
-                        // Keep previous TUN alive — do not open an ISP window.
-                        shared_state.android_tun_hold = tombstone;
-                        return ErrorState::enter(ErrorStateReason::TunnelProvider, shared_state)
-                            .await;
-                    }
+                    return ErrorState::enter(ErrorStateReason::TunnelProvider, shared_state).await;
                 }
                 #[cfg(not(target_os = "android"))]
                 {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
@@ -4,13 +4,8 @@
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use std::net::SocketAddr;
 #[cfg(target_os = "ios")]
-use std::{
-    net::{IpAddr, Ipv4Addr, Ipv6Addr},
-    sync::Arc,
-};
+use std::{net::IpAddr, sync::Arc};
 
-#[cfg(target_os = "ios")]
-use ipnetwork::IpNetwork;
 #[cfg(target_os = "macos")]
 use nym_dns::DnsConfig;
 use tokio::sync::mpsc;
@@ -20,7 +15,8 @@ use tokio_util::sync::CancellationToken;
     target_os = "linux",
     target_os = "macos",
     target_os = "windows",
-    target_os = "ios"
+    target_os = "ios",
+    target_os = "android"
 ))]
 use nym_common::trace_err_chain;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
@@ -29,9 +25,9 @@ use nym_firewall::{AllowedClients, AllowedEndpoint, Endpoint, FirewallPolicy, Tr
 use nym_http_api_client::HickoryDnsResolver;
 
 #[cfg(target_os = "ios")]
-use crate::tunnel_provider::{OSTunProvider, TunnelSettings};
+use crate::tunnel_provider::OSTunProvider;
 #[cfg(target_os = "ios")]
-use crate::tunnel_state_machine::tunnel::wireguard::two_hop_config::MIN_IPV6_MTU;
+use crate::tunnel_state_machine::blocking_tun::blocking_tunnel_settings;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use crate::tunnel_state_machine::{Error, Result};
 use crate::tunnel_state_machine::{
@@ -39,15 +35,6 @@ use crate::tunnel_state_machine::{
     TunnelStateHandler,
     states::{ConnectingState, DisconnectedState, OfflineState},
 };
-
-/// Interface addresses used as placeholders when in error state.
-#[cfg(target_os = "ios")]
-const BLOCKING_INTERFACE_ADDRS: [IpAddr; 2] = [
-    IpAddr::V4(Ipv4Addr::new(169, 254, 0, 10)),
-    IpAddr::V6(Ipv6Addr::new(
-        0xfdcc, 0x9fc0, 0xe75a, 0x53c3, 0xfa25, 0x241f, 0x21c0, 0x70d0,
-    )),
-];
 
 pub struct ErrorState {
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
@@ -76,10 +63,13 @@ impl ErrorState {
             .await;
         }
 
-        // todo: activate kill switch on Android
+        #[cfg(target_os = "android")]
+        if let Err(err) = shared_state.ensure_android_blocking_tun() {
+            trace_err_chain!(err, "Failed to install Android blocking TUN in error state");
+        }
 
-        // Android: traffic should flow freely since there should be no tunnel device at this point
-        // iOS: network extensions bypass the tunnel by default
+        // Mobile: allow discovery/account networking; device traffic is covered by blocking TUN
+        // (Android) or NE blocking settings (iOS). Control-plane sockets use bypass() on Android.
         #[cfg(any(target_os = "android", target_os = "ios"))]
         shared_state.allow_networking().await;
 
@@ -193,12 +183,7 @@ impl ErrorState {
         tun_provider: Arc<dyn OSTunProvider>,
         dns_server: IpAddr,
     ) {
-        let tunnel_network_settings = TunnelSettings {
-            remote_addresses: vec![],
-            interface_addresses: BLOCKING_INTERFACE_ADDRS.map(IpNetwork::from).to_vec(),
-            dns_servers: vec![dns_server],
-            mtu: MIN_IPV6_MTU,
-        };
+        let tunnel_network_settings = blocking_tunnel_settings(dns_server);
 
         if let Err(e) = tun_provider
             .set_tunnel_network_settings(tunnel_network_settings)

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -1086,6 +1086,7 @@ impl TunnelMonitor {
                 interface_addresses,
                 remote_addresses: vec![assigned_addresses.entry_mixnet_gateway_ip],
                 mtu,
+                exclude_vpn_app: false,
             };
 
             self.create_tun_device(packet_tunnel_settings).await?
@@ -1786,6 +1787,7 @@ impl TunnelMonitor {
             interface_addresses,
             remote_addresses: vec![entry_endpoint],
             mtu,
+            exclude_vpn_app: false,
         };
 
         let tun_device = self.create_tun_device(packet_tunnel_settings).await?;


### PR DESCRIPTION
## Description

- On Android server switch, a blocking placeholder VPN interface is installed before the old tunnel is released, so other apps cannot fall back to the ISP path during reconnect.
- The VPN app itself is excluded from that placeholder so control-plane registration can still reach gateways; other apps stay covered.
- Cold connect does not use the placeholder, avoiding a regression where entry registration timed out.
- Error state uses the same cover instead of leaving Android traffic uncovered.
- Intentional disconnect still tears everything down so normal internet returns.
- Shared blocking settings live in one Rust module with unit tests for settings and install-before-release ordering.

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6016)
<!-- Reviewable:end -->
