### PR TITLE
Purge cache on macos, because of incoming uniffi dep change

### DIFF
--- a/.github/workflows/ci-nym-vpn-app-macos.yml
+++ b/.github/workflows/ci-nym-vpn-app-macos.yml
@@ -75,6 +75,14 @@ jobs:
           swift package init --type library --name NymVPNLib --disable-xctest --disable-swift-testing
           echo "✅ Stubs added successfully."
 
+      - name: Purge caches
+        run: |
+          # This runner is persistent (self-hosted), so stale SPM/DerivedData state from
+          # packages removed/renamed between runs survives
+          # the workspace checkout and corrupts module resolution for later builds.
+          rm -rf "$HOME/Library/Caches/org.swift.swiftpm/" || true
+          rm -rf "$HOME/Library/Developer/Xcode/DerivedData/" || true
+
       - name: Build rpc-swift-package
         run: |
           make -C nym-vpn-core -f macOS.mk rpc-swift-package RELEASE="false"


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6031)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved macOS build reliability by clearing cached package data and build artifacts before CI builds.
  * Reduced failures caused by stale state on persistent build machines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->