### PR TITLE
Don't fail installation if vc_redist is already installed.

### DIFF
--- a/nym-vpn-app/src-tauri/bundle/windows/installer.nsi
+++ b/nym-vpn-app/src-tauri/bundle/windows/installer.nsi
@@ -742,6 +742,8 @@ Section VCRedist
     ${ElseIf} $5 = 3010 ; ERROR_SUCCESS_REBOOT_REQUIRED
       DetailPrint "Visual C++ Redistributable installed successfully, a reboot is required"
       SetRebootFlag true
+    ${ElseIf} $5 = 1638 ; ERROR_PRODUCT_VERSION: a matching/newer version is already installed
+      DetailPrint "Visual C++ Redistributable is already installed"
     ${Else}
       DetailPrint "vc_redist.exe install failed: $5"
       Abort "Failed to install the Visual C++ Redistributable [$5]"


### PR DESCRIPTION
At the moment if the correct version of the Visual Studio runtime is already installed, then the installation fails.  This only happens with using the `/FORCEVCREDIST` argument to the installer and not during a normal installation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6051)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows installation handling when a compatible or newer Visual C++ Redistributable is already installed.
  * The installer now continues successfully and records the status instead of stopping unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->