### PR TITLE
Fix Split Tunnel IPv6 edge-case

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Detect when the diagnostics check should be run (https://github.com/nymtech/nym-vpn-client/pull/5993)
 - Implement the "suggest diagnostics" event on Tauri (https://github.com/nymtech/nym-vpn-client/pull/6006)
 - Persist gateway list to disk, seeded from a built-in list (https://github.com/nymtech/nym-vpn-client/pull/6015)
+- If the host doesn't have an IPv6 address then split tunnelling is disabled for IPv6 (https://github.com/nymtech/nym-vpn-client/pull/6052) 
 
 ### Changed
 

--- a/nym-vpn-core/crates/nym-split-tunnel/src/windows/mod.rs
+++ b/nym-vpn-core/crates/nym-split-tunnel/src/windows/mod.rs
@@ -492,8 +492,14 @@ impl InitializedSplitTunnel {
                         result
                     }
                     Request::RegisterIps(mut ips) => {
-                        if ips.internet_ipv4.is_none() && ips.internet_ipv6.is_none() {
+                        // If there's no real (non-tunnel) route for a given address family,
+                        // don't register a tunnel address for it either: otherwise excluded
+                        // processes have nowhere to be redirected to for that family and their
+                        // traffic falls through to the tunnel's own default route, leaking it.
+                        if ips.internet_ipv4.is_none() {
                             ips.tunnel_ipv4 = None;
+                        }
+                        if ips.internet_ipv6.is_none() {
                             ips.tunnel_ipv6 = None;
                         }
                         if previous_addresses == ips {


### PR DESCRIPTION
If the default internet doesn't have an IPv6 address but the tunnel does have an IPv6 address, Split Tunnelling can fail if the app uses IPv6.

This change also means the split tunnelled app loses IPv6 access, which should perhaps be surfaced to the user via the UI?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6052)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved split-tunnel address handling on Windows.
  * Tunnel addresses are now cleared correctly based on whether the corresponding internet address family is available.
  * IPv6 split tunneling is disabled when the host has no IPv6 address.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->