### PR TITLE
Fix Split Tunnel IPv6 edge-case (#6052)

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+
+
 ## [2026.12.0] - TBD
 
 ### Added

--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+
+## [2026.12.0] - TBD
 
 ### Added
 
@@ -13,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Recents manager for storing successful gateway connections (https://github.com/nymtech/nym-vpn-client/pull/5903)
 - Favorites manager for storing UI favorites (https://github.com/nymtech/nym-vpn-client/pull/5914)
 - Geo-Exclusion now supports Russia (https://github.com/nymtech/nym-vpn-client/pull/5917)
+- If the host doesn't have an IPv6 address then split tunnelling is disabled for IPv6 (https://github.com/nymtech/nym-vpn-client/pull/6052) 
 
 ### Changed
 

--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -8,9 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-
-## [2026.12.0] - TBD
-
 ### Added
 
 - [CLI] Add short option `-l` for `nym-vpnc status --listen` (https://github.com/nymtech/nym-vpn-client/pull/5839)

--- a/nym-vpn-core/crates/nym-split-tunnel/src/windows/mod.rs
+++ b/nym-vpn-core/crates/nym-split-tunnel/src/windows/mod.rs
@@ -492,8 +492,14 @@ impl InitializedSplitTunnel {
                         result
                     }
                     Request::RegisterIps(mut ips) => {
-                        if ips.internet_ipv4.is_none() && ips.internet_ipv6.is_none() {
+                        // If there's no real (non-tunnel) route for a given address family,
+                        // don't register a tunnel address for it either: otherwise excluded
+                        // processes have nowhere to be redirected to for that family and their
+                        // traffic falls through to the tunnel's own default route, leaking it.
+                        if ips.internet_ipv4.is_none() {
                             ips.tunnel_ipv4 = None;
+                        }
+                        if ips.internet_ipv6.is_none() {
                             ips.tunnel_ipv6 = None;
                         }
                         if previous_addresses == ips {


### PR DESCRIPTION
If the default internet doesn't have an IPv6 address but the tunnel does have an IPv6 address, Split Tunnelling can fail if the app uses IPv6.

This change also means the split tunnelled app loses IPv6 access, which should perhaps be surfaced to the user via the UI?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6055)
<!-- Reviewable:end -->
