### PR TITLE
(tauri) Mixnet tuning updates - Develop

### DIFF
--- a/nym-vpn-app/src/i18n/en/settings.json
+++ b/nym-vpn-app/src/i18n/en/settings.json
@@ -114,13 +114,17 @@
     "title": "Mixnet tuning",
     "desc": "Customize traffic patterns of Mixnet mode",
     "top-description": "Customize your <strong>mixnet</strong> traffic patterns.",
-    "learn-more": "Learn more about mixnet parameters",
+    "learn-more": "Learn more about mixnet tuning",
     "save-custom-settings": "Save custom settings",
     "restore-default-settings": "Reset to default settings",
+    "slider": {
+      "faster": "Faster",
+      "anonymity": "+ Anonymity"
+    },
     "performance": {
-      "title": "Expected performance based on current settings",
+      "title": "Expected performance of current settings:",
       "speed": {
-        "title": "Packet Rate",
+        "title": "Packet rate",
         "value": "Up to {{value}}"
       },
       "privacy": {
@@ -130,47 +134,39 @@
       "footer": "Expected round-trip latency (RTT) on a standard network"
     },
     "continuous-traffic": {
-      "title": "Send traffic continuously",
-      "continuous": {
-        "title": "Cover traffic is always sent to keep the pattern uniform. Adjust the sending rate of your packets.",
-        "use-less-battery-and-data": "Use less battery & data",
-        "max-anonymity": "Max. anonymity",
-        "low": {
-          "label": "Low"
-        },
-        "balanced": {
-          "label": "Balanced"
-        },
-        "high": {
-          "label": "High"
-        }
+      "title": "Send continuous traffic",
+      "description": "Cover traffic is always sent to keep the pattern uniform. Adjust the sending rate of your packets.",
+      "warning": "⚠️ Your packets will be sent as they become available. This could reveal traffic patterns.",
+      "low": {
+        "label": "Low"
       },
-      "background-cover-traffic": {
-        "warning": "⚠️ Continuous traffic is turned off. Your packets will be sent as they become available. This could reveal traffic patterns.",
-        "title": "Background cover traffic rate",
-        "description": "We’ll still send cover traffic independently of your real traffic. Choose how much cover you need.",
-        "use-less-battery-and-data": "Use less battery & data",
-        "max-anonymity": "Max. anonymity",
-        "base": {
-          "label": "Base"
-        },
-        "balanced": {
-          "label": "Balanced\n5x"
-        },
-        "medium": {
-          "label": "Medium\n10x"
-        },
-        "high": {
-          "label": "High\n20x"
-        }
+      "balanced": {
+        "label": "Balanced"
+      },
+      "high": {
+        "label": "High"
+      }
+    },
+    "background-cover": {
+      "title": "Background cover traffic rate",
+      "description": "Choose how much cover you need.",
+      "low": {
+        "label": "Low"
+      },
+      "balanced": {
+        "label": "Balanced\n5x"
+      },
+      "medium": {
+        "label": "Medium\n10x"
+      },
+      "high": {
+        "label": "High\n20x"
       }
     },
     "mixing-delay": {
-      "title": "Mixing delays",
-      "description": "Adjust timing delays to change how your packets are mixed.",
+      "title": "Packet mixing",
+      "description": "Adjust timing delays to change how well your packets are mixed.",
       "warning": "⚠️ Timing protection is currently turned off. This could put your privacy at risk.",
-      "faster": "Faster",
-      "max-anonymity": "Max. anonymity",
       "low": {
         "label": "Low"
       },

--- a/nym-vpn-app/src/i18n/en/settings.json
+++ b/nym-vpn-app/src/i18n/en/settings.json
@@ -167,6 +167,7 @@
       "title": "Packet mixing",
       "description": "Adjust timing delays to change how well your packets are mixed.",
       "warning": "⚠️ Timing protection is currently turned off. This could put your privacy at risk.",
+      "ms-value": "{{value}} ms",
       "low": {
         "label": "Low"
       },

--- a/nym-vpn-app/src/screens/settings/mixnet-tuning/BackgroundCoverCard.tsx
+++ b/nym-vpn-app/src/screens/settings/mixnet-tuning/BackgroundCoverCard.tsx
@@ -1,0 +1,107 @@
+import clsx from 'clsx';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@headlessui/react';
+import { CardHeaderSwitch, CardNew, CardNewBody, Slider } from '../../../ui';
+import { useMixnetTrafficConfig } from './context';
+
+const BACKGROUND_COVER_TRAFFIC_RATE_LABELS = [
+  'low',
+  'balanced',
+  'medium',
+  'high',
+] as const;
+
+function BackgroundCoverSlider({
+  value,
+  setValue,
+  disabled,
+}: {
+  value: number;
+  setValue: (value: number) => void;
+  disabled?: boolean;
+}) {
+  const { t } = useTranslation('settings');
+  const { backgroundCoverItems } = useMixnetTrafficConfig();
+
+  const items = backgroundCoverItems.map((item, index) => ({
+    value: item.value,
+    label: BACKGROUND_COVER_TRAFFIC_RATE_LABELS[index],
+  }));
+
+  return (
+    <div className="w-full space-y-5">
+      <p className="text-text-secondary text-sm whitespace-pre-line">
+        {t('mixnet-tuning.background-cover.description')}
+      </p>
+
+      <div className="text-text-secondary flex justify-between text-sm">
+        <span>{t('mixnet-tuning.slider.faster')}</span>
+        <span>{t('mixnet-tuning.slider.anonymity')}</span>
+      </div>
+      <Slider
+        className="px-2"
+        value={value}
+        onValueCommitted={setValue}
+        min={0}
+        max={3}
+        step={1}
+        disabled={disabled}
+        ariaLabel={t('mixnet-tuning.background-cover.title')}
+        labels={items.map((item, index) => (
+          <Button
+            onClick={() => setValue(index)}
+            key={item.label}
+            className={clsx('flex flex-col text-sm whitespace-nowrap', {
+              'items-start': index === 0,
+              'items-end': index === backgroundCoverItems.length - 1,
+              'items-center':
+                index !== 0 && index !== backgroundCoverItems.length - 1,
+              'text-brand-primary': value === index,
+              'text-text-secondary': value !== index,
+            })}
+          >
+            <span className="whitespace-pre-line">
+              {t(`mixnet-tuning.background-cover.${item.label}.label`)}
+            </span>
+          </Button>
+        ))}
+      />
+    </div>
+  );
+}
+
+export function BackgroundCoverCard() {
+  const { t } = useTranslation('settings');
+
+  const { state, updateField, backgroundCoverItems } = useMixnetTrafficConfig();
+
+  const enabled = !state.disableBackgroundCoverTraffic;
+  const toggle = () => updateField('disableBackgroundCoverTraffic', enabled);
+
+  const setPoissonParameterForLoopCoverStream = (index: number) => {
+    const item = backgroundCoverItems[index];
+    if (item) {
+      updateField('poissonParameterForLoopCoverStream', item.value);
+    }
+  };
+
+  return (
+    <CardNew>
+      <CardHeaderSwitch
+        checked={enabled}
+        onClick={toggle}
+        header={t('mixnet-tuning.background-cover.title')}
+      />
+
+      <CardNewBody className="pb-5">
+        <BackgroundCoverSlider
+          value={backgroundCoverItems.findIndex(
+            (item) => item.value === state.poissonParameterForLoopCoverStream,
+          )}
+          setValue={setPoissonParameterForLoopCoverStream}
+          disabled={!enabled}
+        />
+      </CardNewBody>
+    </CardNew>
+  );
+}

--- a/nym-vpn-app/src/screens/settings/mixnet-tuning/BackgroundCoverCard.tsx
+++ b/nym-vpn-app/src/screens/settings/mixnet-tuning/BackgroundCoverCard.tsx
@@ -51,6 +51,7 @@ function BackgroundCoverSlider({
           <Button
             onClick={() => setValue(index)}
             key={item.label}
+            disabled={disabled}
             className={clsx('flex flex-col text-sm whitespace-nowrap', {
               'items-start': index === 0,
               'items-end': index === backgroundCoverItems.length - 1,

--- a/nym-vpn-app/src/screens/settings/mixnet-tuning/ContinuousTrafficCard.tsx
+++ b/nym-vpn-app/src/screens/settings/mixnet-tuning/ContinuousTrafficCard.tsx
@@ -1,96 +1,8 @@
 import clsx from 'clsx';
 import { useTranslation } from 'react-i18next';
-import { useMemo } from 'react';
 import { Button } from '@headlessui/react';
 import { CardHeaderSwitch, CardNew, CardNewBody, Slider } from '../../../ui';
 import { useMixnetTrafficConfig } from './context';
-
-const BACKGROUND_COVER_TRAFFIC_RATE_LABELS = [
-  'base',
-  'balanced',
-  'medium',
-  'high',
-] as const;
-
-function BackgroundCoverTrafficRateSlider({
-  value,
-  setValue,
-}: {
-  value: number;
-  setValue: (value: number) => void;
-}) {
-  const { t } = useTranslation('settings');
-  const { backgroundCoverItems } = useMixnetTrafficConfig();
-
-  const items = useMemo(
-    () =>
-      backgroundCoverItems.map((item, index) => ({
-        value: item.value,
-        label: BACKGROUND_COVER_TRAFFIC_RATE_LABELS[index],
-      })),
-    [backgroundCoverItems],
-  );
-
-  return (
-    <div className="w-full space-y-5">
-      <p className="text-status-warning text-sm whitespace-pre-line">
-        {t('mixnet-tuning.continuous-traffic.background-cover-traffic.warning')}
-      </p>
-
-      <p className="text-text-primary truncate text-base select-none">
-        {t('mixnet-tuning.continuous-traffic.background-cover-traffic.title')}
-      </p>
-      <p className="text-text-secondary text-sm whitespace-pre-line">
-        {t(
-          'mixnet-tuning.continuous-traffic.background-cover-traffic.description',
-        )}
-      </p>
-      <div className="text-text-secondary flex justify-between text-sm">
-        <span>
-          {t(
-            'mixnet-tuning.continuous-traffic.background-cover-traffic.use-less-battery-and-data',
-          )}
-        </span>
-        <span>
-          {t(
-            'mixnet-tuning.continuous-traffic.background-cover-traffic.max-anonymity',
-          )}
-        </span>
-      </div>
-      <Slider
-        className="px-2"
-        value={value}
-        onValueCommitted={setValue}
-        min={0}
-        max={3}
-        step={1}
-        ariaLabel={t(
-          'mixnet-tuning.continuous-traffic.background-cover-traffic.title',
-        )}
-        labels={items.map((item, index) => (
-          <Button
-            onClick={() => setValue(index)}
-            key={item.label}
-            className={clsx('flex flex-col text-sm whitespace-nowrap', {
-              'items-start': index === 0,
-              'items-end': index === backgroundCoverItems.length - 1,
-              'items-center':
-                index !== 0 && index !== backgroundCoverItems.length - 1,
-              'text-text-primary': value === index,
-              'text-text-secondary': value !== index,
-            })}
-          >
-            <span className="whitespace-pre-line">
-              {t(
-                `mixnet-tuning.continuous-traffic.background-cover-traffic.${item.label}.label`,
-              )}
-            </span>
-          </Button>
-        ))}
-      />
-    </div>
-  );
-}
 
 const CONTINUOUS_TRAFFIC_SENDING_RATE_LABELS = [
   'low',
@@ -101,37 +13,30 @@ const CONTINUOUS_TRAFFIC_SENDING_RATE_LABELS = [
 function ContinuousTrafficSlider({
   value,
   setValue,
+  disabled,
 }: {
   value: number;
   setValue: (value: number) => void;
+  disabled?: boolean;
 }) {
   const { t } = useTranslation('settings');
   const { continuousItems } = useMixnetTrafficConfig();
 
-  const items = useMemo(
-    () =>
-      continuousItems.map((item, index) => ({
-        value: item.value,
-        label: CONTINUOUS_TRAFFIC_SENDING_RATE_LABELS[index],
-        speed: item.label,
-      })),
-    [continuousItems],
-  );
+  const items = continuousItems.map((item, index) => ({
+    value: item.value,
+    label: CONTINUOUS_TRAFFIC_SENDING_RATE_LABELS[index],
+    speed: item.label,
+  }));
+
   return (
     <div className="mt-0 w-full space-y-5">
       <p className="text-text-secondary text-sm whitespace-pre-line">
-        {t('mixnet-tuning.continuous-traffic.continuous.title')}
+        {t('mixnet-tuning.continuous-traffic.description')}
       </p>
 
       <div className="text-text-secondary flex justify-between text-sm">
-        <span>
-          {t(
-            'mixnet-tuning.continuous-traffic.continuous.use-less-battery-and-data',
-          )}
-        </span>
-        <span>
-          {t('mixnet-tuning.continuous-traffic.continuous.max-anonymity')}
-        </span>
+        <span>{t('mixnet-tuning.slider.faster')}</span>
+        <span>{t('mixnet-tuning.slider.anonymity')}</span>
       </div>
       <Slider
         className="px-2"
@@ -140,12 +45,13 @@ function ContinuousTrafficSlider({
         min={0}
         max={2}
         step={1}
-        ariaLabel={t('mixnet-tuning.continuous-traffic.continuous.title')}
+        disabled={disabled}
+        ariaLabel={t('mixnet-tuning.continuous-traffic.title')}
         labels={items.map((item, index) => (
           <Button
             key={item.label}
             className={clsx('flex flex-col text-sm', {
-              'text-text-primary': value === index,
+              'text-brand-primary': value === index,
               'text-text-secondary': value !== index,
               'items-start': index === 0,
               'items-end': index === continuousItems.length - 1,
@@ -155,9 +61,7 @@ function ContinuousTrafficSlider({
             onClick={() => setValue(index)}
           >
             <span className="whitespace-nowrap">
-              {t(
-                `mixnet-tuning.continuous-traffic.continuous.${item.label}.label`,
-              )}
+              {t(`mixnet-tuning.continuous-traffic.${item.label}.label`)}
             </span>
             <span className="whitespace-nowrap">{item.speed}</span>
           </Button>
@@ -170,12 +74,10 @@ function ContinuousTrafficSlider({
 export function ContinuousTrafficCard() {
   const { t } = useTranslation('settings');
 
-  const { state, updateField, continuousItems, backgroundCoverItems } =
-    useMixnetTrafficConfig();
+  const { state, updateField, continuousItems } = useMixnetTrafficConfig();
 
   const enabled = !state.disablePoissonRate;
-  const setEnabled = (enabled: boolean) =>
-    updateField('disablePoissonRate', enabled);
+  const toggle = () => updateField('disablePoissonRate', enabled);
 
   const setMessageSendingAverageDelay = (index: number) => {
     const item = continuousItems[index];
@@ -184,42 +86,27 @@ export function ContinuousTrafficCard() {
     }
   };
 
-  const setPoissonParameterForLoopCoverStream = (index: number) => {
-    const item = backgroundCoverItems[index];
-    if (item) {
-      updateField('poissonParameterForLoopCoverStream', item.value);
-    }
-  };
-
   return (
-    <div className="flex flex-col gap-10">
-      <CardNew>
-        <CardHeaderSwitch
-          checked={enabled}
-          onClick={() => setEnabled(enabled)}
-          header={t('mixnet-tuning.continuous-traffic.title')}
-        />
+    <CardNew>
+      <CardHeaderSwitch
+        checked={enabled}
+        onClick={toggle}
+        header={t('mixnet-tuning.continuous-traffic.title')}
+        subheader={
+          enabled ? undefined : t('mixnet-tuning.continuous-traffic.warning')
+        }
+        subheaderColor="king-nacho"
+      />
 
-        <CardNewBody className="pb-5">
-          {enabled && (
-            <ContinuousTrafficSlider
-              value={continuousItems.findIndex(
-                (item) => item.value === state.messageSendingAverageDelay,
-              )}
-              setValue={(index) => setMessageSendingAverageDelay(index)}
-            />
+      <CardNewBody className="pb-5">
+        <ContinuousTrafficSlider
+          value={continuousItems.findIndex(
+            (item) => item.value === state.messageSendingAverageDelay,
           )}
-          {!enabled && (
-            <BackgroundCoverTrafficRateSlider
-              value={backgroundCoverItems.findIndex(
-                (item) =>
-                  item.value === state.poissonParameterForLoopCoverStream,
-              )}
-              setValue={(index) => setPoissonParameterForLoopCoverStream(index)}
-            />
-          )}
-        </CardNewBody>
-      </CardNew>
-    </div>
+          setValue={setMessageSendingAverageDelay}
+          disabled={!enabled}
+        />
+      </CardNewBody>
+    </CardNew>
   );
 }

--- a/nym-vpn-app/src/screens/settings/mixnet-tuning/ContinuousTrafficCard.tsx
+++ b/nym-vpn-app/src/screens/settings/mixnet-tuning/ContinuousTrafficCard.tsx
@@ -50,6 +50,7 @@ function ContinuousTrafficSlider({
         labels={items.map((item, index) => (
           <Button
             key={item.label}
+            disabled={disabled}
             className={clsx('flex flex-col text-sm', {
               'text-brand-primary': value === index,
               'text-text-secondary': value !== index,

--- a/nym-vpn-app/src/screens/settings/mixnet-tuning/MixingDelayCard.tsx
+++ b/nym-vpn-app/src/screens/settings/mixnet-tuning/MixingDelayCard.tsx
@@ -3,11 +3,6 @@ import { useTranslation } from 'react-i18next';
 import { CardNew, CardNewBody, CardNewHeader, Slider } from '../../../ui';
 import { useMixnetTrafficConfig } from './context';
 
-const MIXING_DELAY_LEVELS: { label: 'low' | 'high'; speed: string }[] = [
-  { label: 'low', speed: '0ms' },
-  { label: 'high', speed: '200ms' },
-];
-
 function MixingDelaySlider({
   value,
   setValue,
@@ -18,11 +13,17 @@ function MixingDelaySlider({
   const { t } = useTranslation('settings');
   const { mixingDelay } = useMixnetTrafficConfig();
 
+  // endpoints are the daemon's allowed range
+  const levels = [
+    { key: 'low', ms: mixingDelay.minValue },
+    { key: 'high', ms: mixingDelay.maxValue },
+  ] as const;
+
   return (
     <div className="mt-5 w-full space-y-5">
       <div className="text-text-secondary flex justify-between text-sm">
-        <span>{t('mixnet-tuning.mixing-delay.faster')}</span>
-        <span>{t('mixnet-tuning.mixing-delay.max-anonymity')}</span>
+        <span>{t('mixnet-tuning.slider.faster')}</span>
+        <span>{t('mixnet-tuning.slider.anonymity')}</span>
       </div>
 
       <Slider
@@ -34,20 +35,19 @@ function MixingDelaySlider({
         step={1}
         valueIndicator
         ariaLabel={t('mixnet-tuning.mixing-delay.title')}
-        labels={MIXING_DELAY_LEVELS.map((item, index) => (
+        labels={levels.map((level, index) => (
           <div
-            key={item.label}
+            key={level.key}
             className={clsx('flex flex-col text-sm', {
               'items-start': index === 0,
-              'items-end': index === MIXING_DELAY_LEVELS.length - 1,
-              'items-center':
-                index !== 0 && index !== MIXING_DELAY_LEVELS.length - 1,
+              'items-end': index === levels.length - 1,
+              'items-center': index !== 0 && index !== levels.length - 1,
             })}
           >
             <span className="whitespace-nowrap">
-              {t(`mixnet-tuning.mixing-delay.${item.label}.label`)}
+              {t(`mixnet-tuning.mixing-delay.${level.key}.label`)}
             </span>
-            <span className="whitespace-nowrap">{item.speed}</span>
+            <span className="whitespace-nowrap">{level.ms} ms</span>
           </div>
         ))}
       />

--- a/nym-vpn-app/src/screens/settings/mixnet-tuning/MixingDelayCard.tsx
+++ b/nym-vpn-app/src/screens/settings/mixnet-tuning/MixingDelayCard.tsx
@@ -47,7 +47,9 @@ function MixingDelaySlider({
             <span className="whitespace-nowrap">
               {t(`mixnet-tuning.mixing-delay.${level.key}.label`)}
             </span>
-            <span className="whitespace-nowrap">{level.ms} ms</span>
+            <span className="whitespace-nowrap">
+              {t('mixnet-tuning.mixing-delay.ms-value', { value: level.ms })}
+            </span>
           </div>
         ))}
       />

--- a/nym-vpn-app/src/screens/settings/mixnet-tuning/MixnetTuning.tsx
+++ b/nym-vpn-app/src/screens/settings/mixnet-tuning/MixnetTuning.tsx
@@ -6,6 +6,7 @@ import { Button, Link, PageAnim } from '../../../ui';
 import { MixnetParametersLearnMoreUrl } from '../../../constants';
 import { MixnetTrafficConfigProvider, useMixnetTrafficConfig } from './context';
 import { ContinuousTrafficCard } from './ContinuousTrafficCard';
+import { BackgroundCoverCard } from './BackgroundCoverCard';
 import { MixingDelayCard } from './MixingDelayCard';
 import { PerformanceCard } from './PerformanceCard';
 
@@ -52,6 +53,7 @@ function MixnetTuning() {
 
         <PerformanceCard />
         <ContinuousTrafficCard />
+        <BackgroundCoverCard />
         <MixingDelayCard />
 
         <Link

--- a/nym-vpn-app/src/ui/Slider.tsx
+++ b/nym-vpn-app/src/ui/Slider.tsx
@@ -18,6 +18,7 @@ export type SliderProps = {
   className?: string;
   valueIndicator?: boolean;
   ariaLabel?: string;
+  disabled?: boolean;
 };
 
 function Slider({
@@ -32,6 +33,7 @@ function Slider({
   valueIndicator,
   className,
   ariaLabel,
+  disabled,
 }: SliderProps) {
   const { t, i18n } = useTranslation('common');
 
@@ -69,9 +71,17 @@ function Slider({
   };
 
   return (
-    <div className={clsx('w-full', className)}>
+    <div
+      className={clsx(
+        'w-full',
+        // also neutralizes the clickable labels, which call `onChange` themselves
+        disabled && 'pointer-events-none opacity-50',
+        className,
+      )}
+    >
       <DirectionProvider direction={i18n.dir()}>
         <HuSlider.Root
+          disabled={disabled}
           min={min}
           max={max}
           step={step}

--- a/nym-vpn-app/src/ui/Slider.tsx
+++ b/nym-vpn-app/src/ui/Slider.tsx
@@ -74,7 +74,6 @@ function Slider({
     <div
       className={clsx(
         'w-full',
-        // also neutralizes the clickable labels, which call `onChange` themselves
         disabled && 'pointer-events-none opacity-50',
         className,
       )}

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/service.rs
@@ -415,9 +415,9 @@ impl ContinuousTrafficSendingRate {
 
     pub fn throughput(&self) -> String {
         match self {
-            Self::Ms10 => "2 Mpbs",
-            Self::Ms20 => "1 Mpbs",
-            Self::Ms30 => "0.7 Mpbs",
+            Self::Ms10 => "2 Mbps",
+            Self::Ms20 => "1 Mbps",
+            Self::Ms30 => "0.7 Mbps",
         }
         .to_owned()
     }


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

cherry picked from release PR: https://github.com/nymtech/nym-vpn-client/pull/6053


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6056)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added separate controls for continuous traffic and background-cover traffic.
  * Added options to enable or disable background-cover traffic and adjust its rate.
  * Mixing-delay settings now reflect the configured range and display values in milliseconds.
  * Disabled traffic controls are visibly inactive and cannot be adjusted.

* **Bug Fixes**
  * Corrected traffic-rate labels from “Mpbs” to “Mbps.”
  * Updated Mixnet tuning descriptions, slider labels, and terminology for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->