### PR TITLE
Disable nightly iOS builds

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -18,7 +18,7 @@ jobs:
       fdroid: true
       linux: true
       windows: true
-      ios: true
+      ios: false
       macos: true
       publish-metadata: false
     secrets: inherit


### PR DESCRIPTION


## Description

Disable nightly iOS builds to avoid confusion with beta builds that are tested by QA before the release. Alternative considered: separate distribution group for nightly. However it seems that there isn't much demand for that from the team. 

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6058)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Nightly releases will no longer include iOS builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->