### PR TITLE
[Android] Fix routing from GenerationScreen

### DIFF
--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/account/generating/GeneratingScreen.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/account/generating/GeneratingScreen.kt
@@ -28,6 +28,7 @@ import net.nymtech.nymvpn.ui.common.snackbar.AlertMessage
 import net.nymtech.nymvpn.ui.common.snackbar.AlertType
 import net.nymtech.nymvpn.ui.theme.*
 import net.nymtech.nymvpn.util.extensions.navigateAndForget
+import net.nymtech.nymvpn.util.extensions.navigateAndForgetToMain
 import kotlin.time.Duration.Companion.milliseconds
 
 @Composable
@@ -47,7 +48,7 @@ fun GeneratingScreen(viewModel: GeneratingViewModel = hiltViewModel()) {
 
 	LaunchedEffect(animationEnded, readyForSelectPlan) {
 		if (!readyForSelectPlan || !animationEnded) return@LaunchedEffect
-		navController.navigateAndForget(Route.SelectPlan)
+		navController.navigateAndForgetToMain(Route.SelectPlan)
 	}
 
 	GeneratingContent(

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/util/extensions/UiExtensions.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/util/extensions/UiExtensions.kt
@@ -84,6 +84,19 @@ fun NavController.navigateAndForget(route: Route) {
 	}
 }
 
+fun NavController.navigateAndForgetToMain(route: Route) {
+	if (currentBackStackEntry?.isCurrentRoute(route::class) == true) return
+	try {
+		navigate(route) {
+			popUpTo<Route.Main> { inclusive = route is Route.Main }
+			launchSingleTop = true
+		}
+	} catch (e: Exception) {
+		Timber.e("Navigation failed: ${e.message}")
+		goFromRoot(Route.Main())
+	}
+}
+
 fun NavController.replaceCurrentWith(route: Route) {
 	val currentRoute = currentBackStackEntry?.destination?.route ?: return
 	try {


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

Add new function to start routing between screens from `Main`.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6063)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation when selecting a plan by preventing unintended return paths to previously visited screens.
  * Added safer handling for navigation failures, including a fallback to the main screen.
  * Avoided duplicate navigation when already viewing the selected destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->