### PR TITLE
ci: combine checksums into checksums.txt

### DIFF
--- a/.github/scripts/e2e/release-core.sh
+++ b/.github/scripts/e2e/release-core.sh
@@ -92,7 +92,7 @@ fetch() {
 
   local version archive archive_dir work src bin checksum
   load_archive_vars "$tag"
-  checksum="${archive}.sha256sum"
+  checksum="checksums.txt"
 
   mkdir -p "$dest"
   work="$(mktemp -d)"
@@ -106,7 +106,7 @@ fetch() {
   }
   (
     cd "$work"
-    sha256sum -c "$checksum"
+    sha256sum --ignore-missing -c "$checksum"
   )
 
   tar -xzf "${work}/${archive}" -C "$work"

--- a/.github/workflows/release-release-artifacts.yml
+++ b/.github/workflows/release-release-artifacts.yml
@@ -96,6 +96,7 @@ env:
   RELEASE_ASSETS: release-assets.txt
   RELEASE_PAYLOAD_ARTIFACT: release-payload
   RELEASE_PAYLOAD: release-payload.json
+  CHECKSUM_FILE: checksums.txt
 
 jobs:
   resolve:
@@ -449,12 +450,16 @@ jobs:
           cp -v "${{ env.APP_ARTIFACTS_ANDROID_FDROID }}/${ANDROID_APK}" "${{ env.OUTPUT_DIR }}"
 
       - name: Generate checksums
+        working-directory: ${{ env.OUTPUT_DIR }}
         run: |
-          cd "${{ env.OUTPUT_DIR }}"
+          if [ -f "$CHECKSUM_FILE" ]; then
+            rm "$CHECKSUM_FILE"
+          fi
+
           for file in *; do
-            if [ -f "$file" ] && [[ "$file" != *.sha256sum ]]; then
-              echo "#️⃣ Generating SHA: $file > ${file}.sha256sum"
-              sha256sum "$file" > "${file}.sha256sum"
+            if [ -f "$file" ] ; then
+              echo "#️⃣ Generating SHA: $file"
+              sha256sum "$file" >> "$CHECKSUM_FILE"
             fi
           done
 
@@ -487,64 +492,45 @@ jobs:
           if [ "${{ needs.resolve.outputs.linux }}" = "true" ]; then
             FILES+=(
               "${ARCHIVE_LINUX_X86_64}"
-              "${ARCHIVE_LINUX_X86_64}.sha256sum"
               "${ARCHIVE_LINUX_AARCH64}"
-              "${ARCHIVE_LINUX_AARCH64}.sha256sum"
               "${LINUX_INSTALL}"
-              "${LINUX_INSTALL}.sha256sum"
               "${LINUX_APP_X64_BIN}"
-              "${LINUX_APP_X64_BIN}.sha256sum"
               "${LINUX_APP_ARM64_BIN}"
-              "${LINUX_APP_ARM64_BIN}.sha256sum"
               "${LINUX_APP_DEB_X64}"
-              "${LINUX_APP_DEB_X64}.sha256sum"
               "${LINUX_APP_DEB_ARM64}"
-              "${LINUX_APP_DEB_ARM64}.sha256sum"
               "${LINUX_APP_APPIMAGE_X64}"
-              "${LINUX_APP_APPIMAGE_X64}.sha256sum"
               "${LINUX_APP_APPIMAGE_ARM64}"
-              "${LINUX_APP_APPIMAGE_ARM64}.sha256sum"
               "${VPNC_DEB_X86_64}"
-              "${VPNC_DEB_X86_64}.sha256sum"
               "${VPNC_DEB_AARCH64}"
-              "${VPNC_DEB_AARCH64}.sha256sum"
               "${VPND_DEB_X86_64}"
-              "${VPND_DEB_X86_64}.sha256sum"
               "${VPND_DEB_AARCH64}"
-              "${VPND_DEB_AARCH64}.sha256sum"
             )
           fi
 
           if [ "${{ needs.resolve.outputs.windows }}" = "true" ]; then
             FILES+=(
               "${ARCHIVE_WINDOWS_X64}"
-              "${ARCHIVE_WINDOWS_X64}.sha256sum"
               "${ARCHIVE_WINDOWS_ARM64}"
-              "${ARCHIVE_WINDOWS_ARM64}.sha256sum"
               "${WINDOWS_APP_INSTALLER_X64}"
-              "${WINDOWS_APP_INSTALLER_X64}.sha256sum"
               "${WINDOWS_APP_INSTALLER_ARM64}"
-              "${WINDOWS_APP_INSTALLER_ARM64}.sha256sum"
             )
           fi
 
           if [ "${{ needs.resolve.outputs.macos }}" = "true" ]; then
             FILES+=(
               "${MACOS_INSTALLER_NAME}"
-              "${MACOS_INSTALLER_NAME}.sha256sum"
               "${VPNC_MACOS_INSTALLER_NAME}"
-              "${VPNC_MACOS_INSTALLER_NAME}.sha256sum"
             )
           fi
 
           if [[ "${{ needs.resolve.outputs.fdroid }}" = "true" ]]; then
             FILES+=(
               "${ANDROID_APK}"
-              "${ANDROID_APK}.sha256sum"
             )
           fi
 
           if [ ${#FILES[@]} -gt 0 ]; then
+            FILES+=("$CHECKSUM_FILE")
             printf "%s\n" "${FILES[@]}" > "${{ env.RELEASE_ASSETS }}"
           else
             echo "::error::No files to upload"


### PR DESCRIPTION


## Description

- Reduce pollution in Github releases and combine all SHA256 checksums into `checksums.txt`
- Adapt e2e scripts to use `checksums.txt`

⚠️ if this PR is merged it better be merged before the release, so that we didn't have to support back-compatibility with older releases in e2e workflow ⚠️ 

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6064)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Release downloads now use a single `checksums.txt` manifest for SHA-256 verification.
  * Checksum validation supports manifests containing entries for files that were not downloaded.
  * Release artifacts now include one consolidated checksum file instead of separate checksum files for each asset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->