### PR TITLE
Sync daemon settings on rpc connect

### DIFF
--- a/nym-vpn-apple/CHANGELOG.md
+++ b/nym-vpn-apple/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix switching between modes to always land on the last selected mode (https://github.com/nymtech/nym-vpn-client/pull/6023)
 - Show full version in settings (https://github.com/nymtech/nym-vpn-client/pull/6032)
+- Sync daemon settings on rpc connect. Fixes issues with stale configuration being displayed in UI (https://github.com/nymtech/nym-vpn-client/pull/6067)
 
 
 ## [2.11.0]

--- a/nym-vpn-apple/NymVPNDaemon/NymVPNDaemonApp.swift
+++ b/nym-vpn-apple/NymVPNDaemon/NymVPNDaemonApp.swift
@@ -159,7 +159,6 @@ private extension NymVPNDaemonApp {
             NotificationsManager.shared.setup()
             SentryManager.shared.setup()
             Migrations.shared.setup()
-            await ConnectionManager.shared.bootstrapFromDaemonIfNeeded()
         }
     }
 }

--- a/nym-vpn-apple/Services/Sources/Services/AppSettings/AppSettings.swift
+++ b/nym-vpn-apple/Services/Sources/Services/AppSettings/AppSettings.swift
@@ -55,9 +55,6 @@ import ConnectionTypes
     @AppStorage(AppSettingKey.smallScreen.rawValue)
     public var isSmallScreen = false
 
-    @AppStorage(AppSettingKey.didCompleteFirstLaunch.rawValue)
-    public var didCompleteFirstLaunch = false
-
     // Technical opt ins
     @AppStorage(AppSettingKey.welcomeScreenDidDisplay.rawValue)
     public var welcomeScreenDidDisplay = false
@@ -257,7 +254,6 @@ public enum AppSettingKey: String {
     case errorReporting
     case credenitalExists
     case smallScreen
-    case didCompleteFirstLaunch
     case welcomeScreenDidDisplay
     case onboardingDidDisplay
     case lastConnectionIntent

--- a/nym-vpn-apple/Services/Sources/Services/ConnectionManager/ConnectionManager+macOS.swift
+++ b/nym-vpn-apple/Services/Sources/Services/ConnectionManager/ConnectionManager+macOS.swift
@@ -21,56 +21,6 @@ extension ConnectionManager {
     }
 }
 
-// MARK: - First-launch bootstrap -
-extension ConnectionManager {
-    /// First-launch reconciliation with the daemon.
-    ///
-    /// Runs only when:
-    ///   1. `appSettings.didCompleteFirstLaunch == false`, and
-    ///   2. the stored ConnectionConfig is byte-identical to the freshly
-    ///      generated initial config (i.e. the user hasn't touched anything).
-    ///
-    /// Replaces the local config with the daemon's, then forces `entry` and
-    /// `exit` back to the app's initial values and pushes them to the daemon.
-    /// Sets the flag so subsequent launches no-op.
-    @MainActor public func bootstrapFromDaemonIfNeeded() async {
-        guard !appSettings.didCompleteFirstLaunch else { return }
-
-        guard connectionStorage.isUsingInitialConfig
-        else {
-            appSettings.didCompleteFirstLaunch = true
-            return
-        }
-
-        await waitUntilDaemonServing()
-
-        guard let daemonConfig = await grpcManager.config() else { return }
-
-        let preservedCustomAppPaths = connectionConfig.splitTunnelConfig.customAppPaths
-        connectionConfig = daemonConfig
-        connectionConfig.splitTunnelConfig.customAppPaths = preservedCustomAppPaths
-        connectionType = daemonConfig.enableTwoHop ? .wireguard : .mixnet5hop
-        entryGateway = daemonConfig.entry
-        exitRouter = daemonConfig.exit
-
-        appSettings.isLanBypassEnabled = daemonConfig.allowLan
-        appSettings.isIPv6TrafficEnabled = !daemonConfig.disableIpv6
-        appSettings.isAdBlockerEnabled = daemonConfig.enableAdBlocking
-        appSettings.isQuicEnabled = daemonConfig.enableBridges
-        appSettings.customDns = daemonConfig.dns ?? []
-        appSettings.isCustomDnsEnabled = !(daemonConfig.dns?.isEmpty ?? true)
-
-        appSettings.didCompleteFirstLaunch = true
-    }
-
-    @MainActor private func waitUntilDaemonServing() async {
-        guard !grpcManager.isServing else { return }
-        for await serving in grpcManager.$isServing.values where serving {
-            return
-        }
-    }
-}
-
 extension ConnectionManager {
     @MainActor public func connectDisconnect() async throws {
         if MockMode.isEnabled {
@@ -91,9 +41,20 @@ extension ConnectionManager {
 }
 
 // MARK: - Setup -
+
 extension ConnectionManager {
     func setupGRPCManagerObservers() {
         updateWidgetState(for: currentTunnelStatus)
+
+        grpcManager.$isServing.dropFirst()
+            .sink { [weak self] isConnectedToDaemon in
+                guard isConnectedToDaemon else { return }
+
+                Task { @MainActor [weak self] in
+                    await self?.fetchDaemonConfig()
+                }
+            }
+            .store(in: &cancellables)
 
         grpcManager.$tunnelStatus.sink { [weak self] status in
             Task { @MainActor [weak self] in
@@ -129,6 +90,24 @@ extension ConnectionManager {
             .receive(on: DispatchQueue.main)
             .assign(to: \.connectionInfoData, on: self)
             .store(in: &cancellables)
+    }
+
+    @MainActor private func fetchDaemonConfig() async {
+        guard let daemonConfig = await grpcManager.config() else { return }
+
+        let preservedCustomAppPaths = connectionConfig.splitTunnelConfig.customAppPaths
+        connectionConfig = daemonConfig
+        connectionConfig.splitTunnelConfig.customAppPaths = preservedCustomAppPaths
+        connectionType = daemonConfig.enableTwoHop ? .wireguard : .mixnet5hop
+        entryGateway = daemonConfig.entry
+        exitRouter = daemonConfig.exit
+
+        appSettings.isLanBypassEnabled = daemonConfig.allowLan
+        appSettings.isIPv6TrafficEnabled = !daemonConfig.disableIpv6
+        appSettings.isAdBlockerEnabled = daemonConfig.enableAdBlocking
+        appSettings.isQuicEnabled = daemonConfig.enableBridges
+        appSettings.customDns = daemonConfig.dns ?? []
+        appSettings.isCustomDnsEnabled = !(daemonConfig.dns?.isEmpty ?? true)
     }
 }
 

--- a/nym-vpn-apple/Services/Sources/Services/ConnectionManager/ConnectionManager+macOS.swift
+++ b/nym-vpn-apple/Services/Sources/Services/ConnectionManager/ConnectionManager+macOS.swift
@@ -46,15 +46,14 @@ extension ConnectionManager {
     func setupGRPCManagerObservers() {
         updateWidgetState(for: currentTunnelStatus)
 
-        grpcManager.$isServing.dropFirst()
-            .sink { [weak self] isConnectedToDaemon in
-                guard isConnectedToDaemon else { return }
+        grpcManager.$isServing.sink { [weak self] isConnectedToDaemon in
+            guard isConnectedToDaemon else { return }
 
-                Task { @MainActor [weak self] in
-                    await self?.fetchDaemonConfig()
-                }
+            Task { @MainActor [weak self] in
+                await self?.fetchDaemonConfig()
             }
-            .store(in: &cancellables)
+        }
+        .store(in: &cancellables)
 
         grpcManager.$tunnelStatus.sink { [weak self] status in
             Task { @MainActor [weak self] in

--- a/nym-vpn-apple/ServicesMacOS/Sources/GRPCManager/GRPCManager+Info.swift
+++ b/nym-vpn-apple/ServicesMacOS/Sources/GRPCManager/GRPCManager+Info.swift
@@ -1,27 +1,6 @@
-extension GRPCManager {
-    public func version() async throws {
-        do {
-            guard let result = try await rpcClient?.getInfo()
-            else {
-                Task { @MainActor in
-                    daemonVersion = "noVersion"
-                }
-                return
-            }
-            Task { @MainActor in
-                daemonVersion = result.version
-                networkName = result.nymNetwork.networkName
-                logger.info("🛜 \(result.nymNetwork.networkName)")
-            }
-        } catch {
-            Task { @MainActor in
-                guard daemonVersion != "noVersion" || daemonVersion != "update" else { return }
-                daemonVersion = "noVersion"
-            }
-            throw error
-        }
-    }
+import NymVPNRpc
 
+extension GRPCManager {
     public func updateErrorReportingIfNeeded(with isEnabled: Bool) async throws {
         if isEnabled {
             try await rpcClient?.enableSentry()

--- a/nym-vpn-apple/ServicesMacOS/Sources/GRPCManager/GRPCManager+TunnelStatus.swift
+++ b/nym-vpn-apple/ServicesMacOS/Sources/GRPCManager/GRPCManager+TunnelStatus.swift
@@ -5,57 +5,6 @@ import ErrorReason
 import TunnelStatus
 
 extension GRPCManager {
-    func startDaemonInitialStatusPingerIfNeeded() {
-        guard versionPingTask == nil || versionPingTask?.isCancelled == true else { return }
-
-        versionPingTask = Task { [weak self] in
-            guard let self else { return }
-            await self.pingDaemonInitialStatus()
-        }
-    }
-
-    func stopInitialStatusPinger() {
-        versionPingTask?.cancel()
-        versionPingTask = nil
-    }
-
-    func pingDaemonInitialStatus() async {
-        var retryCount = 0
-        while !isServing {
-            do {
-                try await version()
-                guard let tunnelState = try await rpcClient?.getTunnelState() else { return }
-                await MainActor.run {
-                    updateTunnelStatus(with: tunnelState)
-                }
-            } catch is CancellationError {
-                return
-            } catch {
-                 logger.debug("pingDaemonInitialStatus error: \(error)")
-            }
-
-            if !isServing {
-                retryCount += 1
-                if retryCount == 2 {
-                    daemonVersion = "update"
-                }
-                do {
-                    try await Task.sleep(for: .seconds(5))
-                } catch is CancellationError {
-                    logger.debug("pingDaemonInitialStatus cancelled during sleep")
-                    return
-                } catch {
-                    logger.debug("Ping Daemon initial status: \(error)")
-                }
-            }
-            if isServing {
-                stopInitialStatusPinger()
-            }
-        }
-    }
-}
-
-extension GRPCManager {
     func updateTunnelStatus(with state: TunnelState) {
         switch state {
         case let .connected(details):
@@ -98,9 +47,6 @@ extension GRPCManager {
                 tunnelStatus = .offline
             }
         }
-
-        guard !isServing else { return }
-        isServing = true
     }
 }
 

--- a/nym-vpn-apple/ServicesMacOS/Sources/GRPCManager/GRPCManager.swift
+++ b/nym-vpn-apple/ServicesMacOS/Sources/GRPCManager/GRPCManager.swift
@@ -69,7 +69,12 @@ private extension GRPCManager {
         eventObserver = try await rpcClient.listenToEvents(observer: newRpcObserver)
         self.rpcClient = rpcClient
 
-        try await onConnect(rpcClient: rpcClient)
+        do {
+            try await onConnect(rpcClient: rpcClient)
+        } catch {
+            await onDisconnect()
+            throw error
+        }
 
         for await event in newRpcObserver.stream {
             didReceive(event: event)

--- a/nym-vpn-apple/ServicesMacOS/Sources/GRPCManager/GRPCManager.swift
+++ b/nym-vpn-apple/ServicesMacOS/Sources/GRPCManager/GRPCManager.swift
@@ -11,18 +11,16 @@ import Constants
 import ConnectionTypes
 import TunnelStatus
 
-let RPC_RECONNECT_DELAY = Duration.seconds(5)
+let kRpcReconnectDelay = Duration.seconds(5)
 
 @MainActor public final class GRPCManager: ObservableObject {
     private var cancellables = Set<AnyCancellable>()
-    private var listenToEventsObserver: StreamObserver?
+    private var eventObserver: StreamObserver?
 
     public static let shared = GRPCManager()
 
     let logger = Logger(label: "GRPC Manager")
-    // TODO: create actor
     var rpcClient: RpcClient?
-    var versionPingTask: Task<Void, Never>?
 
     @Published public var isServing = false
     @Published public var tunnelStatus: TunnelStatus = .unknown
@@ -44,72 +42,79 @@ let RPC_RECONNECT_DELAY = Duration.seconds(5)
     }
 
     private init() {
-        setup()
+        startConnectionLoop()
     }
 
-    func setup() {
+    func startConnectionLoop() {
         Task { @MainActor in
-            try? await configureRpcClient()
-            await pingDaemonInitialStatus()
+            while !Task.isCancelled {
+                do {
+                    try await connectRpcAndHandleEvents()
+                } catch {
+                    let error = (error as? RpcError)?.displayChain() ?? error.localizedDescription
+                    logger.error("RPC error: \(error)")
+                }
+
+                try await Task.sleep(for: kRpcReconnectDelay)
+            }
         }
     }
 }
 
 private extension GRPCManager {
-    func configureRpcClient() async throws {
-        do {
-            let rpcClient = try await RpcClient()
-            self.rpcClient = rpcClient
+    func connectRpcAndHandleEvents() async throws {
+        let rpcClient = try await RpcClient()
+        let newRpcObserver = RPCTunnelObserver()
 
-            let newRpcObserver = RPCTunnelObserver()
-            listenToEventsObserver = try await rpcClient.listenToEvents(observer: newRpcObserver)
+        eventObserver = try await rpcClient.listenToEvents(observer: newRpcObserver)
+        self.rpcClient = rpcClient
 
-            Task { [weak self] in
-                for await event in newRpcObserver.stream {
-                    self?.didReceive(event: event)
-                }
+        try await onConnect(rpcClient: rpcClient)
 
-                await self?.onDisconnect()
-            }
-
-            stopInitialStatusPinger()
-            startDaemonInitialStatusPingerIfNeeded()
-        } catch {
-            let error = (error as? RpcError)?.displayChain() ?? error.localizedDescription
-            logger.error("Failed to connect RpcClient: \(error)")
-            try? await Task.sleep(for: RPC_RECONNECT_DELAY)
-            setup()
+        for await event in newRpcObserver.stream {
+            didReceive(event: event)
         }
+
+        await onDisconnect()
     }
 
     func didReceive(event: TunnelEvent) {
         switch event {
         case let .newState(tunnelState):
-            Task { @MainActor in
-                updateTunnelStatus(with: tunnelState)
-            }
+            updateTunnelStatus(with: tunnelState)
         case .mixnetState:
             break
         case .configChanged:
             break
         case .accountState:
             break
-        case .diagnosticsSuggested(_):
+        case .diagnosticsSuggested:
             break
         }
     }
 
+    func onConnect(rpcClient: RpcClient) async throws {
+        logger.info("RPC connected")
+
+        let serviceInfo = try await rpcClient.getInfo()
+        let tunnelState = try await rpcClient.getTunnelState()
+
+        daemonVersion = serviceInfo.version
+        networkName = serviceInfo.nymNetwork.networkName
+        logger.info("🛜 \(serviceInfo.nymNetwork.networkName)")
+
+        updateTunnelStatus(with: tunnelState)
+
+        isServing = true
+    }
+
     func onDisconnect() async {
-        logger.warning("🛩️ RPC connection closed")
+        logger.info("RPC disconnected")
 
         isServing = false
         tunnelStatus = .unknown
-        listenToEventsObserver = nil
-        stopInitialStatusPinger()
+        eventObserver = nil
         rpcClient = nil
-
-        try? await Task.sleep(for: RPC_RECONNECT_DELAY)
-        setup()
     }
 }
 

--- a/nym-vpn-apple/ServicesMutual/Sources/NymLogger/NymLogger.swift
+++ b/nym-vpn-apple/ServicesMutual/Sources/NymLogger/NymLogger.swift
@@ -19,9 +19,20 @@ private enum Bootstrap {
     static func once(using manager: LogFileManager) {
         lock.sync {
             guard !didBootstrap else { return }
+
             LoggingSystem.bootstrap { label in
-                FileLogHandler(label: label, logFileManager: manager)
+                let fileLogger = FileLogHandler(label: label, logFileManager: manager)
+
+#if DEBUG
+                return MultiplexLogHandler([
+                    StreamLogHandler.standardOutput(label: label),
+                    fileLogger
+                ])
+#else
+                return fileLogger
+#endif
             }
+
             didBootstrap = true
         }
     }

--- a/nym-vpn-apple/Settings/Sources/Settings/Santa/SantasView.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/Santa/SantasView.swift
@@ -67,11 +67,6 @@ private extension SantasView {
                 .padding(4)
             Text("Daemon/lib version: \(viewModel.libVersion)")
                 .padding(4)
-#if os(macOS)
-            Button("Refetch daemon info") {
-                viewModel.updateDaemonInfo()
-            }
-#endif
         }
         .padding(16)
     }

--- a/nym-vpn-apple/Settings/Sources/Settings/Santa/SantasViewModel.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/Santa/SantasViewModel.swift
@@ -172,16 +172,5 @@ import Theme
         }
         return ByteCountFormatter.string(fromByteCount: Int64(totalSize), countStyle: .file)
     }
-
-#if os(macOS)
-    func updateDaemonInfo() {
-        Task {
-            try? await grpcManager.version()
-            Task { @MainActor in
-                objectWillChange.send()
-            }
-        }
-    }
-#endif
 }
 #endif


### PR DESCRIPTION
## Ticket

JIRA-NYM-1748

## Description

- Always fetch daemon config on connect to RPC. Fixes issue with app using cached config.
- Streamline GRPC lifecycle, remove indirection
- Enable console logging in macOS when in debug mode

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6067)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daemon connection reliability with continuous automatic reconnection.
  * Updated connection and tunnel status handling to keep displayed state synchronized.
  * Synchronized daemon settings when connected and fixed stale configuration in the interface.
  * Preserved custom split-tunnel paths when applying daemon configuration.

* **Improvements**
  * Enhanced debug logging with both console and file output.
  * Removed the macOS option to manually refetch daemon information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->