### PR TITLE
Make resolver more resilient.

### DIFF
--- a/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/gateway.rs
+++ b/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/gateway.rs
@@ -137,7 +137,7 @@ impl GatewayDiagnostic {
             None,
         )?;
 
-        GatewayClient::new(config, new_user_agent!())
+        GatewayClient::new(config, new_user_agent!()).await
     }
 
     async fn lookup_gateway(

--- a/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/http.rs
+++ b/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/http.rs
@@ -236,6 +236,7 @@ async fn build_vpn_api_clients(network: &Network) -> Result<Vec<VpnApiClient>> {
         let plain_url =
             Url::new(url.inner_url().clone(), None).map_err(|_| Error::MissingApiUrl)?;
         let mut plain_client = VpnApiClient::new(vec![plain_url], Some(new_user_agent!()))
+            .await
             .map_err(|_| Error::MissingApiUrl)?;
 
         plain_client.as_mut().set_front_policy(FrontPolicy::Off);
@@ -249,6 +250,7 @@ async fn build_vpn_api_clients(network: &Network) -> Result<Vec<VpnApiClient>> {
 
                 let mut fronted_client =
                     VpnApiClient::new(vec![fronted_url], Some(new_user_agent!()))
+                        .await
                         .map_err(|_| Error::MissingApiUrl)?;
                 fronted_client
                     .as_mut()

--- a/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/mod.rs
+++ b/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/mod.rs
@@ -71,5 +71,5 @@ impl DiagnosticHandler {
 
 pub async fn build_api_client(network: &Network) -> Result<Client> {
     let nym_urls = api_urls_to_urls(&network.nym_api_urls().ok_or(Error::MissingApiUrl)?)?;
-    Ok(fronted_http_client(nym_urls, None, None)?)
+    Ok(fronted_http_client(nym_urls, None, None).await?)
 }

--- a/nym-vpn-core/crates/nym-diagnostic/src/main.rs
+++ b/nym-vpn-core/crates/nym-diagnostic/src/main.rs
@@ -26,6 +26,7 @@ async fn main() -> anyhow::Result<()> {
         Network::mainnet_default().with_context(|| "Missing network config")?
     } else if let Some(discovery) = Discovery::default_discovery(&args.network) {
         let fetcher = Fetcher::new(discovery.clone(), None)
+            .await
             .context("Failed to build non mainnet env : fetcher")?;
         let network_details = fetcher
             .fetch_network_details()

--- a/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
@@ -179,16 +179,16 @@ pub struct GatewayClient {
 impl GatewayClient {
     pub async fn new(config: Config, user_agent: UserAgent) -> Result<Self> {
         let nym_urls = api_urls_to_urls(config.nym_api_urls())?;
-        let nym_urls = ResolverOverrides::resolve_and_prune(&nym_urls).await;
 
         let api_client = fronted_http_client(nym_urls, Some(user_agent.clone()), None)
+            .await
             .map_err(Error::VpnApiClientError)?;
 
         let nym_vpn_urls = api_urls_to_urls(config.nym_vpn_api_urls())?;
-        let nym_vpn_urls = ResolverOverrides::resolve_and_prune(&nym_vpn_urls).await;
 
         let vpn_api_client =
             nym_vpn_api_client::VpnApiClient::new(nym_vpn_urls, Some(user_agent.clone()))
+                .await
                 .map_err(Error::VpnApiClientError)?;
 
         Ok(GatewayClient {
@@ -208,9 +208,9 @@ impl GatewayClient {
         user_agent: UserAgent,
     ) -> Result<Self> {
         let nym_urls = api_urls_to_urls(&config.nym_api_urls)?;
-        let nym_urls = ResolverOverrides::resolve_and_prune(&nym_urls).await;
 
         let api_client = fronted_http_client(nym_urls, Some(user_agent.clone()), None)
+            .await
             .map_err(Error::VpnApiClientError)?;
 
         let vpn_api_client = nym_vpn_api_client::VpnApiClient::from_network(

--- a/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/gateway_client.rs
@@ -177,13 +177,15 @@ pub struct GatewayClient {
 }
 
 impl GatewayClient {
-    pub fn new(config: Config, user_agent: UserAgent) -> Result<Self> {
+    pub async fn new(config: Config, user_agent: UserAgent) -> Result<Self> {
         let nym_urls = api_urls_to_urls(config.nym_api_urls())?;
+        let nym_urls = ResolverOverrides::resolve_and_prune(&nym_urls).await;
 
         let api_client = fronted_http_client(nym_urls, Some(user_agent.clone()), None)
             .map_err(Error::VpnApiClientError)?;
 
         let nym_vpn_urls = api_urls_to_urls(config.nym_vpn_api_urls())?;
+        let nym_vpn_urls = ResolverOverrides::resolve_and_prune(&nym_vpn_urls).await;
 
         let vpn_api_client =
             nym_vpn_api_client::VpnApiClient::new(nym_vpn_urls, Some(user_agent.clone()))
@@ -206,8 +208,8 @@ impl GatewayClient {
         user_agent: UserAgent,
     ) -> Result<Self> {
         let nym_urls = api_urls_to_urls(&config.nym_api_urls)?;
+        let nym_urls = ResolverOverrides::resolve_and_prune(&nym_urls).await;
 
-        // No resolver overrides for this client?
         let api_client = fronted_http_client(nym_urls, Some(user_agent.clone()), None)
             .map_err(Error::VpnApiClientError)?;
 
@@ -604,21 +606,21 @@ mod test {
         }
     }
 
-    fn mainnet_gateway_client() -> GatewayClient {
+    async fn mainnet_gateway_client() -> GatewayClient {
         let config = new_mainnet();
-        GatewayClient::new(config, user_agent()).unwrap()
+        GatewayClient::new(config, user_agent()).await.unwrap()
     }
 
     #[tokio::test]
     async fn lookup_described_gateways() {
-        let client = mainnet_gateway_client();
+        let client = mainnet_gateway_client().await;
         let gateways = client.lookup_described_nodes().await.unwrap();
         assert!(!gateways.is_empty());
     }
 
     #[tokio::test]
     async fn lookup_gateways_in_nym_vpn_api() {
-        let client = mainnet_gateway_client();
+        let client = mainnet_gateway_client().await;
         let gateways = client
             .lookup_gateways(GatewayType::MixnetExit)
             .await

--- a/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/common/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/common/mod.rs
@@ -236,7 +236,7 @@ impl TestBench {
 
         let urls = api_urls_to_urls(&[api_url])?;
 
-        let nym_vpn_api_client = VpnApiClient::new(urls, Some(mock_user_agent()))?;
+        let nym_vpn_api_client = VpnApiClient::new(urls, Some(mock_user_agent())).await?;
 
         let nyxd_server = MockServer::start().await;
         let mut network_env = Network::mainnet_default().unwrap();

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/client.rs
@@ -86,17 +86,18 @@ impl VpnApiClient {
     /// dedicated HTTP client. Useful for constructing a `SkewManager` before any `VpnApiClient`
     /// exists, so it can be shared (injected via `new`/`from_network`) rather than owned solely
     /// by the client.
-    pub fn health_endpoint_time_provider(
+    pub async fn health_endpoint_time_provider(
         urls: Vec<Url>,
         user_agent: Option<UserAgent>,
     ) -> Result<impl RemoteTimeProvider + Send + Sync + 'static> {
-        let inner = fronted_http_client(urls, user_agent, Some(NYM_VPN_API_TIMEOUT))?;
+        let inner = fronted_http_client(urls, user_agent, Some(NYM_VPN_API_TIMEOUT)).await?;
         Ok(VpnApiRemoteTimeProvider::new(inner))
     }
 
-    pub fn new(urls: Vec<Url>, user_agent: Option<UserAgent>) -> Result<Self> {
+    pub async fn new(urls: Vec<Url>, user_agent: Option<UserAgent>) -> Result<Self> {
         let inner =
-            fronted_http_client(urls.clone(), user_agent.clone(), Some(NYM_VPN_API_TIMEOUT))?;
+            fronted_http_client(urls.clone(), user_agent.clone(), Some(NYM_VPN_API_TIMEOUT))
+                .await?;
 
         let skew_manager = SkewManager::new(VpnApiRemoteTimeProvider::new(inner.clone()));
 
@@ -122,7 +123,8 @@ impl VpnApiClient {
         let urls = api_urls_to_urls(api_urls)?;
 
         let inner =
-            fronted_http_client(urls.clone(), user_agent.clone(), Some(NYM_VPN_API_TIMEOUT))?;
+            fronted_http_client(urls.clone(), user_agent.clone(), Some(NYM_VPN_API_TIMEOUT))
+                .await?;
 
         let skew_manager = SkewManager::new(VpnApiRemoteTimeProvider::new(inner.clone()));
 
@@ -1630,7 +1632,7 @@ mod tests {
 
     // Returns a client that never makes real network requests: the device clock is fixed and
     // remote time requests are counted and answered with `remote_time`.
-    fn test_client(remote_time: OffsetDateTime) -> (VpnApiClient, Arc<AtomicUsize>) {
+    async fn test_client(remote_time: OffsetDateTime) -> (VpnApiClient, Arc<AtomicUsize>) {
         let calls = Arc::new(AtomicUsize::new(0));
         let remote_time_provider = CountingRemoteTimeProvider {
             calls: calls.clone(),
@@ -1643,6 +1645,7 @@ mod tests {
             None,
             Some(NYM_VPN_API_TIMEOUT),
         )
+        .await
         .unwrap();
         (
             VpnApiClient {
@@ -1674,7 +1677,7 @@ mod tests {
 
     #[tokio::test]
     async fn date_header_skew_avoids_remote_time_request() {
-        let (client, remote_calls) = test_client(device_time());
+        let (client, remote_calls) = test_client(device_time()).await;
         // Remote time is 2 hours behind the device time
         let headers = headers_with_date("Thu, 16 Jul 2026 10:00:00 GMT");
 
@@ -1701,7 +1704,7 @@ mod tests {
 
     #[tokio::test]
     async fn date_header_negligible_skew_retries_with_local_time() {
-        let (client, remote_calls) = test_client(device_time());
+        let (client, remote_calls) = test_client(device_time()).await;
         // Remote time is only 30 seconds ahead of the device time: below the threshold
         let headers = headers_with_date("Thu, 16 Jul 2026 12:00:30 GMT");
 
@@ -1715,7 +1718,7 @@ mod tests {
 
     #[tokio::test]
     async fn aligned_date_header_corrects_stale_cached_skew_and_retries() {
-        let (client, remote_calls) = test_client(device_time());
+        let (client, remote_calls) = test_client(device_time()).await;
 
         // Seed the cache with a stale skew: the device clock used to be 2 hours ahead
         client
@@ -1748,7 +1751,7 @@ mod tests {
 
     #[tokio::test]
     async fn missing_date_header_falls_back_to_remote_time_request() {
-        let (client, remote_calls) = test_client(device_time() - Duration::from_hours(2));
+        let (client, remote_calls) = test_client(device_time() - Duration::from_hours(2)).await;
 
         let RemoteTimeRetry::Retry(Some(jwt)) = client
             .remote_time_for_retry(&HeaderMap::new(), device_time(), device_time())
@@ -1763,7 +1766,7 @@ mod tests {
 
     #[tokio::test]
     async fn malformed_date_header_falls_back_to_remote_time_request() {
-        let (client, remote_calls) = test_client(device_time() - Duration::from_hours(2));
+        let (client, remote_calls) = test_client(device_time() - Duration::from_hours(2)).await;
         let headers = headers_with_date("not a date");
 
         let RemoteTimeRetry::Retry(Some(jwt)) = client
@@ -1779,7 +1782,7 @@ mod tests {
 
     #[tokio::test]
     async fn untrustworthy_request_time_falls_back_to_remote_time_request() {
-        let (client, remote_calls) = test_client(device_time() - Duration::from_hours(2));
+        let (client, remote_calls) = test_client(device_time() - Duration::from_hours(2)).await;
         let headers = headers_with_date("Thu, 16 Jul 2026 10:00:00 GMT");
 
         // The request appears to have finished before it started, so the Date header

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/fronted_http_client.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/fronted_http_client.rs
@@ -1,15 +1,15 @@
 use std::time::Duration;
 
-use crate::error::VpnApiClientError;
+use crate::{error::VpnApiClientError, types::ResolverOverrides};
 use nym_http_api_client::{Client, ClientBuilder, FrontPolicy, Url, UserAgent};
 use nym_network_defaults::ApiUrl;
 
-pub fn fronted_http_client(
+pub async fn fronted_http_client(
     urls: Vec<Url>,
     user_agent: Option<UserAgent>,
     timeout: Option<Duration>,
 ) -> Result<Client, VpnApiClientError> {
-    let builder = fronted_http_client_builder(urls, user_agent, timeout)?;
+    let builder = fronted_http_client_builder(urls, user_agent, timeout).await?;
 
     let client = builder
         .build()
@@ -19,11 +19,12 @@ pub fn fronted_http_client(
     Ok(client)
 }
 
-pub fn fronted_http_client_builder(
+pub async fn fronted_http_client_builder(
     urls: Vec<Url>,
     user_agent: Option<UserAgent>,
     timeout: Option<Duration>,
 ) -> Result<ClientBuilder, VpnApiClientError> {
+    let urls = ResolverOverrides::resolve_and_prune(&urls).await;
     let has_front = urls.iter().any(|url| url.has_front());
 
     let mut builder = ClientBuilder::new_with_urls(urls)

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/types/resolver_overrides.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/types/resolver_overrides.rs
@@ -5,7 +5,6 @@ use std::{
     net::{IpAddr, SocketAddr},
 };
 
-use itertools::{Either, Itertools};
 use tokio::task::JoinSet;
 
 use nym_common::ErrorExt;
@@ -22,21 +21,30 @@ pub struct ResolverOverrides {
 impl ResolverOverrides {
     /// Create a new set of resolver overrides from the provided URLs.
     /// Resolves all domains in parallel for faster startup and reconnection.
+    ///
+    /// Fronting domains are only ever used as a fallback route, so a front that fails to
+    /// resolve is dropped rather than treated as fatal. Resolution only fails outright if
+    /// none of the primary URLs could be resolved either, meaning there is no usable route
+    /// at all.
     pub async fn from_urls(urls: &[Url]) -> Result<Self, VpnApiClientError> {
         let mut join_set = JoinSet::new();
 
         tracing::debug!("getting overrides for {urls:?}");
 
-        let urls_to_resolve = urls
-            .iter()
-            .flat_map(|url| {
-                [url.inner_url().clone()]
-                    .into_iter()
-                    .chain(url.fronts().unwrap_or_default().iter().cloned())
-            })
-            .collect::<HashSet<_>>();
+        // Track, for each unique domain, whether it is a primary endpoint for at least one
+        // candidate, as opposed to only ever appearing as a fronting decoy.
+        let mut candidates: HashMap<url::Url, bool> = HashMap::new();
+        for url in urls {
+            candidates.insert(url.inner_url().clone(), true);
+        }
+        for url in urls {
+            for front in url.fronts().unwrap_or_default() {
+                candidates.entry(front.clone()).or_insert(false);
+            }
+        }
 
-        for url in urls_to_resolve {
+        let mut spawned_any = false;
+        for (url, is_primary) in candidates {
             let Some(domain) = url.domain().map(|s| s.to_owned()) else {
                 tracing::warn!(
                     "Ignoring API URL '{}' for resolver overrides as it does not have a valid domain",
@@ -45,6 +53,7 @@ impl ResolverOverrides {
                 continue;
             };
 
+            spawned_any = true;
             join_set.spawn(async move {
                 let result = url_to_socket_addr(&url, Some((1, 1)))
                     .await
@@ -56,38 +65,63 @@ impl ResolverOverrides {
                             ))
                         );
                     });
-                (domain, result)
+                (domain, is_primary, result)
             });
         }
 
         // Execute all resolution tasks in parallel
         let results = join_set.join_all().await;
 
-        // Collect successful and failed resolutions
-        let (successes, failures): (Vec<(String, HashSet<SocketAddr>)>, HashSet<String>) = results
-            .into_iter()
-            .partition_map(|(domain, result)| match result {
-                Ok(addresses) => Either::Left((domain, HashSet::from_iter(addresses))),
-                Err(_) => Either::Right(domain),
-            });
+        let mut overrides = HashMap::new();
+        let mut failed_primaries = HashSet::new();
+        let mut failed_fronts = HashSet::new();
+        let mut resolved_any_primary = false;
 
-        if failures.is_empty() {
-            tracing::debug!(
-                "Successfully resolved domains in parallel: {:?}",
-                successes.iter().map(|v| v.0.as_str()).collect::<Vec<_>>()
-            );
-
-            Ok(Self {
-                overrides: HashMap::from_iter(successes),
-            })
-        } else {
-            // At least one resolution failed.
-            tracing::warn!("Failed to resolve one or more URLs: {:?}", failures);
-
-            Err(VpnApiClientError::HostnamesResolutionError {
-                hostnames: failures,
-            })
+        for (domain, is_primary, result) in results {
+            match result {
+                Ok(addresses) => {
+                    resolved_any_primary |= is_primary;
+                    overrides.insert(domain, HashSet::from_iter(addresses));
+                }
+                Err(_) if is_primary => {
+                    failed_primaries.insert(domain);
+                }
+                Err(_) => {
+                    failed_fronts.insert(domain);
+                }
+            }
         }
+
+        if !failed_fronts.is_empty() {
+            tracing::warn!(
+                "Ignoring unresolvable fronting domain(s), continuing without them as fallback routes: {:?}",
+                failed_fronts
+            );
+        }
+
+        if spawned_any && !resolved_any_primary {
+            tracing::warn!(
+                "Failed to resolve any usable primary API URL: {:?}",
+                failed_primaries
+            );
+            return Err(VpnApiClientError::HostnamesResolutionError {
+                hostnames: failed_primaries,
+            });
+        }
+
+        if !failed_primaries.is_empty() {
+            tracing::warn!(
+                "Failed to resolve some primary API URL(s), continuing with the remaining ones: {:?}",
+                failed_primaries
+            );
+        }
+
+        tracing::debug!(
+            "Successfully resolved domains in parallel: {:?}",
+            overrides.keys().collect::<Vec<_>>()
+        );
+
+        Ok(Self { overrides })
     }
 
     /// Create resolver overrides from the provided ApiUrls
@@ -174,7 +208,9 @@ mod test {
     }
 
     #[tokio::test]
-    async fn overrides_return_error() -> Result<(), VpnApiClientError> {
+    async fn unresolvable_front_is_tolerated() -> Result<(), VpnApiClientError> {
+        // A front is only ever a fallback route. If it fails to resolve but the primary
+        // URLs are fine, the call should still succeed, just without that front available.
         let urls: Vec<Url> = vec![
             Url::new("https://nymvpn.com", None).unwrap(),
             Url::new(
@@ -184,11 +220,31 @@ mod test {
             .unwrap(),
         ];
 
+        let overrides = ResolverOverrides::from_urls(&urls).await?;
+        assert!(overrides.addresses("nymvpn.com").is_some());
+        assert!(overrides.addresses("validator.nymtech.net").is_some());
+        assert!(overrides.addresses("non-existent.nymtech.net").is_none());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn overrides_return_error_when_no_primary_resolves() -> Result<(), VpnApiClientError> {
+        let urls: Vec<Url> = vec![
+            Url::new("https://non-existent-1.nymtech.net", None).unwrap(),
+            Url::new(
+                "https://non-existent-2.nymtech.net",
+                Some(vec!["https://non-existent-3.nymtech.net"]),
+            )
+            .unwrap(),
+        ];
+
         let result = ResolverOverrides::from_urls(&urls).await;
         assert!(result.is_err());
 
         let mut expected = HashSet::new();
-        expected.insert("non-existent.nymtech.net".to_string());
+        expected.insert("non-existent-1.nymtech.net".to_string());
+        expected.insert("non-existent-2.nymtech.net".to_string());
         match result {
             Ok(_) => panic!("unreachable"),
             Err(VpnApiClientError::HostnamesResolutionError { hostnames }) => {

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/types/resolver_overrides.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/types/resolver_overrides.rs
@@ -132,6 +132,73 @@ impl ResolverOverrides {
         Self::from_urls(&urls).await
     }
 
+    /// Resolve the given URLs and return a pruned copy with every front that failed to
+    /// resolve removed, and any candidate whose primary and every front failed to resolve
+    /// dropped entirely.
+    ///
+    /// This lets an HTTP client built from the result never attempt a host we already know
+    /// is unreachable, instead of finding out at request time (DNS lookup, then most likely
+    /// a firewall-blocked connection attempt).
+    ///
+    /// Never errors: if resolution fails so completely that pruning would leave nothing at
+    /// all, the original, unpruned list is returned so callers still have something to try.
+    pub async fn resolve_and_prune(urls: &[Url]) -> Vec<Url> {
+        match Self::from_urls(urls).await {
+            Ok(overrides) => {
+                let pruned = Self::prune(urls, &overrides);
+                if pruned.is_empty() && !urls.is_empty() {
+                    tracing::warn!(
+                        "Pruning unresolvable API URLs would leave none usable; keeping the original list instead"
+                    );
+                    urls.to_vec()
+                } else {
+                    pruned
+                }
+            }
+            Err(_) => urls.to_vec(),
+        }
+    }
+
+    /// Filter out fronts (and whole candidates) that `overrides` couldn't resolve.
+    pub fn prune(urls: &[Url], overrides: &ResolverOverrides) -> Vec<Url> {
+        urls.iter()
+            .filter_map(|url| {
+                let primary_resolved = url
+                    .inner_url()
+                    .domain()
+                    .is_some_and(|domain| overrides.addresses(domain).is_some());
+
+                let resolved_fronts: Vec<url::Url> = url
+                    .fronts()
+                    .unwrap_or_default()
+                    .iter()
+                    .filter(|front| {
+                        front
+                            .domain()
+                            .is_some_and(|domain| overrides.addresses(domain).is_some())
+                    })
+                    .cloned()
+                    .collect();
+
+                if !primary_resolved && resolved_fronts.is_empty() {
+                    tracing::warn!(
+                        "Dropping unusable API URL '{url}': neither its primary domain nor any of its fronts could be resolved"
+                    );
+                    return None;
+                }
+
+                Url::new(
+                    url.inner_url().clone(),
+                    (!resolved_fronts.is_empty()).then_some(resolved_fronts),
+                )
+                .inspect_err(|err| {
+                    tracing::warn!("Failed to rebuild pruned URL for '{url}': {err}")
+                })
+                .ok()
+            })
+            .collect()
+    }
+
     /// Extend the current overrides with another set of overrides.
     pub fn extend(&mut self, other: &ResolverOverrides) {
         for (domain, addresses) in other.overrides.iter() {
@@ -255,5 +322,63 @@ mod test {
             Err(e) => panic!("unexpected err: {e}"),
         }
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn prune_drops_unresolvable_front_but_keeps_working_candidates() {
+        let urls: Vec<Url> = vec![
+            Url::new("https://nymvpn.com", None).unwrap(),
+            Url::new(
+                "https://validator.nymtech.net",
+                Some(vec!["https://non-existent.nymtech.net"]),
+            )
+            .unwrap(),
+        ];
+
+        let pruned = ResolverOverrides::resolve_and_prune(&urls).await;
+        assert_eq!(pruned.len(), 2);
+
+        let validator = pruned
+            .iter()
+            .find(|url| url.inner_url().domain() == Some("validator.nymtech.net"))
+            .expect("validator.nymtech.net should still be present");
+        assert!(validator.fronts().unwrap_or_default().is_empty());
+
+        let nymvpn = pruned
+            .iter()
+            .find(|url| url.inner_url().domain() == Some("nymvpn.com"))
+            .expect("nymvpn.com should still be present");
+        assert!(nymvpn.fronts().unwrap_or_default().is_empty());
+    }
+
+    #[tokio::test]
+    async fn prune_drops_candidate_with_no_resolvable_route() {
+        let urls: Vec<Url> = vec![
+            Url::new("https://nymvpn.com", None).unwrap(),
+            Url::new(
+                "https://non-existent-1.nymtech.net",
+                Some(vec!["https://non-existent-2.nymtech.net"]),
+            )
+            .unwrap(),
+        ];
+
+        let pruned = ResolverOverrides::resolve_and_prune(&urls).await;
+        assert_eq!(pruned.len(), 1);
+        assert_eq!(pruned[0].inner_url().domain(), Some("nymvpn.com"));
+    }
+
+    #[tokio::test]
+    async fn resolve_and_prune_falls_back_to_original_when_nothing_resolves() {
+        let urls: Vec<Url> = vec![
+            Url::new("https://non-existent-1.nymtech.net", None).unwrap(),
+            Url::new(
+                "https://non-existent-2.nymtech.net",
+                Some(vec!["https://non-existent-3.nymtech.net"]),
+            )
+            .unwrap(),
+        ];
+
+        let pruned = ResolverOverrides::resolve_and_prune(&urls).await;
+        assert_eq!(pruned.len(), urls.len());
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/types/resolver_overrides.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/types/resolver_overrides.rs
@@ -31,20 +31,22 @@ impl ResolverOverrides {
 
         tracing::debug!("getting overrides for {urls:?}");
 
-        // Track, for each unique domain, whether it is a primary endpoint for at least one
-        // candidate, as opposed to only ever appearing as a fronting decoy.
-        let mut candidates: HashMap<url::Url, bool> = HashMap::new();
-        for url in urls {
-            candidates.insert(url.inner_url().clone(), true);
-        }
-        for url in urls {
-            for front in url.fronts().unwrap_or_default() {
-                candidates.entry(front.clone()).or_insert(false);
-            }
-        }
+        // A domain counts as primary if it's the primary URL for at least one candidate,
+        // as opposed to only ever appearing as a fronting decoy.
+        let primaries: HashSet<url::Url> = urls.iter().map(|url| url.inner_url().clone()).collect();
+
+        let candidates: HashSet<url::Url> = urls
+            .iter()
+            .flat_map(|url| {
+                [url.inner_url().clone()]
+                    .into_iter()
+                    .chain(url.fronts().unwrap_or_default().iter().cloned())
+            })
+            .collect();
 
         let mut spawned_any = false;
-        for (url, is_primary) in candidates {
+        for url in candidates {
+            let is_primary = primaries.contains(&url);
             let Some(domain) = url.domain().map(|s| s.to_owned()) else {
                 tracing::warn!(
                     "Ignoring API URL '{}' for resolver overrides as it does not have a valid domain",

--- a/nym-vpn-core/crates/nym-vpn-api-client/tests/account_summary_data_unavailable.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/tests/account_summary_data_unavailable.rs
@@ -85,6 +85,7 @@ async fn account_summary_with_device_round_trips_data_unavailable() {
         vec![url],
         Some(UserAgent::from_str("nym-test/0.1.0/ci/wiremock").expect("user agent")),
     )
+    .await
     .expect("vpn api client");
 
     let account = VpnAccount::new(

--- a/nym-vpn-core/crates/nym-vpn-api-client/tests/delete_device.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/tests/delete_device.rs
@@ -25,13 +25,14 @@ impl Match for HeaderAbsent {
     }
 }
 
-fn client_and_account(server: &MockServer) -> (VpnApiClient, VpnAccount) {
+async fn client_and_account(server: &MockServer) -> (VpnApiClient, VpnAccount) {
     let base = format!("{}/", server.uri().trim_end_matches('/'));
     let url = Url::new(&base, None).expect("base url");
     let client = VpnApiClient::new(
         vec![url],
         Some(UserAgent::from_str("nym-test/0.1.0/ci/wiremock").expect("user agent")),
     )
+    .await
     .expect("vpn api client");
     let account = VpnAccount::new(
         Mnemonic::parse(TEST_MNEMONIC).expect("mnemonic"),
@@ -44,7 +45,7 @@ fn client_and_account(server: &MockServer) -> (VpnApiClient, VpnAccount) {
 #[tokio::test]
 async fn delete_device_uses_account_auth_only() {
     let server = MockServer::start().await;
-    let (client, account) = client_and_account(&server);
+    let (client, account) = client_and_account(&server).await;
     let device_identity = "SomeOrphanedDeviceIdentityKey";
     let expected_path = format!(
         "/public/v1/account/{}/device/{device_identity}",
@@ -72,7 +73,7 @@ async fn delete_device_uses_account_auth_only() {
 #[tokio::test]
 async fn delete_device_propagates_non_success_response() {
     let server = MockServer::start().await;
-    let (client, account) = client_and_account(&server);
+    let (client, account) = client_and_account(&server).await;
 
     Mock::given(method("PATCH"))
         .respond_with(ResponseTemplate::new(500).set_body_json(serde_json::json!({

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/gateway_cache.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/gateway_cache.rs
@@ -56,8 +56,9 @@ impl NymGatewayCache {
         .map_err(|e| VpnError::InternalError {
             details: format!("Failed to create config: {e:#?}"),
         })?;
-        let gateway_client =
-            GatewayClient::new(directory_config, user_agent.into()).map_err(VpnError::internal)?;
+        let gateway_client = GatewayClient::new(directory_config, user_agent.into())
+            .await
+            .map_err(VpnError::internal)?;
         let (gateway_cache_handle, join_handle) = GatewayCache::spawn(
             gateway_client,
             offline_monitor.inner(),

--- a/nym-vpn-core/crates/nym-vpn-lib/src/cache_refresh.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/cache_refresh.rs
@@ -75,7 +75,7 @@ pub async fn update_caches_for_network(
         }
     };
 
-    let new_gateway_client = match GatewayClient::new(gateway_config, user_agent.clone()) {
+    let new_gateway_client = match GatewayClient::new(gateway_config, user_agent.clone()).await {
         Ok(client) => client,
         Err(e) => {
             tracing::error!(

--- a/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/topology_service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/mixnet/topology_service.rs
@@ -191,6 +191,7 @@ impl VpnTopologyService {
             Some(self.user_agent.clone()),
             None,
         )
+        .await
         .map_err(VpnTopologyServiceError::CreateHttpClient)?;
 
         let mut topology_provider = NymApiTopologyProvider::new(

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
@@ -529,6 +529,7 @@ impl NymVpnService {
             api_urls_to_urls(&skew_time_provider_urls).map_err(Error::ConvertApiUrls)?,
             Some(parameters.user_agent.clone()),
         )
+        .await
         .map_err(Error::CreateApiClient)?;
         let skew_manager = nym_vpn_api_client::SkewManager::new(skew_time_provider);
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
@@ -629,6 +629,7 @@ impl NymVpnService {
 
         let gateway_directory_client =
             GatewayClient::new(gateway_config, parameters.user_agent.clone())
+                .await
                 .map_err(Error::CreateGatewayClient)?;
         let (gateway_cache_handle, gateway_cache_join_handle) = GatewayCache::spawn(
             gateway_directory_client.clone(),

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/tests/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/tests/mod.rs
@@ -180,9 +180,9 @@ fn new_mainnet() -> Config {
     .unwrap()
 }
 
-fn mainnet_gateway_client() -> GatewayClient {
+async fn mainnet_gateway_client() -> GatewayClient {
     let config = new_mainnet();
-    GatewayClient::new(config, user_agent()).unwrap()
+    GatewayClient::new(config, user_agent()).await.unwrap()
 }
 
 pub fn default_tunnel_settings() -> TunnelSettings {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -434,6 +434,7 @@ impl TunnelMonitor {
         let user_agent = self.tunnel_parameters.user_agent.clone();
         let gateway_directory_client =
             GatewayClient::new(gateway_config.clone(), user_agent.clone())
+                .await
                 .map_err(Error::GatewayDirectoryClient)?;
 
         self.gateway_provider

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/discovery.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/discovery.rs
@@ -201,7 +201,9 @@ mod tests {
     }
 
     async fn test_discovery_equality(discovery: Discovery) {
-        let fetcher = Fetcher::new(Discovery::default_mainnet(), None).unwrap();
+        let fetcher = Fetcher::new(Discovery::default_mainnet(), None)
+            .await
+            .unwrap();
         let fetched = fetcher
             .fetch_discovery(&discovery.network_name)
             .await

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/envs.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/envs.rs
@@ -103,7 +103,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_envs_default_same_as_fetched() {
-        let fetcher = Fetcher::new(Discovery::default_mainnet(), None).unwrap();
+        let fetcher = Fetcher::new(Discovery::default_mainnet(), None)
+            .await
+            .unwrap();
         let default_envs = RegisteredNetworks::default();
         let fetched_envs = fetcher.fetch_registered_networks().await.unwrap();
 

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/fetcher.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/fetcher.rs
@@ -23,24 +23,24 @@ pub struct Fetcher {
 
 impl Fetcher {
     /// Create an instance of `Fetcher` using HTTP API endpoints from the given discovery.
-    pub fn new(discovery: Discovery, user_agent: Option<UserAgent>) -> Result<Self> {
+    pub async fn new(discovery: Discovery, user_agent: Option<UserAgent>) -> Result<Self> {
         Ok(Self {
             user_agent: user_agent.clone(),
-            api_client: build_api_client(&discovery, user_agent.clone())?,
-            vpn_api_client: build_vpn_api_client(&discovery, user_agent)?,
+            api_client: build_api_client(&discovery, user_agent.clone()).await?,
+            vpn_api_client: build_vpn_api_client(&discovery, user_agent).await?,
             discovery: Box::new(discovery),
         })
     }
 
     /// Update internal discovery used by the fetcher.
     /// This causes recreation of the underlying HTTP API clients.
-    pub(crate) fn set_discovery(&mut self, new_discovery: Discovery) -> Result<()> {
+    pub(crate) async fn set_discovery(&mut self, new_discovery: Discovery) -> Result<()> {
         if *self.discovery == new_discovery {
             return Ok(());
         }
 
-        self.api_client = build_api_client(&new_discovery, self.user_agent.clone())?;
-        self.vpn_api_client = build_vpn_api_client(&new_discovery, self.user_agent.clone())?;
+        self.api_client = build_api_client(&new_discovery, self.user_agent.clone()).await?;
+        self.vpn_api_client = build_vpn_api_client(&new_discovery, self.user_agent.clone()).await?;
         *self.discovery = new_discovery;
 
         Ok(())
@@ -79,22 +79,28 @@ impl Fetcher {
     }
 }
 
-fn build_api_client(discovery: &Discovery, user_agent: Option<UserAgent>) -> Result<HttpApiClient> {
+async fn build_api_client(
+    discovery: &Discovery,
+    user_agent: Option<UserAgent>,
+) -> Result<HttpApiClient> {
     let api_urls =
         api_urls_to_urls(&discovery.nym_api_urls()).map_err(Error::CreateVpnApiClient)?;
 
     fronted_http_client::fronted_http_client(api_urls, user_agent, Some(NETWORK_TIMEOUT))
+        .await
         .map_err(Error::CreateVpnApiClient)
 }
 
-fn build_vpn_api_client(
+async fn build_vpn_api_client(
     discovery: &Discovery,
     user_agent: Option<UserAgent>,
 ) -> Result<VpnApiClient> {
     let vpn_api_urls =
         api_urls_to_urls(&discovery.nym_vpn_api_urls()).map_err(Error::CreateVpnApiClient)?;
 
-    VpnApiClient::new(vpn_api_urls, user_agent).map_err(Error::CreateVpnApiClient)
+    VpnApiClient::new(vpn_api_urls, user_agent)
+        .await
+        .map_err(Error::CreateVpnApiClient)
 }
 
 #[cfg(test)]
@@ -104,7 +110,9 @@ mod tests {
     #[tokio::test]
     async fn test_discovery_fetch() {
         let network_name = "mainnet";
-        let fetcher = Fetcher::new(Discovery::default_mainnet(), None).unwrap();
+        let fetcher = Fetcher::new(Discovery::default_mainnet(), None)
+            .await
+            .unwrap();
         let discovery = fetcher.fetch_discovery(network_name).await.unwrap();
         assert_eq!(discovery.network_name, network_name);
     }

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/lib.rs
@@ -248,7 +248,7 @@ impl NetworkCache {
                     }
                 })?;
 
-        let fetcher = Fetcher::new(persistent_discovery.value().clone(), user_agent)?;
+        let fetcher = Fetcher::new(persistent_discovery.value().clone(), user_agent).await?;
 
         Ok(Self {
             cache_dir,
@@ -273,7 +273,7 @@ impl NetworkCache {
 
             // Update fetcher discovery so that it could pick up new API endpoints if they changed.
             if new_discovery != *self.persistent_discovery.value()
-                && let Err(err) = self.fetcher.set_discovery(new_discovery.clone())
+                && let Err(err) = self.fetcher.set_discovery(new_discovery.clone()).await
             {
                 trace_err_chain!(err, "failed to update fetcher discovery");
             }

--- a/nym-vpn-core/crates/test/test-manager/src/run_tests.rs
+++ b/nym-vpn-core/crates/test/test-manager/src/run_tests.rs
@@ -2,13 +2,13 @@
 // Copyright 2025 Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use crate::vm::ssh::SSHSession;
 use crate::{
     logging::{Logger, Panic, TestOutput, TestResult},
     nym_daemon::{self, RpcClientProvider},
     summary::SummaryLogger,
     tests::{TestContext, TestMetadata, TestWrapperFunctionNym},
     vm,
+    vm::ssh::SSHSession,
 };
 use anyhow::{Context, Result};
 use futures::FutureExt;

--- a/nym-vpn-core/crates/test/test-manager/src/tests/helpers_nym.rs
+++ b/nym-vpn-core/crates/test/test-manager/src/tests/helpers_nym.rs
@@ -1118,9 +1118,7 @@ mod tests {
     use crate::tests::{Error, WAIT_FOR_TUNNEL_CONNECTED_TIMEOUT, WAIT_FOR_TUNNEL_STATE_TIMEOUT};
     use futures::StreamExt;
     use nym_vpn_proto::rpc_client::Error as NymClientError;
-    use std::cell::Cell;
-    use std::collections::VecDeque;
-    use std::sync::Mutex;
+    use std::{cell::Cell, collections::VecDeque, sync::Mutex};
 
     fn sample_addr() -> std::net::SocketAddr {
         "93.184.216.34:443"


### PR DESCRIPTION
- `ResolverOverrides::from_urls` now tracks each candidate domain as either a primary endpoint or a front (decoy fallback), instead of flattening them into one undifferentiated set.
- A front that fails to resolve is dropped and logged as a warning; it just won't be available as a fallback route.
- The whole call only fails (`HostnamesResolutionError`) if no primary URL at all resolved, meaning there's truly no usable route.
- If some but not all primaries resolve, it proceeds with what worked and logs a warning about the ones that didn't.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6068)
<!-- Reviewable:end -->
