### PR TITLE
[Apple] Fix display for GeoExclusion port

### DIFF
--- a/nym-vpn-apple/Settings/Sources/Settings/GeoExclusion/GeoExclusionView.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/GeoExclusion/GeoExclusionView.swift
@@ -105,7 +105,7 @@ private extension GeoExclusionView {
                         .foregroundStyle(Color.Nym.textSecondary)
                         .nymTextStyle(.bodyDefault)
                     Spacer()
-                    Text("\(viewModel.listenPort)")
+                    Text(String(viewModel.listenPort))
                         .foregroundStyle(Color.Nym.textPrimary)
                         .font(Font.custom("Courier New", size: 15))
                         .kerning(0.3)


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

Fix display format for GeoExclusion port


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6070)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the display of the SOCKS5 listen port in Geo-Exclusion settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->