### PR TITLE
Bump nym core deps to Amsterdam tip

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -3733,7 +3733,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -5099,7 +5099,7 @@ dependencies = [
 [[package]]
 name = "nym-api-requests"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "bs58",
  "celes",
@@ -5152,7 +5152,7 @@ dependencies = [
 [[package]]
 name = "nym-authenticator-client"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "bincode",
  "futures",
@@ -5176,7 +5176,7 @@ dependencies = [
 [[package]]
 name = "nym-authenticator-requests"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -5200,7 +5200,7 @@ dependencies = [
 [[package]]
 name = "nym-bandwidth-controller"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "async-trait",
  "log",
@@ -5222,7 +5222,7 @@ dependencies = [
 [[package]]
 name = "nym-bandwidth-fetcher"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5244,7 +5244,7 @@ dependencies = [
 [[package]]
 name = "nym-bin-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "const-str",
  "log",
@@ -5286,7 +5286,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5347,7 +5347,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-config-types"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "humantime-serde",
  "nym-config",
@@ -5363,7 +5363,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-gateways-storage"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5383,7 +5383,7 @@ dependencies = [
 [[package]]
 name = "nym-client-core-surb-storage"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5402,7 +5402,7 @@ dependencies = [
 [[package]]
 name = "nym-coconut-dkg-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -5416,7 +5416,7 @@ dependencies = [
 [[package]]
 name = "nym-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "tracing",
  "tracing-test",
@@ -5433,7 +5433,7 @@ dependencies = [
 [[package]]
 name = "nym-compact-ecash"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "bincode",
  "bs58",
@@ -5456,7 +5456,7 @@ dependencies = [
 [[package]]
 name = "nym-config"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "dirs",
  "handlebars",
@@ -5489,7 +5489,7 @@ dependencies = [
 [[package]]
 name = "nym-contracts-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -5504,7 +5504,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-proxy-requests"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "async-trait",
  "nym-credentials",
@@ -5525,7 +5525,7 @@ dependencies = [
 [[package]]
 name = "nym-credential-storage"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5546,7 +5546,7 @@ dependencies = [
 [[package]]
 name = "nym-credentials"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "bincode",
  "cosmrs",
@@ -5572,7 +5572,7 @@ dependencies = [
 [[package]]
 name = "nym-credentials-interface"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "nym-bls12_381-fork",
  "nym-compact-ecash",
@@ -5591,7 +5591,7 @@ dependencies = [
 [[package]]
 name = "nym-crypto"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "aead",
  "aes 0.8.4",
@@ -5711,7 +5711,7 @@ dependencies = [
 [[package]]
 name = "nym-ecash-contract-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -5725,7 +5725,7 @@ dependencies = [
 [[package]]
 name = "nym-ecash-signer-check-types"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "nym-coconut-dkg-common",
  "nym-crypto",
@@ -5741,7 +5741,7 @@ dependencies = [
 [[package]]
 name = "nym-ecash-time"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "nym-compact-ecash",
  "time",
@@ -5759,7 +5759,7 @@ dependencies = [
 [[package]]
 name = "nym-exit-policy"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "serde",
  "serde_json",
@@ -5830,7 +5830,7 @@ dependencies = [
 [[package]]
 name = "nym-gateway-client"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "futures",
  "getrandom 0.2.17",
@@ -5895,7 +5895,7 @@ dependencies = [
 [[package]]
 name = "nym-gateway-requests"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "bs58",
  "futures",
@@ -5925,7 +5925,7 @@ dependencies = [
 [[package]]
 name = "nym-group-contract-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "cosmwasm-schema",
  "cw-controllers",
@@ -5937,7 +5937,7 @@ dependencies = [
 [[package]]
 name = "nym-http-api-client"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5971,7 +5971,7 @@ dependencies = [
 [[package]]
 name = "nym-http-api-client-macro"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5983,7 +5983,7 @@ dependencies = [
 [[package]]
 name = "nym-http-api-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "bincode",
  "serde",
@@ -5994,7 +5994,7 @@ dependencies = [
 [[package]]
 name = "nym-id"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "nym-credential-storage",
  "nym-credentials",
@@ -6022,7 +6022,7 @@ dependencies = [
 [[package]]
 name = "nym-ip-packet-client"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "bincode",
  "bytes",
@@ -6039,7 +6039,7 @@ dependencies = [
 [[package]]
 name = "nym-ip-packet-requests"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "bincode",
  "bytes",
@@ -6087,7 +6087,7 @@ dependencies = [
 [[package]]
 name = "nym-kkt"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "libcrux-chacha20poly1305",
  "libcrux-ecdh",
@@ -6108,7 +6108,7 @@ dependencies = [
 [[package]]
 name = "nym-kkt-ciphersuite"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "blake3",
  "libcrux-sha3",
@@ -6122,7 +6122,7 @@ dependencies = [
 [[package]]
 name = "nym-kkt-context"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "num_enum",
  "nym-kkt-ciphersuite",
@@ -6132,7 +6132,7 @@ dependencies = [
 [[package]]
 name = "nym-lp"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "bs58",
  "bytes",
@@ -6153,7 +6153,7 @@ dependencies = [
 [[package]]
 name = "nym-lp-data"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "bytes",
  "num_enum",
@@ -6174,7 +6174,7 @@ dependencies = [
 [[package]]
 name = "nym-metrics"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "dashmap",
  "lazy_static",
@@ -6185,7 +6185,7 @@ dependencies = [
 [[package]]
 name = "nym-mixnet-client"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "dashmap",
  "futures",
@@ -6203,7 +6203,7 @@ dependencies = [
 [[package]]
 name = "nym-mixnet-contract-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "bs58",
  "cosmwasm-schema",
@@ -6224,7 +6224,7 @@ dependencies = [
 [[package]]
 name = "nym-multisig-contract-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -6240,7 +6240,7 @@ dependencies = [
 [[package]]
 name = "nym-network-defaults"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "cargo_metadata 0.19.2",
  "dotenvy",
@@ -6256,7 +6256,7 @@ dependencies = [
 [[package]]
 name = "nym-network-monitors-contract-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -6269,7 +6269,7 @@ dependencies = [
 [[package]]
 name = "nym-node-families-contract-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -6285,7 +6285,7 @@ dependencies = [
 [[package]]
 name = "nym-node-requests"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "celes",
  "humantime-serde",
@@ -6310,7 +6310,7 @@ dependencies = [
 [[package]]
 name = "nym-noise"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -6331,7 +6331,7 @@ dependencies = [
 [[package]]
 name = "nym-noise-keys"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "nym-crypto",
  "schemars 0.8.22",
@@ -6342,7 +6342,7 @@ dependencies = [
 [[package]]
 name = "nym-nonexhaustive-delayqueue"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -6372,7 +6372,7 @@ dependencies = [
 [[package]]
 name = "nym-ordered-buffer"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "log",
  "thiserror 2.0.18",
@@ -6381,7 +6381,7 @@ dependencies = [
 [[package]]
 name = "nym-outfox"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "blake3",
  "chacha20 0.9.1",
@@ -6395,7 +6395,7 @@ dependencies = [
 [[package]]
 name = "nym-pemstore"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "pem",
  "tracing",
@@ -6405,7 +6405,7 @@ dependencies = [
 [[package]]
 name = "nym-performance-contract-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -6433,7 +6433,7 @@ dependencies = [
 [[package]]
 name = "nym-registration-client"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "bincode",
  "bytes",
@@ -6461,7 +6461,7 @@ dependencies = [
 [[package]]
 name = "nym-registration-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "bincode",
  "nym-authenticator-requests",
@@ -6498,7 +6498,7 @@ dependencies = [
 [[package]]
 name = "nym-sdk"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6557,7 +6557,7 @@ dependencies = [
 [[package]]
 name = "nym-serde-helpers"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -6569,7 +6569,7 @@ dependencies = [
 [[package]]
 name = "nym-service-provider-requests-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -6578,7 +6578,7 @@ dependencies = [
 [[package]]
 name = "nym-service-providers-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "async-trait",
  "log",
@@ -6602,7 +6602,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-client-core"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "anyhow",
  "dirs",
@@ -6662,7 +6662,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-proxy-helpers"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "bytes",
  "futures",
@@ -6685,7 +6685,7 @@ dependencies = [
 [[package]]
 name = "nym-socks5-requests"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "bincode",
  "log",
@@ -6701,7 +6701,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "nym-crypto",
  "nym-metrics",
@@ -6727,7 +6727,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-acknowledgements"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "nym-crypto",
  "nym-pemstore",
@@ -6744,7 +6744,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-addressing"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-types",
@@ -6755,7 +6755,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-anonymous-replies"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "bs58",
  "nym-crypto",
@@ -6773,7 +6773,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-chunking"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "dashmap",
  "log",
@@ -6792,7 +6792,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-cover"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-acknowledgements",
@@ -6810,7 +6810,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-forwarding"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "nym-sphinx-addressing",
  "nym-sphinx-anonymous-replies",
@@ -6822,7 +6822,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-framing"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -6839,7 +6839,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-params"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-types",
@@ -6850,7 +6850,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-routing"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "nym-sphinx-addressing",
  "nym-sphinx-types",
@@ -6860,7 +6860,7 @@ dependencies = [
 [[package]]
 name = "nym-sphinx-types"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "nym-outfox",
  "sphinx-packet",
@@ -6909,7 +6909,7 @@ dependencies = [
 [[package]]
 name = "nym-sqlx-pool-guard"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "proc_pidinfo",
  "sqlx",
@@ -6953,7 +6953,7 @@ dependencies = [
 [[package]]
 name = "nym-statistics-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "futures",
  "log",
@@ -6978,7 +6978,7 @@ dependencies = [
 [[package]]
 name = "nym-task"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "cfg-if",
  "futures",
@@ -6995,7 +6995,7 @@ dependencies = [
 [[package]]
 name = "nym-ticketbooks-merkle"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "nym-credentials-interface",
  "nym-serde-helpers",
@@ -7010,7 +7010,7 @@ dependencies = [
 [[package]]
 name = "nym-topology"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "async-trait",
  "nym-api-requests",
@@ -7030,7 +7030,7 @@ dependencies = [
 [[package]]
 name = "nym-upgrade-mode-check"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "jwt-simple",
  "nym-crypto",
@@ -7047,7 +7047,7 @@ dependencies = [
 [[package]]
 name = "nym-validator-client"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7099,7 +7099,7 @@ dependencies = [
 [[package]]
 name = "nym-vesting-contract-common"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -7553,7 +7553,7 @@ dependencies = [
 [[package]]
 name = "nym-wasm-utils"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "futures",
  "getrandom 0.2.17",
@@ -7617,7 +7617,7 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-private-metadata-client"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "async-trait",
  "nym-http-api-client",
@@ -7628,7 +7628,7 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-private-metadata-shared"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "axum",
  "bincode",
@@ -7642,7 +7642,7 @@ dependencies = [
 [[package]]
 name = "nym-wireguard-types"
 version = "1.21.4"
-source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#ab72e03625ef09a1c50dd22bd99494a3c340b2c7"
+source = "git+https://github.com/nymtech/nym?branch=vpn%2Frelease%2F2026.14-amsterdam#63f54fc8d3e9f080004aa54abd7282dfad24ef59"
 dependencies = [
  "base64 0.22.1",
  "nym-crypto",
@@ -8666,7 +8666,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -8687,7 +8687,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8700,7 +8700,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10158,7 +10158,7 @@ version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
- "errno 0.2.8",
+ "errno 0.3.14",
  "libc",
 ]
 


### PR DESCRIPTION
## Summary
- Updates `nym-vpn-core/Cargo.lock` so Amsterdam nym git deps move from `ab72e036` to `63f54fc8` (merge of nym#7045).
- Embeds the edge1.streaming-gateway.com → 139.162.57.231 static pin in client builds that use this lock.
- Cargo.toml already pointed at `vpn/release/2026.14-amsterdam`; builds use the locked rev, so a lock bump was required (not automatic on a normal core build).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6072)
<!-- Reviewable:end -->
