### PR TITLE
Configuration profiles

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/lib.rs
@@ -43,6 +43,7 @@ mod network;
 mod network_stats;
 mod paths;
 mod privy;
+mod profile;
 mod rpc_requests;
 mod service;
 mod socks5;
@@ -95,6 +96,7 @@ pub use network::{
 pub use network_stats::{NetworkStatisticsConfig, NetworkStatisticsIdentity};
 pub use paths::LogPath;
 pub use privy::PrivyDerivationMessage;
+pub use profile::{Profile, ProfileOptions};
 pub use rpc_requests::{
     AccountBalanceResponse, AccountCommandResponse, Coin, ListGatewaysOptions, StoreAccountRequest,
 };

--- a/nym-vpn-core/crates/nym-vpn-lib-types/src/profile.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/src/profile.rs
@@ -1,0 +1,34 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+#[cfg(feature = "typescript-bindings")]
+use ts_rs::TS;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "uniffi-bindings", derive(uniffi::Enum))]
+#[cfg_attr(
+    feature = "typescript-bindings",
+    derive(TS),
+    ts(export),
+    ts(export_to = "bindings.ts")
+)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "typescript-bindings", serde(rename_all = "camelCase"))]
+pub enum Profile {
+    // 2 hop configuration with automatic selection with different jurisdictions.
+    Safest,
+    // 5 hop configuration with automatic selection with different jurisdictions.
+    MostPrivate,
+    // 2 hop configuration with automatic selection regardless of jurisdiction.
+    Fastest,
+    // 2 hop configuration with random servers.
+    Random,
+}
+
+#[derive(Debug)]
+#[cfg_attr(feature = "uniffi-bindings", derive(uniffi::Record))]
+pub struct ProfileOptions {
+    pub profile: Profile,
+}

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/mobile.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/mobile.rs
@@ -13,7 +13,7 @@ use tokio::runtime::Runtime;
 use nym_vpn_lib_types::{
     DiagnosticRunParams, EntryPoint, ExitPoint, FrontingMode, GatewayIndependence,
     GatewaySelectionAlgorithmConfig, GeoExclusionSettings, MixnetTrafficConfig,
-    NetworkStatisticsConfig, PrivyDerivationMessage, SplitTunnelSettings, UserAgent,
+    NetworkStatisticsConfig, PrivyDerivationMessage, Profile, SplitTunnelSettings, UserAgent,
     VpnServiceConfig,
 };
 
@@ -60,6 +60,21 @@ pub async fn runDiagnostic(
         .await
         .map_err(VpnError::internal)?;
     serde_json::to_string_pretty(&report).map_err(VpnError::internal)
+}
+
+#[allow(non_snake_case)]
+#[uniffi::export]
+pub fn applyProfileToConfig(mut config: VPNConfig, profile: Profile) -> VPNConfig {
+    let profile_specifics = nym_vpn_lib::service::ProfileSpecifics::from(profile);
+    config.entry_gateway = profile_specifics.entry_point;
+    config.exit_router = profile_specifics.exit_point;
+    config.enable_two_hop = matches!(
+        profile_specifics.tunnel_type,
+        nym_vpn_lib_types::TunnelType::Wireguard
+    );
+    config.fronting_mode = profile_specifics.fronting_mode;
+
+    config
 }
 
 #[derive(uniffi::Record)]

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/rpc.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/rpc.rs
@@ -14,12 +14,10 @@ use nym_vpn_lib_types::{
     AccountCommandError, AccountControllerState, AutologinResponse, EntryPoint, ExitPoint,
     FeatureFlags, FrontingMode, Gateway, GatewayType, GetDeeplinkParams, HttpRpcSettings, LogPath,
     MixnetTrafficConfig, NetworkCompatibility, NymVpnDevice, NymVpnUsage, ParsedAccountLinks,
-    PrivyDerivationMessage, RecentGateways, Socks5Settings, Socks5Status, StoreAccountRequest,
-    StoredAccountMode, SystemMessage, TunnelEvent, TunnelState, TunnelType, VpnAccountSummary,
-    VpnServiceConfig, VpnServiceInfo,
+    PrivyDerivationMessage, Profile, RecentGateways, Socks5Settings, Socks5Status, SplitApp,
+    SplitTunnelExcludedProcessList, StoreAccountRequest, StoredAccountMode, SystemMessage,
+    TunnelEvent, TunnelState, TunnelType, VpnAccountSummary, VpnServiceConfig, VpnServiceInfo,
 };
-#[cfg(target_os = "macos")]
-use nym_vpn_lib_types::{SplitApp, SplitTunnelExcludedProcessList};
 
 #[derive(Clone, uniffi::Object)]
 struct RpcClient {
@@ -450,7 +448,6 @@ impl RpcClient {
     }
 }
 
-#[cfg(target_os = "macos")]
 #[uniffi::export(async_runtime = "tokio")]
 impl RpcClient {
     pub async fn set_enable_split_tunnel(&self, enable: bool) -> Result<()> {
@@ -496,6 +493,12 @@ impl RpcClient {
             skip_hybrid_transport: false,
         };
         Ok(self.inner.clone().run_diagnostic_raw(params).await?)
+    }
+
+    pub async fn set_profile(&self, profile: Profile) -> Result<()> {
+        let profile_options = nym_vpn_lib_types::ProfileOptions { profile };
+        self.inner.clone().set_profile(profile_options).await?;
+        Ok(())
     }
 }
 

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_service_command_sender.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_service_command_sender.rs
@@ -12,7 +12,7 @@ use tokio::sync::{mpsc, oneshot};
 use nym_vpn_lib_types::{
     AccountCommandError, AccountControllerState, AutologinResponse, DiagnosticRunParams,
     EntryPoint, ExitPoint, FeatureFlags, FrontingMode, Gateway, GetDeeplinkParams,
-    ListGatewaysOptions, MixnetTrafficConfig, NetworkCompatibility, ParsedAccountLinks,
+    ListGatewaysOptions, MixnetTrafficConfig, NetworkCompatibility, ParsedAccountLinks, Profile,
     RecentGateways, RegisterAccountRequest, RegisterAccountResponse, StoreAccountRequest,
     StoredAccountMode, SystemMessage, TargetState, TentativeGateways, TunnelState, TunnelType,
     VpnAccountSummary, VpnServiceConfig, VpnServiceInfo,
@@ -445,5 +445,11 @@ impl NymVpnServiceCommandSender {
             .send_and_wait(VpnServiceCommand::GetRecentGateways, tunnel_type)
             .await?
             .map_err(NymVpnServiceCommandInnerError::ListGateway)?)
+    }
+
+    pub async fn set_profile(&self, profile: Profile) -> Result<()> {
+        self.send_and_wait(VpnServiceCommand::SetProfile, profile)
+            .await?;
+        Ok(())
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/config/config_manager.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/config/config_manager.rs
@@ -20,7 +20,7 @@ use crate::{
     service::{
         config::{
             DEFAULT_CONFIG_FILE_JSON, DEFAULT_CONFIG_FILE_TOML, VpnServiceConfigExt,
-            VpnServiceConfigVersion, geo_exclusion_settings, legacy,
+            VpnServiceConfigVersion, geo_exclusion_settings, legacy, profile::ProfileSpecifics,
         },
         error::{Error, GeoExclusionConfigError, Result},
         read_json_config_file, read_toml_config_file, write_json_config_file,
@@ -343,6 +343,42 @@ impl VpnServiceConfigManager {
         }
 
         Ok(())
+    }
+
+    pub async fn set_profile(&mut self, profile: nym_vpn_lib_types::Profile) {
+        let profile_specifics = ProfileSpecifics::from(profile);
+        let mut changed = false;
+        if self.config.entry_point != profile_specifics.entry_point {
+            self.config.entry_point = profile_specifics.entry_point;
+            changed = true;
+        }
+        if self.config.exit_point != profile_specifics.exit_point {
+            self.config.exit_point = profile_specifics.exit_point;
+            changed = true;
+        }
+        let enable_two_hop = matches!(
+            profile_specifics.tunnel_type,
+            nym_vpn_lib_types::TunnelType::Wireguard
+        );
+        if self.config.enable_two_hop != enable_two_hop {
+            self.config.enable_two_hop = enable_two_hop;
+            changed = true;
+        }
+        if self.config.fronting_mode != profile_specifics.fronting_mode {
+            // Change the shared fronting policy
+            let front_policy = match profile_specifics.fronting_mode {
+                nym_vpn_lib_types::FrontingMode::Off => FrontPolicy::Off,
+                nym_vpn_lib_types::FrontingMode::OnRetry => FrontPolicy::OnRetry,
+                nym_vpn_lib_types::FrontingMode::Always => FrontPolicy::Always,
+            };
+            Client::set_shared_front_policy(front_policy);
+
+            self.config.fronting_mode = profile_specifics.fronting_mode;
+            changed = true;
+        }
+        if changed {
+            self.save_config_and_send_event().await;
+        }
     }
 
     async fn save_config_and_send_event(&self) {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/config/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/config/mod.rs
@@ -10,6 +10,7 @@ mod geo_exclusion_settings;
 mod legacy;
 mod mixnet_traffic;
 mod network_stats;
+mod profile;
 mod split_tunnel_settings;
 mod v1;
 mod v10;
@@ -28,6 +29,7 @@ mod v9;
 mod tests;
 
 pub use config_manager::VpnServiceConfigManager;
+pub use profile::ProfileSpecifics;
 
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use std::{

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/config/profile.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/config/profile.rs
@@ -1,0 +1,63 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use nym_vpn_lib_types::{EntryPoint, ExitPoint, FrontingMode, Profile, TunnelType};
+
+pub struct ProfileSpecifics {
+    pub entry_point: EntryPoint,
+    pub exit_point: ExitPoint,
+    pub tunnel_type: TunnelType,
+    pub fronting_mode: FrontingMode,
+}
+
+impl From<Profile> for ProfileSpecifics {
+    fn from(profile: Profile) -> Self {
+        let (entry_point, exit_point, tunnel_type, fronting_mode) = match profile {
+            Profile::Safest => (
+                EntryPoint::Auto {
+                    exclude_user_country: true,
+                },
+                ExitPoint::Auto {
+                    exclude_entry_point_country: true,
+                    exclude_user_country: true,
+                },
+                TunnelType::Wireguard,
+                FrontingMode::Always,
+            ),
+            Profile::MostPrivate => (
+                EntryPoint::Auto {
+                    exclude_user_country: true,
+                },
+                ExitPoint::Auto {
+                    exclude_entry_point_country: true,
+                    exclude_user_country: true,
+                },
+                TunnelType::Mixnet,
+                FrontingMode::OnRetry,
+            ),
+            Profile::Fastest => (
+                EntryPoint::Auto {
+                    exclude_user_country: false,
+                },
+                ExitPoint::Auto {
+                    exclude_entry_point_country: false,
+                    exclude_user_country: false,
+                },
+                TunnelType::Wireguard,
+                FrontingMode::OnRetry,
+            ),
+            Profile::Random => (
+                EntryPoint::Random,
+                ExitPoint::Random,
+                TunnelType::Wireguard,
+                FrontingMode::OnRetry,
+            ),
+        };
+        Self {
+            entry_point,
+            exit_point,
+            tunnel_type,
+            fronting_mode,
+        }
+    }
+}

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/mod.rs
@@ -8,7 +8,7 @@ mod vpn_service;
 
 pub use config::{
     ConfigSetupError, DEFAULT_GLOBAL_CONFIG_FILE_JSON, DEFAULT_GLOBAL_CONFIG_FILE_TOML,
-    read_json_config_file, read_toml_config_file, write_json_config_file,
+    ProfileSpecifics, read_json_config_file, read_toml_config_file, write_json_config_file,
 };
 pub use error::{
     AccountLinksError, Error, GeoExclusionConfigError, GlobalConfigError, ListGatewaysError,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
@@ -55,9 +55,9 @@ use nym_vpn_lib_types::{
     EnableSocks5Request, EntryPoint, ExitPoint, FeatureFlags, Gateway, GetDeeplinkParams,
     ListGatewaysOptions, LogPath, LookupGatewayFilters, MixnetTrafficConfig, NetworkCompatibility,
     NetworkStatisticsIdentity, NymNetworkDetails, NymVpnDevice, NymVpnNetwork, NymVpnUsage,
-    ParsedAccountLinks, RecentGateways, RegistrationReport, StorableAccount, StoreAccountRequest,
-    StoredAccountMode, SystemMessage, TargetState, TentativeGateways, TunnelEvent, TunnelState,
-    TunnelType, VpnAccountSummary, VpnServiceConfig, VpnServiceInfo,
+    ParsedAccountLinks, Profile, RecentGateways, RegistrationReport, StorableAccount,
+    StoreAccountRequest, StoredAccountMode, SystemMessage, TargetState, TentativeGateways,
+    TunnelEvent, TunnelState, TunnelType, VpnAccountSummary, VpnServiceConfig, VpnServiceInfo,
 };
 #[cfg(any(target_os = "android", target_os = "ios"))]
 use nym_vpn_lib_types::{RegisterAccountRequest, RegisterAccountResponse};
@@ -259,6 +259,7 @@ pub enum VpnServiceCommand {
     ClearSplitTunnelProcesses(oneshot::Sender<()>, ()),
     #[cfg(target_os = "macos")]
     NeedFullDiskPermissions(oneshot::Sender<bool>, ()),
+    SetProfile(oneshot::Sender<()>, Profile),
 }
 
 /// Type of service configuration storage used by the VPN service.
@@ -1349,6 +1350,10 @@ impl NymVpnService {
             }
             VpnServiceCommand::GetRecentGateways(tx, gateway_type) => {
                 let _ = tx.send(self.handle_get_recent_gateways(gateway_type).await);
+            }
+            VpnServiceCommand::SetProfile(tx, profile) => {
+                self.handle_set_profile(profile).await;
+                let _ = tx.send(());
             }
         }
     }
@@ -2474,5 +2479,10 @@ impl NymVpnService {
             .get_recent(tunnel_type)
             .await
             .map_err(ListGatewaysError::GetRecentGateways)
+    }
+
+    async fn handle_set_profile(&mut self, profile: Profile) {
+        self.config_manager.set_profile(profile).await;
+        self.update_tunnel_settings_with_throttle();
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
+++ b/nym-vpn-core/crates/nym-vpn-proto/proto/nym_vpn_service.proto
@@ -450,6 +450,17 @@ message Performance {
   float uptime_percentage_last_24_hours = 4;
 }
 
+message ProfileOptions {
+  Profile profile = 1;
+}
+
+enum Profile {
+  SAFEST = 0;
+  MOST_PRIVATE = 1;
+  FASTEST = 2;
+  RANDOM = 3;
+}
+
 enum Score {
   OFFLINE = 0;
   LOW = 1;
@@ -1371,4 +1382,7 @@ service NymVpnService {
 
   // Get recent gateways
   rpc GetRecentGateways(GetRecentGatewaysParams) returns (RecentGateways) {}
+
+  // Set a pre-configured batch of settings following a certain profile
+  rpc SetProfile(ProfileOptions) returns (google.protobuf.Empty) {}
 }

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/mod.rs
@@ -10,6 +10,7 @@ pub mod gateway_independence;
 pub mod gateway_selection_algorithm;
 pub mod network_config;
 pub mod network_stats;
+pub mod profile;
 pub mod prost;
 pub mod recents;
 pub mod service;

--- a/nym-vpn-core/crates/nym-vpn-proto/src/conversions/profile.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/conversions/profile.rs
@@ -1,0 +1,51 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use nym_vpn_lib_types::{Profile, ProfileOptions};
+
+use crate::{conversions::ConversionError, proto};
+
+impl From<proto::Profile> for Profile {
+    fn from(proto_profile: proto::Profile) -> Self {
+        match proto_profile {
+            proto::Profile::Safest => Self::Safest,
+            proto::Profile::MostPrivate => Self::MostPrivate,
+            proto::Profile::Fastest => Self::Fastest,
+            proto::Profile::Random => Self::Random,
+        }
+    }
+}
+
+impl From<Profile> for proto::Profile {
+    fn from(profile: Profile) -> Self {
+        match profile {
+            Profile::Safest => Self::Safest,
+            Profile::MostPrivate => Self::MostPrivate,
+            Profile::Fastest => Self::Fastest,
+            Profile::Random => Self::Random,
+        }
+    }
+}
+
+impl TryFrom<proto::ProfileOptions> for ProfileOptions {
+    type Error = ConversionError;
+
+    fn try_from(value: proto::ProfileOptions) -> Result<Self, Self::Error> {
+        let proto_profile = proto::Profile::try_from(value.profile)
+            .map_err(|err| ConversionError::Decode("ProfileOptions.profile", err))?;
+        let profile = Profile::from(proto_profile);
+
+        Ok(Self { profile })
+    }
+}
+
+impl TryFrom<ProfileOptions> for proto::ProfileOptions {
+    type Error = ConversionError;
+
+    fn try_from(value: ProfileOptions) -> Result<Self, Self::Error> {
+        let proto_profile = proto::Profile::from(value.profile);
+        Ok(Self {
+            profile: proto_profile as i32,
+        })
+    }
+}

--- a/nym-vpn-core/crates/nym-vpn-proto/src/rpc_client.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/rpc_client.rs
@@ -16,9 +16,9 @@ use nym_vpn_lib_types::{
     AvailableTickets, DiagnosticReport, EntryPoint, ExitPoint, FeatureFlags, FrontingMode, Gateway,
     GetDeeplinkParams, HttpRpcSettings, ListGatewaysOptions, LogPath, LookupGatewayFilters,
     NetworkCompatibility, NetworkStatisticsIdentity, NymVpnDevice, NymVpnUsage, ParsedAccountLinks,
-    PrivyDerivationMessage, RecentGateways, RegistrationReport, Socks5Settings, Socks5Status,
-    StoreAccountRequest, StoredAccountMode, SystemMessage, TentativeGateways, TunnelEvent,
-    TunnelState, VpnAccountSummary, VpnServiceConfig, VpnServiceInfo,
+    PrivyDerivationMessage, ProfileOptions, RecentGateways, RegistrationReport, Socks5Settings,
+    Socks5Status, StoreAccountRequest, StoredAccountMode, SystemMessage, TentativeGateways,
+    TunnelEvent, TunnelState, VpnAccountSummary, VpnServiceConfig, VpnServiceInfo,
 };
 
 use crate::proto::{self, nym_vpn_service_client::NymVpnServiceClient};
@@ -1026,6 +1026,19 @@ impl RpcClient {
             .await
             .map(|v| v.into_inner())
             .map_err(Error::Rpc)
+    }
+
+    pub async fn set_profile(&mut self, profile_options: ProfileOptions) -> Result<()> {
+        let profile_options_proto =
+            proto::ProfileOptions::try_from(profile_options).map_err(Error::InvalidRequest)?;
+
+        self.0
+            .set_profile(profile_options_proto)
+            .await
+            .map_err(Error::Rpc)?
+            .into_inner();
+
+        Ok(())
     }
 }
 

--- a/nym-vpn-core/crates/nym-vpnc/src/commands/mod.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub mod geo_exclusion;
 pub mod lan;
 pub mod network;
 pub mod network_stats;
+pub mod profile;
 pub mod sentry;
 pub mod session;
 pub mod socks5;

--- a/nym-vpn-core/crates/nym-vpnc/src/commands/profile.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/commands/profile.rs
@@ -1,0 +1,50 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use anyhow::Result;
+
+use nym_vpn_lib_types::ProfileOptions;
+use nym_vpn_proto::rpc_client::RpcClient;
+
+#[derive(Debug, Clone, clap::Subcommand)]
+pub enum Profile {
+    /// 2 hop configuration with automatic selection with different jurisdictions.
+    Safest,
+    /// 5 hop configuration with automatic selection with different jurisdictions.
+    MostPrivate,
+    /// 2 hop configuration with automatic selection regardless of jurisdiction.
+    Fastest,
+    /// 2 hop configuration with random servers.
+    Random,
+}
+
+impl From<Profile> for nym_vpn_lib_types::Profile {
+    fn from(profile: Profile) -> Self {
+        match profile {
+            Profile::Safest => Self::Safest,
+            Profile::MostPrivate => Self::MostPrivate,
+            Profile::Fastest => Self::Fastest,
+            Profile::Random => Self::Random,
+        }
+    }
+}
+
+#[derive(Debug, Clone, clap::Subcommand)]
+pub enum Command {
+    /// Set a configuration profile.
+    #[command(subcommand)]
+    Set(Profile),
+}
+
+impl Command {
+    pub async fn execute(self, mut rpc_client: RpcClient) -> Result<()> {
+        match self {
+            Command::Set(profile) => rpc_client
+                .set_profile(ProfileOptions {
+                    profile: profile.into(),
+                })
+                .await
+                .map_err(|err| err.into()),
+        }
+    }
+}

--- a/nym-vpn-core/crates/nym-vpnc/src/commands/session.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/commands/session.rs
@@ -74,6 +74,7 @@ async fn respond(line: &str, rpc_client: RpcClient) -> Result<bool> {
         Command::Favorites { subcommand } => subcommand.execute().await?,
         #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
         Command::SplitTunnel { subcommand } => subcommand.execute(rpc_client).await?,
+        Command::Profile { subcommand } => subcommand.execute(rpc_client).await?,
     }
 
     Ok(false)

--- a/nym-vpn-core/crates/nym-vpnc/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnc/src/main.rs
@@ -156,6 +156,7 @@ pub enum Command {
         subcommand: nym_diagnostic::cli::Command,
     },
 
+    /// Favorites management
     Favorites {
         #[command(subcommand)]
         subcommand: commands::favorites::Command,
@@ -166,6 +167,12 @@ pub enum Command {
     SplitTunnel {
         #[command(subcommand)]
         subcommand: commands::split_tunnel::Command,
+    },
+
+    /// Profiles management.
+    Profile {
+        #[command(subcommand)]
+        subcommand: commands::profile::Command,
     },
 }
 
@@ -209,6 +216,7 @@ impl Command {
             Command::Favorites { subcommand } => subcommand.execute().await,
             #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
             Command::SplitTunnel { subcommand } => subcommand.execute(rpc_client).await,
+            Command::Profile { subcommand } => subcommand.execute(rpc_client).await,
         }
     }
 

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface.rs
@@ -20,7 +20,7 @@ use tonic::{Request, Response, Status, transport::Server};
 use nym_vpn_lib_types::SplitApp;
 use nym_vpn_lib_types::{
     EnableSocks5Request, EntryPoint, ExitPoint, GetDeeplinkParams, ListGatewaysOptions,
-    LookupGatewayFilters, TargetState, TunnelEvent,
+    LookupGatewayFilters, ProfileOptions, TargetState, TunnelEvent,
 };
 
 use nym_vpn_proto::proto::{
@@ -1365,6 +1365,21 @@ impl NymVpnService for CommandInterface {
 
         #[cfg(not(target_os = "linux"))]
         Err(tonic::Status::internal("Unsupported platform"))
+    }
+
+    async fn set_profile(
+        &self,
+        request: tonic::Request<proto::ProfileOptions>,
+    ) -> Result<tonic::Response<()>> {
+        let profile_options = ProfileOptions::try_from(request.into_inner())
+            .map_err(|e| tonic::Status::invalid_argument(format!("Invalid profile: {e}")))?;
+
+        let _ = self
+            .send_and_wait(VpnServiceCommand::SetProfile, profile_options.profile)
+            .await
+            .map_err(|e| tonic::Status::internal(format!("Failed to set profile: {e}")))?;
+
+        Ok(tonic::Response::new(()))
     }
 }
 


### PR DESCRIPTION
## Ticket

JIRA-NYM-1712

## Description

Introduce configuration profiles that set in bulk settings specific to certain user profiles.

This change needs https://github.com/nymtech/nym-vpn-client/pull/6010 being merged, so it's targeting `feature/NYM-1712-merge-uniffi-crates` until that happens. It will target `develop` afterwards.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6073)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added four connection profiles: Safest, Most Private, Fastest, and Random.
  * Profiles automatically configure routing, tunnel type, entry and exit points, and fronting behavior.
  * Added profile selection and updates through the command-line interface.
  * Profile changes are applied to active VPN service configuration.
  * Added validation and error handling for invalid or unsuccessful profile requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->