### PR TITLE
Fix uniffi bindings

### DIFF
--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/NymVpn.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/NymVpn.kt
@@ -46,7 +46,7 @@ import javax.inject.Inject
 
 object NymVpnLib {
 	init {
-		System.loadLibrary("nym_vpn_lib")
+		System.loadLibrary("nym_vpn_lib_uniffi")
 	}
 	external fun initContext(context: Context)
 }

--- a/nym-vpn-core/Android.mk
+++ b/nym-vpn-core/Android.mk
@@ -51,8 +51,6 @@ DYNAMIC_LIB_PATH := $(CURDIR)/target/aarch64-linux-android/$(TARGET_DIR)/libnym_
 WIREGUARD_DIR := $(CURDIR)/../wireguard
 LICENSES_FILE := $(ANDROID_DIR)/core/src/main/assets/licenses_rust.json
 
-STRIP_TARGETS := libnym_vpn_lib.so libnym_vpn_lib_types.so
-
 # todo: consider migrating libwg builds to makefile to avoid rebuilds but for now this should make this makefile aware of changes to go sources
 LIBWG_SOURCES := $(wildcard $(WIREGUARD_DIR)/libwg/*.go) $(wildcard $(WIREGUARD_DIR)/libwg/*/*.go)
 
@@ -68,35 +66,27 @@ build: $(ARM64_V8_BUILD_DIR)/libwg.so $(ARMEABI_V7_BUILD_DIR)/libwg.so $(X86_64_
 	fi
 
 	$(ALL_IDEMPOTENT_FLAGS) cargo ndk -t $(ARCH_ARM64_V8) -t $(ARCH_ARMEABI_V7) -t $(ARCH_X86_64) -o $(JNI_LIBS_DIR) build --package nym-vpn-lib-uniffi --package nym-vpn-lib-types $(RELEASE_FLAG)
-	cd $(ARM64_V8_BUILD_DIR) ; \
-	mv libnym_vpn_lib_uniffi.so libnym_vpn_lib.so
-	cd $(ARMEABI_V7_BUILD_DIR) ; \
-	mv libnym_vpn_lib_uniffi.so libnym_vpn_lib.so
-	cd $(X86_64_BUILD_DIR) ; \
-	mv libnym_vpn_lib_uniffi.so libnym_vpn_lib.so
+	for dir in $(ARM64_V8_BUILD_DIR) $(ARMEABI_V7_BUILD_DIR) $(X86_64_BUILD_DIR); do \
+		pushd $$dir ; \
+		mv libnym_vpn_lib_uniffi.so libnym_vpn_lib.so ; \
+		popd ; \
+	done
 
 clippy:
 	$(ALL_IDEMPOTENT_FLAGS) cargo ndk -t $(ARCH_ARM64_V8) -t $(ARCH_ARMEABI_V7) -t $(ARCH_X86_64) -o $(JNI_LIBS_DIR) clippy --package nym-vpn-lib-uniffi --package nym-vpn-lib-types $(RELEASE_FLAG)
 
 strip: build
-	cd $(ARM64_V8_BUILD_DIR) ; \
-	for target in $(STRIP_TARGETS); do \
-		echo "Stripping $${target}" ; \
-        $(STRIP_TOOL) --strip-unneeded --strip-debug --remove-section=.comment -o "stripped_$${target}" "$${target}" ; \
-        mv stripped_$${target} $${target} ; \
-    done
-	cd $(ARMEABI_V7_BUILD_DIR) ; \
-	for target in $(STRIP_TARGETS); do \
-		echo "Stripping $${target}" ; \
-        $(STRIP_TOOL) --strip-unneeded --strip-debug --remove-section=.comment -o "stripped_$${target}" "$${target}" ; \
-        mv stripped_$${target} $${target} ; \
-    done
-	cd $(X86_64_BUILD_DIR) ; \
-	for target in $(STRIP_TARGETS); do \
-		echo "Stripping $${target}" ; \
-        $(STRIP_TOOL) --strip-unneeded --strip-debug --remove-section=.comment -o "stripped_$${target}" "$${target}" ; \
-        mv stripped_$${target} $${target} ; \
-    done
+	for dir in $(ARM64_V8_BUILD_DIR) $(ARMEABI_V7_BUILD_DIR) $(X86_64_BUILD_DIR); do \
+		pushd $$dir ; \
+		for file in *.so; do \
+			if [ -f "$$file" ]; then \
+				echo "Stripping $$file in $$dir" ; \
+				$(STRIP_TOOL) --strip-unneeded --strip-debug --remove-section=.comment -o "stripped_$$file" "$$file" ; \
+				mv "stripped_$$file" "$$file" ; \
+			fi ; \
+		done ; \
+		popd ; \
+	done
 
 uniffi: build
 	cargo run --bin uniffi-bindgen generate \

--- a/nym-vpn-core/Android.mk
+++ b/nym-vpn-core/Android.mk
@@ -71,7 +71,7 @@ clippy:
 
 strip: build
 	for dir in $(ARM64_V8_BUILD_DIR) $(ARMEABI_V7_BUILD_DIR) $(X86_64_BUILD_DIR); do \
-		pushd $$dir ; \
+		cd $$dir ; \
 		for file in *.so; do \
 			if [ -f "$$file" ]; then \
 				echo "Stripping $$file in $$dir" ; \
@@ -79,7 +79,7 @@ strip: build
 				mv "stripped_$$file" "$$file" ; \
 			fi ; \
 		done ; \
-		popd ; \
+		cd - ; \
 	done
 
 uniffi: build

--- a/nym-vpn-core/Android.mk
+++ b/nym-vpn-core/Android.mk
@@ -64,16 +64,10 @@ build: $(ARM64_V8_BUILD_DIR)/libwg.so $(ARMEABI_V7_BUILD_DIR)/libwg.so $(X86_64_
 	else \
 		echo "Sentry DSN is set!" ; \
 	fi
-
-	$(ALL_IDEMPOTENT_FLAGS) cargo ndk -t $(ARCH_ARM64_V8) -t $(ARCH_ARMEABI_V7) -t $(ARCH_X86_64) -o $(JNI_LIBS_DIR) build --package nym-vpn-lib-uniffi --package nym-vpn-lib-types $(RELEASE_FLAG)
-	for dir in $(ARM64_V8_BUILD_DIR) $(ARMEABI_V7_BUILD_DIR) $(X86_64_BUILD_DIR); do \
-		pushd $$dir ; \
-		mv libnym_vpn_lib_uniffi.so libnym_vpn_lib.so ; \
-		popd ; \
-	done
+	$(ALL_IDEMPOTENT_FLAGS) cargo ndk -t $(ARCH_ARM64_V8) -t $(ARCH_ARMEABI_V7) -t $(ARCH_X86_64) -o $(JNI_LIBS_DIR) build --package nym-vpn-lib-uniffi $(RELEASE_FLAG)
 
 clippy:
-	$(ALL_IDEMPOTENT_FLAGS) cargo ndk -t $(ARCH_ARM64_V8) -t $(ARCH_ARMEABI_V7) -t $(ARCH_X86_64) -o $(JNI_LIBS_DIR) clippy --package nym-vpn-lib-uniffi --package nym-vpn-lib-types $(RELEASE_FLAG)
+	$(ALL_IDEMPOTENT_FLAGS) cargo ndk -t $(ARCH_ARM64_V8) -t $(ARCH_ARMEABI_V7) -t $(ARCH_X86_64) -o $(JNI_LIBS_DIR) clippy --package nym-vpn-lib-uniffi $(RELEASE_FLAG)
 
 strip: build
 	for dir in $(ARM64_V8_BUILD_DIR) $(ARMEABI_V7_BUILD_DIR) $(X86_64_BUILD_DIR); do \

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -7517,7 +7517,6 @@ dependencies = [
  "log",
  "ndk-context",
  "nym-bandwidth-controller",
- "nym-bridges-types",
  "nym-common 2026.13.0-beta.1",
  "nym-diagnostic",
  "nym-favorites",

--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -5343,8 +5343,8 @@ dependencies = [
 
 [[package]]
 name = "nym-bridges"
-version = "0.2.0"
-source = "git+https://github.com/nymtech/nym-bridges?branch=v0.2.0-1#9e0aba059940050fd165db3190eb03e47aabd4c7"
+version = "0.2.1-rc.1"
+source = "git+https://github.com/nymtech/nym-bridges?branch=fix-nym-bridges-types#11bcbdf5f42d60e455cd66e2d2ed52c2084f9624"
 dependencies = [
  "anyhow",
  "base64 0.23.0",
@@ -5369,7 +5369,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slab",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
@@ -5384,8 +5384,8 @@ dependencies = [
 
 [[package]]
 name = "nym-bridges-types"
-version = "0.2.0"
-source = "git+https://github.com/nymtech/nym-bridges?branch=v0.2.0-1#9e0aba059940050fd165db3190eb03e47aabd4c7"
+version = "0.2.1-rc.1"
+source = "git+https://github.com/nymtech/nym-bridges?branch=fix-nym-bridges-types#11bcbdf5f42d60e455cd66e2d2ed52c2084f9624"
 dependencies = [
  "serde",
  "ts-rs",
@@ -7517,6 +7517,7 @@ dependencies = [
  "log",
  "ndk-context",
  "nym-bandwidth-controller",
+ "nym-bridges-types",
  "nym-common 2026.13.0-beta.1",
  "nym-diagnostic",
  "nym-favorites",

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -319,8 +319,8 @@ nym-wireguard-private-metadata-shared = { git = "https://github.com/nymtech/nym"
 nym-wireguard-types = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.15-bydgoszcz" }
 nym-sqlx-pool-guard = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.15-bydgoszcz" }
 
-nym-bridges = { git = "https://github.com/nymtech/nym-bridges", branch = "v0.2.0-1" }
-nym-bridges-types = { git = "https://github.com/nymtech/nym-bridges", branch = "v0.2.0-1" }
+nym-bridges = { git = "https://github.com/nymtech/nym-bridges", branch = "fix-nym-bridges-types" }
+nym-bridges-types = { git = "https://github.com/nymtech/nym-bridges", branch = "fix-nym-bridges-types" }
 
 # For local development
 # [patch."https://github.com/nymtech/nym"]

--- a/nym-vpn-core/crates/nym-vpn-lib-types/uniffi.toml
+++ b/nym-vpn-core/crates/nym-vpn-lib-types/uniffi.toml
@@ -1,5 +1,4 @@
 [bindings.kotlin]
-cdylib_name = "nym_vpn_lib_types"
 package_name = "nym_vpn_lib_types"
 # Skip the runtime API-checksum integrity check. Bindings are always generated
 # from the exact library being shipped (see Android.mk `uniffi: build`), so the

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/Cargo.toml
@@ -38,12 +38,11 @@ nym-bandwidth-controller = { workspace = true }
 nym-sdk.workspace = true
 nym-offline-monitor.workspace = true
 nym-diagnostic.workspace = true
-nym-vpn-lib = { workspace = true, features = ["uniffi-bindings"] }
+nym-vpn-lib.workspace = true
 nym-vpn-lib-types = { workspace = true, features = [
     "uniffi-bindings",
     "nym-type-conversions",
 ] }
-nym-bridges-types = { workspace = true, features = ["uniffi-bindings", "serde"] }
 nym-vpn-account-controller.workspace = true
 nym-vpn-network-config.workspace = true
 nym-vpn-store.workspace = true

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/Cargo.toml
@@ -38,11 +38,12 @@ nym-bandwidth-controller = { workspace = true }
 nym-sdk.workspace = true
 nym-offline-monitor.workspace = true
 nym-diagnostic.workspace = true
-nym-vpn-lib.workspace = true
+nym-vpn-lib = { workspace = true, features = ["uniffi-bindings"] }
 nym-vpn-lib-types = { workspace = true, features = [
     "uniffi-bindings",
     "nym-type-conversions",
 ] }
+nym-bridges-types = { workspace = true, features = ["uniffi-bindings", "serde"] }
 nym-vpn-account-controller.workspace = true
 nym-vpn-network-config.workspace = true
 nym-vpn-store.workspace = true

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/uniffi.toml
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/uniffi.toml
@@ -1,5 +1,4 @@
 [bindings.kotlin]
-cdylib_name = "nym_vpn_lib"
 package_name = "nym_vpn_lib"
 # Skip the runtime API-checksum integrity check. Bindings are always generated
 # from the exact library being shipped (see Android.mk `uniffi: build`), so the

--- a/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
@@ -135,7 +135,7 @@ urlencoding.workspace = true
 webpki-roots.workspace = true
 x509-parser = { workspace = true, features = ["verify"] }
 
-nym-bridges =  {workspace = true, features = ["serde"] }
+nym-bridges = {workspace = true, features = ["serde"] }
 
 # UNIX-specific dependencies
 [target.'cfg(unix)'.dependencies]
@@ -218,7 +218,6 @@ vergen-gitcl = { workspace = true, default-features = false, features = [
 default = ["cgroup2"]
 metrics-server = ["nym-client-core/metrics-server"]
 cgroup2 = ["nym-split-tunnel/cgroup2", "nym-firewall/cgroup2"]
-uniffi-bindings = ["nym-bridges/uniffi-bindings"]
 
 [package.metadata.cargo-machete]
 ignored = ["vergen"]

--- a/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
@@ -135,7 +135,7 @@ urlencoding.workspace = true
 webpki-roots.workspace = true
 x509-parser = { workspace = true, features = ["verify"] }
 
-nym-bridges =  {workspace = true, features=["serde"] }
+nym-bridges =  {workspace = true, features = ["serde"] }
 
 # UNIX-specific dependencies
 [target.'cfg(unix)'.dependencies]
@@ -218,6 +218,7 @@ vergen-gitcl = { workspace = true, default-features = false, features = [
 default = ["cgroup2"]
 metrics-server = ["nym-client-core/metrics-server"]
 cgroup2 = ["nym-split-tunnel/cgroup2", "nym-firewall/cgroup2"]
+uniffi-bindings = ["nym-bridges/uniffi-bindings"]
 
 [package.metadata.cargo-machete]
 ignored = ["vergen"]


### PR DESCRIPTION
## Ticket

JIRA-NYM-1749

## Description

- Remove cdylib overrides for Kotlin. Rely on defaults for simplicity
- Update Kotlin code to load `nym_vpn_lib_uniffi.so. Note that package name is still `nym_vpn_lib`
- Remove manual inclusion of `nym-vpn-lib-types` via `cargo ndk` which has no effect. Everything works fine without it.
- Strip all Android binaries within jniLibs directory
- Point nym-bridges to https://github.com/nymtech/nym-bridges/pull/62 

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6075)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Android VPN integration to load the correct native library.
  * Improved native library packaging and stripping across supported architectures for more reliable builds.

* **Maintenance**
  * Updated bridge components to a compatible development revision.
  * Removed obsolete native library naming configuration and unused build settings.
  * Streamlined native library processing without changing user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->