### PR TITLE
fix(android): drop stale getDaemonVersion override from MockBackendManager

### DIFF
--- a/nym-vpn-android/app/src/mock/java/net/nymtech/nymvpn/manager/backend/MockBackendManager.kt
+++ b/nym-vpn-android/app/src/mock/java/net/nymtech/nymvpn/manager/backend/MockBackendManager.kt
@@ -291,8 +291,6 @@ class MockBackendManager @Inject constructor(@ApplicationScope private val appli
 
 	override suspend fun getAccountState(): AccountControllerState = AccountControllerState.ReadyToConnect
 
-	override suspend fun getDaemonVersion(): String = "mock-1.0.0"
-
 	override suspend fun getDeviceId(): String = "mock-device-id"
 
 	override suspend fun getAccountId(): String = "mock-account-id"


### PR DESCRIPTION
d99627f26 removed getDaemonVersion() from the BackendManager interface, but MockBackendManager kept overriding it. The mock source set is only compiled by the Maestro UI-test workflow, so this went unnoticed until ci-maestro-android failed at :app:compileMockDebugKotlin with "'getDaemonVersion' overrides nothing" -- 25 minutes into the job, after the full Rust cross-build.

Nothing else in nym-vpn-android referenced getDaemonVersion.

## Ticket

JIRA-NYM-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6078)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed an obsolete mock backend version method.
  * No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->