### PR TITLE
Update apple makefile

### DIFF
--- a/nym-vpn-apple/Makefile
+++ b/nym-vpn-apple/Makefile
@@ -7,24 +7,77 @@ NYM_VPN_LIB_MACOS_DIR :=$(CURDIR)/macos
 NYM_VPN_LIB_IOS_DIR :=$(CURDIR)/ios
 NYM_VPN_LIB_MACOS_DEST := $(NYM_VPN_LIB_MACOS_DIR)/NymVPNLib
 NYM_VPN_LIB_IOS_DEST := $(NYM_VPN_LIB_IOS_DIR)/NymVPNLib
+NYM_VPN_LIB_UNIVERSAL_DEST := $(CURDIR)/NymVPNLib
 
 NYM_VPND_SRC_DIR := $(CORE_DIR)/upload/mac
 NYM_VPND_DEST_DIR := ${CURDIR}/NymVPND
 
-.PHONY: all build-mac build-ios
+TARGETS := nym-vpnd nym-socks5-proxy nym-diagnostic nym-setup
 
-all: build-mac build-ios
+.PHONY: all build-mac build-ios build-universal build-mac-package build-ios-package
 
-build-mac:
+all: build-universal
+
+# Build NymVPNLib for iOS only
+build-ios: build-ios-package
+	mv $(NYM_VPN_LIB_IOS_DEST) $(NYM_VPN_LIB_UNIVERSAL_DEST)
+
+# Build NymVPNLib for macOS only
+build-mac: build-mac-package
+	mv $(NYM_VPN_LIB_MACOS_DEST) $(NYM_VPN_LIB_UNIVERSAL_DEST)
+
+# Build universal NymVPNLib for iOS and macOS
+build-universal: build-mac-package build-ios-package
+	rm -rf $(NYM_VPN_LIB_UNIVERSAL_DEST) || true
+	mkdir -p $(NYM_VPN_LIB_UNIVERSAL_DEST)
+
+	# Merge iOS and macOS frameworks together
+	xcodebuild -create-xcframework \
+	  -library $(NYM_VPN_LIB_MACOS_DEST)/NymVPNLibUniffi.xcframework/macos-arm64_x86_64/libnym_vpn_lib_uniffi.a\
+	  -headers $(NYM_VPN_LIB_MACOS_DEST)/NymVPNLibUniffi.xcframework/macos-arm64_x86_64/Headers \
+	  -library $(NYM_VPN_LIB_IOS_DEST)/NymVPNLibUniffi.xcframework/ios-arm64/libnym_vpn_lib_uniffi.a \
+	  -headers $(NYM_VPN_LIB_IOS_DEST)/NymVPNLibUniffi.xcframework/ios-arm64/Headers \
+	  -output $(NYM_VPN_LIB_UNIVERSAL_DEST)/NymVPNLibUniffi.xcframework
+
+	mkdir -p $(NYM_VPN_LIB_UNIVERSAL_DEST)/Sources/NymVPNLib/{ios,macos}
+
+	# Add package.swift for universal binary framework
+	cp "$(CURDIR)/NymVPNLib-Package.swift.template" "$(NYM_VPN_LIB_UNIVERSAL_DEST)/Package.swift"
+
+	# Copy Swift sources into different directories
+	cp $(NYM_VPN_LIB_IOS_DEST)/Sources/NymVPNLib/*.swift "$(NYM_VPN_LIB_UNIVERSAL_DEST)/Sources/NymVPNLib/ios"
+	cp $(NYM_VPN_LIB_MACOS_DEST)/Sources/NymVPNLib/*.swift "$(NYM_VPN_LIB_UNIVERSAL_DEST)/Sources/NymVPNLib/macos"
+
+	# Add per-platform conditional compilation to source files
+	pushd "$(NYM_VPN_LIB_UNIVERSAL_DEST)/Sources/NymVPNLib/ios" ; \
+	find . -name "*.swift" -type f | while read -r file; do \
+		echo "Processing $$file" ; \
+	    content=$$(cat "$$file") ; \
+		new_file="$${file%.swift}-ios.swift" ; \
+	    printf "#if os(iOS)\n\n%s\n\n#endif\n" "$$content" > "$$new_file" ; \
+		rm "$$file" ; \
+	done ; \
+	popd
+
+	pushd "$(NYM_VPN_LIB_UNIVERSAL_DEST)/Sources/NymVPNLib/macos" ; \
+	find . -name "*.swift" -type f | while read -r file; do \
+	    echo "Processing $$file" ; \
+	    content=$$(cat "$$file") ; \
+		new_file="$${file%.swift}-macos.swift" ; \
+	    printf "#if os(macOS)\n\n%s\n\n#endif\n" "$$content" > "$$new_file" ; \
+		rm "$$file" ; \
+	done ; \
+	popd
+
+build-mac-package:
 	$(MAKE) -C $(CORE_DIR) -f macOS.mk build-all RELEASE=$(RELEASE) ARCH=$(ARCH)
-
 	rm -rf "${NYM_VPN_LIB_MACOS_DEST}"
 	mkdir -p "$(NYM_VPN_LIB_MACOS_DIR)"
 	cp -R "${NYM_VPN_LIB_SRC}" "${NYM_VPN_LIB_MACOS_DEST}"
 	echo "Copied NymVPNLib → ${NYM_VPN_LIB_MACOS_DEST}"
 
 	mkdir -p "$(NYM_VPND_DEST_DIR)"
-	for f in nym-vpnd nym-socks5-proxy nym-diagnostic nym-setup; do \
+	for f in $(TARGETS); do \
 	    if [[ ! -f "$(NYM_VPND_SRC_DIR)/$${f}" ]]; then \
 	        echo "$(NYM_VPND_SRC_DIR)/$${f} not found!"; \
 	        exit 1; \
@@ -34,11 +87,9 @@ build-mac:
 	    echo "Copied $${f} → $(NYM_VPND_DEST_DIR)"; \
 	done
 
-build-ios:
+build-ios-package:
 	$(MAKE) -C $(CORE_DIR) -f iOS.mk RELEASE=$(RELEASE)
-
 	rm -rf "${NYM_VPN_LIB_IOS_DEST}"
 	mkdir -p "$(NYM_VPN_LIB_IOS_DIR)"
 	cp -R "${NYM_VPN_LIB_SRC}" "${NYM_VPN_LIB_IOS_DEST}"
 	echo "Copied NymVPNLib → ${NYM_VPN_LIB_IOS_DEST}"
-

--- a/nym-vpn-apple/Makefile
+++ b/nym-vpn-apple/Makefile
@@ -20,7 +20,12 @@ all: build-universal
 
 # Build NymVPNLib for iOS only
 build-ios: build-ios-package
+	rm -rf "$(NYM_VPN_LIB_UNIVERSAL_DEST)"
 	mv $(NYM_VPN_LIB_IOS_DEST) $(NYM_VPN_LIB_UNIVERSAL_DEST)
+
+build-mac: build-mac-package
+	rm -rf "$(NYM_VPN_LIB_UNIVERSAL_DEST)"
+	mv $(NYM_VPN_LIB_MACOS_DEST) $(NYM_VPN_LIB_UNIVERSAL_DEST)
 
 # Build NymVPNLib for macOS only
 build-mac: build-mac-package

--- a/nym-vpn-apple/NymVPNLib-Package.swift.template
+++ b/nym-vpn-apple/NymVPNLib-Package.swift.template
@@ -1,0 +1,28 @@
+// swift-tools-version:5.10
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "NymVPNLib",
+    platforms: [
+        .iOS(.v17),
+        .macOS(.v14)
+    ],
+    products: [
+        .library(
+            name: "NymVPNLib",
+            targets: ["NymVPNLib"]
+        )
+    ],
+    dependencies: [ ],
+    targets: [
+        .binaryTarget(name: "NymVPNLibUniffi", path: "./NymVPNLibUniffi.xcframework"),
+        .target(
+            name: "NymVPNLib",
+            dependencies: [
+                .target(name: "NymVPNLibUniffi")
+            ]
+        ),
+    ]
+)

--- a/nym-vpn-apple/ServicesMacOS/Sources/GRPCManager/GRPCManager+Info.swift
+++ b/nym-vpn-apple/ServicesMacOS/Sources/GRPCManager/GRPCManager+Info.swift
@@ -1,4 +1,4 @@
-import NymVPNRpc
+import NymVPNLib
 
 extension GRPCManager {
     public func updateErrorReportingIfNeeded(with isEnabled: Bool) async throws {


### PR DESCRIPTION
## Description

Update makefile for apple with support for universal NymVPNLib that includes both iOS and macOS binaries + Swift shims. 

This should be handy for development purposes and should enable switching targets in Xcode without rebuilding NymVPNLib.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6080)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added universal iOS and macOS package builds for NymVPNLib.
  - Added an XCFramework-based Swift Package Manager library supporting iOS 17 and macOS 14.
  - Added platform-specific Swift source handling for iOS and macOS.

- **Build Improvements**
  - Updated the default build workflow to produce the universal package automatically.
  - Added separate commands for building iOS, macOS, and universal packages.
  - Updated macOS services to use the unified NymVPNLib package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->