### PR TITLE
Apply Bridge Lib Patch

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -5343,8 +5343,8 @@ dependencies = [
 
 [[package]]
 name = "nym-bridges"
-version = "0.2.1-rc.1"
-source = "git+https://github.com/nymtech/nym-bridges?branch=fix-nym-bridges-types#11bcbdf5f42d60e455cd66e2d2ed52c2084f9624"
+version = "0.2.0"
+source = "git+https://github.com/nymtech/nym-bridges?branch=v0.2.0-2#9613c71076217b65277223a13c65151b5dd1b044"
 dependencies = [
  "anyhow",
  "base64 0.23.0",
@@ -5384,8 +5384,8 @@ dependencies = [
 
 [[package]]
 name = "nym-bridges-types"
-version = "0.2.1-rc.1"
-source = "git+https://github.com/nymtech/nym-bridges?branch=fix-nym-bridges-types#11bcbdf5f42d60e455cd66e2d2ed52c2084f9624"
+version = "0.2.0"
+source = "git+https://github.com/nymtech/nym-bridges?branch=v0.2.0-2#9613c71076217b65277223a13c65151b5dd1b044"
 dependencies = [
  "serde",
  "ts-rs",

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -318,8 +318,8 @@ nym-wireguard-private-metadata-shared = { git = "https://github.com/nymtech/nym"
 nym-wireguard-types = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.15-bydgoszcz" }
 nym-sqlx-pool-guard = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.15-bydgoszcz" }
 
-nym-bridges = { git = "https://github.com/nymtech/nym-bridges", branch = "fix-nym-bridges-types" }
-nym-bridges-types = { git = "https://github.com/nymtech/nym-bridges", branch = "fix-nym-bridges-types" }
+nym-bridges = { git = "https://github.com/nymtech/nym-bridges", branch = "v0.2.0-2" }
+nym-bridges-types = { git = "https://github.com/nymtech/nym-bridges", branch = "v0.2.0-2" }
 
 # For local development
 # [patch."https://github.com/nymtech/nym"]


### PR DESCRIPTION

## Description

Apply changes from https://github.com/nymtech/nym-bridges/pull/62

> *  Set crate-type for nym-bridges-types. Without it the corresponding .so library has not been generated and included into Android builds
> * Remove cdylib_name from configuration. When specified, it tells uniffi to load the library with that exact name. However Rust outputs binaries with different name, i.e libnym_bridges_types-f2638afbb399dcbc.so. This is not the case for local binaries within workspace, but it's the case when nym-bridges is consumed externally.

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6081)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal bridge components to a newer release branch, improving compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->