### PR TITLE
Boost cache to 60GB

### DIFF
--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -14,7 +14,7 @@ runs:
       run: |
         echo "RUSTC_WRAPPER=$SCCACHE_PATH" >> "$GITHUB_ENV"
         echo "SCCACHE_DIR=$HOME/.cache/sccache" >> "$GITHUB_ENV"
-        echo "SCCACHE_CACHE_SIZE=10G" >> "$GITHUB_ENV" # keep it lower for unix runners (macos is a bottleneck!)
+        echo "SCCACHE_CACHE_SIZE=60G" >> "$GITHUB_ENV"
         echo "SCCACHE_IDLE_TIMEOUT=0" >> "$GITHUB_ENV"
         echo "CARGO_INCREMENTAL=0" >> "$GITHUB_ENV"
 
@@ -24,6 +24,6 @@ runs:
       run: |
         Add-Content -Path $env:GITHUB_ENV -Value "RUSTC_WRAPPER=$env:SCCACHE_PATH" -Encoding utf8
         Add-Content -Path $env:GITHUB_ENV -Value "SCCACHE_DIR=$env:USERPROFILE\.cache\sccache" -Encoding utf8
-        Add-Content -Path $env:GITHUB_ENV -Value "SCCACHE_CACHE_SIZE=15G" -Encoding utf8
+        Add-Content -Path $env:GITHUB_ENV -Value "SCCACHE_CACHE_SIZE=60G" -Encoding utf8
         Add-Content -Path $env:GITHUB_ENV -Value "SCCACHE_IDLE_TIMEOUT=0" -Encoding utf8
         Add-Content -Path $env:GITHUB_ENV -Value "CARGO_INCREMENTAL=0" -Encoding utf8


### PR DESCRIPTION

## Description

Our runners are about to receive more disk space for caches. This PR increases sccache allocation to 60GB on macOS and Windows runners.

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6085)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased build cache capacity for improved build performance and reliability across supported operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->