### PR TITLE
Prevent refresh storm

### DIFF
--- a/nym-vpn-core/crates/nym-gateway-directory/src/gateway_cache.rs
+++ b/nym-vpn-core/crates/nym-gateway-directory/src/gateway_cache.rs
@@ -33,14 +33,6 @@ impl GatewayCacheHandle {
         Self { tx }
     }
 
-    /// Refresh all gateways and countries without blocking until the operation is complete.
-    pub async fn refresh_all(&self) -> Result<()> {
-        self.tx.send(Command::RefreshAll).map_err(|_| {
-            tracing::error!("Gateway cache command channel closed (RefreshAll)");
-            Error::Cancelled
-        })
-    }
-
     /// Lookup gateways waiting for any pending fetch request or initiating one if needed.
     pub async fn lookup_gateways(&self, gw_type: GatewayType) -> Result<GatewayList> {
         let (tx, rx) = tokio::sync::oneshot::channel();
@@ -190,7 +182,6 @@ impl GatewayCacheHandle {
 }
 
 enum Command {
-    RefreshAll,
     LookupGateways(
         GatewayType,
         tokio::sync::oneshot::Sender<Result<GatewayList>>,
@@ -281,9 +272,6 @@ impl GatewayCache {
             tokio::select! {
                 Some(cmd) = self.command_rx.recv() => {
                     match cmd {
-                        Command::RefreshAll => {
-                            self.refresh_all().await;
-                        }
                         Command::LookupGateways(gw_type, tx) => {
                             tx.send(self.lookup_gateways(gw_type).await).ok();
                         }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/gateway_cache.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/gateway_cache.rs
@@ -7,7 +7,6 @@ use nym_gateway_directory::{Error, GatewayCacheHandle, GatewayClient, GatewayLis
 pub trait GatewayCache: Clone + Send + Sync + 'static {
     async fn lookup_gateways(&self, gw_type: GatewayType) -> Result<GatewayList, Error>;
     fn replace_gateway_client(&self, gateway_client: GatewayClient) -> Result<(), Error>;
-    async fn refresh_all(&self) -> Result<(), Error>;
     fn set_paused(&self, paused: bool) -> Result<(), Error>;
 }
 
@@ -19,10 +18,6 @@ impl GatewayCache for GatewayCacheHandle {
 
     fn replace_gateway_client(&self, gateway_client: GatewayClient) -> Result<(), Error> {
         self.replace_gateway_client(gateway_client)
-    }
-
-    async fn refresh_all(&self) -> Result<(), Error> {
-        self.refresh_all().await
     }
 
     fn set_paused(&self, paused: bool) -> Result<(), Error> {
@@ -79,10 +74,6 @@ pub mod tests {
         }
 
         fn replace_gateway_client(&self, _gateway_client: GatewayClient) -> Result<(), Error> {
-            Ok(())
-        }
-
-        async fn refresh_all(&self) -> Result<(), Error> {
             Ok(())
         }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/mod.rs
@@ -277,7 +277,6 @@ impl<C: GatewayCache> GatewayProvider<C> {
         self.gateway_cache
             .replace_gateway_client(gateway_client)
             .ok();
-        self.gateway_cache.refresh_all().await.ok();
     }
 
     pub fn set_gateway_cache_paused(&self, paused: bool) {


### PR DESCRIPTION



## Description

`GatewayCache::lookup_gateways` already performs network request when gateways become stale. Since call to `GatewayCache::refresh_all()` happens too frequently, it could double number of requests in case of failure to connect to our API. Instead, let's rely on `GatewayCache::lookup_gateways` alone.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6087)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Gateway information is no longer refreshed automatically when the gateway client is replaced.
  * Gateway refreshes continue to occur during initial setup and after connectivity changes.
  * Removed the manual “refresh all gateways” operation from the available interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->