### PR TITLE
[Linux] UNIX group authentication

### DIFF
--- a/.github/workflows/publish-aur-nym-vpnd.yml
+++ b/.github/workflows/publish-aur-nym-vpnd.yml
@@ -74,6 +74,7 @@ jobs:
       REPOSITORY: ${{ github.repository }}
       TARBALL: ${{ github.workspace }}/sources.tar.gz
       SERVICE_FILE: ${{ github.workspace }}/nym-vpn-core/crates/nym-vpnd/.pkg/aur/nym-vpnd.service
+      CONF_FILE: ${{ github.workspace }}/nym-vpn-core/crates/nym-vpnd/.pkg/aur/nym-vpn.conf
       LINUX_BIN_X86_64: linux-bin-x86_64
       LINUX_BIN_AARCH64: linux-bin-aarch64
     steps:
@@ -119,7 +120,8 @@ jobs:
         run: |
           export SRC_TARBALL_SHA256=$(sha256sum "${{ env.TARBALL }}" | cut -d' ' -f1)
           export SERVICE_SHA256=$(sha256sum "${{ env.SERVICE_FILE }}" | cut -d' ' -f1)
-          envsubst '$PKGVER,$PKGREL,$RELEASE_TAG,$SRC_TARBALL_SHA256,$SERVICE_SHA256' < "$PKGBUILD" > "$PKGBUILD.tmp"
+          export CONF_SHA256=$(sha256sum "${{ env.CONF_FILE }}" | cut -d' ' -f1)
+          envsubst '$PKGVER,$PKGREL,$RELEASE_TAG,$SRC_TARBALL_SHA256,$SERVICE_SHA256,$CONF_SHA256' < "$PKGBUILD" > "$PKGBUILD.tmp"
           mv "$PKGBUILD.tmp" "$PKGBUILD"
 
       - name: Update PKGBUILD (bin)
@@ -133,7 +135,8 @@ jobs:
           export TARBALL_SHA256_X86_64=$(sha256sum "${{ env.LINUX_BIN_X86_64 }}" | cut -d' ' -f1)
           export TARBALL_SHA256_AARCH64=$(sha256sum "${{ env.LINUX_BIN_AARCH64 }}" | cut -d' ' -f1)
           export SERVICE_SHA256=$(sha256sum "${{ env.SERVICE_FILE }}" | cut -d' ' -f1)
-          envsubst '$PKGVER,$PKGREL,$RELEASE_TAG,$TARBALL_SHA256_X86_64,$TARBALL_SHA256_AARCH64,$SERVICE_SHA256' < "$PKGBUILD" > "$PKGBUILD.tmp"
+          export CONF_SHA256=$(sha256sum "${{ env.CONF_FILE }}" | cut -d' ' -f1)
+          envsubst '$PKGVER,$PKGREL,$RELEASE_TAG,$TARBALL_SHA256_X86_64,$TARBALL_SHA256_AARCH64,$SERVICE_SHA256,$CONF_SHA256' < "$PKGBUILD" > "$PKGBUILD.tmp"
           mv "$PKGBUILD.tmp" "$PKGBUILD"
 
       - name: Rename PKGBUILD (bin)
@@ -158,3 +161,4 @@ jobs:
           commit_message: ${{ inputs.commit_msg || format('v{0}', steps.app-version.outputs.metadata) }}
           assets: |
             nym-vpn-core/crates/nym-vpnd/.pkg/aur/nym-vpnd.service
+            nym-vpn-core/crates/nym-vpnd/.pkg/aur/nym-vpn.conf

--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement the "suggest diagnostics" event on Tauri (https://github.com/nymtech/nym-vpn-client/pull/6006)
 - Persist gateway list to disk, seeded from a built-in list (https://github.com/nymtech/nym-vpn-client/pull/6015)
 - If the host doesn't have an IPv6 address then split tunnelling is disabled for IPv6 (https://github.com/nymtech/nym-vpn-client/pull/6052) 
+- [Linux] Authenticate also via UNIX group "nym-vpn" membership, or root (https://github.com/nymtech/nym-vpn-client/pull/6100)
 
 ### Changed
 

--- a/nym-vpn-core/crates/nym-ipc/src/authentication/linux.rs
+++ b/nym-vpn-core/crates/nym-ipc/src/authentication/linux.rs
@@ -1,10 +1,13 @@
 // Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::time::Duration;
+use std::{ffi::CString, time::Duration};
 
-use nix::sys::socket::{UnixCredentials, getsockopt, sockopt::PeerCredentials};
-use tokio::{io::AsyncWriteExt, net::UnixStream};
+use nix::{
+    sys::socket::{UnixCredentials, getsockopt, sockopt::PeerCredentials},
+    unistd::{Gid, Uid, User, getgrouplist},
+};
+use tokio::io::AsyncWriteExt;
 use tokio_stream::Stream;
 use tokio_util::sync::CancellationToken;
 use zbus::Connection;
@@ -250,14 +253,56 @@ pub(crate) async fn is_authenticated(
     stream: &mut Transport,
     auth_material: AuthenticationMaterial,
 ) -> Result<(), AuthenticationError> {
-    authenticate_with_prompt(stream, PolkitPrompter::new(auth_material.shutdown_token)).await
+    let cred = getsockopt(stream, PeerCredentials).map_err(AuthenticationError::GetSockOpt)?;
+    if let Some(gid) = auth_material.nym_vpn_gid
+        && user_in_group(cred.uid().into(), gid)
+    {
+        tracing::debug!("User is part of the nym-vpn group");
+        Ok(())
+    } else {
+        authenticate_with_prompt(cred, PolkitPrompter::new(auth_material.shutdown_token)).await
+    }
+}
+
+fn user_in_group(uid: Uid, gid: Gid) -> bool {
+    if uid.is_root() {
+        tracing::trace!("User is root");
+        return true;
+    }
+
+    let Ok(Some(user)) = User::from_uid(uid) else {
+        tracing::debug!("User {uid} could not be parsed or it disappeared");
+        return false;
+    };
+    if user.gid == gid {
+        tracing::trace!("User is primary of the group");
+        return true;
+    }
+
+    let Ok(name) = CString::new(user.name.as_bytes()) else {
+        tracing::warn!("User name could not be parsed into CString");
+        return false;
+    };
+    let Ok(group_list) = getgrouplist(&name, user.gid)
+        .inspect_err(|err| tracing::warn!("Could not get the group list: {err:?}"))
+    else {
+        return false;
+    };
+
+    let in_group = group_list.contains(&gid);
+    if !in_group {
+        tracing::info!(
+            "Connecting user is not in the nym-vpn UNIX group. If they would be added, prompt authentication would not be needed anymore"
+        );
+    }
+
+    in_group
 }
 
 async fn authenticate_with_prompt(
-    stream: &mut UnixStream,
+    cred: UnixCredentials,
     prompter: impl Prompter,
 ) -> Result<(), AuthenticationError> {
-    let cred = getsockopt(stream, PeerCredentials).map_err(AuthenticationError::GetSockOpt)?;
     let auth_result = prompter.prompt_for_authorization(cred).await?;
 
     if auth_result.is_authorized {
@@ -296,7 +341,10 @@ mod tests {
         task::Poll,
     };
 
-    use tokio::sync::{Mutex, RwLock};
+    use tokio::{
+        net::UnixStream,
+        sync::{Mutex, RwLock},
+    };
 
     use crate::{auth_result::AuthenticaticationResult, authentication::authorize};
 
@@ -458,9 +506,9 @@ mod tests {
 
     #[tokio::test]
     async fn authorized_by_prompt() {
-        let (_, mut server) = UnixStream::pair().unwrap();
+        let (_, server) = UnixStream::pair().unwrap();
         authenticate_with_prompt(
-            &mut server,
+            getsockopt(&server, PeerCredentials).unwrap(),
             MockPrompter {
                 is_authorized: true,
             },
@@ -471,9 +519,9 @@ mod tests {
 
     #[tokio::test]
     async fn denied_by_prompt() {
-        let (_, mut server) = UnixStream::pair().unwrap();
+        let (_, server) = UnixStream::pair().unwrap();
         let err = authenticate_with_prompt(
-            &mut server,
+            getsockopt(&server, PeerCredentials).unwrap(),
             MockPrompter {
                 is_authorized: false,
             },

--- a/nym-vpn-core/crates/nym-ipc/src/authentication/linux.rs
+++ b/nym-vpn-core/crates/nym-ipc/src/authentication/linux.rs
@@ -254,9 +254,7 @@ pub(crate) async fn is_authenticated(
     auth_material: AuthenticationMaterial,
 ) -> Result<(), AuthenticationError> {
     let cred = getsockopt(stream, PeerCredentials).map_err(AuthenticationError::GetSockOpt)?;
-    if let Some(gid) = auth_material.nym_vpn_gid
-        && user_in_group(cred.uid().into(), gid)
-    {
+    if user_in_group(cred.uid().into(), auth_material.nym_vpn_gid) {
         tracing::debug!("User is part of the nym-vpn group");
         Ok(())
     } else {
@@ -264,7 +262,7 @@ pub(crate) async fn is_authenticated(
     }
 }
 
-fn user_in_group(uid: Uid, gid: Gid) -> bool {
+fn user_in_group(uid: Uid, gid: Option<Gid>) -> bool {
     if uid.is_root() {
         tracing::trace!("User is root");
         return true;
@@ -272,6 +270,10 @@ fn user_in_group(uid: Uid, gid: Gid) -> bool {
 
     let Ok(Some(user)) = User::from_uid(uid) else {
         tracing::debug!("User {uid} could not be parsed or it disappeared");
+        return false;
+    };
+    let Some(gid) = gid else {
+        tracing::debug!("No nym-vpn group");
         return false;
     };
     if user.gid == gid {

--- a/nym-vpn-core/crates/nym-ipc/src/authentication/mod.rs
+++ b/nym-vpn-core/crates/nym-ipc/src/authentication/mod.rs
@@ -5,6 +5,8 @@
 mod linux;
 #[cfg(target_os = "linux")]
 pub(crate) use linux::{Transport, incoming, is_authenticated};
+#[cfg(target_os = "linux")]
+use nix::unistd::{Gid, Group};
 
 #[cfg(target_os = "macos")]
 mod macos;
@@ -68,6 +70,8 @@ pub struct AuthenticationMaterial {
     pub(crate) nym_certificate_serial_number: String,
     #[cfg(target_os = "macos")]
     pub(crate) signing_requirements: SigningRequirements,
+    #[cfg(target_os = "linux")]
+    pub(crate) nym_vpn_gid: Option<Gid>,
     #[cfg(unix)]
     pub(crate) shutdown_token: tokio_util::sync::CancellationToken,
 }
@@ -77,14 +81,29 @@ impl AuthenticationMaterial {
         disable_client_verification: bool,
         #[cfg(target_os = "windows")] nym_certificate_serial_number: String,
         #[cfg(target_os = "macos")] signing_requirements: SigningRequirements,
+        #[cfg(target_os = "linux")] nym_vpn_group: &str,
         #[cfg(unix)] shutdown_token: tokio_util::sync::CancellationToken,
     ) -> Self {
+        #[cfg(target_os = "linux")]
+        let nym_vpn_gid = Group::from_name(nym_vpn_group)
+            .inspect_err(|err| tracing::warn!("Could not get the group {nym_vpn_group}: {err}"))
+            .inspect(|g| {
+                if g.is_none() {
+                    tracing::warn!("Not group found for {nym_vpn_group}")
+                }
+            })
+            .ok()
+            .flatten()
+            .map(|g| g.gid);
+
         Self {
             disable_client_verification,
             #[cfg(target_os = "windows")]
             nym_certificate_serial_number,
             #[cfg(target_os = "macos")]
             signing_requirements,
+            #[cfg(target_os = "linux")]
+            nym_vpn_gid,
             #[cfg(unix)]
             shutdown_token,
         }

--- a/nym-vpn-core/crates/nym-vpn-proto/src/rpc_client.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/rpc_client.rs
@@ -1066,7 +1066,9 @@ pub enum Error {
     #[error("Failed to parse rpc response: {0}")]
     InvalidResponse(#[source] crate::conversions::ConversionError),
 
-    #[error("Authentication is required to access the daemon")]
+    #[error(
+        "Authentication is required to access the daemon. Consider adding your user to the nym-vpn group: usermod -aG nym-vpn \"$USER\" (needs root permissions)"
+    )]
     AuthenticationRequired,
 }
 

--- a/nym-vpn-core/crates/nym-vpn-proto/src/rpc_client.rs
+++ b/nym-vpn-core/crates/nym-vpn-proto/src/rpc_client.rs
@@ -1066,9 +1066,14 @@ pub enum Error {
     #[error("Failed to parse rpc response: {0}")]
     InvalidResponse(#[source] crate::conversions::ConversionError),
 
+    #[cfg(target_os = "linux")]
     #[error(
         "Authentication is required to access the daemon. Consider adding your user to the nym-vpn group: usermod -aG nym-vpn \"$USER\" (needs root permissions)"
     )]
+    AuthenticationRequired,
+
+    #[cfg(not(target_os = "linux"))]
+    #[error("Authentication is required to access the daemon.")]
     AuthenticationRequired,
 }
 

--- a/nym-vpn-core/crates/nym-vpnd/.pkg/aur/PKGBUILD
+++ b/nym-vpn-core/crates/nym-vpnd/.pkg/aur/PKGBUILD
@@ -59,4 +59,5 @@ package() {
   popd
 
   install -Dm644 nym-vpnd.service "$pkgdir/usr/lib/systemd/system/nym-vpnd.service"
+  install -Dm644 "../sysusers.d/nym-vpn.conf" "$pkgdir/usr/lib/sysusers.d/nym-vpn.conf"
 }

--- a/nym-vpn-core/crates/nym-vpnd/.pkg/aur/PKGBUILD
+++ b/nym-vpn-core/crates/nym-vpnd/.pkg/aur/PKGBUILD
@@ -15,8 +15,8 @@ makedepends=('rust' 'cargo' 'go' 'protobuf')
 provides=('nym-vpnd' 'nym-exclude' 'nym-socks5-proxy')
 conflicts=('nym-vpnd')
 options=(!debug)
-source=("$url/archive/refs/tags/${RELEASE_TAG}.tar.gz" 'nym-vpnd.service')
-sha256sums=($SRC_TARBALL_SHA256 $SERVICE_SHA256)
+source=("$url/archive/refs/tags/${RELEASE_TAG}.tar.gz" 'nym-vpnd.service' 'nym-vpn.conf')
+sha256sums=($SRC_TARBALL_SHA256 $SERVICE_SHA256 $CONF_SHA256)
 _srcdir="nym-vpn-client-${RELEASE_TAG}"
 
 prepare() {
@@ -59,5 +59,5 @@ package() {
   popd
 
   install -Dm644 nym-vpnd.service "$pkgdir/usr/lib/systemd/system/nym-vpnd.service"
-  install -Dm644 "../sysusers.d/nym-vpn.conf" "$pkgdir/usr/lib/sysusers.d/nym-vpn.conf"
+  install -Dm644 nym-vpn.conf "$pkgdir/usr/lib/sysusers.d/nym-vpn.conf"
 }

--- a/nym-vpn-core/crates/nym-vpnd/.pkg/aur/PKGBUILD-bin
+++ b/nym-vpn-core/crates/nym-vpnd/.pkg/aur/PKGBUILD-bin
@@ -29,4 +29,5 @@ package() {
   popd
 
   install -Dm644 nym-vpnd.service "$pkgdir/usr/lib/systemd/system/nym-vpnd.service"
+  install -Dm644 "../sysusers.d/nym-vpn.conf" "$pkgdir/usr/lib/sysusers.d/nym-vpn.conf"
 }

--- a/nym-vpn-core/crates/nym-vpnd/.pkg/aur/PKGBUILD-bin
+++ b/nym-vpn-core/crates/nym-vpnd/.pkg/aur/PKGBUILD-bin
@@ -15,10 +15,10 @@ makedepends=()
 provides=('nym-vpnd' 'nym-exclude' 'nym-socks5-proxy')
 conflicts=('nym-vpnd')
 options=(!debug)
-source_x86_64=("$url/releases/download/${RELEASE_TAG}/nym-vpn-core-v${PKGVER}_linux_x86_64.tar.gz" 'nym-vpnd.service')
-source_aarch64=("$url/releases/download/${RELEASE_TAG}/nym-vpn-core-v${PKGVER}_linux_aarch64.tar.gz" 'nym-vpnd.service')
-sha256sums_x86_64=($TARBALL_SHA256_X86_64 $SERVICE_SHA256)
-sha256sums_aarch64=($TARBALL_SHA256_AARCH64 $SERVICE_SHA256)
+source_x86_64=("$url/releases/download/${RELEASE_TAG}/nym-vpn-core-v${PKGVER}_linux_x86_64.tar.gz" 'nym-vpnd.service' 'nym-vpn.conf')
+source_aarch64=("$url/releases/download/${RELEASE_TAG}/nym-vpn-core-v${PKGVER}_linux_aarch64.tar.gz" 'nym-vpnd.service' 'nym-vpn.conf')
+sha256sums_x86_64=($TARBALL_SHA256_X86_64 $SERVICE_SHA256 $CONF_SHA256)
+sha256sums_aarch64=($TARBALL_SHA256_AARCH64 $SERVICE_SHA256 $CONF_SHA256)
 
 package() {
   pushd "nym-vpn-core-v${PKGVER}_linux_${CARCH}"
@@ -29,5 +29,5 @@ package() {
   popd
 
   install -Dm644 nym-vpnd.service "$pkgdir/usr/lib/systemd/system/nym-vpnd.service"
-  install -Dm644 "../sysusers.d/nym-vpn.conf" "$pkgdir/usr/lib/sysusers.d/nym-vpn.conf"
+  install -Dm644 nym-vpn.conf "$pkgdir/usr/lib/sysusers.d/nym-vpn.conf"
 }

--- a/nym-vpn-core/crates/nym-vpnd/.pkg/aur/nym-vpn.conf
+++ b/nym-vpn-core/crates/nym-vpnd/.pkg/aur/nym-vpn.conf
@@ -1,0 +1,1 @@
+g nym-vpn -

--- a/nym-vpn-core/crates/nym-vpnd/.pkg/sysusers.d/nym-vpn.conf
+++ b/nym-vpn-core/crates/nym-vpnd/.pkg/sysusers.d/nym-vpn.conf
@@ -1,0 +1,1 @@
+g nym-vpn -

--- a/nym-vpn-core/crates/nym-vpnd/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpnd/Cargo.toml
@@ -81,11 +81,12 @@ This package contains the nym-vpnd daemon binary, which runs as a background ser
 End-users should use either the CLI client, nym-vpnc, or the GUI client, nym-vpn-app.'''
 maintainer-scripts = "linux/scripts"
 recommends = "nym-vpnc"
-depends = "$auto, policykit-1 | polkit | polkitd"
+depends = "$auto, adduser, policykit-1 | polkit | polkitd"
 assets = [
     "$auto",
     { source = "target/release/nym-exclude", dest = "usr/bin/nym-exclude", mode = "755" },
     { source = "target/release/nym-socks5-proxy", dest = "usr/bin/nym-socks5-proxy", mode = "755" },
+    { source = ".pkg/sysusers.d/nym-vpn.conf", dest = "usr/lib/sysusers.d/nym-vpn.conf", mode = "644" },
 ]
 revision = ""
 

--- a/nym-vpn-core/crates/nym-vpnd/linux/scripts/postinst
+++ b/nym-vpn-core/crates/nym-vpnd/linux/scripts/postinst
@@ -4,6 +4,13 @@ set -e
 
 if [ "$1" = "configure" ] ; then
     chmod u+s /usr/bin/nym-exclude
+    
+    if command -v systemd-sysusers >/dev/null 2>&1; then
+      systemd-sysusers /usr/lib/sysusers.d/nym-vpn.conf
+    elif ! getent group nym-vpn >/dev/null; then
+      addgroup --system nym-vpn
+    fi
+
 fi
 
 #DEBHELPER#

--- a/nym-vpn-core/crates/nym-vpnd/src/command_interface.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/command_interface.rs
@@ -42,6 +42,8 @@ const NYM_CERTIFICATE_SERIAL_NUMBER: &str = "4ec9356d8c87f9cf3ccf60e7bdad022f";
 const CLIENT_SIGNING_REQUIREMENT: &str = r#"anchor apple generic and certificate leaf[subject.OU] = "VW5DZLFHM5" and (identifier "net.nymtech.vpn" or identifier "net.nymtech.vpn.cli")"#;
 #[cfg(target_os = "macos")]
 const DAEMON_SIGNING_REQUIREMENT: &str = r#"anchor apple generic and certificate leaf[subject.OU] = "VW5DZLFHM5" and identifier "net.nymtech.vpn.daemon""#;
+#[cfg(target_os = "linux")]
+const NYM_VPN_GROUP_NAME: &str = "nym-vpn";
 
 pub struct CommandInterface {
     // Send commands to the VPN service
@@ -1404,6 +1406,8 @@ pub async fn start_command_interface(
                 daemon_req: DAEMON_SIGNING_REQUIREMENT.to_string(),
                 client_req: CLIENT_SIGNING_REQUIREMENT.to_string(),
             },
+            #[cfg(target_os = "linux")]
+            NYM_VPN_GROUP_NAME,
             #[cfg(unix)]
             shutdown_token.child_token(),
         ),


### PR DESCRIPTION
## Ticket

JIRA-NYM-1733

## Description

Add the option of authenticating via UNIX group on Linux, or being `root`.

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6100)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Linux users who are root or members of the `nym-vpn` group can authenticate without an additional permission prompt.
  * The `nym-vpn` system group is now created automatically during package installation.
  * Authentication errors now explain how to join the `nym-vpn` group or use root privileges.

* **Documentation**
  * Added Linux authentication details to the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->