### PR TITLE
Fix race of initial location querying

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -92,12 +92,6 @@ impl ConnectingState {
         #[cfg(any(target_os = "android", target_os = "ios"))]
         shared_state.allow_networking().await;
 
-        // Disallow geolocating while connected to prevent incorrect data from being queried
-        shared_state
-            .gateway_provider
-            .set_active_geo_location(false)
-            .await;
-
         #[cfg(target_os = "macos")]
         if let Err(e) = Self::set_local_dns_resolver(shared_state).await {
             trace_err_chain!(e, "Failed to configure system to use filtering resolver");

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -643,6 +643,9 @@ impl TunnelMonitor {
         let (entry_metadata_addr_tx, entry_metadata_addr_rx) = tokio::sync::oneshot::channel();
         let (bridge_close_tx, mut bridge_close_rx) = mpsc::unbounded_channel();
 
+        // We have to stop querying for location before starting the tunnels, to prevent incorrect data.
+        self.gateway_provider.set_active_geo_location(false).await;
+
         // todo: refactor
         let (
             StartTunnelResult {


### PR DESCRIPTION
The query for the initial location was being awaited while the `Connecting` state was cutting off the querying from the other end.
With this patch, the cut off happens after gateway selection happened, right before tunnels are setup (which is what would introduce bogus geo location data that we were trying to avoid in the first place, with the cut offs)

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6101)
<!-- Reviewable:end -->
