### PR TITLE
NYM-1664: (tauri) Implement recents

### DIFF
--- a/nym-vpn-app/CHANGELOG.md
+++ b/nym-vpn-app/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Allow marking specific server, country or region as favorite
 - Add Safest server option for entry and exit
+- Add support for Recents - recently connected servers
 
 ### Fixed
 

--- a/nym-vpn-app/e2e/pages/MainPage.ts
+++ b/nym-vpn-app/e2e/pages/MainPage.ts
@@ -19,7 +19,9 @@ class MainPage {
     this.themeButton = page.getByTestId('top-bar-left-button-container');
     this.settingsButton = page.getByRole('button', { name: 'settings' });
     this.statusText = page.getByTestId('connection-status-text');
-    this.fastMode = page.getByRole('button', { name: 'Fast', exact: true });
+    // Fast mode (`wg`) is labelled "dVPN" in the UI; the mode names stay
+    // internal so a copy change only touches this locator.
+    this.fastMode = page.getByRole('button', { name: 'dVPN', exact: true });
     this.mixnetMode = page.getByRole('button', { name: 'Mixnet', exact: true });
     this.entryServerLabel = page.getByText('Entry server', { exact: true });
     this.exitServerLabel = page.getByText('Exit server', { exact: true });

--- a/nym-vpn-app/e2e/pages/NodeList.ts
+++ b/nym-vpn-app/e2e/pages/NodeList.ts
@@ -18,6 +18,16 @@ class NodeListPage {
   readonly locationAccuracyHeading: Locator;
   readonly closeModalButton: Locator;
 
+  readonly viewToggle: Locator;
+  readonly favoritesView: Locator;
+  readonly recentsView: Locator;
+  readonly allView: Locator;
+  readonly recentsList: Locator;
+  readonly recentRows: Locator;
+  readonly recentsEmpty: Locator;
+  readonly recentsNoResults: Locator;
+  readonly recentsError: Locator;
+
   constructor(private readonly page: Page) {
     this.backButton = page.getByRole('button', { name: 'keyboard_arrow_left' });
     this.infoButton = page.getByRole('button', { name: 'info' }).first();
@@ -41,6 +51,16 @@ class NodeListPage {
       name: 'Location accuracy',
     });
     this.closeModalButton = page.getByRole('button', { name: 'Ok' });
+
+    this.viewToggle = page.getByTestId('node-list-view-toggle');
+    this.favoritesView = page.getByTestId('node-list-view-favorites');
+    this.recentsView = page.getByTestId('node-list-view-recents');
+    this.allView = page.getByTestId('node-list-view-all');
+    this.recentsList = page.getByTestId('recents-list');
+    this.recentRows = this.recentsList.getByTestId('gateway-row');
+    this.recentsEmpty = page.getByTestId('recents-empty');
+    this.recentsNoResults = page.getByTestId('recents-no-results');
+    this.recentsError = page.getByTestId('recents-error');
   }
 
   async goto() {
@@ -86,6 +106,17 @@ class NodeListPage {
 
   async clickNodeDetailsButton(index: number) {
     await this.nodeDetailsButtons.nth(index).click();
+  }
+
+  async showRecents() {
+    await this.recentsView.click();
+  }
+
+  /** Recent server names, in the order the list renders them. */
+  async recentNames(): Promise<string[]> {
+    // A row renders its name then its location as sibling paragraphs, so the
+    // name is the one that is first in its container.
+    return await this.recentRows.locator('p:first-child').allTextContents();
   }
 
   async openInfoModal() {

--- a/nym-vpn-app/e2e/tests/nodes.recents.spec.ts
+++ b/nym-vpn-app/e2e/tests/nodes.recents.spec.ts
@@ -1,0 +1,148 @@
+import { expect, test } from '@playwright/test';
+import MainPage from '../pages/MainPage';
+import NodeListPage from '../pages/NodeList';
+
+/**
+ * The recents view of the node location screen.
+ *
+ * The mocked daemon (`src/dev/setup.ts`) serves recents per mode and hop: dVPN
+ * mode has recents for both hops, mixnet has none. The screen opens on the Exit
+ * tab, so that hop's recents are what the default assertions describe.
+ */
+test.describe('NodesRecents', () => {
+  let nodeListPage: NodeListPage;
+
+  test.beforeEach(async ({ page }) => {
+    nodeListPage = new NodeListPage(page);
+    await nodeListPage.goto();
+  });
+
+  test('renders the recents tab in the view toggle', async () => {
+    await expect(nodeListPage.viewToggle).toBeVisible();
+    await expect(nodeListPage.recentsView).toBeVisible();
+    await expect(nodeListPage.allView).toHaveAttribute('aria-pressed', 'true');
+    await expect(nodeListPage.recentsView).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    );
+  });
+
+  test('switches to the recents view', async () => {
+    await nodeListPage.showRecents();
+
+    await expect(nodeListPage.recentsView).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+    await expect(nodeListPage.recentsList).toBeVisible();
+  });
+
+  test('lists recent servers most-recent-first', async () => {
+    await nodeListPage.showRecents();
+
+    await expect(nodeListPage.recentRows).toHaveCount(2);
+    expect(await nodeListPage.recentNames()).toEqual([
+      'Mikhaïl Boulgakov 😼',
+      'High speed gateway',
+    ]);
+  });
+
+  test('shows the full location on a recent server row', async ({ page }) => {
+    await nodeListPage.showRecents();
+
+    // Recents are ungrouped, so each row carries its own country context.
+    await expect(page.getByText('Elektrozavodsk, Russia')).toBeVisible();
+    await expect(
+      page.getByText('New York, New York, United States'),
+    ).toBeVisible();
+  });
+
+  test('tracks the selected view per hop', async () => {
+    await nodeListPage.showRecents();
+    await expect(nodeListPage.recentsView).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+
+    await nodeListPage.entryTab.click();
+
+    // Each hop keeps its own view, so Entry is still on the full list.
+    await expect(nodeListPage.allView).toHaveAttribute('aria-pressed', 'true');
+    await expect(nodeListPage.recentsList).toHaveCount(0);
+  });
+
+  test('lists the recents of the selected hop', async () => {
+    await nodeListPage.entryTab.click();
+    await nodeListPage.showRecents();
+
+    await expect(nodeListPage.recentRows).toHaveCount(3);
+    expect(await nodeListPage.recentNames()).toEqual([
+      'High speed gateway',
+      'la porte en bois',
+      'Mikhaïl Boulgakov 😼',
+    ]);
+  });
+
+  test('filters recents by search term', async () => {
+    await nodeListPage.showRecents();
+    await nodeListPage.fillSearchInput('New York');
+
+    await expect(nodeListPage.recentRows).toHaveCount(1);
+    expect(await nodeListPage.recentNames()).toEqual(['High speed gateway']);
+  });
+
+  test('shows no results for an unknown search term', async () => {
+    await nodeListPage.showRecents();
+    await nodeListPage.fillSearchInput('nowhere-at-all');
+
+    await expect(nodeListPage.recentsNoResults).toBeVisible();
+    await expect(nodeListPage.recentRows).toHaveCount(0);
+    // A search matching nothing must not read as "no recents".
+    await expect(nodeListPage.recentsEmpty).toHaveCount(0);
+  });
+
+  test('restores the list after clearing the search', async () => {
+    await nodeListPage.showRecents();
+    await nodeListPage.fillSearchInput('nowhere-at-all');
+    await expect(nodeListPage.recentRows).toHaveCount(0);
+
+    await nodeListPage.clearSearchInput();
+
+    await expect(nodeListPage.recentRows).toHaveCount(2);
+  });
+
+  test('shows the empty state when the mode has no recents', async ({
+    page,
+  }) => {
+    const mainPage = new MainPage(page);
+    await mainPage.goto();
+    await mainPage.mixnetMode.click();
+    await expect(mainPage.mixnetMode).toHaveAttribute('aria-pressed', 'true');
+
+    // Reached through the UI rather than a reload: the mocked backend does not
+    // persist the mode, so reloading would drop back to dVPN.
+    await mainPage.serverRow('Exit').click();
+    await expect(page).toHaveURL(/\/node-location/);
+    await nodeListPage.showRecents();
+
+    await expect(nodeListPage.recentsEmpty).toBeVisible();
+    await expect(nodeListPage.recentsList).toHaveCount(0);
+  });
+
+  test('keeps the recents view when navigating to node details and back', async ({
+    page,
+  }) => {
+    await nodeListPage.showRecents();
+    await nodeListPage.clickNodeDetailsButton(0);
+    await expect(page).toHaveURL(/\/node-details/);
+
+    await nodeListPage.backButton.click();
+
+    await expect(page).toHaveURL(/\/node-location/);
+    await expect(nodeListPage.recentsView).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+    await expect(nodeListPage.recentsList).toBeVisible();
+  });
+});

--- a/nym-vpn-app/src-tauri/src/commands/gateway.rs
+++ b/nym-vpn-app/src-tauri/src/commands/gateway.rs
@@ -8,8 +8,9 @@ use ts_rs::TS;
 
 use crate::country::Country;
 use crate::error::{BackendError, ErrorKey};
+use crate::state::app::VpnMode;
 use crate::vpnd::client::VpndClient;
-use crate::vpnd::gateway::{Gateway, GatewayType};
+use crate::vpnd::gateway::{Gateway, GatewayType, RecentGateways};
 
 #[derive(Debug, Serialize, Deserialize, TS, Clone)]
 #[ts(export, export_to = "tauri.ts")]
@@ -170,6 +171,31 @@ pub async fn get_gateways(
                     .iter()
                     .for_each(|region| trace!("{}", region));
             }
+        })
+}
+
+#[instrument(skip(vpnd))]
+#[tauri::command]
+pub async fn get_recent_gateways(
+    vpn_mode: VpnMode,
+    vpnd: State<'_, VpndClient>,
+) -> Result<RecentGateways, BackendError> {
+    info!("fetching recent gateways");
+    vpnd.recent_gateways(&vpn_mode)
+        .await
+        .map_err(|e| {
+            BackendError::with_detail(
+                &format!("failed to get recent gateways for {vpn_mode}"),
+                ErrorKey::Internal,
+                e.to_string(),
+            )
+        })
+        .inspect(|recents| {
+            info!(
+                "recent gateways: entry #{}, exit #{}",
+                recents.entry.len(),
+                recents.exit.len()
+            );
         })
 }
 

--- a/nym-vpn-app/src-tauri/src/main.rs
+++ b/nym-vpn-app/src-tauri/src/main.rs
@@ -364,6 +364,7 @@ async fn main() -> Result<()> {
             cmd_db::db_del,
             cmd_db::db_flush,
             cmd_gw::get_gateways,
+            cmd_gw::get_recent_gateways,
             cmd_favorites::get_favorites,
             cmd_favorites::add_favorite,
             cmd_favorites::remove_favorite,

--- a/nym-vpn-app/src-tauri/src/vpnd/client.rs
+++ b/nym-vpn-app/src-tauri/src/vpnd/client.rs
@@ -12,7 +12,7 @@ pub use super::{
 use super::{
     config::{MixnetTrafficConfig, VpndConfig},
     events::{DiagnosticsSuggestedReason, MixnetEvent},
-    gateway::{Gateway, GatewayType},
+    gateway::{Gateway, GatewayType, RecentGateways, parse_gateways},
     tentative_gateways::TentativeGateways,
     tunnel::{FrontingMode, SplitApp, TunnelState},
 };
@@ -37,7 +37,7 @@ pub use crate::vpnd::network::NetworkCompatVersions;
 use crate::{
     error::BackendError,
     events::AppHandleEventEmitter,
-    state::SharedAppState,
+    state::{SharedAppState, app::VpnMode},
     vpnd::account::{AccountState, log_account_state},
 };
 
@@ -654,17 +654,46 @@ impl VpndClient {
 
         debug!("vpnd gateways count: {}", gateways.len());
 
-        let gateways: Vec<Gateway> = gateways
-            .into_iter()
-            .filter_map(|gateway| {
-                Gateway::from_lib(gateway, gw_type)
-                    .inspect_err(|e| warn!("failed to parse gateway from lib: {e}"))
-                    .ok()
-            })
-            .collect();
+        let gateways = parse_gateways(gateways, gw_type);
 
         debug!("parsed gateway #{}", gateways.len());
         Ok(gateways)
+    }
+
+    /// Get the gateways of the most recent successful connections for the given
+    /// mode, most-recent-first.
+    #[instrument(skip(self))]
+    pub async fn recent_gateways(&self, mode: &VpnMode) -> Result<RecentGateways, VpndError> {
+        let mut vpnd = self.vpnd().await?;
+
+        let params = lib::GetRecentGatewaysParams {
+            tunnel_type: match mode {
+                VpnMode::Mixnet => lib::TunnelType::Mixnet,
+                VpnMode::Wg => lib::TunnelType::Wireguard,
+            },
+        };
+
+        let recents = vpnd
+            .get_recent_gateways(params)
+            .or_else(async |e| self.handle_rpc_error("get_recent_gateways", e).await)
+            .await?;
+
+        let (entry_type, exit_type) = match mode {
+            VpnMode::Mixnet => (GatewayType::MxEntry, GatewayType::MxExit),
+            VpnMode::Wg => (GatewayType::Wg, GatewayType::Wg),
+        };
+
+        let recents = RecentGateways {
+            entry: parse_gateways(recents.entry, entry_type),
+            exit: parse_gateways(recents.exit, exit_type),
+        };
+
+        debug!(
+            "parsed recent gateways: entry #{}, exit #{}",
+            recents.entry.len(),
+            recents.exit.len()
+        );
+        Ok(recents)
     }
 
     #[instrument(skip(self, app))]

--- a/nym-vpn-app/src-tauri/src/vpnd/gateway.rs
+++ b/nym-vpn-app/src-tauri/src/vpnd/gateway.rs
@@ -89,6 +89,27 @@ pub struct Gateway {
     pub node_family_name: Option<String>,
 }
 
+/// Convert daemon gateways into their app representation, dropping any that
+/// cannot be parsed (a missing location makes a gateway unusable to the UI).
+pub fn parse_gateways(gateways: Vec<lib::Gateway>, gw_type: GatewayType) -> Vec<Gateway> {
+    gateways
+        .into_iter()
+        .filter_map(|gateway| {
+            Gateway::from_lib(gateway, gw_type)
+                .inspect_err(|e| warn!("failed to parse gateway from lib: {e}"))
+                .ok()
+        })
+        .collect()
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, TS, Default)]
+#[ts(export, export_to = "tauri.ts")]
+#[serde(rename_all = "camelCase")]
+pub struct RecentGateways {
+    pub entry: Vec<Gateway>,
+    pub exit: Vec<Gateway>,
+}
+
 impl Gateway {
     #[instrument]
     pub fn from_lib(gateway: lib::Gateway, gw_type: GatewayType) -> Result<Self> {

--- a/nym-vpn-app/src/contexts/main/provider.tsx
+++ b/nym-vpn-app/src/contexts/main/provider.tsx
@@ -43,7 +43,11 @@ function MainStateProvider({ children, init }: Props) {
       return;
     }
     gatewaysInit = true;
-    const { fetchGateways } = useAppStore.getState();
+    const { fetchGateways, fetchRecents } = useAppStore.getState();
+    // Warm the recents list so the first visit to the node list has it in hand.
+    // Fire-and-forget: a failure here is stored on `recentsError` for the
+    // recents view alone and must never hold up init or surface a toast.
+    fetchRecents(vpnMode);
     if (vpnMode === 'wg') {
       await fetchGateways('wg');
       console.info('[wg] gateways initialized');

--- a/nym-vpn-app/src/dev/setup.ts
+++ b/nym-vpn-app/src/dev/setup.ts
@@ -5,14 +5,17 @@ import {
   Cli,
   DbKey,
   FeatureFlags,
+  Gateway,
   GatewayType,
   GatewaysByCountry,
   NetworkCompat,
+  RecentGateways,
   TAccountMode,
   TAccountState,
   TTunnelState,
   UiTheme,
   UpdateMetadata,
+  VpnMode,
   VpndStatus,
 } from '../types';
 import { AccountStateEvent, TunnelStateEvent } from '../constants';
@@ -57,6 +60,36 @@ const featureFlags: FeatureFlags = {
   quic: true,
   domainFronting: true,
   zknymCredential: true,
+};
+
+/**
+ * Takes the first gateway of each named country, in the order given.
+ *
+ * Recents reuse the gateways the list already serves so selecting one behaves
+ * the same from either view, and the argument order stands in for the daemon's
+ * most-recent-first ordering.
+ */
+function pickGateways(
+  source: GatewaysByCountry[],
+  countryCodes: string[],
+): Gateway[] {
+  return countryCodes.flatMap((code) => {
+    const country = source.find((c) => c.country.code === code);
+    return country?.gateways[0] ? [country.gateways[0]] : [];
+  });
+}
+
+// The mixnet lists are empty fixtures, so mixnet recents come out empty too —
+// which is how the empty state gets exercised in dev-browser mode.
+const recents: Record<VpnMode, RecentGateways> = {
+  wg: {
+    entry: pickGateways(wgGwJson as GatewaysByCountry[], ['US', 'FR', 'RU']),
+    exit: pickGateways(wgGwJson as GatewaysByCountry[], ['RU', 'US']),
+  },
+  mixnet: {
+    entry: pickGateways(mxEntryGwJson, ['FR']),
+    exit: pickGateways(mxExitGwJson, ['US']),
+  },
 };
 
 export function mockTauriIPC() {
@@ -125,6 +158,12 @@ export function mockTauriIPC() {
               return;
           }
         });
+      }
+
+      if (cmd === 'get_recent_gateways') {
+        return new Promise<RecentGateways>((resolve) =>
+          resolve(recents[(args as ArgsObj<VpnMode>).vpnMode]),
+        );
       }
 
       if (cmd === 'db_get') {

--- a/nym-vpn-app/src/hooks/useNodeListData.ts
+++ b/nym-vpn-app/src/hooks/useNodeListData.ts
@@ -172,6 +172,9 @@ export function useNodeListData(hop: NodeHop) {
     mxEntryError,
     mxExitError,
     wgError,
+    recents,
+    recentsLoading,
+    recentsError,
   } = useAppStore(
     useShallow((s) => ({
       vpnMode: s.vpnMode,
@@ -188,6 +191,9 @@ export function useNodeListData(hop: NodeHop) {
       mxEntryError: s.mxEntryError,
       mxExitError: s.mxExitError,
       wgError: s.wgError,
+      recents: s.recents,
+      recentsLoading: s.recentsLoading,
+      recentsError: s.recentsError,
     })),
   );
 
@@ -228,6 +234,20 @@ export function useNodeListData(hop: NodeHop) {
     return flat.sort((a, b) => compare(a.name, b.name));
   }, [nodes, compare]);
 
+  // The daemon returns these most-recent-first and they render as a flat list,
+  // so the order is passed through untouched — sorting here destroys it.
+  const recentGateways = useMemo(
+    () =>
+      gatewaysToUi(
+        recents[vpnMode][hop],
+        entryNode,
+        exitNode,
+        quicFilter,
+        favoriteKeys,
+      ),
+    [recents, vpnMode, hop, entryNode, exitNode, quicFilter, favoriteKeys],
+  );
+
   const loading = useMemo(() => {
     if (nodes.length > 0) return false;
     if (vpnMode === 'mixnet' && hop === 'entry') return mxEntryLoading;
@@ -241,5 +261,15 @@ export function useNodeListData(hop: NodeHop) {
     return wgError;
   }, [vpnMode, hop, mxEntryError, mxExitError, wgError]);
 
-  return { nodes, gateways, loading, error, vpnMode, quicFilter };
+  return {
+    nodes,
+    gateways,
+    recentGateways,
+    loading,
+    recentsLoading,
+    error,
+    recentsError,
+    vpnMode,
+    quicFilter,
+  };
 }

--- a/nym-vpn-app/src/hooks/useNodeListData.ts
+++ b/nym-vpn-app/src/hooks/useNodeListData.ts
@@ -192,8 +192,8 @@ export function useNodeListData(hop: NodeHop) {
       mxExitError: s.mxExitError,
       wgError: s.wgError,
       recents: s.recents,
-      recentsLoading: s.recentsLoading,
-      recentsError: s.recentsError,
+      recentsLoading: s.recentsLoading[s.vpnMode],
+      recentsError: s.recentsError[s.vpnMode],
     })),
   );
 

--- a/nym-vpn-app/src/i18n/en/node-location.json
+++ b/nym-vpn-app/src/i18n/en/node-location.json
@@ -81,6 +81,7 @@
   },
   "favorites": {
     "tab-favorites": "Favorites",
+    "tab-recents": "Recents",
     "tab-all": "All servers",
     "add": "Add to favorites",
     "remove": "Remove from favorites",
@@ -91,6 +92,13 @@
       "unavailable": "None of your favorites are available here.",
       "unavailable-description": "Your favorites aren't in this mode's server list. Switch mode or pick another server."
     }
+  },
+  "recents": {
+    "empty": {
+      "title": "No recent servers yet.",
+      "description": "Servers you connect to will show up here."
+    },
+    "error": "Failed to load recent servers."
   },
   "search-other-nodes": "Servers",
   "no-results-found": {

--- a/nym-vpn-app/src/screens/home/ModeToggle.tsx
+++ b/nym-vpn-app/src/screens/home/ModeToggle.tsx
@@ -7,7 +7,12 @@ import {
   GatewayAnonymousIcon,
   GatewayFastIcon,
 } from '../../assets/icons/gateway-mode';
-import { dispatch, useAppStore, useFetchGateways } from '../../store';
+import {
+  dispatch,
+  useAppStore,
+  useFetchGateways,
+  useFetchRecents,
+} from '../../store';
 import { useToast } from '../../hooks';
 import { VpnMode } from '../../types';
 
@@ -22,6 +27,7 @@ export const ModeToggle = () => {
   const { t } = useTranslation('home');
   const { add } = useToast();
   const fetchGateways = useFetchGateways();
+  const fetchRecents = useFetchRecents();
 
   const { vpnMode } = useAppStore(
     useShallow((s) => ({
@@ -42,6 +48,7 @@ export const ModeToggle = () => {
       } else {
         fetchGateways('wg');
       }
+      fetchRecents(mode);
       return true;
     } catch (error: unknown) {
       console.error(`failed to set vpn mode to [${mode}]`, error);

--- a/nym-vpn-app/src/screens/node/Node.tsx
+++ b/nym-vpn-app/src/screens/node/Node.tsx
@@ -2,7 +2,6 @@ import { useDeferredValue, useEffect, useMemo, useRef } from 'react';
 import clsx from 'clsx';
 import { useNavigate } from 'react-router';
 import { Trans, useTranslation } from 'react-i18next';
-import { motion } from 'motion/react';
 import { invoke } from '@tauri-apps/api/core';
 import { Button } from '@headlessui/react';
 import { useDialog } from '../../contexts';
@@ -13,18 +12,26 @@ import {
   uiNodeToSelectedNode,
 } from '../../types/node';
 import { Link, MsIcon, PageAnim, SmileyIcon, TextInput } from '../../ui';
-import { useI18nError, useToast } from '../../hooks';
+import { useI18nError, useLang, useToast } from '../../hooks';
 import { useNodeListData } from '../../hooks/useNodeListData';
 import { routes } from '../../router';
-import { dispatch, useAppStore, useFetchGateways } from '../../store';
+import {
+  dispatch,
+  useAppStore,
+  useFetchGateways,
+  useFetchRecents,
+} from '../../store';
 import { useNodeListState } from '../../store/nodeListState';
 import { useFavorites } from '../../store/favoritesState';
 import { LocationDetailsDialog } from './location-details-dialog';
 import {
   FavoritesEmpty,
+  ListLoading,
   NodeList,
+  RecentsPanel,
   ViewToggle,
   filterToFavorites,
+  searchGateways,
   useFilterList,
 } from './list';
 
@@ -37,14 +44,18 @@ function Node({ node }: { node: NodeHop }) {
     node === 'entry' ? s.entryNode : s.exitNode,
   );
   const fetchGateways = useFetchGateways();
+  const fetchRecents = useFetchRecents();
 
   const {
     loading,
+    recentsLoading,
     error,
+    recentsError,
     vpnMode,
     quicFilter,
     nodes: rawNodes,
     gateways: rawGateways,
+    recentGateways,
   } = useNodeListData(node);
 
   const { isOpen, close } = useDialog();
@@ -67,6 +78,7 @@ function Node({ node }: { node: NodeHop }) {
   const favorites = useFavorites(node);
 
   const { tE } = useI18nError();
+  const { getCountryName } = useLang();
   const navigate = useNavigate();
   const { add } = useToast();
   const { t } = useTranslation('node-location');
@@ -95,17 +107,31 @@ function Node({ node }: { node: NodeHop }) {
   const deferredGateways = useDeferredValue(gateways);
   const searchRef = useRef<HTMLInputElement>(null);
 
+  const searchedRecents = useMemo(
+    () => searchGateways(recentGateways, search || '', getCountryName),
+    [recentGateways, search, getCountryName],
+  );
+
+  const isRecents = view === 'recents';
+
   const countriesCount = useMemo(() => {
+    if (isRecents) {
+      return new Set(searchedRecents.map((gw) => gw.country.code)).size;
+    }
     return new Set(nodes.map((node) => node.country.code)).size;
-  }, [nodes]);
+  }, [isRecents, searchedRecents, nodes]);
 
   const nodesCount = useMemo(() => {
+    if (isRecents) return searchedRecents.length;
     return nodes.reduce((acc, node) => acc + node.gateways.length, 0);
-  }, [nodes]);
+  }, [isRecents, searchedRecents, nodes]);
 
   useEffect(() => {
     if (daemonStatus === 'down') return;
     fetchGateways(vpnMode === 'mixnet' ? `mx-${node}` : 'wg');
+    // One call covers both hops — the daemon returns the entry and exit queues
+    // together, keyed only on tunnel type.
+    fetchRecents(vpnMode);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [node, vpnMode, daemonStatus]);
 
@@ -245,60 +271,66 @@ function Node({ node }: { node: NodeHop }) {
           </div>
         </div>
         <div className="min-h-0 flex-1 overflow-y-auto">
-          {loading && (
-            <motion.div
-              className="text-text-secondary mt-4 flex justify-center text-base"
-              initial={{ opacity: 0, y: 6 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.2, ease: 'easeOut' }}
-              data-testid="node-loading-indicator"
-            >
-              {t('loading')}
-            </motion.div>
-          )}
-          {!loading && view === 'favorites' && favoritesEmpty && (
-            <FavoritesEmpty hasFavorites={favorites.length > 0} />
-          )}
-          {!loading && !(view === 'favorites' && favoritesEmpty) && (
+          {isRecents ? (
+            <RecentsPanel
+              gateways={recentGateways}
+              searched={searchedRecents}
+              loading={recentsLoading}
+              error={recentsError}
+              onSelect={handleSelect}
+              onNodeDetails={handleNodeDetails}
+              hop={node}
+              vpnMode={vpnMode}
+              quicFilter={quicFilter}
+            />
+          ) : (
             <>
-              {view === 'all' && (
-                <div className="flex w-full flex-col gap-3 px-3 pt-3">
-                  <Button
-                    onClick={handleSafest}
-                    className={clsx(QUICK_PICK_CLASSES, {
-                      'border-brand-primary-active border-2': safestActive,
-                    })}
-                    data-testid="node-quick-pick-safest"
-                  >
-                    <SmileyIcon className="h-6 w-6" />
-                    <span className="text-text-primary text-base">
-                      {t('quick-pick.safest')}
-                    </span>
-                  </Button>
-                  <Button
-                    onClick={handleRandom}
-                    className={clsx(QUICK_PICK_CLASSES, {
-                      'border-brand-primary-active border-2': randomActive,
-                    })}
-                  >
-                    <MsIcon icon="shuffle" className="text-text-primary" />
-                    <span className="text-text-primary text-base">
-                      {t('quick-pick.random')}
-                    </span>
-                  </Button>
-                </div>
+              {loading && <ListLoading />}
+              {!loading && view === 'favorites' && favoritesEmpty && (
+                <FavoritesEmpty hasFavorites={favorites.length > 0} />
               )}
-              <NodeList
-                nodes={deferredNodes}
-                gateways={deferredGateways}
-                onSelect={handleSelect}
-                onNodeDetails={handleNodeDetails}
-                hop={node}
-                vpnMode={vpnMode}
-                quicFilter={quicFilter}
-                expanded={expanded}
-                focused={focused}
-              />
+              {!loading && !(view === 'favorites' && favoritesEmpty) && (
+                <>
+                  {view === 'all' && (
+                    <div className="flex w-full flex-col gap-3 px-3 pt-3">
+                      <Button
+                        onClick={handleSafest}
+                        className={clsx(QUICK_PICK_CLASSES, {
+                          'border-brand-primary-active border-2': safestActive,
+                        })}
+                        data-testid="node-quick-pick-safest"
+                      >
+                        <SmileyIcon className="h-6 w-6" />
+                        <span className="text-text-primary text-base">
+                          {t('quick-pick.safest')}
+                        </span>
+                      </Button>
+                      <Button
+                        onClick={handleRandom}
+                        className={clsx(QUICK_PICK_CLASSES, {
+                          'border-brand-primary-active border-2': randomActive,
+                        })}
+                      >
+                        <MsIcon icon="shuffle" className="text-text-primary" />
+                        <span className="text-text-primary text-base">
+                          {t('quick-pick.random')}
+                        </span>
+                      </Button>
+                    </div>
+                  )}
+                  <NodeList
+                    nodes={deferredNodes}
+                    gateways={deferredGateways}
+                    onSelect={handleSelect}
+                    onNodeDetails={handleNodeDetails}
+                    hop={node}
+                    vpnMode={vpnMode}
+                    quicFilter={quicFilter}
+                    expanded={expanded}
+                    focused={focused}
+                  />
+                </>
+              )}
             </>
           )}
         </div>

--- a/nym-vpn-app/src/screens/node/list/GatewayItem.tsx
+++ b/nym-vpn-app/src/screens/node/list/GatewayItem.tsx
@@ -87,7 +87,7 @@ const GatewayItem = ({
         'hover:bg-surface-hair',
         'last:border-illustration-accent',
         'group-last/region:last:rounded-b-2xl',
-        'border-surface-hair border-b',
+        'border-surface-hair border-b last:border-b-0',
       )}
     >
       <Button

--- a/nym-vpn-app/src/screens/node/list/GatewayItem.tsx
+++ b/nym-vpn-app/src/screens/node/list/GatewayItem.tsx
@@ -19,7 +19,12 @@ type GatewayRowProps = {
   node: NodeHop;
   vpnMode: VpnMode;
   quicLabel: boolean;
-  inSearchResult?: boolean;
+  /**
+   * Show the country (and region, where applicable) alongside the city. Needed
+   * wherever a row is shown outside its country grouping — search results and
+   * the recents list — since nothing else supplies that context.
+   */
+  fullLocation?: boolean;
 };
 
 const GatewayItem = ({
@@ -29,7 +34,7 @@ const GatewayItem = ({
   onSelect,
   onNodeDetails,
   quicLabel,
-  inSearchResult,
+  fullLocation,
 }: GatewayRowProps) => {
   const { exit: exitNodeList, entry: entryNodeList } = useNodeListState();
   const focused =
@@ -49,7 +54,7 @@ const GatewayItem = ({
   };
 
   const location = () => {
-    if (inSearchResult) {
+    if (fullLocation) {
       const countryName =
         getCountryName(gateway.country.code) || gateway.country.name;
       if (countriesWithRegions.includes(gateway.country.code)) {
@@ -81,7 +86,7 @@ const GatewayItem = ({
         'hover:bg-surface-hair',
         'last:border-illustration-accent',
         'group-last/region:last:rounded-b-2xl',
-        'border-surface-hair border-b last:border-b-0',
+        'border-surface-hair border-b',
       )}
     >
       <Button

--- a/nym-vpn-app/src/screens/node/list/GatewayItem.tsx
+++ b/nym-vpn-app/src/screens/node/list/GatewayItem.tsx
@@ -81,6 +81,7 @@ const GatewayItem = ({
   return (
     <div
       ref={scrollToGatewayRef}
+      data-testid="gateway-row"
       className={clsx(
         'flex flex-row items-center justify-between p-2 select-none',
         'hover:bg-surface-hair',

--- a/nym-vpn-app/src/screens/node/list/ListLoading.tsx
+++ b/nym-vpn-app/src/screens/node/list/ListLoading.tsx
@@ -1,0 +1,20 @@
+import { motion } from 'motion/react';
+import { useTranslation } from 'react-i18next';
+
+function ListLoading() {
+  const { t } = useTranslation('node-location');
+
+  return (
+    <motion.div
+      className="text-text-secondary mt-4 flex justify-center text-base"
+      initial={{ opacity: 0, y: 6 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.2, ease: 'easeOut' }}
+      data-testid="node-loading-indicator"
+    >
+      {t('loading')}
+    </motion.div>
+  );
+}
+
+export default ListLoading;

--- a/nym-vpn-app/src/screens/node/list/NodeList.tsx
+++ b/nym-vpn-app/src/screens/node/list/NodeList.tsx
@@ -127,7 +127,7 @@ const NodeList = memo(function NodeList({
                 onNodeDetails={onNodeDetails}
                 vpnMode={vpnMode}
                 quicLabel={quicFilter}
-                inSearchResult
+                fullLocation
               />
             </PanelContent>
           ))}

--- a/nym-vpn-app/src/screens/node/list/RecentsEmpty.tsx
+++ b/nym-vpn-app/src/screens/node/list/RecentsEmpty.tsx
@@ -1,0 +1,16 @@
+import { useTranslation } from 'react-i18next';
+
+function RecentsEmpty() {
+  const { t } = useTranslation('node-location');
+
+  return (
+    <div className="space-y-4 px-6 py-4" data-testid="recents-empty">
+      <p className="text-text-primary truncate">{t('recents.empty.title')}</p>
+      <p className="text-text-secondary whitespace-pre-line">
+        {t('recents.empty.description')}
+      </p>
+    </div>
+  );
+}
+
+export default RecentsEmpty;

--- a/nym-vpn-app/src/screens/node/list/RecentsList.tsx
+++ b/nym-vpn-app/src/screens/node/list/RecentsList.tsx
@@ -56,7 +56,10 @@ const RecentsList = memo(function RecentsList({
   }
 
   return (
-    <div className="pt-2" data-testid="recents-list">
+    <div
+      className="divide-surface-hair divide-y pt-2"
+      data-testid="recents-list"
+    >
       {gateways.map((gateway) => (
         <PanelContent animate key={gateway.id}>
           <GatewayItem

--- a/nym-vpn-app/src/screens/node/list/RecentsList.tsx
+++ b/nym-vpn-app/src/screens/node/list/RecentsList.tsx
@@ -1,0 +1,88 @@
+import { memo } from 'react';
+import { dequal } from 'dequal';
+import { Trans, useTranslation } from 'react-i18next';
+import { NodeHop, VpnMode } from '../../../types';
+import { SelectedUiNode, UiGateway } from '../../../types/node';
+import { Link } from '../../../ui';
+import { ContactSupportUrl, DocsUrl } from '../../../constants';
+import GatewayItem from './GatewayItem';
+import { PanelContent } from './NodeListPanelContent';
+
+export type RecentsListProps = {
+  gateways: UiGateway[];
+  onSelect: (node: SelectedUiNode) => void;
+  onNodeDetails: (node: UiGateway) => void;
+  hop: NodeHop;
+  vpnMode: VpnMode;
+  quicFilter: boolean;
+};
+
+/**
+ * Flat list of the most recently connected gateways, in the order the daemon
+ * reports them (most recent first).
+ *
+ * Not grouped by country, unlike the all/favorites views: grouping destroys the
+ * recency ordering that gives the list its meaning. Rows therefore render their
+ * full location, since no country header supplies that context.
+ */
+const RecentsList = memo(function RecentsList({
+  gateways,
+  onSelect,
+  onNodeDetails,
+  hop,
+  vpnMode,
+  quicFilter,
+}: RecentsListProps) {
+  const { t } = useTranslation('node-location');
+
+  if (gateways.length === 0) {
+    return (
+      <div className="space-y-4 px-6 py-4" data-testid="recents-no-results">
+        <p className="text-text-primary truncate">
+          {t('no-results-found.title')}
+        </p>
+        <p className="text-text-secondary whitespace-pre-line">
+          <Trans
+            i18nKey="no-results-found.description"
+            ns="node-location"
+            components={{
+              1: <Link url={ContactSupportUrl} color="primary" />,
+              2: <Link url={DocsUrl} color="primary" />,
+            }}
+          />
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="pt-2" data-testid="recents-list">
+      {gateways.map((gateway) => (
+        <PanelContent animate key={gateway.id}>
+          <GatewayItem
+            node={hop}
+            gateway={gateway}
+            onSelect={onSelect}
+            onNodeDetails={onNodeDetails}
+            vpnMode={vpnMode}
+            quicLabel={quicFilter}
+            fullLocation
+          />
+        </PanelContent>
+      ))}
+    </div>
+  );
+}, arePropsEqual);
+
+export default RecentsList;
+
+function arePropsEqual(
+  oldProps: RecentsListProps,
+  newProps: RecentsListProps,
+): boolean {
+  if (oldProps.hop !== newProps.hop) return false;
+  if (oldProps.vpnMode !== newProps.vpnMode) return false;
+  if (oldProps.quicFilter !== newProps.quicFilter) return false;
+  if (oldProps.gateways.length !== newProps.gateways.length) return false;
+  return dequal(oldProps.gateways, newProps.gateways);
+}

--- a/nym-vpn-app/src/screens/node/list/RecentsPanel.tsx
+++ b/nym-vpn-app/src/screens/node/list/RecentsPanel.tsx
@@ -1,0 +1,74 @@
+import { useTranslation } from 'react-i18next';
+import { AppError, NodeHop, VpnMode } from '../../../types';
+import { SelectedUiNode, UiGateway } from '../../../types/node';
+import ListLoading from './ListLoading';
+import RecentsEmpty from './RecentsEmpty';
+import RecentsList from './RecentsList';
+
+export type RecentsPanelProps = {
+  /** Every recent gateway for this hop, before the search term is applied. */
+  gateways: UiGateway[];
+  /** The subset left after the search term, in daemon recency order. */
+  searched: UiGateway[];
+  loading: boolean;
+  error: AppError | null;
+  onSelect: (node: SelectedUiNode) => void;
+  onNodeDetails: (node: UiGateway) => void;
+  hop: NodeHop;
+  vpnMode: VpnMode;
+  quicFilter: boolean;
+};
+
+/**
+ * The recents view of the node list.
+ *
+ * Recents comes from its own daemon lookup rather than the country tree, so this
+ * panel owns its loading, error and empty states. An error stays inside it:
+ * unlike a gateway list failure, a failed recents lookup must not take the
+ * screen down.
+ *
+ * Order matters below. Anything already fetched wins, so a search matching
+ * nothing falls through to `RecentsList`'s no-results copy rather than reading as
+ * "no recents". And loading is checked before the empty state, so a user who
+ * *has* recents never sees the empty copy flash on the way in.
+ */
+function RecentsPanel({
+  gateways,
+  searched,
+  loading,
+  error,
+  onSelect,
+  onNodeDetails,
+  hop,
+  vpnMode,
+  quicFilter,
+}: RecentsPanelProps) {
+  const { t } = useTranslation('node-location');
+
+  if (gateways.length > 0) {
+    return (
+      <RecentsList
+        gateways={searched}
+        onSelect={onSelect}
+        onNodeDetails={onNodeDetails}
+        hop={hop}
+        vpnMode={vpnMode}
+        quicFilter={quicFilter}
+      />
+    );
+  }
+
+  if (loading) return <ListLoading />;
+
+  if (error) {
+    return (
+      <p className="text-status-error px-6 py-4" data-testid="recents-error">
+        {t('recents.error')}
+      </p>
+    );
+  }
+
+  return <RecentsEmpty />;
+}
+
+export default RecentsPanel;

--- a/nym-vpn-app/src/screens/node/list/ViewToggle.tsx
+++ b/nym-vpn-app/src/screens/node/list/ViewToggle.tsx
@@ -34,7 +34,12 @@ function ViewToggle({
       data-testid="node-list-view-toggle"
     >
       {/*
-        The buttons are `flex-1`, so each is (row - padding - gaps) / count wide.
+        The buttons are `flex-1` and `min-w-0`, so each is exactly
+        (row - padding - gaps) / count wide. The `min-w-0` is load-bearing: a
+        flex item otherwise refuses to shrink below its own label, and buttons
+        wider than an equal share overflow the row and leave this indicator —
+        which is sized off the container — pointing between them.
+
         The percentage in `translateX` resolves against the indicator's own width
         rather than the container's, so stepping by that width plus one gap lands
         it on the nth button at any count.
@@ -56,7 +61,7 @@ function ViewToggle({
             aria-pressed={isSelected}
             data-testid={`node-list-view-${item.id}`}
             className={clsx(
-              'relative z-10 flex flex-1 cursor-default items-center justify-center gap-1.5 rounded-full px-4.5 py-2.5 text-sm font-bold transition-colors',
+              'relative z-10 flex min-w-0 flex-1 cursor-default items-center justify-center gap-1.5 rounded-full px-2 py-2.5 text-sm font-bold transition-colors',
               isSelected
                 ? 'text-primary'
                 : 'text-text-secondary hover:bg-surface-elev',
@@ -65,9 +70,9 @@ function ViewToggle({
             <MsIcon
               icon={item.icon}
               filled={item.id === 'favorites' && isSelected}
-              className="h-4 w-auto text-base! leading-none"
+              className="h-4 w-auto shrink-0 text-base! leading-none"
             />
-            <span>{t(item.label)}</span>
+            <span className="truncate">{t(item.label)}</span>
           </button>
         );
       })}

--- a/nym-vpn-app/src/screens/node/list/ViewToggle.tsx
+++ b/nym-vpn-app/src/screens/node/list/ViewToggle.tsx
@@ -5,8 +5,14 @@ import { ListView } from '../../../store/nodeListState';
 
 const VIEWS = [
   { id: 'favorites', icon: 'star', label: 'favorites.tab-favorites' },
+  { id: 'recents', icon: 'history', label: 'favorites.tab-recents' },
   { id: 'all', icon: 'format_list_bulleted', label: 'favorites.tab-all' },
 ] as const;
+
+// Must match the container's `gap-2` and `p-0.5` for the indicator to line up
+// with the buttons it tracks.
+const GAP = '0.5rem';
+const PADDING = '0.25rem'; // 0.125rem on each side
 
 function ViewToggle({
   view,
@@ -17,15 +23,27 @@ function ViewToggle({
 }) {
   const { t } = useTranslation('node-location');
 
+  const selectedIndex = Math.max(
+    0,
+    VIEWS.findIndex((item) => item.id === view),
+  );
+
   return (
     <div
       className="bg-surface-bg relative flex items-center gap-2 rounded-full p-0.5"
       data-testid="node-list-view-toggle"
     >
+      {/*
+        The buttons are `flex-1`, so each is (row - padding - gaps) / count wide.
+        The percentage in `translateX` resolves against the indicator's own width
+        rather than the container's, so stepping by that width plus one gap lands
+        it on the nth button at any count.
+      */}
       <div
-        className="bg-surface-elev absolute inset-y-0.5 w-[calc(50%-0.375rem)] rounded-full transition-[left] duration-300 ease-out"
+        className="bg-surface-elev absolute inset-y-0.5 left-0.5 rounded-full transition-transform duration-300 ease-out"
         style={{
-          left: view === 'favorites' ? '0.125rem' : 'calc(50% + 0.25rem)',
+          width: `calc((100% - ${PADDING} - ${GAP} * ${VIEWS.length - 1}) / ${VIEWS.length})`,
+          transform: `translateX(calc(${selectedIndex} * (100% + ${GAP})))`,
         }}
       />
       {VIEWS.map((item) => {

--- a/nym-vpn-app/src/screens/node/list/index.ts
+++ b/nym-vpn-app/src/screens/node/list/index.ts
@@ -1,5 +1,7 @@
 export { default as NodeList } from './NodeList';
 export { default as ViewToggle } from './ViewToggle';
 export { default as FavoritesEmpty } from './FavoritesEmpty';
+export { default as ListLoading } from './ListLoading';
+export { default as RecentsPanel } from './RecentsPanel';
 export { useFilterList } from './useFilterList';
-export { filterToFavorites } from './util';
+export { filterToFavorites, searchGateways } from './util';

--- a/nym-vpn-app/src/screens/node/list/util.ts
+++ b/nym-vpn-app/src/screens/node/list/util.ts
@@ -1,5 +1,5 @@
 import { Score } from '../../../types';
-import { UiGatewaysByCountry, UiRegion } from '../../../types/node';
+import { UiGateway, UiGatewaysByCountry, UiRegion } from '../../../types/node';
 
 const scoreOrder: Record<Score, number> = {
   offline: 0,
@@ -13,6 +13,30 @@ export function sortByScore(a: Score, b: Score): number {
     return 0;
   }
   return scoreOrder[b] - scoreOrder[a];
+}
+
+/**
+ * Narrows a flat gateway list to those matching a search term, testing gateway
+ * name, city, country name and id. Input order is preserved, so a recency-ordered
+ * list stays recency-ordered.
+ */
+export function searchGateways(
+  gateways: UiGateway[],
+  search: string,
+  getCountryName: (code: string) => string | null | undefined,
+): UiGateway[] {
+  const term = search.trim().toLowerCase();
+  if (term.length === 0) return gateways;
+
+  return gateways.filter((gw) => {
+    const country = getCountryName(gw.country.code) || gw.country.name;
+    return (
+      gw.name.toLowerCase().includes(term) ||
+      gw.location.city.toLowerCase().includes(term) ||
+      country.toLowerCase().includes(term) ||
+      gw.id.toLowerCase().includes(term)
+    );
+  });
 }
 
 function regionToFavorites(

--- a/nym-vpn-app/src/store/index.ts
+++ b/nym-vpn-app/src/store/index.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand';
 import { useShallow } from 'zustand/react/shallow';
 import type { AppState, InitState } from '../types';
 import { createGatewaysSlice } from './slices/gateways/createGatewaysSlice';
-import type { GatewaysSlice, GatewaysState } from './slices/gateways/types';
+import type { GatewayListsState, GatewaysSlice } from './slices/gateways/types';
 import { createMainSlice } from './slices/createMainSlice';
 import type { MainSlice, StateAction } from './slices/createMainSlice';
 import { createSocks5Slice } from './slices/createSocks5Slice';
@@ -107,7 +107,7 @@ export const useMainState = (): AppState =>
   );
 
 // gateways state
-export const useGateways = (): GatewaysState =>
+export const useGateways = (): GatewayListsState =>
   useAppStore(
     useShallow((s) => ({
       mxEntry: s.mxEntry,
@@ -122,6 +122,8 @@ export const useGateways = (): GatewaysState =>
     })),
   );
 export const useFetchGateways = () => useAppStore((s) => s.fetchGateways);
+
+export const useFetchRecents = () => useAppStore((s) => s.fetchRecents);
 
 export const useLookupGw = () => useAppStore((s) => s.lookupGw);
 

--- a/nym-vpn-app/src/store/nodeListState.ts
+++ b/nym-vpn-app/src/store/nodeListState.ts
@@ -10,7 +10,7 @@ export type Focused = {
 };
 
 /** Which subset of the node list is shown. */
-export type ListView = 'all' | 'favorites';
+export type ListView = 'all' | 'favorites' | 'recents';
 
 type HopState = {
   expanded: string[];

--- a/nym-vpn-app/src/store/slices/gateways/createGatewaysSlice.ts
+++ b/nym-vpn-app/src/store/slices/gateways/createGatewaysSlice.ts
@@ -69,7 +69,16 @@ export const createGatewaysSlice: StateCreator<
         vpnMode,
       });
       set((s) => ({
-        recents: { ...s.recents, [vpnMode]: recents },
+        // Normalised on the way in: consumers index straight into
+        // `recents[mode][hop]`, so a payload without both hops would take the
+        // whole node list screen down rather than just emptying recents.
+        recents: {
+          ...s.recents,
+          [vpnMode]: {
+            entry: recents?.entry ?? [],
+            exit: recents?.exit ?? [],
+          },
+        },
         recentsError: { ...s.recentsError, [vpnMode]: null },
       }));
     } catch (e) {

--- a/nym-vpn-app/src/store/slices/gateways/createGatewaysSlice.ts
+++ b/nym-vpn-app/src/store/slices/gateways/createGatewaysSlice.ts
@@ -1,7 +1,12 @@
 import { invoke } from '@tauri-apps/api/core';
 import { dequal } from 'dequal';
 import { StateCreator } from 'zustand';
-import { BackendError, Gateway, GatewaysByCountry } from '../../../types';
+import {
+  BackendError,
+  Gateway,
+  GatewaysByCountry,
+  RecentGateways,
+} from '../../../types';
 import { CCache } from '../../../cache';
 import { GatewaysCacheDuration } from '../../../constants';
 import {
@@ -48,6 +53,32 @@ export const createGatewaysSlice: StateCreator<
   mxEntryError: null,
   mxExitError: null,
   wgError: null,
+  recents: {
+    mixnet: { entry: [], exit: [] },
+    wg: { entry: [], exit: [] },
+  },
+  recentsLoading: false,
+  recentsError: null,
+
+  fetchRecents: async (vpnMode) => {
+    if (get().recentsLoading) return;
+
+    set({ recentsLoading: true });
+    try {
+      const recents = await invoke<RecentGateways>('get_recent_gateways', {
+        vpnMode,
+      });
+      set((s) => ({
+        recents: { ...s.recents, [vpnMode]: recents },
+        recentsError: null,
+      }));
+    } catch (e) {
+      console.error('failed to get recent gateways', e);
+      set({ recentsError: e as BackendError });
+    } finally {
+      set({ recentsLoading: false });
+    }
+  },
 
   fetchGateways: async (nodeType) => {
     const {

--- a/nym-vpn-app/src/store/slices/gateways/createGatewaysSlice.ts
+++ b/nym-vpn-app/src/store/slices/gateways/createGatewaysSlice.ts
@@ -57,26 +57,30 @@ export const createGatewaysSlice: StateCreator<
     mixnet: { entry: [], exit: [] },
     wg: { entry: [], exit: [] },
   },
-  recentsLoading: false,
-  recentsError: null,
+  recentsLoading: { mixnet: false, wg: false },
+  recentsError: { mixnet: null, wg: null },
 
   fetchRecents: async (vpnMode) => {
-    if (get().recentsLoading) return;
+    if (get().recentsLoading[vpnMode]) return;
 
-    set({ recentsLoading: true });
+    set((s) => ({ recentsLoading: { ...s.recentsLoading, [vpnMode]: true } }));
     try {
       const recents = await invoke<RecentGateways>('get_recent_gateways', {
         vpnMode,
       });
       set((s) => ({
         recents: { ...s.recents, [vpnMode]: recents },
-        recentsError: null,
+        recentsError: { ...s.recentsError, [vpnMode]: null },
       }));
     } catch (e) {
       console.error('failed to get recent gateways', e);
-      set({ recentsError: e as BackendError });
+      set((s) => ({
+        recentsError: { ...s.recentsError, [vpnMode]: e as BackendError },
+      }));
     } finally {
-      set({ recentsLoading: false });
+      set((s) => ({
+        recentsLoading: { ...s.recentsLoading, [vpnMode]: false },
+      }));
     }
   },
 

--- a/nym-vpn-app/src/store/slices/gateways/createGatewaysSlice.ts
+++ b/nym-vpn-app/src/store/slices/gateways/createGatewaysSlice.ts
@@ -68,17 +68,17 @@ export const createGatewaysSlice: StateCreator<
       const recents = await invoke<RecentGateways>('get_recent_gateways', {
         vpnMode,
       });
+      const next: RecentGateways = {
+        entry: recents?.entry ?? [],
+        exit: recents?.exit ?? [],
+      };
       set((s) => ({
-        // Normalised on the way in: consumers index straight into
-        // `recents[mode][hop]`, so a payload without both hops would take the
-        // whole node list screen down rather than just emptying recents.
-        recents: {
-          ...s.recents,
-          [vpnMode]: {
-            entry: recents?.entry ?? [],
-            exit: recents?.exit ?? [],
-          },
-        },
+        // This runs on every visit to the node list and usually returns the
+        // same gateways. `recents` is selected whole, so handing back a new
+        // object re-renders every consumer; reuse the old one when it matches.
+        recents: dequal(next, s.recents[vpnMode])
+          ? s.recents
+          : { ...s.recents, [vpnMode]: next },
         recentsError: { ...s.recentsError, [vpnMode]: null },
       }));
     } catch (e) {

--- a/nym-vpn-app/src/store/slices/gateways/types.ts
+++ b/nym-vpn-app/src/store/slices/gateways/types.ts
@@ -40,8 +40,8 @@ export type RecentsState = {
    * gateway they just used.
    */
   recents: Record<VpnMode, RecentGateways>;
-  recentsLoading: boolean;
-  recentsError: AppError | null;
+  recentsLoading: Record<VpnMode, boolean>;
+  recentsError: Record<VpnMode, AppError | null>;
 };
 
 export type GatewaysState = GatewayListsState & RecentsState;

--- a/nym-vpn-app/src/store/slices/gateways/types.ts
+++ b/nym-vpn-app/src/store/slices/gateways/types.ts
@@ -3,10 +3,13 @@ import {
   Gateway,
   GatewayType,
   GatewaysByCountry,
+  RecentGateways,
+  VpnMode,
 } from '../../../types';
 
 export type GatewaysSlice = GatewaysState & {
   fetchGateways: (nodeType: GatewayType) => Promise<void>;
+  fetchRecents: (vpnMode: VpnMode) => Promise<void>;
   lookupGw: (
     id: string,
     type: 'entry' | 'exit',
@@ -14,7 +17,8 @@ export type GatewaysSlice = GatewaysState & {
   ) => Gateway | null;
 };
 
-export type GatewaysState = {
+/** The country-grouped gateway lists, one per gateway type. */
+export type GatewayListsState = {
   mxEntry: GatewaysByCountry[];
   mxExit: GatewaysByCountry[];
   wg: GatewaysByCountry[];
@@ -25,3 +29,19 @@ export type GatewaysState = {
   mxExitError: AppError | null;
   wgError: AppError | null;
 };
+
+export type RecentsState = {
+  /**
+   * Most recently connected gateways per mode, as reported by the daemon,
+   * ordered most-recent-first.
+   *
+   * Not cached: the daemon only appends here on a successful connection —
+   * exactly when the user is most likely to open the list — so a TTL hides the
+   * gateway they just used.
+   */
+  recents: Record<VpnMode, RecentGateways>;
+  recentsLoading: boolean;
+  recentsError: AppError | null;
+};
+
+export type GatewaysState = GatewayListsState & RecentsState;

--- a/nym-vpn-app/src/types/tauri.ts
+++ b/nym-vpn-app/src/types/tauri.ts
@@ -287,6 +287,8 @@ export type Performance = {
   uptime24h: number;
 };
 
+export type RecentGateways = { entry: Array<Gateway>; exit: Array<Gateway> };
+
 export type Region = {
   name: string;
   country: Country;


### PR DESCRIPTION
## Ticket

[JIRA-NYM-1664](https://nymtech.atlassian.net/browse/NYM-1664)

## Description

Add support for Recents


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)
<img width="412" height="756" alt="image" src="https://github.com/user-attachments/assets/1a40a7aa-c65c-432e-833f-932f25293443" />


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6118)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Added a **Recents** tab showing recently connected entry and exit servers.
- Recents load for the selected VPN mode while preserving connection order.
- Added localized loading, empty, and error states.
- Recent servers can be searched by name, location, country, or ID.
- Improved the server view toggle to support multiple tabs.
- Recent server selections remain available when navigating to server details and back.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->