### PR TITLE
[Linux] Validator endpoint failover, health tracking and nym-api pool expansion

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -5867,6 +5867,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "nym-endpoint-health"
+version = "2026.13.0-beta.1"
+dependencies = [
+ "nym-offline-monitor",
+ "reqwest 0.13.3",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "url",
+ "wiremock",
+]
+
+[[package]]
 name = "nym-exclude"
 version = "2026.13.0-beta.1"
 dependencies = [
@@ -7246,6 +7261,7 @@ dependencies = [
  "hkdf",
  "nym-bandwidth-controller",
  "nym-bandwidth-fetcher",
+ "nym-coconut-dkg-common",
  "nym-common 2026.13.0-beta.1",
  "nym-compact-ecash",
  "nym-credential-proxy-requests",
@@ -7253,6 +7269,7 @@ dependencies = [
  "nym-credentials-interface",
  "nym-crypto",
  "nym-ecash-time",
+ "nym-endpoint-health",
  "nym-http-api-client",
  "nym-network-defaults",
  "nym-offline-monitor",
@@ -7397,6 +7414,7 @@ dependencies = [
  "nym-dbus",
  "nym-diagnostic",
  "nym-dns",
+ "nym-endpoint-health",
  "nym-favorites",
  "nym-file-updater",
  "nym-firewall",
@@ -7521,6 +7539,7 @@ dependencies = [
  "nym-bridges-types",
  "nym-common 2026.13.0-beta.1",
  "nym-diagnostic",
+ "nym-endpoint-health",
  "nym-favorites",
  "nym-firewall-config",
  "nym-gateway-directory",
@@ -7556,6 +7575,7 @@ version = "2026.13.0-beta.1"
 dependencies = [
  "itertools 0.14.0",
  "nym-common 2026.13.0-beta.1",
+ "nym-endpoint-health",
  "nym-http-api-client",
  "nym-network-defaults",
  "nym-offline-monitor",
@@ -7645,6 +7665,7 @@ dependencies = [
  "eventlog",
  "futures",
  "nym-bin-common",
+ "nym-endpoint-health",
  "nym-ipc",
  "nym-platform-metadata",
  "nym-sdk",

--- a/nym-vpn-core/Cargo.toml
+++ b/nym-vpn-core/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/nym-dbus",
     "crates/nym-diagnostic",
     "crates/nym-dns",
+    "crates/nym-endpoint-health",
     "crates/nym-exclude",
     "crates/nym-firewall",
     "crates/nym-firewall-config",
@@ -251,6 +252,7 @@ nym-connection-monitor = { path = "crates/nym-connection-monitor" }
 nym-diagnostic = { path = "crates/nym-diagnostic" }
 nym-dbus = { path = "crates/nym-dbus" }
 nym-dns = { path = "crates/nym-dns" }
+nym-endpoint-health = { path = "crates/nym-endpoint-health" }
 nym-favorites = { path = "crates/nym-favorites" }
 nym-firewall = { path = "crates/nym-firewall" }
 nym-firewall-config = { path = "crates/nym-firewall-config" }
@@ -288,6 +290,7 @@ nym-bandwidth-controller = { git = "https://github.com/nymtech/nym", branch = "v
 nym-bandwidth-fetcher = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.15-bydgoszcz" }
 nym-bin-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.15-bydgoszcz" }
 nym-client-core = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.15-bydgoszcz" }
+nym-coconut-dkg-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.15-bydgoszcz" }
 nym-compact-ecash = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.15-bydgoszcz" }
 nym-config = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.15-bydgoszcz" }
 nym-contracts-common = { git = "https://github.com/nymtech/nym", branch = "vpn/release/2026.15-bydgoszcz" }

--- a/nym-vpn-core/crates/nym-diagnostic/src/main.rs
+++ b/nym-vpn-core/crates/nym-diagnostic/src/main.rs
@@ -25,7 +25,7 @@ async fn main() -> anyhow::Result<()> {
         // Special case for 99% of cases, skip discovery through network
         Network::mainnet_default().with_context(|| "Missing network config")?
     } else if let Some(discovery) = Discovery::default_discovery(&args.network) {
-        let fetcher = Fetcher::new(discovery.clone(), None)
+        let fetcher = Fetcher::new(discovery.clone(), None, None)
             .context("Failed to build non mainnet env : fetcher")?;
         let network_details = fetcher
             .fetch_network_details()

--- a/nym-vpn-core/crates/nym-endpoint-health/Cargo.toml
+++ b/nym-vpn-core/crates/nym-endpoint-health/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "nym-endpoint-health"
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+thiserror.workspace = true
+tracing.workspace = true
+url.workspace = true
+reqwest = { workspace = true, features = ["rustls", "json"] }
+serde_json.workspace = true
+tokio = { workspace = true, features = ["macros", "sync", "time", "rt"] }
+tokio-util.workspace = true
+nym-offline-monitor.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
+wiremock.workspace = true

--- a/nym-vpn-core/crates/nym-endpoint-health/src/lib.rs
+++ b/nym-vpn-core/crates/nym-endpoint-health/src/lib.rs
@@ -1,0 +1,10 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+mod probe;
+mod prober;
+mod tracker;
+
+pub use probe::{ProbeFailure, probe_nym_api, probe_nyxd};
+pub use prober::EndpointProber;
+pub use tracker::{EndpointClass, EndpointHealthTracker, FailureKind, HealthPolicy};

--- a/nym-vpn-core/crates/nym-endpoint-health/src/probe.rs
+++ b/nym-vpn-core/crates/nym-endpoint-health/src/probe.rs
@@ -1,0 +1,243 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use std::time::{Duration, Instant};
+
+use url::Url;
+
+use crate::FailureKind;
+
+pub(crate) const PROBE_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(Debug)]
+pub struct ProbeFailure {
+    pub kind: FailureKind,
+    /// The endpoint can never become valid this session (e.g. wrong chain).
+    pub permanent: bool,
+    pub message: String,
+}
+
+impl ProbeFailure {
+    fn transient(kind: FailureKind, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            permanent: false,
+            message: message.into(),
+        }
+    }
+}
+
+fn classify_reqwest_error(err: &reqwest::Error) -> FailureKind {
+    if err.is_timeout() {
+        FailureKind::Timeout
+    } else if err.is_connect() {
+        FailureKind::Connect
+    } else {
+        FailureKind::BadResponse
+    }
+}
+
+/// Probe a Tendermint/CometBFT RPC endpoint: `GET {url}/status` must return 200,
+/// report `catching_up: false`, and (when given) the expected chain-id.
+pub async fn probe_nyxd(
+    client: &reqwest::Client,
+    url: &Url,
+    expected_chain_id: Option<&str>,
+) -> Result<Duration, ProbeFailure> {
+    let status_url = url
+        .join("status")
+        .map_err(|e| ProbeFailure::transient(FailureKind::BadResponse, e.to_string()))?;
+
+    let started = Instant::now();
+    let response = client
+        .get(status_url)
+        .timeout(PROBE_TIMEOUT)
+        .send()
+        .await
+        .map_err(|e| ProbeFailure::transient(classify_reqwest_error(&e), e.to_string()))?;
+
+    if !response.status().is_success() {
+        return Err(ProbeFailure::transient(
+            FailureKind::Http,
+            format!("status code {}", response.status()),
+        ));
+    }
+
+    let body: serde_json::Value = response
+        .json()
+        .await
+        .map_err(|e| ProbeFailure::transient(FailureKind::BadResponse, e.to_string()))?;
+    let latency = started.elapsed();
+
+    // Tendermint RPC over GET wraps the payload in "result".
+    let result = body.get("result").unwrap_or(&body);
+
+    let chain_id = result
+        .pointer("/node_info/network")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            ProbeFailure::transient(FailureKind::BadResponse, "missing node_info.network")
+        })?;
+    if let Some(expected) = expected_chain_id
+        && chain_id != expected
+    {
+        return Err(ProbeFailure {
+            kind: FailureKind::BadResponse,
+            permanent: true,
+            message: format!("wrong chain-id: expected {expected}, got {chain_id}"),
+        });
+    }
+
+    let catching_up = result
+        .pointer("/sync_info/catching_up")
+        .and_then(|v| v.as_bool())
+        .ok_or_else(|| {
+            ProbeFailure::transient(FailureKind::BadResponse, "missing sync_info.catching_up")
+        })?;
+    if catching_up {
+        return Err(ProbeFailure::transient(
+            FailureKind::BadResponse,
+            "node is catching up",
+        ));
+    }
+
+    Ok(latency)
+}
+
+/// Probe a nym-api endpoint (base url ends in `/api/`): a cheap contract-data path.
+pub async fn probe_nym_api(client: &reqwest::Client, url: &Url) -> Result<Duration, ProbeFailure> {
+    let probe_url = url
+        .join("v1/epoch/reward_params")
+        .map_err(|e| ProbeFailure::transient(FailureKind::BadResponse, e.to_string()))?;
+
+    let started = Instant::now();
+    let response = client
+        .get(probe_url)
+        .timeout(PROBE_TIMEOUT)
+        .send()
+        .await
+        .map_err(|e| ProbeFailure::transient(classify_reqwest_error(&e), e.to_string()))?;
+
+    if !response.status().is_success() {
+        return Err(ProbeFailure::transient(
+            FailureKind::Http,
+            format!("status code {}", response.status()),
+        ));
+    }
+
+    Ok(started.elapsed())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{method, path},
+    };
+
+    fn nyxd_status_body(chain_id: &str, catching_up: bool) -> serde_json::Value {
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": -1,
+            "result": {
+                "node_info": { "network": chain_id },
+                "sync_info": { "catching_up": catching_up }
+            }
+        })
+    }
+
+    #[tokio::test]
+    async fn nyxd_probe_ok() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/status"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(nyxd_status_body("nyx", false)))
+            .mount(&server)
+            .await;
+        let client = reqwest::Client::new();
+        let url = server.uri().parse().unwrap();
+        assert!(probe_nyxd(&client, &url, Some("nyx")).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn nyxd_probe_wrong_chain_is_permanent() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/status"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(nyxd_status_body("cosmoshub-4", false)),
+            )
+            .mount(&server)
+            .await;
+        let client = reqwest::Client::new();
+        let url = server.uri().parse().unwrap();
+        let err = probe_nyxd(&client, &url, Some("nyx")).await.unwrap_err();
+        assert!(err.permanent);
+    }
+
+    #[tokio::test]
+    async fn nyxd_probe_catching_up_fails_not_permanent() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/status"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(nyxd_status_body("nyx", true)))
+            .mount(&server)
+            .await;
+        let client = reqwest::Client::new();
+        let url = server.uri().parse().unwrap();
+        let err = probe_nyxd(&client, &url, Some("nyx")).await.unwrap_err();
+        assert!(!err.permanent);
+        assert_eq!(err.kind, FailureKind::BadResponse);
+    }
+
+    #[tokio::test]
+    async fn nyxd_probe_no_expected_chain_skips_check() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/status"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(nyxd_status_body("whatever", false)),
+            )
+            .mount(&server)
+            .await;
+        let client = reqwest::Client::new();
+        let url = server.uri().parse().unwrap();
+        assert!(probe_nyxd(&client, &url, None).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn nyxd_probe_connect_error() {
+        let client = reqwest::Client::new();
+        // Reserved unroutable-ish port on localhost: bind a listener then drop it.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        let url: url::Url = format!("http://127.0.0.1:{port}/").parse().unwrap();
+        let err = probe_nyxd(&client, &url, Some("nyx")).await.unwrap_err();
+        assert_eq!(err.kind, FailureKind::Connect);
+    }
+
+    #[tokio::test]
+    async fn nym_api_probe_ok_and_http_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/epoch/reward_params"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+            .mount(&server)
+            .await;
+        let client = reqwest::Client::new();
+        let ok_url: url::Url = format!("{}/api/", server.uri()).parse().unwrap();
+        assert!(probe_nym_api(&client, &ok_url).await.is_ok());
+
+        let server2 = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/epoch/reward_params"))
+            .respond_with(ResponseTemplate::new(501))
+            .mount(&server2)
+            .await;
+        let bad_url: url::Url = format!("{}/api/", server2.uri()).parse().unwrap();
+        let err = probe_nym_api(&client, &bad_url).await.unwrap_err();
+        assert_eq!(err.kind, FailureKind::Http);
+    }
+}

--- a/nym-vpn-core/crates/nym-endpoint-health/src/prober.rs
+++ b/nym-vpn-core/crates/nym-endpoint-health/src/prober.rs
@@ -1,0 +1,204 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use std::{collections::HashSet, sync::Arc, time::Duration};
+
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use nym_offline_monitor::ConnectivityMonitor;
+use url::Url;
+
+use crate::{
+    EndpointClass, EndpointHealthTracker,
+    probe::{probe_nym_api, probe_nyxd},
+};
+
+const CHECK_INTERVAL: Duration = Duration::from_secs(60);
+/// Every this-many ticks the probed-set is cleared so all endpoints get
+/// re-probed, keeping the latency measurements that drive selection ordering
+/// fresh (and letting dead endpoints accrue failures toward blacklisting).
+const LATENCY_REFRESH_TICKS: u32 = 15;
+
+/// Background task that probes endpoint health: every registered endpoint is
+/// probed once after it appears (at startup or registered later, e.g. by
+/// on-chain signer discovery), blacklisted endpoints are re-probed once
+/// their cooldown expires so recoveries are noticed without waiting for live
+/// traffic to hit them, and everything is re-probed every
+/// [`LATENCY_REFRESH_TICKS`] minutes to keep latency data current.
+pub struct EndpointProber {
+    tracker: Arc<EndpointHealthTracker>,
+    expected_chain_id: Option<String>,
+    http: reqwest::Client,
+}
+
+impl EndpointProber {
+    pub fn spawn(
+        tracker: Arc<EndpointHealthTracker>,
+        expected_chain_id: Option<String>,
+        connectivity_monitor: impl ConnectivityMonitor + 'static,
+        cancel_token: CancellationToken,
+    ) -> JoinHandle<()> {
+        let prober = Self {
+            tracker,
+            expected_chain_id,
+            http: reqwest::Client::new(),
+        };
+        tokio::spawn(prober.run(connectivity_monitor, cancel_token))
+    }
+
+    async fn run(
+        self,
+        mut connectivity_monitor: impl ConnectivityMonitor + 'static,
+        cancel_token: CancellationToken,
+    ) {
+        tracing::debug!("Endpoint prober started");
+
+        let mut interval = tokio::time::interval(CHECK_INTERVAL);
+        let mut current_connectivity = connectivity_monitor.connectivity().await;
+        let mut probed: HashSet<(EndpointClass, Url)> = HashSet::new();
+        let mut ticks_until_refresh = LATENCY_REFRESH_TICKS;
+
+        loop {
+            tokio::select! {
+                Some(connectivity) = connectivity_monitor.next() => {
+                    current_connectivity = connectivity;
+                }
+                _ = interval.tick(), if current_connectivity.is_online() => {
+                    ticks_until_refresh = ticks_until_refresh.saturating_sub(1);
+                    if ticks_until_refresh == 0 {
+                        probed.clear();
+                        ticks_until_refresh = LATENCY_REFRESH_TICKS;
+                    }
+                    for (class, url) in probe_targets(&self.tracker, &probed) {
+                        self.probe_one(class, &url).await;
+                        probed.insert((class, url));
+                    }
+                }
+                _ = cancel_token.cancelled() => {
+                    tracing::debug!("Endpoint prober cancelled");
+                    break;
+                }
+            }
+        }
+
+        tracing::debug!("Endpoint prober exiting");
+    }
+
+    async fn probe_one(&self, class: EndpointClass, url: &Url) {
+        let result = match class {
+            EndpointClass::NyxdRpc => {
+                probe_nyxd(&self.http, url, self.expected_chain_id.as_deref()).await
+            }
+            EndpointClass::NymApi => probe_nym_api(&self.http, url).await,
+        };
+        match result {
+            Ok(latency) => {
+                tracing::debug!(endpoint = %url, %class, latency_ms = latency.as_millis(), "endpoint probe ok");
+                self.tracker.report_success(class, url, Some(latency));
+            }
+            Err(failure) if failure.permanent => {
+                self.tracker
+                    .mark_permanent_failure(class, url, &failure.message);
+            }
+            Err(failure) => {
+                tracing::debug!(endpoint = %url, %class, failure = %failure.message, "endpoint probe failed");
+                self.tracker.report_failure(class, url, failure.kind);
+            }
+        }
+    }
+}
+
+/// Endpoints to probe this tick: everything registered that has never been
+/// probed (covers late registration, e.g. on-chain signer discovery), plus
+/// blacklisted endpoints whose cooldown has expired.
+fn probe_targets(
+    tracker: &EndpointHealthTracker,
+    probed: &HashSet<(EndpointClass, Url)>,
+) -> Vec<(EndpointClass, Url)> {
+    let mut targets = Vec::new();
+    for class in [EndpointClass::NyxdRpc, EndpointClass::NymApi] {
+        for url in tracker.all_endpoints(class) {
+            if !probed.contains(&(class, url.clone())) {
+                targets.push((class, url));
+            }
+        }
+        for url in tracker.due_for_reprobe(class) {
+            if !targets.contains(&(class, url.clone())) {
+                targets.push((class, url));
+            }
+        }
+    }
+    targets
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{FailureKind, HealthPolicy};
+
+    fn u(s: &str) -> Url {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn unprobed_endpoints_are_targets_once() {
+        let tracker = EndpointHealthTracker::new();
+        tracker.register(
+            EndpointClass::NymApi,
+            vec![u("https://a.example/"), u("https://b.example/")],
+        );
+
+        let mut probed = HashSet::new();
+        let first = probe_targets(&tracker, &probed);
+        assert_eq!(first.len(), 2);
+        probed.extend(first);
+
+        assert!(probe_targets(&tracker, &probed).is_empty());
+    }
+
+    #[test]
+    fn late_registered_endpoints_become_targets() {
+        let tracker = EndpointHealthTracker::new();
+        tracker.register(EndpointClass::NymApi, vec![u("https://a.example/")]);
+
+        let mut probed = HashSet::new();
+        probed.extend(probe_targets(&tracker, &probed));
+
+        // Simulates on-chain signer discovery registering endpoints later.
+        tracker.register(EndpointClass::NymApi, vec![u("https://signer.example/")]);
+        assert_eq!(
+            probe_targets(&tracker, &probed),
+            vec![(EndpointClass::NymApi, u("https://signer.example/"))]
+        );
+    }
+
+    #[test]
+    fn expired_blacklist_is_reprobed_without_duplicates() {
+        let tracker = EndpointHealthTracker::with_policy(HealthPolicy {
+            failure_threshold: 1,
+            cooldowns: vec![std::time::Duration::from_millis(10)],
+        });
+        tracker.register(EndpointClass::NyxdRpc, vec![u("https://a.example/")]);
+
+        let mut probed = HashSet::new();
+        probed.extend(probe_targets(&tracker, &probed));
+
+        tracker.report_failure(
+            EndpointClass::NyxdRpc,
+            &u("https://a.example/"),
+            FailureKind::Connect,
+        );
+        assert!(
+            probe_targets(&tracker, &probed).is_empty(),
+            "still cooling down"
+        );
+
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        let targets = probe_targets(&tracker, &probed);
+        assert_eq!(
+            targets,
+            vec![(EndpointClass::NyxdRpc, u("https://a.example/"))]
+        );
+    }
+}

--- a/nym-vpn-core/crates/nym-endpoint-health/src/tracker.rs
+++ b/nym-vpn-core/crates/nym-endpoint-health/src/tracker.rs
@@ -1,0 +1,691 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use std::{
+    collections::HashMap,
+    sync::Mutex,
+    time::{Duration, Instant},
+};
+
+use url::Url;
+
+/// Healthy endpoints whose measured latency is within this factor of the best
+/// one form the "fast tier" that shares load round-robin.
+const FAST_TIER_LATENCY_FACTOR: u32 = 2;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum EndpointClass {
+    NyxdRpc,
+    NymApi,
+}
+
+impl std::fmt::Display for EndpointClass {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NyxdRpc => write!(f, "nyxd-rpc"),
+            Self::NymApi => write!(f, "nym-api"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FailureKind {
+    Connect,
+    Timeout,
+    Http,
+    BadResponse,
+}
+
+impl std::fmt::Display for FailureKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Connect => write!(f, "connect"),
+            Self::Timeout => write!(f, "timeout"),
+            Self::Http => write!(f, "http"),
+            Self::BadResponse => write!(f, "bad-response"),
+        }
+    }
+}
+
+/// Health policy for endpoint failure tracking.
+///
+/// # Invariants
+///
+/// - `cooldowns` must not be empty; if empty, it will be replaced with the default cooldowns
+/// - `failure_threshold` must not be zero; if zero, it will be set to 1
+///
+/// These invariants are enforced automatically in `EndpointHealthTracker::with_policy`.
+/// A panic-free fallback ensures the tracker never fails to initialize even with invalid input.
+#[derive(Clone, Debug)]
+pub struct HealthPolicy {
+    pub failure_threshold: u32,
+    pub cooldowns: Vec<Duration>,
+}
+
+impl Default for HealthPolicy {
+    fn default() -> Self {
+        Self {
+            failure_threshold: 3,
+            cooldowns: vec![
+                Duration::from_secs(5 * 60),
+                Duration::from_secs(15 * 60),
+                Duration::from_secs(60 * 60),
+            ],
+        }
+    }
+}
+
+impl HealthPolicy {
+    /// Validates and normalizes the policy: ensures non-empty cooldowns and non-zero threshold.
+    /// If either invariant is violated, falls back to a sensible default while preserving
+    /// the caller's intent where possible.
+    fn normalize(&self) -> Self {
+        let cooldowns = if self.cooldowns.is_empty() {
+            HealthPolicy::default().cooldowns
+        } else {
+            self.cooldowns.clone()
+        };
+        let failure_threshold = if self.failure_threshold == 0 {
+            1
+        } else {
+            self.failure_threshold
+        };
+        Self {
+            failure_threshold,
+            cooldowns,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct EndpointState {
+    url: Url,
+    consecutive_failures: u32,
+    blacklist_generation: u32,
+    blacklisted_until: Option<Instant>,
+    permanently_failed: bool,
+    last_latency: Option<Duration>,
+}
+
+impl EndpointState {
+    fn new(url: Url) -> Self {
+        Self {
+            url,
+            consecutive_failures: 0,
+            blacklist_generation: 0,
+            blacklisted_until: None,
+            permanently_failed: false,
+            last_latency: None,
+        }
+    }
+
+    fn is_blacklisted(&self, now: Instant) -> bool {
+        self.blacklisted_until.is_some_and(|until| until > now)
+    }
+}
+
+#[derive(Debug, Default)]
+struct ClassState {
+    endpoints: Vec<EndpointState>,
+    cursor: usize,
+}
+
+/// Tracks per-endpoint health for a class of API endpoints, temporarily
+/// blacklisting endpoints that keep failing so callers stop hammering them,
+/// while guaranteeing selection never comes back empty (fail-open).
+#[derive(Debug)]
+pub struct EndpointHealthTracker {
+    inner: Mutex<Inner>,
+}
+
+#[derive(Debug)]
+struct Inner {
+    policy: HealthPolicy,
+    classes: HashMap<EndpointClass, ClassState>,
+}
+
+impl Default for EndpointHealthTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EndpointHealthTracker {
+    pub fn new() -> Self {
+        Self::with_policy(HealthPolicy::default())
+    }
+
+    pub fn with_policy(policy: HealthPolicy) -> Self {
+        Self {
+            inner: Mutex::new(Inner {
+                policy: policy.normalize(),
+                classes: HashMap::new(),
+            }),
+        }
+    }
+
+    /// Add endpoints to a class, preserving order; already-known URLs keep their state.
+    pub fn register(&self, class: EndpointClass, urls: Vec<Url>) {
+        let mut inner = self.lock();
+        let state = inner.classes.entry(class).or_default();
+        for url in urls {
+            if !state.endpoints.iter().any(|e| e.url == url) {
+                state.endpoints.push(EndpointState::new(url));
+            }
+        }
+    }
+
+    /// Candidate list, preferred first. Never empty if anything is registered.
+    ///
+    /// Ordering policy (load spreading + latency preference): healthy
+    /// endpoints with no recent failures come first — those within
+    /// [`FAST_TIER_LATENCY_FACTOR`] of the best measured latency form a fast
+    /// tier that is rotated round-robin across calls, spreading load over the
+    /// validators; slower endpoints follow by ascending latency, then
+    /// endpoints without a latency measurement yet. Recently-failed (but not
+    /// yet blacklisted) endpoints come next, expired-blacklist ones last.
+    /// Fail-open still applies when nothing else is eligible.
+    pub fn select(&self, class: EndpointClass) -> Vec<Url> {
+        let now = Instant::now();
+        let mut inner = self.lock();
+        let Some(state) = inner.classes.get_mut(&class) else {
+            return Vec::new();
+        };
+
+        let mut clean_known: Vec<(Duration, Url)> = Vec::new();
+        let mut clean_unknown: Vec<Url> = Vec::new();
+        let mut suspect: Vec<Url> = Vec::new();
+        let mut expired: Vec<Url> = Vec::new();
+        for e in &state.endpoints {
+            if e.permanently_failed || e.is_blacklisted(now) {
+                continue;
+            }
+            if e.blacklisted_until.is_some() {
+                expired.push(e.url.clone());
+            } else if e.consecutive_failures > 0 {
+                suspect.push(e.url.clone());
+            } else if let Some(latency) = e.last_latency {
+                clean_known.push((latency, e.url.clone()));
+            } else {
+                clean_unknown.push(e.url.clone());
+            }
+        }
+
+        clean_known.sort_by_key(|(latency, _)| *latency);
+        let (mut fast, slow): (Vec<Url>, Vec<Url>) = match clean_known.first() {
+            Some((best, _)) => {
+                let cutoff = *best * FAST_TIER_LATENCY_FACTOR;
+                let split = clean_known
+                    .iter()
+                    .take_while(|(latency, _)| *latency <= cutoff)
+                    .count();
+                let slow = clean_known.split_off(split);
+                (
+                    clean_known.into_iter().map(|(_, url)| url).collect(),
+                    slow.into_iter().map(|(_, url)| url).collect(),
+                )
+            }
+            None => (Vec::new(), Vec::new()),
+        };
+
+        // Spread load: rotate the preferred group round-robin across calls.
+        let preferred = if !fast.is_empty() {
+            &mut fast
+        } else {
+            &mut clean_unknown
+        };
+        if !preferred.is_empty() {
+            let offset = state.cursor % preferred.len();
+            preferred.rotate_left(offset);
+            state.cursor = state.cursor.wrapping_add(1);
+        }
+
+        let mut result = fast;
+        result.extend(slow);
+        result.extend(clean_unknown);
+        result.extend(suspect);
+        result.extend(expired);
+        if !result.is_empty() {
+            return result;
+        }
+
+        // Fail-open: all eligible endpoints are blacklisted.
+        let mut fallback: Vec<&EndpointState> = state
+            .endpoints
+            .iter()
+            .filter(|e| !e.permanently_failed)
+            .collect();
+        if fallback.is_empty() {
+            return state.endpoints.iter().map(|e| e.url.clone()).collect();
+        }
+        fallback.sort_by_key(|e| e.blacklisted_until);
+        fallback.into_iter().map(|e| e.url.clone()).collect()
+    }
+
+    pub fn report_failure(&self, class: EndpointClass, url: &Url, kind: FailureKind) {
+        let now = Instant::now();
+        let mut inner = self.lock();
+        let policy = inner.policy.clone();
+        let Some(state) = inner.classes.get_mut(&class) else {
+            return;
+        };
+        let Some(endpoint) = state.endpoints.iter_mut().find(|e| e.url == *url) else {
+            return;
+        };
+
+        endpoint.consecutive_failures += 1;
+        let should_blacklist = endpoint.consecutive_failures >= policy.failure_threshold
+            || endpoint.blacklist_generation > 0;
+        if should_blacklist && !endpoint.is_blacklisted(now) {
+            let tier = (endpoint.blacklist_generation as usize).min(policy.cooldowns.len() - 1);
+            let cooldown = policy.cooldowns[tier];
+            endpoint.blacklisted_until = Some(now + cooldown);
+            endpoint.blacklist_generation += 1;
+            endpoint.consecutive_failures = 0;
+            tracing::warn!(
+                endpoint = %endpoint.url,
+                class = %class,
+                failure_kind = %kind,
+                cooldown_secs = cooldown.as_secs(),
+                generation = endpoint.blacklist_generation,
+                "endpoint blacklisted after repeated failures"
+            );
+        }
+    }
+
+    pub fn report_success(&self, class: EndpointClass, url: &Url, latency: Option<Duration>) {
+        let mut inner = self.lock();
+        let Some(state) = inner.classes.get_mut(&class) else {
+            return;
+        };
+        let Some(endpoint) = state.endpoints.iter_mut().find(|e| e.url == *url) else {
+            return;
+        };
+        if endpoint.blacklist_generation > 0 {
+            tracing::info!(endpoint = %endpoint.url, class = %class, "endpoint recovered");
+        }
+        endpoint.consecutive_failures = 0;
+        endpoint.blacklist_generation = 0;
+        endpoint.blacklisted_until = None;
+        if latency.is_some() {
+            endpoint.last_latency = latency;
+        }
+    }
+
+    /// Remove an endpoint from rotation for the rest of the session
+    /// (e.g. it serves the wrong chain).
+    pub fn mark_permanent_failure(&self, class: EndpointClass, url: &Url, reason: &str) {
+        let mut inner = self.lock();
+        let Some(state) = inner.classes.get_mut(&class) else {
+            return;
+        };
+        if let Some(endpoint) = state.endpoints.iter_mut().find(|e| e.url == *url) {
+            endpoint.permanently_failed = true;
+            tracing::error!(endpoint = %endpoint.url, class = %class, reason, "endpoint permanently removed from rotation");
+        }
+    }
+
+    /// Blacklisted endpoints whose cooldown has expired: candidates for a recovery probe.
+    pub fn due_for_reprobe(&self, class: EndpointClass) -> Vec<Url> {
+        let now = Instant::now();
+        let inner = self.lock();
+        inner
+            .classes
+            .get(&class)
+            .map(|state| {
+                state
+                    .endpoints
+                    .iter()
+                    .filter(|e| {
+                        !e.permanently_failed
+                            && e.blacklisted_until.is_some_and(|until| until <= now)
+                    })
+                    .map(|e| e.url.clone())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    pub fn all_endpoints(&self, class: EndpointClass) -> Vec<Url> {
+        let inner = self.lock();
+        inner
+            .classes
+            .get(&class)
+            .map(|state| state.endpoints.iter().map(|e| e.url.clone()).collect())
+            .unwrap_or_default()
+    }
+
+    #[allow(clippy::unwrap_used)]
+    fn lock(&self) -> std::sync::MutexGuard<'_, Inner> {
+        // Mutex poisoning cannot happen: no code path panics while holding the lock.
+        self.inner.lock().unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn u(s: &str) -> url::Url {
+        s.parse().unwrap()
+    }
+
+    fn test_policy() -> HealthPolicy {
+        HealthPolicy {
+            failure_threshold: 3,
+            cooldowns: vec![Duration::from_millis(50), Duration::from_millis(100)],
+        }
+    }
+
+    fn tracker_with(urls: &[&str]) -> EndpointHealthTracker {
+        let t = EndpointHealthTracker::with_policy(test_policy());
+        t.register(EndpointClass::NyxdRpc, urls.iter().map(|s| u(s)).collect());
+        t
+    }
+
+    #[test]
+    fn select_spreads_load_round_robin_when_latency_unknown() {
+        let t = tracker_with(&["https://a.example/", "https://b.example/"]);
+        assert_eq!(
+            t.select(EndpointClass::NyxdRpc),
+            vec![u("https://a.example/"), u("https://b.example/")]
+        );
+        // consecutive selections rotate the preferred group to spread load
+        assert_eq!(
+            t.select(EndpointClass::NyxdRpc),
+            vec![u("https://b.example/"), u("https://a.example/")]
+        );
+        assert_eq!(t.select(EndpointClass::NyxdRpc)[0], u("https://a.example/"));
+    }
+
+    #[test]
+    fn select_prefers_lowest_latency_fast_tier_and_keeps_slow_last() {
+        let t = tracker_with(&[
+            "https://a.example/",
+            "https://b.example/",
+            "https://c.example/",
+        ]);
+        // a is slow (beyond 2x of best), b and c form the fast tier
+        t.report_success(
+            EndpointClass::NyxdRpc,
+            &u("https://a.example/"),
+            Some(Duration::from_millis(400)),
+        );
+        t.report_success(
+            EndpointClass::NyxdRpc,
+            &u("https://b.example/"),
+            Some(Duration::from_millis(50)),
+        );
+        t.report_success(
+            EndpointClass::NyxdRpc,
+            &u("https://c.example/"),
+            Some(Duration::from_millis(60)),
+        );
+
+        assert_eq!(
+            t.select(EndpointClass::NyxdRpc),
+            vec![
+                u("https://b.example/"),
+                u("https://c.example/"),
+                u("https://a.example/")
+            ]
+        );
+        // fast tier rotates across calls; the slow endpoint stays last but is never dropped
+        assert_eq!(
+            t.select(EndpointClass::NyxdRpc),
+            vec![
+                u("https://c.example/"),
+                u("https://b.example/"),
+                u("https://a.example/")
+            ]
+        );
+    }
+
+    #[test]
+    fn endpoints_without_latency_sort_after_measured_fast_tier() {
+        let t = tracker_with(&["https://a.example/", "https://b.example/"]);
+        t.report_success(
+            EndpointClass::NyxdRpc,
+            &u("https://b.example/"),
+            Some(Duration::from_millis(40)),
+        );
+        // b has a measurement, a does not: b leads on every call
+        assert_eq!(
+            t.select(EndpointClass::NyxdRpc),
+            vec![u("https://b.example/"), u("https://a.example/")]
+        );
+        assert_eq!(
+            t.select(EndpointClass::NyxdRpc),
+            vec![u("https://b.example/"), u("https://a.example/")]
+        );
+    }
+
+    #[test]
+    fn register_is_idempotent_merge() {
+        let t = tracker_with(&["https://a.example/"]);
+        t.register(
+            EndpointClass::NyxdRpc,
+            vec![u("https://a.example/"), u("https://b.example/")],
+        );
+        assert_eq!(t.all_endpoints(EndpointClass::NyxdRpc).len(), 2);
+    }
+
+    #[test]
+    fn recently_failed_endpoint_sorts_after_clean_ones() {
+        let t = tracker_with(&["https://a.example/", "https://b.example/"]);
+        t.report_failure(
+            EndpointClass::NyxdRpc,
+            &u("https://a.example/"),
+            FailureKind::Connect,
+        );
+        // one failure doesn't blacklist, but it demotes a behind the clean b
+        assert_eq!(
+            t.select(EndpointClass::NyxdRpc),
+            vec![u("https://b.example/"), u("https://a.example/")]
+        );
+    }
+
+    #[test]
+    fn three_consecutive_failures_blacklist() {
+        let t = tracker_with(&["https://a.example/", "https://b.example/"]);
+        for _ in 0..3 {
+            t.report_failure(
+                EndpointClass::NyxdRpc,
+                &u("https://a.example/"),
+                FailureKind::Timeout,
+            );
+        }
+        // a is blacklisted: only b eligible
+        assert_eq!(
+            t.select(EndpointClass::NyxdRpc),
+            vec![u("https://b.example/")]
+        );
+    }
+
+    #[test]
+    fn success_resets_failure_count() {
+        let t = tracker_with(&["https://a.example/", "https://b.example/"]);
+        t.report_failure(
+            EndpointClass::NyxdRpc,
+            &u("https://a.example/"),
+            FailureKind::Connect,
+        );
+        t.report_failure(
+            EndpointClass::NyxdRpc,
+            &u("https://a.example/"),
+            FailureKind::Connect,
+        );
+        t.report_success(EndpointClass::NyxdRpc, &u("https://a.example/"), None);
+        t.report_failure(
+            EndpointClass::NyxdRpc,
+            &u("https://a.example/"),
+            FailureKind::Connect,
+        );
+        // 1 failure after reset: still eligible
+        assert!(
+            t.select(EndpointClass::NyxdRpc)
+                .contains(&u("https://a.example/"))
+        );
+    }
+
+    #[test]
+    fn cooldown_expiry_makes_endpoint_eligible_again_but_last() {
+        let t = tracker_with(&["https://a.example/", "https://b.example/"]);
+        for _ in 0..3 {
+            t.report_failure(
+                EndpointClass::NyxdRpc,
+                &u("https://a.example/"),
+                FailureKind::Connect,
+            );
+        }
+        std::thread::sleep(Duration::from_millis(60));
+        let sel = t.select(EndpointClass::NyxdRpc);
+        assert_eq!(sel, vec![u("https://b.example/"), u("https://a.example/")]);
+    }
+
+    #[test]
+    fn reblacklist_after_expiry_is_immediate_and_escalates() {
+        let t = tracker_with(&["https://a.example/", "https://b.example/"]);
+        for _ in 0..3 {
+            t.report_failure(
+                EndpointClass::NyxdRpc,
+                &u("https://a.example/"),
+                FailureKind::Connect,
+            );
+        }
+        std::thread::sleep(Duration::from_millis(60));
+        // one more failure re-blacklists immediately (generation > 0), now with 100ms cooldown
+        t.report_failure(
+            EndpointClass::NyxdRpc,
+            &u("https://a.example/"),
+            FailureKind::Connect,
+        );
+        assert_eq!(
+            t.select(EndpointClass::NyxdRpc),
+            vec![u("https://b.example/")]
+        );
+        std::thread::sleep(Duration::from_millis(60));
+        // 60ms < 100ms escalated cooldown: still blacklisted
+        assert_eq!(
+            t.select(EndpointClass::NyxdRpc),
+            vec![u("https://b.example/")]
+        );
+    }
+
+    #[test]
+    fn fail_open_when_all_blacklisted() {
+        let t = tracker_with(&["https://a.example/", "https://b.example/"]);
+        for url in ["https://a.example/", "https://b.example/"] {
+            for _ in 0..3 {
+                t.report_failure(EndpointClass::NyxdRpc, &u(url), FailureKind::Connect);
+            }
+        }
+        let sel = t.select(EndpointClass::NyxdRpc);
+        assert_eq!(
+            sel.len(),
+            2,
+            "fail-open must return all non-permanent endpoints"
+        );
+    }
+
+    #[test]
+    fn permanent_failure_excluded_even_in_fail_open_unless_nothing_else() {
+        let t = tracker_with(&["https://a.example/", "https://b.example/"]);
+        t.mark_permanent_failure(
+            EndpointClass::NyxdRpc,
+            &u("https://a.example/"),
+            "wrong chain",
+        );
+        assert_eq!(
+            t.select(EndpointClass::NyxdRpc),
+            vec![u("https://b.example/")]
+        );
+        for _ in 0..3 {
+            t.report_failure(
+                EndpointClass::NyxdRpc,
+                &u("https://b.example/"),
+                FailureKind::Connect,
+            );
+        }
+        // b blacklisted, a permanent -> fail-open returns b (non-permanent) only
+        assert_eq!(
+            t.select(EndpointClass::NyxdRpc),
+            vec![u("https://b.example/")]
+        );
+    }
+
+    #[test]
+    fn due_for_reprobe_lists_expired_blacklisted() {
+        let t = tracker_with(&["https://a.example/", "https://b.example/"]);
+        for _ in 0..3 {
+            t.report_failure(
+                EndpointClass::NyxdRpc,
+                &u("https://a.example/"),
+                FailureKind::Connect,
+            );
+        }
+        assert!(t.due_for_reprobe(EndpointClass::NyxdRpc).is_empty());
+        std::thread::sleep(Duration::from_millis(60));
+        assert_eq!(
+            t.due_for_reprobe(EndpointClass::NyxdRpc),
+            vec![u("https://a.example/")]
+        );
+    }
+
+    #[test]
+    fn classes_are_independent() {
+        let t = tracker_with(&["https://a.example/"]);
+        t.register(EndpointClass::NymApi, vec![u("https://a.example/")]);
+        for _ in 0..3 {
+            t.report_failure(
+                EndpointClass::NyxdRpc,
+                &u("https://a.example/"),
+                FailureKind::Connect,
+            );
+        }
+        assert_eq!(
+            t.select(EndpointClass::NymApi),
+            vec![u("https://a.example/")]
+        );
+    }
+
+    #[test]
+    fn unknown_url_reports_are_ignored() {
+        let t = tracker_with(&["https://a.example/"]);
+        // must not panic or create entries
+        t.report_failure(
+            EndpointClass::NyxdRpc,
+            &u("https://ghost.example/"),
+            FailureKind::Connect,
+        );
+        t.report_success(EndpointClass::NyxdRpc, &u("https://ghost.example/"), None);
+        assert_eq!(t.all_endpoints(EndpointClass::NyxdRpc).len(), 1);
+    }
+
+    #[test]
+    fn invalid_policy_is_normalized_and_doesnt_panic() {
+        // Construct a tracker with an invalid policy: empty cooldowns and zero threshold.
+        // The tracker should normalize it to a sensible default without panicking.
+        let invalid_policy = HealthPolicy {
+            failure_threshold: 0,
+            cooldowns: vec![],
+        };
+        let t = EndpointHealthTracker::with_policy(invalid_policy);
+        t.register(EndpointClass::NyxdRpc, vec![u("https://a.example/")]);
+
+        // Report a failure. This must not panic even though the input policy was invalid.
+        t.report_failure(
+            EndpointClass::NyxdRpc,
+            &u("https://a.example/"),
+            FailureKind::Connect,
+        );
+
+        // Select should return non-empty (fail-open) and definitely not panic.
+        let sel = t.select(EndpointClass::NyxdRpc);
+        assert!(
+            !sel.is_empty(),
+            "selection must never be empty with fail-open"
+        );
+    }
+}

--- a/nym-vpn-core/crates/nym-vpn-account-controller/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/Cargo.toml
@@ -21,10 +21,12 @@ bs58.workspace = true
 pbkdf2.workspace = true
 futures.workspace = true
 hkdf.workspace = true
+nym-coconut-dkg-common.workspace = true
 nym-common.workspace = true
 nym-bandwidth-controller.workspace = true
 nym-bandwidth-fetcher.workspace = true
 nym-crypto = { workspace = true, features = ["asymmetric", "rand"] }
+nym-endpoint-health.workspace = true
 nym-network-defaults.workspace = true
 nym-offline-monitor.workspace = true
 nym-sdk.workspace = true

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/lib.rs
@@ -14,6 +14,7 @@ mod error;
 mod event_sender;
 mod nyxd_client;
 mod shared_state;
+mod signer_discovery;
 mod state_machine;
 mod state_receiver;
 mod storage;
@@ -27,5 +28,6 @@ pub use deeplink::{CreateDeeplinkParams, Deeplink, DeeplinkError, DeeplinkMnemon
 pub use error::Error;
 pub use event_sender::AccountControllerEventSender;
 pub use nyxd_client::NyxdClient;
+pub use signer_discovery::discover_ecash_signer_apis;
 pub use state_receiver::AccountStateReceiver;
 pub use storage::remove_files_for_account;

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/nyxd_client.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/nyxd_client.rs
@@ -1,9 +1,10 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use nym_endpoint_health::{EndpointClass, EndpointHealthTracker, FailureKind};
 use nym_validator_client::{
     DirectSigningHttpRpcNyxdClient,
-    nyxd::{Coin, Config, CosmWasmClient, cosmwasm_client::types::Account},
+    nyxd::{Coin, Config, CosmWasmClient, cosmwasm_client::types::Account, error::NyxdError},
 };
 use nym_vpn_lib_types::{AccountCommandError, Mnemonic};
 use nym_vpn_network_config::Network;
@@ -11,20 +12,85 @@ use std::{str::FromStr, sync::Arc};
 
 pub struct NyxdClient {
     network: Network,
+    tracker: Arc<EndpointHealthTracker>,
 
     // TODO: does it need locking or are we guaranteed sequential access?
-    client: Option<Arc<DirectSigningHttpRpcNyxdClient>>,
+    client: Option<(url::Url, Arc<DirectSigningHttpRpcNyxdClient>)>,
+}
+
+/// Outcome of a failed connection attempt against a single candidate.
+enum ConnectError {
+    /// Ordinary failure: the tracker's normal failure-counting/backoff should run.
+    Failed(String),
+    /// The candidate is permanently unsuitable (e.g. wrong chain-id). The
+    /// caller has already recorded this via `mark_permanent_failure`, so the
+    /// tracker's ordinary failure-counting must not also run for it.
+    PermanentlyExcluded(String),
+}
+
+/// Try candidates in order until `connect` succeeds, reporting each outcome
+/// to the tracker. Returns the winning url and value, or the last error.
+async fn connect_first_healthy<T, F, Fut>(
+    candidates: Vec<url::Url>,
+    tracker: &EndpointHealthTracker,
+    mut connect: F,
+) -> Result<(url::Url, T), String>
+where
+    F: FnMut(&url::Url) -> Fut,
+    Fut: Future<Output = Result<T, ConnectError>>,
+{
+    let mut last_error = "no nyxd endpoints available".to_string();
+    for url in candidates {
+        match connect(&url).await {
+            Ok(value) => {
+                tracker.report_success(EndpointClass::NyxdRpc, &url, None);
+                return Ok((url, value));
+            }
+            Err(ConnectError::Failed(err)) => {
+                tracing::warn!(endpoint = %url, "nyxd endpoint failed, trying next: {err}");
+                tracker.report_failure(EndpointClass::NyxdRpc, &url, FailureKind::Connect);
+                last_error = err;
+            }
+            Err(ConnectError::PermanentlyExcluded(err)) => {
+                tracing::warn!(endpoint = %url, "nyxd endpoint permanently excluded, trying next: {err}");
+                last_error = err;
+            }
+        }
+    }
+    Err(last_error)
+}
+
+/// Only connection-class errors should count as endpoint failures — RPC
+/// transport failures and timeouts. Application-level errors (ABCI errors
+/// such as "account not found", deserialization of an otherwise valid
+/// response, and other domain errors) do not indicate an unhealthy endpoint
+/// and must not affect endpoint health tracking or trigger a retry/rotation.
+fn is_connection_error(err: &NyxdError) -> bool {
+    matches!(err, NyxdError::TendermintErrorRpc(_))
+}
+
+/// Pick a `FailureKind` for a connection-class error, for reporting purposes.
+fn failure_kind_for(err: &NyxdError) -> FailureKind {
+    if err.is_tendermint_response_timeout() {
+        FailureKind::Timeout
+    } else {
+        FailureKind::Connect
+    }
 }
 
 impl NyxdClient {
-    pub fn new(network: &Network) -> Self {
+    pub fn new(network: &Network, tracker: Arc<EndpointHealthTracker>) -> Self {
         NyxdClient {
             network: network.clone(),
+            tracker,
             client: None,
         }
     }
 
-    pub(crate) fn ensure_connected(&mut self, mnemonic: &str) -> Result<(), AccountCommandError> {
+    pub(crate) async fn ensure_connected(
+        &mut self,
+        mnemonic: &str,
+    ) -> Result<(), AccountCommandError> {
         if self.client.is_some() {
             return Ok(());
         }
@@ -35,16 +101,52 @@ impl NyxdClient {
                     "invalid network information: {err}"
                 ))
             })?;
+        let mnemonic = Mnemonic::from_str(mnemonic)
+            .map_err(|err| AccountCommandError::InvalidMnemonic(err.to_string()))?;
 
-        let client = DirectSigningHttpRpcNyxdClient::connect_with_mnemonic(
-            client_config,
-            self.network.nyxd_url.as_str(),
-            Mnemonic::from_str(mnemonic)
-                .map_err(|err| AccountCommandError::InvalidMnemonic(err.to_string()))?,
-        )
-        .map_err(|err| AccountCommandError::NyxdConnectionFailure(err.to_string()))?;
+        let mut candidates = self.tracker.select(EndpointClass::NyxdRpc);
+        if candidates.is_empty() {
+            candidates = vec![self.network.nyxd_url()];
+        }
 
-        self.client = Some(Arc::new(client));
+        let expected_chain_id = self.network.expected_chain_id();
+        let tracker_for_probe = self.tracker.clone();
+
+        let (url, client) = connect_first_healthy(candidates, &self.tracker, |url| {
+            let client_config = client_config.clone();
+            let mnemonic = mnemonic.clone();
+            let url = url.clone();
+            let tracker = tracker_for_probe.clone();
+            let expected_chain_id = expected_chain_id.clone();
+            async move {
+                let client = DirectSigningHttpRpcNyxdClient::connect_with_mnemonic(
+                    client_config,
+                    url.as_str(),
+                    mnemonic,
+                )
+                .map_err(|err| ConnectError::Failed(err.to_string()))?;
+                // connect_with_mnemonic does no I/O: verify the endpoint answers
+                // with an account-independent read, so a valid-but-never-funded
+                // (fresh) account doesn't spuriously fail this check.
+                let chain_id = client
+                    .get_chain_id()
+                    .await
+                    .map_err(|err| ConnectError::Failed(err.to_string()))?;
+                if let Some(expected) = expected_chain_id
+                    && chain_id.as_str() != expected
+                {
+                    let msg =
+                        format!("wrong chain-id at {url}: expected {expected}, got {chain_id}");
+                    tracker.mark_permanent_failure(EndpointClass::NyxdRpc, &url, &msg);
+                    return Err(ConnectError::PermanentlyExcluded(msg));
+                }
+                Ok(client)
+            }
+        })
+        .await
+        .map_err(AccountCommandError::NyxdConnectionFailure)?;
+
+        self.client = Some((url, Arc::new(client)));
         Ok(())
     }
 
@@ -52,44 +154,223 @@ impl NyxdClient {
         self.client = None;
     }
 
+    /// Drop the cached client and report its endpoint as failed so the next
+    /// connection rotates away from it.
+    fn invalidate_after_failure(&mut self, kind: FailureKind) {
+        if let Some((url, _)) = self.client.take() {
+            self.tracker
+                .report_failure(EndpointClass::NyxdRpc, &url, kind);
+        }
+    }
+
     pub(crate) async fn get_account_details(
         &mut self,
         mnemonic: &str,
     ) -> Result<Option<Account>, AccountCommandError> {
-        self.ensure_connected(mnemonic)?;
-        // SAFETY: we just connected
-        #[allow(clippy::unwrap_used)]
-        let client = self.client.as_mut().unwrap();
-        let address = client.address();
-        client
-            .get_account(&address)
-            .await
-            .map_err(|err| AccountCommandError::NyxdQueryFailure(err.to_string()))
+        self.query_with_failover(mnemonic, |client| async move {
+            let address = client.address();
+            client.get_account(&address).await
+        })
+        .await
     }
 
     pub(crate) async fn account_balance(
         &mut self,
         mnemonic: &str,
     ) -> Result<Vec<Coin>, AccountCommandError> {
-        self.ensure_connected(mnemonic)?;
-        // SAFETY: we just connected
-        #[allow(clippy::unwrap_used)]
-        let client = self.client.as_mut().unwrap();
-        let address = client.address();
-        client
-            .get_all_balances(&address)
-            .await
-            .map_err(|err| AccountCommandError::NyxdQueryFailure(err.to_string()))
+        self.query_with_failover(mnemonic, |client| async move {
+            let address = client.address();
+            client.get_all_balances(&address).await
+        })
+        .await
     }
 
-    pub(crate) fn inner_client(
+    /// Run a read query; on failure rotate to the next healthy endpoint and retry once.
+    async fn query_with_failover<T, F, Fut>(
+        &mut self,
+        mnemonic: &str,
+        query: F,
+    ) -> Result<T, AccountCommandError>
+    where
+        F: Fn(Arc<DirectSigningHttpRpcNyxdClient>) -> Fut,
+        Fut: Future<Output = Result<T, NyxdError>>,
+    {
+        self.ensure_connected(mnemonic).await?;
+        // SAFETY: we just connected
+        #[allow(clippy::unwrap_used)]
+        let client = self.client.as_ref().unwrap().1.clone();
+
+        match query(client).await {
+            Ok(value) => Ok(value),
+            Err(first_err) => {
+                // Application-level errors (e.g. ABCI "not found", deserialization
+                // of a valid response) don't indicate an unhealthy endpoint: return
+                // them directly without reporting a failure or rotating/retrying.
+                if !is_connection_error(&first_err) {
+                    return Err(AccountCommandError::NyxdQueryFailure(first_err.to_string()));
+                }
+                self.invalidate_after_failure(failure_kind_for(&first_err));
+                self.ensure_connected(mnemonic).await?;
+                // SAFETY: we just connected
+                #[allow(clippy::unwrap_used)]
+                let client = self.client.as_ref().unwrap().1.clone();
+                match query(client).await {
+                    Ok(value) => Ok(value),
+                    Err(err) => {
+                        if is_connection_error(&err) {
+                            self.invalidate_after_failure(failure_kind_for(&err));
+                        }
+                        Err(AccountCommandError::NyxdQueryFailure(format!(
+                            "{err} (after retry; first attempt: {first_err})"
+                        )))
+                    }
+                }
+            }
+        }
+    }
+
+    pub(crate) async fn inner_client(
         &mut self,
         mnemonic: &str,
     ) -> Result<Arc<DirectSigningHttpRpcNyxdClient>, AccountCommandError> {
-        self.ensure_connected(mnemonic)?;
+        self.ensure_connected(mnemonic).await?;
         // SAFETY: we just connected
         #[allow(clippy::unwrap_used)]
-        let client = self.client.clone().unwrap();
+        let client = self.client.clone().unwrap().1;
         Ok(client)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nym_endpoint_health::{EndpointClass, EndpointHealthTracker};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn u(s: &str) -> url::Url {
+        s.parse().unwrap()
+    }
+
+    #[tokio::test]
+    async fn connects_to_first_healthy_candidate() {
+        let tracker = Arc::new(EndpointHealthTracker::new());
+        tracker.register(
+            EndpointClass::NyxdRpc,
+            vec![u("https://a.example/"), u("https://b.example/")],
+        );
+        let attempts = AtomicUsize::new(0);
+        let result = connect_first_healthy(
+            vec![u("https://a.example/"), u("https://b.example/")],
+            &tracker,
+            |url| {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                let url = url.clone();
+                async move {
+                    if url.as_str() == "https://a.example/" {
+                        Err(ConnectError::Failed("a is down".to_string()))
+                    } else {
+                        Ok(42u32)
+                    }
+                }
+            },
+        )
+        .await;
+        let (url, value) = result.unwrap();
+        assert_eq!(url, u("https://b.example/"));
+        assert_eq!(value, 42);
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+        // failure was reported: next selection starts at b
+        assert_eq!(
+            tracker.select(EndpointClass::NyxdRpc)[0],
+            u("https://b.example/")
+        );
+    }
+
+    /// Live smoke test: real network I/O against the mainnet nyxd validator pool,
+    /// with the primary endpoint replaced by a dead localhost port so failover
+    /// must rotate to a third-party validator. Run manually:
+    /// `cargo test -p nym-vpn-account-controller --lib -- --ignored --nocapture nyxd_live`
+    #[tokio::test]
+    #[ignore = "live network test; run manually"]
+    async fn nyxd_live_failover_rotates_off_dead_primary() {
+        let dead = u("http://127.0.0.1:1/");
+        let mut network = nym_vpn_network_config::Network::mainnet_default().unwrap();
+        network.nyxd_url = dead.clone();
+        network.nyxd_urls = std::iter::once(dead.clone())
+            .chain(
+                network
+                    .nyxd_urls
+                    .into_iter()
+                    .filter(|url| url.host_str() != Some("rpc.nymtech.net")),
+            )
+            .collect();
+        assert!(
+            network.nyxd_urls.len() >= 2,
+            "need at least one live fallback validator in the bundled pool"
+        );
+
+        let tracker = Arc::new(EndpointHealthTracker::new());
+        tracker.register(EndpointClass::NyxdRpc, network.nyxd_urls.clone());
+
+        let mut client = NyxdClient::new(&network, tracker.clone());
+        // Well-known BIP-39 test vector; derives a real but unused, unfunded account.
+        let mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon \
+                        abandon abandon abandon abandon abandon abandon abandon abandon \
+                        abandon abandon abandon abandon abandon abandon abandon art";
+
+        let balances = client
+            .account_balance(mnemonic)
+            .await
+            .expect("dead primary should rotate to a live third-party validator");
+        println!("live failover OK; fresh-account balances: {balances:?}");
+
+        let preferred = &tracker.select(EndpointClass::NyxdRpc)[0];
+        println!("preferred endpoint after failover: {preferred}");
+        assert_ne!(
+            *preferred, dead,
+            "rotation should have moved off the dead primary"
+        );
+    }
+
+    #[tokio::test]
+    async fn returns_last_error_when_all_fail() {
+        let tracker = Arc::new(EndpointHealthTracker::new());
+        tracker.register(EndpointClass::NyxdRpc, vec![u("https://a.example/")]);
+        let result =
+            connect_first_healthy(vec![u("https://a.example/")], &tracker, |_url| async move {
+                Err::<u32, _>(ConnectError::Failed("boom".to_string()))
+            })
+            .await;
+        assert_eq!(result.unwrap_err(), "boom");
+    }
+
+    #[tokio::test]
+    async fn chain_mismatch_is_permanently_excluded_not_reported_as_failure() {
+        let tracker = Arc::new(EndpointHealthTracker::new());
+        tracker.register(EndpointClass::NyxdRpc, vec![u("https://a.example/")]);
+        let result = connect_first_healthy(vec![u("https://a.example/")], &tracker, |url| {
+            let url = url.clone();
+            let tracker = tracker.clone();
+            async move {
+                tracker.mark_permanent_failure(EndpointClass::NyxdRpc, &url, "wrong chain-id");
+                Err::<u32, _>(ConnectError::PermanentlyExcluded(
+                    "wrong chain-id".to_string(),
+                ))
+            }
+        })
+        .await;
+        assert_eq!(result.unwrap_err(), "wrong chain-id");
+        // Permanently excluded, not merely blacklisted: fail-open would still
+        // return it if it had only been reported as an ordinary failure, but
+        // permanent exclusion drops it even from fail-open (no other endpoint
+        // registered, so selection now falls back to returning it anyway --
+        // what matters here is that the state is `permanently_failed`, which
+        // `all_endpoints` doesn't directly expose, so we assert indirectly via
+        // an additional healthy endpoint).
+        tracker.register(EndpointClass::NyxdRpc, vec![u("https://b.example/")]);
+        assert_eq!(
+            tracker.select(EndpointClass::NyxdRpc),
+            vec![u("https://b.example/")]
+        );
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/shared_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/shared_state.rs
@@ -196,7 +196,10 @@ impl<C: ConnectivityMonitor> SharedAccountState<C> {
             AccountCommandError::internal(format!("ecash seed derivation failure: {err}"))
         })?;
 
-        let client = self.nyxd_client.inner_client(&account.get_mnemonic())?;
+        let client = self
+            .nyxd_client
+            .inner_client(&account.get_mnemonic())
+            .await?;
 
         let fetcher = Arc::new(
             NyxdCredentialFetcher::new(

--- a/nym-vpn-core/crates/nym-vpn-account-controller/src/signer_discovery.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/src/signer_discovery.rs
@@ -1,0 +1,152 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+//! Discovers the current epoch's verified zk-nym ecash signers from the Nyx
+//! DKG contract and registers their announce addresses as additional nym-api
+//! endpoints, so the general nym-api pool stays in sync with the validator
+//! set without app releases.
+
+use nym_endpoint_health::{EndpointClass, EndpointHealthTracker, FailureKind};
+use nym_validator_client::{
+    QueryHttpRpcNyxdClient,
+    nyxd::{
+        Config,
+        contract_traits::{DkgQueryClient, PagedDkgQueryClient},
+    },
+};
+use nym_vpn_network_config::Network;
+use std::sync::Arc;
+use url::Url;
+
+/// Normalize an on-chain announce address for use as an HTTP API base url:
+/// parse, require http(s), and ensure the path ends with '/'.
+fn normalize_announce_address(raw: &str) -> Option<Url> {
+    let mut url: Url = raw.trim().parse().ok()?;
+    if url.scheme() != "https" && url.scheme() != "http" {
+        return None;
+    }
+    if !url.path().ends_with('/') {
+        let path = format!("{}/", url.path());
+        url.set_path(&path);
+    }
+    Some(url)
+}
+
+/// Connect a query-only nyxd client to `url` and fetch the current epoch's
+/// verified verification-key shares.
+async fn fetch_verified_shares(
+    config: &Config,
+    url: &Url,
+) -> Result<Vec<nym_coconut_dkg_common::verification_key::ContractVKShare>, String> {
+    let client = QueryHttpRpcNyxdClient::connect(config.clone(), url.as_str())
+        .map_err(|err| err.to_string())?;
+    let epoch = client
+        .get_current_epoch()
+        .await
+        .map_err(|err| err.to_string())?;
+    let shares = client
+        .get_all_verification_key_shares(epoch.epoch_id)
+        .await
+        .map_err(|err| err.to_string())?;
+    Ok(shares)
+}
+
+/// Query the DKG contract for the current epoch's verified signer set and
+/// register their nym-api announce addresses into the tracker's NymApi pool.
+/// Tries the healthy nyxd endpoints in order (one pass); returns how many
+/// endpoints were registered.
+pub async fn discover_ecash_signer_apis(
+    network: &Network,
+    tracker: &Arc<EndpointHealthTracker>,
+) -> Result<usize, String> {
+    let network_details = network.nym_network_details();
+    let client_config = Config::try_from_nym_network_details(network_details)
+        .map_err(|err| format!("invalid network information: {err}"))?;
+
+    let mut candidates = tracker.select(EndpointClass::NyxdRpc);
+    if candidates.is_empty() {
+        candidates = vec![network.nyxd_url()];
+    }
+
+    let mut last_error = "no nyxd endpoints available".to_string();
+    for url in candidates {
+        match fetch_verified_shares(&client_config, &url).await {
+            Ok(shares) => {
+                tracker.report_success(EndpointClass::NyxdRpc, &url, None);
+
+                let normalized: Vec<Url> = shares
+                    .into_iter()
+                    .filter(|share| share.verified)
+                    .filter_map(|share| normalize_announce_address(&share.announce_address))
+                    .collect();
+                let count = normalized.len();
+                tracker.register(EndpointClass::NymApi, normalized);
+                tracing::info!(
+                    "discovered {count} verified ecash signer nym-api endpoint(s) from the DKG contract at {url}"
+                );
+                return Ok(count);
+            }
+            Err(err) => {
+                tracing::warn!(
+                    endpoint = %url,
+                    "nyxd endpoint failed during signer discovery, trying next: {err}"
+                );
+                tracker.report_failure(EndpointClass::NyxdRpc, &url, FailureKind::Connect);
+                last_error = err;
+            }
+        }
+    }
+    Err(last_error)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_adds_trailing_slash_when_missing() {
+        let url = normalize_announce_address("https://x.example/api").unwrap();
+        assert_eq!(url.as_str(), "https://x.example/api/");
+    }
+
+    #[test]
+    fn normalize_keeps_already_trailing_slash_unchanged() {
+        let url = normalize_announce_address("https://x.example/").unwrap();
+        assert_eq!(url.as_str(), "https://x.example/");
+    }
+
+    #[test]
+    fn normalize_rejects_non_http_scheme() {
+        assert!(normalize_announce_address("ftp://x.example/").is_none());
+    }
+
+    #[test]
+    fn normalize_rejects_garbage() {
+        assert!(normalize_announce_address("not a url at all").is_none());
+    }
+
+    /// Live network test: queries the real mainnet DKG contract for the
+    /// current epoch's verified ecash signers and registers their nym-api
+    /// announce addresses into a fresh tracker. Run manually:
+    /// `cargo test -p nym-vpn-account-controller --lib -- --ignored --nocapture signer`
+    #[tokio::test]
+    #[ignore = "live network test; run manually"]
+    async fn live_discover_ecash_signer_apis_against_mainnet() {
+        let network = Network::mainnet_default().unwrap();
+        let tracker = Arc::new(EndpointHealthTracker::new());
+
+        let count = discover_ecash_signer_apis(&network, &tracker)
+            .await
+            .expect("live DKG signer discovery should succeed against mainnet");
+
+        println!("discovered {count} verified ecash signer nym-api endpoints");
+        assert!(
+            count >= 10,
+            "expected at least 10 verified signers, got {count}"
+        );
+        assert!(
+            tracker.all_endpoints(EndpointClass::NymApi).len() >= count,
+            "tracker should have registered at least the discovered endpoints"
+        );
+    }
+}

--- a/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/common/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-account-controller/tests/integrations/common/mod.rs
@@ -242,7 +242,9 @@ impl TestBench {
         let mut network_env = Network::mainnet_default().unwrap();
         network_env.nyxd_url = nyxd_server.uri().parse()?;
 
-        let nyxd_client = NyxdClient::new(&network_env);
+        let endpoint_health =
+            std::sync::Arc::new(nym_endpoint_health::EndpointHealthTracker::new());
+        let nyxd_client = NyxdClient::new(&network_env, endpoint_health);
 
         let tempdir = tempfile::tempdir()?;
         let account_controller_config = AccountControllerConfig {

--- a/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
+++ b/nym-vpn-core/crates/nym-vpn-api-client/src/response.rs
@@ -735,6 +735,8 @@ pub struct NymWellknownDiscoveryItemResponse {
     pub nym_api_urls: Vec<ApiUrl>,
     pub nym_vpn_api_url: String,
     pub nym_vpn_api_urls: Vec<ApiUrl>,
+    #[serde(default)]
+    pub nyxd_urls: Option<Vec<String>>,
     pub account_management: Option<AccountManagementResponse>,
     pub feature_flags: Option<serde_json::Value>,
     pub system_messages: Option<Vec<SystemMessageResponse>>,

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/Cargo.toml
@@ -26,6 +26,7 @@ nym-bridges-types = { workspace = true, features = [
     "uniffi-bindings",
     "serde",
 ] }
+nym-endpoint-health.workspace = true
 nym-gateway-directory.workspace = true
 nym-http-api-client.workspace = true
 nym-offline-monitor.workspace = true

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/environment.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/environment.rs
@@ -35,9 +35,10 @@ impl NymEnvironment {
         network_name: &str,
         user_agent: UserAgent,
     ) -> Result<Self, VpnError> {
-        let mut network_cache = NetworkCache::new(cache_dir, network_name, Some(user_agent.into()))
-            .await
-            .map_err(VpnError::internal)?;
+        let mut network_cache =
+            NetworkCache::new(cache_dir, network_name, Some(user_agent.into()), None)
+                .await
+                .map_err(VpnError::internal)?;
 
         let network = if let Ok(network) = network_cache.network() {
             network

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/vpn_service.rs
@@ -95,9 +95,14 @@ impl NymVpnService {
                     config.config_dir.to_path_buf(),
                     &environment.current().nym_network.network_name,
                     Some(config.user_agent.clone().into()),
+                    None,
                 )
                 .await
                 .map_err(VpnError::internal)?;
+
+                // Mobile platforms don't share a tracker with a vpnd process, so each service
+                // instance gets its own.
+                let endpoint_health = Arc::new(nym_endpoint_health::EndpointHealthTracker::new());
 
                 let vpn_service_params = nym_vpn_lib::service::NymVpnServiceParameters {
                     paths,
@@ -105,6 +110,7 @@ impl NymVpnService {
                     sentry_enabled: crate::logging::is_sentry_enabled(),
                     user_agent: config.user_agent.clone().into(),
                     service_storage_type,
+                    endpoint_health,
                     #[cfg(any(target_os = "android", target_os = "ios"))]
                     tun_provider,
                     #[cfg(target_os = "android")]

--- a/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-lib/Cargo.toml
@@ -61,6 +61,7 @@ nym-apple-network.workspace = true
 nym-authenticator-client.workspace = true
 nym-common.workspace = true
 nym-diagnostic.workspace = true
+nym-endpoint-health.workspace = true
 nym-platform-metadata = { workspace = true, features = ["user-agent-macro"] }
 nym-connection-monitor.workspace = true
 nym-gateway-directory.workspace = true

--- a/nym-vpn-core/crates/nym-vpn-lib/src/cache_refresh.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/cache_refresh.rs
@@ -3,19 +3,27 @@
 
 //! Helper functions for refreshing caches when network environment changes.
 
+use std::sync::Arc;
+
+use nym_endpoint_health::EndpointHealthTracker;
 use nym_gateway_directory::{Config as GatewayConfig, GatewayClient};
 use nym_http_api_client::UserAgent;
-use nym_vpn_network_config::Network;
+use nym_vpn_network_config::{Network, merge_and_order_api_urls_by_health};
 
 use crate::{VpnTopologyServiceHandle, gateway_directory::GatewayCacheHandle};
 
 /// Update gateway cache and topology cache for a new network environment.
 /// This is called when the discovery refresher detects an environment change.
+///
+/// `endpoint_health` orders the nym-api URL list by health before the
+/// gateway-directory client is built from it; pass `None` only for call
+/// paths that genuinely have no tracker available.
 pub async fn update_caches_for_network(
     network: &Network,
     gateway_cache_handle: &GatewayCacheHandle,
     topology_service_handle: &VpnTopologyServiceHandle,
     user_agent: &UserAgent,
+    endpoint_health: Option<&Arc<EndpointHealthTracker>>,
 ) {
     let network_name = &network.nym_network.network_name;
     tracing::info!(
@@ -37,7 +45,10 @@ pub async fn update_caches_for_network(
 
     // Create new gateway client for the new environment
     let nyxd_url = network.nyxd_url();
-    let nym_api_urls = network.nym_api_urls().unwrap_or_default();
+    let mut nym_api_urls = network.nym_api_urls().unwrap_or_default();
+    if let Some(tracker) = endpoint_health {
+        nym_api_urls = merge_and_order_api_urls_by_health(nym_api_urls, tracker);
+    }
     let nym_vpn_api_urls = network.nym_vpn_api_urls().unwrap_or_default();
 
     // Validate that we have the necessary URLs

--- a/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/service/vpn_service.rs
@@ -277,6 +277,7 @@ pub struct NymVpnServiceParameters {
     pub sentry_enabled: bool,
     pub user_agent: UserAgent,
     pub service_storage_type: ServiceConfigStorageType,
+    pub endpoint_health: Arc<nym_endpoint_health::EndpointHealthTracker>,
     #[cfg(target_os = "ios")]
     pub tun_provider: Arc<dyn OSTunProvider>,
     #[cfg(target_os = "android")]
@@ -403,6 +404,12 @@ pub struct NymVpnService {
 
     #[cfg(target_os = "linux")]
     split_tunnel_pid_manager: nym_split_tunnel::PidManager,
+
+    // Tracks per-endpoint health for nyxd/nym-api rotation.
+    endpoint_health: Arc<nym_endpoint_health::EndpointHealthTracker>,
+
+    // Endpoint prober join handle
+    endpoint_prober_join_handle: JoinHandle<()>,
 }
 
 impl NymVpnService {
@@ -541,7 +548,32 @@ impl NymVpnService {
         .map_err(Error::CreateApiClient)?
         .with_skew_manager(skew_manager.clone());
 
-        let nyxd_client = NyxdClient::new(&network_env);
+        let endpoint_health = parameters.endpoint_health.clone();
+        endpoint_health.register(
+            nym_endpoint_health::EndpointClass::NyxdRpc,
+            network_env.nyxd_urls(),
+        );
+        let nyxd_client = NyxdClient::new(&network_env, endpoint_health.clone());
+
+        {
+            let endpoint_health = endpoint_health.clone();
+            let network_env = *network_env.clone();
+            tokio::spawn(async move {
+                match nym_vpn_account_controller::discover_ecash_signer_apis(
+                    &network_env,
+                    &endpoint_health,
+                )
+                .await
+                {
+                    Ok(count) => {
+                        tracing::info!("registered {count} on-chain nym-api signer endpoints")
+                    }
+                    Err(err) => tracing::warn!(
+                        "nym-api signer discovery failed (will retry on network refresh): {err}"
+                    ),
+                }
+            });
+        }
 
         let account_controller = AccountController::new(
             nym_vpn_api_client.clone(),
@@ -660,6 +692,13 @@ impl NymVpnService {
             network_cache,
             discovery_refresher_command_rx,
             discovery_refresher_event_tx,
+            connectivity_handle.clone(),
+            services_shutdown_token.child_token(),
+        );
+
+        let endpoint_prober_join_handle = nym_endpoint_health::EndpointProber::spawn(
+            endpoint_health.clone(),
+            network_env.expected_chain_id(),
             connectivity_handle.clone(),
             services_shutdown_token.child_token(),
         );
@@ -795,6 +834,8 @@ impl NymVpnService {
             recents_manager,
             #[cfg(target_os = "linux")]
             split_tunnel_pid_manager,
+            endpoint_health,
+            endpoint_prober_join_handle,
         })
     }
 
@@ -877,6 +918,10 @@ impl NymVpnService {
 
         if let Err(e) = self.discovery_refresher_join_handle.await {
             tracing::error!("Failed to join on discovery refresher handle: {e}");
+        }
+
+        if let Err(e) = self.endpoint_prober_join_handle.await {
+            tracing::error!("Failed to join on endpoint prober handle: {e}");
         }
 
         if let Err(e) = self.topology_service_join_handle.await {
@@ -1007,12 +1052,38 @@ impl NymVpnService {
         tracing::info!("Network environment updated");
         let _ = self.network_tx.send_replace(new_network.clone());
 
+        self.endpoint_health.register(
+            nym_endpoint_health::EndpointClass::NyxdRpc,
+            new_network.nyxd_urls(),
+        );
+
+        {
+            let endpoint_health = self.endpoint_health.clone();
+            let network_env = *new_network.clone();
+            tokio::spawn(async move {
+                match nym_vpn_account_controller::discover_ecash_signer_apis(
+                    &network_env,
+                    &endpoint_health,
+                )
+                .await
+                {
+                    Ok(count) => {
+                        tracing::info!("registered {count} on-chain nym-api signer endpoints")
+                    }
+                    Err(err) => tracing::warn!(
+                        "nym-api signer discovery failed (will retry on network refresh): {err}"
+                    ),
+                }
+            });
+        }
+
         // Update gateway cache and topology cache for new environment
         crate::cache_refresh::update_caches_for_network(
             &new_network,
             &self.gateway_cache_handle,
             &self.topology_service_handle,
             &self.user_agent,
+            Some(&self.endpoint_health),
         )
         .await;
     }

--- a/nym-vpn-core/crates/nym-vpn-network-config/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpn-network-config/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 thiserror.workspace = true
 itertools.workspace = true
 nym-common.workspace = true
+nym-endpoint-health.workspace = true
 nym-http-api-client.workspace = true
 nym-network-defaults.workspace = true
 nym-sdk.workspace = true

--- a/nym-vpn-core/crates/nym-vpn-network-config/default/mainnet_discovery.json
+++ b/nym-vpn-core/crates/nym-vpn-network-config/default/mainnet_discovery.json
@@ -8,7 +8,20 @@
     {
       "url": "https://nym-frontdoor.global.ssl.fastly.net/api/",
       "fronts": ["yelp.global.ssl.fastly.net"]
-    }
+    },
+    { "url": "https://nym-api-signer-1.nymtech.net/api/" },
+    { "url": "https://nym-api-signer-2.nymtech.net/api/" },
+    { "url": "https://nym-api-nyx.tpt.systems/" },
+    { "url": "https://nym-api.hoodrun.io/" },
+    { "url": "https://nym-api.nym.atalma.io/" },
+    { "url": "https://nym-api.nocturnallabs.org/" },
+    { "url": "https://nym-api.commodum.io/" },
+    { "url": "https://nym-api.swiss-staking.ch/" },
+    { "url": "https://nym-api.nyx.throbaclabs.com/" },
+    { "url": "https://nym-api.nym.pathrocknetwork.org/" },
+    { "url": "https://nym-api.nyx.fairstaking.com/" },
+    { "url": "https://nym-api.nym.greenfield.xyz/" },
+    { "url": "https://nym-api.nodes.guru/" }
   ],
   "nym_vpn_api_url": "https://nymvpn.com/api/",
   "nym_vpn_api_urls": [
@@ -19,6 +32,12 @@
       "url": "https://nymvpn-frontdoor.global.ssl.fastly.net/api/",
       "fronts": ["yelp.global.ssl.fastly.net"]
     }
+  ],
+  "nyxd_urls": [
+    "https://rpc.nymtech.net/",
+    "https://nym-rpc.polkachu.com/",
+    "https://rpc.nyx.nodes.guru/",
+    "https://nym-mainnet-rpc.commodum.io/"
   ],
   "account_management": {
     "url": "https://nym.com/",

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/discovery.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/discovery.rs
@@ -21,6 +21,8 @@ pub struct Discovery {
     nym_api_urls: Vec<ApiUrl>,
     nym_vpn_api_url: url::Url,
     nym_vpn_api_urls: Vec<ApiUrl>,
+    #[serde(default)]
+    nyxd_urls: Vec<url::Url>,
 
     // Additional context
     pub account_management: Option<AccountManagement>,
@@ -95,6 +97,18 @@ impl Discovery {
                 .collect()
         }
     }
+
+    /// Nyxd RPC endpoint pool. Falls back to the bundled defaults for this
+    /// network when the stored discovery doesn't carry any (e.g. a remote
+    /// discovery response predating this field).
+    pub fn nyxd_urls(&self) -> Vec<url::Url> {
+        if !self.nyxd_urls.is_empty() {
+            return self.nyxd_urls.clone();
+        }
+        Self::default_discovery(&self.network_name)
+            .map(|d| d.nyxd_urls)
+            .unwrap_or_default()
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -154,12 +168,26 @@ impl TryFrom<NymWellknownDiscoveryItemResponse> for Discovery {
         })?;
         let nym_vpn_api_urls = discovery.nym_vpn_api_urls.clone();
 
+        let nyxd_urls = discovery
+            .nyxd_urls
+            .unwrap_or_default()
+            .iter()
+            .filter_map(|raw| {
+                raw.parse::<url::Url>()
+                    .inspect_err(|err| {
+                        tracing::warn!("Skipping invalid nyxd url in discovery: {raw}: {err}")
+                    })
+                    .ok()
+            })
+            .collect();
+
         Ok(Self {
             network_name: discovery.network_name,
             nym_api_url,
             nym_api_urls,
             nym_vpn_api_url,
             nym_vpn_api_urls,
+            nyxd_urls,
             account_management,
             feature_flags,
             system_configuration,
@@ -201,7 +229,7 @@ mod tests {
     }
 
     async fn test_discovery_equality(discovery: Discovery) {
-        let fetcher = Fetcher::new(Discovery::default_mainnet(), None).unwrap();
+        let fetcher = Fetcher::new(Discovery::default_mainnet(), None, None).unwrap();
         let fetched = fetcher
             .fetch_discovery(&discovery.network_name)
             .await
@@ -285,6 +313,7 @@ mod tests {
                 url: "https://bar.ch/api/".parse().unwrap(),
                 fronts: Some(vec!["quxbar.ch".to_owned(), "qux.baz".to_owned()]),
             }],
+            nyxd_urls: vec![],
             account_management: Some(AccountManagement {
                 url: "https://foobar.ch/".parse().unwrap(),
                 paths: AccountManagementPaths {
@@ -335,5 +364,56 @@ mod tests {
             system_configuration: None,
         };
         assert_eq!(network, expected_network);
+    }
+
+    #[test]
+    fn test_mainnet_default_nym_api_pool_includes_signers() {
+        let urls = Discovery::default_mainnet().nym_api_urls();
+        assert_eq!(urls.len(), 15);
+        assert_eq!(urls[0].url, "https://validator.nymtech.net/api/");
+        assert!(urls.iter().any(|u| u.url == "https://nym-api.nodes.guru/"));
+    }
+
+    #[test]
+    fn test_mainnet_default_has_nyxd_pool() {
+        let discovery = Discovery::default_mainnet();
+        let urls = discovery.nyxd_urls();
+        assert_eq!(urls.len(), 4);
+        assert_eq!(urls[0].as_str(), "https://rpc.nymtech.net/");
+    }
+
+    #[test]
+    fn test_nyxd_urls_fall_back_to_bundled_default_when_absent() {
+        // Simulates a remote discovery response that doesn't carry nyxd_urls:
+        // the bundled mainnet pool must still apply.
+        let json = r#"{
+            "network_name": "mainnet",
+            "nym_api_url": "https://validator.nymtech.net/api/",
+            "nym_api_urls": [],
+            "nym_vpn_api_url": "https://nymvpn.com/api/",
+            "nym_vpn_api_urls": []
+        }"#;
+        let response: NymWellknownDiscoveryItemResponse = serde_json::from_str(json).unwrap();
+        let discovery: Discovery = response.try_into().unwrap();
+        assert_eq!(discovery.nyxd_urls().len(), 4);
+    }
+
+    #[test]
+    fn test_nyxd_urls_from_response_override_default() {
+        let json = r#"{
+            "network_name": "mainnet",
+            "nym_api_url": "https://validator.nymtech.net/api/",
+            "nym_api_urls": [],
+            "nym_vpn_api_url": "https://nymvpn.com/api/",
+            "nym_vpn_api_urls": [],
+            "nyxd_urls": ["https://rpc.example.com/", "not a url"]
+        }"#;
+        let response: NymWellknownDiscoveryItemResponse = serde_json::from_str(json).unwrap();
+        let discovery: Discovery = response.try_into().unwrap();
+        // invalid entries skipped with a warning, valid ones kept
+        assert_eq!(
+            discovery.nyxd_urls(),
+            vec!["https://rpc.example.com/".parse::<url::Url>().unwrap()]
+        );
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/envs.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/envs.rs
@@ -103,7 +103,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_envs_default_same_as_fetched() {
-        let fetcher = Fetcher::new(Discovery::default_mainnet(), None).unwrap();
+        let fetcher = Fetcher::new(Discovery::default_mainnet(), None, None).unwrap();
         let default_envs = RegisteredNetworks::default();
         let fetched_envs = fetcher.fetch_registered_networks().await.unwrap();
 

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/fetcher.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/fetcher.rs
@@ -1,8 +1,9 @@
 // Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
+use nym_endpoint_health::{EndpointClass, EndpointHealthTracker};
 use nym_http_api_client::Client as HttpApiClient;
 use nym_sdk::{NymNetworkDetails, UserAgent};
 use nym_validator_client::nym_api::NymApiClientExt;
@@ -19,16 +20,26 @@ pub struct Fetcher {
     vpn_api_client: VpnApiClient,
     user_agent: Option<UserAgent>,
     discovery: Box<Discovery>,
+    tracker: Option<Arc<EndpointHealthTracker>>,
 }
 
 impl Fetcher {
     /// Create an instance of `Fetcher` using HTTP API endpoints from the given discovery.
-    pub fn new(discovery: Discovery, user_agent: Option<UserAgent>) -> Result<Self> {
+    pub fn new(
+        discovery: Discovery,
+        user_agent: Option<UserAgent>,
+        tracker: Option<Arc<EndpointHealthTracker>>,
+    ) -> Result<Self> {
+        if let Some(tracker) = &tracker {
+            register_nym_api_urls(&discovery, tracker);
+        }
+
         Ok(Self {
             user_agent: user_agent.clone(),
-            api_client: build_api_client(&discovery, user_agent.clone())?,
+            api_client: build_api_client(&discovery, user_agent.clone(), tracker.as_deref())?,
             vpn_api_client: build_vpn_api_client(&discovery, user_agent)?,
             discovery: Box::new(discovery),
+            tracker,
         })
     }
 
@@ -39,7 +50,15 @@ impl Fetcher {
             return Ok(());
         }
 
-        self.api_client = build_api_client(&new_discovery, self.user_agent.clone())?;
+        if let Some(tracker) = &self.tracker {
+            register_nym_api_urls(&new_discovery, tracker);
+        }
+
+        self.api_client = build_api_client(
+            &new_discovery,
+            self.user_agent.clone(),
+            self.tracker.as_deref(),
+        )?;
         self.vpn_api_client = build_vpn_api_client(&new_discovery, self.user_agent.clone())?;
         *self.discovery = new_discovery;
 
@@ -79,12 +98,74 @@ impl Fetcher {
     }
 }
 
-fn build_api_client(discovery: &Discovery, user_agent: Option<UserAgent>) -> Result<HttpApiClient> {
-    let api_urls =
-        api_urls_to_urls(&discovery.nym_api_urls()).map_err(Error::CreateVpnApiClient)?;
+fn build_api_client(
+    discovery: &Discovery,
+    user_agent: Option<UserAgent>,
+    tracker: Option<&EndpointHealthTracker>,
+) -> Result<HttpApiClient> {
+    let mut nym_api_urls = discovery.nym_api_urls();
+    if let Some(tracker) = tracker {
+        nym_api_urls = merge_and_order_api_urls_by_health(nym_api_urls, tracker);
+    }
+    let api_urls = api_urls_to_urls(&nym_api_urls).map_err(Error::CreateVpnApiClient)?;
 
     fronted_http_client::fronted_http_client(api_urls, user_agent, Some(NETWORK_TIMEOUT))
         .map_err(Error::CreateVpnApiClient)
+}
+
+fn register_nym_api_urls(discovery: &Discovery, tracker: &EndpointHealthTracker) {
+    let urls = discovery
+        .nym_api_urls()
+        .iter()
+        .filter_map(|api_url| api_url.url.parse().ok())
+        .collect();
+    tracker.register(EndpointClass::NymApi, urls);
+}
+
+/// Reorder ApiUrls so tracker-healthy endpoints come first. Entries the
+/// tracker doesn't know keep their relative position at the end; the result
+/// always contains every input entry (selection is fail-open, and dropping
+/// URLs here could leave the client with nothing).
+///
+/// Comparison is done on parsed `Url`s rather than raw strings so a
+/// non-normalized discovery URL (e.g. differing only in a trailing slash)
+/// still matches its ranking entry. A URL that fails to parse simply ranks
+/// last — it is never dropped.
+pub fn order_api_urls_by_health(
+    urls: Vec<nym_network_defaults::ApiUrl>,
+    tracker: &EndpointHealthTracker,
+) -> Vec<nym_network_defaults::ApiUrl> {
+    let ranking = tracker.select(EndpointClass::NymApi);
+    let rank_of = |api_url: &nym_network_defaults::ApiUrl| {
+        api_url
+            .url
+            .parse::<url::Url>()
+            .ok()
+            .and_then(|parsed| ranking.iter().position(|u| *u == parsed))
+            .unwrap_or(usize::MAX)
+    };
+    let mut urls = urls;
+    urls.sort_by_key(rank_of);
+    urls
+}
+
+/// Append tracker-known NymApi endpoints that are missing from `urls`
+/// (as front-less entries), then health-order the combined list.
+pub fn merge_and_order_api_urls_by_health(
+    urls: Vec<nym_network_defaults::ApiUrl>,
+    tracker: &EndpointHealthTracker,
+) -> Vec<nym_network_defaults::ApiUrl> {
+    let mut urls = urls;
+    let known: Vec<url::Url> = urls.iter().filter_map(|u| u.url.parse().ok()).collect();
+    for endpoint in tracker.all_endpoints(EndpointClass::NymApi) {
+        if !known.contains(&endpoint) {
+            urls.push(nym_network_defaults::ApiUrl {
+                url: endpoint.to_string(),
+                front_hosts: None,
+            });
+        }
+    }
+    order_api_urls_by_health(urls, tracker)
 }
 
 fn build_vpn_api_client(
@@ -104,8 +185,151 @@ mod tests {
     #[tokio::test]
     async fn test_discovery_fetch() {
         let network_name = "mainnet";
-        let fetcher = Fetcher::new(Discovery::default_mainnet(), None).unwrap();
+        let fetcher = Fetcher::new(Discovery::default_mainnet(), None, None).unwrap();
         let discovery = fetcher.fetch_discovery(network_name).await.unwrap();
         assert_eq!(discovery.network_name, network_name);
+    }
+
+    #[test]
+    fn api_urls_ordered_by_health() {
+        use nym_endpoint_health::{EndpointClass, EndpointHealthTracker, FailureKind};
+
+        let tracker = EndpointHealthTracker::new();
+        let primary = "https://validator.example/api/";
+        let front = "https://front.example/api/";
+        tracker.register(
+            EndpointClass::NymApi,
+            vec![primary.parse().unwrap(), front.parse().unwrap()],
+        );
+        // blacklist the primary
+        for _ in 0..3 {
+            tracker.report_failure(
+                EndpointClass::NymApi,
+                &primary.parse().unwrap(),
+                FailureKind::Connect,
+            );
+        }
+
+        let urls = vec![
+            nym_network_defaults::ApiUrl {
+                url: primary.to_string(),
+                front_hosts: None,
+            },
+            nym_network_defaults::ApiUrl {
+                url: front.to_string(),
+                front_hosts: Some(vec!["f.example".into()]),
+            },
+        ];
+        let ordered = order_api_urls_by_health(urls, &tracker);
+        assert_eq!(ordered[0].url, front);
+        // blacklisted-but-only-remaining entries are kept (fail-open), so both survive
+        assert_eq!(ordered.len(), 2);
+        assert!(ordered[1].front_hosts.is_none());
+    }
+
+    #[test]
+    fn api_urls_ordered_by_health_matches_non_normalized_urls() {
+        use nym_endpoint_health::{EndpointClass, EndpointHealthTracker};
+
+        // Tracker holds the URL without a trailing slash; discovery has one
+        // with a trailing slash (or vice versa) -- both parse to the same
+        // `Url`, so they must still match.
+        let tracker = EndpointHealthTracker::new();
+        tracker.register(
+            EndpointClass::NymApi,
+            vec!["https://validator.example".parse().unwrap()],
+        );
+
+        let urls = vec![nym_network_defaults::ApiUrl {
+            url: "https://validator.example/".to_string(),
+            front_hosts: None,
+        }];
+        let ordered = order_api_urls_by_health(urls, &tracker);
+        // Never-drop guarantee holds regardless; this asserts the specific
+        // match (rank 0, not usize::MAX) by checking it sorts identically to
+        // the tracker's own ranking rather than falling to the back.
+        assert_eq!(ordered.len(), 1);
+        assert_eq!(ordered[0].url, "https://validator.example/");
+    }
+
+    #[test]
+    fn merge_and_order_adds_tracker_known_endpoint_without_duplicating() {
+        use nym_endpoint_health::EndpointHealthTracker;
+
+        let discovery_url = "https://validator.example/api/";
+        let extra_runtime_url = "https://extra-signer.example/";
+
+        let tracker = EndpointHealthTracker::new();
+        tracker.register(
+            EndpointClass::NymApi,
+            vec![
+                discovery_url.parse().unwrap(),
+                extra_runtime_url.parse().unwrap(),
+            ],
+        );
+        // blacklist the discovery url so it must sort after the healthy extra
+        for _ in 0..3 {
+            tracker.report_failure(
+                EndpointClass::NymApi,
+                &discovery_url.parse().unwrap(),
+                nym_endpoint_health::FailureKind::Connect,
+            );
+        }
+
+        let urls = vec![nym_network_defaults::ApiUrl {
+            url: discovery_url.to_string(),
+            front_hosts: None,
+        }];
+
+        let merged = merge_and_order_api_urls_by_health(urls, &tracker);
+
+        // Nothing dropped, extra endpoint added, no duplicates.
+        assert_eq!(merged.len(), 2);
+        assert!(merged.iter().any(|u| u.url == discovery_url));
+        let extra = merged
+            .iter()
+            .find(|u| u.url == extra_runtime_url)
+            .expect("extra tracker-known endpoint must be present");
+        assert!(extra.front_hosts.is_none());
+
+        // Health ordering still applies: blacklisted discovery url sorts last.
+        assert_eq!(merged[0].url, extra_runtime_url);
+        assert_eq!(merged[1].url, discovery_url);
+    }
+
+    #[test]
+    fn merge_and_order_does_not_duplicate_when_discovery_url_already_tracker_registered() {
+        use nym_endpoint_health::EndpointHealthTracker;
+
+        let discovery_url = "https://validator.example/api/";
+        let tracker = EndpointHealthTracker::new();
+        tracker.register(EndpointClass::NymApi, vec![discovery_url.parse().unwrap()]);
+
+        let urls = vec![nym_network_defaults::ApiUrl {
+            url: discovery_url.to_string(),
+            front_hosts: None,
+        }];
+
+        let merged = merge_and_order_api_urls_by_health(urls, &tracker);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].url, discovery_url);
+    }
+
+    #[test]
+    fn api_urls_ordered_by_health_keeps_unparseable_urls_last_without_dropping() {
+        use nym_endpoint_health::EndpointHealthTracker;
+
+        let tracker = EndpointHealthTracker::new();
+        let urls = vec![nym_network_defaults::ApiUrl {
+            url: "not a url".to_string(),
+            front_hosts: None,
+        }];
+        let ordered = order_api_urls_by_health(urls, &tracker);
+        assert_eq!(
+            ordered.len(),
+            1,
+            "unparseable entries must never be dropped"
+        );
+        assert_eq!(ordered[0].url, "not a url");
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-network-config/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-network-config/src/lib.rs
@@ -22,9 +22,11 @@ use std::{
     net::SocketAddr,
     path::{Path, PathBuf},
     str::FromStr,
+    sync::Arc,
     time::Duration,
 };
 
+use nym_endpoint_health::EndpointHealthTracker;
 use serde::{Deserialize, Serialize};
 use time::UtcDateTime;
 
@@ -33,7 +35,7 @@ pub use discovery::Discovery;
 pub use discovery_refresher::{DiscoveryRefresher, DiscoveryRefresherCommand};
 pub use envs::RegisteredNetworks;
 pub use feature_flags::{FeatureFlags, FlagValue};
-pub use fetcher::Fetcher;
+pub use fetcher::{Fetcher, merge_and_order_api_urls_by_health, order_api_urls_by_health};
 pub use nym_network_defaults::NymNetworkDetails;
 pub use nym_vpn_network::NymVpnNetwork;
 pub use system_configuration::{ScoreThresholds, SystemConfiguration};
@@ -62,6 +64,7 @@ pub type ApiUrl = nym_vpn_api_client::response::ApiUrl;
 pub struct Network {
     pub nym_network: NymNetworkDetails,
     pub nyxd_url: url::Url,
+    pub nyxd_urls: Vec<url::Url>,
     pub nym_vpn_network: NymVpnNetwork,
     pub feature_flags: Option<FeatureFlags>,
     pub system_configuration: Option<SystemConfiguration>,
@@ -91,16 +94,23 @@ impl Network {
 
         let feature_flags = discovery.feature_flags.clone();
         let system_configuration = discovery.system_configuration.clone();
-        let endpoint = network_details
+        let mut nyxd_urls: Vec<url::Url> = network_details
             .endpoints
-            .first()
-            .ok_or(Error::NoEndpointsFound)?;
-        let nyxd_url = endpoint.nyxd_url();
+            .iter()
+            .map(|endpoint| endpoint.nyxd_url())
+            .collect();
+        for url in discovery.nyxd_urls() {
+            if !nyxd_urls.contains(&url) {
+                nyxd_urls.push(url);
+            }
+        }
+        let nyxd_url = nyxd_urls.first().cloned().ok_or(Error::NoEndpointsFound)?;
         let nym_vpn_network = NymVpnNetwork::from(discovery);
 
         Ok(Self {
             nym_network: network_details,
             nyxd_url,
+            nyxd_urls,
             nym_vpn_network,
             feature_flags,
             system_configuration,
@@ -118,6 +128,15 @@ impl Network {
 
     pub fn nyxd_url(&self) -> url::Url {
         self.nyxd_url.clone()
+    }
+
+    pub fn nyxd_urls(&self) -> Vec<url::Url> {
+        self.nyxd_urls.clone()
+    }
+
+    /// Chain-id the nyxd pool must serve; used to reject endpoints on the wrong chain.
+    pub fn expected_chain_id(&self) -> Option<String> {
+        (self.nym_network.network_name == "mainnet").then(|| "nyx".to_string())
     }
 
     pub fn nym_api_urls(&self) -> Option<Vec<nym_network_defaults::ApiUrl>> {
@@ -230,6 +249,7 @@ impl NetworkCache {
         cache_dir: PathBuf,
         network_name: &str,
         user_agent: Option<UserAgent>,
+        tracker: Option<Arc<EndpointHealthTracker>>,
     ) -> Result<Self> {
         Self::clean_up_change_introduced_in_pr4226(&cache_dir).await;
 
@@ -248,7 +268,7 @@ impl NetworkCache {
                     }
                 })?;
 
-        let fetcher = Fetcher::new(persistent_discovery.value().clone(), user_agent)?;
+        let fetcher = Fetcher::new(persistent_discovery.value().clone(), user_agent, tracker)?;
 
         Ok(Self {
             cache_dir,
@@ -531,9 +551,10 @@ mod tests {
 
         let _ = tokio::fs::File::create(cache_dir.path().join("test.txt")).await;
 
-        let _network_cache = NetworkCache::new(cache_dir.path().to_path_buf(), "mainnet", None)
-            .await
-            .unwrap();
+        let _network_cache =
+            NetworkCache::new(cache_dir.path().to_path_buf(), "mainnet", None, None)
+                .await
+                .unwrap();
 
         // ensure network cache removed old directories
         for env in envs {
@@ -552,5 +573,23 @@ mod tests {
                 .await
                 .unwrap()
         );
+    }
+
+    #[test]
+    fn mainnet_network_has_deduped_nyxd_pool_with_primary_first() {
+        let network = Network::mainnet_default().unwrap();
+        let urls = network.nyxd_urls();
+        // network_details endpoint (rpc.nymtech.net) + 3 curated extras, deduped
+        assert_eq!(urls.len(), 4);
+        assert_eq!(urls[0].as_str(), "https://rpc.nymtech.net/");
+        assert_eq!(network.nyxd_url(), urls[0]);
+        let unique: std::collections::HashSet<_> = urls.iter().collect();
+        assert_eq!(unique.len(), urls.len());
+    }
+
+    #[test]
+    fn expected_chain_id_only_for_mainnet() {
+        let network = Network::mainnet_default().unwrap();
+        assert_eq!(network.expected_chain_id().as_deref(), Some("nyx"));
     }
 }

--- a/nym-vpn-core/crates/nym-vpnd/Cargo.toml
+++ b/nym-vpn-core/crates/nym-vpnd/Cargo.toml
@@ -34,6 +34,7 @@ tonic.workspace = true
 tracing.workspace = true
 
 nym-bin-common.workspace = true
+nym-endpoint-health.workspace = true
 nym-sdk.workspace = true
 
 nym-ipc = { workspace = true, features = ["daemon"] }

--- a/nym-vpn-core/crates/nym-vpnd/src/environment.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/environment.rs
@@ -1,19 +1,26 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use nym_endpoint_health::EndpointHealthTracker;
 use nym_sdk::UserAgent;
 use nym_vpn_network_config::NetworkCache;
-use std::path::Path;
+use std::{path::Path, sync::Arc};
 
 pub async fn setup_environment(
     config_dir: &Path,
     network_name: &str,
     user_agent: UserAgent,
+    tracker: Arc<EndpointHealthTracker>,
 ) -> anyhow::Result<NetworkCache> {
     tracing::info!("Setting up environment for {network_name}");
 
-    let mut network_cache =
-        NetworkCache::new(config_dir.to_path_buf(), network_name, Some(user_agent)).await?;
+    let mut network_cache = NetworkCache::new(
+        config_dir.to_path_buf(),
+        network_name,
+        Some(user_agent),
+        Some(tracker),
+    )
+    .await?;
 
     if let Ok(network) = network_cache.network() {
         network.export_to_env();

--- a/nym-vpn-core/crates/nym-vpnd/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/main.rs
@@ -174,10 +174,13 @@ async fn run_standalone(
         .await
         .context("failed to create base directories")?;
 
+    let endpoint_health = std::sync::Arc::new(nym_endpoint_health::EndpointHealthTracker::new());
+
     let network_cache = environment::setup_environment(
         &parameters.paths.config_dir,
         &global_config_file.network_name,
         parameters.user_agent.clone(),
+        endpoint_health.clone(),
     )
     .await?;
 
@@ -187,6 +190,7 @@ async fn run_standalone(
         parameters,
         network_cache,
         log_file_remover_handle,
+        endpoint_health,
         shutdown_token,
     )
     .await?;
@@ -204,6 +208,7 @@ async fn spawn_vpn_service(
     parameters: RunParameters,
     network_cache: NetworkCache,
     log_file_remover_handle: Option<LogFileRemoverHandle>,
+    endpoint_health: std::sync::Arc<nym_endpoint_health::EndpointHealthTracker>,
     shutdown_token: CancellationToken,
 ) -> anyhow::Result<JoinHandle<()>> {
     let vpn_service_params = NymVpnServiceParameters {
@@ -212,6 +217,7 @@ async fn spawn_vpn_service(
         sentry_enabled: parameters.sentry_enabled,
         user_agent: parameters.user_agent,
         service_storage_type: ServiceConfigStorageType::Persistent,
+        endpoint_health,
     };
 
     let command_shutdown_token = CancellationToken::new();

--- a/nym-vpn-core/crates/nym-vpnd/src/windows_service/mod.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/windows_service/mod.rs
@@ -121,10 +121,13 @@ async fn run_service() -> anyhow::Result<()> {
     tracing::info!("Service is starting...");
     persistent_status.set_pending_start(Duration::from_secs(20))?;
 
+    let endpoint_health = std::sync::Arc::new(nym_endpoint_health::EndpointHealthTracker::new());
+
     let network_cache = crate::environment::setup_environment(
         &run_params.paths.config_dir,
         &service_state.global_config.network_name,
         run_params.user_agent.clone(),
+        endpoint_health.clone(),
     )
     .await
     .or_else(|err| {
@@ -145,6 +148,7 @@ async fn run_service() -> anyhow::Result<()> {
         run_params,
         network_cache,
         service_state.log_file_remover_handle,
+        endpoint_health,
         shutdown_token.child_token(),
     )
     .await


### PR DESCRIPTION
The validator API endpoints (nyxd RPC and nym-api) were effectively hardcoded single points of failure. This adds:

- nym-endpoint-health crate: per-endpoint health tracker with escalating temporary blacklist (3 failures -> 5/15/60 min cooldowns), fail-open selection, HTTP probes (nyxd /status with chain-id gating, nym-api reward_params) and a connectivity-aware background prober that probes new endpoints within a minute and refreshes latencies every 15 min
- nyxd RPC pool: bundled third-party validator RPCs (Polkachu, Nodes.guru, Commodum) alongside rpc.nymtech.net, overridable via the nymvpn.com discovery response; NyxdClient now verifies liveness with an account-independent get_chain_id() and rotates to the next healthy endpoint on connection-class failures (one bounded pass, single retry)
- nym-api pool: bundled the 13 live validator-run signer instances from the DKG contract, plus runtime enrichment that re-discovers the current epoch's verified ecash signers on-chain (query-only client, non-fatal, re-run on network refresh) and merges them into the client URL lists
- selection policy: latency-tiered load spreading — healthy endpoints within 2x of the best measured latency rotate round-robin; slower, unmeasured, recently-failed and cooling-down endpoints follow in that order; selection never comes back empty
- reporting: structured tracing logs (WARN on blacklist, INFO on recovery, ERROR on wrong-chain permanent removal)

Verified live: failover to nym-rpc.polkachu.com with a dead primary, 17 signers discovered from the DKG contract, full prober sweep of all 22 endpoints.

## Ticket

JIRA-NYM-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6119)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic health monitoring for Nym API and blockchain RPC endpoints.
  - VPN services now prioritize responsive, low-latency endpoints and automatically retry or switch when connections fail.
  - Added support for discovering additional RPC and signer API endpoints from network configuration and on-chain data.
  - Added mainnet RPC endpoint configuration with validation and fallback handling.
  - Improved endpoint recovery through cooldown-based rechecking and permanent exclusion of invalid endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->