### PR TITLE
[KEEP AS DRAFT FOR ANALYSIS] - fix iOS QUIC bridge first packet timeout

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ad-blocker and nym-socks5-proxy files are no longer stored in the network directory. (https://github.com/nymtech/nym-vpn-client/pull/5826)
 - Improve behavior of forwarding resolver by not sending empty response when hostname resolution fails. Instead simulate timeout to let clients retry more aggressively. (https://github.com/nymtech/nym-vpn-client/pull/5832)
 - When no VPN tunnel is active the geo-exclusion feature rejects non-excluded traffic. (https://github.com/nymtech/nym-vpn-client/pull/5872)
-- QUIC bridges stay up when the first WireGuard packet is late on cellular, and still give up after 60s if no packet arrives. iOS skips rebinding the loopback entry socket on path changes. (https://github.com/nymtech/nym-vpn-client/pull/6120)
+- QUIC bridges wait 21s for the first WireGuard packet (was 10s). (https://github.com/nymtech/nym-vpn-client/pull/6120)
 
 
 ## [2026.11.0] - 2026-07-10

--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ad-blocker and nym-socks5-proxy files are no longer stored in the network directory. (https://github.com/nymtech/nym-vpn-client/pull/5826)
 - Improve behavior of forwarding resolver by not sending empty response when hostname resolution fails. Instead simulate timeout to let clients retry more aggressively. (https://github.com/nymtech/nym-vpn-client/pull/5832)
 - When no VPN tunnel is active the geo-exclusion feature rejects non-excluded traffic. (https://github.com/nymtech/nym-vpn-client/pull/5872)
+- QUIC bridges stay up when the first WireGuard packet is late on cellular, and still give up after 60s if no packet arrives. iOS skips rebinding the loopback entry socket on path changes. (https://github.com/nymtech/nym-vpn-client/pull/6120)
 
 
 ## [2026.11.0] - 2026-07-10

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/transports/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/transports/mod.rs
@@ -30,10 +30,8 @@ pub use nym_vpn_api_client::response::{BridgeInformation, BridgeParameters, Quic
 use crate::tunnel_state_machine::tunnel::wireguard::two_hop_config::ETHERNET_V2_MTU;
 
 const LENGTH_DELIMITER_BYTELEN: usize = 2;
-/// Log interval only; do not treat as a give-up timeout.
-const INITIAL_DATAGRAM_LOG_INTERVAL: Duration = Duration::from_secs(10);
-/// Give up if no first WG datagram arrives (aligned with QUIC idle).
-const INITIAL_DATAGRAM_MAX_WAIT: Duration = Duration::from_secs(60);
+/// First WG datagram wait: five handshake attempts at RekeyTimeout (5s).
+const INITIAL_CONNECTION_TIMEOUT: Duration = Duration::from_secs(21);
 const QUIC_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[derive(thiserror::Error, Debug)]
@@ -156,40 +154,27 @@ async fn recv_first_peer_datagram(
     sock: &UdpSocket,
     dn_buf: &mut BytesMut,
     token: &CancellationToken,
-    wait_log_interval: Duration,
-    max_wait: Duration,
+    timeout: Duration,
 ) -> Option<(usize, SocketAddr)> {
-    let deadline = Instant::now() + max_wait;
-    loop {
-        let remaining = deadline.saturating_duration_since(Instant::now());
-        if remaining.is_zero() {
-            debug!("gave up waiting for first wg datagram on bridge forwarder");
-            return None;
+    match token
+        .run_until_cancelled(tokio::time::timeout(
+            timeout,
+            sock.recv_buf_from(&mut *dn_buf),
+        ))
+        .await
+    {
+        Some(Ok(Ok((len, src)))) => Some((len, src)),
+        Some(Ok(Err(e))) => {
+            debug!("error receiving from egress socket: {e}");
+            None
         }
-        let this_wait = wait_log_interval.min(remaining);
-        match token
-            .run_until_cancelled(tokio::time::timeout(
-                this_wait,
-                sock.recv_buf_from(&mut *dn_buf),
-            ))
-            .await
-        {
-            Some(Ok(Ok((len, src)))) => return Some((len, src)),
-            Some(Ok(Err(e))) => {
-                debug!("error receiving from egress socket: {e}");
-                return None;
-            }
-            Some(Err(_)) => {
-                if Instant::now() >= deadline {
-                    debug!("gave up waiting for first wg datagram on bridge forwarder");
-                    return None;
-                }
-                debug!("still waiting for first wg datagram on bridge forwarder");
-            }
-            None => {
-                debug!("forwarder cancelled before initial receive");
-                return None;
-            }
+        Some(Err(_)) => {
+            debug!("forwarder timed out");
+            None
+        }
+        None => {
+            debug!("forwarder cancelled before initial receive");
+            None
         }
     }
 }
@@ -217,14 +202,8 @@ pub async fn process_udp<R, W>(
         .length_field_length(LENGTH_DELIMITER_BYTELEN)
         .new_read(reader);
 
-    let Some((len, src)) = recv_first_peer_datagram(
-        &sock,
-        &mut dn_buf,
-        &token,
-        INITIAL_DATAGRAM_LOG_INTERVAL,
-        INITIAL_DATAGRAM_MAX_WAIT,
-    )
-    .await
+    let Some((len, src)) =
+        recv_first_peer_datagram(&sock, &mut dn_buf, &token, INITIAL_CONNECTION_TIMEOUT).await
     else {
         close_tx.send(()).ok();
         return;
@@ -578,23 +557,20 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn late_first_datagram_does_not_give_up() {
+    async fn first_datagram_arrives_before_timeout() {
         let (sock, listen) = bind_forwarder_socket().await;
         let token = CancellationToken::new();
-        let wait = Duration::from_millis(20);
+        let timeout = Duration::from_millis(200);
         let recv = tokio::spawn({
             let sock = sock.clone();
             let token = token.clone();
             async move {
                 let mut buf = BytesMut::with_capacity(1280);
-                recv_first_peer_datagram(&sock, &mut buf, &token, wait, Duration::from_secs(2))
-                    .await
+                recv_first_peer_datagram(&sock, &mut buf, &token, timeout).await
             }
         });
 
-        tokio::time::sleep(wait.saturating_mul(2) + Duration::from_millis(10)).await;
-        assert!(!recv.is_finished());
-
+        tokio::time::sleep(Duration::from_millis(20)).await;
         let client = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0))
             .await
             .expect("bind client");
@@ -612,23 +588,22 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn max_wait_without_datagram_gives_up() {
+    async fn timeout_without_datagram_gives_up() {
         let (sock, _listen) = bind_forwarder_socket().await;
         let token = CancellationToken::new();
-        let log_interval = Duration::from_millis(15);
-        let max_wait = Duration::from_millis(45);
+        let timeout = Duration::from_millis(40);
         let started = Instant::now();
         let mut buf = BytesMut::with_capacity(1280);
-        let got = recv_first_peer_datagram(&sock, &mut buf, &token, log_interval, max_wait).await;
+        let got = recv_first_peer_datagram(&sock, &mut buf, &token, timeout).await;
         assert!(got.is_none());
         let elapsed = started.elapsed();
         assert!(
-            elapsed >= max_wait,
-            "gave up too early: {elapsed:?} < {max_wait:?}"
+            elapsed >= timeout,
+            "gave up too early: {elapsed:?} < {timeout:?}"
         );
         assert!(
             elapsed < Duration::from_secs(1),
-            "hung after max wait: {elapsed:?}"
+            "hung after timeout: {elapsed:?}"
         );
     }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/transports/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/transports/mod.rs
@@ -30,10 +30,10 @@ pub use nym_vpn_api_client::response::{BridgeInformation, BridgeParameters, Quic
 use crate::tunnel_state_machine::tunnel::wireguard::two_hop_config::ETHERNET_V2_MTU;
 
 const LENGTH_DELIMITER_BYTELEN: usize = 2;
-/// How often to log while waiting for the first WG datagram. Must not abort the
-/// forwarder: iOS LTE path churn can delay that datagram past 10s, and closing
-/// the bridge then kills a still-viable QUIC session.
-const INITIAL_DATAGRAM_WAIT_LOG_INTERVAL: Duration = Duration::from_secs(10);
+/// Log interval only; do not treat as a give-up timeout.
+const INITIAL_DATAGRAM_LOG_INTERVAL: Duration = Duration::from_secs(10);
+/// Give up if no first WG datagram arrives (aligned with QUIC idle).
+const INITIAL_DATAGRAM_MAX_WAIT: Duration = Duration::from_secs(60);
 const QUIC_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[derive(thiserror::Error, Debug)]
@@ -152,18 +152,24 @@ impl UdpForwarder {
     }
 }
 
-/// Wait until the first UDP datagram arrives, or the forwarder is cancelled / hits a socket error.
-/// Recv timeouts only log; they must not close the bridge.
 async fn recv_first_peer_datagram(
     sock: &UdpSocket,
     dn_buf: &mut BytesMut,
     token: &CancellationToken,
     wait_log_interval: Duration,
+    max_wait: Duration,
 ) -> Option<(usize, SocketAddr)> {
+    let deadline = Instant::now() + max_wait;
     loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            debug!("gave up waiting for first wg datagram on bridge forwarder");
+            return None;
+        }
+        let this_wait = wait_log_interval.min(remaining);
         match token
             .run_until_cancelled(tokio::time::timeout(
-                wait_log_interval,
+                this_wait,
                 sock.recv_buf_from(&mut *dn_buf),
             ))
             .await
@@ -174,6 +180,10 @@ async fn recv_first_peer_datagram(
                 return None;
             }
             Some(Err(_)) => {
+                if Instant::now() >= deadline {
+                    debug!("gave up waiting for first wg datagram on bridge forwarder");
+                    return None;
+                }
                 debug!("still waiting for first wg datagram on bridge forwarder");
             }
             None => {
@@ -211,7 +221,8 @@ pub async fn process_udp<R, W>(
         &sock,
         &mut dn_buf,
         &token,
-        INITIAL_DATAGRAM_WAIT_LOG_INTERVAL,
+        INITIAL_DATAGRAM_LOG_INTERVAL,
+        INITIAL_DATAGRAM_MAX_WAIT,
     )
     .await
     else {
@@ -225,7 +236,7 @@ pub async fn process_udp<R, W>(
         close_tx.send(()).ok();
         return;
     }
-    trace!("[tr] <- wrote {len}B");
+    trace!(" [tr]<- wrote {len}B");
     let fwd_addr = src;
 
     if let Err(e) = sock.connect(fwd_addr).await {
@@ -576,7 +587,8 @@ mod tests {
             let token = token.clone();
             async move {
                 let mut buf = BytesMut::with_capacity(1280);
-                recv_first_peer_datagram(&sock, &mut buf, &token, wait).await
+                recv_first_peer_datagram(&sock, &mut buf, &token, wait, Duration::from_secs(2))
+                    .await
             }
         });
 
@@ -597,6 +609,27 @@ mod tests {
             .expect("recv task join");
         let (len, _src) = got.expect("first datagram");
         assert_eq!(len, b"hello-wg".len());
+    }
+
+    #[tokio::test]
+    async fn max_wait_without_datagram_gives_up() {
+        let (sock, _listen) = bind_forwarder_socket().await;
+        let token = CancellationToken::new();
+        let log_interval = Duration::from_millis(15);
+        let max_wait = Duration::from_millis(45);
+        let started = Instant::now();
+        let mut buf = BytesMut::with_capacity(1280);
+        let got = recv_first_peer_datagram(&sock, &mut buf, &token, log_interval, max_wait).await;
+        assert!(got.is_none());
+        let elapsed = started.elapsed();
+        assert!(
+            elapsed >= max_wait,
+            "gave up too early: {elapsed:?} < {max_wait:?}"
+        );
+        assert!(
+            elapsed < Duration::from_secs(1),
+            "hung after max wait: {elapsed:?}"
+        );
     }
 
     #[tokio::test]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/transports/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/transports/mod.rs
@@ -30,7 +30,10 @@ pub use nym_vpn_api_client::response::{BridgeInformation, BridgeParameters, Quic
 use crate::tunnel_state_machine::tunnel::wireguard::two_hop_config::ETHERNET_V2_MTU;
 
 const LENGTH_DELIMITER_BYTELEN: usize = 2;
-const INITIAL_CONNECTION_TIMEOUT: Duration = Duration::from_secs(10);
+/// How often to log while waiting for the first WG datagram. Must not abort the
+/// forwarder: iOS LTE path churn can delay that datagram past 10s, and closing
+/// the bridge then kills a still-viable QUIC session.
+const INITIAL_DATAGRAM_WAIT_LOG_INTERVAL: Duration = Duration::from_secs(10);
 const QUIC_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[derive(thiserror::Error, Debug)]
@@ -149,12 +152,43 @@ impl UdpForwarder {
     }
 }
 
+/// Wait until the first UDP datagram arrives, or the forwarder is cancelled / hits a socket error.
+/// Recv timeouts only log; they must not close the bridge.
+async fn recv_first_peer_datagram(
+    sock: &UdpSocket,
+    dn_buf: &mut BytesMut,
+    token: &CancellationToken,
+    wait_log_interval: Duration,
+) -> Option<(usize, SocketAddr)> {
+    loop {
+        match token
+            .run_until_cancelled(tokio::time::timeout(
+                wait_log_interval,
+                sock.recv_buf_from(&mut *dn_buf),
+            ))
+            .await
+        {
+            Some(Ok(Ok((len, src)))) => return Some((len, src)),
+            Some(Ok(Err(e))) => {
+                debug!("error receiving from egress socket: {e}");
+                return None;
+            }
+            Some(Err(_)) => {
+                debug!("still waiting for first wg datagram on bridge forwarder");
+            }
+            None => {
+                debug!("forwarder cancelled before initial receive");
+                return None;
+            }
+        }
+    }
+}
+
 pub async fn process_udp<R, W>(
     reader: R,
     writer: W,
     sock: Arc<UdpSocket>,
     mtu: u16,
-    // close_hook: Option<fn(SocketAddr)>,
     close_tx: UnboundedSender<()>,
     token: CancellationToken,
 ) where
@@ -173,44 +207,26 @@ pub async fn process_udp<R, W>(
         .length_field_length(LENGTH_DELIMITER_BYTELEN)
         .new_read(reader);
 
-    // receive (and forward) a first message to establish a consistent peer address
-    let fwd_initial_recv_fut =
-        tokio::time::timeout(INITIAL_CONNECTION_TIMEOUT, sock.recv_buf_from(&mut dn_buf));
-
-    let fwd_addr = match token.run_until_cancelled(fwd_initial_recv_fut).await {
-        Some(res) => {
-            match res {
-                Ok(Ok((len, src))) => {
-                    trace!(" <- [fw] read {len}B");
-                    if let Err(e) = framed_writer.send(dn_buf.copy_to_bytes(len)).await {
-                        debug!("error sending to transport connection: {e}");
-                        None
-                    } else {
-                        trace!("[tr] <- wrote {len}B");
-                        // keep track of the address of the sender for the initial write
-                        Some(src)
-                    }
-                }
-                Ok(Err(e)) => {
-                    debug!("error receiving from egress socket: {e}");
-                    None
-                }
-                Err(_) => {
-                    debug!("forwarder timed out");
-                    None
-                }
-            }
-        }
-        None => {
-            debug!("forwarder cancelled before initial receive");
-            None
-        }
-    };
-
-    let Some(fwd_addr) = fwd_addr else {
+    let Some((len, src)) = recv_first_peer_datagram(
+        &sock,
+        &mut dn_buf,
+        &token,
+        INITIAL_DATAGRAM_WAIT_LOG_INTERVAL,
+    )
+    .await
+    else {
         close_tx.send(()).ok();
         return;
     };
+
+    trace!(" <- [fw] read {len}B");
+    if let Err(e) = framed_writer.send(dn_buf.copy_to_bytes(len)).await {
+        debug!("error sending to transport connection: {e}");
+        close_tx.send(()).ok();
+        return;
+    }
+    trace!("[tr] <- wrote {len}B");
+    let fwd_addr = src;
 
     if let Err(e) = sock.connect(fwd_addr).await {
         error!("udp sock config failure: {e}");
@@ -535,4 +551,72 @@ fn make_socket(addr: Option<SocketAddr>) -> io::Result<std::net::UdpSocket> {
     let socket = std::net::UdpSocket::bind(addr)?;
     socket.set_nonblocking(true)?;
     Ok(socket)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::sync::mpsc;
+
+    async fn bind_forwarder_socket() -> (Arc<UdpSocket>, SocketAddr) {
+        let sock = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0))
+            .await
+            .expect("bind forwarder");
+        let addr = sock.local_addr().expect("local addr");
+        (Arc::new(sock), addr)
+    }
+
+    #[tokio::test]
+    async fn late_first_datagram_does_not_give_up() {
+        let (sock, listen) = bind_forwarder_socket().await;
+        let token = CancellationToken::new();
+        let wait = Duration::from_millis(20);
+        let recv = tokio::spawn({
+            let sock = sock.clone();
+            let token = token.clone();
+            async move {
+                let mut buf = BytesMut::with_capacity(1280);
+                recv_first_peer_datagram(&sock, &mut buf, &token, wait).await
+            }
+        });
+
+        tokio::time::sleep(wait.saturating_mul(2) + Duration::from_millis(10)).await;
+        assert!(!recv.is_finished());
+
+        let client = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0))
+            .await
+            .expect("bind client");
+        client
+            .send_to(b"hello-wg", listen)
+            .await
+            .expect("send first datagram");
+
+        let got = tokio::time::timeout(Duration::from_secs(1), recv)
+            .await
+            .expect("timed out waiting for first datagram")
+            .expect("recv task join");
+        let (len, _src) = got.expect("first datagram");
+        assert_eq!(len, b"hello-wg".len());
+    }
+
+    #[tokio::test]
+    async fn cancel_before_first_datagram_closes_bridge() {
+        let (sock, _listen) = bind_forwarder_socket().await;
+        let (reader, writer) = tokio::io::duplex(4096);
+        let (close_tx, mut close_rx) = mpsc::unbounded_channel();
+        let token = CancellationToken::new();
+
+        let handle = tokio::spawn(process_udp(
+            reader,
+            writer,
+            sock,
+            1280,
+            close_tx,
+            token.clone(),
+        ));
+
+        token.cancel();
+        handle.await.expect("forwarder join");
+        assert_eq!(close_rx.try_recv(), Ok(()));
+    }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
@@ -719,21 +719,15 @@ impl TunnelHandle {
 #[cfg(test)]
 mod tests {
     use super::should_bump_entry_sockets_on_path_change;
-    use std::net::{Ipv4Addr, SocketAddr};
+    use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 
     #[test]
     fn skip_entry_socket_bump_when_bridged_on_loopback() {
-        let loopback = SocketAddr::from((Ipv4Addr::LOCALHOST, 1));
+        let loopback_v4 = SocketAddr::from((Ipv4Addr::LOCALHOST, 1));
+        let loopback_v6 = SocketAddr::from((Ipv6Addr::LOCALHOST, 1));
         let routed = SocketAddr::from((Ipv4Addr::new(203, 0, 113, 8), 51820));
-        assert!(!should_bump_entry_sockets_on_path_change(loopback));
+        assert!(!should_bump_entry_sockets_on_path_change(loopback_v4));
+        assert!(!should_bump_entry_sockets_on_path_change(loopback_v6));
         assert!(should_bump_entry_sockets_on_path_change(routed));
-        assert_eq!(
-            should_bump_entry_sockets_on_path_change(loopback),
-            !loopback.ip().is_loopback()
-        );
-        assert_eq!(
-            should_bump_entry_sockets_on_path_change(routed),
-            !routed.ip().is_loopback()
-        );
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
@@ -719,3 +719,14 @@ impl TunnelHandle {
         self.wintun_exit_interface.as_ref()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::should_bump_entry_sockets_on_path_change;
+
+    #[test]
+    fn skip_entry_socket_bump_when_bridged_on_loopback() {
+        assert!(!should_bump_entry_sockets_on_path_change(true));
+        assert!(should_bump_entry_sockets_on_path_change(false));
+    }
+}

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
@@ -64,12 +64,10 @@ use crate::{
 #[cfg(target_os = "ios")]
 const DEFAULT_PATH_DEBOUNCE: Duration = Duration::from_millis(250);
 
-/// Bridged netstack entry peers listen on loopback. Rebinding that socket on
-/// iOS path updates delays the first handshake until after the bridge forwarder
-/// used to abort, which never reaches Connected.
+/// Skip rebind on loopback entry (QUIC local forwarder).
 #[cfg(any(test, target_os = "ios"))]
-pub(crate) fn should_bump_entry_sockets_on_path_change(entry_is_loopback: bool) -> bool {
-    !entry_is_loopback
+pub(crate) fn should_bump_entry_sockets_on_path_change(entry_endpoint: SocketAddr) -> bool {
+    !entry_endpoint.ip().is_loopback()
 }
 
 pub struct ConnectedTunnel {
@@ -492,9 +490,7 @@ impl ConnectedTunnel {
 
                             // Rebind wireguard-go on tun device.
                             exit_tunnel.bump_sockets();
-                            if should_bump_entry_sockets_on_path_change(
-                                entry_peer_update.is_loopback(),
-                            ) {
+                            if should_bump_entry_sockets_on_path_change(entry_peer_update.endpoint) {
                                 entry_tunnel.bump_sockets();
                             }
                         }
@@ -723,10 +719,21 @@ impl TunnelHandle {
 #[cfg(test)]
 mod tests {
     use super::should_bump_entry_sockets_on_path_change;
+    use std::net::{Ipv4Addr, SocketAddr};
 
     #[test]
     fn skip_entry_socket_bump_when_bridged_on_loopback() {
-        assert!(!should_bump_entry_sockets_on_path_change(true));
-        assert!(should_bump_entry_sockets_on_path_change(false));
+        let loopback = SocketAddr::from((Ipv4Addr::LOCALHOST, 1));
+        let routed = SocketAddr::from((Ipv4Addr::new(203, 0, 113, 8), 51820));
+        assert!(!should_bump_entry_sockets_on_path_change(loopback));
+        assert!(should_bump_entry_sockets_on_path_change(routed));
+        assert_eq!(
+            should_bump_entry_sockets_on_path_change(loopback),
+            !loopback.ip().is_loopback()
+        );
+        assert_eq!(
+            should_bump_entry_sockets_on_path_change(routed),
+            !routed.ip().is_loopback()
+        );
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
@@ -64,6 +64,14 @@ use crate::{
 #[cfg(target_os = "ios")]
 const DEFAULT_PATH_DEBOUNCE: Duration = Duration::from_millis(250);
 
+/// Bridged netstack entry peers listen on loopback. Rebinding that socket on
+/// iOS path updates delays the first handshake until after the bridge forwarder
+/// used to abort, which never reaches Connected.
+#[cfg(any(test, target_os = "ios"))]
+pub(crate) fn should_bump_entry_sockets_on_path_change(entry_is_loopback: bool) -> bool {
+    !entry_is_loopback
+}
+
 pub struct ConnectedTunnel {
     entry_wg_keypair: Arc<x25519::KeyPair>,
     exit_wg_keypair: Arc<x25519::KeyPair>,
@@ -484,7 +492,11 @@ impl ConnectedTunnel {
 
                             // Rebind wireguard-go on tun device.
                             exit_tunnel.bump_sockets();
-                            entry_tunnel.bump_sockets();
+                            if should_bump_entry_sockets_on_path_change(
+                                entry_peer_update.is_loopback(),
+                            ) {
+                                entry_tunnel.bump_sockets();
+                            }
                         }
                         _ = child_shutdown_token.cancelled() => {
                             tracing::debug!("Received tunnel shutdown event. Exiting event loop.");

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/wireguard/connected_tunnel.rs
@@ -64,12 +64,6 @@ use crate::{
 #[cfg(target_os = "ios")]
 const DEFAULT_PATH_DEBOUNCE: Duration = Duration::from_millis(250);
 
-/// Skip rebind on loopback entry (QUIC local forwarder).
-#[cfg(any(test, target_os = "ios"))]
-pub(crate) fn should_bump_entry_sockets_on_path_change(entry_endpoint: SocketAddr) -> bool {
-    !entry_endpoint.ip().is_loopback()
-}
-
 pub struct ConnectedTunnel {
     entry_wg_keypair: Arc<x25519::KeyPair>,
     exit_wg_keypair: Arc<x25519::KeyPair>,
@@ -490,9 +484,7 @@ impl ConnectedTunnel {
 
                             // Rebind wireguard-go on tun device.
                             exit_tunnel.bump_sockets();
-                            if should_bump_entry_sockets_on_path_change(entry_peer_update.endpoint) {
-                                entry_tunnel.bump_sockets();
-                            }
+                            entry_tunnel.bump_sockets();
                         }
                         _ = child_shutdown_token.cancelled() => {
                             tracing::debug!("Received tunnel shutdown event. Exiting event loop.");
@@ -713,21 +705,5 @@ impl TunnelHandle {
     #[cfg(windows)]
     pub fn exit_wintun_interface(&self) -> Option<&WintunInterface> {
         self.wintun_exit_interface.as_ref()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::should_bump_entry_sockets_on_path_change;
-    use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
-
-    #[test]
-    fn skip_entry_socket_bump_when_bridged_on_loopback() {
-        let loopback_v4 = SocketAddr::from((Ipv4Addr::LOCALHOST, 1));
-        let loopback_v6 = SocketAddr::from((Ipv6Addr::LOCALHOST, 1));
-        let routed = SocketAddr::from((Ipv4Addr::new(203, 0, 113, 8), 51820));
-        assert!(!should_bump_entry_sockets_on_path_change(loopback_v4));
-        assert!(!should_bump_entry_sockets_on_path_change(loopback_v6));
-        assert!(should_bump_entry_sockets_on_path_change(routed));
     }
 }


### PR DESCRIPTION
## Description
We had an issue where Fastest/QUIC (anti-censorship) on iPhone over LTE looked like it was connecting, then never actually connected. The QUIC hop to the entry node was fine. The app then waited 10 seconds for the first WireGuard packet, gave up, and tore the tunnel down. So the VPN hung up on itself even though the path was alive.

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6120)
<!-- Reviewable:end -->
