### PR TITLE
Wait 21s for the first WireGuard packet on QUIC bridges

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- QUIC bridges wait 21s for the first WireGuard packet (was 10s).
+
 ## [2026.12.0] - 2026-08-18
 
 ### Added

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/transports/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/transports/mod.rs
@@ -30,7 +30,8 @@ pub use nym_vpn_api_client::response::{BridgeInformation, BridgeParameters, Quic
 use crate::tunnel_state_machine::tunnel::wireguard::two_hop_config::ETHERNET_V2_MTU;
 
 const LENGTH_DELIMITER_BYTELEN: usize = 2;
-const INITIAL_CONNECTION_TIMEOUT: Duration = Duration::from_secs(10);
+/// First WG datagram wait: five handshake attempts at RekeyTimeout (5s).
+const INITIAL_CONNECTION_TIMEOUT: Duration = Duration::from_secs(21);
 const QUIC_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[derive(thiserror::Error, Debug)]


### PR DESCRIPTION
## Description

iOS PathMonitor bump_sockets can delay the local handshake past 10s after QUIC itself already succeeded. Five RekeyTimeout attempts is 21s.

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6123)
<!-- Reviewable:end -->
