### PR TITLE
fix(android): trim v2026.12.0 Play changelog under 500-char limit

### DIFF
--- a/.github/scripts/release/check-changelog-length.sh
+++ b/.github/scripts/release/check-changelog-length.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Fail fast if the release notes about to be published exceed Google's limit.
+# fastlane supply uploads the changelog whose filename matches the AAB's
+# version code, so this guard checks exactly changelogs/<VERSION_CODE>.txt in
+# every locale that has one. Historical changelogs are left alone.
+set -euo pipefail
+
+METADATA_DIR="${METADATA_DIR:-fastlane/metadata/android}"
+MAX_CHARS="${MAX_CHARS:-500}"
+CONSTANTS_FILE="${CONSTANTS_FILE:-nym-vpn-android/buildSrc/src/main/kotlin/Constants.kt}"
+
+if [[ -z "${VERSION_CODE:-}" ]]; then
+  if [[ ! -f "$CONSTANTS_FILE" ]]; then
+    echo "::error::VERSION_CODE not set and constants file not found: $CONSTANTS_FILE"
+    exit 1
+  fi
+  VERSION_CODE="$(grep -oE 'VERSION_CODE[[:space:]]*=[[:space:]]*[0-9]+' "$CONSTANTS_FILE" | grep -oE '[0-9]+' | head -n1)"
+fi
+
+if [[ -z "${VERSION_CODE:-}" ]]; then
+  echo "::error::Could not determine VERSION_CODE."
+  exit 1
+fi
+
+if [[ ! -d "$METADATA_DIR" ]]; then
+  echo "::error::Metadata dir not found: $METADATA_DIR"
+  exit 1
+fi
+
+echo "Checking release notes for version code ${VERSION_CODE} (limit ${MAX_CHARS} chars)..."
+fail=0
+checked=0
+while IFS= read -r -d '' file; do
+  checked=$((checked + 1))
+  n="$(python3 -c "import sys; print(len(open(sys.argv[1], encoding='utf-8').read().rstrip('\n')))" "$file")"
+  if (( n > MAX_CHARS )); then
+    echo "::error file=${file}::Release notes are ${n} chars (limit ${MAX_CHARS}): ${file}"
+    fail=1
+  else
+    echo "  ok (${n}): ${file}"
+  fi
+done < <(find "$METADATA_DIR" -type f -path "*/changelogs/${VERSION_CODE}.txt" -print0)
+
+if (( checked == 0 )); then
+  echo "No changelogs/${VERSION_CODE}.txt found under ${METADATA_DIR} (nothing to upload)."
+fi
+if (( fail == 0 )); then
+  echo "OK: all ${checked} release-notes file(s) for ${VERSION_CODE} are <= ${MAX_CHARS} chars."
+else
+  echo "::error::Release notes for ${VERSION_CODE} exceed the ${MAX_CHARS}-character Play Store limit (see above)."
+fi
+exit "$fail"

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -30,3 +30,15 @@ jobs:
     steps:
       - if: github.event.pull_request.milestone == null && contains( env.LABELS, 'no-milestone' ) == false
         run: exit 1
+
+  check-changelog-length:
+    name: Play Store changelog length
+    runs-on: arc-linux-latest
+    # Only run on real code changes, not label/milestone toggles.
+    if: contains( fromJSON('["opened","reopened","synchronize"]'), github.event.action )
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - name: Check release-notes length (<= 500 chars)
+        run: bash .github/scripts/release/check-changelog-length.sh

--- a/.github/workflows/publish-nym-vpn-android.yml
+++ b/.github/workflows/publish-nym-vpn-android.yml
@@ -65,6 +65,10 @@ jobs:
         with:
           name: ${{ env.UPLOAD_DIR_ANDROID }}
 
+      - name: Validate Play Store changelog lengths
+        if: ${{ inputs.publish_metadata }}
+        run: bash .github/scripts/release/check-changelog-length.sh
+
       - name: Distribute app to fastlane track ${{ inputs.track }} 🚀
         env:
           FASTLANE_OPT_OUT_USAGE: "YES"

--- a/fastlane/metadata/android/en-US/changelogs/20261200.txt
+++ b/fastlane/metadata/android/en-US/changelogs/20261200.txt
@@ -1,11 +1,11 @@
-New quick connect with “safest” servers. NymVPN automatically picks the most optimal server for you which is safely located in a country next door, not your own. Safest connection is currently set at default.
+Quick connect now defaults to "safest" servers: NymVPN picks an optimal server in a neighbouring country, not your own.
 
-A redesigned onboarding flow walks you through NymVPN features, plan selection, and account creation.
+Redesigned onboarding covers features, plan selection, and account creation.
 
-Camouflage icon: Hide your NymVPN app with a set of discreet alternative icons in Settings → Appearance.
+Camouflage icon: hide the app behind discreet alternative icons in Settings > Appearance.
 
-Updated Mixnet Tuning screen with clearer wording and a set of interface fixes.
+Mixnet Tuning screen updated with clearer wording and interface fixes.
 
-Fixed auto-connect getting stuck after restarting your device.
+Fixed auto-connect getting stuck after a device restart.
 
-Clearer error messages when a server selection can't meet the network's independence requirements.
+Clearer errors when a server can't meet the network's independence rules.


### PR DESCRIPTION
Google Play caps release notes at 500 chars; en-US changelogs/20261200.txt was 662, causing 'metadata character limit exceeded' in publish-nym-vpn-android. Trims it to 493 (all six items kept) and adds a VERSION_CODE-scoped pre-flight check that runs before fastlane supply.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6124)
<!-- Reviewable:end -->
