### PR TITLE
[Android] Add check changelog workflow

### DIFF
--- a/.github/workflows/check-changelog.yaml
+++ b/.github/workflows/check-changelog.yaml
@@ -8,6 +8,7 @@ on:
       - opened
       - reopened
       - synchronize
+      - edited
     paths:
       - "fastlane/metadata/android/en-US/changelogs/**"
 
@@ -17,6 +18,7 @@ permissions:
 jobs:
   check-changelog:
     name: Check Changelog
+    if: github.event.action != 'edited' || github.event.changes.base != null
     runs-on: arc-linux-latest
     steps:
       - name: Checkout

--- a/.github/workflows/check-changelog.yaml
+++ b/.github/workflows/check-changelog.yaml
@@ -1,0 +1,53 @@
+name: check-changelog
+
+on:
+  pull_request:
+    branches:
+      - develop
+    types:
+      - opened
+      - reopened
+      - synchronize
+    paths:
+      - "fastlane/metadata/android/en-US/changelogs/**"
+
+permissions:
+  contents: read
+
+jobs:
+  check-changelog:
+    name: Check Changelog
+    runs-on: arc-linux-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Check new changelog files against Play Store char limit
+        run: |
+          set -euo pipefail
+          CHANGELOG_DIR="fastlane/metadata/android/en-US/changelogs"
+
+          ADDED_FILES=$(git diff --diff-filter=A --name-only \
+            "${{ github.event.pull_request.base.sha }}" \
+            "${{ github.event.pull_request.head.sha }}" \
+            -- "$CHANGELOG_DIR")
+
+          if [ -z "$ADDED_FILES" ]; then
+            echo "No new changelog files added, skipping check."
+            exit 0
+          fi
+
+          FAILED=0
+          while IFS= read -r file; do
+            [ -z "$file" ] && continue
+            LEN=$(wc -m < "$file" | tr -d ' ')
+            echo "$file: $LEN chars"
+            if [ "$LEN" -gt 500 ]; then
+              echo "::error file=$file::Changelog exceeds Play Store limit of 500 characters ($LEN chars)."
+              FAILED=1
+            fi
+          done <<< "$ADDED_FILES"
+
+          exit $FAILED

--- a/fastlane/metadata/android/en-US/changelogs/20261200.txt
+++ b/fastlane/metadata/android/en-US/changelogs/20261200.txt
@@ -1,11 +1,11 @@
-New quick connect with “safest” servers. NymVPN automatically picks the most optimal server for you which is safely located in a country next door, not your own. Safest connection is currently set at default.
+Quick connect now defaults to "safest" servers: NymVPN picks an optimal server in a neighbouring country, not your own.
 
-A redesigned onboarding flow walks you through NymVPN features, plan selection, and account creation.
+Redesigned onboarding covers features, plan selection, and account creation.
 
-Camouflage icon: Hide your NymVPN app with a set of discreet alternative icons in Settings → Appearance.
+Camouflage icon: hide the app behind discreet alternative icons in Settings > Appearance.
 
-Updated Mixnet Tuning screen with clearer wording and a set of interface fixes.
+Mixnet Tuning screen updated with clearer wording and interface fixes.
 
-Fixed auto-connect getting stuck after restarting your device.
+Fixed auto-connect getting stuck after a device restart.
 
-Clearer error messages when a server selection can't meet the network's independence requirements.
+Clearer errors when a server can't meet the network's independence rules.

--- a/fastlane/metadata/android/en-US/changelogs/20261200.txt
+++ b/fastlane/metadata/android/en-US/changelogs/20261200.txt
@@ -1,0 +1,11 @@
+New quick connect with “safest” servers. NymVPN automatically picks the most optimal server for you which is safely located in a country next door, not your own. Safest connection is currently set at default.
+
+A redesigned onboarding flow walks you through NymVPN features, plan selection, and account creation.
+
+Camouflage icon: Hide your NymVPN app with a set of discreet alternative icons in Settings → Appearance.
+
+Updated Mixnet Tuning screen with clearer wording and a set of interface fixes.
+
+Fixed auto-connect getting stuck after restarting your device.
+
+Clearer error messages when a server selection can't meet the network's independence requirements.

--- a/nym-vpn-android/CHANGELOG.md
+++ b/nym-vpn-android/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Changelog validation workflow for Play Store (https://github.com/nymtech/nym-vpn-client/pull/6128)
+
 ### Changed
 - Improved account signup and subscription flow (https://github.com/nymtech/nym-vpn-client/pull/6014)
 


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

New workflow file added: `check-changelog.yaml`
- Triggered only on PRs targeting develop, and only when files under fastlane/metadata/android/en-US/changelogs/change.                                                                             
- Fails when char count in new changelog files is over 500. 


## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6128)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Quick Connect now defaults to the safest available server.
  - Introduced redesigned onboarding with feature highlights, plan selection, and account creation.
  - Added a camouflage icon option under Settings > Appearance.
  - Improved the Mixnet Tuning screen with clearer wording and interface updates.

- **Bug Fixes**
  - Fixed auto-connect getting stuck after device restarts.
  - Improved errors when servers cannot meet network independence requirements.

- **Chores**
  - Added automated validation for Android Play Store changelog length.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->