### PR TITLE
(ci) Run Maestro UI tests nightly only and report to Zulip

### DIFF
--- a/.github/scripts/ui/compose_zulip_ui_message.sh
+++ b/.github/scripts/ui/compose_zulip_ui_message.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+# Compose Zulip markdown for the ci-maestro-* notify-zulip jobs.
+# One message per platform; both workflows call this script.
+#
+# Verbosity: counts + failed/skipped names (no pass name list).
+# Artifacts: GitHub artifact-url links only (auth-gated).
+#
+# Usage:
+#   compose_zulip_ui_message.sh [--report PATH]
+#
+# Required env:
+#   UI_PLATFORM UI_STATUS UI_BRANCH UI_SHA UI_EVENT_NAME UI_RUN_URL
+# Optional env:
+#   UI_SCHEDULE_CRON UI_REPORT_URL UI_DEBUG_URL
+#
+# A missing, empty, or unparseable report degrades to a "(no test report)"
+# message and still exits 0 - the notification must always be delivered.
+set -euo pipefail
+
+# Stay under Zulip send-message 10000-byte content limit.
+MAX_BYTES=9000
+
+PASS_MARK=$'\xe2\x9c\x85'             # OK
+FAIL_MARK=$'\xe2\x9d\x8c'             # X
+SKIP_MARK=$'\xe2\x86\xa9\xef\xb8\x8f' # arrow
+
+REPORT=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --report)
+      REPORT="${2:-}"
+      shift 2
+      ;;
+    -h | --help)
+      echo "usage: $0 [--report PATH]" >&2
+      exit 2
+      ;;
+    *)
+      echo "usage: $0 [--report PATH]" >&2
+      exit 2
+      ;;
+  esac
+done
+
+: "${UI_PLATFORM:?UI_PLATFORM is required}"
+: "${UI_STATUS:?UI_STATUS is required}"
+: "${UI_BRANCH:?UI_BRANCH is required}"
+: "${UI_SHA:?UI_SHA is required}"
+: "${UI_EVENT_NAME:?UI_EVENT_NAME is required}"
+: "${UI_RUN_URL:?UI_RUN_URL is required}"
+
+case "$UI_PLATFORM" in
+  android) PLATFORM_LABEL="Android" ;;
+  ios) PLATFORM_LABEL="iOS" ;;
+  *) PLATFORM_LABEL="$UI_PLATFORM" ;;
+esac
+
+case "$UI_STATUS" in
+  passed) STATUS_MARK="$PASS_MARK" ;;
+  skipped) STATUS_MARK="$SKIP_MARK" ;;
+  *) STATUS_MARK="$FAIL_MARK" ;;
+esac
+
+passed=0
+failed=0
+skipped=0
+failed_names=()
+skipped_names=()
+
+# Emits "key<TAB>value" lines. Exits non-zero when the report is unusable, so
+# the caller falls through to the no-report path.
+parse_junit() {
+  local path="$1"
+  [[ -f "$path" && -s "$path" ]] || return 1
+  python3 - "$path" <<'PY'
+import sys
+import xml.etree.ElementTree as ET
+
+# Text-mode stdout translates "\n" to "\r\n" on Windows hosts, which would leave
+# a stray CR inside every parsed value. Pin the line ending and the encoding.
+sys.stdout.reconfigure(newline="\n", encoding="utf-8")
+
+try:
+    root = ET.parse(sys.argv[1]).getroot()
+except Exception:
+    sys.exit(1)
+
+# Maestro emits <testsuites> for grouped flows and a bare <testsuite> otherwise.
+cases = root.findall(".//testcase")
+if not cases:
+    sys.exit(1)
+
+passed = failed = skipped = 0
+failed_names = []
+skipped_names = []
+
+for case in cases:
+    name = case.get("name") or case.get("classname") or "unnamed"
+    if case.find("skipped") is not None:
+        state = "skipped"
+    elif case.find("failure") is not None or case.find("error") is not None:
+        state = "failed"
+    else:
+        # No child element: fall back to a status attribute when Maestro sets one.
+        status = (case.get("status") or "").strip().upper()
+        if status in ("SKIPPED", "IGNORED"):
+            state = "skipped"
+        elif status in ("FAILED", "ERROR"):
+            state = "failed"
+        else:
+            state = "passed"
+
+    if state == "skipped":
+        skipped += 1
+        skipped_names.append(name)
+    elif state == "failed":
+        failed += 1
+        failed_names.append(name)
+    else:
+        passed += 1
+
+out = sys.stdout
+out.write("passed\t%d\n" % passed)
+out.write("failed\t%d\n" % failed)
+out.write("skipped\t%d\n" % skipped)
+for name in failed_names:
+    out.write("fail\t%s\n" % name.replace("\t", " ").replace("\n", " "))
+for name in skipped_names:
+    out.write("skip\t%s\n" % name.replace("\t", " ").replace("\n", " "))
+PY
+}
+
+has_report=false
+if [[ -n "$REPORT" ]]; then
+  parsed_file="$(mktemp "${TMPDIR:-/tmp}/zulip-ui-parsed.XXXXXX")"
+  trap 'rm -f "$parsed_file"' EXIT
+  if parse_junit "$REPORT" >"$parsed_file" 2>/dev/null; then
+    has_report=true
+    while IFS=$'\t' read -r key value; do
+      # Belt and braces: tolerate a CR from any python that ignores the above.
+      value="${value%$'\r'}"
+      case "$key" in
+        passed) passed="$value" ;;
+        failed) failed="$value" ;;
+        skipped) skipped="$value" ;;
+        fail) failed_names+=("$value") ;;
+        skip) skipped_names+=("$value") ;;
+      esac
+    done <"$parsed_file"
+  fi
+fi
+
+emit_artifact_links() {
+  if [[ -n "${UI_REPORT_URL:-}" || -n "${UI_DEBUG_URL:-}" ]]; then
+    echo "- artifacts:"
+    if [[ -n "${UI_REPORT_URL:-}" ]]; then
+      echo "  - [maestro-${UI_PLATFORM}-report](${UI_REPORT_URL})"
+    fi
+    if [[ -n "${UI_DEBUG_URL:-}" ]]; then
+      echo "  - [maestro-${UI_PLATFORM}-debug](${UI_DEBUG_URL})"
+    fi
+  fi
+}
+
+# Args: include_skips (true|false), max_failed_names (int, -1 = all)
+emit_body() {
+  local include_skips="$1"
+  local max_failed="$2"
+  local truncated_fails=false
+  local name shown=0 omitted=0
+
+  echo "**UI ${PLATFORM_LABEL}** ${STATUS_MARK} ${UI_STATUS}"
+  echo ""
+  echo "- Branch: \`${UI_BRANCH}\` @ \`${UI_SHA}\`"
+  echo "- Event: \`${UI_EVENT_NAME}\`"
+  if [[ "${UI_EVENT_NAME}" == "schedule" && -n "${UI_SCHEDULE_CRON:-}" ]]; then
+    echo "- cron: \`${UI_SCHEDULE_CRON}\`"
+  fi
+
+  if [[ "$has_report" == "true" ]]; then
+    echo "- Results: ${passed} passed, ${failed} failed, ${skipped} skipped"
+    if [[ "${#failed_names[@]}" -gt 0 ]]; then
+      echo "- Failed:"
+      for name in "${failed_names[@]}"; do
+        if [[ "$max_failed" -ge 0 && "$shown" -ge "$max_failed" ]]; then
+          omitted=$((omitted + 1))
+          continue
+        fi
+        echo "  - \`${name}\`"
+        shown=$((shown + 1))
+      done
+      if [[ "$omitted" -gt 0 ]]; then
+        echo "  - _...and ${omitted} more (truncated)_"
+        truncated_fails=true
+      fi
+    fi
+    if [[ "$include_skips" == "true" && "${#skipped_names[@]}" -gt 0 ]]; then
+      echo "- Skipped:"
+      for name in "${skipped_names[@]}"; do
+        echo "  - \`${name}\`"
+      done
+    fi
+  else
+    echo "- Results: (no test report)"
+  fi
+
+  emit_artifact_links
+
+  echo "- run: ${UI_RUN_URL}"
+
+  if [[ "$include_skips" != "true" || "$truncated_fails" == "true" ]]; then
+    echo ""
+    echo "_(message truncated to stay under Zulip size limit)_"
+  fi
+}
+
+msg_file="$(mktemp "${TMPDIR:-/tmp}/zulip-ui-msg.XXXXXX")"
+trap 'rm -f "$msg_file" "${parsed_file:-}"' EXIT
+
+emit_body true -1 >"$msg_file"
+byte_len=$(wc -c <"$msg_file" | tr -d ' ')
+
+if [[ "$byte_len" -gt "$MAX_BYTES" ]]; then
+  # Drop skipped names first.
+  emit_body false -1 >"$msg_file"
+  byte_len=$(wc -c <"$msg_file" | tr -d ' ')
+fi
+
+if [[ "$byte_len" -gt "$MAX_BYTES" && "${#failed_names[@]}" -gt 0 ]]; then
+  # Binary-search how many failed names fit under MAX_BYTES.
+  local_lo=0
+  local_hi=${#failed_names[@]}
+  local_best=0
+  while [[ "$local_lo" -le "$local_hi" ]]; do
+    local_mid=$(((local_lo + local_hi) / 2))
+    emit_body false "$local_mid" >"$msg_file"
+    byte_len=$(wc -c <"$msg_file" | tr -d ' ')
+    if [[ "$byte_len" -le "$MAX_BYTES" ]]; then
+      local_best=$local_mid
+      local_lo=$((local_mid + 1))
+    else
+      local_hi=$((local_mid - 1))
+    fi
+  done
+  emit_body false "$local_best" >"$msg_file"
+  byte_len=$(wc -c <"$msg_file" | tr -d ' ')
+fi
+
+if [[ "$byte_len" -gt "$MAX_BYTES" ]]; then
+  # Last resort: minimal header + URLs (always under cap for normal inputs).
+  {
+    echo "**UI ${PLATFORM_LABEL}** ${STATUS_MARK} ${UI_STATUS}"
+    echo ""
+    echo "- Branch: \`${UI_BRANCH}\` @ \`${UI_SHA}\`"
+    echo "- Event: \`${UI_EVENT_NAME}\`"
+    if [[ "$has_report" == "true" ]]; then
+      echo "- Results: ${passed} passed, ${failed} failed, ${skipped} skipped (truncated)"
+    else
+      echo "- Results: (no test report)"
+    fi
+    emit_artifact_links
+    echo "- run: ${UI_RUN_URL}"
+    echo ""
+    echo "_(message truncated to stay under Zulip size limit)_"
+  } >"$msg_file"
+fi
+
+cat "$msg_file"

--- a/.github/workflows/ci-maestro-android.yml
+++ b/.github/workflows/ci-maestro-android.yml
@@ -1,19 +1,22 @@
 name: ci-maestro-android
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-    paths:
-      - '.github/workflows/ci-maestro-android.yml'
-      - 'nym-vpn-android/**'
-      - 'nym-vpn-core/**'
+  schedule:
+    # Three hours ahead of the earliest e2e cron (0 2 * * *), so a run that
+    # consumes its full timeout still finishes before e2e starts.
+    - cron: "0 23 * * *"
   workflow_dispatch:
+
+env:
+  UI_SCRIPTS_DIR: .github/scripts/ui
 
 jobs:
   maestro-ui-tests:
-    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    outputs:
+      report_url: ${{ steps.upload-report.outputs.artifact-url }}
+      debug_url: ${{ steps.upload-debug.outputs.artifact-url }}
 
     steps:
       - name: Checkout
@@ -120,6 +123,7 @@ jobs:
             maestro test nym-vpn-android/maestro --format junit --output maestro-report.xml --debug-output maestro-debug; STATUS=$?; adb logcat -d > maestro-debug/logcat.txt; exit $STATUS
 
       - name: Upload Maestro report
+        id: upload-report
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -128,6 +132,7 @@ jobs:
           retention-days: 14
 
       - name: Upload Maestro debug artifacts
+        id: upload-debug
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -135,3 +140,76 @@ jobs:
           path: maestro-debug
           retention-days: 14
           if-no-files-found: warn
+
+  notify-zulip:
+    name: Zulip UI status
+    needs: [maestro-ui-tests]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout notify scripts
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          sparse-checkout: |
+            .github/scripts/ui
+
+      # The report travels as an artifact, not a job output: a JUnit file with
+      # failure traces can exceed the 1MB job-output cap. A missing artifact is
+      # not fatal - the composer degrades to a "(no test report)" message.
+      - name: Download Maestro report
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-android-report
+          path: downloaded-report
+
+      - name: Compose message
+        id: msg
+        env:
+          NEEDS_RESULT: ${{ needs.maestro-ui-tests.result }}
+          UI_BRANCH: ${{ github.ref_name }}
+          UI_SHA: ${{ github.sha }}
+          UI_EVENT_NAME: ${{ github.event_name }}
+          UI_SCHEDULE_CRON: ${{ github.event.schedule }}
+          UI_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          UI_REPORT_URL: ${{ needs.maestro-ui-tests.outputs.report_url }}
+          UI_DEBUG_URL: ${{ needs.maestro-ui-tests.outputs.debug_url }}
+        run: |
+          case "$NEEDS_RESULT" in
+            success) UI_STATUS="passed" ;;
+            failure) UI_STATUS="failed" ;;
+            cancelled) UI_STATUS="cancelled" ;;
+            skipped) UI_STATUS="skipped" ;;
+            *) UI_STATUS="$NEEDS_RESULT" ;;
+          esac
+          export UI_STATUS UI_PLATFORM="android"
+
+          REPORT_ARGS=()
+          REPORT_FILE="$(find downloaded-report -name '*.xml' -type f 2>/dev/null | head -1)"
+          if [ -n "$REPORT_FILE" ]; then
+            REPORT_ARGS=(--report "$REPORT_FILE")
+          fi
+
+          chmod +x "${UI_SCRIPTS_DIR}/compose_zulip_ui_message.sh"
+          {
+            echo "content<<MSG_EOF"
+            "${UI_SCRIPTS_DIR}/compose_zulip_ui_message.sh" "${REPORT_ARGS[@]}"
+            echo "MSG_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      # Deliberately not continue-on-error: a missing TEST_UI_ZULIP_TOPIC must
+      # go red, because an absent message looks identical to a night with no run.
+      - name: Send Zulip notification
+        uses: zulip/github-actions-zulip/send-message@v2
+        with:
+          api-key: ${{ secrets.TEST_HARNESS_ZULIP_BOT_API_KEY }}
+          email: ${{ secrets.TEST_HARNESS_ZULIP_BOT_EMAIL }}
+          organization-url: ${{ secrets.ZULIP_ORG_URL }}
+          to: ${{ secrets.TEST_HARNESS_ZULIP_CHANNEL }}
+          type: "stream"
+          topic: ${{ secrets.TEST_UI_ZULIP_TOPIC }}
+          content: ${{ steps.msg.outputs.content }}

--- a/.github/workflows/ci-maestro-ios.yml
+++ b/.github/workflows/ci-maestro-ios.yml
@@ -2,22 +2,29 @@ name: ci-maestro-ios
 
 on:
   schedule:
-    - cron: "0 4 * * *"
-  pull_request:
-    types: [opened, synchronize, reopened]
-    paths:
-      - ".github/workflows/ci-maestro-ios.yml"
-      - "nym-vpn-apple/**"
-      - "nym-vpn-core/**"
-      - "wireguard/**"
+    # Three hours ahead of the earliest e2e cron (0 2 * * *), so a run that
+    # consumes its full timeout still finishes before e2e starts.
+    - cron: "0 23 * * *"
   workflow_dispatch:
+
+# The AppleSilicon runner is shared with the Apple build workflows and has a
+# persistent $HOME. Two concurrent runs would collide over simulators and the
+# staged NymVPNLib; queue instead, and never discard a nightly run in progress.
+concurrency:
+  group: ci-maestro-ios
+  cancel-in-progress: false
+
+env:
+  UI_SCRIPTS_DIR: .github/scripts/ui
 
 jobs:
   maestro-ui-tests:
-    if: github.actor != 'dependabot[bot]'
     # Self-hosted Apple Silicon: builds the Rust core (sim slice) the mock app links.
     runs-on: AppleSilicon
     timeout-minutes: 90
+    outputs:
+      report_url: ${{ steps.upload-report.outputs.artifact-url }}
+      debug_url: ${{ steps.upload-debug.outputs.artifact-url }}
 
     steps:
       - name: Checkout
@@ -247,6 +254,7 @@ jobs:
             --debug-output maestro-debug
 
       - name: Upload Maestro report
+        id: upload-report
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -256,6 +264,7 @@ jobs:
 
       # Screenshots and per-command logs for failed flows.
       - name: Upload Maestro debug artifacts
+        id: upload-debug
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -265,3 +274,78 @@ jobs:
             nym-vpn-apple/launch-diagnostics
           retention-days: 14
           if-no-files-found: warn
+
+  # Runs on ubuntu-latest, not AppleSilicon: the notification must never queue
+  # behind the self-hosted runner it is reporting on.
+  notify-zulip:
+    name: Zulip UI status
+    needs: [maestro-ui-tests]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout notify scripts
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          sparse-checkout: |
+            .github/scripts/ui
+
+      # The report travels as an artifact, not a job output: a JUnit file with
+      # failure traces can exceed the 1MB job-output cap. A missing artifact is
+      # not fatal - the composer degrades to a "(no test report)" message.
+      - name: Download Maestro report
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: maestro-ios-report
+          path: downloaded-report
+
+      - name: Compose message
+        id: msg
+        env:
+          NEEDS_RESULT: ${{ needs.maestro-ui-tests.result }}
+          UI_BRANCH: ${{ github.ref_name }}
+          UI_SHA: ${{ github.sha }}
+          UI_EVENT_NAME: ${{ github.event_name }}
+          UI_SCHEDULE_CRON: ${{ github.event.schedule }}
+          UI_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          UI_REPORT_URL: ${{ needs.maestro-ui-tests.outputs.report_url }}
+          UI_DEBUG_URL: ${{ needs.maestro-ui-tests.outputs.debug_url }}
+        run: |
+          case "$NEEDS_RESULT" in
+            success) UI_STATUS="passed" ;;
+            failure) UI_STATUS="failed" ;;
+            cancelled) UI_STATUS="cancelled" ;;
+            skipped) UI_STATUS="skipped" ;;
+            *) UI_STATUS="$NEEDS_RESULT" ;;
+          esac
+          export UI_STATUS UI_PLATFORM="ios"
+
+          REPORT_ARGS=()
+          REPORT_FILE="$(find downloaded-report -name '*.xml' -type f 2>/dev/null | head -1)"
+          if [ -n "$REPORT_FILE" ]; then
+            REPORT_ARGS=(--report "$REPORT_FILE")
+          fi
+
+          chmod +x "${UI_SCRIPTS_DIR}/compose_zulip_ui_message.sh"
+          {
+            echo "content<<MSG_EOF"
+            "${UI_SCRIPTS_DIR}/compose_zulip_ui_message.sh" "${REPORT_ARGS[@]}"
+            echo "MSG_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      # Deliberately not continue-on-error: a missing TEST_UI_ZULIP_TOPIC must
+      # go red, because an absent message looks identical to a night with no run.
+      - name: Send Zulip notification
+        uses: zulip/github-actions-zulip/send-message@v2
+        with:
+          api-key: ${{ secrets.TEST_HARNESS_ZULIP_BOT_API_KEY }}
+          email: ${{ secrets.TEST_HARNESS_ZULIP_BOT_EMAIL }}
+          organization-url: ${{ secrets.ZULIP_ORG_URL }}
+          to: ${{ secrets.TEST_HARNESS_ZULIP_CHANNEL }}
+          type: "stream"
+          topic: ${{ secrets.TEST_UI_ZULIP_TOPIC }}
+          content: ${{ steps.msg.outputs.content }}


### PR DESCRIPTION
Maestro UI tests gated pull requests at 45m (Android) and 90m (iOS) without anyone reliably watching the result. Drop the pull_request trigger from both workflows and run them on a nightly cron instead. The paths filters and the now-unreachable dependabot guard go with it.

Both run at 0 23 * * *, three hours ahead of the earliest e2e cron (0 2 * * *), so a run consuming its full timeout still finishes before e2e starts. This also moves iOS off 0 4 * * *, which collided with the e2e weekday-beta cron.

Each workflow gains a notify-zulip job posting one message per platform to the existing Zulip channel under a new TEST_UI_ZULIP_TOPIC secret. The jobs stay independent, so a stalled AppleSilicon runner does not delay the Android report. compose_zulip_ui_message.sh parses Maestro's JUnit XML and is shared by both, parameterised by UI_PLATFORM.

The report reaches the notify job as an artifact rather than a job output: a JUnit file carrying failure traces can exceed the 1MB job-output cap. A missing artifact degrades to a "(no test report)" message instead of failing.

The Zulip send step is deliberately not continue-on-error, so a missing topic secret goes red rather than silently sending nothing.

iOS also gains a concurrency group: a manual dispatch during the nightly run would otherwise double-book the shared self-hosted runner.

## Ticket

JIRA-NYM-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6130)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated Zulip notifications for nightly Android and iOS UI test results.
  * Notifications include test status, failed or skipped test names, and links to reports and debug artifacts.
  * Added fallback handling for missing, invalid, or oversized test reports.

* **CI Improvements**
  * Android and iOS UI tests now run nightly at 23:00 UTC and remain available for manual runs.
  * Added serialized iOS test execution to improve runner reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->