### PR TITLE
Remove "trace only logging" mode

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/logging.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/logging.rs
@@ -39,11 +39,11 @@ pub const DEFAULT_OLD_LOG_FILE: &str = "nym-vpnd.old.log";
 /// hickory resolver when configured for use with client traffic can log DNS lookups at the DEBUG
 /// level. We do not want information related to client traffic logged except in controlled trace
 /// situations (away from platform apps).
-static TRACE_ONLY_LOGGING: [&str; 3] = [
-    "hickory_resolver",
+static TRACE_ONLY_LOGGING: [&str; 0] = [
+    //"hickory_resolver",
     // proto is probably okay, but disabling for now.
-    "hickory_proto",
-    "hickory_net",
+    //"hickory_proto",
+    //"hickory_net",
 ];
 
 static INFO_TARGETS: [&str; 13] = [

--- a/nym-vpn-core/crates/nym-vpn-lib/src/logging.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/logging.rs
@@ -3,6 +3,7 @@
 
 use std::{path::PathBuf, sync::Arc};
 
+use itertools::Itertools;
 use opentelemetry::trace::TracerProvider;
 use sentry::integrations::tracing as sentry_tracing;
 use tokio::{
@@ -35,18 +36,7 @@ pub const DEFAULT_LOG_FILE: &str = "nym-vpnd.log";
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub const DEFAULT_OLD_LOG_FILE: &str = "nym-vpnd.old.log";
 
-/// Targets which we do not want any logs under normal (up to debug) circumstances. For example the
-/// hickory resolver when configured for use with client traffic can log DNS lookups at the DEBUG
-/// level. We do not want information related to client traffic logged except in controlled trace
-/// situations (away from platform apps).
-static TRACE_ONLY_LOGGING: [&str; 0] = [
-    //"hickory_resolver",
-    // proto is probably okay, but disabling for now.
-    //"hickory_proto",
-    //"hickory_net",
-];
-
-static INFO_TARGETS: [&str; 13] = [
+static INFO_TARGETS: [&str; 16] = [
     "hyper",
     "netlink_proto",
     "hyper_util",
@@ -60,6 +50,9 @@ static INFO_TARGETS: [&str; 13] = [
     "nym_client_core::client::real_messages_control",
     "nym_client_core::client::received_buffer",
     "tonic::transport::server",
+    "hickory_resolver",
+    "hickory_proto",
+    "hickory_net",
 ];
 
 static WARN_TARGETS: [&str; 3] = ["hickory_server", "quinn::connection", "zbus"];
@@ -295,37 +288,27 @@ pub fn setup_logging(options: Options) -> Option<LoggingSetup> {
     // ! This does not configure any additional telemetry, it's just additional data added locally !
     let enable_opentelemetry = options.enable_json_log;
 
-    let mut env_filter = EnvFilter::builder()
-        .with_default_directive(options.verbosity_level.into())
-        .from_env_lossy();
-
-    for crate_name in INFO_TARGETS {
-        env_filter = env_filter.add_directive(
-            format!("{crate_name}=info")
-                .parse()
-                .expect("failed to parse directive"),
-        );
-    }
-    for crate_name in WARN_TARGETS {
-        env_filter = env_filter.add_directive(
-            format!("{crate_name}=warn")
-                .parse()
-                .expect("failed to parse directive"),
-        );
-    }
-
-    let level = if options.verbosity_level == Level::TRACE {
-        "trace"
+    // Setup from RUST_LOG if set and not empty. Otherwise use production configuration
+    let env_filter = if std::env::var(EnvFilter::DEFAULT_ENV).is_ok_and(|s| !s.trim().is_empty()) {
+        EnvFilter::builder()
+            .with_default_directive(options.verbosity_level.into())
+            .from_env_lossy()
     } else {
-        "off"
+        let default_directives = std::iter::once(options.verbosity_level.to_string())
+            .chain(
+                INFO_TARGETS
+                    .iter()
+                    .map(|crate_name| format!("{crate_name}=info"))
+                    .chain(
+                        WARN_TARGETS
+                            .iter()
+                            .map(|crate_name| format!("{crate_name}=warn")),
+                    ),
+            )
+            .join(",");
+
+        EnvFilter::new(default_directives)
     };
-    for crate_name in TRACE_ONLY_LOGGING {
-        env_filter = env_filter.add_directive(
-            format!("{crate_name}={level}")
-                .parse()
-                .expect("failed to parse directive"),
-        );
-    }
 
     let mut layers = Vec::new();
 


### PR DESCRIPTION


## Description

- Remove `TRACE_ONLY_LOGGING` since it enforces `trace` level in order to look at hickory logs which is very inconvenient
- Limit `hickory_resolver`, `hickory_proto` and `hickory_net` to `info` level by default which is production configuration
- Initialize tracing from `RUST_LOG` if set and not empty. This enables better flexibility as it enables full override over `RUST_LOG`

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6131)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging configuration when `RUST_LOG` is set.
  * Updated default logging filters to provide more relevant INFO and WARN output.
  * Added appropriate logging coverage for Hickory components.
  * Removed obsolete trace-level logging configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->