### PR TITLE
Streamline DNS

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -19,8 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [macOS] Sign cli with net.nymtech.vpn.cli bundle identifier. Add it to client signing requirement. (https://github.com/nymtech/nym-vpn-client/pull/5998)
 - Merge rpc-uniffi crate into lib-uniffi (https://github.com/nymtech/nym-vpn-client/pull/6010)
+- Local DNS resolver will respond with `serv_fail` on timeout from upstream DNS server (https://github.com/nymtech/nym-vpn-client/pull/6132)
+- Remove IPv6 DNS addresses from default DNS configuration due to reliability issues (https://github.com/nymtech/nym-vpn-client/pull/6132)
 
-## [2026.12.0] - TBD
+
+## [2026.12.0] - 2026-08-18
 
 ### Added
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/lib.rs
@@ -56,7 +56,11 @@ static DEFAULT_DNS_SERVERS_CONFIG: LazyLock<Vec<NameServerConfig>> = LazyLock::n
         .chain(QUAD9.https())
         .chain(CLOUDFLARE.tls())
         .chain(CLOUDFLARE.https())
-        .collect()
+        .filter(|ns| {
+            // Exclude IPv6 addresses due to reliability issues
+            ns.ip.is_ipv4()
+        })
+        .collect::<Vec<_>>()
 });
 
 /// Routing table id used for routing all traffic through the tunnel.

--- a/nym-vpn-core/crates/nym-vpn-lib/src/resolver/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/resolver/mod.rs
@@ -590,7 +590,6 @@ impl LocalResolver {
         let mut resolver_opts = ResolverOpts::default();
         resolver_opts.ip_strategy = LookupIpStrategy::Ipv4AndIpv6;
         resolver_opts.server_ordering_strategy = ServerOrderingStrategy::QueryStatistics;
-        resolver_opts.num_concurrent_reqs = 4;
 
         let resolver = TokioResolver::builder_with_config(forward_config, connection_provider)
             .with_options(resolver_opts)

--- a/nym-vpn-core/crates/nym-vpn-lib/src/resolver/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/resolver/mod.rs
@@ -704,8 +704,15 @@ impl ResolverImpl {
                             trace_err_chain!(err, "failed to send response");
                         })
                 } else {
+                    let response = MessageResponseBuilder::from_message_request(message)
+                        .error_msg(&message.metadata, ResponseCode::ServFail);
                     trace_err_chain!(resolve_err, "failed to resolve hostname");
-                    Err(resolve_err)
+                    response_handler
+                        .send_response(response)
+                        .await
+                        .inspect_err(|err| {
+                            trace_err_chain!(err, "failed to send response");
+                        })
                 }
             }
             Err(_error) => Err(NetError::Message("channel is closed")),

--- a/nym-vpn-core/crates/nym-vpn-lib/src/resolver/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/resolver/mod.rs
@@ -661,7 +661,7 @@ impl ResolverImpl {
 
         let Some(query) = message.queries.queries().first() else {
             tracing::error!("Received a message without query");
-            return Ok(serve_failed(message));
+            return send_error_response(message, response_handler, ResponseCode::ServFail).await;
         };
 
         // BIND does not support multiple questions.
@@ -679,12 +679,13 @@ impl ResolverImpl {
             .is_err()
         {
             tracing::error!("Failed to send query to resolver");
-            return Ok(serve_failed(message));
+            return send_error_response(message, response_handler, ResponseCode::ServFail).await;
         };
 
         match response_rx.await {
             Ok(Ok(ref lookup)) => {
                 let response = Self::build_response(message, lookup);
+
                 response_handler
                     .send_response(response)
                     .await
@@ -694,9 +695,9 @@ impl ResolverImpl {
             }
             Ok(Err(resolve_err)) => {
                 if let NetError::Dns(DnsError::NoRecordsFound(no_records)) = resolve_err {
-                    let response_code = no_records.response_code;
                     let response = MessageResponseBuilder::from_message_request(message)
-                        .error_msg(&message.metadata, response_code);
+                        .error_msg(&message.metadata, no_records.response_code);
+
                     response_handler
                         .send_response(response)
                         .await
@@ -704,15 +705,8 @@ impl ResolverImpl {
                             trace_err_chain!(err, "failed to send response");
                         })
                 } else {
-                    let response = MessageResponseBuilder::from_message_request(message)
-                        .error_msg(&message.metadata, ResponseCode::ServFail);
                     trace_err_chain!(resolve_err, "failed to resolve hostname");
-                    response_handler
-                        .send_response(response)
-                        .await
-                        .inspect_err(|err| {
-                            trace_err_chain!(err, "failed to send response");
-                        })
+                    send_error_response(message, response_handler, ResponseCode::ServFail).await
                 }
             }
             Err(_error) => Err(NetError::Message("channel is closed")),
@@ -729,7 +723,10 @@ impl RequestHandler for ResolverImpl {
     ) -> ResponseInfo {
         if !request.src().ip().is_loopback() {
             tracing::error!("Dropping a stray request from outside: {}", request.src());
-            refused(request)
+
+            send_error_response(request, response_handle, ResponseCode::Refused)
+                .await
+                .unwrap_or_else(|_| refused(request))
         } else if request.metadata.message_type == MessageType::Query
             && request.metadata.op_code == OpCode::Query
         {
@@ -738,7 +735,10 @@ impl RequestHandler for ResolverImpl {
                 .unwrap_or_else(|_err| serve_failed(request))
         } else {
             tracing::trace!("Dropping non-query request: {:?}", request);
-            refused(request)
+
+            send_error_response(request, response_handle, ResponseCode::Refused)
+                .await
+                .unwrap_or_else(|_| refused(request))
         }
     }
 }
@@ -775,4 +775,23 @@ fn response_from(request: &Request, response_code: ResponseCode) -> ResponseInfo
         metadata,
         counts: HeaderCounts::default(),
     })
+}
+
+async fn send_error_response<R: ResponseHandler>(
+    request: &Request,
+    mut response_handler: R,
+    response_code: ResponseCode,
+) -> Result<ResponseInfo, NetError> {
+    let mut metadata = Metadata::response_from_request(&request.metadata);
+    metadata.response_code = response_code;
+
+    let response =
+        MessageResponseBuilder::from_message_request(request).error_msg(&metadata, response_code);
+
+    response_handler
+        .send_response(response)
+        .await
+        .inspect_err(|err| {
+            trace_err_chain!(err, "failed to send response");
+        })
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/resolver/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/resolver/mod.rs
@@ -705,7 +705,7 @@ impl ResolverImpl {
                         })
                 } else {
                     trace_err_chain!(resolve_err, "failed to resolve hostname");
-                    return resolve_err;
+                    Err(resolve_err)
                 }
             }
             Err(_error) => Err(NetError::Message("channel is closed")),

--- a/nym-vpn-core/crates/nym-vpn-lib/src/resolver/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/resolver/mod.rs
@@ -587,6 +587,7 @@ impl LocalResolver {
 
         let mut resolver_opts = ResolverOpts::default();
         resolver_opts.ip_strategy = LookupIpStrategy::Ipv4AndIpv6;
+        resolver_opts.num_concurrent_reqs = 4;
 
         let resolver = TokioResolver::builder_with_config(forward_config, connection_provider)
             .with_options(resolver_opts)

--- a/nym-vpn-core/crates/nym-vpn-lib/src/resolver/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/resolver/mod.rs
@@ -46,7 +46,9 @@ use std::{
 };
 
 use async_trait::async_trait;
-use hickory_resolver::config::{LookupIpStrategy, NameServerConfig, ResolverOpts};
+use hickory_resolver::config::{
+    LookupIpStrategy, NameServerConfig, ResolverOpts, ServerOrderingStrategy,
+};
 use hickory_server::{
     net::runtime::Time,
     proto::{
@@ -587,6 +589,7 @@ impl LocalResolver {
 
         let mut resolver_opts = ResolverOpts::default();
         resolver_opts.ip_strategy = LookupIpStrategy::Ipv4AndIpv6;
+        resolver_opts.server_ordering_strategy = ServerOrderingStrategy::QueryStatistics;
         resolver_opts.num_concurrent_reqs = 4;
 
         let resolver = TokioResolver::builder_with_config(forward_config, connection_provider)

--- a/nym-vpn-core/crates/nym-vpn-lib/src/resolver/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/resolver/mod.rs
@@ -709,7 +709,9 @@ impl ResolverImpl {
                     send_error_response(message, response_handler, ResponseCode::ServFail).await
                 }
             }
-            Err(_error) => Err(NetError::Message("channel is closed")),
+            Err(_error) => {
+                send_error_response(message, response_handler, ResponseCode::ServFail).await
+            }
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/resolver/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/resolver/mod.rs
@@ -46,9 +46,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use hickory_resolver::config::{
-    LookupIpStrategy, NameServerConfig, ResolverOpts, ServerOrderingStrategy,
-};
+use hickory_resolver::config::{LookupIpStrategy, NameServerConfig, ResolverOpts};
 use hickory_server::{
     net::runtime::Time,
     proto::{
@@ -589,7 +587,6 @@ impl LocalResolver {
 
         let mut resolver_opts = ResolverOpts::default();
         resolver_opts.ip_strategy = LookupIpStrategy::Ipv4AndIpv6;
-        resolver_opts.server_ordering_strategy = ServerOrderingStrategy::QueryStatistics;
 
         let resolver = TokioResolver::builder_with_config(forward_config, connection_provider)
             .with_options(resolver_opts)

--- a/nym-vpn-core/crates/nym-vpn-lib/src/resolver/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/resolver/mod.rs
@@ -661,7 +661,7 @@ impl ResolverImpl {
 
         let Some(query) = message.queries.queries().first() else {
             tracing::error!("Received a message without query");
-            return Ok(make_response_info(message, ResponseCode::ServFail));
+            return Ok(serve_failed(message));
         };
 
         // BIND does not support multiple questions.
@@ -679,7 +679,7 @@ impl ResolverImpl {
             .is_err()
         {
             tracing::error!("Failed to send query to resolver");
-            return Ok(make_response_info(message, ResponseCode::ServFail));
+            return Ok(serve_failed(message));
         };
 
         match response_rx.await {
@@ -705,22 +705,12 @@ impl ResolverImpl {
                         })
                 } else {
                     trace_err_chain!(resolve_err, "failed to resolve hostname");
-                    Err(resolve_err)
+                    return resolve_err;
                 }
             }
             Err(_error) => Err(NetError::Message("channel is closed")),
         }
     }
-}
-
-fn make_response_info(message: &Request, response_code: ResponseCode) -> ResponseInfo {
-    let mut metadata = Metadata::response_from_request(&message.metadata);
-    metadata.response_code = response_code;
-    let header = Header {
-        metadata,
-        counts: HeaderCounts::default(),
-    };
-    ResponseInfo::from(header)
 }
 
 #[async_trait::async_trait]
@@ -732,16 +722,16 @@ impl RequestHandler for ResolverImpl {
     ) -> ResponseInfo {
         if !request.src().ip().is_loopback() {
             tracing::error!("Dropping a stray request from outside: {}", request.src());
-            make_response_info(request, ResponseCode::Refused)
+            refused(request)
         } else if request.metadata.message_type == MessageType::Query
             && request.metadata.op_code == OpCode::Query
         {
             self.lookup(request, response_handle)
                 .await
-                .unwrap_or_else(|_err| make_response_info(request, ResponseCode::ServFail))
+                .unwrap_or_else(|_err| serve_failed(request))
         } else {
             tracing::trace!("Dropping non-query request: {:?}", request);
-            make_response_info(request, ResponseCode::Refused)
+            refused(request)
         }
     }
 }
@@ -757,4 +747,25 @@ pub fn random_loopback_ipv4() -> IpAddr {
         // keep last octet in the range of 1-254 to avoid special addresses
         rand::thread_rng().gen_range(1..=254),
     ))
+}
+
+fn serve_failed(request: &Request) -> ResponseInfo {
+    response_from(request, ResponseCode::ServFail)
+}
+
+fn refused(request: &Request) -> ResponseInfo {
+    response_from(request, ResponseCode::Refused)
+}
+
+fn response_from(request: &Request, response_code: ResponseCode) -> ResponseInfo {
+    let mut metadata = Metadata::new(
+        request.metadata.id,
+        MessageType::Response,
+        request.metadata.op_code,
+    );
+    metadata.response_code = response_code;
+    ResponseInfo::from(Header {
+        metadata,
+        counts: HeaderCounts::default(),
+    })
 }


### PR DESCRIPTION


## Description

- Filter out IPv6 addresses due to reliability issues. For some reason not all of IPv6 DNS are reachable over VPN tunnel.
- Respond with `serv_fail` in the event of timeout from upstream DNS server

## Checklist:

- [x] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6132)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved DNS resolution reliability through refined server selection and query handling.
  - Default DNS configuration now uses IPv4 name servers for improved compatibility.
  - DNS failures now return clear error responses instead of exposing internal resolver errors.
  - Invalid or unsupported DNS requests receive appropriate responses while preserving request details.
  - Improved consistency when handling DNS queries and resolver failures across supported configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->