### PR TITLE
Skip duplicate iOS account prepare, macOS snackbar dismiss, and sandbox gateway lists

### DIFF
--- a/nym-vpn-apple/Services/Package.swift
+++ b/nym-vpn-apple/Services/Package.swift
@@ -300,6 +300,7 @@ let package = Package(
                 "AccountPrefetchGates",
                 "AppSettings",
                 "CredentialsManager",
+                "SnackbarManager",
                 .product(name: "ErrorHandler", package: "ServicesIOS"),
                 .product(name: "NymVPNLib", package: "NymVPNLib"),
                 .product(name: "Theme", package: "Theme"),

--- a/nym-vpn-apple/Services/Sources/Services/CredentialsManager/CredentialsManager+iOSAccountController.swift
+++ b/nym-vpn-apple/Services/Sources/Services/CredentialsManager/CredentialsManager+iOSAccountController.swift
@@ -75,6 +75,7 @@ extension CredentialsManager {
                     )
                 }
             }
+            hasPreparedRegisteredAccountThisSession = true
         } catch let error as VpnError {
             throw AccountRegistrationSupport.mapToVPNErrorReason(error)
         }

--- a/nym-vpn-apple/Services/Sources/Services/CredentialsManager/CredentialsManager.swift
+++ b/nym-vpn-apple/Services/Sources/Services/CredentialsManager/CredentialsManager.swift
@@ -51,6 +51,7 @@ import PathManager
     private var accountRegistrationTask: Task<Void, Error>?
     var accountControllerShutdown: (() async -> Void)?
     private(set) var isLoggingOut = false
+    var hasPreparedRegisteredAccountThisSession = false
 #endif
 
     public static let shared = CredentialsManager()
@@ -286,6 +287,9 @@ import PathManager
     }
 
     public func ensureDeviceRegisteredForLogin() async throws {
+        if hasPreparedRegisteredAccountThisSession {
+            return
+        }
         let env = try resolvedRegistrationEnvironment()
         _ = try await AccountRegistrationSupport.withAccountStoreRetry(
             operation: "ensureDeviceRegisteredForLogin",
@@ -300,6 +304,10 @@ import PathManager
         onAccountPhaseChange: (@MainActor (OnboardingAccountPreparationPolicy.AccountStatePhase) -> Void)?
     ) async throws {
 #if os(iOS)
+        if hasPreparedRegisteredAccountThisSession {
+            onAccountPhaseChange?(.readyToConnect)
+            return
+        }
         let env = try resolvedNetworkEnvironment()
         try await prepareRegisteredAccount(
             environment: env,
@@ -344,6 +352,7 @@ import PathManager
     public func beginLogout() async {
 #if os(iOS)
         isLoggingOut = true
+        hasPreparedRegisteredAccountThisSession = false
         accountSummaryUpdateTask?.cancel()
         accountSummaryUpdateTask = nil
         await shutdownControllersAndWait()
@@ -364,6 +373,7 @@ import PathManager
             return
         }
 #if os(iOS)
+        hasPreparedRegisteredAccountThisSession = false
         let envOpt = configurationManager.networkEnv
         try await Task {
             let dataDir = try PathManager.dataFolderURL().path()

--- a/nym-vpn-apple/Services/Sources/Services/GatewayManager/GatewayManager.swift
+++ b/nym-vpn-apple/Services/Sources/Services/GatewayManager/GatewayManager.swift
@@ -383,8 +383,11 @@ extension GatewayManager {
         defer { isLoading = false }
         do {
             let result = try await worker.fetchGateways()
+            logger.info(
+                "Fetched gateways entry=\(result.entry.count) exit=\(result.exit.count) vpn=\(result.vpn.count)"
+            )
 
-            guard !result.entry.isEmpty, !result.exit.isEmpty, !result.vpn.isEmpty
+            guard !result.entry.isEmpty || !result.exit.isEmpty || !result.vpn.isEmpty
             else {
                 logger.info("Empty gateways from API")
                 return

--- a/nym-vpn-apple/Services/Sources/Services/SnackbarManager/SnackbarItem.swift
+++ b/nym-vpn-apple/Services/Sources/Services/SnackbarManager/SnackbarItem.swift
@@ -7,6 +7,10 @@ public struct SnackbarItem: Identifiable {
         case neutral
         case negative
         case warning
+
+        /// Close control is always available. Critical used to hide it, which left
+        /// macOS users stuck on login/processing errors with no dismiss control.
+        public var showsCloseButton: Bool { true }
     }
 
     public let id: UUID

--- a/nym-vpn-apple/Services/Tests/CredentialsManagerTests/SnackbarItemStyleTests.swift
+++ b/nym-vpn-apple/Services/Tests/CredentialsManagerTests/SnackbarItemStyleTests.swift
@@ -1,0 +1,15 @@
+import Testing
+import SnackbarManager
+
+struct SnackbarItemStyleTests {
+    @Test func criticalStyleShowsCloseButton() {
+        #expect(SnackbarItem.Style.critical.showsCloseButton)
+    }
+
+    @Test func nonCriticalStylesShowCloseButton() {
+        #expect(SnackbarItem.Style.confirmation.showsCloseButton)
+        #expect(SnackbarItem.Style.warning.showsCloseButton)
+        #expect(SnackbarItem.Style.neutral.showsCloseButton)
+        #expect(SnackbarItem.Style.negative.showsCloseButton)
+    }
+}

--- a/nym-vpn-apple/UIComponents/Sources/UIComponents/26/Snackbar/NymSnackbar.swift
+++ b/nym-vpn-apple/UIComponents/Sources/UIComponents/26/Snackbar/NymSnackbar.swift
@@ -31,6 +31,7 @@ public struct NymSnackbar: View {
         .padding(NymSpacing.large)
         .background(item.style.backgroundColor)
         .clipShape(RoundedRectangle(cornerRadius: Constants.cornerRadius, style: .continuous))
+        .contentShape(RoundedRectangle(cornerRadius: Constants.cornerRadius, style: .continuous))
         .shadow(color: .black.opacity(0.15), radius: 12, x: 0, y: 2)
     }
 }
@@ -113,6 +114,11 @@ private extension NymSnackbar {
                 .scaledToFit()
                 .frame(width: Constants.CloseIcon.size, height: Constants.CloseIcon.size)
                 .foregroundStyle(item.style.textColor)
+                .frame(
+                    width: AccessibilityConstants.MinTapTarget.size,
+                    height: AccessibilityConstants.MinTapTarget.size,
+                    alignment: .top
+                )
                 .contentShape(Rectangle())
         }
         .accessibilityLabel(Text("close".localizedString))
@@ -144,6 +150,7 @@ private struct SnackbarChromeButton<Label: View>: View {
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .contentShape(Rectangle())
         .focusEffectDisabled(!voiceOverEnabled)
 #if os(macOS)
         .focusable(voiceOverEnabled)
@@ -198,10 +205,6 @@ private extension SnackbarItem.Style {
         default:
             Color.Nym.textPrimary
         }
-    }
-
-    var showsCloseButton: Bool {
-        self != .critical
     }
 
     var actionBackground: Color {
@@ -260,6 +263,7 @@ private struct NymSnackbarManagerModifier: ViewModifier {
                 .frame(maxWidth: NymSpacing.drawerMaxWidth)
                 .padding(.horizontal, NymSpacing.standard)
                 .padding(.top, Constants.topInset)
+                .fixedSize(horizontal: false, vertical: true)
                 .transition(.move(edge: .top).combined(with: .opacity))
             }
         }


### PR DESCRIPTION
- Cherry-pick of #6140 from vanilnoir onto develop.
- iOS skips a second in-session account prepare after login.
- Critical login and processing snackbars show a close control on macOS.
- Gateway fetch keeps Fast/WG nodes when sandbox mixnet exits are empty.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6142)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account preparation to avoid repeated registration work during a session.
  * Reset account preparation state when logging out or removing credentials.
  * Gateway loading now succeeds when any gateway category has available results.
  * Improved snackbar hit areas and accessibility, including reliable close controls.

* **UI Improvements**
  * Snackbars now maintain a consistent vertical size and provide accessible close-button targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->