### PR TITLE
fix(apple/home): stop pre-auth drawer stranding on the Home screen

### DIFF
--- a/nym-vpn-apple/Home/Sources/26/AppFeature/AppFeatureViewModel.swift
+++ b/nym-vpn-apple/Home/Sources/26/AppFeature/AppFeatureViewModel.swift
@@ -643,7 +643,7 @@ private extension AppFeatureViewModel {
         case .none:
             break
         case .setWelcome:
-            pendingDrawerContent = .welcome
+            stagePreauthDrawer(.welcome)
         case .setOneClick:
             pendingDrawerContent = .oneClick
             drawerContent = .oneClick
@@ -651,7 +651,7 @@ private extension AppFeatureViewModel {
             pendingDrawerContent = nil
             drawerContent = .oneClick
         case .setTechnicalOptIns:
-            pendingDrawerContent = .technicalOptIns
+            stagePreauthDrawer(.technicalOptIns)
         case .stageOneClickForCheckout:
             beginCheckoutDrawerTransition(
                 deferNavigationUntilDrawerHidden: result.navigationIntent == .pushPlanPurchase
@@ -675,6 +675,30 @@ private extension AppFeatureViewModel {
         default:
             break
         }
+    }
+
+    /// Moves the drawer to a pre-auth state (`.welcome` / `.technicalOptIns`).
+    ///
+    /// `.welcome`, `.technicalOptIns` and `.processing` share one `slideID`
+    /// (`.preauth`), so a transition among them doesn't change `drawerSlideID`.
+    /// `DrawerView` only slides — and `drawerTransitionCompleted()`, the sole
+    /// committer of `pendingDrawerContent` and the only place a finished
+    /// `processingViewModel` is freed, only runs — on a slideID change. Staging
+    /// a pre-auth state via `pendingDrawerContent` alone therefore never
+    /// commits: `drawerTag` renders the staged state while `drawerContent`
+    /// stays stale. When the slide identity won't change we commit directly (as
+    /// `startProcessingTransition` does); otherwise stage and let the slide
+    /// commit it, preserving the slide animation.
+    private func stagePreauthDrawer(_ content: AppDrawerContent) {
+        guard (drawerContent ?? .welcome).slideID == content.slideID else {
+            pendingDrawerContent = content
+            return
+        }
+        pendingDrawerContent = nil
+        if drawerContent?.isProcessing == true {
+            processingViewModel = nil
+        }
+        drawerContent = content
     }
 
     func beginCheckoutDrawerTransition(deferNavigationUntilDrawerHidden: Bool) {

--- a/nym-vpn-apple/Home/Sources/26/AppFeature/AppFeatureViewModel.swift
+++ b/nym-vpn-apple/Home/Sources/26/AppFeature/AppFeatureViewModel.swift
@@ -228,6 +228,33 @@ import GRPCManager
         }
     }
 
+    /// Moves the drawer to a pre-auth state (`.welcome` / `.technicalOptIns`).
+    ///
+    /// `.welcome`, `.technicalOptIns` and `.processing` share one `slideID`
+    /// (`.preauth`), so a transition among them doesn't change `drawerSlideID`.
+    /// `DrawerView` only slides — and `drawerTransitionCompleted()`, the sole
+    /// committer of `pendingDrawerContent` and the only place a finished
+    /// `processingViewModel` is freed, only runs — on a slideID change. Staging
+    /// a pre-auth state via `pendingDrawerContent` alone therefore never
+    /// commits: `drawerTag` renders the staged state while `drawerContent`
+    /// stays stale. When the slide identity won't change we commit directly (as
+    /// `startProcessingTransition` does); otherwise stage and let the slide
+    /// commit it, preserving the slide animation.
+    func stagePreauthDrawer(_ content: AppDrawerContent) {
+        // Compare against `drawerTag` (`pendingDrawerContent ?? drawerContent`) —
+        // the exact value `drawerSlideID` observes — so this predicts whether a
+        // slide will actually fire, leaving no guard/trigger divergence.
+        guard (pendingDrawerContent ?? drawerContent ?? .welcome).slideID == content.slideID else {
+            pendingDrawerContent = content
+            return
+        }
+        pendingDrawerContent = nil
+        if drawerContent?.isProcessing == true {
+            processingViewModel = nil
+        }
+        drawerContent = content
+    }
+
     func handleSceneBecameActive() {
         guard !connectionStatus.isConnectingLike, !isFamilyWarningModalDisplayed else { return }
 
@@ -675,30 +702,6 @@ private extension AppFeatureViewModel {
         default:
             break
         }
-    }
-
-    /// Moves the drawer to a pre-auth state (`.welcome` / `.technicalOptIns`).
-    ///
-    /// `.welcome`, `.technicalOptIns` and `.processing` share one `slideID`
-    /// (`.preauth`), so a transition among them doesn't change `drawerSlideID`.
-    /// `DrawerView` only slides — and `drawerTransitionCompleted()`, the sole
-    /// committer of `pendingDrawerContent` and the only place a finished
-    /// `processingViewModel` is freed, only runs — on a slideID change. Staging
-    /// a pre-auth state via `pendingDrawerContent` alone therefore never
-    /// commits: `drawerTag` renders the staged state while `drawerContent`
-    /// stays stale. When the slide identity won't change we commit directly (as
-    /// `startProcessingTransition` does); otherwise stage and let the slide
-    /// commit it, preserving the slide animation.
-    private func stagePreauthDrawer(_ content: AppDrawerContent) {
-        guard (drawerContent ?? .welcome).slideID == content.slideID else {
-            pendingDrawerContent = content
-            return
-        }
-        pendingDrawerContent = nil
-        if drawerContent?.isProcessing == true {
-            processingViewModel = nil
-        }
-        drawerContent = content
     }
 
     func beginCheckoutDrawerTransition(deferNavigationUntilDrawerHidden: Bool) {

--- a/nym-vpn-apple/Home/Tests/HomeTests/AppFeatureViewModelDrawerStrandTests.swift
+++ b/nym-vpn-apple/Home/Tests/HomeTests/AppFeatureViewModelDrawerStrandTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+@testable import Home
+import AppSettings
+import ConnectionManager
+import CredentialsManager
+import GatewayManager
+import ImpactGenerator
+import NetworkMonitor
+import SnackbarManager
+
+@MainActor
+final class AppFeatureViewModelDrawerStrandTests: XCTestCase {
+    private func makeViewModel() -> AppFeatureViewModel {
+#if os(iOS)
+        AppFeatureViewModel(
+            appSettings: .shared,
+            credentialsManager: .shared,
+            connectionManager: .shared,
+            gatewayManager: .shared,
+            snackbarManager: .shared,
+            impactGenerator: .shared,
+            networkMonitor: .shared
+        )
+#elseif os(macOS)
+        AppFeatureViewModel(
+            appSettings: .shared,
+            credentialsManager: .shared,
+            connectionManager: .shared,
+            gatewayManager: .shared,
+            snackbarManager: .shared,
+            impactGenerator: .shared,
+            networkMonitor: .shared,
+            grpcManager: .shared
+        )
+#endif
+    }
+
+    /// Regression for the pre-auth drawer strand.
+    ///
+    /// `.welcome`, `.processing` and `.technicalOptIns` share one `slideID`
+    /// (`.preauth`), so a transition among them never changes `drawerSlideID`,
+    /// never fires `DrawerView`'s slide, and therefore never runs
+    /// `drawerTransitionCompleted()` — the only code that commits
+    /// `pendingDrawerContent` into `drawerContent` and frees a finished
+    /// `processingViewModel`. Moving from `.processing` to a pre-auth state must
+    /// therefore commit `drawerContent` directly and free the processing VM,
+    /// not merely stage `pendingDrawerContent` (which strands the drawer on a
+    /// stale `.processing`).
+    ///
+    /// Mutation this kills: revert `stagePreauthDrawer` to stage-only
+    /// (`pendingDrawerContent = content; return`) and `drawerContent` stays
+    /// `.processing` — the first assertion fails.
+    func testStagePreauthFromProcessingCommitsDirectlyAndFreesProcessingVM() {
+        let viewModel = makeViewModel()
+
+        // Deterministically land on a real `.processing` drawer.
+        // (Mirrors AppFeatureViewModelCheckoutTransitionTests
+        // .testLoginAuthCompletedStartsLoginProcessingDrawer.)
+        viewModel.handleSessionEvent(.authCompleted(outcome: .loginReady, flow: .login))
+        XCTAssertEqual(viewModel.drawerContent, .processing, "precondition: drawer is .processing")
+        XCTAssertNotNil(viewModel.processingViewModel, "precondition: processing view-model present")
+
+        viewModel.stagePreauthDrawer(.technicalOptIns)
+
+        XCTAssertEqual(
+            viewModel.drawerContent,
+            .technicalOptIns,
+            "pre-auth transition must commit drawerContent directly, not strand on .processing"
+        )
+        XCTAssertNil(viewModel.pendingDrawerContent, "must not be left staged")
+        XCTAssertNil(viewModel.processingViewModel, "finished processing view-model must be freed")
+    }
+}


### PR DESCRIPTION
## Problem
On the Home screen (native SwiftUI, **iOS + macOS**) the bottom drawer intermittently shows the wrong stage: the sign-in "Get started" content, or empty dead space, where server selection should be. Reported on macOS v2026.12.1 beta 2; present since ~v2026.11 (the "26" redesign).

## Cause
`.welcome`, `.processing`, and `.technicalOptIns` share one `slideID` (`.preauth`). `DrawerView` only slides — and `drawerTransitionCompleted()`, the sole committer of `pendingDrawerContent` into `drawerContent` and the only place a finished `processingViewModel` is freed, only runs on a `slideID` change. The `.setWelcome` / `.setTechnicalOptIns` arms of `applySessionResult` staged via `pendingDrawerContent` only, so a transition between two pre-auth states never committed: the view rendered the staged state while `drawerContent` stayed a stale `.processing`, which then poisoned every guard that reads it (e.g. the auth-deeplink callback in `beginPrivyLoginProcessing`, the settings gear).

## Fix
Route those two commands through a helper that commits `drawerContent` directly when the current drawer already shares the target's slide identity (mirroring the existing `startProcessingTransition`), and otherwise stages as before. The shared `.preauth` `slideID` is intentional (internal cross-fade instead of a modal slide) and is left unchanged.

## Verify
- CI (`ci-nym-vpn-app-macos`) runs `HomeTests`, including the added `AppFeatureViewModelDrawerStrandTests`, plus `AppSessionReducerTests`.
- Locally (Xcode): run `HomeTests`. The new test drives a real `.processing` drawer, then asserts a pre-auth transition commits `drawerContent` directly and frees `processingViewModel`. Mutation check: revert the helper body to stage-only (`pendingDrawerContent = content; return`) and the test goes red.

## Notes
- Shared iOS/macOS file — behaviour changes identically on both.
- Independently reviewed by a separate agent (recommendation: ship); no test previously locked this invariant.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6146)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drawer transitions between processing, welcome, and technical opt-in screens.
  * Ensured technical opt-in content appears immediately when transitioning from processing.

* **Tests**
  * Added regression coverage for drawer content updates and cleanup during transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->