### PR TITLE
feat(macos/geo-exclusion): add Server row; trim setup instructions

### DIFF
--- a/nym-vpn-apple/NymVPN/Resources/Localizable.xcstrings
+++ b/nym-vpn-apple/NymVPN/Resources/Localizable.xcstrings
@@ -15605,7 +15605,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Works with macOS system-wide proxy settings, Firefox, and Web3 wallets."
+            "value" : "On Firefox or browsers that permit SOCKS5 configurations."
           }
         }
       }
@@ -15749,6 +15749,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Setup instructions"
+          }
+        }
+      }
+    },
+    "geoExclusion.server" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Server"
           }
         }
       }

--- a/nym-vpn-apple/Settings/Sources/Settings/GeoExclusion/GeoExclusionInstructionsView.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/GeoExclusion/GeoExclusionInstructionsView.swift
@@ -1,24 +1,17 @@
 #if os(macOS)
-import AppKit
 import SwiftUI
 import Theme
 import UIComponents
 
 public struct GeoExclusionInstructionsView: View {
     @Binding private var path: NavigationPath
-    @State private var addressCopied = false
     private let listenPort: UInt16
 
     private static let proxyHost = "127.0.0.1"
-    private static let web3RpcURL = "http://127.0.0.1:8545"
 
     public init(path: Binding<NavigationPath>, listenPort: UInt16) {
         _path = path
         self.listenPort = listenPort
-    }
-
-    private var proxyAddress: String {
-        "\(Self.proxyHost):\(listenPort)"
     }
 
     public var body: some View {
@@ -34,10 +27,7 @@ public struct GeoExclusionInstructionsView: View {
                         .foregroundStyle(Color.Nym.textSecondary)
                         .nymTextStyle(.bodyDefault)
 
-                    systemWideSection
-                    appSection
-                    web3Section
-                    proxyAddressCard
+                    appStepsCard
                 }
                 .frame(maxWidth: MagicNumbers.maxWidth)
                 .padding(.vertical, 24)
@@ -61,55 +51,12 @@ private extension GeoExclusionInstructionsView {
         path.removeLast()
     }
 
-    var systemWideSection: some View {
-        section(
-            title: "geoExclusion.setup.systemWide.title",
-            subtitle: "geoExclusion.setup.systemWide.subtitle",
-            steps: [
-                plainStep("geoExclusion.setup.systemWide.step1"),
-                plainStep("geoExclusion.setup.systemWide.step2"),
-                highlightedStep("geoExclusion.setup.systemWide.step3", values: [Self.proxyHost, "\(listenPort)"]),
-                plainStep("geoExclusion.setup.systemWide.step4")
-            ]
-        )
-    }
-
-    var appSection: some View {
-        section(
-            title: "geoExclusion.setup.app.title",
-            subtitle: "geoExclusion.setup.app.subtitle",
-            steps: [
-                plainStep("geoExclusion.setup.app.step1"),
-                highlightedStep("geoExclusion.setup.app.step2", values: [Self.proxyHost, "\(listenPort)"]),
-                plainStep("geoExclusion.setup.app.step3")
-            ]
-        )
-    }
-
-    var web3Section: some View {
-        section(
-            title: "geoExclusion.setup.web3.title",
-            subtitle: nil,
-            steps: [
-                highlightedStep("geoExclusion.setup.web3.step1", values: [Self.web3RpcURL])
-            ]
-        )
-    }
-
-    func section(title: String, subtitle: String?, steps: [Text]) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text(title.localizedString)
-                .foregroundStyle(Color.Nym.textPrimary)
-                .nymTextStyle(.titleSection)
-
-            if let subtitle {
-                Text(subtitle.localizedString)
-                    .foregroundStyle(Color.Nym.textSecondary)
-                    .nymTextStyle(.bodyDefault)
-            }
-
-            stepsCard(steps)
-        }
+    var appStepsCard: some View {
+        stepsCard([
+            plainStep("geoExclusion.setup.app.step1"),
+            highlightedStep("geoExclusion.setup.app.step2", values: [Self.proxyHost, "\(listenPort)"]),
+            plainStep("geoExclusion.setup.app.step3")
+        ])
     }
 
     func stepsCard(_ steps: [Text]) -> some View {
@@ -142,43 +89,6 @@ private extension GeoExclusionInstructionsView {
             Text("\(number)")
                 .foregroundStyle(Color.Nym.primary)
                 .nymTextStyle(.bodySmallBold)
-        }
-    }
-
-    var proxyAddressCard: some View {
-        Button(action: copyProxyAddress) {
-            VStack(alignment: .leading, spacing: 8) {
-                Text("geoExclusion.setup.proxyAddress".localizedString.uppercased())
-                    .foregroundStyle(Color.Nym.textTertiary)
-                    .nymTextStyle(.bodySmallBold)
-                HStack(spacing: 12) {
-                    Text(proxyAddress)
-                        .foregroundStyle(Color.Nym.textPrimary)
-                        .font(Font.custom("Courier New", size: 15))
-                        .kerning(0.3)
-                    GenericImage(imageName: addressCopied ? "checkmarkSeeThrough" : "copy")
-                        .frame(width: 24, height: 24)
-                    Spacer(minLength: 0)
-                }
-            }
-            .padding(16)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .background(RoundedRectangle(cornerRadius: 12).fill(Color.Nym.surface))
-    }
-
-    func copyProxyAddress() {
-        NSPasteboard.general.prepareForNewContents()
-        NSPasteboard.general.setString(proxyAddress, forType: .string)
-        withAnimation {
-            guard !addressCopied else { return }
-            addressCopied = true
-            Task { @MainActor in
-                try? await Task.sleep(for: .seconds(3))
-                addressCopied = false
-            }
         }
     }
 

--- a/nym-vpn-apple/Settings/Sources/Settings/GeoExclusion/GeoExclusionView.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/GeoExclusion/GeoExclusionView.swift
@@ -99,6 +99,29 @@ private extension GeoExclusionView {
 
     var socks5PortCard: some View {
         VStack(spacing: 0) {
+            Button(action: { viewModel.copyServer() }) {
+                HStack(spacing: 0) {
+                    Text("geoExclusion.server".localizedString)
+                        .foregroundStyle(Color.Nym.textSecondary)
+                        .nymTextStyle(.bodyDefault)
+                    Spacer()
+                    Text(viewModel.serverAddress)
+                        .foregroundStyle(Color.Nym.textPrimary)
+                        .font(Font.custom("Courier New", size: 15))
+                        .kerning(0.3)
+                        .padding(.trailing, 12)
+                    GenericImage(imageName: viewModel.serverCopied ? "checkmarkSeeThrough" : "copy")
+                        .frame(width: 24, height: 24)
+                }
+                .padding(16)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            Divider()
+                .frame(height: 1)
+                .overlay(Color.Nym.divider)
+
             Button(action: { viewModel.copyPort() }) {
                 HStack(spacing: 0) {
                     Text("geoExclusion.socks5Port".localizedString)

--- a/nym-vpn-apple/Settings/Sources/Settings/GeoExclusion/GeoExclusionViewModel.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/GeoExclusion/GeoExclusionViewModel.swift
@@ -20,8 +20,12 @@ import Theme
     @Published var portText = "\(GeoExclusionConfig.defaultPort)"
     @Published var portError: String?
     @Published var portCopied = false
+    @Published var serverCopied = false
 
     private(set) var listenPort = GeoExclusionConfig.defaultPort
+
+    /// The loopback host shown in the Server row; the proxy always listens on 127.0.0.1.
+    let serverAddress = "127.0.0.1"
 
     /// Beta: the excluded region list is hardcoded to China.
     let excludedCountryName = "geoExclusion.china".localizedString
@@ -120,6 +124,19 @@ import Theme
             Task { @MainActor in
                 try? await Task.sleep(for: .seconds(3))
                 portCopied = false
+            }
+        }
+    }
+
+    func copyServer() {
+        NSPasteboard.general.prepareForNewContents()
+        NSPasteboard.general.setString(serverAddress, forType: .string)
+        withAnimation {
+            guard !serverCopied else { return }
+            serverCopied = true
+            Task { @MainActor in
+                try? await Task.sleep(for: .seconds(3))
+                serverCopied = false
             }
         }
     }


### PR DESCRIPTION
## What changed
Two UI changes to the macOS Geo Exclusion feature:

- **Geo Exclusion screen** — added a copyable "Server" row showing `127.0.0.1`, directly above the existing "SOCKS5 port" row in the same card (same styling; tap to copy).
- **Setup Instructions screen** — trimmed to the intro subheading plus the three numbered steps. Removed the System-wide and Web3 sections, the proxy-address card, and the App section's title/subtitle. The subheading is reworded to "On Firefox or browsers that permit SOCKS5 configurations."

## Scope
macOS only — every `GeoExclusion*` view is `#if os(macOS)`-guarded. The same two changes will follow for Windows and Tauri in separate PRs.

## Strings
- New: `geoExclusion.server` ("Server").
- Reworded: `geoExclusion.setup.description`.
- Both need Crowdin re-translation. Strings for the removed sections (`setup.systemWide.*`, `setup.web3.*`, `setup.proxyAddress`, `setup.app.title`, `setup.app.subtitle`) are now unused but left in place.

## Verify
- `ci-nym-vpn-app-macos` compiles and runs the Settings/Home suites.
- Manual: Settings → Geo Exclusion → enable → the Server row copies `127.0.0.1` and the SOCKS5 port row copies the port; open Setup instructions and confirm it shows the subheading plus steps 1–3 only.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6148)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a copyable SOCKS5 server address to the Geo-exclusion settings.
  * Added visual confirmation when the server address is copied.
  * Streamlined setup instructions to focus on configuring the app.

* **Documentation**
  * Updated English localization for SOCKS5 browser support and server labeling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->