### PR TITLE
feat(app/geo-exclusion): add Server row; trim setup instructions

### DIFF
--- a/nym-vpn-app/src/i18n/en/settings.json
+++ b/nym-vpn-app/src/i18n/en/settings.json
@@ -344,6 +344,7 @@
     "beta-note": "Beta version: China and Russia only for now. More regions coming.",
     "warning": "Traffic to excluded regions bypasses the VPN.",
     "port": {
+      "server": "Server",
       "socks5-port": "SOCKS5 port",
       "custom-port": "Custom port",
       "range": "1024–65535",
@@ -363,65 +364,31 @@
       "sections": {
         "macos": [
           {
-            "intro": "Works with any app that supports SOCKS5 in its network settings:",
+            "intro": "On Firefox or browsers that permit SOCKS5 configurations.",
             "steps": [
-              "Copy the SOCKS5 port.",
-              "Open your app's proxy or network settings.",
-              "Set proxy to 127.0.0.1 with the copied port."
+              "Settings → Network Settings → Manual proxy.",
+              "SOCKS Host 127.0.0.1, Port {{port}}, select SOCKS v5.",
+              "Check Proxy DNS when using SOCKS v5 (prevents DNS leaks)."
             ]
           }
         ],
         "windows": [
           {
-            "heading": "System-wide (Proxifier)",
-            "intro": "Windows' built-in proxy settings don't support SOCKS5. Use a tool like Proxifier:",
-            "steps": [
-              "Add a proxy: host 127.0.0.1, port {{port}}, type SOCKS5.",
-              "Leave authentication empty.",
-              "Add a rule to route the apps you want through it."
-            ]
-          },
-          {
-            "heading": "App (e.g. browser)",
-            "intro": "Any app with SOCKS5 support. Firefox example:",
+            "intro": "On Firefox or browsers that permit SOCKS5 configurations.",
             "steps": [
               "Settings → Network Settings → Manual proxy.",
               "SOCKS Host 127.0.0.1, Port {{port}}, select SOCKS v5.",
               "Check Proxy DNS when using SOCKS v5 (prevents DNS leaks)."
-            ],
-            "note": "Chrome and Edge do not have built-in SOCKS5 UI on Windows. Use Firefox, a browser extension that supports SOCKS5, or route the browser through Proxifier instead."
-          },
-          {
-            "heading": "Web3 wallet",
-            "steps": [
-              "Open your wallet's network / RPC settings.",
-              "Set the RPC URL to http://127.0.0.1:8545."
             ]
           }
         ],
         "linux": [
           {
-            "heading": "System-wide (proxychains)",
-            "intro": "Use proxychains-ng:",
-            "steps": [
-              "In /etc/proxychains.conf, set the last line to socks5 127.0.0.1 {{port}}.",
-              "Launch an app through it: proxychains4 <command>."
-            ]
-          },
-          {
-            "heading": "App (e.g. browser)",
-            "intro": "Any app with SOCKS5 support. Firefox example:",
+            "intro": "On Firefox or browsers that permit SOCKS5 configurations.",
             "steps": [
               "Settings → Network Settings → Manual proxy.",
               "SOCKS Host 127.0.0.1, Port {{port}}, select SOCKS v5.",
               "Check Proxy DNS when using SOCKS v5 (prevents DNS leaks)."
-            ]
-          },
-          {
-            "heading": "Web3 wallet",
-            "steps": [
-              "Open your wallet's network / RPC settings.",
-              "Set the RPC URL to http://127.0.0.1:8545."
             ]
           }
         ]

--- a/nym-vpn-app/src/screens/settings/geo-exclusion/SetupInstructions.tsx
+++ b/nym-vpn-app/src/screens/settings/geo-exclusion/SetupInstructions.tsx
@@ -1,14 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import clsx from 'clsx';
 import { OsType, type } from '@tauri-apps/plugin-os';
-import {
-  ButtonIconNew,
-  CardNew,
-  CardNewBody,
-  CardNewHeader,
-  PageAnim,
-} from '../../../ui';
-import { useClipboard } from '../../../hooks';
+import { CardNew, CardNewBody, PageAnim } from '../../../ui';
 import { useGeoExclusion } from './utils/useGeoExclusion';
 
 const Platforms = [
@@ -49,7 +42,6 @@ function StepList({ steps }: { steps: string[] }) {
 }
 
 function SetupInstructions() {
-  const { copy } = useClipboard();
   const { t } = useTranslation('settings');
   const { listenPort } = useGeoExclusion();
   const os = type();
@@ -89,25 +81,6 @@ function SetupInstructions() {
           )}
         </div>
       ))}
-
-      <CardNew>
-        <CardNewHeader>
-          <div className="flex flex-col">
-            <p className="text-text-secondary text-xs uppercase">
-              {t('geo-exclusion.setup-instructions.proxy-address')}
-            </p>
-            <div className="flex items-center gap-2">
-              <p className="text-text-primary font-mono">{`127.0.0.1:${listenPort}`}</p>
-              <ButtonIconNew
-                icon="content_copy"
-                onClick={() => copy(`127.0.0.1:${listenPort}`)}
-                clickFeedback
-                noDefaultSize
-              />
-            </div>
-          </div>
-        </CardNewHeader>
-      </CardNew>
     </PageAnim>
   );
 }

--- a/nym-vpn-app/src/screens/settings/geo-exclusion/components/Socks5PortCard.tsx
+++ b/nym-vpn-app/src/screens/settings/geo-exclusion/components/Socks5PortCard.tsx
@@ -47,6 +47,23 @@ function Socks5PortCard({ listenPort, onCommitPort }: Socks5PortCardProps) {
       <CardNewHeader>
         <div className="flex w-full items-center justify-between">
           <p className="text-text-secondary select-none">
+            {t('geo-exclusion.port.server')}
+          </p>
+          <div className="flex items-center gap-2">
+            <span className="text-text-primary font-mono">127.0.0.1</span>
+            <ButtonIconNew
+              icon="content_copy"
+              onClick={() => copy('127.0.0.1', false)}
+              clickFeedback
+              size="small"
+            />
+          </div>
+        </div>
+      </CardNewHeader>
+      <CardDivider className="" />
+      <CardNewHeader>
+        <div className="flex w-full items-center justify-between">
+          <p className="text-text-secondary select-none">
             {t('geo-exclusion.port.socks5-port')}
           </p>
           <div className="flex items-center gap-2">


### PR DESCRIPTION
## What changed
The Tauri app (Windows/Linux) counterpart to the native macOS Geo Exclusion changes:

- **Geo Exclusion screen** (`Socks5PortCard.tsx`) — added a copyable "Server" row showing `127.0.0.1`, directly above the existing "SOCKS5 port" row in the same card.
- **Setup Instructions screen** (`SetupInstructions.tsx` + i18n) — trimmed each platform's sections down to a single block: the subheading "On Firefox or browsers that permit SOCKS5 configurations." plus the three App steps. Removed the System-wide and Web3 sections, the App heading/subtitle, and the proxy-address card (and its now-unused imports).

## Scope
`nym-vpn-app` only — this is the UI that ships on **Windows and Linux**. macOS uses the native `nym-vpn-apple` app (changed in a separate PR). `nym-vpn-windows` is driver/firewall code with no UI and needs nothing.

## Strings (`i18n/en/settings.json`)
- New: `geo-exclusion.port.server` ("Server").
- Reworked: `geo-exclusion.setup-instructions.sections.{macos,windows,linux}` collapsed to one section each with the new subheading.
- `geo-exclusion.setup-instructions.proxy-address` is now unused but left in place.
- English source only (other locales are managed in Crowdin); these need re-translation on the next sync.

## Verify
- `ci-nym-vpn-app-js` (lint + tscheck + fmt) is the relevant check.
- Manual: Settings → Geo Exclusion → enable → the Server row copies `127.0.0.1` and the SOCKS5 row copies the port; open Setup instructions and confirm it shows the subheading plus three steps only, with no proxy-address card.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6149)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a copyable local server address to the SOCKS5 configuration.
  * Added a clearer “Server” label for the Geo Exclusion port settings.

* **Improvements**
  * Simplified Geo Exclusion setup instructions across macOS, Windows, and Linux with a consistent Firefox/SOCKS5 configuration flow.
  * Removed outdated platform-specific, system-wide, and wallet setup guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->