### PR TITLE
(android) Fix home screen server score indicator - Develop

### DIFF
--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/MainScreen.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/MainScreen.kt
@@ -65,13 +65,13 @@ import net.nymtech.nymvpn.ui.theme.Theme
 import net.nymtech.nymvpn.util.extensions.convertSecondsToTimeString
 import net.nymtech.nymvpn.util.extensions.goFromRoot
 import net.nymtech.nymvpn.util.extensions.openWebUrl
+import net.nymtech.nymvpn.util.extensions.scoreFor
 import net.nymtech.nymvpn.util.extensions.toConnectMode
 import nym_vpn_lib_types.AccountControllerErrorStateReason
 import nym_vpn_lib_types.AccountControllerState
 import nym_vpn_lib_types.DeeplinkKind
 import nym_vpn_lib_types.EntryPoint
 import nym_vpn_lib_types.ExitPoint
-import nym_vpn_lib_types.Score
 
 @Composable
 fun MainScreen(appViewModel: AppViewModel, appUiState: AppUiState, autoStart: Boolean, authRoute: AuthRoute? = null, loginProcessing: Boolean = false, viewModel: MainViewModel = hiltViewModel()) {
@@ -386,7 +386,7 @@ private fun MainScreenContent(
 			name = appUiState.exitPointName,
 			countryCode = appUiState.exitPointCountry,
 			location = appUiState.exitPointLocation,
-			score = appUiState.exitPointGateway?.wgScore ?: Score.HIGH,
+			score = appUiState.exitPointGateway?.scoreFor(appUiState.vpnConfig.mode),
 			selectionType = when (appUiState.vpnConfig.exitPoint) {
 				is ExitPoint.Random -> NodeSelectionType.RANDOM
 				is ExitPoint.Auto -> NodeSelectionType.AUTO
@@ -403,7 +403,7 @@ private fun MainScreenContent(
 				is EntryPoint.Auto -> NodeSelectionType.AUTO
 				else -> NodeSelectionType.NODE
 			},
-			score = appUiState.entryPointGateway?.wgScore ?: Score.HIGH,
+			score = appUiState.entryPointGateway?.scoreFor(appUiState.vpnConfig.mode),
 		),
 		initialPanelState = initialPanelState,
 		isSubscriptionExpired = appUiState.subscription?.expiryState == ExpiryState.EXPIRED,

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/panel/ConnectPanelModels.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/panel/ConnectPanelModels.kt
@@ -12,7 +12,7 @@ enum class ConnectAction { CONNECT, DISCONNECT, STOP_KILL_SWITCH, GET_STARTED, R
 
 enum class NodeSelectionType { NODE, RANDOM, AUTO }
 
-data class ServerNode(val id: String = "", val name: String?, val countryCode: String?, val location: String?, val score: Score, val selectionType: NodeSelectionType = NodeSelectionType.NODE)
+data class ServerNode(val id: String = "", val name: String?, val countryCode: String?, val location: String?, val score: Score?, val selectionType: NodeSelectionType = NodeSelectionType.NODE)
 
 data class ConnectPanelState(
 	val connectionState: ConnectionState,

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/panel/components/NodeSection.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/panel/components/NodeSection.kt
@@ -8,6 +8,7 @@ import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
@@ -34,7 +35,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import net.nymtech.nymvpn.ui.screens.details.components.CountryFlag
 import net.nymtech.nymvpn.ui.screens.main.panel.ServerNode
-import net.nymtech.nymvpn.ui.theme.LocalNymColors
 import net.nymtech.nymvpn.ui.theme.iconSize
 import net.nymtech.nymvpn.util.extensions.getScoreIcon
 
@@ -113,10 +113,9 @@ private fun ServerRow(node: ServerNode, isClickable: Boolean, onServerClick: () 
 		modifier = modifier.fillMaxWidth(),
 	) {
 		val (icon, description) = getScoreIcon(node.score)
-		Icon(
+		Image(
 			icon,
 			contentDescription = description,
-			tint = LocalNymColors.current.success,
 			modifier = Modifier.size(iconSize).padding(2.dp),
 		)
 

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/util/extensions/UiExtensions.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/util/extensions/UiExtensions.kt
@@ -191,11 +191,13 @@ fun VpnException.toUserMessage(context: Context): String = when (this) {
 	else -> context.getString(R.string.unexpected_error) + " ${this.javaClass.simpleName}"
 }
 
+fun NymGateway.scoreFor(mode: Tunnel.Mode): Score? = when (mode) {
+	Tunnel.Mode.FIVE_HOP_MIXNET -> mixnetScore
+	Tunnel.Mode.TWO_HOP_MIXNET -> wgScore
+}
+
 fun List<NymGateway>.scoreSorted(mode: Tunnel.Mode): List<NymGateway> = this.sortedBy {
-	when (mode) {
-		Tunnel.Mode.FIVE_HOP_MIXNET -> it.mixnetScore ?: Score.OFFLINE
-		Tunnel.Mode.TWO_HOP_MIXNET -> it.wgScore ?: Score.OFFLINE
-	}
+	it.scoreFor(mode) ?: Score.OFFLINE
 }
 
 fun toDisplayCountry(twoLetterIsoCountryCode: String): String = Locale(twoLetterIsoCountryCode, twoLetterIsoCountryCode).displayCountry
@@ -216,17 +218,16 @@ fun NymGateway.getScoreIcon(gatewayType: GatewayType): Pair<ImageVector, String>
 		GatewayType.MIXNET_ENTRY, GatewayType.MIXNET_EXIT -> mixnetScore
 		GatewayType.WG -> wgScore
 	}
-	return score?.let {
-		getScoreIcon(score)
-	} ?: Pair(ImageVector.vectorResource(R.drawable.faq), stringResource(R.string.unknown))
+	return getScoreIcon(score)
 }
 
 @Composable
-fun getScoreIcon(score: Score): Pair<ImageVector, String> = when (score) {
+fun getScoreIcon(score: Score?): Pair<ImageVector, String> = when (score) {
 	Score.HIGH -> Pair(ImageVector.vectorResource(R.drawable.bars_3), stringResource(R.string.bars_3))
 	Score.MEDIUM -> Pair(ImageVector.vectorResource(R.drawable.bars_2), stringResource(R.string.bars_2))
 	Score.LOW -> Pair(ImageVector.vectorResource(R.drawable.bar_1), stringResource(R.string.bars_1))
 	Score.OFFLINE -> Pair(ImageVector.vectorResource(R.drawable.bar_0), stringResource(R.string.unknown))
+	null -> Pair(ImageVector.vectorResource(R.drawable.faq), stringResource(R.string.unknown))
 }
 
 @Composable

--- a/nym-vpn-android/app/src/main/res/values/strings.xml
+++ b/nym-vpn-android/app/src/main/res/values/strings.xml
@@ -204,7 +204,7 @@
 	<string name="connection_state_connecting_mixnet_client">Registering anonymously with servers (6/7)</string>
 	<string name="connection_state_connecting_tunnel">Establishing server connection (7/7)</string>
 	<!-- One-click mode -->
-	<string name="one_click_mode_fast">Fast</string>
+	<string name="one_click_mode_fast">dVPN</string>
 	<string name="connect_mode_mixnet">Mixnet</string>
 	<string name="one_click_nym_exit_node">Exit server</string>
 	<string name="one_click_nym_entry_node">Entry server</string>

--- a/nym-vpn-android/app/src/test/java/net/nymtech/nymvpn/util/extensions/ScoreForModeTest.kt
+++ b/nym-vpn-android/app/src/test/java/net/nymtech/nymvpn/util/extensions/ScoreForModeTest.kt
@@ -1,0 +1,51 @@
+package net.nymtech.nymvpn.util.extensions
+
+import net.nymtech.vpn.backend.Tunnel
+import net.nymtech.vpn.model.NymGateway
+import nym_vpn_lib_types.Score
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ScoreForModeTest {
+
+	private fun gateway(mixnetScore: Score?, wgScore: Score?) = NymGateway(
+		identity = "id",
+		twoLetterCountryISO = "fr",
+		description = null,
+		mixnetScore = mixnetScore,
+		wgScore = wgScore,
+		wgLoad = null,
+		wgUptime = null,
+		lastUpdated = null,
+		name = "gateway",
+		city = null,
+		region = null,
+		asn = null,
+		asnName = null,
+		asnKind = null,
+		buildVersion = null,
+		exitIpv4s = emptyList(),
+		exitIpv6s = emptyList(),
+		bridgeInformation = null,
+	)
+
+	@Test
+	fun fiveHopModeUsesMixnetScore() {
+		val gateway = gateway(mixnetScore = Score.LOW, wgScore = Score.HIGH)
+		assertEquals(Score.LOW, gateway.scoreFor(Tunnel.Mode.FIVE_HOP_MIXNET))
+	}
+
+	@Test
+	fun twoHopModeUsesWgScore() {
+		val gateway = gateway(mixnetScore = Score.HIGH, wgScore = Score.LOW)
+		assertEquals(Score.LOW, gateway.scoreFor(Tunnel.Mode.TWO_HOP_MIXNET))
+	}
+
+	@Test
+	fun missingScoreIsNullNotHigh() {
+		val gateway = gateway(mixnetScore = null, wgScore = null)
+		assertNull(gateway.scoreFor(Tunnel.Mode.FIVE_HOP_MIXNET))
+		assertNull(gateway.scoreFor(Tunnel.Mode.TWO_HOP_MIXNET))
+	}
+}


### PR DESCRIPTION
## Ticket

JIRA-NYM-XXXX

## Description

cherry picks of https://github.com/nymtech/nym-vpn-client/pull/6147


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6154)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Connection and server scores now reflect the selected VPN mode more accurately.
  * Servers without available scores are handled gracefully with an unknown status instead of an inflated default.
  * Updated score icons for clearer status presentation.
* **UI Updates**
  * Renamed the fast one-click mode from “Fast” to “dVPN.”
* **Quality**
  * Added coverage for score selection across supported VPN modes and unavailable-score scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->