### PR TITLE
Login processing bars stay in sequence with setup copy

### DIFF
--- a/nym-vpn-apple/Home/Sources/26/ProcessingAccount/ProcessingAccountView.swift
+++ b/nym-vpn-apple/Home/Sources/26/ProcessingAccount/ProcessingAccountView.swift
@@ -196,7 +196,8 @@ private extension ProcessingAccountView {
             isSyncing: viewModel.phase == .syncing,
             isPrefetching: viewModel.phase == .prefetching,
             holdsPrefetchCopyThroughAdvance: viewModel.phase == .awaitingAdvance
-                && viewModel.hasReachedPrefetchPhase
+                && viewModel.hasReachedPrefetchPhase,
+            didFinishSetupCarousel: viewModel.didFinishSetupCarousel
         )
     }
 

--- a/nym-vpn-apple/Home/Sources/26/ProcessingAccount/ProcessingAccountViewModel.swift
+++ b/nym-vpn-apple/Home/Sources/26/ProcessingAccount/ProcessingAccountViewModel.swift
@@ -75,7 +75,8 @@ public final class ProcessingAccountViewModel {
         guard let keys = LoginProcessingProgressPolicy.credentialsCopyKeys(
             isSyncing: phase == .syncing,
             isPrefetching: phase == .prefetching,
-            holdsPrefetchCopyThroughAdvance: holdsPrefetchCopyThroughAdvance
+            holdsPrefetchCopyThroughAdvance: holdsPrefetchCopyThroughAdvance,
+            didFinishSetupCarousel: didFinishSetupCarousel
         ) else { return nil }
         return (keys.title.localizedString, keys.subtitle.localizedString)
     }
@@ -100,7 +101,6 @@ public final class ProcessingAccountViewModel {
     func start() {
         switch phase {
         case .awaitingAdvance:
-            latchSetupCarouselIfNeeded()
             updateAnimationReady()
             evaluateAdvance()
             return
@@ -259,15 +259,8 @@ public final class ProcessingAccountViewModel {
         }
         phase = .awaitingAdvance
         syncProgressStep()
-        latchSetupCarouselIfNeeded()
         workCompleted = true
         updateAnimationReady()
-    }
-
-    private func latchSetupCarouselIfNeeded() {
-        guard !usesStaticCopy, !didFinishSetupCarousel else { return }
-        didFinishSetupCarousel = true
-        syncProgressStep()
     }
 
     private func updateAnimationReady() {

--- a/nym-vpn-apple/Home/Tests/HomeTests/ProcessingAccountTitleBlockTests.swift
+++ b/nym-vpn-apple/Home/Tests/HomeTests/ProcessingAccountTitleBlockTests.swift
@@ -3,20 +3,21 @@ import AccountPrefetchGates
 @testable import Home
 
 struct ProcessingAccountTitleBlockTests {
-    @Test func titleBlockMode_prefetchBeforeSetupComplete_showsCredentials() {
+    @Test func titleBlockMode_prefetchBeforeSetupComplete_keepsSetupCarousel() {
         let showsCredentials = LoginProcessingCarouselVisibilityPolicy.showsCredentialsCopy(
             usesStaticCopy: false,
             didShowFinalMessage: false,
             isSyncing: false,
-            isPrefetching: true
+            isPrefetching: true,
+            didFinishSetupCarousel: false
         )
-        #expect(showsCredentials)
+        #expect(!showsCredentials)
         #expect(
             ProcessingAccountView.titleBlockMode(
                 usesStaticCopy: false,
                 didShowFinalMessage: false,
                 showsCredentialsCarousel: showsCredentials
-            ) == .credentials
+            ) == .setupCarousel
         )
     }
 
@@ -25,7 +26,8 @@ struct ProcessingAccountTitleBlockTests {
             usesStaticCopy: false,
             didShowFinalMessage: false,
             isSyncing: true,
-            isPrefetching: false
+            isPrefetching: false,
+            didFinishSetupCarousel: true
         )
         #expect(showsCredentials)
         #expect(

--- a/nym-vpn-apple/Home/Tests/HomeTests/ProcessingAccountViewModelTests.swift
+++ b/nym-vpn-apple/Home/Tests/HomeTests/ProcessingAccountViewModelTests.swift
@@ -128,6 +128,12 @@ private func makeViewModel(
 }
 
 @MainActor
+private func finishSetupCarousel(_ viewModel: ProcessingAccountViewModel) async {
+    viewModel.animationDidFinish()
+    await viewModel.awaitFinalMessage()
+}
+
+@MainActor
 struct ProcessingAccountViewModelTests {
     @Test func loginRunsImportPrepSyncPrefetchThenAdvances() async {
         let processing = FakeProcessing()
@@ -137,7 +143,7 @@ struct ProcessingAccountViewModelTests {
         await viewModel.run()
 
         #expect(processing.calls == [.ensure, .ensureDeviceRegistered, .prepare, .sync, .isActive, .prefetch])
-        await viewModel.awaitFinalMessage()
+        await finishSetupCarousel(viewModel)
         #expect(viewModel.phase == .finished)
         #expect(coordinator.actions == [.session(.processingFinished)])
     }
@@ -164,8 +170,8 @@ struct ProcessingAccountViewModelTests {
             .isActive,
             .prefetch
         ])
-        #expect(viewModel.phase == .finished || viewModel.phase == .finalizing)
-        await viewModel.awaitFinalMessage()
+        #expect(viewModel.phase == .awaitingAdvance)
+        await finishSetupCarousel(viewModel)
         #expect(viewModel.phase == .finished)
         #expect(coordinator.actions == [.session(.processingFinished)])
     }
@@ -203,7 +209,7 @@ struct ProcessingAccountViewModelTests {
         await viewModel.run()
 
         #expect(processing.calls == [.ensure, .sync, .isActive, .prefetch])
-        await viewModel.awaitFinalMessage()
+        await finishSetupCarousel(viewModel)
         #expect(viewModel.phase == .finished)
     }
 
@@ -228,7 +234,7 @@ struct ProcessingAccountViewModelTests {
 
         #expect(processing.calls == [.ensure, .sync, .isActive])
         #expect(!processing.calls.contains(.prefetch))
-        await viewModel.awaitFinalMessage()
+        await finishSetupCarousel(viewModel)
         #expect(viewModel.phase == .finished)
     }
 
@@ -252,48 +258,47 @@ struct ProcessingAccountViewModelTests {
         }
     }
 
-    @Test func advanceWhenWorkCompletesWithoutWaitingForCarousel() async {
+    @Test func workCompleteBeforeCarousel_holdsFirstSegmentUntilSetupTicks() async {
         let processing = FakeProcessing()
         let coordinator = FakeCoordinator()
         let viewModel = makeViewModel(flow: .createAccount, processing: processing, coordinator: coordinator)
 
         await viewModel.run()
 
-        #expect(viewModel.didFinishSetupCarousel)
-        #expect(viewModel.didFinishAnimatingText)
-        #expect(viewModel.currentStep == 4)
-
-        await viewModel.awaitFinalMessage()
-        #expect(viewModel.phase == .finished)
-        #expect(coordinator.actions == [.session(.processingFinished)])
+        #expect(!viewModel.didFinishSetupCarousel)
+        #expect(!viewModel.didFinishAnimatingText)
+        #expect(viewModel.currentStep == LoginProcessingUI.initialProgressStep)
+        #expect(coordinator.actions.isEmpty)
+        #expect(viewModel.credentialsDisplayPair == nil)
     }
 
-    @Test func inactiveAccountAdvancesToStepFourWithoutPrefetch() async {
+    @Test func inactiveAccountHoldsSetupBarsUntilCarouselFinishes() async {
         let processing = FakeProcessing()
         processing.accountActive = false
         let coordinator = FakeCoordinator()
         let viewModel = makeViewModel(flow: .createAccount, processing: processing, coordinator: coordinator)
 
         await viewModel.run()
-        #expect(viewModel.currentStep == 4)
+        #expect(viewModel.currentStep == LoginProcessingUI.initialProgressStep)
         #expect(viewModel.credentialsDisplayPair == nil)
-        #expect(viewModel.didFinishSetupCarousel)
+        #expect(!viewModel.didFinishSetupCarousel)
 
-        await viewModel.awaitFinalMessage()
+        await finishSetupCarousel(viewModel)
+        #expect(viewModel.currentStep == 4)
         #expect(viewModel.phase == .finished)
     }
 
-    @Test func navigationAdvancesWhenWorkCompletesBeforeCarousel() async {
+    @Test func navigationWaitsForCarouselAfterWorkCompletes() async {
         let processing = FakeProcessing()
         let coordinator = FakeCoordinator()
         let viewModel = makeViewModel(flow: .createAccount, processing: processing, coordinator: coordinator)
 
         await viewModel.run()
+        #expect(coordinator.actions.isEmpty)
 
+        await finishSetupCarousel(viewModel)
         #expect(viewModel.didFinishSetupCarousel)
         #expect(viewModel.didFinishAnimatingText)
-
-        await viewModel.awaitFinalMessage()
         #expect(viewModel.phase == .finished)
         #expect(coordinator.actions == [.session(.processingFinished)])
     }
@@ -432,7 +437,7 @@ struct ProcessingAccountViewModelTests {
         #expect(deviceIndex < prepareIndex)
     }
 
-    @Test func prefetchCompletingBeforeCarouselDoesNotRegressProgressBar() async {
+    @Test func prefetchCompletingBeforeCarousel_sequencesBarsThenHoldsFourth() async {
         let processing = FakeProcessing()
         processing.prefetchDelay = .zero
         let coordinator = FakeCoordinator()
@@ -441,13 +446,21 @@ struct ProcessingAccountViewModelTests {
         await viewModel.run()
 
         #expect(viewModel.hasReachedPrefetchPhase)
+        #expect(viewModel.currentStep == LoginProcessingUI.initialProgressStep)
+        #expect(!viewModel.didFinishSetupCarousel)
+        #expect(viewModel.credentialsDisplayPair == nil)
+
+        viewModel.noteSetupCarouselStepBarTick(atIndex: 1)
+        #expect(viewModel.currentStep == 2)
+
+        viewModel.noteSetupCarouselStepBarTick(atIndex: 2)
+        #expect(viewModel.currentStep == 3)
+
+        viewModel.animationDidFinish()
         #expect(viewModel.currentStep == 4)
         #expect(viewModel.didFinishSetupCarousel)
 
         viewModel.noteSetupCarouselStepBarTick(atIndex: 0)
-        #expect(viewModel.currentStep == 4)
-
-        viewModel.noteSetupCarouselStepBarTick(atIndex: 1)
         #expect(viewModel.currentStep == 4)
 
         await viewModel.awaitFinalMessage()
@@ -482,18 +495,18 @@ struct ProcessingAccountViewModelTests {
 
         #expect(viewModel.phase == .prefetching)
         #expect(viewModel.hasReachedPrefetchPhase)
-        #expect(viewModel.currentStep == 4)
+        #expect(viewModel.currentStep == LoginProcessingUI.initialProgressStep)
         #expect(viewModel.setupCarouselIndex == 0)
         #expect(!viewModel.didFinishSetupCarousel)
-        #expect(viewModel.credentialsDisplayPair != nil)
+        #expect(viewModel.credentialsDisplayPair == nil)
 
         processing.releasePrepare()
         await runTask.value
-        await viewModel.awaitFinalMessage()
+        await finishSetupCarousel(viewModel)
         #expect(viewModel.phase == .finished)
     }
 
-    @Test func syncSummaryRefresh_keepsPrefetchPhaseWhenLatchSet() async {
+    @Test func syncSummaryRefresh_keepsPrefetchPhaseAfterSetupFinishes() async {
         let processing = FakeProcessing()
         processing.preparePhaseScript = [.requestingZkNyms]
         let coordinator = FakeCoordinator()
@@ -502,6 +515,8 @@ struct ProcessingAccountViewModelTests {
         await viewModel.run()
 
         #expect(viewModel.hasReachedPrefetchPhase)
+        #expect(viewModel.currentStep == LoginProcessingUI.initialProgressStep)
+        viewModel.animationDidFinish()
         #expect(viewModel.currentStep == 4)
     }
 }

--- a/nym-vpn-apple/Services/Sources/AccountPrefetchGates/ProcessingUIPolicy.swift
+++ b/nym-vpn-apple/Services/Sources/AccountPrefetchGates/ProcessingUIPolicy.swift
@@ -116,8 +116,10 @@ public enum LoginProcessingProgressPolicy: Sendable {
     public static func credentialsCopyKeys(
         isSyncing: Bool,
         isPrefetching: Bool,
-        holdsPrefetchCopyThroughAdvance: Bool = false
+        holdsPrefetchCopyThroughAdvance: Bool = false,
+        didFinishSetupCarousel: Bool = false
     ) -> (title: String, subtitle: String)? {
+        guard didFinishSetupCarousel else { return nil }
         if isPrefetching || holdsPrefetchCopyThroughAdvance {
             return (
                 LoginProcessingUI.almostReadyTitleKey,
@@ -138,7 +140,8 @@ public enum LoginProcessingProgressPolicy: Sendable {
         isAwaitingAdvance: Bool,
         hasReachedPrefetchPhase: Bool = false
     ) -> Int {
-        if isPrefetching || isAwaitingAdvance || hasReachedPrefetchPhase {
+        // Lockstep: bars 1-3 follow setup copy. Prefetch must not skip to 4 mid-carousel.
+        if didFinishSetupCarousel && (isPrefetching || isAwaitingAdvance || hasReachedPrefetchPhase) {
             return LoginProcessingUI.progressStep
         }
         if didFinishSetupCarousel {
@@ -154,9 +157,10 @@ public enum LoginProcessingCarouselVisibilityPolicy: Sendable {
         didShowFinalMessage: Bool,
         isSyncing: Bool,
         isPrefetching: Bool,
-        holdsPrefetchCopyThroughAdvance: Bool = false
+        holdsPrefetchCopyThroughAdvance: Bool = false,
+        didFinishSetupCarousel: Bool = false
     ) -> Bool {
-        guard !usesStaticCopy, !didShowFinalMessage else { return false }
+        guard !usesStaticCopy, !didShowFinalMessage, didFinishSetupCarousel else { return false }
         return isSyncing || isPrefetching || holdsPrefetchCopyThroughAdvance
     }
 }

--- a/nym-vpn-apple/Services/Tests/CredentialsManagerTests/LoginProcessingPolicyTests.swift
+++ b/nym-vpn-apple/Services/Tests/CredentialsManagerTests/LoginProcessingPolicyTests.swift
@@ -69,22 +69,34 @@ struct LoginProcessingPolicyTests {
     @Test func credentialsCopyKeys_syncingAndPrefetch() {
         #expect(LoginProcessingProgressPolicy.credentialsCopyKeys(isSyncing: false, isPrefetching: false) == nil)
 
-        let syncing = LoginProcessingProgressPolicy.credentialsCopyKeys(isSyncing: true, isPrefetching: false)
+        let syncing = LoginProcessingProgressPolicy.credentialsCopyKeys(
+            isSyncing: true,
+            isPrefetching: false,
+            didFinishSetupCarousel: true
+        )
         #expect(syncing?.title == LoginProcessingUI.loadingCredentialsTitleKey)
         #expect(syncing?.subtitle == LoginProcessingUI.loadingCredentialsSubtitleKey)
 
-        let prefetching = LoginProcessingProgressPolicy.credentialsCopyKeys(isSyncing: false, isPrefetching: true)
+        let prefetching = LoginProcessingProgressPolicy.credentialsCopyKeys(
+            isSyncing: false,
+            isPrefetching: true,
+            didFinishSetupCarousel: true
+        )
         #expect(prefetching?.title == LoginProcessingUI.almostReadyTitleKey)
         #expect(prefetching?.subtitle == LoginProcessingUI.almostReadySubtitleKey)
 
         #expect(
-            LoginProcessingProgressPolicy.credentialsCopyKeys(isSyncing: true, isPrefetching: true)?.title
-                == LoginProcessingUI.almostReadyTitleKey
+            LoginProcessingProgressPolicy.credentialsCopyKeys(
+                isSyncing: true,
+                isPrefetching: true,
+                didFinishSetupCarousel: true
+            )?.title == LoginProcessingUI.almostReadyTitleKey
         )
         let awaitingAfterPrefetch = LoginProcessingProgressPolicy.credentialsCopyKeys(
             isSyncing: false,
             isPrefetching: false,
-            holdsPrefetchCopyThroughAdvance: true
+            holdsPrefetchCopyThroughAdvance: true,
+            didFinishSetupCarousel: true
         )
         #expect(awaitingAfterPrefetch?.title == LoginProcessingUI.almostReadyTitleKey)
     }
@@ -145,24 +157,81 @@ struct LoginProcessingPolicyTests {
         )
     }
 
-    @Test func progressStep_latchAfterPrefetchPreventsRegressionDuringCarousel() {
+    @Test func progressStep_prefetchDuringSetup_staysOnCarouselSegment() {
         #expect(
             LoginProcessingProgressPolicy.progressStep(
                 setupCarouselIndex: 0,
                 didFinishSetupCarousel: false,
-                isPrefetching: false,
+                isPrefetching: true,
                 isAwaitingAdvance: false,
                 hasReachedPrefetchPhase: true
-            ) == 4
+            ) == 1
         )
         #expect(
             LoginProcessingProgressPolicy.progressStep(
                 setupCarouselIndex: 1,
                 didFinishSetupCarousel: false,
-                isPrefetching: false,
+                isPrefetching: true,
+                isAwaitingAdvance: false,
+                hasReachedPrefetchPhase: true
+            ) == 2
+        )
+        #expect(
+            LoginProcessingProgressPolicy.progressStep(
+                setupCarouselIndex: 2,
+                didFinishSetupCarousel: false,
+                isPrefetching: true,
+                isAwaitingAdvance: false,
+                hasReachedPrefetchPhase: true
+            ) == 3
+        )
+    }
+
+    @Test func progressStep_fourthSegmentOnlyAfterSetupFinishes() {
+        #expect(
+            LoginProcessingProgressPolicy.progressStep(
+                setupCarouselIndex: 0,
+                didFinishSetupCarousel: true,
+                isPrefetching: true,
                 isAwaitingAdvance: false,
                 hasReachedPrefetchPhase: true
             ) == 4
+        )
+    }
+
+    @Test func credentialsCopy_hiddenUntilSetupCarouselFinishes() {
+        #expect(
+            LoginProcessingProgressPolicy.credentialsCopyKeys(
+                isSyncing: true,
+                isPrefetching: true,
+                didFinishSetupCarousel: false
+            ) == nil
+        )
+        #expect(
+            !LoginProcessingCarouselVisibilityPolicy.showsCredentialsCopy(
+                usesStaticCopy: false,
+                didShowFinalMessage: false,
+                isSyncing: true,
+                isPrefetching: true,
+                didFinishSetupCarousel: false
+            )
+        )
+    }
+
+    @Test func credentialsCopy_defaultHidesUntilSetupFinishes() {
+        #expect(
+            LoginProcessingProgressPolicy.credentialsCopyKeys(
+                isSyncing: true,
+                isPrefetching: true
+            ) == nil
+        )
+        #expect(
+            !LoginProcessingCarouselVisibilityPolicy.showsCredentialsCopy(
+                usesStaticCopy: false,
+                didShowFinalMessage: false,
+                isSyncing: true,
+                isPrefetching: true
+            )
         )
     }
 
@@ -189,7 +258,8 @@ struct LoginProcessingPolicyTests {
                 usesStaticCopy: false,
                 didShowFinalMessage: false,
                 isSyncing: true,
-                isPrefetching: false
+                isPrefetching: false,
+                didFinishSetupCarousel: true
             )
         )
         #expect(
@@ -197,7 +267,8 @@ struct LoginProcessingPolicyTests {
                 usesStaticCopy: false,
                 didShowFinalMessage: false,
                 isSyncing: false,
-                isPrefetching: true
+                isPrefetching: true,
+                didFinishSetupCarousel: true
             )
         )
         #expect(


### PR DESCRIPTION
- Login setup copy and the four step bars stay on the same beat instead of jumping to the last bar when account prefetch finishes early.
- Credentials copy and the fourth bar wait until the setup carousel finishes, then hold through leftover prefetch.
- Unit tests cover prefetch-during-setup, bar order 1-2-3-4, and no step-down after the fourth bar.

## Ticket

JIRA-NYM-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6156)
<!-- Reviewable:end -->
