### PR TITLE
Cherry-pick geo exclusion UI updates into release

### DIFF
--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/geoexclusion/GeoExclusionScreen.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/geoexclusion/GeoExclusionScreen.kt
@@ -51,6 +51,7 @@ import net.nymtech.nymvpn.util.extensions.scaledHeight
 import net.nymtech.nymvpn.util.extensions.scaledWidth
 
 private const val DEFAULT_PORT = "1081"
+private const val LOOPBACK_ADDRESS = "127.0.0.1"
 private const val PORT_MIN = 1024
 private const val PORT_MAX = 65535
 private const val FORBIDDEN_PORT = 1080
@@ -60,6 +61,11 @@ fun GeoExclusionScreen(appUiState: AppUiState, viewModel: GeoExclusionViewModel 
 	val navController = LocalNavController.current
 	val clipboard = LocalClipboard.current
 	val scope = rememberCoroutineScope()
+	fun copyToClipboard(text: String) {
+		scope.launch {
+			clipboard.setClipEntry(ClipData.newPlainText(text, text).toClipEntry())
+		}
+	}
 	val failedToStart by viewModel.failedToStart.collectAsStateWithLifecycle()
 	val initialPort = remember(appUiState.vpnConfig.geoExclusionPort) {
 		appUiState.vpnConfig.geoExclusionPort.toString()
@@ -96,12 +102,8 @@ fun GeoExclusionScreen(appUiState: AppUiState, viewModel: GeoExclusionViewModel 
 				}
 			}
 		},
-		onCopyAddress = {
-			val address = "127.0.0.1:$lastValidPort"
-			scope.launch {
-				clipboard.setClipEntry(ClipData.newPlainText(address, address).toClipEntry())
-			}
-		},
+		onCopyAddress = { copyToClipboard("$LOOPBACK_ADDRESS:$lastValidPort") },
+		onCopyServer = { copyToClipboard(LOOPBACK_ADDRESS) },
 		onSetupClick = {
 			navController.navigate(Route.Setup)
 		},
@@ -119,6 +121,7 @@ fun GeoExclusionScreen(
 	onPortChange: (String) -> Unit,
 	onPortCommit: () -> Unit,
 	onCopyAddress: () -> Unit,
+	onCopyServer: () -> Unit = {},
 	onSetupClick: () -> Unit,
 ) {
 	Column(
@@ -155,6 +158,7 @@ fun GeoExclusionScreen(
 			WarningCard(stringResource(R.string.geo_exclusion_traffic_bypass_text))
 
 			Socks5AddressCard(
+				onCopyServer = onCopyServer,
 				proxyAddress = proxyAddress,
 				onCopy = onCopyAddress,
 				portInput = portInput,
@@ -221,7 +225,7 @@ internal fun PreviewGeoExclusionScreenOff() {
 			failedToStart = false,
 			portInput = DEFAULT_PORT,
 			portError = null,
-			proxyAddress = "127.0.0.1:$DEFAULT_PORT",
+			proxyAddress = "$LOOPBACK_ADDRESS:$DEFAULT_PORT",
 			onGeoExclusionEnable = {},
 			onPortChange = {},
 			onPortCommit = {},

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/geoexclusion/components/Socks5AddressCard.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/geoexclusion/components/Socks5AddressCard.kt
@@ -31,8 +31,10 @@ import androidx.compose.ui.unit.dp
 import net.nymtech.nymvpn.R
 import net.nymtech.nymvpn.ui.common.textbox.CustomTextField
 
+private const val LOOPBACK_ADDRESS = "127.0.0.1"
+
 @Composable
-fun Socks5AddressCard(proxyAddress: String, onCopy: () -> Unit, portInput: String, @StringRes portError: Int?, onPortChange: (String) -> Unit, onPortCommit: () -> Unit) {
+fun Socks5AddressCard(onCopyServer: () -> Unit, proxyAddress: String, onCopy: () -> Unit, portInput: String, @StringRes portError: Int?, onPortChange: (String) -> Unit, onPortCommit: () -> Unit) {
 	Card(
 		shape = RoundedCornerShape(14.dp),
 		colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
@@ -40,34 +42,17 @@ fun Socks5AddressCard(proxyAddress: String, onCopy: () -> Unit, portInput: Strin
 			.fillMaxWidth()
 			.wrapContentHeight(),
 	) {
-		Column(modifier = Modifier.padding(16.dp)) {
-			Row(
-				modifier = Modifier.fillMaxWidth(),
-				verticalAlignment = Alignment.CenterVertically,
-			) {
-				Text(
-					text = stringResource(R.string.geo_exclusion_sock55_title),
-					style = MaterialTheme.typography.bodyMedium,
-					color = MaterialTheme.colorScheme.onBackground,
-					modifier = Modifier.weight(1f),
-				)
-				Text(
-					text = proxyAddress,
-					style = MaterialTheme.typography.bodyLarge,
-					color = MaterialTheme.colorScheme.onBackground,
-					modifier = Modifier.clickable { onCopy() },
-				)
-				Spacer(Modifier.width(8.dp))
-				Icon(
-					imageVector = Icons.Outlined.ContentCopy,
-					contentDescription = stringResource(R.string.geo_exclusion_copy_proxy_label),
-					modifier = Modifier
-						.size(16.dp)
-						.clickable { onCopy() },
-					tint = MaterialTheme.colorScheme.onBackground,
-				)
-			}
-		}
+		AddressRow(
+			label = stringResource(R.string.geo_exclusion_server_title),
+			value = LOOPBACK_ADDRESS,
+			onCopy = onCopyServer,
+		)
+		HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant, thickness = 1.dp)
+		AddressRow(
+			label = stringResource(R.string.geo_exclusion_sock55_title),
+			value = proxyAddress,
+			onCopy = onCopy,
+		)
 		HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant, thickness = 1.dp)
 		Column(modifier = Modifier.padding(16.dp)) {
 			Text(
@@ -97,6 +82,38 @@ fun Socks5AddressCard(proxyAddress: String, onCopy: () -> Unit, portInput: Strin
 				style = MaterialTheme.typography.bodySmall,
 				color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f),
 				modifier = Modifier.padding(top = 6.dp),
+			)
+		}
+	}
+}
+
+@Composable
+private fun AddressRow(label: String, value: String, onCopy: () -> Unit) {
+	Column(modifier = Modifier.padding(16.dp)) {
+		Row(
+			modifier = Modifier.fillMaxWidth(),
+			verticalAlignment = Alignment.CenterVertically,
+		) {
+			Text(
+				text = label,
+				style = MaterialTheme.typography.bodyMedium,
+				color = MaterialTheme.colorScheme.onBackground,
+				modifier = Modifier.weight(1f),
+			)
+			Text(
+				text = value,
+				style = MaterialTheme.typography.bodyLarge,
+				color = MaterialTheme.colorScheme.onBackground,
+				modifier = Modifier.clickable { onCopy() },
+			)
+			Spacer(Modifier.width(8.dp))
+			Icon(
+				imageVector = Icons.Outlined.ContentCopy,
+				contentDescription = stringResource(R.string.geo_exclusion_copy_proxy_label),
+				modifier = Modifier
+					.size(16.dp)
+					.clickable { onCopy() },
+				tint = MaterialTheme.colorScheme.onBackground,
 			)
 		}
 	}

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/geoexclusion/setup/SetupScreen.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/geoexclusion/setup/SetupScreen.kt
@@ -1,6 +1,5 @@
 package net.nymtech.nymvpn.ui.screens.settings.geoexclusion.setup
 
-import android.content.ClipData
 import android.content.res.Configuration
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -12,11 +11,8 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalClipboard
-import androidx.compose.ui.platform.toClipEntry
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
@@ -24,12 +20,9 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import kotlinx.coroutines.launch
 import net.nymtech.nymvpn.R
 import net.nymtech.nymvpn.ui.AppUiState
-import net.nymtech.nymvpn.ui.screens.settings.geoexclusion.setup.components.CopyCard
-import net.nymtech.nymvpn.ui.screens.settings.geoexclusion.setup.components.StepCard
-import net.nymtech.nymvpn.ui.theme.CustomTypography
+import net.nymtech.nymvpn.ui.screens.settings.geoexclusion.setup.components.StepsCard
 import net.nymtech.nymvpn.ui.theme.NymVPNTheme
 import net.nymtech.nymvpn.ui.theme.Theme
 import net.nymtech.nymvpn.util.extensions.scaledHeight
@@ -37,22 +30,25 @@ import net.nymtech.nymvpn.util.extensions.scaledWidth
 
 @Composable
 fun SetupScreen(appUiState: AppUiState) {
-	val clipboard = LocalClipboard.current
-	val scope = rememberCoroutineScope()
-	val proxyAddress = "127.0.0.1:${appUiState.vpnConfig.geoExclusionPort}"
-
-	SetupScreen(
-		proxyAddress = proxyAddress,
-		onCopyAddress = {
-			scope.launch {
-				clipboard.setClipEntry(ClipData.newPlainText(proxyAddress, proxyAddress).toClipEntry())
-			}
-		},
-	)
+	SetupScreen(proxyAddress = "127.0.0.1:${appUiState.vpnConfig.geoExclusionPort}")
 }
 
 @Composable
-fun SetupScreen(proxyAddress: String, onCopyAddress: () -> Unit) {
+fun SetupScreen(proxyAddress: String) {
+	val port = proxyAddress.substringAfterLast(":")
+	val socksStep = buildAnnotatedString {
+		append(stringResource(R.string.setup_instructions_step_socks_host))
+		append(" ")
+		withStyle(SpanStyle(color = MaterialTheme.colorScheme.primary)) {
+			append("127.0.0.1")
+		}
+		append(stringResource(R.string.setup_instructions_step_socks_port))
+		append(" ")
+		withStyle(SpanStyle(color = MaterialTheme.colorScheme.primary)) {
+			append(port)
+		}
+		append(stringResource(R.string.setup_instructions_step_socks_suffix))
+	}
 	Column(
 		horizontalAlignment = Alignment.Start,
 		modifier = Modifier
@@ -67,79 +63,13 @@ fun SetupScreen(proxyAddress: String, onCopyAddress: () -> Unit) {
 			color = MaterialTheme.colorScheme.onBackground,
 			modifier = Modifier.fillMaxWidth(),
 		)
-		Text(
-			text = stringResource(R.string.setup_instructions_per_app_title),
-			style = CustomTypography.titleMediumBold,
-			color = MaterialTheme.colorScheme.onPrimaryContainer,
-			modifier = Modifier
-				.fillMaxWidth()
-				.padding(top = 18.dp),
-		)
-		Text(
-			text = stringResource(R.string.setup_instructions_per_app_description),
-			style = MaterialTheme.typography.bodyMedium,
-			color = MaterialTheme.colorScheme.onBackground,
-			modifier = Modifier
-				.fillMaxWidth()
-				.padding(top = 8.dp),
-		)
-		StepCard(1, AnnotatedString(stringResource(R.string.setup_instructions_pert_app_step)), modifier = Modifier.padding(top = 8.dp))
-
-		Text(
-			text = stringResource(R.string.setup_instructions_browser_title),
-			style = CustomTypography.titleMediumBold,
-			color = MaterialTheme.colorScheme.onPrimaryContainer,
-			modifier = Modifier
-				.fillMaxWidth()
-				.padding(top = 18.dp),
-		)
-		Text(
-			text = stringResource(R.string.setup_instructions_browser_description),
-			style = MaterialTheme.typography.bodyMedium,
-			color = MaterialTheme.colorScheme.onBackground,
-			modifier = Modifier
-				.fillMaxWidth()
-				.padding(top = 8.dp),
-		)
-		val port = proxyAddress.substringAfterLast(":")
-		val browserStepText = buildAnnotatedString {
-			append(stringResource(R.string.setup_instructions_browser_step_1))
-			append(" ")
-			withStyle(SpanStyle(color = MaterialTheme.colorScheme.primary)) {
-				append(stringResource(R.string.setup_instructions_browser_step_2))
-			}
-			append(stringResource(R.string.setup_instructions_browser_step_3))
-			append(" ")
-			withStyle(SpanStyle(color = MaterialTheme.colorScheme.primary)) {
-				append(port)
-			}
-			append(stringResource(R.string.setup_instructions_browser_step_5))
-		}
-		StepCard(1, browserStepText, modifier = Modifier.padding(top = 8.dp))
-
-		Text(
-			text = stringResource(R.string.setup_instructions_wallet_title),
-			style = CustomTypography.titleMediumBold,
-			color = MaterialTheme.colorScheme.onPrimaryContainer,
-			modifier = Modifier
-				.fillMaxWidth()
-				.padding(top = 18.dp),
-		)
-		val walletStepText = buildAnnotatedString {
-			append(stringResource(R.string.setup_instructions_wallet_step_1))
-			append("\n")
-			withStyle(SpanStyle(color = MaterialTheme.colorScheme.primary)) {
-				append(stringResource(R.string.setup_instructions_wallet_step_2))
-			}
-			append(".")
-		}
-		StepCard(1, walletStepText, modifier = Modifier.padding(top = 8.dp))
-
-		CopyCard(
-			title = stringResource(R.string.setup_instructions_proxy_title),
-			value = proxyAddress,
-			onClick = onCopyAddress,
-			modifier = Modifier.padding(top = 8.dp),
+		StepsCard(
+			steps = listOf(
+				AnnotatedString(stringResource(R.string.setup_instructions_step_manual)),
+				socksStep,
+				AnnotatedString(stringResource(R.string.setup_instructions_step_dns)),
+			),
+			modifier = Modifier.padding(top = 12.dp),
 		)
 	}
 }
@@ -148,9 +78,6 @@ fun SetupScreen(proxyAddress: String, onCopyAddress: () -> Unit) {
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 internal fun PreviewSetupScreen() {
 	NymVPNTheme(Theme.default()) {
-		SetupScreen(
-			proxyAddress = "127.0.0.1:1081",
-			onCopyAddress = {},
-		)
+		SetupScreen(proxyAddress = "127.0.0.1:1081")
 	}
 }

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/geoexclusion/setup/components/StepsCard.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/geoexclusion/setup/components/StepsCard.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -21,7 +22,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun StepCard(step: Int, text: AnnotatedString, modifier: Modifier = Modifier) {
+fun StepsCard(steps: List<AnnotatedString>, modifier: Modifier = Modifier) {
 	Card(
 		modifier = modifier
 			.fillMaxWidth()
@@ -29,38 +30,43 @@ fun StepCard(step: Int, text: AnnotatedString, modifier: Modifier = Modifier) {
 		shape = RoundedCornerShape(14.dp),
 		colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
 	) {
-		Row(
-			modifier = Modifier
-				.fillMaxWidth()
-				.padding(16.dp),
-			verticalAlignment = Alignment.CenterVertically,
-		) {
-			Card(
-				modifier = Modifier.size(40.dp),
-				shape = CircleShape,
-				colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.1f)),
-				border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary),
-			) {
-				Row(
-					modifier = Modifier.fillMaxSize(),
-					verticalAlignment = Alignment.CenterVertically,
-					horizontalArrangement = Arrangement.Center,
-				) {
-					Text(
-						text = step.toString(),
-						color = MaterialTheme.colorScheme.primary,
-						style = MaterialTheme.typography.labelLarge,
-					)
-				}
+		steps.forEachIndexed { index, step ->
+			if (index > 0) {
+				HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant, thickness = 1.dp)
 			}
-			Text(
-				text = text,
+			Row(
 				modifier = Modifier
-					.weight(1f)
-					.padding(start = 16.dp),
-				color = MaterialTheme.colorScheme.onPrimaryContainer,
-				style = MaterialTheme.typography.bodyMedium,
-			)
+					.fillMaxWidth()
+					.padding(16.dp),
+				verticalAlignment = Alignment.CenterVertically,
+			) {
+				Card(
+					modifier = Modifier.size(40.dp),
+					shape = CircleShape,
+					colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.1f)),
+					border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary),
+				) {
+					Row(
+						modifier = Modifier.fillMaxSize(),
+						verticalAlignment = Alignment.CenterVertically,
+						horizontalArrangement = Arrangement.Center,
+					) {
+						Text(
+							text = (index + 1).toString(),
+							color = MaterialTheme.colorScheme.primary,
+							style = MaterialTheme.typography.labelLarge,
+						)
+					}
+				}
+				Text(
+					text = step,
+					modifier = Modifier
+						.weight(1f)
+						.padding(start = 16.dp),
+					color = MaterialTheme.colorScheme.onPrimaryContainer,
+					style = MaterialTheme.typography.bodyMedium,
+				)
+			}
 		}
 	}
 }

--- a/nym-vpn-android/app/src/main/res/values/strings.xml
+++ b/nym-vpn-android/app/src/main/res/values/strings.xml
@@ -622,6 +622,7 @@
 	<string name="geo_exclusion_description">Routes traffic for selected regions outside the VPN tunnel, so domestic apps work at full speed. Everything else stays protected.</string>
 	<string name="geo_exclusion_beta_text">Beta version:  China only for now. More regions coming.</string>
 	<string name="geo_exclusion_traffic_bypass_text">Traffic to excluded regions bypasses the VPN.</string>
+	<string name="geo_exclusion_server_title">Server</string>
 	<string name="geo_exclusion_sock55_title">SOCKS5 port</string>
 	<string name="geo_exclusion_custom_port_title">Custom port</string>
 	<string name="geo_exclusion_ports_text">1024–65535</string>
@@ -639,7 +640,12 @@
 	<string name="geo_exclusion_copy_proxy_label">Copy proxy address</string>
 	<!-- Setup instructions screen -->
 	<string name="setup_instructions_title">Setup instructions</string>
-	<string name="setup_instructions_description">Configure apps and browsers to route traffic through the Nym SOCKS5 proxy.</string>
+	<string name="setup_instructions_step_manual">Settings → Network Settings → Manual proxy.</string>
+	<string name="setup_instructions_step_socks_host">SOCKS Host</string>
+	<string name="setup_instructions_step_socks_port">, Port</string>
+	<string name="setup_instructions_step_socks_suffix">, select SOCKS v5.</string>
+	<string name="setup_instructions_step_dns">Check Proxy DNS when using SOCKS v5 (prevents DNS leaks).</string>
+	<string name="setup_instructions_description">On Firefox or browsers that permit SOCKS5 configurations.</string>
 	<string name="setup_instructions_per_app_title">Per-app (SOCKS5-capable app)</string>
 	<string name="setup_instructions_per_app_description">Android has no system-wide SOCKS5 setting.</string>
 	<string name="setup_instructions_pert_app_step">Use an app that supports a SOCKS5 proxy directly.</string>

--- a/nym-vpn-app/src/i18n/en/settings.json
+++ b/nym-vpn-app/src/i18n/en/settings.json
@@ -344,6 +344,7 @@
     "beta-note": "Beta version: China and Russia only for now. More regions coming.",
     "warning": "Traffic to excluded regions bypasses the VPN.",
     "port": {
+      "server": "Server",
       "socks5-port": "SOCKS5 port",
       "custom-port": "Custom port",
       "range": "1024–65535",
@@ -363,65 +364,31 @@
       "sections": {
         "macos": [
           {
-            "intro": "Works with any app that supports SOCKS5 in its network settings:",
+            "intro": "On Firefox or browsers that permit SOCKS5 configurations.",
             "steps": [
-              "Copy the SOCKS5 port.",
-              "Open your app's proxy or network settings.",
-              "Set proxy to 127.0.0.1 with the copied port."
+              "Settings → Network Settings → Manual proxy.",
+              "SOCKS Host 127.0.0.1, Port {{port}}, select SOCKS v5.",
+              "Check Proxy DNS when using SOCKS v5 (prevents DNS leaks)."
             ]
           }
         ],
         "windows": [
           {
-            "heading": "System-wide (Proxifier)",
-            "intro": "Windows' built-in proxy settings don't support SOCKS5. Use a tool like Proxifier:",
-            "steps": [
-              "Add a proxy: host 127.0.0.1, port {{port}}, type SOCKS5.",
-              "Leave authentication empty.",
-              "Add a rule to route the apps you want through it."
-            ]
-          },
-          {
-            "heading": "App (e.g. browser)",
-            "intro": "Any app with SOCKS5 support. Firefox example:",
+            "intro": "On Firefox or browsers that permit SOCKS5 configurations.",
             "steps": [
               "Settings → Network Settings → Manual proxy.",
               "SOCKS Host 127.0.0.1, Port {{port}}, select SOCKS v5.",
               "Check Proxy DNS when using SOCKS v5 (prevents DNS leaks)."
-            ],
-            "note": "Chrome and Edge do not have built-in SOCKS5 UI on Windows. Use Firefox, a browser extension that supports SOCKS5, or route the browser through Proxifier instead."
-          },
-          {
-            "heading": "Web3 wallet",
-            "steps": [
-              "Open your wallet's network / RPC settings.",
-              "Set the RPC URL to http://127.0.0.1:8545."
             ]
           }
         ],
         "linux": [
           {
-            "heading": "System-wide (proxychains)",
-            "intro": "Use proxychains-ng:",
-            "steps": [
-              "In /etc/proxychains.conf, set the last line to socks5 127.0.0.1 {{port}}.",
-              "Launch an app through it: proxychains4 <command>."
-            ]
-          },
-          {
-            "heading": "App (e.g. browser)",
-            "intro": "Any app with SOCKS5 support. Firefox example:",
+            "intro": "On Firefox or browsers that permit SOCKS5 configurations.",
             "steps": [
               "Settings → Network Settings → Manual proxy.",
               "SOCKS Host 127.0.0.1, Port {{port}}, select SOCKS v5.",
               "Check Proxy DNS when using SOCKS v5 (prevents DNS leaks)."
-            ]
-          },
-          {
-            "heading": "Web3 wallet",
-            "steps": [
-              "Open your wallet's network / RPC settings.",
-              "Set the RPC URL to http://127.0.0.1:8545."
             ]
           }
         ]

--- a/nym-vpn-app/src/screens/settings/geo-exclusion/SetupInstructions.tsx
+++ b/nym-vpn-app/src/screens/settings/geo-exclusion/SetupInstructions.tsx
@@ -1,14 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import clsx from 'clsx';
 import { OsType, type } from '@tauri-apps/plugin-os';
-import {
-  ButtonIconNew,
-  CardNew,
-  CardNewBody,
-  CardNewHeader,
-  PageAnim,
-} from '../../../ui';
-import { useClipboard } from '../../../hooks';
+import { CardNew, CardNewBody, PageAnim } from '../../../ui';
 import { useGeoExclusion } from './utils/useGeoExclusion';
 
 const Platforms = [
@@ -49,7 +42,6 @@ function StepList({ steps }: { steps: string[] }) {
 }
 
 function SetupInstructions() {
-  const { copy } = useClipboard();
   const { t } = useTranslation('settings');
   const { listenPort } = useGeoExclusion();
   const os = type();
@@ -89,25 +81,6 @@ function SetupInstructions() {
           )}
         </div>
       ))}
-
-      <CardNew>
-        <CardNewHeader>
-          <div className="flex flex-col">
-            <p className="text-text-secondary text-xs uppercase">
-              {t('geo-exclusion.setup-instructions.proxy-address')}
-            </p>
-            <div className="flex items-center gap-2">
-              <p className="text-text-primary font-mono">{`127.0.0.1:${listenPort}`}</p>
-              <ButtonIconNew
-                icon="content_copy"
-                onClick={() => copy(`127.0.0.1:${listenPort}`)}
-                clickFeedback
-                noDefaultSize
-              />
-            </div>
-          </div>
-        </CardNewHeader>
-      </CardNew>
     </PageAnim>
   );
 }

--- a/nym-vpn-app/src/screens/settings/geo-exclusion/components/Socks5PortCard.tsx
+++ b/nym-vpn-app/src/screens/settings/geo-exclusion/components/Socks5PortCard.tsx
@@ -47,6 +47,23 @@ function Socks5PortCard({ listenPort, onCommitPort }: Socks5PortCardProps) {
       <CardNewHeader>
         <div className="flex w-full items-center justify-between">
           <p className="text-text-secondary select-none">
+            {t('geo-exclusion.port.server')}
+          </p>
+          <div className="flex items-center gap-2">
+            <span className="text-text-primary font-mono">127.0.0.1</span>
+            <ButtonIconNew
+              icon="content_copy"
+              onClick={() => copy('127.0.0.1', false)}
+              clickFeedback
+              size="small"
+            />
+          </div>
+        </div>
+      </CardNewHeader>
+      <CardDivider className="" />
+      <CardNewHeader>
+        <div className="flex w-full items-center justify-between">
+          <p className="text-text-secondary select-none">
             {t('geo-exclusion.port.socks5-port')}
           </p>
           <div className="flex items-center gap-2">

--- a/nym-vpn-apple/NymVPN/Resources/Localizable.xcstrings
+++ b/nym-vpn-apple/NymVPN/Resources/Localizable.xcstrings
@@ -15605,7 +15605,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Works with macOS system-wide proxy settings, Firefox, and Web3 wallets."
+            "value" : "On Firefox or browsers that permit SOCKS5 configurations."
           }
         }
       }
@@ -15749,6 +15749,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Setup instructions"
+          }
+        }
+      }
+    },
+    "geoExclusion.server" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Server"
           }
         }
       }

--- a/nym-vpn-apple/Settings/Sources/Settings/GeoExclusion/GeoExclusionInstructionsView.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/GeoExclusion/GeoExclusionInstructionsView.swift
@@ -1,24 +1,17 @@
 #if os(macOS)
-import AppKit
 import SwiftUI
 import Theme
 import UIComponents
 
 public struct GeoExclusionInstructionsView: View {
     @Binding private var path: NavigationPath
-    @State private var addressCopied = false
     private let listenPort: UInt16
 
     private static let proxyHost = "127.0.0.1"
-    private static let web3RpcURL = "http://127.0.0.1:8545"
 
     public init(path: Binding<NavigationPath>, listenPort: UInt16) {
         _path = path
         self.listenPort = listenPort
-    }
-
-    private var proxyAddress: String {
-        "\(Self.proxyHost):\(listenPort)"
     }
 
     public var body: some View {
@@ -34,10 +27,7 @@ public struct GeoExclusionInstructionsView: View {
                         .foregroundStyle(Color.Nym.textSecondary)
                         .nymTextStyle(.bodyDefault)
 
-                    systemWideSection
-                    appSection
-                    web3Section
-                    proxyAddressCard
+                    appStepsCard
                 }
                 .frame(maxWidth: MagicNumbers.maxWidth)
                 .padding(.vertical, 24)
@@ -61,55 +51,12 @@ private extension GeoExclusionInstructionsView {
         path.removeLast()
     }
 
-    var systemWideSection: some View {
-        section(
-            title: "geoExclusion.setup.systemWide.title",
-            subtitle: "geoExclusion.setup.systemWide.subtitle",
-            steps: [
-                plainStep("geoExclusion.setup.systemWide.step1"),
-                plainStep("geoExclusion.setup.systemWide.step2"),
-                highlightedStep("geoExclusion.setup.systemWide.step3", values: [Self.proxyHost, "\(listenPort)"]),
-                plainStep("geoExclusion.setup.systemWide.step4")
-            ]
-        )
-    }
-
-    var appSection: some View {
-        section(
-            title: "geoExclusion.setup.app.title",
-            subtitle: "geoExclusion.setup.app.subtitle",
-            steps: [
-                plainStep("geoExclusion.setup.app.step1"),
-                highlightedStep("geoExclusion.setup.app.step2", values: [Self.proxyHost, "\(listenPort)"]),
-                plainStep("geoExclusion.setup.app.step3")
-            ]
-        )
-    }
-
-    var web3Section: some View {
-        section(
-            title: "geoExclusion.setup.web3.title",
-            subtitle: nil,
-            steps: [
-                highlightedStep("geoExclusion.setup.web3.step1", values: [Self.web3RpcURL])
-            ]
-        )
-    }
-
-    func section(title: String, subtitle: String?, steps: [Text]) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text(title.localizedString)
-                .foregroundStyle(Color.Nym.textPrimary)
-                .nymTextStyle(.titleSection)
-
-            if let subtitle {
-                Text(subtitle.localizedString)
-                    .foregroundStyle(Color.Nym.textSecondary)
-                    .nymTextStyle(.bodyDefault)
-            }
-
-            stepsCard(steps)
-        }
+    var appStepsCard: some View {
+        stepsCard([
+            plainStep("geoExclusion.setup.app.step1"),
+            highlightedStep("geoExclusion.setup.app.step2", values: [Self.proxyHost, "\(listenPort)"]),
+            plainStep("geoExclusion.setup.app.step3")
+        ])
     }
 
     func stepsCard(_ steps: [Text]) -> some View {
@@ -142,43 +89,6 @@ private extension GeoExclusionInstructionsView {
             Text("\(number)")
                 .foregroundStyle(Color.Nym.primary)
                 .nymTextStyle(.bodySmallBold)
-        }
-    }
-
-    var proxyAddressCard: some View {
-        Button(action: copyProxyAddress) {
-            VStack(alignment: .leading, spacing: 8) {
-                Text("geoExclusion.setup.proxyAddress".localizedString.uppercased())
-                    .foregroundStyle(Color.Nym.textTertiary)
-                    .nymTextStyle(.bodySmallBold)
-                HStack(spacing: 12) {
-                    Text(proxyAddress)
-                        .foregroundStyle(Color.Nym.textPrimary)
-                        .font(Font.custom("Courier New", size: 15))
-                        .kerning(0.3)
-                    GenericImage(imageName: addressCopied ? "checkmarkSeeThrough" : "copy")
-                        .frame(width: 24, height: 24)
-                    Spacer(minLength: 0)
-                }
-            }
-            .padding(16)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .background(RoundedRectangle(cornerRadius: 12).fill(Color.Nym.surface))
-    }
-
-    func copyProxyAddress() {
-        NSPasteboard.general.prepareForNewContents()
-        NSPasteboard.general.setString(proxyAddress, forType: .string)
-        withAnimation {
-            guard !addressCopied else { return }
-            addressCopied = true
-            Task { @MainActor in
-                try? await Task.sleep(for: .seconds(3))
-                addressCopied = false
-            }
         }
     }
 

--- a/nym-vpn-apple/Settings/Sources/Settings/GeoExclusion/GeoExclusionView.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/GeoExclusion/GeoExclusionView.swift
@@ -99,6 +99,29 @@ private extension GeoExclusionView {
 
     var socks5PortCard: some View {
         VStack(spacing: 0) {
+            Button(action: { viewModel.copyServer() }) {
+                HStack(spacing: 0) {
+                    Text("geoExclusion.server".localizedString)
+                        .foregroundStyle(Color.Nym.textSecondary)
+                        .nymTextStyle(.bodyDefault)
+                    Spacer()
+                    Text(viewModel.serverAddress)
+                        .foregroundStyle(Color.Nym.textPrimary)
+                        .font(Font.custom("Courier New", size: 15))
+                        .kerning(0.3)
+                        .padding(.trailing, 12)
+                    GenericImage(imageName: viewModel.serverCopied ? "checkmarkSeeThrough" : "copy")
+                        .frame(width: 24, height: 24)
+                }
+                .padding(16)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            Divider()
+                .frame(height: 1)
+                .overlay(Color.Nym.divider)
+
             Button(action: { viewModel.copyPort() }) {
                 HStack(spacing: 0) {
                     Text("geoExclusion.socks5Port".localizedString)

--- a/nym-vpn-apple/Settings/Sources/Settings/GeoExclusion/GeoExclusionViewModel.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/GeoExclusion/GeoExclusionViewModel.swift
@@ -20,8 +20,12 @@ import Theme
     @Published var portText = "\(GeoExclusionConfig.defaultPort)"
     @Published var portError: String?
     @Published var portCopied = false
+    @Published var serverCopied = false
 
     private(set) var listenPort = GeoExclusionConfig.defaultPort
+
+    /// The loopback host shown in the Server row; the proxy always listens on 127.0.0.1.
+    let serverAddress = "127.0.0.1"
 
     /// Beta: the excluded region list is hardcoded to China.
     let excludedCountryName = "geoExclusion.china".localizedString
@@ -120,6 +124,19 @@ import Theme
             Task { @MainActor in
                 try? await Task.sleep(for: .seconds(3))
                 portCopied = false
+            }
+        }
+    }
+
+    func copyServer() {
+        NSPasteboard.general.prepareForNewContents()
+        NSPasteboard.general.setString(serverAddress, forType: .string)
+        withAnimation {
+            guard !serverCopied else { return }
+            serverCopied = true
+            Task { @MainActor in
+                try? await Task.sleep(for: .seconds(3))
+                serverCopied = false
             }
         }
     }


### PR DESCRIPTION
Cherry-picks the three merged Geo Exclusion UI PRs onto `release/2026.12-vanilnoir`. No new changes — straight picks of commits already merged to `develop`.

Picked (merge order):
- `b79703c3f` — feat(apple/geo-exclusion): add Server row; trim setup instructions (#6148)
- `02ae2ac01` — feat(app/geo-exclusion): add Server row; trim setup instructions (#6149)
- `974eef852` — feat(android/geo-exclusion): add Server row; trim setup instructions (#6151)

## What these carry
Across all three UI apps (native macOS/iOS, Tauri Windows/Linux, Android): a copyable "Server" (`127.0.0.1`) row above the SOCKS5 port row on the Geo Exclusion screen, and the Setup Instructions screen trimmed to the reworded subheading plus the app/browser steps (System-wide, Web3, and proxy-address card removed).

## Notes
- String changes need Crowdin re-translation on the next sync (as flagged in the original PRs).
- CI and the Sonar gate re-run here on the release branch.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6157)
<!-- Reviewable:end -->
