### PR TITLE
(libwg) Fix MTE crash on dVPN connect by replacing C.GoString

### DIFF
--- a/wireguard/libwg/libwg.go
+++ b/wireguard/libwg/libwg.go
@@ -30,6 +30,25 @@ type TunnelContext struct {
 	Logger *device.Logger
 }
 
+// goStringFixed converts a NUL-terminated C string to a Go string without
+// reading outside the string's allocation. The standard C.GoString locates
+// the terminator with vectorized scans that read up to 31 bytes beyond it and
+// before the start of the string; under ARM MTE (16-byte tag granules) those
+// out-of-bounds reads hit differently-tagged granules and kill the process
+// with SEGV_MTESERR. See https://github.com/mullvad/mullvadvpn-app/pull/6727.
+func goStringFixed(cString *C.char) string {
+	if cString == nil {
+		return ""
+	}
+	ptr := unsafe.Pointer(cString)
+	length := 0
+	for *(*byte)(unsafe.Pointer(uintptr(ptr) + uintptr(length))) != 0 {
+		length++
+	}
+	// C.GoStringN copies exactly length bytes and never reads past them.
+	return C.GoStringN(cString, C.int(length))
+}
+
 var tunnels container.Container[TunnelContext]
 
 func init() {

--- a/wireguard/libwg/libwg_android.go
+++ b/wireguard/libwg/libwg_android.go
@@ -37,7 +37,7 @@ func wgTurnOn(cSettings *C.char, fd int, logSink LogSink, logContext LogContext)
 		logger.Errorf("cSettings is null\n")
 		return ERROR_GENERAL_FAILURE
 	}
-	settings := C.GoString(cSettings)
+	settings := goStringFixed(cSettings)
 
 	tunDevice, _, err := tun.CreateUnmonitoredTUNFromFD(fd)
 	if err != nil {
@@ -148,7 +148,7 @@ func wgTurnOnWithProxyFd(cSettings *C.char, fd int, mtu int32, logSink LogSink, 
 		logger.Errorf("cSettings is null\n")
 		return ERROR_GENERAL_FAILURE
 	}
-	settings := C.GoString(cSettings)
+	settings := goStringFixed(cSettings)
 
 	tunDevice, err := newSocketTunFromFD(fd, int(mtu))
 	if err != nil {

--- a/wireguard/libwg/libwg_default.go
+++ b/wireguard/libwg/libwg_default.go
@@ -37,7 +37,7 @@ func wgTurnOn(mtu int, cSettings *C.char, fd int, logSink LogSink, logContext Lo
 		logger.Errorf("cSettings is null\n")
 		return ERROR_GENERAL_FAILURE
 	}
-	settings := C.GoString(cSettings)
+	settings := goStringFixed(cSettings)
 
 	file := os.NewFile(uintptr(fd), "")
 	tunDevice, err := tun.CreateTUNFromFile(file, mtu)
@@ -85,7 +85,7 @@ func wgSetConfig(tunnelHandle int32, cSettings *C.char) int32 {
 		tunnel.Logger.Errorf("cSettings is null\n")
 		return ERROR_GENERAL_FAILURE
 	}
-	settings := C.GoString(cSettings)
+	settings := goStringFixed(cSettings)
 
 	setError := tunnel.Device.IpcSetOperation(bufio.NewReader(strings.NewReader(settings)))
 	if setError != nil {

--- a/wireguard/libwg/libwg_ios.go
+++ b/wireguard/libwg/libwg_ios.go
@@ -37,7 +37,7 @@ func wgTurnOn(settings *C.char, tunFd int32, logSink LogSink, logContext LogCont
 	logger.Verbosef("Attaching to interface")
 	dev := device.NewDevice(tun, conn.NewStdNetBind(), logger)
 
-	err = dev.IpcSet(C.GoString(settings))
+	err = dev.IpcSet(goStringFixed(settings))
 	if err != nil {
 		logger.Errorf("Unable to set IPC settings: %v", err)
 		unix.Close(int(tunFd))

--- a/wireguard/libwg/libwg_mobile.go
+++ b/wireguard/libwg/libwg_mobile.go
@@ -25,7 +25,7 @@ func wgSetConfig(tunnelHandle int32, cSettings *C.char) int32 {
 		tunnel.Logger.Errorf("cSettings is null\n")
 		return ERROR_GENERAL_FAILURE
 	}
-	settings := C.GoString(cSettings)
+	settings := goStringFixed(cSettings)
 
 	err = tunnel.Device.IpcSetOperation(bufio.NewReader(strings.NewReader(settings)))
 	if err != nil {

--- a/wireguard/libwg/libwg_windows.go
+++ b/wireguard/libwg/libwg_windows.go
@@ -56,10 +56,10 @@ func wgTurnOn(cIfaceName *C.char, cRequestedGUID *C.char, cWintunTunnelType *C.c
 		return ERROR_GENERAL_FAILURE
 	}
 
-	settings := C.GoString(cSettings)
-	ifaceName := C.GoString(cIfaceName)
-	requestedGUID := C.GoString(cRequestedGUID)
-	wintunTunnelType := C.GoString(cWintunTunnelType)
+	settings := goStringFixed(cSettings)
+	ifaceName := goStringFixed(cIfaceName)
+	requestedGUID := goStringFixed(cRequestedGUID)
+	wintunTunnelType := goStringFixed(cWintunTunnelType)
 
 	networkId, err := windows.GUIDFromString(requestedGUID)
 	if err != nil {
@@ -134,7 +134,7 @@ func wgSetConfig(tunnelHandle int32, cSettings *C.char) int32 {
 		tunnel.Logger.Errorf("cSettings is null\n")
 		return ERROR_GENERAL_FAILURE
 	}
-	settings := C.GoString(cSettings)
+	settings := goStringFixed(cSettings)
 
 	setError := tunnel.Device.IpcSetOperation(bufio.NewReader(strings.NewReader(settings)))
 	if setError != nil {

--- a/wireguard/libwg/netstack.go
+++ b/wireguard/libwg/netstack.go
@@ -72,7 +72,7 @@ func wgNetStartUDPConnectionProxy(netTunnelHandle int32, listenPort uint16, clie
 		return ERROR_GENERAL_FAILURE
 	}
 
-	addr, err := netip.ParseAddrPort(C.GoString(endpoint))
+	addr, err := netip.ParseAddrPort(goStringFixed(endpoint))
 	if err != nil {
 		dev.Errorf("Failed to parse endpoint: %v", err)
 		return ERROR_GENERAL_FAILURE
@@ -126,7 +126,7 @@ func wgNetStartTCPConnectionProxy(netTunnelHandle int32, endpoint *C.char, outLi
 		return ERROR_GENERAL_FAILURE
 	}
 
-	addr, err := netip.ParseAddrPort(C.GoString(endpoint))
+	addr, err := netip.ParseAddrPort(goStringFixed(endpoint))
 	if err != nil {
 		dev.Errorf("Failed to parse endpoint: %v", err)
 		return ERROR_GENERAL_FAILURE

--- a/wireguard/libwg/netstack_default.go
+++ b/wireguard/libwg/netstack_default.go
@@ -26,14 +26,14 @@ func wgNetTurnOn(localAddresses *C.char, dnsAddresses *C.char, mtu int, settings
 	logger := logging.NewLogger(logSink, logContext)
 
 	// Parse comma separated list of IP addresses
-	tunAddrs, err := parseIPAddrs(C.GoString(localAddresses))
+	tunAddrs, err := parseIPAddrs(goStringFixed(localAddresses))
 	if err != nil {
 		logger.Errorf("Failed to parse local addresses: %v", err)
 		return ERROR_GENERAL_FAILURE
 	}
 
 	// Parse comma separated list of DNS addresses
-	dnsAddrs, err := parseIPAddrs(C.GoString(dnsAddresses))
+	dnsAddrs, err := parseIPAddrs(goStringFixed(dnsAddresses))
 	if err != nil {
 		logger.Errorf("Failed to parse dns addresses: %v", err)
 		return ERROR_GENERAL_FAILURE
@@ -55,7 +55,7 @@ func wgNetTurnOn(localAddresses *C.char, dnsAddresses *C.char, mtu int, settings
 		return ERROR_GENERAL_FAILURE
 	}
 
-	err = dev.IpcSet(C.GoString(settings))
+	err = dev.IpcSet(goStringFixed(settings))
 	if err != nil {
 		logger.Errorf("Unable to set IPC settings: %v", err)
 		dev.Close()
@@ -87,7 +87,7 @@ func wgNetSetConfig(netTunnelHandle int32, settings *C.char) int64 {
 	if err != nil {
 		return 0
 	}
-	err = dev.IpcSet(C.GoString(settings))
+	err = dev.IpcSet(goStringFixed(settings))
 	if err != nil {
 		dev.Errorf("Unable to set IPC settings: %v", err)
 		if ipcErr, ok := err.(*device.IPCError); ok {

--- a/wireguard/libwg/netstack_mobile.go
+++ b/wireguard/libwg/netstack_mobile.go
@@ -26,14 +26,14 @@ func wgNetTurnOn(localAddresses *C.char, dnsAddresses *C.char, mtu int, settings
 	logger := logging.NewLogger(logSink, logContext)
 
 	// Parse comma separated list of IP addresses
-	tunAddrs, err := parseIPAddrs(C.GoString(localAddresses))
+	tunAddrs, err := parseIPAddrs(goStringFixed(localAddresses))
 	if err != nil {
 		logger.Errorf("Failed to parse local addresses: %v", err)
 		return ERROR_GENERAL_FAILURE
 	}
 
 	// Parse comma separated list of DNS addresses
-	dnsAddrs, err := parseIPAddrs(C.GoString(dnsAddresses))
+	dnsAddrs, err := parseIPAddrs(goStringFixed(dnsAddresses))
 	if err != nil {
 		logger.Errorf("Failed to parse dns addresses: %v", err)
 		return ERROR_GENERAL_FAILURE
@@ -55,7 +55,7 @@ func wgNetTurnOn(localAddresses *C.char, dnsAddresses *C.char, mtu int, settings
 		return ERROR_GENERAL_FAILURE
 	}
 
-	err = dev.IpcSet(C.GoString(settings))
+	err = dev.IpcSet(goStringFixed(settings))
 	if err != nil {
 		logger.Errorf("Unable to set IPC settings: %v", err)
 		dev.Close()
@@ -88,7 +88,7 @@ func wgNetSetConfig(netTunnelHandle int32, settings *C.char) int64 {
 	if err != nil {
 		return 0
 	}
-	err = dev.IpcSet(C.GoString(settings))
+	err = dev.IpcSet(goStringFixed(settings))
 	if err != nil {
 		dev.Errorf("Unable to set IPC settings: %v", err)
 		if ipcErr, ok := err.(*device.IPCError); ok {


### PR DESCRIPTION
Go's C.GoString locates the NUL terminator via runtime.findnull, whose arm64 IndexByteString does a 32-byte-aligned vector load that reads up to 31 bytes outside the string's allocation. With ARM MTE enabled (e.g. GrapheneOS on Pixel 8/9), the uapi-config CStrings passed from Rust live in 16-byte-tagged Scudo granules, so the out-of-bounds read hits a differently-tagged granule and kills the process with SEGV_MTESERR (crash in libwg.so at internal/bytealg.IndexByteString, right after "Created tun device"). Only dVPN mode loads the Go library, which is why mixnet was unaffected. Triggering depends on allocation alignment (~50% per string), not on app version.

Replace all C.GoString call sites with goStringFixed(), which finds the length byte-by-byte and copies via the strictly-in-bounds C.GoStringN — same approach as mullvad/mullvadvpn-app#6727.

Verified on Pixel 9 Pro / GrapheneOS with MTE force-enabled: unpatched build crashes on first dVPN connect at pc 0x150c08; patched build survives 6 consecutive tunnel establishments.

## Ticket

JIRA-NYM-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6173)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of configuration, endpoint, address, and DNS values across supported platforms.
  * Prevented potential memory overreads when processing tunnel setup and network configuration data.
  * Preserved existing validation, error handling, and tunnel behavior while improving stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->