### PR TITLE
Don't buffer offline errors in gateway selection

### DIFF
--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Local DNS resolver will respond with `serv_fail` on timeout from upstream DNS server (https://github.com/nymtech/nym-vpn-client/pull/6132)
 - Remove IPv6 DNS addresses from default DNS configuration due to reliability issues (https://github.com/nymtech/nym-vpn-client/pull/6132)
 
+### Fixed
+
+- Don't buffer transient offline errors in gateway selection, which could delay the first connection after boot (https://github.com/nymtech/nym-vpn-client/pull/6174)
+
 
 ## [2026.12.0] - 2026-08-18
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/algorithm.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/algorithm.rs
@@ -1,6 +1,8 @@
 // Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use std::time::Duration;
+
 use nym_gateway_directory::{BlacklistedGateways, Location};
 use nym_vpn_store::keys::wireguard::WireguardKeysDb;
 use tokio::sync::mpsc;
@@ -9,15 +11,25 @@ use tokio_util::sync::CancellationToken;
 use crate::tunnel_state_machine::{
     TunnelSettings,
     tunnel::gateway_provider::{
-        SelectionResultSender, gateway_cache::GatewayCache, geo_ip::GeoIpProvider,
-        selector::select_gateways,
+        GatewayProviderError, SelectionResultSender, gateway_cache::GatewayCache,
+        geo_ip::GeoIpProvider, selector::select_gateways,
     },
 };
+
+const OFFLINE_RETRY_MIN_BACKOFF: Duration = Duration::from_millis(100);
+const OFFLINE_RETRY_MAX_BACKOFF: Duration = Duration::from_secs(1);
 
 #[derive(Clone)]
 pub struct SelectAndSend {
     pub tunnel_settings: TunnelSettings,
     pub selection_tx: SelectionResultSender,
+}
+
+fn is_transient(error: &GatewayProviderError) -> bool {
+    matches!(
+        error,
+        GatewayProviderError::LookupGateways(nym_gateway_directory::Error::Offline)
+    )
 }
 
 async fn continuous_select<C: GatewayCache>(
@@ -27,6 +39,7 @@ async fn continuous_select<C: GatewayCache>(
     device_location: Option<Location>,
     wg_keys_db: &WireguardKeysDb,
 ) {
+    let mut backoff = OFFLINE_RETRY_MIN_BACKOFF;
     loop {
         // make sure the buffer is not full before deciding on other possible selections
         let Ok(selection_tx) = select_and_send.selection_tx.reserve().await else {
@@ -41,6 +54,18 @@ async fn continuous_select<C: GatewayCache>(
             wg_keys_db,
         )
         .await;
+
+        if let Err(error) = &selection
+            && is_transient(error)
+        {
+            tracing::debug!("Discarding transient gateway selection failure: {error}");
+            drop(selection_tx);
+            tokio::time::sleep(backoff).await;
+            backoff = (backoff * 2).min(OFFLINE_RETRY_MAX_BACKOFF);
+            continue;
+        }
+
+        backoff = OFFLINE_RETRY_MIN_BACKOFF;
         selection_tx.send(selection);
     }
 }
@@ -105,7 +130,10 @@ impl<C: GatewayCache> SelectionAlgorithm<C> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
 
     use tokio::sync::RwLock;
 
@@ -201,5 +229,80 @@ mod tests {
 
         shutdown_token.cancel();
         handle.await.unwrap();
+    }
+
+    fn offline_select_task() -> (
+        MockGatewayCache,
+        mpsc::Receiver<SelectionResult>,
+        Arc<AtomicBool>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let (selection_tx, selection_rx) = mpsc::channel(1);
+        let gateways = [
+            "2zHiExNRKiCXVKS35SNKtK4apGfZELMpA1jJ2gVevJoz",
+            "38zcSsvjXsAX7C28ko2H3Lt55X4TYxfZYkPADxKXZHUj",
+        ]
+        .map(gateway_id_to_gateway)
+        .to_vec();
+
+        let cache = MockGatewayCache::new(Arc::new(RwLock::new(Some(gateways))));
+        let offline = cache.offline_flag();
+        offline.store(true, Ordering::SeqCst);
+
+        let task_cache = cache.clone();
+        let handle = tokio::spawn(async move {
+            continuous_select(
+                SelectAndSend {
+                    tunnel_settings: default_tunnel_settings(),
+                    selection_tx,
+                },
+                task_cache,
+                &BlacklistedGateways::new(),
+                None,
+                &WireguardKeysDb::Ephemeral(Default::default()),
+            )
+            .await;
+        });
+
+        (cache, selection_rx, offline, handle)
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn offline_errors_not_buffered() {
+        let (cache, mut selection_rx, _offline, handle) = offline_select_task();
+
+        tokio::time::sleep(Duration::from_secs(5)).await;
+
+        assert!(cache.lookup_count() > 1);
+        assert!(selection_rx.try_recv().is_err());
+
+        handle.abort();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn offline_backoff_capped() {
+        let (cache, _selection_rx, _offline, handle) = offline_select_task();
+        let window = Duration::from_secs(10);
+
+        tokio::time::sleep(window).await;
+        let lookups = cache.lookup_count() as u128;
+
+        assert!(lookups <= window.as_millis() / OFFLINE_RETRY_MIN_BACKOFF.as_millis());
+        assert!(lookups >= window.as_millis() / OFFLINE_RETRY_MAX_BACKOFF.as_millis());
+
+        handle.abort();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn selection_resumes_when_online() {
+        let (_cache, mut selection_rx, offline, handle) = offline_select_task();
+
+        tokio::time::sleep(Duration::from_secs(5)).await;
+        assert!(selection_rx.try_recv().is_err());
+
+        offline.store(false, Ordering::SeqCst);
+        assert!(selection_rx.recv().await.unwrap().is_ok());
+
+        handle.abort();
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/gateway_cache.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/gateway_cache.rs
@@ -27,7 +27,13 @@ impl GatewayCache for GatewayCacheHandle {
 
 #[cfg(test)]
 pub mod tests {
-    use std::{sync::Arc, time::Duration};
+    use std::{
+        sync::{
+            Arc,
+            atomic::{AtomicBool, AtomicUsize, Ordering},
+        },
+        time::Duration,
+    };
 
     use nym_gateway_directory::Gateway;
     use tokio::sync::RwLock;
@@ -40,6 +46,8 @@ pub mod tests {
         /// Artificial delay applied to every `lookup_gateways` call, used to
         /// model a fresh selection that hasn't landed a value in the stream yet.
         lookup_delay: Duration,
+        offline: Arc<AtomicBool>,
+        lookups: Arc<AtomicUsize>,
     }
 
     impl MockGatewayCache {
@@ -47,6 +55,8 @@ pub mod tests {
             Self {
                 gateways,
                 lookup_delay: Duration::ZERO,
+                offline: Arc::new(AtomicBool::new(false)),
+                lookups: Arc::new(AtomicUsize::new(0)),
             }
         }
 
@@ -57,7 +67,17 @@ pub mod tests {
             Self {
                 gateways,
                 lookup_delay,
+                offline: Arc::new(AtomicBool::new(false)),
+                lookups: Arc::new(AtomicUsize::new(0)),
             }
+        }
+
+        pub fn offline_flag(&self) -> Arc<AtomicBool> {
+            self.offline.clone()
+        }
+
+        pub fn lookup_count(&self) -> usize {
+            self.lookups.load(Ordering::SeqCst)
         }
     }
 
@@ -66,6 +86,10 @@ pub mod tests {
         async fn lookup_gateways(&self, gw_type: GatewayType) -> Result<GatewayList, Error> {
             if !self.lookup_delay.is_zero() {
                 tokio::time::sleep(self.lookup_delay).await;
+            }
+            self.lookups.fetch_add(1, Ordering::SeqCst);
+            if self.offline.load(Ordering::SeqCst) {
+                return Err(Error::Offline);
             }
             Ok(GatewayList::new(
                 Some(gw_type),


### PR DESCRIPTION
## Ticket

n/a

## Description

First connect after boot takes ~100s on linux. Restarting vpnd fixes it.

What I found:
- its not slow connecting, it fails 10x then works on the 11th
- every failure is instant, "failed to lookup gateways / no connectivity"
- but 1ms later the cache logs "returning 569 cached gateways" so its not offline
- the 100s is just backoff piling up

continuous_select buffers selections ahead and errors get buffered too, so
offline errors from a blip at boot get eaten by connect attempts later when the
network is fine again.

Patch skips buffering those and retries instead, with a small backoff so it
doesnt spin when actually offline.

been running it for a couple days now, connects are instant

## Checklist:

- [x] Changelog

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6174)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gateway selection recovery after temporary offline errors.
  * Prevented transient failures from being buffered, reducing delays before the first connection after startup.
  * Added controlled retry timing that increases briefly between attempts and resets after successful recovery.
  * Improved connection responsiveness when connectivity returns, helping avoid unnecessary delays during startup and temporary network interruptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->