### PR TITLE
fix(android): restore offline "No internet" status and one-press disconnect

### DIFF
--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/service/tile/VpnQuickTile.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/service/tile/VpnQuickTile.kt
@@ -90,7 +90,7 @@ class VpnQuickTile :
 				setActive()
 			}
 
-			Tunnel.State.Offline -> {
+			is Tunnel.State.Offline -> {
 				setTileDescription(this@VpnQuickTile.getString(R.string.offline))
 				setActive()
 			}

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/common/animations/Pulse.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/common/animations/Pulse.kt
@@ -1,0 +1,96 @@
+package net.nymtech.nymvpn.ui.common.animations
+
+import androidx.compose.animation.core.InfiniteRepeatableSpec
+import androidx.compose.animation.core.RepeatMode.Restart
+import androidx.compose.animation.core.StartOffset
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun Pulse(color: Color = Color(0xFFFF4444)) {
+	MultiplePulsarEffect(pulsarColor = color) { modifier ->
+		Canvas(
+			modifier = modifier.size(5.dp),
+			onDraw = {
+				drawCircle(color = color)
+			},
+		)
+	}
+}
+
+@Composable
+fun MultiplePulsarEffect(nbPulsar: Int = 2, pulsarRadius: Float = 10f, pulsarColor: Color, circle: @Composable (Modifier) -> Unit = {}) {
+	var circleSize by remember { mutableStateOf(IntSize(0, 0)) }
+
+	val effects: List<Pair<Float, Float>> = List(nbPulsar) {
+		pulsarBuilder(pulsarRadius = pulsarRadius, size = circleSize.width, delay = it * 500)
+	}
+
+	Box(
+		Modifier,
+		contentAlignment = Alignment.Center,
+	) {
+		Canvas(
+			Modifier,
+			onDraw = {
+				for (i in 0 until nbPulsar) {
+					val (radius, alpha) = effects[i]
+					drawCircle(color = pulsarColor, radius = radius, alpha = alpha)
+				}
+			},
+		)
+		circle(
+			Modifier
+				.padding((pulsarRadius).dp)
+				.onGloballyPositioned {
+					if (it.isAttached) {
+						circleSize = it.size
+					}
+				},
+		)
+	}
+}
+
+@Composable
+fun pulsarBuilder(pulsarRadius: Float, size: Int, delay: Int): Pair<Float, Float> {
+	val infiniteTransition = rememberInfiniteTransition(label = "infinite")
+
+	val radius by infiniteTransition.animateFloat(
+		initialValue = (size / 2).toFloat(),
+		targetValue = size + (pulsarRadius * 2),
+		animationSpec = InfiniteRepeatableSpec(
+			animation = tween(3000),
+			initialStartOffset = StartOffset(delay),
+			repeatMode = Restart,
+		),
+		label = "radius",
+	)
+	val alpha by infiniteTransition.animateFloat(
+		initialValue = 1f,
+		targetValue = 0f,
+		animationSpec = InfiniteRepeatableSpec(
+			animation = tween(3000),
+			initialStartOffset = StartOffset(delay + 100),
+			repeatMode = Restart,
+		),
+		label = "alpha",
+	)
+
+	return radius to alpha
+}

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/model/ConnectionState.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/model/ConnectionState.kt
@@ -31,7 +31,10 @@ sealed interface ConnectionState {
 			Tunnel.State.Down -> Disconnected
 			Tunnel.State.Up -> Connected
 			Tunnel.State.Disconnecting -> Disconnecting
-			Tunnel.State.Offline -> WaitingForConnection
+			// A session that is armed to auto-reconnect once back online is treated as
+			// "waiting"; with no session armed there is nothing to wait for, so it is a
+			// plain offline (disconnected) state.
+			is Tunnel.State.Offline -> if (tunnelState.reconnect) WaitingForConnection else Offline
 
 			is Tunnel.State.Error -> Error(tunnelState.reason)
 

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/MainViewModel.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/MainViewModel.kt
@@ -225,6 +225,15 @@ constructor(
 				ConnectionState.Disconnecting
 			managerState.isRestarting ->
 				ConnectionState.from(managerState.tunnelState, managerState.establishConnectionState)
+			managerState.tunnelState is Tunnel.State.Offline ->
+				// The backend reports Offline both for a paused-but-armed session (reconnect)
+				// and while fully disconnected with no network; only the former is a "waiting"
+				// state, the latter is a plain offline/disconnected state.
+				if ((managerState.tunnelState as Tunnel.State.Offline).reconnect) {
+					ConnectionState.WaitingForConnection
+				} else {
+					ConnectionState.Offline
+				}
 			managerState.tunnelState !is Tunnel.State.Down &&
 				managerState.tunnelState !is Tunnel.State.Error &&
 				networkStatus == NetworkStatus.Disconnected ->

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/components/ConnectionStatus.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/components/ConnectionStatus.kt
@@ -10,10 +10,13 @@ import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -34,6 +37,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import net.nymtech.nymvpn.R
+import net.nymtech.nymvpn.ui.common.animations.Pulse
 import net.nymtech.nymvpn.ui.model.ConnectionState
 import net.nymtech.nymvpn.ui.theme.NymVPNTheme
 import net.nymtech.nymvpn.ui.theme.Theme
@@ -132,13 +136,15 @@ fun ConnectionStatus(
 	val failedLabel = stringResource(R.string.connection_failed)
 	val disconnectingLabel = stringResource(R.string.disconnecting)
 	val notProtectedLabel = stringResource(R.string.connection_status_not_protected)
+	val offlineLabel = stringResource(R.string.offline)
 
 	val currentLabel: String? = when (connectionState) {
 		ConnectionState.Connected -> connectedLabel
 		is ConnectionState.Connecting -> connectionState.label.asString(context)
 		is ConnectionState.Error, is ConnectionState.StartFailure -> failedLabel
 		ConnectionState.Disconnecting -> disconnectingLabel
-		ConnectionState.Disconnected, ConnectionState.Offline, ConnectionState.WaitingForConnection -> notProtectedLabel
+		ConnectionState.Offline, ConnectionState.WaitingForConnection -> offlineLabel
+		ConnectionState.Disconnected -> notProtectedLabel
 	}
 
 	val labelAlpha by animateFloatAsState(
@@ -233,15 +239,27 @@ fun ConnectionStatus(
 			modifier = Modifier.alpha(labelAlpha),
 		) {
 			Spacer(Modifier.height(LABEL_OFFSET.dp))
-			Text(
-				text = (currentLabel ?: "").uppercase(),
-				style = MaterialTheme.typography.labelSmall,
-				color = when {
-					isError -> MaterialTheme.colorScheme.error
-					isConnected -> MaterialTheme.colorScheme.primary
-					else -> MaterialTheme.colorScheme.onSurfaceVariant
-				},
-			)
+			val isOffline = connectionState == ConnectionState.Offline ||
+				connectionState == ConnectionState.WaitingForConnection
+			Row(
+				verticalAlignment = Alignment.CenterVertically,
+				horizontalArrangement = Arrangement.Center,
+			) {
+				if (isOffline) {
+					Pulse(color = MaterialTheme.colorScheme.error)
+					Spacer(Modifier.width(6.dp))
+				}
+				Text(
+					text = (currentLabel ?: "").uppercase(),
+					style = MaterialTheme.typography.labelSmall,
+					color = when {
+						isError -> MaterialTheme.colorScheme.error
+						isConnected -> MaterialTheme.colorScheme.primary
+						isOffline -> MaterialTheme.colorScheme.error
+						else -> MaterialTheme.colorScheme.onSurfaceVariant
+					},
+				)
+			}
 			Spacer(Modifier.height(8.dp))
 			Text(
 				text = connectionTime ?: "",

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/panel/components/ActionButton.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/panel/components/ActionButton.kt
@@ -40,7 +40,6 @@ internal fun ActionButton(
 	when (connectionState) {
 		ConnectionState.Disconnected,
 		ConnectionState.Offline,
-		ConnectionState.WaitingForConnection,
 		-> {
 			val isAccountNotActive = accountState is AccountControllerState.Error &&
 				accountState.v1 is AccountControllerErrorStateReason.AccountStatusNotActive
@@ -67,6 +66,16 @@ internal fun ActionButton(
 				shape = buttonShape,
 			)
 		}
+
+		ConnectionState.WaitingForConnection -> MainStyledButton(
+			onClick = { onAction(ConnectAction.DISCONNECT) },
+			textColor = MaterialTheme.colorScheme.onPrimaryContainer,
+			content = { Text(stringResource(R.string.disconnect), style = MaterialTheme.typography.titleMedium) },
+			color = Color.Transparent,
+			borderStroke = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
+			modifier = buttonModifier,
+			shape = buttonShape,
+		)
 
 		is ConnectionState.Connecting -> MainStyledButton(
 			onClick = { onAction(ConnectAction.DISCONNECT) },

--- a/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/Tunnel.kt
+++ b/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/Tunnel.kt
@@ -17,7 +17,7 @@ interface Tunnel {
 		data object InitializingClient : State()
 		data object EstablishingConnection : State()
 		data object Disconnecting : State()
-		data object Offline : State()
+		data class Offline(val reconnect: Boolean) : State()
 		data class Error(val reason: ErrorStateReason) : State()
 	}
 

--- a/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/service/VpnService.kt
+++ b/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/service/VpnService.kt
@@ -80,7 +80,7 @@ class VpnService :
 			if (caps.ownerUid == Process.myUid()) return
 
 			val currentState = core.state
-			if (currentState == Tunnel.State.Down || currentState == Tunnel.State.Offline) return
+			if (currentState == Tunnel.State.Down || currentState is Tunnel.State.Offline) return
 
 			Timber.tag(TAG).w("Competing VPN detected (network=$network uid=${caps.ownerUid}), disconnecting")
 			_events.tryEmit(VpnServiceEvent.CompetingVpnDetected)
@@ -189,7 +189,7 @@ class VpnService :
 
 			ioScope.launch {
 				core.ensureReadyForManagementBestEffort()
-				if (core.state == Tunnel.State.Down || core.state == Tunnel.State.Offline) {
+				if (core.state == Tunnel.State.Down || core.state is Tunnel.State.Offline) {
 					core.connectLocked()
 				}
 			}

--- a/nym-vpn-android/core/src/main/java/net/nymtech/vpn/util/extensions/LibExtensions.kt
+++ b/nym-vpn-android/core/src/main/java/net/nymtech/vpn/util/extensions/LibExtensions.kt
@@ -18,7 +18,7 @@ fun TunnelEvent.NewState.asTunnelState(): Tunnel.State = when (this.v1) {
 	is TunnelState.Disconnected -> Tunnel.State.Down
 	is TunnelState.Disconnecting -> Tunnel.State.Disconnecting
 	is TunnelState.Error -> Tunnel.State.Error(this.v1.v1)
-	is TunnelState.Offline -> Tunnel.State.Offline
+	is TunnelState.Offline -> Tunnel.State.Offline((this.v1 as TunnelState.Offline).reconnect)
 }
 
 enum class GatewaySelectionMode(val value: String) {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/offline_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/offline_state.rs
@@ -138,12 +138,24 @@ impl TunnelStateHandler for OfflineState {
                         }
                     },
                     TunnelCommand::Disconnect => {
-                        if self.reconnect {
-                            self.reconnect = false;
-                            let new_state = PrivateTunnelState::Offline { reconnect: self.reconnect };
-                            NextTunnelState::NewState((self, new_state))
-                        } else {
-                            NextTunnelState::SameState(self)
+                        // An explicit user-initiated disconnect while offline should tear the
+                        // tunnel down immediately rather than only disarming auto-reconnect and
+                        // lingering in the offline state. Otherwise the first disconnect merely
+                        // re-emits `Offline`, which races the client's optimistic `Down` and
+                        // resurrects the offline UI, forcing the user to press disconnect twice.
+                        #[cfg(target_os = "android")]
+                        {
+                            NextTunnelState::NewState(DisconnectedState::enter(None, shared_state).await)
+                        }
+                        #[cfg(not(target_os = "android"))]
+                        {
+                            if self.reconnect {
+                                self.reconnect = false;
+                                let new_state = PrivateTunnelState::Offline { reconnect: self.reconnect };
+                                NextTunnelState::NewState((self, new_state))
+                            } else {
+                                NextTunnelState::SameState(self)
+                            }
                         }
                     },
                     TunnelCommand::SetTunnelSettings(tunnel_settings) => {


### PR DESCRIPTION
The v3.5.0 main-screen rewrite collapsed ConnectionState.Offline and WaitingForConnection into the disconnected "not protected" branch, so losing connectivity while connected no longer surfaced an offline state. The backend still detects offline and emits Tunnel.State.Offline correctly; this was purely a UI regression.

- ConnectionStatus: render Offline/WaitingForConnection as "No internet" with the red status color, and restore the pulsing red indicator dot (recreate the Pulse animation removed in the rewrite).
- ActionButton: show "Disconnect" for WaitingForConnection instead of "Connect"; the resolver only produces this state while a tunnel session is active, so disconnect is always the correct action.
- offline_state: a user-initiated Disconnect while offline now tears the tunnel down (DisconnectedState) instead of only disarming auto-reconnect and re-emitting Offline. The stale Offline event raced the client's optimistic Down and forced a second press to disconnect. Gated to Android to preserve desktop kill-switch teardown behavior.

## Ticket

JIRA-NYM-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6180)
<!-- Reviewable:end -->
