### PR TITLE
(ci) Fix nightly Maestro Android suite

### DIFF
--- a/nym-vpn-android/maestro/flows/main_screen/node_selection.yaml
+++ b/nym-vpn-android/maestro/flows/main_screen/node_selection.yaml
@@ -9,7 +9,7 @@ tags:
 - assertVisible: "Exit server"
 
 - tapOn:
-    text: "Random"
+    text: "Safest"
     below: "Exit server"
 
 - extendedWaitUntil:
@@ -27,7 +27,7 @@ tags:
 - assertVisible: "Germany"
 
 - tapOn:
-    text: "Random"
+    text: "Safest"
     below: "Entry server"
 
 - extendedWaitUntil:

--- a/nym-vpn-android/maestro/flows/nodes/node_info.yaml
+++ b/nym-vpn-android/maestro/flows/nodes/node_info.yaml
@@ -6,7 +6,7 @@ tags:
 - runFlow: ../../subflows/open_app.yaml
 
 - tapOn:
-    text: "Random"
+    text: "Safest"
     below: "Exit server"
 
 - extendedWaitUntil:

--- a/nym-vpn-android/maestro/flows/nodes/node_not_found_search.yaml
+++ b/nym-vpn-android/maestro/flows/nodes/node_not_found_search.yaml
@@ -1,15 +1,9 @@
 appId: net.nymtech.nymvpn.mock.debug
 ---
-- clearState
-- launchApp
-
-- extendedWaitUntil:
-    visible:
-      text: "Connect"
-    timeout: 15000
+- runFlow: ../../subflows/open_app.yaml
 
 - tapOn:
-    text: "Random"
+    text: "Safest"
     index: 0
 
 - assertNotVisible: "No results found."

--- a/nym-vpn-android/maestro/flows/nodes/node_search.yaml
+++ b/nym-vpn-android/maestro/flows/nodes/node_search.yaml
@@ -1,15 +1,9 @@
 appId: net.nymtech.nymvpn.mock.debug
 ---
-- clearState
-- launchApp
-
-- extendedWaitUntil:
-    visible:
-      text: "Connect"
-    timeout: 15000
+- runFlow: ../../subflows/open_app.yaml
 
 - tapOn:
-    text: "Random"
+    text: "Safest"
     index: 0
 
 - assertNotVisible: "Mock-Entry-DE-01"

--- a/nym-vpn-android/maestro/flows/settings_screen/customize_dns.yaml
+++ b/nym-vpn-android/maestro/flows/settings_screen/customize_dns.yaml
@@ -1,12 +1,6 @@
 appId: net.nymtech.nymvpn.mock.debug
 ---
-- clearState
-- launchApp
-
-- extendedWaitUntil:
-      visible:
-          text: "Connect"
-      timeout: 15000
+- runFlow: ../../subflows/open_app.yaml
 
 - tapOn: "Settings"
 

--- a/nym-vpn-android/maestro/flows/settings_screen/passphrase.yaml
+++ b/nym-vpn-android/maestro/flows/settings_screen/passphrase.yaml
@@ -1,11 +1,6 @@
 appId: net.nymtech.nymvpn.mock.debug
 ---
-- launchApp
-
-- extendedWaitUntil:
-      visible:
-          text: "Connect"
-      timeout: 15000
+- runFlow: ../../subflows/open_app.yaml
 
 - tapOn: "Settings"
 

--- a/nym-vpn-android/maestro/flows/settings_screen/settings_components.yaml
+++ b/nym-vpn-android/maestro/flows/settings_screen/settings_components.yaml
@@ -62,5 +62,3 @@ tags:
 
 - assertVisible:
     text: "App version:.*"
-- assertVisible:
-    text: "Daemon version:.*"

--- a/nym-vpn-android/maestro/flows/settings_screen/settings_navigation.yaml
+++ b/nym-vpn-android/maestro/flows/settings_screen/settings_navigation.yaml
@@ -1,11 +1,6 @@
 appId: net.nymtech.nymvpn.mock.debug
 ---
-- launchApp
-
-- extendedWaitUntil:
-    visible:
-      text: "Connect"
-    timeout: 15000
+- runFlow: ../../subflows/open_app.yaml
 
 - tapOn:
     text: "Settings"

--- a/nym-vpn-android/maestro/flows/settings_screen/split_tunelling.yaml
+++ b/nym-vpn-android/maestro/flows/settings_screen/split_tunelling.yaml
@@ -1,11 +1,6 @@
 appId: net.nymtech.nymvpn.mock.debug
 ---
-- launchApp
-
-- extendedWaitUntil:
-    visible:
-      text: "Connect"
-    timeout: 15000
+- runFlow: ../../subflows/open_app.yaml
 
 - tapOn: "Settings"
 

--- a/nym-vpn-android/maestro/flows/settings_screen/theme_switch.yaml
+++ b/nym-vpn-android/maestro/flows/settings_screen/theme_switch.yaml
@@ -1,12 +1,6 @@
 appId: net.nymtech.nymvpn.mock.debug
 ---
-- clearState
-- launchApp
-
-- extendedWaitUntil:
-    visible:
-      text: "Connect"
-    timeout: 15000
+- runFlow: ../../subflows/open_app.yaml
 
 - tapOn: "Settings"
 

--- a/nym-vpn-android/maestro/subflows/open_app.yaml
+++ b/nym-vpn-android/maestro/subflows/open_app.yaml
@@ -2,17 +2,23 @@
 appId: net.nymtech.nymvpn.mock.debug
 ---
 - launchApp:
-    clearState: true
-    permissions:
-      all: allow
+      clearState: true
+      permissions:
+          all: allow
 
 - runFlow:
-    when:
-      visible: "Connection request"
-    commands:
-      - tapOn: "OK"
+      when:
+          visible: "Connection request"
+      commands:
+          - tapOn: "OK"
 
 - extendedWaitUntil:
-    visible:
-      text: "Connect"
-    timeout: 20000
+      visible:
+          text: "Help us improve NymVPN"
+      timeout: 20000
+- tapOn: "Continue"
+
+- extendedWaitUntil:
+      visible:
+          text: "Connect"
+      timeout: 20000


### PR DESCRIPTION
## Problem

The nightly `ci-maestro-android` workflow has failed every run since the cron was introduced in #6130 (Aug 21, 22, 23), with all 16 flows failing identically at the first step:

```
[Failed] app_launch (24s) (Assertion is false: "Connect" is visible)
16/16 Flows Failed
```

Because every flow was blocked at launch, three weeks of unrelated UI drift accumulated behind it, invisible.

## Root cause of the blocker

Every flow starts by waiting for the text `Connect` on the home screen. #6014 added a second branch to the auth-sheet effect in `MainScreen.kt`:

```kotlin
isMnemonicStored && !settings.technicalOptCompleted -> Auth(AuthRoute.TechOpt)
```

`MockBackendManager` reports `isMnemonicStored = true`, and Maestro's `clearState` resets `technicalOptCompleted`, so the "Help us improve NymVPN" tech-opt bottom sheet opens over the home screen on every launch and hides the Connect button.

Logcat from the failing runs confirms the app itself starts cleanly (`app-vm: AppReady`, `ui-main-vm` active, no crash) — it was purely the sheet blocking the assertion.

Timeline matches: last green Maestro run was Aug 5, the sheet landed Aug 6, the nightly cron started Aug 21.

## Changes

1. **Dismiss the tech-opt sheet** in `subflows/open_app.yaml` before waiting for the home screen.

2. **Route every flow through that subflow.** Seven flows inlined their own `launchApp` + wait-for-Connect and so missed the fix: `node_search`, `node_not_found_search`, `customize_dns`, `passphrase`, `settings_navigation`, `split_tunelling`, `theme_switch`. This also removes a race — `split_tunelling` and `settings_navigation` passed locally but failed in CI depending on whether the `Connect` wait landed in the instant before the sheet opened.

3. **`"Random"` → `"Safest"`** on the home screen node rows (#5996 changed the default auto-selection label). The server picker still offers "Random server", so that assertion is unchanged.

4. **Drop the `Daemon version:.*` assertion** — removed from settings in #6039. `App version:` stays.

## Testing

`16/16 Flows Passed in 8m 45s` locally, on an API 34 / x86_64 / Pixel 6 emulator matching the CI device.

This workflow is `workflow_dispatch` / `schedule` only, so it does not run on PRs — dispatched manually against this branch.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6185)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated app launch handling to support the “Help us improve NymVPN” screen before showing the “Connect” screen.
  * Node selection flows now use the “Safest” option for entry and exit servers.
  * Improved navigation through node search, node information, and settings screens.
  * Removed an unreliable settings check tied to daemon version text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->