### PR TITLE
LAN bypass was dropping the exit metadata address.

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -5825,6 +5825,7 @@ name = "nym-firewall-config"
 version = "2026.12.2-beta.1"
 dependencies = [
  "ipnetwork",
+ "nym-network-defaults",
 ]
 
 [[package]]

--- a/nym-vpn-core/crates/nym-firewall-config/Cargo.toml
+++ b/nym-vpn-core/crates/nym-firewall-config/Cargo.toml
@@ -11,6 +11,7 @@ rust-version.workspace = true
 
 [dependencies]
 ipnetwork.workspace = true
+nym-network-defaults.workspace = true
 
 [lints]
 workspace = true

--- a/nym-vpn-core/crates/nym-firewall-config/src/lib.rs
+++ b/nym-vpn-core/crates/nym-firewall-config/src/lib.rs
@@ -114,6 +114,22 @@ mod tests {
     }
 
     #[test]
+    fn keep_on_tunnel_after_lan_bypass_emits_host_prefixes() {
+        let iface = [
+            IpAddr::V4(Ipv4Addr::new(10, 1, 0, 2)),
+            IpAddr::V6("fc01::2".parse().unwrap()),
+        ];
+        for net in keep_on_tunnel_after_lan_bypass(iface) {
+            let expected = if net.is_ipv4() { 32 } else { 128 };
+            assert_eq!(
+                net.prefix(),
+                expected,
+                "{net} must be a host route so Android Ipv4Net/Ipv6Net::new cannot fail"
+            );
+        }
+    }
+
+    #[test]
     fn keep_on_tunnel_after_lan_bypass_does_not_include_typical_lan_host() {
         let nets = keep_on_tunnel_after_lan_bypass(std::iter::empty());
         for lan in [

--- a/nym-vpn-core/crates/nym-firewall-config/src/lib.rs
+++ b/nym-vpn-core/crates/nym-firewall-config/src/lib.rs
@@ -4,6 +4,7 @@
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
+use nym_network_defaults::{WG_TUN_DEVICE_IP_ADDRESS_V4, WG_TUN_DEVICE_IP_ADDRESS_V6};
 
 /// Value used to mark packets and associated connections.
 /// This should be an arbitrary but unique integer.
@@ -58,6 +59,20 @@ pub fn is_local_address(address: &IpAddr) -> bool {
         .any(|net| net.contains(address))
 }
 
+/// Host routes that must stay on the tunnel after LAN bypass carves out RFC1918/ULA.
+///
+/// Exit WG metadata is `WG_TUN_DEVICE_IP_ADDRESS_V4` (`10.1.0.1`), which sits inside `10.0.0.0/8`.
+pub fn keep_on_tunnel_after_lan_bypass(
+    interface_addrs: impl IntoIterator<Item = IpAddr>,
+) -> Vec<IpNetwork> {
+    let mut nets = vec![
+        v4(WG_TUN_DEVICE_IP_ADDRESS_V4, 32),
+        v6(WG_TUN_DEVICE_IP_ADDRESS_V6, 128),
+    ];
+    nets.extend(interface_addrs.into_iter().map(IpNetwork::from));
+    nets
+}
+
 // Short-hand for `IpNetwork::V4(Ipv4Network::new_checked(address, prefix).unwrap())`.
 const fn v4(address: Ipv4Addr, prefix: u8) -> IpNetwork {
     IpNetwork::V4(Ipv4Network::new_checked(address, prefix).unwrap())
@@ -66,4 +81,54 @@ const fn v4(address: Ipv4Addr, prefix: u8) -> IpNetwork {
 // Short-hand for `IpNetwork::V6(Ipv6Network::new_checked(address, prefix).unwrap())`.
 const fn v6(address: Ipv6Addr, prefix: u8) -> IpNetwork {
     IpNetwork::V6(Ipv6Network::new_checked(address, prefix).unwrap())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keep_on_tunnel_after_lan_bypass_includes_wg_metadata_v4() {
+        let nets = keep_on_tunnel_after_lan_bypass(std::iter::empty());
+        let meta = IpAddr::V4(WG_TUN_DEVICE_IP_ADDRESS_V4);
+        assert!(
+            ALLOWED_LAN_NETS.iter().any(|net| net.contains(meta)),
+            "WG metadata v4 must sit inside LAN bypass nets (the collision this keep-list exists for)"
+        );
+        assert!(nets.iter().any(|net| net.contains(meta)));
+    }
+
+    #[test]
+    fn keep_on_tunnel_after_lan_bypass_includes_wg_metadata_v6() {
+        let nets = keep_on_tunnel_after_lan_bypass(std::iter::empty());
+        let meta = IpAddr::V6(WG_TUN_DEVICE_IP_ADDRESS_V6);
+        assert!(ALLOWED_LAN_NETS.iter().any(|net| net.contains(meta)));
+        assert!(nets.iter().any(|net| net.contains(meta)));
+    }
+
+    #[test]
+    fn keep_on_tunnel_after_lan_bypass_includes_interface_addr() {
+        let client = Ipv4Addr::new(10, 1, 0, 2);
+        let nets = keep_on_tunnel_after_lan_bypass(std::iter::once(IpAddr::V4(client)));
+        assert!(nets.iter().any(|net| net.contains(IpAddr::V4(client))));
+    }
+
+    #[test]
+    fn keep_on_tunnel_after_lan_bypass_does_not_include_typical_lan_host() {
+        let nets = keep_on_tunnel_after_lan_bypass(std::iter::empty());
+        for lan in [
+            IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)),
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+            IpAddr::V4(Ipv4Addr::new(172, 16, 0, 1)),
+        ] {
+            assert!(
+                ALLOWED_LAN_NETS.iter().any(|net| net.contains(lan)),
+                "{lan} should remain in the LAN bypass set"
+            );
+            assert!(
+                !nets.iter().any(|net| net.contains(lan)),
+                "{lan} must not be re-added to the tunnel"
+            );
+        }
+    }
 }

--- a/nym-vpn-core/crates/nym-firewall-config/src/lib.rs
+++ b/nym-vpn-core/crates/nym-firewall-config/src/lib.rs
@@ -62,15 +62,11 @@ pub fn is_local_address(address: &IpAddr) -> bool {
 /// Host routes that must stay on the tunnel after LAN bypass carves out RFC1918/ULA.
 ///
 /// Exit WG metadata is `WG_TUN_DEVICE_IP_ADDRESS_V4` (`10.1.0.1`), which sits inside `10.0.0.0/8`.
-pub fn keep_on_tunnel_after_lan_bypass(
-    interface_addrs: impl IntoIterator<Item = IpAddr>,
-) -> Vec<IpNetwork> {
-    let mut nets = vec![
+pub fn keep_on_tunnel_after_lan_bypass() -> [IpNetwork; 2] {
+    [
         v4(WG_TUN_DEVICE_IP_ADDRESS_V4, 32),
         v6(WG_TUN_DEVICE_IP_ADDRESS_V6, 128),
-    ];
-    nets.extend(interface_addrs.into_iter().map(IpNetwork::from));
-    nets
+    ]
 }
 
 // Short-hand for `IpNetwork::V4(Ipv4Network::new_checked(address, prefix).unwrap())`.
@@ -89,7 +85,7 @@ mod tests {
 
     #[test]
     fn keep_on_tunnel_after_lan_bypass_includes_wg_metadata_v4() {
-        let nets = keep_on_tunnel_after_lan_bypass(std::iter::empty());
+        let nets = keep_on_tunnel_after_lan_bypass();
         let meta = IpAddr::V4(WG_TUN_DEVICE_IP_ADDRESS_V4);
         assert!(
             ALLOWED_LAN_NETS.iter().any(|net| net.contains(meta)),
@@ -100,38 +96,23 @@ mod tests {
 
     #[test]
     fn keep_on_tunnel_after_lan_bypass_includes_wg_metadata_v6() {
-        let nets = keep_on_tunnel_after_lan_bypass(std::iter::empty());
+        let nets = keep_on_tunnel_after_lan_bypass();
         let meta = IpAddr::V6(WG_TUN_DEVICE_IP_ADDRESS_V6);
         assert!(ALLOWED_LAN_NETS.iter().any(|net| net.contains(meta)));
         assert!(nets.iter().any(|net| net.contains(meta)));
     }
 
     #[test]
-    fn keep_on_tunnel_after_lan_bypass_includes_interface_addr() {
-        let client = Ipv4Addr::new(10, 1, 0, 2);
-        let nets = keep_on_tunnel_after_lan_bypass(std::iter::once(IpAddr::V4(client)));
-        assert!(nets.iter().any(|net| net.contains(IpAddr::V4(client))));
-    }
-
-    #[test]
     fn keep_on_tunnel_after_lan_bypass_emits_host_prefixes() {
-        let iface = [
-            IpAddr::V4(Ipv4Addr::new(10, 1, 0, 2)),
-            IpAddr::V6("fc01::2".parse().unwrap()),
-        ];
-        for net in keep_on_tunnel_after_lan_bypass(iface) {
+        for net in keep_on_tunnel_after_lan_bypass() {
             let expected = if net.is_ipv4() { 32 } else { 128 };
-            assert_eq!(
-                net.prefix(),
-                expected,
-                "{net} must be a host route so Android Ipv4Net/Ipv6Net::new cannot fail"
-            );
+            assert_eq!(net.prefix(), expected, "{net} must be a host route");
         }
     }
 
     #[test]
     fn keep_on_tunnel_after_lan_bypass_does_not_include_typical_lan_host() {
-        let nets = keep_on_tunnel_after_lan_bypass(std::iter::empty());
+        let nets = keep_on_tunnel_after_lan_bypass();
         for lan in [
             IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)),
             IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/tunnel_provider/tunnel_settings.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/tunnel_provider/tunnel_settings.rs
@@ -313,8 +313,8 @@ impl TunnelNetworkSettings {
             for network in nym_firewall_config::keep_on_tunnel_after_lan_bypass(interface_addrs) {
                 match network {
                     IpNetwork::V4(address) => {
-                        if let Ok(net) = Ipv4Net::new(address.ip(), address.prefix())
-                            .inspect_err(|e| {
+                        if let Ok(net) =
+                            Ipv4Net::new(address.ip(), address.prefix()).inspect_err(|e| {
                                 tracing::error!(
                                     "Failed to re-add IPv4 keep-on-tunnel route for {}: {}",
                                     address,
@@ -326,8 +326,8 @@ impl TunnelNetworkSettings {
                         }
                     }
                     IpNetwork::V6(address) => {
-                        if let Ok(net) = Ipv6Net::new(address.ip(), address.prefix())
-                            .inspect_err(|e| {
+                        if let Ok(net) =
+                            Ipv6Net::new(address.ip(), address.prefix()).inspect_err(|e| {
                                 tracing::error!(
                                     "Failed to re-add IPv6 keep-on-tunnel route for {}: {}",
                                     address,

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/tunnel_provider/tunnel_settings.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/tunnel_provider/tunnel_settings.rs
@@ -263,22 +263,32 @@ impl TunnelNetworkSettings {
                 .chain(ALLOWED_LAN_MULTICAST_NETS.iter())
             {
                 match network {
-                    IpNetwork::V4(address) => match Ipv4Net::new(address.ip(), address.prefix()) {
-                        Ok(ipv4_net) => {
+                    IpNetwork::V4(address) => {
+                        if let Ok(ipv4_net) = Ipv4Net::new(address.ip(), address.prefix())
+                            .inspect_err(|e| {
+                                tracing::error!(
+                                    "Failed to create IPv4 network for {}: {}",
+                                    address,
+                                    e
+                                )
+                            })
+                        {
                             exclude_ipv4_lan.add(ipv4_net);
                         }
-                        Err(e) => {
-                            tracing::error!("Failed to create IPv4 network for {}: {}", address, e)
-                        }
-                    },
-                    IpNetwork::V6(address) => match Ipv6Net::new(address.ip(), address.prefix()) {
-                        Ok(ipv6_net) => {
+                    }
+                    IpNetwork::V6(address) => {
+                        if let Ok(ipv6_net) = Ipv6Net::new(address.ip(), address.prefix())
+                            .inspect_err(|e| {
+                                tracing::error!(
+                                    "Failed to create IPv6 network for {}: {}",
+                                    address,
+                                    e
+                                )
+                            })
+                        {
                             exclude_ipv6_lan.add(ipv6_net);
                         }
-                        Err(e) => {
-                            tracing::error!("Failed to create IPv6 network for {}: {}", address, e)
-                        }
-                    },
+                    }
                 }
             }
 
@@ -303,12 +313,28 @@ impl TunnelNetworkSettings {
             for network in nym_firewall_config::keep_on_tunnel_after_lan_bypass(interface_addrs) {
                 match network {
                     IpNetwork::V4(address) => {
-                        if let Ok(net) = Ipv4Net::new(address.ip(), address.prefix()) {
+                        if let Ok(net) = Ipv4Net::new(address.ip(), address.prefix())
+                            .inspect_err(|e| {
+                                tracing::error!(
+                                    "Failed to re-add IPv4 keep-on-tunnel route for {}: {}",
+                                    address,
+                                    e
+                                )
+                            })
+                        {
                             tunnel_ipv4.add(net);
                         }
                     }
                     IpNetwork::V6(address) => {
-                        if let Ok(net) = Ipv6Net::new(address.ip(), address.prefix()) {
+                        if let Ok(net) = Ipv6Net::new(address.ip(), address.prefix())
+                            .inspect_err(|e| {
+                                tracing::error!(
+                                    "Failed to re-add IPv6 keep-on-tunnel route for {}: {}",
+                                    address,
+                                    e
+                                )
+                            })
+                        {
                             tunnel_ipv6.add(net);
                         }
                     }

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/tunnel_provider/tunnel_settings.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/tunnel_provider/tunnel_settings.rs
@@ -263,78 +263,38 @@ impl TunnelNetworkSettings {
                 .chain(ALLOWED_LAN_MULTICAST_NETS.iter())
             {
                 match network {
-                    IpNetwork::V4(address) => {
-                        if let Ok(ipv4_net) = Ipv4Net::new(address.ip(), address.prefix())
-                            .inspect_err(|e| {
-                                tracing::error!(
-                                    "Failed to create IPv4 network for {}: {}",
-                                    address,
-                                    e
-                                )
-                            })
-                        {
+                    IpNetwork::V4(address) => match Ipv4Net::new(address.ip(), address.prefix()) {
+                        Ok(ipv4_net) => {
                             exclude_ipv4_lan.add(ipv4_net);
                         }
-                    }
-                    IpNetwork::V6(address) => {
-                        if let Ok(ipv6_net) = Ipv6Net::new(address.ip(), address.prefix())
-                            .inspect_err(|e| {
-                                tracing::error!(
-                                    "Failed to create IPv6 network for {}: {}",
-                                    address,
-                                    e
-                                )
-                            })
-                        {
+                        Err(e) => {
+                            tracing::error!("Failed to create IPv4 network for {}: {}", address, e)
+                        }
+                    },
+                    IpNetwork::V6(address) => match Ipv6Net::new(address.ip(), address.prefix()) {
+                        Ok(ipv6_net) => {
                             exclude_ipv6_lan.add(ipv6_net);
                         }
-                    }
+                        Err(e) => {
+                            tracing::error!("Failed to create IPv6 network for {}: {}", address, e)
+                        }
+                    },
                 }
             }
 
             tunnel_ipv4 = tunnel_ipv4.exclude(&exclude_ipv4_lan);
             tunnel_ipv6 = tunnel_ipv6.exclude(&exclude_ipv6_lan);
 
-            // WG metadata (10.1.0.1) lives inside the RFC1918 LAN carve-out.
-            let interface_addrs = self
-                .ipv4_settings
-                .as_ref()
-                .into_iter()
-                .flat_map(|settings| settings.addresses.iter().map(|net| IpAddr::V4(net.ip())))
-                .chain(
-                    self.ipv6_settings
-                        .as_ref()
-                        .into_iter()
-                        .flat_map(|settings| {
-                            settings.addresses.iter().map(|net| IpAddr::V6(net.ip()))
-                        }),
-                );
-
-            for network in nym_firewall_config::keep_on_tunnel_after_lan_bypass(interface_addrs) {
+            // Exit metadata is 10.1.0.1 / fc01::1, inside the LAN carve-out.
+            for network in nym_firewall_config::keep_on_tunnel_after_lan_bypass() {
                 match network {
                     IpNetwork::V4(address) => {
-                        if let Ok(net) =
-                            Ipv4Net::new(address.ip(), address.prefix()).inspect_err(|e| {
-                                tracing::error!(
-                                    "Failed to re-add IPv4 keep-on-tunnel route for {}: {}",
-                                    address,
-                                    e
-                                )
-                            })
-                        {
+                        if let Ok(net) = Ipv4Net::new(address.ip(), address.prefix()) {
                             tunnel_ipv4.add(net);
                         }
                     }
                     IpNetwork::V6(address) => {
-                        if let Ok(net) =
-                            Ipv6Net::new(address.ip(), address.prefix()).inspect_err(|e| {
-                                tracing::error!(
-                                    "Failed to re-add IPv6 keep-on-tunnel route for {}: {}",
-                                    address,
-                                    e
-                                )
-                            })
-                        {
+                        if let Ok(net) = Ipv6Net::new(address.ip(), address.prefix()) {
                             tunnel_ipv6.add(net);
                         }
                     }

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/tunnel_provider/tunnel_settings.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/tunnel_provider/tunnel_settings.rs
@@ -284,6 +284,36 @@ impl TunnelNetworkSettings {
 
             tunnel_ipv4 = tunnel_ipv4.exclude(&exclude_ipv4_lan);
             tunnel_ipv6 = tunnel_ipv6.exclude(&exclude_ipv6_lan);
+
+            // WG metadata (10.1.0.1) lives inside the RFC1918 LAN carve-out.
+            let interface_addrs = self
+                .ipv4_settings
+                .as_ref()
+                .into_iter()
+                .flat_map(|settings| settings.addresses.iter().map(|net| IpAddr::V4(net.ip())))
+                .chain(
+                    self.ipv6_settings
+                        .as_ref()
+                        .into_iter()
+                        .flat_map(|settings| {
+                            settings.addresses.iter().map(|net| IpAddr::V6(net.ip()))
+                        }),
+                );
+
+            for network in nym_firewall_config::keep_on_tunnel_after_lan_bypass(interface_addrs) {
+                match network {
+                    IpNetwork::V4(address) => {
+                        if let Ok(net) = Ipv4Net::new(address.ip(), address.prefix()) {
+                            tunnel_ipv4.add(net);
+                        }
+                    }
+                    IpNetwork::V6(address) => {
+                        if let Ok(net) = Ipv6Net::new(address.ip(), address.prefix()) {
+                            tunnel_ipv6.add(net);
+                        }
+                    }
+                }
+            }
         }
 
         tunnel_ipv4


### PR DESCRIPTION
## Description
Alow_lan=true removes 10.0.0.0/8 from VpnService. Exit metadata is http://10.1.0.1:51830, so that packet leaves on Wi-Fi. Handshake still succeeds; HTTP never returns; we log Metadata endpoints not reachable and never reach Connected.

Samsung dump (LAN on, QUIC off): handshake -500ms, then starting new connection Some("10.1.0.1"), then 10s later Metadata endpoints not reachable. Four retries, zero Connected. Same phone with this keep-route reached Connected at 11:33:46 after debug apk was deployed to device in question.

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6186)
<!-- Reviewable:end -->
