### PR TITLE
LAN bypass was dropping the exit metadata address. (#6186)

### DIFF
--- a/nym-vpn-core/Cargo.lock
+++ b/nym-vpn-core/Cargo.lock
@@ -5944,6 +5944,7 @@ name = "nym-firewall-config"
 version = "2026.13.0-beta.1"
 dependencies = [
  "ipnetwork",
+ "nym-network-defaults",
 ]
 
 [[package]]

--- a/nym-vpn-core/crates/nym-firewall-config/Cargo.toml
+++ b/nym-vpn-core/crates/nym-firewall-config/Cargo.toml
@@ -11,6 +11,7 @@ rust-version.workspace = true
 
 [dependencies]
 ipnetwork.workspace = true
+nym-network-defaults.workspace = true
 
 [lints]
 workspace = true

--- a/nym-vpn-core/crates/nym-firewall-config/src/lib.rs
+++ b/nym-vpn-core/crates/nym-firewall-config/src/lib.rs
@@ -4,6 +4,7 @@
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
+use nym_network_defaults::{WG_TUN_DEVICE_IP_ADDRESS_V4, WG_TUN_DEVICE_IP_ADDRESS_V6};
 
 /// Value used to mark packets and associated connections.
 /// This should be an arbitrary but unique integer.
@@ -58,6 +59,16 @@ pub fn is_local_address(address: &IpAddr) -> bool {
         .any(|net| net.contains(address))
 }
 
+/// Host routes that must stay on the tunnel after LAN bypass carves out RFC1918/ULA.
+///
+/// Exit WG metadata is `WG_TUN_DEVICE_IP_ADDRESS_V4` (`10.1.0.1`), which sits inside `10.0.0.0/8`.
+pub fn keep_on_tunnel_after_lan_bypass() -> [IpNetwork; 2] {
+    [
+        v4(WG_TUN_DEVICE_IP_ADDRESS_V4, 32),
+        v6(WG_TUN_DEVICE_IP_ADDRESS_V6, 128),
+    ]
+}
+
 // Short-hand for `IpNetwork::V4(Ipv4Network::new_checked(address, prefix).unwrap())`.
 const fn v4(address: Ipv4Addr, prefix: u8) -> IpNetwork {
     IpNetwork::V4(Ipv4Network::new_checked(address, prefix).unwrap())
@@ -66,4 +77,55 @@ const fn v4(address: Ipv4Addr, prefix: u8) -> IpNetwork {
 // Short-hand for `IpNetwork::V6(Ipv6Network::new_checked(address, prefix).unwrap())`.
 const fn v6(address: Ipv6Addr, prefix: u8) -> IpNetwork {
     IpNetwork::V6(Ipv6Network::new_checked(address, prefix).unwrap())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keep_on_tunnel_after_lan_bypass_includes_wg_metadata_v4() {
+        let nets = keep_on_tunnel_after_lan_bypass();
+        let meta = IpAddr::V4(WG_TUN_DEVICE_IP_ADDRESS_V4);
+        assert!(
+            ALLOWED_LAN_NETS.iter().any(|net| net.contains(meta)),
+            "WG metadata v4 must sit inside LAN bypass nets (the collision this keep-list exists for)"
+        );
+        assert!(nets.iter().any(|net| net.contains(meta)));
+    }
+
+    #[test]
+    fn keep_on_tunnel_after_lan_bypass_includes_wg_metadata_v6() {
+        let nets = keep_on_tunnel_after_lan_bypass();
+        let meta = IpAddr::V6(WG_TUN_DEVICE_IP_ADDRESS_V6);
+        assert!(ALLOWED_LAN_NETS.iter().any(|net| net.contains(meta)));
+        assert!(nets.iter().any(|net| net.contains(meta)));
+    }
+
+    #[test]
+    fn keep_on_tunnel_after_lan_bypass_emits_host_prefixes() {
+        for net in keep_on_tunnel_after_lan_bypass() {
+            let expected = if net.is_ipv4() { 32 } else { 128 };
+            assert_eq!(net.prefix(), expected, "{net} must be a host route");
+        }
+    }
+
+    #[test]
+    fn keep_on_tunnel_after_lan_bypass_does_not_include_typical_lan_host() {
+        let nets = keep_on_tunnel_after_lan_bypass();
+        for lan in [
+            IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)),
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+            IpAddr::V4(Ipv4Addr::new(172, 16, 0, 1)),
+        ] {
+            assert!(
+                ALLOWED_LAN_NETS.iter().any(|net| net.contains(lan)),
+                "{lan} should remain in the LAN bypass set"
+            );
+            assert!(
+                !nets.iter().any(|net| net.contains(lan)),
+                "{lan} must not be re-added to the tunnel"
+            );
+        }
+    }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/tunnel_provider/tunnel_settings.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/tunnel_provider/tunnel_settings.rs
@@ -284,6 +284,22 @@ impl TunnelNetworkSettings {
 
             tunnel_ipv4 = tunnel_ipv4.exclude(&exclude_ipv4_lan);
             tunnel_ipv6 = tunnel_ipv6.exclude(&exclude_ipv6_lan);
+
+            // Exit metadata is 10.1.0.1 / fc01::1, inside the LAN carve-out.
+            for network in nym_firewall_config::keep_on_tunnel_after_lan_bypass() {
+                match network {
+                    IpNetwork::V4(address) => {
+                        if let Ok(net) = Ipv4Net::new(address.ip(), address.prefix()) {
+                            tunnel_ipv4.add(net);
+                        }
+                    }
+                    IpNetwork::V6(address) => {
+                        if let Ok(net) = Ipv6Net::new(address.ip(), address.prefix()) {
+                            tunnel_ipv6.add(net);
+                        }
+                    }
+                }
+            }
         }
 
         tunnel_ipv4


### PR DESCRIPTION
Cherry-pick of #6186 onto develop. allow_lan removes 10.0.0.0/8 from VpnService routes and exit metadata is 10.1.0.1, so metadata HTTP never completed and connect never reached Connected.

## Ticket

JIRA-NYM-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6188)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved LAN bypass behavior on Android by keeping essential tunnel metadata traffic routed through the VPN.
  * Added support for preserving required IPv4 and IPv6 tunnel routes while allowing other local network traffic to bypass the VPN.
* **Bug Fixes**
  * Prevented tunnel metadata connectivity from being disrupted when LAN bypass is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->