### PR TITLE
feat(gateway-selection): treat Greater China as a single jurisdiction

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/geo_ip.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/geo_ip.rs
@@ -36,13 +36,33 @@ fn geo_distance(x: &Location, y: &Location) -> f64 {
     Haversine.distance(p1, p2)
 }
 
+/// Groups of ISO country codes that are treated as a single jurisdiction for
+/// gateway-safety purposes, beyond an exact country-code match. Membership is
+/// symmetric: for any two codes in the same group, neither is offered as an
+/// entry or exit relative to the other (or to a user located in the group).
+const JURISDICTION_GROUPS: &[&[&str]] = &[
+    // Greater China: mainland China, Taiwan, Macau.
+    &["CN", "TW", "MO"],
+];
+
+/// Returns true if two ISO country codes belong to the same safety jurisdiction
+/// group. Exact-match equality is handled separately by [`same_jurisdiction`].
+fn same_jurisdiction_group(a: &str, b: &str) -> bool {
+    JURISDICTION_GROUPS
+        .iter()
+        .any(|group| group.contains(&a) && group.contains(&b))
+}
+
 pub(crate) fn same_jurisdiction(x: &Location, y: &Location) -> bool {
-    if x.two_letter_iso_country_code == y.two_letter_iso_country_code
-        && x.two_letter_iso_country_code == "US"
-    {
-        return x.region == y.region;
+    let (a, b) = (
+        x.two_letter_iso_country_code.as_str(),
+        y.two_letter_iso_country_code.as_str(),
+    );
+    if a == b {
+        // US gateways are distinguished per-region rather than per-country.
+        return if a == "US" { x.region == y.region } else { true };
     }
-    x.two_letter_iso_country_code == y.two_letter_iso_country_code
+    same_jurisdiction_group(a, b)
 }
 
 // Compare two gateways' distance to a given reference point
@@ -247,6 +267,28 @@ impl GeoIpProvider {
 #[cfg(test)]
 pub mod tests {
     use super::*;
+
+    #[test]
+    fn greater_china_shares_jurisdiction() {
+        let group = ["CN", "TW", "MO"];
+        // Every pair within the group shares a jurisdiction (symmetric),
+        // including each code with itself.
+        for a in group {
+            for b in group {
+                assert!(
+                    same_jurisdiction_group(a, b),
+                    "{a}/{b} should share a jurisdiction",
+                );
+            }
+        }
+        // Codes outside the group are not affected (Hong Kong is intentionally excluded).
+        assert!(!same_jurisdiction_group("HK", "CN"));
+        assert!(!same_jurisdiction_group("HK", "TW"));
+        assert!(!same_jurisdiction_group("CN", "US"));
+        assert!(!same_jurisdiction_group("TW", "JP"));
+        assert!(!same_jurisdiction_group("US", "GB"));
+        assert!(!same_jurisdiction_group("DE", "FR"));
+    }
 
     #[derive(Clone)]
     pub struct MockGeoIpClient {}


### PR DESCRIPTION
Groups CN, TW and MO into one jurisdiction in `same_jurisdiction` so entry and exit auto-selection with `exclude_user_country` never routes a user in any of them through a gateway in the others. Symmetric; US per-region behaviour unchanged. Adds a unit test.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6192)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved geo-location safety checks for China, Taiwan, and Macau by treating them as a single jurisdiction.
  - Preserved region-level matching for the United States and exact country matching elsewhere.
  - Added coverage for Greater China jurisdiction combinations and excluded countries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->