### PR TITLE
fix(android): don't crash server search on locales without ISO3 mapping

### DIFF
--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/server/ServerViewModel.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/server/ServerViewModel.kt
@@ -15,6 +15,7 @@ import net.nymtech.nymvpn.manager.backend.BackendManager
 import net.nymtech.nymvpn.manager.favorites.FavoritesManager
 import net.nymtech.nymvpn.service.gateway.GatewayCacheService
 import net.nymtech.nymvpn.util.extensions.isQuicSupported
+import net.nymtech.nymvpn.util.extensions.iso3CountryOrEmpty
 import net.nymtech.nymvpn.util.extensions.scoreSorted
 import net.nymtech.nymvpn.util.extensions.toLocale
 import net.nymtech.vpn.backend.Tunnel
@@ -198,7 +199,7 @@ class ServerViewModel @Inject constructor(
 					(
 						locale.displayCountry.lowercase().contains(lowercaseQuery) ||
 							locale.country.lowercase().contains(lowercaseQuery) ||
-							locale.isO3Country.lowercase().contains(lowercaseQuery) ||
+							locale.iso3CountryOrEmpty().lowercase().contains(lowercaseQuery) ||
 							countryGateways.any { it.region?.lowercase()?.contains(lowercaseQuery) == true }
 						)
 			}
@@ -276,7 +277,7 @@ class ServerViewModel @Inject constructor(
 				query.isBlank() ||
 					item.locale.displayCountry.lowercase().contains(lowercaseQuery) ||
 					item.locale.country.lowercase().contains(lowercaseQuery) ||
-					item.locale.isO3Country.lowercase().contains(lowercaseQuery) ||
+					item.locale.iso3CountryOrEmpty().lowercase().contains(lowercaseQuery) ||
 					item.regions?.any { it.region.lowercase().contains(lowercaseQuery) } == true
 			}
 			.sortedWith(compareBy(collator) { it.locale.displayCountry })

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/util/extensions/GeneralExtensions.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/util/extensions/GeneralExtensions.kt
@@ -6,6 +6,7 @@ import net.nymtech.nymvpn.ui.screens.main.panel.ConnectMode
 import net.nymtech.vpn.backend.Tunnel
 import net.nymtech.vpn.model.NymGateway
 import java.util.Locale
+import java.util.MissingResourceException
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
@@ -21,6 +22,14 @@ fun String.capitalize(locale: Locale): String = this.replaceFirstChar { if (it.i
 fun String.truncateWithEllipsis(length: Int): String = if (this.length <= length) this else "${take(length)}..."
 
 fun NymGateway.toLocale(): Locale? = twoLetterCountryISO?.let { Locale(it, it) }
+
+// Locale.isO3Country throws MissingResourceException for codes without an ISO3 mapping
+// (user-assigned codes like "XK"/Kosovo on older ICU data, e.g. Android 9)
+fun Locale.iso3CountryOrEmpty(): String = try {
+	isO3Country
+} catch (_: MissingResourceException) {
+	""
+}
 
 private const val ALWAYS_ON_VPN_APP = "always_on_vpn_app"
 


### PR DESCRIPTION
Locale.getISO3Country() throws MissingResourceException for user-assigned codes like XK (Kosovo) on older ICU data (reproduced 100% on Android 9): the first keystroke in the server-list search crashed the app. Guard the two search-filter call sites with a safe iso3CountryOrEmpty() extension. Verified on SM-G900F/Android 9 (crash gone, Kosovo searchable via name and "xk") and Pixel 9/Android 17 (ISO3 search "deu" unaffected).

## Ticket

JIRA-NYM-XXXX

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6193)
<!-- Reviewable:end -->
