### PR TITLE
fix(android): keep server search field at min 48dp on short screens

### DIFF
--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/server/ServerScreen.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/server/ServerScreen.kt
@@ -313,7 +313,9 @@ internal fun ServerScreenContent(
 						onValueChange = onQueryChange,
 						modifier = Modifier
 							.fillMaxWidth()
-							.height(48.dp.scaledHeight())
+							// scaledHeight shrinks below the content height on short screens (e.g. 48dp -> ~33dp
+							// on a 1080x1920 xxhdpi device), clipping the text — keep the M3 48dp minimum
+							.height(48.dp.scaledHeight().coerceAtLeast(48.dp))
 							.background(MaterialTheme.colorScheme.background, RoundedCornerShape(12.dp)),
 						placeholder = {
 							Text(


### PR DESCRIPTION
scaledHeight() scales 48dp down to ~33dp on 1080x1920 xxhdpi devices (e.g. Galaxy S5), clipping the search text vertically since the field content needs 48dp (12+12dp padding + bodyLarge line). Clamp to the Material 48dp minimum touch target; no-op on taller screens. Verified on SM-G900F (Android 9) and Pixel 9 (Android 17).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6194)
<!-- Reviewable:end -->
