### PR TITLE
reduced MAX_RECONNECT_ATTEMPTS to 3

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -1065,7 +1065,7 @@ impl ConnectingPolicyParameters {
 
 /// Maximum number of consecutive reconnect attempts before transitioning to the error
 /// state instead of silently retrying forever.
-const MAX_RECONNECT_ATTEMPTS: u32 = 10;
+const MAX_RECONNECT_ATTEMPTS: u32 = 3;
 
 /// Decision on what to do for the given reconnect attempt.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
10 is too long

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6198)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * VPN connections now enter an error state after three failed reconnection attempts instead of ten, providing faster feedback when reconnection repeatedly fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->