### PR TITLE
style(gateway-selection): fix rustfmt in same_jurisdiction

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/geo_ip.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel/gateway_provider/geo_ip.rs
@@ -60,7 +60,7 @@ pub(crate) fn same_jurisdiction(x: &Location, y: &Location) -> bool {
     );
     if a == b {
         // US gateways are distinguished per-region rather than per-country.
-        return if a == "US" { x.region == y.region } else { true };
+        return a != "US" || x.region == y.region;
     }
     same_jurisdiction_group(a, b)
 }


### PR DESCRIPTION
cargo fmt --check (stable) rejected the return-if/else expression added in `a != "US" || x.region == y.region`, which is rustfmt-clean on stable and nightly and reads no worse.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6201)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gateway jurisdiction matching for US regions while preserving country-based matching for all other locations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->