### PR TITLE
Unstick login processing when carousel is interrupted

### DIFF
--- a/nym-vpn-apple/Home/Sources/26/ProcessingAccount/ProcessingAccountView.swift
+++ b/nym-vpn-apple/Home/Sources/26/ProcessingAccount/ProcessingAccountView.swift
@@ -28,21 +28,13 @@ struct ProcessingAccountView: View {
         .frame(maxWidth: .infinity)
         .frame(height: minHeight > 0 ? minHeight : nil, alignment: .top)
         .onAppear {
-            if scenePhase == .active {
-                viewModel.noteCarouselResumed()
-            } else {
-                viewModel.noteCarouselInterrupted()
-            }
+            applyCarouselScenePhase(scenePhase)
         }
         .onDisappear {
             viewModel.noteCarouselInterrupted()
         }
         .onChange(of: scenePhase) { _, newPhase in
-            if newPhase == .active {
-                viewModel.noteCarouselResumed()
-            } else {
-                viewModel.noteCarouselInterrupted()
-            }
+            applyCarouselScenePhase(newPhase)
         }
     }
 }
@@ -118,6 +110,17 @@ private extension ProcessingAccountView {
         .hidden()
         .accessibilityHidden(true)
         .allowsHitTesting(false)
+    }
+
+    func applyCarouselScenePhase(_ phase: ScenePhase) {
+        switch ProcessingAccountView.carouselSceneAction(for: phase) {
+        case .resume:
+            viewModel.noteCarouselResumed()
+        case .interrupt:
+            viewModel.noteCarouselInterrupted()
+        case .ignore:
+            break
+        }
     }
 
     func titlePairMeasurement(title: String, subtitle: String) -> some View {
@@ -252,6 +255,12 @@ private extension ProcessingAccountView {
     }
 }
 
+enum ProcessingAccountCarouselSceneAction: Equatable {
+    case resume
+    case interrupt
+    case ignore
+}
+
 enum ProcessingAccountTitleBlockMode: Equatable {
     case staticCopy
     case welcome
@@ -260,6 +269,19 @@ enum ProcessingAccountTitleBlockMode: Equatable {
 }
 
 extension ProcessingAccountView {
+    static func carouselSceneAction(for phase: ScenePhase) -> ProcessingAccountCarouselSceneAction {
+        switch phase {
+        case .active:
+            return .resume
+        case .background:
+            return .interrupt
+        case .inactive:
+            return .ignore
+        @unknown default:
+            return .ignore
+        }
+    }
+
     static func titleBlockMode(
         usesStaticCopy: Bool,
         didShowFinalMessage: Bool,

--- a/nym-vpn-apple/Home/Sources/26/ProcessingAccount/ProcessingAccountView.swift
+++ b/nym-vpn-apple/Home/Sources/26/ProcessingAccount/ProcessingAccountView.swift
@@ -7,6 +7,7 @@ struct ProcessingAccountView: View {
     @Bindable var viewModel: ProcessingAccountViewModel
     let minHeight: CGFloat
 
+    @Environment(\.scenePhase) private var scenePhase
     @State private var titleBlockHeight: CGFloat = 0
 
     init(viewModel: ProcessingAccountViewModel, minHeight: CGFloat = 0) {
@@ -26,6 +27,23 @@ struct ProcessingAccountView: View {
         .padding(.vertical, AuthLayout.processingCarouselVerticalPadding)
         .frame(maxWidth: .infinity)
         .frame(height: minHeight > 0 ? minHeight : nil, alignment: .top)
+        .onAppear {
+            if scenePhase == .active {
+                viewModel.noteCarouselResumed()
+            } else {
+                viewModel.noteCarouselInterrupted()
+            }
+        }
+        .onDisappear {
+            viewModel.noteCarouselInterrupted()
+        }
+        .onChange(of: scenePhase) { _, newPhase in
+            if newPhase == .active {
+                viewModel.noteCarouselResumed()
+            } else {
+                viewModel.noteCarouselInterrupted()
+            }
+        }
     }
 }
 

--- a/nym-vpn-apple/Home/Sources/26/ProcessingAccount/ProcessingAccountViewModel.swift
+++ b/nym-vpn-apple/Home/Sources/26/ProcessingAccount/ProcessingAccountViewModel.swift
@@ -45,6 +45,7 @@ public final class ProcessingAccountViewModel {
     private(set) var setupCarouselIndex = 0
     /// Set when backend prefetch begins; keeps bar segment 4 until navigation advances.
     private(set) var hasReachedPrefetchPhase = false
+    @ObservationIgnored private var isCarouselInterrupted = false
 
     var didFinishAnimatingText = false {
         didSet { evaluateAdvance() }
@@ -246,6 +247,17 @@ public final class ProcessingAccountViewModel {
         updateAnimationReady()
     }
 
+    /// Background / teardown only. Foreground work-complete still waits for animation (#6156).
+    func noteCarouselInterrupted() {
+        isCarouselInterrupted = true
+        latchCarouselIfWorkCompleteAndInterrupted()
+    }
+
+    func noteCarouselResumed() {
+        latchCarouselIfWorkCompleteAndInterrupted()
+        isCarouselInterrupted = false
+    }
+
     /// Awaits the post-advance welcome-message delay. Test hook only.
     func awaitFinalMessage() async {
         await finalMessageTask?.value
@@ -260,7 +272,15 @@ public final class ProcessingAccountViewModel {
         phase = .awaitingAdvance
         syncProgressStep()
         workCompleted = true
+        latchCarouselIfWorkCompleteAndInterrupted()
         updateAnimationReady()
+    }
+
+    private func latchCarouselIfWorkCompleteAndInterrupted() {
+        guard !usesStaticCopy, workCompleted, isCarouselInterrupted, !didFinishSetupCarousel else {
+            return
+        }
+        animationDidFinish()
     }
 
     private func updateAnimationReady() {

--- a/nym-vpn-apple/Home/Tests/HomeTests/ProcessingAccountCarouselInterruptTests.swift
+++ b/nym-vpn-apple/Home/Tests/HomeTests/ProcessingAccountCarouselInterruptTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 import Testing
 import AccountPrefetchGates
 @testable import Home
@@ -76,5 +77,11 @@ struct ProcessingAccountCarouselInterruptTests {
         await viewModel.awaitFinalMessage()
         #expect(viewModel.phase == .finished)
         #expect(coordinator.actions == [.session(.processingFinished)])
+    }
+
+    @Test func scenePhaseMapsOnlyBackgroundToInterrupt() {
+        #expect(ProcessingAccountView.carouselSceneAction(for: .active) == .resume)
+        #expect(ProcessingAccountView.carouselSceneAction(for: .inactive) == .ignore)
+        #expect(ProcessingAccountView.carouselSceneAction(for: .background) == .interrupt)
     }
 }

--- a/nym-vpn-apple/Home/Tests/HomeTests/ProcessingAccountCarouselInterruptTests.swift
+++ b/nym-vpn-apple/Home/Tests/HomeTests/ProcessingAccountCarouselInterruptTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Testing
+import AccountPrefetchGates
+@testable import Home
+
+@MainActor
+struct ProcessingAccountCarouselInterruptTests {
+    @Test func workCompleteThenInterrupted_advancesWithoutAnimationCallback() async {
+        let processing = FakeProcessing()
+        let coordinator = FakeCoordinator()
+        let viewModel = makeViewModel(flow: .login, processing: processing, coordinator: coordinator)
+
+        await viewModel.run()
+        #expect(viewModel.phase == .awaitingAdvance)
+        #expect(!viewModel.didFinishSetupCarousel)
+        #expect(coordinator.actions.isEmpty)
+
+        viewModel.noteCarouselInterrupted()
+        await viewModel.awaitFinalMessage()
+
+        #expect(viewModel.didFinishSetupCarousel)
+        #expect(viewModel.phase == .finished)
+        #expect(coordinator.actions == [.session(.processingFinished)])
+    }
+
+    @Test func interruptedBeforeWorkCompletes_latchesWhenWorkFinishes() async {
+        let processing = FakeProcessing()
+        let coordinator = FakeCoordinator()
+        let viewModel = makeViewModel(flow: .createAccount, processing: processing, coordinator: coordinator)
+
+        viewModel.noteCarouselInterrupted()
+        #expect(!viewModel.didFinishSetupCarousel)
+        #expect(coordinator.actions.isEmpty)
+
+        await viewModel.run()
+        await viewModel.awaitFinalMessage()
+
+        #expect(viewModel.didFinishSetupCarousel)
+        #expect(viewModel.phase == .finished)
+        #expect(coordinator.actions == [.session(.processingFinished)])
+    }
+
+    @Test func resumedBeforeWorkCompletes_stillWaitsForAnimation() async {
+        let processing = FakeProcessing()
+        let coordinator = FakeCoordinator()
+        let viewModel = makeViewModel(flow: .login, processing: processing, coordinator: coordinator)
+
+        viewModel.noteCarouselInterrupted()
+        viewModel.noteCarouselResumed()
+        await viewModel.run()
+
+        #expect(!viewModel.didFinishSetupCarousel)
+        #expect(!viewModel.didFinishAnimatingText)
+        #expect(viewModel.phase == .awaitingAdvance)
+        #expect(viewModel.currentStep == LoginProcessingUI.initialProgressStep)
+        #expect(coordinator.actions.isEmpty)
+    }
+
+    @Test func interruptDuringInFlightPrepare_doesNotJumpBarsUntilWorkCompletes() async {
+        let processing = FakeProcessing()
+        processing.holdPrepareUntilReleased = true
+        let coordinator = FakeCoordinator()
+        let viewModel = makeViewModel(flow: .login, processing: processing, coordinator: coordinator)
+
+        let runTask = Task { await viewModel.run() }
+        await Task.yield()
+        try? await Task.sleep(for: .milliseconds(20))
+        viewModel.noteCarouselInterrupted()
+
+        #expect(!viewModel.didFinishSetupCarousel)
+        #expect(viewModel.currentStep == LoginProcessingUI.initialProgressStep)
+        #expect(coordinator.actions.isEmpty)
+
+        processing.releasePrepare()
+        await runTask.value
+        await viewModel.awaitFinalMessage()
+        #expect(viewModel.phase == .finished)
+        #expect(coordinator.actions == [.session(.processingFinished)])
+    }
+}

--- a/nym-vpn-apple/Home/Tests/HomeTests/ProcessingAccountViewModelTests.swift
+++ b/nym-vpn-apple/Home/Tests/HomeTests/ProcessingAccountViewModelTests.swift
@@ -4,7 +4,7 @@ import AccountPrefetchGates
 @testable import Home
 
 @MainActor
-private final class FakeProcessing: AccountProcessing {
+final class FakeProcessing: AccountProcessing {
     enum Call: Equatable, Sendable {
         case ensure
         case prepare
@@ -102,7 +102,7 @@ private final class FakeProcessing: AccountProcessing {
 }
 
 @MainActor
-private final class FakeCoordinator: AppSessionCoordinating {
+final class FakeCoordinator: AppSessionCoordinating {
     private(set) var actions: [CoordinatorAction] = []
 
     func handle(_ action: CoordinatorAction) {
@@ -111,7 +111,7 @@ private final class FakeCoordinator: AppSessionCoordinating {
 }
 
 @MainActor
-private func makeViewModel(
+func makeViewModel(
     flow: ProcessingFlow,
     processing: FakeProcessing,
     coordinator: FakeCoordinator,
@@ -128,7 +128,7 @@ private func makeViewModel(
 }
 
 @MainActor
-private func finishSetupCarousel(_ viewModel: ProcessingAccountViewModel) async {
+func finishSetupCarousel(_ viewModel: ProcessingAccountViewModel) async {
     viewModel.animationDidFinish()
     await viewModel.awaitFinalMessage()
 }

--- a/nym-vpn-apple/ServicesMacOS/Sources/GRPCManager/GRPCManager+TunnelStatus.swift
+++ b/nym-vpn-apple/ServicesMacOS/Sources/GRPCManager/GRPCManager+TunnelStatus.swift
@@ -109,8 +109,6 @@ extension GRPCManager {
             ErrorReason.credentialFetchingFailed
         case .noCredentialAvailable:
             ErrorReason.noCredentialAvailable
-        case .connectionAttemptsExceeded:
-            ErrorReason.connectionAttemptsExceeded
         }
     }
 }
@@ -175,8 +173,6 @@ extension ErrorReason {
             self = .credentialFetchingFailed
         case .noCredentialAvailable:
             self = .noCredentialAvailable
-        case .connectionAttemptsExceeded:
-            self = .connectionAttemptsExceeded
         }
     }
 }

--- a/nym-vpn-apple/ServicesMacOS/Sources/GRPCManager/GRPCManager+TunnelStatus.swift
+++ b/nym-vpn-apple/ServicesMacOS/Sources/GRPCManager/GRPCManager+TunnelStatus.swift
@@ -109,6 +109,8 @@ extension GRPCManager {
             ErrorReason.credentialFetchingFailed
         case .noCredentialAvailable:
             ErrorReason.noCredentialAvailable
+        case .connectionAttemptsExceeded:
+            ErrorReason.connectionAttemptsExceeded
         }
     }
 }
@@ -173,6 +175,8 @@ extension ErrorReason {
             self = .credentialFetchingFailed
         case .noCredentialAvailable:
             self = .noCredentialAvailable
+        case .connectionAttemptsExceeded:
+            self = .connectionAttemptsExceeded
         }
     }
 }


### PR DESCRIPTION
## Ticket
[JIRA-NYM-1756](https://nymtech.atlassian.net/browse/NYM-1756)

## Description

Latch setup-carousel completion only when account work is done and the processing view is backgrounded or torn down, so a missed animation callback cannot leave the Home drawer on processing. Foreground bar order stays animation-driven.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6203)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account setup progress when the app is backgrounded or interrupted, allowing completed work to finish without waiting for an animation.
  * Preserved setup progress when interruptions occur before processing completes.
  * Improved macOS tunnel error reporting for repeated connection failures.

* **Tests**
  * Added coverage for account setup interruptions, resumptions, and in-progress animations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->