### PR TITLE
fix(macos): show explicit min-OS message in pkg installer

### DIFF
--- a/.github/workflows/build-nym-vpn-app-macos.yml
+++ b/.github/workflows/build-nym-vpn-app-macos.yml
@@ -597,6 +597,27 @@ jobs:
               --append '//installer-gui-script/domains' --type attr -n 'enable_localSystem' --value 'true' \
               "$DIST_XML_FILE"
 
+          # Fail early with an explicit message on unsupported macOS versions.
+          # Without this, the min-os-version requirement baked into the nested pkg only
+          # surfaces on the Destination Select pane as a generic "You cannot install
+          # NymVPN in this location" error, which doesn't tell the user why.
+          INSTALL_CHECK_JS="
+          function installCheck() {
+              if (system.compareVersions(system.version.ProductVersion, '$MIN_OS_VERSION') >= 0) {
+                  return true;
+              }
+              my.result.title = 'Unsupported macOS version';
+              my.result.message = 'NymVPN requires macOS $MIN_OS_VERSION or later. Please update macOS and try again.';
+              my.result.type = 'Fatal';
+              return false;
+          }
+          "
+          xmlstarlet edit --inplace \
+            --subnode '//installer-gui-script' --type elem -n 'script' --value "$INSTALL_CHECK_JS" \
+            --subnode '//installer-gui-script' --type elem -n 'installation-check' \
+            --append '$prev' --type attr -n 'script' --value 'installCheck()' \
+            "$DIST_XML_FILE"
+
           # Add element to prompt user to close the app before installation
           xmlstarlet edit --inplace \
             --subnode '//installer-gui-script' \


### PR DESCRIPTION
Add an installation-check to the Distribution XML that fails with "NymVPN requires macOS 14.0 or later" on unsupported systems. The min-os-version requirement previously only surfaced on the Destination Select pane as a generic "You cannot install NymVPN in this location" error, without telling the user why.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6204)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * macOS installation now checks system compatibility before proceeding.
  * Unsupported macOS versions are rejected with a clear message indicating the minimum required version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->