### PR TITLE
feat(macos): launch app after pkg installation completes

### DIFF
--- a/nym-vpn-apple/Installer/Scripts/postinstall
+++ b/nym-vpn-apple/Installer/Scripts/postinstall
@@ -13,3 +13,17 @@ echo "Running postinstall at $(date)"
 
 # Install launchd config
 "$NYM_SETUP_BIN" install-service
+
+# Launch the app so the user sees the installation succeeded. This script runs
+# as root, so launch in the GUI session of the logged-in console user instead
+# of root. Skipped for headless installs (installer CLI over ssh), where no
+# user owns the console.
+CONSOLE_USER="$(stat -f%Su /dev/console)"
+if [ -n "$CONSOLE_USER" ] && [ "$CONSOLE_USER" != "root" ] && [ "$CONSOLE_USER" != "_mbsetupuser" ]; then
+    CONSOLE_UID="$(id -u "$CONSOLE_USER")"
+    echo "Launching NymVPN.app as $CONSOLE_USER (uid $CONSOLE_UID)"
+    launchctl asuser "$CONSOLE_UID" sudo -u "$CONSOLE_USER" \
+        open -a "$INSTALL_DIR/NymVPN.app" || echo "Failed to launch NymVPN.app"
+else
+    echo "No console user, skipping app launch"
+fi

--- a/nym-vpn-apple/Settings/Sources/Settings/GeoExclusion/GeoExclusionInstructionsView.swift
+++ b/nym-vpn-apple/Settings/Sources/Settings/GeoExclusion/GeoExclusionInstructionsView.swift
@@ -102,18 +102,22 @@ private extension GeoExclusionInstructionsView {
     func highlightedStep(_ key: String, values: [String]) -> Text {
         let mono = Font.custom("Courier New", size: 14)
         let parts = key.localizedString.components(separatedBy: "%@")
-        var result = Text(verbatim: "")
+        var pieces: [Text] = []
         for (index, part) in parts.enumerated() {
-            result = result + Text(verbatim: part)
-                .font(.Nym.bodyDefault)
-                .foregroundColor(Color.Nym.textPrimary)
+            pieces.append(
+                Text(verbatim: part)
+                    .font(.Nym.bodyDefault)
+                    .foregroundColor(Color.Nym.textPrimary)
+            )
             if index < values.count {
-                result = result + Text(verbatim: values[index])
-                    .font(mono)
-                    .foregroundColor(Color.Nym.primary)
+                pieces.append(
+                    Text(verbatim: values[index])
+                        .font(mono)
+                        .foregroundColor(Color.Nym.primary)
+                )
             }
         }
-        return result
+        return pieces.reduce(Text(verbatim: ""), +)
     }
 }
 #endif


### PR DESCRIPTION
Launch NymVPN.app from the postinstall script in the console user's GUI session (not as root), so the user immediately sees the install succeeded. Skipped for headless installs where no user owns the console; failures are logged without failing the install.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6205)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NymVPN now opens automatically after installation when a logged-in desktop user is present.
  * Headless installations and system setup sessions are handled without launching the app.

* **Bug Fixes**
  * Installation continues successfully even if the app cannot be launched, with the failure recorded for troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->