### PR TITLE
ci: run the post-release fan-out when release-all-platforms publishes

### DIFF
--- a/.github/workflows/on-release-publish.yml
+++ b/.github/workflows/on-release-publish.yml
@@ -2,7 +2,7 @@ name: on-release-publish
 
 # Auto-runs the post-publish steps that release-all-platforms DEFERS while the
 # unified release is still a draft (they consume PUBLIC release assets that 404
-# on a draft). Fires the moment a human clicks "Publish release" on the ship draft:
+# on a draft). Runs as soon as the release is public -- see the trigger notes below:
 #   aur-vpnd, aur-app        -> publish PKGBUILDs to AUR
 #   post-release             -> changelog/installer/flatpak PR
 #   win-sigs + windows-updater -> tauri Windows updater feed PR (skips if no win build)
@@ -22,7 +22,21 @@ name: on-release-publish
 #
 # Assumes this workflow + its callees exist on the release commit / default
 # branch (reusable callees resolve at the caller's ref).
+#
+# Three ways in:
+#   release: [released] -- a human clicks Publish on a draft (the gh_release=draft path)
+#   workflow_call       -- release-all-platforms calls us directly when it publishes the
+#                          release itself (the gh_release=auto + ship path). That path gets
+#                          NO webhook: create-release publishes with GITHUB_TOKEN, and
+#                          GitHub deliberately emits no events for GITHUB_TOKEN actions.
+#   workflow_dispatch   -- manual recovery for a release that missed both of the above
 on:
+  workflow_call:
+    inputs:
+      tag_name:
+        type: string
+        description: Release tag
+        required: true
   workflow_dispatch:
     inputs:
       tag_name:
@@ -34,8 +48,10 @@ on:
 permissions:
   contents: read
 
+# github.event.release is empty on the workflow_call/dispatch paths, so fall back to the
+# input -- otherwise every non-webhook run shares one constant group.
 concurrency:
-  group: on-release-publish-${{ github.event.release.tag_name }}
+  group: on-release-publish-${{ github.event.release.tag_name || inputs.tag_name }}
   cancel-in-progress: false
 
 jobs:
@@ -194,8 +210,37 @@ jobs:
       signature_x64: ${{ needs.win-sigs.outputs.sig_x64 }}
       signature_arm64: ${{ needs.win-sigs.outputs.sig_arm64 }}
 
+  # Sparkle appcast feed. macos-updater.yml downloads NymVPN-*.pkg off the release, so a
+  # ship that did not build macOS has nothing for it to do -- probe first rather than
+  # letting `gh release download` fail the job with "no assets match the file pattern".
+  # Same shape as win-sigs above.
+  mac-pkg:
+    needs: setup
+    runs-on: arc-linux-latest
+    outputs:
+      enabled: ${{ steps.pkg.outputs.enabled }}
+    steps:
+      - name: Check for a macOS pkg on the release
+        id: pkg
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ needs.setup.outputs.tag }}
+        run: |
+          set -euo pipefail
+          pkg=$(gh release view "$TAG" --json assets \
+            -q '.assets[].name | select(startswith("NymVPN-") and endswith(".pkg"))' | head -n1)
+          if [ -z "$pkg" ]; then
+            echo "::notice:: no macOS pkg on ${TAG} — skipping Sparkle appcast"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice:: found ${pkg} — will update Sparkle appcast"
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
   macos-updater:
-    needs: [setup]
+    needs: [setup, mac-pkg]
+    if: ${{ needs.mac-pkg.outputs.enabled == 'true' }}
     uses: ./.github/workflows/macos-updater.yml
     secrets: inherit
     permissions:

--- a/.github/workflows/release-all-platforms.yml
+++ b/.github/workflows/release-all-platforms.yml
@@ -613,3 +613,30 @@ jobs:
       android_apk_url: ${{ needs.release.outputs.android_apk_url }}
       ios_build: ${{ needs.build-outputs.outputs.ios_build }}
     secrets: inherit
+
+  # Post-publish fan-out: changelog/installer PR, tauri + Sparkle updater feeds, AUR
+  # packages, F-Droid dispatch, nym.com cache bust. Normally on-release-publish.yml
+  # drives itself off `release: [released]` when a human clicks Publish on a draft.
+  #
+  # That webhook NEVER fires on the gh_release=auto + ship path: create-release
+  # publishes the release itself with GITHUB_TOKEN, and GitHub deliberately emits no
+  # events for actions taken with GITHUB_TOKEN. So call it directly instead of
+  # relying on a webhook that cannot arrive.
+  #
+  # Scoped to gh_release_type == 'release' on purpose:
+  #   draft      -> stays on the human-publish route, where the webhook does fire
+  #   prerelease -> beta/nightly must not reach AUR or the stable updater feeds
+  # so this can never double-run against the webhook path.
+  post-release-fanout:
+    needs: [resolve, release]
+    if: |
+      !cancelled() && needs.release.result == 'success' &&
+      needs.resolve.outputs.publish_github == 'true' &&
+      needs.resolve.outputs.gh_release_type == 'release'
+    uses: ./.github/workflows/on-release-publish.yml
+    permissions:
+      contents: write
+      pull-requests: write
+    with:
+      tag_name: ${{ needs.resolve.outputs.tag }}
+    secrets: inherit


### PR DESCRIPTION
## Problem

`release-all-platforms` ran green for `v2026.12.2` and the release was created, but none of the post-release work happened — no changelog PR, no tauri updater feed PR, no AUR publish, no beta cleanup, no F-Droid dispatch, no nym.com cache bust.

`on-release-publish.yml` hosts that entire fan-out and triggers only on `release: [released]`. **That webhook can never fire on the `gh_release=auto` + `ship` path:** `create-release` publishes the release itself with `secrets.GITHUB_TOKEN` (`release-release-artifacts.yml:588,622`), and GitHub deliberately emits no events for actions taken with `GITHUB_TOKEN`.

Timeline confirms it — `gh run list --workflow=on-release-publish.yml`:

| release | how it was published | fan-out |
| --- | --- | --- |
| 2026.11.0 – 2026.11.3 | draft, human clicked Publish | ✅ `release` event |
| 2026.12.1 (Aug 21) | `auto` + ship, by `GITHUB_TOKEN` | ❌ never ran, hand-dispatched Aug 22 |
| 2026.12.2 (Aug 25) | `auto` + ship, by `GITHUB_TOKEN` | ❌ never ran, hand-dispatched today |

`auto` was introduced in #5927 (2026-07-28), which is exactly where the table flips. #6169 patched the symptoms (a manual `workflow_dispatch` escape hatch) but not the cause, so every ship still needs a human to remember to fire it.

## Fix

Give `on-release-publish.yml` a `workflow_call` trigger and have `release-all-platforms` call it directly when it publishes the release itself. Draft runs keep the human-publish route where the webhook does fire, so the two paths are mutually exclusive by construction — `post-release-fanout` is gated on `gh_release_type == 'release'`, and `draft`/`prerelease` never reach it.

Two related bugs fixed in passing:

- **`concurrency` group collapsed to a constant** on the non-webhook paths, since `github.event.release` is empty there. Now falls back to the input.
- **`macos-updater` hard-fails on any ship without macOS.** #6169 changed it from `if: needs.win-sigs.outputs.enabled == 'true'` to `needs: [setup]` with no guard, so `gh release download --pattern "NymVPN-*.pkg"` exits 1 with `no assets match the file pattern`. Reproduced in [run 32857392051](https://github.com/nymtech/nym-vpn-client/actions/runs/32857392051). Now probes for the pkg first, same shape as the existing `win-sigs` job.

## Verification

- `actionlint` reports zero findings on `on-release-publish.yml` and no new findings on `release-all-platforms.yml` versus the `origin/develop` baseline.
- Negative test proving the `workflow_call` contract is really checked: typo'ing the input to `tag_nam` makes actionlint fail with `input "tag_name" is required by "./.github/workflows/on-release-publish.yml"`. The real version passes.
- `resolve.outputs.tag` is `nym-vpn-v<version>` (`resolve-version.sh:78`), so it satisfies `setup`'s `startsWith(…, 'nym-vpn-v')` guard.
- The new probe matches `NymVPN-2026.12.1.pkg` and correctly ignores `nym-vpnc-2026.12.1.pkg`.
- Nesting depth is 3 workflow files; `release-all-platforms → build-release-artifacts → build-nym-vpn-core → build-nym-vpn-core-windows → build-winfw-windows` already runs 5 deep.

Only a real ship can exercise the `workflow_call` path end to end — worth watching the next one.

## Follow-up

`release/2026.12-vanilnoir` has neither this commit nor #6169, so it is still missing the `.sig` release assets and the escape hatch. Cherry-picks tracked separately.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6208)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stable releases can now invoke platform package publishing through a coordinated reusable workflow.
  * Release publishing workflows support reusable and manual execution with a required release tag.
  * macOS updater publishing can be controlled with an optional setting, enabled by default.

* **Bug Fixes**
  * Improved release tag handling and coordination across automated publishing workflows.
  * Prevented publishing workflows from running through unsupported release webhook triggers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->