### PR TITLE
ci: cherry-pick tauri updater sig fix onto release/2026.12

### DIFF
--- a/.github/workflows/macos-updater.yml
+++ b/.github/workflows/macos-updater.yml
@@ -50,7 +50,7 @@ jobs:
           REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release download "$RELEASE_TAG" --repo "$REPO" --pattern "*.pkg"
+          gh release download "$RELEASE_TAG" --repo "$REPO" --pattern "NymVPN-*.pkg"
 
       - name: Find PKG file
         id: find_pkg

--- a/.github/workflows/on-release-publish.yml
+++ b/.github/workflows/on-release-publish.yml
@@ -189,8 +189,37 @@ jobs:
       signature_x64: ${{ needs.win-sigs.outputs.sig_x64 }}
       signature_arm64: ${{ needs.win-sigs.outputs.sig_arm64 }}
 
+  # Sparkle appcast feed. macos-updater.yml downloads NymVPN-*.pkg off the release, so a
+  # ship that did not build macOS has nothing for it to do -- probe first rather than
+  # letting `gh release download` fail the job with "no assets match the file pattern".
+  # Same shape as win-sigs above.
+  mac-pkg:
+    needs: setup
+    runs-on: arc-linux-latest
+    outputs:
+      enabled: ${{ steps.pkg.outputs.enabled }}
+    steps:
+      - name: Check for a macOS pkg on the release
+        id: pkg
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ needs.setup.outputs.tag }}
+        run: |
+          set -euo pipefail
+          pkg=$(gh release view "$TAG" --json assets \
+            -q '.assets[].name | select(startswith("NymVPN-") and endswith(".pkg"))' | head -n1)
+          if [ -z "$pkg" ]; then
+            echo "::notice:: no macOS pkg on ${TAG} — skipping Sparkle appcast"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice:: found ${pkg} — will update Sparkle appcast"
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
   macos-updater:
-    needs: [setup]
+    needs: [setup, mac-pkg]
+    if: ${{ needs.mac-pkg.outputs.enabled == 'true' }}
     uses: ./.github/workflows/macos-updater.yml
     secrets: inherit
     permissions:

--- a/.github/workflows/on-release-publish.yml
+++ b/.github/workflows/on-release-publish.yml
@@ -190,9 +190,9 @@ jobs:
       signature_arm64: ${{ needs.win-sigs.outputs.sig_arm64 }}
 
   macos-updater:
-    needs: [setup, win-sigs]
-    if: ${{ needs.win-sigs.outputs.enabled == 'true' }}
+    needs: [setup]
     uses: ./.github/workflows/macos-updater.yml
+    secrets: inherit
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/release-release-artifacts.yml
+++ b/.github/workflows/release-release-artifacts.yml
@@ -221,6 +221,8 @@ jobs:
       linux_app_appimage_arm64: ${{ steps.linux_app.outputs.linux_app_appimage_arm64 }}
       windows_app_installer_x64: ${{ steps.windows_app.outputs.windows_app_installer_x64 }}
       windows_app_installer_arm64: ${{ steps.windows_app.outputs.windows_app_installer_arm64 }}
+      windows_app_installer_x64_sig: ${{ steps.windows_app.outputs.windows_app_installer_x64_sig }}
+      windows_app_installer_arm64_sig: ${{ steps.windows_app.outputs.windows_app_installer_arm64_sig }}
       android_apk: ${{ steps.android_app.outputs.android_apk }}
 
     steps:
@@ -319,8 +321,14 @@ jobs:
           WINDOWS_APP_INSTALLER_X64="${BASENAME}_x64-setup.exe"
           WINDOWS_APP_INSTALLER_ARM64="${BASENAME}_arm64-setup.exe"
 
+          WINDOWS_APP_INSTALLER_X64_SIG="${WINDOWS_APP_INSTALLER_X64}.sig"
+          WINDOWS_APP_INSTALLER_ARM64_SIG="${WINDOWS_APP_INSTALLER_ARM64}.sig"
+
           echo "windows_app_installer_x64=$WINDOWS_APP_INSTALLER_X64" >> $GITHUB_OUTPUT
           echo "windows_app_installer_arm64=$WINDOWS_APP_INSTALLER_ARM64" >> $GITHUB_OUTPUT
+
+          echo "windows_app_installer_x64_sig=$WINDOWS_APP_INSTALLER_X64_SIG" >> $GITHUB_OUTPUT
+          echo "windows_app_installer_arm64_sig=$WINDOWS_APP_INSTALLER_ARM64_SIG" >> $GITHUB_OUTPUT
 
       - name: App artifacts (Android)
         id: android_app
@@ -475,9 +483,13 @@ jobs:
         env:
           WINDOWS_APP_INSTALLER_X64: ${{ needs.resolve-artifacts.outputs.windows_app_installer_x64 }}
           WINDOWS_APP_INSTALLER_ARM64: ${{ needs.resolve-artifacts.outputs.windows_app_installer_arm64 }}
+          WINDOWS_APP_INSTALLER_X64_SIG: ${{ needs.resolve-artifacts.outputs.windows_app_installer_x64_sig }}
+          WINDOWS_APP_INSTALLER_ARM64_SIG: ${{ needs.resolve-artifacts.outputs.windows_app_installer_arm64_sig }}
         run: |
           cp -v "${{ env.APP_ARTIFACTS_WINDOWS_X64 }}/${WINDOWS_APP_INSTALLER_X64}" "${{ env.OUTPUT_DIR }}"
           cp -v "${{ env.APP_ARTIFACTS_WINDOWS_ARM64 }}/${WINDOWS_APP_INSTALLER_ARM64}" "${{ env.OUTPUT_DIR }}"
+          cp -v "${{ env.APP_ARTIFACTS_WINDOWS_X64 }}/${WINDOWS_APP_INSTALLER_X64_SIG}" "${{ env.OUTPUT_DIR }}"
+          cp -v "${{ env.APP_ARTIFACTS_WINDOWS_ARM64 }}/${WINDOWS_APP_INSTALLER_ARM64_SIG}" "${{ env.OUTPUT_DIR }}"
 
       - name: Copy artifacts (Android)
         if: ${{ needs.resolve.outputs.fdroid == 'true' }}
@@ -521,6 +533,8 @@ jobs:
           ARCHIVE_WINDOWS_ARM64: ${{ needs.resolve-artifacts.outputs.archive_windows_arm64 }}
           WINDOWS_APP_INSTALLER_X64: ${{ needs.resolve-artifacts.outputs.windows_app_installer_x64 }}
           WINDOWS_APP_INSTALLER_ARM64: ${{ needs.resolve-artifacts.outputs.windows_app_installer_arm64 }}
+          WINDOWS_APP_INSTALLER_X64_SIG: ${{ needs.resolve-artifacts.outputs.windows_app_installer_x64_sig }}
+          WINDOWS_APP_INSTALLER_ARM64_SIG: ${{ needs.resolve-artifacts.outputs.windows_app_installer_arm64_sig }}
           MACOS_INSTALLER_NAME: ${{ needs.resolve-artifacts.outputs.macos_installer_name }}
           VPNC_MACOS_INSTALLER_NAME: ${{ needs.resolve-artifacts.outputs.vpnc_macos_installer_name }}
         run: |
@@ -550,6 +564,8 @@ jobs:
               "${ARCHIVE_WINDOWS_ARM64}"
               "${WINDOWS_APP_INSTALLER_X64}"
               "${WINDOWS_APP_INSTALLER_ARM64}"
+              "${WINDOWS_APP_INSTALLER_X64_SIG}"
+              "${WINDOWS_APP_INSTALLER_ARM64_SIG}"
             )
           fi
 


### PR DESCRIPTION
Cherry-pick of #6169 (`0fbac4133`) onto `release/2026.12-vanilnoir`, plus one guard.

## Why

`v2026.12.2` shipped with **no tauri-updater PR**. Two independent causes; this PR is the second one.

`create-release` copies only `NymVPN_*-setup.exe` into the release asset dir and drops the sibling `*-setup.exe.sig`. `on-release-publish`'s `win-sigs` job recovers the updater signatures *from release assets*, finds none, sets `enabled=false`, and `windows-updater` skips. Confirmed on the release: `NymVPN_2026.12.2_x64-setup.exe` is attached, the `.sig` is not — even though the build produced it correctly (`UPDATER_ENABLED: true`, `.sig` copied into `app_artifacts_windows_x64`).

This has been silently broken for a while: `windows-updater` was skipped for `2026.11.3` too, and `.pkg/tauri-updater/stable.json` has only ever been updated by hand (#6172, #5836).

#6169 fixed it on `develop` on Aug 24 but was never cherry-picked here — and `release/2026.12-vanilnoir` is the branch `2026.12.2` shipped from.

## Contents

- `0fbac4133` verbatim: plumbs `windows_app_installer_{x64,arm64}_sig` through `resolve-artifacts` → copy step → release assets list. Also brings the `workflow_dispatch` escape hatch on `on-release-publish.yml`.
- One extra commit: guard `macos-updater` on a macOS pkg actually being present. #6169 dropped that job's condition, so it hard-fails on any ship without macOS — [reproduced today](https://github.com/nymtech/nym-vpn-client/actions/runs/32857392051), `no assets match the file pattern`. `release` events run the workflow from the tag's commit, so the release branch's copy is what a draft-publish executes; cherry-picking #6169 alone would plant a known-red job here. The hunk is identical to the one in #6208.

## Verification

- `actionlint` is clean on `on-release-publish.yml`, and reports the same 46 pre-existing findings on `release-release-artifacts.yml` as `develop` — nothing introduced.
- The new probe matches `NymVPN-2026.12.1.pkg` and correctly ignores `nym-vpnc-2026.12.1.pkg`.
- Cherry-pick applied with no conflicts.

## Not included

The root-cause fix for why `on-release-publish` never ran at all — `release-all-platforms` publishes the release with `GITHUB_TOKEN`, which emits no `release` event — is #6208 against `develop`. That one gets cherry-picked here once it merges.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6209)
<!-- Reviewable:end -->
