### PR TITLE
Fix android ip switch issue

### DIFF
--- a/nym-vpn-android/CHANGELOG.md
+++ b/nym-vpn-android/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Proper status handling for Notification Manager (https://github.com/nymtech/nym-vpn-client/pull/6268)
 - Fix Quick Tile crash after service destroy (https://github.com/nymtech/nym-vpn-client/pull/6232)
 - Disable Sentry Session Replay to stop foreground ANR kills (https://github.com/nymtech/nym-vpn-client/pull/6248)
+- Fail tunnel configure if the VPN app cannot be excluded from the blocking interface (https://github.com/nymtech/nym-vpn-client/pull/6016)
 
 ## [2026.12.3] - 2026-08-27
 

--- a/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/controller/VpnTunController.kt
+++ b/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/controller/VpnTunController.kt
@@ -13,9 +13,6 @@ import timber.log.Timber
 class VpnTunController(private val service: VpnService) {
 	companion object {
 		private const val TAG = "core-vpn"
-
-		// Must match nym_vpn_lib blocking_tun::BLOCKING_INTERFACE_ADDRS[0] / android_blocking_dns().
-		private const val BLOCKING_INTERFACE_V4 = "169.254.0.10"
 	}
 
 	@Volatile private var disallowedApps: List<String> = emptyList()
@@ -41,11 +38,11 @@ class VpnTunController(private val service: VpnService) {
 				runCatching { builder.addDisallowedApplication(pkg) }
 			}
 
-			// Blocking placeholder blackholes all routes. Exclude this app so control-plane
-			// (LP registration, API) can use the physical interface; other apps stay covered.
-			if (isBlockingPlaceholder(config)) {
+			// Blocking placeholder: exclude this app so control-plane can use the physical
+			// interface while other apps stay covered. Flag comes from Rust TunnelSettings.
+			if (config.excludeVpnApp) {
 				runCatching { builder.addDisallowedApplication(service.packageName) }
-					.onFailure { Timber.tag(TAG).w(it, "Failed to exclude VPN app from blocking TUN") }
+					.onFailure { Timber.tag(TAG).w(it, "Failed to exclude VPN app from tunnel") }
 			}
 
 			config.ipv4Settings?.addresses.orEmpty().forEach { cidr ->
@@ -95,15 +92,5 @@ class VpnTunController(private val service: VpnService) {
 
 	fun closeInterfaceSafely() {
 		// Rust will close the FD when the tunnel is stopped or reconfigured.
-	}
-
-	private fun isBlockingPlaceholder(config: TunnelNetworkSettings): Boolean {
-		val hasBlockingDns = config.dnsSettings?.servers.orEmpty().any { server ->
-			server.toString() == BLOCKING_INTERFACE_V4
-		}
-		val hasBlockingAddr = config.ipv4Settings?.addresses.orEmpty().any { cidr ->
-			cidr.trim().startsWith("$BLOCKING_INTERFACE_V4/")
-		}
-		return hasBlockingDns || hasBlockingAddr
 	}
 }

--- a/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/controller/VpnTunController.kt
+++ b/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/controller/VpnTunController.kt
@@ -13,6 +13,9 @@ import timber.log.Timber
 class VpnTunController(private val service: VpnService) {
 	companion object {
 		private const val TAG = "core-vpn"
+
+		// Must match nym_vpn_lib blocking_tun::BLOCKING_INTERFACE_ADDRS[0] / android_blocking_dns().
+		private const val BLOCKING_INTERFACE_V4 = "169.254.0.10"
 	}
 
 	@Volatile private var disallowedApps: List<String> = emptyList()
@@ -36,6 +39,13 @@ class VpnTunController(private val service: VpnService) {
 
 			disallowedApps.forEach { pkg ->
 				runCatching { builder.addDisallowedApplication(pkg) }
+			}
+
+			// Blocking placeholder blackholes all routes. Exclude this app so control-plane
+			// (LP registration, API) can use the physical interface; other apps stay covered.
+			if (isBlockingPlaceholder(config)) {
+				runCatching { builder.addDisallowedApplication(service.packageName) }
+					.onFailure { Timber.tag(TAG).w(it, "Failed to exclude VPN app from blocking TUN") }
 			}
 
 			config.ipv4Settings?.addresses.orEmpty().forEach { cidr ->
@@ -85,5 +95,15 @@ class VpnTunController(private val service: VpnService) {
 
 	fun closeInterfaceSafely() {
 		// Rust will close the FD when the tunnel is stopped or reconfigured.
+	}
+
+	private fun isBlockingPlaceholder(config: TunnelNetworkSettings): Boolean {
+		val hasBlockingDns = config.dnsSettings?.servers.orEmpty().any { server ->
+			server.toString() == BLOCKING_INTERFACE_V4
+		}
+		val hasBlockingAddr = config.ipv4Settings?.addresses.orEmpty().any { cidr ->
+			cidr.trim().startsWith("$BLOCKING_INTERFACE_V4/")
+		}
+		return hasBlockingDns || hasBlockingAddr
 	}
 }

--- a/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/controller/VpnTunController.kt
+++ b/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/controller/VpnTunController.kt
@@ -39,10 +39,14 @@ class VpnTunController(private val service: VpnService) {
 			}
 
 			// Blocking placeholder: exclude this app so control-plane can use the physical
-			// interface while other apps stay covered. Flag comes from Rust TunnelSettings.
+			// interface while other apps stay covered. Failure here traps the app in the cover
+			// and reintroduces the registration-timeout bug - surface it to Rust.
 			if (config.excludeVpnApp) {
-				runCatching { builder.addDisallowedApplication(service.packageName) }
-					.onFailure { Timber.tag(TAG).w(it, "Failed to exclude VPN app from tunnel") }
+				try {
+					builder.addDisallowedApplication(service.packageName)
+				} catch (t: Throwable) {
+					throw VpnException.InternalException("Failed to exclude VPN app from tunnel: ${t.message}")
+				}
 			}
 
 			config.ipv4Settings?.addresses.orEmpty().forEach { cidr ->

--- a/nym-vpn-core/CHANGELOG.md
+++ b/nym-vpn-core/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Avoid blocking daemon command loop when handling recents which may perform network calls (https://github.com/nymtech/nym-vpn-client/pull/6294)
 - Remove failed pending requests before creating new ones (https://github.com/nymtech/nym-vpn-client/pull/6295)
 - [Android] Don't use `reqwest` HTTP client to avoid `rustls-platform-verifier` panic (https://github.com/nymtech/nym-vpn-client/pull/6316)
+- [Android] Keep a blocking VPN interface up on connect, reconnect, error, offline, and unexpected tunnel down so other apps cannot leak to the ISP. The VPN app is excluded so gateway registration still works. (https://github.com/nymtech/nym-vpn-client/pull/6016) 
+
 
 ## [2026.12.3] - 2026-08-27
 

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/tunnel_provider/tunnel_settings.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/tunnel_provider/tunnel_settings.rs
@@ -234,6 +234,9 @@ pub struct TunnelNetworkSettings {
 
     /// Tunnel device MTU.
     pub mtu: u16,
+
+    /// When true on Android, exclude the VPN app from the tunnel (blocking placeholder).
+    pub exclude_vpn_app: bool,
 }
 
 #[cfg(target_os = "android")]
@@ -354,6 +357,7 @@ impl From<nym_vpn_lib::tunnel_provider::TunnelSettings> for TunnelNetworkSetting
                 match_domains: Some(vec!["".to_owned()]),
             }),
             mtu: settings.mtu,
+            exclude_vpn_app: settings.exclude_vpn_app,
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/tunnel_provider/tunnel_settings.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/tunnel_provider/tunnel_settings.rs
@@ -235,7 +235,8 @@ pub struct TunnelNetworkSettings {
     /// Tunnel device MTU.
     pub mtu: u16,
 
-    /// When true on Android, exclude the VPN app from the tunnel (blocking placeholder).
+    /// Android-only; iOS PacketTunnel conversion ignores this (NE has no equivalent).
+    #[uniffi(default = false)]
     pub exclude_vpn_app: bool,
 }
 
@@ -446,5 +447,28 @@ impl TunnelNetworkSettings {
             IpNetwork::V4(address) => Either::Left(address),
             IpNetwork::V6(address) => Either::Right(address),
         })
+    }
+}
+
+#[cfg(all(test, any(target_os = "ios", target_os = "android")))]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr};
+
+    use super::*;
+
+    fn settings(exclude_vpn_app: bool) -> nym_vpn_lib::tunnel_provider::TunnelSettings {
+        nym_vpn_lib::tunnel_provider::TunnelSettings {
+            interface_addresses: vec![],
+            dns_servers: vec![IpAddr::V4(Ipv4Addr::LOCALHOST)],
+            remote_addresses: vec![],
+            mtu: 1280,
+            exclude_vpn_app,
+        }
+    }
+
+    #[test]
+    fn from_tunnel_settings_copies_exclude_vpn_app() {
+        assert!(TunnelNetworkSettings::from(settings(true)).exclude_vpn_app);
+        assert!(!TunnelNetworkSettings::from(settings(false)).exclude_vpn_app);
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/tunnel_provider/tunnel_settings.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib-uniffi/src/tunnel_provider/tunnel_settings.rs
@@ -449,26 +449,3 @@ impl TunnelNetworkSettings {
         })
     }
 }
-
-#[cfg(all(test, any(target_os = "ios", target_os = "android")))]
-mod tests {
-    use std::net::{IpAddr, Ipv4Addr};
-
-    use super::*;
-
-    fn settings(exclude_vpn_app: bool) -> nym_vpn_lib::tunnel_provider::TunnelSettings {
-        nym_vpn_lib::tunnel_provider::TunnelSettings {
-            interface_addresses: vec![],
-            dns_servers: vec![IpAddr::V4(Ipv4Addr::LOCALHOST)],
-            remote_addresses: vec![],
-            mtu: 1280,
-            exclude_vpn_app,
-        }
-    }
-
-    #[test]
-    fn from_tunnel_settings_copies_exclude_vpn_app() {
-        assert!(TunnelNetworkSettings::from(settings(true)).exclude_vpn_app);
-        assert!(!TunnelNetworkSettings::from(settings(false)).exclude_vpn_app);
-    }
-}

--- a/nym-vpn-core/crates/nym-vpn-lib/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/lib.rs
@@ -19,7 +19,6 @@ pub mod service;
 #[cfg(not(target_os = "ios"))]
 pub(crate) mod socks5_proxy;
 mod tunnel_health;
-#[cfg(any(target_os = "ios", target_os = "android"))]
 pub mod tunnel_provider;
 pub mod tunnel_state_machine;
 mod wg_config;

--- a/nym-vpn-core/crates/nym-vpn-lib/src/lib.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/lib.rs
@@ -19,6 +19,7 @@ pub mod service;
 #[cfg(not(target_os = "ios"))]
 pub(crate) mod socks5_proxy;
 mod tunnel_health;
+#[cfg(any(target_os = "ios", target_os = "android", test))]
 pub mod tunnel_provider;
 pub mod tunnel_state_machine;
 mod wg_config;

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_provider/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_provider/mod.rs
@@ -38,4 +38,8 @@ pub struct TunnelSettings {
 
     /// Tunnel device MTU.
     pub mtu: u16,
+
+    /// When true on Android, exclude the VPN app from the tunnel so control-plane traffic can
+    /// use the physical interface (used by the blocking placeholder during reconnect/error).
+    pub exclude_vpn_app: bool,
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_provider/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_provider/mod.rs
@@ -40,6 +40,7 @@ pub struct TunnelSettings {
     pub mtu: u16,
 
     /// When true on Android, exclude the VPN app from the tunnel so control-plane traffic can
-    /// use the physical interface (used by the blocking placeholder during reconnect/error).
+    /// use the physical interface. Set on the blocking placeholder for Connecting / reconnect /
+    /// error. iOS has no equivalent and ignores the UniFFI copy of this field.
     pub exclude_vpn_app: bool,
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/blocking_tun.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/blocking_tun.rs
@@ -1,8 +1,6 @@
 // Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-//! Shared blocking / placeholder TUN settings used on iOS and Android while the real tunnel is down.
-
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use ipnetwork::IpNetwork;
@@ -31,27 +29,8 @@ pub fn blocking_tunnel_settings(dns_server: IpAddr) -> TunnelSettings {
     }
 }
 
-/// Default DNS for Android blocking TUN (no local filtering resolver on Android).
-#[cfg(any(target_os = "android", test))]
-pub fn android_blocking_dns() -> IpAddr {
-    BLOCKING_INTERFACE_ADDRS[0]
-}
-
-/// Install blocking cover before releasing the previous TUN so reconnect cannot open an ISP window.
-#[cfg(any(target_os = "android", test))]
-pub fn with_blocking_before_tun_release<E>(
-    install_blocking: impl FnOnce() -> Result<(), E>,
-    release_previous_tun: impl FnOnce(),
-) -> Result<(), E> {
-    install_blocking()?;
-    release_previous_tun();
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
-    use std::cell::RefCell;
-
     use super::*;
 
     #[test]
@@ -61,46 +40,11 @@ mod tests {
         assert_eq!(settings.mtu, BLOCKING_TUN_MTU);
         assert_eq!(settings.dns_servers, vec![dns]);
         assert!(settings.remote_addresses.is_empty());
+        // Connecting and reconnect both use this cover; skip-on-cold-connect would leak.
         assert!(settings.exclude_vpn_app);
         assert_eq!(
             settings.interface_addresses,
             BLOCKING_INTERFACE_ADDRS.map(IpNetwork::from).to_vec()
         );
-    }
-
-    #[test]
-    fn android_blocking_dns_is_link_local_v4() {
-        assert_eq!(
-            android_blocking_dns(),
-            IpAddr::V4(Ipv4Addr::new(169, 254, 0, 10))
-        );
-    }
-
-    #[test]
-    fn with_blocking_before_tun_release_installs_before_drop() {
-        let steps = RefCell::new(Vec::new());
-        with_blocking_before_tun_release::<()>(
-            || {
-                steps.borrow_mut().push("install");
-                Ok(())
-            },
-            || steps.borrow_mut().push("drop"),
-        )
-        .expect("install ok");
-        assert_eq!(steps.into_inner(), ["install", "drop"]);
-    }
-
-    #[test]
-    fn with_blocking_before_tun_release_skips_drop_on_install_error() {
-        let steps = RefCell::new(Vec::new());
-        let err = with_blocking_before_tun_release(
-            || {
-                steps.borrow_mut().push("install");
-                Err("fail")
-            },
-            || steps.borrow_mut().push("drop"),
-        );
-        assert_eq!(err, Err("fail"));
-        assert_eq!(steps.into_inner(), ["install"]);
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/blocking_tun.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/blocking_tun.rs
@@ -27,6 +27,7 @@ pub fn blocking_tunnel_settings(dns_server: IpAddr) -> TunnelSettings {
         interface_addresses: BLOCKING_INTERFACE_ADDRS.map(IpNetwork::from).to_vec(),
         dns_servers: vec![dns_server],
         mtu: BLOCKING_TUN_MTU,
+        exclude_vpn_app: true,
     }
 }
 
@@ -60,6 +61,7 @@ mod tests {
         assert_eq!(settings.mtu, BLOCKING_TUN_MTU);
         assert_eq!(settings.dns_servers, vec![dns]);
         assert!(settings.remote_addresses.is_empty());
+        assert!(settings.exclude_vpn_app);
         assert_eq!(
             settings.interface_addresses,
             BLOCKING_INTERFACE_ADDRS.map(IpNetwork::from).to_vec()

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/blocking_tun.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/blocking_tun.rs
@@ -103,4 +103,23 @@ mod tests {
         assert_eq!(err, Err("fail"));
         assert_eq!(steps.into_inner(), ["install"]);
     }
+
+    /// Connecting/Connected unexpected Down must use this ordering (not cold Connecting::enter).
+    #[test]
+    fn reconnect_down_cover_ordering_is_install_then_release() {
+        let steps = RefCell::new(Vec::new());
+        with_blocking_before_tun_release::<()>(
+            || {
+                steps.borrow_mut().push("blocking_cover");
+                Ok(())
+            },
+            || steps.borrow_mut().push("release_tombstone"),
+        )
+        .expect("cover ok");
+        assert_eq!(
+            steps.into_inner(),
+            ["blocking_cover", "release_tombstone"],
+            "ISP window if tombstone is released before blocking establish"
+        );
+    }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/blocking_tun.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/blocking_tun.rs
@@ -103,23 +103,4 @@ mod tests {
         assert_eq!(err, Err("fail"));
         assert_eq!(steps.into_inner(), ["install"]);
     }
-
-    /// Connecting/Connected unexpected Down must use this ordering (not cold Connecting::enter).
-    #[test]
-    fn reconnect_down_cover_ordering_is_install_then_release() {
-        let steps = RefCell::new(Vec::new());
-        with_blocking_before_tun_release::<()>(
-            || {
-                steps.borrow_mut().push("blocking_cover");
-                Ok(())
-            },
-            || steps.borrow_mut().push("release_tombstone"),
-        )
-        .expect("cover ok");
-        assert_eq!(
-            steps.into_inner(),
-            ["blocking_cover", "release_tombstone"],
-            "ISP window if tombstone is released before blocking establish"
-        );
-    }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/blocking_tun.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/blocking_tun.rs
@@ -78,5 +78,11 @@ mod tests {
             android_error_reason_if_uncovered(ErrorStateReason::TunnelProvider, false),
             ErrorStateReason::TunnelProvider
         );
+        // Connecting unexpected-Down and Disconnecting Reconnect must publish this, not
+        // reconnect() / ConnectionAttemptsExceeded, when cover install failed.
+        assert_eq!(
+            android_error_reason_if_uncovered(ErrorStateReason::ConnectionAttemptsExceeded, false),
+            ErrorStateReason::TunnelProvider
+        );
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/blocking_tun.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/blocking_tun.rs
@@ -29,6 +29,20 @@ pub fn blocking_tunnel_settings(dns_server: IpAddr) -> TunnelSettings {
     }
 }
 
+/// When the device has no blocking TUN and no held live TUN, publish `TunnelProvider` so the UI
+/// does not show a "blocked" reason (bandwidth, account, …) while traffic uses the ISP.
+#[cfg(any(test, target_os = "android"))]
+pub(crate) fn android_error_reason_if_uncovered(
+    requested: nym_vpn_lib_types::ErrorStateReason,
+    covered: bool,
+) -> nym_vpn_lib_types::ErrorStateReason {
+    if covered {
+        requested
+    } else {
+        nym_vpn_lib_types::ErrorStateReason::TunnelProvider
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -45,6 +59,24 @@ mod tests {
         assert_eq!(
             settings.interface_addresses,
             BLOCKING_INTERFACE_ADDRS.map(IpNetwork::from).to_vec()
+        );
+    }
+
+    #[test]
+    fn android_error_reason_if_uncovered_overrides_blocked_reasons() {
+        use nym_vpn_lib_types::ErrorStateReason;
+
+        assert_eq!(
+            android_error_reason_if_uncovered(ErrorStateReason::BandwidthExceeded, false),
+            ErrorStateReason::TunnelProvider
+        );
+        assert_eq!(
+            android_error_reason_if_uncovered(ErrorStateReason::BandwidthExceeded, true),
+            ErrorStateReason::BandwidthExceeded
+        );
+        assert_eq!(
+            android_error_reason_if_uncovered(ErrorStateReason::TunnelProvider, false),
+            ErrorStateReason::TunnelProvider
         );
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/blocking_tun.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/blocking_tun.rs
@@ -1,0 +1,104 @@
+// Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+//! Shared blocking / placeholder TUN settings used on iOS and Android while the real tunnel is down.
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+use ipnetwork::IpNetwork;
+
+use crate::tunnel_provider::TunnelSettings;
+
+/// Placeholder interface addresses used while the real tunnel is down (Error / reconnect gap).
+pub const BLOCKING_INTERFACE_ADDRS: [IpAddr; 2] = [
+    IpAddr::V4(Ipv4Addr::new(169, 254, 0, 10)),
+    IpAddr::V6(Ipv6Addr::new(
+        0xfdcc, 0x9fc0, 0xe75a, 0x53c3, 0xfa25, 0x241f, 0x21c0, 0x70d0,
+    )),
+];
+
+/// Minimum IPv6 MTU; used for the blocking placeholder interface.
+pub const BLOCKING_TUN_MTU: u16 = 1280;
+
+/// Tunnel settings that keep a VPN interface up without forwarding traffic (blackhole).
+pub fn blocking_tunnel_settings(dns_server: IpAddr) -> TunnelSettings {
+    TunnelSettings {
+        remote_addresses: vec![],
+        interface_addresses: BLOCKING_INTERFACE_ADDRS.map(IpNetwork::from).to_vec(),
+        dns_servers: vec![dns_server],
+        mtu: BLOCKING_TUN_MTU,
+    }
+}
+
+/// Default DNS for Android blocking TUN (no local filtering resolver on Android).
+#[cfg(any(target_os = "android", test))]
+pub fn android_blocking_dns() -> IpAddr {
+    BLOCKING_INTERFACE_ADDRS[0]
+}
+
+/// Install blocking cover before releasing the previous TUN so reconnect cannot open an ISP window.
+#[cfg(any(target_os = "android", test))]
+pub fn with_blocking_before_tun_release<E>(
+    install_blocking: impl FnOnce() -> Result<(), E>,
+    release_previous_tun: impl FnOnce(),
+) -> Result<(), E> {
+    install_blocking()?;
+    release_previous_tun();
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+
+    use super::*;
+
+    #[test]
+    fn blocking_tunnel_settings_uses_shared_addrs_and_mtu() {
+        let dns = IpAddr::V4(Ipv4Addr::new(169, 254, 0, 10));
+        let settings = blocking_tunnel_settings(dns);
+        assert_eq!(settings.mtu, BLOCKING_TUN_MTU);
+        assert_eq!(settings.dns_servers, vec![dns]);
+        assert!(settings.remote_addresses.is_empty());
+        assert_eq!(
+            settings.interface_addresses,
+            BLOCKING_INTERFACE_ADDRS.map(IpNetwork::from).to_vec()
+        );
+    }
+
+    #[test]
+    fn android_blocking_dns_is_link_local_v4() {
+        assert_eq!(
+            android_blocking_dns(),
+            IpAddr::V4(Ipv4Addr::new(169, 254, 0, 10))
+        );
+    }
+
+    #[test]
+    fn with_blocking_before_tun_release_installs_before_drop() {
+        let steps = RefCell::new(Vec::new());
+        with_blocking_before_tun_release::<()>(
+            || {
+                steps.borrow_mut().push("install");
+                Ok(())
+            },
+            || steps.borrow_mut().push("drop"),
+        )
+        .expect("install ok");
+        assert_eq!(steps.into_inner(), ["install", "drop"]);
+    }
+
+    #[test]
+    fn with_blocking_before_tun_release_skips_drop_on_install_error() {
+        let steps = RefCell::new(Vec::new());
+        let err = with_blocking_before_tun_release(
+            || {
+                steps.borrow_mut().push("install");
+                Err("fail")
+            },
+            || steps.borrow_mut().push("drop"),
+        );
+        assert_eq!(err, Err("fail"));
+        assert_eq!(steps.into_inner(), ["install"]);
+    }
+}

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -38,7 +38,9 @@ use crate::tunnel_provider::AndroidTunProvider;
 #[cfg(target_os = "ios")]
 use crate::tunnel_provider::OSTunProvider;
 #[cfg(target_os = "android")]
-use crate::tunnel_state_machine::blocking_tun::{android_blocking_dns, blocking_tunnel_settings};
+use crate::tunnel_state_machine::blocking_tun::{
+    BLOCKING_INTERFACE_ADDRS, blocking_tunnel_settings,
+};
 
 use crate::adblocker;
 #[cfg(not(target_os = "android"))]
@@ -785,7 +787,7 @@ pub struct SharedState {
     tun_provider: Arc<dyn OSTunProvider>,
     #[cfg(target_os = "android")]
     tun_provider: Arc<dyn AndroidTunProvider>,
-    /// Held FD for the Android blocking / placeholder VPN interface during Connecting / Error.
+    /// Held FD for the Android blocking / placeholder VPN interface during Connecting / Error / Offline.
     #[cfg(target_os = "android")]
     android_blocking_tun: Option<OwnedFd>,
     /// Previous live TUN kept when blocking install fails mid-reconnect (avoids ISP window).
@@ -838,7 +840,7 @@ impl SharedState {
     /// Establish (or replace) the Android blocking VPN interface and retain its FD.
     #[cfg(target_os = "android")]
     fn install_android_blocking_tun(&mut self) -> std::io::Result<()> {
-        let settings = blocking_tunnel_settings(android_blocking_dns());
+        let settings = blocking_tunnel_settings(BLOCKING_INTERFACE_ADDRS[0]);
         let raw_fd = self.tun_provider.configure_tunnel(settings)?;
         // Safety: configure_tunnel returns a freshly owned FD from VpnService.Builder.establish().
         let owned = unsafe { OwnedFd::from_raw_fd(raw_fd) };
@@ -848,7 +850,8 @@ impl SharedState {
         Ok(())
     }
 
-    /// Install blocking TUN when none is held yet.
+    /// Install blocking TUN when none is held yet. After a live TUN may have replaced the cover,
+    /// use `prepare_blocking_cover_before_release` so a stale FD cannot skip reinstall.
     #[cfg(target_os = "android")]
     fn ensure_android_blocking_tun(&mut self) -> std::io::Result<()> {
         if self.android_blocking_tun.is_some() {
@@ -871,18 +874,16 @@ impl SharedState {
         &mut self,
         mut tombstone: Option<tunnel::Tombstone>,
     ) -> std::io::Result<()> {
-        use crate::tunnel_state_machine::blocking_tun::with_blocking_before_tun_release;
-
-        let result = with_blocking_before_tun_release(
-            || self.install_android_blocking_tun(),
-            || {
+        match self.install_android_blocking_tun() {
+            Ok(()) => {
                 drop(tombstone.take());
-            },
-        );
-        if result.is_err() {
-            self.android_tun_hold = tombstone;
+                Ok(())
+            }
+            Err(err) => {
+                self.android_tun_hold = tombstone;
+                Err(err)
+            }
         }
-        result
     }
 
     #[cfg(target_os = "linux")]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -815,7 +815,8 @@ pub struct SharedState {
 }
 
 impl SharedState {
-    /// Notify discovery, account controller, and gateway cache when network is unrestricted.
+    /// Unpause discovery / account / gateway cache. This is not a device kill-switch; on Android
+    /// other apps follow the VpnService interface, not this flag.
     async fn allow_networking(&self) {
         self.discovery_refresher_command_tx
             .send(DiscoveryRefresherCommand::Pause(false))
@@ -858,6 +859,14 @@ impl SharedState {
             return Ok(());
         }
         self.install_android_blocking_tun()
+    }
+
+    /// Unpause control-plane only when a blocking placeholder or a held live TUN still covers apps.
+    #[cfg(target_os = "android")]
+    async fn allow_networking_if_android_covered(&self) {
+        if self.android_blocking_tun.is_some() || self.android_tun_hold.is_some() {
+            self.allow_networking().await;
+        }
     }
 
     /// Drop blocking TUN and any retained previous TUN (intentional Disconnect / real tunnel up).

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 mod account;
+#[cfg(any(target_os = "android", target_os = "ios", test))]
+mod blocking_tun;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 mod dns_handler;
 mod entry_blame;
@@ -29,9 +31,14 @@ use std::{
 };
 
 #[cfg(target_os = "android")]
+use std::os::fd::{FromRawFd, OwnedFd};
+
+#[cfg(target_os = "android")]
 use crate::tunnel_provider::AndroidTunProvider;
 #[cfg(target_os = "ios")]
 use crate::tunnel_provider::OSTunProvider;
+#[cfg(target_os = "android")]
+use crate::tunnel_state_machine::blocking_tun::{android_blocking_dns, blocking_tunnel_settings};
 
 use crate::adblocker;
 #[cfg(not(target_os = "android"))]
@@ -778,6 +785,12 @@ pub struct SharedState {
     tun_provider: Arc<dyn OSTunProvider>,
     #[cfg(target_os = "android")]
     tun_provider: Arc<dyn AndroidTunProvider>,
+    /// Held FD for the Android blocking / placeholder VPN interface during Connecting / Error.
+    #[cfg(target_os = "android")]
+    android_blocking_tun: Option<OwnedFd>,
+    /// Previous live TUN kept when blocking install fails mid-reconnect (avoids ISP window).
+    #[cfg(target_os = "android")]
+    android_tun_hold: Option<tunnel::Tombstone>,
     account_command_tx: AccountCommandSender,
     account_controller_state: AccountStateReceiver,
     bandwidth_command_tx: BandwidthControllerRequestSender,
@@ -820,6 +833,35 @@ impl SharedState {
         self.account_command_tx.set_vpn_api_firewall_up().await.ok();
         self.gateway_provider.set_active_geo_location(false).await;
         self.gateway_provider.set_gateway_cache_paused(true);
+    }
+
+    /// Establish (or replace) the Android blocking VPN interface and retain its FD.
+    #[cfg(target_os = "android")]
+    fn install_android_blocking_tun(&mut self) -> std::io::Result<()> {
+        let settings = blocking_tunnel_settings(android_blocking_dns());
+        let raw_fd = self.tun_provider.configure_tunnel(settings)?;
+        // Safety: configure_tunnel returns a freshly owned FD from VpnService.Builder.establish().
+        let owned = unsafe { OwnedFd::from_raw_fd(raw_fd) };
+        self.android_blocking_tun = Some(owned);
+        // Blocking interface replaced any prior live TUN; drop retained tombstone if present.
+        self.android_tun_hold = None;
+        Ok(())
+    }
+
+    /// Install blocking TUN when none is held yet.
+    #[cfg(target_os = "android")]
+    fn ensure_android_blocking_tun(&mut self) -> std::io::Result<()> {
+        if self.android_blocking_tun.is_some() {
+            return Ok(());
+        }
+        self.install_android_blocking_tun()
+    }
+
+    /// Drop blocking TUN and any retained previous TUN (intentional Disconnect / real tunnel up).
+    #[cfg(target_os = "android")]
+    fn clear_android_blocking_tun(&mut self) {
+        self.android_blocking_tun = None;
+        self.android_tun_hold = None;
     }
 
     #[cfg(target_os = "linux")]
@@ -1248,6 +1290,10 @@ impl TunnelStateMachine {
             status_listener_handle: None,
             #[cfg(any(target_os = "ios", target_os = "android"))]
             tun_provider,
+            #[cfg(target_os = "android")]
+            android_blocking_tun: None,
+            #[cfg(target_os = "android")]
+            android_tun_hold: None,
             account_command_tx,
             account_controller_state,
             bandwidth_command_tx,

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -861,12 +861,21 @@ impl SharedState {
         self.install_android_blocking_tun()
     }
 
-    /// Unpause control-plane only when a blocking placeholder or a held live TUN still covers apps.
+    /// Install cover if needed, unpause control-plane only when covered, and publish
+    /// `TunnelProvider` when the device has no blocking TUN and no held live TUN.
     #[cfg(target_os = "android")]
-    async fn allow_networking_if_android_covered(&self) {
-        if self.android_blocking_tun.is_some() || self.android_tun_hold.is_some() {
+    async fn apply_android_error_cover(&mut self, requested: ErrorStateReason) -> ErrorStateReason {
+        if let Err(err) = self.ensure_android_blocking_tun() {
+            nym_common::trace_err_chain!(
+                err,
+                "failed to install Android blocking TUN in error state"
+            );
+        }
+        let covered = self.android_blocking_tun.is_some() || self.android_tun_hold.is_some();
+        if covered {
             self.allow_networking().await;
         }
+        blocking_tun::android_error_reason_if_uncovered(requested, covered)
     }
 
     /// Drop blocking TUN and any retained previous TUN (intentional Disconnect / real tunnel up).

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -864,6 +864,27 @@ impl SharedState {
         self.android_tun_hold = None;
     }
 
+    /// Install blocking cover, then release the previous TUN. On install failure, keep the previous
+    /// TUN in `android_tun_hold` so reconnect/error cannot open an ISP window.
+    #[cfg(target_os = "android")]
+    fn prepare_blocking_cover_before_release(
+        &mut self,
+        mut tombstone: Option<tunnel::Tombstone>,
+    ) -> std::io::Result<()> {
+        use crate::tunnel_state_machine::blocking_tun::with_blocking_before_tun_release;
+
+        let result = with_blocking_before_tun_release(
+            || self.install_android_blocking_tun(),
+            || {
+                drop(tombstone.take());
+            },
+        );
+        if result.is_err() {
+            self.android_tun_hold = tombstone;
+        }
+        result
+    }
+
     #[cfg(target_os = "linux")]
     pub fn disable_nm_connectivity_check(&mut self) {
         if self.nm_connectivity_check_enabled.is_none()

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -840,9 +840,12 @@ impl SharedState {
 
     /// Establish (or replace) the Android blocking VPN interface and retain its FD.
     #[cfg(target_os = "android")]
-    fn install_android_blocking_tun(&mut self) -> std::io::Result<()> {
+    fn install_android_blocking_tun(&mut self) -> Result<()> {
         let settings = blocking_tunnel_settings(BLOCKING_INTERFACE_ADDRS[0]);
-        let raw_fd = self.tun_provider.configure_tunnel(settings)?;
+        let raw_fd = self
+            .tun_provider
+            .configure_tunnel(settings)
+            .map_err(|e| Error::ConfigureTunnelProvider(e.to_string()))?;
         // Safety: configure_tunnel returns a freshly owned FD from VpnService.Builder.establish().
         let owned = unsafe { OwnedFd::from_raw_fd(raw_fd) };
         self.android_blocking_tun = Some(owned);
@@ -854,11 +857,11 @@ impl SharedState {
     /// Install blocking TUN when none is held yet. After a live TUN may have replaced the cover,
     /// use `prepare_blocking_cover_before_release` so a stale FD cannot skip reinstall.
     #[cfg(target_os = "android")]
-    fn ensure_android_blocking_tun(&mut self) -> std::io::Result<()> {
-        if self.android_blocking_tun.is_some() {
-            return Ok(());
+    fn ensure_android_blocking_tun(&mut self) -> Result<()> {
+        match self.android_blocking_tun.as_ref() {
+            Some(_) => Ok(()),
+            None => self.install_android_blocking_tun(),
         }
-        self.install_android_blocking_tun()
     }
 
     /// Install cover if needed, unpause control-plane only when covered, and publish
@@ -891,7 +894,7 @@ impl SharedState {
     fn prepare_blocking_cover_before_release(
         &mut self,
         mut tombstone: Option<tunnel::Tombstone>,
-    ) -> std::io::Result<()> {
+    ) -> Result<()> {
         match self.install_android_blocking_tun() {
             Ok(()) => {
                 drop(tombstone.take());

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
@@ -13,8 +13,6 @@ use tokio_util::sync::CancellationToken;
 
 #[cfg(target_os = "ios")]
 use crate::tunnel_state_machine::Result;
-#[cfg(target_os = "android")]
-use crate::tunnel_state_machine::tunnel::Tombstone;
 use crate::tunnel_state_machine::{
     ConnectionData, NextTunnelState, PrivateActionAfterDisconnect, PrivateTunnelState, SharedState,
     TunnelCommand, TunnelInterface, TunnelStateHandler,
@@ -34,7 +32,6 @@ use nym_http_api_client::HickoryDnsResolver;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use nym_vpn_lib_types::TunnelConnectionData;
 
-#[cfg(target_os = "android")]
 use super::ErrorState;
 
 pub struct ConnectedState {
@@ -286,43 +283,12 @@ impl ConnectedState {
         Self::prepare_for_disconnect(shared_state).await;
 
         match error_state_reason {
-            // Ordered cover via Disconnecting (same as Connecting Down → Error).
-            Some(block_reason) => NextTunnelState::NewState(
-                DisconnectingState::enter(
-                    PrivateActionAfterDisconnect::Error(block_reason),
-                    Some(self.tunnel_monitor_handle),
-                    shared_state,
-                )
-                .await,
-            ),
-            None => {
-                // Preserve selected gateways (Disconnecting(Reconnect) would clear them).
-                // Install Android blocking cover before releasing the TUN, then re-enter Connecting.
-                self.tunnel_monitor_handle.cancel();
-                let tombstone = self.tunnel_monitor_handle.wait().await;
-
-                #[cfg(target_os = "android")]
-                {
-                    if let Err(err) =
-                        shared_state.prepare_blocking_cover_before_release(Some(tombstone))
-                    {
-                        tracing::error!(
-                            "Failed to install Android blocking TUN before Connected reconnect: {err}"
-                        );
-                        return NextTunnelState::NewState(
-                            ErrorState::enter(ErrorStateReason::TunnelProvider, shared_state).await,
-                        );
-                    }
-                    // Cover already released the live TUN; still clear socks5 / side-effects.
-                    ConnectingState::handle_tunnel_close(Tombstone::default(), shared_state).await;
-                }
-                #[cfg(not(target_os = "android"))]
-                ConnectingState::handle_tunnel_close(tombstone, shared_state).await;
-
-                NextTunnelState::NewState(
-                    ConnectingState::enter(0, Some(self.selected_gateways), shared_state).await,
-                )
+            Some(block_reason) => {
+                NextTunnelState::NewState(ErrorState::enter(block_reason, shared_state).await)
             }
+            None => NextTunnelState::NewState(
+                ConnectingState::enter(0, Some(self.selected_gateways), shared_state).await,
+            ),
         }
     }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
@@ -56,6 +56,10 @@ impl ConnectedState {
         tunnel_monitor_event_receiver: TunnelMonitorEventReceiver,
         shared_state: &mut SharedState,
     ) -> (Box<dyn TunnelStateHandler>, PrivateTunnelState) {
+        // Real tunnel replaced the blocking placeholder via configure_tunnel; drop the stale FD.
+        #[cfg(target_os = "android")]
+        shared_state.clear_android_blocking_tun();
+
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         let wg_entry_endpoint =
             if let TunnelConnectionData::Wireguard(ref wg) = connection_data.tunnel {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connected_state.rs
@@ -13,6 +13,8 @@ use tokio_util::sync::CancellationToken;
 
 #[cfg(target_os = "ios")]
 use crate::tunnel_state_machine::Result;
+#[cfg(target_os = "android")]
+use crate::tunnel_state_machine::tunnel::Tombstone;
 use crate::tunnel_state_machine::{
     ConnectionData, NextTunnelState, PrivateActionAfterDisconnect, PrivateTunnelState, SharedState,
     TunnelCommand, TunnelInterface, TunnelStateHandler,
@@ -32,6 +34,7 @@ use nym_http_api_client::HickoryDnsResolver;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use nym_vpn_lib_types::TunnelConnectionData;
 
+#[cfg(target_os = "android")]
 use super::ErrorState;
 
 pub struct ConnectedState {
@@ -283,12 +286,43 @@ impl ConnectedState {
         Self::prepare_for_disconnect(shared_state).await;
 
         match error_state_reason {
-            Some(block_reason) => {
-                NextTunnelState::NewState(ErrorState::enter(block_reason, shared_state).await)
-            }
-            None => NextTunnelState::NewState(
-                ConnectingState::enter(0, Some(self.selected_gateways), shared_state).await,
+            // Ordered cover via Disconnecting (same as Connecting Down → Error).
+            Some(block_reason) => NextTunnelState::NewState(
+                DisconnectingState::enter(
+                    PrivateActionAfterDisconnect::Error(block_reason),
+                    Some(self.tunnel_monitor_handle),
+                    shared_state,
+                )
+                .await,
             ),
+            None => {
+                // Preserve selected gateways (Disconnecting(Reconnect) would clear them).
+                // Install Android blocking cover before releasing the TUN, then re-enter Connecting.
+                self.tunnel_monitor_handle.cancel();
+                let tombstone = self.tunnel_monitor_handle.wait().await;
+
+                #[cfg(target_os = "android")]
+                {
+                    if let Err(err) =
+                        shared_state.prepare_blocking_cover_before_release(Some(tombstone))
+                    {
+                        tracing::error!(
+                            "Failed to install Android blocking TUN before Connected reconnect: {err}"
+                        );
+                        return NextTunnelState::NewState(
+                            ErrorState::enter(ErrorStateReason::TunnelProvider, shared_state).await,
+                        );
+                    }
+                    // Cover already released the live TUN; still clear socks5 / side-effects.
+                    ConnectingState::handle_tunnel_close(Tombstone::default(), shared_state).await;
+                }
+                #[cfg(not(target_os = "android"))]
+                ConnectingState::handle_tunnel_close(tombstone, shared_state).await;
+
+                NextTunnelState::NewState(
+                    ConnectingState::enter(0, Some(self.selected_gateways), shared_state).await,
+                )
+            }
         }
     }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -289,7 +289,10 @@ impl ConnectingState {
         )
     }
 
-    async fn handle_tunnel_close(tombstone: Tombstone, shared_state: &mut SharedState) {
+    async fn handle_tunnel_close(
+        tombstone: Tombstone,
+        shared_state: &mut SharedState,
+    ) -> std::io::Result<()> {
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         shared_state.route_handler.remove_routes().await;
 
@@ -299,14 +302,10 @@ impl ConnectingState {
         }
 
         // Real TUN may have replaced the cover while still Connecting; a held stale FD would
-        // make ensure_android_blocking_tun a no-op after this drop.
+        // make ensure_android_blocking_tun a no-op after this drop. Same contract as
+        // DisconnectingState Reconnect: install failure must not continue uncovered.
         #[cfg(target_os = "android")]
-        if let Err(err) = shared_state.prepare_blocking_cover_before_release(Some(tombstone)) {
-            trace_err_chain!(
-                err,
-                "failed to install Android blocking TUN before tunnel close"
-            );
-        }
+        shared_state.prepare_blocking_cover_before_release(Some(tombstone))?;
 
         #[cfg(not(target_os = "android"))]
         {
@@ -315,6 +314,8 @@ impl ConnectingState {
 
         #[cfg(target_os = "ios")]
         let _ = shared_state;
+
+        Ok(())
     }
 
     async fn handle_reconnect_delay(
@@ -738,7 +739,13 @@ impl TunnelStateHandler for ConnectingState {
                         } else {
                             if let Some(tunnel_monitor_handle) = self.tunnel_monitor_handle.take() {
                                 let tombstone = tunnel_monitor_handle.wait().await;
-                                Self::handle_tunnel_close(tombstone, shared_state).await;
+                                if let Err(reason) = unexpected_down_after_cover(
+                                    Self::handle_tunnel_close(tombstone, shared_state).await,
+                                ) {
+                                    return NextTunnelState::NewState(
+                                        ErrorState::enter(reason, shared_state).await,
+                                    );
+                                }
                             }
 
                             tracing::info!("Tunnel closed");
@@ -1086,6 +1093,17 @@ enum ReconnectDecision {
     Abort,
 }
 
+fn unexpected_down_after_cover(cover: std::io::Result<()>) -> Result<(), ErrorStateReason> {
+    cover
+        .inspect_err(|err| {
+            trace_err_chain!(
+                err,
+                "failed to install Android blocking TUN before tunnel close"
+            );
+        })
+        .map_err(|_| ErrorStateReason::TunnelProvider)
+}
+
 fn reconnect_decision(next_attempt: u32) -> ReconnectDecision {
     if next_attempt >= MAX_RECONNECT_ATTEMPTS {
         ReconnectDecision::Abort
@@ -1137,6 +1155,15 @@ mod test {
             reconnect_decision(MAX_RECONNECT_ATTEMPTS - 1),
             ReconnectDecision::Retry { .. }
         ));
+    }
+
+    #[test]
+    fn unexpected_down_cover_failure_is_tunnel_provider_not_reconnect() {
+        assert_eq!(
+            unexpected_down_after_cover(Err(std::io::Error::other("configure_tunnel"))),
+            Err(ErrorStateReason::TunnelProvider)
+        );
+        assert_eq!(unexpected_down_after_cover(Ok(())), Ok(()));
     }
 
     #[test]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -85,6 +85,7 @@ impl ConnectingState {
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         shared_state.disallow_networking().await;
 
+        // Reconnect also enters here with retry_attempt 0; skip would leak.
         #[cfg(target_os = "android")]
         if let Err(err) = shared_state.ensure_android_blocking_tun() {
             trace_err_chain!(err, "failed to install Android blocking TUN");
@@ -297,11 +298,23 @@ impl ConnectingState {
             shared_state.set_socks5_proxy_tunnel_addrs(None, None);
         }
 
-        #[cfg(any(target_os = "android", target_os = "ios"))]
-        let _ = shared_state; // Avoid unused variable warning
+        // Real TUN may have replaced the cover while still Connecting; a held stale FD would
+        // make ensure_android_blocking_tun a no-op after this drop.
+        #[cfg(target_os = "android")]
+        if let Err(err) = shared_state.prepare_blocking_cover_before_release(Some(tombstone)) {
+            trace_err_chain!(
+                err,
+                "failed to install Android blocking TUN before tunnel close"
+            );
+        }
 
-        // drop tombstone to close tunnel devices
-        let _ = tombstone;
+        #[cfg(not(target_os = "android"))]
+        {
+            let _ = tombstone;
+        }
+
+        #[cfg(target_os = "ios")]
+        let _ = shared_state;
     }
 
     async fn handle_reconnect_delay(

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -282,7 +282,7 @@ impl ConnectingState {
         )
     }
 
-    async fn handle_tunnel_close(tombstone: Tombstone, shared_state: &mut SharedState) {
+    pub(super) async fn handle_tunnel_close(tombstone: Tombstone, shared_state: &mut SharedState) {
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         shared_state.route_handler.remove_routes().await;
 
@@ -719,6 +719,28 @@ impl TunnelStateHandler for ConnectingState {
                         } else {
                             if let Some(tunnel_monitor_handle) = self.tunnel_monitor_handle.take() {
                                 let tombstone = tunnel_monitor_handle.wait().await;
+                                #[cfg(target_os = "android")]
+                                {
+                                    // Install blocking cover before releasing the live TUN (same
+                                    // ordering as Disconnecting(Reconnect)).
+                                    if let Err(err) = shared_state
+                                        .prepare_blocking_cover_before_release(Some(tombstone))
+                                    {
+                                        tracing::error!(
+                                            "Failed to install Android blocking TUN before Connecting reconnect: {err}"
+                                        );
+                                        return NextTunnelState::NewState(
+                                            ErrorState::enter(
+                                                ErrorStateReason::TunnelProvider,
+                                                shared_state,
+                                            )
+                                            .await,
+                                        );
+                                    }
+                                    Self::handle_tunnel_close(Tombstone::default(), shared_state)
+                                        .await;
+                                }
+                                #[cfg(not(target_os = "android"))]
                                 Self::handle_tunnel_close(tombstone, shared_state).await;
                             }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -292,7 +292,7 @@ impl ConnectingState {
     async fn handle_tunnel_close(
         tombstone: Tombstone,
         shared_state: &mut SharedState,
-    ) -> std::io::Result<()> {
+    ) -> Result<()> {
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         shared_state.route_handler.remove_routes().await;
 
@@ -739,11 +739,10 @@ impl TunnelStateHandler for ConnectingState {
                         } else {
                             if let Some(tunnel_monitor_handle) = self.tunnel_monitor_handle.take() {
                                 let tombstone = tunnel_monitor_handle.wait().await;
-                                if let Err(reason) = unexpected_down_after_cover(
-                                    Self::handle_tunnel_close(tombstone, shared_state).await,
-                                ) {
+
+                                if Self::handle_tunnel_close(tombstone, shared_state).await.is_err() {
                                     return NextTunnelState::NewState(
-                                        ErrorState::enter(reason, shared_state).await,
+                                        ErrorState::enter(ErrorStateReason::TunnelProvider, shared_state).await,
                                     );
                                 }
                             }
@@ -1093,17 +1092,6 @@ enum ReconnectDecision {
     Abort,
 }
 
-fn unexpected_down_after_cover(cover: std::io::Result<()>) -> Result<(), ErrorStateReason> {
-    cover
-        .inspect_err(|err| {
-            trace_err_chain!(
-                err,
-                "failed to install Android blocking TUN before tunnel close"
-            );
-        })
-        .map_err(|_| ErrorStateReason::TunnelProvider)
-}
-
 fn reconnect_decision(next_attempt: u32) -> ReconnectDecision {
     if next_attempt >= MAX_RECONNECT_ATTEMPTS {
         ReconnectDecision::Abort
@@ -1155,15 +1143,6 @@ mod test {
             reconnect_decision(MAX_RECONNECT_ATTEMPTS - 1),
             ReconnectDecision::Retry { .. }
         ));
-    }
-
-    #[test]
-    fn unexpected_down_cover_failure_is_tunnel_provider_not_reconnect() {
-        assert_eq!(
-            unexpected_down_after_cover(Err(std::io::Error::other("configure_tunnel"))),
-            Err(ErrorStateReason::TunnelProvider)
-        );
-        assert_eq!(unexpected_down_after_cover(Ok(())), Ok(()));
     }
 
     #[test]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -85,6 +85,12 @@ impl ConnectingState {
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         shared_state.disallow_networking().await;
 
+        #[cfg(target_os = "android")]
+        if let Err(err) = shared_state.ensure_android_blocking_tun() {
+            trace_err_chain!(err, "failed to install Android blocking TUN");
+            return ErrorState::enter(ErrorStateReason::TunnelProvider, shared_state).await;
+        }
+
         // Always allow networking on mobile since there is no configurable firewall
         #[cfg(any(target_os = "android", target_os = "ios"))]
         shared_state.allow_networking().await;
@@ -282,7 +288,7 @@ impl ConnectingState {
         )
     }
 
-    pub(super) async fn handle_tunnel_close(tombstone: Tombstone, shared_state: &mut SharedState) {
+    async fn handle_tunnel_close(tombstone: Tombstone, shared_state: &mut SharedState) {
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         shared_state.route_handler.remove_routes().await;
 
@@ -719,28 +725,6 @@ impl TunnelStateHandler for ConnectingState {
                         } else {
                             if let Some(tunnel_monitor_handle) = self.tunnel_monitor_handle.take() {
                                 let tombstone = tunnel_monitor_handle.wait().await;
-                                #[cfg(target_os = "android")]
-                                {
-                                    // Install blocking cover before releasing the live TUN (same
-                                    // ordering as Disconnecting(Reconnect)).
-                                    if let Err(err) = shared_state
-                                        .prepare_blocking_cover_before_release(Some(tombstone))
-                                    {
-                                        tracing::error!(
-                                            "Failed to install Android blocking TUN before Connecting reconnect: {err}"
-                                        );
-                                        return NextTunnelState::NewState(
-                                            ErrorState::enter(
-                                                ErrorStateReason::TunnelProvider,
-                                                shared_state,
-                                            )
-                                            .await,
-                                        );
-                                    }
-                                    Self::handle_tunnel_close(Tombstone::default(), shared_state)
-                                        .await;
-                                }
-                                #[cfg(not(target_os = "android"))]
                                 Self::handle_tunnel_close(tombstone, shared_state).await;
                             }
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnected_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnected_state.rs
@@ -34,6 +34,11 @@ impl DisconnectedState {
         // Drop tombstone to close tunnel devices.
         drop(tombstone);
 
+        // Intentional disconnect: release Android blocking / held TUN so ISP path is available again
+        // (OS Always-On / block-without-VPN remain a user choice).
+        #[cfg(target_os = "android")]
+        shared_state.clear_android_blocking_tun();
+
         // Clear addresses from the pre-resolve table in the (shared) DNS resolver.
         HickoryDnsResolver::shared().clear_preresolve();
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnecting_state.rs
@@ -6,6 +6,8 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 #[cfg(target_os = "android")]
+use nym_common::trace_err_chain;
+#[cfg(target_os = "android")]
 use nym_vpn_lib_types::ErrorStateReason;
 
 use crate::tunnel_state_machine::{
@@ -64,8 +66,9 @@ impl DisconnectingState {
             PrivateActionAfterDisconnect::Error(reason) => {
                 #[cfg(target_os = "android")]
                 if let Err(err) = shared_state.prepare_blocking_cover_before_release(tombstone) {
-                    tracing::error!(
-                        "Failed to install Android blocking TUN before error state: {err}"
+                    trace_err_chain!(
+                        err,
+                        "failed to install Android blocking TUN before error state"
                     );
                 }
                 #[cfg(not(target_os = "android"))]
@@ -77,8 +80,9 @@ impl DisconnectingState {
             PrivateActionAfterDisconnect::Reconnect => {
                 #[cfg(target_os = "android")]
                 if let Err(err) = shared_state.prepare_blocking_cover_before_release(tombstone) {
-                    tracing::error!(
-                        "Failed to install Android blocking TUN before reconnect: {err}"
+                    trace_err_chain!(
+                        err,
+                        "failed to install Android blocking TUN before reconnect"
                     );
                     return ErrorState::enter(ErrorStateReason::TunnelProvider, shared_state).await;
                 }
@@ -91,7 +95,17 @@ impl DisconnectingState {
             PrivateActionAfterDisconnect::Offline {
                 reconnect,
                 gateways,
-            } => OfflineState::enter(reconnect, gateways, shared_state).await,
+            } => {
+                #[cfg(target_os = "android")]
+                if let Err(err) = shared_state.prepare_blocking_cover_before_release(tombstone) {
+                    trace_err_chain!(err, "failed to install Android blocking TUN before offline");
+                }
+                #[cfg(not(target_os = "android"))]
+                {
+                    let _ = tombstone;
+                }
+                OfflineState::enter(reconnect, gateways, shared_state).await
+            }
         }
     }
 }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnecting_state.rs
@@ -5,6 +5,11 @@ use futures::future::{BoxFuture, Fuse, FusedFuture, FutureExt};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
+#[cfg(target_os = "android")]
+use nym_vpn_lib_types::ErrorStateReason;
+
+#[cfg(target_os = "android")]
+use crate::tunnel_state_machine::blocking_tun::with_blocking_before_tun_release;
 use crate::tunnel_state_machine::{
     NextTunnelState, PrivateActionAfterDisconnect, PrivateTunnelState, SharedState, TunnelCommand,
     TunnelStateHandler,
@@ -59,9 +64,51 @@ impl DisconnectingState {
                 DisconnectedState::enter(tombstone, shared_state).await
             }
             PrivateActionAfterDisconnect::Error(reason) => {
+                #[cfg(target_os = "android")]
+                {
+                    let mut tombstone = tombstone;
+                    if let Err(err) = with_blocking_before_tun_release(
+                        || shared_state.install_android_blocking_tun(),
+                        || {
+                            drop(tombstone.take());
+                        },
+                    ) {
+                        tracing::error!(
+                            "Failed to install Android blocking TUN before error state: {err}"
+                        );
+                        shared_state.android_tun_hold = tombstone;
+                    }
+                }
+                #[cfg(not(target_os = "android"))]
+                {
+                    let _ = tombstone;
+                }
                 ErrorState::enter(reason, shared_state).await
             }
             PrivateActionAfterDisconnect::Reconnect => {
+                #[cfg(target_os = "android")]
+                {
+                    let mut tombstone = tombstone;
+                    let install_result = with_blocking_before_tun_release(
+                        || shared_state.install_android_blocking_tun(),
+                        || {
+                            drop(tombstone.take());
+                        },
+                    );
+                    if let Err(err) = install_result {
+                        tracing::error!(
+                            "Failed to install Android blocking TUN before reconnect: {err}"
+                        );
+                        // Keep previous TUN alive — do not open an ISP window.
+                        shared_state.android_tun_hold = tombstone;
+                        return ErrorState::enter(ErrorStateReason::TunnelProvider, shared_state)
+                            .await;
+                    }
+                }
+                #[cfg(not(target_os = "android"))]
+                {
+                    let _ = tombstone;
+                }
                 ConnectingState::enter(0, None, shared_state).await
             }
             PrivateActionAfterDisconnect::Offline {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/disconnecting_state.rs
@@ -8,8 +8,6 @@ use tokio_util::sync::CancellationToken;
 #[cfg(target_os = "android")]
 use nym_vpn_lib_types::ErrorStateReason;
 
-#[cfg(target_os = "android")]
-use crate::tunnel_state_machine::blocking_tun::with_blocking_before_tun_release;
 use crate::tunnel_state_machine::{
     NextTunnelState, PrivateActionAfterDisconnect, PrivateTunnelState, SharedState, TunnelCommand,
     TunnelStateHandler,
@@ -65,19 +63,10 @@ impl DisconnectingState {
             }
             PrivateActionAfterDisconnect::Error(reason) => {
                 #[cfg(target_os = "android")]
-                {
-                    let mut tombstone = tombstone;
-                    if let Err(err) = with_blocking_before_tun_release(
-                        || shared_state.install_android_blocking_tun(),
-                        || {
-                            drop(tombstone.take());
-                        },
-                    ) {
-                        tracing::error!(
-                            "Failed to install Android blocking TUN before error state: {err}"
-                        );
-                        shared_state.android_tun_hold = tombstone;
-                    }
+                if let Err(err) = shared_state.prepare_blocking_cover_before_release(tombstone) {
+                    tracing::error!(
+                        "Failed to install Android blocking TUN before error state: {err}"
+                    );
                 }
                 #[cfg(not(target_os = "android"))]
                 {
@@ -87,23 +76,11 @@ impl DisconnectingState {
             }
             PrivateActionAfterDisconnect::Reconnect => {
                 #[cfg(target_os = "android")]
-                {
-                    let mut tombstone = tombstone;
-                    let install_result = with_blocking_before_tun_release(
-                        || shared_state.install_android_blocking_tun(),
-                        || {
-                            drop(tombstone.take());
-                        },
+                if let Err(err) = shared_state.prepare_blocking_cover_before_release(tombstone) {
+                    tracing::error!(
+                        "Failed to install Android blocking TUN before reconnect: {err}"
                     );
-                    if let Err(err) = install_result {
-                        tracing::error!(
-                            "Failed to install Android blocking TUN before reconnect: {err}"
-                        );
-                        // Keep previous TUN alive — do not open an ISP window.
-                        shared_state.android_tun_hold = tombstone;
-                        return ErrorState::enter(ErrorStateReason::TunnelProvider, shared_state)
-                            .await;
-                    }
+                    return ErrorState::enter(ErrorStateReason::TunnelProvider, shared_state).await;
                 }
                 #[cfg(not(target_os = "android"))]
                 {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
@@ -65,7 +65,7 @@ impl ErrorState {
 
         #[cfg(target_os = "android")]
         if let Err(err) = shared_state.ensure_android_blocking_tun() {
-            trace_err_chain!(err, "Failed to install Android blocking TUN in error state");
+            trace_err_chain!(err, "failed to install Android blocking TUN in error state");
         }
 
         // Mobile: allow discovery/account networking; device traffic is covered by blocking TUN

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
@@ -4,13 +4,8 @@
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use std::net::SocketAddr;
 #[cfg(target_os = "ios")]
-use std::{
-    net::{IpAddr, Ipv4Addr, Ipv6Addr},
-    sync::Arc,
-};
+use std::{net::IpAddr, sync::Arc};
 
-#[cfg(target_os = "ios")]
-use ipnetwork::IpNetwork;
 #[cfg(target_os = "macos")]
 use nym_dns::DnsConfig;
 use tokio::sync::mpsc;
@@ -20,7 +15,8 @@ use tokio_util::sync::CancellationToken;
     target_os = "linux",
     target_os = "macos",
     target_os = "windows",
-    target_os = "ios"
+    target_os = "ios",
+    target_os = "android"
 ))]
 use nym_common::trace_err_chain;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
@@ -29,9 +25,9 @@ use nym_firewall::{AllowedClients, AllowedEndpoint, Endpoint, FirewallPolicy, Tr
 use nym_http_api_client::HickoryDnsResolver;
 
 #[cfg(target_os = "ios")]
-use crate::tunnel_provider::{OSTunProvider, TunnelSettings};
+use crate::tunnel_provider::OSTunProvider;
 #[cfg(target_os = "ios")]
-use crate::tunnel_state_machine::tunnel::wireguard::two_hop_config::MIN_IPV6_MTU;
+use crate::tunnel_state_machine::blocking_tun::blocking_tunnel_settings;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use crate::tunnel_state_machine::{Error, Result};
 use crate::tunnel_state_machine::{
@@ -39,15 +35,6 @@ use crate::tunnel_state_machine::{
     TunnelStateHandler,
     states::{ConnectingState, DisconnectedState, OfflineState},
 };
-
-/// Interface addresses used as placeholders when in error state.
-#[cfg(target_os = "ios")]
-const BLOCKING_INTERFACE_ADDRS: [IpAddr; 2] = [
-    IpAddr::V4(Ipv4Addr::new(169, 254, 0, 10)),
-    IpAddr::V6(Ipv6Addr::new(
-        0xfdcc, 0x9fc0, 0xe75a, 0x53c3, 0xfa25, 0x241f, 0x21c0, 0x70d0,
-    )),
-];
 
 pub struct ErrorState {
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
@@ -76,10 +63,13 @@ impl ErrorState {
             .await;
         }
 
-        // todo: activate kill switch on Android
+        #[cfg(target_os = "android")]
+        if let Err(err) = shared_state.ensure_android_blocking_tun() {
+            trace_err_chain!(err, "Failed to install Android blocking TUN in error state");
+        }
 
-        // Android: traffic should flow freely since there should be no tunnel device at this point
-        // iOS: network extensions bypass the tunnel by default
+        // Mobile: allow discovery/account networking; device traffic is covered by blocking TUN
+        // (Android) or NE blocking settings (iOS). Control-plane sockets use bypass() on Android.
         #[cfg(any(target_os = "android", target_os = "ios"))]
         shared_state.allow_networking().await;
 
@@ -193,12 +183,7 @@ impl ErrorState {
         tun_provider: Arc<dyn OSTunProvider>,
         dns_server: IpAddr,
     ) {
-        let tunnel_network_settings = TunnelSettings {
-            remote_addresses: vec![],
-            interface_addresses: BLOCKING_INTERFACE_ADDRS.map(IpNetwork::from).to_vec(),
-            dns_servers: vec![dns_server],
-            mtu: MIN_IPV6_MTU,
-        };
+        let tunnel_network_settings = blocking_tunnel_settings(dns_server);
 
         if let Err(e) = tun_provider
             .set_tunnel_network_settings(tunnel_network_settings)

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
@@ -63,16 +63,10 @@ impl ErrorState {
             .await;
         }
 
+        // Android: cover if possible; publish TunnelProvider when uncovered so the UI does not
+        // show a blocked/account reason while traffic uses the ISP. iOS uses NE settings.
         #[cfg(target_os = "android")]
-        if let Err(err) = shared_state.ensure_android_blocking_tun() {
-            trace_err_chain!(err, "failed to install Android blocking TUN in error state");
-        }
-
-        // iOS: NE blocking settings cover the device. Android: unpause control-plane only when a
-        // blocking TUN or a held live TUN is present. Skipping allow_networking does not deny
-        // other apps; without VpnService they already use the ISP.
-        #[cfg(target_os = "android")]
-        shared_state.allow_networking_if_android_covered().await;
+        let reason = shared_state.apply_android_error_cover(reason).await;
         #[cfg(target_os = "ios")]
         shared_state.allow_networking().await;
 

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
@@ -15,8 +15,7 @@ use tokio_util::sync::CancellationToken;
     target_os = "linux",
     target_os = "macos",
     target_os = "windows",
-    target_os = "ios",
-    target_os = "android"
+    target_os = "ios"
 ))]
 use nym_common::trace_err_chain;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/error_state.rs
@@ -68,9 +68,12 @@ impl ErrorState {
             trace_err_chain!(err, "failed to install Android blocking TUN in error state");
         }
 
-        // Mobile: allow discovery/account networking; device traffic is covered by blocking TUN
-        // (Android) or NE blocking settings (iOS). Control-plane sockets use bypass() on Android.
-        #[cfg(any(target_os = "android", target_os = "ios"))]
+        // iOS: NE blocking settings cover the device. Android: unpause control-plane only when a
+        // blocking TUN or a held live TUN is present. Skipping allow_networking does not deny
+        // other apps; without VpnService they already use the ISP.
+        #[cfg(target_os = "android")]
+        shared_state.allow_networking_if_android_covered().await;
+        #[cfg(target_os = "ios")]
         shared_state.allow_networking().await;
 
         #[cfg(not(any(target_os = "android", target_os = "ios")))]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/tunnel_monitor.rs
@@ -1294,6 +1294,7 @@ impl TunnelMonitor {
                 interface_addresses,
                 remote_addresses: vec![assigned_addresses.entry_mixnet_gateway_ip],
                 mtu,
+                exclude_vpn_app: false,
             };
 
             self.create_tun_device(packet_tunnel_settings).await?
@@ -1994,6 +1995,7 @@ impl TunnelMonitor {
             interface_addresses,
             remote_addresses: vec![entry_endpoint],
             mtu,
+            exclude_vpn_app: false,
         };
 
         let tun_device = self.create_tun_device(packet_tunnel_settings).await?;


### PR DESCRIPTION
## Ticket

JIRA-NYM-1741

## Description

Fix android IP leak when switching servers

## Checklist:

- [ ] Changelog

## Screenshots (optional, if UI related)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6213)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Android traffic protection during connection, reconnection, errors, offline periods, and unexpected tunnel closures by maintaining a blocking VPN interface.
  - Prevented traffic leaks to the ISP when the secure tunnel is unavailable.
  - Excluded the VPN app from the blocking interface so gateway registration and recovery can continue.
  - Improved handling when the VPN app cannot be excluded, reporting the failure instead of leaving the app blocked.
  - Intentional disconnects now correctly restore network access while respecting Always-On and block-without-VPN settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->