### PR TITLE
Cherry pick/missed cherry picks

### DIFF
--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/service/tile/VpnQuickTile.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/service/tile/VpnQuickTile.kt
@@ -92,7 +92,7 @@ class VpnQuickTile :
 
 			is Tunnel.State.Offline -> {
 				setTileDescription(this@VpnQuickTile.getString(R.string.offline))
-				setActive()
+				if (state.reconnect) setActive() else setInactive()
 			}
 
 			is Tunnel.State.Error -> {
@@ -121,8 +121,10 @@ class VpnQuickTile :
 		super.onClick()
 		unlockAndRun {
 			lifecycleScope.launch {
-				when (backendManager.getState()) {
+				when (val state = backendManager.getState()) {
 					Tunnel.State.Down -> backendManager.startTunnel()
+					is Tunnel.State.Offline ->
+						if (state.reconnect) backendManager.stopTunnel() else backendManager.startTunnel()
 					else -> backendManager.stopTunnel()
 				}
 			}

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/service/tile/VpnQuickTile.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/service/tile/VpnQuickTile.kt
@@ -90,7 +90,7 @@ class VpnQuickTile :
 				setActive()
 			}
 
-			Tunnel.State.Offline -> {
+			is Tunnel.State.Offline -> {
 				setTileDescription(this@VpnQuickTile.getString(R.string.offline))
 				setActive()
 			}

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/common/animations/Pulse.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/common/animations/Pulse.kt
@@ -47,7 +47,7 @@ fun MultiplePulsarEffect(nbPulsar: Int = 2, pulsarRadius: Float = 10f, pulsarCol
 		contentAlignment = Alignment.Center,
 	) {
 		Canvas(
-			Modifier,
+			Modifier.matchParentSize(),
 			onDraw = {
 				for (i in 0 until nbPulsar) {
 					val (radius, alpha) = effects[i]

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/common/animations/Pulse.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/common/animations/Pulse.kt
@@ -1,0 +1,96 @@
+package net.nymtech.nymvpn.ui.common.animations
+
+import androidx.compose.animation.core.InfiniteRepeatableSpec
+import androidx.compose.animation.core.RepeatMode.Restart
+import androidx.compose.animation.core.StartOffset
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun Pulse(color: Color = Color(0xFFFF4444)) {
+	MultiplePulsarEffect(pulsarColor = color) { modifier ->
+		Canvas(
+			modifier = modifier.size(5.dp),
+			onDraw = {
+				drawCircle(color = color)
+			},
+		)
+	}
+}
+
+@Composable
+fun MultiplePulsarEffect(nbPulsar: Int = 2, pulsarRadius: Float = 10f, pulsarColor: Color, circle: @Composable (Modifier) -> Unit = {}) {
+	var circleSize by remember { mutableStateOf(IntSize(0, 0)) }
+
+	val effects: List<Pair<Float, Float>> = List(nbPulsar) {
+		pulsarBuilder(pulsarRadius = pulsarRadius, size = circleSize.width, delay = it * 500)
+	}
+
+	Box(
+		Modifier,
+		contentAlignment = Alignment.Center,
+	) {
+		Canvas(
+			Modifier,
+			onDraw = {
+				for (i in 0 until nbPulsar) {
+					val (radius, alpha) = effects[i]
+					drawCircle(color = pulsarColor, radius = radius, alpha = alpha)
+				}
+			},
+		)
+		circle(
+			Modifier
+				.padding((pulsarRadius).dp)
+				.onGloballyPositioned {
+					if (it.isAttached) {
+						circleSize = it.size
+					}
+				},
+		)
+	}
+}
+
+@Composable
+fun pulsarBuilder(pulsarRadius: Float, size: Int, delay: Int): Pair<Float, Float> {
+	val infiniteTransition = rememberInfiniteTransition(label = "infinite")
+
+	val radius by infiniteTransition.animateFloat(
+		initialValue = (size / 2).toFloat(),
+		targetValue = size + (pulsarRadius * 2),
+		animationSpec = InfiniteRepeatableSpec(
+			animation = tween(3000),
+			initialStartOffset = StartOffset(delay),
+			repeatMode = Restart,
+		),
+		label = "radius",
+	)
+	val alpha by infiniteTransition.animateFloat(
+		initialValue = 1f,
+		targetValue = 0f,
+		animationSpec = InfiniteRepeatableSpec(
+			animation = tween(3000),
+			initialStartOffset = StartOffset(delay + 100),
+			repeatMode = Restart,
+		),
+		label = "alpha",
+	)
+
+	return radius to alpha
+}

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/model/ConnectionState.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/model/ConnectionState.kt
@@ -31,7 +31,10 @@ sealed interface ConnectionState {
 			Tunnel.State.Down -> Disconnected
 			Tunnel.State.Up -> Connected
 			Tunnel.State.Disconnecting -> Disconnecting
-			Tunnel.State.Offline -> WaitingForConnection
+			// A session that is armed to auto-reconnect once back online is treated as
+			// "waiting"; with no session armed there is nothing to wait for, so it is a
+			// plain offline (disconnected) state.
+			is Tunnel.State.Offline -> if (tunnelState.reconnect) WaitingForConnection else Offline
 
 			is Tunnel.State.Error -> Error(tunnelState.reason)
 

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/MainScreen.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/MainScreen.kt
@@ -65,13 +65,13 @@ import net.nymtech.nymvpn.ui.theme.Theme
 import net.nymtech.nymvpn.util.extensions.convertSecondsToTimeString
 import net.nymtech.nymvpn.util.extensions.goFromRoot
 import net.nymtech.nymvpn.util.extensions.openWebUrl
+import net.nymtech.nymvpn.util.extensions.scoreFor
 import net.nymtech.nymvpn.util.extensions.toConnectMode
 import nym_vpn_lib_types.AccountControllerErrorStateReason
 import nym_vpn_lib_types.AccountControllerState
 import nym_vpn_lib_types.DeeplinkKind
 import nym_vpn_lib_types.EntryPoint
 import nym_vpn_lib_types.ExitPoint
-import nym_vpn_lib_types.Score
 
 @Composable
 fun MainScreen(appViewModel: AppViewModel, appUiState: AppUiState, autoStart: Boolean, authRoute: AuthRoute? = null, loginProcessing: Boolean = false, viewModel: MainViewModel = hiltViewModel()) {
@@ -386,7 +386,7 @@ private fun MainScreenContent(
 			name = appUiState.exitPointName,
 			countryCode = appUiState.exitPointCountry,
 			location = appUiState.exitPointLocation,
-			score = appUiState.exitPointGateway?.wgScore ?: Score.HIGH,
+			score = appUiState.exitPointGateway?.scoreFor(appUiState.vpnConfig.mode),
 			selectionType = when (appUiState.vpnConfig.exitPoint) {
 				is ExitPoint.Random -> NodeSelectionType.RANDOM
 				is ExitPoint.Auto -> NodeSelectionType.AUTO
@@ -403,7 +403,7 @@ private fun MainScreenContent(
 				is EntryPoint.Auto -> NodeSelectionType.AUTO
 				else -> NodeSelectionType.NODE
 			},
-			score = appUiState.entryPointGateway?.wgScore ?: Score.HIGH,
+			score = appUiState.entryPointGateway?.scoreFor(appUiState.vpnConfig.mode),
 		),
 		initialPanelState = initialPanelState,
 		isSubscriptionExpired = appUiState.subscription?.expiryState == ExpiryState.EXPIRED,

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/MainViewModel.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/MainViewModel.kt
@@ -225,6 +225,15 @@ constructor(
 				ConnectionState.Disconnecting
 			managerState.isRestarting ->
 				ConnectionState.from(managerState.tunnelState, managerState.establishConnectionState)
+			managerState.tunnelState is Tunnel.State.Offline ->
+				// The backend reports Offline both for a paused-but-armed session (reconnect)
+				// and while fully disconnected with no network; only the former is a "waiting"
+				// state, the latter is a plain offline/disconnected state.
+				if ((managerState.tunnelState as Tunnel.State.Offline).reconnect) {
+					ConnectionState.WaitingForConnection
+				} else {
+					ConnectionState.Offline
+				}
 			managerState.tunnelState !is Tunnel.State.Down &&
 				managerState.tunnelState !is Tunnel.State.Error &&
 				networkStatus == NetworkStatus.Disconnected ->

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/components/ConnectionStatus.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/components/ConnectionStatus.kt
@@ -10,10 +10,13 @@ import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -34,6 +37,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import net.nymtech.nymvpn.R
+import net.nymtech.nymvpn.ui.common.animations.Pulse
 import net.nymtech.nymvpn.ui.model.ConnectionState
 import net.nymtech.nymvpn.ui.theme.NymVPNTheme
 import net.nymtech.nymvpn.ui.theme.Theme
@@ -132,13 +136,15 @@ fun ConnectionStatus(
 	val failedLabel = stringResource(R.string.connection_failed)
 	val disconnectingLabel = stringResource(R.string.disconnecting)
 	val notProtectedLabel = stringResource(R.string.connection_status_not_protected)
+	val offlineLabel = stringResource(R.string.offline)
 
 	val currentLabel: String? = when (connectionState) {
 		ConnectionState.Connected -> connectedLabel
 		is ConnectionState.Connecting -> connectionState.label.asString(context)
 		is ConnectionState.Error, is ConnectionState.StartFailure -> failedLabel
 		ConnectionState.Disconnecting -> disconnectingLabel
-		ConnectionState.Disconnected, ConnectionState.Offline, ConnectionState.WaitingForConnection -> notProtectedLabel
+		ConnectionState.Offline, ConnectionState.WaitingForConnection -> offlineLabel
+		ConnectionState.Disconnected -> notProtectedLabel
 	}
 
 	val labelAlpha by animateFloatAsState(
@@ -233,15 +239,27 @@ fun ConnectionStatus(
 			modifier = Modifier.alpha(labelAlpha),
 		) {
 			Spacer(Modifier.height(LABEL_OFFSET.dp))
-			Text(
-				text = (currentLabel ?: "").uppercase(),
-				style = MaterialTheme.typography.labelSmall,
-				color = when {
-					isError -> MaterialTheme.colorScheme.error
-					isConnected -> MaterialTheme.colorScheme.primary
-					else -> MaterialTheme.colorScheme.onSurfaceVariant
-				},
-			)
+			val isOffline = connectionState == ConnectionState.Offline ||
+				connectionState == ConnectionState.WaitingForConnection
+			Row(
+				verticalAlignment = Alignment.CenterVertically,
+				horizontalArrangement = Arrangement.Center,
+			) {
+				if (isOffline) {
+					Pulse(color = MaterialTheme.colorScheme.error)
+					Spacer(Modifier.width(6.dp))
+				}
+				Text(
+					text = (currentLabel ?: "").uppercase(),
+					style = MaterialTheme.typography.labelSmall,
+					color = when {
+						isError -> MaterialTheme.colorScheme.error
+						isConnected -> MaterialTheme.colorScheme.primary
+						isOffline -> MaterialTheme.colorScheme.error
+						else -> MaterialTheme.colorScheme.onSurfaceVariant
+					},
+				)
+			}
 			Spacer(Modifier.height(8.dp))
 			Text(
 				text = connectionTime ?: "",

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/panel/ConnectPanelModels.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/panel/ConnectPanelModels.kt
@@ -12,7 +12,7 @@ enum class ConnectAction { CONNECT, DISCONNECT, STOP_KILL_SWITCH, GET_STARTED, R
 
 enum class NodeSelectionType { NODE, RANDOM, AUTO }
 
-data class ServerNode(val id: String = "", val name: String?, val countryCode: String?, val location: String?, val score: Score, val selectionType: NodeSelectionType = NodeSelectionType.NODE)
+data class ServerNode(val id: String = "", val name: String?, val countryCode: String?, val location: String?, val score: Score?, val selectionType: NodeSelectionType = NodeSelectionType.NODE)
 
 data class ConnectPanelState(
 	val connectionState: ConnectionState,

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/panel/components/ActionButton.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/panel/components/ActionButton.kt
@@ -40,7 +40,6 @@ internal fun ActionButton(
 	when (connectionState) {
 		ConnectionState.Disconnected,
 		ConnectionState.Offline,
-		ConnectionState.WaitingForConnection,
 		-> {
 			val isAccountNotActive = accountState is AccountControllerState.Error &&
 				accountState.v1 is AccountControllerErrorStateReason.AccountStatusNotActive
@@ -67,6 +66,16 @@ internal fun ActionButton(
 				shape = buttonShape,
 			)
 		}
+
+		ConnectionState.WaitingForConnection -> MainStyledButton(
+			onClick = { onAction(ConnectAction.DISCONNECT) },
+			textColor = MaterialTheme.colorScheme.onPrimaryContainer,
+			content = { Text(stringResource(R.string.disconnect), style = MaterialTheme.typography.titleMedium) },
+			color = Color.Transparent,
+			borderStroke = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
+			modifier = buttonModifier,
+			shape = buttonShape,
+		)
 
 		is ConnectionState.Connecting -> MainStyledButton(
 			onClick = { onAction(ConnectAction.DISCONNECT) },

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/panel/components/NodeSection.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/panel/components/NodeSection.kt
@@ -8,6 +8,7 @@ import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
@@ -34,7 +35,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import net.nymtech.nymvpn.ui.screens.details.components.CountryFlag
 import net.nymtech.nymvpn.ui.screens.main.panel.ServerNode
-import net.nymtech.nymvpn.ui.theme.LocalNymColors
 import net.nymtech.nymvpn.ui.theme.iconSize
 import net.nymtech.nymvpn.util.extensions.getScoreIcon
 
@@ -113,10 +113,9 @@ private fun ServerRow(node: ServerNode, isClickable: Boolean, onServerClick: () 
 		modifier = modifier.fillMaxWidth(),
 	) {
 		val (icon, description) = getScoreIcon(node.score)
-		Icon(
+		Image(
 			icon,
 			contentDescription = description,
-			tint = LocalNymColors.current.success,
 			modifier = Modifier.size(iconSize).padding(2.dp),
 		)
 

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/util/extensions/UiExtensions.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/util/extensions/UiExtensions.kt
@@ -192,11 +192,13 @@ fun VpnException.toUserMessage(context: Context): String = when (this) {
 	else -> context.getString(R.string.unexpected_error) + " ${this.javaClass.simpleName}"
 }
 
+fun NymGateway.scoreFor(mode: Tunnel.Mode): Score? = when (mode) {
+	Tunnel.Mode.FIVE_HOP_MIXNET -> mixnetScore
+	Tunnel.Mode.TWO_HOP_MIXNET -> wgScore
+}
+
 fun List<NymGateway>.scoreSorted(mode: Tunnel.Mode): List<NymGateway> = this.sortedBy {
-	when (mode) {
-		Tunnel.Mode.FIVE_HOP_MIXNET -> it.mixnetScore ?: Score.OFFLINE
-		Tunnel.Mode.TWO_HOP_MIXNET -> it.wgScore ?: Score.OFFLINE
-	}
+	it.scoreFor(mode) ?: Score.OFFLINE
 }
 
 fun toDisplayCountry(twoLetterIsoCountryCode: String): String = Locale(twoLetterIsoCountryCode, twoLetterIsoCountryCode).displayCountry
@@ -217,17 +219,16 @@ fun NymGateway.getScoreIcon(gatewayType: GatewayType): Pair<ImageVector, String>
 		GatewayType.MIXNET_ENTRY, GatewayType.MIXNET_EXIT -> mixnetScore
 		GatewayType.WG -> wgScore
 	}
-	return score?.let {
-		getScoreIcon(score)
-	} ?: Pair(ImageVector.vectorResource(R.drawable.faq), stringResource(R.string.unknown))
+	return getScoreIcon(score)
 }
 
 @Composable
-fun getScoreIcon(score: Score): Pair<ImageVector, String> = when (score) {
+fun getScoreIcon(score: Score?): Pair<ImageVector, String> = when (score) {
 	Score.HIGH -> Pair(ImageVector.vectorResource(R.drawable.bars_3), stringResource(R.string.bars_3))
 	Score.MEDIUM -> Pair(ImageVector.vectorResource(R.drawable.bars_2), stringResource(R.string.bars_2))
 	Score.LOW -> Pair(ImageVector.vectorResource(R.drawable.bar_1), stringResource(R.string.bars_1))
 	Score.OFFLINE -> Pair(ImageVector.vectorResource(R.drawable.bar_0), stringResource(R.string.unknown))
+	null -> Pair(ImageVector.vectorResource(R.drawable.faq), stringResource(R.string.unknown))
 }
 
 @Composable

--- a/nym-vpn-android/app/src/main/res/values/strings.xml
+++ b/nym-vpn-android/app/src/main/res/values/strings.xml
@@ -205,7 +205,7 @@
 	<string name="connection_state_connecting_mixnet_client">Registering anonymously with servers (6/7)</string>
 	<string name="connection_state_connecting_tunnel">Establishing server connection (7/7)</string>
 	<!-- One-click mode -->
-	<string name="one_click_mode_fast">Fast</string>
+	<string name="one_click_mode_fast">dVPN</string>
 	<string name="connect_mode_mixnet">Mixnet</string>
 	<string name="one_click_nym_exit_node">Exit server</string>
 	<string name="one_click_nym_entry_node">Entry server</string>

--- a/nym-vpn-android/app/src/test/java/net/nymtech/nymvpn/util/extensions/ScoreForModeTest.kt
+++ b/nym-vpn-android/app/src/test/java/net/nymtech/nymvpn/util/extensions/ScoreForModeTest.kt
@@ -1,0 +1,51 @@
+package net.nymtech.nymvpn.util.extensions
+
+import net.nymtech.vpn.backend.Tunnel
+import net.nymtech.vpn.model.NymGateway
+import nym_vpn_lib_types.Score
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ScoreForModeTest {
+
+	private fun gateway(mixnetScore: Score?, wgScore: Score?) = NymGateway(
+		identity = "id",
+		twoLetterCountryISO = "fr",
+		description = null,
+		mixnetScore = mixnetScore,
+		wgScore = wgScore,
+		wgLoad = null,
+		wgUptime = null,
+		lastUpdated = null,
+		name = "gateway",
+		city = null,
+		region = null,
+		asn = null,
+		asnName = null,
+		asnKind = null,
+		buildVersion = null,
+		exitIpv4s = emptyList(),
+		exitIpv6s = emptyList(),
+		bridgeInformation = null,
+	)
+
+	@Test
+	fun fiveHopModeUsesMixnetScore() {
+		val gateway = gateway(mixnetScore = Score.LOW, wgScore = Score.HIGH)
+		assertEquals(Score.LOW, gateway.scoreFor(Tunnel.Mode.FIVE_HOP_MIXNET))
+	}
+
+	@Test
+	fun twoHopModeUsesWgScore() {
+		val gateway = gateway(mixnetScore = Score.HIGH, wgScore = Score.LOW)
+		assertEquals(Score.LOW, gateway.scoreFor(Tunnel.Mode.TWO_HOP_MIXNET))
+	}
+
+	@Test
+	fun missingScoreIsNullNotHigh() {
+		val gateway = gateway(mixnetScore = null, wgScore = null)
+		assertNull(gateway.scoreFor(Tunnel.Mode.FIVE_HOP_MIXNET))
+		assertNull(gateway.scoreFor(Tunnel.Mode.TWO_HOP_MIXNET))
+	}
+}

--- a/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/Tunnel.kt
+++ b/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/Tunnel.kt
@@ -17,7 +17,7 @@ interface Tunnel {
 		data object InitializingClient : State()
 		data object EstablishingConnection : State()
 		data object Disconnecting : State()
-		data object Offline : State()
+		data class Offline(val reconnect: Boolean) : State()
 		data class Error(val reason: ErrorStateReason) : State()
 	}
 

--- a/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/service/VpnService.kt
+++ b/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/service/VpnService.kt
@@ -80,7 +80,7 @@ class VpnService :
 			if (caps.ownerUid == Process.myUid()) return
 
 			val currentState = core.state
-			if (currentState == Tunnel.State.Down || currentState == Tunnel.State.Offline) return
+			if (currentState == Tunnel.State.Down || currentState is Tunnel.State.Offline) return
 
 			Timber.tag(TAG).w("Competing VPN detected (network=$network uid=${caps.ownerUid}), disconnecting")
 			_events.tryEmit(VpnServiceEvent.CompetingVpnDetected)
@@ -189,7 +189,7 @@ class VpnService :
 
 			ioScope.launch {
 				core.ensureReadyForManagementBestEffort()
-				if (core.state == Tunnel.State.Down || core.state == Tunnel.State.Offline) {
+				if (core.state == Tunnel.State.Down || core.state is Tunnel.State.Offline) {
 					core.connectLocked()
 				}
 			}

--- a/nym-vpn-android/core/src/main/java/net/nymtech/vpn/util/extensions/LibExtensions.kt
+++ b/nym-vpn-android/core/src/main/java/net/nymtech/vpn/util/extensions/LibExtensions.kt
@@ -18,7 +18,7 @@ fun TunnelEvent.NewState.asTunnelState(): Tunnel.State = when (this.v1) {
 	is TunnelState.Disconnected -> Tunnel.State.Down
 	is TunnelState.Disconnecting -> Tunnel.State.Disconnecting
 	is TunnelState.Error -> Tunnel.State.Error(this.v1.v1)
-	is TunnelState.Offline -> Tunnel.State.Offline
+	is TunnelState.Offline -> Tunnel.State.Offline((this.v1 as TunnelState.Offline).reconnect)
 }
 
 enum class GatewaySelectionMode(val value: String) {

--- a/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/registration/mixnet_client.rs
+++ b/nym-vpn-core/crates/nym-diagnostic/src/diagnostic/registration/mixnet_client.rs
@@ -180,7 +180,7 @@ impl MixnetClientRegistration {
     async fn wireguard_registration(
         mixnet_client: MixnetClient,
         wg_registration_config: &WgRegistrationConfig,
-    ) -> Result<WireguardConfiguration, RegistrationError> {
+    ) -> Result<WireguardConfiguration, Box<RegistrationError>> {
         let address = *mixnet_client.nym_address();
 
         let mixnet_listener =
@@ -207,7 +207,7 @@ impl MixnetClientRegistration {
         // Stopping mixnet client
         mixnet_listener.stop().await;
 
-        auth_res
+        auth_res.map_err(Box::new)
     }
 
     async fn mixnet_ipr_connect(

--- a/nym-vpn-core/crates/nym-favorites/src/error.rs
+++ b/nym-vpn-core/crates/nym-favorites/src/error.rs
@@ -8,7 +8,7 @@ pub enum FavoritesError {
     #[error("failed to lookup gateway cache")]
     GetGateways {
         tunnel_type: TunnelType,
-        source: nym_gateway_directory::Error,
+        source: Box<nym_gateway_directory::Error>,
     },
 
     #[error("{0}")]

--- a/nym-vpn-core/crates/nym-favorites/src/recents.rs
+++ b/nym-vpn-core/crates/nym-favorites/src/recents.rs
@@ -158,7 +158,7 @@ impl<C: RecentGatewayCache> RecentsManager<C> {
             .await
             .map_err(|source| FavoritesError::GetGateways {
                 tunnel_type,
-                source,
+                source: Box::new(source),
             })
     }
 }

--- a/nym-vpn-core/crates/nym-split-tunnel/src/macos/mod.rs
+++ b/nym-vpn-core/crates/nym-split-tunnel/src/macos/mod.rs
@@ -552,12 +552,12 @@ impl State {
                     Err(error) => {
                         return Err(ErrorWithTransition {
                             error: error.into(),
-                            next_state: Some(State::Active {
+                            next_state: Some(Box::new(State::Active {
                                 route_manager,
                                 process,
                                 tun_handle,
                                 vpn_interface: old_vpn_interface,
-                            }),
+                            })),
                         });
                     }
                 };
@@ -592,10 +592,10 @@ impl State {
                     Err(error) => {
                         return Err(ErrorWithTransition {
                             error: error.into(),
-                            next_state: Some(State::ProcessMonitorOnly {
+                            next_state: Some(Box::new(State::ProcessMonitorOnly {
                                 route_manager,
                                 process,
-                            }),
+                            })),
                         });
                     }
                 };
@@ -666,7 +666,7 @@ impl State {
                 error,
                 next_state: Some(next_state),
             }) => {
-                *self = next_state;
+                *self = *next_state;
                 Err(error)
             }
             Err(ErrorWithTransition {
@@ -694,7 +694,7 @@ async fn classify_packet(packet: &PktapPacket, proc_states: ProcessStates) -> Ro
 
 struct ErrorWithTransition {
     error: Error,
-    next_state: Option<State>,
+    next_state: Option<Box<State>>,
 }
 
 impl<T: Into<Error>> From<T> for ErrorWithTransition {

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/offline_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/offline_state.rs
@@ -138,12 +138,24 @@ impl TunnelStateHandler for OfflineState {
                         }
                     },
                     TunnelCommand::Disconnect => {
-                        if self.reconnect {
-                            self.reconnect = false;
-                            let new_state = PrivateTunnelState::Offline { reconnect: self.reconnect };
-                            NextTunnelState::NewState((self, new_state))
-                        } else {
-                            NextTunnelState::SameState(self)
+                        // An explicit user-initiated disconnect while offline should tear the
+                        // tunnel down immediately rather than only disarming auto-reconnect and
+                        // lingering in the offline state. Otherwise the first disconnect merely
+                        // re-emits `Offline`, which races the client's optimistic `Down` and
+                        // resurrects the offline UI, forcing the user to press disconnect twice.
+                        #[cfg(target_os = "android")]
+                        {
+                            NextTunnelState::NewState(DisconnectedState::enter(None, shared_state).await)
+                        }
+                        #[cfg(not(target_os = "android"))]
+                        {
+                            if self.reconnect {
+                                self.reconnect = false;
+                                let new_state = PrivateTunnelState::Offline { reconnect: self.reconnect };
+                                NextTunnelState::NewState((self, new_state))
+                            } else {
+                                NextTunnelState::SameState(self)
+                            }
                         }
                     },
                     TunnelCommand::SetTunnelSettings(tunnel_settings) => {


### PR DESCRIPTION
Add missed cherry-picks from release/2026.12-vanilnoir.

- Fix home screen server score indicator (#6147)
- restore offline "No internet" status and correct offline action (#6180)

Also make some error types return via boxing to avoid clippy warnings
about large enum variants.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6214)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pulsing indicators for offline and reconnecting VPN states.
  * Added a clear “Disconnect” action while waiting for reconnection.
  * Updated fast-mode labeling to “dVPN.”
  * Improved VPN quick-tile actions for reconnecting and offline states.

* **Bug Fixes**
  * Improved offline and reconnecting state handling, including immediate Android disconnects.
  * Server scores now reflect the selected VPN mode and safely support unavailable scores.
  * Offline status now displays clearer error styling and messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->