### PR TITLE
UI: Android stub for ConflictDetected tunnel event

### DIFF
--- a/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/controller/VpnCoreController.kt
+++ b/nym-vpn-android/core/src/main/java/net/nymtech/vpn/backend/controller/VpnCoreController.kt
@@ -220,6 +220,7 @@ class VpnCoreController(
 				events.tryEmit(Log("TunnelEvent config_changed"))
 			}
 			is TunnelEvent.DiagnosticsSuggested -> events.tryEmit(Log("TunnelEvent diagnostics_suggested"))
+			is TunnelEvent.ConflictDetected -> events.tryEmit(Log("TunnelEvent conflict_detected: ${event.v1}"))
 		}
 	}
 


### PR DESCRIPTION
Stacked on #6218. Part of the split of #6122 (VPN-4910: detect conflicting
software).

Logs the new `TunnelEvent.ConflictDetected` variant so the app compiles
against the updated uniffi bindings. No UI surface yet.

Part of the stack: #6216 → #6217 → #6218 → this PR (+ ui-tauri, ui-ios-macos) → `topic/nym-4910-detect-conflict` → `develop`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6220)
<!-- Reviewable:end -->
