### PR TITLE
fix(android): hide connection counter while offline, resume with cumulative session time

### DIFF
--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/manager/backend/VpnEventReducer.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/manager/backend/VpnEventReducer.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.update
 import net.nymtech.nymvpn.manager.backend.model.BackendUiEvent
+import net.nymtech.nymvpn.manager.backend.model.ConnectionInfo
 import net.nymtech.nymvpn.manager.backend.model.MixnetConnectionState
 import net.nymtech.nymvpn.manager.backend.model.TunnelManagerState
 import net.nymtech.nymvpn.manager.backend.model.toInfo
@@ -19,12 +20,42 @@ import net.nymtech.vpn.backend.Tunnel
 import net.nymtech.vpn.backend.api.VpnServiceApi
 import net.nymtech.vpn.model.VpnServiceEvent
 import nym_vpn_lib_types.ErrorStateReason
+import nym_vpn_lib_types.EstablishConnectionState
 import timber.log.Timber
 
 /**
  * Reduces VpnServiceEvent into TunnelManagerState.
  */
 class VpnEventReducer(private val context: Context, private val state: MutableStateFlow<TunnelManagerState>) {
+
+	companion object {
+		// A session lasts from the first Connected event until the tunnel is Down; its
+		// connectedAt survives offline gaps and reconnects so the timer shows cumulative
+		// session time.
+		internal fun reduceStateChanged(current: TunnelManagerState, newState: Tunnel.State): TunnelManagerState {
+			val next = current.copy(tunnelState = newState, isRestarting = false, backendUiEvent = null)
+			return if (newState == Tunnel.State.Down) {
+				next.copy(establishConnectionState = null, mixnetConnectionState = null, connectionData = null)
+			} else {
+				next
+			}
+		}
+
+		internal fun reduceEstablishConnection(current: TunnelManagerState, establishState: EstablishConnectionState, newInfo: ConnectionInfo?): TunnelManagerState {
+			val preserved = newInfo?.let { info ->
+				current.connectionData?.connectedAt?.let { info.copy(connectedAt = it) } ?: info
+			} ?: current.connectionData
+			return current.copy(establishConnectionState = establishState, connectionData = preserved)
+		}
+
+		internal fun reduceConnected(current: TunnelManagerState, newInfo: ConnectionInfo?): TunnelManagerState {
+			val preserved = newInfo?.let { info ->
+				current.connectionData?.connectedAt?.let { info.copy(connectedAt = it) } ?: info
+			} ?: current.connectionData
+			return current.copy(connectionData = preserved, establishConnectionState = null)
+		}
+	}
+
 	fun observe(scope: CoroutineScope, dispatcher: CoroutineDispatcher, apiFlow: StateFlow<VpnServiceApi?>) {
 		scope.launch(dispatcher) {
 			apiFlow
@@ -38,38 +69,16 @@ class VpnEventReducer(private val context: Context, private val state: MutableSt
 	private fun handle(event: VpnServiceEvent) {
 		when (event) {
 			is VpnServiceEvent.StateChanged -> {
-				state.update { s ->
-					val next = s.copy(tunnelState = event.state, isRestarting = false, backendUiEvent = null)
-					if (event.state == Tunnel.State.Down) {
-						next.copy(establishConnectionState = null, mixnetConnectionState = null)
-					} else {
-						next
-					}
-				}
+				state.update { s -> reduceStateChanged(s, event.state) }
 				context.requestTileServiceStateUpdate()
 			}
 
 			is VpnServiceEvent.EstablishConnection -> {
-				state.update { s ->
-					s.copy(
-						establishConnectionState = event.state,
-						connectionData = event.data?.toInfo(),
-					)
-				}
+				state.update { s -> reduceEstablishConnection(s, event.state, event.data?.toInfo()) }
 			}
 
 			is VpnServiceEvent.Connected -> {
-				state.update { current ->
-					val newInfo = event.data?.toInfo()
-					val preserved =
-						if (current.isRestarting && current.connectionData?.connectedAt != null && newInfo != null) {
-							newInfo.copy(connectedAt = current.connectionData!!.connectedAt)
-						} else {
-							newInfo
-						}
-
-					current.copy(connectionData = preserved, establishConnectionState = null)
-				}
+				state.update { current -> reduceConnected(current, event.data?.toInfo()) }
 			}
 
 			is VpnServiceEvent.MixnetConnectionEvent -> {
@@ -94,6 +103,7 @@ class VpnEventReducer(private val context: Context, private val state: MutableSt
 								tunnelState = Tunnel.State.Down,
 								establishConnectionState = null,
 								mixnetConnectionState = null,
+								connectionData = null,
 								backendUiEvent = null,
 							)
 						}
@@ -110,6 +120,7 @@ class VpnEventReducer(private val context: Context, private val state: MutableSt
 						tunnelState = Tunnel.State.Down,
 						establishConnectionState = null,
 						mixnetConnectionState = null,
+						connectionData = null,
 					)
 				}
 				context.requestTileServiceStateUpdate()

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/ConnectionTimerPolicy.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/ConnectionTimerPolicy.kt
@@ -1,0 +1,24 @@
+package net.nymtech.nymvpn.ui.screens.main
+
+import net.nymtech.vpn.backend.Tunnel
+
+/**
+ * Decides what the main-screen connection timer should do for a tunnel state change.
+ */
+object ConnectionTimerPolicy {
+
+	sealed interface Command {
+		data class Start(val connectedAtSeconds: Long) : Command
+		data object Stop : Command
+		data object None : Command
+	}
+
+	// The timer is only shown while the tunnel is Up; the session start (connectedAt) is
+	// preserved across offline gaps and reconnects, so on recovery the timer resumes with
+	// the cumulative session time. Up may briefly be reported before the Connected event
+	// delivers connectedAt — leave the timer untouched rather than restarting it.
+	fun evaluate(tunnelState: Tunnel.State, connectedAtSeconds: Long?): Command = when (tunnelState) {
+		is Tunnel.State.Up -> if (connectedAtSeconds != null) Command.Start(connectedAtSeconds) else Command.None
+		else -> Command.Stop
+	}
+}

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/MainViewModel.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/MainViewModel.kt
@@ -66,7 +66,6 @@ constructor(
 	val isAppInForeground = NymVpn.AppLifecycleObserver.isInForeground
 
 	private var timerJob: Job? = null
-	private var lastConnectedAt: Long? = null
 	private var pendingNodeFamiliesConfirmAction: (suspend () -> Unit)? = null
 	private var nodeFamiliesEventHandled = false
 
@@ -198,7 +197,6 @@ constructor(
 
 	fun onDisconnect() = viewModelScope.launch {
 		Timber.tag(TAG).i("DisconnectRequested")
-		lastConnectedAt = null
 		stopConnectionTimerInternal()
 		runCatching { backendManager.stopTunnel() }
 			.onFailure { Timber.tag(TAG).e(it, "DisconnectFailed") }
@@ -263,35 +261,10 @@ constructor(
 	}
 
 	private fun handleTunnelStateChange(tunnelState: Tunnel.State, connectedAt: Long?) {
-		when (tunnelState) {
-			is Tunnel.State.Up -> {
-				if (connectedAt != null) {
-					lastConnectedAt = connectedAt
-					startConnectionTimer(connectedAt)
-				}
-			}
-			is Tunnel.State.Disconnecting -> {
-				lastConnectedAt = null
-				stopConnectionTimerInternal()
-			}
-			is Tunnel.State.InitializingClient,
-			is Tunnel.State.EstablishingConnection,
-			is Tunnel.State.Offline,
-			-> {
-				if (connectedAt != null) {
-					lastConnectedAt = connectedAt
-					startConnectionTimer(connectedAt)
-				} else {
-					lastConnectedAt = null
-					stopConnectionTimerInternal()
-				}
-			}
-			is Tunnel.State.Down,
-			is Tunnel.State.Error,
-			-> {
-				if (connectedAt == null) lastConnectedAt = null
-				stopConnectionTimerInternal()
-			}
+		when (val command = ConnectionTimerPolicy.evaluate(tunnelState, connectedAt)) {
+			is ConnectionTimerPolicy.Command.Start -> startConnectionTimer(command.connectedAtSeconds)
+			ConnectionTimerPolicy.Command.Stop -> stopConnectionTimerInternal()
+			ConnectionTimerPolicy.Command.None -> Unit
 		}
 	}
 

--- a/nym-vpn-android/app/src/test/java/net/nymtech/nymvpn/manager/backend/VpnEventReducerTest.kt
+++ b/nym-vpn-android/app/src/test/java/net/nymtech/nymvpn/manager/backend/VpnEventReducerTest.kt
@@ -1,0 +1,72 @@
+package net.nymtech.nymvpn.manager.backend
+
+import net.nymtech.nymvpn.manager.backend.model.ConnectionInfo
+import net.nymtech.nymvpn.manager.backend.model.TunnelManagerState
+import net.nymtech.vpn.backend.Tunnel
+import nym_vpn_lib_types.EstablishConnectionState
+import nym_vpn_lib_types.GatewayLightInfo
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class VpnEventReducerTest {
+
+	private fun gateway(id: String) = GatewayLightInfo(id, "FR")
+
+	private fun info(connectedAt: Long?) = ConnectionInfo(gateway("entry"), gateway("exit"), connectedAt, null)
+
+	@Test
+	fun establishConnection_preservesSessionStart() {
+		val current = TunnelManagerState(tunnelState = Tunnel.State.EstablishingConnection, connectionData = info(1000L))
+
+		val next = VpnEventReducer.reduceEstablishConnection(current, EstablishConnectionState.RESOLVING_API_ADDRESSES, info(null))
+
+		assertEquals(1000L, next.connectionData?.connectedAt)
+	}
+
+	@Test
+	fun establishConnection_withoutEventData_keepsPreviousConnectionData() {
+		val current = TunnelManagerState(tunnelState = Tunnel.State.EstablishingConnection, connectionData = info(1000L))
+
+		val next = VpnEventReducer.reduceEstablishConnection(current, EstablishConnectionState.RESOLVING_API_ADDRESSES, null)
+
+		assertEquals(1000L, next.connectionData?.connectedAt)
+	}
+
+	@Test
+	fun connected_preservesSessionStartAcrossOfflineReconnect() {
+		// Offline auto-reconnect does not set isRestarting; the session start must survive anyway
+		val current = TunnelManagerState(tunnelState = Tunnel.State.Up, connectionData = info(1000L), isRestarting = false)
+
+		val next = VpnEventReducer.reduceConnected(current, info(2000L))
+
+		assertEquals(1000L, next.connectionData?.connectedAt)
+	}
+
+	@Test
+	fun connected_withoutEventData_keepsPreviousConnectionData() {
+		val current = TunnelManagerState(tunnelState = Tunnel.State.Up, connectionData = info(1000L))
+
+		val next = VpnEventReducer.reduceConnected(current, null)
+
+		assertEquals(1000L, next.connectionData?.connectedAt)
+	}
+
+	@Test
+	fun connected_freshSession_usesNewConnectedAt() {
+		val current = TunnelManagerState(tunnelState = Tunnel.State.Up, connectionData = null)
+
+		val next = VpnEventReducer.reduceConnected(current, info(2000L))
+
+		assertEquals(2000L, next.connectionData?.connectedAt)
+	}
+
+	@Test
+	fun stateChangedDown_clearsConnectionData() {
+		val current = TunnelManagerState(tunnelState = Tunnel.State.Up, connectionData = info(1000L))
+
+		val next = VpnEventReducer.reduceStateChanged(current, Tunnel.State.Down)
+
+		assertNull(next.connectionData)
+	}
+}

--- a/nym-vpn-android/app/src/test/java/net/nymtech/nymvpn/ui/screens/main/ConnectionTimerPolicyTest.kt
+++ b/nym-vpn-android/app/src/test/java/net/nymtech/nymvpn/ui/screens/main/ConnectionTimerPolicyTest.kt
@@ -1,0 +1,42 @@
+package net.nymtech.nymvpn.ui.screens.main
+
+import net.nymtech.nymvpn.ui.screens.main.ConnectionTimerPolicy.Command
+import net.nymtech.vpn.backend.Tunnel
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ConnectionTimerPolicyTest {
+
+	@Test
+	fun up_withSessionStart_startsTimer() {
+		assertEquals(Command.Start(1000L), ConnectionTimerPolicy.evaluate(Tunnel.State.Up, 1000L))
+	}
+
+	@Test
+	fun up_withoutSessionStart_leavesTimerUntouched() {
+		assertEquals(Command.None, ConnectionTimerPolicy.evaluate(Tunnel.State.Up, null))
+	}
+
+	@Test
+	fun offline_stopsTimer_evenWithSessionActive() {
+		assertEquals(Command.Stop, ConnectionTimerPolicy.evaluate(Tunnel.State.Offline(reconnect = true), 1000L))
+		assertEquals(Command.Stop, ConnectionTimerPolicy.evaluate(Tunnel.State.Offline(reconnect = false), 1000L))
+	}
+
+	@Test
+	fun offline_withoutSession_stopsTimer() {
+		assertEquals(Command.Stop, ConnectionTimerPolicy.evaluate(Tunnel.State.Offline(reconnect = false), null))
+	}
+
+	@Test
+	fun establishing_stopsTimer_untilTunnelIsUp() {
+		assertEquals(Command.Stop, ConnectionTimerPolicy.evaluate(Tunnel.State.EstablishingConnection, 1000L))
+		assertEquals(Command.Stop, ConnectionTimerPolicy.evaluate(Tunnel.State.InitializingClient, 1000L))
+	}
+
+	@Test
+	fun down_disconnecting_error_stopTimer() {
+		assertEquals(Command.Stop, ConnectionTimerPolicy.evaluate(Tunnel.State.Down, 1000L))
+		assertEquals(Command.Stop, ConnectionTimerPolicy.evaluate(Tunnel.State.Disconnecting, 1000L))
+	}
+}


### PR DESCRIPTION
The counter stayed on screen (and kept counting) when the device went offline, because timer visibility was driven only by connectedAt being set. Whether it survived into offline depended on where in the reconnect cycle connectivity dropped, so toggling airplane mode gave inconsistent results, and each reconnect restarted the counter from zero.

The timer now runs only while the tunnel is Up. The session start (connectedAt) is preserved across establish/offline/reconnect in VpnEventReducer and cleared only when the tunnel reaches Down, so the counter disappears while offline and reappears on reconnect showing cumulative session time.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6224)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved connection timer behavior during reconnects and temporary tunnel state changes.
  - Preserved the original connection start time across reconnects.
  - Cleared connection information when the tunnel goes down or encounters a fatal provider event.
  - Prevented the timer from starting until an active connection timestamp is available.

- **Tests**
  - Added coverage for connection state transitions, reconnects, missing event data, and timer start/stop behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->