### PR TITLE
fix(android): prevent quick tile crash when onStartListening arrives after onDestroy

### DIFF
--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/service/tile/VpnQuickTile.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/service/tile/VpnQuickTile.kt
@@ -14,6 +14,7 @@ import net.nymtech.nymvpn.R
 import net.nymtech.nymvpn.data.SettingsRepository
 import net.nymtech.nymvpn.data.config.VpnConfigRepository
 import net.nymtech.nymvpn.manager.backend.BackendManager
+import net.nymtech.nymvpn.util.extensions.handleLifecycleEventSafely
 import net.nymtech.nymvpn.util.extensions.toDisplayCountry
 import net.nymtech.nymvpn.util.extensions.truncateWithEllipsis
 import net.nymtech.vpn.backend.Tunnel
@@ -46,7 +47,9 @@ class VpnQuickTile :
 
 	override fun onStartListening() {
 		super.onStartListening()
-		lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_START)
+		// a queued onStartListening can be delivered after onDestroy
+		if (lifecycleRegistry.currentState == Lifecycle.State.DESTROYED) return
+		lifecycleRegistry.handleLifecycleEventSafely(Lifecycle.Event.ON_START)
 
 		if (isCollecting) return
 		isCollecting = true
@@ -108,7 +111,7 @@ class VpnQuickTile :
 	}
 
 	override fun onStopListening() {
-		lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+		lifecycleRegistry.handleLifecycleEventSafely(Lifecycle.Event.ON_STOP)
 		isCollecting = false
 	}
 

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/util/extensions/LifecycleExtensions.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/util/extensions/LifecycleExtensions.kt
@@ -1,0 +1,14 @@
+package net.nymtech.nymvpn.util.extensions
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleRegistry
+
+/**
+ * TileService delivers its callbacks through a handler, so a queued onStartListening/onStopListening
+ * can arrive after onDestroy. Lifecycle 2.9+ throws IllegalStateException when moving a DESTROYED
+ * registry, so ignore events once destroyed.
+ */
+fun LifecycleRegistry.handleLifecycleEventSafely(event: Lifecycle.Event) {
+	if (currentState == Lifecycle.State.DESTROYED) return
+	handleLifecycleEvent(event)
+}

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/util/extensions/LifecycleExtensions.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/util/extensions/LifecycleExtensions.kt
@@ -3,11 +3,7 @@ package net.nymtech.nymvpn.util.extensions
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleRegistry
 
-/**
- * TileService delivers its callbacks through a handler, so a queued onStartListening/onStopListening
- * can arrive after onDestroy. Lifecycle 2.9+ throws IllegalStateException when moving a DESTROYED
- * registry, so ignore events once destroyed.
- */
+/** Ignores the event instead of throwing if the registry is already DESTROYED. */
 fun LifecycleRegistry.handleLifecycleEventSafely(event: Lifecycle.Event) {
 	if (currentState == Lifecycle.State.DESTROYED) return
 	handleLifecycleEvent(event)

--- a/nym-vpn-android/app/src/test/java/net/nymtech/nymvpn/util/extensions/LifecycleExtensionsTest.kt
+++ b/nym-vpn-android/app/src/test/java/net/nymtech/nymvpn/util/extensions/LifecycleExtensionsTest.kt
@@ -47,8 +47,7 @@ class LifecycleExtensionsTest {
 		registry.handleLifecycleEventSafely(Lifecycle.Event.ON_STOP)
 		registry.handleLifecycleEventSafely(Lifecycle.Event.ON_DESTROY)
 
-		// TileService delivers callbacks through a handler, so a queued
-		// onStartListening can arrive after onDestroy
+		// simulates a queued onStartListening arriving after onDestroy
 		registry.handleLifecycleEventSafely(Lifecycle.Event.ON_START)
 
 		assertEquals(Lifecycle.State.DESTROYED, registry.currentState)

--- a/nym-vpn-android/app/src/test/java/net/nymtech/nymvpn/util/extensions/LifecycleExtensionsTest.kt
+++ b/nym-vpn-android/app/src/test/java/net/nymtech/nymvpn/util/extensions/LifecycleExtensionsTest.kt
@@ -1,0 +1,68 @@
+package net.nymtech.nymvpn.util.extensions
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LifecycleExtensionsTest {
+
+	private fun registry(): LifecycleRegistry {
+		lateinit var registry: LifecycleRegistry
+		val owner = object : LifecycleOwner {
+			override val lifecycle: Lifecycle
+				get() = registry
+		}
+		registry = LifecycleRegistry.createUnsafe(owner)
+		return registry
+	}
+
+	@Test
+	fun eventsBeforeDestroy_moveStateNormally() {
+		val registry = registry()
+
+		registry.handleLifecycleEventSafely(Lifecycle.Event.ON_CREATE)
+		registry.handleLifecycleEventSafely(Lifecycle.Event.ON_START)
+
+		assertEquals(Lifecycle.State.STARTED, registry.currentState)
+	}
+
+	@Test
+	fun stopAfterStart_movesBackToCreated() {
+		val registry = registry()
+
+		registry.handleLifecycleEventSafely(Lifecycle.Event.ON_CREATE)
+		registry.handleLifecycleEventSafely(Lifecycle.Event.ON_START)
+		registry.handleLifecycleEventSafely(Lifecycle.Event.ON_STOP)
+
+		assertEquals(Lifecycle.State.CREATED, registry.currentState)
+	}
+
+	@Test
+	fun startAfterDestroy_isIgnored() {
+		val registry = registry()
+		registry.handleLifecycleEventSafely(Lifecycle.Event.ON_CREATE)
+		registry.handleLifecycleEventSafely(Lifecycle.Event.ON_START)
+		registry.handleLifecycleEventSafely(Lifecycle.Event.ON_STOP)
+		registry.handleLifecycleEventSafely(Lifecycle.Event.ON_DESTROY)
+
+		// TileService delivers callbacks through a handler, so a queued
+		// onStartListening can arrive after onDestroy
+		registry.handleLifecycleEventSafely(Lifecycle.Event.ON_START)
+
+		assertEquals(Lifecycle.State.DESTROYED, registry.currentState)
+	}
+
+	@Test
+	fun stopAfterDestroy_isIgnored() {
+		val registry = registry()
+		registry.handleLifecycleEventSafely(Lifecycle.Event.ON_CREATE)
+		registry.handleLifecycleEventSafely(Lifecycle.Event.ON_START)
+		registry.handleLifecycleEventSafely(Lifecycle.Event.ON_DESTROY)
+
+		registry.handleLifecycleEventSafely(Lifecycle.Event.ON_STOP)
+
+		assertEquals(Lifecycle.State.DESTROYED, registry.currentState)
+	}
+}


### PR DESCRIPTION
TileService delivers callbacks through a handler, so a queued onStartListening/onStopListening can land after onDestroy. Since lifecycle 2.9 moving a DESTROYED LifecycleRegistry throws IllegalStateException (checkLifecycleStateTransition), crashing VpnQuickTile on Android 17.

Ignore lifecycle events once the registry is DESTROYED via a new handleLifecycleEventSafely extension, and return early from onStartListening on a destroyed tile.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6232)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved VPN Quick Tile reliability during start and stop transitions.
  - Prevented delayed lifecycle callbacks from being processed after the tile is destroyed.
  - Avoided invalid state changes when lifecycle events arrive after destruction.
  - Ensured the Quick Tile remains in a stable, destroyed state when late events are received.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->