### PR TITLE
fix(core): survive system sleep during reconnect and auto-recover from error state

### DIFF
--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/mod.rs
@@ -11,6 +11,7 @@ mod ipv6_availability;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 mod route_handler;
 mod states;
+mod system_sleep;
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 mod tun_ipv6;
 #[cfg(any(target_os = "ios", target_os = "android"))]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/states/connecting_state.rs
@@ -22,6 +22,7 @@ use crate::tunnel_state_machine::{
     ErrorStateReason, NextTunnelState, PrivateActionAfterDisconnect, PrivateTunnelState, Result,
     SharedState, TunnelCommand, TunnelInterface, TunnelStateHandler,
     states::{ConnectedState, DisconnectingState, ErrorState, OfflineState},
+    system_sleep::SleepMarker,
     tunnel::{SelectedGateways, Tombstone},
     tunnel_monitor::{
         TunnelMonitor, TunnelMonitorEvent, TunnelMonitorEventReceiver, TunnelMonitorEventSender,
@@ -67,6 +68,7 @@ type ReconnectDelayFuture = BoxFuture<'static, ()>;
 
 pub struct ConnectingState {
     retry_attempt: u32,
+    attempt_start: SleepMarker,
     tunnel_monitor_handle: Option<TunnelMonitorHandle>,
     tunnel_monitor_event_sender: Option<TunnelMonitorEventSender>,
     tunnel_monitor_event_receiver: TunnelMonitorEventReceiver,
@@ -188,6 +190,7 @@ impl ConnectingState {
             tunnel_monitor_event_sender: Some(monitor_event_sender),
             tunnel_monitor_event_receiver: monitor_event_receiver,
             retry_attempt,
+            attempt_start: SleepMarker::now(),
             selected_gateways,
             connection_data: initial_connection_data.clone(),
             resolve_api_addrs_fut: Fuse::terminated(),
@@ -241,34 +244,26 @@ impl ConnectingState {
     }
 
     async fn reconnect(self, shared_state: &mut SharedState) -> NextTunnelState {
-        let next_attempt = self.retry_attempt.saturating_add(1);
-
-        match reconnect_decision(next_attempt) {
-            ReconnectDecision::Retry { reset_gateways } => {
-                let next_gateways = if reset_gateways {
-                    None
-                } else {
-                    self.selected_gateways
-                };
-
-                tracing::info!("Reconnecting, attempt {next_attempt}");
-
-                NextTunnelState::NewState(
-                    ConnectingState::enter(next_attempt, next_gateways, shared_state).await,
-                )
-            }
-            ReconnectDecision::Abort => {
-                tracing::error!(
-                    "Giving up after {} reconnect attempts, entering error state",
-                    self.retry_attempt
-                );
-
-                NextTunnelState::NewState(
-                    ErrorState::enter(ErrorStateReason::ConnectionAttemptsExceeded, shared_state)
-                        .await,
-                )
-            }
+        let system_slept = self.attempt_start.system_slept();
+        if system_slept {
+            tracing::info!(
+                "System sleep interrupted connection attempt #{}; not counting it as a failed attempt",
+                self.retry_attempt
+            );
         }
+        let next_attempt = next_retry_attempt(self.retry_attempt, system_slept);
+
+        let next_gateways = if reconnect_resets_gateways(next_attempt, system_slept) {
+            None
+        } else {
+            self.selected_gateways
+        };
+
+        tracing::info!("Reconnecting, attempt {next_attempt}");
+
+        NextTunnelState::NewState(
+            ConnectingState::enter(next_attempt, next_gateways, shared_state).await,
+        )
     }
 
     async fn disconnect(
@@ -302,9 +297,14 @@ impl ConnectingState {
     }
 
     async fn handle_reconnect_delay(
-        #[allow(unused_mut)] mut self: Box<Self>,
+        mut self: Box<Self>,
         shared_state: &mut SharedState,
     ) -> NextTunnelState {
+        // The attempt proper starts now. Sleep during the reconnect delay must not be
+        // mistaken for sleep interrupting the attempt, or a genuine failure right after
+        // wake-up would go uncounted and leave a bad gateway unblacklisted.
+        self.attempt_start = SleepMarker::now();
+
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         {
             let gateway_config = shared_state.nym_config.gateway_config.clone();
@@ -760,35 +760,45 @@ impl TunnelStateHandler for ConnectingState {
                         }
                     }
                     TunnelMonitorEvent::ConnectionFailed { entry_gateway_id, exit_gateway_id, exit_handshake_completed } => {
-                        // WG handshake timed out or connectivity probe failed without a healthy
-                        // metadata path; blacklist the exit so a different one is selected.
-                        shared_state.gateway_provider.add_blacklisted_gateway(
-                            exit_gateway_id,
-                            BlacklistReason::ConnectionFailed,
-                        ).await;
-                        // A failure before the exit handshake ever completed may equally be the
-                        // entry gateway's fault. Once the same entry accumulates enough
-                        // pre-handshake failures while exits rotate, blacklist it too.
-                        if shared_state.entry_blame.record_failure(entry_gateway_id, exit_handshake_completed) {
-                            tracing::warn!(
-                                "Blacklisted entry gateway {entry_gateway_id} after repeated connection failures without a completed exit handshake"
-                            );
+                        if self.attempt_start.system_slept() {
+                            // The failure was in all likelihood caused by the system going to
+                            // sleep mid-attempt, so it says nothing about the gateways.
+                            tracing::info!("Not blacklisting gateways: system sleep interrupted the connection attempt");
+                        } else {
+                            // WG handshake timed out or connectivity probe failed without a healthy
+                            // metadata path; blacklist the exit so a different one is selected.
                             shared_state.gateway_provider.add_blacklisted_gateway(
-                                entry_gateway_id,
-                                BlacklistReason::EntryBlamedForRepeatedFailures,
+                                exit_gateway_id,
+                                BlacklistReason::ConnectionFailed,
                             ).await;
+                            // A failure before the exit handshake ever completed may equally be the
+                            // entry gateway's fault. Once the same entry accumulates enough
+                            // pre-handshake failures while exits rotate, blacklist it too.
+                            if shared_state.entry_blame.record_failure(entry_gateway_id, exit_handshake_completed) {
+                                tracing::warn!(
+                                    "Blacklisted entry gateway {entry_gateway_id} after repeated connection failures without a completed exit handshake"
+                                );
+                                shared_state.gateway_provider.add_blacklisted_gateway(
+                                    entry_gateway_id,
+                                    BlacklistReason::EntryBlamedForRepeatedFailures,
+                                ).await;
+                            }
+                            self.selected_gateways = None;
                         }
-                        self.selected_gateways = None;
                         NextTunnelState::SameState(self)
                     }
                     TunnelMonitorEvent::RegistrationFailed { gateway_id } => {
-                        // Registration with the entry gateway failed; blacklist it to avoid
-                        // re-selecting the same failing gateway.
-                        shared_state.gateway_provider.add_blacklisted_gateway(
-                            gateway_id,
-                            BlacklistReason::RegistrationFailed,
-                        ).await;
-                        self.selected_gateways = None;
+                        if self.attempt_start.system_slept() {
+                            tracing::info!("Not blacklisting gateway {gateway_id}: system sleep interrupted the registration");
+                        } else {
+                            // Registration with the entry gateway failed; blacklist it to avoid
+                            // re-selecting the same failing gateway.
+                            shared_state.gateway_provider.add_blacklisted_gateway(
+                                gateway_id,
+                                BlacklistReason::RegistrationFailed,
+                            ).await;
+                            self.selected_gateways = None;
+                        }
                         NextTunnelState::SameState(self)
                     }
                 }
@@ -1072,27 +1082,27 @@ impl ConnectingPolicyParameters {
     }
 }
 
-/// Maximum number of consecutive reconnect attempts before transitioning to the error
-/// state instead of silently retrying forever.
-const MAX_RECONNECT_ATTEMPTS: u32 = 3;
-
-/// Decision on what to do for the given reconnect attempt.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ReconnectDecision {
-    /// Keep retrying; when `reset_gateways` is set, the gateway selection is redone.
-    Retry { reset_gateways: bool },
-    /// Give up and surface an error to the user.
-    Abort,
+/// Computes the reconnect attempt number for the next attempt. An attempt interrupted
+/// by system sleep is not counted: its failure says nothing about the network or the
+/// selected gateways, and counting it would skip ahead in the backoff schedule.
+///
+/// Connection failures are recoverable by definition, so the connecting state never gives
+/// up on its own: it keeps retrying with the backoff from [`wait_delay`] until the tunnel
+/// comes up, the user disconnects, or an irrecoverable error moves it to the error state.
+fn next_retry_attempt(current_attempt: u32, system_slept: bool) -> u32 {
+    if system_slept {
+        current_attempt
+    } else {
+        current_attempt.saturating_add(1)
+    }
 }
 
-fn reconnect_decision(next_attempt: u32) -> ReconnectDecision {
-    if next_attempt >= MAX_RECONNECT_ATTEMPTS {
-        ReconnectDecision::Abort
-    } else {
-        ReconnectDecision::Retry {
-            reset_gateways: next_attempt.is_multiple_of(2),
-        }
-    }
+/// Whether the gateway selection is redone for the given reconnect attempt. Odd attempts
+/// reuse the previously selected gateways, even attempts pick fresh ones. An attempt
+/// interrupted by system sleep never triggers a reset: its failure says nothing about
+/// the selected gateways.
+fn reconnect_resets_gateways(next_attempt: u32, system_slept: bool) -> bool {
+    !system_slept && next_attempt.is_multiple_of(2)
 }
 
 fn wait_delay(retry_attempt: u32) -> Duration {
@@ -1116,39 +1126,44 @@ mod test {
 
     #[test]
     fn reconnect_keeps_gateways_on_odd_attempts_and_resets_on_even() {
-        assert_eq!(
-            reconnect_decision(1),
-            ReconnectDecision::Retry {
-                reset_gateways: false
-            }
-        );
-        assert_eq!(
-            reconnect_decision(2),
-            ReconnectDecision::Retry {
-                reset_gateways: true
-            }
-        );
+        assert!(!reconnect_resets_gateways(1, false));
+        assert!(reconnect_resets_gateways(2, false));
+        assert!(!reconnect_resets_gateways(3, false));
+        assert!(reconnect_resets_gateways(4, false));
     }
 
     #[test]
-    fn reconnect_retries_below_max_attempts() {
-        assert!(matches!(
-            reconnect_decision(MAX_RECONNECT_ATTEMPTS - 1),
-            ReconnectDecision::Retry { .. }
-        ));
+    fn attempt_counts_without_sleep() {
+        assert_eq!(next_retry_attempt(0, false), 1);
+        assert_eq!(next_retry_attempt(2, false), 3);
     }
 
     #[test]
-    fn reconnect_aborts_once_max_attempts_reached() {
+    fn sleep_interrupted_attempt_is_not_counted() {
         assert_eq!(
-            reconnect_decision(MAX_RECONNECT_ATTEMPTS),
-            ReconnectDecision::Abort,
-            "the reconnect loop must not retry silently forever"
+            next_retry_attempt(0, true),
+            0,
+            "an attempt interrupted by system sleep must not advance the backoff schedule"
         );
-        assert_eq!(
-            reconnect_decision(MAX_RECONNECT_ATTEMPTS + 5),
-            ReconnectDecision::Abort
-        );
+        assert_eq!(next_retry_attempt(2, true), 2);
+    }
+
+    #[test]
+    fn sleep_interrupted_attempt_keeps_gateways() {
+        // A sleep-interrupted attempt says nothing about the gateways, so they are kept
+        // even on attempt numbers that would otherwise redo the selection.
+        assert!(!reconnect_resets_gateways(0, true));
+        assert!(!reconnect_resets_gateways(2, true));
+        assert!(reconnect_resets_gateways(2, false));
+    }
+
+    #[test]
+    fn reconnect_schedule_has_no_upper_bound() {
+        // The connecting state retries indefinitely, so the schedule must stay well
+        // defined for arbitrarily large attempt numbers instead of overflowing.
+        assert_eq!(next_retry_attempt(u32::MAX, false), u32::MAX);
+        assert_eq!(wait_delay(u32::MAX), MAX_WAIT_DELAY);
+        assert!(reconnect_resets_gateways(u32::MAX - 1, false));
     }
 
     #[test]

--- a/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/system_sleep.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/tunnel_state_machine/system_sleep.rs
@@ -1,0 +1,81 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+//! Detection of system sleep intervals overlapping an operation.
+//!
+//! The monotonic clock pauses while the system is asleep whereas the wall clock does
+//! not, so a wall-vs-monotonic divergence since a marker was created reveals that the
+//! system slept in between. On platforms where the monotonic clock keeps counting
+//! through sleep the clocks never diverge and detection simply reports no sleep.
+
+use std::time::{Duration, Instant, SystemTime};
+
+/// Minimum wall-vs-monotonic divergence interpreted as a system sleep interval,
+/// large enough to not be confused with NTP clock adjustments.
+const SLEEP_DETECTION_THRESHOLD: Duration = Duration::from_secs(10);
+
+/// A point in time captured on both the wall and monotonic clocks.
+#[derive(Debug, Clone, Copy)]
+pub struct SleepMarker {
+    wall: SystemTime,
+    monotonic: Instant,
+}
+
+impl SleepMarker {
+    pub fn now() -> Self {
+        Self {
+            wall: SystemTime::now(),
+            monotonic: Instant::now(),
+        }
+    }
+
+    /// Returns true when the system appears to have slept since the marker was created.
+    pub fn system_slept(&self) -> bool {
+        system_slept(
+            self.wall.elapsed().unwrap_or_default(),
+            self.monotonic.elapsed(),
+        )
+    }
+}
+
+fn system_slept(wall_elapsed: Duration, monotonic_elapsed: Duration) -> bool {
+    wall_elapsed.saturating_sub(monotonic_elapsed) >= SLEEP_DETECTION_THRESHOLD
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_sleep_when_clocks_agree() {
+        assert!(!system_slept(
+            Duration::from_secs(60),
+            Duration::from_secs(60)
+        ));
+    }
+
+    #[test]
+    fn no_sleep_on_small_clock_jitter() {
+        assert!(!system_slept(
+            Duration::from_secs(63),
+            Duration::from_secs(60)
+        ));
+    }
+
+    #[test]
+    fn sleep_detected_when_wall_clock_ran_ahead() {
+        // Observed on macOS: 15m56s of wall time vs 11s of monotonic time across a nap.
+        assert!(system_slept(
+            Duration::from_secs(956),
+            Duration::from_secs(11)
+        ));
+    }
+
+    #[test]
+    fn no_sleep_when_wall_clock_moved_backwards() {
+        assert!(!system_slept(
+            Duration::from_secs(10),
+            Duration::from_secs(60)
+        ));
+    }
+}


### PR DESCRIPTION
Repeated macOS sleep/wake cycles during a reconnect burned the entire retry budget, blacklisted healthy gateways, and left the daemon in Error(ConnectionAttemptsExceeded) with the blocking firewall engaged until manual intervention.

- Detect sleep via wall-vs-monotonic clock divergence (SleepMarker)
- Don't count sleep-interrupted attempts towards the reconnect limit
- Don't blacklist gateways when sleep caused the failure
- Auto-recover from ConnectionAttemptsExceeded after 60s

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6233)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VPN reconnection handling after device sleep or wake events.
  * Sleep-interrupted connection attempts no longer consume retry limits or unnecessarily blacklist gateways.
  * Gateway selection errors now distinguish invalid pinned identities from temporarily unavailable gateways.

* **Improvements**
  * Connection attempts continue retrying instead of stopping after a fixed number of failures.
  * Gateway blacklist entries now include the reason for the failure.
  * Selected gateways are retained when a connection attempt is interrupted by system sleep.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->