### PR TITLE
fix(core): rebuild DNS forwarder on repeated upstream failures, throttle error logs

### DIFF
--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/util/ExitReasons.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/util/ExitReasons.kt
@@ -1,0 +1,38 @@
+package net.nymtech.nymvpn.util
+
+import android.app.ApplicationExitInfo
+import java.time.Instant
+
+/**
+ * Formats ApplicationExitInfo records into single log lines so log bundles
+ * explain why previous processes died (OS kill vs crash vs user swipe).
+ */
+object ExitReasons {
+
+	fun reasonName(reason: Int): String = when (reason) {
+		ApplicationExitInfo.REASON_UNKNOWN -> "UNKNOWN"
+		ApplicationExitInfo.REASON_EXIT_SELF -> "EXIT_SELF"
+		ApplicationExitInfo.REASON_SIGNALED -> "SIGNALED"
+		ApplicationExitInfo.REASON_LOW_MEMORY -> "LOW_MEMORY"
+		ApplicationExitInfo.REASON_CRASH -> "CRASH"
+		ApplicationExitInfo.REASON_CRASH_NATIVE -> "CRASH_NATIVE"
+		ApplicationExitInfo.REASON_ANR -> "ANR"
+		ApplicationExitInfo.REASON_INITIALIZATION_FAILURE -> "INITIALIZATION_FAILURE"
+		ApplicationExitInfo.REASON_PERMISSION_CHANGE -> "PERMISSION_CHANGE"
+		ApplicationExitInfo.REASON_EXCESSIVE_RESOURCE_USAGE -> "EXCESSIVE_RESOURCE_USAGE"
+		ApplicationExitInfo.REASON_USER_REQUESTED -> "USER_REQUESTED"
+		ApplicationExitInfo.REASON_USER_STOPPED -> "USER_STOPPED"
+		ApplicationExitInfo.REASON_DEPENDENCY_DIED -> "DEPENDENCY_DIED"
+		ApplicationExitInfo.REASON_OTHER -> "OTHER"
+		ApplicationExitInfo.REASON_FREEZER -> "FREEZER"
+		ApplicationExitInfo.REASON_PACKAGE_STATE_CHANGE -> "PACKAGE_STATE_CHANGE"
+		ApplicationExitInfo.REASON_PACKAGE_UPDATED -> "PACKAGE_UPDATED"
+		else -> "UNKNOWN($reason)"
+	}
+
+	fun formatLine(timestampMs: Long, reason: Int, status: Int, importance: Int, description: String?): String {
+		val base = "PriorExit time=${Instant.ofEpochMilli(timestampMs)} reason=${reasonName(reason)} " +
+			"status=$status importance=$importance"
+		return if (description.isNullOrBlank()) base else "$base description=$description"
+	}
+}

--- a/nym-vpn-core/crates/nym-vpn-credential-fetcher/tests/common/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-credential-fetcher/tests/common/mod.rs
@@ -1,0 +1,546 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+//! A mock VPN API for exercising the credential fetcher end to end: it issues
+//! cryptographically valid zk-nym ticketbooks (the ecash fixture is adapted from the
+//! nym-vpn-account-controller integration tests' MockCredentialProxy) while letting each test
+//! control when a requested zk-nym transitions from `Pending` to `Active` or `Error`.
+
+use std::{
+    collections::HashMap,
+    str::FromStr,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use nym_compact_ecash::{
+    Base58, EncodedDate, KeyPairAuth, PublicKeyUser, SecretKeyAuth, VerificationKeyAuth,
+    WithdrawalRequest, aggregate_verification_keys, constants, issue,
+    scheme::{
+        coin_indices_signatures::{aggregate_annotated_indices_signatures, sign_coin_indices},
+        expiration_date_signatures::{
+            aggregate_annotated_expiration_signatures, sign_expiration_date,
+        },
+        keygen::ttp_keygen,
+    },
+    setup::Parameters,
+};
+use nym_credential_proxy_requests::api::v1::ticketbook::models::{
+    AggregatedCoinIndicesSignaturesResponse, AggregatedExpirationDateSignaturesResponse,
+    MasterVerificationKeyResponse, PartialVerificationKey, PartialVerificationKeysResponse,
+    TicketbookWalletSharesResponse, WalletShare,
+};
+use nym_credentials::{AggregatedCoinIndicesSignatures, AggregatedExpirationDateSignatures};
+use nym_credentials_interface::{
+    AnnotatedCoinIndexSignature, AnnotatedExpirationDateSignature, CoinIndexSignatureShare,
+    ExpirationDateSignatureShare, TicketType,
+};
+use nym_ecash_time::EcashTime;
+use nym_vpn_api_client::{
+    request::RequestZkNymRequestBody,
+    response::{
+        NymVpnHealthResponse, NymVpnZkNym, NymVpnZkNymPost, NymVpnZkNymResponse, NymVpnZkNymStatus,
+        StatusOk,
+    },
+};
+use rand::distributions::{Alphanumeric, DistString};
+use time::{Date, OffsetDateTime, macros::format_description};
+use wiremock::{
+    Mock, MockServer, Request, Respond, ResponseTemplate,
+    matchers::{method, path, path_regex},
+};
+
+const ACCOUNT_REGEX: &str = r"n1\w*";
+const DEVICE_REGEX: &str = r"\w*";
+// Issued ids are 15 alphanumeric characters, so this can never match the `available` sub-route.
+const ZK_NYM_ID_REGEX: &str = r"[A-Za-z0-9]{15}";
+
+struct ZkNymRecord {
+    status: NymVpnZkNymStatus,
+    request: RequestZkNymRequestBody,
+}
+
+#[derive(Default)]
+struct State {
+    records: HashMap<String, ZkNymRecord>,
+    /// When set, the next poll of any zk-nym id first flips every `Pending` record to `Active`.
+    activate_on_next_poll: bool,
+    /// Every polled id, in order of arrival.
+    polls: Vec<String>,
+    posts: usize,
+}
+
+/// The crypto material and mutable zk-nym registry backing the mock VPN API.
+pub struct MockZkNymApi {
+    coin_indices_signatures: Vec<AnnotatedCoinIndexSignature>,
+    expiration_date_signatures: Vec<AnnotatedExpirationDateSignature>,
+    master_key: VerificationKeyAuth,
+    authorities_keypairs: Vec<KeyPairAuth>,
+    state: Arc<Mutex<State>>,
+}
+
+impl Clone for MockZkNymApi {
+    fn clone(&self) -> Self {
+        Self {
+            coin_indices_signatures: self.coin_indices_signatures.clone(),
+            expiration_date_signatures: self.expiration_date_signatures.clone(),
+            master_key: self.master_key.clone(),
+            authorities_keypairs: self
+                .authorities_keypairs
+                .iter()
+                .map(|k| {
+                    KeyPairAuth::new(
+                        k.secret_key().clone(),
+                        k.verification_key().clone(),
+                        k.index,
+                    )
+                })
+                .collect(),
+            state: self.state.clone(),
+        }
+    }
+}
+
+impl MockZkNymApi {
+    pub fn new() -> anyhow::Result<MockZkNymApi> {
+        let total_coins = 10;
+        let params = Parameters::new(total_coins);
+
+        let expiration_date = nym_ecash_time::cred_exp_date().ecash_unix_timestamp();
+
+        let authorities_keypairs = ttp_keygen(2, 3).unwrap();
+        let indices: [u64; 3] = [1, 2, 3];
+        let secret_keys_authorities: Vec<&SecretKeyAuth> = authorities_keypairs
+            .iter()
+            .map(|keypair| keypair.secret_key())
+            .collect();
+        let verification_keys_auth: Vec<VerificationKeyAuth> = authorities_keypairs
+            .iter()
+            .map(|keypair| keypair.verification_key())
+            .collect();
+
+        let verification_key =
+            aggregate_verification_keys(&verification_keys_auth, Some(&[1, 2, 3]))?;
+
+        let dates_signatures = generate_expiration_date_signatures(
+            expiration_date,
+            &secret_keys_authorities,
+            &verification_keys_auth,
+            &verification_key,
+            &indices,
+        )?;
+
+        let coin_indices_signatures = generate_coin_indices_signatures(
+            &params,
+            &secret_keys_authorities,
+            &verification_keys_auth,
+            &verification_key,
+            &indices,
+        )?;
+
+        Ok(MockZkNymApi {
+            coin_indices_signatures,
+            expiration_date_signatures: dates_signatures,
+            master_key: verification_key,
+            authorities_keypairs,
+            state: Arc::new(Mutex::new(State::default())),
+        })
+    }
+
+    /// Register every route the credential fetcher needs on `server`.
+    pub async fn register(&self, server: &MockServer) {
+        let zknym_path = format!("^/public/v1/account/{ACCOUNT_REGEX}/device/{DEVICE_REGEX}/zknym");
+
+        server
+            .register(
+                Mock::given(method("GET"))
+                    .and(path("/public/v1/health"))
+                    .respond_with(
+                        ResponseTemplate::new(200).set_body_json(NymVpnHealthResponse {
+                            status: "ok".to_string(),
+                            timestamp_utc: OffsetDateTime::now_utc(),
+                        }),
+                    ),
+            )
+            .await;
+        server
+            .register(
+                Mock::given(method("POST"))
+                    .and(path_regex(format!("{zknym_path}$")))
+                    .respond_with(self.clone().post_zknym()),
+            )
+            .await;
+        server
+            .register(
+                Mock::given(method("GET"))
+                    .and(path_regex(format!("{zknym_path}$")))
+                    .respond_with(self.clone().list_zknyms()),
+            )
+            .await;
+        server
+            .register(
+                Mock::given(method("GET"))
+                    .and(path_regex(format!("{zknym_path}/available$")))
+                    .respond_with(self.clone().list_available_zknyms()),
+            )
+            .await;
+        server
+            .register(
+                Mock::given(method("GET"))
+                    .and(path_regex(format!("{zknym_path}/{ZK_NYM_ID_REGEX}$")))
+                    .respond_with(self.clone().poll_zknym()),
+            )
+            .await;
+        server
+            .register(
+                Mock::given(method("DELETE"))
+                    .and(path_regex(format!("{zknym_path}/{ZK_NYM_ID_REGEX}$")))
+                    .respond_with(ResponseTemplate::new(200).set_body_json(StatusOk {
+                        status: "ok".to_string(),
+                    })),
+            )
+            .await;
+        server
+            .register(
+                Mock::given(method("GET"))
+                    .and(path(
+                        "/public/v1/directory/zk-nyms/ticketbook/partial-verification-keys",
+                    ))
+                    .respond_with(
+                        ResponseTemplate::new(200).set_body_json(self.partial_verification_keys()),
+                    ),
+            )
+            .await;
+        server
+            .register(
+                Mock::given(method("GET"))
+                    .and(path(
+                        "/public/v1/directory/zk-nyms/ticketbook/master-verification-key",
+                    ))
+                    .respond_with(ResponseTemplate::new(200).set_body_json(
+                        MasterVerificationKeyResponse {
+                            epoch_id: 0,
+                            bs58_encoded_key: self.master_key.to_bs58(),
+                        },
+                    )),
+            )
+            .await;
+    }
+
+    //---------------------
+    // Test controls
+    //---------------------
+
+    /// Make the next poll of any zk-nym id flip every `Pending` record to `Active` first, so the
+    /// poll observes a finished issuance.
+    pub fn activate_pending_on_next_poll(&self) {
+        self.state.lock().unwrap().activate_on_next_poll = true;
+    }
+
+    /// Mark every record as failed server-side: subsequent polls return status `Error`.
+    pub fn fail_all_requests(&self) {
+        for record in self.state.lock().unwrap().records.values_mut() {
+            record.status = NymVpnZkNymStatus::Error;
+        }
+    }
+
+    /// Number of zk-nym creation requests (POSTs) received so far.
+    pub fn post_count(&self) -> usize {
+        self.state.lock().unwrap().posts
+    }
+
+    /// Wait until at least `count` polls have been received, panicking after `timeout`.
+    pub async fn wait_for_polls(&self, count: usize, timeout: Duration) {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            if self.state.lock().unwrap().polls.len() >= count {
+                return;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "gave up waiting for {count} zk-nym polls"
+            );
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    }
+
+    //---------------------
+    // Route handlers
+    //---------------------
+
+    fn post_zknym(self) -> impl Respond {
+        move |req: &Request| {
+            let request: RequestZkNymRequestBody = req.body_json().unwrap();
+            let id = Alphanumeric.sample_string(&mut rand::thread_rng(), 15);
+            let response = post_response(&id, &request.ticketbook_type);
+
+            let mut state = self.state.lock().unwrap();
+            state.posts += 1;
+            state.records.insert(
+                id,
+                ZkNymRecord {
+                    status: NymVpnZkNymStatus::Pending,
+                    request,
+                },
+            );
+
+            ResponseTemplate::new(200).set_body_json(response)
+        }
+    }
+
+    fn poll_zknym(self) -> impl Respond {
+        move |req: &Request| {
+            let id = req.url.path_segments().unwrap().next_back().unwrap();
+
+            let mut state = self.state.lock().unwrap();
+            state.polls.push(id.to_string());
+            if state.activate_on_next_poll {
+                state.activate_on_next_poll = false;
+                for record in state.records.values_mut() {
+                    if record.status == NymVpnZkNymStatus::Pending {
+                        record.status = NymVpnZkNymStatus::Active;
+                    }
+                }
+            }
+
+            let Some(record) = state.records.get(id) else {
+                return ResponseTemplate::new(404);
+            };
+            let shares = (record.status == NymVpnZkNymStatus::Active).then(|| {
+                self.issue_wallet_shares(clone_request(&record.request))
+                    .unwrap()
+            });
+            ResponseTemplate::new(200).set_body_json(zknym_response(
+                id,
+                &record.request.ticketbook_type,
+                record.status.clone(),
+                shares,
+            ))
+        }
+    }
+
+    fn list_zknyms(self) -> impl Respond {
+        move |_req: &Request| {
+            let state = self.state.lock().unwrap();
+            let items = state
+                .records
+                .iter()
+                .map(|(id, record)| {
+                    zknym_response(
+                        id,
+                        &record.request.ticketbook_type,
+                        record.status.clone(),
+                        None,
+                    )
+                })
+                .collect::<Vec<_>>();
+            ResponseTemplate::new(200).set_body_json(listing(items))
+        }
+    }
+
+    fn list_available_zknyms(self) -> impl Respond {
+        move |_req: &Request| {
+            let state = self.state.lock().unwrap();
+            let items = state
+                .records
+                .iter()
+                .filter(|(_, record)| record.status == NymVpnZkNymStatus::Active)
+                .map(|(id, record)| {
+                    zknym_response(
+                        id,
+                        &record.request.ticketbook_type,
+                        record.status.clone(),
+                        None,
+                    )
+                })
+                .collect::<Vec<_>>();
+            ResponseTemplate::new(200).set_body_json(listing(items))
+        }
+    }
+
+    //---------------------
+    // Crypto helpers
+    //---------------------
+
+    fn issue_wallet_shares(
+        &self,
+        request: RequestZkNymRequestBody,
+    ) -> anyhow::Result<TicketbookWalletSharesResponse> {
+        let user_key = PublicKeyUser::from_base58_string(request.ecash_pubkey)?;
+        let format = format_description!("[year]-[month]-[day]");
+        let expiration_date =
+            Date::parse(&request.expiration_date, &format)?.ecash_unix_timestamp();
+        let t_type = TicketType::from_str(&request.ticketbook_type)?.encode();
+        let req = WithdrawalRequest::try_from_bs58(request.withdrawal_request)?;
+        let mut shares = Vec::new();
+        for auth_keypair in &self.authorities_keypairs {
+            let blind_signature = issue(
+                auth_keypair.secret_key(),
+                user_key,
+                &req,
+                expiration_date,
+                t_type,
+            )?;
+            shares.push(WalletShare {
+                node_index: auth_keypair.index.unwrap(),
+                bs58_encoded_share: blind_signature.to_bs58(),
+            });
+        }
+
+        Ok(TicketbookWalletSharesResponse {
+            epoch_id: 0,
+            shares,
+            master_verification_key: Some(MasterVerificationKeyResponse {
+                epoch_id: 0,
+                bs58_encoded_key: self.master_key.to_bs58(),
+            }),
+            aggregated_coin_index_signatures: Some(AggregatedCoinIndicesSignaturesResponse {
+                signatures: AggregatedCoinIndicesSignatures {
+                    epoch_id: 0,
+                    signatures: self.coin_indices_signatures.clone(),
+                },
+            }),
+            aggregated_expiration_date_signatures: Some(
+                AggregatedExpirationDateSignaturesResponse {
+                    signatures: AggregatedExpirationDateSignatures {
+                        epoch_id: 0,
+                        signatures: self.expiration_date_signatures.clone(),
+                        expiration_date: nym_ecash_time::cred_exp_date().ecash_date(),
+                    },
+                },
+            ),
+        })
+    }
+
+    fn partial_verification_keys(&self) -> PartialVerificationKeysResponse {
+        PartialVerificationKeysResponse {
+            epoch_id: 0,
+            keys: self
+                .authorities_keypairs
+                .iter()
+                .map(|k| PartialVerificationKey {
+                    node_index: k.index.unwrap(),
+                    bs58_encoded_key: k.verification_key().to_bs58(),
+                })
+                .collect(),
+        }
+    }
+}
+
+// RequestZkNymRequestBody does not derive Clone
+fn clone_request(request: &RequestZkNymRequestBody) -> RequestZkNymRequestBody {
+    RequestZkNymRequestBody {
+        withdrawal_request: request.withdrawal_request.clone(),
+        ecash_pubkey: request.ecash_pubkey.clone(),
+        expiration_date: request.expiration_date.clone(),
+        ticketbook_type: request.ticketbook_type.clone(),
+    }
+}
+
+fn post_response(id: &str, ticketbook_type: &str) -> NymVpnZkNymPost {
+    let now = OffsetDateTime::now_utc();
+    NymVpnZkNymPost {
+        created_on_utc: now.to_string(),
+        last_updated_utc: now.to_string(),
+        id: id.to_string(),
+        ticketbook_type: ticketbook_type.to_string(),
+        valid_until_utc: (now + Duration::from_secs(3600 * 24 * 30)).to_string(),
+        valid_from_utc: now.to_string(),
+        issued_bandwidth_in_gb: 25f64,
+        blinded_shares: None,
+        status: NymVpnZkNymStatus::Pending,
+    }
+}
+
+fn zknym_response(
+    id: &str,
+    ticketbook_type: &str,
+    status: NymVpnZkNymStatus,
+    blinded_shares: Option<TicketbookWalletSharesResponse>,
+) -> NymVpnZkNym {
+    let now = OffsetDateTime::now_utc();
+    NymVpnZkNym {
+        created_on_utc: now.to_string(),
+        last_updated_utc: now.to_string(),
+        id: id.to_string(),
+        ticketbook_type: ticketbook_type.to_string(),
+        valid_until_utc: (now + Duration::from_secs(3600 * 24 * 30)).to_string(),
+        valid_from_utc: now.to_string(),
+        issued_bandwidth_in_gb: 25f64,
+        blinded_shares,
+        status,
+        upgrade_mode: None,
+    }
+}
+
+fn listing(items: Vec<NymVpnZkNym>) -> NymVpnZkNymResponse {
+    NymVpnZkNymResponse {
+        total_items: items.len() as u64,
+        page: 0,
+        page_size: items.len().max(1) as u64,
+        items,
+    }
+}
+
+fn generate_expiration_date_signatures(
+    expiration_date: EncodedDate,
+    secret_keys_authorities: &[&SecretKeyAuth],
+    verification_keys_auth: &[VerificationKeyAuth],
+    verification_key: &VerificationKeyAuth,
+    indices: &[u64],
+) -> anyhow::Result<Vec<AnnotatedExpirationDateSignature>> {
+    let mut edt_partial_signatures: Vec<Vec<_>> =
+        Vec::with_capacity(constants::CRED_VALIDITY_PERIOD_DAYS as usize);
+    for sk_auth in secret_keys_authorities.iter() {
+        let sign = sign_expiration_date(sk_auth, expiration_date).unwrap();
+        edt_partial_signatures.push(sign);
+    }
+    let combined_data: Vec<_> = indices
+        .iter()
+        .zip(
+            verification_keys_auth
+                .iter()
+                .zip(edt_partial_signatures.iter()),
+        )
+        .map(|(i, (vk, sigs))| ExpirationDateSignatureShare {
+            index: *i,
+            key: vk.clone(),
+            signatures: sigs.clone(),
+        })
+        .collect();
+
+    Ok(aggregate_annotated_expiration_signatures(
+        verification_key,
+        expiration_date,
+        &combined_data,
+    )?)
+}
+
+fn generate_coin_indices_signatures(
+    params: &Parameters,
+    secret_keys_authorities: &[&SecretKeyAuth],
+    verification_keys_auth: &[VerificationKeyAuth],
+    verification_key: &VerificationKeyAuth,
+    indices: &[u64],
+) -> anyhow::Result<Vec<AnnotatedCoinIndexSignature>> {
+    let partial_signatures: Vec<Vec<_>> = secret_keys_authorities
+        .iter()
+        .map(|sk_auth| sign_coin_indices(params, verification_key, sk_auth).unwrap())
+        .collect();
+
+    let combined_data: Vec<_> = indices
+        .iter()
+        .zip(verification_keys_auth.iter().zip(partial_signatures.iter()))
+        .map(|(i, (vk, sigs))| CoinIndexSignatureShare {
+            index: *i,
+            key: vk.clone(),
+            signatures: sigs.clone(),
+        })
+        .collect();
+
+    Ok(aggregate_annotated_indices_signatures(
+        params,
+        verification_key,
+        &combined_data,
+    )?)
+}

--- a/nym-vpn-core/crates/nym-vpn-credential-fetcher/tests/zknym_request_flow.rs
+++ b/nym-vpn-core/crates/nym-vpn-credential-fetcher/tests/zknym_request_flow.rs
@@ -1,0 +1,153 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+//! End-to-end tests of the zk-nym request flow against a mock VPN API, covering the request-storm
+//! regression from incident NYM-APAC-2026-001: an interrupted fetch must resume its pending
+//! zk-nym request on the server instead of issuing a fresh one, because every abandoned request
+//! counts against the per-device rate limiter.
+
+mod common;
+
+use std::{sync::Arc, time::Duration};
+
+use nym_bandwidth_controller::CredentialFetcher;
+use nym_credentials_interface::TicketType;
+use nym_crypto::asymmetric::ed25519;
+use nym_vpn_api_client::{
+    VpnApiClient, api_urls_to_urls,
+    types::{Device, VpnAccount, VpnAccountMode},
+};
+use nym_vpn_credential_fetcher::VpnApiCredentialFetcher;
+use tokio_util::sync::CancellationToken;
+use wiremock::MockServer;
+
+use common::MockZkNymApi;
+
+const TEST_MNEMONIC: &str = "range mystery picture decline olympic acoustic lesson quick rebuild panda royal fold start leader egg hammer width olympic worry length crawl couch link mobile";
+
+struct TestBench {
+    api: MockZkNymApi,
+    fetcher: Arc<VpnApiCredentialFetcher>,
+    _server: MockServer,
+    _data_dir: tempfile::TempDir,
+}
+
+async fn setup() -> anyhow::Result<TestBench> {
+    let server = MockServer::start().await;
+    let api = MockZkNymApi::new()?;
+    api.register(&server).await;
+
+    let api_url = nym_network_defaults::ApiUrl {
+        url: server.uri(),
+        front_hosts: None,
+    };
+    let client = VpnApiClient::new(
+        api_urls_to_urls(&[api_url])?,
+        Some(nym_http_api_client::UserAgent {
+            application: "nym-vpn-credential-fetcher-tests".to_string(),
+            version: "0.0.0".to_string(),
+            platform: "test".to_string(),
+            git_commit: "0000000".to_string(),
+        }),
+    )?;
+
+    let account = VpnAccount::new(
+        bip39::Mnemonic::parse::<&str>(TEST_MNEMONIC)?,
+        VpnAccountMode::Api,
+    )?;
+    let device = Device::from(ed25519::KeyPair::new(&mut rand::rngs::OsRng));
+
+    let data_dir = tempfile::tempdir()?;
+    let fetcher = VpnApiCredentialFetcher::new(
+        client,
+        Arc::new(account),
+        device,
+        data_dir.path(),
+        CancellationToken::new(),
+    )
+    .await?;
+
+    Ok(TestBench {
+        api,
+        fetcher: Arc::new(fetcher),
+        _server: server,
+        _data_dir: data_dir,
+    })
+}
+
+/// The NYM-APAC-2026-001 regression: pausing and resuming the fetcher mid-issuance (which the
+/// tunnel state machine does on every connect, via the firewall commands) must not create a
+/// second zk-nym request on the VPN API — the pending one has to be resumed.
+#[tokio::test(flavor = "multi_thread")]
+async fn pause_resume_reuses_the_pending_zknym_request() -> anyhow::Result<()> {
+    let bench = setup().await?;
+
+    let fetch = tokio::spawn({
+        let fetcher = bench.fetcher.clone();
+        async move {
+            fetcher
+                .fetch_ticketbooks(TicketType::V1WireguardEntry)
+                .await
+        }
+    });
+
+    // Wait until the request was posted and polled once (still pending), then interrupt the
+    // in-flight fetch the way a connect attempt does.
+    bench.api.wait_for_polls(1, Duration::from_secs(10)).await;
+    bench.fetcher.pause();
+    // Give the runtime a moment to actually drop the in-flight fetch future.
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    // Once the fetch is running again, let the issuance finish on the next poll.
+    bench.api.activate_pending_on_next_poll();
+    bench.fetcher.resume();
+
+    let credentials = fetch.await?.expect("fetch should succeed after resuming");
+    assert_eq!(credentials.len(), 1);
+    assert_eq!(
+        bench.api.post_count(),
+        1,
+        "an interrupted fetch must resume its pending zk-nym request, not post a new one"
+    );
+
+    Ok(())
+}
+
+/// A pending request the server has marked failed must not be resumed forever: the next fetch
+/// discards it and issues a fresh request.
+#[tokio::test(flavor = "multi_thread")]
+async fn errored_zknym_request_is_discarded_and_a_fresh_one_issued() -> anyhow::Result<()> {
+    let bench = setup().await?;
+
+    let fetch = tokio::spawn({
+        let fetcher = bench.fetcher.clone();
+        async move {
+            fetcher
+                .fetch_ticketbooks(TicketType::V1WireguardEntry)
+                .await
+        }
+    });
+
+    // Let the first request get posted, then fail it server-side.
+    bench.api.wait_for_polls(1, Duration::from_secs(10)).await;
+    bench.api.fail_all_requests();
+    assert!(
+        fetch.await?.is_err(),
+        "a server-side issuance failure is terminal for the running fetch"
+    );
+
+    // The next fetch must not get stuck on the dead request: fresh request, successful issuance.
+    bench.api.activate_pending_on_next_poll();
+    let credentials = bench
+        .fetcher
+        .fetch_ticketbooks(TicketType::V1WireguardEntry)
+        .await
+        .expect("a fresh fetch should succeed");
+    assert_eq!(credentials.len(), 1);
+    assert_eq!(
+        bench.api.post_count(),
+        2,
+        "the dead request must be replaced by exactly one fresh request"
+    );
+
+    Ok(())
+}

--- a/nym-vpn-core/crates/nym-vpn-lib/src/resolver/mod.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/resolver/mod.rs
@@ -29,7 +29,9 @@ pub(crate) use windows::flush_system_cache;
 mod tests;
 
 mod tcp;
+mod upstream_health;
 use tcp::new_tcp_listener;
+use upstream_health::{LogThrottle, UpstreamHealth};
 
 mod udp;
 use udp::new_random_socket;
@@ -144,6 +146,8 @@ pub struct LocalResolver {
     inner_resolver: Resolver,
     dns_filter: DnsFilter,
     shutdown_token: CancellationToken,
+    /// Config used to build the active forwarding resolver, kept for rebuilds.
+    active_forward_config: Option<Config>,
 }
 
 /// A message to [LocalResolver]
@@ -200,6 +204,9 @@ enum Resolver {
     Forwarding {
         resolver: Box<TokioResolver>,
         dns_filter: DnsFilter,
+        /// Health of this resolver generation only. Each rebuild gets a fresh tracker so
+        /// lookups still in flight on a retired generation cannot count against the new one.
+        upstream_health: Arc<UpstreamHealth>,
     },
 }
 
@@ -211,10 +218,12 @@ impl Resolver {
             Resolver::Forwarding {
                 resolver,
                 dns_filter,
+                upstream_health,
             } => Either::Right(Self::resolve_forward(
                 resolver.as_ref().clone(),
                 query,
                 dns_filter.clone(),
+                upstream_health.clone(),
             )),
         };
 
@@ -259,6 +268,7 @@ impl Resolver {
         resolver: TokioResolver,
         query: LowerQuery,
         dns_filter: DnsFilter,
+        upstream_health: Arc<UpstreamHealth>,
     ) -> Result<AuthLookup, NetError> {
         let return_query = query.original().clone();
         let qname = return_query.name().to_ascii();
@@ -269,11 +279,19 @@ impl Resolver {
 
         let result: AuthLookup = match decision {
             DnsFilterDecision::Pass => {
-                let lookup = resolver
+                let lookup_result = resolver
                     .lookup(return_query.name().clone(), return_query.query_type())
-                    .await?;
+                    .await;
 
-                AuthLookup::from(lookup)
+                match &lookup_result {
+                    // A negative answer (e.g. NXDOMAIN) is still a healthy upstream interaction.
+                    Ok(_) | Err(NetError::Dns(DnsError::NoRecordsFound(_))) => {
+                        upstream_health.record_success()
+                    }
+                    Err(_) => upstream_health.record_failure(),
+                }
+
+                AuthLookup::from(lookup_result?)
             }
             DnsFilterDecision::Block(DnsFilterStrategy::EmptyRecord) => AuthLookup::Empty,
             DnsFilterDecision::Block(DnsFilterStrategy::Localhost) => {
@@ -475,6 +493,7 @@ impl LocalResolver {
             inner_resolver: Resolver::Blocking,
             dns_filter,
             shutdown_token,
+            active_forward_config: None,
         };
 
         // Spawn onto the multi-thread runtime (requires LocalResolver: Send)
@@ -488,7 +507,10 @@ impl LocalResolver {
         tcp_listener: Option<TcpListener>,
         tx: mpsc::UnboundedSender<ResolverMessage>,
     ) -> Result<Server<ResolverImpl>, Error> {
-        let mut server = Server::new(ResolverImpl { tx });
+        let mut server = Server::new(ResolverImpl {
+            tx,
+            error_log_throttle: LogThrottle::new(RESOLVE_ERROR_LOG_WINDOW),
+        });
         server.register_socket(server_socket);
         if let Some(tcp_listener) = tcp_listener {
             server.register_listener(tcp_listener, TCP_CLIENT_TIMEOUT, TCP_RESPONSE_BUFFER_SIZE);
@@ -521,6 +543,7 @@ impl LocalResolver {
                             let _ = response_tx.send(());
                         }
                         Some(ResolverMessage::Query { dns_query, response_tx }) => {
+                            self.maybe_rebuild_forwarding_resolver();
                             self.inner_resolver.resolve(dns_query, response_tx);
                         }
                         None => {
@@ -547,6 +570,7 @@ impl LocalResolver {
 
         match config {
             Config::Blocking => {
+                self.active_forward_config = None;
                 self.blocking();
                 Ok(())
             }
@@ -557,12 +581,49 @@ impl LocalResolver {
             } => {
                 // make sure not to accidentally forward queries to ourselves
                 dns_servers.retain(|addr| addr.ip != self.bound_to.ip());
+                self.active_forward_config = Some(Config::Forwarding {
+                    dns_servers: dns_servers.clone(),
+                    #[cfg(target_os = "ios")]
+                    bind_interface: bind_interface.clone(),
+                });
                 self.forwarding(
                     dns_servers,
                     #[cfg(target_os = "ios")]
                     bind_interface,
                 )
             }
+        }
+    }
+
+    /// Rebuilds the forwarding resolver when upstream health requested it, replacing
+    /// potentially stale pooled connections (e.g. after system sleep or a network change).
+    fn maybe_rebuild_forwarding_resolver(&mut self) {
+        let Resolver::Forwarding {
+            upstream_health, ..
+        } = &self.inner_resolver
+        else {
+            return;
+        };
+        if !upstream_health.take_rebuild_request() {
+            return;
+        }
+
+        let Some(Config::Forwarding {
+            dns_servers,
+            #[cfg(target_os = "ios")]
+            bind_interface,
+        }) = self.active_forward_config.clone()
+        else {
+            return;
+        };
+
+        tracing::warn!("Rebuilding forwarding DNS resolver after repeated upstream failures");
+        if let Err(err) = self.forwarding(
+            dns_servers,
+            #[cfg(target_os = "ios")]
+            bind_interface,
+        ) {
+            trace_err_chain!(err, "failed to rebuild forwarding DNS resolver");
         }
     }
 
@@ -593,18 +654,27 @@ impl LocalResolver {
             .build()
             .map_err(Error::CreateResolver)?;
 
+        // A fresh tracker per generation: lookups spawned against the previous resolver
+        // still hold the old `Arc` and their late results are ignored by construction.
         self.inner_resolver = Resolver::Forwarding {
             resolver: Box::new(resolver),
             dns_filter: self.dns_filter.clone(),
+            upstream_health: Arc::new(UpstreamHealth::new()),
         };
 
         Ok(())
     }
 }
 
+/// How often at most a resolution failure is logged at error level; failures in
+/// between are counted and logged at debug level. Dead upstream connections (e.g.
+/// after system sleep) produce bursts of hundreds of identical failures.
+const RESOLVE_ERROR_LOG_WINDOW: Duration = Duration::from_secs(5);
+
 /// An implementation of [RequestHandler] that forwards queries.
 struct ResolverImpl {
     tx: mpsc::UnboundedSender<ResolverMessage>,
+    error_log_throttle: LogThrottle,
 }
 
 impl ResolverImpl {
@@ -701,7 +771,14 @@ impl ResolverImpl {
                             trace_err_chain!(err, "failed to send response");
                         })
                 } else {
-                    trace_err_chain!(resolve_err, "failed to resolve hostname");
+                    match self.error_log_throttle.try_log(Instant::now()) {
+                        Some(0) => trace_err_chain!(resolve_err, "failed to resolve hostname"),
+                        Some(suppressed) => trace_err_chain!(
+                            resolve_err,
+                            "failed to resolve hostname ({suppressed} similar errors suppressed)"
+                        ),
+                        None => tracing::debug!("failed to resolve hostname: {resolve_err}"),
+                    }
                     send_error_response(message, response_handler, ResponseCode::ServFail).await
                 }
             }

--- a/nym-vpn-core/crates/nym-vpn-lib/src/resolver/upstream_health.rs
+++ b/nym-vpn-core/crates/nym-vpn-lib/src/resolver/upstream_health.rs
@@ -1,0 +1,186 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+//! Health tracking for the upstream DNS forwarder.
+//!
+//! The forwarding resolver keeps pooled connections (e.g. DoH/DoT streams) that go
+//! stale when the system sleeps or the network is reconfigured, producing bursts of
+//! failed lookups. [`UpstreamHealth`] counts consecutive upstream failures so the
+//! resolver can be rebuilt with fresh connections, and [`LogThrottle`] keeps those
+//! bursts from flooding the log with identical errors.
+
+use std::{
+    sync::{
+        Mutex,
+        atomic::{AtomicBool, AtomicU32, Ordering},
+    },
+    time::{Duration, Instant},
+};
+
+/// Number of consecutive upstream failures after which the forwarding resolver is
+/// rebuilt to replace potentially stale pooled connections.
+const CONSECUTIVE_FAILURES_BEFORE_REBUILD: u32 = 5;
+
+/// Tracks consecutive upstream lookup failures and requests a resolver rebuild once
+/// they accumulate. Safe to share between concurrent lookup tasks.
+#[derive(Debug, Default)]
+pub struct UpstreamHealth {
+    consecutive_failures: AtomicU32,
+    rebuild_requested: AtomicBool,
+}
+
+impl UpstreamHealth {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Records a successful upstream interaction, resetting the failure streak.
+    pub fn record_success(&self) {
+        self.consecutive_failures.store(0, Ordering::Relaxed);
+    }
+
+    /// Records a failed upstream interaction.
+    pub fn record_failure(&self) {
+        let failures = self.consecutive_failures.fetch_add(1, Ordering::Relaxed) + 1;
+        if failures >= CONSECUTIVE_FAILURES_BEFORE_REBUILD {
+            self.consecutive_failures.store(0, Ordering::Relaxed);
+            self.rebuild_requested.store(true, Ordering::Relaxed);
+        }
+    }
+
+    /// Returns true when enough consecutive failures accumulated since the last
+    /// request. The request is consumed: subsequent calls return false until another
+    /// full streak of failures accumulates.
+    pub fn take_rebuild_request(&self) -> bool {
+        self.rebuild_requested.swap(false, Ordering::Relaxed)
+    }
+}
+
+/// Rate limiter for repetitive log statements: allows one log line per window and
+/// counts how many were suppressed in between.
+#[derive(Debug)]
+pub struct LogThrottle {
+    window: Duration,
+    state: Mutex<ThrottleState>,
+}
+
+#[derive(Debug, Default)]
+struct ThrottleState {
+    last_logged: Option<Instant>,
+    suppressed: u64,
+}
+
+impl LogThrottle {
+    pub fn new(window: Duration) -> Self {
+        Self {
+            window,
+            state: Mutex::new(ThrottleState::default()),
+        }
+    }
+
+    /// Returns `Some(suppressed)` when the caller should log now, where `suppressed`
+    /// is the number of occurrences swallowed since the last logged one; returns
+    /// `None` when the statement should be suppressed.
+    pub fn try_log(&self, now: Instant) -> Option<u64> {
+        let mut state = self.state.lock().unwrap();
+        match state.last_logged {
+            Some(last_logged) if now.duration_since(last_logged) < self.window => {
+                state.suppressed += 1;
+                None
+            }
+            _ => {
+                let suppressed = state.suppressed;
+                state.last_logged = Some(now);
+                state.suppressed = 0;
+                Some(suppressed)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_rebuild_below_failure_threshold() {
+        let health = UpstreamHealth::new();
+        for _ in 0..CONSECUTIVE_FAILURES_BEFORE_REBUILD - 1 {
+            health.record_failure();
+        }
+        assert!(!health.take_rebuild_request());
+    }
+
+    #[test]
+    fn rebuild_requested_after_consecutive_failures() {
+        let health = UpstreamHealth::new();
+        for _ in 0..CONSECUTIVE_FAILURES_BEFORE_REBUILD {
+            health.record_failure();
+        }
+        assert!(health.take_rebuild_request());
+        assert!(
+            !health.take_rebuild_request(),
+            "the rebuild request must be consumed by taking it"
+        );
+    }
+
+    #[test]
+    fn success_resets_failure_streak() {
+        let health = UpstreamHealth::new();
+        for _ in 0..CONSECUTIVE_FAILURES_BEFORE_REBUILD - 1 {
+            health.record_failure();
+        }
+        health.record_success();
+        for _ in 0..CONSECUTIVE_FAILURES_BEFORE_REBUILD - 1 {
+            health.record_failure();
+        }
+        assert!(!health.take_rebuild_request());
+    }
+
+    #[test]
+    fn another_full_streak_is_required_after_a_rebuild_request() {
+        let health = UpstreamHealth::new();
+        for _ in 0..CONSECUTIVE_FAILURES_BEFORE_REBUILD {
+            health.record_failure();
+        }
+        assert!(health.take_rebuild_request());
+
+        health.record_failure();
+        assert!(!health.take_rebuild_request());
+    }
+
+    #[test]
+    fn throttle_allows_first_log() {
+        let throttle = LogThrottle::new(Duration::from_secs(5));
+        assert_eq!(throttle.try_log(Instant::now()), Some(0));
+    }
+
+    #[test]
+    fn throttle_suppresses_within_window() {
+        let throttle = LogThrottle::new(Duration::from_secs(5));
+        let start = Instant::now();
+        assert_eq!(throttle.try_log(start), Some(0));
+        assert_eq!(throttle.try_log(start + Duration::from_secs(1)), None);
+        assert_eq!(throttle.try_log(start + Duration::from_secs(2)), None);
+    }
+
+    #[test]
+    fn throttle_logs_again_after_window_with_suppressed_count() {
+        let throttle = LogThrottle::new(Duration::from_secs(5));
+        let start = Instant::now();
+        assert_eq!(throttle.try_log(start), Some(0));
+        assert_eq!(throttle.try_log(start + Duration::from_secs(1)), None);
+        assert_eq!(throttle.try_log(start + Duration::from_secs(2)), None);
+        assert_eq!(throttle.try_log(start + Duration::from_secs(6)), Some(2));
+    }
+
+    #[test]
+    fn throttle_resets_suppressed_count_after_logging() {
+        let throttle = LogThrottle::new(Duration::from_secs(5));
+        let start = Instant::now();
+        assert_eq!(throttle.try_log(start), Some(0));
+        assert_eq!(throttle.try_log(start + Duration::from_secs(1)), None);
+        assert_eq!(throttle.try_log(start + Duration::from_secs(6)), Some(1));
+        assert_eq!(throttle.try_log(start + Duration::from_secs(12)), Some(0));
+    }
+}


### PR DESCRIPTION
Pooled DoH/DoT connections inside the forwarding resolver go stale after system sleep or network changes, producing prolonged bursts of failed lookups and hundreds of identical error log lines per burst.

- Track consecutive upstream failures; rebuild the forwarding resolver (fresh connection pool) after 5 in a row
- Rate-limit the "failed to resolve hostname" error log to one line per 5s with a suppressed-error count

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6234)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNS reliability by rebuilding forwarding resolution after repeated upstream failures.
  * Reset upstream health tracking after successful lookups or resolver rebuilds.
  * Reduced repetitive resolution error messages while preserving visibility into suppressed failures.
  * Improved Android application-exit diagnostics with clearer reason and status information.
  * Improved credential request recovery when issuance is paused, resumed, or fails server-side.

* **Tests**
  * Added coverage for DNS recovery, throttled error logging, and credential request flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->