### PR TITLE
feat(android): log prior process exit reasons on startup

### DIFF
--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/NymVpn.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/NymVpn.kt
@@ -1,5 +1,6 @@
 package net.nymtech.nymvpn
 
+import android.app.ActivityManager
 import android.app.Application
 import android.content.Context
 import android.os.Build
@@ -35,6 +36,7 @@ import net.nymtech.nymvpn.di.qualifiers.IoDispatcher
 import net.nymtech.nymvpn.di.qualifiers.MainDispatcher
 import net.nymtech.nymvpn.manager.backend.BackendManager
 import net.nymtech.nymvpn.util.Constants
+import net.nymtech.nymvpn.util.ExitReasons
 import net.nymtech.nymvpn.util.GraphicsFallback
 import net.nymtech.nymvpn.util.LocaleUtil
 import net.nymtech.nymvpn.util.extensions.requestTileServiceStateUpdate
@@ -56,6 +58,7 @@ class NymVpn : Application() {
 
 	companion object {
 		private const val TAG = "app"
+		private const val PRIOR_EXIT_REASONS_MAX = 5
 
 		val isInitialized: Boolean get() = ::instance.isInitialized
 
@@ -107,6 +110,9 @@ class NymVpn : Application() {
 	@Volatile
 	private var logReaderStarted: Boolean = false
 
+	@Volatile
+	private var priorExitReasonsLogged: Boolean = false
+
 	private var logsObserverJob: Job? = null
 
 	override fun onCreate() {
@@ -132,6 +138,7 @@ class NymVpn : Application() {
 					applyLoggingConfig(enabled, debugEnabled)
 					if (enabled) {
 						ensureLogReaderStarted()
+						logPriorExitReasonsOnce()
 					}
 				}
 		}
@@ -231,6 +238,27 @@ class NymVpn : Application() {
 		if (!BuildConfig.DEBUG) return
 		StrictMode.setThreadPolicy(StrictMode.ThreadPolicy.LAX)
 		StrictMode.setVmPolicy(StrictMode.VmPolicy.LAX)
+	}
+
+	private suspend fun logPriorExitReasonsOnce() {
+		if (priorExitReasonsLogged) return
+		priorExitReasonsLogged = true
+
+		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) return
+		runCatching {
+			val activityManager = getSystemService(ACTIVITY_SERVICE) as ActivityManager
+			activityManager.getHistoricalProcessExitReasons(packageName, 0, PRIOR_EXIT_REASONS_MAX)
+				.forEach { info ->
+					// written directly to the log files: lines emitted this early would be
+					// wiped by the log reader's logcat -c
+					logReader.writeDiagnostic(
+						TAG,
+						ExitReasons.formatLine(info.timestamp, info.reason, info.status, info.importance, info.description),
+					)
+				}
+		}.onFailure { t ->
+			Timber.tag(TAG).w(t, "PriorExitReasonsFailed")
+		}
 	}
 
 	private fun ensureLogReaderStarted() {

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/NymVpn.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/NymVpn.kt
@@ -36,13 +36,13 @@ import net.nymtech.nymvpn.di.qualifiers.IoDispatcher
 import net.nymtech.nymvpn.di.qualifiers.MainDispatcher
 import net.nymtech.nymvpn.manager.backend.BackendManager
 import net.nymtech.nymvpn.util.Constants
-import net.nymtech.nymvpn.util.ExitReasons
+import net.nymtech.nymvpn.util.logs.ExitReasons
 import net.nymtech.nymvpn.util.GraphicsFallback
 import net.nymtech.nymvpn.util.LocaleUtil
 import net.nymtech.nymvpn.util.extensions.requestTileServiceStateUpdate
-import net.nymtech.nymvpn.util.timber.DebugTree
-import net.nymtech.nymvpn.util.timber.NoLogTree
-import net.nymtech.nymvpn.util.timber.ReleaseTree
+import net.nymtech.nymvpn.util.logs.timber.DebugTree
+import net.nymtech.nymvpn.util.logs.timber.NoLogTree
+import net.nymtech.nymvpn.util.logs.timber.ReleaseTree
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -242,20 +242,25 @@ class NymVpn : Application() {
 
 	private suspend fun logPriorExitReasonsOnce() {
 		if (priorExitReasonsLogged) return
-		priorExitReasonsLogged = true
 
-		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) return
+		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+			priorExitReasonsLogged = true
+			return
+		}
+
+		// Written via writeDiagnostic() instead of Timber, since this runs before the log reader
+		// clears logcat and a Timber line here could be wiped before it's captured.
 		runCatching {
 			val activityManager = getSystemService(ACTIVITY_SERVICE) as ActivityManager
 			activityManager.getHistoricalProcessExitReasons(packageName, 0, PRIOR_EXIT_REASONS_MAX)
 				.forEach { info ->
-					// written directly to the log files: lines emitted this early would be
-					// wiped by the log reader's logcat -c
 					logReader.writeDiagnostic(
 						TAG,
 						ExitReasons.formatLine(info.timestamp, info.reason, info.status, info.importance, info.description),
 					)
 				}
+		}.onSuccess {
+			priorExitReasonsLogged = true
 		}.onFailure { t ->
 			Timber.tag(TAG).w(t, "PriorExitReasonsFailed")
 		}

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/util/ExitReasons.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/util/ExitReasons.kt
@@ -1,0 +1,38 @@
+package net.nymtech.nymvpn.util
+
+import android.app.ApplicationExitInfo
+import java.time.Instant
+
+/**
+ * Formats ApplicationExitInfo records into single log lines so log bundles
+ * explain why previous processes died (OS kill vs crash vs user swipe).
+ */
+object ExitReasons {
+
+	fun reasonName(reason: Int): String = when (reason) {
+		ApplicationExitInfo.REASON_UNKNOWN -> "UNKNOWN"
+		ApplicationExitInfo.REASON_EXIT_SELF -> "EXIT_SELF"
+		ApplicationExitInfo.REASON_SIGNALED -> "SIGNALED"
+		ApplicationExitInfo.REASON_LOW_MEMORY -> "LOW_MEMORY"
+		ApplicationExitInfo.REASON_CRASH -> "CRASH"
+		ApplicationExitInfo.REASON_CRASH_NATIVE -> "CRASH_NATIVE"
+		ApplicationExitInfo.REASON_ANR -> "ANR"
+		ApplicationExitInfo.REASON_INITIALIZATION_FAILURE -> "INITIALIZATION_FAILURE"
+		ApplicationExitInfo.REASON_PERMISSION_CHANGE -> "PERMISSION_CHANGE"
+		ApplicationExitInfo.REASON_EXCESSIVE_RESOURCE_USAGE -> "EXCESSIVE_RESOURCE_USAGE"
+		ApplicationExitInfo.REASON_USER_REQUESTED -> "USER_REQUESTED"
+		ApplicationExitInfo.REASON_USER_STOPPED -> "USER_STOPPED"
+		ApplicationExitInfo.REASON_DEPENDENCY_DIED -> "DEPENDENCY_DIED"
+		ApplicationExitInfo.REASON_OTHER -> "OTHER"
+		ApplicationExitInfo.REASON_FREEZER -> "FREEZER"
+		ApplicationExitInfo.REASON_PACKAGE_STATE_CHANGE -> "PACKAGE_STATE_CHANGE"
+		ApplicationExitInfo.REASON_PACKAGE_UPDATED -> "PACKAGE_UPDATED"
+		else -> "UNKNOWN($reason)"
+	}
+
+	fun formatLine(timestampMs: Long, reason: Int, status: Int, importance: Int, description: String?): String {
+		val base = "PriorExit time=${Instant.ofEpochMilli(timestampMs)} reason=${reasonName(reason)} " +
+			"status=$status importance=$importance"
+		return if (description.isNullOrBlank()) base else "$base description=$description"
+	}
+}

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/util/logs/ExitReasons.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/util/logs/ExitReasons.kt
@@ -1,12 +1,9 @@
-package net.nymtech.nymvpn.util
+package net.nymtech.nymvpn.util.logs
 
 import android.app.ApplicationExitInfo
 import java.time.Instant
 
-/**
- * Formats ApplicationExitInfo records into single log lines so log bundles
- * explain why previous processes died (OS kill vs crash vs user swipe).
- */
+/** Formats ApplicationExitInfo records into single log lines. */
 object ExitReasons {
 
 	fun reasonName(reason: Int): String = when (reason) {
@@ -33,6 +30,7 @@ object ExitReasons {
 	fun formatLine(timestampMs: Long, reason: Int, status: Int, importance: Int, description: String?): String {
 		val base = "PriorExit time=${Instant.ofEpochMilli(timestampMs)} reason=${reasonName(reason)} " +
 			"status=$status importance=$importance"
-		return if (description.isNullOrBlank()) base else "$base description=$description"
+		val singleLineDescription = description?.replace(Regex("\\s*[\r\n]+\\s*"), " ")?.trim()
+		return if (singleLineDescription.isNullOrBlank()) base else "$base description=$singleLineDescription"
 	}
 }

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/util/logs/timber/DebugTree.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/util/logs/timber/DebugTree.kt
@@ -1,4 +1,4 @@
-package net.nymtech.nymvpn.util.timber
+package net.nymtech.nymvpn.util.logs.timber
 
 import timber.log.Timber
 

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/util/logs/timber/NoLogTree.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/util/logs/timber/NoLogTree.kt
@@ -1,4 +1,4 @@
-package net.nymtech.nymvpn.util.timber
+package net.nymtech.nymvpn.util.logs.timber
 
 import timber.log.Timber
 

--- a/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/util/logs/timber/ReleaseTree.kt
+++ b/nym-vpn-android/app/src/main/java/net/nymtech/nymvpn/util/logs/timber/ReleaseTree.kt
@@ -1,4 +1,4 @@
-package net.nymtech.nymvpn.util.timber
+package net.nymtech.nymvpn.util.logs.timber
 
 import timber.log.Timber
 

--- a/nym-vpn-android/app/src/test/java/net/nymtech/nymvpn/util/ExitReasonsTest.kt
+++ b/nym-vpn-android/app/src/test/java/net/nymtech/nymvpn/util/ExitReasonsTest.kt
@@ -1,0 +1,52 @@
+package net.nymtech.nymvpn.util
+
+import android.app.ApplicationExitInfo
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ExitReasonsTest {
+
+	@Test
+	fun reasonName_mapsKnownCodes() {
+		assertEquals("CRASH_NATIVE", ExitReasons.reasonName(ApplicationExitInfo.REASON_CRASH_NATIVE))
+		assertEquals("LOW_MEMORY", ExitReasons.reasonName(ApplicationExitInfo.REASON_LOW_MEMORY))
+		assertEquals("USER_REQUESTED", ExitReasons.reasonName(ApplicationExitInfo.REASON_USER_REQUESTED))
+		assertEquals("ANR", ExitReasons.reasonName(ApplicationExitInfo.REASON_ANR))
+		assertEquals("SIGNALED", ExitReasons.reasonName(ApplicationExitInfo.REASON_SIGNALED))
+	}
+
+	@Test
+	fun reasonName_fallsBackToCodeForUnknown() {
+		assertEquals("UNKNOWN(99)", ExitReasons.reasonName(99))
+	}
+
+	@Test
+	fun formatLine_includesTimestampReasonStatusImportanceAndDescription() {
+		val line = ExitReasons.formatLine(
+			timestampMs = 1787849947000,
+			reason = ApplicationExitInfo.REASON_USER_REQUESTED,
+			status = 0,
+			importance = 400,
+			description = "stop net.nymtech.nymvpn due to from pid 1234",
+		)
+		assertEquals(
+			"PriorExit time=2026-08-27T16:59:07Z reason=USER_REQUESTED status=0 importance=400 description=stop net.nymtech.nymvpn due to from pid 1234",
+			line,
+		)
+	}
+
+	@Test
+	fun formatLine_omitsDescriptionWhenNull() {
+		val line = ExitReasons.formatLine(
+			timestampMs = 1787849947000,
+			reason = ApplicationExitInfo.REASON_LOW_MEMORY,
+			status = 0,
+			importance = 300,
+			description = null,
+		)
+		assertEquals(
+			"PriorExit time=2026-08-27T16:59:07Z reason=LOW_MEMORY status=0 importance=300",
+			line,
+		)
+	}
+}

--- a/nym-vpn-android/app/src/test/java/net/nymtech/nymvpn/util/ExitReasonsTest.kt
+++ b/nym-vpn-android/app/src/test/java/net/nymtech/nymvpn/util/ExitReasonsTest.kt
@@ -1,6 +1,7 @@
 package net.nymtech.nymvpn.util
 
 import android.app.ApplicationExitInfo
+import net.nymtech.nymvpn.util.logs.ExitReasons
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -46,6 +47,22 @@ class ExitReasonsTest {
 		)
 		assertEquals(
 			"PriorExit time=2026-08-27T16:59:07Z reason=LOW_MEMORY status=0 importance=300",
+			line,
+		)
+	}
+
+	@Test
+	fun formatLine_collapsesMultiLineDescriptionToSingleLine() {
+		val line = ExitReasons.formatLine(
+			timestampMs = 1787849947000,
+			reason = ApplicationExitInfo.REASON_CRASH_NATIVE,
+			status = 0,
+			importance = 100,
+			description = "signal 11 (SIGSEGV)\r\nbacktrace:\n  #00 pc 0001",
+		)
+		assertEquals(
+			"PriorExit time=2026-08-27T16:59:07Z reason=CRASH_NATIVE status=0 importance=100 " +
+				"description=signal 11 (SIGSEGV) backtrace: #00 pc 0001",
 			line,
 		)
 	}

--- a/nym-vpn-android/logcatter/src/main/java/net/nymtech/logcatutil/LogReader.kt
+++ b/nym-vpn-android/logcatter/src/main/java/net/nymtech/logcatutil/LogReader.kt
@@ -13,6 +13,9 @@ interface LogReader {
 
 	fun start()
 	fun stop()
+
+	/** Writes a line into the app log stream directly, bypassing logcat capture (survives `logcat -c`). */
+	suspend fun writeDiagnostic(tag: String, message: String)
 	suspend fun zipLogFiles(path: String)
 
 	suspend fun deleteAndClearLogs()

--- a/nym-vpn-android/logcatter/src/main/java/net/nymtech/logcatutil/LogcatManager.kt
+++ b/nym-vpn-android/logcatter/src/main/java/net/nymtech/logcatutil/LogcatManager.kt
@@ -17,12 +17,14 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
+import net.nymtech.logcatutil.model.LogLevel
 import net.nymtech.logcatutil.model.LogMessage
 import net.nymtech.logcatutil.model.LogType
 import timber.log.Timber
 import java.io.File
+import java.time.Instant
 
-class LogcatManager(pid: Int, logDir: String, maxFileSize: Long, maxFolderSize: Long) :
+class LogcatManager(private val pid: Int, logDir: String, maxFileSize: Long, maxFolderSize: Long) :
 	LogReader,
 	DefaultLifecycleObserver {
 
@@ -102,6 +104,23 @@ class LogcatManager(pid: Int, logDir: String, maxFileSize: Long, maxFolderSize: 
 		}
 
 		isStarted = true
+	}
+
+	override suspend fun writeDiagnostic(tag: String, message: String) {
+		val logMessage = LogMessage(
+			time = Instant.now().toString(),
+			epochMillis = System.currentTimeMillis(),
+			pid = pid.toString(),
+			tid = pid.toString(),
+			level = LogLevel.INFO,
+			tag = tag,
+			message = message,
+		)
+		_bufferedLogsApp.emit(logMessage)
+		runCatching {
+			fileManager.writeLog(LogType.LOGCAT, logMessage.toString())
+			fileManager.writeLog(LogType.APP, logMessage.toString())
+		}.onFailure { Timber.tag(TAG).w(it, "DiagnosticWriteFailed") }
 	}
 
 	private fun activateTimberFallback() {

--- a/nym-vpn-android/logcatter/src/main/java/net/nymtech/logcatutil/LogcatManager.kt
+++ b/nym-vpn-android/logcatter/src/main/java/net/nymtech/logcatutil/LogcatManager.kt
@@ -117,10 +117,10 @@ class LogcatManager(private val pid: Int, logDir: String, maxFileSize: Long, max
 			message = message,
 		)
 		_bufferedLogsApp.emit(logMessage)
-		runCatching {
-			fileManager.writeLog(LogType.LOGCAT, logMessage.toString())
-			fileManager.writeLog(LogType.APP, logMessage.toString())
-		}.onFailure { Timber.tag(TAG).w(it, "DiagnosticWriteFailed") }
+		runCatching { fileManager.writeLog(LogType.LOGCAT, logMessage.toString()) }
+			.onFailure { Timber.tag(TAG).w(it, "DiagnosticWriteFailed") }
+		runCatching { fileManager.writeLog(LogType.APP, logMessage.toString()) }
+			.onFailure { Timber.tag(TAG).w(it, "DiagnosticWriteFailed") }
 	}
 
 	private fun activateTimberFallback() {

--- a/nym-vpn-android/logcatter/src/test/java/net/nymtech/logcatutil/LogcatManagerDiagnosticTest.kt
+++ b/nym-vpn-android/logcatter/src/test/java/net/nymtech/logcatutil/LogcatManagerDiagnosticTest.kt
@@ -1,0 +1,31 @@
+package net.nymtech.logcatutil
+
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import net.nymtech.logcatutil.model.LogLevel
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.nio.file.Files
+
+class LogcatManagerDiagnosticTest {
+
+	private fun manager() = LogcatManager(
+		pid = 42,
+		logDir = Files.createTempDirectory("logcat-test").toString(),
+		maxFileSize = 1024,
+		maxFolderSize = 4096,
+	)
+
+	@Test
+	fun writeDiagnostic_emitsToBufferedAppLogs() = runBlocking {
+		val manager = manager()
+
+		manager.writeDiagnostic("app", "PriorExit reason=LOW_MEMORY")
+
+		val replayed = manager.bufferedLogsApp.first()
+		assertEquals("PriorExit reason=LOW_MEMORY", replayed.message)
+		assertEquals("app", replayed.tag)
+		assertEquals(LogLevel.INFO, replayed.level)
+		assertEquals("42", replayed.pid)
+	}
+}


### PR DESCRIPTION
Log bundles from devices with aggressive process killing (e.g. HyperOS) could not show why previous processes died. On startup, read ApplicationExitInfo (API 30+) and write the last 5 exit reasons into the app log stream, e.g.:

  PriorExit time=... reason=USER_REQUESTED status=0 importance=400
  description=[REMOVE TASK] remove task

This distinguishes OS memory kills, MIUI cleaner force-stops, native crashes, and ANRs directly in user-submitted log zips.

The lines are written through a new LogReader.writeDiagnostic() that goes straight to the log files and the in-app viewer buffer, because lines emitted this early via Timber can be wiped by the log reader's logcat -c before capture.

Verified on-device (Volla X23, Android 16): force-stop, task removal, and package update are each correctly attributed on the next launch.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6236)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added diagnostic logging for up to five historical app exit reasons on Android 11 and later.
  * Exit records now include readable reasons, timestamps, status, importance, and descriptions.
  * Diagnostic entries are written directly to app logs and remain available if one log destination fails.

* **Bug Fixes**
  * Improved reliability when collecting historical exit information by retrying failed queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->