### PR TITLE
Wait until the Windows VPN service is running

### DIFF
--- a/nym-vpn-app/src/state/useTauriEvents.ts
+++ b/nym-vpn-app/src/state/useTauriEvents.ts
@@ -73,7 +73,14 @@ export function useTauriEvents(
           } catch {}
         }
       },
-    );
+    ).then(async (unlisten) => {
+      try {
+        const status =
+          (await invoke<VpndStatus | undefined>('daemon_status')) || 'down';
+        daemonStatusUpdate(status, add, close);
+      } catch {}
+      return unlisten;
+    });
   }, [add, close]);
 
   const registerTunnelStateListener = useCallback(() => {

--- a/nym-vpn-app/src/state/useTauriEvents.ts
+++ b/nym-vpn-app/src/state/useTauriEvents.ts
@@ -37,9 +37,11 @@ export function useTauriEvents(
   close: (id: string) => void,
 ) {
   const registerDaemonListener = useCallback(() => {
+    let liveEventSeen = false;
     return listen<VpndStatus>(
       DaemonEvent,
       async ({ event, payload: status }) => {
+        liveEventSeen = true;
         console.log(
           `received event [${event}], status: ${status === 'down' ? status : JSON.stringify(status)}`,
         );
@@ -77,8 +79,12 @@ export function useTauriEvents(
       try {
         const status =
           (await invoke<VpndStatus | undefined>('daemon_status')) || 'down';
-        daemonStatusUpdate(status, add, close);
-      } catch {}
+        if (!liveEventSeen) {
+          daemonStatusUpdate(status, add, close);
+        }
+      } catch (error) {
+        console.info('command [daemon_status] catch-up failed', error);
+      }
       return unlisten;
     });
   }, [add, close]);

--- a/nym-vpn-core/crates/nym-vpnd/src/main.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/main.rs
@@ -56,7 +56,9 @@ async fn main() -> anyhow::Result<()> {
         #[cfg(windows)]
         Command::StartService => {
             println!("Starting {SERVICE_NAME} service...");
-            start_service().context("Failed to start Windows service")?;
+            start_service()
+                .await
+                .context("Failed to start Windows service")?;
             Ok(())
         }
         Command::RunStandalone => run_vpn_service(cli_args, RunArgs::default()).await,

--- a/nym-vpn-core/crates/nym-vpnd/src/windows_service/installation.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/windows_service/installation.rs
@@ -20,6 +20,9 @@ use windows_service::{
 
 use super::{SERVICE_DESCRIPTION, SERVICE_DISPLAY_NAME, SERVICE_NAME, SERVICE_TYPE};
 
+const SERVICE_WAIT_TIMEOUT: Duration = Duration::from_secs(30);
+const SERVICE_POLL_INTERVAL: Duration = Duration::from_secs(1);
+
 pub fn install_service() -> anyhow::Result<()> {
     let manager_access = ServiceManagerAccess::CONNECT | ServiceManagerAccess::CREATE_SERVICE;
     let service_manager = ServiceManager::local_computer(None::<&str>, manager_access)?;
@@ -118,8 +121,7 @@ pub async fn uninstall_service() -> anyhow::Result<()> {
 
     // Poll until service is deleted or timeout.
     let start = Instant::now();
-    let timeout = Duration::from_secs(30);
-    while start.elapsed() < timeout {
+    while start.elapsed() < SERVICE_WAIT_TIMEOUT {
         if let Err(windows_service::Error::Winapi(e)) =
             service_manager.open_service(SERVICE_NAME, ServiceAccess::QUERY_STATUS)
             && e.raw_os_error() == Some(ERROR_SERVICE_DOES_NOT_EXIST.0 as i32)
@@ -127,7 +129,7 @@ pub async fn uninstall_service() -> anyhow::Result<()> {
             println!("{SERVICE_NAME} service was uninstalled successfully.");
             return Ok(());
         }
-        tokio::time::sleep(Duration::from_secs(1)).await;
+        tokio::time::sleep(SERVICE_POLL_INTERVAL).await;
     }
 
     Err(anyhow!(
@@ -135,7 +137,7 @@ pub async fn uninstall_service() -> anyhow::Result<()> {
     ))
 }
 
-pub fn start_service() -> anyhow::Result<()> {
+pub async fn start_service() -> anyhow::Result<()> {
     let manager_access = ServiceManagerAccess::CONNECT;
     let service_manager = ServiceManager::local_computer(None::<&str>, manager_access)?;
 
@@ -147,12 +149,11 @@ pub fn start_service() -> anyhow::Result<()> {
     }
 
     let start = Instant::now();
-    let timeout = Duration::from_secs(30);
-    while start.elapsed() < timeout {
+    while start.elapsed() < SERVICE_WAIT_TIMEOUT {
         if service.query_status()?.current_state == ServiceState::Running {
             return Ok(());
         }
-        std::thread::sleep(Duration::from_secs(1));
+        tokio::time::sleep(SERVICE_POLL_INTERVAL).await;
     }
     Err(anyhow!(
         "timed out waiting for the service to reach running"
@@ -177,5 +178,20 @@ fn get_service_info() -> ServiceInfo {
         ],
         account_name: None, // run as System
         account_password: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn service_wait_timeout_is_thirty_seconds() {
+        assert_eq!(SERVICE_WAIT_TIMEOUT, Duration::from_secs(30));
+    }
+
+    #[test]
+    fn service_poll_interval_is_one_second() {
+        assert_eq!(SERVICE_POLL_INTERVAL, Duration::from_secs(1));
     }
 }

--- a/nym-vpn-core/crates/nym-vpnd/src/windows_service/installation.rs
+++ b/nym-vpn-core/crates/nym-vpnd/src/windows_service/installation.rs
@@ -145,7 +145,18 @@ pub fn start_service() -> anyhow::Result<()> {
     if service.query_status()?.current_state != ServiceState::Running {
         service.start(&[] as &[&std::ffi::OsStr])?;
     }
-    Ok(())
+
+    let start = Instant::now();
+    let timeout = Duration::from_secs(30);
+    while start.elapsed() < timeout {
+        if service.query_status()?.current_state == ServiceState::Running {
+            return Ok(());
+        }
+        std::thread::sleep(Duration::from_secs(1));
+    }
+    Err(anyhow!(
+        "timed out waiting for the service to reach running"
+    ))
 }
 
 fn get_service_info() -> ServiceInfo {


### PR DESCRIPTION
## Description

- Then refresh daemon status after subscribe
- After install, starting the Windows service waits until it is running (or 30 seconds), matching the existing uninstall wait.
- Once the desktop app is listening for daemon status, it reads the current status once so a missed event cannot leave Connect disabled.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym-vpn-client/6245)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection status updates during app startup, preventing stale fallback information from overriding live status.
  * Startup status retrieval failures are now reported for better troubleshooting.
  * Improved Windows VPN service startup and removal by waiting reliably for service state changes and avoiding premature completion.
  * Added a timeout for Windows service operations when the expected state is not reached.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->